### PR TITLE
ci: harden preview explicit-any diff detection

### DIFF
--- a/scripts/__tests__/check-no-explicit-any-in-diff.test.ts
+++ b/scripts/__tests__/check-no-explicit-any-in-diff.test.ts
@@ -45,4 +45,24 @@ describe("check-no-explicit-any-in-diff", () => {
       })
     ).toThrow("git diff failed")
   })
+
+  it("falls back to two-dot diff when merge-base diff is unavailable", () => {
+    const changedFile = "scripts/__tests__/check-no-explicit-any-in-diff.test.ts"
+
+    const runGitImpl = (args: string[]) => {
+      const command = args.join(" ")
+
+      if (command === "diff --name-only --diff-filter=ACMR origin/main...HEAD") {
+        throw new Error("no merge base in shallow clone")
+      }
+
+      if (command === "diff --name-only --diff-filter=ACMR origin/main..HEAD") {
+        return [changedFile]
+      }
+
+      return []
+    }
+
+    expect(collectChangedTypeScriptFiles("origin/main", { runGitImpl })).toEqual([changedFile])
+  })
 })

--- a/scripts/check-no-explicit-any-in-diff.js
+++ b/scripts/check-no-explicit-any-in-diff.js
@@ -74,11 +74,23 @@ function runGit(args) {
   }
 }
 
+function getCommittedChangedFiles(baseRef, runGitImpl) {
+  try {
+    return runGitImpl(["diff", "--name-only", "--diff-filter=ACMR", `${baseRef}...HEAD`])
+  } catch (error) {
+    if (!baseRef) {
+      throw error
+    }
+
+    return runGitImpl(["diff", "--name-only", "--diff-filter=ACMR", `${baseRef}..HEAD`])
+  }
+}
+
 function collectChangedTypeScriptFiles(
   baseRef = DEFAULT_BASE_REF,
   { runGitImpl = runGit } = {}
 ) {
-  const committed = runGitImpl(["diff", "--name-only", "--diff-filter=ACMR", `${baseRef}...HEAD`])
+  const committed = getCommittedChangedFiles(baseRef, runGitImpl)
   const unstaged = runGitImpl(["diff", "--name-only", "--diff-filter=ACMR"])
   const staged = runGitImpl(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
   const untracked = runGitImpl(["ls-files", "--others", "--exclude-standard"])
@@ -131,6 +143,7 @@ module.exports = {
   collectChangedTypeScriptFiles,
   findExplicitAnyViolations,
   formatViolations,
+  getCommittedChangedFiles,
   runGit,
   scanFiles,
 }


### PR DESCRIPTION
## Summary
- add a fallback from `base...HEAD` to `base..HEAD` in `check-no-explicit-any-in-diff.js`
- add a regression test for shallow PR checkouts where merge-base diff is unavailable

## Why
`Preview Checks` still failed before build/typecheck because `git diff origin/main...HEAD` can fail in shallow PR checkouts. Two-dot diff is a safe fallback for determining the changed snapshot against the base ref.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- scripts/__tests__/check-no-explicit-any-in-diff.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the no-explicit-any diff check by falling back to two-dot `git diff` when three-dot fails in shallow clones. This prevents Preview Checks from failing before build/typecheck.

- **Bug Fixes**
  - Added `getCommittedChangedFiles()` to try `${baseRef}...HEAD` then fall back to `${baseRef}..HEAD`.
  - Added a regression test that verifies the fallback in shallow checkout scenarios.

<sup>Written for commit 3c1a73ebba5759c3f2ed353a4d69ec0e3c5304c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for error handling in file change detection when Git commands encounter failures in specific scenarios.

* **Refactor**
  * Enhanced robustness of changed file detection logic with automatic fallback mechanisms for edge cases in repository environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->