### PR TITLE
Refactor MaintenanceReportTab

### DIFF
--- a/src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx
@@ -6,6 +6,31 @@ const mockDynamicBarChart = vi.fn(() => <div data-testid="bar-chart" />)
 const mockDynamicLineChart = vi.fn(() => <div data-testid="line-chart" />)
 const mockDynamicPieChart = vi.fn(() => <div data-testid="pie-chart" />)
 
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode
+    onClick?: () => void
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/calendar", () => ({
+  Calendar: ({ onSelect }: { onSelect?: (range?: { from?: Date; to?: Date }) => void }) => (
+    <button
+      type="button"
+      onClick={() => onSelect?.({ from: new Date("2026-04-14T00:00:00.000Z") })}
+    >
+      Select start date
+    </button>
+  ),
+}))
+
 vi.mock("@/components/ui/card", () => ({
   Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -16,6 +41,12 @@ vi.mock("@/components/ui/card", () => ({
 
 vi.mock("@/components/ui/skeleton", () => ({
   Skeleton: () => <div data-testid="skeleton" />,
+}))
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
 vi.mock("@/components/ui/table", () => ({
@@ -37,6 +68,7 @@ vi.mock("@/components/dynamic-chart", () => ({
   DynamicPieChart: (props: unknown) => mockDynamicPieChart(props),
 }))
 
+import { MaintenanceReportDateFilter } from "../maintenance-report-date-filter"
 import { MaintenanceReportPlanChart } from "../maintenance-report-plan-chart"
 import { MaintenanceReportRepairCharts } from "../maintenance-report-repair-charts"
 import { MaintenanceReportRepairTables } from "../maintenance-report-repair-tables"
@@ -44,6 +76,27 @@ import { MaintenanceReportRepairTables } from "../maintenance-report-repair-tabl
 describe("maintenance report sections", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it("formats a single selected date with the Vietnamese locale and preserves it as a one-day range", () => {
+    const onDateRangeChange = vi.fn()
+    const selectedDate = new Date("2026-04-14T00:00:00.000Z")
+
+    render(
+      <MaintenanceReportDateFilter
+        dateRange={{ from: selectedDate }}
+        onDateRangeChange={onDateRangeChange}
+      />
+    )
+
+    expect(screen.getByText("Thg 4 14, 2026")).toBeInTheDocument()
+
+    screen.getByRole("button", { name: "Select start date" }).click()
+
+    expect(onDateRangeChange).toHaveBeenCalledWith({
+      from: selectedDate,
+      to: selectedDate,
+    })
   })
 
   it("renders repair chart cards and forwards chart data", () => {

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx
@@ -1,0 +1,122 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockDynamicBarChart = vi.fn(() => <div data-testid="bar-chart" />)
+const mockDynamicLineChart = vi.fn(() => <div data-testid="line-chart" />)
+const mockDynamicPieChart = vi.fn(() => <div data-testid="pie-chart" />)
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: () => <div data-testid="skeleton" />,
+}))
+
+vi.mock("@/components/ui/table", () => ({
+  Table: ({ children }: { children: React.ReactNode }) => <table>{children}</table>,
+  TableBody: ({ children }: { children: React.ReactNode }) => <tbody>{children}</tbody>,
+  TableCell: ({ children }: { children: React.ReactNode; className?: string; title?: string }) => <td>{children}</td>,
+  TableHead: ({ children }: { children: React.ReactNode; className?: string }) => <th>{children}</th>,
+  TableHeader: ({ children }: { children: React.ReactNode }) => <thead>{children}</thead>,
+  TableRow: ({ children }: { children: React.ReactNode; className?: string }) => <tr>{children}</tr>,
+}))
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode; variant?: string }) => <span>{children}</span>,
+}))
+
+vi.mock("@/components/dynamic-chart", () => ({
+  DynamicBarChart: (props: unknown) => mockDynamicBarChart(props),
+  DynamicLineChart: (props: unknown) => mockDynamicLineChart(props),
+  DynamicPieChart: (props: unknown) => mockDynamicPieChart(props),
+}))
+
+import { MaintenanceReportPlanChart } from "../maintenance-report-plan-chart"
+import { MaintenanceReportRepairCharts } from "../maintenance-report-repair-charts"
+import { MaintenanceReportRepairTables } from "../maintenance-report-repair-tables"
+
+describe("maintenance report sections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders repair chart cards and forwards chart data", () => {
+    const repairTrendData = [
+      { period: "Thg 1 2026", totalRequests: 9, completedRequests: 7 },
+    ]
+    const repairStatusData = [
+      { name: "Hoàn thành", value: 7, color: "#22c55e" },
+    ]
+
+    render(
+      <MaintenanceReportRepairCharts
+        isLoading={false}
+        repairTrendData={repairTrendData}
+        repairStatusData={repairStatusData}
+      />
+    )
+
+    expect(screen.getByText("Xu hướng sửa chữa theo thời gian")).toBeInTheDocument()
+    expect(screen.getByText("Tình trạng yêu cầu sửa chữa")).toBeInTheDocument()
+    expect(mockDynamicLineChart).toHaveBeenCalledWith(
+      expect.objectContaining({ data: repairTrendData })
+    )
+    expect(mockDynamicPieChart).toHaveBeenCalledWith(
+      expect.objectContaining({ data: repairStatusData })
+    )
+  })
+
+  it("renders maintenance plan empty state when no plan chart data is available", () => {
+    render(<MaintenanceReportPlanChart isLoading={false} maintenancePlanData={[]} />)
+
+    expect(screen.getByText("Kế hoạch vs. Thực tế")).toBeInTheDocument()
+    expect(screen.getByText("Không có dữ liệu kế hoạch bảo trì.")).toBeInTheDocument()
+    expect(mockDynamicBarChart).not.toHaveBeenCalled()
+  })
+
+  it("renders repair tables with formatted counts and dates", () => {
+    const numberFormatter = new Intl.NumberFormat("vi-VN")
+    const formatDateDisplay = (value?: string | null) => (value ? "12/04/2026" : "—")
+
+    render(
+      <MaintenanceReportRepairTables
+        isLoading={false}
+        topEquipmentRows={[
+          {
+            equipmentId: 1,
+            name: "Máy thở",
+            totalRequests: 5,
+            rank: 1,
+            latestStatus: "Hoàn thành",
+            latestCompletedDate: "2026-04-12",
+          },
+        ]}
+        recentRepairHistory={[
+          {
+            id: 99,
+            equipmentName: "Monitor",
+            issue: "Không lên nguồn",
+            requestedDate: "2026-04-12",
+            status: "Đang xử lý",
+            completedDate: null,
+          },
+        ]}
+        numberFormatter={numberFormatter}
+        formatDateDisplay={formatDateDisplay}
+      />
+    )
+
+    expect(screen.getByText("Thiết bị sửa chữa nhiều nhất")).toBeInTheDocument()
+    expect(screen.getByText("Máy thở")).toBeInTheDocument()
+    expect(screen.getByText("5")).toBeInTheDocument()
+    expect(screen.getByText("Lịch sử sửa chữa gần đây")).toBeInTheDocument()
+    expect(screen.getByText("Monitor")).toBeInTheDocument()
+    expect(screen.getAllByText("12/04/2026")).toHaveLength(2)
+  })
+})

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-utils.test.ts
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-utils.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildMaintenancePlanChartData,
+  buildRepairTrendChartData,
+  buildTopEquipmentRepairRows,
+  createMaintenanceReportDateFormatter,
+  normalizeMaintenanceReportSummary,
+  parseMaintenanceReportNumber,
+} from "../maintenance-report-utils"
+
+describe("maintenance-report-utils", () => {
+  it("normalizes numeric summary values from mixed RPC output", () => {
+    const summary = normalizeMaintenanceReportSummary({
+      totalRepairs: "12",
+      repairCompletionRate: 75,
+      totalMaintenancePlanned: "8.5",
+      maintenanceCompletionRate: "bad-data",
+      totalRepairCost: 3500000,
+      averageCompletedRepairCost: "1750000",
+      costRecordedCount: Number.POSITIVE_INFINITY,
+      costMissingCount: null,
+    })
+
+    expect(summary).toEqual({
+      totalRepairs: 12,
+      repairCompletionRate: 75,
+      totalMaintenancePlanned: 8.5,
+      maintenanceCompletionRate: 0,
+      totalRepairCost: 3500000,
+      averageCompletedRepairCost: 1750000,
+      costRecordedCount: 0,
+      costMissingCount: 0,
+    })
+    expect(parseMaintenanceReportNumber("")).toBe(0)
+  })
+
+  it("builds chart and table view models without losing existing fields", () => {
+    expect(
+      buildMaintenancePlanChartData([
+        { name: "Tháng 1", planned: "4", actual: "3" },
+        { name: "Tháng 2", planned: Number.NaN, actual: "not-a-number" },
+      ])
+    ).toEqual([
+      { name: "Tháng 1", planned: 4, actual: 3 },
+      { name: "Tháng 2", planned: 0, actual: 0 },
+    ])
+
+    expect(
+      buildRepairTrendChartData([
+        { period: "2026-01", total: "9", completed: "7" },
+        { period: "unknown", total: "bad", completed: 2 },
+      ])
+    ).toEqual([
+      { period: "thg 1 2026", totalRequests: 9, completedRequests: 7 },
+      { period: "unknown", totalRequests: 0, completedRequests: 2 },
+    ])
+
+    expect(
+      buildTopEquipmentRepairRows([
+        {
+          equipmentId: 7,
+          equipmentName: "Máy thở",
+          totalRequests: "5",
+          latestStatus: "Hoàn thành",
+          latestCompletedDate: "2026-04-01",
+        },
+      ])
+    ).toEqual([
+      {
+        equipmentId: 7,
+        name: "Máy thở",
+        totalRequests: 5,
+        rank: 1,
+        latestStatus: "Hoàn thành",
+        latestCompletedDate: "2026-04-01",
+      },
+    ])
+  })
+
+  it("formats optional ISO dates for the repair tables", () => {
+    const formatDateDisplay = createMaintenanceReportDateFormatter()
+
+    expect(formatDateDisplay("2026-04-12")).toBe("12/04/2026")
+    expect(formatDateDisplay("not-a-date")).toBe("—")
+    expect(formatDateDisplay(null)).toBe("—")
+  })
+})

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-utils.test.ts
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-utils.test.ts
@@ -49,10 +49,12 @@ describe("maintenance-report-utils", () => {
     expect(
       buildRepairTrendChartData([
         { period: "2026-01", total: "9", completed: "7" },
+        { period: "2026-13", total: "4", completed: "3" },
         { period: "unknown", total: "bad", completed: 2 },
       ])
     ).toEqual([
       { period: "thg 1 2026", totalRequests: 9, completedRequests: 7 },
+      { period: "2026-13", totalRequests: 4, completedRequests: 3 },
       { period: "unknown", totalRequests: 0, completedRequests: 2 },
     ])
 

--- a/src/app/(app)/reports/components/maintenance-report-date-filter.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-date-filter.tsx
@@ -11,18 +11,23 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import type { DateRange } from "../hooks/use-maintenance-data.types"
 
+interface MaintenanceReportDateFilterRange {
+  from?: Date
+  to?: Date
+}
+
 interface MaintenanceReportDateFilterProps {
-  dateRange: DateRange
+  dateRange: MaintenanceReportDateFilterRange
   onDateRangeChange: (dateRange: DateRange) => void
 }
 
-function getDateRangeLabel(dateRange: DateRange): React.ReactNode {
+function getDateRangeLabel(dateRange: MaintenanceReportDateFilterRange): React.ReactNode {
   if (!dateRange.from) {
     return <span>Chọn khoảng ngày</span>
   }
 
   if (!dateRange.to) {
-    return format(dateRange.from, "LLL dd, y")
+    return format(dateRange.from, "LLL dd, y", { locale: vi })
   }
 
   return (
@@ -60,12 +65,12 @@ export function MaintenanceReportDateFilter({
               initialFocus
               mode="range"
               defaultMonth={dateRange.from}
-              selected={dateRange}
+              selected={{ from: dateRange.from, to: dateRange.to }}
               onSelect={(range) =>
-                range &&
+                range?.from &&
                 onDateRangeChange({
-                  from: range.from || new Date(),
-                  to: range.to || new Date(),
+                  from: range.from,
+                  to: range.to ?? range.from,
                 })
               }
               numberOfMonths={2}

--- a/src/app/(app)/reports/components/maintenance-report-date-filter.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-date-filter.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import * as React from "react"
+import { format } from "date-fns"
+import { vi } from "date-fns/locale"
+import { Calendar as CalendarIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import type { DateRange } from "../hooks/use-maintenance-data.types"
+
+interface MaintenanceReportDateFilterProps {
+  dateRange: DateRange
+  onDateRangeChange: (dateRange: DateRange) => void
+}
+
+function getDateRangeLabel(dateRange: DateRange): React.ReactNode {
+  if (!dateRange.from) {
+    return <span>Chọn khoảng ngày</span>
+  }
+
+  if (!dateRange.to) {
+    return format(dateRange.from, "LLL dd, y")
+  }
+
+  return (
+    <>
+      {format(dateRange.from, "LLL dd, y", { locale: vi })} -{" "}
+      {format(dateRange.to, "LLL dd, y", { locale: vi })}
+    </>
+  )
+}
+
+export function MaintenanceReportDateFilter({
+  dateRange,
+  onDateRangeChange,
+}: MaintenanceReportDateFilterProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Bộ lọc báo cáo</CardTitle>
+        <CardDescription>Chọn khoảng thời gian để xem báo cáo.</CardDescription>
+      </CardHeader>
+      <CardContent className="flex items-center gap-4">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              id="date"
+              variant="outline"
+              className="w-[300px] justify-start text-left font-normal"
+            >
+              <CalendarIcon className="mr-2 h-4 w-4" />
+              {getDateRangeLabel(dateRange)}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="start">
+            <Calendar
+              initialFocus
+              mode="range"
+              defaultMonth={dateRange.from}
+              selected={dateRange}
+              onSelect={(range) =>
+                range &&
+                onDateRangeChange({
+                  from: range.from || new Date(),
+                  to: range.to || new Date(),
+                })
+              }
+              numberOfMonths={2}
+              locale={vi}
+            />
+          </PopoverContent>
+        </Popover>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(app)/reports/components/maintenance-report-plan-chart.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-plan-chart.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import * as React from "react"
+import { Inbox } from "lucide-react"
+
+import { DynamicBarChart } from "@/components/dynamic-chart"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import type { MaintenancePlanChartPoint } from "./maintenance-report-utils"
+
+interface MaintenanceReportPlanChartProps {
+  isLoading: boolean
+  maintenancePlanData: MaintenancePlanChartPoint[]
+}
+
+export function MaintenanceReportPlanChart({
+  isLoading,
+  maintenancePlanData,
+}: MaintenanceReportPlanChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Kế hoạch vs. Thực tế</CardTitle>
+        <CardDescription>So sánh công việc bảo trì theo kế hoạch và thực tế hoàn thành.</CardDescription>
+      </CardHeader>
+      <CardContent className="pt-2">
+        {isLoading ? (
+          <Skeleton className="h-[360px] w-full" />
+        ) : maintenancePlanData.length === 0 ? (
+          <div className="text-sm text-muted-foreground h-[360px] flex flex-col items-center justify-center gap-2">
+            <Inbox className="h-8 w-8 text-muted-foreground/60" />
+            <span>Không có dữ liệu kế hoạch bảo trì.</span>
+          </div>
+        ) : (
+          <DynamicBarChart
+            data={maintenancePlanData}
+            height={360}
+            xAxisKey="name"
+            bars={[
+              { key: "planned", color: "var(--color-planned)", name: "Kế hoạch" },
+              { key: "actual", color: "var(--color-actual)", name: "Thực tế" },
+            ]}
+            margin={{ top: 20, right: 24, left: 16, bottom: 40 }}
+          />
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(app)/reports/components/maintenance-report-repair-charts.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-repair-charts.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import * as React from "react"
+import { Inbox } from "lucide-react"
+
+import { DynamicLineChart, DynamicPieChart } from "@/components/dynamic-chart"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import type { MaintenanceReportData } from "../hooks/use-maintenance-data.types"
+import type { RepairTrendChartPoint } from "./maintenance-report-utils"
+
+interface MaintenanceReportRepairChartsProps {
+  isLoading: boolean
+  repairTrendData: RepairTrendChartPoint[]
+  repairStatusData: MaintenanceReportData["charts"]["repairStatusDistribution"]
+}
+
+export function MaintenanceReportRepairCharts({
+  isLoading,
+  repairTrendData,
+  repairStatusData,
+}: MaintenanceReportRepairChartsProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>Xu hướng sửa chữa theo thời gian</CardTitle>
+          <CardDescription>Số lượng yêu cầu sửa chữa và hoàn thành theo tháng.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-[340px] w-full" />
+          ) : repairTrendData.length === 0 ? (
+            <div className="text-sm text-muted-foreground h-[340px] flex flex-col items-center justify-center gap-2">
+              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <span>Không có dữ liệu xu hướng sửa chữa.</span>
+            </div>
+          ) : (
+            <DynamicLineChart
+              data={repairTrendData}
+              height={340}
+              xAxisKey="period"
+              lines={[
+                { key: "totalRequests", color: "hsl(var(--chart-1))", name: "Tổng yêu cầu" },
+                { key: "completedRequests", color: "hsl(var(--chart-4))", name: "Hoàn thành" },
+              ]}
+              margin={{ top: 16, right: 24, left: 16, bottom: 12 }}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Tình trạng yêu cầu sửa chữa</CardTitle>
+          <CardDescription>Phân bổ các yêu cầu sửa chữa theo trạng thái.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-[340px] w-full" />
+          ) : repairStatusData.length === 0 ? (
+            <div className="text-sm text-muted-foreground h-[340px] flex flex-col items-center justify-center gap-2">
+              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <span>Không có dữ liệu trạng thái sửa chữa.</span>
+            </div>
+          ) : (
+            <DynamicPieChart
+              data={repairStatusData}
+              height={340}
+              dataKey="value"
+              nameKey="name"
+              colors={repairStatusData.map((entry) => entry.color)}
+              innerRadius={90}
+              outerRadius={130}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(app)/reports/components/maintenance-report-repair-tables.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-repair-tables.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import type { RecentRepairHistoryRow, TopEquipmentRepairRow } from "./maintenance-report-utils"
+
+interface MaintenanceReportRepairTablesProps {
+  isLoading: boolean
+  topEquipmentRows: TopEquipmentRepairRow[]
+  recentRepairHistory: RecentRepairHistoryRow[]
+  numberFormatter: Intl.NumberFormat
+  formatDateDisplay: (value?: string | null) => string
+}
+
+export function MaintenanceReportRepairTables({
+  isLoading,
+  topEquipmentRows,
+  recentRepairHistory,
+  numberFormatter,
+  formatDateDisplay,
+}: MaintenanceReportRepairTablesProps) {
+  return (
+    <>
+      <Card className="border border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle>Thiết bị sửa chữa nhiều nhất</CardTitle>
+          <CardDescription>Top thiết bị có số lượng yêu cầu sửa chữa cao trong khoảng thời gian đã chọn.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-[220px] w-full" />
+          ) : topEquipmentRows.length === 0 ? (
+            <div className="text-sm text-muted-foreground">Không có dữ liệu sửa chữa trong khoảng thời gian đã chọn.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[60px] text-center">#</TableHead>
+                    <TableHead>Thiết bị</TableHead>
+                    <TableHead>Số yêu cầu</TableHead>
+                    <TableHead>Trạng thái gần nhất</TableHead>
+                    <TableHead>Ngày sửa chữa gần nhất</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {topEquipmentRows.map((item) => (
+                    <TableRow key={`${item.equipmentId}-${item.rank}`} className="group">
+                      <TableCell className="text-center">
+                        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary group-hover:bg-primary/20">
+                          {item.rank}
+                        </span>
+                      </TableCell>
+                      <TableCell className="font-medium">{item.name}</TableCell>
+                      <TableCell>{numberFormatter.format(item.totalRequests)}</TableCell>
+                      <TableCell>
+                        <Badge variant={item.latestStatus === "Hoàn thành" ? "default" : "secondary"}>
+                          {item.latestStatus}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{formatDateDisplay(item.latestCompletedDate)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border border-border/60 shadow-sm">
+        <CardHeader>
+          <CardTitle>Lịch sử sửa chữa gần đây</CardTitle>
+          <CardDescription>Các yêu cầu sửa chữa mới nhất nằm trong khoảng thời gian đã chọn.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-[220px] w-full" />
+          ) : recentRepairHistory.length === 0 ? (
+            <div className="text-sm text-muted-foreground">Không có lịch sử sửa chữa trong khoảng thời gian đã chọn.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Thiết bị</TableHead>
+                    <TableHead>Sự cố</TableHead>
+                    <TableHead>Ngày yêu cầu</TableHead>
+                    <TableHead>Trạng thái</TableHead>
+                    <TableHead>Ngày hoàn thành</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {recentRepairHistory.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell className="font-medium">{item.equipmentName}</TableCell>
+                      <TableCell className="max-w-[320px] truncate" title={item.issue}>{item.issue}</TableCell>
+                      <TableCell>{formatDateDisplay(item.requestedDate)}</TableCell>
+                      <TableCell>
+                        <Badge variant={item.status === "Hoàn thành" ? "default" : "secondary"}>{item.status}</Badge>
+                      </TableCell>
+                      <TableCell>{formatDateDisplay(item.completedDate)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </>
+  )
+}

--- a/src/app/(app)/reports/components/maintenance-report-tab.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-tab.tsx
@@ -1,40 +1,23 @@
 "use client"
 
 import * as React from "react"
-import { format, parseISO, startOfYear, endOfYear } from "date-fns"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Calendar } from "@/components/ui/calendar"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Button } from "@/components/ui/button"
-import { Calendar as CalendarIcon, Wrench, CheckCircle, Clock, Inbox } from "lucide-react"
-import { cn } from "@/lib/utils"
-import { vi } from "date-fns/locale"
+import { endOfYear, startOfYear } from "date-fns"
 
 import { useMaintenanceReportData } from "../hooks/use-maintenance-data"
+import type { DateRange } from "../hooks/use-maintenance-data.types"
 import { MaintenanceRepairCostVisualizations } from "./maintenance-repair-cost-visualizations"
+import { MaintenanceReportDateFilter } from "./maintenance-report-date-filter"
+import { MaintenanceReportPlanChart } from "./maintenance-report-plan-chart"
+import { MaintenanceReportRepairCharts } from "./maintenance-report-repair-charts"
+import { MaintenanceReportRepairTables } from "./maintenance-report-repair-tables"
 import { MaintenanceReportSummaryCards } from "./maintenance-report-summary-cards"
-import { Skeleton } from "@/components/ui/skeleton"
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import { Badge } from "@/components/ui/badge"
-import { DynamicBarChart, DynamicLineChart, DynamicPieChart } from "@/components/dynamic-chart"
-
-const parseNumericValue = (value: unknown): number => {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : 0
-  }
-
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value)
-    return Number.isFinite(parsed) ? parsed : 0
-  }
-
-  return 0
-}
-
-interface DateRange {
-  from: Date
-  to: Date
-}
+import {
+  buildMaintenancePlanChartData,
+  buildRepairTrendChartData,
+  buildTopEquipmentRepairRows,
+  createMaintenanceReportDateFormatter,
+  normalizeMaintenanceReportSummary,
+} from "./maintenance-report-utils"
 
 interface MaintenanceReportTabProps {
   tenantFilter?: string
@@ -42,17 +25,15 @@ interface MaintenanceReportTabProps {
   effectiveTenantKey?: string
 }
 
-export function MaintenanceReportTab({ 
-  tenantFilter, 
-  selectedDonVi, 
-  effectiveTenantKey 
+export function MaintenanceReportTab({
+  selectedDonVi,
+  effectiveTenantKey,
 }: MaintenanceReportTabProps) {
   const [dateRange, setDateRange] = React.useState<DateRange>({
     from: startOfYear(new Date()),
     to: endOfYear(new Date()),
   })
 
-  // ✅ Pass tenant parameters for proper scoping
   const { data: reportData, isLoading } = useMaintenanceReportData(
     dateRange,
     selectedDonVi,
@@ -68,200 +49,52 @@ export function MaintenanceReportTab({
   const repairUsageCostCorrelation = charts?.repairUsageCostCorrelation
   const recentRepairHistory = reportData?.recentRepairHistory ?? []
 
-  const normalizedSummary = React.useMemo(() => ({
-    totalRepairs: parseNumericValue(summary?.totalRepairs),
-    repairCompletionRate: parseNumericValue(summary?.repairCompletionRate),
-    totalMaintenancePlanned: parseNumericValue(summary?.totalMaintenancePlanned),
-    maintenanceCompletionRate: parseNumericValue(summary?.maintenanceCompletionRate),
-    totalRepairCost: parseNumericValue(summary?.totalRepairCost),
-    averageCompletedRepairCost: parseNumericValue(summary?.averageCompletedRepairCost),
-    costRecordedCount: parseNumericValue(summary?.costRecordedCount),
-    costMissingCount: parseNumericValue(summary?.costMissingCount),
-  }), [summary])
+  const normalizedSummary = React.useMemo(
+    () => normalizeMaintenanceReportSummary(summary),
+    [summary]
+  )
 
-  const maintenancePlanData = React.useMemo(() => {
-    return (charts?.maintenancePlanVsActual ?? []).map((item) => ({
-      ...item,
-      planned: parseNumericValue(item.planned),
-      actual: parseNumericValue(item.actual),
-    }))
-  }, [charts?.maintenancePlanVsActual])
+  const maintenancePlanData = React.useMemo(
+    () => buildMaintenancePlanChartData(charts?.maintenancePlanVsActual ?? []),
+    [charts?.maintenancePlanVsActual]
+  )
 
-  const numberFormatter = React.useMemo(() => new Intl.NumberFormat("vi-VN"), [])
+  const repairTrendData = React.useMemo(
+    () => buildRepairTrendChartData(repairFrequency),
+    [repairFrequency]
+  )
 
-  const repairTrendData = React.useMemo(() => {
-    return repairFrequency.map(({ period, total, completed }) => {
-      const [year, month] = period.split('-')
-      const parsed = new Date(Number(year), Number(month) - 1)
-      const label = Number.isNaN(parsed.getTime()) ? period : format(parsed, "MMM yyyy", { locale: vi })
-      return {
-        period: label,
-        totalRequests: parseNumericValue(total),
-        completedRequests: parseNumericValue(completed),
-      }
-    })
-  }, [repairFrequency])
-
-  const topEquipmentChartData = React.useMemo(
-    () =>
-      topEquipmentRepairs.slice(0, 8).map((item, index) => ({
-        name: item.equipmentName,
-        totalRequests: parseNumericValue(item.totalRequests),
-        rank: index + 1,
-        latestCompletedDate: item.latestCompletedDate,
-        latestStatus: item.latestStatus,
-      })),
+  const topEquipmentRows = React.useMemo(
+    () => buildTopEquipmentRepairRows(topEquipmentRepairs),
     [topEquipmentRepairs]
   )
 
-  const formatDateDisplay = React.useCallback((value?: string | null) => {
-    if (!value) return "—"
-    try {
-      return format(parseISO(value), "dd/MM/yyyy")
-    } catch {
-      return "—"
-    }
-  }, [])
+  const numberFormatter = React.useMemo(() => new Intl.NumberFormat("vi-VN"), [])
+  const formatDateDisplay = React.useMemo(() => createMaintenanceReportDateFormatter(), [])
 
   return (
     <div className="space-y-6">
-      {/* Filters Section */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Bộ lọc báo cáo</CardTitle>
-          <CardDescription>Chọn khoảng thời gian để xem báo cáo.</CardDescription>
-        </CardHeader>
-        <CardContent className="flex items-center gap-4">
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                id="date"
-                variant={"outline"}
-                className={cn(
-                  "w-[300px] justify-start text-left font-normal",
-                  !dateRange && "text-muted-foreground"
-                )}
-              >
-                <CalendarIcon className="mr-2 h-4 w-4" />
-                {dateRange?.from ? (
-                  dateRange.to ? (
-                    <>
-                      {format(dateRange.from, "LLL dd, y", { locale: vi })} -{" "}
-                      {format(dateRange.to, "LLL dd, y", { locale: vi })}
-                    </>
-                  ) : (
-                    format(dateRange.from, "LLL dd, y")
-                  )
-                ) : (
-                  <span>Chọn khoảng ngày</span>
-                )}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-0" align="start">
-              <Calendar
-                initialFocus
-                mode="range"
-                defaultMonth={dateRange?.from}
-                selected={dateRange}
-                onSelect={(range) => range && setDateRange({ from: range.from || new Date(), to: range.to || new Date()})}
-                numberOfMonths={2}
-                locale={vi}
-              />
-            </PopoverContent>
-          </Popover>
-        </CardContent>
-      </Card>
-      
+      <MaintenanceReportDateFilter
+        dateRange={dateRange}
+        onDateRangeChange={setDateRange}
+      />
+
       <MaintenanceReportSummaryCards
         summary={normalizedSummary}
         isLoading={isLoading}
         numberFormatter={numberFormatter}
       />
-      
-      {/* Charts Section */}
-      <div className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardHeader className="space-y-1">
-            <CardTitle>Xu hướng sửa chữa theo thời gian</CardTitle>
-            <CardDescription>Số lượng yêu cầu sửa chữa và hoàn thành theo tháng.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <Skeleton className="h-[340px] w-full" />
-            ) : repairTrendData.length === 0 ? (
-              <div className="text-sm text-muted-foreground h-[340px] flex flex-col items-center justify-center gap-2">
-                <Inbox className="h-8 w-8 text-muted-foreground/60" />
-                <span>Không có dữ liệu xu hướng sửa chữa.</span>
-              </div>
-            ) : (
-              <DynamicLineChart
-                data={repairTrendData}
-                height={340}
-                xAxisKey="period"
-                lines={[
-                  { key: "totalRequests", color: "hsl(var(--chart-1))", name: "Tổng yêu cầu" },
-                  { key: "completedRequests", color: "hsl(var(--chart-4))", name: "Hoàn thành" },
-                ]}
-                margin={{ top: 16, right: 24, left: 16, bottom: 12 }}
-              />
-            )}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Tình trạng yêu cầu sửa chữa</CardTitle>
-            <CardDescription>Phân bổ các yêu cầu sửa chữa theo trạng thái.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            {isLoading ? (
-              <Skeleton className="h-[340px] w-full" />
-            ) : repairStatusData.length === 0 ? (
-              <div className="text-sm text-muted-foreground h-[340px] flex flex-col items-center justify-center gap-2">
-                <Inbox className="h-8 w-8 text-muted-foreground/60" />
-                <span>Không có dữ liệu trạng thái sửa chữa.</span>
-              </div>
-            ) : (
-              <DynamicPieChart
-                data={repairStatusData}
-                height={340}
-                dataKey="value"
-                nameKey="name"
-                colors={repairStatusData.map(entry => entry.color)}
-                innerRadius={90}
-                outerRadius={130}
-              />
-            )}
-          </CardContent>
-        </Card>
-      </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Kế hoạch vs. Thực tế</CardTitle>
-          <CardDescription>So sánh công việc bảo trì theo kế hoạch và thực tế hoàn thành.</CardDescription>
-        </CardHeader>
-        <CardContent className="pt-2">
-          {isLoading ? (
-            <Skeleton className="h-[360px] w-full" />
-          ) : maintenancePlanData.length === 0 ? (
-            <div className="text-sm text-muted-foreground h-[360px] flex flex-col items-center justify-center gap-2">
-              <Inbox className="h-8 w-8 text-muted-foreground/60" />
-              <span>Không có dữ liệu kế hoạch bảo trì.</span>
-            </div>
-          ) : (
-            <DynamicBarChart
-              data={maintenancePlanData}
-              height={360}
-              xAxisKey="name"
-              bars={[
-                { key: "planned", color: "var(--color-planned)", name: "Kế hoạch" },
-                { key: "actual", color: "var(--color-actual)", name: "Thực tế" },
-              ]}
-              margin={{ top: 20, right: 24, left: 16, bottom: 40 }}
-            />
-          )}
-        </CardContent>
-      </Card>
+      <MaintenanceReportRepairCharts
+        isLoading={isLoading}
+        repairTrendData={repairTrendData}
+        repairStatusData={repairStatusData}
+      />
+
+      <MaintenanceReportPlanChart
+        isLoading={isLoading}
+        maintenancePlanData={maintenancePlanData}
+      />
 
       {repairUsageCostCorrelation ? (
         <MaintenanceRepairCostVisualizations
@@ -270,94 +103,13 @@ export function MaintenanceReportTab({
         />
       ) : null}
 
-      {/* Repair history table */}
-      <Card className="border border-border/60 shadow-sm">
-        <CardHeader>
-          <CardTitle>Thiết bị sửa chữa nhiều nhất</CardTitle>
-          <CardDescription>Top thiết bị có số lượng yêu cầu sửa chữa cao trong khoảng thời gian đã chọn.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <Skeleton className="h-[220px] w-full" />
-          ) : topEquipmentRepairs.length === 0 ? (
-            <div className="text-sm text-muted-foreground">Không có dữ liệu sửa chữa trong khoảng thời gian đã chọn.</div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-[60px] text-center">#</TableHead>
-                    <TableHead>Thiết bị</TableHead>
-                    <TableHead>Số yêu cầu</TableHead>
-                    <TableHead>Trạng thái gần nhất</TableHead>
-                    <TableHead>Ngày sửa chữa gần nhất</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {topEquipmentChartData.map((item) => (
-                    <TableRow key={`${item.name}-${item.rank}`} className="group">
-                      <TableCell className="text-center">
-                        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary group-hover:bg-primary/20">
-                          {item.rank}
-                        </span>
-                      </TableCell>
-                      <TableCell className="font-medium">{item.name}</TableCell>
-                      <TableCell>{numberFormatter.format(item.totalRequests)}</TableCell>
-                      <TableCell>
-                        <Badge variant={item.latestStatus === "Hoàn thành" ? "default" : "secondary"}>
-                          {item.latestStatus}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>{formatDateDisplay(item.latestCompletedDate)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card className="border border-border/60 shadow-sm">
-        <CardHeader>
-          <CardTitle>Lịch sử sửa chữa gần đây</CardTitle>
-          <CardDescription>Các yêu cầu sửa chữa mới nhất nằm trong khoảng thời gian đã chọn.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <Skeleton className="h-[220px] w-full" />
-          ) : recentRepairHistory.length === 0 ? (
-            <div className="text-sm text-muted-foreground">Không có lịch sử sửa chữa trong khoảng thời gian đã chọn.</div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Thiết bị</TableHead>
-                    <TableHead>Sự cố</TableHead>
-                    <TableHead>Ngày yêu cầu</TableHead>
-                    <TableHead>Trạng thái</TableHead>
-                    <TableHead>Ngày hoàn thành</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {recentRepairHistory.map((item) => (
-                    <TableRow key={item.id}>
-                      <TableCell className="font-medium">{item.equipmentName}</TableCell>
-                      <TableCell className="max-w-[320px] truncate" title={item.issue}>{item.issue}</TableCell>
-                      <TableCell>{formatDateDisplay(item.requestedDate)}</TableCell>
-                      <TableCell>
-                        <Badge variant={item.status === "Hoàn thành" ? "default" : "secondary"}>{item.status}</Badge>
-                      </TableCell>
-                      <TableCell>{formatDateDisplay(item.completedDate)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      <MaintenanceReportRepairTables
+        isLoading={isLoading}
+        topEquipmentRows={topEquipmentRows}
+        recentRepairHistory={recentRepairHistory}
+        numberFormatter={numberFormatter}
+        formatDateDisplay={formatDateDisplay}
+      />
     </div>
   )
-} 
+}

--- a/src/app/(app)/reports/components/maintenance-report-utils.ts
+++ b/src/app/(app)/reports/components/maintenance-report-utils.ts
@@ -11,6 +11,7 @@ import type {
 
 type MaintenanceSummary = MaintenanceReportData["summary"]
 type MaintenanceSummaryInput = Partial<Record<keyof MaintenanceSummary, unknown>> | null | undefined
+const REPAIR_FREQUENCY_PERIOD_PATTERN = /^(\d{4})-(\d{2})$/
 
 export interface RepairTrendChartPoint extends ChartData {
   period: string
@@ -78,16 +79,28 @@ export function buildRepairTrendChartData(
   }> = []
 ): RepairTrendChartPoint[] {
   return repairFrequency.map(({ period, total, completed }) => {
-    const [year, month] = period.split("-")
-    const parsed = new Date(Number(year), Number(month) - 1)
-    const label = Number.isNaN(parsed.getTime()) ? period : format(parsed, "MMM yyyy", { locale: vi })
-
     return {
-      period: label,
+      period: formatRepairFrequencyPeriod(period),
       totalRequests: parseMaintenanceReportNumber(total),
       completedRequests: parseMaintenanceReportNumber(completed),
     }
   })
+}
+
+function formatRepairFrequencyPeriod(period: string): string {
+  const match = REPAIR_FREQUENCY_PERIOD_PATTERN.exec(period)
+  if (!match) {
+    return period
+  }
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  if (!Number.isInteger(year) || month < 1 || month > 12) {
+    return period
+  }
+
+  const parsed = new Date(year, month - 1, 1)
+  return Number.isNaN(parsed.getTime()) ? period : format(parsed, "MMM yyyy", { locale: vi })
 }
 
 export function buildTopEquipmentRepairRows(

--- a/src/app/(app)/reports/components/maintenance-report-utils.ts
+++ b/src/app/(app)/reports/components/maintenance-report-utils.ts
@@ -1,0 +1,116 @@
+import { format, parseISO } from "date-fns"
+import { vi } from "date-fns/locale"
+
+import type { ChartData } from "@/lib/chart-utils"
+import type {
+  MaintenanceReportData,
+  RecentRepairHistoryEntry,
+  RepairFrequencyPoint,
+  TopEquipmentRepairEntry,
+} from "../hooks/use-maintenance-data.types"
+
+type MaintenanceSummary = MaintenanceReportData["summary"]
+type MaintenanceSummaryInput = Partial<Record<keyof MaintenanceSummary, unknown>> | null | undefined
+
+export interface RepairTrendChartPoint extends ChartData {
+  period: string
+  totalRequests: number
+  completedRequests: number
+}
+
+export interface MaintenancePlanChartPoint extends ChartData {
+  name: string
+  planned: number
+  actual: number
+}
+
+export interface TopEquipmentRepairRow {
+  equipmentId: number
+  name: string
+  totalRequests: number
+  rank: number
+  latestCompletedDate?: string | null
+  latestStatus: string
+}
+
+export type RecentRepairHistoryRow = RecentRepairHistoryEntry
+
+export function parseMaintenanceReportNumber(value: unknown): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+
+  return 0
+}
+
+export function normalizeMaintenanceReportSummary(summary: MaintenanceSummaryInput): MaintenanceSummary {
+  return {
+    totalRepairs: parseMaintenanceReportNumber(summary?.totalRepairs),
+    repairCompletionRate: parseMaintenanceReportNumber(summary?.repairCompletionRate),
+    totalMaintenancePlanned: parseMaintenanceReportNumber(summary?.totalMaintenancePlanned),
+    maintenanceCompletionRate: parseMaintenanceReportNumber(summary?.maintenanceCompletionRate),
+    totalRepairCost: parseMaintenanceReportNumber(summary?.totalRepairCost),
+    averageCompletedRepairCost: parseMaintenanceReportNumber(summary?.averageCompletedRepairCost),
+    costRecordedCount: parseMaintenanceReportNumber(summary?.costRecordedCount),
+    costMissingCount: parseMaintenanceReportNumber(summary?.costMissingCount),
+  }
+}
+
+export function buildMaintenancePlanChartData(
+  items: Array<{ name: string; planned: unknown; actual: unknown }> = []
+): MaintenancePlanChartPoint[] {
+  return items.map((item) => ({
+    ...item,
+    planned: parseMaintenanceReportNumber(item.planned),
+    actual: parseMaintenanceReportNumber(item.actual),
+  }))
+}
+
+export function buildRepairTrendChartData(
+  repairFrequency: Array<Omit<RepairFrequencyPoint, "total" | "completed"> & {
+    total: unknown
+    completed: unknown
+  }> = []
+): RepairTrendChartPoint[] {
+  return repairFrequency.map(({ period, total, completed }) => {
+    const [year, month] = period.split("-")
+    const parsed = new Date(Number(year), Number(month) - 1)
+    const label = Number.isNaN(parsed.getTime()) ? period : format(parsed, "MMM yyyy", { locale: vi })
+
+    return {
+      period: label,
+      totalRequests: parseMaintenanceReportNumber(total),
+      completedRequests: parseMaintenanceReportNumber(completed),
+    }
+  })
+}
+
+export function buildTopEquipmentRepairRows(
+  items: Array<Omit<TopEquipmentRepairEntry, "totalRequests"> & { totalRequests: unknown }> = []
+): TopEquipmentRepairRow[] {
+  return items.slice(0, 8).map((item, index) => ({
+    equipmentId: item.equipmentId,
+    name: item.equipmentName,
+    totalRequests: parseMaintenanceReportNumber(item.totalRequests),
+    rank: index + 1,
+    latestCompletedDate: item.latestCompletedDate,
+    latestStatus: item.latestStatus,
+  }))
+}
+
+export function createMaintenanceReportDateFormatter() {
+  return (value?: string | null) => {
+    if (!value) return "—"
+
+    try {
+      return format(parseISO(value), "dd/MM/yyyy")
+    } catch {
+      return "—"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Split MaintenanceReportTab into focused, grep-friendly section components and pure report utils.
- Reduced maintenance-report-tab.tsx from 363 lines to 115 lines while preserving the existing lazy-load export contract.
- Added focused tests for the extracted utils and report sections.

## Test Plan
- [x] node scripts/npm-run.js run verify:no-explicit-any
- [x] node scripts/npm-run.js run typecheck
- [x] node scripts/npm-run.js run test:run -- 'src/app/(app)/reports/components/__tests__/maintenance-report-utils.test.ts' 'src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx' 'src/app/(app)/reports/components/__tests__/maintenance-report-tab.test.tsx' 'src/app/(app)/reports/components/__tests__/maintenance-repair-cost-visualizations.test.tsx'
- [x] node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

Closes #245
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the maintenance report tab into focused section components and pure utilities to improve readability and reuse. Also addressed review feedback on date filtering and data formatting, keeping existing behavior and the lazy-load export, aligning with #245.

- **Refactors**
  - Split UI into `MaintenanceReportDateFilter`, `MaintenanceReportPlanChart`, `MaintenanceReportRepairCharts`, and `MaintenanceReportRepairTables`; moved data shaping into `maintenance-report-utils` (e.g., `normalizeMaintenanceReportSummary`, `buildMaintenancePlanChartData`, `buildRepairTrendChartData`, `buildTopEquipmentRepairRows`, `createMaintenanceReportDateFormatter`).
  - Cut `maintenance-report-tab.tsx` from 363 to 115 lines while keeping the same data flow via `useMaintenanceReportData`.
  - Added focused tests for utils and sections to validate number/date normalization and chart/table props.

- **Bug Fixes**
  - Date filter now formats with the Vietnamese locale and preserves a single-day selection when only the start date is chosen.
  - Hardened number parsing and period label formatting for charts; improved empty states and consistent table date formatting.

<sup>Written for commit 84ea2636459b8b40abf9cf1a2c5ed57f8659f6d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added date range filter to maintenance reports for flexible data filtering
  * Added Plan vs. Actual bar chart visualization for maintenance planning metrics
  * Added repair trend line chart and status distribution pie chart for insights
  * Added top repaired equipment table and recent repair history table with detailed metrics

* **Tests**
  * Added comprehensive test coverage for maintenance report components and utility functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->