### PR TITLE
refactor: tighten query-key filter typing

### DIFF
--- a/docs/plans/2026-03-28-quick-win-3-query-key-typing.md
+++ b/docs/plans/2026-03-28-quick-win-3-query-key-typing.md
@@ -1,0 +1,248 @@
+# Quick Win 3 Query-Key Typing TDD Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Tighten the maintenance and inventory-report query-key filter signatures from `Record<string, any>` to `Record<string, unknown>` without changing runtime behavior.
+
+**Architecture:** Drive the change with compile-time assertions first, then make the smallest possible signature edits in the two target modules. Keep this branch strictly scoped to query-key typing so the risky report hook stays runtime-identical.
+
+**Tech Stack:** Next.js App Router, TypeScript, TanStack Query, Vitest, GitNexus CLI, ripgrep
+
+---
+
+## Context
+
+- This is the audited Quick Win 3 from `docs/explicit-any-audit-2026-03-28.md`.
+- Current `any` targets are limited to query-key filter signatures:
+  - `src/hooks/use-cached-maintenance.ts`
+  - `src/app/(app)/reports/hooks/use-inventory-data.ts`
+- GitNexus impact data before editing:
+  - `useInventoryData`
+    - risk: `CRITICAL`
+    - direct upstream caller: `InventoryReportTab`
+  - `useMaintenancePlans`
+    - risk: `LOW`
+    - GitNexus direct upstream caller: `DashboardTabs`
+    - repo grep also shows `MaintenancePageClient` calling it, so treat maintenance UI verification as required
+- Non-goals for this branch:
+  - no `callRpc<any>` cleanup
+  - no `catch (e: any)` or `onError: (error: any)` cleanup
+  - no payload-shape refactors
+  - no shared utility extraction beyond tiny local aliases
+
+## Commit Checkpoint Rule
+
+- Use one narrow commit once RED -> GREEN -> verification is complete:
+  - `refactor: tighten query-key filter typing`
+- Do not bundle Quick Win 4 or unrelated `any` cleanup into the same branch.
+
+## Task 1: Establish a clean baseline in the worktree
+
+**Files:**
+- None
+
+**Step 1: Install dependencies if the worktree does not have them**
+
+Run:
+
+```bash
+if [ ! -d node_modules ]; then npm install; fi
+```
+
+**Step 2: Re-check GitNexus impact in the worktree before editing**
+
+Run:
+
+```bash
+gitnexus impact useInventoryData --repo qltbyt-nam-phong
+gitnexus impact useMaintenancePlans --repo qltbyt-nam-phong
+```
+
+Expected:
+- `useInventoryData` remains a high-risk path, so scope stays type-only
+- `useMaintenancePlans` remains low-risk, but maintenance UI verification is still required
+
+**Step 3: Run baseline checks**
+
+Run:
+
+```bash
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run test:run -- src/hooks/__tests__/use-cached-maintenance-barrel.test.ts
+```
+
+Expected:
+- both commands pass on the untouched worktree
+
+## Task 2: RED - add compile-time assertions that prove the desired signature
+
+**Files:**
+- Create: `src/hooks/use-cached-maintenance.types.assert.ts`
+- Create: `src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts`
+
+**Step 1: Add exact type-equality helpers in both assertion files**
+
+Use this helper block:
+
+```ts
+type Assert<T extends true> = T
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false
+```
+
+**Step 2: Assert the maintenance query-key filter params are `Record<string, unknown>`**
+
+In `src/hooks/use-cached-maintenance.types.assert.ts`, add:
+
+```ts
+import { maintenanceKeys } from "@/hooks/use-cached-maintenance"
+
+type Assert<T extends true> = T
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false
+
+type _listFilters = Assert<
+  Equal<Parameters<typeof maintenanceKeys.list>[0], Record<string, unknown>>
+>
+type _scheduleFilters = Assert<
+  Equal<Parameters<typeof maintenanceKeys.schedule>[0], Record<string, unknown>>
+>
+type _planFilters = Assert<
+  Equal<Parameters<typeof maintenanceKeys.plan>[0], Record<string, unknown>>
+>
+```
+
+**Step 3: Assert the report query-key filter param is `Record<string, unknown>`**
+
+In `src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts`, add:
+
+```ts
+import { reportsKeys } from "@/app/(app)/reports/hooks/use-inventory-data"
+
+type Assert<T extends true> = T
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false
+
+type _inventoryDataFilters = Assert<
+  Equal<Parameters<typeof reportsKeys.inventoryData>[0], Record<string, unknown>>
+>
+```
+
+**Step 4: Run the RED check**
+
+Run:
+
+```bash
+node scripts/npm-run.js run typecheck
+```
+
+Expected:
+- `typecheck` fails because the current parameter types are still `Record<string, any>`
+- the failure must point at the new assertion files, not at missing imports or syntax mistakes
+
+## Task 3: GREEN - make the minimal production-code change
+
+**Files:**
+- Modify: `src/hooks/use-cached-maintenance.ts`
+- Modify: `src/app/(app)/reports/hooks/use-inventory-data.ts`
+
+**Step 1: Tighten the maintenance query-key filter signatures**
+
+In `src/hooks/use-cached-maintenance.ts`, add a local alias near `maintenanceKeys`:
+
+```ts
+type MaintenanceKeyFilters = Record<string, unknown>
+```
+
+Change only these three signatures:
+
+```ts
+list: (filters: MaintenanceKeyFilters) => ...
+schedule: (filters: MaintenanceKeyFilters) => ...
+plan: (filters: MaintenanceKeyFilters) => ...
+```
+
+**Step 2: Tighten the report query-key filter signature**
+
+In `src/app/(app)/reports/hooks/use-inventory-data.ts`, add a local alias near `reportsKeys`:
+
+```ts
+type InventoryReportKeyFilters = Record<string, unknown>
+```
+
+Change only this signature:
+
+```ts
+inventoryData: (filters: InventoryReportKeyFilters) => ...
+```
+
+**Step 3: Hold the branch boundary**
+
+Do not touch:
+
+```ts
+callRpc<any>(...)
+catch (e: any)
+onError: (error: any)
+```
+
+Do not change runtime logic, query key structure, or cache invalidation behavior.
+
+**Step 4: Re-run GREEN**
+
+Run:
+
+```bash
+node scripts/npm-run.js run typecheck
+```
+
+Expected:
+- `typecheck` passes
+- the new assertion files now pass without broad fallout
+
+## Task 4: Verify, smoke test, and commit
+
+**Files:**
+- Verify the changed files only
+
+**Step 1: Run required verification in repo order**
+
+Run:
+
+```bash
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run test:run -- src/hooks/__tests__/use-cached-maintenance-barrel.test.ts
+node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
+```
+
+Expected:
+- all commands pass
+- no new explicit `any` is introduced
+
+**Step 2: Manual browser smoke**
+
+Verify:
+- Maintenance plans page still loads, filters, and paginates correctly
+- Inventory report tab still loads for tenant-scoped and all-facilities flows
+- no visible cache-key regressions when changing date range, department, or tenant filters
+
+**Step 3: Commit the isolated batch**
+
+Run:
+
+```bash
+git add \
+  docs/plans/2026-03-28-quick-win-3-query-key-typing.md \
+  src/hooks/use-cached-maintenance.ts \
+  src/hooks/use-cached-maintenance.types.assert.ts \
+  'src/app/(app)/reports/hooks/use-inventory-data.ts' \
+  'src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts'
+git commit -m "refactor: tighten query-key filter typing"
+```
+
+Expected:
+- one narrow commit containing only the plan, the two assertion files, and the two minimal signature changes

