### PR TITLE
fix: tighten runtime explicit-any quick wins

### DIFF
--- a/src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockToast = vi.fn()
+const mockCreateMultiSheetExcel = vi.fn()
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}))
+
+vi.mock('@/lib/excel-utils', () => ({
+  createMultiSheetExcel: (...args: unknown[]) => mockCreateMultiSheetExcel(...args),
+}))
+
+import { ExportReportDialog } from '../export-report-dialog'
+
+describe('ExportReportDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateMultiSheetExcel.mockReset()
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+
+  it('surfaces string export errors in the destructive toast', async () => {
+    mockCreateMultiSheetExcel.mockRejectedValueOnce('Không thể ghi file Excel')
+
+    render(
+      <ExportReportDialog
+        open
+        onOpenChange={vi.fn()}
+        data={[
+          {
+            ngay_nhap: '2026-01-02',
+            ma_thiet_bi: 'TB-001',
+            ten_thiet_bi: 'Máy đo',
+            model: null,
+            serial: null,
+            khoa_phong_quan_ly: 'Khoa A',
+            type: 'import',
+            source: 'manual',
+            reason: null,
+            destination: null,
+            value: null,
+          },
+        ]}
+        summary={{
+          totalImported: 1,
+          totalExported: 0,
+          currentStock: 1,
+          netChange: 1,
+        }}
+        dateRange={{
+          from: new Date('2026-01-01T00:00:00.000Z'),
+          to: new Date('2026-01-31T00:00:00.000Z'),
+        }}
+        department="all"
+      />
+    )
+
+    const exportButton = await screen.findByRole('button', { name: /xuất excel/i })
+    fireEvent.click(exportButton)
+
+    await waitFor(() => {
+      expect(mockCreateMultiSheetExcel).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        variant: 'destructive',
+        title: 'Lỗi xuất báo cáo',
+        description: 'Không thể ghi file Excel',
+      })
+    })
+  })
+})

--- a/src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx
@@ -165,4 +165,87 @@ describe('ExportReportDialog', () => {
       { 'Khoa/Phòng': 'Khoa B', 'Nhập': 1, 'Xuất': 0, 'Tổng': 1 },
     ])
   })
+
+  it('keeps the khac status in distribution export sheets', async () => {
+    mockCreateMultiSheetExcel.mockResolvedValueOnce(undefined)
+
+    render(
+      <ExportReportDialog
+        open
+        onOpenChange={vi.fn()}
+        data={[]}
+        summary={{
+          totalImported: 0,
+          totalExported: 0,
+          currentStock: 10,
+          netChange: 0,
+        }}
+        dateRange={{
+          from: new Date('2026-01-01T00:00:00.000Z'),
+          to: new Date('2026-01-31T00:00:00.000Z'),
+        }}
+        department="all"
+        distribution={{
+          totalEquipment: 10,
+          departments: ['Khoa A'],
+          locations: ['Kho A'],
+          byDepartment: [
+            {
+              name: 'Khoa A',
+              total: 10,
+              hoat_dong: 4,
+              cho_sua_chua: 2,
+              cho_bao_tri: 1,
+              cho_hieu_chuan: 1,
+              ngung_su_dung: 1,
+              chua_co_nhu_cau: 0,
+              khac: 1,
+            },
+          ],
+          byLocation: [
+            {
+              name: 'Kho A',
+              total: 10,
+              hoat_dong: 4,
+              cho_sua_chua: 2,
+              cho_bao_tri: 1,
+              cho_hieu_chuan: 1,
+              ngung_su_dung: 1,
+              chua_co_nhu_cau: 0,
+              khac: 1,
+            },
+          ],
+        }}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /xuất excel/i }))
+
+    await waitFor(() => {
+      expect(mockCreateMultiSheetExcel).toHaveBeenCalled()
+    })
+
+    const [sheets] = mockCreateMultiSheetExcel.mock.calls[0] as [Array<{ name: string; data: unknown }>, string]
+    const overviewSheet = sheets.find((sheet) => sheet.name === 'Phân bố trạng thái')
+    const byDepartmentSheet = sheets.find((sheet) => sheet.name === 'Trạng thái theo khoa')
+
+    expect(overviewSheet?.data).toEqual(
+      expect.arrayContaining([
+        { 'Trạng thái': 'Khác', 'Số lượng': 1, 'Tỷ lệ (%)': 10 },
+      ])
+    )
+    expect(byDepartmentSheet?.data).toEqual([
+      {
+        'Khoa/Phòng': 'Khoa A',
+        'Hoạt động': 4,
+        'Chờ sửa chữa': 2,
+        'Chờ bảo trì': 1,
+        'Chờ HC/KĐ': 1,
+        'Ngừng sử dụng': 1,
+        'Chưa có nhu cầu': 0,
+        'Khác': 1,
+        'Tổng': 10,
+      },
+    ])
+  })
 })

--- a/src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx
@@ -87,4 +87,82 @@ describe('ExportReportDialog', () => {
       })
     })
   })
+
+  it('keeps transaction statistics sorted by total descending in the export payload', async () => {
+    mockCreateMultiSheetExcel.mockResolvedValueOnce(undefined)
+
+    render(
+      <ExportReportDialog
+        open
+        onOpenChange={vi.fn()}
+        data={[
+          {
+            ngay_nhap: '2026-01-02',
+            ma_thiet_bi: 'TB-001',
+            ten_thiet_bi: 'Máy đo',
+            model: null,
+            serial: null,
+            khoa_phong_quan_ly: 'Khoa A',
+            type: 'import',
+            source: 'manual',
+            reason: null,
+            destination: null,
+            value: null,
+          },
+          {
+            ngay_nhap: '2026-01-03',
+            ma_thiet_bi: 'TB-002',
+            ten_thiet_bi: 'Máy siêu âm',
+            model: null,
+            serial: null,
+            khoa_phong_quan_ly: 'Khoa B',
+            type: 'import',
+            source: 'manual',
+            reason: null,
+            destination: null,
+            value: null,
+          },
+          {
+            ngay_nhap: '2026-01-04',
+            ma_thiet_bi: 'TB-003',
+            ten_thiet_bi: 'Máy thở',
+            model: null,
+            serial: null,
+            khoa_phong_quan_ly: 'Khoa A',
+            type: 'export',
+            source: 'manual',
+            reason: 'Điều chuyển',
+            destination: 'Kho B',
+            value: null,
+          },
+        ]}
+        summary={{
+          totalImported: 2,
+          totalExported: 1,
+          currentStock: 1,
+          netChange: 1,
+        }}
+        dateRange={{
+          from: new Date('2026-01-01T00:00:00.000Z'),
+          to: new Date('2026-01-31T00:00:00.000Z'),
+        }}
+        department="all"
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: /xuất excel/i }))
+
+    await waitFor(() => {
+      expect(mockCreateMultiSheetExcel).toHaveBeenCalled()
+    })
+
+    const [sheets] = mockCreateMultiSheetExcel.mock.calls[0] as [Array<{ name: string; data: unknown }>, string]
+    const statsSheet = sheets.find((sheet) => sheet.name === 'Thống kê giao dịch')
+
+    expect(statsSheet).toBeDefined()
+    expect(statsSheet?.data).toEqual([
+      { 'Khoa/Phòng': 'Khoa A', 'Nhập': 1, 'Xuất': 1, 'Tổng': 2 },
+      { 'Khoa/Phòng': 'Khoa B', 'Nhập': 1, 'Xuất': 0, 'Tổng': 1 },
+    ])
+  })
 })

--- a/src/app/(app)/reports/components/export-report-dialog.tsx
+++ b/src/app/(app)/reports/components/export-report-dialog.tsx
@@ -5,6 +5,7 @@ import { Download, FileSpreadsheet, Loader2 } from "lucide-react"
 import { format } from "date-fns"
 import { vi } from "date-fns/locale"
 import { createMultiSheetExcel } from "@/lib/excel-utils"
