### PR TITLE
fix: dynamic actionLabel in transfer & repair history adapters

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/repairRequestHistoryAdapter.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/repairRequestHistoryAdapter.test.ts
@@ -56,4 +56,33 @@ describe("mapRepairRequestHistoryEntries", () => {
       },
     ])
   })
+
+  it("distinguishes Hoàn thành from Không HT for repair_request_complete", () => {
+    // Given
+    const entries = [
+      {
+        id: 20,
+        action_type: "repair_request_complete",
+        admin_username: "nva",
+        admin_full_name: "Nguyễn Văn A",
+        action_details: { trang_thai: "Hoàn thành", ket_qua_sua_chua: "Đã thay linh kiện" },
+        created_at: "2026-04-06T05:00:00.000Z",
+      },
+      {
+        id: 21,
+        action_type: "repair_request_complete",
+        admin_username: "nva",
+        admin_full_name: "Nguyễn Văn A",
+        action_details: { trang_thai: "Không HT", ly_do_khong_hoan_thanh: "Hết linh kiện" },
+        created_at: "2026-04-06T06:00:00.000Z",
+      },
+    ]
+
+    // When
+    const result = mapRepairRequestHistoryEntries(entries)
+
+    // Then
+    expect(result[0].actionLabel).toBe("Hoàn thành sửa chữa")
+    expect(result[1].actionLabel).toBe("Không hoàn thành sửa chữa")
+  })
 })

--- a/src/app/(app)/repair-requests/_lib/repairRequestHistoryAdapter.ts
+++ b/src/app/(app)/repair-requests/_lib/repairRequestHistoryAdapter.ts
@@ -10,6 +10,25 @@ const REPAIR_HISTORY_ACTION_LABELS: Record<string, string> = {
   repair_request_delete: "Xóa yêu cầu sửa chữa",
 }
 
+const REPAIR_COMPLETE_ACTION_LABELS: Record<string, string> = {
+  "Hoàn thành": "Hoàn thành sửa chữa",
+  "Không HT": "Không hoàn thành sửa chữa",
+}
+
+function resolveRepairActionLabel(
+  actionType: string,
+  actionDetails: Record<string, unknown> | null,
+): string {
+  if (actionType === "repair_request_complete") {
+    const status =
+      typeof actionDetails?.trang_thai === "string" ? actionDetails.trang_thai : null
+    if (status && status in REPAIR_COMPLETE_ACTION_LABELS) {
+      return REPAIR_COMPLETE_ACTION_LABELS[status]
+    }
+  }
+  return REPAIR_HISTORY_ACTION_LABELS[actionType] ?? actionType
+}
+
 const REPAIR_HISTORY_DETAILS_LABELS: Record<string, string> = {
   trang_thai: "Trạng thái",
   mo_ta_su_co: "Mô tả sự cố",
@@ -66,7 +85,7 @@ export function mapRepairRequestHistoryEntries(
   return history.map((item) => ({
     id: String(item.id),
     occurredAt: item.created_at,
-    actionLabel: REPAIR_HISTORY_ACTION_LABELS[item.action_type] ?? item.action_type,
+    actionLabel: resolveRepairActionLabel(item.action_type, item.action_details),
     actorName: item.admin_full_name || null,
     details: getRepairHistoryDetails(item.action_details),
   }))

--- a/src/components/__tests__/transfer-detail-history-adapter.test.ts
+++ b/src/components/__tests__/transfer-detail-history-adapter.test.ts
@@ -65,7 +65,7 @@ describe("mapTransferHistoryEntries", () => {
       {
         id: "3",
         occurredAt: "2026-04-03T00:00:00.000Z",
-        actionLabel: "Cập nhật trạng thái yêu cầu luân chuyển",
+        actionLabel: "Yêu cầu đã được duyệt",
         actorName: "Nguyễn Văn A",
         details: [
           { label: "Trạng thái", value: "Đã duyệt" },
@@ -83,5 +83,63 @@ describe("mapTransferHistoryEntries", () => {
         ],
       },
     ])
+  })
+
+  it("uses status-specific actionLabel for transfer_request_update_status", () => {
+    // Given
+    const entries: TransferChangeHistory[] = [
+      {
+        id: 10,
+        action_type: "transfer_request_update_status",
+        admin_username: "nva",
+        admin_full_name: "Nguyễn Văn A",
+        action_details: { trang_thai: "da_duyet" },
+        created_at: "2026-04-06T01:00:00.000Z",
+      },
+      {
+        id: 11,
+        action_type: "transfer_request_update_status",
+        admin_username: "nva",
+        admin_full_name: "Nguyễn Văn A",
+        action_details: { trang_thai: "dang_luan_chuyen" },
+        created_at: "2026-04-06T02:00:00.000Z",
+      },
+      {
+        id: 12,
+        action_type: "transfer_request_update_status",
+        admin_username: "nva",
+        admin_full_name: "Nguyễn Văn A",
+        action_details: { trang_thai: "da_ban_giao" },
+        created_at: "2026-04-06T03:00:00.000Z",
+      },
+    ]
+
+    // When
+    const result = mapTransferHistoryEntries(entries)
+
+    // Then
+    expect(result[0].actionLabel).toBe("Yêu cầu đã được duyệt")
+    expect(result[1].actionLabel).toBe("Đang luân chuyển")
+    expect(result[2].actionLabel).toBe("Đã bàn giao")
+  })
+
+  it("falls back to static label when trang_thai is missing", () => {
+    // Given
+    const entries: TransferChangeHistory[] = [
+      {
+        id: 13,
+        action_type: "transfer_request_update_status",
+        admin_username: "nva",
+        admin_full_name: "Nguyễn Văn A",
+        action_details: {},
+        created_at: "2026-04-06T04:00:00.000Z",
+      },
+    ]
+
+    // When
+    const result = mapTransferHistoryEntries(entries)
+
+    // Then
+    expect(result[0].actionLabel).toBe("Cập nhật trạng thái yêu cầu luân chuyển")
   })
 })

