### PR TITLE
feat: categorize dashboard recent activities feed

### DIFF
--- a/src/components/dashboard/RecentActivitiesCard.tsx
+++ b/src/components/dashboard/RecentActivitiesCard.tsx
@@ -9,6 +9,8 @@
 import React from "react"
 import { Activity } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -18,14 +20,14 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { useToast } from "@/hooks/use-toast"
 import { ChangeHistoryErrorState } from "@/components/change-history/ChangeHistoryErrorState"
-import { ChangeHistoryTimeline } from "@/components/change-history/ChangeHistoryTimeline"
 import { ChangeHistoryLoadingState } from "@/components/change-history/ChangeHistoryLoadingState"
 import { ChangeHistoryEmptyState } from "@/components/change-history/ChangeHistoryEmptyState"
-import type { ChangeHistoryEntry } from "@/components/change-history/ChangeHistoryTypes"
 import {
   useRecentActivities,
   type RecentActivity,
 } from "@/hooks/use-recent-activities"
+import { formatDistanceToNow, parseISO } from "date-fns"
+import { vi } from "date-fns/locale"
 
 /** Icon mapping for action types */
 const ACTION_ICONS: Record<string, string> = {
@@ -42,10 +44,84 @@ const ACTION_ICONS: Record<string, string> = {
   equipment_create: "➕",
 }
 
-/** Adapt RPC response to shared ChangeHistoryEntry contract */
-function toChangeHistoryEntries(
+type ActivityCategoryKey =
+  | "repair"
+  | "transfer"
+  | "maintenance"
+  | "equipment"
+  | "other"
+
+type ActivityCategoryConfig = {
+  label: string
+  badgeClassName: string
+}
+
+type RecentActivityViewModel = {
+  id: string
+  occurredAt: string
+  actionLabel: string
+  actorName: string
+  details: { label: string; value: string }[]
+  category: ActivityCategoryKey
+}
+
+const CATEGORY_CONFIG: Record<ActivityCategoryKey, ActivityCategoryConfig> = {
+  repair: {
+    label: "Sửa chữa",
+    badgeClassName: "bg-amber-100 text-amber-800 hover:bg-amber-100",
+  },
+  transfer: {
+    label: "Luân chuyển",
+    badgeClassName: "bg-sky-100 text-sky-800 hover:bg-sky-100",
+  },
+  maintenance: {
+    label: "Bảo trì",
+    badgeClassName: "bg-emerald-100 text-emerald-800 hover:bg-emerald-100",
+  },
+  equipment: {
+    label: "Thiết bị",
+    badgeClassName: "bg-violet-100 text-violet-800 hover:bg-violet-100",
+  },
+  other: {
+    label: "Khác",
+    badgeClassName: "bg-slate-100 text-slate-800 hover:bg-slate-100",
+  },
+}
+
+function resolveActivityCategory(activity: RecentActivity): ActivityCategoryKey {
+  switch (activity.entity_type) {
+    case "repair_request":
+      return "repair"
+    case "transfer_request":
+      return "transfer"
+    case "maintenance_plan":
+      return "maintenance"
+    case "device":
+      return "equipment"
+    default:
+      break
+  }
+
+  if (activity.action_type.startsWith("repair_request_")) {
+    return "repair"
+  }
+  if (activity.action_type.startsWith("transfer_request_")) {
+    return "transfer"
+  }
+  if (activity.action_type.startsWith("maintenance_plan_")) {
+    return "maintenance"
+  }
+  if (activity.action_type.startsWith("equipment_")) {
+    return "equipment"
+  }
+
+  return "other"
+}
+
+/** Adapt RPC response to dashboard-specific timeline contract */
+function toRecentActivityViewModels(
   activities: RecentActivity[],
-): ChangeHistoryEntry[] {
+): RecentActivityViewModel[] {
   return activities.map((a) => {
     const icon = ACTION_ICONS[a.action_type] ?? "📌"
     const details: { label: string; value: string }[] = []
@@ -63,8 +139,13 @@ function toChangeHistoryEntries(
       actionLabel: `${icon} ${a.action_label}`,
       actorName: a.actor_name,
       details,
+      category: resolveActivityCategory(a),
     }
   })
+}
+
+function formatRelativeTimestamp(iso: string): string {
+  return formatDistanceToNow(parseISO(iso), { addSuffix: true, locale: vi })
 }
 
 interface RecentActivitiesCardProps {
@@ -74,11 +155,43 @@ interface RecentActivitiesCardProps {
 export function RecentActivitiesCard({ className }: RecentActivitiesCardProps) {
   const { toast } = useToast()
   const { data, error, isError, isLoading } = useRecentActivities(15)
+  const [selectedCategory, setSelectedCategory] = React.useState<
+    ActivityCategoryKey | "all"
+  >("all")
 
-  const entries = React.useMemo(
-    () => (data ? toChangeHistoryEntries(data) : []),
+  const activities = React.useMemo(
+    () => (data ? toRecentActivityViewModels(data) : []),
     [data],
   )
+
+  const availableCategories = React.useMemo(() => {
+    const seen = new Set<ActivityCategoryKey>()
+    for (const activity of activities) {
+      seen.add(activity.category)
+    }
+
+    return (Object.keys(CATEGORY_CONFIG) as ActivityCategoryKey[]).filter((key) =>
+      seen.has(key),
+    )
+  }, [activities])
+
+  const filteredActivities = React.useMemo(() => {
+    if (selectedCategory === "all") {
+      return activities
+    }
+
+    return activities.filter((activity) => activity.category === selectedCategory)
+  }, [activities, selectedCategory])
+
+  React.useEffect(() => {
+    if (selectedCategory === "all") {
+      return
+    }
+
+    if (!availableCategories.includes(selectedCategory)) {
+      setSelectedCategory("all")
+    }
+  }, [availableCategories, selectedCategory])
 
   React.useEffect(() => {
     if (!isError || !error) {
@@ -119,15 +232,87 @@ export function RecentActivitiesCard({ className }: RecentActivitiesCardProps) {
             title="Không thể tải hoạt động gần đây"
             description="Vui lòng thử lại sau."
           />
-        ) : entries.length === 0 ? (
+        ) : activities.length === 0 ? (
           <ChangeHistoryEmptyState />
         ) : (
-          <ScrollArea className="h-[500px] xl:h-[600px]">
-            <ChangeHistoryTimeline
-              entries={entries}
-              timeFormat="relative"
-            />
-          </ScrollArea>
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant={selectedCategory === "all" ? "default" : "outline"}
+                onClick={() => setSelectedCategory("all")}
+              >
+                Tất cả
+              </Button>
+              {availableCategories.map((category) => (
+                <Button
+                  key={category}
+                  type="button"
+                  size="sm"
+                  variant={
+                    selectedCategory === category ? "default" : "outline"
+                  }
+                  onClick={() => setSelectedCategory(category)}
+                >
+                  {CATEGORY_CONFIG[category].label}
+                </Button>
+              ))}
+            </div>
+
+            <ScrollArea className="h-[500px] xl:h-[600px]">
+              <div className="relative pl-6 py-4 pr-4">
+                <div className="absolute left-3 top-0 h-full w-0.5 bg-border" />
+
+                {filteredActivities.map((activity) => (
+                  <div key={activity.id} className="relative mb-8 last:mb-0">
+                    <div className="absolute left-[-12px] top-1.5 size-3 rounded-full bg-primary ring-4 ring-background" />
+
+                    <div className="pl-2">
+                      <div className="flex flex-col gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="font-semibold text-sm">
+                            {activity.actionLabel}
+                          </p>
+                          <Badge
+                            variant="secondary"
+                            className={
+                              CATEGORY_CONFIG[activity.category].badgeClassName
+                            }
+                          >
+                            {CATEGORY_CONFIG[activity.category].label}
+                          </Badge>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {formatRelativeTimestamp(activity.occurredAt)}
+                        </p>
+                      </div>
+
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {activity.actorName}
+                      </p>
+
+                      {activity.details.length > 0 ? (
+                        <div className="mt-2 p-3 rounded-md bg-muted/50 border">
+                          {activity.details.map((detail) => (
+                            <div
+                              key={`${activity.id}-${detail.label}-${detail.value}`}
+                              className="flex items-baseline gap-2 text-sm"
+                            >
+                              <span className="text-muted-foreground shrink-0">
+                                {detail.label}
+                              </span>
+                              <span>{detail.value}</span>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/components/dashboard/RecentActivitiesCard.tsx
+++ b/src/components/dashboard/RecentActivitiesCard.tsx
@@ -8,6 +8,8 @@
 
 import React from "react"
 import { Activity } from "lucide-react"
+import { formatDistanceToNow, parseISO } from "date-fns"
+import { vi } from "date-fns/locale"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -18,16 +20,14 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { useToast } from "@/hooks/use-toast"
 import { ChangeHistoryErrorState } from "@/components/change-history/ChangeHistoryErrorState"
 import { ChangeHistoryLoadingState } from "@/components/change-history/ChangeHistoryLoadingState"
 import { ChangeHistoryEmptyState } from "@/components/change-history/ChangeHistoryEmptyState"
+import { useToast } from "@/hooks/use-toast"
 import {
   useRecentActivities,
   type RecentActivity,
 } from "@/hooks/use-recent-activities"
-import { formatDistanceToNow, parseISO } from "date-fns"
-import { vi } from "date-fns/locale"
 
 /** Icon mapping for action types */
 const ACTION_ICONS: Record<string, string> = {

--- a/src/components/dashboard/RecentActivitiesCard.tsx
+++ b/src/components/dashboard/RecentActivitiesCard.tsx
@@ -175,23 +175,18 @@ export function RecentActivitiesCard({ className }: RecentActivitiesCardProps) {
     )
   }, [activities])
 
+  const effectiveCategory =
+    selectedCategory === "all" || availableCategories.includes(selectedCategory)
+      ? selectedCategory
+      : "all"
+
   const filteredActivities = React.useMemo(() => {
-    if (selectedCategory === "all") {
+    if (effectiveCategory === "all") {
       return activities
     }
 
-    return activities.filter((activity) => activity.category === selectedCategory)
-  }, [activities, selectedCategory])
-
-  React.useEffect(() => {
-    if (selectedCategory === "all") {
-      return
-    }
-
-    if (!availableCategories.includes(selectedCategory)) {
-      setSelectedCategory("all")
-    }
-  }, [availableCategories, selectedCategory])
+    return activities.filter((activity) => activity.category === effectiveCategory)
+  }, [activities, effectiveCategory])
 
   React.useEffect(() => {
     if (!isError || !error) {
@@ -240,7 +235,7 @@ export function RecentActivitiesCard({ className }: RecentActivitiesCardProps) {
               <Button
                 type="button"
                 size="sm"
-                variant={selectedCategory === "all" ? "default" : "outline"}
+                variant={effectiveCategory === "all" ? "default" : "outline"}
                 onClick={() => setSelectedCategory("all")}
               >
                 Tất cả
@@ -250,9 +245,7 @@ export function RecentActivitiesCard({ className }: RecentActivitiesCardProps) {
                   key={category}
                   type="button"
                   size="sm"
-                  variant={
-                    selectedCategory === category ? "default" : "outline"
-                  }
+                  variant={effectiveCategory === category ? "default" : "outline"}
                   onClick={() => setSelectedCategory(category)}
                 >
                   {CATEGORY_CONFIG[category].label}

--- a/src/components/dashboard/__tests__/RecentActivitiesCard.test.tsx
+++ b/src/components/dashboard/__tests__/RecentActivitiesCard.test.tsx
@@ -75,6 +75,26 @@ const sampleActivities: RecentActivity[] = [
     facility_name: null,
     occurred_at: new Date(Date.now() - 60 * 60_000).toISOString(),
   },
+  {
+    activity_id: 103,
+    action_type: "maintenance_plan_create",
+    action_label: "Tạo kế hoạch bảo trì",
+    entity_type: "maintenance_plan",
+    entity_label: "KHBT-20260410-003",
+    actor_name: "Lê Văn C",
+    facility_name: "Bệnh viện Quận 3",
+    occurred_at: new Date(Date.now() - 2 * 60 * 60_000).toISOString(),
+  },
+  {
+    activity_id: 104,
+    action_type: "mystery_action",
+    action_label: "Hành động lạ",
+    entity_type: null,
+    entity_label: "UNK-01",
+    actor_name: "System",
+    facility_name: null,
+    occurred_at: new Date(Date.now() - 3 * 60 * 60_000).toISOString(),
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -123,6 +143,57 @@ describe("RecentActivitiesCard", () => {
     // Actor names
     expect(screen.getByText("Nguyễn Văn A")).toBeInTheDocument()
     expect(screen.getByText("Trần Văn B")).toBeInTheDocument()
+  })
+
+  it("renders only category chips that have data", async () => {
+    mockCallRpc.mockResolvedValue(sampleActivities)
+    render(<RecentActivitiesCard />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Tất cả" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Sửa chữa" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Luân chuyển" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Bảo trì" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Khác" })).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole("button", { name: "Thiết bị" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("filters timeline entries when a category chip is selected", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup()
+
+    mockCallRpc.mockResolvedValue(sampleActivities)
+    render(<RecentActivitiesCard />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Tạo yêu cầu sửa chữa/)).toBeInTheDocument()
+      expect(screen.getByText(/Hoàn thành luân chuyển/)).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole("button", { name: "Sửa chữa" }))
+
+    expect(screen.getByText(/Tạo yêu cầu sửa chữa/)).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Hoàn thành luân chuyển/)
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Tạo kế hoạch bảo trì/)
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows category badges and falls back unknown actions to Khác", async () => {
+    mockCallRpc.mockResolvedValue(sampleActivities)
+    render(<RecentActivitiesCard />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Sửa chữa").length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText("Luân chuyển").length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText("Bảo trì").length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText("Khác").length).toBeGreaterThanOrEqual(1)
+    })
   })
 
   it("renders entity labels in detail rows", async () => {

--- a/src/components/dashboard/__tests__/RecentActivitiesCard.test.tsx
+++ b/src/components/dashboard/__tests__/RecentActivitiesCard.test.tsx
@@ -4,7 +4,7 @@
  * @module components/dashboard/__tests__/RecentActivitiesCard.test
  */
 import React from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi, beforeEach } from "vitest"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
@@ -52,6 +52,14 @@ function createWrapper() {
       </QueryClientProvider>
     )
   }
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
 }
 
 const sampleActivities: RecentActivity[] = [
@@ -194,6 +202,45 @@ describe("RecentActivitiesCard", () => {
       expect(screen.getAllByText("Bảo trì").length).toBeGreaterThanOrEqual(1)
       expect(screen.getAllByText("Khác").length).toBeGreaterThanOrEqual(1)
     })
+  })
+
+  it("falls back to all activities immediately when the selected category disappears", async () => {
+    const user = (await import("@testing-library/user-event")).default.setup()
+    const queryClient = createQueryClient()
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    mockCallRpc.mockResolvedValue(sampleActivities)
+    render(<RecentActivitiesCard />, { wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Sửa chữa" })).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole("button", { name: "Sửa chữa" }))
+
+    expect(screen.getByText(/Tạo yêu cầu sửa chữa/)).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Hoàn thành luân chuyển/)
+    ).not.toBeInTheDocument()
+
+    act(() => {
+      queryClient.setQueryData(
+        ["dashboard-recent-activities", "anonymous", 15],
+        [sampleActivities[1], sampleActivities[2], sampleActivities[3]],
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/Hoàn thành luân chuyển/)).toBeInTheDocument()
+      expect(screen.getByText(/Tạo kế hoạch bảo trì/)).toBeInTheDocument()
+      expect(screen.getByText(/Hành động lạ/)).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByText(/Tạo yêu cầu sửa chữa/)
+    ).not.toBeInTheDocument()
   })
 
   it("renders entity labels in detail rows", async () => {


### PR DESCRIPTION
## Summary
- add client-side category chips to the dashboard recent activities card
- add per-item category badges while keeping a single chronological timeline
- keep Pha 1 UI-only by inferring categories from existing ntity_type / ction_type
- add tests for chip visibility, filtering, and Khác fallback

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test -- src/components/dashboard/__tests__/RecentActivitiesCard.test.tsx
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

## Follow-up
- Pha 2 backend/RPC expansion is tracked in #242
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add category chips and per-item badges to the dashboard Recent Activities, with client-side filtering on a single chronological timeline. Categories are inferred from `entity_type`/`action_type` with a “Khác” fallback.

- **New Features**
  - Filter chips: “Tất cả” plus only categories that have data.
  - Per-item badges with color for repair, transfer, maintenance, equipment, and Khác.
  - Relative timestamps using `date-fns` (vi locale).
  - Tests for chip visibility, filtering, and Khác fallback.

- **Bug Fixes**
  - Prevent stale category selection on data refresh; auto-revert to “Tất cả” if the selected category disappears.

<sup>Written for commit 8ea149890136cf8f8a01fdb7b46fc136a2aad58a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

