### PR TITLE
Add repair cost usage visualizations scaffolding

### DIFF
--- a/docs/schema/supabase-tenant-rpc-template.md
+++ b/docs/schema/supabase-tenant-rpc-template.md
@@ -1,22 +1,74 @@
-# Supabase Tenant-Scoped RPC Template
+# Supabase SQL Migration Pattern
 
-Use this template when adding a new tenant-scoped `SECURITY DEFINER` RPC. The goal is to make the scope model explicit so reviewers do not force the wrong JWT-guard pattern onto modules that support `regional_leader`.
+Use this pattern when adding or replacing Supabase SQL, especially tenant-scoped
+`SECURITY DEFINER` RPCs. The goal is to make live database assumptions explicit
+so agents do not miss grants, JWT guards, search paths, tenant scope, indexes, or
+post-migration verification.
 
 ## Before You Start
 
 - Find the nearest existing detail/list RPC for the same module.
+- Query the live database for the current function definition, grants, indexes,
+  and column types before replacing an existing RPC.
+- Compare the local migration plan with live behavior; preserve compatible
+  contracts unless the OpenSpec change explicitly requires a breaking change.
 - Confirm whether the role model is:
   - single-tenant via `don_vi`
   - multi-tenant via `allowed_don_vi_for_session()` / `dia_ban`
 - If `regional_leader` is allowed, do not add an outer `v_don_vi IS NULL` guard unless the existing module contract already requires it.
+- If a prior user instruction says not to apply a migration yet, create and test
+  the migration file only; wait for explicit approval before calling
+  Supabase MCP `apply_migration`.
+
+## Standard Flow
+
+1. Read the nearest existing migration and smoke test for the same module.
+2. Query live DB state before writing SQL:
+
+   ```sql
+   SELECT p.oid::regprocedure::text AS signature,
+          p.prosecdef AS security_definer,
+          p.proconfig,
+          pg_get_functiondef(p.oid) AS function_definition
+   FROM pg_proc p
+   JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public'
+     AND p.proname = 'example_tenant_rpc';
+
+   SELECT grantee, privilege_type
+   FROM information_schema.routine_privileges
+   WHERE routine_schema = 'public'
+     AND routine_name = 'example_tenant_rpc'
+   ORDER BY grantee, privilege_type;
+   ```
+
+3. Write the SQL smoke test first. Wrap it in `BEGIN; ... ROLLBACK;` and make
+   it fail for the intended missing behavior before changing the migration.
+4. Write the migration with a header comment, explicit function signature,
+   `SECURITY DEFINER`, `SET search_path = public, pg_temp`, JWT guards, scope
+   guards, and grants that match the intended access contract.
+5. Run the focused smoke test until green. For MCP execution, paste the smoke
+   SQL through `execute_sql` only if it is transaction-wrapped and rolls back.
+6. Apply only after approval when approval was requested. Use Supabase MCP
+   `apply_migration` for DDL when migration history is drifted.
+7. After applying, run the smoke test again against live DB and run
+   Supabase MCP `get_advisors(security)`. Run `get_advisors(performance)` when
+   the migration adds or changes filtered, sorted, or joined queries.
+8. Verify the applied function shape and grants from live DB. Note: MCP
+   `apply_migration` may record a generated version timestamp while storing the
+   local migration filename stem as the migration `name`; confirm with
+   `list_migrations`.
 
 ## Checklist
 
 - [ ] `BEGIN; ... COMMIT;`
 - [ ] Header comment explains why the RPC exists
+- [ ] Live function definition/grants/indexes were queried before replacement
 - [ ] `SECURITY DEFINER`
 - [ ] `SET search_path = public, pg_temp`
-- [ ] `GRANT EXECUTE ... TO authenticated`
+- [ ] Existing RPC grants are preserved when replacing a function, unless the
+      spec intentionally changes access
+- [ ] New authenticated-only RPCs use `GRANT EXECUTE ... TO authenticated`
 - [ ] `REVOKE EXECUTE ... FROM PUBLIC`
 - [ ] `v_jwt_claims`, `v_role`, `v_user_id` extracted with `COALESCE(..., '{}')::jsonb`
 - [ ] `v_role` guard
@@ -24,7 +76,12 @@ Use this template when adding a new tenant-scoped `SECURITY DEFINER` RPC. The go
 - [ ] `admin -> global` normalization if the RPC can run outside proxy assumptions
 - [ ] Third scope guard matches the actual role model
 - [ ] `regional_leader` write paths explicitly denied when the RPC mutates data
+- [ ] LIKE/ILIKE user input uses `_sanitize_ilike_pattern()`
+- [ ] No `SELECT *`; fetch only columns needed by the payload
+- [ ] New filters, sorts, and joins either use existing indexes or add a justified index
+- [ ] JSON payload keys intentionally match the frontend contract, usually camelCase
 - [ ] Post-migration smoke script covers authorized scope, blocked scope, and role-specific exceptions
+- [ ] Post-apply `get_advisors(security)` was reviewed; pre-existing advisor noise is separated from new migration risk
 
 ## Template
 