--- a/src/components/transfer-detail-history-adapter.ts
+++ b/src/components/transfer-detail-history-adapter.ts
@@ -12,6 +12,26 @@ const TRANSFER_HISTORY_ACTION_LABELS: Record<string, string> = {
   transfer_request_complete: "Hoàn thành luân chuyển",
 }
 
+const TRANSFER_STATUS_ACTION_LABELS: Record<string, string> = {
+  da_duyet: "Yêu cầu đã được duyệt",
+  dang_luan_chuyen: "Đang luân chuyển",
+  da_ban_giao: "Đã bàn giao",
+}
+
+function resolveTransferActionLabel(
+  actionType: string,
+  actionDetails: Record<string, unknown> | null,
+): string {
+  if (actionType === "transfer_request_update_status") {
+    const status =
+      typeof actionDetails?.trang_thai === "string" ? actionDetails.trang_thai : null
+    if (status && status in TRANSFER_STATUS_ACTION_LABELS) {
+      return TRANSFER_STATUS_ACTION_LABELS[status]
+    }
+  }
+  return TRANSFER_HISTORY_ACTION_LABELS[actionType] ?? actionType
+}
+
 const TRANSFER_HISTORY_DETAILS_LABELS: Record<string, string> = {
   ma_yeu_cau: "Mã yêu cầu",
   trang_thai: "Trạng thái",
@@ -113,7 +133,7 @@ export function mapTransferHistoryEntries(
   return history.map((item) => ({
     id: String(item.id),
     occurredAt: item.created_at,
-    actionLabel: TRANSFER_HISTORY_ACTION_LABELS[item.action_type] ?? item.action_type,
+    actionLabel: resolveTransferActionLabel(item.action_type, item.action_details),
     actorName: item.admin_full_name || null,
     details: getTransferHistoryDetails(item.action_details),
   }))


### PR DESCRIPTION
## Problem

Tab **Lịch sử** trong Transfer Detail Dialog và Repair Request Detail View hiển thị label chung chung (ví dụ: *Cập nhật trạng thái yêu cầu luân chuyển*) thay vì label cụ thể theo trạng thái (*Yêu cầu đã được duyệt*, *Đang luân chuyển*, v.v.).

## Root Cause

UI adapter layer dùng static `Record<action_type, label>` lookup, bỏ qua `action_details.trang_thai` trong audit_logs. Backend đã instrument đúng — bug hoàn toàn ở client.

## Changes

### Transfer Adapter (`transfer-detail-history-adapter.ts`)
- Thêm `TRANSFER_STATUS_ACTION_LABELS` map: `da_duyet` → *Yêu cầu đã được duyệt*, `dang_luan_chuyen` → *Đang luân chuyển*, `da_ban_giao` → *Đã bàn giao*
- Thêm `resolveTransferActionLabel()` — tra cứu `action_details.trang_thai` cho `transfer_request_update_status`, fallback về static label
- Wired vào `mapTransferHistoryEntries()`

### Repair Adapter (`repairRequestHistoryAdapter.ts`)
- Thêm `REPAIR_COMPLETE_ACTION_LABELS` map: *Hoàn thành* → *Hoàn thành sửa chữa*, *Không HT* → *Không hoàn thành sửa chữa*
- Thêm `resolveRepairActionLabel()` — tra cứu `action_details.trang_thai` cho `repair_request_complete`
- Wired vào `mapRepairRequestHistoryEntries()`

## Scope

| ✅ Trong scope | ❌ Ngoài scope |
|---|---|
| Transfer dynamic label (3 statuses) | Đổi fallback copy |
| Repair complete distinction (2 statuses) | `repair_request_approve` (đã có label đúng) |
| | Backfill dữ liệu cũ |

## Verification

- `verify:no-explicit-any` ✅
- `typecheck` ✅  
- 7/7 adapter unit tests ✅
- React Doctor 100/100 ✅

## Forward-only Note

Requests created/transitioned **trước** lifecycle audit deployment vẫn hiển thị label chung chung (forward-only, no backfill).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes history tabs to show status-specific action labels for Transfer and Repair, replacing generic labels for clearer timelines.

- **Bug Fixes**
  - Transfer: resolve actionLabel for `transfer_request_update_status` from `action_details.trang_thai`:
    - `da_duyet` → "Yêu cầu đã được duyệt"
    - `dang_luan_chuyen` → "Đang luân chuyển"
    - `da_ban_giao` → "Đã bàn giao"
  - Repair: for `repair_request_complete`, distinguish "Hoàn thành" → "Hoàn thành sửa chữa" and "Không HT" → "Không hoàn thành sửa chữa".
  - Fallback to the static label when `trang_thai` is missing or unknown.
  - Updated unit tests for both adapters.

<sup>Written for commit b8e86715ee74943683fd9b7919ea86f9a027fdfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced status labels in repair request history to distinguish between "Completed repair" and "Incomplete repair" based on actual completion status.
  * Improved transfer request status labels to display specific statuses such as "Request approved," "In progress," and "Handed over."
  * Both features include fallback to generic labels when status details are unavailable.

* **Tests**
  * Added test coverage for enhanced status labeling logic with various status scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->