### PR TITLE
refactor: compact mobile equipment card for higher density display

### DIFF
--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -277,7 +277,6 @@ const EquipmentPageContent = React.memo(function EquipmentPageContent({
               table={table}
               columns={columns}
               onShowDetails={(eq) => openDetailDialog(eq)}
-              onEdit={(eq) => eq && openEditDialog(eq)}
             />
           </div>
         </CardContent>

--- a/src/app/(app)/equipment/equipment-content.tsx
+++ b/src/app/(app)/equipment/equipment-content.tsx
@@ -5,7 +5,7 @@ import type { ColumnDef, Table } from "@tanstack/react-table"
 import { flexRender } from "@tanstack/react-table"
 import { Loader2 } from "lucide-react"
 
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   Table as UITable,
@@ -55,20 +55,20 @@ export function EquipmentContent({
   // Loading skeleton
   if (isLoading) {
     return isCardView ? (
-      <div className="space-y-4">
-        {Array.from({ length: 5 }).map((_, i) => (
+      <div className="space-y-3">
+        {Array.from({ length: 6 }).map((_, i) => (
           <Card key={i}>
-            <CardHeader className="flex flex-row items-start justify-between pb-4">
-              <div>
-                <Skeleton className="h-5 w-48 mb-2" />
-                <Skeleton className="h-4 w-32" />
+            <CardContent className="p-3 space-y-2">
+              <div className="flex justify-between">
+                <Skeleton className="h-3 w-28" />
+                <Skeleton className="h-4 w-16 rounded-full" />
               </div>
-              <Skeleton className="h-8 w-8 rounded-md" />
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <Skeleton className="h-8 w-full" />
-              <Skeleton className="h-8 w-full" />
-              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-5 w-48" />
+              <Skeleton className="h-3 w-36" />
+              <div className="flex gap-2 pt-0.5">
+                <Skeleton className="h-8 flex-1 rounded-lg" />
+                <Skeleton className="h-8 flex-1 rounded-lg" />
+              </div>
             </CardContent>
           </Card>
         ))}
@@ -146,9 +146,9 @@ export function EquipmentContent({
                   {header.isPlaceholder
                     ? null
                     : flexRender(
-                        header.column.columnDef.header,
-                        header.getContext()
-                      )}
+                      header.column.columnDef.header,
+                      header.getContext()
+                    )}
                 </TableHead>
               ))}
             </TableRow>

--- a/src/app/(app)/equipment/equipment-content.tsx
+++ b/src/app/(app)/equipment/equipment-content.tsx
@@ -122,7 +122,6 @@ export function EquipmentContent({
             key={row.original.id}
             equipment={row.original}
             onShowDetails={onShowDetails}
-            onEdit={onEdit}
           />
         ))}
       </div>

--- a/src/app/(app)/equipment/equipment-content.tsx
+++ b/src/app/(app)/equipment/equipment-content.tsx
@@ -28,7 +28,6 @@ export interface EquipmentContentProps {
   table: Table<Equipment>
   columns: ColumnDef<Equipment>[]
   onShowDetails: (equipment: Equipment) => void
-  onEdit: (equipment: Equipment | null) => void
 }
 
 export function EquipmentContent({
@@ -41,7 +40,6 @@ export function EquipmentContent({
   table,
   columns,
   onShowDetails,
-  onEdit,
 }: EquipmentContentProps) {
   // Global users and regional leaders must select a tenant/facility first
   if ((isGlobal || isRegionalLeader) && !shouldFetchEquipment) {

--- a/src/components/mobile-equipment-list-item.tsx
+++ b/src/components/mobile-equipment-list-item.tsx
@@ -1,19 +1,12 @@
 "use client"
 
-import {
-  ChevronRight,
-  Wrench,
-} from "lucide-react"
+import { Wrench, MapPin, Eye, History, AlertTriangle } from "lucide-react"
 import { useRouter } from "next/navigation"
+import { useSession } from "next-auth/react"
 
 import { type Equipment } from "@/types/database"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
-import { useSession } from "next-auth/react"
 import { MobileUsageActions } from "./mobile-usage-actions"
-import { ActiveUsageIndicator } from "./active-usage-indicator"
-import { cn } from "@/lib/utils"
 import { isEquipmentManagerRole } from "@/lib/rbac"
 
 interface MobileEquipmentListItemProps {
@@ -22,40 +15,33 @@ interface MobileEquipmentListItemProps {
   onEdit: (equipment: Equipment) => void
 }
 
-const getStatusVariant = (status: Equipment["tinh_trang_hien_tai"]) => {
+/**
+ * Maps equipment status to a color scheme for the compact status indicator.
+ * Returns { dot, text, bg } classes for the status pill.
+ */
+const getStatusStyle = (status: Equipment["tinh_trang_hien_tai"]) => {
   switch (status) {
     case "Hoạt động":
-      return "default"
+      return { dot: "bg-green-600", text: "text-green-700", bg: "bg-green-50" }
     case "Chờ bảo trì":
     case "Chờ hiệu chuẩn/kiểm định":
-      return "secondary"
+      return { dot: "bg-amber-500", text: "text-amber-700", bg: "bg-amber-50" }
     case "Chờ sửa chữa":
-      return "destructive"
+      return { dot: "bg-red-600", text: "text-red-700", bg: "bg-red-50" }
     case "Ngưng sử dụng":
     case "Chưa có nhu cầu sử dụng":
-      return "outline"
+      return { dot: "bg-gray-400", text: "text-gray-500", bg: "bg-gray-100" }
     default:
-      return "outline"
+      return { dot: "bg-gray-400", text: "text-gray-500", bg: "bg-gray-100" }
   }
 }
 
-const getClassificationBadgeClasses = (classification: string | null | undefined) => {
-  if (!classification) return "variant-outline"
-  const trimmed = classification.trim().toUpperCase()
-  if (trimmed === 'A' || trimmed === 'LOẠI A') {
-    return "bg-[hsl(var(--primary))]/10 text-[hsl(var(--primary))] border-[hsl(var(--primary))] border"
-  }
-  if (trimmed === 'B' || trimmed === 'LOẠI B') {
-    return "bg-[hsl(var(--secondary))]/10 text-[hsl(var(--secondary-foreground))] border-[hsl(var(--secondary))] border"
-  }
-  if (trimmed === 'C' || trimmed === 'LOẠI C') {
-    return "bg-[hsl(var(--muted))]/60 text-[hsl(var(--muted-foreground))] border-[hsl(var(--border))] border"
-  }
-  if (trimmed === 'D' || trimmed === 'LOẠI D') {
-    return "bg-[hsl(var(--destructive))]/10 text-[hsl(var(--destructive))] border-[hsl(var(--destructive))] border"
-  }
-  return "variant-outline"
-}
+/**
+ * Determines whether the equipment is in a non-operational state.
+ * Used to render muted card styling and restrict available actions.
+ */
+const isOutOfService = (status: Equipment["tinh_trang_hien_tai"]) =>
+  status === "Ngưng sử dụng" || status === "Chưa có nhu cầu sử dụng"
 
 export function MobileEquipmentListItem({
   equipment,
@@ -71,14 +57,16 @@ export function MobileEquipmentListItem({
     (user.role === 'qltb_khoa' && user.khoa_phong === equipment.khoa_phong_quan_ly)
   )
 
+  const status = equipment.tinh_trang_hien_tai
+  const statusStyle = getStatusStyle(status)
+  const outOfService = isOutOfService(status)
+
   const handleCardClick = () => {
     onShowDetails(equipment)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    // Ignore keyboard events from child elements (buttons, dropdowns, etc.)
     if (e.currentTarget !== e.target) return
-    
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
       onShowDetails(equipment)
@@ -86,111 +74,127 @@ export function MobileEquipmentListItem({
   }
 
   return (
-    <Card 
-      className="rounded-xl overflow-hidden transition-all hover:shadow-md cursor-pointer"
+    <Card
+      className={`rounded-xl overflow-hidden transition-all hover:shadow-md cursor-pointer ${outOfService ? "opacity-70" : ""}`}
       role="button"
       tabIndex={0}
       aria-label={`Thiết bị: ${equipment.ten_thiet_bi}`}
       onClick={handleCardClick}
       onKeyDown={handleKeyDown}
     >
-      {/* Card Header - Status & Classification */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
-        <div className="flex items-center gap-2 flex-wrap">
-          {equipment.tinh_trang_hien_tai && (
-            <Badge 
-              variant={getStatusVariant(equipment.tinh_trang_hien_tai)} 
-              className="relative pl-6"
-            >
-              <span className="absolute left-2 top-1/2 -translate-y-1/2 h-2 w-2 rounded-full bg-current" />
-              {equipment.tinh_trang_hien_tai}
-            </Badge>
-          )}
-          {equipment.phan_loai_theo_nd98 && (
-            <Badge className={cn("text-xs font-semibold", getClassificationBadgeClasses(equipment.phan_loai_theo_nd98))}>
-              Loại {equipment.phan_loai_theo_nd98.trim().toUpperCase()}
-            </Badge>
-          )}
-        </div>
-        <ChevronRight className="h-5 w-5 text-muted-foreground shrink-0" />
-      </div>
-
-      {/* Card Body */}
-      <div className="p-4 space-y-4">
-        {/* Equipment Name & Code */}
-        <div className="space-y-1">
-          <div className="flex items-start gap-2">
-            <h3 className="text-base font-bold text-foreground leading-snug flex-1">
-              {equipment.ten_thiet_bi}
-            </h3>
-            <ActiveUsageIndicator equipmentId={equipment.id} />
-          </div>
-          <p className="text-xs font-medium text-muted-foreground">
-            📋 {equipment.ma_thiet_bi}
-          </p>
-        </div>
-
-        {/* Info Grid */}
-        <div className="grid grid-cols-2 gap-3">
-          <div className="bg-muted/50 rounded-lg p-3">
-            <div className="text-[11px] text-muted-foreground font-medium mb-1">Khoa/Phòng</div>
-            <div className="text-sm text-foreground font-semibold leading-tight truncate">
-              {equipment.khoa_phong_quan_ly || "N/A"}
+      <div className="p-3 space-y-2">
+        {/* Row 1: Equipment Code + Status */}
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] font-mono tracking-wider text-muted-foreground uppercase">
+            {equipment.ma_thiet_bi}
+          </span>
+          {status && (
+            <div className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full ${statusStyle.bg}`}>
+              <span className={`w-1.5 h-1.5 rounded-full ${statusStyle.dot}`} />
+              <span className={`text-[10px] font-semibold uppercase tracking-tight ${statusStyle.text}`}>
+                {status}
+              </span>
             </div>
-          </div>
-          <div className="bg-muted/50 rounded-lg p-3">
-            <div className="text-[11px] text-muted-foreground font-medium mb-1">Vị trí</div>
-            <div className="text-sm text-foreground font-semibold leading-tight truncate">
-              {equipment.vi_tri_lap_dat || "N/A"}
-            </div>
-          </div>
-          <div className="bg-muted/50 rounded-lg p-3 col-span-2">
-            <div className="text-[11px] text-muted-foreground font-medium mb-1">Người sử dụng</div>
-            <div className="text-sm text-foreground font-semibold truncate">
-              {equipment.nguoi_dang_truc_tiep_quan_ly || "N/A"}
-            </div>
-          </div>
-          {(equipment.model || equipment.serial) && (
-            <>
-              {equipment.model && (
-                <div className="bg-muted/50 rounded-lg p-3">
-                  <div className="text-[11px] text-muted-foreground font-medium mb-1">Model</div>
-                  <div className="text-sm text-foreground font-semibold leading-tight truncate">
-                    {equipment.model}
-                  </div>
-                </div>
-              )}
-              {equipment.serial && (
-                <div className="bg-muted/50 rounded-lg p-3">
-                  <div className="text-[11px] text-muted-foreground font-medium mb-1">Serial</div>
-                  <div className="text-sm text-foreground font-semibold leading-tight truncate">
-                    {equipment.serial}
-                  </div>
-                </div>
-              )}
-            </>
           )}
         </div>
 
-        {/* Actions Footer */}
-        <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
-          <div className="grid grid-cols-2 gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full h-10 text-sm"
-              onClick={(e) => {
-                e.stopPropagation()
-                router.push(`/repair-requests?equipmentId=${equipment.id}`)
-              }}
-            >
-              <Wrench className="mr-2 h-4 w-4" />
-              Báo sửa chữa
-            </Button>
-            <MobileUsageActions equipment={equipment} className="w-full h-10 text-sm" />
-          </div>
+        {/* Row 2: Equipment Name */}
+        <h3 className="text-[15px] font-bold text-foreground leading-tight">
+          {equipment.ten_thiet_bi}
+        </h3>
+
+        {/* Row 3: Department + Location */}
+        <div className="flex items-center text-xs text-muted-foreground gap-1.5">
+          <MapPin className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">
+            {equipment.khoa_phong_quan_ly || "N/A"}
+            {equipment.vi_tri_lap_dat && ` • ${equipment.vi_tri_lap_dat}`}
+          </span>
+        </div>
+
+        {/* Row 4: Action Buttons */}
+        <div className="flex gap-2 pt-0.5" onClick={(e) => e.stopPropagation()}>
+          {renderActionButtons(equipment, status, outOfService, router, onShowDetails)}
         </div>
       </div>
     </Card>
+  )
+}
+
+/**
+ * Renders context-aware action buttons based on equipment status:
+ * - Hoạt động: "Báo sửa chữa" + "Sử dụng"
+ * - Chờ sửa chữa: "Chi tiết sự cố" (prominent) + disabled play
+ * - Chờ bảo trì / Chờ hiệu chuẩn: "Lịch sử" + "Sử dụng"
+ * - Ngưng sử dụng / Chưa có nhu cầu: "Xem chi tiết" only
+ */
+function renderActionButtons(
+  equipment: Equipment,
+  status: Equipment["tinh_trang_hien_tai"],
+  outOfService: boolean,
+  router: ReturnType<typeof useRouter>,
+  onShowDetails: (equipment: Equipment) => void,
+) {
+  const buttonBase = "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-[11px] font-bold transition-all active:scale-95 duration-150"
+  const ghostBtn = `${buttonBase} bg-muted/60 hover:bg-muted text-muted-foreground`
+  const primaryBtn = `${buttonBase} bg-primary text-primary-foreground hover:opacity-90 shadow-sm`
+
+  // Ngưng sử dụng → "Xem chi tiết" only
+  if (outOfService) {
+    return (
+      <button
+        className={ghostBtn}
+        onClick={() => onShowDetails(equipment)}
+      >
+        <Eye className="h-3.5 w-3.5" />
+        Xem chi tiết
+      </button>
+    )
+  }
+
+  // Chờ sửa chữa → "Chi tiết sự cố" (red) + disabled play
+  if (status === "Chờ sửa chữa") {
+    return (
+      <>
+        <button
+          className={`${buttonBase} flex-[2] bg-destructive text-destructive-foreground hover:opacity-90`}
+          onClick={() => router.push(`/repair-requests?equipmentId=${equipment.id}`)}
+        >
+          <AlertTriangle className="h-3.5 w-3.5" />
+          Chi tiết sự cố
+        </button>
+        <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
+      </>
+    )
+  }
+
+  // Chờ bảo trì / Chờ hiệu chuẩn → "Lịch sử" + "Sử dụng"
+  if (status === "Chờ bảo trì" || status === "Chờ hiệu chuẩn/kiểm định") {
+    return (
+      <>
+        <button
+          className={ghostBtn}
+          onClick={() => onShowDetails(equipment)}
+        >
+          <History className="h-3.5 w-3.5" />
+          Lịch sử
+        </button>
+        <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
+      </>
+    )
+  }
+
+  // Default (Hoạt động) → "Báo sửa chữa" + "Sử dụng"
+  return (
+    <>
+      <button
+        className={ghostBtn}
+        onClick={() => router.push(`/repair-requests?equipmentId=${equipment.id}`)}
+      >
+        <Wrench className="h-3.5 w-3.5" />
+        Báo sửa chữa
+      </button>
+      <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
+    </>
   )
 }

--- a/src/components/mobile-equipment-list-item.tsx
+++ b/src/components/mobile-equipment-list-item.tsx
@@ -124,8 +124,8 @@ export function MobileEquipmentListItem({
 /**
  * Renders context-aware action buttons based on equipment status:
  * - Hoạt động: "Báo sửa chữa" + "Sử dụng"
- * - Chờ sửa chữa: "Chi tiết sự cố" (prominent) + disabled play
- * - Chờ bảo trì / Chờ hiệu chuẩn: "Lịch sử" + "Sử dụng"
+ * - Chờ sửa chữa: "Chi tiết sự cố" (prominent) + usage action
+ * - Chờ bảo trì / Chờ hiệu chuẩn: "Xem chi tiết" + "Sử dụng"
  * - Ngưng sử dụng / Chưa có nhu cầu: "Xem chi tiết" only
  */
 function renderActionButtons(
@@ -137,7 +137,6 @@ function renderActionButtons(
 ) {
   const buttonBase = "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-[11px] font-bold transition-all active:scale-95 duration-150"
   const ghostBtn = `${buttonBase} bg-muted/60 hover:bg-muted text-muted-foreground`
-  const primaryBtn = `${buttonBase} bg-primary text-primary-foreground hover:opacity-90 shadow-sm`
 
   // Ngưng sử dụng → "Xem chi tiết" only
   if (outOfService) {

--- a/src/components/mobile-equipment-list-item.tsx
+++ b/src/components/mobile-equipment-list-item.tsx
@@ -131,6 +131,7 @@ function renderActionButtons(
   if (outOfService) {
     return (
       <button
+        type="button"
         className={ghostBtn}
         onClick={() => onShowDetails(equipment)}
       >
@@ -145,6 +146,7 @@ function renderActionButtons(
     return (
       <>
         <button
+          type="button"
           className={`${buttonBase} flex-[2] bg-destructive text-destructive-foreground hover:opacity-90`}
           onClick={() => router.push(`/repair-requests?equipmentId=${equipment.id}`)}
         >
@@ -156,11 +158,12 @@ function renderActionButtons(
     )
   }
 
-  // Chờ bảo trì / Chờ hiệu chuẩn → "Lịch sử" + "Sử dụng"
+  // Chờ bảo trì / Chờ hiệu chuẩn → "Xem chi tiết" + "Sử dụng"
   if (status === "Chờ bảo trì" || status === "Chờ hiệu chuẩn/kiểm định") {
     return (
       <>
         <button
+          type="button"
           className={ghostBtn}
           onClick={() => onShowDetails(equipment)}
         >
@@ -176,6 +179,7 @@ function renderActionButtons(
   return (
     <>
       <button
+        type="button"
         className={ghostBtn}
         onClick={() => router.push(`/repair-requests?equipmentId=${equipment.id}`)}
       >

--- a/src/components/mobile-equipment-list-item.tsx
+++ b/src/components/mobile-equipment-list-item.tsx
@@ -2,17 +2,14 @@
 
 import { Wrench, MapPin, Eye, AlertTriangle } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { useSession } from "next-auth/react"
 
 import { type Equipment } from "@/types/database"
 import { Card } from "@/components/ui/card"
 import { MobileUsageActions } from "./mobile-usage-actions"
-import { isEquipmentManagerRole } from "@/lib/rbac"
 
 interface MobileEquipmentListItemProps {
   equipment: Equipment
   onShowDetails: (equipment: Equipment) => void
-  onEdit: (equipment: Equipment) => void
 }
 
 /**
@@ -46,16 +43,8 @@ const isOutOfService = (status: Equipment["tinh_trang_hien_tai"]) =>
 export function MobileEquipmentListItem({
   equipment,
   onShowDetails,
-  onEdit,
 }: MobileEquipmentListItemProps) {
   const router = useRouter()
-  const { data: session } = useSession()
-  const user = session?.user as any
-
-  const canEdit = !!user && (
-    isEquipmentManagerRole(user.role) ||
-    (user.role === 'qltb_khoa' && user.khoa_phong === equipment.khoa_phong_quan_ly)
-  )
 
   const status = equipment.tinh_trang_hien_tai
   const statusStyle = getStatusStyle(status)

--- a/src/components/mobile-equipment-list-item.tsx
+++ b/src/components/mobile-equipment-list-item.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Wrench, MapPin, Eye, History, AlertTriangle } from "lucide-react"
+import { Wrench, MapPin, Eye, AlertTriangle } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
 
@@ -176,8 +176,8 @@ function renderActionButtons(
           className={ghostBtn}
           onClick={() => onShowDetails(equipment)}
         >
-          <History className="h-3.5 w-3.5" />
-          Lịch sử
+          <Eye className="h-3.5 w-3.5" />
+          Xem chi tiết
         </button>
         <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
       </>


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the mobile equipment card to a compact, high‑density layout for faster scanning on small screens. Cleaned up dead props, aligned the loading skeleton with the new design, and hardened action buttons.

- **Refactors**
  - Compact 4‑row layout with a small colored status pill; muted card when out of service.
  - Status‑aware actions per `tinh_trang_hien_tai` (e.g., “Chi tiết sự cố” for “Chờ sửa chữa”; read‑only “Xem chi tiết” when out of service).
  - Updated card loading skeleton to match the compact layout.
  - Cleanup: removed `onEdit` from `EquipmentContent` and its caller; dropped dead `onEdit`/`canEdit` and the unused `primaryBtn`.

- **Bug Fixes**
  - Corrected maintenance status action: now “Xem chi tiết” with Eye icon.
  - Added `type="button"` to native buttons to prevent unintended form submissions; fixed a stale inline comment.

<sup>Written for commit a5d7fd19c767e2c6464c5150f51e0bf741e35ef6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the mobile equipment card into a compact 4-row layout for higher-density display, cleans up dead props (`onEdit`, `canEdit`, `primaryBtn`), and aligns the loading skeleton with the new design. The status-aware action logic is well-structured and readable, and the prior review concerns (dead code, icon/label mismatch for "Lịch sử") have all been resolved by this PR.

Key changes:
- New compact `p-3 space-y-2` card layout with equipment code, name, location, and context-sensitive action buttons
- `renderActionButtons` helper cleanly encapsulates per-status button logic
- `onEdit` removed from `MobileEquipmentListItemProps`, `EquipmentContentProps`, and the call-site in `EquipmentPageClient`
- Loading skeleton updated to mirror the new 4-row structure
- Unused `CardHeader` import cleaned up

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; it is a well-scoped UI refactor with all previously flagged issues resolved.

The dead-code removal (onEdit, canEdit, primaryBtn) and the icon/label mismatch raised in prior reviews are fully addressed. The new compact layout is clean and consistent, the loading skeleton matches the new card structure, and no regressions are introduced in the data-access or business-logic layers.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/mobile-equipment-list-item.tsx | Refactored to compact 4-row layout with status-aware action buttons; all previously flagged dead code removed. |
| src/app/(app)/equipment/equipment-content.tsx | Removed onEdit prop and updated loading skeleton to match the new compact card design. |
| src/app/(app)/equipment/_components/EquipmentPageClient.tsx | Removed onEdit prop from EquipmentContent call-site. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: add type=button attributes and fix ..."](https://github.com/thienchi2109/qltbyt-nam-phong/commit/a5d7fd19c767e2c6464c5150f51e0bf741e35ef6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26722087)</sub>

<!-- /greptile_comment -->