### PR TITLE
fix: centralize dynamic chart Recharts typing

### DIFF
--- a/src/components/dynamic-chart.tsx
+++ b/src/components/dynamic-chart.tsx
@@ -1,8 +1,12 @@
 "use client"
 
 import * as React from "react"
-import type { TooltipProps } from "recharts"
-import { loadChartsLibrary, type ChartData, type RechartsComponents } from "@/lib/chart-utils"
+import {
+  loadChartsLibrary,
+  type ChartData,
+  type ChartTooltipProps,
+  type RechartsComponents,
+} from "@/lib/chart-utils"
 import { ChartLoadingFallback, ChartErrorFallback } from "@/components/chart-fallbacks"
 import { buildPieSliceCells } from "@/lib/runtime-list-keys"
 
@@ -152,7 +156,7 @@ interface BarChartProps {
   showTooltip?: boolean
   showLegend?: boolean
   xAxisAngle?: number
-  customTooltip?: React.FC<TooltipProps<number, string>>
+  customTooltip?: React.FC<ChartTooltipProps<number, string>>
   margin?: {
     top?: number
     right?: number

--- a/src/components/interactive-equipment-chart.tsx
+++ b/src/components/interactive-equipment-chart.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { Filter, BarChart3, MapPin, Building2, X } from "lucide-react"
 import { DynamicBarChart } from "@/components/dynamic-chart"
+import type { ChartTooltipProps } from "@/lib/chart-utils"
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -25,18 +26,22 @@ interface InteractiveEquipmentChartProps {
   effectiveTenantKey?: string
 }
 
-type TooltipPayloadEntry = {
-  dataKey?: unknown
-  name?: unknown
-  color?: string
-  value?: number
-}
+type TooltipPayloadEntry = NonNullable<ChartTooltipProps<number, string>['payload']>[number]
 
 // Custom tooltip component — memoized to avoid re-computing keyed entries on unchanged payload
-const CustomTooltip = React.memo(function CustomTooltip({ active, payload, label }: any) {
-  if (active && payload && payload.length) {
-    const total = payload.reduce((sum: number, entry: any) => sum + entry.value, 0)
-    const keyedPayload = buildKeyedTooltipEntries<TooltipPayloadEntry>(payload as TooltipPayloadEntry[])
+const CustomTooltip = React.memo(function CustomTooltip({
+  active,
+  payload,
+  label,
+}: ChartTooltipProps<number, string>) {
+  const tooltipEntries = payload ?? []
+
+  if (active && tooltipEntries.length > 0) {
+    const total = tooltipEntries.reduce(
+      (sum, entry) => sum + (typeof entry.value === 'number' ? entry.value : 0),
+      0,
+    )
+    const keyedPayload = buildKeyedTooltipEntries<TooltipPayloadEntry>(tooltipEntries)
     
     return (
       <div className="bg-background border rounded-lg shadow-lg p-3 min-w-[200px]">

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -5,6 +5,9 @@
 
 type RechartsModule = typeof import('recharts')
 
+export type ChartTooltipProps<TValue extends number | string, TName extends string> =
+  import('recharts').TooltipProps<TValue, TName>
+
 // Type definitions for Recharts (to avoid importing the full library)
 export interface ChartData {
   [key: string]: unknown

--- a/src/lib/chart-utils.types.assert.ts
+++ b/src/lib/chart-utils.types.assert.ts
@@ -1,4 +1,4 @@
-import type { ChartData, RechartsComponents } from '@/lib/chart-utils'
+import type { ChartData, ChartTooltipProps, RechartsComponents } from '@/lib/chart-utils'
 
 type AssertFalse<T extends false> = T
 type IsAny<T> = 0 extends (1 & T) ? true : false
@@ -6,3 +6,4 @@ type IsAny<T> = 0 extends (1 & T) ? true : false
 type _chartDataValueNotAny = AssertFalse<IsAny<ChartData[string]>>
 type _lineChartNotAny = AssertFalse<IsAny<RechartsComponents['LineChart']>>
 type _tooltipNotAny = AssertFalse<IsAny<RechartsComponents['Tooltip']>>
+type _tooltipPropsNotAny = AssertFalse<IsAny<ChartTooltipProps<number, string>>>


### PR DESCRIPTION
## Summary
- centralize the shared Recharts tooltip type in \\src/lib/chart-utils.ts\\
- remove the direct \\echarts\\ import from \\src/components/dynamic-chart.tsx\\
- tighten \\CustomTooltip\\ typing in \\src/components/interactive-equipment-chart.tsx\\ without changing runtime behavior

## Verification
- \\
ode scripts/npm-run.js run verify:no-explicit-any\\
- \\
ode scripts/npm-run.js run typecheck\\
- \\
ode scripts/npm-run.js npx vitest run src/components/__tests__/equipment-distribution-summary.donut.test.tsx src/components/__tests__/unified-inventory-chart.hooks-and-modes.test.tsx\\
- \\
ode scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main\\

Closes #232

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes `recharts` tooltip types and removes direct `recharts` imports to resolve the dynamic-chart warning in #232. Tightens `CustomTooltip` typing without changing behavior.

- **Refactors**
  - Added ChartTooltipProps in src/lib/chart-utils.ts and updated DynamicBarChart/InteractiveEquipmentChart to use it; removed direct `recharts` imports.
  - Strengthened CustomTooltip typing and payload handling; added type assertions to prevent any.

<sup>Written for commit b961aef735e2738227916722b105459cacb93077. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for chart tooltip components across the application
  * Enhanced null-safety checks in tooltip rendering logic to handle edge cases more robustly

* **Tests**
  * Added type assertion tests for tooltip prop types to ensure type correctness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->