### PR TITLE
ci: fetch explicit-any base ref before workflow verify

### DIFF
--- a/.github/workflows/deploy-dual.yml
+++ b/.github/workflows/deploy-dual.yml
@@ -20,6 +20,11 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
 
+      - name: 📡 Fetch verify base ref
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
+          git fetch --no-tags --depth=1 origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -31,6 +36,8 @@ jobs:
 
       - name: 🔎 Verify changed TypeScript files
         run: node scripts/npm-run.js run verify:no-explicit-any
+        env:
+          EXPLICIT_ANY_BASE: origin/${{ github.event.pull_request.base.ref || 'main' }}
 
       - name: 🔍 Type check
         run: npm run typecheck

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -18,6 +18,11 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
 
+      - name: 📡 Fetch verify base ref
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
+          git fetch --no-tags --depth=1 origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -29,6 +34,8 @@ jobs:
 
       - name: 🔎 Verify changed TypeScript files
         run: node scripts/npm-run.js run verify:no-explicit-any
+        env:
+          EXPLICIT_ANY_BASE: origin/${{ github.event.pull_request.base.ref || 'main' }}
 
       - name: 🔍 Type check
         run: npm run typecheck


### PR DESCRIPTION
## Summary
- fetch the PR base branch ref before running `verify:no-explicit-any`
- set `EXPLICIT_ANY_BASE` to `origin/<base>` so the diff script resolves a real git revision in GitHub Actions
- apply the fix to both PR-facing workflows

## Why
Devin identified a valid regression in PR #186: `verify:no-explicit-any` defaults to `git diff main...HEAD`, but `actions/checkout@v4` on pull_request events does not provide a resolvable bare `main` ref with the default shallow checkout.

## Verification
- parsed both workflow YAML files locally with Ruby `YAML.load_file`
- `EXPLICIT_ANY_BASE=origin/main node scripts/check-no-explicit-any-in-diff.js` exits successfully locally
- `git diff --check` clean

Related to #140.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch the PR base branch and set EXPLICIT_ANY_BASE to origin/<base> so the explicit-any diff check resolves a real Git ref and runs reliably in PR workflows. Applies to deploy-dual.yml and preview-deploy.yml; addresses #140 by fixing failures caused by `actions/checkout@v4` shallow clones on pull_request.

<sup>Written for commit d1be6fe52edebddbf89c0bad828b2e4a3b9c32b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to enhance TypeScript code quality verification against the pull request base branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->