### PR TITLE
fix: remove interactive sorting from transfers grid

### DIFF
--- a/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
@@ -27,11 +27,13 @@ const mocks = vi.hoisted(() => ({
   useTransferCounts: vi.fn(),
   useTransferActions: vi.fn(),
   useTransferSearch: vi.fn(),
+  useTransfersFilters: vi.fn(),
   useServerPagination: vi.fn(),
   useIsMobile: vi.fn(),
   KpiStatusBar: vi.fn(),
   OverdueTransfersAlert: vi.fn(),
   TransferDetailDialog: vi.fn(),
+  TransfersTableView: vi.fn(),
 }))
 
 vi.mock("next-auth/react", () => ({
@@ -76,6 +78,10 @@ vi.mock("@/hooks/useTransferActions", () => ({
 
 vi.mock("@/hooks/useTransferSearch", () => ({
   useTransferSearch: () => mocks.useTransferSearch(),
+}))
+
+vi.mock("@/app/(app)/transfers/_components/useTransfersFilters", () => ({
+  useTransfersFilters: () => mocks.useTransfersFilters(),
 }))
 
 vi.mock("@/hooks/useTransferDataGrid", () => ({
@@ -151,7 +157,10 @@ vi.mock("@/components/shared/TenantSelector", () => ({
 }))
 
 vi.mock("@/components/transfers/TransfersTableView", () => ({
-  TransfersTableView: () => <div data-testid="transfers-table-view" />,
+  TransfersTableView: (props: unknown) => {
+    mocks.TransfersTableView(props)
+    return <div data-testid="transfers-table-view" />
+  },
 }))
 
 vi.mock("@/components/transfers/TransfersKanbanView", () => ({
@@ -214,11 +223,20 @@ describe("Transfers KPI", () => {
       pageCount: 1,
     })
 
-    mocks.useTransferSearch.mockReturnValue({
+    mocks.useTransfersFilters.mockReturnValue({
       searchTerm: "",
       setSearchTerm: vi.fn(),
       debouncedSearch: "",
       clearSearch: vi.fn(),
+      statusFilter: [],
+      setStatusFilter: vi.fn(),
+      dateRange: null,
+      setDateRange: vi.fn(),
+      isFilterModalOpen: false,
+      setIsFilterModalOpen: vi.fn(),
+      handleClearAllFilters: vi.fn(),
+      handleRemoveFilter: vi.fn(),
+      activeFilterCount: 0,
     })
 
     mocks.useTransferList.mockReturnValue({
@@ -391,6 +409,51 @@ describe("Transfers KPI", () => {
     expect(screen.queryByTestId("transfers-table-view")).not.toBeInTheDocument()
     expect(screen.queryByTestId("transfers-kanban-view")).not.toBeInTheDocument()
     expect(screen.queryByTestId("transfer-pagination")).not.toBeInTheDocument()
+  })
+
+  it("does not pass interactive sorting props to the desktop transfers table", () => {
+    render(<TransfersPage />)
+
+    expect(mocks.TransfersTableView).toHaveBeenCalled()
+    expect(mocks.TransfersTableView.mock.calls[0]?.[0]).not.toEqual(
+      expect.objectContaining({
+        sorting: expect.anything(),
+        onSortingChange: expect.any(Function),
+      }),
+    )
+  })
+
+  it("propagates the selected date range into transfer list filters", () => {
+    mocks.useTransfersFilters.mockReturnValue({
+      searchTerm: "",
+      setSearchTerm: vi.fn(),
+      debouncedSearch: "",
+      clearSearch: vi.fn(),
+      statusFilter: [],
+      setStatusFilter: vi.fn(),
+      dateRange: {
+        from: new Date("2026-04-02T00:00:00.000Z"),
+        to: new Date("2026-04-05T00:00:00.000Z"),
+      },
+      setDateRange: vi.fn(),
+      isFilterModalOpen: false,
+      setIsFilterModalOpen: vi.fn(),
+      handleClearAllFilters: vi.fn(),
+      handleRemoveFilter: vi.fn(),
+      activeFilterCount: 1,
+    })
+
+    render(<TransfersPage />)
+
+    expect(mocks.useTransferList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dateFrom: "2026-04-02",
+        dateTo: "2026-04-05",
+      }),
+      expect.objectContaining({
+        enabled: true,
+      }),
+    )
   })
 
   it("opens the detail dialog when the overdue alert requests transfer details", () => {

--- a/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
@@ -415,12 +415,9 @@ describe("Transfers KPI", () => {
     render(<TransfersPage />)
 
     expect(mocks.TransfersTableView).toHaveBeenCalled()
-    expect(mocks.TransfersTableView.mock.calls[0]?.[0]).not.toEqual(
-      expect.objectContaining({
-        sorting: expect.anything(),
-        onSortingChange: expect.any(Function),
-      }),
-    )
+    const tableProps = mocks.TransfersTableView.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(tableProps).not.toHaveProperty("sorting")
+    expect(tableProps).not.toHaveProperty("onSortingChange")
   })
 
   it("propagates the selected date range into transfer list filters", () => {
@@ -432,8 +429,8 @@ describe("Transfers KPI", () => {
       statusFilter: [],
       setStatusFilter: vi.fn(),
       dateRange: {
-        from: new Date("2026-04-02T00:00:00.000Z"),
-        to: new Date("2026-04-05T00:00:00.000Z"),
+        from: new Date(2026, 3, 2),
+        to: new Date(2026, 3, 5),
       },
       setDateRange: vi.fn(),
       isFilterModalOpen: false,

--- a/src/app/(app)/transfers/_components/TransfersPageContent.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPageContent.tsx
@@ -122,8 +122,6 @@ export function TransfersPageContent({ user }: TransfersPageContentProps) {
           filters={controller.filters}
           userRole={controller.userRole}
           columns={controller.columns}
-          sorting={controller.sorting}
-          onSortingChange={controller.setSorting}
           pagination={controller.transferPagination.pagination}
           onPaginationChange={controller.transferPagination.setPagination}
           pageCount={controller.transferPagination.pageCount}

--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -3,9 +3,7 @@
 import * as React from "react"
 import type {
   ColumnDef,
-  OnChangeFn,
   PaginationState,
-  SortingState,
   Table as ReactTable,
 } from "@tanstack/react-table"
 import { Filter, Loader2, PlusCircle } from "lucide-react"
@@ -62,10 +60,8 @@ type TransfersPagePanelProps = Readonly<{
   filters: TransferListFilters
   userRole?: TransferUserRole
   columns: ColumnDef<TransferListItem>[]
-  sorting: SortingState
-  onSortingChange: OnChangeFn<SortingState>
   pagination: PaginationState
-  onPaginationChange: OnChangeFn<PaginationState>
+  onPaginationChange: (updater: PaginationState | ((old: PaginationState) => PaginationState)) => void
   pageCount: number
   table: ReactTable<TransferListItem>
   transferEntity: { singular: string }
@@ -114,8 +110,6 @@ export function TransfersPagePanel({
   filters,
   userRole,
   columns,
-  sorting,
-  onSortingChange,
   pagination,
   onPaginationChange,
   pageCount,
@@ -230,8 +224,6 @@ export function TransfersPagePanel({
                     <TransfersTableView
                       data={tableData}
                       columns={columns}
-                      sorting={sorting}
-                      onSortingChange={onSortingChange}
                       pagination={pagination}
                       onPaginationChange={onPaginationChange}
                       pageCount={pageCount}

--- a/src/app/(app)/transfers/_components/useTransfersPageController.ts
+++ b/src/app/(app)/transfers/_components/useTransfersPageController.ts
@@ -4,10 +4,8 @@ import * as React from "react"
 import {
   getCoreRowModel,
   getPaginationRowModel,
-  getSortedRowModel,
   useReactTable,
   type Table,
-  type SortingState,
 } from "@tanstack/react-table"
 import { useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
@@ -68,8 +66,6 @@ export interface TransfersPageControllerResult {
   totalCount: number
   referenceDate: Date
   filters: TransferListFilters
-  sorting: SortingState
-  setSorting: React.Dispatch<React.SetStateAction<SortingState>>
   columns: ReturnType<typeof getColumnsForType>
   table: Table<TransferListItem>
   transferPagination: ReturnType<typeof useServerPagination>
@@ -123,9 +119,6 @@ export function useTransfersPageController(
   const filtersState = useTransfersFilters({ activeTab })
   const [isAddDialogOpen, setIsAddDialogOpen] = React.useState(false)
   const [totalCount, setTotalCount] = React.useState(0)
-  const [sorting, setSorting] = React.useState<SortingState>([
-    { id: "created_at", desc: true },
-  ])
 
   const invalidateTransferQueries = React.useCallback(() => {
     queryClient.invalidateQueries({ queryKey: transferDataGridKeys.all })
@@ -257,11 +250,9 @@ export function useTransfersPageController(
   const table = useReactTable({
     data: tableData,
     columns,
-    state: { sorting, pagination: transferPagination.pagination },
-    onSortingChange: setSorting,
+    state: { pagination: transferPagination.pagination },
     onPaginationChange: transferPagination.setPagination,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     manualPagination: true,
     pageCount: transferPagination.pageCount,
@@ -331,8 +322,6 @@ export function useTransfersPageController(
     totalCount,
     referenceDate,
     filters,
-    sorting,
-    setSorting,
     columns,
     table,
     transferPagination,

--- a/src/components/transfers/TransfersTableView.tsx
+++ b/src/components/transfers/TransfersTableView.tsx
@@ -4,9 +4,7 @@ import {
   flexRender,
   getCoreRowModel,
   getPaginationRowModel,
-  getSortedRowModel,
   useReactTable,
-  type SortingState,
 } from '@tanstack/react-table'
 import { Loader2 } from 'lucide-react'
 import {
@@ -22,8 +20,6 @@ import type { TransferListItem } from '@/types/transfers-data-grid'
 interface TransfersTableViewProps {
   data: TransferListItem[]
   columns: ColumnDef<TransferListItem>[]
-  sorting: SortingState
-  onSortingChange: OnChangeFn<SortingState>
   pagination: PaginationState
   onPaginationChange: OnChangeFn<PaginationState>
   pageCount: number
@@ -34,8 +30,6 @@ interface TransfersTableViewProps {
 export function TransfersTableView({
   data,
   columns,
-  sorting,
-  onSortingChange,
   pagination,
   onPaginationChange,
   pageCount,
@@ -45,11 +39,9 @@ export function TransfersTableView({
   const table = useReactTable({
     data,
     columns,
-    state: { sorting, pagination },
-    onSortingChange,
+    state: { pagination },
     onPaginationChange,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     manualPagination: true,
     pageCount,

--- a/src/components/transfers/__tests__/FilterModal.test.tsx
+++ b/src/components/transfers/__tests__/FilterModal.test.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { FilterModal } from "@/components/transfers/FilterModal"
+
+describe("FilterModal", () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: "(max-width: 767px)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as typeof window.matchMedia
+  })
+
+  it("clears status and date range filters from the modal controls", async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <FilterModal
+        open
+        onOpenChange={vi.fn()}
+        onChange={onChange}
+        value={{
+          statuses: ["cho_duyet"],
+          dateRange: {
+            from: new Date("2026-04-02T00:00:00.000Z"),
+            to: new Date("2026-04-05T00:00:00.000Z"),
+          },
+        }}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Xóa" }))
+
+    expect(onChange).toHaveBeenCalledWith({
+      statuses: [],
+      dateRange: null,
+    })
+  })
+})

--- a/src/components/transfers/columnDefinitions.tsx
+++ b/src/components/transfers/columnDefinitions.tsx
@@ -129,13 +129,11 @@ const createCommonColumns = (options: TransferColumnOptions): ColumnDef<Transfer
     accessorFn: (row) => row.thiet_bi?.ten_thiet_bi ?? "",
     header: "Thiết bị",
     cell: ({ row }) => renderEquipment(row.original),
-    enableSorting: true,
     size: 260,
   },
   {
     accessorKey: "ly_do_luan_chuyen",
     header: "Lý do",
-    enableSorting: true,
     cell: ({ row }) => (
       <p className="max-w-xs text-sm leading-5 text-muted-foreground">
         {row.original.ly_do_luan_chuyen || EMPTY_PLACEHOLDER}
@@ -145,8 +143,6 @@ const createCommonColumns = (options: TransferColumnOptions): ColumnDef<Transfer
   {
     accessorKey: "created_at",
     header: "Ngày tạo",
-    enableSorting: true,
-    sortingFn: "datetime",
     cell: ({ row }) => (
       <span className="text-sm text-muted-foreground">
         {formatDate(row.original.created_at, true)}
@@ -158,7 +154,6 @@ const createCommonColumns = (options: TransferColumnOptions): ColumnDef<Transfer
 const createStatusColumn = (): ColumnDef<TransferListItem> => ({
   accessorKey: "trang_thai",
   header: "Trạng thái",
-  enableSorting: true,
   cell: ({ row }) => renderStatusBadge(row.original.trang_thai),
 })
 
@@ -297,8 +292,6 @@ const createLiquidationColumns = (): ColumnDef<TransferListItem>[] => [
   {
     accessorKey: "ngay_hoan_thanh",
     header: "Ngày hoàn tất",
-    enableSorting: true,
-    sortingFn: "datetime",
     cell: ({ row }) => (
       <span className="text-sm text-muted-foreground">
         {formatDate(row.original.ngay_hoan_thanh, false)}


### PR DESCRIPTION
## Summary
- remove interactive sorting from the transfers desktop grid instead of adding server-side sorting
- keep the existing backend default order (`created_at desc`) and preserve date range, status, search, and tenant filters
- add focused tests to lock the no-sorting behavior and confirm date filtering still propagates correctly

## Why
Issue #222 originally asked for server-side sorting. After reviewing the current flow and product need, the simpler and safer fix was to remove the misleading client-side sorting affordance entirely. The grid was only sorting rows within the current page, which looked sortable but did not produce globally correct ordering.

This PR makes the UI honest: the list keeps the backend default order while users continue to narrow results with the existing filters, including date range.

Closes #222

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- 'src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx' 'src/components/transfers/__tests__/FilterModal.test.tsx'`\n- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove interactive sorting from the transfers desktop grid to avoid misleading per-page ordering. Keep the backend default order (`created_at desc`) with existing filters. Addresses #222.

- **Bug Fixes**
  - Removed sorting state/props across the controller, `TransfersPageContent`, `TransfersPagePanel`, and `TransfersTableView` (including `getSortedRowModel`).
  - Disabled column sorting in `columnDefinitions.tsx`; kept server pagination and removed sort UI on desktop.
  - Strengthened tests: assert no sorting props are passed, verify date range maps to `dateFrom`/`dateTo` string payloads in the list query, and add `FilterModal` clear behavior test.

<sup>Written for commit 00f01c0763580ed42b0fa133a2cef9449abe5adb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed interactive sorting from transfers table and page panel; desktop table no longer receives sorting controls and columns no longer advertise sorting.

* **Tests**
  * Added tests for filter modal clear behavior and for date-range filter propagation into transfer listing calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->