### PR TITLE
refactor: consolidate transfer dialog data hooks

### DIFF
--- a/src/components/__tests__/transfer-dialog.data-fetching.test.tsx
+++ b/src/components/__tests__/transfer-dialog.data-fetching.test.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import "@testing-library/jest-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { AddTransferDialog } from "@/components/add-transfer-dialog"
@@ -140,6 +141,41 @@ describe("transfer dialog data fetching", () => {
     })
 
     expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables internal department selects while departments are still loading", async () => {
+    let resolveDepartments: ((value: { name: string }[]) => void) | null = null
+    mocks.callRpc.mockImplementation(({ fn }: { fn: string }) => {
+      if (fn === "departments_list") {
+        return new Promise<{ name: string }[]>((resolve) => {
+          resolveDepartments = resolve
+        })
+      }
+
+      return Promise.resolve([])
+    })
+
+    const user = userEvent.setup()
+    const queryClient = createTestQueryClient()
+
+    render(
+      <AddTransferDialog open onOpenChange={vi.fn()} onSuccess={vi.fn()} />,
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    const [typeSelect] = screen.getAllByRole("combobox")
+    await user.selectOptions(typeSelect, "noi_bo")
+
+    const selects = screen.getAllByRole("combobox")
+    expect(selects[1]).toBeDisabled()
+    expect(selects[2]).toBeDisabled()
+
+    resolveDepartments?.([{ name: "Khoa A" }, { name: "Khoa B" }])
+
+    await waitFor(() => {
+      expect(selects[1]).not.toBeDisabled()
+      expect(selects[2]).not.toBeDisabled()
+    })
   })
 
 })

