### PR TITLE
ci: fix explicit-any gate on main push

### DIFF
--- a/.github/workflows/deploy-dual.yml
+++ b/.github/workflows/deploy-dual.yml
@@ -16,11 +16,16 @@ jobs:
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
-      - name: 📡 Fetch verify base ref
+      - name: 📡 Determine verify base ref
         run: |
-          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
-          git fetch --no-tags --depth=1 origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            echo "EXPLICIT_ANY_BASE=HEAD^" >> "$GITHUB_ENV"
+          else
+            echo "EXPLICIT_ANY_BASE=HEAD" >> "$GITHUB_ENV"
+          fi
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v4
@@ -33,8 +38,6 @@ jobs:
 
       - name: 🔎 Verify changed TypeScript files
         run: node scripts/npm-run.js run verify:no-explicit-any
-        env:
-          EXPLICIT_ANY_BASE: origin/${{ github.event.pull_request.base.ref || 'main' }}
 
       - name: 🔍 Type check
         run: npm run typecheck

--- a/scripts/setup-cicd.js
+++ b/scripts/setup-cicd.js
@@ -96,7 +96,7 @@ async function setupCICD() {
     if (localVars.includes(varName)) {
       log(`✅ ${varName} (.env.local)`, colors.green);
     } else {
-      log(`❌ ${varName} (missing from both environments)`, colors.red);
+      log(`❌ ${varName} (missing from .env.local)`, colors.red);
       allGood = false;
     }
   });


### PR DESCRIPTION
## Summary
- fix the main-branch explicit-any gate to diff against the previous checked-out commit instead of `origin/main`
- use `fetch-depth: 2` so `HEAD^` exists in GitHub Actions
- fix the stale `.env.local` error message in `scripts/setup-cicd.js`

## Why
Devin correctly flagged that `verify:no-explicit-any` had become a no-op on `push main` after the workflow stopped running on `pull_request`.

## Verification
- YAML parse: `.github/workflows/deploy-dual.yml`
- `node --check scripts/setup-cicd.js`
- `EXPLICIT_ANY_BASE=HEAD^ node scripts/check-no-explicit-any-in-diff.js`
- shallow clone reproduction: `git diff --name-only --diff-filter=ACMR HEAD^...HEAD` returns the merged commit diff
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `verify:no-explicit-any` gate on `push` to `main` by diffing against the previous commit instead of `origin/main`. Also corrects a misleading `.env.local` error message in `scripts/setup-cicd.js`.

- **Bug Fixes**
  - Checkout with `fetch-depth: 2` so `HEAD^` is available.
  - Set `EXPLICIT_ANY_BASE` to `HEAD^` (fallback to `HEAD`); remove fetching `origin/*` and the old env usage in the verify step.
  - Update setup message to “missing from .env.local”.

<sup>Written for commit 026fd4a65503134d429bc36eacda35d562096aa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