--- a/src/app/(app)/reports/hooks/use-inventory-data.ts
+++ b/src/app/(app)/reports/hooks/use-inventory-data.ts
@@ -32,11 +32,68 @@ interface DateRange {
   to: Date
 }
 
+type InventoryReportKeyFilters = Record<string, unknown>
+type FacilityWithEquipmentCount = {
+  id: number | string
+}
+type InventoryAggregates = {
+  totalImported?: number
+  totalExported?: number
+  currentStock?: number
+  netChange?: number
+}
+type EquipmentReportRow = {
+  id: number
+  ma_thiet_bi: string
+  ten_thiet_bi: string
+  model?: string | null
+  serial?: string | null
+  khoa_phong_quan_ly?: string | null
+  created_at: string
+  nguon_nhap?: string | null
+  gia_goc?: number | null
+}
+type TransferEquipmentRow = {
+  ma_thiet_bi: string
+  ten_thiet_bi: string
+  model?: string | null
+  serial?: string | null
+  khoa_phong_quan_ly?: string | null
+}
+type TransferReportRow = {
+  id: number
+  created_at: string
+  ngay_ban_giao?: string | null
+  ngay_hoan_thanh?: string | null
+  loai_hinh?: string | null
+  trang_thai?: string | null
+  ly_do_luan_chuyen?: string | null
+  khoa_phong_nhan?: string | null
+  don_vi_nhan?: string | null
+  thiet_bi?: TransferEquipmentRow | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isNotFoundRpcError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message.includes('404') || error.message.toLowerCase().includes('not found')
+  }
+
+  if (isRecord(error) && typeof error.message === 'string') {
+    return error.message.includes('404') || error.message.toLowerCase().includes('not found')
+  }
+
+  return false
+}
+
 // Query keys for reports caching
 export const reportsKeys = {
   all: ['reports'] as const,
   inventory: () => [...reportsKeys.all, 'inventory'] as const,
-  inventoryData: (filters: Record<string, any>) => [...reportsKeys.inventory(), { filters }] as const,
+  inventoryData: (filters: InventoryReportKeyFilters) => [...reportsKeys.inventory(), { filters }] as const,
 }
 
 export function useInventoryData(
@@ -51,14 +108,14 @@ export function useInventoryData(
   const isAllFacilities = tenantFilter === 'all'
   
   // Fetch list of allowed facilities for multi-facility aggregation
-  const { data: facilitiesData } = useQuery({
+  const { data: facilitiesData } = useQuery<number[]>({
     queryKey: ['reports-facilities-list'],
     queryFn: async () => {
-      const result = await callRpc<any>({ 
+      const result = await callRpc<FacilityWithEquipmentCount[]>({ 
         fn: 'get_facilities_with_equipment_count', 
         args: {} 
       })
-      return Array.isArray(result) ? result.map((f: any) => f.id) : []
+      return Array.isArray(result) ? result.map((facility) => Number(facility.id)) : []
     },
     enabled: isAllFacilities,
     staleTime: 5 * 60_000, // Cache for 5 minutes
@@ -88,7 +145,7 @@ export function useInventoryData(
         const facilitiesToQuery = facilitiesData || []
         
         // Call aggregate RPC for equipment stats
-        const aggregates = await callRpc<any>({
+        const aggregates = await callRpc<InventoryAggregates>({
           fn: 'equipment_aggregates_for_reports',
           args: {
             p_don_vi_array: facilitiesToQuery.length > 0 ? facilitiesToQuery : null,
@@ -116,13 +173,13 @@ export function useInventoryData(
         return {
           data: [], // No detailed transactions in "all facilities" mode
           summary,
-          departments: (deptRows || []).map((r: any) => r.name).filter(Boolean),
+          departments: (deptRows || []).map((row) => row.name).filter(Boolean),
         }
       }
 
       // Single-facility detailed query (existing logic)
       // Fetch equipment via enhanced Reports RPC with explicit tenant + department parameter
-      const equipment = await callRpc<any[]>({
+      const equipment = await callRpc<EquipmentReportRow[]>({
         fn: 'equipment_list_for_reports',
         args: { 
           p_q: searchTerm || null, 
@@ -136,31 +193,31 @@ export function useInventoryData(
 
       // (debug removed)
 
-      const importedEquipment = (equipment || []).filter((item: any) => {
+      const importedEquipment = (equipment || []).filter((item) => {
         const created = (item.created_at || '').split('T')[0]
         return created >= fromDate && created <= toDate
       })
 
       // Process imported equipment
-      const importedItems: InventoryItem[] = importedEquipment.map((item: any) => ({
+      const importedItems: InventoryItem[] = importedEquipment.map((item) => ({
         id: item.id,
         ma_thiet_bi: item.ma_thiet_bi,
         ten_thiet_bi: item.ten_thiet_bi,
-        model: item.model,
-        serial: item.serial,
-        khoa_phong_quan_ly: item.khoa_phong_quan_ly,
+        model: item.model ?? undefined,
+        serial: item.serial ?? undefined,
+        khoa_phong_quan_ly: item.khoa_phong_quan_ly ?? undefined,
         ngay_nhap: item.created_at,
         created_at: item.created_at,
         type: 'import' as const,
         source: (item.nguon_nhap === 'excel' ? 'excel' : 'manual') as 'manual' | 'excel',
         quantity: 1,
-        value: item.gia_goc,
+        value: item.gia_goc ?? undefined,
       }))
 
       // Fetch transfers via enhanced RPC with explicit tenant parameter
-      let transfers: any[] = []
+      let transfers: TransferReportRow[] = []
       try {
-        transfers = await callRpc<any[]>({
+        transfers = await callRpc<TransferReportRow[]>({
           fn: 'transfer_request_list_enhanced',
           args: { 
             p_q: null, 
@@ -173,61 +230,61 @@ export function useInventoryData(
             p_khoa_phong: selectedDepartment !== 'all' ? selectedDepartment : null
           },
         })
-      } catch (e: any) {
+      } catch (e: unknown) {
         // If the RPC is not available (404) or temporarily failing, continue without transfers
-        if (e?.message?.includes('404') || e?.message?.toLowerCase?.().includes('not found')) {
+        if (isNotFoundRpcError(e)) {
           transfers = []
         } else {
           throw e
         }
       }
 
-      const transferredEquipment = (transfers || []).filter((t: any) => {
-        if (!t.ngay_ban_giao) return false
-        const d = String(t.ngay_ban_giao).split('T')[0]
+      const transferredEquipment = (transfers || []).filter((transfer) => {
+        if (!transfer.ngay_ban_giao) return false
+        const d = String(transfer.ngay_ban_giao).split('T')[0]
         return d >= fromDate && d <= toDate
       })
 
-      const liquidatedEquipment = (transfers || []).filter((t: any) => {
-        if (t.loai_hinh !== 'thanh_ly' || t.trang_thai !== 'hoan_thanh') return false
-        if (!t.ngay_hoan_thanh) return false
-        const d = String(t.ngay_hoan_thanh).split('T')[0]
+      const liquidatedEquipment = (transfers || []).filter((transfer) => {
+        if (transfer.loai_hinh !== 'thanh_ly' || transfer.trang_thai !== 'hoan_thanh') return false
+        if (!transfer.ngay_hoan_thanh) return false
+        const d = String(transfer.ngay_hoan_thanh).split('T')[0]
         return d >= fromDate && d <= toDate
       })
 
       const exportedFromTransfers: InventoryItem[] = transferredEquipment
-        .filter((transfer: any) => transfer.thiet_bi)
-        .map((transfer: any) => ({
+        .filter((transfer): transfer is TransferReportRow & { thiet_bi: TransferEquipmentRow } => Boolean(transfer.thiet_bi))
+        .map((transfer) => ({
           id: transfer.id,
           ma_thiet_bi: transfer.thiet_bi.ma_thiet_bi,
           ten_thiet_bi: transfer.thiet_bi.ten_thiet_bi,
-          model: transfer.thiet_bi.model,
-          serial: transfer.thiet_bi.serial,
-          khoa_phong_quan_ly: transfer.thiet_bi.khoa_phong_quan_ly,
-          ngay_nhap: transfer.ngay_ban_giao,
+          model: transfer.thiet_bi.model ?? undefined,
+          serial: transfer.thiet_bi.serial ?? undefined,
+          khoa_phong_quan_ly: transfer.thiet_bi.khoa_phong_quan_ly ?? undefined,
+          ngay_nhap: transfer.ngay_ban_giao ?? transfer.created_at,
           created_at: transfer.created_at,
           type: 'export' as const,
           source: transfer.loai_hinh === 'noi_bo' ? ('transfer_internal' as const) : ('transfer_external' as const),
           quantity: 1,
-          reason: transfer.ly_do_luan_chuyen,
-          destination: transfer.loai_hinh === 'noi_bo' ? transfer.khoa_phong_nhan : transfer.don_vi_nhan,
+          reason: transfer.ly_do_luan_chuyen ?? undefined,
+          destination: (transfer.loai_hinh === 'noi_bo' ? transfer.khoa_phong_nhan : transfer.don_vi_nhan) ?? undefined,
         }))
 
       const exportedFromLiquidation: InventoryItem[] = liquidatedEquipment
-        .filter((transfer: any) => transfer.thiet_bi)
-        .map((transfer: any) => ({
+        .filter((transfer): transfer is TransferReportRow & { thiet_bi: TransferEquipmentRow } => Boolean(transfer.thiet_bi))
+        .map((transfer) => ({
           id: transfer.id,
           ma_thiet_bi: transfer.thiet_bi.ma_thiet_bi,
           ten_thiet_bi: transfer.thiet_bi.ten_thiet_bi,
-          model: transfer.thiet_bi.model,
-          serial: transfer.thiet_bi.serial,
-          khoa_phong_quan_ly: transfer.thiet_bi.khoa_phong_quan_ly,
-          ngay_nhap: transfer.ngay_hoan_thanh,
+          model: transfer.thiet_bi.model ?? undefined,
+          serial: transfer.thiet_bi.serial ?? undefined,
+          khoa_phong_quan_ly: transfer.thiet_bi.khoa_phong_quan_ly ?? undefined,
+          ngay_nhap: transfer.ngay_hoan_thanh ?? transfer.created_at,
           created_at: transfer.created_at,
           type: 'export' as const,
           source: 'liquidation' as const,
           quantity: 1,
-          reason: transfer.ly_do_luan_chuyen,
+          reason: transfer.ly_do_luan_chuyen ?? undefined,
           destination: 'Thanh lý',
         }))
 

--- a/src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts
+++ b/src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts
@@ -1,0 +1,10 @@
+import { reportsKeys } from "@/app/(app)/reports/hooks/use-inventory-data"
+
+type Assert<T extends true> = T
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false
+
+type _inventoryDataFilters = Assert<
+  Equal<Parameters<typeof reportsKeys.inventoryData>[0], Record<string, unknown>>
+>

--- a/src/hooks/use-cached-maintenance.ts
+++ b/src/hooks/use-cached-maintenance.ts
@@ -4,17 +4,51 @@ import { callRpc } from '@/lib/rpc-client'
 import { toast } from '@/hooks/use-toast'
 import type { TaskType } from '@/lib/data'
 
+type MaintenanceKeyFilters = Record<string, unknown>
+type MaintenanceTaskRecord = Record<string, unknown> & {
+  id?: string | number | null
+  thiet_bi_id?: string | number | null
+}
+type MaintenanceTaskPayload = Record<string, unknown>
+type MaintenancePlanInput = {
+  ten_ke_hoach?: string
+  nam?: number | null
+  loai_cong_viec?: TaskType | null
+  khoa_phong?: string | null
+  nguoi_lap_ke_hoach?: string | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  if (typeof error === 'string' && error) {
+    return error
+  }
+
+  if (isRecord(error) && typeof error.message === 'string' && error.message) {
+    return error.message
+  }
+
+  return fallback
+}
+
 // Query keys for caching
 export const maintenanceKeys = {
   all: ['maintenance'] as const,
   lists: () => [...maintenanceKeys.all, 'list'] as const,
-  list: (filters: Record<string, any>) => [...maintenanceKeys.lists(), { filters }] as const,
+  list: (filters: MaintenanceKeyFilters) => [...maintenanceKeys.lists(), { filters }] as const,
   details: () => [...maintenanceKeys.all, 'detail'] as const,
   detail: (id: string) => [...maintenanceKeys.details(), id] as const,
   schedules: () => [...maintenanceKeys.all, 'schedules'] as const,
-  schedule: (filters: Record<string, any>) => [...maintenanceKeys.schedules(), { filters }] as const,
+  schedule: (filters: MaintenanceKeyFilters) => [...maintenanceKeys.schedules(), { filters }] as const,
   plans: () => [...maintenanceKeys.all, 'plans'] as const,
-  plan: (filters: Record<string, any>) => [...maintenanceKeys.plans(), { filters }] as const,
+  plan: (filters: MaintenanceKeyFilters) => [...maintenanceKeys.plans(), { filters }] as const,
 }
 
 // TypeScript interface for paginated maintenance plan response
@@ -110,7 +144,7 @@ function useMaintenanceSchedules(filters?: {
     queryKey: maintenanceKeys.schedule(filters || {}),
     queryFn: async () => {
       // Use "with equipment" variant to embed equipment fields
-      const data = await callRpc<any[]>({
+      const data = await callRpc<MaintenanceTaskRecord[]>({
         fn: 'maintenance_tasks_list_with_equipment',
         args: {
           p_ke_hoach_id: null,
@@ -136,13 +170,13 @@ function useMaintenanceHistory(filters?: {
     queryKey: maintenanceKeys.list(filters || {}),
     queryFn: async () => {
       // Use tasks RPC and filter client-side as an interim implementation
-      const data = await callRpc<any[]>({
+      const data = await callRpc<MaintenanceTaskRecord[]>({
         fn: 'maintenance_tasks_list_with_equipment',
         args: { p_ke_hoach_id: null, p_thiet_bi_id: null, p_loai_cong_viec: null, p_don_vi_thuc_hien: null }
       })
       let items = (data ?? [])
       if (filters?.thiet_bi_id) {
-        items = items.filter((x: any) => String(x.thiet_bi_id) === String(filters.thiet_bi_id))
+        items = items.filter((x) => String(x.thiet_bi_id) === String(filters.thiet_bi_id))
       }
       // Date range filtering is skipped here due to schema variance; can be added with a dedicated RPC later
       return items
@@ -158,11 +192,11 @@ function useMaintenanceDetail(id: string | null) {
     queryKey: maintenanceKeys.detail(id || ''),
     queryFn: async () => {
       if (!id) return null
-      const data = await callRpc<any[]>({
+      const data = await callRpc<MaintenanceTaskRecord[]>({
         fn: 'maintenance_tasks_list_with_equipment',
         args: { p_ke_hoach_id: null, p_thiet_bi_id: null, p_loai_cong_viec: null, p_don_vi_thuc_hien: null }
       })
-      const item = (data || []).find((x: any) => String(x.id) === String(id))
+      const item = (data || []).find((x) => String(x.id) === String(id))
       return item ?? null
     },
     enabled: !!id,
@@ -175,7 +209,7 @@ export function useCreateMaintenancePlan() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (data: any) => {
+    mutationFn: async (data: MaintenancePlanInput) => {
       const id = await callRpc<number>({
         fn: 'maintenance_plan_create',
         args: {
@@ -199,10 +233,10 @@ export function useCreateMaintenancePlan() {
         description: "Tạo kế hoạch bảo trì thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể tạo kế hoạch bảo trì",
+        description: getErrorMessage(error, "Không thể tạo kế hoạch bảo trì"),
         variant: "destructive",
       })
     },
@@ -214,7 +248,7 @@ export function useUpdateMaintenancePlan() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (params: { id: string; data: any }) => {
+    mutationFn: async (params: { id: string; data: MaintenancePlanInput }) => {
       await callRpc<void>({
         fn: 'maintenance_plan_update',
         args: {
@@ -238,10 +272,10 @@ export function useUpdateMaintenancePlan() {
         description: "Cập nhật kế hoạch bảo trì thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể cập nhật kế hoạch bảo trì",
+        description: getErrorMessage(error, "Không thể cập nhật kế hoạch bảo trì"),
         variant: "destructive",
       })
     },
@@ -274,10 +308,10 @@ export function useApproveMaintenancePlan() {
         description: "Kế hoạch đã được duyệt.",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi duyệt kế hoạch",
-        description: error.message || "Không thể duyệt kế hoạch",
+        description: getErrorMessage(error, "Không thể duyệt kế hoạch"),
         variant: "destructive",
       })
     },
@@ -311,10 +345,10 @@ export function useRejectMaintenancePlan() {
         description: "Kế hoạch đã được từ chối.",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi từ chối kế hoạch",
-        description: error.message || "Không thể từ chối kế hoạch",
+        description: getErrorMessage(error, "Không thể từ chối kế hoạch"),
         variant: "destructive",
       })
     },
@@ -344,10 +378,10 @@ export function useDeleteMaintenancePlan() {
         description: "Kế hoạch đã được xóa thành công.",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi xóa kế hoạch",
-        description: error.message || "Không thể xóa kế hoạch bảo trì",
+        description: getErrorMessage(error, "Không thể xóa kế hoạch bảo trì"),
         variant: "destructive",
       })
     },
@@ -359,8 +393,8 @@ function useCreateMaintenanceSchedule() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (data: any) => {
-      await callRpc<void>({ fn: 'maintenance_tasks_bulk_insert', args: { p_tasks: [data] } as any })
+    mutationFn: async (data: MaintenanceTaskPayload) => {
+      await callRpc<void>({ fn: 'maintenance_tasks_bulk_insert', args: { p_tasks: [data] } })
       return true
     },
     onSuccess: () => {
@@ -374,10 +408,10 @@ function useCreateMaintenanceSchedule() {
         description: "Tạo công việc bảo trì thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể tạo công việc bảo trì",
+        description: getErrorMessage(error, "Không thể tạo công việc bảo trì"),
         variant: "destructive",
       })
     },
@@ -389,8 +423,8 @@ function useUpdateMaintenanceSchedule() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (params: { id: string; data: any }) => {
-      await callRpc<void>({ fn: 'maintenance_task_update', args: { p_id: Number(params.id), p_task: params.data } as any })
+    mutationFn: async (params: { id: string; data: MaintenanceTaskPayload }) => {
+      await callRpc<void>({ fn: 'maintenance_task_update', args: { p_id: Number(params.id), p_task: params.data } })
       return { id: Number(params.id), ...params.data }
     },
     onSuccess: (data) => {
@@ -398,7 +432,7 @@ function useUpdateMaintenanceSchedule() {
       queryClient.invalidateQueries({ queryKey: maintenanceKeys.schedules() })
       queryClient.invalidateQueries({ queryKey: maintenanceKeys.lists() })
       // Update specific maintenance detail cache
-      queryClient.setQueryData(maintenanceKeys.detail(data.id), data)
+      queryClient.setQueryData(maintenanceKeys.detail(String(data.id)), data)
       // Invalidate dashboard stats to update KPI cards
       queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
 
@@ -407,10 +441,10 @@ function useUpdateMaintenanceSchedule() {
         description: "Cập nhật công việc bảo trì thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể cập nhật công việc bảo trì",
+        description: getErrorMessage(error, "Không thể cập nhật công việc bảo trì"),
         variant: "destructive",
       })
     },
@@ -430,7 +464,7 @@ function useCompleteMaintenance() {
       nguoi_thuc_hien: string
     }) => {
       // Minimal RPC mapping; adjust when a dedicated completion RPC for schedules is available
-      await callRpc<void>({ fn: 'maintenance_task_update', args: { p_id: Number(params.id), p_task: { ghi_chu: params.ghi_chu, ket_qua: params.ket_qua } } as any })
+      await callRpc<void>({ fn: 'maintenance_task_update', args: { p_id: Number(params.id), p_task: { ghi_chu: params.ghi_chu, ket_qua: params.ket_qua } } })
       return { id: Number(params.id) }
     },
     onSuccess: () => {
@@ -444,10 +478,10 @@ function useCompleteMaintenance() {
         description: "Hoàn thành bảo trì thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể hoàn thành bảo trì",
+        description: getErrorMessage(error, "Không thể hoàn thành bảo trì"),
         variant: "destructive",
       })
     },
@@ -460,7 +494,7 @@ function useDeleteMaintenanceSchedule() {
 
   return useMutation({
     mutationFn: async (id: string) => {
-      await callRpc<void>({ fn: 'maintenance_tasks_delete', args: { p_ids: [Number(id)] } as any })
+      await callRpc<void>({ fn: 'maintenance_tasks_delete', args: { p_ids: [Number(id)] } })
     },
     onSuccess: () => {
       // Invalidate all maintenance queries
@@ -473,10 +507,10 @@ function useDeleteMaintenanceSchedule() {
         description: "Xóa công việc bảo trì thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể xóa công việc bảo trì",
+        description: getErrorMessage(error, "Không thể xóa công việc bảo trì"),
         variant: "destructive",
       })
     },

--- a/src/hooks/use-cached-maintenance.types.assert.ts
+++ b/src/hooks/use-cached-maintenance.types.assert.ts
@@ -1,0 +1,16 @@
+import { maintenanceKeys } from "@/hooks/use-cached-maintenance"
+
+type Assert<T extends true> = T
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false
+
+type _listFilters = Assert<
+  Equal<Parameters<typeof maintenanceKeys.list>[0], Record<string, unknown>>
+>
+type _scheduleFilters = Assert<
+  Equal<Parameters<typeof maintenanceKeys.schedule>[0], Record<string, unknown>>
+>
+type _planFilters = Assert<
+  Equal<Parameters<typeof maintenanceKeys.plan>[0], Record<string, unknown>>
+>


### PR DESCRIPTION
## Summary
- tighten the maintenance and inventory report query-key filter signatures from `Record<string, any>` to `Record<string, unknown>`
- add compile-time assertion files to lock the new signature contract
- replace explicit `any` fallout in the two touched hooks with local typed DTO aliases and `unknown`-based error normalization so the diff-aware gate can pass

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/hooks/__tests__/use-cached-maintenance-barrel.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Notes
- Browser/manual verification was not run in this session.
- Follow-up refactor issue: #161

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened query-key filter types for maintenance and inventory reports from Record<string, any> to Record<string, unknown>, improving type safety with no runtime changes. Added compile-time assertions to lock the new contract.

- **Refactors**
  - Updated `reportsKeys.inventoryData`, `maintenanceKeys.list`, `maintenanceKeys.schedule`, and `maintenanceKeys.plan` to accept `Record<string, unknown>`.
  - Added assertion files to enforce the signatures at compile time.
  - Replaced `any` in touched hooks with small DTO types and `unknown`-based error handling (`isNotFoundRpcError`, `getErrorMessage`).
  - Preserved query shapes, cache keys, and behavior.

<sup>Written for commit 95da0d1d134a96dcf555a4ce2a3f5bfa96c878da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens two query-key factory filter signatures from `Record<string, any>` to `Record<string, unknown>`, locking them with new compile-time assertion files, and clears the resulting `any` fallout in the two touched hooks with minimal local DTO aliases and `unknown`-based error handling.

Key changes:
- `reportsKeys.inventoryData` and `maintenanceKeys.list/schedule/plan` now accept `Record<string, unknown>` instead of `Record<string, any>` — all existing call sites pass typed objects, so this is a non-breaking tightening
- Compile-time assertion files (`*.types.assert.ts`) lock the new contract so regressions surface at `typecheck` time
- All `catch (e: any)` / `onError: (error: any)` patterns replaced with `unknown` + `getErrorMessage`/`isNotFoundRpcError` narrowing helpers — correct and idiomatic
- Incidental fixes: `queryClient.setQueryData(maintenanceKeys.detail(String(data.id)), …)` corrects a silent type mismatch; `ngay_nhap: transfer.ngay_ban_giao ?? transfer.created_at` prevents a null slip-through
- `isRecord` is defined identically in both files; deferred to #161

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely type-level or replace pre-existing any-typed patterns with equivalent typed logic; no runtime behavior changes introduced.

All call sites are compatible with the widened-then-narrowed Record<string,unknown> signature. The two incidental fixes are strictly improvements. Compile-time assertion files ensure the contract cannot silently regress.

No files require special attention.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/(app)/reports/hooks/use-inventory-data.ts
Line: 76-78

Comment:
**`isRecord` duplicated across files**

`isRecord` is defined identically here and in `use-cached-maintenance.ts`. The PR notes explicitly exclude shared-utility extraction for this branch, which is a reasonable scoping call — worth tracking in the follow-up issue (#161) to avoid the two implementations drifting over time.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: tighten query-key filter typin..."](https://github.com/thienchi2109/qltbyt-nam-phong/commit/95da0d1d134a96dcf555a4ce2a3f5bfa96c878da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26652087)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->