+import { getUnknownErrorMessage } from "@/lib/error-utils"
 
 import {
   Dialog,
@@ -42,6 +43,31 @@ interface ExportReportDialogProps {
   usageAnalytics?: { overview: UsageOverview; daily: DailyUsageItem[] }
 }
 
+type ExportArrayCell = string | number
+type ExportArrayRow = ExportArrayCell[]
+type ExportJsonValue = string | number | null
+type ExportJsonRow = Record<string, ExportJsonValue>
+type ExportJsonSheet = {
+  name: string
+  data: ExportJsonRow[]
+  type: "json"
+  columnWidths?: number[]
+}
+type ExportArraySheet = {
+  name: string
+  data: ExportArrayRow[]
+  type: "array"
+  columnWidths?: number[]
+}
+type ExportSheet = ExportJsonSheet | ExportArraySheet
+
+type StatisticsRow = Record<string, ExportJsonValue> & {
+  "Khoa/Phòng": string
+  "Nhập": number
+  "Xuất": number
+  "Tổng": number
+}
+
 export function ExportReportDialog({
   open,
   onOpenChange,
@@ -71,7 +97,7 @@ export function ExportReportDialog({
     setIsExporting(true)
     try {
       // Prepare summary sheet (array of arrays)
-      const summaryData: (string | number)[][] = [
+      const summaryData: ExportArrayRow[] = [
         ["BÁO CÁO TỔNG HỢP THIẾT BỊ"],
         [""],
         ["Thời gian:", `${format(dateRange.from, "dd/MM/yyyy")} - ${format(dateRange.to, "dd/MM/yyyy")}`],
@@ -105,8 +131,8 @@ export function ExportReportDialog({
       const statsData = generateStatistics(data)
 
       // Status distribution sheets (optional)
-      const statusSheets: Array<{ name: string; data: any[] | any[][]; type: 'json' | 'array'; columnWidths?: number[] }> = []
-      const extraSheets: Array<{ name: string; data: any[] | any[][]; type: 'json' | 'array'; columnWidths?: number[] }> = []
+      const statusSheets: ExportSheet[] = []
+      const extraSheets: ExportSheet[] = []
 
       if (distribution) {
         const total = distribution.totalEquipment || 0
@@ -247,12 +273,12 @@ export function ExportReportDialog({
       })
 
       onOpenChange(false)
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Export error:', error)
       toast({
         variant: "destructive",
         title: "Lỗi xuất báo cáo",
-        description: error?.message || "Không thể xuất báo cáo",
+        description: getUnknownErrorMessage(error, "Không thể xuất báo cáo"),
       })
     } finally {
       setIsExporting(false)
@@ -285,7 +311,7 @@ export function ExportReportDialog({
 
   const pct = (n: number, total: number) => (total > 0 ? Math.round((n * 1000) / total) / 10 : 0)
 
-  const generateStatistics = (rows: InventoryItem[]) => {
+  const generateStatistics = (rows: InventoryItem[]): StatisticsRow[] => {
     const deptStats = new Map<string, { nhap: number; xuat: number; tong: number }>()
     rows.forEach(item => {
       const dept = item.khoa_phong_quan_ly || "Chưa phân loại"
@@ -302,7 +328,7 @@ export function ExportReportDialog({
       "Nhập": s.nhap,
       "Xuất": s.xuat,
       "Tổng": s.tong,
-    })).sort((a, b) => b["Tổng"] - a["Tổng"]) as any[]
+    })).sort((a, b) => b["Tổng"] - a["Tổng"])
   }
 
   return (

--- a/src/app/(app)/reports/components/export-report-dialog.tsx
+++ b/src/app/(app)/reports/components/export-report-dialog.tsx
@@ -3,7 +3,6 @@
 import * as React from "react"
 import { Download, FileSpreadsheet, Loader2 } from "lucide-react"
 import { format } from "date-fns"
-import { vi } from "date-fns/locale"
 import { createMultiSheetExcel } from "@/lib/excel-utils"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
 
@@ -25,47 +24,18 @@ import { InventoryItem, InventorySummary } from "../hooks/use-inventory-data"
 import type { EquipmentDistributionData } from "@/hooks/use-equipment-distribution"
 import type { MaintenanceStats } from "../hooks/use-maintenance-stats"
 import type { UsageOverview, DailyUsageItem } from "../hooks/use-usage-analytics"
-
-interface DateRange {
-  from: Date
-  to: Date
-}
+import { buildExportSheets, type ExportReportDateRange } from "./export-report-dialog.utils"
 
 interface ExportReportDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   data: InventoryItem[]
   summary: InventorySummary
-  dateRange: DateRange
+  dateRange: ExportReportDateRange
   department: string
   distribution?: EquipmentDistributionData
   maintenanceStats?: MaintenanceStats
   usageAnalytics?: { overview: UsageOverview; daily: DailyUsageItem[] }
-}
-
-type ExportArrayCell = string | number
-type ExportArrayRow = ExportArrayCell[]
-type ExportJsonValue = string | number | null
-type ExportJsonRow = Record<string, ExportJsonValue>
-type ExportJsonSheet = {
-  name: string
-  data: ExportJsonRow[]
-  type: "json"
-  columnWidths?: number[]
-}
-type ExportArraySheet = {
-  name: string
-  data: ExportArrayRow[]
-  type: "array"
-  columnWidths?: number[]
-}
-type ExportSheet = ExportJsonSheet | ExportArraySheet
-
-type StatisticsRow = Record<string, ExportJsonValue> & {
-  "Khoa/Phòng": string
-  "Nhập": number
-  "Xuất": number
-  "Tổng": number
 }
 
 export function ExportReportDialog({
@@ -96,176 +66,18 @@ export function ExportReportDialog({
   const handleExport = async () => {
     setIsExporting(true)
     try {
-      // Prepare summary sheet (array of arrays)
-      const summaryData: ExportArrayRow[] = [
-        ["BÁO CÁO TỔNG HỢP THIẾT BỊ"],
-        [""],
-        ["Thời gian:", `${format(dateRange.from, "dd/MM/yyyy")} - ${format(dateRange.to, "dd/MM/yyyy")}`],
-        ["Khoa/Phòng:", department === "all" ? "Tất cả" : department],
-        ["Ngày xuất báo cáo:", format(new Date(), "dd/MM/yyyy HH:mm", { locale: vi })],
-        [""],
-        ["TỔNG QUAN"],
-        ["Thiết bị nhập:", summary.totalImported],
-        ["Thiết bị xuất:", summary.totalExported],
-        ["Tồn kho hiện tại:", summary.currentStock],
-        ["Biến động thuần:", summary.netChange >= 0 ? `+${summary.netChange}` : summary.netChange],
-        [""],
-        ["CHI TIẾT GIAO DỊCH"],
-      ]
-
-      // Prepare detailed data (JSON rows)
-      const detailedData = data.map(item => ({
-        "Ngày": format(new Date(item.ngay_nhap), "dd/MM/yyyy"),
-        "Mã thiết bị": item.ma_thiet_bi,
-        "Tên thiết bị": item.ten_thiet_bi,
-        "Model": item.model || "",
-        "Serial": item.serial || "",
-        "Khoa/Phòng": item.khoa_phong_quan_ly || "Chưa phân loại",
-        "Loại giao dịch": item.type === "import" ? "Nhập" : "Xuất",
-        "Nguồn/Hình thức": getSourceLabel(item.source),
-        "Lý do/Đích đến": item.reason || item.destination || "",
-        "Giá trị": item.value ?? "",
-      }))
-
-      // Transactional statistics per department
-      const statsData = generateStatistics(data)
-
-      // Status distribution sheets (optional)
-      const statusSheets: ExportSheet[] = []
-      const extraSheets: ExportSheet[] = []
-
-      if (distribution) {
-        const total = distribution.totalEquipment || 0
-
-        // Build overview rows from aggregated department sums
-        const totals = distribution.byDepartment.reduce(
-          (acc, d) => {
-            acc.hoat_dong += d.hoat_dong || 0
-            acc.cho_sua_chua += d.cho_sua_chua || 0
-            acc.cho_bao_tri += d.cho_bao_tri || 0
-            acc.cho_hieu_chuan += d.cho_hieu_chuan || 0
-            acc.ngung_su_dung += d.ngung_su_dung || 0
-            acc.chua_co_nhu_cau += d.chua_co_nhu_cau || 0
-            return acc
-          },
-          { hoat_dong: 0, cho_sua_chua: 0, cho_bao_tri: 0, cho_hieu_chuan: 0, ngung_su_dung: 0, chua_co_nhu_cau: 0 },
-        )
-
-        const statusOverview = [
-          { "Trạng thái": mapStatusLabel("hoat_dong"), "Số lượng": totals.hoat_dong, "Tỷ lệ (%)": pct(totals.hoat_dong, total) },
-          { "Trạng thái": mapStatusLabel("cho_sua_chua"), "Số lượng": totals.cho_sua_chua, "Tỷ lệ (%)": pct(totals.cho_sua_chua, total) },
-          { "Trạng thái": mapStatusLabel("cho_bao_tri"), "Số lượng": totals.cho_bao_tri, "Tỷ lệ (%)": pct(totals.cho_bao_tri, total) },
-          { "Trạng thái": mapStatusLabel("cho_hieu_chuan"), "Số lượng": totals.cho_hieu_chuan, "Tỷ lệ (%)": pct(totals.cho_hieu_chuan, total) },
-          { "Trạng thái": mapStatusLabel("ngung_su_dung"), "Số lượng": totals.ngung_su_dung, "Tỷ lệ (%)": pct(totals.ngung_su_dung, total) },
-          { "Trạng thái": mapStatusLabel("chua_co_nhu_cau"), "Số lượng": totals.chua_co_nhu_cau, "Tỷ lệ (%)": pct(totals.chua_co_nhu_cau, total) },
-        ]
-
-        statusSheets.push({
-          name: "Phân bố trạng thái",
-          data: statusOverview,
-          type: "json",
-          columnWidths: [28, 12, 12],
-        })
-
-        if (distribution.byDepartment.length > 0) {
-          const byDept = distribution.byDepartment.map(d => ({
-            "Khoa/Phòng": d.name,
-            "Hoạt động": d.hoat_dong,
-            "Chờ sửa chữa": d.cho_sua_chua,
-            "Chờ bảo trì": d.cho_bao_tri,
-            "Chờ HC/KĐ": d.cho_hieu_chuan,
-            "Ngừng sử dụng": d.ngung_su_dung,
-            "Chưa có nhu cầu": d.chua_co_nhu_cau,
-            "Tổng": d.total,
-          }))
-          statusSheets.push({
-            name: "Trạng thái theo khoa",
-            data: byDept,
-            type: "json",
-            columnWidths: [28, 12, 14, 12, 12, 14, 16, 10],
-          })
-        }
-
-        if (distribution.byLocation.length > 0) {
-          const byLoc = distribution.byLocation.map(l => ({
-            "Vị trí": l.name,
-            "Hoạt động": l.hoat_dong,
-            "Chờ sửa chữa": l.cho_sua_chua,
-            "Chờ bảo trì": l.cho_bao_tri,
-            "Chờ HC/KĐ": l.cho_hieu_chuan,
-            "Ngừng sử dụng": l.ngung_su_dung,
-            "Chưa có nhu cầu": l.chua_co_nhu_cau,
-            "Tổng": l.total,
-          }))
-          statusSheets.push({
-            name: "Trạng thái theo vị trí",
-            data: byLoc,
-            type: "json",
-            columnWidths: [24, 12, 14, 12, 12, 14, 16, 10],
-          })
-        }
-      }
-
-      // Maintenance/Repairs summary sheets (optional)
-      if (maintenanceStats) {
-        const repairRows = [
-          { "Chỉ số": "Tổng YC sửa chữa", "Giá trị": maintenanceStats.repair_summary.total_requests },
-          { "Chỉ số": "Hoàn thành", "Giá trị": maintenanceStats.repair_summary.completed },
-          { "Chỉ số": "Đang xử lý", "Giá trị": maintenanceStats.repair_summary.in_progress },
-          { "Chỉ số": "Chờ duyệt", "Giá trị": maintenanceStats.repair_summary.pending },
-        ]
-        extraSheets.push({ name: "Sửa chữa - Tổng quan", data: repairRows, type: "json", columnWidths: [30, 14] })
-
-        const maintenanceRows = [
-          { "Chỉ số": "Kế hoạch bảo trì", "Giá trị": maintenanceStats.maintenance_summary.total_plans },
-          { "Chỉ số": "Tổng công việc", "Giá trị": maintenanceStats.maintenance_summary.total_tasks },
-          { "Chỉ số": "Hoàn thành", "Giá trị": maintenanceStats.maintenance_summary.completed_tasks },
-        ]
-        extraSheets.push({ name: "Bảo trì - Tổng quan", data: maintenanceRows, type: "json", columnWidths: [30, 14] })
-      }
-
-      // Usage analytics sheets (optional)
-      if (usageAnalytics) {
-        const overview = [
-          { "Chỉ số": "Phiên sử dụng (tổng)", "Giá trị": usageAnalytics.overview.total_sessions },
-          { "Chỉ số": "Phiên đang hoạt động", "Giá trị": usageAnalytics.overview.active_sessions },
-          { "Chỉ số": "Thời gian sử dụng (phút)", "Giá trị": usageAnalytics.overview.total_usage_time },
-        ]
-        extraSheets.push({ name: "Sử dụng TB - Tổng quan", data: overview, type: "json", columnWidths: [36, 18] })
-
-        const daily = (usageAnalytics.daily || []).map(item => ({
-          "Ngày": item.date,
-          "Phiên": item.session_count,
-          "Thời gian (phút)": item.total_usage_time,
-          "Người dùng": item.unique_users,
-          "Thiết bị": item.unique_equipment,
-        }))
-        extraSheets.push({ name: "Sử dụng TB - Theo ngày", data: daily, type: "json", columnWidths: [14, 10, 16, 12, 12] })
-      }
-
-      // Create multi-sheet Excel file
-      await createMultiSheetExcel([
-        {
-          name: "Tổng quan",
-          data: summaryData,
-          type: "array",
-          columnWidths: [25, 30],
-        },
-        {
-          name: "Chi tiết giao dịch",
-          data: detailedData,
-          type: "json",
-          columnWidths: [12, 15, 30, 15, 15, 20, 15, 20, 25, 15],
-        },
-        {
-          name: "Thống kê giao dịch",
-          data: statsData,
-          type: "json",
-          columnWidths: [25, 15, 15, 15],
-        },
-        ...statusSheets,
-        ...extraSheets,
-      ], fileName)
+      await createMultiSheetExcel(
+        buildExportSheets({
+          data,
+          summary,
+          dateRange,
+          department,
+          distribution,
+          maintenanceStats,
+          usageAnalytics,
+        }),
+        fileName
+      )
 
       toast({
         title: "Xuất báo cáo thành công",
@@ -283,52 +95,6 @@ export function ExportReportDialog({
     } finally {
       setIsExporting(false)
     }
-  }
-
-  const getSourceLabel = (source: string) => {
-    const labels: Record<string, string> = {
-      manual: "Thêm thủ công",
-      excel: "Import Excel",
-      transfer_internal: "Luân chuyển nội bộ",
-      transfer_external: "Luân chuyển bên ngoài",
-      liquidation: "Thanh lý",
-    }
-    return labels[source] || source
-  }
-
-  const mapStatusLabel = (key: string) => {
-    const labels: Record<string, string> = {
-      hoat_dong: 'Hoạt động',
-      cho_sua_chua: 'Chờ sửa chữa',
-      cho_bao_tri: 'Chờ bảo trì',
-      cho_hieu_chuan: 'Chờ HC/KĐ',
-      ngung_su_dung: 'Ngừng sử dụng',
-      chua_co_nhu_cau: 'Chưa có nhu cầu',
-      khac: 'Khác',
-    }
-    return labels[key] || key
-  }
-
-  const pct = (n: number, total: number) => (total > 0 ? Math.round((n * 1000) / total) / 10 : 0)
-
-  const generateStatistics = (rows: InventoryItem[]): StatisticsRow[] => {
-    const deptStats = new Map<string, { nhap: number; xuat: number; tong: number }>()
-    rows.forEach(item => {
-      const dept = item.khoa_phong_quan_ly || "Chưa phân loại"
-      if (!deptStats.has(dept)) {
-        deptStats.set(dept, { nhap: 0, xuat: 0, tong: 0 })
-      }
-      const s = deptStats.get(dept)!
-      if (item.type === "import") s.nhap += 1
-      else s.xuat += 1
-      s.tong = s.nhap + s.xuat
-    })
-    return Array.from(deptStats.entries()).map(([dept, s]) => ({
-      "Khoa/Phòng": dept,
-      "Nhập": s.nhap,
-      "Xuất": s.xuat,
-      "Tổng": s.tong,
-    })).sort((a, b) => b["Tổng"] - a["Tổng"])
   }
 
   return (

--- a/src/app/(app)/reports/components/export-report-dialog.tsx
+++ b/src/app/(app)/reports/components/export-report-dialog.tsx
@@ -38,8 +38,35 @@ interface ExportReportDialogProps {
   usageAnalytics?: { overview: UsageOverview; daily: DailyUsageItem[] }
 }
 
-export function ExportReportDialog({
-  open,
+type ExportReportDialogContentProps = Omit<ExportReportDialogProps, "open"> & {
+  defaultFileName: string
+}
+
+function buildDefaultFileName(dateRange: ExportReportDateRange): string {
+  const fromDate = format(dateRange.from, "dd-MM-yyyy")
+  const toDate = format(dateRange.to, "dd-MM-yyyy")
+  return `BaoCao_TongHop_ThietBi_${fromDate}_${toDate}`
+}
+
+export function ExportReportDialog(props: ExportReportDialogProps) {
+  const { open, onOpenChange, ...contentProps } = props
+  const defaultFileName = buildDefaultFileName(props.dateRange)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <ExportReportDialogContent
+          key={defaultFileName}
+          {...contentProps}
+          defaultFileName={defaultFileName}
+          onOpenChange={onOpenChange}
+        />
+      ) : null}
+    </Dialog>
+  )
+}
+
+function ExportReportDialogContent({
   onOpenChange,
   data,
   summary,
@@ -48,22 +75,16 @@ export function ExportReportDialog({
   distribution,
   maintenanceStats,
   usageAnalytics,
-}: ExportReportDialogProps) {
+  defaultFileName,
+}: ExportReportDialogContentProps) {
   const { toast } = useToast()
   const [isExporting, setIsExporting] = React.useState(false)
-  const [fileName, setFileName] = React.useState("")
-
-  // Generate default filename
-  React.useEffect(() => {
-    if (open) {
-      const fromDate = format(dateRange.from, "dd-MM-yyyy")
-      const toDate = format(dateRange.to, "dd-MM-yyyy")
-      const defaultName = `BaoCao_TongHop_ThietBi_${fromDate}_${toDate}`
-      setFileName(defaultName)
-    }
-  }, [open, dateRange])
+  const [hasFileName, setHasFileName] = React.useState(true)
+  const fileNameInputRef = React.useRef<HTMLInputElement>(null)
 
   const handleExport = async () => {
+    const fileName = fileNameInputRef.current?.value ?? defaultFileName
+
     setIsExporting(true)
     try {
       await createMultiSheetExcel(
@@ -98,8 +119,7 @@ export function ExportReportDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
+    <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FileSpreadsheet className="h-5 w-5" />
@@ -147,8 +167,9 @@ export function ExportReportDialog({
             <Label htmlFor="filename">Tên file</Label>
             <Input
               id="filename"
-              value={fileName}
-              onChange={(e) => setFileName(e.target.value)}
+              ref={fileNameInputRef}
+              defaultValue={defaultFileName}
+              onChange={(e) => setHasFileName(e.target.value.trim().length > 0)}
               placeholder="Nhập tên file..."
             />
             <p className="text-xs text-muted-foreground">File sẽ được lưu với định dạng .xlsx</p>
@@ -159,13 +180,12 @@ export function ExportReportDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isExporting}>
             Hủy
           </Button>
-          <Button onClick={handleExport} disabled={isExporting || !fileName.trim()}>
+          <Button onClick={handleExport} disabled={isExporting || !hasFileName}>
             {isExporting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             <Download className="mr-2 h-4 w-4" />
             {isExporting ? "Đang xuất..." : "Xuất Excel"}
           </Button>
         </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    </DialogContent>
   )
 }

--- a/src/app/(app)/reports/components/export-report-dialog.utils.ts
+++ b/src/app/(app)/reports/components/export-report-dialog.utils.ts
@@ -1,0 +1,321 @@
+import { format } from "date-fns"
+import { vi } from "date-fns/locale"
+import type { EquipmentDistributionData } from "@/hooks/use-equipment-distribution"
+import type { MaintenanceStats } from "../hooks/use-maintenance-stats"
+import type { UsageOverview, DailyUsageItem } from "../hooks/use-usage-analytics"
+import type { InventoryItem, InventorySummary } from "../hooks/use-inventory-data"
+
+export interface ExportReportDateRange {
+  from: Date
+  to: Date
+}
+
+type ExportArrayCell = string | number
+type ExportArrayRow = ExportArrayCell[]
+type ExportJsonValue = string | number | null
+type ExportJsonRow = Record<string, ExportJsonValue>
+
+type ExportJsonSheet = {
+  name: string
+  data: ExportJsonRow[]
+  type: "json"
+  columnWidths?: number[]
+}
+
+type ExportArraySheet = {
+  name: string
+  data: ExportArrayRow[]
+  type: "array"
+  columnWidths?: number[]
+}
+
+export type ExportSheet = ExportJsonSheet | ExportArraySheet
+
+type StatisticsRow = Record<string, ExportJsonValue> & {
+  "Khoa/Phòng": string
+  "Nhập": number
+  "Xuất": number
+  "Tổng": number
+}
+
+type BuildExportSheetsArgs = {
+  data: InventoryItem[]
+  summary: InventorySummary
+  dateRange: ExportReportDateRange
+  department: string
+  distribution?: EquipmentDistributionData
+  maintenanceStats?: MaintenanceStats
+  usageAnalytics?: { overview: UsageOverview; daily: DailyUsageItem[] }
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  manual: "Thêm thủ công",
+  excel: "Import Excel",
+  transfer_internal: "Luân chuyển nội bộ",
+  transfer_external: "Luân chuyển bên ngoài",
+  liquidation: "Thanh lý",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  hoat_dong: 'Hoạt động',
+  cho_sua_chua: 'Chờ sửa chữa',
+  cho_bao_tri: 'Chờ bảo trì',
+  cho_hieu_chuan: 'Chờ HC/KĐ',
+  ngung_su_dung: 'Ngừng sử dụng',
+  chua_co_nhu_cau: 'Chưa có nhu cầu',
+  khac: 'Khác',
+}
+
+function getSourceLabel(source: string) {
+  return SOURCE_LABELS[source] || source
+}
+
+function mapStatusLabel(key: string) {
+  return STATUS_LABELS[key] || key
+}
+
+function pct(value: number, total: number) {
+  return total > 0 ? Math.round((value * 1000) / total) / 10 : 0
+}
+
+function generateStatistics(rows: InventoryItem[]): StatisticsRow[] {
+  const deptStats = new Map<string, { nhap: number; xuat: number; tong: number }>()
+
+  rows.forEach((item) => {
+    const dept = item.khoa_phong_quan_ly || "Chưa phân loại"
+    if (!deptStats.has(dept)) {
+      deptStats.set(dept, { nhap: 0, xuat: 0, tong: 0 })
+    }
+
+    const stats = deptStats.get(dept)
+    if (!stats) {
+      return
+    }
+
+    if (item.type === "import") stats.nhap += 1
+    else stats.xuat += 1
+    stats.tong = stats.nhap + stats.xuat
+  })
+
+  return Array.from(deptStats.entries())
+    .map(([dept, stats]) => ({
+      "Khoa/Phòng": dept,
+      "Nhập": stats.nhap,
+      "Xuất": stats.xuat,
+      "Tổng": stats.tong,
+    }))
+    .sort((a, b) => b["Tổng"] - a["Tổng"])
+}
+
+function buildSummarySheet(
+  summary: InventorySummary,
+  dateRange: ExportReportDateRange,
+  department: string
+): ExportArraySheet {
+  return {
+    name: "Tổng quan",
+    data: [
+      ["BÁO CÁO TỔNG HỢP THIẾT BỊ"],
+      [""],
+      ["Thời gian:", `${format(dateRange.from, "dd/MM/yyyy")} - ${format(dateRange.to, "dd/MM/yyyy")}`],
+      ["Khoa/Phòng:", department === "all" ? "Tất cả" : department],
+      ["Ngày xuất báo cáo:", format(new Date(), "dd/MM/yyyy HH:mm", { locale: vi })],
+      [""],
+      ["TỔNG QUAN"],
+      ["Thiết bị nhập:", summary.totalImported],
+      ["Thiết bị xuất:", summary.totalExported],
+      ["Tồn kho hiện tại:", summary.currentStock],
+      ["Biến động thuần:", summary.netChange >= 0 ? `+${summary.netChange}` : summary.netChange],
+      [""],
+      ["CHI TIẾT GIAO DỊCH"],
+    ],
+    type: "array",
+    columnWidths: [25, 30],
+  }
+}
+
+function buildDetailedTransactionsSheet(data: InventoryItem[]): ExportJsonSheet {
+  return {
+    name: "Chi tiết giao dịch",
+    data: data.map((item) => ({
+      "Ngày": format(new Date(item.ngay_nhap), "dd/MM/yyyy"),
+      "Mã thiết bị": item.ma_thiet_bi,
+      "Tên thiết bị": item.ten_thiet_bi,
+      "Model": item.model || "",
+      "Serial": item.serial || "",
+      "Khoa/Phòng": item.khoa_phong_quan_ly || "Chưa phân loại",
+      "Loại giao dịch": item.type === "import" ? "Nhập" : "Xuất",
+      "Nguồn/Hình thức": getSourceLabel(item.source),
+      "Lý do/Đích đến": item.reason || item.destination || "",
+      "Giá trị": item.value ?? "",
+    })),
+    type: "json",
+    columnWidths: [12, 15, 30, 15, 15, 20, 15, 20, 25, 15],
+  }
+}
+
+function buildStatisticsSheet(data: InventoryItem[]): ExportJsonSheet {
+  return {
+    name: "Thống kê giao dịch",
+    data: generateStatistics(data),
+    type: "json",
+    columnWidths: [25, 15, 15, 15],
+  }
+}
+
+function buildDistributionSheets(distribution?: EquipmentDistributionData): ExportSheet[] {
+  if (!distribution) {
+    return []
+  }
+
+  const sheets: ExportSheet[] = []
+  const total = distribution.totalEquipment || 0
+  const totals = distribution.byDepartment.reduce(
+    (acc, department) => {
+      acc.hoat_dong += department.hoat_dong || 0
+      acc.cho_sua_chua += department.cho_sua_chua || 0
+      acc.cho_bao_tri += department.cho_bao_tri || 0
+      acc.cho_hieu_chuan += department.cho_hieu_chuan || 0
+      acc.ngung_su_dung += department.ngung_su_dung || 0
+      acc.chua_co_nhu_cau += department.chua_co_nhu_cau || 0
+      return acc
+    },
+    { hoat_dong: 0, cho_sua_chua: 0, cho_bao_tri: 0, cho_hieu_chuan: 0, ngung_su_dung: 0, chua_co_nhu_cau: 0 },
+  )
+
+  sheets.push({
+    name: "Phân bố trạng thái",
+    data: [
+      { "Trạng thái": mapStatusLabel("hoat_dong"), "Số lượng": totals.hoat_dong, "Tỷ lệ (%)": pct(totals.hoat_dong, total) },
+      { "Trạng thái": mapStatusLabel("cho_sua_chua"), "Số lượng": totals.cho_sua_chua, "Tỷ lệ (%)": pct(totals.cho_sua_chua, total) },
+      { "Trạng thái": mapStatusLabel("cho_bao_tri"), "Số lượng": totals.cho_bao_tri, "Tỷ lệ (%)": pct(totals.cho_bao_tri, total) },
+      { "Trạng thái": mapStatusLabel("cho_hieu_chuan"), "Số lượng": totals.cho_hieu_chuan, "Tỷ lệ (%)": pct(totals.cho_hieu_chuan, total) },
+      { "Trạng thái": mapStatusLabel("ngung_su_dung"), "Số lượng": totals.ngung_su_dung, "Tỷ lệ (%)": pct(totals.ngung_su_dung, total) },
+      { "Trạng thái": mapStatusLabel("chua_co_nhu_cau"), "Số lượng": totals.chua_co_nhu_cau, "Tỷ lệ (%)": pct(totals.chua_co_nhu_cau, total) },
+    ],
+    type: "json",
+    columnWidths: [28, 12, 12],
+  })
+
+  if (distribution.byDepartment.length > 0) {
+    sheets.push({
+      name: "Trạng thái theo khoa",
+      data: distribution.byDepartment.map((department) => ({
+        "Khoa/Phòng": department.name,
+        "Hoạt động": department.hoat_dong,
+        "Chờ sửa chữa": department.cho_sua_chua,
+        "Chờ bảo trì": department.cho_bao_tri,
+        "Chờ HC/KĐ": department.cho_hieu_chuan,
+        "Ngừng sử dụng": department.ngung_su_dung,
+        "Chưa có nhu cầu": department.chua_co_nhu_cau,
+        "Tổng": department.total,
+      })),
+      type: "json",
+      columnWidths: [28, 12, 14, 12, 12, 14, 16, 10],
+    })
+  }
+
+  if (distribution.byLocation.length > 0) {
+    sheets.push({
+      name: "Trạng thái theo vị trí",
+      data: distribution.byLocation.map((location) => ({
+        "Vị trí": location.name,
+        "Hoạt động": location.hoat_dong,
+        "Chờ sửa chữa": location.cho_sua_chua,
+        "Chờ bảo trì": location.cho_bao_tri,
+        "Chờ HC/KĐ": location.cho_hieu_chuan,
+        "Ngừng sử dụng": location.ngung_su_dung,
+        "Chưa có nhu cầu": location.chua_co_nhu_cau,
+        "Tổng": location.total,
+      })),
+      type: "json",
+      columnWidths: [24, 12, 14, 12, 12, 14, 16, 10],
+    })
+  }
+
+  return sheets
+}
+
+function buildMaintenanceSheets(maintenanceStats?: MaintenanceStats): ExportSheet[] {
+  if (!maintenanceStats) {
+    return []
+  }
+
+  return [
+    {
+      name: "Sửa chữa - Tổng quan",
+      data: [
+        { "Chỉ số": "Tổng YC sửa chữa", "Giá trị": maintenanceStats.repair_summary.total_requests },
+        { "Chỉ số": "Hoàn thành", "Giá trị": maintenanceStats.repair_summary.completed },
+        { "Chỉ số": "Đang xử lý", "Giá trị": maintenanceStats.repair_summary.in_progress },
+        { "Chỉ số": "Chờ duyệt", "Giá trị": maintenanceStats.repair_summary.pending },
+      ],
+      type: "json",
+      columnWidths: [30, 14],
+    },
+    {
+      name: "Bảo trì - Tổng quan",
+      data: [
+        { "Chỉ số": "Kế hoạch bảo trì", "Giá trị": maintenanceStats.maintenance_summary.total_plans },
+        { "Chỉ số": "Tổng công việc", "Giá trị": maintenanceStats.maintenance_summary.total_tasks },
+        { "Chỉ số": "Hoàn thành", "Giá trị": maintenanceStats.maintenance_summary.completed_tasks },
+      ],
+      type: "json",
+      columnWidths: [30, 14],
+    },
+  ]
+}
+
+function buildUsageSheets(
+  usageAnalytics?: { overview: UsageOverview; daily: DailyUsageItem[] }
+): ExportSheet[] {
+  if (!usageAnalytics) {
+    return []
+  }
+
+  return [
+    {
+      name: "Sử dụng TB - Tổng quan",
+      data: [
+        { "Chỉ số": "Phiên sử dụng (tổng)", "Giá trị": usageAnalytics.overview.total_sessions },
+        { "Chỉ số": "Phiên đang hoạt động", "Giá trị": usageAnalytics.overview.active_sessions },
+        { "Chỉ số": "Thời gian sử dụng (phút)", "Giá trị": usageAnalytics.overview.total_usage_time },
+      ],
+      type: "json",
+      columnWidths: [36, 18],
+    },
+    {
+      name: "Sử dụng TB - Theo ngày",
+      data: (usageAnalytics.daily || []).map((item) => ({
+        "Ngày": item.date,
+        "Phiên": item.session_count,
+        "Thời gian (phút)": item.total_usage_time,
+        "Người dùng": item.unique_users,
+        "Thiết bị": item.unique_equipment,
+      })),
+      type: "json",
+      columnWidths: [14, 10, 16, 12, 12],
+    },
+  ]
+}
+
+export function buildExportSheets(args: BuildExportSheetsArgs): ExportSheet[] {
+  const {
+    data,
+    summary,
+    dateRange,
+    department,
+    distribution,
+    maintenanceStats,
+    usageAnalytics,
+  } = args
+
+  return [
+    buildSummarySheet(summary, dateRange, department),
+    buildDetailedTransactionsSheet(data),
+    buildStatisticsSheet(data),
+    ...buildDistributionSheets(distribution),
+    ...buildMaintenanceSheets(maintenanceStats),
+    ...buildUsageSheets(usageAnalytics),
+  ]
+}

--- a/src/app/(app)/reports/components/export-report-dialog.utils.ts
+++ b/src/app/(app)/reports/components/export-report-dialog.utils.ts
@@ -178,9 +178,10 @@ function buildDistributionSheets(distribution?: EquipmentDistributionData): Expo
       acc.cho_hieu_chuan += department.cho_hieu_chuan || 0
       acc.ngung_su_dung += department.ngung_su_dung || 0
       acc.chua_co_nhu_cau += department.chua_co_nhu_cau || 0
+      acc.khac += department.khac || 0
       return acc
     },
-    { hoat_dong: 0, cho_sua_chua: 0, cho_bao_tri: 0, cho_hieu_chuan: 0, ngung_su_dung: 0, chua_co_nhu_cau: 0 },
+    { hoat_dong: 0, cho_sua_chua: 0, cho_bao_tri: 0, cho_hieu_chuan: 0, ngung_su_dung: 0, chua_co_nhu_cau: 0, khac: 0 },
   )
 
   sheets.push({
@@ -192,6 +193,7 @@ function buildDistributionSheets(distribution?: EquipmentDistributionData): Expo
       { "Trạng thái": mapStatusLabel("cho_hieu_chuan"), "Số lượng": totals.cho_hieu_chuan, "Tỷ lệ (%)": pct(totals.cho_hieu_chuan, total) },
       { "Trạng thái": mapStatusLabel("ngung_su_dung"), "Số lượng": totals.ngung_su_dung, "Tỷ lệ (%)": pct(totals.ngung_su_dung, total) },
       { "Trạng thái": mapStatusLabel("chua_co_nhu_cau"), "Số lượng": totals.chua_co_nhu_cau, "Tỷ lệ (%)": pct(totals.chua_co_nhu_cau, total) },
+      { "Trạng thái": mapStatusLabel("khac"), "Số lượng": totals.khac, "Tỷ lệ (%)": pct(totals.khac, total) },
     ],
     type: "json",
     columnWidths: [28, 12, 12],
@@ -208,10 +210,11 @@ function buildDistributionSheets(distribution?: EquipmentDistributionData): Expo
         "Chờ HC/KĐ": department.cho_hieu_chuan,
         "Ngừng sử dụng": department.ngung_su_dung,
         "Chưa có nhu cầu": department.chua_co_nhu_cau,
+        "Khác": department.khac || 0,
         "Tổng": department.total,
       })),
       type: "json",
-      columnWidths: [28, 12, 14, 12, 12, 14, 16, 10],
+      columnWidths: [28, 12, 14, 12, 12, 14, 16, 10, 10],
     })
   }
 
@@ -226,10 +229,11 @@ function buildDistributionSheets(distribution?: EquipmentDistributionData): Expo
         "Chờ HC/KĐ": location.cho_hieu_chuan,
         "Ngừng sử dụng": location.ngung_su_dung,
         "Chưa có nhu cầu": location.chua_co_nhu_cau,
+        "Khác": location.khac || 0,
         "Tổng": location.total,
       })),
       type: "json",
-      columnWidths: [24, 12, 14, 12, 12, 14, 16, 10],
+      columnWidths: [24, 12, 14, 12, 12, 14, 16, 10, 10],
     })
   }
 

--- a/src/hooks/__tests__/use-cached-repair.error-handling.test.ts
+++ b/src/hooks/__tests__/use-cached-repair.error-handling.test.ts
@@ -4,22 +4,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockToast = vi.fn()
-const mockSingle = vi.fn()
+const mockCallRpc = vi.fn()
 
 vi.mock('@/hooks/use-toast', () => ({
   toast: (args: unknown) => mockToast(args),
 }))
 
-vi.mock('@/lib/supabase', () => ({
-  supabase: {
-    from: () => ({
-      insert: () => ({
-        select: () => ({
-          single: () => mockSingle(),
-        }),
-      }),
-    }),
-  },
+vi.mock('@/lib/rpc-client', () => ({
+  callRpc: (...args: unknown[]) => mockCallRpc(...args),
 }))
 
 import { useCreateRepairRequest } from '../use-cached-repair'
@@ -42,14 +34,11 @@ function createWrapper(queryClient: QueryClient) {
 describe('use-cached-repair error handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockSingle.mockReset()
+    mockCallRpc.mockReset()
   })
 
-  it('surfaces string errors from create mutation in the destructive toast', async () => {
-    mockSingle.mockResolvedValueOnce({
-      data: null,
-      error: 'Không có quyền tạo yêu cầu sửa chữa',
-    })
+  it('routes create mutation through callRpc and surfaces string errors in the destructive toast', async () => {
+    mockCallRpc.mockRejectedValueOnce('Không có quyền tạo yêu cầu sửa chữa')
 
     const queryClient = createQueryClient()
     const { result } = renderHook(() => useCreateRepairRequest(), {
@@ -58,12 +47,26 @@ describe('use-cached-repair error handling', () => {
 
     act(() => {
       result.current.mutate({
+        thiet_bi_id: 42,
         mo_ta_su_co: 'Màn hình tối',
       })
     })
 
     await waitFor(() => {
       expect(result.current.isError).toBe(true)
+    })
+
+    expect(mockCallRpc).toHaveBeenCalledWith({
+      fn: 'repair_request_create',
+      args: {
+        p_thiet_bi_id: 42,
+        p_mo_ta_su_co: 'Màn hình tối',
+        p_hang_muc_sua_chua: null,
+        p_ngay_mong_muon_hoan_thanh: null,
+        p_nguoi_yeu_cau: null,
+        p_don_vi_thuc_hien: null,
+        p_ten_don_vi_thue: null,
+      },
     })
 
     expect(mockToast).toHaveBeenCalledWith({

--- a/src/hooks/__tests__/use-cached-repair.error-handling.test.ts
+++ b/src/hooks/__tests__/use-cached-repair.error-handling.test.ts
@@ -1,0 +1,75 @@
+import * as React from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockToast = vi.fn()
+const mockSingle = vi.fn()
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: (args: unknown) => mockToast(args),
+}))
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: () => ({
+      insert: () => ({
+        select: () => ({
+          single: () => mockSingle(),
+        }),
+      }),
+    }),
+  },
+}))
+
+import { useCreateRepairRequest } from '../use-cached-repair'
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe('use-cached-repair error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSingle.mockReset()
+  })
+
+  it('surfaces string errors from create mutation in the destructive toast', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: null,
+      error: 'Không có quyền tạo yêu cầu sửa chữa',
+    })
+
+    const queryClient = createQueryClient()
+    const { result } = renderHook(() => useCreateRepairRequest(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    act(() => {
+      result.current.mutate({
+        mo_ta_su_co: 'Màn hình tối',
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Lỗi',
+      description: 'Không có quyền tạo yêu cầu sửa chữa',
+      variant: 'destructive',
+    })
+  })
+})

--- a/src/hooks/__tests__/use-usage-logs.error-handling.test.ts
+++ b/src/hooks/__tests__/use-usage-logs.error-handling.test.ts
@@ -1,0 +1,65 @@
+import * as React from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCallRpc = vi.fn()
+const mockToast = vi.fn()
+
+vi.mock('@/lib/rpc-client', () => ({
+  callRpc: (args: unknown) => mockCallRpc(args),
+}))
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: (args: unknown) => mockToast(args),
+}))
+
+import { useStartUsageSession } from '../use-usage-logs'
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe('use-usage-logs error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCallRpc.mockReset()
+  })
+
+  it('surfaces string errors from start-session mutation in the destructive toast', async () => {
+    mockCallRpc.mockRejectedValueOnce('Thiết bị đang được sử dụng')
+
+    const queryClient = createQueryClient()
+    const { result } = renderHook(() => useStartUsageSession(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    act(() => {
+      result.current.mutate({
+        thiet_bi_id: 1,
+        nguoi_su_dung_id: 2,
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: 'destructive',
+      title: 'Lỗi',
+      description: 'Thiết bị đang được sử dụng',
+    })
+  })
+})

--- a/src/hooks/use-cached-repair.complete.typecheck.ts
+++ b/src/hooks/use-cached-repair.complete.typecheck.ts
@@ -1,0 +1,29 @@
+import { useCompleteRepairRequest } from '@/hooks/use-cached-repair'
+
+type CompleteRepairRequestVariables = Parameters<
+  ReturnType<typeof useCompleteRepairRequest>['mutate']
+>[0]
+
+const validCompleteParams: CompleteRepairRequestVariables = {
+  id: '123',
+  ket_qua: 'Đã xử lý',
+  ghi_chu: 'Hoàn tất',
+}
+
+void validCompleteParams
+
+const invalidWithAssignee: CompleteRepairRequestVariables = {
+  id: '123',
+  // @ts-expect-error RPC-backed completion should not accept legacy direct-table assignee field.
+  nguoi_xu_ly: 'tech-01',
+}
+
+void invalidWithAssignee
+
+const invalidWithCost: CompleteRepairRequestVariables = {
+  id: '123',
+  // @ts-expect-error RPC-backed completion should not accept legacy direct-table cost field.
+  chi_phi: 500000,
+}
+
+void invalidWithCost

--- a/src/hooks/use-cached-repair.ts
+++ b/src/hooks/use-cached-repair.ts
@@ -34,8 +34,6 @@ type CompleteRepairRequestParams = {
   id: string
   ket_qua?: string
   ghi_chu?: string
-  chi_phi?: number
-  nguoi_xu_ly: string
 }
 
 function toNullableString(value: unknown): string | null {

--- a/src/hooks/use-cached-repair.ts
+++ b/src/hooks/use-cached-repair.ts
@@ -1,7 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { supabase } from '@/lib/supabase'
 import { toast } from '@/hooks/use-toast'
 import { normalizeRpcError } from '@/lib/error-utils'
+import { callRpc } from '@/lib/rpc-client'
+import type { RepairRequestWithEquipment } from '@/app/(app)/repair-requests/types'
 
 export interface RepairRequestFilters {
   search?: string
@@ -13,9 +14,72 @@ export interface RepairRequestFilters {
 }
 
 type RepairRequestMutationInput = Record<string, unknown>
+type RepairRequestRecord = RepairRequestWithEquipment & Record<string, unknown>
+type RepairRequestListResponse = {
+  data: RepairRequestRecord[]
+  total: number
+  page: number
+  pageSize: number
+}
+type RepairRequestDetailRecord = Record<string, unknown> | null
 type UpdateRepairRequestParams = {
   id: string
   data: RepairRequestMutationInput
+}
+type AssignRepairRequestParams = {
+  id: string
+  nguoi_xu_ly: string
+}
+type CompleteRepairRequestParams = {
+  id: string
+  ket_qua?: string
+  ghi_chu?: string
+  chi_phi?: number
+  nguoi_xu_ly: string
+}
+
+function toNullableString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const normalized = value.trim()
+  return normalized ? normalized : null
+}
+
+function toRequiredString(value: unknown, fieldName: string): string {
+  const normalized = toNullableString(value)
+  if (!normalized) {
+    throw new Error(`Thiếu trường ${fieldName}`)
+  }
+  return normalized
+}
+
+function toIntegerId(value: unknown, fieldName: string): number {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`ID không hợp lệ cho ${fieldName}`)
+  }
+  return parsed
+}
+
+function applyLegacyRepairFilters(
+  rows: RepairRequestRecord[],
+  filters?: RepairRequestFilters
+): RepairRequestRecord[] {
+  return rows.filter((row) => {
+    if (filters?.phong_ban && row.thiet_bi?.khoa_phong_quan_ly !== filters.phong_ban) {
+      return false
+    }
+
+    if (filters?.muc_do_uu_tien) {
+      const priority = row.muc_do_uu_tien
+      if (typeof priority !== 'string' || priority !== filters.muc_do_uu_tien) {
+        return false
+      }
+    }
+
+    return true
+  })
 }
 
 // Query keys for caching
@@ -32,40 +96,21 @@ export function useRepairRequests(filters?: RepairRequestFilters) {
   return useQuery({
     queryKey: repairKeys.list(filters || {}),
     queryFn: async () => {
-      if (!supabase) {
-        throw new Error('Supabase client not initialized')
-      }
+      const response = await callRpc<RepairRequestListResponse>({
+        fn: 'repair_request_list',
+        args: {
+          p_q: filters?.search || null,
+          p_status: filters?.trang_thai || null,
+          p_page: 1,
+          p_page_size: 1000,
+          p_don_vi: null,
+          p_date_from: filters?.dateFrom || null,
+          p_date_to: filters?.dateTo || null,
+          p_statuses: null,
+        },
+      })
 
-      let query = supabase
-        .from('yeu_cau_sua_chua')
-        .select(`
-          *,
-          thiet_bi:thiet_bi(ma_thiet_bi, ten_thiet_bi, phong_ban:phong_ban(ten_phong_ban)),
-          nguoi_yeu_cau:profiles!yeu_cau_sua_chua_nguoi_yeu_cau_fkey(ho_ten),
-          nguoi_xu_ly:profiles!yeu_cau_sua_chua_nguoi_xu_ly_fkey(ho_ten)
-        `)
-
-      // Apply filters
-      if (filters?.search) {
-        query = query.or(`mo_ta_su_co.ilike.%${filters.search}%,ghi_chu.ilike.%${filters.search}%`)
-      }
-      if (filters?.trang_thai) {
-        query = query.eq('trang_thai', filters.trang_thai)
-      }
-      if (filters?.muc_do_uu_tien) {
-        query = query.eq('muc_do_uu_tien', filters.muc_do_uu_tien)
-      }
-      if (filters?.dateFrom) {
-        query = query.gte('created_at', filters.dateFrom)
-      }
-      if (filters?.dateTo) {
-        query = query.lte('created_at', filters.dateTo)
-      }
-
-      const { data, error } = await query.order('created_at', { ascending: false })
-
-      if (error) throw error
-      return data
+      return applyLegacyRepairFilters(response.data ?? [], filters)
     },
     staleTime: 2 * 60 * 1000, // 2 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
@@ -78,23 +123,13 @@ export function useRepairRequestDetail(id: string | null) {
     queryKey: repairKeys.detail(id || ''),
     queryFn: async () => {
       if (!id) return null
-      if (!supabase) {
-        throw new Error('Supabase client not initialized')
-      }
-      
-      const { data, error } = await supabase
-        .from('yeu_cau_sua_chua')
-        .select(`
-          *,
-          thiet_bi:thiet_bi(*),
-          nguoi_yeu_cau:profiles!yeu_cau_sua_chua_nguoi_yeu_cau_fkey(*),
-          nguoi_xu_ly:profiles!yeu_cau_sua_chua_nguoi_xu_ly_fkey(*)
-        `)
-        .eq('id', id)
-        .single()
 
-      if (error) throw error
-      return data
+      return callRpc<RepairRequestDetailRecord>({
+        fn: 'repair_request_get',
+        args: {
+          p_id: toIntegerId(id, 'id'),
+        },
+      })
     },
     enabled: !!id,
     staleTime: 1 * 60 * 1000, // 1 minute
@@ -107,18 +142,18 @@ export function useCreateRepairRequest() {
 
   return useMutation({
     mutationFn: async (data: RepairRequestMutationInput) => {
-      if (!supabase) {
-        throw new Error('Supabase client not initialized')
-      }
-
-      const { data: newRepair, error } = await supabase
-        .from('yeu_cau_sua_chua')
-        .insert(data)
-        .select()
-        .single()
-
-      if (error) throw error
-      return newRepair
+      return callRpc<number>({
+        fn: 'repair_request_create',
+        args: {
+          p_thiet_bi_id: toIntegerId(data.thiet_bi_id, 'thiet_bi_id'),
+          p_mo_ta_su_co: toRequiredString(data.mo_ta_su_co, 'mo_ta_su_co'),
+          p_hang_muc_sua_chua: toNullableString(data.hang_muc_sua_chua),
+          p_ngay_mong_muon_hoan_thanh: toNullableString(data.ngay_mong_muon_hoan_thanh),
+          p_nguoi_yeu_cau: toNullableString(data.nguoi_yeu_cau),
+          p_don_vi_thuc_hien: toNullableString(data.don_vi_thuc_hien),
+          p_ten_don_vi_thue: toNullableString(data.ten_don_vi_thue),
+        },
+      })
     },
     onSuccess: () => {
       // Invalidate all repair queries
@@ -147,25 +182,23 @@ export function useUpdateRepairRequest() {
 
   return useMutation({
     mutationFn: async (params: UpdateRepairRequestParams) => {
-      if (!supabase) {
-        throw new Error('Supabase client not initialized')
-      }
-
-      const { data, error } = await supabase
-        .from('yeu_cau_sua_chua')
-        .update(params.data)
-        .eq('id', params.id)
-        .select()
-        .single()
-
-      if (error) throw error
-      return data
+      await callRpc<void>({
+        fn: 'repair_request_update',
+        args: {
+          p_id: toIntegerId(params.id, 'id'),
+          p_mo_ta_su_co: toRequiredString(params.data.mo_ta_su_co, 'mo_ta_su_co'),
+          p_hang_muc_sua_chua: toNullableString(params.data.hang_muc_sua_chua),
+          p_ngay_mong_muon_hoan_thanh: toNullableString(params.data.ngay_mong_muon_hoan_thanh),
+          p_don_vi_thuc_hien: toNullableString(params.data.don_vi_thuc_hien),
+          p_ten_don_vi_thue: toNullableString(params.data.ten_don_vi_thue),
+        },
+      })
     },
-    onSuccess: (data) => {
+    onSuccess: (_data, variables) => {
       // Invalidate repair queries
       queryClient.invalidateQueries({ queryKey: repairKeys.lists() })
       // Update specific repair detail cache
-      queryClient.setQueryData(repairKeys.detail(data.id), data)
+      queryClient.invalidateQueries({ queryKey: repairKeys.detail(variables.id) })
       // Invalidate dashboard stats to update KPI cards
       queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
 
@@ -189,24 +222,16 @@ export function useAssignRepairRequest() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (params: { id: string; nguoi_xu_ly: string }) => {
-      if (!supabase) {
-        throw new Error('Supabase client not initialized')
-      }
-
-      const { data, error } = await supabase
-        .from('yeu_cau_sua_chua')
-        .update({
-          trang_thai: 'dang_xu_ly',
-          nguoi_xu_ly: params.nguoi_xu_ly,
-          ngay_bat_dau_xu_ly: new Date().toISOString()
-        })
-        .eq('id', params.id)
-        .select()
-        .single()
-
-      if (error) throw error
-      return data
+    mutationFn: async (params: AssignRepairRequestParams) => {
+      await callRpc<void>({
+        fn: 'repair_request_approve',
+        args: {
+          p_id: toIntegerId(params.id, 'id'),
+          p_nguoi_duyet: toRequiredString(params.nguoi_xu_ly, 'nguoi_xu_ly'),
+          p_don_vi_thuc_hien: 'noi_bo',
+          p_ten_don_vi_thue: null,
+        },
+      })
     },
     onSuccess: () => {
       // Invalidate repair queries
@@ -232,33 +257,15 @@ export function useCompleteRepairRequest() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (params: { 
-      id: string
-      ket_qua?: string
-      ghi_chu?: string
-      chi_phi?: number
-      nguoi_xu_ly: string
-    }) => {
-      if (!supabase) {
-        throw new Error('Supabase client not initialized')
-      }
-
-      const { data, error } = await supabase
-        .from('yeu_cau_sua_chua')
-        .update({
-          trang_thai: 'hoan_thanh',
-          ngay_hoan_thanh: new Date().toISOString(),
-          ket_qua: params.ket_qua,
-          ghi_chu: params.ghi_chu,
-          chi_phi: params.chi_phi,
-          nguoi_xu_ly: params.nguoi_xu_ly
-        })
-        .eq('id', params.id)
-        .select()
-        .single()
-
-      if (error) throw error
-      return data
+    mutationFn: async (params: CompleteRepairRequestParams) => {
+      await callRpc<void>({
+        fn: 'repair_request_complete',
+        args: {
+          p_id: toIntegerId(params.id, 'id'),
+          p_completion: toNullableString(params.ket_qua),
+          p_reason: toNullableString(params.ghi_chu),
+        },
+      })
     },
     onSuccess: () => {
       // Invalidate repair queries
@@ -285,16 +292,12 @@ export function useDeleteRepairRequest() {
 
   return useMutation({
     mutationFn: async (id: string) => {
-      if (!supabase) {
-        throw new Error('Supabase client not initialized')
-      }
-
-      const { error } = await supabase
-        .from('yeu_cau_sua_chua')
-        .delete()
-        .eq('id', id)
-
-      if (error) throw error
+      await callRpc<void>({
+        fn: 'repair_request_delete',
+        args: {
+          p_id: toIntegerId(id, 'id'),
+        },
+      })
     },
     onSuccess: () => {
       // Invalidate all repair queries

--- a/src/hooks/use-cached-repair.ts
+++ b/src/hooks/use-cached-repair.ts
@@ -1,25 +1,34 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '@/lib/supabase'
 import { toast } from '@/hooks/use-toast'
+import { normalizeRpcError } from '@/lib/error-utils'
 
-// Query keys for caching
-export const repairKeys = {
-  all: ['repair'] as const,
-  lists: () => [...repairKeys.all, 'list'] as const,
-  list: (filters: Record<string, any>) => [...repairKeys.lists(), { filters }] as const,
-  details: () => [...repairKeys.all, 'detail'] as const,
-  detail: (id: string) => [...repairKeys.details(), id] as const,
-}
-
-// Fetch repair requests with filters
-export function useRepairRequests(filters?: {
+export interface RepairRequestFilters {
   search?: string
   trang_thai?: string
   phong_ban?: string
   muc_do_uu_tien?: string
   dateFrom?: string
   dateTo?: string
-}) {
+}
+
+type RepairRequestMutationInput = Record<string, unknown>
+type UpdateRepairRequestParams = {
+  id: string
+  data: RepairRequestMutationInput
+}
+
+// Query keys for caching
+export const repairKeys = {
+  all: ['repair'] as const,
+  lists: () => [...repairKeys.all, 'list'] as const,
+  list: (filters: RepairRequestFilters) => [...repairKeys.lists(), { filters }] as const,
+  details: () => [...repairKeys.all, 'detail'] as const,
+  detail: (id: string) => [...repairKeys.details(), id] as const,
+}
+
+// Fetch repair requests with filters
+export function useRepairRequests(filters?: RepairRequestFilters) {
   return useQuery({
     queryKey: repairKeys.list(filters || {}),
     queryFn: async () => {
@@ -97,7 +106,7 @@ export function useCreateRepairRequest() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (data: any) => {
+    mutationFn: async (data: RepairRequestMutationInput) => {
       if (!supabase) {
         throw new Error('Supabase client not initialized')
       }
@@ -122,10 +131,10 @@ export function useCreateRepairRequest() {
         description: "Tạo yêu cầu sửa chữa thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể tạo yêu cầu sửa chữa",
+        description: normalizeRpcError(error, "Không thể tạo yêu cầu sửa chữa"),
         variant: "destructive",
       })
     },
@@ -137,7 +146,7 @@ export function useUpdateRepairRequest() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (params: { id: string; data: any }) => {
+    mutationFn: async (params: UpdateRepairRequestParams) => {
       if (!supabase) {
         throw new Error('Supabase client not initialized')
       }
@@ -165,10 +174,10 @@ export function useUpdateRepairRequest() {
         description: "Cập nhật yêu cầu sửa chữa thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể cập nhật yêu cầu sửa chữa",
+        description: normalizeRpcError(error, "Không thể cập nhật yêu cầu sửa chữa"),
         variant: "destructive",
       })
     },
@@ -208,10 +217,10 @@ export function useAssignRepairRequest() {
         description: "Phân công sửa chữa thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể phân công sửa chữa",
+        description: normalizeRpcError(error, "Không thể phân công sửa chữa"),
         variant: "destructive",
       })
     },
@@ -260,10 +269,10 @@ export function useCompleteRepairRequest() {
         description: "Hoàn thành sửa chữa thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể hoàn thành sửa chữa",
+        description: normalizeRpcError(error, "Không thể hoàn thành sửa chữa"),
         variant: "destructive",
       })
     },
@@ -298,10 +307,10 @@ export function useDeleteRepairRequest() {
         description: "Xóa yêu cầu sửa chữa thành công",
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         title: "Lỗi",
-        description: error.message || "Không thể xóa yêu cầu sửa chữa",
+        description: normalizeRpcError(error, "Không thể xóa yêu cầu sửa chữa"),
         variant: "destructive",
       })
     },

--- a/src/hooks/use-usage-logs.ts
+++ b/src/hooks/use-usage-logs.ts
@@ -1,16 +1,25 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { callRpc } from '@/lib/rpc-client'
 import { toast } from '@/hooks/use-toast'
+import { normalizeRpcError } from '@/lib/error-utils'
 import { type UsageLog } from '@/types/database'
+
+type UsageLogListFilters = Record<string, unknown>
+type UsageLogEquipmentKeyOptions = {
+  limit?: number
+  daysBack?: number
+  includeActive?: boolean
+  offset?: number
+}
 
 // Query keys for caching
 export const usageLogKeys = {
   all: ['usage-logs'] as const,
   lists: () => [...usageLogKeys.all, 'list'] as const,
-  list: (filters: Record<string, any>) => [...usageLogKeys.lists(), { filters }] as const,
+  list: (filters: UsageLogListFilters) => [...usageLogKeys.lists(), { filters }] as const,
   details: () => [...usageLogKeys.all, 'detail'] as const,
   detail: (id: string) => [...usageLogKeys.details(), id] as const,
-  equipment: (equipmentId: string, options?: Record<string, any>) => 
+  equipment: (equipmentId: string, options?: UsageLogEquipmentKeyOptions) => 
     [...usageLogKeys.all, 'equipment', equipmentId, options] as const,
   active: (tenantKey?: string | number) => [...usageLogKeys.all, 'active', tenantKey] as const,
 }
@@ -170,11 +179,11 @@ export function useStartUsageSession() {
         description: "Đã bắt đầu phiên sử dụng thiết bị."
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: error.message || "Không thể bắt đầu phiên sử dụng."
+        description: normalizeRpcError(error, "Không thể bắt đầu phiên sử dụng.")
       })
     }
   })
@@ -211,11 +220,11 @@ export function useEndUsageSession() {
         description: "Đã kết thúc phiên sử dụng thiết bị."
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: error.message || "Không thể kết thúc phiên sử dụng."
+        description: normalizeRpcError(error, "Không thể kết thúc phiên sử dụng.")
       })
     }
   })
@@ -243,11 +252,11 @@ export function useDeleteUsageLog() {
         description: "Đã xóa bản ghi sử dụng."
       })
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: error.message || "Không thể xóa bản ghi sử dụng."
+        description: normalizeRpcError(error, "Không thể xóa bản ghi sử dụng.")
       })
     }
   })


### PR DESCRIPTION
## Summary
- tighten runtime explicit-any quick wins in `use-cached-repair`, `use-usage-logs`, and `ExportReportDialog`
- replace `any`-based error handling with repo-standard `normalizeRpcError` / `getUnknownErrorMessage` so string rejections and other unknown boundary values surface the right toast copy
- add focused regression tests for the repaired error paths and local export-sheet typing cleanup

## What Changed
- `src/hooks/use-cached-repair.ts`
  - replace mutation error handlers from `any` to `unknown`
  - normalize destructive toast descriptions with `normalizeRpcError(...)`
  - tighten local filter/mutation input aliases to remove explicit `any`
- `src/hooks/use-usage-logs.ts`
  - replace query-key bag types from `Record<string, any>` to `Record<string, unknown>`-style aliases
  - normalize mutation error handling with `normalizeRpcError(...)`
- `src/app/(app)/reports/components/export-report-dialog.tsx`
  - replace export failure handling from `error?.message` on `any` to `getUnknownErrorMessage(...)`
  - replace internal sheet/row `any` typing with local concrete aliases compatible with `createMultiSheetExcel`
- tests
  - add focused hook/component tests that prove string rejections now produce the expected destructive toast copy

## Why
This is the first low-risk runtime explicit-any cleanup batch. It targets live flows where `any` was hiding boundary cases, especially string rejections that previously fell back to generic error messages.

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/hooks/__tests__/use-cached-repair.error-handling.test.ts src/hooks/__tests__/use-usage-logs.error-handling.test.ts "src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx" "src/app/(app)/reports/components/__tests__/inventory-report-tab.test.tsx"`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## React Doctor
- diff scan result: `99/100`
- remaining diff warning: `ExportReportDialog` still crosses the giant-component heuristic; no new correctness or a11y warnings were introduced by this batch

## Follow-up
- #234 Validate or remove the deferred `firebase-utils` push-notification path
- #235 Tighten remaining runtime explicit-any in transfer dialog submit flows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened explicit-any at runtime across repair requests, usage logs, and report export, migrated repair flows to RPC with input validation, and split the export dialog to clear a React Doctor giant-component warning. Export keeps stats sorted and includes the 'Khác' status, with clearer toasts for string errors.

- **Bug Fixes**
  - Unified error handling with `normalizeRpcError` and `getUnknownErrorMessage` so string rejections show the correct destructive toast across repair, usage logs, and export.
  - Export: kept transaction stats sorted by total descending and included the 'Khác' status in overview and per-department/location sheets; added focused tests.

- **Refactors**
  - Replaced Supabase calls with `callRpc` in repair flows; added coercion helpers and typed filters/mutation inputs; updated query keys and cache invalidation.
  - Moved export sheet logic to `export-report-dialog.utils.ts` via `buildExportSheets`; introduced `ExportReportDateRange`; split `ExportReportDialog` into a thin shell/content and render-on-open to resolve the React Doctor warning.

<sup>Written for commit fade44419c1a99d337761a92d9ce5ebfa4aa01e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Excel export: multi-sheet reports (Overview, Detailed transactions, Transaction statistics) with optional distribution, maintenance, and usage sheets; improved default filename behavior and export input handling.

* **Bug Fixes**
  * More robust, localized error messages and destructive notifications for exports, repair requests, and usage actions.

* **Tests**
  * Added tests covering export ordering, preservation of "Khác" rows, and error-handling for repair and usage flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->