@@ -104,3 +161,12 @@ Add a short comment when using helper-based scope:
 ```
 
 That one note prevents future review churn.
+
+Add a short comment when preserving existing grants that are broader than the
+default authenticated-only template:
+
+```sql
+-- NOTE: this replaces an existing report RPC. Preserve the live EXECUTE grants
+-- for anon/authenticated/service_role to avoid changing the established access
+-- contract; JWT guards inside the SECURITY DEFINER function still enforce scope.
+```

--- a/openspec/changes/add-repair-cost-usage-visualizations/tasks.md
+++ b/openspec/changes/add-repair-cost-usage-visualizations/tasks.md
@@ -1,31 +1,31 @@
 ## 1. SQL / Data Contract
-- [ ] 1.1 Add failing SQL smoke coverage for live schema assumptions, top repair-cost sorting, exact camelCase payload keys, and usage-log seed equipment IDs that fit `nhat_ky_su_dung.thiet_bi_id integer`.
-- [ ] 1.2 Add failing SQL smoke coverage for valid usage-hour aggregation, invalid/open usage-log exclusion, cumulative-vs-range mode including usage intervals crossing past `p_date_to`, sparse-data counts, and tenant/global scoping.
-- [ ] 1.3 Extend the latest `get_maintenance_report_data(date,date,bigint)` body from live Supabase MCP / `20260412100000_add_repair_request_cost_statistics.sql` to return `topEquipmentRepairCosts` sorted by completed repair cost descending, preserving all existing payload keys and empty/default return payloads.
-- [ ] 1.4 Extend the same RPC without changing its signature to return `charts.repairUsageCostCorrelation.period` and `charts.repairUsageCostCorrelation.cumulative`, each with `points` and `dataQuality`, using explicit scoped-equipment, usage, period-cost, cumulative-cost, point, and quality CTEs.
-- [ ] 1.5 Preserve JWT guards, `admin`/`global` handling, regional scope, `SECURITY DEFINER`, `SET search_path = public, pg_temp`, `GRANT`/`REVOKE`, existing live ACL posture unless explicitly hardened, and `COMMENT ON FUNCTION`, using `tb.don_vi = ANY(v_effective)` for equipment tenant scoping and documenting the `nhat_ky_su_dung.thiet_bi_id` integer to `thiet_bi.id` bigint join without casting the indexed usage-log column.
-- [ ] 1.6 Run the focused SQL smoke test and confirm it passes.
+- [x] 1.1 Add failing SQL smoke coverage for live schema assumptions, top repair-cost sorting, exact camelCase payload keys, and usage-log seed equipment IDs that fit `nhat_ky_su_dung.thiet_bi_id integer`.
+- [x] 1.2 Add failing SQL smoke coverage for valid usage-hour aggregation, invalid/open usage-log exclusion, cumulative-vs-range mode including usage intervals crossing past `p_date_to`, sparse-data counts, and tenant/global scoping.
+- [x] 1.3 Extend the latest `get_maintenance_report_data(date,date,bigint)` body from live Supabase MCP / `20260412100000_add_repair_request_cost_statistics.sql` to return `topEquipmentRepairCosts` sorted by completed repair cost descending, preserving all existing payload keys and empty/default return payloads.
+- [x] 1.4 Extend the same RPC without changing its signature to return `charts.repairUsageCostCorrelation.period` and `charts.repairUsageCostCorrelation.cumulative`, each with `points` and `dataQuality`, using explicit scoped-equipment, usage, period-cost, cumulative-cost, point, and quality CTEs.
+- [x] 1.5 Preserve JWT guards, `admin`/`global` handling, regional scope, `SECURITY DEFINER`, `SET search_path = public, pg_temp`, `GRANT`/`REVOKE`, existing live ACL posture unless explicitly hardened, and `COMMENT ON FUNCTION`, using `tb.don_vi = ANY(v_effective)` for equipment tenant scoping and documenting the `nhat_ky_su_dung.thiet_bi_id` integer to `thiet_bi.id` bigint join without casting the indexed usage-log column.
+- [x] 1.6 Run the focused SQL smoke test and confirm it passes.
 
 ## 2. TypeScript Contract
-- [ ] 2.1 Add failing compile-time type assertion coverage for the maintenance report hook default payload and new report fields; do not rely on the mocked `maintenance-report-tab.test.tsx` fixture for the RED contract step.
-- [ ] 2.2 Extract/export maintenance report data types for `topEquipmentRepairCosts` and `repairUsageCostCorrelation.{period,cumulative}.{points,dataQuality}` into `use-maintenance-data.types.ts`.
-- [ ] 2.3 Keep `topEquipmentRepairs` unchanged for request-count ranking.
-- [ ] 2.4 Run `node scripts/npm-run.js run typecheck` and confirm the type assertions pass.
+- [x] 2.1 Add failing compile-time type assertion coverage for the maintenance report hook default payload and new report fields; do not rely on the mocked `maintenance-report-tab.test.tsx` fixture for the RED contract step.
+- [x] 2.2 Extract/export maintenance report data types for `topEquipmentRepairCosts` and `repairUsageCostCorrelation.{period,cumulative}.{points,dataQuality}` into `use-maintenance-data.types.ts`.
+- [x] 2.3 Keep `topEquipmentRepairs` unchanged for request-count ranking.
+- [x] 2.4 Run `node scripts/npm-run.js run typecheck` and confirm the type assertions pass.
 
 ## 3. UI
-- [ ] 3.1 Add failing component tests for the Top 10 repair-cost chart, usage-cost correlation chart, cumulative toggle, insufficient-data state, and `DynamicScatterChart` test mock wiring.
-- [ ] 3.2 Add scatter support in `src/lib/chart-utils.ts` and `src/components/dynamic-chart.tsx`.
-- [ ] 3.3 Extract new chart/formatting helpers from `maintenance-report-tab.tsx` into focused report component files before adding chart UI.
-- [ ] 3.4 Render a horizontal bar chart for “Top 10 thiết bị có chi phí sửa chữa cao nhất”.
-- [ ] 3.5 Render a scatter/bubble chart for “Giờ sử dụng và chi phí sửa chữa” only when the data-quality threshold is met.
-- [ ] 3.6 Render a data-quality empty state when fewer than three equipment have both positive usage hours and recorded repair cost.
-- [ ] 3.7 Run the focused report UI tests and confirm they pass.
+- [x] 3.1 Add failing component tests for the Top 10 repair-cost chart, usage-cost correlation chart, cumulative toggle, insufficient-data state, and `DynamicScatterChart` test mock wiring.
+- [x] 3.2 Add scatter support in `src/lib/chart-utils.ts` and `src/components/dynamic-chart.tsx`.
+- [x] 3.3 Extract new chart/formatting helpers from `maintenance-report-tab.tsx` into focused report component files before adding chart UI.
+- [x] 3.4 Render a horizontal bar chart for “Top 10 thiết bị có chi phí sửa chữa cao nhất”.
+- [x] 3.5 Render a scatter/bubble chart for “Giờ sử dụng và chi phí sửa chữa” only when the data-quality threshold is met.
+- [x] 3.6 Render a data-quality empty state when fewer than three equipment have both positive usage hours and recorded repair cost.
+- [x] 3.7 Run the focused report UI tests and confirm they pass.
 
 ## 4. Verification
-- [ ] 4.1 Run `node scripts/npm-run.js run verify:no-explicit-any`.
-- [ ] 4.2 Run `node scripts/npm-run.js run typecheck`.
-- [ ] 4.3 Run focused SQL smoke tests.
-- [ ] 4.4 Run focused Vitest suites for reports and repair cost.
-- [ ] 4.5 Run `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`.
-- [ ] 4.6 Run Supabase MCP `get_advisors(security)`.
-- [ ] 4.7 Run `openspec validate add-repair-cost-usage-visualizations --strict`.
+- [x] 4.1 Run `node scripts/npm-run.js run verify:no-explicit-any`.
+- [x] 4.2 Run `node scripts/npm-run.js run typecheck`.
+- [x] 4.3 Run focused SQL smoke tests.
+- [x] 4.4 Run focused Vitest suites for reports and repair cost.
+- [x] 4.5 Run `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`.
+- [x] 4.6 Run Supabase MCP `get_advisors(security)`.
+- [x] 4.7 Run `openspec validate add-repair-cost-usage-visualizations --strict`.

--- a/src/app/(app)/reports/components/__tests__/maintenance-repair-cost-visualizations.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-repair-cost-visualizations.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockDynamicBarChart = vi.fn(() => <div data-testid="repair-cost-bar-chart" />)
 const mockDynamicScatterChart = vi.fn(() => <div data-testid="repair-usage-cost-scatter" />)
@@ -38,6 +38,10 @@ vi.mock('@/components/dynamic-chart', () => ({
 import { MaintenanceRepairCostVisualizations } from '../maintenance-repair-cost-visualizations'
 
 describe('MaintenanceRepairCostVisualizations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   const topEquipmentRepairCosts = [
     {
       equipmentId: 1,

--- a/src/app/(app)/reports/components/__tests__/maintenance-repair-cost-visualizations.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-repair-cost-visualizations.test.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+const mockDynamicBarChart = vi.fn(() => <div data-testid="repair-cost-bar-chart" />)
+const mockDynamicScatterChart = vi.fn(() => <div data-testid="repair-usage-cost-scatter" />)
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/components/dynamic-chart', () => ({
+  DynamicBarChart: (props: unknown) => mockDynamicBarChart(props),
+  DynamicScatterChart: (props: unknown) => mockDynamicScatterChart(props),
+}))
+
+import { MaintenanceRepairCostVisualizations } from '../maintenance-repair-cost-visualizations'
+
+describe('MaintenanceRepairCostVisualizations', () => {
+  const topEquipmentRepairCosts = [
+    {
+      equipmentId: 1,
+      equipmentName: 'Monitor 1',
+      equipmentCode: 'TB-001',
+      totalRepairCost: 5000000,
+      averageCompletedRepairCost: 2500000,
+      completedRepairRequests: 2,
+      costRecordedCount: 2,
+    },
+    {
+      equipmentId: 2,
+      equipmentName: 'Ventilator 2',
+      equipmentCode: 'TB-002',
+      totalRepairCost: 3200000,
+      averageCompletedRepairCost: 1600000,
+      completedRepairRequests: 2,
+      costRecordedCount: 2,
+    },
+  ]
+
+  const period = {
+    points: [
+      {
+        equipmentId: 1,
+        equipmentName: 'Monitor 1',
+        equipmentCode: 'TB-001',
+        totalUsageHours: 120,
+        totalRepairCost: 5000000,
+        completedRepairRequests: 2,
+        costRecordedCount: 2,
+      },
+      {
+        equipmentId: 2,
+        equipmentName: 'Ventilator 2',
+        equipmentCode: 'TB-002',
+        totalUsageHours: 88,
+        totalRepairCost: 3200000,
+        completedRepairRequests: 2,
+        costRecordedCount: 2,
+      },
+      {
+        equipmentId: 3,
+        equipmentName: 'Pump 3',
+        equipmentCode: 'TB-003',
+        totalUsageHours: 45,
+        totalRepairCost: 1800000,
+        completedRepairRequests: 1,
+        costRecordedCount: 1,
+      },
+    ],
+    dataQuality: {
+      equipmentWithUsage: 4,
+      equipmentWithRepairCost: 3,
+      equipmentWithBoth: 3,
+    },
+  }
+
+  const cumulative = {
+    points: [
+      {
+        equipmentId: 1,
+        equipmentName: 'Monitor 1',
+        equipmentCode: 'TB-001',
+        totalUsageHours: 180,
+        totalRepairCost: 6500000,
+        completedRepairRequests: 3,
+        costRecordedCount: 3,
+      },
+      {
+        equipmentId: 2,
+        equipmentName: 'Ventilator 2',
+        equipmentCode: 'TB-002',
+        totalUsageHours: 110,
+        totalRepairCost: 3200000,
+        completedRepairRequests: 2,
+        costRecordedCount: 2,
+      },
+      {
+        equipmentId: 3,
+        equipmentName: 'Pump 3',
+        equipmentCode: 'TB-003',
+        totalUsageHours: 70,
+        totalRepairCost: 2100000,
+        completedRepairRequests: 2,
+        costRecordedCount: 1,
+      },
+    ],
+    dataQuality: {
+      equipmentWithUsage: 5,
+      equipmentWithRepairCost: 4,
+      equipmentWithBoth: 3,
+    },
+  }
+
+  it('renders the top repair-cost chart and period correlation chart by default', () => {
+    render(
+      <MaintenanceRepairCostVisualizations
+        topEquipmentRepairCosts={topEquipmentRepairCosts}
+        repairUsageCostCorrelation={{ period, cumulative }}
+      />
+    )
+
+    expect(screen.getByText('Top 10 thiết bị có chi phí sửa chữa cao nhất')).toBeInTheDocument()
+    expect(screen.getByText('Giờ sử dụng và chi phí sửa chữa')).toBeInTheDocument()
+    expect(screen.getByTestId('repair-cost-bar-chart')).toBeInTheDocument()
+    expect(screen.getByTestId('repair-usage-cost-scatter')).toBeInTheDocument()
+
+    expect(mockDynamicBarChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            equipmentName: 'Monitor 1',
+            totalRepairCost: 5000000,
+          }),
+        ]),
+      })
+    )
+
+    expect(mockDynamicScatterChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: period.points,
+      })
+    )
+  })
+
+  it('switches the correlation chart to cumulative mode without changing the top repair-cost chart', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MaintenanceRepairCostVisualizations
+        topEquipmentRepairCosts={topEquipmentRepairCosts}
+        repairUsageCostCorrelation={{ period, cumulative }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Lũy kế' }))
+
+    expect(mockDynamicScatterChart).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: cumulative.points,
+      })
+    )
+    expect(mockDynamicBarChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            equipmentCode: 'TB-001',
+            totalRepairCost: 5000000,
+          }),
+        ]),
+      })
+    )
+  })
+
+  it('renders a correlation data-quality empty state when fewer than three equipment have both usage and repair cost', () => {
+    render(
+      <MaintenanceRepairCostVisualizations
+        topEquipmentRepairCosts={topEquipmentRepairCosts}
+        repairUsageCostCorrelation={{
+          period: {
+            points: period.points.slice(0, 2),
+            dataQuality: {
+              equipmentWithUsage: 5,
+              equipmentWithRepairCost: 4,
+              equipmentWithBoth: 2,
+            },
+          },
+          cumulative,
+        }}
+      />
+    )
+
+    expect(screen.getByText('Chưa đủ dữ liệu để hiển thị tương quan.')).toBeInTheDocument()
+    expect(screen.getByText('Thiết bị có giờ sử dụng: 5')).toBeInTheDocument()
+    expect(screen.getByText('Thiết bị có chi phí sửa chữa: 4')).toBeInTheDocument()
+    expect(screen.getByText('Thiết bị có đủ cả hai: 2')).toBeInTheDocument()
+    expect(screen.queryByTestId('repair-usage-cost-scatter')).not.toBeInTheDocument()
+  })
+
+  it('renders a repair-cost empty state when no recorded repair cost data exists in the selected period', () => {
+    render(
+      <MaintenanceRepairCostVisualizations
+        topEquipmentRepairCosts={[]}
+        repairUsageCostCorrelation={{ period, cumulative }}
+      />
+    )
+
+    expect(screen.getByText('Không có dữ liệu chi phí sửa chữa trong khoảng thời gian đã chọn.')).toBeInTheDocument()
+    expect(screen.queryByTestId('repair-cost-bar-chart')).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-tab.test.tsx
@@ -53,6 +53,7 @@ vi.mock("@/components/dynamic-chart", () => ({
   DynamicBarChart: () => <div data-testid="bar-chart" />,
   DynamicLineChart: () => <div data-testid="line-chart" />,
   DynamicPieChart: () => <div data-testid="pie-chart" />,
+  DynamicScatterChart: () => <div data-testid="scatter-chart" />,
 }))
 
 import { MaintenanceReportTab } from "../maintenance-report-tab"
@@ -76,8 +77,27 @@ describe("MaintenanceReportTab", () => {
           repairStatusDistribution: [],
           maintenancePlanVsActual: [],
           repairFrequencyByMonth: [],
+          repairUsageCostCorrelation: {
+            period: {
+              points: [],
+              dataQuality: {
+                equipmentWithUsage: 0,
+                equipmentWithRepairCost: 0,
+                equipmentWithBoth: 0,
+              },
+            },
+            cumulative: {
+              points: [],
+              dataQuality: {
+                equipmentWithUsage: 0,
+                equipmentWithRepairCost: 0,
+                equipmentWithBoth: 0,
+              },
+            },
+          },
         },
         topEquipmentRepairs: [],
+        topEquipmentRepairCosts: [],
         recentRepairHistory: [],
       },
       isLoading: false,

--- a/src/app/(app)/reports/components/maintenance-repair-cost-visualizations.tsx
+++ b/src/app/(app)/reports/components/maintenance-repair-cost-visualizations.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import * as React from "react"
+import { Inbox } from "lucide-react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { DynamicBarChart, DynamicScatterChart } from "@/components/dynamic-chart"
+import type {
+  RepairUsageCostCorrelation,
+  TopEquipmentRepairCostEntry,
+} from "../hooks/use-maintenance-data.types"
+
+const MIN_CORRELATION_POINTS = 3
+
+interface MaintenanceRepairCostVisualizationsProps {
+  topEquipmentRepairCosts: TopEquipmentRepairCostEntry[]
+  repairUsageCostCorrelation: RepairUsageCostCorrelation
+}
+
+type CorrelationScopeKey = keyof RepairUsageCostCorrelation
+
+export function MaintenanceRepairCostVisualizations({
+  topEquipmentRepairCosts,
+  repairUsageCostCorrelation,
+}: MaintenanceRepairCostVisualizationsProps) {
+  const [scope, setScope] = React.useState<CorrelationScopeKey>("period")
+
+  const activeCorrelationScope = repairUsageCostCorrelation[scope]
+  const hasRepairCostData = topEquipmentRepairCosts.length > 0
+  const hasCorrelationData =
+    activeCorrelationScope.dataQuality.equipmentWithBoth >= MIN_CORRELATION_POINTS
+
+  const topRepairCostChartData = React.useMemo(
+    () =>
+      topEquipmentRepairCosts.slice(0, 10).map((item) => ({
+        equipmentName: item.equipmentName,
+        equipmentCode: item.equipmentCode,
+        equipmentLabel: `${item.equipmentName} (${item.equipmentCode})`,
+        totalRepairCost: item.totalRepairCost,
+        completedRepairRequests: item.completedRepairRequests,
+        costRecordedCount: item.costRecordedCount,
+      })),
+    [topEquipmentRepairCosts]
+  )
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Top 10 thiết bị có chi phí sửa chữa cao nhất</CardTitle>
+          <CardDescription>Thiết bị được xếp theo tổng chi phí sửa chữa hoàn thành trong khoảng thời gian đã chọn.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!hasRepairCostData ? (
+            <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <span>Không có dữ liệu chi phí sửa chữa trong khoảng thời gian đã chọn.</span>
+            </div>
+          ) : (
+            <DynamicBarChart
+              data={topRepairCostChartData}
+              height={360}
+              xAxisKey="equipmentLabel"
+              yAxisKey="equipmentLabel"
+              layout="vertical"
+              bars={[
+                { key: "totalRepairCost", color: "hsl(var(--chart-1))", name: "Chi phí sửa chữa" },
+              ]}
+              margin={{ top: 16, right: 24, left: 16, bottom: 12 }}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="gap-3">
+          <div className="space-y-1">
+            <CardTitle>Giờ sử dụng và chi phí sửa chữa</CardTitle>
+            <CardDescription>
+              {scope === "period"
+                ? "Tương quan giữa giờ sử dụng hoàn thành và chi phí sửa chữa trong kỳ."
+                : "Tương quan lũy kế đến ngày kết thúc đã chọn."}
+            </CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant={scope === "period" ? "default" : "outline"}
+              onClick={() => setScope("period")}
+            >
+              Theo kỳ
+            </Button>
+            <Button
+              variant={scope === "cumulative" ? "default" : "outline"}
+              onClick={() => setScope("cumulative")}
+            >
+              Lũy kế
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {!hasCorrelationData ? (
+            <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <span>Chưa đủ dữ liệu để hiển thị tương quan.</span>
+              <span>Thiết bị có giờ sử dụng: {activeCorrelationScope.dataQuality.equipmentWithUsage}</span>
+              <span>Thiết bị có chi phí sửa chữa: {activeCorrelationScope.dataQuality.equipmentWithRepairCost}</span>
+              <span>Thiết bị có đủ cả hai: {activeCorrelationScope.dataQuality.equipmentWithBoth}</span>
+            </div>
+          ) : (
+            <DynamicScatterChart
+              data={activeCorrelationScope.points}
+              height={360}
+              xAxisKey="totalUsageHours"
+              yAxisKey="totalRepairCost"
+              zAxisKey="completedRepairRequests"
+              scatterName="Thiết bị"
+              fill="hsl(var(--chart-2))"
+              margin={{ top: 16, right: 24, left: 16, bottom: 12 }}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(app)/reports/components/maintenance-report-summary-cards.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-summary-cards.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import * as React from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { CheckCircle, Clock, Wrench } from "lucide-react"
+import type { MaintenanceReportData } from "../hooks/use-maintenance-data.types"
+
+interface MaintenanceReportSummaryCardsProps {
+  summary: MaintenanceReportData["summary"]
+  isLoading: boolean
+  numberFormatter: Intl.NumberFormat
+}
+
+export function MaintenanceReportSummaryCards({
+  summary,
+  isLoading,
+  numberFormatter,
+}: MaintenanceReportSummaryCardsProps) {
+  return (
+    <>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Yêu cầu sửa chữa</CardTitle>
+            <Wrench className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{summary.totalRepairs}</div>}
+            <p className="text-xs text-muted-foreground">Tổng số yêu cầu trong kỳ</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Tỷ lệ hoàn thành (Sửa chữa)</CardTitle>
+            <CheckCircle className="h-4 w-4 text-green-500" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{summary.repairCompletionRate.toFixed(1)}%</div>}
+            <p className="text-xs text-muted-foreground">So với tổng số yêu cầu</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Công việc bảo trì (Kế hoạch)</CardTitle>
+            <Clock className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{summary.totalMaintenancePlanned}</div>}
+            <p className="text-xs text-muted-foreground">Tổng công việc trong kỳ</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Tỷ lệ hoàn thành (Bảo trì)</CardTitle>
+            <CheckCircle className="h-4 w-4 text-blue-500" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{summary.maintenanceCompletionRate.toFixed(1)}%</div>}
+            <p className="text-xs text-muted-foreground">So với kế hoạch</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Tổng chi phí sửa chữa</CardTitle>
+            <Wrench className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <Skeleton className="h-8 w-16" />
+            ) : (
+              <div className="text-2xl font-bold">{numberFormatter.format(summary.totalRepairCost)} đ</div>
+            )}
+            <p className="text-xs text-muted-foreground">Tổng chi phí sửa chữa trong kỳ</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Chi phí TB ca hoàn thành</CardTitle>
+            <CheckCircle className="h-4 w-4 text-green-500" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <Skeleton className="h-8 w-16" />
+            ) : (
+              <div className="text-2xl font-bold">{numberFormatter.format(summary.averageCompletedRepairCost)} đ</div>
+            )}
+            <p className="text-xs text-muted-foreground">Trung bình trên các ca có ghi nhận chi phí</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Có ghi nhận chi phí</CardTitle>
+            <CheckCircle className="h-4 w-4 text-emerald-500" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <Skeleton className="h-8 w-16" />
+            ) : (
+              <div className="text-2xl font-bold">{numberFormatter.format(summary.costRecordedCount)}</div>
+            )}
+            <p className="text-xs text-muted-foreground">{numberFormatter.format(summary.costRecordedCount)} ca hoàn thành đã ghi nhận</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Thiếu chi phí</CardTitle>
+            <Clock className="h-4 w-4 text-amber-500" />
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <Skeleton className="h-8 w-16" />
+            ) : (
+              <div className="text-2xl font-bold">{numberFormatter.format(summary.costMissingCount)}</div>
+            )}
+            <p className="text-xs text-muted-foreground">{numberFormatter.format(summary.costMissingCount)} ca hoàn thành chưa ghi nhận</p>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  )
+}

--- a/src/app/(app)/reports/components/maintenance-report-tab.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-tab.tsx
@@ -11,6 +11,8 @@ import { cn } from "@/lib/utils"
 import { vi } from "date-fns/locale"
 
 import { useMaintenanceReportData } from "../hooks/use-maintenance-data"
+import { MaintenanceRepairCostVisualizations } from "./maintenance-repair-cost-visualizations"
+import { MaintenanceReportSummaryCards } from "./maintenance-report-summary-cards"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
@@ -62,6 +64,8 @@ export function MaintenanceReportTab({
   const repairFrequency = charts?.repairFrequencyByMonth ?? []
   const repairStatusData = charts?.repairStatusDistribution ?? []
   const topEquipmentRepairs = reportData?.topEquipmentRepairs ?? []
+  const topEquipmentRepairCosts = reportData?.topEquipmentRepairCosts ?? []
+  const repairUsageCostCorrelation = charts?.repairUsageCostCorrelation
   const recentRepairHistory = reportData?.recentRepairHistory ?? []
 
   const normalizedSummary = React.useMemo(() => ({
@@ -168,108 +172,11 @@ export function MaintenanceReportTab({
         </CardContent>
       </Card>
       
-      {/* Summary Cards */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Yêu cầu sửa chữa</CardTitle>
-            <Wrench className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{normalizedSummary.totalRepairs}</div>}
-            <p className="text-xs text-muted-foreground">Tổng số yêu cầu trong kỳ</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Tỷ lệ hoàn thành (Sửa chữa)</CardTitle>
-            <CheckCircle className="h-4 w-4 text-green-500" />
-          </CardHeader>
-          <CardContent>
-            {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{normalizedSummary.repairCompletionRate.toFixed(1)}%</div>}
-            <p className="text-xs text-muted-foreground">So với tổng số yêu cầu</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Công việc bảo trì (Kế hoạch)</CardTitle>
-            <Clock className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{normalizedSummary.totalMaintenancePlanned}</div>}
-            <p className="text-xs text-muted-foreground">Tổng công việc trong kỳ</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Tỷ lệ hoàn thành (Bảo trì)</CardTitle>
-            <CheckCircle className="h-4 w-4 text-blue-500" />
-          </CardHeader>
-          <CardContent>
-            {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{normalizedSummary.maintenanceCompletionRate.toFixed(1)}%</div>}
-            <p className="text-xs text-muted-foreground">So với kế hoạch</p>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Tổng chi phí sửa chữa</CardTitle>
-            <Wrench className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <Skeleton className="h-8 w-16" />
-            ) : (
-              <div className="text-2xl font-bold">{numberFormatter.format(normalizedSummary.totalRepairCost)} đ</div>
-            )}
-            <p className="text-xs text-muted-foreground">Tổng chi phí sửa chữa trong kỳ</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Chi phí TB ca hoàn thành</CardTitle>
-            <CheckCircle className="h-4 w-4 text-green-500" />
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <Skeleton className="h-8 w-16" />
-            ) : (
-              <div className="text-2xl font-bold">{numberFormatter.format(normalizedSummary.averageCompletedRepairCost)} đ</div>
-            )}
-            <p className="text-xs text-muted-foreground">Trung bình trên các ca có ghi nhận chi phí</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Có ghi nhận chi phí</CardTitle>
-            <CheckCircle className="h-4 w-4 text-emerald-500" />
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <Skeleton className="h-8 w-16" />
-            ) : (
-              <div className="text-2xl font-bold">{numberFormatter.format(normalizedSummary.costRecordedCount)}</div>
-            )}
-            <p className="text-xs text-muted-foreground">{numberFormatter.format(normalizedSummary.costRecordedCount)} ca hoàn thành đã ghi nhận</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Thiếu chi phí</CardTitle>
-            <Clock className="h-4 w-4 text-amber-500" />
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <Skeleton className="h-8 w-16" />
-            ) : (
-              <div className="text-2xl font-bold">{numberFormatter.format(normalizedSummary.costMissingCount)}</div>
-            )}
-            <p className="text-xs text-muted-foreground">{numberFormatter.format(normalizedSummary.costMissingCount)} ca hoàn thành chưa ghi nhận</p>
-          </CardContent>
-        </Card>
-      </div>
+      <MaintenanceReportSummaryCards
+        summary={normalizedSummary}
+        isLoading={isLoading}
+        numberFormatter={numberFormatter}
+      />
       
       {/* Charts Section */}
       <div className="grid gap-4 md:grid-cols-2">
@@ -355,6 +262,13 @@ export function MaintenanceReportTab({
           )}
         </CardContent>
       </Card>
+
+      {repairUsageCostCorrelation ? (
+        <MaintenanceRepairCostVisualizations
+          topEquipmentRepairCosts={topEquipmentRepairCosts}
+          repairUsageCostCorrelation={repairUsageCostCorrelation}
+        />
+      ) : null}
 
       {/* Repair history table */}
       <Card className="border border-border/60 shadow-sm">

--- a/src/app/(app)/reports/hooks/use-maintenance-data.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.ts
@@ -1,62 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
 import { callRpc } from '@/lib/rpc-client'
 import { format, startOfYear, endOfYear } from 'date-fns'
+import {
+  defaultMaintenanceReportData,
+  type DateRange,
+  mergeMaintenanceReportData,
+  type MaintenanceReportData,
+} from './use-maintenance-data.types'
 
-interface DateRange {
-  from: Date
-  to: Date
-}
-
-interface RepairFrequencyPoint {
-  period: string
-  total: number
-  completed: number
-}
-
-interface TopEquipmentRepairEntry {
-  equipmentId: number
-  equipmentName: string
-  totalRequests: number
-  latestStatus: string
-  latestCompletedDate?: string | null
-}
-
-interface RecentRepairHistoryEntry {
-  id: number
-  equipmentName: string
-  issue: string
-  status: string
-  requestedDate: string
-  completedDate?: string | null
-}
-
-interface MaintenanceReportData {
-  summary: {
-    totalRepairs: number
-    repairCompletionRate: number
-    totalMaintenancePlanned: number
-    maintenanceCompletionRate: number
-    totalRepairCost: number
-    averageCompletedRepairCost: number
-    costRecordedCount: number
-    costMissingCount: number
-  }
-  charts: {
-    repairStatusDistribution: Array<{
-      name: string
-      value: number
-      color: string
-    }>
-    maintenancePlanVsActual: Array<{
-      name: string
-      planned: number
-      actual: number
-    }>
-    repairFrequencyByMonth?: RepairFrequencyPoint[]
-  }
-  topEquipmentRepairs?: TopEquipmentRepairEntry[]
-  recentRepairHistory?: RecentRepairHistoryEntry[]
-}
+export { defaultMaintenanceReportData } from './use-maintenance-data.types'
 
 // Query keys for maintenance reports caching
 export const maintenanceReportKeys = {
@@ -95,25 +47,7 @@ export function useMaintenanceReportData(
         }
       })
 
-      return result || {
-        summary: {
-          totalRepairs: 0,
-          repairCompletionRate: 0,
-          totalMaintenancePlanned: 0,
-          maintenanceCompletionRate: 0,
-          totalRepairCost: 0,
-          averageCompletedRepairCost: 0,
-          costRecordedCount: 0,
-          costMissingCount: 0,
-        },
-        charts: {
-          repairStatusDistribution: [],
-          maintenancePlanVsActual: [],
-          repairFrequencyByMonth: []
-        },
-        topEquipmentRepairs: [],
-        recentRepairHistory: []
-      }
+      return mergeMaintenanceReportData(result)
     },
     enabled: (effectiveTenantKey ?? 'auto') !== 'unset',  // ✅ Gate for global users
     staleTime: 30 * 1000,

--- a/src/app/(app)/reports/hooks/use-maintenance-data.types.assert.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.types.assert.ts
@@ -1,0 +1,28 @@
+import { defaultMaintenanceReportData } from '@/app/(app)/reports/hooks/use-maintenance-data'
+import type {
+  MaintenanceReportData,
+  RepairUsageCostCorrelation,
+  RepairUsageCostCorrelationScope,
+  TopEquipmentRepairCostEntry,
+} from '@/app/(app)/reports/hooks/use-maintenance-data.types'
+
+type Assert<T extends true> = T
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false
+
+type _defaultPayload = Assert<
+  Equal<typeof defaultMaintenanceReportData, MaintenanceReportData>
+>
+
+type _topEquipmentRepairCostsEntry = Assert<
+  Equal<MaintenanceReportData['topEquipmentRepairCosts'][number], TopEquipmentRepairCostEntry>
+>
+
+type _repairUsageCostCorrelation = Assert<
+  Equal<MaintenanceReportData['charts']['repairUsageCostCorrelation'], RepairUsageCostCorrelation>
+>
+
+type _periodCorrelationScope = Assert<
+  Equal<MaintenanceReportData['charts']['repairUsageCostCorrelation']['period'], RepairUsageCostCorrelationScope>
+>

--- a/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
@@ -1,0 +1,183 @@
+export interface DateRange {
+  from: Date
+  to: Date
+}
+
+export interface RepairFrequencyPoint {
+  period: string
+  total: number
+  completed: number
+}
+
+export interface TopEquipmentRepairEntry {
+  equipmentId: number
+  equipmentName: string
+  totalRequests: number
+  latestStatus: string
+  latestCompletedDate?: string | null
+}
+
+export interface TopEquipmentRepairCostEntry {
+  equipmentId: number
+  equipmentName: string
+  equipmentCode: string
+  totalRepairCost: number
+  averageCompletedRepairCost: number
+  completedRepairRequests: number
+  costRecordedCount: number
+}
+
+export interface RecentRepairHistoryEntry {
+  id: number
+  equipmentName: string
+  issue: string
+  status: string
+  requestedDate: string
+  completedDate?: string | null
+  repairCost?: number | null
+}
+
+export interface RepairUsageCostCorrelationPoint {
+  equipmentId: number
+  equipmentName: string
+  equipmentCode: string
+  totalUsageHours: number
+  totalRepairCost: number
+  completedRepairRequests: number
+  costRecordedCount: number
+  [key: string]: unknown
+}
+
+export interface RepairUsageCostCorrelationDataQuality {
+  equipmentWithUsage: number
+  equipmentWithRepairCost: number
+  equipmentWithBoth: number
+}
+
+export interface RepairUsageCostCorrelationScope {
+  points: RepairUsageCostCorrelationPoint[]
+  dataQuality: RepairUsageCostCorrelationDataQuality
+}
+
+export interface RepairUsageCostCorrelation {
+  period: RepairUsageCostCorrelationScope
+  cumulative: RepairUsageCostCorrelationScope
+}
+
+export interface MaintenanceReportData {
+  summary: {
+    totalRepairs: number
+    repairCompletionRate: number
+    totalMaintenancePlanned: number
+    maintenanceCompletionRate: number
+    totalRepairCost: number
+    averageCompletedRepairCost: number
+    costRecordedCount: number
+    costMissingCount: number
+  }
+  charts: {
+    repairStatusDistribution: Array<{
+      name: string
+      value: number
+      color: string
+    }>
+    maintenancePlanVsActual: Array<{
+      name: string
+      planned: number
+      actual: number
+    }>
+    repairFrequencyByMonth: RepairFrequencyPoint[]
+    repairUsageCostCorrelation: RepairUsageCostCorrelation
+  }
+  topEquipmentRepairs: TopEquipmentRepairEntry[]
+  topEquipmentRepairCosts: TopEquipmentRepairCostEntry[]
+  recentRepairHistory: RecentRepairHistoryEntry[]
+}
+
+const defaultRepairUsageCostCorrelationScope: RepairUsageCostCorrelationScope = {
+  points: [],
+  dataQuality: {
+    equipmentWithUsage: 0,
+    equipmentWithRepairCost: 0,
+    equipmentWithBoth: 0,
+  },
+}
+
+export const defaultMaintenanceReportData: MaintenanceReportData = {
+  summary: {
+    totalRepairs: 0,
+    repairCompletionRate: 0,
+    totalMaintenancePlanned: 0,
+    maintenanceCompletionRate: 0,
+    totalRepairCost: 0,
+    averageCompletedRepairCost: 0,
+    costRecordedCount: 0,
+    costMissingCount: 0,
+  },
+  charts: {
+    repairStatusDistribution: [],
+    maintenancePlanVsActual: [],
+    repairFrequencyByMonth: [],
+    repairUsageCostCorrelation: {
+      period: defaultRepairUsageCostCorrelationScope,
+      cumulative: defaultRepairUsageCostCorrelationScope,
+    },
+  },
+  topEquipmentRepairs: [],
+  topEquipmentRepairCosts: [],
+  recentRepairHistory: [],
+}
+
+export function mergeMaintenanceReportData(
+  report: Partial<MaintenanceReportData> | null | undefined
+): MaintenanceReportData {
+  const nextCharts = report?.charts
+  const nextCorrelation = nextCharts?.repairUsageCostCorrelation
+
+  return {
+    ...defaultMaintenanceReportData,
+    ...report,
+    summary: {
+      ...defaultMaintenanceReportData.summary,
+      ...report?.summary,
+    },
+    charts: {
+      ...defaultMaintenanceReportData.charts,
+      ...nextCharts,
+      repairStatusDistribution:
+        nextCharts?.repairStatusDistribution ?? defaultMaintenanceReportData.charts.repairStatusDistribution,
+      maintenancePlanVsActual:
+        nextCharts?.maintenancePlanVsActual ?? defaultMaintenanceReportData.charts.maintenancePlanVsActual,
+      repairFrequencyByMonth:
+        nextCharts?.repairFrequencyByMonth ?? defaultMaintenanceReportData.charts.repairFrequencyByMonth,
+      repairUsageCostCorrelation: {
+        period: {
+          ...defaultMaintenanceReportData.charts.repairUsageCostCorrelation.period,
+          ...nextCorrelation?.period,
+          points:
+            nextCorrelation?.period?.points ??
+            defaultMaintenanceReportData.charts.repairUsageCostCorrelation.period.points,
+          dataQuality: {
+            ...defaultMaintenanceReportData.charts.repairUsageCostCorrelation.period.dataQuality,
+            ...nextCorrelation?.period?.dataQuality,
+          },
+        },
+        cumulative: {
+          ...defaultMaintenanceReportData.charts.repairUsageCostCorrelation.cumulative,
+          ...nextCorrelation?.cumulative,
+          points:
+            nextCorrelation?.cumulative?.points ??
+            defaultMaintenanceReportData.charts.repairUsageCostCorrelation.cumulative.points,
+          dataQuality: {
+            ...defaultMaintenanceReportData.charts.repairUsageCostCorrelation.cumulative.dataQuality,
+            ...nextCorrelation?.cumulative?.dataQuality,
+          },
+        },
+      },
+    },
+    topEquipmentRepairs: report?.topEquipmentRepairs ?? defaultMaintenanceReportData.topEquipmentRepairs,
+    topEquipmentRepairCosts:
+      report?.topEquipmentRepairCosts ?? defaultMaintenanceReportData.topEquipmentRepairCosts,
+    recentRepairHistory: report?.recentRepairHistory ?? defaultMaintenanceReportData.recentRepairHistory,
+  }
+}

--- a/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
@@ -45,7 +45,6 @@ export interface RepairUsageCostCorrelationPoint {
   totalRepairCost: number
   completedRepairRequests: number
   costRecordedCount: number
-  [key: string]: unknown
 }
 
 export interface RepairUsageCostCorrelationDataQuality {
@@ -94,13 +93,15 @@ export interface MaintenanceReportData {
   recentRepairHistory: RecentRepairHistoryEntry[]
 }
 
-const defaultRepairUsageCostCorrelationScope: RepairUsageCostCorrelationScope = {
-  points: [],
-  dataQuality: {
-    equipmentWithUsage: 0,
-    equipmentWithRepairCost: 0,
-    equipmentWithBoth: 0,
-  },
+function createDefaultRepairUsageCostCorrelationScope(): RepairUsageCostCorrelationScope {
+  return {
+    points: [],
+    dataQuality: {
+      equipmentWithUsage: 0,
+      equipmentWithRepairCost: 0,
+      equipmentWithBoth: 0,
+    },
+  }
 }
 
 export const defaultMaintenanceReportData: MaintenanceReportData = {
@@ -119,8 +120,8 @@ export const defaultMaintenanceReportData: MaintenanceReportData = {
     maintenancePlanVsActual: [],
     repairFrequencyByMonth: [],
     repairUsageCostCorrelation: {
-      period: defaultRepairUsageCostCorrelationScope,
-      cumulative: defaultRepairUsageCostCorrelationScope,
+      period: createDefaultRepairUsageCostCorrelationScope(),
+      cumulative: createDefaultRepairUsageCostCorrelationScope(),
     },
   },
   topEquipmentRepairs: [],

--- a/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
@@ -9,6 +9,23 @@ export interface RepairFrequencyPoint {
   completed: number
 }
 
+export interface RepairCostByMonthPoint {
+  period: string
+  totalCost: number
+  averageCost: number
+  costRecordedCount: number
+  costMissingCount: number
+}
+
+export interface RepairCostByFacilityPoint {
+  facilityId: number | null
+  facilityName: string
+  totalCost: number
+  averageCost: number
+  costRecordedCount: number
+  costMissingCount: number
+}
+
 export interface TopEquipmentRepairEntry {
   equipmentId: number
   equipmentName: string
@@ -86,6 +103,8 @@ export interface MaintenanceReportData {
       actual: number
     }>
     repairFrequencyByMonth: RepairFrequencyPoint[]
+    repairCostByMonth: RepairCostByMonthPoint[]
+    repairCostByFacility: RepairCostByFacilityPoint[]
     repairUsageCostCorrelation: RepairUsageCostCorrelation
   }
   topEquipmentRepairs: TopEquipmentRepairEntry[]
@@ -119,6 +138,8 @@ export const defaultMaintenanceReportData: MaintenanceReportData = {
     repairStatusDistribution: [],
     maintenancePlanVsActual: [],
     repairFrequencyByMonth: [],
+    repairCostByMonth: [],
+    repairCostByFacility: [],
     repairUsageCostCorrelation: {
       period: createDefaultRepairUsageCostCorrelationScope(),
       cumulative: createDefaultRepairUsageCostCorrelationScope(),
@@ -129,8 +150,14 @@ export const defaultMaintenanceReportData: MaintenanceReportData = {
   recentRepairHistory: [],
 }
 
+type DeepPartial<T> = T extends readonly unknown[]
+  ? T
+  : T extends object
+    ? { [P in keyof T]?: DeepPartial<T[P]> }
+    : T
+
 export function mergeMaintenanceReportData(
-  report: Partial<MaintenanceReportData> | null | undefined
+  report: DeepPartial<MaintenanceReportData> | null | undefined
 ): MaintenanceReportData {
   const nextCharts = report?.charts
   const nextCorrelation = nextCharts?.repairUsageCostCorrelation
@@ -151,6 +178,10 @@ export function mergeMaintenanceReportData(
         nextCharts?.maintenancePlanVsActual ?? defaultMaintenanceReportData.charts.maintenancePlanVsActual,
       repairFrequencyByMonth:
         nextCharts?.repairFrequencyByMonth ?? defaultMaintenanceReportData.charts.repairFrequencyByMonth,
+      repairCostByMonth:
+        nextCharts?.repairCostByMonth ?? defaultMaintenanceReportData.charts.repairCostByMonth,
+      repairCostByFacility:
+        nextCharts?.repairCostByFacility ?? defaultMaintenanceReportData.charts.repairCostByFacility,
       repairUsageCostCorrelation: {
         period: {
           ...defaultMaintenanceReportData.charts.repairUsageCostCorrelation.period,

--- a/src/components/dynamic-chart.tsx
+++ b/src/components/dynamic-chart.tsx
@@ -146,6 +146,8 @@ interface BarChartProps {
   data: ChartData[]
   height?: number
   xAxisKey: string
+  yAxisKey?: string
+  layout?: 'horizontal' | 'vertical'
   bars: Array<{
     key: string
     color: string
@@ -169,6 +171,8 @@ export function DynamicBarChart({
   data,
   height = 300,
   xAxisKey,
+  yAxisKey,
+  layout = 'horizontal',
   bars,
   showGrid = true,
   showTooltip = true,
@@ -177,11 +181,14 @@ export function DynamicBarChart({
   customTooltip,
   margin,
 }: BarChartProps) {
+  const isVertical = layout === 'vertical'
+
   return (
     <DynamicChart height={height}>
       {({ BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer }) => (
         <ResponsiveContainer width="100%" height={height}>
           <BarChart
+            layout={isVertical ? 'vertical' : undefined}
             data={data}
             margin={margin || {
               top: 20,
@@ -191,14 +198,23 @@ export function DynamicBarChart({
             }}
           >
             {showGrid && <CartesianGrid strokeDasharray="3 3" />}
-            <XAxis
-              dataKey={xAxisKey}
-              angle={xAxisAngle}
-              textAnchor={xAxisAngle !== 0 ? "end" : "middle"}
-              height={xAxisAngle !== 0 ? 100 : undefined}
-              interval={0}
-            />
-            <YAxis />
+            {isVertical ? (
+              <>
+                <XAxis type="number" />
+                <YAxis dataKey={yAxisKey ?? xAxisKey} type="category" width={180} />
+              </>
+            ) : (
+              <>
+                <XAxis
+                  dataKey={xAxisKey}
+                  angle={xAxisAngle}
+                  textAnchor={xAxisAngle !== 0 ? "end" : "middle"}
+                  height={xAxisAngle !== 0 ? 100 : undefined}
+                  interval={0}
+                />
+                <YAxis />
+              </>
+            )}
             {showTooltip && (customTooltip ? <Tooltip content={customTooltip} /> : <Tooltip />)}
             {showLegend && <Legend />}
             {bars.map(bar => (
@@ -211,6 +227,66 @@ export function DynamicBarChart({
               />
             ))}
           </BarChart>
+        </ResponsiveContainer>
+      )}
+    </DynamicChart>
+  )
+}
+
+interface ScatterChartProps {
+  data: ChartData[]
+  height?: number
+  xAxisKey: string
+  yAxisKey: string
+  zAxisKey?: string
+  scatterName?: string
+  fill?: string
+  showGrid?: boolean
+  showTooltip?: boolean
+  showLegend?: boolean
+  margin?: {
+    top?: number
+    right?: number
+    bottom?: number
+    left?: number
+  }
+}
+
+export function DynamicScatterChart({
+  data,
+  height = 300,
+  xAxisKey,
+  yAxisKey,
+  zAxisKey,
+  scatterName,
+  fill = 'hsl(var(--chart-1))',
+  showGrid = true,
+  showTooltip = true,
+  showLegend = true,
+  margin,
+}: ScatterChartProps) {
+  return (
+    <DynamicChart height={height}>
+      {({ ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer }) => (
+        <ResponsiveContainer width="100%" height={height}>
+          <ScatterChart
+            margin={
+              margin || {
+                top: 20,
+                right: 30,
+                left: 20,
+                bottom: 5,
+              }
+            }
+          >
+            {showGrid && <CartesianGrid strokeDasharray="3 3" />}
+            <XAxis dataKey={xAxisKey} type="number" />
+            <YAxis dataKey={yAxisKey} type="number" />
+            {zAxisKey ? <ZAxis dataKey={zAxisKey} range={[100, 320]} /> : null}
+            {showTooltip && <Tooltip cursor={{ strokeDasharray: '3 3' }} />}
+            {showLegend && <Legend />}
+            <Scatter data={data} fill={fill} name={scatterName || yAxisKey} />
+          </ScatterChart>
         </ResponsiveContainer>
       )}
     </DynamicChart>

--- a/src/components/dynamic-chart.tsx
+++ b/src/components/dynamic-chart.tsx
@@ -233,8 +233,8 @@ export function DynamicBarChart({
   )
 }
 
-interface ScatterChartProps {
-  data: ChartData[]
+interface ScatterChartProps<TData extends object> {
+  data: TData[]
   height?: number
   xAxisKey: string
   yAxisKey: string
@@ -252,7 +252,7 @@ interface ScatterChartProps {
   }
 }
 
-export function DynamicScatterChart({
+export function DynamicScatterChart<TData extends object>({
   data,
   height = 300,
   xAxisKey,
@@ -264,7 +264,7 @@ export function DynamicScatterChart({
   showTooltip = true,
   showLegend = true,
   margin,
-}: ScatterChartProps) {
+}: ScatterChartProps<TData>) {
   return (
     <DynamicChart height={height}>
       {({ ScatterChart, Scatter, XAxis, YAxis, ZAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer }) => (

--- a/src/components/dynamic-chart.tsx
+++ b/src/components/dynamic-chart.tsx
@@ -142,12 +142,10 @@ export function DynamicLineChart({
   )
 }
 
-interface BarChartProps {
+interface BarChartBaseProps {
   data: ChartData[]
   height?: number
   xAxisKey: string
-  yAxisKey?: string
-  layout?: 'horizontal' | 'vertical'
   bars: Array<{
     key: string
     color: string
@@ -167,6 +165,10 @@ interface BarChartProps {
   }
 }
 
+type BarChartProps =
+  | (BarChartBaseProps & { layout?: 'horizontal'; yAxisKey?: string })
+  | (BarChartBaseProps & { layout: 'vertical'; yAxisKey: string })
+
 export function DynamicBarChart({
   data,
   height = 300,
@@ -182,6 +184,11 @@ export function DynamicBarChart({
   margin,
 }: BarChartProps) {
   const isVertical = layout === 'vertical'
+  const verticalYAxisKey = yAxisKey
+
+  if (isVertical && !verticalYAxisKey) {
+    throw new Error('DynamicBarChart requires yAxisKey when layout is vertical')
+  }
 
   return (
     <DynamicChart height={height}>
@@ -201,7 +208,7 @@ export function DynamicBarChart({
             {isVertical ? (
               <>
                 <XAxis type="number" />
-                <YAxis dataKey={yAxisKey ?? xAxisKey} type="category" width={180} />
+                <YAxis dataKey={verticalYAxisKey} type="category" width={180} />
               </>
             ) : (
               <>

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -31,15 +31,18 @@ export type RechartsComponents = Pick<
   | 'BarChart'
   | 'AreaChart'
   | 'PieChart'
+  | 'ScatterChart'
   | 'ResponsiveContainer'
   | 'XAxis'
   | 'YAxis'
+  | 'ZAxis'
   | 'CartesianGrid'
   | 'Tooltip'
   | 'Legend'
   | 'Line'
   | 'Bar'
   | 'Area'
+  | 'Scatter'
   | 'Pie'
   | 'Cell'
 >
@@ -57,15 +60,18 @@ export async function loadChartsLibrary(): Promise<RechartsComponents> {
       BarChart: recharts.BarChart,
       AreaChart: recharts.AreaChart,
       PieChart: recharts.PieChart,
+      ScatterChart: recharts.ScatterChart,
       ResponsiveContainer: recharts.ResponsiveContainer,
       XAxis: recharts.XAxis,
       YAxis: recharts.YAxis,
+      ZAxis: recharts.ZAxis,
       CartesianGrid: recharts.CartesianGrid,
       Tooltip: recharts.Tooltip,
       Legend: recharts.Legend,
       Line: recharts.Line,
       Bar: recharts.Bar,
       Area: recharts.Area,
+      Scatter: recharts.Scatter,
       Pie: recharts.Pie,
       Cell: recharts.Cell,
     }

--- a/supabase/migrations/20260413152000_add_repair_cost_usage_visualizations.sql
+++ b/supabase/migrations/20260413152000_add_repair_cost_usage_visualizations.sql
@@ -1,0 +1,750 @@
+-- Issue #256: add repair cost usage visualizations to the maintenance report RPC.
+-- Prepared for review only; do not apply automatically from the agent session.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_maintenance_report_data(
+  p_date_from date,
+  p_date_to date,
+  p_don_vi bigint DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_is_global boolean := false;
+  v_allowed bigint[];
+  v_effective bigint[];
+  v_result jsonb;
+  v_from_year integer := extract(year from p_date_from)::integer;
+  v_to_year integer := extract(year from p_date_to)::integer;
+BEGIN
+  v_role := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global := v_role IN ('global', 'admin');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_is_global THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    v_allowed := public.allowed_don_vi_for_session_safe();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object(
+        'summary', jsonb_build_object(
+          'totalRepairs', 0,
+          'repairCompletionRate', 0,
+          'totalMaintenancePlanned', 0,
+          'maintenanceCompletionRate', 0,
+          'totalRepairCost', 0,
+          'averageCompletedRepairCost', 0,
+          'costRecordedCount', 0,
+          'costMissingCount', 0
+        ),
+        'charts', jsonb_build_object(
+          'repairStatusDistribution', '[]'::jsonb,
+          'maintenancePlanVsActual', '[]'::jsonb,
+          'repairFrequencyByMonth', '[]'::jsonb,
+          'repairCostByMonth', '[]'::jsonb,
+          'repairCostByFacility', '[]'::jsonb,
+          'repairUsageCostCorrelation', jsonb_build_object(
+            'period', jsonb_build_object(
+              'points', '[]'::jsonb,
+              'dataQuality', jsonb_build_object(
+                'equipmentWithUsage', 0,
+                'equipmentWithRepairCost', 0,
+                'equipmentWithBoth', 0
+              )
+            ),
+            'cumulative', jsonb_build_object(
+              'points', '[]'::jsonb,
+              'dataQuality', jsonb_build_object(
+                'equipmentWithUsage', 0,
+                'equipmentWithRepairCost', 0,
+                'equipmentWithBoth', 0
+              )
+            )
+          )
+        ),
+        'topEquipmentRepairs', '[]'::jsonb,
+        'topEquipmentRepairCosts', '[]'::jsonb,
+        'recentRepairHistory', '[]'::jsonb
+      );
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective := ARRAY[p_don_vi];
+      ELSE
+        RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING errcode = '42501';
+      END IF;
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  WITH scoped_equipment AS (
+    SELECT
+      tb.id AS equipment_id,
+      coalesce(nullif(trim(tb.ten_thiet_bi), ''), tb.ma_thiet_bi, 'Không xác định') AS equipment_name,
+      tb.ma_thiet_bi AS equipment_code,
+      tb.don_vi AS facility_id
+    FROM public.thiet_bi tb
+    WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+  ),
+  repair_data_raw AS (
+    SELECT
+      yc.id,
+      yc.trang_thai,
+      yc.mo_ta_su_co,
+      yc.ngay_yeu_cau,
+      yc.ngay_duyet,
+      yc.ngay_hoan_thanh,
+      yc.chi_phi_sua_chua,
+      se.equipment_id,
+      se.equipment_name,
+      se.equipment_code,
+      se.facility_id,
+      coalesce(dv.name, 'Không xác định') AS facility_name,
+      coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh) AS reference_timestamp,
+      (
+        lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%'
+        OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%'
+      ) AS is_completed
+    FROM public.yeu_cau_sua_chua yc
+    INNER JOIN scoped_equipment se ON yc.thiet_bi_id = se.equipment_id
+    LEFT JOIN public.don_vi dv ON dv.id = se.facility_id
+  ),
+  repair_data AS (
+    SELECT
+      id,
+      trang_thai,
+      mo_ta_su_co,
+      ngay_yeu_cau,
+      ngay_duyet,
+      ngay_hoan_thanh,
+      chi_phi_sua_chua,
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      facility_id,
+      facility_name,
+      reference_timestamp,
+      is_completed
+    FROM repair_data_raw
+    WHERE reference_timestamp IS NOT NULL
+      AND (reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN p_date_from AND p_date_to
+  ),
+  cumulative_repair_data AS (
+    SELECT
+      id,
+      trang_thai,
+      mo_ta_su_co,
+      ngay_yeu_cau,
+      ngay_duyet,
+      ngay_hoan_thanh,
+      chi_phi_sua_chua,
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      facility_id,
+      facility_name,
+      reference_timestamp,
+      is_completed
+    FROM repair_data_raw
+    WHERE reference_timestamp IS NOT NULL
+      AND (reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+  ),
+  repair_summary AS (
+    SELECT
+      count(*) AS total_repairs,
+      count(*) FILTER (WHERE is_completed) AS completed,
+      count(*) FILTER (WHERE lower(coalesce(trang_thai, '')) LIKE '%không ht%') AS not_completed,
+      count(*) FILTER (
+        WHERE lower(coalesce(trang_thai, '')) LIKE '%đã duyệt%'
+           OR lower(coalesce(trang_thai, '')) LIKE '%da duyet%'
+      ) AS approved,
+      count(*) FILTER (
+        WHERE lower(coalesce(trang_thai, '')) LIKE '%chờ%'
+           OR lower(coalesce(trang_thai, '')) LIKE '%cho%'
+      ) AS pending,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL) AS cost_missing_count
+    FROM repair_data
+  ),
+  maintenance_data AS (
+    SELECT
+      kh.id AS plan_id,
+      kh.nam,
+      kh.trang_thai,
+      kh.don_vi,
+      cv.id AS task_id,
+      cv.loai_cong_viec,
+      cv.thang_1,
+      cv.thang_1_hoan_thanh,
+      cv.thang_2,
+      cv.thang_2_hoan_thanh,
+      cv.thang_3,
+      cv.thang_3_hoan_thanh,
+      cv.thang_4,
+      cv.thang_4_hoan_thanh,
+      cv.thang_5,
+      cv.thang_5_hoan_thanh,
+      cv.thang_6,
+      cv.thang_6_hoan_thanh,
+      cv.thang_7,
+      cv.thang_7_hoan_thanh,
+      cv.thang_8,
+      cv.thang_8_hoan_thanh,
+      cv.thang_9,
+      cv.thang_9_hoan_thanh,
+      cv.thang_10,
+      cv.thang_10_hoan_thanh,
+      cv.thang_11,
+      cv.thang_11_hoan_thanh,
+      cv.thang_12,
+      cv.thang_12_hoan_thanh
+    FROM public.ke_hoach_bao_tri kh
+    LEFT JOIN public.cong_viec_bao_tri cv ON kh.id = cv.ke_hoach_id
+    WHERE (v_effective IS NULL OR kh.don_vi = ANY(v_effective))
+      AND kh.nam BETWEEN v_from_year AND v_to_year
+      AND kh.trang_thai = 'Đã duyệt'
+  ),
+  maintenance_summary AS (
+    SELECT
+      loai_cong_viec,
+      (
+        CASE WHEN thang_1 THEN 1 ELSE 0 END + CASE WHEN thang_2 THEN 1 ELSE 0 END +
+        CASE WHEN thang_3 THEN 1 ELSE 0 END + CASE WHEN thang_4 THEN 1 ELSE 0 END +
+        CASE WHEN thang_5 THEN 1 ELSE 0 END + CASE WHEN thang_6 THEN 1 ELSE 0 END +
+        CASE WHEN thang_7 THEN 1 ELSE 0 END + CASE WHEN thang_8 THEN 1 ELSE 0 END +
+        CASE WHEN thang_9 THEN 1 ELSE 0 END + CASE WHEN thang_10 THEN 1 ELSE 0 END +
+        CASE WHEN thang_11 THEN 1 ELSE 0 END + CASE WHEN thang_12 THEN 1 ELSE 0 END
+      ) AS planned,
+      (
+        CASE WHEN thang_1_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_2_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_3_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_4_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_5_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_6_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_7_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_8_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_9_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_10_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_11_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_12_hoan_thanh THEN 1 ELSE 0 END
+      ) AS actual
+    FROM maintenance_data
+    WHERE loai_cong_viec IN ('Bảo trì', 'Hiệu chuẩn', 'Kiểm định')
+  ),
+  maintenance_aggregated AS (
+    SELECT
+      loai_cong_viec,
+      sum(planned) AS total_planned,
+      sum(actual) AS total_actual
+    FROM maintenance_summary
+    GROUP BY loai_cong_viec
+  ),
+  repair_frequency AS (
+    SELECT
+      to_char(date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
+      count(*)::integer AS total,
+      count(*) FILTER (WHERE is_completed)::integer AS completed
+    FROM repair_data
+    GROUP BY date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  ),
+  repair_cost_by_month AS (
+    SELECT
+      to_char(date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  ),
+  repair_cost_by_facility AS (
+    SELECT
+      facility_id,
+      facility_name,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY facility_id, facility_name
+  ),
+  equipment_repairs AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      count(*)::integer AS total_requests,
+      max(reference_timestamp) AS latest_event_at,
+      max(ngay_hoan_thanh) AS latest_completed_at,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  equipment_latest_status AS (
+    SELECT DISTINCT ON (equipment_id)
+      equipment_id,
+      coalesce(trang_thai, 'Không xác định') AS latest_status,
+      coalesce(ngay_hoan_thanh, ngay_duyet, ngay_yeu_cau, reference_timestamp) AS status_timestamp
+    FROM repair_data
+    ORDER BY equipment_id, coalesce(ngay_hoan_thanh, ngay_duyet, ngay_yeu_cau, reference_timestamp) DESC
+  ),
+  top_equipment AS (
+    SELECT
+      er.equipment_id,
+      er.equipment_name,
+      er.equipment_code,
+      er.total_requests,
+      er.total_repair_cost,
+      er.average_completed_repair_cost,
+      er.cost_recorded_count,
+      er.cost_missing_count,
+      els.latest_status,
+      CASE
+        WHEN er.latest_completed_at IS NOT NULL THEN to_char(er.latest_completed_at, 'YYYY-MM-DD"T"HH24:MI:SS')
+        ELSE NULL
+      END AS latest_completed_date
+    FROM equipment_repairs er
+    LEFT JOIN equipment_latest_status els ON els.equipment_id = er.equipment_id
+    ORDER BY er.total_requests DESC, er.equipment_name
+    LIMIT 10
+  ),
+  usage_data_raw AS (
+    SELECT
+      se.equipment_id,
+      se.equipment_name,
+      se.equipment_code,
+      nk.thoi_gian_bat_dau,
+      nk.thoi_gian_ket_thuc,
+      extract(epoch from (nk.thoi_gian_ket_thuc - nk.thoi_gian_bat_dau)) / 3600.0 AS usage_hours
+    FROM scoped_equipment se
+    INNER JOIN public.nhat_ky_su_dung nk
+      ON nk.thiet_bi_id = se.equipment_id
+    WHERE nk.thoi_gian_ket_thuc IS NOT NULL
+      AND nk.thoi_gian_ket_thuc > nk.thoi_gian_bat_dau
+  ),
+  period_usage_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      sum(usage_hours) AS total_usage_hours
+    FROM usage_data_raw
+    WHERE (thoi_gian_bat_dau AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN p_date_from AND p_date_to
+      AND (thoi_gian_ket_thuc AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  cumulative_usage_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      sum(usage_hours) AS total_usage_hours
+    FROM usage_data_raw
+    WHERE (thoi_gian_bat_dau AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+      AND (thoi_gian_ket_thuc AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  period_repair_costs_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed)::integer AS completed_repair_requests,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count
+    FROM repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  cumulative_repair_costs_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed)::integer AS completed_repair_requests,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count
+    FROM cumulative_repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  top_equipment_repair_costs AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      total_repair_cost,
+      average_completed_repair_cost,
+      completed_repair_requests,
+      cost_recorded_count
+    FROM period_repair_costs_by_equipment
+    WHERE cost_recorded_count > 0
+    ORDER BY total_repair_cost DESC, equipment_name
+    LIMIT 10
+  ),
+  period_correlation_points AS (
+    SELECT
+      pu.equipment_id,
+      pu.equipment_name,
+      pu.equipment_code,
+      pu.total_usage_hours,
+      pr.total_repair_cost,
+      pr.completed_repair_requests,
+      pr.cost_recorded_count
+    FROM period_usage_by_equipment pu
+    INNER JOIN period_repair_costs_by_equipment pr ON pr.equipment_id = pu.equipment_id
+    WHERE pu.total_usage_hours > 0
+      AND pr.cost_recorded_count > 0
+  ),
+  cumulative_correlation_points AS (
+    SELECT
+      cu.equipment_id,
+      cu.equipment_name,
+      cu.equipment_code,
+      cu.total_usage_hours,
+      cr.total_repair_cost,
+      cr.completed_repair_requests,
+      cr.cost_recorded_count
+    FROM cumulative_usage_by_equipment cu
+    INNER JOIN cumulative_repair_costs_by_equipment cr ON cr.equipment_id = cu.equipment_id
+    WHERE cu.total_usage_hours > 0
+      AND cr.cost_recorded_count > 0
+  ),
+  period_correlation_data_quality AS (
+    SELECT
+      (SELECT count(*)::integer FROM period_usage_by_equipment WHERE total_usage_hours > 0) AS equipment_with_usage,
+      (SELECT count(*)::integer FROM period_repair_costs_by_equipment WHERE cost_recorded_count > 0) AS equipment_with_repair_cost,
+      (SELECT count(*)::integer FROM period_correlation_points) AS equipment_with_both
+  ),
+  cumulative_correlation_data_quality AS (
+    SELECT
+      (SELECT count(*)::integer FROM cumulative_usage_by_equipment WHERE total_usage_hours > 0) AS equipment_with_usage,
+      (SELECT count(*)::integer FROM cumulative_repair_costs_by_equipment WHERE cost_recorded_count > 0) AS equipment_with_repair_cost,
+      (SELECT count(*)::integer FROM cumulative_correlation_points) AS equipment_with_both
+  ),
+  recent_repairs AS (
+    SELECT
+      rd.id,
+      rd.equipment_name,
+      coalesce(nullif(trim(rd.mo_ta_su_co), ''), 'Không có mô tả') AS issue,
+      coalesce(rd.trang_thai, 'Không xác định') AS status,
+      rd.chi_phi_sua_chua,
+      to_char(reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh', 'YYYY-MM-DD"T"HH24:MI:SS') AS requested_date,
+      CASE
+        WHEN rd.ngay_hoan_thanh IS NOT NULL THEN to_char(rd.ngay_hoan_thanh AT TIME ZONE 'Asia/Ho_Chi_Minh', 'YYYY-MM-DD"T"HH24:MI:SS')
+        ELSE NULL
+      END AS completed_date
+    FROM repair_data rd
+    ORDER BY reference_timestamp DESC
+    LIMIT 20
+  )
+  SELECT jsonb_build_object(
+    'summary', (
+      SELECT jsonb_build_object(
+        'totalRepairs', coalesce(rs.total_repairs, 0),
+        'repairCompletionRate',
+          CASE
+            WHEN coalesce(rs.total_repairs, 0) > 0
+              THEN (coalesce(rs.completed, 0)::numeric / rs.total_repairs * 100)
+            ELSE 0
+          END,
+        'totalMaintenancePlanned', coalesce((SELECT sum(ma.total_planned) FROM maintenance_aggregated ma), 0),
+        'maintenanceCompletionRate',
+          CASE
+            WHEN coalesce((SELECT sum(ma.total_planned) FROM maintenance_aggregated ma), 0) > 0 THEN
+              (
+                coalesce((SELECT sum(ma.total_actual) FROM maintenance_aggregated ma), 0)::numeric /
+                (SELECT sum(ma.total_planned) FROM maintenance_aggregated ma) * 100
+              )
+            ELSE 0
+          END,
+        'totalRepairCost', coalesce(rs.total_repair_cost, 0),
+        'averageCompletedRepairCost', coalesce(rs.average_completed_repair_cost, 0),
+        'costRecordedCount', coalesce(rs.cost_recorded_count, 0),
+        'costMissingCount', coalesce(rs.cost_missing_count, 0)
+      )
+      FROM repair_summary rs
+    ),
+    'charts', jsonb_build_object(
+      'repairStatusDistribution', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'name', status_name,
+              'value', status_count,
+              'color', status_color
+            )
+          ),
+          '[]'::jsonb
+        )
+        FROM (
+          SELECT 'Hoàn thành' AS status_name, completed AS status_count, 'hsl(var(--chart-1))' AS status_color
+          FROM repair_summary
+          WHERE completed > 0
+          UNION ALL
+          SELECT 'Không HT', not_completed, 'hsl(var(--chart-5))'
+          FROM repair_summary
+          WHERE not_completed > 0
+          UNION ALL
+          SELECT 'Đã duyệt', approved, 'hsl(var(--chart-2))'
+          FROM repair_summary
+          WHERE approved > 0
+          UNION ALL
+          SELECT 'Chờ xử lý', pending, 'hsl(var(--chart-3))'
+          FROM repair_summary
+          WHERE pending > 0
+        ) statuses
+      ),
+      'maintenancePlanVsActual', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'name', loai_cong_viec,
+              'planned', total_planned,
+              'actual', total_actual
+            )
+            ORDER BY loai_cong_viec
+          ),
+          '[]'::jsonb
+        )
+        FROM maintenance_aggregated
+      ),
+      'repairFrequencyByMonth', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'period', period,
+              'total', total,
+              'completed', completed
+            )
+            ORDER BY period
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_frequency
+      ),
+      'repairCostByMonth', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'period', period,
+              'totalCost', total_cost,
+              'averageCost', coalesce(average_cost, 0),
+              'costRecordedCount', cost_recorded_count,
+              'costMissingCount', cost_missing_count
+            )
+            ORDER BY period
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_cost_by_month
+      ),
+      'repairCostByFacility', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'facilityId', facility_id,
+              'facilityName', facility_name,
+              'totalCost', total_cost,
+              'averageCost', coalesce(average_cost, 0),
+              'costRecordedCount', cost_recorded_count,
+              'costMissingCount', cost_missing_count
+            )
+            ORDER BY facility_name
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_cost_by_facility
+      ),
+      'repairUsageCostCorrelation', jsonb_build_object(
+        'period', jsonb_build_object(
+          'points', (
+            SELECT coalesce(
+              jsonb_agg(
+                jsonb_build_object(
+                  'equipmentId', pcp.equipment_id,
+                  'equipmentName', pcp.equipment_name,
+                  'equipmentCode', pcp.equipment_code,
+                  'totalUsageHours', pcp.total_usage_hours,
+                  'totalRepairCost', pcp.total_repair_cost,
+                  'completedRepairRequests', pcp.completed_repair_requests,
+                  'costRecordedCount', pcp.cost_recorded_count
+                )
+                ORDER BY pcp.total_repair_cost DESC, pcp.equipment_name
+              ),
+              '[]'::jsonb
+            )
+            FROM period_correlation_points pcp
+          ),
+          'dataQuality', (
+            SELECT jsonb_build_object(
+              'equipmentWithUsage', coalesce(pcq.equipment_with_usage, 0),
+              'equipmentWithRepairCost', coalesce(pcq.equipment_with_repair_cost, 0),
+              'equipmentWithBoth', coalesce(pcq.equipment_with_both, 0)
+            )
+            FROM period_correlation_data_quality pcq
+          )
+        ),
+        'cumulative', jsonb_build_object(
+          'points', (
+            SELECT coalesce(
+              jsonb_agg(
+                jsonb_build_object(
+                  'equipmentId', ccp.equipment_id,
+                  'equipmentName', ccp.equipment_name,
+                  'equipmentCode', ccp.equipment_code,
+                  'totalUsageHours', ccp.total_usage_hours,
+                  'totalRepairCost', ccp.total_repair_cost,
+                  'completedRepairRequests', ccp.completed_repair_requests,
+                  'costRecordedCount', ccp.cost_recorded_count
+                )
+                ORDER BY ccp.total_repair_cost DESC, ccp.equipment_name
+              ),
+              '[]'::jsonb
+            )
+            FROM cumulative_correlation_points ccp
+          ),
+          'dataQuality', (
+            SELECT jsonb_build_object(
+              'equipmentWithUsage', coalesce(ccq.equipment_with_usage, 0),
+              'equipmentWithRepairCost', coalesce(ccq.equipment_with_repair_cost, 0),
+              'equipmentWithBoth', coalesce(ccq.equipment_with_both, 0)
+            )
+            FROM cumulative_correlation_data_quality ccq
+          )
+        )
+      )
+    ),
+    'topEquipmentRepairs', (
+      SELECT coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'equipmentId', te.equipment_id,
+            'equipmentName', te.equipment_name,
+            'totalRequests', te.total_requests,
+            'latestStatus', coalesce(te.latest_status, 'Không xác định'),
+            'latestCompletedDate', te.latest_completed_date,
+            'totalRepairCost', te.total_repair_cost,
+            'averageCompletedRepairCost', coalesce(te.average_completed_repair_cost, 0),
+            'costRecordedCount', te.cost_recorded_count,
+            'costMissingCount', te.cost_missing_count
+          )
+          ORDER BY te.total_requests DESC, te.equipment_name
+        ),
+        '[]'::jsonb
+      )
+      FROM top_equipment te
+    ),
+    'topEquipmentRepairCosts', (
+      SELECT coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'equipmentId', terc.equipment_id,
+            'equipmentName', terc.equipment_name,
+            'equipmentCode', terc.equipment_code,
+            'totalRepairCost', terc.total_repair_cost,
+            'averageCompletedRepairCost', coalesce(terc.average_completed_repair_cost, 0),
+            'completedRepairRequests', terc.completed_repair_requests,
+            'costRecordedCount', terc.cost_recorded_count
+          )
+          ORDER BY terc.total_repair_cost DESC, terc.equipment_name
+        ),
+        '[]'::jsonb
+      )
+      FROM top_equipment_repair_costs terc
+    ),
+    'recentRepairHistory', (
+      SELECT coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'id', rr.id,
+            'equipmentName', rr.equipment_name,
+            'issue', rr.issue,
+            'status', rr.status,
+            'repairCost', rr.chi_phi_sua_chua,
+            'requestedDate', rr.requested_date,
+            'completedDate', rr.completed_date
+          )
+          ORDER BY rr.requested_date DESC, rr.id DESC
+        ),
+        '[]'::jsonb
+      )
+      FROM recent_repairs rr
+    )
+  ) INTO v_result;
+
+  RETURN coalesce(
+    v_result,
+    jsonb_build_object(
+      'summary', jsonb_build_object(
+        'totalRepairs', 0,
+        'repairCompletionRate', 0,
+        'totalMaintenancePlanned', 0,
+        'maintenanceCompletionRate', 0,
+        'totalRepairCost', 0,
+        'averageCompletedRepairCost', 0,
+        'costRecordedCount', 0,
+        'costMissingCount', 0
+      ),
+      'charts', jsonb_build_object(
+        'repairStatusDistribution', '[]'::jsonb,
+        'maintenancePlanVsActual', '[]'::jsonb,
+        'repairFrequencyByMonth', '[]'::jsonb,
+        'repairCostByMonth', '[]'::jsonb,
+        'repairCostByFacility', '[]'::jsonb,
+        'repairUsageCostCorrelation', jsonb_build_object(
+          'period', jsonb_build_object(
+            'points', '[]'::jsonb,
+            'dataQuality', jsonb_build_object(
+              'equipmentWithUsage', 0,
+              'equipmentWithRepairCost', 0,
+              'equipmentWithBoth', 0
+            )
+          ),
+          'cumulative', jsonb_build_object(
+            'points', '[]'::jsonb,
+            'dataQuality', jsonb_build_object(
+              'equipmentWithUsage', 0,
+              'equipmentWithRepairCost', 0,
+              'equipmentWithBoth', 0
+            )
+          )
+        )
+      ),
+      'topEquipmentRepairs', '[]'::jsonb,
+      'topEquipmentRepairCosts', '[]'::jsonb,
+      'recentRepairHistory', '[]'::jsonb
+    )
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO anon;
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) FROM PUBLIC;
+
+COMMENT ON FUNCTION public.get_maintenance_report_data(date, date, bigint)
+IS 'Returns maintenance report data with tenant-aware aggregation, repair cost visualizations, top equipment rankings, recent history, and usage-cost correlation datasets.';
+
+COMMIT;

--- a/supabase/migrations/20260413152000_add_repair_cost_usage_visualizations.sql
+++ b/supabase/migrations/20260413152000_add_repair_cost_usage_visualizations.sql
@@ -1,5 +1,9 @@
 -- Issue #256: add repair cost usage visualizations to the maintenance report RPC.
 -- Prepared for review only; do not apply automatically from the agent session.
+--
+-- Rollback: restore the previous get_maintenance_report_data definition from
+-- supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql
+-- if the new visualization payload needs to be removed.
 
 BEGIN;
 

--- a/supabase/tests/repair_cost_usage_visualizations_smoke.sql
+++ b/supabase/tests/repair_cost_usage_visualizations_smoke.sql
@@ -273,7 +273,7 @@ BEGIN
     (
       v_equipment_a,
       (v_date_from - 2)::timestamp + interval '10 hours',
-      (v_date_from - 1)::timestamp + interval '13 hours',
+      (v_date_from - 2)::timestamp + interval '13 hours',
       'hoan_thanh',
       'Valid cumulative-only usage A'
     ),

--- a/supabase/tests/repair_cost_usage_visualizations_smoke.sql
+++ b/supabase/tests/repair_cost_usage_visualizations_smoke.sql
@@ -1,0 +1,457 @@
+-- supabase/tests/repair_cost_usage_visualizations_smoke.sql
+-- Purpose: smoke-test repair cost + usage visualization payload contract after the migration is applied.
+-- How to run (local): docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_cost_usage_visualizations_smoke.sql
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp._rcuv_set_claims(
+  p_role text,
+  p_user_id bigint,
+  p_don_vi bigint DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', p_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::text,
+      'sub', p_user_id::text,
+      'don_vi', p_don_vi::text
+    )::text,
+    true
+  );
+END;
+$$;
+
+DO $$
+DECLARE
+  v_cost_type text;
+  v_cost_precision integer;
+  v_cost_scale integer;
+  v_cost_nullable text;
+  v_cost_default text;
+  v_cost_constraint_count integer;
+  v_usage_equipment_type text;
+  v_equipment_id_type text;
+BEGIN
+  SELECT c.data_type, c.numeric_precision, c.numeric_scale, c.is_nullable, c.column_default
+  INTO v_cost_type, v_cost_precision, v_cost_scale, v_cost_nullable, v_cost_default
+  FROM information_schema.columns c
+  WHERE c.table_schema = 'public'
+    AND c.table_name = 'yeu_cau_sua_chua'
+    AND c.column_name = 'chi_phi_sua_chua';
+
+  IF v_cost_type IS NULL THEN
+    RAISE EXCEPTION 'Expected public.yeu_cau_sua_chua.chi_phi_sua_chua to exist';
+  END IF;
+
+  IF v_cost_type <> 'numeric' OR v_cost_precision <> 14 OR v_cost_scale <> 2 THEN
+    RAISE EXCEPTION 'Expected chi_phi_sua_chua numeric(14,2), got %(%,%)', v_cost_type, v_cost_precision, v_cost_scale;
+  END IF;
+
+  IF v_cost_nullable <> 'YES' THEN
+    RAISE EXCEPTION 'Expected chi_phi_sua_chua to stay nullable';
+  END IF;
+
+  IF v_cost_default IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected chi_phi_sua_chua to have no default, got %', v_cost_default;
+  END IF;
+
+  SELECT count(*)
+  INTO v_cost_constraint_count
+  FROM pg_constraint con
+  JOIN pg_class rel ON rel.oid = con.conrelid
+  JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+  WHERE nsp.nspname = 'public'
+    AND rel.relname = 'yeu_cau_sua_chua'
+    AND con.conname = 'yeu_cau_sua_chua_chi_phi_sua_chua_non_negative';
+
+  IF v_cost_constraint_count <> 1 THEN
+    RAISE EXCEPTION 'Expected chi_phi_sua_chua non-negative constraint to exist';
+  END IF;
+
+  SELECT data_type
+  INTO v_usage_equipment_type
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'nhat_ky_su_dung'
+    AND column_name = 'thiet_bi_id';
+
+  IF v_usage_equipment_type <> 'integer' THEN
+    RAISE EXCEPTION 'Expected nhat_ky_su_dung.thiet_bi_id integer, got %', v_usage_equipment_type;
+  END IF;
+
+  SELECT data_type
+  INTO v_equipment_id_type
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'thiet_bi'
+    AND column_name = 'id';
+
+  IF v_equipment_id_type <> 'bigint' THEN
+    RAISE EXCEPTION 'Expected thiet_bi.id bigint, got %', v_equipment_id_type;
+  END IF;
+
+  RAISE NOTICE 'OK: live schema expectations for repair cost usage visualizations passed';
+END $$;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_date_from date := current_date - 30;
+  v_date_to date := current_date;
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_user_id bigint;
+  v_equipment_a bigint;
+  v_equipment_b bigint;
+  v_equipment_c bigint;
+  v_equipment_other bigint;
+  v_report jsonb;
+  v_admin_scoped_report jsonb;
+  v_period_points jsonb;
+  v_cumulative_points jsonb;
+  v_period_quality jsonb;
+  v_cumulative_quality jsonb;
+  v_a_period_hours numeric;
+  v_a_cumulative_hours numeric;
+  v_b_cumulative_hours numeric;
+  v_both_count integer;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair usage visual smoke tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair usage visual smoke other tenant ' || v_suffix, true)
+  RETURNING id INTO v_other_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_usage_visual_smoke_' || v_suffix,
+    'smoke-password',
+    'Repair Usage Visualization Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai, is_deleted)
+  VALUES
+    ('RCUV-A-' || v_suffix, 'Thiết bị A ' || v_suffix, v_tenant, 'Hoạt động', false),
+    ('RCUV-B-' || v_suffix, 'Thiết bị B ' || v_suffix, v_tenant, 'Hoạt động', false),
+    ('RCUV-C-' || v_suffix, 'Thiết bị C ' || v_suffix, v_tenant, 'Hoạt động', false),
+    ('RCUV-X-' || v_suffix, 'Thiết bị khác tenant ' || v_suffix, v_other_tenant, 'Hoạt động', false);
+
+  SELECT id INTO v_equipment_a
+  FROM public.thiet_bi
+  WHERE ma_thiet_bi = 'RCUV-A-' || v_suffix;
+
+  SELECT id INTO v_equipment_b
+  FROM public.thiet_bi
+  WHERE ma_thiet_bi = 'RCUV-B-' || v_suffix;
+
+  SELECT id INTO v_equipment_c
+  FROM public.thiet_bi
+  WHERE ma_thiet_bi = 'RCUV-C-' || v_suffix;
+
+  SELECT id INTO v_equipment_other
+  FROM public.thiet_bi
+  WHERE ma_thiet_bi = 'RCUV-X-' || v_suffix;
+
+  IF greatest(v_equipment_a, v_equipment_b, v_equipment_c, v_equipment_other) > 2147483647 THEN
+    RAISE EXCEPTION 'Seeded equipment ids must stay within signed integer range for usage logs';
+  END IF;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    trang_thai,
+    ngay_yeu_cau,
+    ngay_duyet,
+    ngay_hoan_thanh,
+    nguoi_yeu_cau,
+    don_vi_thuc_hien,
+    chi_phi_sua_chua
+  )
+  VALUES
+    (
+      v_equipment_a,
+      'Smoke repair A cost',
+      'Repair item A',
+      'Hoàn thành',
+      (v_date_from + 1)::timestamp + interval '10 hours',
+      (v_date_from + 2)::timestamp + interval '10 hours',
+      (v_date_from + 3)::timestamp + interval '10 hours',
+      'Smoke requester A',
+      'noi_bo',
+      1000000
+    ),
+    (
+      v_equipment_a,
+      'Smoke repair A null cost',
+      'Repair item A2',
+      'Hoàn thành',
+      (v_date_from + 4)::timestamp + interval '10 hours',
+      (v_date_from + 5)::timestamp + interval '10 hours',
+      (v_date_from + 6)::timestamp + interval '10 hours',
+      'Smoke requester A2',
+      'noi_bo',
+      NULL
+    ),
+    (
+      v_equipment_b,
+      'Smoke repair B cost',
+      'Repair item B',
+      'Hoàn thành',
+      (v_date_from + 7)::timestamp + interval '10 hours',
+      (v_date_from + 8)::timestamp + interval '10 hours',
+      (v_date_from + 9)::timestamp + interval '10 hours',
+      'Smoke requester B',
+      'noi_bo',
+      600000
+    ),
+    (
+      v_equipment_b,
+      'Smoke repair B cumulative cost',
+      'Repair item B2',
+      'Hoàn thành',
+      (v_date_from - 7)::timestamp + interval '10 hours',
+      (v_date_from - 6)::timestamp + interval '10 hours',
+      (v_date_from - 5)::timestamp + interval '10 hours',
+      'Smoke requester B2',
+      'noi_bo',
+      300000
+    ),
+    (
+      v_equipment_c,
+      'Smoke repair C cost',
+      'Repair item C',
+      'Hoàn thành',
+      (v_date_from + 10)::timestamp + interval '10 hours',
+      (v_date_from + 11)::timestamp + interval '10 hours',
+      (v_date_from + 12)::timestamp + interval '10 hours',
+      'Smoke requester C',
+      'noi_bo',
+      200000
+    ),
+    (
+      v_equipment_other,
+      'Smoke repair other tenant cost',
+      'Repair item X',
+      'Hoàn thành',
+      (v_date_from + 1)::timestamp + interval '10 hours',
+      (v_date_from + 2)::timestamp + interval '10 hours',
+      (v_date_from + 3)::timestamp + interval '10 hours',
+      'Smoke requester X',
+      'noi_bo',
+      9999999
+    );
+
+  INSERT INTO public.nhat_ky_su_dung(
+    thiet_bi_id,
+    thoi_gian_bat_dau,
+    thoi_gian_ket_thuc,
+    trang_thai,
+    ghi_chu
+  )
+  VALUES
+    (
+      v_equipment_a,
+      (v_date_from + 2)::timestamp + interval '10 hours',
+      (v_date_from + 2)::timestamp + interval '12 hours',
+      'hoan_thanh',
+      'Valid period usage A'
+    ),
+    (
+      v_equipment_a,
+      (v_date_from - 2)::timestamp + interval '10 hours',
+      (v_date_from - 1)::timestamp + interval '13 hours',
+      'hoan_thanh',
+      'Valid cumulative-only usage A'
+    ),
+    (
+      v_equipment_a,
+      (v_date_from + 3)::timestamp + interval '10 hours',
+      NULL,
+      'dang_su_dung',
+      'Open usage A'
+    ),
+    (
+      v_equipment_a,
+      (v_date_from + 3)::timestamp + interval '15 hours',
+      (v_date_from + 3)::timestamp + interval '13 hours',
+      'hoan_thanh',
+      'Invalid usage A'
+    ),
+    (
+      v_equipment_b,
+      (v_date_from + 8)::timestamp + interval '8 hours',
+      (v_date_from + 8)::timestamp + interval '13 hours',
+      'hoan_thanh',
+      'Valid period usage B'
+    ),
+    (
+      v_equipment_b,
+      v_date_to::timestamp + interval '10 hours',
+      (v_date_to + 1)::timestamp + interval '2 hours',
+      'hoan_thanh',
+      'Crossing end-date usage B'
+    ),
+    (
+      v_equipment_c,
+      (v_date_from + 11)::timestamp + interval '9 hours',
+      (v_date_from + 11)::timestamp + interval '10 hours 30 minutes',
+      'hoan_thanh',
+      'Valid period usage C'
+    ),
+    (
+      v_equipment_other,
+      (v_date_from + 2)::timestamp + interval '10 hours',
+      (v_date_from + 2)::timestamp + interval '12 hours',
+      'hoan_thanh',
+      'Other tenant usage'
+    );
+
+  PERFORM pg_temp._rcuv_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_report := public.get_maintenance_report_data(v_date_from, v_date_to, v_tenant);
+
+  IF NOT (v_report ? 'topEquipmentRepairCosts') THEN
+    RAISE EXCEPTION 'Expected topEquipmentRepairCosts payload key, got %', v_report;
+  END IF;
+
+  IF jsonb_array_length(v_report->'topEquipmentRepairCosts') <> 3 THEN
+    RAISE EXCEPTION 'Expected 3 top repair cost rows, got %', v_report->'topEquipmentRepairCosts';
+  END IF;
+
+  IF (v_report->'topEquipmentRepairCosts'->0->>'equipmentCode') IS NULL THEN
+    RAISE EXCEPTION 'Expected equipmentCode on topEquipmentRepairCosts rows, got %', v_report->'topEquipmentRepairCosts';
+  END IF;
+
+  IF (v_report->'topEquipmentRepairCosts'->0->>'totalRepairCost')::numeric
+     < (v_report->'topEquipmentRepairCosts'->1->>'totalRepairCost')::numeric THEN
+    RAISE EXCEPTION 'Expected topEquipmentRepairCosts sorted descending, got %', v_report->'topEquipmentRepairCosts';
+  END IF;
+
+  v_period_points := v_report #> '{charts,repairUsageCostCorrelation,period,points}';
+  v_cumulative_points := v_report #> '{charts,repairUsageCostCorrelation,cumulative,points}';
+  v_period_quality := v_report #> '{charts,repairUsageCostCorrelation,period,dataQuality}';
+  v_cumulative_quality := v_report #> '{charts,repairUsageCostCorrelation,cumulative,dataQuality}';
+
+  IF v_period_points IS NULL OR v_cumulative_points IS NULL THEN
+    RAISE EXCEPTION 'Expected repairUsageCostCorrelation period/cumulative points, got %', v_report;
+  END IF;
+
+  IF jsonb_array_length(v_period_points) <> 3 OR jsonb_array_length(v_cumulative_points) <> 3 THEN
+    RAISE EXCEPTION 'Expected 3 period and 3 cumulative points, got period=% cumulative=%', v_period_points, v_cumulative_points;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_period_points) AS point(row_data)
+    WHERE row_data ? 'equipment_name'
+       OR row_data ? 'total_usage_hours'
+       OR row_data ? 'total_repair_cost'
+  ) THEN
+    RAISE EXCEPTION 'Expected camelCase correlation point keys, got %', v_period_points;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_each(v_period_quality) AS pair(key_name, value_data)
+    WHERE key_name ~ '_'
+  ) THEN
+    RAISE EXCEPTION 'Expected camelCase dataQuality keys, got %', v_period_quality;
+  END IF;
+
+  SELECT (row_data->>'totalUsageHours')::numeric
+  INTO v_a_period_hours
+  FROM jsonb_array_elements(v_period_points) AS point(row_data)
+  WHERE row_data->>'equipmentCode' = 'RCUV-A-' || v_suffix;
+
+  IF v_a_period_hours IS DISTINCT FROM 2 THEN
+    RAISE EXCEPTION 'Expected equipment A period usage 2 hours, got % in %', v_a_period_hours, v_period_points;
+  END IF;
+
+  SELECT (row_data->>'totalUsageHours')::numeric
+  INTO v_a_cumulative_hours
+  FROM jsonb_array_elements(v_cumulative_points) AS point(row_data)
+  WHERE row_data->>'equipmentCode' = 'RCUV-A-' || v_suffix;
+
+  IF v_a_cumulative_hours IS DISTINCT FROM 5 THEN
+    RAISE EXCEPTION 'Expected equipment A cumulative usage 5 hours, got % in %', v_a_cumulative_hours, v_cumulative_points;
+  END IF;
+
+  SELECT (row_data->>'totalUsageHours')::numeric
+  INTO v_b_cumulative_hours
+  FROM jsonb_array_elements(v_cumulative_points) AS point(row_data)
+  WHERE row_data->>'equipmentCode' = 'RCUV-B-' || v_suffix;
+
+  IF v_b_cumulative_hours IS DISTINCT FROM 5 THEN
+    RAISE EXCEPTION 'Expected equipment B cumulative usage to exclude crossing interval and stay 5 hours, got % in %', v_b_cumulative_hours, v_cumulative_points;
+  END IF;
+
+  IF (v_report->'topEquipmentRepairCosts'->0->>'completedRepairRequests')::integer IS DISTINCT FROM 2
+     OR (v_report->'topEquipmentRepairCosts'->0->>'costRecordedCount')::integer IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Expected equipment A completedRepairRequests=2 and costRecordedCount=1, got %', v_report->'topEquipmentRepairCosts';
+  END IF;
+
+  IF (v_period_quality->>'equipmentWithUsage')::integer IS DISTINCT FROM 3
+     OR (v_period_quality->>'equipmentWithRepairCost')::integer IS DISTINCT FROM 3
+     OR (v_period_quality->>'equipmentWithBoth')::integer IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'Expected period dataQuality usage=3 repairCost=3 both=3, got %', v_period_quality;
+  END IF;
+
+  IF (v_cumulative_quality->>'equipmentWithUsage')::integer IS DISTINCT FROM 3
+     OR (v_cumulative_quality->>'equipmentWithRepairCost')::integer IS DISTINCT FROM 3
+     OR (v_cumulative_quality->>'equipmentWithBoth')::integer IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'Expected cumulative dataQuality usage=3 repairCost=3 both=3, got %', v_cumulative_quality;
+  END IF;
+
+  IF NOT (
+    v_report ? 'summary'
+    AND v_report #> '{charts,repairStatusDistribution}' IS NOT NULL
+    AND v_report #> '{charts,maintenancePlanVsActual}' IS NOT NULL
+    AND v_report #> '{charts,repairFrequencyByMonth}' IS NOT NULL
+    AND v_report #> '{charts,repairCostByMonth}' IS NOT NULL
+    AND v_report #> '{charts,repairCostByFacility}' IS NOT NULL
+    AND v_report ? 'topEquipmentRepairs'
+    AND v_report ? 'recentRepairHistory'
+  ) THEN
+    RAISE EXCEPTION 'Expected existing maintenance report payload keys to remain present, got %', v_report;
+  END IF;
+
+  SELECT count(*)
+  INTO v_both_count
+  FROM jsonb_array_elements(v_period_points) AS point(row_data)
+  WHERE row_data->>'equipmentCode' = 'RCUV-X-' || v_suffix;
+
+  IF v_both_count <> 0 THEN
+    RAISE EXCEPTION 'Expected other-tenant equipment to be excluded from non-global scoped payload, got %', v_period_points;
+  END IF;
+
+  PERFORM pg_temp._rcuv_set_claims('admin', v_user_id, NULL);
+
+  v_admin_scoped_report := public.get_maintenance_report_data(v_date_from, v_date_to, v_tenant);
+
+  SELECT count(*)
+  INTO v_both_count
+  FROM jsonb_array_elements(v_admin_scoped_report #> '{charts,repairUsageCostCorrelation,period,points}') AS point(row_data)
+  WHERE row_data->>'equipmentCode' = 'RCUV-X-' || v_suffix;
+
+  IF v_both_count <> 0 THEN
+    RAISE EXCEPTION 'Expected admin/global payload with p_don_vi to stay facility-scoped, got %', v_admin_scoped_report;
+  END IF;
+
+  RAISE NOTICE 'OK: repair cost usage visualization payload contract passed';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add typed maintenance-report contract support for `topEquipmentRepairCosts` and `charts.repairUsageCostCorrelation.{period,cumulative}` with safe default merging
- add report UI scaffolding for repair-cost visualizations: Top 10 repair-cost chart, period/cumulative usage-vs-cost correlation chart, and explicit empty/data-quality states
- add and apply the Supabase migration for `get_maintenance_report_data(date,date,bigint)` plus a focused SQL smoke test for the expanded payload
- document the repo-standard Supabase SQL migration pattern so future migrations start from live DB assumptions and do not miss grants, JWT guards, search paths, smoke tests, or advisors

## What Changed
- extracted maintenance report payload types into `src/app/(app)/reports/hooks/use-maintenance-data.types.ts` and added compile-time assertions in `src/app/(app)/reports/hooks/use-maintenance-data.types.assert.ts`
- updated `useMaintenanceReportData` to merge partial RPC payloads onto a complete default contract
- split summary cards out of `maintenance-report-tab.tsx` and added `MaintenanceRepairCostVisualizations`
- extended dynamic chart support with vertical bar support and `DynamicScatterChart`
- added focused Vitest coverage for the new visualization behavior and updated the existing maintenance report tab test fixture
- created `supabase/migrations/20260413152000_add_repair_cost_usage_visualizations.sql` from the live `get_maintenance_report_data(date,date,bigint)` definition
- created `supabase/tests/repair_cost_usage_visualizations_smoke.sql` to validate sorting, camelCase payload keys, period/cumulative usage rules, sparse-data handling, and facility scoping
- updated `docs/schema/supabase-tenant-rpc-template.md` into the standard Supabase SQL migration pattern for this repo

## Live DB Baseline Used
Queried live Supabase before writing and before applying the migration:
- `public.get_maintenance_report_data(date,date,bigint)` was already `SECURITY DEFINER` with `SET search_path = public, pg_temp`
- current routine privileges for `get_maintenance_report_data` included `anon`, `authenticated`, and `service_role`; the migration preserves that access contract and still revokes `PUBLIC`
- `public.nhat_ky_su_dung.thiet_bi_id` is `integer`, while `public.thiet_bi.id` is `bigint`
- `public.yeu_cau_sua_chua.chi_phi_sua_chua` is `numeric(14,2) NULL`
- `public.nhat_ky_su_dung.trang_thai` currently allows `dang_su_dung` and `hoan_thanh`

## Migration Status
- [x] Applied via Supabase MCP `apply_migration`
- [x] Confirmed in Supabase migration history as name `20260413152000_add_repair_cost_usage_visualizations` with recorded version `20260414013614`
- [x] Re-ran `supabase/tests/repair_cost_usage_visualizations_smoke.sql` against live DB through Supabase MCP `execute_sql`; it completed without exception
- [x] Re-queried live function shape: `SECURITY DEFINER`, `search_path=public, pg_temp`, `topEquipmentRepairCosts` present, `repairUsageCostCorrelation` present
- [x] Re-queried live grants: `anon`, `authenticated`, and `service_role` have EXECUTE; `PUBLIC` does not
- [x] Ran Supabase MCP `get_advisors(security)` after apply; output still contains existing project-wide advisor noise, with no finding tied to the replaced report RPC in the reviewed output
- [x] Ran Supabase MCP `get_advisors(performance)` because the feature adds reporting aggregations; output contains existing project-wide index/unused-index notices, with no obvious new finding tied to this migration in the reviewed output

## Verification
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- 'src/app/(app)/reports/components/__tests__/maintenance-repair-cost-visualizations.test.tsx' 'src/app/(app)/reports/components/__tests__/maintenance-report-tab.test.tsx'`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- [x] `openspec validate add-repair-cost-usage-visualizations --strict`
- [x] `git diff --check`

## Reviewer Notes
- The `anon`/`authenticated`/`service_role` grants are intentionally preserved from the live RPC baseline rather than narrowed in this feature PR.
- The SQL uses the existing report RPC access contract where `admin` is treated as global for this function, consistent with the live function and `/api/rpc/[fn]` proxy normalization.
- React Doctor still reports the pre-existing `MaintenanceReportTab` size warning; this feature extracted summary cards but did not fully split the tab component.

## Main Files
- `src/app/(app)/reports/hooks/use-maintenance-data.types.ts`
- `src/app/(app)/reports/hooks/use-maintenance-data.ts`
- `src/app/(app)/reports/components/maintenance-report-tab.tsx`
- `src/app/(app)/reports/components/maintenance-report-summary-cards.tsx`
- `src/app/(app)/reports/components/maintenance-repair-cost-visualizations.tsx`
- `src/components/dynamic-chart.tsx`
- `src/lib/chart-utils.ts`
- `supabase/migrations/20260413152000_add_repair_cost_usage_visualizations.sql`
- `supabase/tests/repair_cost_usage_visualizations_smoke.sql`
- `docs/schema/supabase-tenant-rpc-template.md`
