### PR TITLE
fix: transfer detail history uses transfer_change_history_list

### DIFF
--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -53,7 +53,7 @@ const ALLOWED_FUNCTIONS = new Set<string>([
   'transfer_request_update_status',
   'transfer_request_delete',
   'transfer_request_complete',
-  'transfer_history_list',
+  'transfer_change_history_list',
   'transfer_request_external_pending_returns',
   'get_transfer_request_facilities',
   // Transfers - Data Grid

--- a/src/components/__tests__/transfer-detail-dialog.test.tsx
+++ b/src/components/__tests__/transfer-detail-dialog.test.tsx
@@ -144,7 +144,7 @@ describe("TransferDetailDialog related people", () => {
           nguoi_duyet: approver,
         })
       }
-      if (fn === "transfer_history_list") {
+      if (fn === "transfer_change_history_list") {
         return []
       }
       throw new Error(`Unexpected RPC: ${fn}`)
@@ -187,7 +187,7 @@ describe("TransferDetailDialog related people", () => {
           ngay_duyet: undefined,
         })
       }
-      if (fn === "transfer_history_list") {
+      if (fn === "transfer_change_history_list") {
         return []
       }
       throw new Error(`Unexpected RPC: ${fn}`)
@@ -226,7 +226,7 @@ describe("TransferDetailDialog related people", () => {
           nguoi_duyet: approver,
         })
       }
-      if (fn === "transfer_history_list") {
+      if (fn === "transfer_change_history_list") {
         return []
       }
       throw new Error(`Unexpected RPC: ${fn}`)
@@ -254,7 +254,7 @@ describe("TransferDetailDialog related people", () => {
       if (fn === "transfer_request_get") {
         return makeTransferRow()
       }
-      if (fn === "transfer_history_list") {
+      if (fn === "transfer_change_history_list") {
         return []
       }
       throw new Error(`Unexpected RPC: ${fn}`)
@@ -289,7 +289,7 @@ describe("TransferDetailDialog related people", () => {
       if (fn === "transfer_request_get") {
         return makeTransferRow()
       }
-      if (fn === "transfer_history_list") {
+      if (fn === "transfer_change_history_list") {
         return []
       }
       throw new Error(`Unexpected RPC: ${fn}`)
@@ -307,7 +307,7 @@ describe("TransferDetailDialog related people", () => {
         mockCallRpc.mock.calls.filter(([call]) => call.fn === "transfer_request_get"),
       ).toHaveLength(1)
       expect(
-        mockCallRpc.mock.calls.filter(([call]) => call.fn === "transfer_history_list"),
+        mockCallRpc.mock.calls.filter(([call]) => call.fn === "transfer_change_history_list"),
       ).toHaveLength(1)
     })
 
@@ -319,7 +319,7 @@ describe("TransferDetailDialog related people", () => {
         mockCallRpc.mock.calls.filter(([call]) => call.fn === "transfer_request_get"),
       ).toHaveLength(1)
       expect(
-        mockCallRpc.mock.calls.filter(([call]) => call.fn === "transfer_history_list"),
+        mockCallRpc.mock.calls.filter(([call]) => call.fn === "transfer_change_history_list"),
       ).toHaveLength(1)
     })
   })
@@ -344,7 +344,7 @@ describe("TransferDetailDialog related people", () => {
       if (fn === "transfer_request_get") {
         return new Promise(() => undefined)
       }
-      if (fn === "transfer_history_list") {
+      if (fn === "transfer_change_history_list") {
         return Promise.resolve([])
       }
       throw new Error(`Unexpected RPC: ${fn}`)
@@ -366,5 +366,37 @@ describe("TransferDetailDialog related people", () => {
 
     expect(screen.getByText("Đã duyệt")).toBeInTheDocument()
     expect(screen.queryByText("Chờ duyệt")).not.toBeInTheDocument()
+  })
+  it("renders transfer request action label and actor from change history contract", async () => {
+    const transferRequestCreateLabel = "Tạo yêu cầu luân chuyển"
+
+    mockCallRpc.mockImplementation(async ({ fn }) => {
+      if (fn === "transfer_request_get") {
+        return makeTransferRow()
+      }
+      if (fn === "transfer_change_history_list") {
+        return [
+          {
+            id: 1,
+            action_type: "transfer_request_create",
+            admin_username: "nva",
+            admin_full_name: "Nguyễn Văn A",
+            action_details: null,
+            created_at: "2026-04-02T00:00:00.000Z",
+          },
+        ]
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+
+    render(
+      <TransferDetailDialog open onOpenChange={vi.fn()} transfer={makeTransferRow()} />,
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(transferRequestCreateLabel)).toBeInTheDocument()
+      expect(screen.getByText(/Thực hiện bởi: Nguyễn Văn A/)).toBeInTheDocument()
+    })
   })
 })

--- a/src/components/transfer-detail-dialog.data.ts
+++ b/src/components/transfer-detail-dialog.data.ts
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query"
 import { useToast } from "@/hooks/use-toast"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
 import { callRpc } from "@/lib/rpc-client"
-import type { TransferHistory, TransferRequest } from "@/types/database"
+import type { TransferChangeHistory, TransferRequest } from "@/types/database"
 
 interface UseTransferDetailDialogDataParams {
   open: boolean
@@ -15,9 +15,9 @@ export const transferDetailDialogQueryKeys = {
   detailRoot: ["transfer_request_get"] as const,
   detail: (transferId: number | null) =>
     [...transferDetailDialogQueryKeys.detailRoot, { id: transferId }] as const,
-  historyRoot: ["transfer_history_list"] as const,
+  historyRoot: ["transfer_change_history_list"] as const,
   history: (transferId: number | null) =>
-    [...transferDetailDialogQueryKeys.historyRoot, { yeu_cau_id: transferId }] as const,
+    [...transferDetailDialogQueryKeys.historyRoot, { p_entity_id: transferId }] as const,
 }
 
 export function useTransferDetailDialogData({
@@ -44,9 +44,9 @@ export function useTransferDetailDialogData({
   const historyQuery = useQuery({
     queryKey: transferDetailDialogQueryKeys.history(transferId),
     queryFn: async ({ signal }) => {
-      const data = await callRpc<TransferHistory[]>({
-        fn: "transfer_history_list",
-        args: { p_yeu_cau_id: transferId! },
+      const data = await callRpc<TransferChangeHistory[]>({
+        fn: "transfer_change_history_list",
+        args: { p_entity_id: transferId! },
         signal,
       })
 

--- a/src/components/transfer-detail-dialog.tsx
+++ b/src/components/transfer-detail-dialog.tsx
@@ -28,6 +28,11 @@ interface TransferDetailDialogProps {
   transfer: TransferRequest | null
 }
 
+const TRANSFER_HISTORY_ACTION_LABELS: Record<string, string> = {
+  transfer_request_create: "Tạo yêu cầu luân chuyển",
+  transfer_request_update: "Cập nhật yêu cầu luân chuyển",
+}
+
 export function TransferDetailDialog({ open, onOpenChange, transfer }: TransferDetailDialogProps) {
   const { history, isLoadingHistory, resolvedTransfer, transferId } = useTransferDetailDialogData({
     open,
@@ -286,29 +291,22 @@ export function TransferDetailDialog({ open, onOpenChange, transfer }: TransferD
                       <div className="flex-shrink-0 w-2 h-2 rounded-full bg-primary mt-2"></div>
                       <div className="flex-grow space-y-1">
                         <div className="flex items-center justify-between">
-                          <span className="font-medium text-sm">{item.hanh_dong}</span>
+                          <span className="font-medium text-sm">
+                            {TRANSFER_HISTORY_ACTION_LABELS[item.action_type] ?? item.action_type}
+                          </span>
                           <span className="text-xs text-muted-foreground">
-                            {formatDateTime(item.thoi_gian)}
+                            {formatDateTime(item.created_at)}
                           </span>
                         </div>
-                        {item.mo_ta && (
-                          <p className="text-sm text-muted-foreground">{item.mo_ta}</p>
-                        )}
-                        {item.nguoi_thuc_hien && (
-                          <p className="text-xs text-muted-foreground">
-                            Thực hiện bởi: {item.nguoi_thuc_hien.full_name}
+                        {item.action_details && (
+                          <p className="text-sm text-muted-foreground break-all">
+                            {JSON.stringify(item.action_details)}
                           </p>
                         )}
-                        {item.trang_thai_cu && item.trang_thai_moi && (
-                          <div className="flex items-center gap-2 text-xs">
-                            <Badge variant="outline" className="text-xs">
-                              {TRANSFER_STATUSES[item.trang_thai_cu as keyof typeof TRANSFER_STATUSES]}
-                            </Badge>
-                            <span>→</span>
-                            <Badge variant="outline" className="text-xs">
-                              {TRANSFER_STATUSES[item.trang_thai_moi as keyof typeof TRANSFER_STATUSES]}
-                            </Badge>
-                          </div>
+                        {item.admin_full_name && (
+                          <p className="text-xs text-muted-foreground">
+                            Thực hiện bởi: {item.admin_full_name}
+                          </p>
                         )}
                       </div>
                     </div>

--- a/src/hooks/__tests__/useTransferActions.test.tsx
+++ b/src/hooks/__tests__/useTransferActions.test.tsx
@@ -135,7 +135,7 @@ describe("useTransferActions", () => {
         queryKey: ["transfer_request_get"],
       })
       expect(invalidateSpy).toHaveBeenCalledWith({
-        queryKey: ["transfer_history_list"],
+        queryKey: ["transfer_change_history_list"],
       })
     })
   })

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -172,18 +172,13 @@ export interface TransferRequest {
   updated_by_user?: UserSummary | null;
 }
 
-export interface TransferHistory {
+export interface TransferChangeHistory {
   id: number;
-  yeu_cau_id: number;
-  trang_thai_cu?: string;
-  trang_thai_moi: string;
-  hanh_dong: string;
-  mo_ta?: string;
-  nguoi_thuc_hien_id?: number;
-  thoi_gian: string;
-  
-  // Relations
-  nguoi_thuc_hien?: UserSummary | null;
+  action_type: string;
+  admin_username: string;
+  admin_full_name: string;
+  action_details: Record<string, unknown> | null;
+  created_at: string;
 }
 
 // Constants for transfer system


### PR DESCRIPTION
## Summary
- replace transfer detail history RPC usage from transfer_history_list to transfer_change_history_list
- switch transfer history query args from p_yeu_cau_id to p_entity_id
- migrate transfer history type from legacy TransferHistory to TransferChangeHistory
- update transfer detail history rendering to the new audit-log contract (action_type, created_at, admin_full_name, action_details)
- update RPC whitelist to allow transfer_change_history_list
- keep TanStack Query key propagation consistent via transferDetailDialogQueryKeys.historyRoot and matching invalidation in useTransferActions

## Root cause
transfer_history_list was tied to stale history shape/table assumptions and no longer matched runtime source/contract for transfer history.

## Changes
### Frontend
- src/components/transfer-detail-dialog.data.ts
  - historyRoot -> ['transfer_change_history_list']
  - call RPC transfer_change_history_list with { p_entity_id }
  - use TransferChangeHistory[]
- src/components/transfer-detail-dialog.tsx
  - render label from action_type (with transfer-request mapping)
  - render timestamp from created_at
  - render actor from admin_full_name
  - render optional action_details
  - remove legacy status-transition history rendering fields
- src/types/database.ts
  - replace legacy transfer history interface with TransferChangeHistory
- src/app/api/rpc/[fn]/route.ts
  - replace whitelist entry transfer_history_list -> transfer_change_history_list

### Tests
- src/components/__tests__/transfer-detail-dialog.test.tsx
  - switch mocks/assertions to transfer_change_history_list
  - add regression test for rendering transfer_request_create action label and actor name
- src/hooks/__tests__/useTransferActions.test.tsx
  - update invalidation expectation to ['transfer_change_history_list']

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js npx vitest --reporter=verbose --run src/components/__tests__/transfer-detail-dialog.test.tsx
- node scripts/npm-run.js npx vitest --reporter=verbose --run src/hooks/__tests__/useTransferActions.test.tsx
- node scripts/npm-run.js npx vitest --reporter=verbose --run src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

## Notes
- Backend migration/function deployment was completed separately on the same branch as confirmed in session updates.
