### PR TITLE
Drop legacy equipment_count_enhanced overload

### DIFF
--- a/supabase/migrations/20250921_reports_enhanced_rpcs.sql
+++ b/supabase/migrations/20250921_reports_enhanced_rpcs.sql
@@ -15,7 +15,8 @@ AS $$
   SELECT COALESCE(current_setting('request.jwt.claims', true)::jsonb ->> claim, NULL);
 $$;
 
--- Enhanced equipment_count with explicit tenant & department parameters
+-- Drop legacy 3-arg overload so deployments remain idempotent when adding p_khoa_phong
+DROP FUNCTION IF EXISTS public.equipment_count_enhanced(TEXT[], TEXT, BIGINT);
 CREATE OR REPLACE FUNCTION public.equipment_count_enhanced(
   p_statuses TEXT[] DEFAULT NULL,
   p_q TEXT DEFAULT NULL,


### PR DESCRIPTION
## Summary
- drop the legacy 3-argument equipment_count_enhanced overload before recreating the enhanced function
- add commentary explaining why the drop keeps the migration idempotent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d207167e0883338ab4d51872d143d3