### PR TITLE
fix(api): add 'thanh_ly' type support to transfer API routes

### DIFF
--- a/src/app/api/transfers/counts/route.ts
+++ b/src/app/api/transfers/counts/route.ts
@@ -15,7 +15,7 @@ export const runtime = 'nodejs'
  * - facilityId: facility filter (global users only)
  * - dateFrom: date range start (YYYY-MM-DD)
  * - dateTo: date range end (YYYY-MM-DD)
- * - types: comma-separated types (noi_bo, ben_ngoai)
+ * - types: comma-separated types (noi_bo, ben_ngoai, thanh_ly)
  * - assigneeIds: comma-separated assignee IDs
  */
 export async function GET(request: NextRequest) {
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
     const types = searchParams.get('types')
       ?.split(',')
       .map((t: string) => t.trim())
-      .filter((t: string) => ['noi_bo', 'ben_ngoai'].includes(t)) || null
+      .filter((t: string) => ['noi_bo', 'ben_ngoai', 'thanh_ly'].includes(t)) || null
 
     const assigneeIds = searchParams.get('assigneeIds')
       ?.split(',')

--- a/src/app/api/transfers/list/route.ts
+++ b/src/app/api/transfers/list/route.ts
@@ -12,7 +12,7 @@ export const runtime = 'nodejs'
  * Query Parameters:
  * - q: search text (equipment name, transfer code, reason)
  * - statuses: comma-separated status values
- * - types: comma-separated types (noi_bo, ben_ngoai)
+ * - types: comma-separated types (noi_bo, ben_ngoai, thanh_ly)
  * - page: page number (1-indexed)
  * - pageSize: items per page
  * - facilityId: facility filter (global users only)
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
     const types = searchParams.get('types')
       ?.split(',')
       .map((t: string) => t.trim())
-      .filter((t: string) => ['noi_bo', 'ben_ngoai'].includes(t)) || null
+      .filter((t: string) => ['noi_bo', 'ben_ngoai', 'thanh_ly'].includes(t)) || null
 
     const page = parseInt(searchParams.get('page') || '1')
     const pageSize = parseInt(searchParams.get('pageSize') || '50')


### PR DESCRIPTION
Add 'thanh_ly' (liquidation) to allowed transfer types in both list and counts API routes to enable 3-tab design (Internal/External/Liquidation).

Changes:
- /api/transfers/list: Add 'thanh_ly' to type filter whitelist
- /api/transfers/counts: Add 'thanh_ly' to type filter whitelist
- Update JSDoc comments to reflect all three transfer types

This fix ensures compatibility with Task 4 frontend implementation which requires tabbed design with separate Liquidation tab.

Related: openspec/changes/refactor-transfer-board-data-grid/proposal.md