### PR TITLE
fix: update stale test expectations (#141, #142, #143)

### DIFF
--- a/src/app/api/chat/__tests__/route.attachment-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.attachment-tools.test.ts
@@ -104,7 +104,7 @@ describe('/api/chat attachmentLookup tool', () => {
 
     expect(res.status).toBe(400)
     expect(text).toBe(
-      'Please select a facility before using assistant tools.',
+      'Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.',
     )
     expect(streamTextMock).not.toHaveBeenCalled()
   })
@@ -126,7 +126,7 @@ describe('attachmentLookup contract shape', () => {
 
     const schema = def.inputSchema as import('zod').ZodObject<Record<string, unknown>>
     const keys = Object.keys(schema.shape)
-    expect(keys).toEqual(['thiet_bi_id'])
+    expect(keys).toEqual(['p_thiet_bi_id'])
   })
 
   it('description reflects normalized access contract', async () => {
@@ -152,11 +152,11 @@ describe('attachmentLookup contract shape', () => {
     const schema = def.inputSchema
 
     // Valid input should pass
-    const valid = schema.safeParse({ thiet_bi_id: 42 })
+    const valid = schema.safeParse({ p_thiet_bi_id: 42 })
     expect(valid.success).toBe(true)
 
     // Extra fields should be rejected (strict schema)
-    const invalid = schema.safeParse({ thiet_bi_id: 42, extra: true })
+    const invalid = schema.safeParse({ p_thiet_bi_id: 42, extra: true })
     expect(invalid.success).toBe(false)
   })
 })

--- a/src/app/api/chat/__tests__/route.draft-output.test.ts
+++ b/src/app/api/chat/__tests__/route.draft-output.test.ts
@@ -316,8 +316,8 @@ describe('repairRequestDraft safety', () => {
     )
   })
 
-  it('system prompt version is v2.2.3', () => {
-    expect(SYSTEM_PROMPT_VERSION).toBe('v2.2.3')
+  it('system prompt version is v2.3.0', () => {
+    expect(SYSTEM_PROMPT_VERSION).toBe('v2.3.0')
   })
 
   it('prompt prevents auto-submission of repair requests', () => {

--- a/src/app/api/chat/__tests__/route.error-safety.test.ts
+++ b/src/app/api/chat/__tests__/route.error-safety.test.ts
@@ -84,7 +84,7 @@ describe('/api/chat error safety — non-stream contract', () => {
 
     expect(res.status).toBe(400)
     expect(res.headers.get('content-type')).toContain('text/plain')
-    expect(text).toBe('Please select a facility before using assistant tools.')
+    expect(text).toBe('Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.')
     expect(streamTextMock).not.toHaveBeenCalled()
   })
 
@@ -104,7 +104,7 @@ describe('/api/chat error safety — non-stream contract', () => {
 
     expect(res.status).toBe(400)
     expect(res.headers.get('content-type')).toContain('text/plain')
-    expect(text).toBe('Please select a facility before using assistant tools.')
+    expect(text).toBe('Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.')
     expect(streamTextMock).not.toHaveBeenCalled()
   })
 

--- a/src/app/api/chat/__tests__/route.quota-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.quota-tools.test.ts
@@ -124,7 +124,7 @@ describe('/api/chat quota tools', () => {
 
     expect(res.status).toBe(400)
     expect(text).toBe(
-      'Please select a facility before using assistant tools.',
+      'Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.',
     )
     expect(streamTextMock).not.toHaveBeenCalled()
   })
@@ -144,7 +144,7 @@ describe('/api/chat quota tools', () => {
 
     expect(res.status).toBe(400)
     expect(text).toBe(
-      'Please select a facility before using assistant tools.',
+      'Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.',
     )
     expect(streamTextMock).not.toHaveBeenCalled()
   })

--- a/src/app/api/chat/__tests__/route.tenant-policy.test.ts
+++ b/src/app/api/chat/__tests__/route.tenant-policy.test.ts
@@ -89,7 +89,7 @@ describe('/api/chat tenant policy', () => {
     const text = await res.text()
 
     expect(res.status).toBe(400)
-    expect(text).toBe('Please select a facility before using assistant tools.')
+    expect(text).toBe('Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.')
     expect(streamTextMock).not.toHaveBeenCalled()
   })
 

--- a/src/app/api/chat/__tests__/route.troubleshooting.test.ts
+++ b/src/app/api/chat/__tests__/route.troubleshooting.test.ts
@@ -246,8 +246,8 @@ describe('troubleshooting draft safety', () => {
     }
   })
 
-  it('system prompt version is v2.2.3', () => {
-    expect(SYSTEM_PROMPT_VERSION).toBe('v2.2.3')
+  it('system prompt version is v2.3.0', () => {
+    expect(SYSTEM_PROMPT_VERSION).toBe('v2.3.0')
   })
 
   it('prompt labels troubleshooting output as Draft/Inference, never Fact', () => {

--- a/src/app/api/chat/__tests__/route.usage-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.usage-tools.test.ts
@@ -104,7 +104,7 @@ describe('/api/chat usageHistory tool', () => {
 
     expect(res.status).toBe(400)
     expect(text).toBe(
-      'Please select a facility before using assistant tools.',
+      'Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.',
     )
     expect(streamTextMock).not.toHaveBeenCalled()
   })

--- a/src/components/assistant/__tests__/AssistantPanel.ui.test.tsx
+++ b/src/components/assistant/__tests__/AssistantPanel.ui.test.tsx
@@ -63,6 +63,7 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/contexts/TenantSelectionContext', () => ({
     useTenantSelection: () => ({
         selectedFacilityId: 1,
+        facilities: [],
         showSelector: false,
         shouldFetchData: true,
     }),


### PR DESCRIPTION
- #141: add missing facilities mock to AssistantPanel.ui.test.tsx
- #142: update 10 facility guidance assertions (English → Vietnamese)
- #143: update 2 prompt version assertions (v2.2.3 → v2.3.0)
- bonus: update 3 attachmentLookup schema assertions (thiet_bi_id → p_thiet_bi_id)

All 26 previously-failing tests now pass. Zero production code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated stale test expectations to match current strings, prompt version, and schema so CI is green again. All 26 previously failing tests now pass; no production code changes.

- **Bug Fixes**
  - Added missing `facilities` mock in `AssistantPanel.ui.test.tsx`.
  - Switched 10 facility guidance assertions from English to Vietnamese.
  - Bumped prompt version assertions from v2.2.3 to v2.3.0.
  - Updated `attachmentLookup` schema assertions: `thiet_bi_id` → `p_thiet_bi_id` (including strictness checks).

<sup>Written for commit 1c5d74b4ebd752cfbfe99dc57f0b4cfed51418b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

