### PR TITLE
Fix CalendarWidget react-doctor warning

### DIFF
--- a/src/components/ui/__tests__/calendar-widget.test.tsx
+++ b/src/components/ui/__tests__/calendar-widget.test.tsx
@@ -98,7 +98,7 @@ describe("CalendarWidget", () => {
     expect(screen.getAllByText("Đã hoàn thành").length).toBeGreaterThan(0)
   })
 
-  it("shows a destructive toast when data loading fails", async () => {
+  it("shows an inline alert instead of a toast when data loading fails", async () => {
     mockUseCalendarData.mockReturnValue({
       data: undefined,
       error: new Error("RPC failed"),
@@ -107,15 +107,9 @@ describe("CalendarWidget", () => {
 
     render(<CalendarWidget />)
 
-    await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          variant: "destructive",
-          title: "Lỗi tải dữ liệu",
-          description: "RPC failed",
-        })
-      )
-    })
+    expect(await screen.findByRole("alert")).toHaveTextContent("Không thể tải lịch bảo trì")
+    expect(screen.getByText("Vui lòng thử lại sau.")).toBeInTheDocument()
+    expect(mockToast).not.toHaveBeenCalled()
   })
 
   it("handles swipe gestures even when the touch starts at clientX 0", async () => {

--- a/src/components/ui/__tests__/calendar-widget.test.tsx
+++ b/src/components/ui/__tests__/calendar-widget.test.tsx
@@ -112,6 +112,48 @@ describe("CalendarWidget", () => {
     expect(mockToast).not.toHaveBeenCalled()
   })
 
+  it("keeps rendering cached events when a background refetch fails", async () => {
+    mockUseCalendarData.mockReturnValue({
+      data: {
+        departments: ["Khoa A"],
+        events: [
+          {
+            id: 1,
+            title: "Bảo trì máy siêu âm",
+            type: "Bảo trì",
+            date: new Date("2026-04-11T00:00:00.000Z"),
+            equipmentCode: "TB-001",
+            equipmentName: "Máy siêu âm",
+            department: "Khoa A",
+            isCompleted: false,
+            planName: "Kế hoạch 1",
+            planId: 10,
+            taskId: 100,
+          },
+        ],
+        stats: {
+          total: 1,
+          completed: 0,
+          pending: 1,
+          byType: {
+            "Bảo trì": 1,
+          },
+        },
+      },
+      error: new Error("Background refetch failed"),
+      isLoading: false,
+    })
+
+    render(<CalendarWidget />)
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Bảo trì máy siêu âm").length).toBeGreaterThan(0)
+    })
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    expect(mockToast).not.toHaveBeenCalled()
+  })
+
   it("handles swipe gestures even when the touch starts at clientX 0", async () => {
     mockUseCalendarData.mockReturnValue({
       data: {

--- a/src/components/ui/calendar-widget.tsx
+++ b/src/components/ui/calendar-widget.tsx
@@ -16,9 +16,12 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { useCalendarData, type CalendarEvent, type CalendarStats } from "@/hooks/use-calendar-data"
 import type { TaskType } from "@/lib/data"
 
-import { CalendarWidgetGrid } from "./calendar-widget/CalendarWidgetGrid"
-import { CalendarWidgetHeader, CalendarWidgetMonthControls } from "./calendar-widget/CalendarWidgetHeader"
-import { CalendarWidgetStats } from "./calendar-widget/CalendarWidgetStats"
+import { CalendarWidgetGrid } from "@/components/ui/calendar-widget/CalendarWidgetGrid"
+import {
+  CalendarWidgetHeader,
+  CalendarWidgetMonthControls,
+} from "@/components/ui/calendar-widget/CalendarWidgetHeader"
+import { CalendarWidgetStats } from "@/components/ui/calendar-widget/CalendarWidgetStats"
 import {
   CalendarGridSkeleton,
   CalendarSkeleton,
@@ -26,7 +29,7 @@ import {
   EMPTY_CALENDAR_STATS,
   type CalendarWidgetImplProps,
   type CalendarWidgetProps,
-} from "./calendar-widget/CalendarWidgetShared"
+} from "@/components/ui/calendar-widget/CalendarWidgetShared"
 
 let initialClientCalendarDate: Date | null = null
 const EMPTY_SUBSCRIBE = () => () => {}
@@ -160,7 +163,7 @@ function CalendarWidgetImpl({
 
         {isLoading ? (
           <CalendarGridSkeleton />
-        ) : error ? (
+        ) : error && !data ? (
           <CalendarWidgetErrorState />
         ) : (
           <CalendarWidgetGrid

--- a/src/components/ui/calendar-widget.tsx
+++ b/src/components/ui/calendar-widget.tsx
@@ -14,7 +14,6 @@ import {
 
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { useCalendarData, type CalendarEvent, type CalendarStats } from "@/hooks/use-calendar-data"
-import { useToast } from "@/hooks/use-toast"
 import type { TaskType } from "@/lib/data"
 
 import { CalendarWidgetGrid } from "./calendar-widget/CalendarWidgetGrid"
@@ -23,6 +22,7 @@ import { CalendarWidgetStats } from "./calendar-widget/CalendarWidgetStats"
 import {
   CalendarGridSkeleton,
   CalendarSkeleton,
+  CalendarWidgetErrorState,
   EMPTY_CALENDAR_STATS,
   type CalendarWidgetImplProps,
   type CalendarWidgetProps,
@@ -103,7 +103,6 @@ function CalendarWidgetImpl({
   onToday,
 }: CalendarWidgetImplProps) {
   const [selectedDepartment, setSelectedDepartment] = React.useState("all")
-  const { toast } = useToast()
 
   const monthStart = startOfMonth(currentDate)
   const monthEnd = endOfMonth(currentDate)
@@ -117,16 +116,6 @@ function CalendarWidgetImpl({
 
   const events = data?.events ?? []
   const departments = data?.departments ?? []
-
-  React.useEffect(() => {
-    if (error) {
-      toast({
-        variant: "destructive",
-        title: "Lỗi tải dữ liệu",
-        description: error.message || "Không thể tải lịch bảo trì.",
-      })
-    }
-  }, [error, toast])
 
   const filteredEvents = React.useMemo(() => {
     if (selectedDepartment === "all") {
@@ -171,6 +160,8 @@ function CalendarWidgetImpl({
 
         {isLoading ? (
           <CalendarGridSkeleton />
+        ) : error ? (
+          <CalendarWidgetErrorState />
         ) : (
           <CalendarWidgetGrid
             calendarDays={calendarDays}

--- a/src/components/ui/calendar-widget.tsx
+++ b/src/components/ui/calendar-widget.tsx
@@ -139,6 +139,20 @@ function CalendarWidgetImpl({
 
   const swipeHandlers = useCalendarSwipeNavigation({ onNextMonth, onPrevMonth })
 
+  let calendarContent: React.ReactNode = (
+    <CalendarWidgetGrid
+      calendarDays={calendarDays}
+      currentDate={currentDate}
+      getEventsForDate={getEventsForDate}
+    />
+  )
+
+  if (isLoading) {
+    calendarContent = <CalendarGridSkeleton />
+  } else if (error && !data) {
+    calendarContent = <CalendarWidgetErrorState />
+  }
+
   return (
     <Card className={className}>
       <CardHeader className="pb-4 md:p-8 md:pb-6">
@@ -161,17 +175,7 @@ function CalendarWidgetImpl({
           onToday={onToday}
         />
 
-        {isLoading ? (
-          <CalendarGridSkeleton />
-        ) : error && !data ? (
-          <CalendarWidgetErrorState />
-        ) : (
-          <CalendarWidgetGrid
-            calendarDays={calendarDays}
-            currentDate={currentDate}
-            getEventsForDate={getEventsForDate}
-          />
-        )}
+        {calendarContent}
       </CardContent>
     </Card>
   )

--- a/src/components/ui/calendar-widget/CalendarWidgetShared.tsx
+++ b/src/components/ui/calendar-widget/CalendarWidgetShared.tsx
@@ -123,7 +123,7 @@ export function CalendarGridSkeleton() {
   )
 }
 
-export function CalendarWidgetErrorState() {
+export function CalendarWidgetErrorState(): React.JSX.Element {
   return (
     <div
       role="alert"

--- a/src/components/ui/calendar-widget/CalendarWidgetShared.tsx
+++ b/src/components/ui/calendar-widget/CalendarWidgetShared.tsx
@@ -123,6 +123,19 @@ export function CalendarGridSkeleton() {
   )
 }
 
+export function CalendarWidgetErrorState() {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center justify-center py-12 text-center text-destructive"
+    >
+      <CalendarIcon className="mb-3 h-8 w-8" />
+      <p className="font-semibold">Không thể tải lịch bảo trì</p>
+      <p className="mt-1 text-sm text-muted-foreground">Vui lòng thử lại sau.</p>
+    </div>
+  )
+}
+
 export function CalendarSkeleton({ className }: CalendarWidgetProps) {
   return (
     <Card className={className}>


### PR DESCRIPTION
## Summary
- Replace CalendarWidget query-error toast effect with an inline alert state
- Remove the event-like useEffect that React Doctor flagged
- Update CalendarWidget test coverage to assert inline error UI and no toast

Closes #240

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run src/components/ui/__tests__/calendar-widget.test.tsx
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

## Notes
- GitNexus impact for CalendarWidget/CalendarWidgetImpl: LOW
- GitNexus detect_changes after patch: low risk, no affected processes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced CalendarWidget’s toast-based error handling with an inline alert and simplified render logic to resolve the `react-doctor` warning and make errors clearer. Cached events still show if a background refetch fails.

- **Bug Fixes**
  - Removed toast `useEffect` flagged by `react-doctor`.
  - Added `CalendarWidgetErrorState`; render only when `error` and no `data`.
  - Updated tests to assert the inline alert, verify cached events persist on refetch error, and ensure no toast calls.

- **Refactors**
  - Consolidated conditional rendering into a single `calendarContent` branch and switched to aliased imports for clarity.

<sup>Written for commit 5d9b68acc47bcab10f66ffd54d137aff68c4e1fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar widget now shows an inline error state with a clear message when maintenance data cannot be loaded.

* **Bug Fixes**
  * Removed separate destructive toast for calendar load errors so feedback appears directly in the widget.
  * When background refresh fails but cached events exist, the widget continues showing cached data without an error alert.

* **Tests**
  * Updated tests to verify inline alert behavior and cached-data rendering; toast expectations removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->