### PR TITLE
feat: Phase 0 and phase 1 done

### DIFF
--- a/docs/plans/2026-03-06-suggested-mapping-implementation-plan.md
+++ b/docs/plans/2026-03-06-suggested-mapping-implementation-plan.md
@@ -68,12 +68,12 @@
 - Modify: `docs/plans/2026-03-06-suggested-mapping-design.md`
 
 **Tasks:**
-- [ ] Chốt exact semantic scan cho v1, không thêm HNSW trong migration đầu tiên.
-- [ ] Chốt partial index cho query `unassigned_names`.
-- [ ] Chốt command model: manual flow giữ `dinh_muc_thiet_bi_link`; suggested flow dùng `dinh_muc_thiet_bi_link_batch` với grouped payload riêng.
-- [ ] Chốt contract race-safe cho `dinh_muc_thiet_bi_link_batch`.
-- [ ] Chốt lifecycle refresh embedding và loại `dinh_muc_unified_import` khỏi danh sách refresh.
-- [ ] Chốt chiến lược reuse component và giới hạn file-size cho preview UI.
+- [x] Chốt exact semantic scan cho v1, không thêm HNSW trong migration đầu tiên.
+- [x] Chốt partial index cho query `unassigned_names`.
+- [x] Chốt command model: manual flow giữ `dinh_muc_thiet_bi_link`; suggested flow dùng `dinh_muc_thiet_bi_link_batch` với grouped payload riêng.
+- [x] Chốt contract race-safe cho `dinh_muc_thiet_bi_link_batch`.
+- [x] Chốt lifecycle refresh embedding và loại `dinh_muc_unified_import` khỏi danh sách refresh.
+- [x] Chốt chiến lược reuse component và giới hạn file-size cho preview UI.
 
 **Exit criteria:** Design doc và implementation plan thống nhất hoàn toàn về query shape, index strategy, permission, concurrency guard, và interaction model giữa manual flow với suggested flow.
 

--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -152,6 +152,9 @@ const ALLOWED_FUNCTIONS = new Set<string>([
   // Compliance
   'dinh_muc_compliance_summary',
   'dinh_muc_compliance_detail',
+  // Suggested Mapping (read-path)
+  'hybrid_search_category_batch',
+  'dinh_muc_thiet_bi_unassigned_names',
 ])
 
 // SECURITY: Maximum request body size (2MB) to prevent DoS via memory exhaustion

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -45,4 +45,20 @@ describe('RPC proxy whitelist', () => {
     expect(res.status).toBe(411)
     await expect(res.json()).resolves.toEqual({ error: 'Content-Length header required' })
   })
+
+  it('allows hybrid_search_category_batch through whitelist checks', async () => {
+    const res = await invokeRpcProxy('hybrid_search_category_batch')
+
+    // Whitelist check passed; next guard is missing Content-Length.
+    expect(res.status).toBe(411)
+    await expect(res.json()).resolves.toEqual({ error: 'Content-Length header required' })
+  })
+
+  it('allows dinh_muc_thiet_bi_unassigned_names through whitelist checks', async () => {
+    const res = await invokeRpcProxy('dinh_muc_thiet_bi_unassigned_names')
+
+    // Whitelist check passed; next guard is missing Content-Length.
+    expect(res.status).toBe(411)
+    await expect(res.json()).resolves.toEqual({ error: 'Content-Length header required' })
+  })
 })

