### PR TITLE
fix: use local date parsing to prevent timezone shift bugs

### DIFF
--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialog.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialog.tsx
@@ -36,22 +36,9 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
+import { parseLocalDate } from "@/lib/date-utils"
 
 import { useDeviceQuotaDecisionsContext } from "../_hooks/useDeviceQuotaDecisionsContext"
-
-// ============================================
-// Helpers
-// ============================================
-
-/**
- * Parse a YYYY-MM-DD date string as a local date (not UTC).
- * Using new Date("2024-01-15") parses as UTC midnight, which can shift
- * the day in non-UTC timezones. This function creates a local date.
- */
-function parseLocalDate(dateString: string): Date {
-  const [year, month, day] = dateString.split("-").map(Number)
-  return new Date(year, month - 1, day)
-}
 
 // ============================================
 // Validation Schema
@@ -133,10 +120,10 @@ export function DeviceQuotaDecisionDialog() {
     if (isEditMode && selectedDecision) {
       form.reset({
         so_quyet_dinh: selectedDecision.so_quyet_dinh,
-        ngay_ban_hanh: parseLocalDate(selectedDecision.ngay_ban_hanh),
-        ngay_hieu_luc: parseLocalDate(selectedDecision.ngay_hieu_luc),
+        ngay_ban_hanh: parseLocalDate(selectedDecision.ngay_ban_hanh) ?? undefined,
+        ngay_hieu_luc: parseLocalDate(selectedDecision.ngay_hieu_luc) ?? undefined,
         ngay_het_hieu_luc: selectedDecision.ngay_het_hieu_luc
-          ? parseLocalDate(selectedDecision.ngay_het_hieu_luc)
+          ? parseLocalDate(selectedDecision.ngay_het_hieu_luc) ?? undefined
           : null,
         nguoi_ky: selectedDecision.nguoi_ky,
         chuc_vu_nguoi_ky: selectedDecision.chuc_vu_nguoi_ky,

--- a/src/app/(app)/maintenance/_components/maintenance-columns.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-columns.tsx
@@ -5,6 +5,7 @@ import type { ColumnDef, SortingState, Row } from "@tanstack/react-table"
 import { ArrowUpDown, MoreHorizontal, Check, X, Edit, Trash2, Save, CheckCircle2, Loader2 } from "lucide-react"
 import { format, parseISO } from 'date-fns'
 import { vi } from 'date-fns/locale'
+import { parseLocalDate } from '@/lib/date-utils'
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Badge } from "@/components/ui/badge"
@@ -332,7 +333,7 @@ export function useTaskColumns(options: TaskColumnOptions): ColumnDef<Maintenanc
           if (isCompletedFromDB) {
             const completionDateField = `ngay_hoan_thanh_${month}` as keyof MaintenanceTask;
             const completionDate = row.original[completionDateField] as string;
-            const formattedDate = completionDate ? new Date(completionDate).toLocaleDateString('vi-VN') : '';
+            const formattedDate = completionDate ? parseLocalDate(completionDate)?.toLocaleDateString('vi-VN') : '';
 
             return (
               <div className="flex justify-center items-center h-full">

--- a/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { cn } from "@/lib/utils"
+import { parseLocalDate } from "@/lib/date-utils"
 import { Calendar as CalendarIcon, Loader2 } from "lucide-react"
 import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
 import type { RepairUnit } from "../types"
@@ -135,7 +136,7 @@ export function RepairRequestsEditDialog() {
                   initialFocus
                   disabled={(date) => {
                     const requestDate = requestToEdit?.ngay_yeu_cau
-                      ? new Date(requestToEdit.ngay_yeu_cau)
+                      ? parseLocalDate(requestToEdit.ngay_yeu_cau) ?? new Date()
                       : new Date()
                     return date < new Date(requestDate.setHours(0, 0, 0, 0))
                   }}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -70,6 +70,7 @@ import {
   type UiFilters as UiFiltersPrefs,
   type ColumnVisibility as ColumnVisibilityPrefs,
 } from "@/lib/rr-prefs"
+import { parseLocalDate } from "@/lib/date-utils"
 // Auto department filter removed
 
 
@@ -663,8 +664,8 @@ function RepairRequestsPageClientInner() {
                       status: uiFilters.status,
                       facilityId: selectedFacilityId ?? null,
                       dateRange: uiFilters.dateRange ? {
-                        from: uiFilters.dateRange.from ? new Date(uiFilters.dateRange.from) : null,
-                        to: uiFilters.dateRange.to ? new Date(uiFilters.dateRange.to) : null,
+                        from: uiFilters.dateRange.from ? parseLocalDate(uiFilters.dateRange.from) : null,
+                        to: uiFilters.dateRange.to ? parseLocalDate(uiFilters.dateRange.to) : null,
                       } : { from: null, to: null },
                     }}
                     onChange={(v) => {

--- a/src/app/(app)/repair-requests/utils.ts
+++ b/src/app/(app)/repair-requests/utils.ts
@@ -1,3 +1,5 @@
+import { parseLocalDate } from "@/lib/date-utils"
+
 export type DaysRemainingInfo = {
   days: number
   status: 'success' | 'warning' | 'danger'
@@ -10,7 +12,8 @@ export function calculateDaysRemaining(desiredDate: string | null): DaysRemainin
   if (!desiredDate) return null
 
   const today = new Date()
-  const targetDate = new Date(desiredDate)
+  const targetDate = parseLocalDate(desiredDate)
+  if (!targetDate) return null
   const diffTime = targetDate.getTime() - today.getTime()
   const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
 

--- a/src/app/(app)/reports/components/export-report-dialog.tsx
+++ b/src/app/(app)/reports/components/export-report-dialog.tsx
@@ -5,6 +5,7 @@ import { Download, FileSpreadsheet, Loader2 } from "lucide-react"
 import { format } from "date-fns"
 import { vi } from "date-fns/locale"
 import { createMultiSheetExcel } from "@/lib/excel-utils"
+import { parseLocalDate } from "@/lib/date-utils"
 
 import {
   Dialog,
@@ -89,7 +90,7 @@ export function ExportReportDialog({
 
       // Prepare detailed data (JSON rows)
       const detailedData = data.map(item => ({
-        "Ngày": format(new Date(item.ngay_nhap), "dd/MM/yyyy"),
+        "Ngày": format(parseLocalDate(item.ngay_nhap) ?? new Date(), "dd/MM/yyyy"),
         "Mã thiết bị": item.ma_thiet_bi,
         "Tên thiết bị": item.ten_thiet_bi,
         "Model": item.model || "",

--- a/src/app/(app)/reports/hooks/use-inventory-data.ts
+++ b/src/app/(app)/reports/hooks/use-inventory-data.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { callRpc } from '@/lib/rpc-client'
 import { format } from 'date-fns'
+import { parseLocalDate } from '@/lib/date-utils'
 import * as React from 'react'
 
 export interface InventoryItem {
@@ -247,7 +248,11 @@ export function useInventoryData(
       }
 
       // Sort by date
-      allItems.sort((a, b) => new Date(b.ngay_nhap).getTime() - new Date(a.ngay_nhap).getTime())
+      allItems.sort((a, b) => {
+        const dateA = parseLocalDate(a.ngay_nhap)?.getTime() ?? 0
+        const dateB = parseLocalDate(b.ngay_nhap)?.getTime() ?? 0
+        return dateB - dateA
+      })
 
       // Calculate summary
       const totalImported = importedItems.length

--- a/src/app/(app)/reports/hooks/use-report-filters.ts
+++ b/src/app/(app)/reports/hooks/use-report-filters.ts
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import { useQueryClient } from '@tanstack/react-query'
+import { parseLocalDate } from '@/lib/date-utils'
 
 export interface DateRange {
   from: Date
@@ -48,8 +49,8 @@ function deserializeFilters(raw: string | null): ReportInventoryFilters | null {
     const parsed = JSON.parse(raw)
     const fromStr = parsed?.dateRange?.from
     const toStr = parsed?.dateRange?.to
-    const from = fromStr ? new Date(fromStr) : undefined
-    const to = toStr ? new Date(toStr) : undefined
+    const from = fromStr ? parseLocalDate(fromStr) : undefined
+    const to = toStr ? parseLocalDate(toStr) : undefined
     if (!from || !to || Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
       return null
     }

--- a/src/components/overdue-transfers-alert.tsx
+++ b/src/components/overdue-transfers-alert.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { callRpc } from "@/lib/rpc-client"
+import { parseLocalDate } from "@/lib/date-utils"
 import { TransferRequest } from "@/types/database"
 
 interface OverdueTransfersAlertProps {
@@ -42,12 +43,12 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
       // Prevent setState on unmounted component
       if (!isMountedRef.current) return
       
-      const overdue = transfers.filter(t => 
-        new Date(t.ngay_du_kien_tra!) < today
+      const overdue = transfers.filter(t =>
+        parseLocalDate(t.ngay_du_kien_tra)! < today
       )
-      
+
       const upcoming = transfers.filter(t => {
-        const dueDate = new Date(t.ngay_du_kien_tra!)
+        const dueDate = parseLocalDate(t.ngay_du_kien_tra)!
         return dueDate >= today && dueDate <= nextWeek
       })
 
@@ -69,7 +70,7 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
 
   const getDaysOverdue = (dueDate: string) => {
     const today = new Date()
-    const due = new Date(dueDate)
+    const due = parseLocalDate(dueDate)!
     const diffTime = today.getTime() - due.getTime()
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
     return diffDays
@@ -77,7 +78,7 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
 
   const getDaysUntilDue = (dueDate: string) => {
     const today = new Date()
-    const due = new Date(dueDate)
+    const due = parseLocalDate(dueDate)!
     const diffTime = due.getTime() - today.getTime()
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
     return diffDays

--- a/src/components/transfer-detail-dialog.tsx
+++ b/src/components/transfer-detail-dialog.tsx
@@ -16,6 +16,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { TransferStatusProgress } from "@/components/transfers/TransferStatusProgress"
 import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
+import { parseLocalDate } from "@/lib/date-utils"
 import { 
   TRANSFER_TYPES, 
   TRANSFER_STATUSES,
@@ -195,7 +196,7 @@ export function TransferDetailDialog({ open, onOpenChange, transfer }: TransferD
                         <Calendar className="h-4 w-4 text-muted-foreground" />
                         <span className="font-medium">Ngày dự kiến trả về:</span>
                       </div>
-                      <p className="ml-6">{new Date(transfer.ngay_du_kien_tra).toLocaleDateString('vi-VN')}</p>
+                      <p className="ml-6">{parseLocalDate(transfer.ngay_du_kien_tra)?.toLocaleDateString('vi-VN')}</p>
                     </div>
                   )}
                 </div>

--- a/src/components/transfers/TransfersKanbanCard.tsx
+++ b/src/components/transfers/TransfersKanbanCard.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card'
 import type { TransferListItem } from '@/types/transfers-data-grid'
 import { formatDistanceToNow } from 'date-fns'
 import { vi } from 'date-fns/locale'
+import { parseLocalDate } from '@/lib/date-utils'
 
 interface TransfersKanbanCardProps {
   transfer: TransferListItem
@@ -42,7 +43,8 @@ function getTypeLabel(type: string): string {
 
 function isOverdue(dateStr: string | null, currentDate: Date): boolean {
   if (!dateStr) return false
-  const dueDate = new Date(dateStr)
+  const dueDate = parseLocalDate(dateStr)
+  if (!dueDate) return false
   return dueDate < currentDate && dueDate.getTime() !== 0
 }
 

--- a/src/components/usage-log-print.tsx
+++ b/src/components/usage-log-print.tsx
@@ -27,6 +27,7 @@ import {
 import { useEquipmentUsageLogs } from "@/hooks/use-usage-logs"
 import { useTenantBranding } from "@/hooks/use-tenant-branding"
 import { type Equipment, type UsageLog } from "@/types/database"
+import { parseLocalDate } from "@/lib/date-utils"
 
 interface UsageLogPrintProps {
   equipment: Pick<Equipment, 'id' | 'ten_thiet_bi' | 'ma_thiet_bi'> & Partial<Equipment>
@@ -83,9 +84,10 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
     if (!usageLogs) return []
 
     // Pre-calculate date boundaries to avoid creating Date objects in loop
-    const fromDate = dateFrom ? new Date(dateFrom) : null
+    const fromDate = dateFrom ? parseLocalDate(dateFrom) : null
     const toDate = dateTo ? (() => {
-      const date = new Date(dateTo)
+      const date = parseLocalDate(dateTo)
+      if (!date) return null
       date.setHours(23, 59, 59, 999) // End of day
       return date
     })() : null
@@ -153,8 +155,8 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
 
   const generatePrintContent = () => {
     const currentDate = format(new Date(), 'dd/MM/yyyy HH:mm', { locale: vi })
-    const dateRange = dateFrom || dateTo 
-      ? `(${dateFrom ? format(new Date(dateFrom), 'dd/MM/yyyy', { locale: vi }) : '...'} - ${dateTo ? format(new Date(dateTo), 'dd/MM/yyyy', { locale: vi }) : '...'})`
+    const dateRange = dateFrom || dateTo
+      ? `(${dateFrom ? format(parseLocalDate(dateFrom) ?? new Date(), 'dd/MM/yyyy', { locale: vi }) : '...'} - ${dateTo ? format(parseLocalDate(dateTo) ?? new Date(), 'dd/MM/yyyy', { locale: vi }) : '...'})`
       : ''
 
     return `

--- a/src/hooks/use-calendar-data.ts
+++ b/src/hooks/use-calendar-data.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { callRpc } from '@/lib/rpc-client'
+import { parseLocalDate } from '@/lib/date-utils'
 import { type TaskType } from '@/lib/data'
 
 export interface CalendarEvent {
@@ -64,7 +65,7 @@ export function useCalendarData(year: number, month: number, options?: { enabled
       // Transform events: convert date strings to Date objects
       const calendarEvents: CalendarEvent[] = data.events.map(event => ({
         ...event,
-        date: new Date(event.date)
+        date: parseLocalDate(event.date) ?? new Date()
       }))
 
       return {

--- a/src/hooks/use-repair-alerts.ts
+++ b/src/hooks/use-repair-alerts.ts
@@ -1,7 +1,8 @@
 "use client"
 
 import * as React from "react"
-import { differenceInDays, parseISO, startOfDay } from "date-fns"
+import { differenceInDays, startOfDay } from "date-fns"
+import { parseLocalDate } from "@/lib/date-utils"
 
 // Các trạng thái được coi là chưa hoàn thành
 const UNCOMPLETED_REPAIR_STATUSES = ['Chờ xử lý', 'Đã duyệt'];
@@ -39,7 +40,9 @@ export function useRepairAlerts<T extends MinimalRepairRequest>(
         return; // Bỏ qua nếu không có ngày mong muốn
       }
       try {
-        const dueDate = startOfDay(parseISO(req.ngay_mong_muon_hoan_thanh));
+        const parsedDate = parseLocalDate(req.ngay_mong_muon_hoan_thanh);
+        if (!parsedDate) return;
+        const dueDate = startOfDay(parsedDate);
         const daysDifference = differenceInDays(dueDate, today);
 
         const isOverdue = daysDifference < 0;

--- a/src/hooks/use-transfer-alerts.ts
+++ b/src/hooks/use-transfer-alerts.ts
@@ -1,7 +1,8 @@
 "use client" // Vì sử dụng Date, có thể không cần nếu logic thuần túy
 
 import * as React from "react"
-import { differenceInDays, parseISO, startOfDay, addDays } from "date-fns"
+import { differenceInDays, startOfDay, addDays } from "date-fns"
+import { parseLocalDate } from "@/lib/date-utils"
 import type { TransferRequest } from "@/types/database" // Đảm bảo type này có thông tin thiết bị
 
 // Các trạng thái của yêu cầu luân chuyển 'ben_ngoai' cần theo dõi ngày hoàn trả
@@ -31,7 +32,9 @@ export function useTransferAlerts(allTransferRequests: TransferRequest[] | null 
         RELEVANT_TRANSFER_STATUSES_FOR_RETURN_ALERT.includes(req.trang_thai)
       ) {
         try {
-          const dueDate = startOfDay(parseISO(req.ngay_du_kien_tra));
+          const parsedDate = parseLocalDate(req.ngay_du_kien_tra);
+          if (!parsedDate) return;
+          const dueDate = startOfDay(parsedDate);
           const daysDifference = differenceInDays(dueDate, today);
 
           const isOverdue = daysDifference < 0;

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -256,3 +256,30 @@ export function isValidPartialDate(value: string | null | undefined): boolean {
 
   return false
 }
+
+// =============================================================================
+// LOCAL DATE PARSING
+// Fixes timezone shift when parsing YYYY-MM-DD date strings from database
+// =============================================================================
+
+/**
+ * Parses a YYYY-MM-DD date string as a local date (not UTC).
+ * Prevents timezone shift issues with date-only database fields.
+ */
+export function parseLocalDate(dateString: string | null | undefined): Date | null {
+  if (!dateString) return null
+
+  const trimmed = String(dateString).trim()
+  if (!trimmed) return null
+
+  const match = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!match) return null
+
+  const year = parseInt(match[1], 10)
+  const month = parseInt(match[2], 10)
+  const day = parseInt(match[3], 10)
+
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null
+
+  return new Date(year, month - 1, day)
+}


### PR DESCRIPTION
- Add parseLocalDate() utility to src/lib/date-utils.ts
- Update 16 files with date-only string parsing issues
- Replace new Date("YYYY-MM-DD") and parseISO() calls
- Prevents dates shifting by -1 day in western timezones
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parse date-only strings as local dates to stop timezone-related day shifts. Adds a shared parseLocalDate and replaces unsafe parsing across the app, fixing off-by-one day bugs (e.g., showing the previous day in western timezones).

- **Bug Fixes**
  - Added parseLocalDate to parse YYYY-MM-DD as a local date (not UTC).
  - Replaced new Date("YYYY-MM-DD") and parseISO() in device quota decisions, maintenance tables, repair requests, reports (export and inventory hooks), calendar data, transfer alerts/details/Kanban, and usage-log printing.
  - Fixed incorrect sorting, filtering, formatting, and overdue/due-soon calculations caused by timezone shifts.

- **Migration**
  - For any new date-only fields, use parseLocalDate instead of new Date(...) or parseISO().

<sup>Written for commit 97277e18805e9b5e901c6ca77e4c54822b72991c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

