### PR TITLE
Fix maintenance pagination reset effect

### DIFF
--- a/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
@@ -187,11 +187,11 @@ function createMaintenanceContext() {
   }
 }
 
-function expectLastPlanRequest(request: MaintenancePlanRequest) {
+function expectLastPlanRequest(request: MaintenancePlanRequest): Promise<void> {
   return waitFor(() => expect(mocks.useMaintenancePlans).toHaveBeenLastCalledWith(request))
 }
 
-function expectPlanRequestMissing(request: MaintenancePlanRequest) {
+function expectPlanRequestMissing(request: MaintenancePlanRequest): void {
   expect(mocks.useMaintenancePlans).not.toHaveBeenCalledWith(request)
 }
 
@@ -271,6 +271,24 @@ describe("Maintenance KPI integration", () => {
     await expectLastPlanRequest({ search: undefined, facilityId: null, page: 3, pageSize: 50 })
 
     await user.click(screen.getByRole("button", { name: "set-search" }))
+
+    expectPlanRequestMissing({ search: "ngoai tim", facilityId: null, page: 3, pageSize: 50 })
+    await expectLastPlanRequest({ search: "ngoai tim", facilityId: null, page: 1, pageSize: 50 })
+  })
+
+  it("resets plan pagination when debounced search settles after page navigation", async () => {
+    let debouncedPlanSearch = ""
+    mocks.useSearchDebounce.mockImplementation(() => debouncedPlanSearch)
+
+    const user = userEvent.setup()
+    const { rerender } = render(<MaintenancePageClient />)
+
+    await user.click(screen.getByRole("button", { name: "set-search" }))
+    await user.click(screen.getByRole("button", { name: "set-page-3" }))
+    await expectLastPlanRequest({ search: undefined, facilityId: null, page: 3, pageSize: 50 })
+
+    debouncedPlanSearch = "ngoai tim"
+    rerender(<MaintenancePageClient />)
 
     expectPlanRequestMissing({ search: "ngoai tim", facilityId: null, page: 3, pageSize: 50 })
     await expectLastPlanRequest({ search: "ngoai tim", facilityId: null, page: 1, pageSize: 50 })

--- a/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
@@ -287,6 +287,7 @@ describe("Maintenance KPI integration", () => {
     await user.click(screen.getByRole("button", { name: "set-page-3" }))
     await expectLastPlanRequest({ search: undefined, facilityId: null, page: 3, pageSize: 50 })
 
+    // Simulate the mocked debounce value settling after the user navigated.
     debouncedPlanSearch = "ngoai tim"
     rerender(<MaintenancePageClient />)
 

--- a/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
@@ -1,12 +1,20 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockCounts = {
   "Bản nháp": 2,
   "Đã duyệt": 3,
   "Không duyệt": 1,
+}
+
+type MaintenancePlanRequest = {
+  search: string | undefined
+  facilityId: number | null
+  page: number
+  pageSize: number
 }
 
 const mocks = vi.hoisted(() => ({
@@ -91,12 +99,14 @@ vi.mock("../_components/maintenance-page-desktop-content", () => ({
     isCountsError,
     onFacilityChange,
     onPlanSearchChange,
+    onPageChange,
   }: {
     statusCounts?: Record<string, number>
     isCountsLoading?: boolean
     isCountsError?: boolean
     onFacilityChange: (facilityId: number | null) => void
     onPlanSearchChange: (value: string) => void
+    onPageChange: (page: number) => void
   }) => (
     <div
       data-testid="desktop-layout"
@@ -109,6 +119,9 @@ vi.mock("../_components/maintenance-page-desktop-content", () => ({
       </button>
       <button type="button" onClick={() => onPlanSearchChange("ngoai tim")}>
         set-search
+      </button>
+      <button type="button" onClick={() => onPageChange(3)}>
+        set-page-3
       </button>
     </div>
   ),
@@ -174,6 +187,14 @@ function createMaintenanceContext() {
   }
 }
 
+function expectLastPlanRequest(request: MaintenancePlanRequest) {
+  return waitFor(() => expect(mocks.useMaintenancePlans).toHaveBeenLastCalledWith(request))
+}
+
+function expectPlanRequestMissing(request: MaintenancePlanRequest) {
+  expect(mocks.useMaintenancePlans).not.toHaveBeenCalledWith(request)
+}
+
 describe("Maintenance KPI integration", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -227,6 +248,32 @@ describe("Maintenance KPI integration", () => {
         search: "ngoai tim",
       })
     )
+  })
+
+  it("resets plan pagination before applying a facility filter", async () => {
+    const user = userEvent.setup()
+    render(<MaintenancePageClient />)
+
+    await user.click(screen.getByRole("button", { name: "set-page-3" }))
+    await expectLastPlanRequest({ search: undefined, facilityId: null, page: 3, pageSize: 50 })
+
+    await user.click(screen.getByRole("button", { name: "set-facility" }))
+
+    expectPlanRequestMissing({ search: undefined, facilityId: 7, page: 3, pageSize: 50 })
+    await expectLastPlanRequest({ search: undefined, facilityId: 7, page: 1, pageSize: 50 })
+  })
+
+  it("resets plan pagination before applying debounced search", async () => {
+    const user = userEvent.setup()
+    render(<MaintenancePageClient />)
+
+    await user.click(screen.getByRole("button", { name: "set-page-3" }))
+    await expectLastPlanRequest({ search: undefined, facilityId: null, page: 3, pageSize: 50 })
+
+    await user.click(screen.getByRole("button", { name: "set-search" }))
+
+    expectPlanRequestMissing({ search: "ngoai tim", facilityId: null, page: 3, pageSize: 50 })
+    await expectLastPlanRequest({ search: "ngoai tim", facilityId: null, page: 1, pageSize: 50 })
   })
 
   it("passes loading state to desktop layout", () => {

--- a/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
@@ -22,6 +22,7 @@ import { useSearchDebounce } from "@/hooks/use-debounce"
 
 import { useMaintenanceContext } from "../_hooks/useMaintenanceContext"
 import { useMaintenanceDeepLink } from "../_hooks/use-maintenance-deep-link"
+import { useMaintenancePlanListControls } from "../_hooks/use-maintenance-plan-list-controls"
 import { useSelectedPlanSync } from "../_hooks/use-selected-plan-sync"
 import { MobileMaintenanceLayout } from "./mobile-maintenance-layout"
 import { usePlanColumns, useTaskColumns } from "./maintenance-columns"
@@ -36,13 +37,24 @@ export function MaintenancePageClient() {
   const mobileMaintenanceEnabled = useFeatureFlag("mobile-maintenance-redesign")
   const shouldUseMobileMaintenance = isMobile && mobileMaintenanceEnabled
 
-  const [planSearchTerm, setPlanSearchTerm] = React.useState("")
+  const {
+    planSearchTerm,
+    handlePlanSearchChange,
+    handleClearSearch,
+    selectedFacilityId,
+    handleFacilityChange,
+    currentPage,
+    setCurrentPage,
+    pageSize,
+    handlePageSizeChange,
+    isMobileFilterSheetOpen,
+    handleMobileFilterSheetOpenChange,
+    pendingFacilityFilter,
+    setPendingFacilityFilter,
+    handleMobileFilterApply,
+    handleMobileFilterClear,
+  } = useMaintenancePlanListControls()
   const debouncedPlanSearch = useSearchDebounce(planSearchTerm)
-  const [selectedFacilityId, setSelectedFacilityId] = React.useState<number | null>(null)
-  const [currentPage, setCurrentPage] = React.useState(1)
-  const [pageSize, setPageSize] = React.useState(50)
-  const [isMobileFilterSheetOpen, setIsMobileFilterSheetOpen] = React.useState(false)
-  const [pendingFacilityFilter, setPendingFacilityFilter] = React.useState<number | null>(null)
   const [expandedTaskIds, setExpandedTaskIds] = React.useState<Record<number, boolean>>({})
 
   const [planSorting, setPlanSorting] = React.useState<SortingState>([])
@@ -130,38 +142,10 @@ export function MaintenancePageClient() {
   })
 
   React.useEffect(() => {
-    setCurrentPage(1)
-  }, [selectedFacilityId, debouncedPlanSearch])
-
-  React.useEffect(() => {
-    if (isMobileFilterSheetOpen) {
-      setPendingFacilityFilter(selectedFacilityId ?? null)
-    }
-  }, [isMobileFilterSheetOpen, selectedFacilityId])
-
-  React.useEffect(() => {
     if (ctx.selectedPlan?.id) {
       setExpandedTaskIds({})
     }
   }, [ctx.selectedPlan?.id])
-
-  const handleMobileFilterApply = React.useCallback(() => {
-    setSelectedFacilityId(pendingFacilityFilter ?? null)
-    setCurrentPage(1)
-    setIsMobileFilterSheetOpen(false)
-  }, [pendingFacilityFilter])
-
-  const handleMobileFilterClear = React.useCallback(() => {
-    setPendingFacilityFilter(null)
-    setSelectedFacilityId(null)
-    setCurrentPage(1)
-    setIsMobileFilterSheetOpen(false)
-  }, [])
-
-  const handlePageSizeChange = React.useCallback((size: number) => {
-    setPageSize(size)
-    setCurrentPage(1)
-  }, [])
 
   const toggleTaskExpansion = React.useCallback((taskId: number) => {
     setExpandedTaskIds((prev) => ({
@@ -285,8 +269,8 @@ export function MaintenancePageClient() {
           plans={plans}
           isLoadingPlans={isLoadingPlans}
           planSearchTerm={planSearchTerm}
-          setPlanSearchTerm={setPlanSearchTerm}
-          onClearSearch={() => setPlanSearchTerm("")}
+          setPlanSearchTerm={handlePlanSearchChange}
+          onClearSearch={handleClearSearch}
           totalPages={totalPages}
           totalCount={totalCount}
           currentPage={currentPage}
@@ -296,7 +280,7 @@ export function MaintenancePageClient() {
           selectedFacilityId={selectedFacilityId}
           isLoadingFacilities={isLoadingFacilities}
           isMobileFilterSheetOpen={isMobileFilterSheetOpen}
-          setIsMobileFilterSheetOpen={setIsMobileFilterSheetOpen}
+          setIsMobileFilterSheetOpen={handleMobileFilterSheetOpenChange}
           pendingFacilityFilter={pendingFacilityFilter}
           setPendingFacilityFilter={setPendingFacilityFilter}
           handleMobileFilterApply={handleMobileFilterApply}
@@ -319,11 +303,11 @@ export function MaintenancePageClient() {
         showFacilityFilter={showFacilityFilter}
         facilities={facilities}
         selectedFacilityId={selectedFacilityId}
-        onFacilityChange={setSelectedFacilityId}
+        onFacilityChange={handleFacilityChange}
         isLoadingFacilities={isLoadingFacilities}
         totalCount={totalCount}
         planSearchTerm={planSearchTerm}
-        onPlanSearchChange={setPlanSearchTerm}
+        onPlanSearchChange={handlePlanSearchChange}
         isMobile={isMobile}
         mobilePlanCards={legacyMobileCards}
         planTable={planTable}

--- a/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
@@ -18,7 +18,6 @@ import { useMaintenancePlans } from "@/hooks/use-cached-maintenance"
 import { useMaintenancePlanCounts } from "@/hooks/useMaintenancePlanCounts"
 import type { FacilityOption } from "@/types/tenant"
 import { useFeatureFlag } from "@/lib/feature-flags"
-import { useSearchDebounce } from "@/hooks/use-debounce"
 
 import { useMaintenanceContext } from "../_hooks/useMaintenanceContext"
 import { useMaintenanceDeepLink } from "../_hooks/use-maintenance-deep-link"
@@ -39,6 +38,7 @@ export function MaintenancePageClient() {
 
   const {
     planSearchTerm,
+    debouncedPlanSearch,
     handlePlanSearchChange,
     handleClearSearch,
     selectedFacilityId,
@@ -54,7 +54,6 @@ export function MaintenancePageClient() {
     handleMobileFilterApply,
     handleMobileFilterClear,
   } = useMaintenancePlanListControls()
-  const debouncedPlanSearch = useSearchDebounce(planSearchTerm)
   const [expandedTaskIds, setExpandedTaskIds] = React.useState<Record<number, boolean>>({})
 
   const [planSorting, setPlanSorting] = React.useState<SortingState>([])

--- a/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
@@ -86,7 +86,6 @@ export function MaintenancePageClient() {
   const {
     data: facilities = [],
     isLoading: isLoadingFacilities,
-    error: facilitiesError,
   } = useQuery<Array<{ id: number; name: string }>>({
     queryKey: ["maintenance", "facilities", ctx.user?.role ?? null],
     queryFn: async () => {
@@ -104,12 +103,6 @@ export function MaintenancePageClient() {
     staleTime: 5 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
   })
-
-  React.useEffect(() => {
-    if (facilitiesError) {
-      console.error("[Maintenance] Failed to fetch facilities:", facilitiesError)
-    }
-  }, [facilitiesError])
 
   const activeMobileFilterCount = React.useMemo(() => {
     let count = 0

--- a/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
+++ b/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
@@ -1,12 +1,46 @@
 import * as React from "react"
 
-export function useMaintenancePlanListControls() {
+import { useSearchDebounce } from "@/hooks/use-debounce"
+
+export interface MaintenancePlanListControls {
+  planSearchTerm: string
+  debouncedPlanSearch: string
+  handlePlanSearchChange: (value: string) => void
+  handleClearSearch: () => void
+  selectedFacilityId: number | null
+  handleFacilityChange: (facilityId: number | null) => void
+  currentPage: number
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>
+  pageSize: number
+  handlePageSizeChange: (size: number) => void
+  isMobileFilterSheetOpen: boolean
+  handleMobileFilterSheetOpenChange: (open: boolean) => void
+  pendingFacilityFilter: number | null
+  setPendingFacilityFilter: React.Dispatch<React.SetStateAction<number | null>>
+  handleMobileFilterApply: () => void
+  handleMobileFilterClear: () => void
+}
+
+export function useMaintenancePlanListControls(): MaintenancePlanListControls {
   const [planSearchTerm, setPlanSearchTerm] = React.useState("")
   const [selectedFacilityId, setSelectedFacilityId] = React.useState<number | null>(null)
   const [currentPage, setCurrentPage] = React.useState(1)
   const [pageSize, setPageSize] = React.useState(50)
   const [isMobileFilterSheetOpen, setIsMobileFilterSheetOpen] = React.useState(false)
   const [pendingFacilityFilter, setPendingFacilityFilter] = React.useState<number | null>(null)
+  const debouncedPlanSearch = useSearchDebounce(planSearchTerm)
+
+  // Keep the query page reset in the same render where debounced search changes.
+  // This prevents one stale fetch with the new search and the old page number.
+  let effectiveCurrentPage = currentPage
+  const previousDebouncedPlanSearch = React.useRef(debouncedPlanSearch)
+  if (debouncedPlanSearch !== previousDebouncedPlanSearch.current) {
+    previousDebouncedPlanSearch.current = debouncedPlanSearch
+    effectiveCurrentPage = 1
+    if (currentPage !== 1) {
+      setCurrentPage(1)
+    }
+  }
 
   const handlePlanSearchChange = React.useCallback((value: string) => {
     setPlanSearchTerm(value)
@@ -53,11 +87,12 @@ export function useMaintenancePlanListControls() {
 
   return {
     planSearchTerm,
+    debouncedPlanSearch,
     handlePlanSearchChange,
     handleClearSearch,
     selectedFacilityId,
     handleFacilityChange,
-    currentPage,
+    currentPage: effectiveCurrentPage,
     setCurrentPage,
     pageSize,
     handlePageSizeChange,

--- a/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
+++ b/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
@@ -1,0 +1,71 @@
+import * as React from "react"
+
+export function useMaintenancePlanListControls() {
+  const [planSearchTerm, setPlanSearchTerm] = React.useState("")
+  const [selectedFacilityId, setSelectedFacilityId] = React.useState<number | null>(null)
+  const [currentPage, setCurrentPage] = React.useState(1)
+  const [pageSize, setPageSize] = React.useState(50)
+  const [isMobileFilterSheetOpen, setIsMobileFilterSheetOpen] = React.useState(false)
+  const [pendingFacilityFilter, setPendingFacilityFilter] = React.useState<number | null>(null)
+
+  const handlePlanSearchChange = React.useCallback((value: string) => {
+    setPlanSearchTerm(value)
+    setCurrentPage(1)
+  }, [])
+
+  const handleClearSearch = React.useCallback(() => {
+    setPlanSearchTerm("")
+    setCurrentPage(1)
+  }, [])
+
+  const handleFacilityChange = React.useCallback((facilityId: number | null) => {
+    setSelectedFacilityId(facilityId)
+    setCurrentPage(1)
+  }, [])
+
+  const handlePageSizeChange = React.useCallback((size: number) => {
+    setPageSize(size)
+    setCurrentPage(1)
+  }, [])
+
+  const handleMobileFilterSheetOpenChange = React.useCallback(
+    (open: boolean) => {
+      setIsMobileFilterSheetOpen(open)
+      if (open) {
+        setPendingFacilityFilter(selectedFacilityId ?? null)
+      }
+    },
+    [selectedFacilityId]
+  )
+
+  const handleMobileFilterApply = React.useCallback(() => {
+    setSelectedFacilityId(pendingFacilityFilter ?? null)
+    setCurrentPage(1)
+    setIsMobileFilterSheetOpen(false)
+  }, [pendingFacilityFilter])
+
+  const handleMobileFilterClear = React.useCallback(() => {
+    setPendingFacilityFilter(null)
+    setSelectedFacilityId(null)
+    setCurrentPage(1)
+    setIsMobileFilterSheetOpen(false)
+  }, [])
+
+  return {
+    planSearchTerm,
+    handlePlanSearchChange,
+    handleClearSearch,
+    selectedFacilityId,
+    handleFacilityChange,
+    currentPage,
+    setCurrentPage,
+    pageSize,
+    handlePageSizeChange,
+    isMobileFilterSheetOpen,
+    handleMobileFilterSheetOpenChange,
+    pendingFacilityFilter,
+    setPendingFacilityFilter,
+    handleMobileFilterApply,
+    handleMobileFilterClear,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract maintenance plan list controls into a local hook so filter/search/page-size handlers reset pagination directly.
- Remove the React Doctor `no-derived-state-effect` reset effect from `MaintenancePageClient`.
- Remove the redundant facilities error logging effect that React Doctor flagged in follow-up #249; RPC failures remain logged by `callRpc`.
- Add focused `user-event` regression tests for facility/search pagination reset behavior.

Closes #248
Closes #249

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- 'src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx'`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose --no --project nextn --offline` (before #249 follow-up; full scan had no errors but retained unrelated warnings/non-fatal dead-code exception)

## Notes
- React Doctor diff scan now reports `No issues found!` for changed files.
- Full React Doctor scan previously showed no errors after #248; it still has existing full-repo warnings outside this PR and a non-fatal dead-code detector exception: `TypeError: issues.files is not iterable`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized maintenance plan list controls for consistent search, facility, pagination and mobile filter behavior across layouts.

* **Bug Fixes**
  * Pagination now reliably resets to page 1 when changing facility, page size, or performing a search; mobile filter apply/clear and sheet open/close stay synchronized to avoid stale queries.

* **Tests**
  * Added integration tests and helpers to verify pagination reset semantics and filter/search interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->