--- a/src/components/__tests__/transfer-dialog.data-fetching.test.tsx
+++ b/src/components/__tests__/transfer-dialog.data-fetching.test.tsx
@@ -2,8 +2,9 @@ import * as React from "react"
 import "@testing-library/jest-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen, waitFor } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AddTransferDialog } from "@/components/add-transfer-dialog"
 
 const mocks = vi.hoisted(() => ({
   callRpc: vi.fn(),
@@ -69,25 +70,28 @@ vi.mock("@/components/ui/select", () => ({
   ),
 }))
 
-import { AddTransferDialog } from "@/components/add-transfer-dialog"
-
-function createWrapper() {
-  const queryClient = new QueryClient({
+function createTestQueryClient() {
+  return new QueryClient({
     defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
     },
   })
+}
 
+function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   }
 }
 
-describe("AddTransferDialog payload shaping", () => {
+describe("transfer dialog data fetching", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-
     mocks.useSession.mockReturnValue({
       data: {
         user: {
@@ -99,90 +103,43 @@ describe("AddTransferDialog payload shaping", () => {
     })
   })
 
-  it("drops stale external fields after switching from external to internal transfer", async () => {
+  it("reuses cached departments data across add dialog remounts with the same query client", async () => {
     mocks.callRpc.mockImplementation(async ({ fn }: { fn: string }) => {
       if (fn === "departments_list") {
         return [{ name: "Khoa A" }, { name: "Khoa B" }]
       }
 
-      if (fn === "equipment_list_enhanced") {
-        return {
-          data: [
-            {
-              id: 11,
-              ma_thiet_bi: "TB-11",
-              ten_thiet_bi: "Máy siêu âm",
-              khoa_phong_quan_ly: "Khoa A",
-            },
-          ],
-        }
-      }
-
-      if (fn === "transfer_request_create") {
-        return { id: 501 }
-      }
-
       return []
     })
 
-    const user = userEvent.setup()
-    const onOpenChange = vi.fn()
-    const onSuccess = vi.fn()
+    const queryClient = createTestQueryClient()
+    const wrapper = createWrapper(queryClient)
 
-    render(
-      <AddTransferDialog open onOpenChange={onOpenChange} onSuccess={onSuccess} />,
-      { wrapper: createWrapper() },
+    const firstRender = render(
+      <AddTransferDialog open onOpenChange={vi.fn()} onSuccess={vi.fn()} />,
+      { wrapper },
     )
 
-    await user.type(screen.getByLabelText(/Thiết bị/), "Máy")
-    await user.click(await screen.findByText("Máy siêu âm (TB-11)"))
-
-    let selects = screen.getAllByRole("combobox")
-    await user.selectOptions(selects[0], "ben_ngoai")
-
-    selects = screen.getAllByRole("combobox")
-    await user.selectOptions(selects[1], "sua_chua")
-
-    await user.type(screen.getByLabelText(/Đơn vị nhận/), " Đơn vị B ")
-    await user.type(screen.getByLabelText(/Địa chỉ đơn vị/), " 12 Nguyễn Trãi ")
-    await user.type(screen.getByLabelText(/Người liên hệ/), " Nguyễn Văn B ")
-    await user.type(screen.getByLabelText(/Số điện thoại/), " 0900000000 ")
-    await user.type(screen.getByLabelText(/Ngày dự kiến trả về/), "2026-05-01")
-    await user.type(screen.getByLabelText(/Lý do/), "  Điều phối ")
-
-    selects = screen.getAllByRole("combobox")
-    await user.selectOptions(selects[0], "noi_bo")
-
-    selects = screen.getAllByRole("combobox")
-    await user.selectOptions(selects[2], "Khoa B")
-
-    await user.click(screen.getByRole("button", { name: "Tạo yêu cầu" }))
-
     await waitFor(() => {
+      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
       expect(mocks.callRpc).toHaveBeenCalledWith({
-        fn: "transfer_request_create",
-        args: {
-          p_data: {
-            thiet_bi_id: 11,
-            loai_hinh: "noi_bo",
-            ly_do_luan_chuyen: "Điều phối",
-            nguoi_yeu_cau_id: 42,
-            created_by: 42,
-            updated_by: 42,
-            khoa_phong_hien_tai: "Khoa A",
-            khoa_phong_nhan: "Khoa B",
-            muc_dich: null,
-            don_vi_nhan: null,
-            dia_chi_don_vi: null,
-            nguoi_lien_he: null,
-            so_dien_thoai: null,
-            ngay_du_kien_tra: null,
-          },
-        },
+        fn: "departments_list",
+        args: {},
       })
     })
 
-    expect(onSuccess).toHaveBeenCalled()
-    expect(onOpenChange).toHaveBeenCalledWith(false)
+    firstRender.unmount()
+
+    render(
+      <AddTransferDialog open onOpenChange={vi.fn()} onSuccess={vi.fn()} />,
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Thiết bị/)).toBeInTheDocument()
+    })
+
+    expect(mocks.callRpc).toHaveBeenCalledTimes(1)
   })
+
 })

--- a/src/components/__tests__/transfer-dialog.data.test.tsx
+++ b/src/components/__tests__/transfer-dialog.data.test.tsx
@@ -91,7 +91,7 @@ describe("transfer-dialog.data", () => {
 
     const { rerender } = renderHook(
       ({ open, canSearch, searchTerm }) =>
-        useTransferEquipmentSearch({ open, canSearch, searchTerm }),
+        useTransferEquipmentSearch({ open, canSearch, searchTerm, skipSearch: false }),
       {
         initialProps: {
           open: false,
@@ -130,6 +130,7 @@ describe("transfer-dialog.data", () => {
           open: true,
           canSearch: true,
           searchTerm: " Máy ",
+          skipSearch: false,
         }),
       {
         wrapper,
@@ -172,6 +173,7 @@ describe("transfer-dialog.data", () => {
           open: true,
           canSearch: true,
           searchTerm: "Máy",
+          skipSearch: false,
         }),
       {
         wrapper,
@@ -190,6 +192,7 @@ describe("transfer-dialog.data", () => {
 
     unmount()
     mocks.toast.mockClear()
+    mocks.callRpc.mockClear()
     mocks.callRpc.mockRejectedValueOnce(new DOMException("aborted", "AbortError"))
 
     renderHook(
@@ -198,6 +201,7 @@ describe("transfer-dialog.data", () => {
           open: true,
           canSearch: true,
           searchTerm: "Máy",
+          skipSearch: false,
         }),
       {
         wrapper: createWrapper(createTestQueryClient()),
@@ -205,9 +209,29 @@ describe("transfer-dialog.data", () => {
     )
 
     await waitFor(() => {
-      expect(mocks.callRpc).toHaveBeenCalled()
+      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
     })
 
     expect(mocks.toast).not.toHaveBeenCalled()
+  })
+
+  it("does not search when the input is only mirroring the selected equipment label", async () => {
+    const queryClient = createTestQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    renderHook(
+      () =>
+        useTransferEquipmentSearch({
+          open: true,
+          canSearch: true,
+          searchTerm: "Máy siêu âm (TB-11)",
+          skipSearch: true,
+        }),
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(mocks.callRpc).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/components/__tests__/transfer-dialog.data.test.tsx
+++ b/src/components/__tests__/transfer-dialog.data.test.tsx
@@ -1,0 +1,213 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+  toast: vi.fn(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: mocks.callRpc,
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}))
+
+vi.mock("@/hooks/use-debounce", () => ({
+  useSearchDebounce: (value: string) => value,
+}))
+
+import {
+  useTransferDepartments,
+  useTransferEquipmentSearch,
+} from "@/components/transfer-dialog.data"
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe("transfer-dialog.data", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("reuses cached departments data when the add dialog reopens", async () => {
+    mocks.callRpc.mockResolvedValue([{ name: "Khoa A" }, { name: "Khoa B" }])
+    const queryClient = createTestQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    const { result, rerender } = renderHook(
+      ({ open }) => useTransferDepartments({ open }),
+      {
+        initialProps: { open: true },
+        wrapper,
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.departments).toEqual(["Khoa A", "Khoa B"])
+    })
+
+    rerender({ open: false })
+    rerender({ open: true })
+
+    await waitFor(() => {
+      expect(result.current.departments).toEqual(["Khoa A", "Khoa B"])
+    })
+
+    expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+    expect(mocks.callRpc).toHaveBeenCalledWith({
+      fn: "departments_list",
+      args: {},
+    })
+  })
+
+  it("does not search equipment until the dialog can search with at least two characters", async () => {
+    const queryClient = createTestQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    const { rerender } = renderHook(
+      ({ open, canSearch, searchTerm }) =>
+        useTransferEquipmentSearch({ open, canSearch, searchTerm }),
+      {
+        initialProps: {
+          open: false,
+          canSearch: true,
+          searchTerm: "Máy",
+        },
+        wrapper,
+      },
+    )
+
+    rerender({ open: true, canSearch: false, searchTerm: "Máy" })
+    rerender({ open: true, canSearch: true, searchTerm: "M" })
+
+    await waitFor(() => {
+      expect(mocks.callRpc).not.toHaveBeenCalled()
+    })
+  })
+
+  it("searches equipment with the existing RPC contract and maps the result rows", async () => {
+    mocks.callRpc.mockResolvedValue({
+      data: [
+        {
+          id: 11,
+          ma_thiet_bi: "TB-11",
+          ten_thiet_bi: "Máy siêu âm",
+          khoa_phong_quan_ly: "Khoa A",
+        },
+      ],
+    })
+    const queryClient = createTestQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    const { result } = renderHook(
+      () =>
+        useTransferEquipmentSearch({
+          open: true,
+          canSearch: true,
+          searchTerm: " Máy ",
+        }),
+      {
+        wrapper,
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.equipmentResults).toEqual([
+        {
+          id: 11,
+          ma_thiet_bi: "TB-11",
+          ten_thiet_bi: "Máy siêu âm",
+          khoa_phong_quan_ly: "Khoa A",
+        },
+      ])
+    })
+
+    expect(result.current.trimmedSearch).toBe("Máy")
+    expect(mocks.callRpc).toHaveBeenCalledWith({
+      fn: "equipment_list_enhanced",
+      args: {
+        p_q: "Máy",
+        p_sort: "ten_thiet_bi.asc",
+        p_page: 1,
+        p_page_size: 20,
+      },
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it("shows a toast for equipment search errors but skips abort errors", async () => {
+    const queryClient = createTestQueryClient()
+    const wrapper = createWrapper(queryClient)
+
+    mocks.callRpc.mockRejectedValueOnce(new Error("Boom"))
+
+    const { unmount } = renderHook(
+      () =>
+        useTransferEquipmentSearch({
+          open: true,
+          canSearch: true,
+          searchTerm: "Máy",
+        }),
+      {
+        wrapper,
+      },
+    )
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: "Lỗi tìm kiếm thiết bị",
+          description: "Boom",
+        }),
+      )
+    })
+
+    unmount()
+    mocks.toast.mockClear()
+    mocks.callRpc.mockRejectedValueOnce(new DOMException("aborted", "AbortError"))
+
+    renderHook(
+      () =>
+        useTransferEquipmentSearch({
+          open: true,
+          canSearch: true,
+          searchTerm: "Máy",
+        }),
+      {
+        wrapper: createWrapper(createTestQueryClient()),
+      },
+    )
+
+    await waitFor(() => {
+      expect(mocks.callRpc).toHaveBeenCalled()
+    })
+
+    expect(mocks.toast).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/add-transfer-dialog.tsx
+++ b/src/components/add-transfer-dialog.tsx
@@ -64,7 +64,13 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     }
   }, [open, resetForm])
 
-  const { departments } = useTransferDepartments({ open })
+  const { departments, isLoadingDepartments } = useTransferDepartments({ open })
+  const selectedValueLabel = selectedEquipment
+    ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
+    : ""
+  const isSelectedValueActive = Boolean(
+    selectedEquipment && searchTerm.trim() === selectedValueLabel,
+  )
   const {
     equipmentResults,
     isEquipmentLoading,
@@ -73,10 +79,8 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     open,
     canSearch: true,
     searchTerm,
+    skipSearch: isSelectedValueActive,
   })
-  const selectedValueLabel = selectedEquipment
-    ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
-    : ""
 
   const filteredEquipment = React.useMemo(() => {
     if (trimmedSearch.length < 2) {
@@ -90,7 +94,6 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     return equipmentResults
   }, [equipmentResults, trimmedSearch, searchTerm, selectedEquipment, selectedValueLabel])
 
-  const isSelectedValueActive = Boolean(selectedEquipment && searchTerm === selectedValueLabel)
   const showResultsDropdown =
     trimmedSearch.length >= 2 && !isEquipmentLoading && filteredEquipment.length > 0
   const showNoResults =
@@ -234,7 +237,7 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
             {formData.loai_hinh === 'noi_bo' && (
               <TransferInternalSelectFields
                 departments={departments}
-                disabled={isLoading}
+                disabled={isLoading || isLoadingDepartments}
                 formData={formData}
                 setFormData={setFormData}
                 lockCurrentDepartment={Boolean(selectedEquipment)}

--- a/src/components/add-transfer-dialog.tsx
+++ b/src/components/add-transfer-dialog.tsx
@@ -16,12 +16,14 @@ import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
 import { isRegionalLeaderRole } from "@/lib/rbac"
 import { useSession } from "next-auth/react"
-import { useSearchDebounce } from "@/hooks/use-debounce"
+import {
+  useTransferDepartments,
+  useTransferEquipmentSearch,
+} from "@/components/transfer-dialog.data"
 import {
   buildCreateTransferPayload,
   createEmptyTransferDialogFormData,
   getTransferDialogErrorMessage,
-  mapEquipmentSearchResults,
   normalizeSessionUserId,
   type TransferEquipmentOption,
 } from "@/components/transfer-dialog.shared"
@@ -32,10 +34,6 @@ import {
   TransferReasonField,
   TransferTypeField,
 } from "@/components/transfer-dialog.form-sections"
-
-type EquipmentListEnhancedResponse = {
-  data?: unknown[] | null
-}
 
 interface AddTransferDialogProps {
   open: boolean
@@ -49,12 +47,8 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
   const currentUserId = normalizeSessionUserId(session?.user)
   const isRegionalLeader = isRegionalLeaderRole(session?.user?.role)
   const [isLoading, setIsLoading] = React.useState(false)
-  const [equipmentResults, setEquipmentResults] = React.useState<TransferEquipmentOption[]>([])
-  const [isEquipmentLoading, setIsEquipmentLoading] = React.useState(false)
   const [searchTerm, setSearchTerm] = React.useState("")
-  const debouncedSearch = useSearchDebounce(searchTerm)
   const [selectedEquipment, setSelectedEquipment] = React.useState<TransferEquipmentOption | null>(null)
-  const [departments, setDepartments] = React.useState<string[]>([])
   const [formData, setFormData] = React.useState(createEmptyTransferDialogFormData)
 
   const resetForm = React.useCallback(() => {
@@ -66,101 +60,26 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
   React.useEffect(() => {
     if (!open) {
       resetForm()
-      setEquipmentResults([])
       return
     }
+  }, [open, resetForm])
 
-    if (departments.length === 0) {
-      (async () => {
-        try {
-          const deps = await callRpc<{ name: string }[]>({ fn: "departments_list", args: {} })
-          setDepartments((deps || []).map((department) => department.name).filter(Boolean))
-        } catch (error: unknown) {
-          toast({
-            variant: "destructive",
-            title: "Lỗi tải danh sách khoa phòng",
-            description: getTransferDialogErrorMessage(
-              error,
-              "Không thể tải danh sách khoa phòng.",
-            ),
-          })
-        }
-      })()
-    }
-  }, [open, departments.length, resetForm, toast])
-
-  const trimmedDebouncedSearch = (debouncedSearch ?? "").trim()
+  const { departments } = useTransferDepartments({ open })
+  const {
+    equipmentResults,
+    isEquipmentLoading,
+    trimmedSearch,
+  } = useTransferEquipmentSearch({
+    open,
+    canSearch: true,
+    searchTerm,
+  })
   const selectedValueLabel = selectedEquipment
     ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
     : ""
 
-  React.useEffect(() => {
-    if (!open) {
-      return
-    }
-
-    if (trimmedDebouncedSearch.length < 2) {
-      setEquipmentResults([])
-      setIsEquipmentLoading(false)
-      return
-    }
-
-    let isMounted = true
-    const controller = new AbortController()
-
-    setIsEquipmentLoading(true)
-    setEquipmentResults([])
-
-    ;(async () => {
-      try {
-        const result = await callRpc<EquipmentListEnhancedResponse>({
-          fn: "equipment_list_enhanced",
-          args: {
-            p_q: trimmedDebouncedSearch,
-            p_sort: "ten_thiet_bi.asc",
-            p_page: 1,
-            p_page_size: 20,
-          },
-          signal: controller.signal,
-        })
-
-        if (!isMounted) {
-          return
-        }
-
-        const rows = Array.isArray(result?.data) ? result.data : []
-        setEquipmentResults(mapEquipmentSearchResults(rows))
-      } catch (error: unknown) {
-        if (!isMounted) {
-          return
-        }
-        if (error instanceof DOMException && error.name === "AbortError") {
-          return
-        }
-
-        toast({
-          variant: "destructive",
-          title: "Lỗi tìm kiếm thiết bị",
-          description: getTransferDialogErrorMessage(
-            error,
-            "Không thể tải danh sách thiết bị.",
-          ),
-        })
-      } finally {
-        if (isMounted) {
-          setIsEquipmentLoading(false)
-        }
-      }
-    })()
-
-    return () => {
-      isMounted = false
-      controller.abort()
-    }
-  }, [open, trimmedDebouncedSearch, toast])
-
   const filteredEquipment = React.useMemo(() => {
-    if (trimmedDebouncedSearch.length < 2) {
+    if (trimmedSearch.length < 2) {
       return [] as TransferEquipmentOption[]
     }
 
@@ -169,15 +88,15 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     }
 
     return equipmentResults
-  }, [equipmentResults, trimmedDebouncedSearch, searchTerm, selectedEquipment, selectedValueLabel])
+  }, [equipmentResults, trimmedSearch, searchTerm, selectedEquipment, selectedValueLabel])
 
   const isSelectedValueActive = Boolean(selectedEquipment && searchTerm === selectedValueLabel)
   const showResultsDropdown =
-    trimmedDebouncedSearch.length >= 2 && !isEquipmentLoading && filteredEquipment.length > 0
+    trimmedSearch.length >= 2 && !isEquipmentLoading && filteredEquipment.length > 0
   const showNoResults =
-    trimmedDebouncedSearch.length >= 2 && !isEquipmentLoading && filteredEquipment.length === 0 && !isSelectedValueActive
+    trimmedSearch.length >= 2 && !isEquipmentLoading && filteredEquipment.length === 0 && !isSelectedValueActive
   const showMinCharsHint =
-    trimmedDebouncedSearch.length > 0 && trimmedDebouncedSearch.length < 2
+    trimmedSearch.length > 0 && trimmedSearch.length < 2
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value)
@@ -288,7 +207,7 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
               disabled={isLoading}
               required
               searchTerm={searchTerm}
-              trimmedSearch={trimmedDebouncedSearch}
+              trimmedSearch={trimmedSearch}
               selectedEquipment={selectedEquipment}
               isEquipmentLoading={isEquipmentLoading}
               showResultsDropdown={showResultsDropdown}

--- a/src/components/edit-transfer-dialog.tsx
+++ b/src/components/edit-transfer-dialog.tsx
@@ -81,6 +81,9 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
   const selectedValueLabel = selectedEquipment
     ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
     : ""
+  const isSelectedValueActive = Boolean(
+    selectedEquipment && searchTerm.trim() === selectedValueLabel,
+  )
 
   const canSearchEquipment = Boolean(canEdit && !isRegionalLeader)
   const {
@@ -91,6 +94,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     open,
     canSearch: canSearchEquipment,
     searchTerm,
+    skipSearch: isSelectedValueActive,
   })
 
   const filteredEquipment = React.useMemo(() => {
@@ -105,7 +109,6 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     return equipmentResults
   }, [equipmentResults, trimmedSearch, searchTerm, selectedEquipment, selectedValueLabel])
 
-  const isSelectedValueActive = Boolean(selectedEquipment && searchTerm === selectedValueLabel)
   const showResultsDropdown =
     canSearchEquipment &&
     trimmedSearch.length >= 2 &&

--- a/src/components/edit-transfer-dialog.tsx
+++ b/src/components/edit-transfer-dialog.tsx
@@ -17,14 +17,13 @@ import { callRpc } from "@/lib/rpc-client"
 import { isRegionalLeaderRole } from "@/lib/rbac"
 import { useSession } from "next-auth/react"
 import { type TransferRequest } from "@/types/database"
-import { useSearchDebounce } from "@/hooks/use-debounce"
+import { useTransferEquipmentSearch } from "@/components/transfer-dialog.data"
 import {
   buildUpdateTransferPayload,
   createEmptyTransferDialogFormData,
   createTransferDialogFormDataFromTransfer,
   getSelectedEquipmentFromTransfer,
   getTransferDialogErrorMessage,
-  mapEquipmentSearchResults,
   normalizeSessionUserId,
   type TransferEquipmentOption,
 } from "@/components/transfer-dialog.shared"
@@ -35,10 +34,6 @@ import {
   TransferReasonField,
   TransferTypeField,
 } from "@/components/transfer-dialog.form-sections"
-
-type EquipmentListEnhancedResponse = {
-  data?: unknown[] | null
-}
 
 interface EditTransferDialogProps {
   open: boolean
@@ -53,10 +48,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
   const currentUserId = normalizeSessionUserId(session?.user)
   const isRegionalLeader = isRegionalLeaderRole(session?.user?.role)
   const [isLoading, setIsLoading] = React.useState(false)
-  const [equipmentResults, setEquipmentResults] = React.useState<TransferEquipmentOption[]>([])
-  const [isEquipmentLoading, setIsEquipmentLoading] = React.useState(false)
   const [searchTerm, setSearchTerm] = React.useState("")
-  const debouncedSearch = useSearchDebounce(searchTerm)
   const [selectedEquipment, setSelectedEquipment] = React.useState<TransferEquipmentOption | null>(null)
   const [formData, setFormData] = React.useState(createEmptyTransferDialogFormData)
 
@@ -86,84 +78,23 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     }
   }, [open, transfer, resetForm])
 
-  const trimmedDebouncedSearch = (debouncedSearch ?? "").trim()
   const selectedValueLabel = selectedEquipment
     ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
     : ""
 
   const canSearchEquipment = Boolean(canEdit && !isRegionalLeader)
-
-  React.useEffect(() => {
-    if (!open || !canSearchEquipment) {
-      if (!open) {
-        setEquipmentResults([])
-      }
-      setIsEquipmentLoading(false)
-      return
-    }
-
-    if (trimmedDebouncedSearch.length < 2) {
-      setEquipmentResults([])
-      setIsEquipmentLoading(false)
-      return
-    }
-
-    let isMounted = true
-    const controller = new AbortController()
-
-    setIsEquipmentLoading(true)
-    setEquipmentResults([])
-
-    ;(async () => {
-      try {
-        const result = await callRpc<EquipmentListEnhancedResponse>({
-          fn: "equipment_list_enhanced",
-          args: {
-            p_q: trimmedDebouncedSearch,
-            p_sort: "ten_thiet_bi.asc",
-            p_page: 1,
-            p_page_size: 20,
-          },
-          signal: controller.signal,
-        })
-
-        if (!isMounted) {
-          return
-        }
-
-        const rows = Array.isArray(result?.data) ? result.data : []
-        setEquipmentResults(mapEquipmentSearchResults(rows))
-      } catch (error: unknown) {
-        if (!isMounted) {
-          return
-        }
-        if (error instanceof DOMException && error.name === "AbortError") {
-          return
-        }
-
-        toast({
-          variant: "destructive",
-          title: "Lỗi tìm kiếm thiết bị",
-          description: getTransferDialogErrorMessage(
-            error,
-            "Không thể tải danh sách thiết bị.",
-          ),
-        })
-      } finally {
-        if (isMounted) {
-          setIsEquipmentLoading(false)
-        }
-      }
-    })()
-
-    return () => {
-      isMounted = false
-      controller.abort()
-    }
-  }, [open, canSearchEquipment, trimmedDebouncedSearch, toast])
+  const {
+    equipmentResults,
+    isEquipmentLoading,
+    trimmedSearch,
+  } = useTransferEquipmentSearch({
+    open,
+    canSearch: canSearchEquipment,
+    searchTerm,
+  })
 
   const filteredEquipment = React.useMemo(() => {
-    if (trimmedDebouncedSearch.length < 2) {
+    if (trimmedSearch.length < 2) {
       return [] as TransferEquipmentOption[]
     }
 
@@ -172,24 +103,24 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     }
 
     return equipmentResults
-  }, [equipmentResults, trimmedDebouncedSearch, searchTerm, selectedEquipment, selectedValueLabel])
+  }, [equipmentResults, trimmedSearch, searchTerm, selectedEquipment, selectedValueLabel])
 
   const isSelectedValueActive = Boolean(selectedEquipment && searchTerm === selectedValueLabel)
   const showResultsDropdown =
     canSearchEquipment &&
-    trimmedDebouncedSearch.length >= 2 &&
+    trimmedSearch.length >= 2 &&
     !isEquipmentLoading &&
     filteredEquipment.length > 0
   const showNoResults =
     canSearchEquipment &&
-    trimmedDebouncedSearch.length >= 2 &&
+    trimmedSearch.length >= 2 &&
     !isEquipmentLoading &&
     filteredEquipment.length === 0 &&
     !isSelectedValueActive
   const showMinCharsHint =
     canSearchEquipment &&
-    trimmedDebouncedSearch.length > 0 &&
-    trimmedDebouncedSearch.length < 2
+    trimmedSearch.length > 0 &&
+    trimmedSearch.length < 2
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!canSearchEquipment) {
@@ -323,7 +254,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
               disabled={isLoading || !canSearchEquipment}
               canSearch={canSearchEquipment}
               searchTerm={searchTerm}
-              trimmedSearch={trimmedDebouncedSearch}
+              trimmedSearch={trimmedSearch}
               selectedEquipment={selectedEquipment}
               isEquipmentLoading={isEquipmentLoading}
               showResultsDropdown={showResultsDropdown}

--- a/src/components/transfer-dialog.data.ts
+++ b/src/components/transfer-dialog.data.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 
 import { useSearchDebounce } from "@/hooks/use-debounce"
 import { useToast } from "@/hooks/use-toast"
@@ -13,6 +13,28 @@ import {
 
 type EquipmentListEnhancedResponse = {
   data?: unknown[] | null
+}
+
+type TransferDepartmentsParams = {
+  open: boolean
+}
+
+type TransferEquipmentSearchParams = {
+  open: boolean
+  canSearch: boolean
+  searchTerm: string
+  skipSearch: boolean
+}
+
+export type TransferDepartmentsResult = {
+  departments: string[]
+  isLoadingDepartments: boolean
+}
+
+export type TransferEquipmentSearchResult = {
+  equipmentResults: ReturnType<typeof mapEquipmentSearchResults>
+  isEquipmentLoading: boolean
+  trimmedSearch: string
 }
 
 function isAbortError(error: unknown): boolean {
@@ -41,7 +63,9 @@ export const transferDialogQueryKeys = {
     ["equipment_list_enhanced", "transfer-dialog", { q: searchTerm }] as const,
 }
 
-export function useTransferDepartments({ open }: { open: boolean }) {
+export function useTransferDepartments({
+  open,
+}: TransferDepartmentsParams): TransferDepartmentsResult {
   const { toast } = useToast()
   const query = useQuery({
     queryKey: transferDialogQueryKeys.departments,
@@ -76,31 +100,16 @@ export function useTransferEquipmentSearch({
   open,
   canSearch,
   searchTerm,
-}: {
-  open: boolean
-  canSearch: boolean
-  searchTerm: string
-}) {
+  skipSearch,
+}: TransferEquipmentSearchParams): TransferEquipmentSearchResult {
   const { toast } = useToast()
-  const queryClient = useQueryClient()
   const debouncedSearch = useSearchDebounce(searchTerm)
   const trimmedSearch = (debouncedSearch ?? "").trim()
-  const isEnabled = open && canSearch && trimmedSearch.length >= 2
-  const queryKey = transferDialogQueryKeys.equipmentSearch(trimmedSearch)
+  const isEnabled = open && canSearch && trimmedSearch.length >= 2 && !skipSearch
 
   const query = useQuery({
-    queryKey,
+    queryKey: transferDialogQueryKeys.equipmentSearch(trimmedSearch),
     queryFn: async ({ signal }) => {
-      const cachedResults = queryClient.getQueryData<ReturnType<typeof mapEquipmentSearchResults>>(queryKey)
-      const cachedState = queryClient.getQueryState(queryKey)
-      if (
-        cachedResults &&
-        cachedState?.dataUpdatedAt &&
-        Date.now() - cachedState.dataUpdatedAt < 30_000
-      ) {
-        return cachedResults
-      }
-
       const result = await callRpc<EquipmentListEnhancedResponse>({
         fn: "equipment_list_enhanced",
         args: {

--- a/src/components/transfer-dialog.data.ts
+++ b/src/components/transfer-dialog.data.ts
@@ -1,0 +1,144 @@
+"use client"
+
+import * as React from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useSearchDebounce } from "@/hooks/use-debounce"
+import { useToast } from "@/hooks/use-toast"
+import { callRpc } from "@/lib/rpc-client"
+import {
+  getTransferDialogErrorMessage,
+  mapEquipmentSearchResults,
+} from "@/components/transfer-dialog.shared"
+
+type EquipmentListEnhancedResponse = {
+  data?: unknown[] | null
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    error instanceof DOMException && error.name === "AbortError"
+  ) || (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "AbortError"
+  )
+}
+
+async function fetchTransferDepartments(): Promise<string[]> {
+  const list = await callRpc<{ name: string }[]>({
+    fn: "departments_list",
+    args: {},
+  })
+
+  return (list || []).map((item) => item.name).filter(Boolean)
+}
+
+export const transferDialogQueryKeys = {
+  departments: ["departments_list"] as const,
+  equipmentSearch: (searchTerm: string) =>
+    ["equipment_list_enhanced", "transfer-dialog", { q: searchTerm }] as const,
+}
+
+export function useTransferDepartments({ open }: { open: boolean }) {
+  const { toast } = useToast()
+  const query = useQuery({
+    queryKey: transferDialogQueryKeys.departments,
+    queryFn: fetchTransferDepartments,
+    enabled: open,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  })
+
+  React.useEffect(() => {
+    if (!query.error || isAbortError(query.error)) {
+      return
+    }
+
+    toast({
+      variant: "destructive",
+      title: "Lỗi tải danh sách khoa phòng",
+      description: getTransferDialogErrorMessage(
+        query.error,
+        "Không thể tải danh sách khoa phòng.",
+      ),
+    })
+  }, [toast, query.error, query.errorUpdatedAt])
+
+  return {
+    departments: query.data ?? [],
+    isLoadingDepartments: query.isLoading,
+  }
+}
+
+export function useTransferEquipmentSearch({
+  open,
+  canSearch,
+  searchTerm,
+}: {
+  open: boolean
+  canSearch: boolean
+  searchTerm: string
+}) {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const debouncedSearch = useSearchDebounce(searchTerm)
+  const trimmedSearch = (debouncedSearch ?? "").trim()
+  const isEnabled = open && canSearch && trimmedSearch.length >= 2
+  const queryKey = transferDialogQueryKeys.equipmentSearch(trimmedSearch)
+
+  const query = useQuery({
+    queryKey,
+    queryFn: async ({ signal }) => {
+      const cachedResults = queryClient.getQueryData<ReturnType<typeof mapEquipmentSearchResults>>(queryKey)
+      const cachedState = queryClient.getQueryState(queryKey)
+      if (
+        cachedResults &&
+        cachedState?.dataUpdatedAt &&
+        Date.now() - cachedState.dataUpdatedAt < 30_000
+      ) {
+        return cachedResults
+      }
+
+      const result = await callRpc<EquipmentListEnhancedResponse>({
+        fn: "equipment_list_enhanced",
+        args: {
+          p_q: trimmedSearch,
+          p_sort: "ten_thiet_bi.asc",
+          p_page: 1,
+          p_page_size: 20,
+        },
+        signal,
+      })
+
+      const rows = Array.isArray(result?.data) ? result.data : []
+      return mapEquipmentSearchResults(rows)
+    },
+    enabled: isEnabled,
+    staleTime: 30_000,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  })
+
+  React.useEffect(() => {
+    if (!query.error || isAbortError(query.error)) {
+      return
+    }
+
+    toast({
+      variant: "destructive",
+      title: "Lỗi tìm kiếm thiết bị",
+      description: getTransferDialogErrorMessage(
+        query.error,
+        "Không thể tải danh sách thiết bị.",
+      ),
+    })
+  }, [toast, query.error, query.errorUpdatedAt])
+
+  return {
+    equipmentResults: isEnabled ? (query.data ?? []) : [],
+    isEquipmentLoading: isEnabled ? query.isFetching : false,
+    trimmedSearch,
+  }
+}


### PR DESCRIPTION
## Summary
- extract shared transfer dialog data hooks for departments loading and equipment search
- move AddTransferDialog departments loading to TanStack Query cache and reuse the shared search flow in add/edit dialogs
- add focused tests for the new data layer and keep existing payload-shaping coverage green

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- 'src/components/__tests__/transfer-dialog.data.test.tsx' 'src/components/__tests__/transfer-dialog.data-fetching.test.tsx' 'src/components/__tests__/transfer-dialogs.payload.test.tsx' 'src/components/__tests__/transfer-dialog.components.test.tsx' 'src/app/(app)/transfers/__tests__/TransfersDialogs.test.tsx'
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

## Notes
- React Doctor still reports one existing state-orchestration warning in `src/components/edit-transfer-dialog.tsx`; that follow-up remains tracked by #251 and is intentionally out of scope here.

Closes #254
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates transfer dialog data fetching into shared hooks using `@tanstack/react-query`, integrated into add/edit dialogs to reduce duplication and RPC calls. Adds cache-backed departments and debounced equipment search with better error handling and loading UX (closes #254).

- **Refactors**
  - Added `transfer-dialog.data.ts` with `useTransferDepartments` (5m stale, 10m GC) and `useTransferEquipmentSearch` (30s stale, no refetch on mount/focus); skips AbortError toasts and maps results to UI format.
  - Updated `AddTransferDialog` and `EditTransferDialog` to use the hooks; removed local effects/state, disabled internal department selects while loading, and gated search (2+ chars, skips when input matches selected label); caches are reused across dialog remounts.

<sup>Written for commit 89c2a8ac17ddaba6f1aef58a9b2cc45794b5bcd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for the transfer dialog covering data fetching, cache reuse across reopenings, loading states, and equipment search/error handling.

* **Refactor**
  * Transfer dialogs now use centralized data hooks improving caching and preventing duplicate requests; UI disables dependent controls while data loads, search input is trimmed and gated by minimum characters, and errors surface as destructive toasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->