--- a/supabase/migrations/2026-03-07/20260307120000_add_hybrid_search_category.sql
+++ b/supabase/migrations/2026-03-07/20260307120000_add_hybrid_search_category.sql
@@ -1,0 +1,178 @@
+-- Migration: add hybrid search foundation for suggested mapping
+-- Purpose: enable pgvector extension, add embedding + fts columns to nhom_thiet_bi,
+--          create hybrid_search_category_batch RPC with tenant isolation and exact cosine scan
+-- Decision: NO HNSW index in v1 — exact scan is sufficient for ~567 categories
+
+BEGIN;
+
+-- ============================================================
+-- 1. Enable pgvector extension (384-dim embeddings for gte-small)
+-- ============================================================
+CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA extensions;
+
+-- ============================================================
+-- 2. Add embedding column to nhom_thiet_bi
+-- ============================================================
+ALTER TABLE public.nhom_thiet_bi
+ADD COLUMN IF NOT EXISTS embedding extensions.vector(384);
+
+-- ============================================================
+-- 3. Add generated tsvector column for full-text search
+--    Uses 'simple' config — suitable for Vietnamese names (no stemming)
+-- ============================================================
+ALTER TABLE public.nhom_thiet_bi
+ADD COLUMN IF NOT EXISTS fts tsvector
+GENERATED ALWAYS AS (to_tsvector('simple', COALESCE(ten_nhom, ''))) STORED;
+
+-- ============================================================
+-- 4. GIN index for full-text search
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_nhom_thiet_bi_fts
+ON public.nhom_thiet_bi USING gin (fts);
+
+-- ============================================================
+-- 5. hybrid_search_category_batch RPC
+--    Hybrid search combining full-text + exact cosine similarity + RRF
+--    Processes one chunk of queries at a time (recommended max 50/call)
+--
+--    Security:
+--      - SECURITY DEFINER + tight search_path
+--      - Standalone JWT guards for v_role, v_user_id, v_don_vi
+--      - Tenant isolation per role
+--      - GRANT authenticated / REVOKE PUBLIC
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.hybrid_search_category_batch(
+  p_queries JSONB,
+  p_don_vi BIGINT DEFAULT NULL,
+  p_match_count INT DEFAULT 1,
+  p_full_text_weight FLOAT DEFAULT 1.0,
+  p_semantic_weight FLOAT DEFAULT 1.0,
+  p_rrf_k INT DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  -- Standalone JWT claim extraction (mandatory guards per RPC Security Standards)
+  v_role TEXT := current_setting('request.jwt.claims', true)::json->>'app_role';
+  v_user_id TEXT := current_setting('request.jwt.claims', true)::json->>'user_id';
+  v_don_vi TEXT := current_setting('request.jwt.claims', true)::json->>'don_vi';
+  v_allowed_facilities BIGINT[];
+  v_query JSONB;
+  v_query_text TEXT;
+  v_query_embedding extensions.vector(384);
+  v_results JSONB := '[]'::JSONB;
+  v_matches JSONB;
+BEGIN
+  -- ── Role guard ──────────────────────────────────────────────
+  IF v_role IS NULL OR v_role = '' THEN
+    v_role := current_setting('request.jwt.claims', true)::json->>'role';
+  END IF;
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING errcode = '42501';
+  END IF;
+
+  -- ── User ID guard ──────────────────────────────────────────
+  IF v_user_id IS NULL OR v_user_id = '' THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING errcode = '42501';
+  END IF;
+
+  -- ── Tenant guard (non-global must have don_vi) ─────────────
+  IF v_role NOT IN ('global', 'admin') AND (v_don_vi IS NULL OR v_don_vi = '') THEN
+    RAISE EXCEPTION 'Missing don_vi claim' USING errcode = '42501';
+  END IF;
+
+  -- ── Tenant isolation per role ──────────────────────────────
+  IF v_role IN ('global', 'admin') THEN
+    -- global/admin: honour the caller-supplied p_don_vi
+    NULL;
+  ELSIF v_role = 'regional_leader' THEN
+    v_allowed_facilities := public.allowed_don_vi_for_session();
+    IF p_don_vi IS NULL OR NOT (p_don_vi = ANY(v_allowed_facilities)) THEN
+      RAISE EXCEPTION 'Access denied: facility % is not in your region', p_don_vi;
+    END IF;
+  ELSE
+    -- to_qltb and other roles: force p_don_vi from JWT claim
+    p_don_vi := NULLIF(v_don_vi, '')::BIGINT;
+  END IF;
+
+  -- ── Null don_vi guard (prevent cross-tenant exposure) ──────
+  IF p_don_vi IS NULL THEN
+    RETURN '[]'::JSONB;
+  END IF;
+
+  -- ── Process each query in the batch ────────────────────────
+  FOR v_query IN SELECT * FROM jsonb_array_elements(p_queries)
+  LOOP
+    v_query_text := NULLIF(BTRIM(v_query->>'text'), '');
+
+    -- Null-safe embedding extraction: skip semantic branch if null
+    IF jsonb_typeof(v_query->'embedding') = 'array' THEN
+      v_query_embedding := (v_query->>'embedding')::extensions.vector(384);
+    ELSE
+      v_query_embedding := NULL;
+    END IF;
+
+    -- Hybrid search with RRF (Reciprocal Rank Fusion)
+    SELECT jsonb_agg(row_to_json(r)) INTO v_matches
+    FROM (
+      WITH tenant_categories AS (
+        SELECT id, ten_nhom, ma_nhom, phan_loai, fts, embedding
+        FROM public.nhom_thiet_bi
+        WHERE don_vi_id = p_don_vi
+      ),
+      full_text AS (
+        SELECT ft.id, ft.rank_ix
+        FROM (
+          SELECT tc.id,
+            row_number() OVER (
+              ORDER BY ts_rank_cd(tc.fts, plainto_tsquery('simple', v_query_text)) DESC, tc.id
+            ) AS rank_ix
+          FROM tenant_categories tc
+          WHERE v_query_text IS NOT NULL
+            AND tc.fts @@ plainto_tsquery('simple', v_query_text)
+        ) ft
+        ORDER BY ft.rank_ix
+        LIMIT p_match_count * 2
+      ),
+      semantic AS (
+        SELECT s.id, s.rank_ix
+        FROM (
+          SELECT tc.id,
+            row_number() OVER (
+              ORDER BY tc.embedding <=> v_query_embedding, tc.id
+            ) AS rank_ix
+          FROM tenant_categories tc
+          WHERE v_query_embedding IS NOT NULL
+            AND tc.embedding IS NOT NULL
+        ) s
+        ORDER BY s.rank_ix
+        LIMIT p_match_count * 2
+      )
+      SELECT tc.id, tc.ten_nhom, tc.ma_nhom, tc.phan_loai,
+        (COALESCE(1.0 / (p_rrf_k + ft.rank_ix), 0.0) * p_full_text_weight +
+         COALESCE(1.0 / (p_rrf_k + s.rank_ix), 0.0) * p_semantic_weight)::FLOAT AS rrf_score
+      FROM full_text ft
+      FULL OUTER JOIN semantic s ON ft.id = s.id
+      JOIN tenant_categories tc ON tc.id = COALESCE(ft.id, s.id)
+      ORDER BY rrf_score DESC, tc.id
+      LIMIT p_match_count
+    ) r;
+
+    v_results := v_results || jsonb_build_object(
+      'query_text', v_query_text,
+      'results', COALESCE(v_matches, '[]'::JSONB)
+    );
+  END LOOP;
+
+  RETURN v_results;
+END;
+$$;
+
+-- ── Permission grants ────────────────────────────────────────
+GRANT EXECUTE ON FUNCTION public.hybrid_search_category_batch(JSONB, BIGINT, INT, FLOAT, FLOAT, INT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.hybrid_search_category_batch(JSONB, BIGINT, INT, FLOAT, FLOAT, INT) FROM PUBLIC;
+
+COMMIT;

--- a/supabase/migrations/2026-03-07/20260307120100_add_suggest_mapping_helper_rpcs.sql
+++ b/supabase/migrations/2026-03-07/20260307120100_add_suggest_mapping_helper_rpcs.sql
@@ -1,0 +1,104 @@
+-- Migration: add read-path helper RPCs for suggested mapping preview
+-- Purpose: partial index for unassigned-name aggregation + dinh_muc_thiet_bi_unassigned_names RPC
+-- Note: dinh_muc_thiet_bi_link_batch is NOT created here — it belongs in Phase 4
+
+BEGIN;
+
+-- ============================================================
+-- 1. Partial composite index for unassigned-name aggregation
+--    Optimizes: WHERE don_vi = ? AND nhom_thiet_bi_id IS NULL
+--               GROUP BY ten_thiet_bi
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_thiet_bi_unassigned_name_by_unit
+ON public.thiet_bi (don_vi, ten_thiet_bi)
+WHERE nhom_thiet_bi_id IS NULL;
+
+-- ============================================================
+-- 2. dinh_muc_thiet_bi_unassigned_names RPC
+--    Returns distinct device names with counts and device_id arrays
+--    for all unassigned equipment in the selected facility.
+--
+--    Security:
+--      - SECURITY DEFINER + tight search_path
+--      - Standalone JWT guards for v_role, v_user_id, v_don_vi
+--      - Tenant isolation per role
+--      - GRANT authenticated / REVOKE PUBLIC
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dinh_muc_thiet_bi_unassigned_names(
+  p_don_vi BIGINT DEFAULT NULL
+)
+RETURNS TABLE (
+  ten_thiet_bi TEXT,
+  device_count BIGINT,
+  device_ids BIGINT[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  -- Standalone JWT claim extraction (mandatory guards per RPC Security Standards)
+  v_role TEXT := current_setting('request.jwt.claims', true)::json->>'app_role';
+  v_user_id TEXT := current_setting('request.jwt.claims', true)::json->>'user_id';
+  v_don_vi TEXT := current_setting('request.jwt.claims', true)::json->>'don_vi';
+  v_allowed_facilities BIGINT[];
+BEGIN
+  -- ── Role guard ──────────────────────────────────────────────
+  IF v_role IS NULL OR v_role = '' THEN
+    v_role := current_setting('request.jwt.claims', true)::json->>'role';
+  END IF;
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING errcode = '42501';
+  END IF;
+
+  -- ── User ID guard ──────────────────────────────────────────
+  IF v_user_id IS NULL OR v_user_id = '' THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING errcode = '42501';
+  END IF;
+
+  -- ── Tenant guard (non-global must have don_vi) ─────────────
+  IF v_role NOT IN ('global', 'admin') AND (v_don_vi IS NULL OR v_don_vi = '') THEN
+    RAISE EXCEPTION 'Missing don_vi claim' USING errcode = '42501';
+  END IF;
+
+  -- ── Tenant isolation per role ──────────────────────────────
+  IF v_role IN ('global', 'admin') THEN
+    -- global/admin: honour the caller-supplied p_don_vi
+    NULL;
+  ELSIF v_role = 'regional_leader' THEN
+    v_allowed_facilities := public.allowed_don_vi_for_session();
+    IF p_don_vi IS NULL OR NOT (p_don_vi = ANY(v_allowed_facilities)) THEN
+      RAISE EXCEPTION 'Access denied: facility % is not in your region', p_don_vi;
+    END IF;
+  ELSE
+    -- to_qltb and other roles: force p_don_vi from JWT claim
+    p_don_vi := NULLIF(v_don_vi, '')::BIGINT;
+  END IF;
+
+  -- ── Null don_vi guard (prevent cross-tenant exposure) ──────
+  IF p_don_vi IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- ── Query: grouped unassigned device names ─────────────────
+  -- BTRIM normalizes whitespace to reduce duplicate groups
+  -- Filters out blank/null names to avoid noise in suggestions
+  RETURN QUERY
+  SELECT
+    BTRIM(tb.ten_thiet_bi) AS ten_thiet_bi,
+    COUNT(*)::BIGINT AS device_count,
+    ARRAY_AGG(tb.id ORDER BY tb.id) AS device_ids
+  FROM public.thiet_bi tb
+  WHERE tb.don_vi = p_don_vi
+    AND tb.nhom_thiet_bi_id IS NULL
+    AND NULLIF(BTRIM(tb.ten_thiet_bi), '') IS NOT NULL
+  GROUP BY BTRIM(tb.ten_thiet_bi)
+  ORDER BY COUNT(*) DESC, BTRIM(tb.ten_thiet_bi);
+END;
+$$;
+
+-- ── Permission grants ────────────────────────────────────────
+GRANT EXECUTE ON FUNCTION public.dinh_muc_thiet_bi_unassigned_names(BIGINT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.dinh_muc_thiet_bi_unassigned_names(BIGINT) FROM PUBLIC;
+
+COMMIT;


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the read-path for Suggested Mapping (Phase 0–1). Provides hybrid category search and unassigned device name aggregation, with strict tenant guards, RPC whitelisting, and tests.

- **New Features**
  - hybrid_search_category_batch RPC: FTS + embeddings with RRF scoring; exact cosine scan (no HNSW in v1); tenant-aware access controls.
  - dinh_muc_thiet_bi_unassigned_names RPC: groups unassigned device names with counts and device IDs; tenant-aware access controls.
  - RPC proxy whitelist updated and unit tests added for both RPCs.

- **Migration**
  - Enables pgvector; adds embedding (vector(384)) and generated FTS columns to nhom_thiet_bi; creates GIN index.
  - Adds partial composite index on thiet_bi (don_vi, ten_thiet_bi) where nhom_thiet_bi_id IS NULL.
  - Creates both RPCs with SECURITY DEFINER and role/tenant guards.

<sup>Written for commit c58503f821b5bcfed39ca5036899c061d2285cf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

