### PR TITLE
fix: Show typing indicator during submitted status in AI chat panel

### DIFF
--- a/src/components/assistant/AssistantMessageList.tsx
+++ b/src/components/assistant/AssistantMessageList.tsx
@@ -54,13 +54,14 @@ export function AssistantMessageList({
         userScrolledUp.current = !isNearBottom
     }, [])
 
-    // Determine if thinking indicator should show
+    const isSubmitted = status === "submitted"
     const isStreaming = status === "streaming"
     const lastMessage = messages[messages.length - 1]
     const showThinking =
-        isStreaming &&
-        lastMessage?.role === "assistant" &&
-        !lastMessage.parts.some((p) => p.type === "text")
+        isSubmitted ||
+        (isStreaming &&
+            lastMessage?.role === "assistant" &&
+            !lastMessage.parts.some((p) => p.type === "text"))
 
     return (
         <div

--- a/src/components/assistant/__tests__/AssistantMessageList.test.tsx
+++ b/src/components/assistant/__tests__/AssistantMessageList.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('ai', () => ({
@@ -173,6 +174,22 @@ describe('AssistantMessageList', () => {
             <AssistantMessageList
                 messages={messages as never}
                 status="streaming"
+                onApplyDraft={vi.fn()}
+            />,
+        )
+
+        expect(screen.getByTestId('assistant-thinking-container')).toBeInTheDocument()
+    })
+
+    it('shows thinking indicator when status is submitted', () => {
+        const messages = [
+            makeMessage('user', [{ type: 'text', text: 'Xin chào' }]),
+        ]
+
+        render(
+            <AssistantMessageList
+                messages={messages as never}
+                status="submitted"
                 onApplyDraft={vi.fn()}
             />,
         )


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the assistant typing indicator during `submitted` status so users get immediate feedback after sending a message.

- **Bug Fixes**
  - Update `AssistantMessageList` to show the thinking indicator when `status === "submitted"` (in addition to existing streaming logic).
  - Add a test to verify the indicator renders for `submitted`.

<sup>Written for commit 476646264d0477f8eac9c2eabac88e17bcf6aa3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated thinking indicator to display when assistant status transitions to submitted, providing feedback earlier in the response cycle alongside existing streaming state behavior.

* **Tests**
  * Added test coverage verifying the thinking indicator renders correctly when the component status is in submitted state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->