### PR TITLE
Issue #237 backend: add repair request cost statistics contract

### DIFF
--- a/docs/plans/2026-04-12-issue-237-repair-request-cost-statistics.md
+++ b/docs/plans/2026-04-12-issue-237-repair-request-cost-statistics.md
@@ -15,7 +15,7 @@
 - Do not add the cost field to create, update, or approve dialogs.
 - Show optional "Tổng chi phí sửa chữa" only in the completion dialog when the user is about to mark a request `Hoàn thành`.
 - Blank UI input sends SQL `NULL`; explicit `0` sends numeric `0`.
-- DB column is nullable and has default `0` for future omitted inserts, but existing rows must remain `NULL`.
+- DB column is nullable and has no default, so omitted and existing repair costs remain `NULL`.
 - No DB backfill for already completed repair requests.
 
 ---
@@ -49,7 +49,7 @@ Change ID: `add-repair-request-cost-statistics`
 - [ ] **Step 1: Write the failing smoke test**
 
 Cover these cases:
-- `public.yeu_cau_sua_chua` has `chi_phi_sua_chua numeric(14,2) NULL DEFAULT 0`.
+- `public.yeu_cau_sua_chua` has `chi_phi_sua_chua numeric(14,2) NULL` with no default.
 - Existing rows created before the migration remain `NULL`.
 - Completing with `p_chi_phi_sua_chua := NULL` stores `NULL`.
 - Completing with `p_chi_phi_sua_chua := 0` stores `0`.
@@ -85,7 +85,7 @@ ALTER TABLE public.yeu_cau_sua_chua
   ADD COLUMN IF NOT EXISTS chi_phi_sua_chua numeric(14,2) NULL;
 
 ALTER TABLE public.yeu_cau_sua_chua
-  ALTER COLUMN chi_phi_sua_chua SET DEFAULT 0;
+  ALTER COLUMN chi_phi_sua_chua DROP DEFAULT;
 
 ALTER TABLE public.yeu_cau_sua_chua
   ADD CONSTRAINT yeu_cau_sua_chua_chi_phi_sua_chua_non_negative

