### PR TITLE
chore: tighten explicit any typing in production helpers

### DIFF
--- a/src/components/dynamic-chart.tsx
+++ b/src/components/dynamic-chart.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import type { TooltipProps } from "recharts"
 import { loadChartsLibrary, type ChartData, type RechartsComponents } from "@/lib/chart-utils"
 import { ChartLoadingFallback, ChartErrorFallback } from "@/components/chart-fallbacks"
 import { buildPieSliceCells } from "@/lib/runtime-list-keys"
@@ -151,7 +152,7 @@ interface BarChartProps {
   showTooltip?: boolean
   showLegend?: boolean
   xAxisAngle?: number
-  customTooltip?: React.ComponentType<any>
+  customTooltip?: React.FC<TooltipProps<number, string>>
   margin?: {
     top?: number
     right?: number

--- a/src/hooks/use-audit-logs.ts
+++ b/src/hooks/use-audit-logs.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { useSession } from 'next-auth/react'
+import { callRpc } from '@/lib/rpc-client'
 import { isGlobalRole } from '@/lib/rbac'
 
 type AuditActionDetailValue =
@@ -11,24 +12,13 @@ type AuditActionDetailValue =
   | { [key: string]: AuditActionDetailValue }
 
 export type AuditActionDetails = Record<string, AuditActionDetailValue>
-type AuditLogErrorResponse = { error?: string }
+export type AuditActionDetailsInput = AuditActionDetails | string
 type AuditLogEntityType =
   | 'device'
   | 'repair_request'
   | 'transfer_request'
   | 'maintenance_plan'
   | 'user'
-type AuditLogListResponse = AuditLogEntry[] | AuditLogErrorResponse
-type AuditLogStatsResponse = AuditLogStats[] | AuditLogErrorResponse
-type AuditLogSummaryResponse = AuditLogSummary[] | AuditLogErrorResponse
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}
-
-function hasErrorMessage(value: unknown): value is { error: string } {
-  return isRecord(value) && typeof value.error === 'string'
-}
 
 function getDetailString(details: AuditActionDetails, key: string): string | null {
   const value = details[key]
@@ -45,7 +35,7 @@ export interface AuditLogEntry {
   target_user_id: number | null
   target_username: string | null
   target_full_name: string | null
-  action_details: AuditActionDetails | null
+  action_details: AuditActionDetailsInput | null
   ip_address: string | null
   user_agent: string | null
   created_at: string
@@ -85,24 +75,6 @@ export interface AuditLogFilters {
   don_vi?: string | null
 }
 
-// RPC call function
-async function callAuditLogsRPC<T>(functionName: string, params: Record<string, unknown> = {}): Promise<T> {
-  const response = await fetch(`/api/rpc/${functionName}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(params),
-  })
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Network error' }))
-    throw new Error(error.error || `Failed to call ${functionName}`)
-  }
-
-  return response.json()
-}
-
 // Hook to fetch audit logs list
 export function useAuditLogs(
   filters: AuditLogFilters = {},
@@ -116,26 +88,20 @@ export function useAuditLogs(
   return useQuery<AuditLogEntry[], Error>({
     queryKey: ['audit-logs', filters],
     queryFn: async () => {
-      const result = await callAuditLogsRPC<AuditLogListResponse>('audit_logs_list_v2', {
-        p_limit: filters.limit || 50,
-        p_offset: filters.offset || 0,
-        p_user_id: filters.user_id,
-        p_entity_type: filters.entity_type || null,
-        p_entity_id: filters.entity_id || null,
-        p_action_type: filters.action_type,
-        p_text_search: filters.text_search || null,
-        p_date_from: filters.date_from,
-        p_date_to: filters.date_to,
+      return callRpc<AuditLogEntry[]>({
+        fn: 'audit_logs_list_v2',
+        args: {
+          p_limit: filters.limit || 50,
+          p_offset: filters.offset || 0,
+          p_user_id: filters.user_id,
+          p_entity_type: filters.entity_type || null,
+          p_entity_id: filters.entity_id || null,
+          p_action_type: filters.action_type,
+          p_text_search: filters.text_search || null,
+          p_date_from: filters.date_from,
+          p_date_to: filters.date_to,
+        },
       })
-      
-      // Handle different response formats
-      if (Array.isArray(result)) {
-        return result
-      } else if (hasErrorMessage(result)) {
-        throw new Error(result.error)
-      } else {
-        return []
-      }
     },
     enabled: !!session && isGlobalUser,
     staleTime: 30 * 1000, // 30 seconds
@@ -160,20 +126,14 @@ export function useAuditLogsStats(
   return useQuery<AuditLogStats[], Error>({
     queryKey: ['audit-logs-stats', filters],
     queryFn: async () => {
-      const result = await callAuditLogsRPC<AuditLogStatsResponse>('audit_logs_stats', {
-        p_date_from: filters.date_from,
-        p_date_to: filters.date_to,
-        p_don_vi: filters.don_vi,
+      return callRpc<AuditLogStats[]>({
+        fn: 'audit_logs_stats',
+        args: {
+          p_date_from: filters.date_from,
+          p_date_to: filters.date_to,
+          p_don_vi: filters.don_vi,
+        },
       })
-      
-      // Handle different response formats
-      if (Array.isArray(result)) {
-        return result
-      } else if (hasErrorMessage(result)) {
-        throw new Error(result.error)
-      } else {
-        return []
-      }
     },
     enabled: !!session && isGlobalUser,
     staleTime: 2 * 60 * 1000, // 2 minutes
@@ -193,16 +153,9 @@ export function useAuditLogsRecentSummary(
   return useQuery<AuditLogSummary[], Error>({
     queryKey: ['audit-logs-recent-summary'],
     queryFn: async () => {
-      const result = await callAuditLogsRPC<AuditLogSummaryResponse>('audit_logs_recent_summary')
-      
-      // Handle different response formats
-      if (Array.isArray(result)) {
-        return result
-      } else if (hasErrorMessage(result)) {
-        throw new Error(result.error)
-      } else {
-        return []
-      }
+      return callRpc<AuditLogSummary[]>({
+        fn: 'audit_logs_recent_summary',
+      })
     },
     enabled: !!session && isGlobalUser,
     staleTime: 1 * 60 * 1000, // 1 minute
@@ -275,9 +228,10 @@ export function getActionTypeLabel(actionType: string): string {
 }
 
 // Format action details for display
-export function formatActionDetails(actionType: string, details: AuditActionDetails | null): string {
+export function formatActionDetails(actionType: string, details: AuditActionDetailsInput | null): string {
   if (!details) return ''
-  
+  if (typeof details === 'string') return details
+
   switch (actionType) {
     case 'equipment_create':
     case 'equipment_update':
@@ -298,7 +252,7 @@ export function formatActionDetails(actionType: string, details: AuditActionDeta
       return getDetailString(details, 'equipment_name')
         ? `TB: ${getDetailString(details, 'equipment_name')}`
         : ''
-    default:
+    default: {
       // Try to extract meaningful info from details
       const description = getDetailString(details, 'description')
       if (description) return description
@@ -307,5 +261,6 @@ export function formatActionDetails(actionType: string, details: AuditActionDeta
       if (message) return message
 
       return ''
+    }
   }
 }

--- a/src/hooks/use-audit-logs.ts
+++ b/src/hooks/use-audit-logs.ts
@@ -2,6 +2,39 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query'
 import { useSession } from 'next-auth/react'
 import { isGlobalRole } from '@/lib/rbac'
 
+type AuditActionDetailValue =
+  | string
+  | number
+  | boolean
+  | null
+  | AuditActionDetailValue[]
+  | { [key: string]: AuditActionDetailValue }
+
+export type AuditActionDetails = Record<string, AuditActionDetailValue>
+type AuditLogErrorResponse = { error?: string }
+type AuditLogEntityType =
+  | 'device'
+  | 'repair_request'
+  | 'transfer_request'
+  | 'maintenance_plan'
+  | 'user'
+type AuditLogListResponse = AuditLogEntry[] | AuditLogErrorResponse
+type AuditLogStatsResponse = AuditLogStats[] | AuditLogErrorResponse
+type AuditLogSummaryResponse = AuditLogSummary[] | AuditLogErrorResponse
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function hasErrorMessage(value: unknown): value is { error: string } {
+  return isRecord(value) && typeof value.error === 'string'
+}
+
+function getDetailString(details: AuditActionDetails, key: string): string | null {
+  const value = details[key]
+  return typeof value === 'string' ? value : null
+}
+
 // Types for audit logs
 export interface AuditLogEntry {
   id: number
@@ -12,12 +45,12 @@ export interface AuditLogEntry {
   target_user_id: number | null
   target_username: string | null
   target_full_name: string | null
-  action_details: Record<string, any> | null
+  action_details: AuditActionDetails | null
   ip_address: string | null
   user_agent: string | null
   created_at: string
   // New entity fields
-  entity_type?: 'device' | 'repair_request' | 'transfer_request' | 'maintenance_plan' | 'user' | null
+  entity_type?: AuditLogEntityType | null
   entity_id?: number | null
   entity_label?: string | null
   total_count: number
@@ -43,7 +76,7 @@ export interface AuditLogFilters {
   offset?: number
   user_id?: number | null
   // entity filters (v2)
-  entity_type?: 'device' | 'repair_request' | 'transfer_request' | 'maintenance_plan' | 'user' | null
+  entity_type?: AuditLogEntityType | null
   entity_id?: number | null
   text_search?: string | null
   action_type?: string | null
@@ -53,7 +86,7 @@ export interface AuditLogFilters {
 }
 
 // RPC call function
-async function callAuditLogsRPC<T>(functionName: string, params: any = {}): Promise<T> {
+async function callAuditLogsRPC<T>(functionName: string, params: Record<string, unknown> = {}): Promise<T> {
   const response = await fetch(`/api/rpc/${functionName}`, {
     method: 'POST',
     headers: {
@@ -78,12 +111,12 @@ export function useAuditLogs(
   const { data: session } = useSession()
   
   // Only global users can access audit logs
-  const isGlobalUser = isGlobalRole((session?.user as any)?.role)
+  const isGlobalUser = isGlobalRole(session?.user?.role)
 
   return useQuery<AuditLogEntry[], Error>({
     queryKey: ['audit-logs', filters],
     queryFn: async () => {
-      const result = await callAuditLogsRPC<any>('audit_logs_list_v2', {
+      const result = await callAuditLogsRPC<AuditLogListResponse>('audit_logs_list_v2', {
         p_limit: filters.limit || 50,
         p_offset: filters.offset || 0,
         p_user_id: filters.user_id,
@@ -97,11 +130,11 @@ export function useAuditLogs(
       
       // Handle different response formats
       if (Array.isArray(result)) {
-        return result as AuditLogEntry[]
-      } else if (result && typeof result === 'object' && result.error) {
+        return result
+      } else if (hasErrorMessage(result)) {
         throw new Error(result.error)
       } else {
-        return [] as AuditLogEntry[]
+        return []
       }
     },
     enabled: !!session && isGlobalUser,
@@ -122,12 +155,12 @@ export function useAuditLogsStats(
 ) {
   const { data: session } = useSession()
   
-  const isGlobalUser = isGlobalRole((session?.user as any)?.role)
+  const isGlobalUser = isGlobalRole(session?.user?.role)
 
   return useQuery<AuditLogStats[], Error>({
     queryKey: ['audit-logs-stats', filters],
     queryFn: async () => {
-      const result = await callAuditLogsRPC<any>('audit_logs_stats', {
+      const result = await callAuditLogsRPC<AuditLogStatsResponse>('audit_logs_stats', {
         p_date_from: filters.date_from,
         p_date_to: filters.date_to,
         p_don_vi: filters.don_vi,
@@ -135,11 +168,11 @@ export function useAuditLogsStats(
       
       // Handle different response formats
       if (Array.isArray(result)) {
-        return result as AuditLogStats[]
-      } else if (result && typeof result === 'object' && result.error) {
+        return result
+      } else if (hasErrorMessage(result)) {
         throw new Error(result.error)
       } else {
-        return [] as AuditLogStats[]
+        return []
       }
     },
     enabled: !!session && isGlobalUser,
@@ -155,20 +188,20 @@ export function useAuditLogsRecentSummary(
 ) {
   const { data: session } = useSession()
   
-  const isGlobalUser = isGlobalRole((session?.user as any)?.role)
+  const isGlobalUser = isGlobalRole(session?.user?.role)
 
   return useQuery<AuditLogSummary[], Error>({
     queryKey: ['audit-logs-recent-summary'],
     queryFn: async () => {
-      const result = await callAuditLogsRPC<any>('audit_logs_recent_summary')
+      const result = await callAuditLogsRPC<AuditLogSummaryResponse>('audit_logs_recent_summary')
       
       // Handle different response formats
       if (Array.isArray(result)) {
-        return result as AuditLogSummary[]
-      } else if (result && typeof result === 'object' && result.error) {
+        return result
+      } else if (hasErrorMessage(result)) {
         throw new Error(result.error)
       } else {
-        return [] as AuditLogSummary[]
+        return []
       }
     },
     enabled: !!session && isGlobalUser,
@@ -242,26 +275,37 @@ export function getActionTypeLabel(actionType: string): string {
 }
 
 // Format action details for display
-export function formatActionDetails(actionType: string, details: Record<string, any> | null): string {
+export function formatActionDetails(actionType: string, details: AuditActionDetails | null): string {
   if (!details) return ''
   
   switch (actionType) {
     case 'equipment_create':
     case 'equipment_update':
-      return details.equipment_name ? `Thiết bị: ${details.equipment_name}` : ''
+      return getDetailString(details, 'equipment_name')
+        ? `Thiết bị: ${getDetailString(details, 'equipment_name')}`
+        : ''
     case 'USER_UPDATE':
-      return details.username ? `Người dùng: ${details.username}` : ''
+      return getDetailString(details, 'username')
+        ? `Người dùng: ${getDetailString(details, 'username')}`
+        : ''
     case 'maintenance_plan_create':
     case 'maintenance_plan_update':
-      return details.plan_name ? `Kế hoạch: ${details.plan_name}` : ''
+      return getDetailString(details, 'plan_name')
+        ? `Kế hoạch: ${getDetailString(details, 'plan_name')}`
+        : ''
     case 'transfer_create':
     case 'transfer_update':
-      return details.equipment_name ? `TB: ${details.equipment_name}` : ''
+      return getDetailString(details, 'equipment_name')
+        ? `TB: ${getDetailString(details, 'equipment_name')}`
+        : ''
     default:
       // Try to extract meaningful info from details
-      if (typeof details === 'string') return details
-      if (details.description) return details.description
-      if (details.message) return details.message
+      const description = getDetailString(details, 'description')
+      if (description) return description
+
+      const message = getDetailString(details, 'message')
+      if (message) return message
+
       return ''
   }
 }

--- a/src/hooks/use-audit-logs.types.assert.ts
+++ b/src/hooks/use-audit-logs.types.assert.ts
@@ -1,0 +1,10 @@
+import { formatActionDetails, type AuditLogEntry } from '@/hooks/use-audit-logs'
+
+type AssertFalse<T extends false> = T
+type IsAny<T> = 0 extends (1 & T) ? true : false
+
+type ActionDetails = NonNullable<AuditLogEntry['action_details']>
+type FormatActionDetailsArg = Exclude<Parameters<typeof formatActionDetails>[1], null>
+
+type _auditLogActionDetailsValueNotAny = AssertFalse<IsAny<ActionDetails[string]>>
+type _formatActionDetailsArgValueNotAny = AssertFalse<IsAny<FormatActionDetailsArg[string]>>

--- a/src/hooks/use-audit-logs.types.assert.ts
+++ b/src/hooks/use-audit-logs.types.assert.ts
@@ -3,8 +3,8 @@ import { formatActionDetails, type AuditLogEntry } from '@/hooks/use-audit-logs'
 type AssertFalse<T extends false> = T
 type IsAny<T> = 0 extends (1 & T) ? true : false
 
-type ActionDetails = NonNullable<AuditLogEntry['action_details']>
-type FormatActionDetailsArg = Exclude<Parameters<typeof formatActionDetails>[1], null>
+type ActionDetailsRecord = Extract<NonNullable<AuditLogEntry['action_details']>, Record<string, unknown>>
+type FormatActionDetailsArgRecord = Extract<Exclude<Parameters<typeof formatActionDetails>[1], null>, Record<string, unknown>>
 
-type _auditLogActionDetailsValueNotAny = AssertFalse<IsAny<ActionDetails[string]>>
-type _formatActionDetailsArgValueNotAny = AssertFalse<IsAny<FormatActionDetailsArg[string]>>
+type _auditLogActionDetailsValueNotAny = AssertFalse<IsAny<ActionDetailsRecord[string]>>
+type _formatActionDetailsArgValueNotAny = AssertFalse<IsAny<FormatActionDetailsArgRecord[string]>>

--- a/src/lib/__tests__/audit_logs_utils.spec.ts
+++ b/src/lib/__tests__/audit_logs_utils.spec.ts
@@ -18,6 +18,10 @@ describe('Activity Logs utilities', () => {
     expect(text).toContain('Máy siêu âm A1')
   })
 
+  it('keeps legacy string details visible', () => {
+    expect(formatActionDetails('login_failed', 'Sai mật khẩu 3 lần')).toBe('Sai mật khẩu 3 lần')
+  })
+
   it('AuditLogEntry type includes entity fields (compile-time)', () => {
     const row: AuditLogEntry = {
       id: 1,
@@ -28,7 +32,7 @@ describe('Activity Logs utilities', () => {
       target_user_id: null,
       target_username: null,
       target_full_name: null,
-      action_details: { a: 1 },
+      action_details: 'Legacy audit payload',
       ip_address: null,
       user_agent: null,
       created_at: new Date().toISOString(),

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -3,9 +3,11 @@
  * This ensures Recharts is only loaded when actually needed for chart rendering
  */
 
+type RechartsModule = typeof import('recharts')
+
 // Type definitions for Recharts (to avoid importing the full library)
 export interface ChartData {
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export interface ChartProps {
@@ -20,23 +22,24 @@ export interface ChartProps {
   }
 }
 
-export interface RechartsComponents {
-  LineChart: any
-  BarChart: any
-  AreaChart: any
-  PieChart: any
-  ResponsiveContainer: any
-  XAxis: any
-  YAxis: any
-  CartesianGrid: any
-  Tooltip: any
-  Legend: any
-  Line: any
-  Bar: any
-  Area: any
-  Pie: any
-  Cell: any
-}
+export type RechartsComponents = Pick<
+  RechartsModule,
+  | 'LineChart'
+  | 'BarChart'
+  | 'AreaChart'
+  | 'PieChart'
+  | 'ResponsiveContainer'
+  | 'XAxis'
+  | 'YAxis'
+  | 'CartesianGrid'
+  | 'Tooltip'
+  | 'Legend'
+  | 'Line'
+  | 'Bar'
+  | 'Area'
+  | 'Pie'
+  | 'Cell'
+>
 
 /**
  * Dynamically import Recharts library only when needed
@@ -153,7 +156,7 @@ export function formatChartPercentage(value: number, total: number): string {
 /**
  * Generate chart data with proper formatting
  */
-export function processChartData<T extends Record<string, any>>(
+export function processChartData<T extends Record<string, unknown>>(
   data: T[],
   keyField: keyof T,
   valueField: keyof T,

--- a/src/lib/chart-utils.types.assert.ts
+++ b/src/lib/chart-utils.types.assert.ts
@@ -1,0 +1,8 @@
+import type { ChartData, RechartsComponents } from '@/lib/chart-utils'
+
+type AssertFalse<T extends false> = T
+type IsAny<T> = 0 extends (1 & T) ? true : false
+
+type _chartDataValueNotAny = AssertFalse<IsAny<ChartData[string]>>
+type _lineChartNotAny = AssertFalse<IsAny<RechartsComponents['LineChart']>>
+type _tooltipNotAny = AssertFalse<IsAny<RechartsComponents['Tooltip']>>


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened types in audit log hooks and chart utilities to eliminate explicit `any`. Preserves legacy string audit details and switches to the shared RPC client without changing behavior.

- **Refactors**
  - Introduced `AuditActionDetails` and `AuditLogEntityType`; `action_details` now supports structured records or strings; `formatActionDetails` handles both.
  - Replaced custom fetch with shared `callRpc`; simplified role checks (`isGlobalRole(session?.user?.role)`).
  - Typed `recharts` via `Pick<typeof import('recharts')>`; `ChartData` now uses `unknown`; tightened `processChartData` generics; `DynamicChart` `customTooltip` is `React.FC<TooltipProps<number, string>>`.
  - Added `*.types.assert.ts` to guard against `any`; tests updated to ensure string details are displayed.

<sup>Written for commit 70f12e4a1e316973489a5b1350c0f3c13f76c0bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across charting and audit-logging code, tightening constraints and introducing stronger compile-time checks to reduce regressions.
* **Tests**
  * Added unit and type-assertion tests covering audit-details handling and chart type contracts to ensure legacy string payloads and component typings remain correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->