### PR TITLE
chore: clean up presentation generation dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ firebase_config.md
 # bv (beads viewer) local config and caches
 .bv/
 tmpclaude-*-cwd
+
+# Presentation workspace
+/workspace/
+create-pptx.js


### PR DESCRIPTION
Remove pptxgenjs and playwright dev dependencies after generating presentation. Add workspace folder to gitignore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add /workspace/ and create-pptx.js to .gitignore to keep presentation generation artifacts out of version control. This prevents accidental commits of local workspace files and the helper script.

<sup>Written for commit c8051692cc3f32cd97e11ad3acd7e76fc83fbaf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