--- a/docs/plans/2026-04-12-issue-237-repair-request-cost-statistics.md
+++ b/docs/plans/2026-04-12-issue-237-repair-request-cost-statistics.md
@@ -1,0 +1,356 @@
+# Issue 237 Repair Request Cost Statistics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add optional repair cost capture at request completion and expose the cost in repair statistics and export flows.
+
+**Architecture:** Split implementation into two batches. Batch 1 owns the database contract, hardened RPC migration, SQL smoke tests, and report JSON payloads. Batch 2 owns TypeScript types, completion-dialog UX, report/export rendering, and focused React/Vitest coverage after the backend contract is stable.
+
+**Tech Stack:** Supabase Postgres RPCs/migrations, SQL smoke tests, Next.js App Router, React, TanStack Query, Vitest, React Doctor, OpenSpec.
+
+**Issue:** GitHub #237, "MVP: thêm chi_phi_sua_chua vào yeu_cau_sua_chua để thống kê chi phí sửa chữa".
+
+**Key decisions:**
+- `chi_phi_sua_chua` is a final completion-time value, not an approval-time estimate.
+- Do not add the cost field to create, update, or approve dialogs.
+- Show optional "Tổng chi phí sửa chữa" only in the completion dialog when the user is about to mark a request `Hoàn thành`.
+- Blank UI input sends SQL `NULL`; explicit `0` sends numeric `0`.
+- DB column is nullable and has default `0` for future omitted inserts, but existing rows must remain `NULL`.
+- No DB backfill for already completed repair requests.
+
+---
+
+## OpenSpec Tracking
+
+Change ID: `add-repair-request-cost-statistics`
+
+- [ ] 1. Backend batch complete
+- [x] 1.1 Write SQL smoke tests for cost schema, completion write contract, terminal lock, and report aggregates.
+- [x] 1.2 Add migration for `yeu_cau_sua_chua.chi_phi_sua_chua`.
+- [x] 1.3 Recreate `repair_request_complete` with optional cost while preserving hardened security.
+- [x] 1.4 Extend repair list/detail/report RPC payloads with cost fields and counts.
+- [ ] 1.5 Run SQL smoke tests and Supabase security advisors.
+- [ ] 2. Frontend batch complete
+- [ ] 2.1 Add cost parser/formatter tests and helper.
+- [ ] 2.2 Update completion mutation contract and completion dialog UX.
+- [ ] 2.3 Update repair request types and detail display.
+- [ ] 2.4 Update maintenance report/export types and rendering.
+- [ ] 2.5 Run required TypeScript/React verification gates.
+
+## Batch 1: Backend
+
+### Task 1: Add failing SQL smoke coverage
+
+**Files:**
+- Create: `supabase/tests/repair_request_cost_smoke.sql`
+- Reference: `supabase/tests/repair_request_lifecycle_audit_smoke.sql`
+- Reference: latest local repair lifecycle migrations under `supabase/migrations/20260406*.sql`
+
+- [ ] **Step 1: Write the failing smoke test**
+
+Cover these cases:
+- `public.yeu_cau_sua_chua` has `chi_phi_sua_chua numeric(14,2) NULL DEFAULT 0`.
+- Existing rows created before the migration remain `NULL`.
+- Completing with `p_chi_phi_sua_chua := NULL` stores `NULL`.
+- Completing with `p_chi_phi_sua_chua := 0` stores `0`.
+- Completing with a positive value stores that numeric value.
+- Negative cost is rejected.
+- A terminal request cannot be completed again to change cost.
+- Tenant-scoped users cannot complete another tenant's request.
+- Missing role or missing `user_id` claims are rejected.
+
+- [ ] **Step 2: Run the smoke test and confirm the intended red state**
+
+Run against the dev database:
+
+```bash
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/repair_request_cost_smoke.sql
+```
+
+Expected: FAIL because the column/signature/cost behavior does not exist yet, not because fixture setup or JWT claims are broken.
+
+### Task 2: Add schema and hardened completion RPC migration
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDDHHMMSS_add_repair_request_cost_statistics.sql`
+- Reference: `supabase/migrations/20260406082735_fix_repair_request_complete_idempotency.sql`
+- Reference: `supabase/migrations/20260406103000_fix_repair_request_update_approve_audit_fail_closed.sql`
+
+- [ ] **Step 1: Add the column without backfilling old rows**
+
+Use the two-step pattern:
+
+```sql
+ALTER TABLE public.yeu_cau_sua_chua
+  ADD COLUMN IF NOT EXISTS chi_phi_sua_chua numeric(14,2) NULL;
+
+ALTER TABLE public.yeu_cau_sua_chua
+  ALTER COLUMN chi_phi_sua_chua SET DEFAULT 0;
+
+ALTER TABLE public.yeu_cau_sua_chua
+  ADD CONSTRAINT yeu_cau_sua_chua_chi_phi_sua_chua_non_negative
+  CHECK (chi_phi_sua_chua IS NULL OR chi_phi_sua_chua >= 0);
+```
+
+- [ ] **Step 2: Replace `repair_request_complete` contract**
+
+Drop the old overload and recreate:
+
+```sql
+DROP FUNCTION IF EXISTS public.repair_request_complete(integer, text, text);
+CREATE OR REPLACE FUNCTION public.repair_request_complete(
+  p_id integer,
+  p_completion text DEFAULT NULL,
+  p_reason text DEFAULT NULL,
+  p_chi_phi_sua_chua numeric DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+-- Port the full current hardened body, then add cost validation/write.
+$$;
+```
+
+Keep the current lifecycle behavior:
+- validate JWT role and normalized `user_id` before business logic
+- keep `admin` and `global` behavior
+- keep explicit non-global tenant guard
+- keep current `regional_leader` write rejection
+- lock request/equipment rows with `FOR UPDATE`
+- reject terminal states
+- keep equipment status updates, `lich_su_thiet_bi`, and audit log writes
+
+Add only the new cost behavior:
+- if derived status is `Hoàn thành`, set `chi_phi_sua_chua = p_chi_phi_sua_chua`
+- if derived status is `Không HT`, leave `chi_phi_sua_chua` as `NULL`
+- reject `p_chi_phi_sua_chua < 0`
+- include `chi_phi_sua_chua` in completion audit details for the `Hoàn thành` path
+
+- [ ] **Step 3: Run SQL smoke test**
+
+Run:
+
+```bash
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/repair_request_cost_smoke.sql
+```
+
+Expected: schema and completion-cost cases pass.
+
+### Task 3: Extend repair read/report RPC payloads
+
+**Files:**
+- Modify in the same migration: `repair_request_list`
+- Modify in the same migration: `get_maintenance_report_data(date,date,bigint)`
+- Modify in the same migration: `maintenance_stats_for_reports(date,date,bigint,text)`
+
+- [ ] **Step 1: Add list payload support**
+
+Add `chi_phi_sua_chua` to the JSON rows returned by `repair_request_list`.
+
+If the function body is replaced, also update raw `ILIKE` pattern building to use `public._sanitize_ilike_pattern()` according to the repo SQL safety rule.
+
+- [ ] **Step 2: Add report aggregates**
+
+Use these semantics:
+- total: `COALESCE(SUM(chi_phi_sua_chua), 0)`
+- average: `AVG(chi_phi_sua_chua)` so missing values are excluded
+- `cost_recorded_count`: completed requests where `chi_phi_sua_chua IS NOT NULL`
+- `cost_missing_count`: completed requests where `chi_phi_sua_chua IS NULL`
+- cost by month/facility/equipment follows the same `NULL` semantics
+
+- [ ] **Step 3: Preserve report security contracts**
+
+For every recreated report RPC:
+- keep `SECURITY DEFINER`
+- add/keep `SET search_path = public, pg_temp`
+- validate role/user claims according to the nearest existing hardened report function
+- preserve global/admin/regional/tenant scoping
+- do not add a generic `don_vi` guard where scope is derived from an approved multi-tenant facility helper
+
+- [ ] **Step 4: Run SQL smoke test and security advisor**
+
+Run:
+
+```bash
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/repair_request_cost_smoke.sql
+```
+
+Then run Supabase MCP `get_advisors(security)` for project `cdthersvldpnlbvpufrr`.
+
+Expected: smoke test passes and no new security advisor regression is introduced.
+
+## Batch 2: Frontend
+
+Start this batch only after Batch 1 is green and the RPC payload shape is stable.
+
+### Task 4: Add cost formatting/parsing helper
+
+**Files:**
+- Create: `src/app/(app)/repair-requests/_utils/repairRequestCost.ts`
+- Create: `src/app/(app)/repair-requests/_utils/repairRequestCost.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Cover:
+- `"1.234.567"` parses to `1234567`
+- `"0"` parses to `0`
+- empty string parses to `null`
+- negative values fail validation
+- non-numeric values fail validation
+- `1234567` formats as `"1.234.567"`
+
+- [ ] **Step 2: Implement helper**
+
+Keep the helper independent from React:
+- `parseRepairCostInput(input: string): number | null`
+- `formatRepairCostInput(value: number | null): string`
+- `formatRepairCostDisplay(value: number | null): string`
+
+- [ ] **Step 3: Run focused helper test**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- "src/app/(app)/repair-requests/_utils/repairRequestCost.test.ts"
+```
+
+Expected: PASS.
+
+### Task 5: Wire completion dialog and mutation contract
+
+**Files:**
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx`
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx`
+- Modify or add focused tests under `src/app/(app)/repair-requests/__tests__/`
+
+- [ ] **Step 1: Write failing dialog/mutation tests**
+
+Cover:
+- cost field is visible only when completion type is `Hoàn thành`
+- helper text recommends entering total repair cost for statistics/analysis
+- blank cost submits `p_chi_phi_sua_chua: null`
+- `"0"` submits `p_chi_phi_sua_chua: 0`
+- `"1.234.567"` submits `p_chi_phi_sua_chua: 1234567`
+- `Không HT` does not submit a cost value
+
+- [ ] **Step 2: Implement minimal UI and mutation changes**
+
+Update the complete mutation payload to pass `p_chi_phi_sua_chua` to `repair_request_complete`.
+
+Keep layout stable and do not add nested cards. If `RepairRequestsContext.tsx` grows further beyond the 350-line soft threshold, extract mutation types/helpers rather than expanding it heavily.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- "src/app/(app)/repair-requests/__tests__"
+```
+
+Expected: completion-cost tests pass without regressing existing repair request tests.
+
+### Task 6: Add repair detail and data type support
+
+**Files:**
+- Modify: `src/app/(app)/repair-requests/types.ts`
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsDetailContent.tsx`
+- Modify or add focused tests under `src/app/(app)/repair-requests/__tests__/`
+
+- [ ] **Step 1: Write failing type/display tests**
+
+Cover:
+- `RepairRequestWithEquipment` accepts `chi_phi_sua_chua: number | null`
+- detail view displays `0` as a real zero cost
+- detail view displays `NULL` as no recorded cost data
+
+- [ ] **Step 2: Implement minimal display**
+
+Use `formatRepairCostDisplay()` from the shared helper.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- "src/app/(app)/repair-requests/__tests__"
+```
+
+Expected: PASS.
+
+### Task 7: Update maintenance reports and export
+
+**Files:**
+- Modify: `src/app/(app)/reports/hooks/use-maintenance-stats.ts`
+- Modify: `src/app/(app)/reports/hooks/use-maintenance-data.ts`
+- Modify: `src/app/(app)/reports/components/maintenance-report-tab.tsx`
+- Modify: `src/app/(app)/reports/components/export-report-dialog.utils.ts`
+- Modify or add focused report/export tests
+
+- [ ] **Step 1: Write failing report/export tests**
+
+Cover:
+- report hook types include total cost, average completed cost, recorded count, and missing count
+- maintenance report UI renders total cost and average completed cost
+- export sheet includes cost summary rows
+- export sheet preserves existing rows and labels
+
+- [ ] **Step 2: Implement minimal report rendering**
+
+Avoid growing report components past the file-size ceiling. If a report component is already above the 350-line soft threshold, extract a small cost summary component/helper before adding UI blocks.
+
+- [ ] **Step 3: Run focused report/export tests**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- "src/app/(app)/reports"
+```
+
+Expected: report and export tests pass.
+
+## Final Verification
+
+- [ ] Run explicit-any gate:
+
+```bash
+node scripts/npm-run.js run verify:no-explicit-any
+```
+
+- [ ] Run typecheck:
+
+```bash
+node scripts/npm-run.js run typecheck
+```
+
+- [ ] Run focused SQL smoke test:
+
+```bash
+psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/repair_request_cost_smoke.sql
+```
+
+- [ ] Run focused Vitest suites for repair requests and reports:
+
+```bash
+node scripts/npm-run.js run test:run -- "src/app/(app)/repair-requests" "src/app/(app)/reports"
+```
+
+- [ ] Run React Doctor diff scan:
+
+```bash
+node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
+```
+
+- [ ] Run Supabase MCP security advisors after applying the migration:
+
+```text
+Supabase MCP: get_advisors(security), project_id = cdthersvldpnlbvpufrr
+```
+
+- [ ] Validate OpenSpec:
+
+```bash
+openspec validate add-repair-request-cost-statistics --strict
+```
+
+- [ ] Commit backend and frontend batches separately if implemented in separate sessions.

--- a/openspec/changes/add-repair-request-cost-statistics/proposal.md
+++ b/openspec/changes/add-repair-request-cost-statistics/proposal.md
@@ -4,7 +4,7 @@ Repair requests currently do not store repair cost, so maintenance reports and e
 GitHub Issue #237 asks for an MVP that stores repair cost on `yeu_cau_sua_chua` and exposes it to statistics. Product clarification: the cost is optional, collected when the user is about to mark a request `Hoàn thành`, and blank cost means unknown (`NULL`), not zero.
 
 ## What Changes
-- Add nullable `chi_phi_sua_chua numeric(14,2)` on `public.yeu_cau_sua_chua` with default `0` for future omitted inserts while leaving existing rows `NULL`.
+- Add nullable `chi_phi_sua_chua numeric(14,2)` on `public.yeu_cau_sua_chua` with no default so omitted values stay `NULL`.
 - Extend `repair_request_complete` to accept optional `p_chi_phi_sua_chua` for the `Hoàn thành` path.
 - Keep create, update, and approve dialogs free of the cost field.
 - Show optional "Tổng chi phí sửa chữa" in the completion dialog as a friendly recommendation for reporting and analysis.

--- a/openspec/changes/add-repair-request-cost-statistics/proposal.md
+++ b/openspec/changes/add-repair-request-cost-statistics/proposal.md
@@ -1,0 +1,22 @@
+## Why
+Repair requests currently do not store repair cost, so maintenance reports and exports cannot answer basic cost questions by time, facility, or equipment.
+
+GitHub Issue #237 asks for an MVP that stores repair cost on `yeu_cau_sua_chua` and exposes it to statistics. Product clarification: the cost is optional, collected when the user is about to mark a request `Hoàn thành`, and blank cost means unknown (`NULL`), not zero.
+
+## What Changes
+- Add nullable `chi_phi_sua_chua numeric(14,2)` on `public.yeu_cau_sua_chua` with default `0` for future omitted inserts while leaving existing rows `NULL`.
+- Extend `repair_request_complete` to accept optional `p_chi_phi_sua_chua` for the `Hoàn thành` path.
+- Keep create, update, and approve dialogs free of the cost field.
+- Show optional "Tổng chi phí sửa chữa" in the completion dialog as a friendly recommendation for reporting and analysis.
+- Expose cost fields and aggregates in repair list/detail/report/export flows.
+- Preserve existing RPC security patterns: JWT guards, tenant scoping, role restrictions, `SECURITY DEFINER`, and `SET search_path = public, pg_temp`.
+
+## Impact
+- Affected specs: `repair-request-cost-statistics` (new capability).
+- Affected code:
+  - Supabase migration for repair request schema and RPC bodies.
+  - Repair request completion dialog, context mutation, and detail display.
+  - Maintenance report hooks/UI and export sheet utilities.
+- Testing:
+  - SQL smoke tests for schema, completion write contract, terminal lock, tenant/security guards, and report aggregates.
+  - Vitest coverage for cost parsing, completion dialog payloads, detail display, reports, and export output.

--- a/openspec/changes/add-repair-request-cost-statistics/specs/repair-request-cost-statistics/spec.md
+++ b/openspec/changes/add-repair-request-cost-statistics/specs/repair-request-cost-statistics/spec.md
@@ -21,13 +21,13 @@ The system SHALL allow users to optionally enter `Tổng chi phí sửa chữa` 
 - **THEN** the system stores `chi_phi_sua_chua` as the numeric value `0`.
 
 ### Requirement: Repair cost storage contract
-The system SHALL store repair cost on `public.yeu_cau_sua_chua.chi_phi_sua_chua` as a nullable numeric value with a default of `0` for future omitted inserts, while leaving existing repair requests without synthetic backfilled costs.
+The system SHALL store repair cost on `public.yeu_cau_sua_chua.chi_phi_sua_chua` as a nullable numeric value with no default, leaving omitted and existing repair costs as `NULL`.
 
 #### Scenario: Existing repair requests remain unbackfilled
 - **GIVEN** repair request rows exist before the cost migration is applied
 - **WHEN** the migration adds `chi_phi_sua_chua`
 - **THEN** existing rows keep `chi_phi_sua_chua` as `NULL`
-- **AND** new rows that omit the column receive the DB default `0`.
+- **AND** new rows that omit the column keep `chi_phi_sua_chua` as `NULL`.
 
 #### Scenario: Negative repair cost is rejected
 - **GIVEN** a user completes a repair request

--- a/openspec/changes/add-repair-request-cost-statistics/specs/repair-request-cost-statistics/spec.md
+++ b/openspec/changes/add-repair-request-cost-statistics/specs/repair-request-cost-statistics/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Completion-time repair cost capture
+The system SHALL allow users to optionally enter `Tổng chi phí sửa chữa` when marking an approved repair request as `Hoàn thành`.
+
+#### Scenario: User completes a repair request with a recorded cost
+- **GIVEN** an approved repair request the user is authorized to complete
+- **WHEN** the user enters `1.234.567` in the completion dialog and confirms completion
+- **THEN** the system stores `chi_phi_sua_chua` as the numeric value `1234567`
+- **AND** the request reaches the `Hoàn thành` terminal state.
+
+#### Scenario: User leaves repair cost blank
+- **GIVEN** an approved repair request the user is authorized to complete
+- **WHEN** the user leaves `Tổng chi phí sửa chữa` blank and confirms completion
+- **THEN** the system stores `chi_phi_sua_chua` as `NULL`
+- **AND** the request reaches the `Hoàn thành` terminal state.
+
+#### Scenario: User enters zero repair cost
+- **GIVEN** an approved repair request the user is authorized to complete
+- **WHEN** the user enters `0` and confirms completion
+- **THEN** the system stores `chi_phi_sua_chua` as the numeric value `0`.
+
+### Requirement: Repair cost storage contract
+The system SHALL store repair cost on `public.yeu_cau_sua_chua.chi_phi_sua_chua` as a nullable numeric value with a default of `0` for future omitted inserts, while leaving existing repair requests without synthetic backfilled costs.
+
+#### Scenario: Existing repair requests remain unbackfilled
+- **GIVEN** repair request rows exist before the cost migration is applied
+- **WHEN** the migration adds `chi_phi_sua_chua`
+- **THEN** existing rows keep `chi_phi_sua_chua` as `NULL`
+- **AND** new rows that omit the column receive the DB default `0`.
+
+#### Scenario: Negative repair cost is rejected
+- **GIVEN** a user completes a repair request
+- **WHEN** the submitted repair cost is negative
+- **THEN** the system rejects the write
+- **AND** the request cost is not changed.
+
+### Requirement: Repair cost reporting
+The system SHALL include repair cost totals, averages, and data-completeness counts in maintenance report and export flows.
+
+#### Scenario: Reports summarize recorded and missing costs
+- **GIVEN** completed repair requests where some rows have `chi_phi_sua_chua` and some rows are `NULL`
+- **WHEN** a user opens maintenance reports or exports maintenance data
+- **THEN** totals use `COALESCE(SUM(chi_phi_sua_chua), 0)`
+- **AND** averages exclude `NULL` values
+- **AND** the payload includes counts for recorded and missing cost rows.
+
+#### Scenario: Report scoping remains tenant-safe
+- **GIVEN** a non-global user requests repair cost report data
+- **WHEN** report RPCs calculate cost aggregates
+- **THEN** the aggregates include only repair requests allowed by the user's existing tenant or facility scope.

--- a/openspec/changes/add-repair-request-cost-statistics/tasks.md
+++ b/openspec/changes/add-repair-request-cost-statistics/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Backend Batch
-- [x] 1.1 Add SQL smoke test for `chi_phi_sua_chua` schema, default, null semantics, and no backfill.
+- [x] 1.1 Add SQL smoke test for `chi_phi_sua_chua` schema, no-default contract, null semantics, and no backfill.
 - [x] 1.2 Add SQL smoke test for `repair_request_complete` storing `NULL`, `0`, and positive cost values.
 - [x] 1.3 Add SQL smoke test for negative cost rejection and terminal-state idempotency.
 - [x] 1.4 Add SQL smoke test for missing JWT claims and wrong-tenant write rejection.
-- [x] 1.5 Create migration adding `yeu_cau_sua_chua.chi_phi_sua_chua numeric(14,2) NULL`, then setting default `0`.
+- [x] 1.5 Create migration adding `yeu_cau_sua_chua.chi_phi_sua_chua numeric(14,2) NULL` with no default.
 - [x] 1.6 Add non-negative check constraint allowing `NULL`.
 - [x] 1.7 Recreate `repair_request_complete` with `p_chi_phi_sua_chua numeric DEFAULT NULL`.
 - [x] 1.8 Preserve hardened lifecycle RPC security: `SECURITY DEFINER`, `SET search_path`, role/user guards, tenant guard, row locks, `admin`/`global` handling, and regional write restriction.

--- a/openspec/changes/add-repair-request-cost-statistics/tasks.md
+++ b/openspec/changes/add-repair-request-cost-statistics/tasks.md
@@ -1,0 +1,36 @@
+## 1. Backend Batch
+- [x] 1.1 Add SQL smoke test for `chi_phi_sua_chua` schema, default, null semantics, and no backfill.
+- [x] 1.2 Add SQL smoke test for `repair_request_complete` storing `NULL`, `0`, and positive cost values.
+- [x] 1.3 Add SQL smoke test for negative cost rejection and terminal-state idempotency.
+- [x] 1.4 Add SQL smoke test for missing JWT claims and wrong-tenant write rejection.
+- [x] 1.5 Create migration adding `yeu_cau_sua_chua.chi_phi_sua_chua numeric(14,2) NULL`, then setting default `0`.
+- [x] 1.6 Add non-negative check constraint allowing `NULL`.
+- [x] 1.7 Recreate `repair_request_complete` with `p_chi_phi_sua_chua numeric DEFAULT NULL`.
+- [x] 1.8 Preserve hardened lifecycle RPC security: `SECURITY DEFINER`, `SET search_path`, role/user guards, tenant guard, row locks, `admin`/`global` handling, and regional write restriction.
+- [x] 1.9 Extend `repair_request_list` payload with `chi_phi_sua_chua`.
+- [x] 1.10 Extend `get_maintenance_report_data` with repair cost totals, averages, recorded count, missing count, and cost breakdowns.
+- [x] 1.11 Extend `maintenance_stats_for_reports(date,date,bigint,text)` with repair cost summary fields while preserving report scoping.
+- [ ] 1.12 Run SQL smoke test and Supabase MCP `get_advisors(security)`.
+
+## 2. Frontend Batch
+- [ ] 2.1 Add cost parser/formatter unit tests for Vietnamese thousands separators, blank-to-`NULL`, zero, positive values, and invalid input.
+- [ ] 2.2 Implement `repairRequestCost` helper.
+- [ ] 2.3 Add completion dialog tests for optional "Tổng chi phí sửa chữa" visibility and payloads.
+- [ ] 2.4 Update completion mutation to send `p_chi_phi_sua_chua` only for the `Hoàn thành` flow.
+- [ ] 2.5 Add `chi_phi_sua_chua: number | null` to repair request/report types.
+- [ ] 2.6 Add repair detail display tests for `NULL` versus `0`.
+- [ ] 2.7 Update repair detail display with Vietnamese cost formatting.
+- [ ] 2.8 Add report hook/UI tests for total cost, average completed cost, recorded count, and missing count.
+- [ ] 2.9 Update maintenance report hooks and UI.
+- [ ] 2.10 Add export sheet tests for cost summary rows and existing row preservation.
+- [ ] 2.11 Update export sheet builder for repair cost statistics.
+- [ ] 2.12 Run TypeScript/React verification gates in repo-required order.
+
+## 3. Verification
+- [ ] 3.1 Run `node scripts/npm-run.js run verify:no-explicit-any`.
+- [ ] 3.2 Run `node scripts/npm-run.js run typecheck`.
+- [ ] 3.3 Run focused SQL smoke test for repair request cost.
+- [ ] 3.4 Run focused Vitest suites for repair requests and reports.
+- [ ] 3.5 Run `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`.
+- [ ] 3.6 Run `openspec validate add-repair-request-cost-statistics --strict`.
+- [ ] 3.7 Commit backend and frontend batches separately if implemented separately.

--- a/supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql
+++ b/supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql
@@ -1,5 +1,8 @@
 -- Issue #237: add optional repair-request cost capture and statistics.
 -- Prepared for review only; do not apply automatically from the agent session.
+-- Rollback note: this forward-only migration replaces several RPC bodies. If rollback
+-- is required, restore those bodies from their previous migrations and drop the
+-- repair-cost constraint/column only before any production cost data exists.
 
 BEGIN;
 
@@ -7,7 +10,7 @@ ALTER TABLE public.yeu_cau_sua_chua
   ADD COLUMN IF NOT EXISTS chi_phi_sua_chua numeric(14,2) NULL;
 
 ALTER TABLE public.yeu_cau_sua_chua
-  ALTER COLUMN chi_phi_sua_chua SET DEFAULT 0;
+  ALTER COLUMN chi_phi_sua_chua DROP DEFAULT;
 
 DO $$
 BEGIN
@@ -319,6 +322,8 @@ DECLARE
   v_allowed bigint[];
   v_effective bigint[];
   v_result jsonb;
+  v_from_year integer := extract(year from p_date_from)::integer;
+  v_to_year integer := extract(year from p_date_to)::integer;
 BEGIN
   v_role := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
   v_user_id := nullif(public._get_jwt_claim('user_id'), '');
@@ -449,7 +454,7 @@ BEGIN
     FROM public.ke_hoach_bao_tri kh
     LEFT JOIN public.cong_viec_bao_tri cv ON kh.id = cv.ke_hoach_id
     WHERE (v_effective IS NULL OR kh.don_vi = ANY(v_effective))
-      AND kh.nam = extract(year from p_date_from)
+      AND kh.nam BETWEEN v_from_year AND v_to_year
       AND kh.trang_thai = 'Đã duyệt'
   ),
   maintenance_summary AS (

--- a/supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql
+++ b/supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql
@@ -1,0 +1,823 @@
+-- Issue #237: add optional repair-request cost capture and statistics.
+-- Prepared for review only; do not apply automatically from the agent session.
+
+BEGIN;
+
+ALTER TABLE public.yeu_cau_sua_chua
+  ADD COLUMN IF NOT EXISTS chi_phi_sua_chua numeric(14,2) NULL;
+
+ALTER TABLE public.yeu_cau_sua_chua
+  ALTER COLUMN chi_phi_sua_chua SET DEFAULT 0;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+    WHERE nsp.nspname = 'public'
+      AND rel.relname = 'yeu_cau_sua_chua'
+      AND con.conname = 'yeu_cau_sua_chua_chi_phi_sua_chua_non_negative'
+  ) THEN
+    ALTER TABLE public.yeu_cau_sua_chua
+      ADD CONSTRAINT yeu_cau_sua_chua_chi_phi_sua_chua_non_negative
+      CHECK (chi_phi_sua_chua IS NULL OR chi_phi_sua_chua >= 0);
+  END IF;
+END $$;
+
+DROP FUNCTION IF EXISTS public.repair_request_complete(integer, text, text);
+
+CREATE OR REPLACE FUNCTION public.repair_request_complete(
+  p_id integer,
+  p_completion text DEFAULT NULL,
+  p_reason text DEFAULT NULL,
+  p_chi_phi_sua_chua numeric DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_thiet_bi_id bigint;
+  v_tb_don_vi bigint;
+  v_locked_status text;
+  v_locked_completed_at timestamptz;
+  v_status text;
+  v_result text;
+  v_reason text;
+  v_cost numeric(14,2);
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  SELECT ycss.thiet_bi_id, ycss.trang_thai, ycss.ngay_hoan_thanh, tb.don_vi
+  INTO v_thiet_bi_id, v_locked_status, v_locked_completed_at, v_tb_don_vi
+  FROM public.yeu_cau_sua_chua ycss
+  JOIN public.thiet_bi tb ON tb.id = ycss.thiet_bi_id
+  WHERE ycss.id = p_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF ycss, tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Yêu cầu không tồn tại';
+  END IF;
+
+  IF NOT v_is_global AND v_tb_don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  IF v_locked_completed_at IS NOT NULL OR v_locked_status IN ('Hoàn thành', 'Không HT') THEN
+    RAISE EXCEPTION 'Không thể hoàn thành lại yêu cầu đã hoàn thành' USING errcode = '22023';
+  END IF;
+
+  IF p_chi_phi_sua_chua IS NOT NULL AND p_chi_phi_sua_chua < 0 THEN
+    RAISE EXCEPTION 'Chi phí sửa chữa không được âm' USING errcode = '22023';
+  END IF;
+
+  IF p_completion IS NOT NULL AND trim(p_completion) <> '' THEN
+    v_status := 'Hoàn thành';
+    v_result := p_completion;
+    v_reason := NULL;
+    v_cost := p_chi_phi_sua_chua;
+  ELSE
+    v_status := 'Không HT';
+    v_result := NULL;
+    v_reason := p_reason;
+    v_cost := NULL;
+  END IF;
+
+  UPDATE public.yeu_cau_sua_chua
+  SET trang_thai = v_status,
+      ngay_hoan_thanh = now(),
+      ket_qua_sua_chua = v_result,
+      ly_do_khong_hoan_thanh = v_reason,
+      chi_phi_sua_chua = v_cost
+  WHERE id = p_id;
+
+  IF v_status = 'Hoàn thành' THEN
+    UPDATE public.thiet_bi
+    SET tinh_trang_hien_tai = 'Hoạt động'
+    WHERE id = v_thiet_bi_id
+      AND is_deleted = false;
+  END IF;
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    v_thiet_bi_id,
+    'Sửa chữa',
+    'Yêu cầu sửa chữa cập nhật trạng thái',
+    jsonb_build_object(
+      'ket_qua', coalesce(v_result, v_reason),
+      'trang_thai', v_status,
+      'chi_phi_sua_chua', v_cost
+    ),
+    p_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_complete',
+    'repair_request',
+    p_id,
+    NULL,
+    jsonb_build_object(
+      'trang_thai', v_status,
+      'ket_qua_sua_chua', v_result,
+      'ly_do_khong_hoan_thanh', v_reason,
+      'chi_phi_sua_chua', v_cost
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', p_id;
+  END IF;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_complete(integer, text, text, numeric) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_complete(integer, text, text, numeric) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_list(
+  p_q text DEFAULT NULL::text,
+  p_status text DEFAULT NULL::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_date_from date DEFAULT NULL::date,
+  p_date_to date DEFAULT NULL::date,
+  p_statuses text[] DEFAULT NULL::text[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role text := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id text := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global boolean := false;
+  v_effective_donvi bigint := NULL;
+  v_allowed bigint[] := NULL;
+  v_limit integer := greatest(coalesce(p_page_size, 50), 1);
+  v_offset integer := greatest((coalesce(p_page, 1) - 1) * v_limit, 0);
+  v_total bigint := 0;
+  v_data jsonb := '[]'::jsonb;
+  v_statuses text[] := NULL;
+  v_sanitized_q text := NULL;
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  v_is_global := v_role IN ('global', 'admin');
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF p_statuses IS NOT NULL AND array_length(p_statuses, 1) IS NOT NULL THEN
+    v_statuses := p_statuses;
+  ELSIF p_status IS NOT NULL AND p_status <> '' THEN
+    v_statuses := ARRAY[p_status];
+  END IF;
+
+  IF v_is_global THEN
+    v_effective_donvi := p_don_vi;
+  ELSE
+    v_allowed := public.allowed_don_vi_for_session();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+    END IF;
+    IF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective_donvi := p_don_vi;
+      ELSE
+        RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+      END IF;
+    END IF;
+  END IF;
+
+  SELECT count(*) INTO v_total
+  FROM public.yeu_cau_sua_chua r
+  LEFT JOIN public.thiet_bi tb ON tb.id = r.thiet_bi_id
+  WHERE (
+    (v_is_global AND (v_effective_donvi IS NULL OR tb.don_vi = v_effective_donvi)) OR
+    (NOT v_is_global AND ((v_effective_donvi IS NOT NULL AND tb.don_vi = v_effective_donvi) OR (v_effective_donvi IS NULL AND tb.don_vi = ANY(v_allowed))))
+  )
+  AND (v_statuses IS NULL OR r.trang_thai = ANY(v_statuses))
+  AND (
+    v_sanitized_q IS NULL OR
+    r.mo_ta_su_co ILIKE '%' || v_sanitized_q || '%' OR
+    r.hang_muc_sua_chua ILIKE '%' || v_sanitized_q || '%' OR
+    tb.ten_thiet_bi ILIKE '%' || v_sanitized_q || '%' OR
+    tb.ma_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+  )
+  AND (p_date_from IS NULL OR r.ngay_yeu_cau >= (p_date_from::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'))
+  AND (p_date_to IS NULL OR r.ngay_yeu_cau < ((p_date_to + interval '1 day')::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'));
+
+  SELECT coalesce(jsonb_agg(row_data ORDER BY ngay_yeu_cau DESC), '[]'::jsonb) INTO v_data
+  FROM (
+    SELECT
+      jsonb_build_object(
+        'id', r.id,
+        'thiet_bi_id', r.thiet_bi_id,
+        'ngay_yeu_cau', r.ngay_yeu_cau,
+        'trang_thai', r.trang_thai,
+        'mo_ta_su_co', r.mo_ta_su_co,
+        'hang_muc_sua_chua', r.hang_muc_sua_chua,
+        'ngay_mong_muon_hoan_thanh', r.ngay_mong_muon_hoan_thanh,
+        'nguoi_yeu_cau', r.nguoi_yeu_cau,
+        'ngay_duyet', r.ngay_duyet,
+        'ngay_hoan_thanh', r.ngay_hoan_thanh,
+        'nguoi_duyet', r.nguoi_duyet,
+        'nguoi_xac_nhan', r.nguoi_xac_nhan,
+        'don_vi_thuc_hien', r.don_vi_thuc_hien,
+        'ten_don_vi_thue', r.ten_don_vi_thue,
+        'ket_qua_sua_chua', r.ket_qua_sua_chua,
+        'ly_do_khong_hoan_thanh', r.ly_do_khong_hoan_thanh,
+        'chi_phi_sua_chua', r.chi_phi_sua_chua,
+        'equipment_is_deleted', tb.is_deleted,
+        'thiet_bi', jsonb_build_object(
+          'ten_thiet_bi', tb.ten_thiet_bi,
+          'ma_thiet_bi', tb.ma_thiet_bi,
+          'model', tb.model,
+          'serial', tb.serial,
+          'khoa_phong_quan_ly', tb.khoa_phong_quan_ly,
+          'facility_name', dv.name,
+          'facility_id', tb.don_vi,
+          'is_deleted', tb.is_deleted
+        )
+      ) AS row_data,
+      r.ngay_yeu_cau
+    FROM public.yeu_cau_sua_chua r
+    LEFT JOIN public.thiet_bi tb ON tb.id = r.thiet_bi_id
+    LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+    WHERE (
+      (v_is_global AND (v_effective_donvi IS NULL OR tb.don_vi = v_effective_donvi)) OR
+      (NOT v_is_global AND ((v_effective_donvi IS NOT NULL AND tb.don_vi = v_effective_donvi) OR (v_effective_donvi IS NULL AND tb.don_vi = ANY(v_allowed))))
+    )
+    AND (v_statuses IS NULL OR r.trang_thai = ANY(v_statuses))
+    AND (
+      v_sanitized_q IS NULL OR
+      r.mo_ta_su_co ILIKE '%' || v_sanitized_q || '%' OR
+      r.hang_muc_sua_chua ILIKE '%' || v_sanitized_q || '%' OR
+      tb.ten_thiet_bi ILIKE '%' || v_sanitized_q || '%' OR
+      tb.ma_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+    )
+    AND (p_date_from IS NULL OR r.ngay_yeu_cau >= (p_date_from::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'))
+    AND (p_date_to IS NULL OR r.ngay_yeu_cau < ((p_date_to + interval '1 day')::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'))
+    ORDER BY r.ngay_yeu_cau DESC
+    OFFSET v_offset
+    LIMIT v_limit
+  ) subq;
+
+  RETURN jsonb_build_object('data', v_data, 'total', v_total, 'page', p_page, 'pageSize', p_page_size);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_list(text, text, integer, integer, bigint, date, date, text[]) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_list(text, text, integer, integer, bigint, date, date, text[]) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.get_maintenance_report_data(
+  p_date_from date,
+  p_date_to date,
+  p_don_vi bigint DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_is_global boolean := false;
+  v_allowed bigint[];
+  v_effective bigint[];
+  v_result jsonb;
+BEGIN
+  v_role := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global := v_role IN ('global', 'admin');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_is_global THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    v_allowed := public.allowed_don_vi_for_session_safe();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object(
+        'summary', jsonb_build_object(
+          'totalRepairs', 0,
+          'repairCompletionRate', 0,
+          'totalMaintenancePlanned', 0,
+          'maintenanceCompletionRate', 0,
+          'totalRepairCost', 0,
+          'averageCompletedRepairCost', 0,
+          'costRecordedCount', 0,
+          'costMissingCount', 0
+        ),
+        'charts', jsonb_build_object(
+          'repairStatusDistribution', '[]'::jsonb,
+          'maintenancePlanVsActual', '[]'::jsonb,
+          'repairFrequencyByMonth', '[]'::jsonb,
+          'repairCostByMonth', '[]'::jsonb,
+          'repairCostByFacility', '[]'::jsonb
+        ),
+        'topEquipmentRepairs', '[]'::jsonb,
+        'recentRepairHistory', '[]'::jsonb
+      );
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective := ARRAY[p_don_vi];
+      ELSE
+        RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING errcode = '42501';
+      END IF;
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  WITH repair_data_raw AS (
+    SELECT
+      yc.id,
+      yc.trang_thai,
+      yc.mo_ta_su_co,
+      yc.ngay_yeu_cau,
+      yc.ngay_duyet,
+      yc.ngay_hoan_thanh,
+      yc.chi_phi_sua_chua,
+      tb.id AS equipment_id,
+      coalesce(nullif(trim(tb.ten_thiet_bi), ''), tb.ma_thiet_bi, 'Không xác định') AS equipment_name,
+      tb.don_vi AS facility_id,
+      coalesce(dv.name, 'Không xác định') AS facility_name,
+      coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh, clock_timestamp()) AS reference_timestamp,
+      (lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%' OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%') AS is_completed
+    FROM public.yeu_cau_sua_chua yc
+    INNER JOIN public.thiet_bi tb ON yc.thiet_bi_id = tb.id
+    LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+    WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+  ),
+  repair_data AS (
+    SELECT
+      id,
+      trang_thai,
+      mo_ta_su_co,
+      ngay_yeu_cau,
+      ngay_duyet,
+      ngay_hoan_thanh,
+      chi_phi_sua_chua,
+      equipment_id,
+      equipment_name,
+      facility_id,
+      facility_name,
+      reference_timestamp,
+      is_completed
+    FROM repair_data_raw
+    WHERE reference_timestamp::date BETWEEN p_date_from AND p_date_to
+  ),
+  repair_summary AS (
+    SELECT
+      count(*) AS total_repairs,
+      count(*) FILTER (WHERE is_completed) AS completed,
+      count(*) FILTER (WHERE lower(coalesce(trang_thai, '')) LIKE '%không ht%') AS not_completed,
+      count(*) FILTER (WHERE lower(coalesce(trang_thai, '')) LIKE '%đã duyệt%' OR lower(coalesce(trang_thai, '')) LIKE '%da duyet%') AS approved,
+      count(*) FILTER (WHERE lower(coalesce(trang_thai, '')) LIKE '%chờ%' OR lower(coalesce(trang_thai, '')) LIKE '%cho%') AS pending,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL) AS cost_missing_count
+    FROM repair_data
+  ),
+  maintenance_data AS (
+    SELECT
+      kh.id AS plan_id,
+      kh.nam,
+      kh.trang_thai,
+      kh.don_vi,
+      cv.id AS task_id,
+      cv.loai_cong_viec,
+      cv.thang_1, cv.thang_1_hoan_thanh,
+      cv.thang_2, cv.thang_2_hoan_thanh,
+      cv.thang_3, cv.thang_3_hoan_thanh,
+      cv.thang_4, cv.thang_4_hoan_thanh,
+      cv.thang_5, cv.thang_5_hoan_thanh,
+      cv.thang_6, cv.thang_6_hoan_thanh,
+      cv.thang_7, cv.thang_7_hoan_thanh,
+      cv.thang_8, cv.thang_8_hoan_thanh,
+      cv.thang_9, cv.thang_9_hoan_thanh,
+      cv.thang_10, cv.thang_10_hoan_thanh,
+      cv.thang_11, cv.thang_11_hoan_thanh,
+      cv.thang_12, cv.thang_12_hoan_thanh
+    FROM public.ke_hoach_bao_tri kh
+    LEFT JOIN public.cong_viec_bao_tri cv ON kh.id = cv.ke_hoach_id
+    WHERE (v_effective IS NULL OR kh.don_vi = ANY(v_effective))
+      AND kh.nam = extract(year from p_date_from)
+      AND kh.trang_thai = 'Đã duyệt'
+  ),
+  maintenance_summary AS (
+    SELECT
+      loai_cong_viec,
+      (CASE WHEN thang_1 THEN 1 ELSE 0 END + CASE WHEN thang_2 THEN 1 ELSE 0 END +
+       CASE WHEN thang_3 THEN 1 ELSE 0 END + CASE WHEN thang_4 THEN 1 ELSE 0 END +
+       CASE WHEN thang_5 THEN 1 ELSE 0 END + CASE WHEN thang_6 THEN 1 ELSE 0 END +
+       CASE WHEN thang_7 THEN 1 ELSE 0 END + CASE WHEN thang_8 THEN 1 ELSE 0 END +
+       CASE WHEN thang_9 THEN 1 ELSE 0 END + CASE WHEN thang_10 THEN 1 ELSE 0 END +
+       CASE WHEN thang_11 THEN 1 ELSE 0 END + CASE WHEN thang_12 THEN 1 ELSE 0 END) AS planned,
+      (CASE WHEN thang_1_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_2_hoan_thanh THEN 1 ELSE 0 END +
+       CASE WHEN thang_3_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_4_hoan_thanh THEN 1 ELSE 0 END +
+       CASE WHEN thang_5_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_6_hoan_thanh THEN 1 ELSE 0 END +
+       CASE WHEN thang_7_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_8_hoan_thanh THEN 1 ELSE 0 END +
+       CASE WHEN thang_9_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_10_hoan_thanh THEN 1 ELSE 0 END +
+       CASE WHEN thang_11_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_12_hoan_thanh THEN 1 ELSE 0 END) AS actual
+    FROM maintenance_data
+    WHERE loai_cong_viec IN ('Bảo trì', 'Hiệu chuẩn', 'Kiểm định')
+  ),
+  maintenance_aggregated AS (
+    SELECT loai_cong_viec, sum(planned) AS total_planned, sum(actual) AS total_actual
+    FROM maintenance_summary
+    GROUP BY loai_cong_viec
+  ),
+  repair_frequency AS (
+    SELECT
+      to_char(date_trunc('month', reference_timestamp), 'YYYY-MM') AS period,
+      count(*)::integer AS total,
+      count(*) FILTER (WHERE is_completed)::integer AS completed
+    FROM repair_data
+    GROUP BY date_trunc('month', reference_timestamp)
+  ),
+  repair_cost_by_month AS (
+    SELECT
+      to_char(date_trunc('month', reference_timestamp), 'YYYY-MM') AS period,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY date_trunc('month', reference_timestamp)
+  ),
+  repair_cost_by_facility AS (
+    SELECT
+      facility_id,
+      facility_name,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY facility_id, facility_name
+  ),
+  equipment_repairs AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      count(*)::integer AS total_requests,
+      max(reference_timestamp) AS latest_event_at,
+      max(ngay_hoan_thanh) AS latest_completed_at,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY equipment_id, equipment_name
+  ),
+  equipment_latest_status AS (
+    SELECT DISTINCT ON (equipment_id)
+      equipment_id,
+      coalesce(trang_thai, 'Không xác định') AS latest_status,
+      coalesce(ngay_hoan_thanh, ngay_duyet, ngay_yeu_cau, reference_timestamp) AS status_timestamp
+    FROM repair_data
+    ORDER BY equipment_id, coalesce(ngay_hoan_thanh, ngay_duyet, ngay_yeu_cau, reference_timestamp) DESC
+  ),
+  top_equipment AS (
+    SELECT
+      er.equipment_id,
+      er.equipment_name,
+      er.total_requests,
+      er.total_repair_cost,
+      er.average_completed_repair_cost,
+      er.cost_recorded_count,
+      er.cost_missing_count,
+      els.latest_status,
+      CASE WHEN er.latest_completed_at IS NOT NULL THEN to_char(er.latest_completed_at, 'YYYY-MM-DD"T"HH24:MI:SS') ELSE NULL END AS latest_completed_date
+    FROM equipment_repairs er
+    LEFT JOIN equipment_latest_status els ON els.equipment_id = er.equipment_id
+    ORDER BY er.total_requests DESC, er.equipment_name
+    LIMIT 10
+  ),
+  recent_repairs AS (
+    SELECT
+      rd.id,
+      rd.equipment_name,
+      coalesce(nullif(trim(rd.mo_ta_su_co), ''), 'Không có mô tả') AS issue,
+      coalesce(rd.trang_thai, 'Không xác định') AS status,
+      rd.chi_phi_sua_chua,
+      to_char(reference_timestamp, 'YYYY-MM-DD"T"HH24:MI:SS') AS requested_date,
+      CASE WHEN rd.ngay_hoan_thanh IS NOT NULL THEN to_char(rd.ngay_hoan_thanh, 'YYYY-MM-DD"T"HH24:MI:SS') ELSE NULL END AS completed_date
+    FROM repair_data rd
+    ORDER BY reference_timestamp DESC
+    LIMIT 20
+  )
+  SELECT jsonb_build_object(
+    'summary', (
+      SELECT jsonb_build_object(
+        'totalRepairs', coalesce(rs.total_repairs, 0),
+        'repairCompletionRate', CASE WHEN coalesce(rs.total_repairs, 0) > 0 THEN (coalesce(rs.completed, 0)::numeric / rs.total_repairs * 100) ELSE 0 END,
+        'totalMaintenancePlanned', coalesce((SELECT sum(ma.total_planned) FROM maintenance_aggregated ma), 0),
+        'maintenanceCompletionRate',
+          CASE
+            WHEN coalesce((SELECT sum(ma.total_planned) FROM maintenance_aggregated ma), 0) > 0 THEN
+              (coalesce((SELECT sum(ma.total_actual) FROM maintenance_aggregated ma), 0)::numeric /
+               (SELECT sum(ma.total_planned) FROM maintenance_aggregated ma) * 100)
+            ELSE 0
+          END,
+        'totalRepairCost', coalesce(rs.total_repair_cost, 0),
+        'averageCompletedRepairCost', coalesce(rs.average_completed_repair_cost, 0),
+        'costRecordedCount', coalesce(rs.cost_recorded_count, 0),
+        'costMissingCount', coalesce(rs.cost_missing_count, 0)
+      )
+      FROM repair_summary rs
+    ),
+    'charts', jsonb_build_object(
+      'repairStatusDistribution', (
+        SELECT coalesce(jsonb_agg(jsonb_build_object('name', status_name, 'value', status_count, 'color', status_color)), '[]'::jsonb)
+        FROM (
+          SELECT 'Hoàn thành' AS status_name, completed AS status_count, 'hsl(var(--chart-1))' AS status_color FROM repair_summary WHERE completed > 0
+          UNION ALL SELECT 'Không HT', not_completed, 'hsl(var(--chart-5))' FROM repair_summary WHERE not_completed > 0
+          UNION ALL SELECT 'Đã duyệt', approved, 'hsl(var(--chart-2))' FROM repair_summary WHERE approved > 0
+          UNION ALL SELECT 'Chờ xử lý', pending, 'hsl(var(--chart-3))' FROM repair_summary WHERE pending > 0
+        ) statuses
+      ),
+      'maintenancePlanVsActual', (
+        SELECT coalesce(jsonb_agg(jsonb_build_object('name', loai_cong_viec, 'planned', total_planned, 'actual', total_actual) ORDER BY loai_cong_viec), '[]'::jsonb)
+        FROM maintenance_aggregated
+      ),
+      'repairFrequencyByMonth', (
+        SELECT coalesce(jsonb_agg(jsonb_build_object('period', period, 'total', total, 'completed', completed) ORDER BY period), '[]'::jsonb)
+        FROM repair_frequency
+      ),
+      'repairCostByMonth', (
+        SELECT coalesce(jsonb_agg(jsonb_build_object('period', period, 'totalCost', total_cost, 'averageCost', coalesce(average_cost, 0), 'costRecordedCount', cost_recorded_count, 'costMissingCount', cost_missing_count) ORDER BY period), '[]'::jsonb)
+        FROM repair_cost_by_month
+      ),
+      'repairCostByFacility', (
+        SELECT coalesce(jsonb_agg(jsonb_build_object('facilityId', facility_id, 'facilityName', facility_name, 'totalCost', total_cost, 'averageCost', coalesce(average_cost, 0), 'costRecordedCount', cost_recorded_count, 'costMissingCount', cost_missing_count) ORDER BY facility_name), '[]'::jsonb)
+        FROM repair_cost_by_facility
+      )
+    ),
+    'topEquipmentRepairs', (
+      SELECT coalesce(jsonb_agg(jsonb_build_object(
+        'equipmentId', te.equipment_id,
+        'equipmentName', te.equipment_name,
+        'totalRequests', te.total_requests,
+        'latestStatus', coalesce(te.latest_status, 'Không xác định'),
+        'latestCompletedDate', te.latest_completed_date,
+        'totalRepairCost', te.total_repair_cost,
+        'averageCompletedRepairCost', coalesce(te.average_completed_repair_cost, 0),
+        'costRecordedCount', te.cost_recorded_count,
+        'costMissingCount', te.cost_missing_count
+      ) ORDER BY te.total_requests DESC, te.equipment_name), '[]'::jsonb)
+      FROM top_equipment te
+    ),
+    'recentRepairHistory', (
+      SELECT coalesce(jsonb_agg(jsonb_build_object(
+        'id', rr.id,
+        'equipmentName', rr.equipment_name,
+        'issue', rr.issue,
+        'status', rr.status,
+        'repairCost', rr.chi_phi_sua_chua,
+        'requestedDate', rr.requested_date,
+        'completedDate', rr.completed_date
+      ) ORDER BY rr.requested_date DESC, rr.id DESC), '[]'::jsonb)
+      FROM recent_repairs rr
+    )
+  ) INTO v_result;
+
+  RETURN coalesce(v_result, jsonb_build_object(
+    'summary', jsonb_build_object(
+      'totalRepairs', 0,
+      'repairCompletionRate', 0,
+      'totalMaintenancePlanned', 0,
+      'maintenanceCompletionRate', 0,
+      'totalRepairCost', 0,
+      'averageCompletedRepairCost', 0,
+      'costRecordedCount', 0,
+      'costMissingCount', 0
+    ),
+    'charts', jsonb_build_object(
+      'repairStatusDistribution', '[]'::jsonb,
+      'maintenancePlanVsActual', '[]'::jsonb,
+      'repairFrequencyByMonth', '[]'::jsonb,
+      'repairCostByMonth', '[]'::jsonb,
+      'repairCostByFacility', '[]'::jsonb
+    ),
+    'topEquipmentRepairs', '[]'::jsonb,
+    'recentRepairHistory', '[]'::jsonb
+  ));
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) FROM PUBLIC;
+
+COMMENT ON FUNCTION public.get_maintenance_report_data(date, date, bigint)
+IS 'Returns maintenance report data with tenant-aware aggregation, top equipment repairs, recent history, and repair cost statistics.';
+
+CREATE OR REPLACE FUNCTION public.maintenance_stats_for_reports(
+  p_date_from date DEFAULT NULL,
+  p_date_to date DEFAULT NULL,
+  p_don_vi bigint DEFAULT NULL,
+  p_khoa_phong text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role text := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id text := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global boolean := false;
+  v_claim_donvi bigint := nullif(public._get_jwt_claim('don_vi'), '')::bigint;
+  v_allowed bigint[];
+  v_effective bigint[];
+  v_from date := coalesce(p_date_from, current_date - interval '1 year');
+  v_to date := coalesce(p_date_to, current_date);
+  v_from_year integer := extract(year from v_from)::integer;
+  v_to_year integer := extract(year from v_to)::integer;
+  result jsonb;
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  v_is_global := v_role IN ('global', 'admin');
+
+  IF v_is_global THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSIF v_role = 'regional_leader' THEN
+    v_allowed := public.allowed_don_vi_for_session_safe();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      v_effective := ARRAY[]::bigint[];
+    ELSIF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective := ARRAY[p_don_vi];
+      ELSE
+        RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING errcode = '42501';
+      END IF;
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  ELSE
+    IF v_claim_donvi IS NULL THEN
+      RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+    END IF;
+    IF p_don_vi IS NOT NULL AND p_don_vi <> v_claim_donvi THEN
+      RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING errcode = '42501';
+    END IF;
+    v_effective := ARRAY[v_claim_donvi];
+  END IF;
+
+  SELECT jsonb_build_object(
+    'repair_summary', (
+      SELECT jsonb_build_object(
+        'total_requests', count(*),
+        'completed', count(*) FILTER (
+          WHERE lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%'
+             OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%'
+        ),
+        'pending', count(*) FILTER (
+          WHERE lower(coalesce(yc.trang_thai, '')) LIKE '%chờ%'
+             OR lower(coalesce(yc.trang_thai, '')) LIKE '%cho%'
+        ),
+        'in_progress', count(*) FILTER (
+          WHERE lower(coalesce(yc.trang_thai, '')) LIKE '%đã duyệt%'
+             OR lower(coalesce(yc.trang_thai, '')) LIKE '%da duyet%'
+        ),
+        'total_cost', coalesce(sum(yc.chi_phi_sua_chua) FILTER (
+          WHERE lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%'
+             OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%'
+        ), 0),
+        'average_completed_cost', coalesce(avg(yc.chi_phi_sua_chua) FILTER (
+          WHERE (lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%'
+             OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%')
+            AND yc.chi_phi_sua_chua IS NOT NULL
+        ), 0),
+        'cost_recorded_count', count(*) FILTER (
+          WHERE (lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%'
+             OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%')
+            AND yc.chi_phi_sua_chua IS NOT NULL
+        ),
+        'cost_missing_count', count(*) FILTER (
+          WHERE (lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%'
+             OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%')
+            AND yc.chi_phi_sua_chua IS NULL
+        )
+      )
+      FROM public.yeu_cau_sua_chua yc
+      LEFT JOIN public.thiet_bi tb ON yc.thiet_bi_id = tb.id
+      WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+        AND (p_khoa_phong IS NULL OR tb.khoa_phong_quan_ly = p_khoa_phong)
+        AND coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh)::date BETWEEN v_from AND v_to
+    ),
+    'maintenance_summary', (
+      SELECT jsonb_build_object(
+        'total_plans', count(DISTINCT kh.id),
+        'total_tasks', count(cv.id),
+        'completed_tasks', count(*) FILTER (
+          WHERE
+            coalesce(cv.thang_1_hoan_thanh,false) OR coalesce(cv.thang_2_hoan_thanh,false) OR
+            coalesce(cv.thang_3_hoan_thanh,false) OR coalesce(cv.thang_4_hoan_thanh,false) OR
+            coalesce(cv.thang_5_hoan_thanh,false) OR coalesce(cv.thang_6_hoan_thanh,false) OR
+            coalesce(cv.thang_7_hoan_thanh,false) OR coalesce(cv.thang_8_hoan_thanh,false) OR
+            coalesce(cv.thang_9_hoan_thanh,false) OR coalesce(cv.thang_10_hoan_thanh,false) OR
+            coalesce(cv.thang_11_hoan_thanh,false) OR coalesce(cv.thang_12_hoan_thanh,false) OR
+            cv.ngay_hoan_thanh_1 IS NOT NULL OR cv.ngay_hoan_thanh_2 IS NOT NULL OR
+            cv.ngay_hoan_thanh_3 IS NOT NULL OR cv.ngay_hoan_thanh_4 IS NOT NULL OR
+            cv.ngay_hoan_thanh_5 IS NOT NULL OR cv.ngay_hoan_thanh_6 IS NOT NULL OR
+            cv.ngay_hoan_thanh_7 IS NOT NULL OR cv.ngay_hoan_thanh_8 IS NOT NULL OR
+            cv.ngay_hoan_thanh_9 IS NOT NULL OR cv.ngay_hoan_thanh_10 IS NOT NULL OR
+            cv.ngay_hoan_thanh_11 IS NOT NULL OR cv.ngay_hoan_thanh_12 IS NOT NULL
+        )
+      )
+      FROM public.ke_hoach_bao_tri kh
+      LEFT JOIN public.cong_viec_bao_tri cv ON kh.id = cv.ke_hoach_id
+      LEFT JOIN public.thiet_bi tb ON cv.thiet_bi_id = tb.id
+      WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+        AND (p_khoa_phong IS NULL OR tb.khoa_phong_quan_ly = p_khoa_phong)
+        AND kh.nam BETWEEN v_from_year AND v_to_year
+    )
+  ) INTO result;
+
+  RETURN coalesce(result, jsonb_build_object(
+    'repair_summary', jsonb_build_object(
+      'total_requests', 0,
+      'completed', 0,
+      'pending', 0,
+      'in_progress', 0,
+      'total_cost', 0,
+      'average_completed_cost', 0,
+      'cost_recorded_count', 0,
+      'cost_missing_count', 0
+    ),
+    'maintenance_summary', jsonb_build_object(
+      'total_plans', 0,
+      'total_tasks', 0,
+      'completed_tasks', 0
+    )
+  ));
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.maintenance_stats_for_reports(date, date, bigint, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.maintenance_stats_for_reports(date, date, bigint, text) FROM PUBLIC;
+
+COMMENT ON FUNCTION public.maintenance_stats_for_reports(date, date, bigint, text)
+IS 'Returns maintenance and repair summary data with tenant-aware repair cost statistics for reports/export.';
+
+COMMIT;

--- a/supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql
+++ b/supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql
@@ -186,6 +186,7 @@ DECLARE
   v_allowed bigint[] := NULL;
   v_limit integer := greatest(coalesce(p_page_size, 50), 1);
   v_offset integer := greatest((coalesce(p_page, 1) - 1) * v_limit, 0);
+  v_page integer := (v_offset / v_limit)::integer + 1;
   v_total bigint := 0;
   v_data jsonb := '[]'::jsonb;
   v_statuses text[] := NULL;
@@ -213,13 +214,13 @@ BEGIN
   ELSE
     v_allowed := public.allowed_don_vi_for_session();
     IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
-      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', v_page, 'pageSize', v_limit);
     END IF;
     IF p_don_vi IS NOT NULL THEN
       IF p_don_vi = ANY(v_allowed) THEN
         v_effective_donvi := p_don_vi;
       ELSE
-        RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+        RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', v_page, 'pageSize', v_limit);
       END IF;
     END IF;
   END IF;
@@ -298,7 +299,7 @@ BEGIN
     LIMIT v_limit
   ) subq;
 
-  RETURN jsonb_build_object('data', v_data, 'total', v_total, 'page', p_page, 'pageSize', p_page_size);
+  RETURN jsonb_build_object('data', v_data, 'total', v_total, 'page', v_page, 'pageSize', v_limit);
 END;
 $function$;
 
@@ -393,7 +394,7 @@ BEGIN
       coalesce(nullif(trim(tb.ten_thiet_bi), ''), tb.ma_thiet_bi, 'Không xác định') AS equipment_name,
       tb.don_vi AS facility_id,
       coalesce(dv.name, 'Không xác định') AS facility_name,
-      coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh, clock_timestamp()) AS reference_timestamp,
+      coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh) AS reference_timestamp,
       (lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%' OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%') AS is_completed
     FROM public.yeu_cau_sua_chua yc
     INNER JOIN public.thiet_bi tb ON yc.thiet_bi_id = tb.id
@@ -416,7 +417,8 @@ BEGIN
       reference_timestamp,
       is_completed
     FROM repair_data_raw
-    WHERE reference_timestamp::date BETWEEN p_date_from AND p_date_to
+    WHERE reference_timestamp IS NOT NULL
+      AND (reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN p_date_from AND p_date_to
   ),
   repair_summary AS (
     SELECT
@@ -482,21 +484,21 @@ BEGIN
   ),
   repair_frequency AS (
     SELECT
-      to_char(date_trunc('month', reference_timestamp), 'YYYY-MM') AS period,
+      to_char(date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
       count(*)::integer AS total,
       count(*) FILTER (WHERE is_completed)::integer AS completed
     FROM repair_data
-    GROUP BY date_trunc('month', reference_timestamp)
+    GROUP BY date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
   ),
   repair_cost_by_month AS (
     SELECT
-      to_char(date_trunc('month', reference_timestamp), 'YYYY-MM') AS period,
+      to_char(date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
       coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
       avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
       count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
       count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
     FROM repair_data
-    GROUP BY date_trunc('month', reference_timestamp)
+    GROUP BY date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
   ),
   repair_cost_by_facility AS (
     SELECT
@@ -554,8 +556,8 @@ BEGIN
       coalesce(nullif(trim(rd.mo_ta_su_co), ''), 'Không có mô tả') AS issue,
       coalesce(rd.trang_thai, 'Không xác định') AS status,
       rd.chi_phi_sua_chua,
-      to_char(reference_timestamp, 'YYYY-MM-DD"T"HH24:MI:SS') AS requested_date,
-      CASE WHEN rd.ngay_hoan_thanh IS NOT NULL THEN to_char(rd.ngay_hoan_thanh, 'YYYY-MM-DD"T"HH24:MI:SS') ELSE NULL END AS completed_date
+      to_char(reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh', 'YYYY-MM-DD"T"HH24:MI:SS') AS requested_date,
+      CASE WHEN rd.ngay_hoan_thanh IS NOT NULL THEN to_char(rd.ngay_hoan_thanh AT TIME ZONE 'Asia/Ho_Chi_Minh', 'YYYY-MM-DD"T"HH24:MI:SS') ELSE NULL END AS completed_date
     FROM repair_data rd
     ORDER BY reference_timestamp DESC
     LIMIT 20
@@ -768,7 +770,8 @@ BEGIN
       LEFT JOIN public.thiet_bi tb ON yc.thiet_bi_id = tb.id
       WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
         AND (p_khoa_phong IS NULL OR tb.khoa_phong_quan_ly = p_khoa_phong)
-        AND coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh)::date BETWEEN v_from AND v_to
+        AND coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh) IS NOT NULL
+        AND (coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh) AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN v_from AND v_to
     ),
     'maintenance_summary', (
       SELECT jsonb_build_object(

--- a/supabase/tests/repair_request_cost_smoke.sql
+++ b/supabase/tests/repair_request_cost_smoke.sql
@@ -1,0 +1,448 @@
+-- supabase/tests/repair_request_cost_smoke.sql
+-- Purpose: smoke-test repair request cost storage and reporting after the migration is applied.
+-- How to run (local): docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_cost_smoke.sql
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp._rr_cost_set_claims(
+  p_role text,
+  p_user_id bigint,
+  p_don_vi bigint DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', p_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::text,
+      'sub', p_user_id::text,
+      'don_vi', p_don_vi::text
+    )::text,
+    true
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp._rr_cost_create_approved_request(
+  p_tenant_id bigint,
+  p_user_id bigint,
+  p_suffix text
+)
+RETURNS bigint
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_equipment_id bigint;
+  v_request_id bigint;
+BEGIN
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (
+    'RR-COST-' || p_suffix,
+    'Repair cost smoke ' || p_suffix,
+    p_tenant_id
+  )
+  RETURNING id INTO v_equipment_id;
+
+  PERFORM pg_temp._rr_cost_set_claims('to_qltb', p_user_id, p_tenant_id);
+
+  v_request_id := public.repair_request_create(
+    v_equipment_id::integer,
+    'Mô tả sửa chữa smoke ' || p_suffix,
+    'Hạng mục sửa chữa smoke ' || p_suffix,
+    CURRENT_DATE + 7,
+    'Người yêu cầu smoke',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_approve(
+    v_request_id::integer,
+    'Người duyệt smoke',
+    'noi_bo',
+    NULL
+  );
+
+  RETURN v_request_id;
+END;
+$$;
+
+-- 1) Schema contract: nullable numeric(14,2), default 0, non-negative constraint.
+DO $$
+DECLARE
+  v_data_type text;
+  v_precision integer;
+  v_scale integer;
+  v_is_nullable text;
+  v_default text;
+  v_constraint_count integer;
+BEGIN
+  SELECT c.data_type, c.numeric_precision, c.numeric_scale, c.is_nullable, c.column_default
+  INTO v_data_type, v_precision, v_scale, v_is_nullable, v_default
+  FROM information_schema.columns c
+  WHERE c.table_schema = 'public'
+    AND c.table_name = 'yeu_cau_sua_chua'
+    AND c.column_name = 'chi_phi_sua_chua';
+
+  IF v_data_type IS NULL THEN
+    RAISE EXCEPTION 'Expected public.yeu_cau_sua_chua.chi_phi_sua_chua to exist';
+  END IF;
+
+  IF v_data_type <> 'numeric' OR v_precision <> 14 OR v_scale <> 2 THEN
+    RAISE EXCEPTION 'Expected chi_phi_sua_chua numeric(14,2), got %(%,%)', v_data_type, v_precision, v_scale;
+  END IF;
+
+  IF v_is_nullable <> 'YES' THEN
+    RAISE EXCEPTION 'Expected chi_phi_sua_chua to be nullable';
+  END IF;
+
+  IF position('0' in coalesce(v_default, '')) = 0 THEN
+    RAISE EXCEPTION 'Expected chi_phi_sua_chua default 0, got %', v_default;
+  END IF;
+
+  SELECT count(*)
+  INTO v_constraint_count
+  FROM pg_constraint con
+  JOIN pg_class rel ON rel.oid = con.conrelid
+  JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+  WHERE nsp.nspname = 'public'
+    AND rel.relname = 'yeu_cau_sua_chua'
+    AND con.conname = 'yeu_cau_sua_chua_chi_phi_sua_chua_non_negative'
+    AND pg_get_constraintdef(con.oid) ILIKE '%chi_phi_sua_chua%>=%0%';
+
+  IF v_constraint_count <> 1 THEN
+    RAISE EXCEPTION 'Expected non-negative chi_phi_sua_chua check constraint';
+  END IF;
+
+  RAISE NOTICE 'OK: repair cost schema contract passed';
+END $$;
+
+-- 2) Completion stores NULL, zero, and positive costs with distinct semantics.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_null_request_id bigint;
+  v_zero_request_id bigint;
+  v_positive_request_id bigint;
+  v_cost numeric;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair cost smoke tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_cost_smoke_' || v_suffix,
+    'smoke-password',
+    'Repair Cost Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  v_null_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-NULL');
+  v_zero_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-ZERO');
+  v_positive_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-POS');
+
+  PERFORM pg_temp._rr_cost_set_claims('to_qltb', v_user_id, v_tenant);
+
+  PERFORM public.repair_request_complete(
+    p_id => v_null_request_id::integer,
+    p_completion => 'Đã hoàn thành smoke null cost',
+    p_reason => NULL,
+    p_chi_phi_sua_chua => NULL
+  );
+
+  PERFORM public.repair_request_complete(
+    p_id => v_zero_request_id::integer,
+    p_completion => 'Đã hoàn thành smoke zero cost',
+    p_reason => NULL,
+    p_chi_phi_sua_chua => 0
+  );
+
+  PERFORM public.repair_request_complete(
+    p_id => v_positive_request_id::integer,
+    p_completion => 'Đã hoàn thành smoke positive cost',
+    p_reason => NULL,
+    p_chi_phi_sua_chua => 1234567
+  );
+
+  SELECT chi_phi_sua_chua INTO v_cost
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_null_request_id;
+
+  IF v_cost IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected blank completion cost to persist NULL, got %', v_cost;
+  END IF;
+
+  SELECT chi_phi_sua_chua INTO v_cost
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_zero_request_id;
+
+  IF v_cost IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'Expected explicit zero completion cost, got %', v_cost;
+  END IF;
+
+  SELECT chi_phi_sua_chua INTO v_cost
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_positive_request_id;
+
+  IF v_cost IS DISTINCT FROM 1234567 THEN
+    RAISE EXCEPTION 'Expected positive completion cost 1234567, got %', v_cost;
+  END IF;
+
+  RAISE NOTICE 'OK: repair_request_complete cost write semantics passed';
+END $$;
+
+-- 3) Invalid or repeated completion attempts cannot mutate cost.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_request_id bigint;
+  v_cost numeric;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair cost invalid smoke tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_cost_invalid_smoke_' || v_suffix,
+    'smoke-password',
+    'Repair Cost Invalid Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  v_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-NEG');
+  PERFORM pg_temp._rr_cost_set_claims('to_qltb', v_user_id, v_tenant);
+
+  BEGIN
+    PERFORM public.repair_request_complete(
+      p_id => v_request_id::integer,
+      p_completion => 'Đã hoàn thành smoke negative cost',
+      p_reason => NULL,
+      p_chi_phi_sua_chua => -1
+    );
+    RAISE EXCEPTION 'Expected negative repair cost to be rejected';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLSTATE <> '22023' THEN
+      RAISE EXCEPTION 'Expected SQLSTATE 22023 for negative repair cost, got [%] %', SQLSTATE, SQLERRM;
+    END IF;
+  END;
+
+  PERFORM public.repair_request_complete(
+    p_id => v_request_id::integer,
+    p_completion => 'Đã hoàn thành smoke terminal cost',
+    p_reason => NULL,
+    p_chi_phi_sua_chua => 321
+  );
+
+  BEGIN
+    PERFORM public.repair_request_complete(
+      p_id => v_request_id::integer,
+      p_completion => 'Cố gắng hoàn thành lại',
+      p_reason => NULL,
+      p_chi_phi_sua_chua => 999
+    );
+    RAISE EXCEPTION 'Expected second completion to be rejected';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLSTATE <> '22023' THEN
+      RAISE EXCEPTION 'Expected SQLSTATE 22023 for second completion, got [%] %', SQLSTATE, SQLERRM;
+    END IF;
+  END;
+
+  SELECT chi_phi_sua_chua INTO v_cost
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_request_id;
+
+  IF v_cost IS DISTINCT FROM 321 THEN
+    RAISE EXCEPTION 'Expected second completion to preserve cost 321, got %', v_cost;
+  END IF;
+
+  RAISE NOTICE 'OK: invalid and repeated completion cost guards passed';
+END $$;
+
+-- 4) Security guards are preserved for missing claims and wrong tenant.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_user_id bigint;
+  v_request_id bigint;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair cost secure tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair cost secure other tenant ' || v_suffix, true)
+  RETURNING id INTO v_other_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_cost_secure_smoke_' || v_suffix,
+    'smoke-password',
+    'Repair Cost Secure Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  v_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-SEC');
+
+  PERFORM set_config('request.jwt.claims', '{}'::text, true);
+
+  BEGIN
+    PERFORM public.repair_request_complete(
+      p_id => v_request_id::integer,
+      p_completion => 'Thiếu claims',
+      p_reason => NULL,
+      p_chi_phi_sua_chua => 1
+    );
+    RAISE EXCEPTION 'Expected missing claims to be rejected';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLSTATE <> '42501' THEN
+      RAISE EXCEPTION 'Expected SQLSTATE 42501 for missing claims, got [%] %', SQLSTATE, SQLERRM;
+    END IF;
+  END;
+
+  PERFORM pg_temp._rr_cost_set_claims('to_qltb', v_user_id, v_other_tenant);
+
+  BEGIN
+    PERFORM public.repair_request_complete(
+      p_id => v_request_id::integer,
+      p_completion => 'Sai đơn vị',
+      p_reason => NULL,
+      p_chi_phi_sua_chua => 1
+    );
+    RAISE EXCEPTION 'Expected wrong tenant to be rejected';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLSTATE <> '42501' THEN
+      RAISE EXCEPTION 'Expected SQLSTATE 42501 for wrong tenant, got [%] %', SQLSTATE, SQLERRM;
+    END IF;
+  END;
+
+  RAISE NOTICE 'OK: repair_request_complete security guards passed';
+END $$;
+
+-- 5) List/detail/report RPCs expose cost values and NULL-aware aggregate semantics.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_null_request_id bigint;
+  v_zero_request_id bigint;
+  v_positive_request_id bigint;
+  v_list jsonb;
+  v_detail jsonb;
+  v_report jsonb;
+  v_stats jsonb;
+  v_total numeric;
+  v_average numeric;
+  v_recorded_count integer;
+  v_missing_count integer;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair cost report smoke tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_cost_report_smoke_' || v_suffix,
+    'smoke-password',
+    'Repair Cost Report Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  v_null_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-REPORT-NULL');
+  v_zero_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-REPORT-ZERO');
+  v_positive_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-REPORT-POS');
+
+  PERFORM pg_temp._rr_cost_set_claims('to_qltb', v_user_id, v_tenant);
+
+  PERFORM public.repair_request_complete(v_null_request_id::integer, 'Report null cost', NULL, NULL);
+  PERFORM public.repair_request_complete(v_zero_request_id::integer, 'Report zero cost', NULL, 0);
+  PERFORM public.repair_request_complete(v_positive_request_id::integer, 'Report positive cost', NULL, 1234567);
+
+  v_list := public.repair_request_list(
+    p_q => NULL,
+    p_status => NULL,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant,
+    p_date_from => CURRENT_DATE - 1,
+    p_date_to => CURRENT_DATE + 1,
+    p_statuses => ARRAY['Hoàn thành']::text[]
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_list->'data') AS item(row_data)
+    WHERE (row_data->>'id')::bigint = v_positive_request_id
+      AND row_data ? 'chi_phi_sua_chua'
+      AND (row_data->>'chi_phi_sua_chua')::numeric = 1234567
+  ) THEN
+    RAISE EXCEPTION 'repair_request_list should include positive chi_phi_sua_chua row, got %', v_list;
+  END IF;
+
+  v_detail := public.repair_request_get(v_positive_request_id::integer);
+
+  IF (v_detail->>'chi_phi_sua_chua')::numeric IS DISTINCT FROM 1234567 THEN
+    RAISE EXCEPTION 'repair_request_get should expose chi_phi_sua_chua 1234567, got %', v_detail->>'chi_phi_sua_chua';
+  END IF;
+
+  v_report := public.get_maintenance_report_data(CURRENT_DATE - 1, CURRENT_DATE + 1, v_tenant);
+  v_total := (v_report #>> '{summary,totalRepairCost}')::numeric;
+  v_average := (v_report #>> '{summary,averageCompletedRepairCost}')::numeric;
+  v_recorded_count := (v_report #>> '{summary,costRecordedCount}')::integer;
+  v_missing_count := (v_report #>> '{summary,costMissingCount}')::integer;
+
+  IF v_total IS DISTINCT FROM 1234567 THEN
+    RAISE EXCEPTION 'Expected report totalRepairCost 1234567, got % in %', v_total, v_report;
+  END IF;
+
+  IF v_average IS DISTINCT FROM 617283.5 THEN
+    RAISE EXCEPTION 'Expected report averageCompletedRepairCost 617283.5, got % in %', v_average, v_report;
+  END IF;
+
+  IF v_recorded_count IS DISTINCT FROM 2 OR v_missing_count IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Expected report cost counts recorded=2 missing=1, got recorded=% missing=% in %', v_recorded_count, v_missing_count, v_report;
+  END IF;
+
+  v_stats := public.maintenance_stats_for_reports(CURRENT_DATE - 1, CURRENT_DATE + 1, v_tenant, NULL);
+
+  IF (v_stats #>> '{repair_summary,total_cost}')::numeric IS DISTINCT FROM 1234567 THEN
+    RAISE EXCEPTION 'Expected stats repair_summary.total_cost 1234567, got %', v_stats;
+  END IF;
+
+  IF (v_stats #>> '{repair_summary,average_completed_cost}')::numeric IS DISTINCT FROM 617283.5 THEN
+    RAISE EXCEPTION 'Expected stats repair_summary.average_completed_cost 617283.5, got %', v_stats;
+  END IF;
+
+  IF (v_stats #>> '{repair_summary,cost_recorded_count}')::integer IS DISTINCT FROM 2
+     OR (v_stats #>> '{repair_summary,cost_missing_count}')::integer IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Expected stats repair cost counts recorded=2 missing=1, got %', v_stats;
+  END IF;
+
+  RAISE NOTICE 'OK: repair cost list/detail/report payloads passed';
+END $$;
+
+ROLLBACK;

--- a/supabase/tests/repair_request_cost_smoke.sql
+++ b/supabase/tests/repair_request_cost_smoke.sql
@@ -358,6 +358,7 @@ DECLARE
   v_zero_request_id bigint;
   v_positive_request_id bigint;
   v_list jsonb;
+  v_pagination jsonb;
   v_detail jsonb;
   v_report jsonb;
   v_stats jsonb;
@@ -410,6 +411,22 @@ BEGIN
       AND (row_data->>'chi_phi_sua_chua')::numeric = 1234567
   ) THEN
     RAISE EXCEPTION 'repair_request_list should include positive chi_phi_sua_chua row, got %', v_list;
+  END IF;
+
+  v_pagination := public.repair_request_list(
+    p_q => NULL,
+    p_status => NULL,
+    p_page => 0,
+    p_page_size => 0,
+    p_don_vi => v_tenant,
+    p_date_from => CURRENT_DATE - 1,
+    p_date_to => CURRENT_DATE + 1,
+    p_statuses => ARRAY['Hoàn thành']::text[]
+  );
+
+  IF (v_pagination->>'page')::integer IS DISTINCT FROM 1
+     OR (v_pagination->>'pageSize')::integer IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'repair_request_list should return normalized pagination metadata page=1 pageSize=1, got %', v_pagination;
   END IF;
 
   v_detail := public.repair_request_get(v_positive_request_id::integer);

--- a/supabase/tests/repair_request_cost_smoke.sql
+++ b/supabase/tests/repair_request_cost_smoke.sql
@@ -71,7 +71,8 @@ BEGIN
 END;
 $$;
 
--- 1) Schema contract: nullable numeric(14,2), default 0, non-negative constraint.
+-- 1) Schema contract: nullable numeric(14,2), no default, non-negative constraint.
+-- No-backfill is covered by the migration DDL order: ADD COLUMN without default, then DROP DEFAULT.
 DO $$
 DECLARE
   v_data_type text;
@@ -100,8 +101,8 @@ BEGIN
     RAISE EXCEPTION 'Expected chi_phi_sua_chua to be nullable';
   END IF;
 
-  IF position('0' in coalesce(v_default, '')) = 0 THEN
-    RAISE EXCEPTION 'Expected chi_phi_sua_chua default 0, got %', v_default;
+  IF v_default IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected chi_phi_sua_chua to have no default, got %', v_default;
   END IF;
 
   SELECT count(*)
@@ -150,6 +151,14 @@ BEGIN
   v_null_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-NULL');
   v_zero_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-ZERO');
   v_positive_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-POS');
+
+  SELECT chi_phi_sua_chua INTO v_cost
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_null_request_id;
+
+  IF v_cost IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected omitted request cost to stay NULL before completion, got %', v_cost;
+  END IF;
 
   PERFORM pg_temp._rr_cost_set_claims('to_qltb', v_user_id, v_tenant);
 


### PR DESCRIPTION
## Summary
- Adds OpenSpec proposal/tasklist and implementation plan for Issue #237.
- Adds backend SQL smoke coverage for `chi_phi_sua_chua` semantics.
- Adds an unapplied Supabase migration for `yeu_cau_sua_chua.chi_phi_sua_chua`, `repair_request_complete`, repair list payloads, and maintenance report/export cost aggregates.

## Important
- Migration is intentionally prepared but not applied in this session.
- Smoke GREEN tests and Supabase security advisors are still apply-dependent.
- Blank completion cost stores `NULL`; explicit `0` stores numeric `0`; existing rows are not backfilled.

## Verification
- `openspec validate add-repair-request-cost-statistics --strict` passed. PostHog telemetry flush logged network errors, but the command exited 0.
- `git diff --cached --check` passed before commit.
- SQL smoke was not run because `psql` is not available in PATH here and the migration was intentionally not applied.

Closes backend batch for #237; frontend batch remains pending.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional repair cost capture at repair completion and adds cost totals/averages to repair lists and maintenance reports to fulfill Issue #237. Migration is prepared but not applied.

- **New Features**
  - Schema: add `chi_phi_sua_chua numeric(14,2) NULL` with no default and non-negative check; no backfill.
  - RPC: extend `repair_request_complete(p_id, p_completion, p_reason, p_chi_phi_sua_chua)` to set cost only for `Hoàn thành`, keep `NULL` for `Không HT`, reject negatives; security and terminal guards preserved.
  - Payloads: `repair_request_list` includes `chi_phi_sua_chua` and uses sanitized ILIKE search; `get_maintenance_report_data` and `maintenance_stats_for_reports` compute totals and averages only for completed repairs, exclude `NULL` in averages, and add recorded/missing counts; add cost series by month and by facility.
  - Tests: SQL smoke covers schema, write semantics, idempotency, tenant/claims guards, and report aggregates.

- **Migration**
  - `supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql` is prepared but not applied.
  - After applying: run the smoke test; verify blank completion stores `NULL`, explicit `0` stores `0`, totals include only completed costs, and averages exclude `NULL`.

<sup>Written for commit fac05e883e3213c202949bd97e43e56fc0e5c1b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture an optional repair cost at completion; UI shows/accepts blank → unknown (NULL), explicit zero, or positive values. Listings, detail views, reports, and exports include per-request cost and aggregated stats (totals, averages, recorded vs missing counts).

* **Documentation**
  * Added implementation plan, specification, and task breakdown for rollout, validation, and phased backend/frontend work.

* **Tests**
  * Added end-to-end SQL smoke tests and frontend test plan validating storage semantics, security/tenant guards, and report aggregates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->