### PR TITLE
refactor: tighten transfer dialog typing and payload shaping

### DIFF
--- a/src/components/__tests__/transfer-dialog.components.test.tsx
+++ b/src/components/__tests__/transfer-dialog.components.test.tsx
@@ -4,8 +4,45 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+    disabled,
+  }: {
+    value?: string
+    onValueChange?: (value: string) => void
+    children: React.ReactNode
+    disabled?: boolean
+  }) => (
+    <select
+      disabled={disabled}
+      value={value ?? ""}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{typeof children === "string" ? children : value}</option>
+  ),
+}))
+
 import { TransferDialogEquipmentSearch } from "@/components/transfer-dialog.equipment-search"
-import { toLocalDateInputValue } from "@/components/transfer-dialog.form-sections"
+import {
+  TransferInternalInputFields,
+  TransferInternalSelectFields,
+  toLocalDateInputValue,
+} from "@/components/transfer-dialog.form-sections"
+import { createEmptyTransferDialogFormData } from "@/components/transfer-dialog.shared"
 
 const equipmentOption = {
   id: 11,
@@ -83,6 +120,91 @@ describe("transfer dialog shared components", () => {
     await user.keyboard("{Enter}")
 
     expect(onSelectEquipment).toHaveBeenCalledWith(equipmentOption)
+  })
+
+  it("shows the no-results state without rendering stale equipment options", () => {
+    render(
+      <TransferDialogEquipmentSearch
+        disabled={false}
+        searchTerm="Máy"
+        trimmedSearch="Máy"
+        selectedEquipment={null}
+        isEquipmentLoading={false}
+        showResultsDropdown={false}
+        showNoResults
+        showMinCharsHint={false}
+        filteredEquipment={[]}
+        onSearchChange={vi.fn()}
+        onSelectEquipment={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText("Không tìm thấy kết quả phù hợp")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /TB-11/ })).not.toBeInTheDocument()
+  })
+
+  it("clears the receiving department when the selected current department changes to the same value", async () => {
+    const user = userEvent.setup()
+
+    function InternalSelectHarness() {
+      const [formData, setFormData] = React.useState(() => ({
+        ...createEmptyTransferDialogFormData(),
+        khoa_phong_hien_tai: "Khoa A",
+        khoa_phong_nhan: "Khoa B",
+      }))
+
+      return (
+        <>
+          <TransferInternalSelectFields
+            departments={["Khoa A", "Khoa B", "Khoa C"]}
+            disabled={false}
+            formData={formData}
+            setFormData={setFormData}
+            lockCurrentDepartment={false}
+          />
+          <output data-testid="receiving-state">{formData.khoa_phong_nhan}</output>
+        </>
+      )
+    }
+
+    render(<InternalSelectHarness />)
+
+    const selectElements = screen.getAllByRole("combobox")
+    await user.selectOptions(selectElements[0], "Khoa B")
+
+    expect(screen.getByTestId("receiving-state")).toHaveTextContent("")
+  })
+
+  it("marks current department as required and clears conflicting receiving input", async () => {
+    const user = userEvent.setup()
+
+    function InternalInputHarness() {
+      const [formData, setFormData] = React.useState(() => ({
+        ...createEmptyTransferDialogFormData(),
+        khoa_phong_hien_tai: "Khoa A",
+        khoa_phong_nhan: "Khoa B",
+      }))
+
+      return (
+        <TransferInternalInputFields
+          disabled={false}
+          formData={formData}
+          setFormData={setFormData}
+        />
+      )
+    }
+
+    render(<InternalInputHarness />)
+
+    const currentDepartmentInput = screen.getByLabelText("Khoa/Phòng hiện tại *")
+    const receivingDepartmentInput = screen.getByLabelText("Khoa/Phòng nhận *")
+
+    expect(currentDepartmentInput).toBeRequired()
+
+    await user.clear(currentDepartmentInput)
+    await user.type(currentDepartmentInput, "Khoa B")
+
+    expect(receivingDepartmentInput).toHaveValue("")
   })
 
   it("formats local dates for date input boundaries without UTC conversion", () => {

--- a/src/components/__tests__/transfer-dialog.components.test.tsx
+++ b/src/components/__tests__/transfer-dialog.components.test.tsx
@@ -1,0 +1,91 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TransferDialogEquipmentSearch } from "@/components/transfer-dialog.equipment-search"
+import { toLocalDateInputValue } from "@/components/transfer-dialog.form-sections"
+
+const equipmentOption = {
+  id: 11,
+  ma_thiet_bi: "TB-11",
+  ten_thiet_bi: "Máy siêu âm",
+  khoa_phong_quan_ly: "Khoa A",
+} as const
+
+describe("transfer dialog shared components", () => {
+  it("shows the equipment required marker only when the field is required", () => {
+    const { rerender } = render(
+      <TransferDialogEquipmentSearch
+        disabled={false}
+        searchTerm=""
+        trimmedSearch=""
+        selectedEquipment={null}
+        isEquipmentLoading={false}
+        showResultsDropdown={false}
+        showNoResults={false}
+        showMinCharsHint={false}
+        filteredEquipment={[]}
+        onSearchChange={vi.fn()}
+        onSelectEquipment={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByLabelText("Thiết bị")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Thiết bị *")).not.toBeInTheDocument()
+
+    rerender(
+      <TransferDialogEquipmentSearch
+        disabled={false}
+        required
+        searchTerm=""
+        trimmedSearch=""
+        selectedEquipment={null}
+        isEquipmentLoading={false}
+        showResultsDropdown={false}
+        showNoResults={false}
+        showMinCharsHint={false}
+        filteredEquipment={[]}
+        onSearchChange={vi.fn()}
+        onSelectEquipment={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByLabelText("Thiết bị *")).toBeInTheDocument()
+  })
+
+  it("allows keyboard selection of an equipment result", async () => {
+    const user = userEvent.setup()
+    const onSelectEquipment = vi.fn()
+
+    render(
+      <TransferDialogEquipmentSearch
+        disabled={false}
+        searchTerm="Máy"
+        trimmedSearch="Máy"
+        selectedEquipment={null}
+        isEquipmentLoading={false}
+        showResultsDropdown
+        showNoResults={false}
+        showMinCharsHint={false}
+        filteredEquipment={[equipmentOption]}
+        onSearchChange={vi.fn()}
+        onSelectEquipment={onSelectEquipment}
+      />,
+    )
+
+    const optionButton = screen.getByRole("button", {
+      name: /Máy siêu âm \(TB-11\)/,
+    })
+
+    optionButton.focus()
+    await user.keyboard("{Enter}")
+
+    expect(onSelectEquipment).toHaveBeenCalledWith(equipmentOption)
+  })
+
+  it("formats local dates for date input boundaries without UTC conversion", () => {
+    expect(toLocalDateInputValue(new Date(2026, 3, 13, 15, 4, 5))).toBe("2026-04-13")
+  })
+})

--- a/src/components/__tests__/transfer-dialog.shared.test.ts
+++ b/src/components/__tests__/transfer-dialog.shared.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildCreateTransferPayload,
+  buildUpdateTransferPayload,
+  getTransferDialogErrorMessage,
+  mapEquipmentSearchResults,
+  normalizeSessionUserId,
+  type TransferDialogFormData,
+} from "@/components/transfer-dialog.shared"
+
+const baseFormData: TransferDialogFormData = {
+  thiet_bi_id: 11,
+  loai_hinh: "ben_ngoai",
+  ly_do_luan_chuyen: "  Điều phối  ",
+  khoa_phong_hien_tai: " Khoa A ",
+  khoa_phong_nhan: " Khoa B ",
+  muc_dich: "sua_chua",
+  don_vi_nhan: " Đơn vị B ",
+  dia_chi_don_vi: " 12 Nguyễn Trãi ",
+  nguoi_lien_he: " Nguyễn Văn B ",
+  so_dien_thoai: " 0900000000 ",
+  ngay_du_kien_tra: "2026-05-01",
+}
+
+describe("transfer-dialog.shared", () => {
+  it("normalizes numeric session user ids and fails closed for invalid ids", () => {
+    expect(normalizeSessionUserId({ id: "42" })).toBe(42)
+    expect(normalizeSessionUserId({ id: "abc" })).toBeNull()
+    expect(normalizeSessionUserId({ id: undefined })).toBeNull()
+  })
+
+  it("drops stale external fields when creating an internal transfer payload", () => {
+    expect(
+      buildCreateTransferPayload({
+        formData: {
+          ...baseFormData,
+          loai_hinh: "noi_bo",
+        },
+        currentUserId: 42,
+      }),
+    ).toEqual({
+      thiet_bi_id: 11,
+      loai_hinh: "noi_bo",
+      ly_do_luan_chuyen: "Điều phối",
+      nguoi_yeu_cau_id: 42,
+      created_by: 42,
+      updated_by: 42,
+      khoa_phong_hien_tai: "Khoa A",
+      khoa_phong_nhan: "Khoa B",
+      muc_dich: null,
+      don_vi_nhan: null,
+      dia_chi_don_vi: null,
+      nguoi_lien_he: null,
+      so_dien_thoai: null,
+      ngay_du_kien_tra: null,
+    })
+  })
+
+  it("nulls external fields when updating an internal transfer payload", () => {
+    expect(
+      buildUpdateTransferPayload({
+        formData: {
+          ...baseFormData,
+          loai_hinh: "noi_bo",
+        },
+        currentUserId: 42,
+      }),
+    ).toEqual({
+      thiet_bi_id: 11,
+      loai_hinh: "noi_bo",
+      ly_do_luan_chuyen: "Điều phối",
+      updated_by: 42,
+      khoa_phong_hien_tai: "Khoa A",
+      khoa_phong_nhan: "Khoa B",
+      muc_dich: null,
+      don_vi_nhan: null,
+      dia_chi_don_vi: null,
+      nguoi_lien_he: null,
+      so_dien_thoai: null,
+      ngay_du_kien_tra: null,
+    })
+  })
+
+  it("maps unknown equipment rows without relying on any", () => {
+    expect(
+      mapEquipmentSearchResults([
+        {
+          id: "11",
+          ma_thiet_bi: "TB-11",
+          ten_thiet_bi: "Máy siêu âm",
+          khoa_phong_quan_ly: "Khoa A",
+        },
+        {
+          id: null,
+          ma_thiet_bi: "bad",
+          ten_thiet_bi: "bad",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: 11,
+        ma_thiet_bi: "TB-11",
+        ten_thiet_bi: "Máy siêu âm",
+        khoa_phong_quan_ly: "Khoa A",
+      },
+    ])
+  })
+
+  it("extracts a human-readable message from unknown errors", () => {
+    expect(getTransferDialogErrorMessage({ message: "Permission denied" }, "Fallback")).toBe(
+      "Permission denied",
+    )
+    expect(getTransferDialogErrorMessage({ detail: "ignored" }, "Fallback")).toBe("Fallback")
+  })
+})

--- a/src/components/__tests__/transfer-dialogs.payload.test.tsx
+++ b/src/components/__tests__/transfer-dialogs.payload.test.tsx
@@ -1,0 +1,173 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+  toast: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: mocks.callRpc,
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/hooks/use-debounce", () => ({
+  useSearchDebounce: (value: string) => value,
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+    disabled,
+  }: {
+    value?: string
+    onValueChange?: (value: string) => void
+    children: React.ReactNode
+    disabled?: boolean
+  }) => (
+    <select
+      disabled={disabled}
+      value={value ?? ""}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{typeof children === "string" ? children : value}</option>
+  ),
+}))
+
+import { AddTransferDialog } from "@/components/add-transfer-dialog"
+
+describe("AddTransferDialog payload shaping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: "42",
+          role: "to_qltb",
+        },
+      },
+      status: "authenticated",
+    })
+  })
+
+  it("drops stale external fields after switching from external to internal transfer", async () => {
+    mocks.callRpc.mockImplementation(async ({ fn }: { fn: string }) => {
+      if (fn === "departments_list") {
+        return [{ name: "Khoa A" }, { name: "Khoa B" }]
+      }
+
+      if (fn === "equipment_list_enhanced") {
+        return {
+          data: [
+            {
+              id: 11,
+              ma_thiet_bi: "TB-11",
+              ten_thiet_bi: "Máy siêu âm",
+              khoa_phong_quan_ly: "Khoa A",
+            },
+          ],
+        }
+      }
+
+      if (fn === "transfer_request_create") {
+        return { id: 501 }
+      }
+
+      return []
+    })
+
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const onSuccess = vi.fn()
+
+    render(
+      <AddTransferDialog open onOpenChange={onOpenChange} onSuccess={onSuccess} />,
+    )
+
+    await user.type(screen.getByLabelText(/Thiết bị/), "Máy")
+    await user.click(await screen.findByText("Máy siêu âm (TB-11)"))
+
+    let selects = screen.getAllByRole("combobox")
+    await user.selectOptions(selects[0], "ben_ngoai")
+
+    selects = screen.getAllByRole("combobox")
+    await user.selectOptions(selects[1], "sua_chua")
+
+    await user.type(screen.getByLabelText(/Đơn vị nhận/), " Đơn vị B ")
+    await user.type(screen.getByLabelText(/Địa chỉ đơn vị/), " 12 Nguyễn Trãi ")
+    await user.type(screen.getByLabelText(/Người liên hệ/), " Nguyễn Văn B ")
+    await user.type(screen.getByLabelText(/Số điện thoại/), " 0900000000 ")
+    await user.type(screen.getByLabelText(/Ngày dự kiến trả về/), "2026-05-01")
+    await user.type(screen.getByLabelText(/Lý do/), "  Điều phối ")
+
+    selects = screen.getAllByRole("combobox")
+    await user.selectOptions(selects[0], "noi_bo")
+
+    selects = screen.getAllByRole("combobox")
+    await user.selectOptions(selects[2], "Khoa B")
+
+    await user.click(screen.getByRole("button", { name: "Tạo yêu cầu" }))
+
+    await waitFor(() => {
+      expect(mocks.callRpc).toHaveBeenCalledWith({
+        fn: "transfer_request_create",
+        args: {
+          p_data: {
+            thiet_bi_id: 11,
+            loai_hinh: "noi_bo",
+            ly_do_luan_chuyen: "Điều phối",
+            nguoi_yeu_cau_id: 42,
+            created_by: 42,
+            updated_by: 42,
+            khoa_phong_hien_tai: "Khoa A",
+            khoa_phong_nhan: "Khoa B",
+            muc_dich: null,
+            don_vi_nhan: null,
+            dia_chi_don_vi: null,
+            nguoi_lien_he: null,
+            so_dien_thoai: null,
+            ngay_du_kien_tra: null,
+          },
+        },
+      })
+    })
+
+    expect(onSuccess).toHaveBeenCalled()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/components/add-transfer-dialog.tsx
+++ b/src/components/add-transfer-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Loader2, Check } from "lucide-react"
+import { Loader2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -12,39 +12,29 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Textarea } from "@/components/ui/textarea"
 import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
 import { isRegionalLeaderRole } from "@/lib/rbac"
 import { useSession } from "next-auth/react"
-import {
-  TRANSFER_TYPES,
-  TRANSFER_PURPOSES,
-  type TransferType,
-  type TransferPurpose,
-  type Equipment
-} from "@/types/database"
-import { Badge } from "@/components/ui/badge"
 import { useSearchDebounce } from "@/hooks/use-debounce"
-
-// Equipment interface matching database schema
-interface EquipmentWithDept {
-  id: number;
-  ma_thiet_bi: string;
-  ten_thiet_bi: string;
-  model?: string;
-  serial?: string;
-  khoa_phong_quan_ly?: string;
-}
+import {
+  buildCreateTransferPayload,
+  createEmptyTransferDialogFormData,
+  getTransferDialogErrorMessage,
+  mapEquipmentSearchResults,
+  normalizeSessionUserId,
+  type TransferEquipmentOption,
+} from "@/components/transfer-dialog.shared"
+import { TransferDialogEquipmentSearch } from "@/components/transfer-dialog.equipment-search"
+import {
+  TransferExternalFields,
+  TransferInternalSelectFields,
+  TransferReasonField,
+  TransferTypeField,
+} from "@/components/transfer-dialog.form-sections"
 
 type EquipmentListEnhancedResponse = {
-  data?: any[] | null
-  total?: number
-  page?: number
-  pageSize?: number
+  data?: unknown[] | null
 }
 
 interface AddTransferDialogProps {
@@ -56,58 +46,19 @@ interface AddTransferDialogProps {
 export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransferDialogProps) {
   const { toast } = useToast()
   const { data: session } = useSession()
-  const user = session?.user as any // Cast NextAuth user to our User type
-  const currentUserId = React.useMemo(() => {
-    const rawId = user?.id
-    if (typeof rawId === "number" && Number.isFinite(rawId)) {
-      return rawId
-    }
-    if (typeof rawId === "string" && /^\d+$/.test(rawId)) {
-      return parseInt(rawId, 10)
-    }
-    return null
-  }, [user?.id])
-  const isRegionalLeader = isRegionalLeaderRole(user?.role)
+  const currentUserId = normalizeSessionUserId(session?.user)
+  const isRegionalLeader = isRegionalLeaderRole(session?.user?.role)
   const [isLoading, setIsLoading] = React.useState(false)
-  const [equipmentResults, setEquipmentResults] = React.useState<EquipmentWithDept[]>([])
+  const [equipmentResults, setEquipmentResults] = React.useState<TransferEquipmentOption[]>([])
   const [isEquipmentLoading, setIsEquipmentLoading] = React.useState(false)
   const [searchTerm, setSearchTerm] = React.useState("")
   const debouncedSearch = useSearchDebounce(searchTerm)
-  const [selectedEquipment, setSelectedEquipment] = React.useState<EquipmentWithDept | null>(null)
+  const [selectedEquipment, setSelectedEquipment] = React.useState<TransferEquipmentOption | null>(null)
   const [departments, setDepartments] = React.useState<string[]>([])
-  
-  const [formData, setFormData] = React.useState({
-    thiet_bi_id: 0,
-    loai_hinh: "" as TransferType | "",
-    ly_do_luan_chuyen: "",
-    
-    // For internal transfers
-    khoa_phong_hien_tai: "",
-    khoa_phong_nhan: "",
-    
-    // For external transfers
-    muc_dich: "" as TransferPurpose | "",
-    don_vi_nhan: "",
-    dia_chi_don_vi: "",
-    nguoi_lien_he: "",
-    so_dien_thoai: "",
-    ngay_du_kien_tra: ""
-  })
+  const [formData, setFormData] = React.useState(createEmptyTransferDialogFormData)
 
   const resetForm = React.useCallback(() => {
-    setFormData({
-      thiet_bi_id: 0,
-      loai_hinh: "",
-      ly_do_luan_chuyen: "",
-      khoa_phong_hien_tai: "",
-      khoa_phong_nhan: "",
-      muc_dich: "",
-      don_vi_nhan: "",
-      dia_chi_don_vi: "",
-      nguoi_lien_he: "",
-      so_dien_thoai: "",
-      ngay_du_kien_tra: ""
-    })
+    setFormData(createEmptyTransferDialogFormData())
     setSelectedEquipment(null)
     setSearchTerm("")
   }, [])
@@ -122,28 +73,26 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     if (departments.length === 0) {
       (async () => {
         try {
-          const deps = await callRpc<{ name: string }[]>({ fn: 'departments_list', args: {} })
-          setDepartments((deps || []).map(x => x.name).filter(Boolean))
-        } catch (error: any) {
+          const deps = await callRpc<{ name: string }[]>({ fn: "departments_list", args: {} })
+          setDepartments((deps || []).map((department) => department.name).filter(Boolean))
+        } catch (error: unknown) {
           toast({
             variant: "destructive",
             title: "Lỗi tải danh sách khoa phòng",
-            description: error.message,
+            description: getTransferDialogErrorMessage(
+              error,
+              "Không thể tải danh sách khoa phòng.",
+            ),
           })
         }
       })()
     }
   }, [open, departments.length, resetForm, toast])
 
-  const trimmedDebouncedSearch = React.useMemo(
-    () => (debouncedSearch ?? '').trim(),
-    [debouncedSearch]
-  )
-
-  const selectedValueLabel = React.useMemo(
-    () => (selectedEquipment ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})` : ''),
-    [selectedEquipment]
-  )
+  const trimmedDebouncedSearch = (debouncedSearch ?? "").trim()
+  const selectedValueLabel = selectedEquipment
+    ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
+    : ""
 
   React.useEffect(() => {
     if (!open) {
@@ -165,10 +114,10 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     ;(async () => {
       try {
         const result = await callRpc<EquipmentListEnhancedResponse>({
-          fn: 'equipment_list_enhanced',
+          fn: "equipment_list_enhanced",
           args: {
             p_q: trimmedDebouncedSearch,
-            p_sort: 'ten_thiet_bi.asc',
+            p_sort: "ten_thiet_bi.asc",
             p_page: 1,
             p_page_size: 20,
           },
@@ -180,55 +129,22 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
         }
 
         const rows = Array.isArray(result?.data) ? result.data : []
-        const mapped = rows.reduce<EquipmentWithDept[]>((acc, item: any) => {
-          const idRaw = item?.id ?? item?.equipment_id
-          const id = typeof idRaw === 'number' ? idRaw : Number(idRaw)
-          const maRaw = item?.ma_thiet_bi ?? item?.ma_tb
-          const tenRaw = item?.ten_thiet_bi ?? item?.ten_tb
-
-          if (!Number.isFinite(id) || id <= 0 || !maRaw || !tenRaw) {
-            return acc
-          }
-
-          const modelRaw = item?.model ?? item?.model_number ?? undefined
-          const serialRaw = item?.serial ?? item?.serial_number ?? undefined
-          const deptRaw = item?.khoa_phong_quan_ly ?? item?.khoa_phong ?? item?.department_name ?? undefined
-
-          const equipment: EquipmentWithDept = {
-            id,
-            ma_thiet_bi: String(maRaw),
-            ten_thiet_bi: String(tenRaw),
-          }
-
-          if (modelRaw) {
-            equipment.model = String(modelRaw)
-          }
-
-          if (serialRaw) {
-            equipment.serial = String(serialRaw)
-          }
-
-          if (deptRaw) {
-            equipment.khoa_phong_quan_ly = String(deptRaw)
-          }
-
-          acc.push(equipment)
-          return acc
-        }, [])
-
-        setEquipmentResults(mapped)
-      } catch (error: any) {
+        setEquipmentResults(mapEquipmentSearchResults(rows))
+      } catch (error: unknown) {
         if (!isMounted) {
           return
         }
-        if (error?.name === 'AbortError') {
+        if (error instanceof DOMException && error.name === "AbortError") {
           return
         }
 
         toast({
-          variant: 'destructive',
-          title: 'Lỗi tìm kiếm thiết bị',
-          description: error?.message || 'Không thể tải danh sách thiết bị.',
+          variant: "destructive",
+          title: "Lỗi tìm kiếm thiết bị",
+          description: getTransferDialogErrorMessage(
+            error,
+            "Không thể tải danh sách thiết bị.",
+          ),
         })
       } finally {
         if (isMounted) {
@@ -245,11 +161,11 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
 
   const filteredEquipment = React.useMemo(() => {
     if (trimmedDebouncedSearch.length < 2) {
-      return [] as EquipmentWithDept[]
+      return [] as TransferEquipmentOption[]
     }
 
     if (selectedEquipment && searchTerm === selectedValueLabel) {
-      return [] as EquipmentWithDept[]
+      return [] as TransferEquipmentOption[]
     }
 
     return equipmentResults
@@ -264,29 +180,25 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     trimmedDebouncedSearch.length > 0 && trimmedDebouncedSearch.length < 2
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTerm(e.target.value);
+    setSearchTerm(e.target.value)
     if (selectedEquipment) {
-      setSelectedEquipment(null);
-      setFormData(prev => ({
+      setSelectedEquipment(null)
+      setFormData((prev) => ({
         ...prev,
         thiet_bi_id: 0,
-        khoa_phong_hien_tai: ""
+        khoa_phong_hien_tai: "",
       }))
     }
   }
 
-  const handleSelectEquipment = (equipment: EquipmentWithDept) => {
-    setSelectedEquipment(equipment);
-    setSearchTerm(`${equipment.ten_thiet_bi} (${equipment.ma_thiet_bi})`);
-    setFormData(prev => ({
+  const handleSelectEquipment = (equipment: TransferEquipmentOption) => {
+    setSelectedEquipment(equipment)
+    setSearchTerm(`${equipment.ten_thiet_bi} (${equipment.ma_thiet_bi})`)
+    setFormData((prev) => ({
       ...prev,
       thiet_bi_id: equipment.id,
-      khoa_phong_hien_tai: equipment.khoa_phong_quan_ly || ""
+      khoa_phong_hien_tai: equipment.khoa_phong_quan_ly || "",
     }))
-  }
-
-  const handleValueChange = (field: keyof typeof formData) => (value: string | number) => {
-    setFormData(prev => ({ ...prev, [field]: value }))
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -332,36 +244,10 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
 
     // Thanh lý không cần validate thêm vì đã có default values
 
-
     setIsLoading(true)
 
     try {
-      const payload: any = {
-        thiet_bi_id: formData.thiet_bi_id,
-        loai_hinh: formData.loai_hinh,
-        ly_do_luan_chuyen: formData.ly_do_luan_chuyen.trim(),
-        nguoi_yeu_cau_id: currentUserId ?? undefined,
-        created_by: currentUserId ?? undefined,
-        updated_by: currentUserId ?? undefined,
-      }
-
-      if (formData.loai_hinh === 'noi_bo') {
-        payload.khoa_phong_hien_tai = formData.khoa_phong_hien_tai.trim()
-        payload.khoa_phong_nhan = formData.khoa_phong_nhan.trim()
-      } else if (formData.loai_hinh === 'ben_ngoai') {
-        payload.muc_dich = formData.muc_dich
-        payload.don_vi_nhan = formData.don_vi_nhan.trim()
-        payload.dia_chi_don_vi = formData.dia_chi_don_vi.trim() || null
-        payload.nguoi_lien_he = formData.nguoi_lien_he.trim() || null
-        payload.so_dien_thoai = formData.so_dien_thoai.trim() || null
-        payload.ngay_du_kien_tra = formData.ngay_du_kien_tra || null
-      } else if (formData.loai_hinh === 'thanh_ly') {
-        payload.muc_dich = 'thanh_ly'
-        payload.don_vi_nhan = 'Tổ QLTB'
-        payload.khoa_phong_hien_tai = formData.khoa_phong_hien_tai.trim()
-        payload.khoa_phong_nhan = 'Tổ QLTB'
-      }
-
+      const payload = buildCreateTransferPayload({ formData, currentUserId })
       await callRpc({ fn: 'transfer_request_create', args: { p_data: payload } })
 
       toast({
@@ -373,11 +259,14 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
 
       onSuccess()
       onOpenChange(false)
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: error.message || "Có lỗi xảy ra khi tạo yêu cầu."
+        description: getTransferDialogErrorMessage(
+          error,
+          "Có lỗi xảy ra khi tạo yêu cầu.",
+        ),
       })
     } finally {
       setIsLoading(false)
@@ -395,96 +284,27 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4 py-4">
-            {/* Equipment Selection */}
-            <div className="grid gap-2">
-              <Label htmlFor="equipment">Thiết bị *</Label>
-              <div className="relative">
-                <Input
-                  id="equipment"
-                  value={searchTerm}
-                  onChange={handleSearchChange}
-                  placeholder="Tìm kiếm thiết bị..."
-                  disabled={isLoading}
-                  required
-                />
-                {showMinCharsHint && (
-                  <div className="absolute z-10 w-full mt-1 bg-popover border rounded-md shadow-lg p-3">
-                    <div className="text-sm text-muted-foreground text-center">
-                      Nhập tối thiểu 2 ký tự để tìm kiếm
-                    </div>
-                  </div>
-                )}
-                {trimmedDebouncedSearch.length >= 2 && (
-                  <>
-                    {isEquipmentLoading && (
-                      <div className="absolute z-20 w-full mt-1 bg-popover border rounded-md shadow-lg p-3">
-                        <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                          <span>Đang tìm kiếm thiết bị...</span>
-                        </div>
-                      </div>
-                    )}
-                    {showResultsDropdown && (
-                      <div className="absolute z-10 w-full mt-1 bg-popover border rounded-md shadow-lg max-h-60 overflow-y-auto">
-                        <div className="p-1">
-                          {filteredEquipment.map((equipment: EquipmentWithDept) => (
-                            <div
-                              key={equipment.id}
-                              className="text-sm p-2 hover:bg-accent rounded-sm cursor-pointer"
-                              onClick={() => handleSelectEquipment(equipment)}
-                            >
-                              <div className="font-medium">{equipment.ten_thiet_bi} ({equipment.ma_thiet_bi})</div>
-                              <div className="text-xs text-muted-foreground">
-                                {equipment.model && `Model: ${equipment.model}`}
-                                {equipment.khoa_phong_quan_ly && ` • ${equipment.khoa_phong_quan_ly}`}
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {showNoResults && (
-                      <div className="absolute z-10 w-full mt-1 bg-popover border rounded-md shadow-lg p-3">
-                        <div className="text-sm text-muted-foreground text-center">
-                          Không tìm thấy kết quả phù hợp
-                        </div>
-                      </div>
-                    )}
-                  </>
-                )}
-              </div>
-              {selectedEquipment && (
-                <p className="text-xs text-muted-foreground flex items-center gap-1.5 pt-1">
-                  <Check className="h-3.5 w-3.5 text-green-600"/>
-                  <span>Đã chọn: {selectedEquipment.ten_thiet_bi} ({selectedEquipment.ma_thiet_bi})</span>
-                </p>
-              )}
-            </div>
+            <TransferDialogEquipmentSearch
+              disabled={isLoading}
+              required
+              searchTerm={searchTerm}
+              trimmedSearch={trimmedDebouncedSearch}
+              selectedEquipment={selectedEquipment}
+              isEquipmentLoading={isEquipmentLoading}
+              showResultsDropdown={showResultsDropdown}
+              showNoResults={showNoResults}
+              showMinCharsHint={showMinCharsHint}
+              filteredEquipment={filteredEquipment}
+              onSearchChange={handleSearchChange}
+              onSelectEquipment={handleSelectEquipment}
+            />
 
-            {/* Transfer Type */}
-            <div className="grid gap-2">
-              <Label htmlFor="type">Loại hình luân chuyển *</Label>
-              <Select
-                value={formData.loai_hinh}
-                onValueChange={(value: TransferType) => setFormData(prev => ({ ...prev, loai_hinh: value }))}
-                disabled={isLoading}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Chọn loại hình" />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(TRANSFER_TYPES).map(([key, label]) => (
-                    <SelectItem key={key} value={key}>
-                      <div className="flex items-center gap-2">
-                        <Badge variant={key === 'noi_bo' ? 'default' : key === 'thanh_ly' ? 'destructive' : 'secondary'}>
-                          {label}
-                        </Badge>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            <TransferTypeField
+              disabled={isLoading}
+              formData={formData}
+              setFormData={setFormData}
+              includeDisposalStyle
+            />
 
             {formData.loai_hinh === 'thanh_ly' && (
               <div className="p-3 mt-2 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-800">
@@ -492,157 +312,30 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
               </div>
             )}
 
-            {/* Conditional Fields for Internal Transfer */}
             {formData.loai_hinh === 'noi_bo' && (
-              <>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="khoa_phong_hien_tai">Khoa/Phòng hiện tại</Label>
-                    <Select
-                      value={formData.khoa_phong_hien_tai}
-                      onValueChange={handleValueChange('khoa_phong_hien_tai')}
-                      disabled={!!selectedEquipment}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Chọn khoa/phòng hiện tại" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {departments.map(dep => (
-                          <SelectItem key={dep} value={dep}>{dep}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="khoa_phong_nhan">Khoa/Phòng nhận</Label>
-                    <Select
-                      value={formData.khoa_phong_nhan}
-                      onValueChange={handleValueChange('khoa_phong_nhan')}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Chọn khoa/phòng nhận" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {departments
-                          .filter(dep => dep !== formData.khoa_phong_hien_tai)
-                          .map(dep => (
-                            <SelectItem key={dep} value={dep}>{dep}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-              </>
-            )}
-
-            {/* Conditional Fields for External Transfer */}
-            {formData.loai_hinh === 'ben_ngoai' && (
-              <>
-                <div className="grid gap-2">
-                  <Label htmlFor="purpose">Mục đích *</Label>
-                  <Select
-                    value={formData.muc_dich}
-                    onValueChange={(value) => setFormData(prev => ({ ...prev, muc_dich: value as TransferPurpose }))}
-                    disabled={isLoading}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Chọn mục đích luân chuyển" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.entries(TRANSFER_PURPOSES).map(([key, label]) => (
-                        <SelectItem key={key} value={key}>
-                          {label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="external_org">Đơn vị nhận *</Label>
-                  <Input
-                    id="external_org"
-                    value={formData.don_vi_nhan}
-                    onChange={(e) => setFormData(prev => ({ ...prev, don_vi_nhan: e.target.value }))}
-                    placeholder="Tên đơn vị/tổ chức nhận thiết bị"
-                    disabled={isLoading}
-                    required
-                  />
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="address">Địa chỉ đơn vị</Label>
-                  <Textarea
-                    id="address"
-                    value={formData.dia_chi_don_vi}
-                    onChange={(e) => setFormData(prev => ({ ...prev, dia_chi_don_vi: e.target.value }))}
-                    placeholder="Địa chỉ của đơn vị nhận"
-                    disabled={isLoading}
-                    rows={2}
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="grid gap-2">
-                    <Label htmlFor="contact_person">Người liên hệ</Label>
-                    <Input
-                      id="contact_person"
-                      value={formData.nguoi_lien_he}
-                      onChange={(e) => setFormData(prev => ({ ...prev, nguoi_lien_he: e.target.value }))}
-                      placeholder="Tên người liên hệ"
-                      disabled={isLoading}
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="phone">Số điện thoại</Label>
-                    <Input
-                      id="phone"
-                      value={formData.so_dien_thoai}
-                      onChange={(e) => setFormData(prev => ({ ...prev, so_dien_thoai: e.target.value }))}
-                      placeholder="Số điện thoại liên hệ"
-                      disabled={isLoading}
-                    />
-                  </div>
-                </div>
-
-                {(formData.muc_dich === 'sua_chua' || formData.muc_dich === 'cho_muon') && (
-                  <div className="grid gap-2">
-                    <Label htmlFor="expected_return">Ngày dự kiến trả về</Label>
-                    <Input
-                      id="expected_return"
-                      type="date"
-                      value={formData.ngay_du_kien_tra}
-                      onChange={(e) => setFormData(prev => ({ ...prev, ngay_du_kien_tra: e.target.value }))}
-                      disabled={isLoading}
-                      min={new Date().toISOString().split('T')[0]}
-                    />
-                  </div>
-                )}
-              </>
-            )}
-
-            {/* Reason */}
-            <div className="grid gap-2">
-              <Label htmlFor="reason">{
-                formData.loai_hinh === 'thanh_ly' 
-                ? 'Lý do thanh lý *' 
-                : 'Lý do luân chuyển *'
-              }</Label>
-              <Textarea
-                id="reason"
-                value={formData.ly_do_luan_chuyen}
-                onChange={(e) => setFormData(prev => ({ ...prev, ly_do_luan_chuyen: e.target.value }))}
-                placeholder={
-                  formData.loai_hinh === 'thanh_ly' 
-                  ? 'Mô tả lý do cần thanh lý thiết bị (ví dụ: hỏng không thể sửa chữa, lỗi thời...)'
-                  : 'Mô tả lý do cần luân chuyển thiết bị'
-                }
+              <TransferInternalSelectFields
+                departments={departments}
                 disabled={isLoading}
-                required
-                rows={3}
+                formData={formData}
+                setFormData={setFormData}
+                lockCurrentDepartment={Boolean(selectedEquipment)}
               />
-            </div>
+            )}
+
+            {formData.loai_hinh === 'ben_ngoai' && (
+              <TransferExternalFields
+                disabled={isLoading}
+                formData={formData}
+                setFormData={setFormData}
+              />
+            )}
+
+            <TransferReasonField
+              disabled={isLoading}
+              formData={formData}
+              setFormData={setFormData}
+              allowDisposalCopy
+            />
           </div>
           
           <DialogFooter>

--- a/src/components/edit-transfer-dialog.tsx
+++ b/src/components/edit-transfer-dialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Loader2, Check } from "lucide-react"
+import { Loader2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -12,43 +12,32 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Textarea } from "@/components/ui/textarea"
 import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
 import { isRegionalLeaderRole } from "@/lib/rbac"
 import { useSession } from "next-auth/react"
-import {
-  TRANSFER_TYPES,
-  TRANSFER_PURPOSES,
-  type TransferType,
-  type TransferPurpose,
-  type TransferRequest
-} from "@/types/database"
+import { type TransferRequest } from "@/types/database"
 import { useSearchDebounce } from "@/hooks/use-debounce"
-import { Badge } from "@/components/ui/badge"
-
-// Temporary interface for equipment with actual database columns
-interface EquipmentWithDept {
-  id: number;
-  ma_thiet_bi: string;
-  ten_thiet_bi: string;
-  model?: string;
-  serial?: string;
-  khoa_phong_quan_ly?: string;
-  tinh_trang?: string;
-  ngay_nhap?: string;
-  created_at?: string;
-  updated_at?: string;
-}
+import {
+  buildUpdateTransferPayload,
+  createEmptyTransferDialogFormData,
+  createTransferDialogFormDataFromTransfer,
+  getSelectedEquipmentFromTransfer,
+  getTransferDialogErrorMessage,
+  mapEquipmentSearchResults,
+  normalizeSessionUserId,
+  type TransferEquipmentOption,
+} from "@/components/transfer-dialog.shared"
+import { TransferDialogEquipmentSearch } from "@/components/transfer-dialog.equipment-search"
+import {
+  TransferExternalFields,
+  TransferInternalInputFields,
+  TransferReasonField,
+  TransferTypeField,
+} from "@/components/transfer-dialog.form-sections"
 
 type EquipmentListEnhancedResponse = {
-  data?: any[] | null
-  total?: number
-  page?: number
-  pageSize?: number
+  data?: unknown[] | null
 }
 
 interface EditTransferDialogProps {
@@ -61,42 +50,15 @@ interface EditTransferDialogProps {
 export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: EditTransferDialogProps) {
   const { toast } = useToast()
   const { data: session } = useSession()
-  const user = session?.user as any // Cast NextAuth user to our User type
-  const currentUserId = React.useMemo(() => {
-    const rawId = user?.id
-    if (typeof rawId === "number" && Number.isFinite(rawId)) {
-      return rawId
-    }
-    if (typeof rawId === "string" && /^\d+$/.test(rawId)) {
-      return parseInt(rawId, 10)
-    }
-    return null
-  }, [user?.id])
-  const isRegionalLeader = isRegionalLeaderRole(user?.role)
+  const currentUserId = normalizeSessionUserId(session?.user)
+  const isRegionalLeader = isRegionalLeaderRole(session?.user?.role)
   const [isLoading, setIsLoading] = React.useState(false)
-  const [equipmentResults, setEquipmentResults] = React.useState<EquipmentWithDept[]>([])
+  const [equipmentResults, setEquipmentResults] = React.useState<TransferEquipmentOption[]>([])
   const [isEquipmentLoading, setIsEquipmentLoading] = React.useState(false)
   const [searchTerm, setSearchTerm] = React.useState("")
   const debouncedSearch = useSearchDebounce(searchTerm)
-  const [selectedEquipment, setSelectedEquipment] = React.useState<EquipmentWithDept | null>(null)
-  
-  const [formData, setFormData] = React.useState({
-    thiet_bi_id: 0,
-    loai_hinh: "" as TransferType | "",
-    ly_do_luan_chuyen: "",
-    
-    // For internal transfers
-    khoa_phong_hien_tai: "",
-    khoa_phong_nhan: "",
-    
-    // For external transfers
-    muc_dich: "" as TransferPurpose | "",
-    don_vi_nhan: "",
-    dia_chi_don_vi: "",
-    nguoi_lien_he: "",
-    so_dien_thoai: "",
-    ngay_du_kien_tra: ""
-  })
+  const [selectedEquipment, setSelectedEquipment] = React.useState<TransferEquipmentOption | null>(null)
+  const [formData, setFormData] = React.useState(createEmptyTransferDialogFormData)
 
   // Check if editing is allowed based on status
   const canEdit = Boolean(
@@ -104,19 +66,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
   )
 
   const resetForm = React.useCallback(() => {
-    setFormData({
-      thiet_bi_id: 0,
-      loai_hinh: "",
-      ly_do_luan_chuyen: "",
-      khoa_phong_hien_tai: "",
-      khoa_phong_nhan: "",
-      muc_dich: "",
-      don_vi_nhan: "",
-      dia_chi_don_vi: "",
-      nguoi_lien_he: "",
-      so_dien_thoai: "",
-      ngay_du_kien_tra: ""
-    })
+    setFormData(createEmptyTransferDialogFormData())
     setSelectedEquipment(null)
     setSearchTerm("")
   }, [])
@@ -124,44 +74,11 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
   // Load transfer data when dialog opens
   React.useEffect(() => {
     if (open && transfer) {
-      setFormData({
-        thiet_bi_id: transfer.thiet_bi_id,
-        loai_hinh: transfer.loai_hinh,
-        ly_do_luan_chuyen: transfer.ly_do_luan_chuyen,
-        khoa_phong_hien_tai: transfer.khoa_phong_hien_tai || "",
-        khoa_phong_nhan: transfer.khoa_phong_nhan || "",
-        muc_dich: transfer.muc_dich || "",
-        don_vi_nhan: transfer.don_vi_nhan || "",
-        dia_chi_don_vi: transfer.dia_chi_don_vi || "",
-        nguoi_lien_he: transfer.nguoi_lien_he || "",
-        so_dien_thoai: transfer.so_dien_thoai || "",
-        ngay_du_kien_tra: transfer.ngay_du_kien_tra || ""
-      })
-      
-      // Set selected equipment
-      if (transfer.thiet_bi && transfer.thiet_bi.id) {
-        const equipment: EquipmentWithDept = {
-          id: transfer.thiet_bi.id,
-          ma_thiet_bi: transfer.thiet_bi.ma_thiet_bi,
-          ten_thiet_bi: transfer.thiet_bi.ten_thiet_bi,
-        }
+      setFormData(createTransferDialogFormDataFromTransfer(transfer))
 
-        const modelValue = transfer.thiet_bi.model ?? undefined
-        const serialValue = (transfer.thiet_bi.serial ?? transfer.thiet_bi.serial_number) ?? undefined
-        const deptValue = transfer.thiet_bi.khoa_phong_quan_ly ?? undefined
-
-        if (modelValue) {
-          equipment.model = String(modelValue)
-        }
-
-        if (serialValue) {
-          equipment.serial = String(serialValue)
-        }
-
-        if (deptValue) {
-          equipment.khoa_phong_quan_ly = String(deptValue)
-        }
-        setSelectedEquipment(equipment)
+      const equipment = getSelectedEquipmentFromTransfer(transfer)
+      setSelectedEquipment(equipment)
+      if (equipment) {
         setSearchTerm(`${equipment.ten_thiet_bi} (${equipment.ma_thiet_bi})`)
       }
     } else if (!open) {
@@ -169,15 +86,10 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     }
   }, [open, transfer, resetForm])
 
-  const trimmedDebouncedSearch = React.useMemo(
-    () => (debouncedSearch ?? '').trim(),
-    [debouncedSearch]
-  )
-
-  const selectedValueLabel = React.useMemo(
-    () => (selectedEquipment ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})` : ''),
-    [selectedEquipment]
-  )
+  const trimmedDebouncedSearch = (debouncedSearch ?? "").trim()
+  const selectedValueLabel = selectedEquipment
+    ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
+    : ""
 
   const canSearchEquipment = Boolean(canEdit && !isRegionalLeader)
 
