### PR TITLE
test: add non-global tenant memberships coverage

### DIFF
--- a/src/app/api/tenants/__tests__/tenant-routes.test.ts
+++ b/src/app/api/tenants/__tests__/tenant-routes.test.ts
@@ -75,6 +75,7 @@ function createClientForNonGlobalMemberships(
 
   return {
     eqMock,
+    selectMock,
   }
 }
 
@@ -165,7 +166,7 @@ describe("tenant routes", () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: "7", role: "to_qltb" },
     })
-    const { eqMock } = createClientForNonGlobalMemberships([
+    const { eqMock, selectMock } = createClientForNonGlobalMemberships([
       { don_vi: { id: 17, name: "Khoa CNTT", code: "CNTT" } },
       { don_vi: { id: 18, name: null, code: null } },
     ])
@@ -180,6 +181,7 @@ describe("tenant routes", () => {
         { don_vi: 18, name: "", code: "" },
       ],
     })
+    expect(selectMock).toHaveBeenCalledWith("don_vi, don_vi:don_vi(id, name, code)")
     expect(eqMock).toHaveBeenCalledWith("user_id", "7")
   })
 
@@ -187,7 +189,7 @@ describe("tenant routes", () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: "7", role: "technician" },
     })
-    const { eqMock } = createClientForNonGlobalMemberships([{ don_vi: 19 }])
+    const { eqMock, selectMock } = createClientForNonGlobalMemberships([{ don_vi: 19 }])
 
     const { GET } = await import("../memberships/route")
     const response = await GET()
@@ -196,6 +198,7 @@ describe("tenant routes", () => {
     await expect(response.json()).resolves.toEqual({
       memberships: [{ don_vi: 19, name: "", code: "" }],
     })
+    expect(selectMock).toHaveBeenCalledWith("don_vi, don_vi:don_vi(id, name, code)")
     expect(eqMock).toHaveBeenCalledWith("user_id", "7")
   })
 


### PR DESCRIPTION
## Summary
- add direct non-global GET /api/tenants/memberships coverage
- cover embedded tenant rows and scalar Supabase fallback rows
- confirm the route needs no production change, only missing direct tests

## Test Plan
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/app/api/tenants/__tests__/tenant-routes.test.ts src/auth/__tests__/auth-types.test.ts src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add targeted tests for GET /api/tenants/memberships covering non-global users. Validates mapping for Supabase embedded tenant rows and scalar tenant IDs (defaulting name/code to empty strings), asserts filtering by `user_id`, and verifies the select join string 'don_vi, don_vi:don_vi(id, name, code)'. No API changes.

<sup>Written for commit 9f00d540108b247b0c2572dad4876f867578c31d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds direct test coverage for the `GET /api/tenants/memberships` route's non-global user path. No production code is changed — the new helper `createClientForNonGlobalMemberships` mirrors the existing `createClientForSwitch` pattern and returns both `eqMock` and `selectMock` so each test can assert the exact Supabase query issued.

Key additions:
- **Embedded-object case**: verifies that when Supabase returns a full `don_vi` join object the route maps `id`/`name`/`code` correctly, including the `null → ""` fallback for missing `name`/`code`.
- **Scalar-id case**: verifies that when Supabase returns just a numeric foreign key the route still produces `name: ""` and `code: ""`.
- **Filter assertion**: both tests confirm `.eq("user_id", "7")` is called, ensuring the session-based filter is exercised — this directly addresses the previous review thread concern.

<h3>Confidence Score: 5/5</h3>

Safe to merge — test-only change, no production code modified, and the prior reviewer concern is fully resolved.

All tests exercise real route behaviour matched against the actual implementation in memberships/route.ts. Both new tests assert the select query string and the eq filter, the mock chain is correctly wired, and the prior thread's concern (unverified eqMock) is addressed. No functional code was touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/tenants/__tests__/tenant-routes.test.ts | Adds two new test cases covering the non-global membership path: one for embedded Supabase join objects and one for scalar foreign-key fallback. Both tests assert the select query string and the eq filter, addressing the prior reviewer concern. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test: assert tenant membership select qu..."](https://github.com/thienchi2109/qltbyt-nam-phong/commit/9f00d540108b247b0c2572dad4876f867578c31d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26645895)</sub>

<!-- /greptile_comment -->