### PR TITLE
ci: drop explicit-any check from main workflow

### DIFF
--- a/.github/workflows/deploy-dual.yml
+++ b/.github/workflows/deploy-dual.yml
@@ -16,16 +16,6 @@ jobs:
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: 📡 Determine verify base ref
-        run: |
-          if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
-            echo "EXPLICIT_ANY_BASE=HEAD^" >> "$GITHUB_ENV"
-          else
-            echo "EXPLICIT_ANY_BASE=HEAD" >> "$GITHUB_ENV"
-          fi
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v4
@@ -35,9 +25,6 @@ jobs:
 
       - name: 📥 Install dependencies
         run: npm ci
-
-      - name: 🔎 Verify changed TypeScript files
-        run: node scripts/npm-run.js run verify:no-explicit-any
 
       - name: 🔍 Type check
         run: npm run typecheck


### PR DESCRIPTION
## Summary
- remove `verify:no-explicit-any` from `Main Branch CI`
- keep the explicit-any gate in `Preview Checks` on pull requests
- simplify `main` workflow back to install, typecheck, and build only

## Why
The diff-aware explicit-any gate is useful on PRs, but it keeps creating brittle false failures on `push main` and `workflow_dispatch`. `Main Branch CI` should validate the merged result, not re-run a fragile diff gate.

## Verification
- YAML parse for `.github/workflows/deploy-dual.yml` and `.github/workflows/preview-deploy.yml`
- `git diff --check`
- confirmed `verify:no-explicit-any` remains only in `preview-deploy.yml`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the diff-based `verify:no-explicit-any` check from the main branch CI to avoid flaky failures on push and manual runs. The main workflow now only installs, typechecks, and builds; the explicit-any gate remains in PR preview checks.

<sup>Written for commit 4e5a9d5d1f3111e3a2dde1bc2e0bc66f9792d296. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