@@ -205,10 +117,10 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     ;(async () => {
       try {
         const result = await callRpc<EquipmentListEnhancedResponse>({
-          fn: 'equipment_list_enhanced',
+          fn: "equipment_list_enhanced",
           args: {
             p_q: trimmedDebouncedSearch,
-            p_sort: 'ten_thiet_bi.asc',
+            p_sort: "ten_thiet_bi.asc",
             p_page: 1,
             p_page_size: 20,
           },
@@ -220,55 +132,22 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
         }
 
         const rows = Array.isArray(result?.data) ? result.data : []
-        const mapped = rows.reduce<EquipmentWithDept[]>((acc, item: any) => {
-          const idRaw = item?.id ?? item?.equipment_id
-          const id = typeof idRaw === 'number' ? idRaw : Number(idRaw)
-          const maRaw = item?.ma_thiet_bi ?? item?.ma_tb
-          const tenRaw = item?.ten_thiet_bi ?? item?.ten_tb
-
-          if (!Number.isFinite(id) || id <= 0 || !maRaw || !tenRaw) {
-            return acc
-          }
-
-          const modelRaw = item?.model ?? item?.model_number ?? undefined
-          const serialRaw = item?.serial ?? item?.serial_number ?? undefined
-          const deptRaw = item?.khoa_phong_quan_ly ?? item?.khoa_phong ?? item?.department_name ?? undefined
-
-          const equipment: EquipmentWithDept = {
-            id,
-            ma_thiet_bi: String(maRaw),
-            ten_thiet_bi: String(tenRaw),
-          }
-
-          if (modelRaw) {
-            equipment.model = String(modelRaw)
-          }
-
-          if (serialRaw) {
-            equipment.serial = String(serialRaw)
-          }
-
-          if (deptRaw) {
-            equipment.khoa_phong_quan_ly = String(deptRaw)
-          }
-
-          acc.push(equipment)
-          return acc
-        }, [])
-
-        setEquipmentResults(mapped)
-      } catch (error: any) {
+        setEquipmentResults(mapEquipmentSearchResults(rows))
+      } catch (error: unknown) {
         if (!isMounted) {
           return
         }
-        if (error?.name === 'AbortError') {
+        if (error instanceof DOMException && error.name === "AbortError") {
           return
         }
 
         toast({
-          variant: 'destructive',
-          title: 'Lỗi tìm kiếm thiết bị',
-          description: error?.message || 'Không thể tải danh sách thiết bị.',
+          variant: "destructive",
+          title: "Lỗi tìm kiếm thiết bị",
+          description: getTransferDialogErrorMessage(
+            error,
+            "Không thể tải danh sách thiết bị.",
+          ),
         })
       } finally {
         if (isMounted) {
@@ -285,11 +164,11 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
 
   const filteredEquipment = React.useMemo(() => {
     if (trimmedDebouncedSearch.length < 2) {
-      return [] as EquipmentWithDept[]
+      return [] as TransferEquipmentOption[]
     }
 
     if (selectedEquipment && searchTerm === selectedValueLabel) {
-      return [] as EquipmentWithDept[]
+      return [] as TransferEquipmentOption[]
     }
 
     return equipmentResults
@@ -321,7 +200,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     setSearchTerm(value)
     if (selectedEquipment && value !== selectedValueLabel) {
       setSelectedEquipment(null)
-      setFormData(prev => ({
+      setFormData((prev) => ({
         ...prev,
         thiet_bi_id: 0,
         khoa_phong_hien_tai: "",
@@ -329,17 +208,17 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     }
   }
 
-  const handleSelectEquipment = (equipment: EquipmentWithDept) => {
+  const handleSelectEquipment = (equipment: TransferEquipmentOption) => {
     if (!canSearchEquipment) {
       return
     }
 
-    setSelectedEquipment(equipment);
-    setSearchTerm(`${equipment.ten_thiet_bi} (${equipment.ma_thiet_bi})`);
-    setFormData(prev => ({
+    setSelectedEquipment(equipment)
+    setSearchTerm(`${equipment.ten_thiet_bi} (${equipment.ma_thiet_bi})`)
+    setFormData((prev) => ({
       ...prev,
       thiet_bi_id: equipment.id,
-      khoa_phong_hien_tai: equipment.khoa_phong_quan_ly || ""
+      khoa_phong_hien_tai: equipment.khoa_phong_quan_ly || "",
     }))
   }
 
@@ -393,34 +272,10 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
       return
     }
 
+    setIsLoading(true)
+
     try {
-      const payload: any = {
-        thiet_bi_id: formData.thiet_bi_id,
-        loai_hinh: formData.loai_hinh,
-        ly_do_luan_chuyen: formData.ly_do_luan_chuyen.trim(),
-        updated_by: currentUserId ?? undefined
-      }
-
-      if (formData.loai_hinh === 'noi_bo') {
-        payload.khoa_phong_hien_tai = formData.khoa_phong_hien_tai.trim()
-        payload.khoa_phong_nhan = formData.khoa_phong_nhan.trim()
-        payload.muc_dich = null
-        payload.don_vi_nhan = null
-        payload.dia_chi_don_vi = null
-        payload.nguoi_lien_he = null
-        payload.so_dien_thoai = null
-        payload.ngay_du_kien_tra = null
-      } else {
-        payload.muc_dich = formData.muc_dich
-        payload.don_vi_nhan = formData.don_vi_nhan.trim()
-        payload.dia_chi_don_vi = formData.dia_chi_don_vi.trim() || null
-        payload.nguoi_lien_he = formData.nguoi_lien_he.trim() || null
-        payload.so_dien_thoai = formData.so_dien_thoai.trim() || null
-        payload.ngay_du_kien_tra = formData.ngay_du_kien_tra || null
-        payload.khoa_phong_hien_tai = null
-        payload.khoa_phong_nhan = null
-      }
-
+      const payload = buildUpdateTransferPayload({ formData, currentUserId })
       await callRpc({ fn: 'transfer_request_update', args: { p_id: transfer.id, p_data: payload } })
 
       toast({
@@ -430,11 +285,14 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
 
       onSuccess()
       onOpenChange(false)
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: error.message || "Có lỗi xảy ra khi cập nhật yêu cầu."
+        description: getTransferDialogErrorMessage(
+          error,
+          "Có lỗi xảy ra khi cập nhật yêu cầu.",
+        ),
       })
     } finally {
       setIsLoading(false)
@@ -461,233 +319,49 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4 py-4">
-            {/* Equipment Selection */}
-            <div className="grid gap-2">
-              <Label htmlFor="equipment">Thiết bị *</Label>
-              <div className="relative">
-                <Input
-                  id="equipment"
-                  value={searchTerm}
-                  onChange={handleSearchChange}
-                  placeholder="Tìm kiếm thiết bị..."
-                  disabled={isLoading || !canSearchEquipment}
-                />
-                {canSearchEquipment && (
-                  <>
-                    {showMinCharsHint && (
-                      <div className="absolute z-10 w-full mt-1 bg-popover border rounded-md shadow-lg p-3">
-                        <div className="text-sm text-muted-foreground text-center">
-                          Nhập tối thiểu 2 ký tự để tìm kiếm
-                        </div>
-                      </div>
-                    )}
-                    {trimmedDebouncedSearch.length >= 2 && (
-                      <>
-                        {isEquipmentLoading && (
-                          <div className="absolute z-20 w-full mt-1 bg-popover border rounded-md shadow-lg p-3">
-                            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                              <span>Đang tìm kiếm thiết bị...</span>
-                            </div>
-                          </div>
-                        )}
-                        {showResultsDropdown && (
-                          <div className="absolute z-10 w-full mt-1 bg-popover border rounded-md shadow-lg max-h-60 overflow-y-auto">
-                            <div className="p-1">
-                              {filteredEquipment.map((equipment) => (
-                                <div
-                                  key={equipment.id}
-                                  className="text-sm p-2 hover:bg-accent rounded-sm cursor-pointer"
-                                  onClick={() => handleSelectEquipment(equipment)}
-                                >
-                                  <div className="font-medium">{equipment.ten_thiet_bi} ({equipment.ma_thiet_bi})</div>
-                                  <div className="text-xs text-muted-foreground">
-                                    {equipment.model && `Model: ${equipment.model}`}
-                                    {equipment.khoa_phong_quan_ly && ` • ${equipment.khoa_phong_quan_ly}`}
-                                  </div>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                        {showNoResults && (
-                          <div className="absolute z-10 w-full mt-1 bg-popover border rounded-md shadow-lg p-3">
-                            <div className="text-sm text-muted-foreground text-center">
-                              Không tìm thấy kết quả phù hợp
-                            </div>
-                          </div>
-                        )}
-                      </>
-                    )}
-                  </>
-                )}
-              </div>
-              {!canSearchEquipment && (
-                <p className="text-xs text-muted-foreground">
-                  Không thể thay đổi thiết bị đối với vai trò hiện tại.
-                </p>
-              )}
-              {selectedEquipment && (
-                <p className="text-xs text-muted-foreground flex items-center gap-1.5 pt-1">
-                  <Check className="h-3.5 w-3.5 text-green-600"/>
-                  <span>Đã chọn: {selectedEquipment.ten_thiet_bi} ({selectedEquipment.ma_thiet_bi})</span>
-                </p>
-              )}
-            </div>
+            <TransferDialogEquipmentSearch
+              disabled={isLoading || !canSearchEquipment}
+              canSearch={canSearchEquipment}
+              searchTerm={searchTerm}
+              trimmedSearch={trimmedDebouncedSearch}
+              selectedEquipment={selectedEquipment}
+              isEquipmentLoading={isEquipmentLoading}
+              showResultsDropdown={showResultsDropdown}
+              showNoResults={showNoResults}
+              showMinCharsHint={showMinCharsHint}
+              filteredEquipment={filteredEquipment}
+              noSearchMessage="Không thể thay đổi thiết bị đối với vai trò hiện tại."
+              onSearchChange={handleSearchChange}
+              onSelectEquipment={handleSelectEquipment}
+            />
 
-            {/* Transfer Type */}
-            <div className="grid gap-2">
-              <Label htmlFor="type">Loại hình luân chuyển *</Label>
-              <Select
-                value={formData.loai_hinh}
-                onValueChange={(value: TransferType) => setFormData(prev => ({ ...prev, loai_hinh: value }))}
-                disabled={isLoading || !canEdit}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Chọn loại hình" />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(TRANSFER_TYPES).map(([key, label]) => (
-                    <SelectItem key={key} value={key}>
-                      <div className="flex items-center gap-2">
-                        <Badge variant={key === 'noi_bo' ? 'default' : 'secondary'}>
-                          {label}
-                        </Badge>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            <TransferTypeField
+              disabled={isLoading || !canEdit}
+              formData={formData}
+              setFormData={setFormData}
+            />
 
-            {/* Conditional Fields for Internal Transfer */}
             {formData.loai_hinh === 'noi_bo' && (
-              <>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="grid gap-2">
-                    <Label htmlFor="current_dept">Khoa/Phòng hiện tại *</Label>
-                    <Input
-                      id="current_dept"
-                      value={formData.khoa_phong_hien_tai}
-                      onChange={(e) => setFormData(prev => ({ ...prev, khoa_phong_hien_tai: e.target.value }))}
-                      placeholder="Khoa/phòng hiện tại quản lý"
-                      disabled={isLoading || !canEdit}
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="receiving_dept">Khoa/Phòng nhận *</Label>
-                    <Input
-                      id="receiving_dept"
-                      value={formData.khoa_phong_nhan}
-                      onChange={(e) => setFormData(prev => ({ ...prev, khoa_phong_nhan: e.target.value }))}
-                      placeholder="Khoa/phòng sẽ nhận thiết bị"
-                      disabled={isLoading || !canEdit}
-                      required
-                    />
-                  </div>
-                </div>
-              </>
-            )}
-
-            {/* Conditional Fields for External Transfer */}
-            {formData.loai_hinh === 'ben_ngoai' && (
-              <>
-                <div className="grid gap-2">
-                  <Label htmlFor="purpose">Mục đích *</Label>
-                  <Select
-                    value={formData.muc_dich}
-                    onValueChange={(value: TransferPurpose) => setFormData(prev => ({ ...prev, muc_dich: value }))}
-                    disabled={isLoading || !canEdit}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Chọn mục đích" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.entries(TRANSFER_PURPOSES).map(([key, label]) => (
-                        <SelectItem key={key} value={key}>
-                          {label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="external_org">Đơn vị nhận *</Label>
-                  <Input
-                    id="external_org"
-                    value={formData.don_vi_nhan}
-                    onChange={(e) => setFormData(prev => ({ ...prev, don_vi_nhan: e.target.value }))}
-                    placeholder="Tên đơn vị/tổ chức nhận thiết bị"
-                    disabled={isLoading || !canEdit}
-                    required
-                  />
-                </div>
-
-                <div className="grid gap-2">
-                  <Label htmlFor="address">Địa chỉ đơn vị</Label>
-                  <Textarea
-                    id="address"
-                    value={formData.dia_chi_don_vi}
-                    onChange={(e) => setFormData(prev => ({ ...prev, dia_chi_don_vi: e.target.value }))}
-                    placeholder="Địa chỉ của đơn vị nhận"
-                    disabled={isLoading || !canEdit}
-                    rows={2}
-                  />
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="grid gap-2">
-                    <Label htmlFor="contact_person">Người liên hệ</Label>
-                    <Input
-                      id="contact_person"
-                      value={formData.nguoi_lien_he}
-                      onChange={(e) => setFormData(prev => ({ ...prev, nguoi_lien_he: e.target.value }))}
-                      placeholder="Tên người liên hệ"
-                      disabled={isLoading || !canEdit}
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="phone">Số điện thoại</Label>
-                    <Input
-                      id="phone"
-                      value={formData.so_dien_thoai}
-                      onChange={(e) => setFormData(prev => ({ ...prev, so_dien_thoai: e.target.value }))}
-                      placeholder="Số điện thoại liên hệ"
-                      disabled={isLoading || !canEdit}
-                    />
-                  </div>
-                </div>
-
-                {(formData.muc_dich === 'sua_chua' || formData.muc_dich === 'cho_muon') && (
-                  <div className="grid gap-2">
-                    <Label htmlFor="expected_return">Ngày dự kiến trả về</Label>
-                    <Input
-                      id="expected_return"
-                      type="date"
-                      value={formData.ngay_du_kien_tra}
-                      onChange={(e) => setFormData(prev => ({ ...prev, ngay_du_kien_tra: e.target.value }))}
-                      disabled={isLoading || !canEdit}
-                      min={new Date().toISOString().split('T')[0]}
-                    />
-                  </div>
-                )}
-              </>
-            )}
-
-            {/* Reason */}
-            <div className="grid gap-2">
-              <Label htmlFor="reason">Lý do luân chuyển *</Label>
-              <Textarea
-                id="reason"
-                value={formData.ly_do_luan_chuyen}
-                onChange={(e) => setFormData(prev => ({ ...prev, ly_do_luan_chuyen: e.target.value }))}
-                placeholder="Mô tả lý do cần luân chuyển thiết bị"
+              <TransferInternalInputFields
                 disabled={isLoading || !canEdit}
-                required
-                rows={3}
+                formData={formData}
+                setFormData={setFormData}
               />
-            </div>
+            )}
+
+            {formData.loai_hinh === 'ben_ngoai' && (
+              <TransferExternalFields
+                disabled={isLoading || !canEdit}
+                formData={formData}
+                setFormData={setFormData}
+              />
+            )}
+
+            <TransferReasonField
+              disabled={isLoading || !canEdit}
+              formData={formData}
+              setFormData={setFormData}
+            />
           </div>
           
           <DialogFooter>

--- a/src/components/transfer-dialog.equipment-search.tsx
+++ b/src/components/transfer-dialog.equipment-search.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+import { Check, Loader2 } from "lucide-react"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { TransferEquipmentOption } from "@/components/transfer-dialog.shared"
+
+type TransferDialogEquipmentSearchProps = {
+  disabled: boolean
+  canSearch?: boolean
+  required?: boolean
+  searchTerm: string
+  trimmedSearch: string
+  selectedEquipment: TransferEquipmentOption | null
+  isEquipmentLoading: boolean
+  showResultsDropdown: boolean
+  showNoResults: boolean
+  showMinCharsHint: boolean
+  filteredEquipment: TransferEquipmentOption[]
+  noSearchMessage?: string
+  onSearchChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onSelectEquipment: (equipment: TransferEquipmentOption) => void
+}
+
+export function TransferDialogEquipmentSearch({
+  disabled,
+  canSearch = true,
+  required = false,
+  searchTerm,
+  trimmedSearch,
+  selectedEquipment,
+  isEquipmentLoading,
+  showResultsDropdown,
+  showNoResults,
+  showMinCharsHint,
+  filteredEquipment,
+  noSearchMessage,
+  onSearchChange,
+  onSelectEquipment,
+}: TransferDialogEquipmentSearchProps) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="equipment">Thiết bị *</Label>
+      <div className="relative">
+        <Input
+          id="equipment"
+          value={searchTerm}
+          onChange={onSearchChange}
+          placeholder="Tìm kiếm thiết bị..."
+          disabled={disabled}
+          required={required}
+        />
+        {canSearch && showMinCharsHint && (
+          <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover p-3 shadow-lg">
+            <div className="text-center text-sm text-muted-foreground">
+              Nhập tối thiểu 2 ký tự để tìm kiếm
+            </div>
+          </div>
+        )}
+        {canSearch && trimmedSearch.length >= 2 && (
+          <>
+            {isEquipmentLoading && (
+              <div className="absolute z-20 mt-1 w-full rounded-md border bg-popover p-3 shadow-lg">
+                <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span>Đang tìm kiếm thiết bị...</span>
+                </div>
+              </div>
+            )}
+            {showResultsDropdown && (
+              <div className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-md border bg-popover shadow-lg">
+                <div className="p-1">
+                  {filteredEquipment.map((equipment) => (
+                    <div
+                      key={equipment.id}
+                      className="cursor-pointer rounded-sm p-2 text-sm hover:bg-accent"
+                      onClick={() => onSelectEquipment(equipment)}
+                    >
+                      <div className="font-medium">
+                        {equipment.ten_thiet_bi} ({equipment.ma_thiet_bi})
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {equipment.model && `Model: ${equipment.model}`}
+                        {equipment.khoa_phong_quan_ly && ` • ${equipment.khoa_phong_quan_ly}`}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {showNoResults && (
+              <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover p-3 shadow-lg">
+                <div className="text-center text-sm text-muted-foreground">
+                  Không tìm thấy kết quả phù hợp
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+      {!canSearch && noSearchMessage && (
+        <p className="text-xs text-muted-foreground">{noSearchMessage}</p>
+      )}
+      {selectedEquipment && (
+        <p className="flex items-center gap-1.5 pt-1 text-xs text-muted-foreground">
+          <Check className="h-3.5 w-3.5 text-green-600" />
+          <span>
+            Đã chọn: {selectedEquipment.ten_thiet_bi} ({selectedEquipment.ma_thiet_bi})
+          </span>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/transfer-dialog.equipment-search.tsx
+++ b/src/components/transfer-dialog.equipment-search.tsx
@@ -42,7 +42,7 @@ export function TransferDialogEquipmentSearch({
 }: TransferDialogEquipmentSearchProps) {
   return (
     <div className="grid gap-2">
-      <Label htmlFor="equipment">Thiết bị *</Label>
+      <Label htmlFor="equipment">Thiết bị{required ? " *" : ""}</Label>
       <div className="relative">
         <Input
           id="equipment"
@@ -73,9 +73,10 @@ export function TransferDialogEquipmentSearch({
               <div className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-md border bg-popover shadow-lg">
                 <div className="p-1">
                   {filteredEquipment.map((equipment) => (
-                    <div
+                    <button
+                      type="button"
                       key={equipment.id}
-                      className="cursor-pointer rounded-sm p-2 text-sm hover:bg-accent"
+                      className="w-full rounded-sm p-2 text-left text-sm hover:bg-accent focus:bg-accent focus:outline-none"
                       onClick={() => onSelectEquipment(equipment)}
                     >
                       <div className="font-medium">
@@ -85,7 +86,7 @@ export function TransferDialogEquipmentSearch({
                         {equipment.model && `Model: ${equipment.model}`}
                         {equipment.khoa_phong_quan_ly && ` • ${equipment.khoa_phong_quan_ly}`}
                       </div>
-                    </div>
+                    </button>
                   ))}
                 </div>
               </div>

--- a/src/components/transfer-dialog.form-sections.tsx
+++ b/src/components/transfer-dialog.form-sections.tsx
@@ -17,6 +17,18 @@ import type { TransferDialogFormData } from "@/components/transfer-dialog.shared
 
 type SetFormData = React.Dispatch<React.SetStateAction<TransferDialogFormData>>
 
+function updateCurrentDepartmentFields(
+  previous: TransferDialogFormData,
+  currentDepartment: string,
+): TransferDialogFormData {
+  return {
+    ...previous,
+    khoa_phong_hien_tai: currentDepartment,
+    khoa_phong_nhan:
+      previous.khoa_phong_nhan === currentDepartment ? "" : previous.khoa_phong_nhan,
+  }
+}
+
 export function toLocalDateInputValue(date: Date): string {
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, "0")
@@ -93,7 +105,7 @@ export function TransferInternalSelectFields({
         <Select
           value={formData.khoa_phong_hien_tai}
           onValueChange={(value) =>
-            setFormData((previous) => ({ ...previous, khoa_phong_hien_tai: value }))
+            setFormData((previous) => updateCurrentDepartmentFields(previous, value))
           }
           disabled={lockCurrentDepartment || disabled}
         >
@@ -154,13 +166,13 @@ export function TransferInternalInputFields({
           id="current_dept"
           value={formData.khoa_phong_hien_tai}
           onChange={(event) =>
-            setFormData((previous) => ({
-              ...previous,
-              khoa_phong_hien_tai: event.target.value,
-            }))
+            setFormData((previous) =>
+              updateCurrentDepartmentFields(previous, event.target.value),
+            )
           }
           placeholder="Khoa/phòng hiện tại quản lý"
           disabled={disabled}
+          required
         />
       </div>
       <div className="grid gap-2">

--- a/src/components/transfer-dialog.form-sections.tsx
+++ b/src/components/transfer-dialog.form-sections.tsx
@@ -1,0 +1,321 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  TRANSFER_PURPOSES,
+  TRANSFER_TYPES,
+  type TransferPurpose,
+  type TransferType,
+} from "@/types/database"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import type { TransferDialogFormData } from "@/components/transfer-dialog.shared"
+
+type SetFormData = React.Dispatch<React.SetStateAction<TransferDialogFormData>>
+
+export function TransferTypeField({
+  disabled,
+  formData,
+  setFormData,
+  includeDisposalStyle = false,
+}: {
+  disabled: boolean
+  formData: TransferDialogFormData
+  setFormData: SetFormData
+  includeDisposalStyle?: boolean
+}) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="type">Loại hình luân chuyển *</Label>
+      <Select
+        value={formData.loai_hinh}
+        onValueChange={(value: TransferType) =>
+          setFormData((previous) => ({ ...previous, loai_hinh: value }))
+        }
+        disabled={disabled}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="Chọn loại hình" />
+        </SelectTrigger>
+        <SelectContent>
+          {Object.entries(TRANSFER_TYPES).map(([key, label]) => (
+            <SelectItem key={key} value={key}>
+              <div className="flex items-center gap-2">
+                <Badge
+                  variant={
+                    key === "noi_bo"
+                      ? "default"
+                      : includeDisposalStyle && key === "thanh_ly"
+                        ? "destructive"
+                        : "secondary"
+                  }
+                >
+                  {label}
+                </Badge>
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+export function TransferInternalSelectFields({
+  departments,
+  disabled,
+  formData,
+  setFormData,
+  lockCurrentDepartment,
+}: {
+  departments: string[]
+  disabled: boolean
+  formData: TransferDialogFormData
+  setFormData: SetFormData
+  lockCurrentDepartment: boolean
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className="space-y-2">
+        <Label htmlFor="khoa_phong_hien_tai">Khoa/Phòng hiện tại</Label>
+        <Select
+          value={formData.khoa_phong_hien_tai}
+          onValueChange={(value) =>
+            setFormData((previous) => ({ ...previous, khoa_phong_hien_tai: value }))
+          }
+          disabled={lockCurrentDepartment || disabled}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Chọn khoa/phòng hiện tại" />
+          </SelectTrigger>
+          <SelectContent>
+            {departments.map((department) => (
+              <SelectItem key={department} value={department}>
+                {department}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="khoa_phong_nhan">Khoa/Phòng nhận</Label>
+        <Select
+          value={formData.khoa_phong_nhan}
+          onValueChange={(value) =>
+            setFormData((previous) => ({ ...previous, khoa_phong_nhan: value }))
+          }
+          disabled={disabled}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Chọn khoa/phòng nhận" />
+          </SelectTrigger>
+          <SelectContent>
+            {departments
+              .filter((department) => department !== formData.khoa_phong_hien_tai)
+              .map((department) => (
+                <SelectItem key={department} value={department}>
+                  {department}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}
+
+export function TransferInternalInputFields({
+  disabled,
+  formData,
+  setFormData,
+}: {
+  disabled: boolean
+  formData: TransferDialogFormData
+  setFormData: SetFormData
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className="grid gap-2">
+        <Label htmlFor="current_dept">Khoa/Phòng hiện tại *</Label>
+        <Input
+          id="current_dept"
+          value={formData.khoa_phong_hien_tai}
+          onChange={(event) =>
+            setFormData((previous) => ({
+              ...previous,
+              khoa_phong_hien_tai: event.target.value,
+            }))
+          }
+          placeholder="Khoa/phòng hiện tại quản lý"
+          disabled={disabled}
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="receiving_dept">Khoa/Phòng nhận *</Label>
+        <Input
+          id="receiving_dept"
+          value={formData.khoa_phong_nhan}
+          onChange={(event) =>
+            setFormData((previous) => ({
+              ...previous,
+              khoa_phong_nhan: event.target.value,
+            }))
+          }
+          placeholder="Khoa/phòng sẽ nhận thiết bị"
+          disabled={disabled}
+          required
+        />
+      </div>
+    </div>
+  )
+}
+
+export function TransferExternalFields({
+  disabled,
+  formData,
+  setFormData,
+}: {
+  disabled: boolean
+  formData: TransferDialogFormData
+  setFormData: SetFormData
+}) {
+  return (
+    <>
+      <div className="grid gap-2">
+        <Label htmlFor="purpose">Mục đích *</Label>
+        <Select
+          value={formData.muc_dich}
+          onValueChange={(value: TransferPurpose) =>
+            setFormData((previous) => ({ ...previous, muc_dich: value }))
+          }
+          disabled={disabled}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Chọn mục đích luân chuyển" />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.entries(TRANSFER_PURPOSES).map(([key, label]) => (
+              <SelectItem key={key} value={key}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="external_org">Đơn vị nhận *</Label>
+        <Input
+          id="external_org"
+          value={formData.don_vi_nhan}
+          onChange={(event) =>
+            setFormData((previous) => ({ ...previous, don_vi_nhan: event.target.value }))
+          }
+          placeholder="Tên đơn vị/tổ chức nhận thiết bị"
+          disabled={disabled}
+          required
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="address">Địa chỉ đơn vị</Label>
+        <Textarea
+          id="address"
+          value={formData.dia_chi_don_vi}
+          onChange={(event) =>
+            setFormData((previous) => ({ ...previous, dia_chi_don_vi: event.target.value }))
+          }
+          placeholder="Địa chỉ của đơn vị nhận"
+          disabled={disabled}
+          rows={2}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="grid gap-2">
+          <Label htmlFor="contact_person">Người liên hệ</Label>
+          <Input
+            id="contact_person"
+            value={formData.nguoi_lien_he}
+            onChange={(event) =>
+              setFormData((previous) => ({ ...previous, nguoi_lien_he: event.target.value }))
+            }
+            placeholder="Tên người liên hệ"
+            disabled={disabled}
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="phone">Số điện thoại</Label>
+          <Input
+            id="phone"
+            value={formData.so_dien_thoai}
+            onChange={(event) =>
+              setFormData((previous) => ({ ...previous, so_dien_thoai: event.target.value }))
+            }
+            placeholder="Số điện thoại liên hệ"
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      {(formData.muc_dich === "sua_chua" || formData.muc_dich === "cho_muon") && (
+        <div className="grid gap-2">
+          <Label htmlFor="expected_return">Ngày dự kiến trả về</Label>
+          <Input
+            id="expected_return"
+            type="date"
+            value={formData.ngay_du_kien_tra}
+            onChange={(event) =>
+              setFormData((previous) => ({ ...previous, ngay_du_kien_tra: event.target.value }))
+            }
+            disabled={disabled}
+            min={new Date().toISOString().split("T")[0]}
+          />
+        </div>
+      )}
+    </>
+  )
+}
+
+export function TransferReasonField({
+  disabled,
+  formData,
+  setFormData,
+  allowDisposalCopy = false,
+}: {
+  disabled: boolean
+  formData: TransferDialogFormData
+  setFormData: SetFormData
+  allowDisposalCopy?: boolean
+}) {
+  const isDisposal = allowDisposalCopy && formData.loai_hinh === "thanh_ly"
+
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="reason">{isDisposal ? "Lý do thanh lý *" : "Lý do luân chuyển *"}</Label>
+      <Textarea
+        id="reason"
+        value={formData.ly_do_luan_chuyen}
+        onChange={(event) =>
+          setFormData((previous) => ({
+            ...previous,
+            ly_do_luan_chuyen: event.target.value,
+          }))
+        }
+        placeholder={
+          isDisposal
+            ? "Mô tả lý do cần thanh lý thiết bị (ví dụ: hỏng không thể sửa chữa, lỗi thời...)"
+            : "Mô tả lý do cần luân chuyển thiết bị"
+        }
+        disabled={disabled}
+        required
+        rows={3}
+      />
+    </div>
+  )
+}

--- a/src/components/transfer-dialog.form-sections.tsx
+++ b/src/components/transfer-dialog.form-sections.tsx
@@ -17,6 +17,14 @@ import type { TransferDialogFormData } from "@/components/transfer-dialog.shared
 
 type SetFormData = React.Dispatch<React.SetStateAction<TransferDialogFormData>>
 
+export function toLocalDateInputValue(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+
+  return `${year}-${month}-${day}`
+}
+
 export function TransferTypeField({
   disabled,
   formData,
@@ -184,6 +192,8 @@ export function TransferExternalFields({
   formData: TransferDialogFormData
   setFormData: SetFormData
 }) {
+  const minimumReturnDate = React.useMemo(() => toLocalDateInputValue(new Date()), [])
+
   return (
     <>
       <div className="grid gap-2">
@@ -274,7 +284,7 @@ export function TransferExternalFields({
               setFormData((previous) => ({ ...previous, ngay_du_kien_tra: event.target.value }))
             }
             disabled={disabled}
-            min={new Date().toISOString().split("T")[0]}
+            min={minimumReturnDate}
           />
         </div>
       )}

--- a/src/components/transfer-dialog.shared.ts
+++ b/src/components/transfer-dialog.shared.ts
@@ -1,0 +1,316 @@
+import type { Equipment, TransferPurpose, TransferRequest, TransferType } from "@/types/database"
+
+export type TransferDialogFormData = {
+  thiet_bi_id: number
+  loai_hinh: TransferType | ""
+  ly_do_luan_chuyen: string
+  khoa_phong_hien_tai: string
+  khoa_phong_nhan: string
+  muc_dich: TransferPurpose | ""
+  don_vi_nhan: string
+  dia_chi_don_vi: string
+  nguoi_lien_he: string
+  so_dien_thoai: string
+  ngay_du_kien_tra: string
+}
+
+export type TransferEquipmentOption = Pick<
+  Equipment,
+  "id" | "ma_thiet_bi" | "ten_thiet_bi" | "model" | "serial" | "khoa_phong_quan_ly"
+>
+
+type TransferDialogPayload = {
+  thiet_bi_id: number
+  loai_hinh: TransferType
+  ly_do_luan_chuyen: string
+  nguoi_yeu_cau_id?: number
+  created_by?: number
+  updated_by?: number
+  khoa_phong_hien_tai?: string | null
+  khoa_phong_nhan?: string | null
+  muc_dich?: TransferPurpose | null
+  don_vi_nhan?: string | null
+  dia_chi_don_vi?: string | null
+  nguoi_lien_he?: string | null
+  so_dien_thoai?: string | null
+  ngay_du_kien_tra?: string | null
+}
+
+const EMPTY_FORM_DATA: TransferDialogFormData = {
+  thiet_bi_id: 0,
+  loai_hinh: "",
+  ly_do_luan_chuyen: "",
+  khoa_phong_hien_tai: "",
+  khoa_phong_nhan: "",
+  muc_dich: "",
+  don_vi_nhan: "",
+  dia_chi_don_vi: "",
+  nguoi_lien_he: "",
+  so_dien_thoai: "",
+  ngay_du_kien_tra: "",
+}
+
+function trimValue(value: string): string {
+  return value.trim()
+}
+
+function trimToNull(value: string): string | null {
+  const trimmed = trimValue(value)
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key]
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+function buildInternalTransferFields(formData: TransferDialogFormData) {
+  return {
+    khoa_phong_hien_tai: trimValue(formData.khoa_phong_hien_tai),
+    khoa_phong_nhan: trimValue(formData.khoa_phong_nhan),
+    muc_dich: null,
+    don_vi_nhan: null,
+    dia_chi_don_vi: null,
+    nguoi_lien_he: null,
+    so_dien_thoai: null,
+    ngay_du_kien_tra: null,
+  } satisfies Pick<
+    TransferDialogPayload,
+    | "khoa_phong_hien_tai"
+    | "khoa_phong_nhan"
+    | "muc_dich"
+    | "don_vi_nhan"
+    | "dia_chi_don_vi"
+    | "nguoi_lien_he"
+    | "so_dien_thoai"
+    | "ngay_du_kien_tra"
+  >
+}
+
+function buildExternalTransferFields(formData: TransferDialogFormData) {
+  return {
+    muc_dich: formData.muc_dich || null,
+    don_vi_nhan: trimToNull(formData.don_vi_nhan),
+    dia_chi_don_vi: trimToNull(formData.dia_chi_don_vi),
+    nguoi_lien_he: trimToNull(formData.nguoi_lien_he),
+    so_dien_thoai: trimToNull(formData.so_dien_thoai),
+    ngay_du_kien_tra: trimToNull(formData.ngay_du_kien_tra),
+    khoa_phong_hien_tai: null,
+    khoa_phong_nhan: null,
+  } satisfies Pick<
+    TransferDialogPayload,
+    | "muc_dich"
+    | "don_vi_nhan"
+    | "dia_chi_don_vi"
+    | "nguoi_lien_he"
+    | "so_dien_thoai"
+    | "ngay_du_kien_tra"
+    | "khoa_phong_hien_tai"
+    | "khoa_phong_nhan"
+  >
+}
+
+function buildDisposalTransferFields(formData: TransferDialogFormData) {
+  return {
+    muc_dich: "thanh_ly",
+    don_vi_nhan: "Tổ QLTB",
+    khoa_phong_hien_tai: trimValue(formData.khoa_phong_hien_tai),
+    khoa_phong_nhan: "Tổ QLTB",
+    dia_chi_don_vi: null,
+    nguoi_lien_he: null,
+    so_dien_thoai: null,
+    ngay_du_kien_tra: null,
+  } satisfies Pick<
+    TransferDialogPayload,
+    | "muc_dich"
+    | "don_vi_nhan"
+    | "khoa_phong_hien_tai"
+    | "khoa_phong_nhan"
+    | "dia_chi_don_vi"
+    | "nguoi_lien_he"
+    | "so_dien_thoai"
+    | "ngay_du_kien_tra"
+  >
+}
+
+export function createEmptyTransferDialogFormData(): TransferDialogFormData {
+  return { ...EMPTY_FORM_DATA }
+}
+
+export function normalizeSessionUserId(user: { id?: unknown } | null | undefined): number | null {
+  const rawId = user?.id
+
+  if (typeof rawId === "number" && Number.isFinite(rawId)) {
+    return rawId
+  }
+
+  if (typeof rawId === "string" && /^\d+$/.test(rawId)) {
+    return Number.parseInt(rawId, 10)
+  }
+
+  return null
+}
+
+export function getTransferDialogErrorMessage(error: unknown, fallback: string): string {
+  if (typeof error === "object" && error !== null) {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message
+    }
+  }
+
+  return fallback
+}
+
+export function mapEquipmentSearchResults(rows: unknown[]): TransferEquipmentOption[] {
+  return rows.reduce<TransferEquipmentOption[]>((accumulator, row) => {
+    if (typeof row !== "object" || row === null) {
+      return accumulator
+    }
+
+    const record = row as Record<string, unknown>
+    const id = readNumber(record, "id") ?? readNumber(record, "equipment_id")
+    const maThietBi = readString(record, "ma_thiet_bi") ?? readString(record, "ma_tb")
+    const tenThietBi = readString(record, "ten_thiet_bi") ?? readString(record, "ten_tb")
+
+    if (id === null || id <= 0 || maThietBi === null || tenThietBi === null) {
+      return accumulator
+    }
+
+    const equipment: TransferEquipmentOption = {
+      id,
+      ma_thiet_bi: maThietBi,
+      ten_thiet_bi: tenThietBi,
+    }
+
+    const model = readString(record, "model") ?? readString(record, "model_number")
+    const serial = readString(record, "serial") ?? readString(record, "serial_number")
+    const department =
+      readString(record, "khoa_phong_quan_ly") ??
+      readString(record, "khoa_phong") ??
+      readString(record, "department_name")
+
+    if (model !== null) {
+      equipment.model = model
+    }
+
+    if (serial !== null) {
+      equipment.serial = serial
+    }
+
+    if (department !== null) {
+      equipment.khoa_phong_quan_ly = department
+    }
+
+    accumulator.push(equipment)
+    return accumulator
+  }, [])
+}
+
+export function createTransferDialogFormDataFromTransfer(
+  transfer: TransferRequest,
+): TransferDialogFormData {
+  return {
+    thiet_bi_id: transfer.thiet_bi_id,
+    loai_hinh: transfer.loai_hinh,
+    ly_do_luan_chuyen: transfer.ly_do_luan_chuyen,
+    khoa_phong_hien_tai: transfer.khoa_phong_hien_tai || "",
+    khoa_phong_nhan: transfer.khoa_phong_nhan || "",
+    muc_dich: transfer.muc_dich || "",
+    don_vi_nhan: transfer.don_vi_nhan || "",
+    dia_chi_don_vi: transfer.dia_chi_don_vi || "",
+    nguoi_lien_he: transfer.nguoi_lien_he || "",
+    so_dien_thoai: transfer.so_dien_thoai || "",
+    ngay_du_kien_tra: transfer.ngay_du_kien_tra || "",
+  }
+}
+
+export function getSelectedEquipmentFromTransfer(
+  transfer: TransferRequest | null,
+): TransferEquipmentOption | null {
+  const equipment = transfer?.thiet_bi
+  if (!equipment?.id) {
+    return null
+  }
+
+  return {
+    id: equipment.id,
+    ma_thiet_bi: equipment.ma_thiet_bi,
+    ten_thiet_bi: equipment.ten_thiet_bi,
+    model: equipment.model ?? undefined,
+    serial: (equipment.serial ?? equipment.serial_number) ?? undefined,
+    khoa_phong_quan_ly: equipment.khoa_phong_quan_ly ?? undefined,
+  }
+}
+
+export function buildCreateTransferPayload({
+  formData,
+  currentUserId,
+}: {
+  formData: TransferDialogFormData
+  currentUserId: number | null
+}): TransferDialogPayload {
+  const payload: TransferDialogPayload = {
+    thiet_bi_id: formData.thiet_bi_id,
+    loai_hinh: formData.loai_hinh as TransferType,
+    ly_do_luan_chuyen: trimValue(formData.ly_do_luan_chuyen),
+  }
+
+  if (currentUserId !== null) {
+    payload.nguoi_yeu_cau_id = currentUserId
+    payload.created_by = currentUserId
+    payload.updated_by = currentUserId
+  }
+
+  if (formData.loai_hinh === "noi_bo") {
+    return { ...payload, ...buildInternalTransferFields(formData) }
+  }
+
+  if (formData.loai_hinh === "ben_ngoai") {
+    return { ...payload, ...buildExternalTransferFields(formData) }
+  }
+
+  return { ...payload, ...buildDisposalTransferFields(formData) }
+}
+
+export function buildUpdateTransferPayload({
+  formData,
+  currentUserId,
+}: {
+  formData: TransferDialogFormData
+  currentUserId: number | null
+}): TransferDialogPayload {
+  const payload: TransferDialogPayload = {
+    thiet_bi_id: formData.thiet_bi_id,
+    loai_hinh: formData.loai_hinh as TransferType,
+    ly_do_luan_chuyen: trimValue(formData.ly_do_luan_chuyen),
+  }
+
+  if (currentUserId !== null) {
+    payload.updated_by = currentUserId
+  }
+
+  if (formData.loai_hinh === "noi_bo") {
+    return { ...payload, ...buildInternalTransferFields(formData) }
+  }
+
+  if (formData.loai_hinh === "thanh_ly") {
+    return { ...payload, ...buildDisposalTransferFields(formData) }
+  }
+
+  return { ...payload, ...buildExternalTransferFields(formData) }
+}


### PR DESCRIPTION
## Summary
- remove explicit `any` usage from the add/edit transfer dialogs by extracting shared typed helpers and UI sections
- fix payload shaping so switching from external to internal transfer clears stale external fields before submit
- add focused tests for transfer dialog helper behavior and add-dialog payload shaping

## Why
Issue #235 targets the unsafe `any` usage inside the transfer dialogs. While tightening those runtime paths, this PR also fixes a real bug in the create flow: external-only fields could leak into the payload after the user switched the form back to an internal transfer.

This PR keeps scope inside the transfer dialog module. Remaining React Doctor state-management warnings are tracked separately in #251.

Closes #235

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- 'src/components/__tests__/transfer-dialog.shared.test.ts' 'src/components/__tests__/transfer-dialogs.payload.test.tsx'`\n- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the add/edit transfer dialogs to eliminate explicit `any`, share typed helpers/UI, and improve equipment search and validation. Fixed payload shaping so switching from external to internal clears external-only fields and avoids stale data.

- **Refactors**
  - Extracted shared logic into `transfer-dialog.shared.ts`, `transfer-dialog.form-sections.tsx`, and `transfer-dialog.equipment-search.tsx`; simplified dialog components; aligns with #235.
  - Added strict types and typed payload builders; `toLocalDateInputValue`; normalized session user IDs; mapped equipment search results; standardized errors.
  - Improved equipment search UX with a min‑chars hint and required marker handling.

- **Bug Fixes**
  - Clear external‑only fields when switching to internal in both add and edit dialogs.
  - Stricter department validation (disallow same current/receiving and clear conflicts). Hardened edge cases (user ID parsing, local date input) and added focused tests for helpers, UI, and payload assembly.

<sup>Written for commit 4122342515dd1083d28d4e002de539ac5221ec95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New equipment search control with selectable results, loading/no-results states, and minimum-character hint.
  * New modular form sections and date handling for transfer type, internal/external fields, and reason.
  * New shared utilities and payload builders to normalize user IDs, map search results, extract error messages, and assemble create/update payloads.

* **Tests**
  * Added comprehensive tests for form behavior, payload construction, equipment search, date formatting, and error messaging.

* **Refactor**
  * Reorganized transfer dialogs into shared, reusable components and utilities while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->