### PR TITLE
feat: add usage log split status — backend batch (migration + smoke tests + openspec)

### DIFF
--- a/openspec/changes/add-usage-log-split-status/design.md
+++ b/openspec/changes/add-usage-log-split-status/design.md
@@ -1,0 +1,71 @@
+## Context
+
+Equipment usage sessions currently record a single `tinh_trang_thiet_bi` (equipment condition) value that serves as both the starting and ending condition. This makes it impossible to determine whether equipment condition changed during a usage session, which is critical for incident audit and accountability.
+
+The existing data:
+- 1 row in `nhat_ky_su_dung` with `tinh_trang_thiet_bi = 'Hoạt động'`, `trang_thai = 'hoan_thanh'`.
+- 4 RPCs: `usage_session_start`, `usage_session_end`, `usage_log_list` (2 overloads).
+- `usage_session_end` has a security gap: uses body-level `set_config` instead of DDL-level `SET search_path`.
+- `usage_session_end` has an admin role guard bug: uses `v_role <> 'global'` which bypasses `admin` users.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Split status into `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` for audit traceability.
+  - Fix `usage_session_end` security gaps (search_path + admin role).
+  - Maintain backward compatibility with existing API consumers.
+  - Comply with 350-line file ceiling for `usage-log-print.tsx`.
+
+- Non-Goals:
+  - Dropping the legacy `tinh_trang_thiet_bi` column.
+  - Adding database-level NOT NULL constraints on new columns.
+  - Converting free-text status to a strict enum.
+  - Migrating other modules to split-status pattern.
+
+## Decisions
+
+- **Column type**: `text` (functionally equivalent to legacy `varchar` in PostgreSQL).
+- **Validation strategy**: Enforced via RPC `RAISE EXCEPTION`, not via DB constraints. This allows migration to succeed on historical data that may have NULL status values.
+- **Backward compatibility**: New RPC params use `DEFAULT NULL`. When param is NULL (old caller omitted it), validation is **skipped** and RPC writes only the legacy column — no exception. When param is explicitly empty string `''` (new caller error), validation raises exception. Legacy column continues to be written alongside new columns during transition period. This avoids breaking existing consumers while enforcing fail-closed for updated consumers.
+
+- **Input approach**: Free-text with native HTML `<datalist>` for suggestions. No new UI library dependency.
+- **Backfill**: Both new columns are populated from `tinh_trang_thiet_bi` for existing rows. This is an **approximation** — historical records didn't distinguish before/after status. `tinh_trang_ket_thuc` is only filled for completed sessions (`trang_thai = 'hoan_thanh'`).
+- **File splitting**: `usage-log-print.tsx` (491 lines) must be split before adding columns. Extract `usage-log-print-html-builder.ts` and `usage-log-print-csv-builder.ts`.
+
+## Risks / Trade-offs
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Backfill overwrites intentionally-null data | Very Low | Low | Only fills when new column IS NULL |
+| Legacy callers break from validation | Medium | High | Continue writing legacy column; only validate when new param is explicitly provided (or coordinate atomic FE+BE deploy) |
+| `usage-log-print.tsx` refactor introduces regressions | Low | Medium | TDD: write column tests before refactoring |
+
+## Migration Plan (2-Batch Deploy)
+
+### Batch 1: Backend (deploy independently)
+1. Apply schema migration (additive columns + backfill).
+2. Deploy updated RPCs (new params with `DEFAULT NULL`).
+3. Verify: old frontend continues working because `NULL` param → skip validation → write legacy column only.
+
+### Batch 2: Frontend (deploy after Batch 1 is on production)
+1. Extract `usage-log-print.tsx` builders (pre-requisite refactor).
+2. Deploy frontend sending new `p_tinh_trang_ban_dau` / `p_tinh_trang_ket_thuc` params.
+3. New columns start getting populated; legacy column also written for transition safety.
+
+### Why backend-first is safe
+
+| State | Old FE + New BE | New FE + New BE |
+|-------|----------------|-----------------|
+| `usage_session_start` | Sends `p_tinh_trang_thiet_bi` only → param NULL → no exception → legacy column written | Sends both → validation passes → both columns written |
+| `usage_session_end` | Same pattern | Same pattern |
+| `usage_log_list` | Returns new fields as NULL for old rows (backfilled rows show values) | Reads new fields; fallback to legacy when NULL |
+
+### Rollback
+1. Columns are additive — no destructive schema change.
+2. RPCs can be reverted via `CREATE OR REPLACE` with old body.
+3. FE changes are isolated — revert via git.
+
+## Resolved Questions
+
+- **Validation timing vs backward compat**: Resolved — validation only triggers on empty string `''`, not on NULL (default). Old callers omitting the param continue working. New callers sending empty string get fail-closed. See spec: "Legacy Column Backward Compatibility" requirement.
+

--- a/openspec/changes/add-usage-log-split-status/proposal.md
+++ b/openspec/changes/add-usage-log-split-status/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+`nhat_ky_su_dung.tinh_trang_thiet_bi` ghi chung một cột cho cả thời điểm bắt đầu và kết thúc phiên sử dụng. Khi audit/điều tra sự cố, không thể phân biệt thiết bị đang ở trạng thái nào **trước** và **sau** khi sử dụng. Tách thành hai cột riêng biệt (`tinh_trang_ban_dau`, `tinh_trang_ket_thuc`) cho phép theo dõi chính xác tình trạng thiết bị tại mỗi thời điểm.
+
+Issue: Audit requirement from [2026-04-13-usage-log-split-status-audit-plan.md](file:/docs/plans/2026-04-13-usage-log-split-status-audit-plan.md)
+
+## What Changes
+
+- **BREAKING**: None. New columns and RPC params use `DEFAULT NULL`; existing callers are unaffected.
+- Add columns `tinh_trang_ban_dau text` and `tinh_trang_ket_thuc text` to `nhat_ky_su_dung`.
+- Backfill existing data from legacy `tinh_trang_thiet_bi` column (approximation for historical records).
+- Modify `usage_session_start` RPC to accept and validate `p_tinh_trang_ban_dau`, write to the new column, and include it in the JSON response.
+- Modify `usage_session_end` RPC to accept and validate `p_tinh_trang_ket_thuc`, write to the new column, include it in the JSON response, and **fix** missing DDL-level `SET search_path = public, pg_temp`.
+- **Fix** `usage_session_end` admin role guard: change `v_role <> 'global'` to `NOT v_is_global` to include `admin` role (per repo `isGlobalRole` convention).
+- Modify both `usage_log_list` overloads to project the two new fields in JSON response.
+- Retain legacy `tinh_trang_thiet_bi` column for backward reads; continue writing to it for backward compatibility until all consumers are migrated.
+- Modify frontend dialogs (`start-usage-dialog.tsx`, `end-usage-dialog.tsx`) to use split status fields with free-text + datalist input.
+- Update `use-usage-logs.ts` mutation payloads and response parsing.
+- Update `database.ts` types with optional new fields.
+- Update `usage-history-tab.tsx` to display split status with legacy fallback.
+- Update `usage-log-print.tsx` print + CSV with 2 status columns (requires pre-requisite refactor: extract HTML/CSV builders to comply with 350-line file ceiling).
+
+## Capabilities
+
+### New Capabilities
+- `usage-log-sessions`: Split initial/final equipment status tracking for usage session audit.
+
+### Modified Capabilities
+- None (no existing OpenSpec capability for usage logs).
+
+## Impact
+
+- Affected code:
+  - `supabase/migrations/YYYYMMDDHHMMSS_usage_log_split_status_columns.sql` [NEW]
+  - `supabase/tests/usage_log_split_status_smoke.sql` [NEW]
+  - `src/types/database.ts`
+  - `src/hooks/use-usage-logs.ts`
+  - `src/components/start-usage-dialog.tsx`
+  - `src/components/end-usage-dialog.tsx`
+  - `src/components/usage-history-tab.tsx`
+  - `src/components/usage-log-print.tsx`
+  - `src/components/usage-log-print-html-builder.ts` [NEW — extracted from usage-log-print.tsx]
+  - `src/components/usage-log-print-csv-builder.ts` [NEW — extracted from usage-log-print.tsx]
+  - `src/components/__tests__/start-usage-dialog.validation.test.tsx` [NEW]
+  - `src/components/__tests__/end-usage-dialog.validation.test.tsx` [NEW]
+  - `src/components/__tests__/usage-log-print.columns.test.tsx` [NEW]
+- Security impact:
+  - Fixes `usage_session_end` missing DDL-level `search_path` (currently body-only `set_config`; `pg_proc.proconfig = null`).
+  - Fixes `usage_session_end` admin role bypass bug (`v_role <> 'global'` → `NOT v_is_global`).
+  - All modified RPCs retain `SECURITY DEFINER`, tenant guards via `allowed_don_vi_for_session()`.
+- Performance impact: None. Schema is additive, backfill touches 1 existing row.
+- Data impact:
+  - Backfill is an approximation: historical records have the same value for both initial and final status. This is documented as an accepted limitation since the original data did not distinguish between the two.
+- Pre-requisite refactor:
+  - `usage-log-print.tsx` is 491 lines (exceeds 350-line ceiling). Must extract HTML builder and CSV builder into separate files before adding new columns.
+- Out of scope:
+  - Dropping or deprecating legacy `tinh_trang_thiet_bi` column
+  - Adding CHECK constraints on new columns (enforced via RPC validation)
+  - Changing the free-text input to a strict enum

--- a/openspec/changes/add-usage-log-split-status/specs/usage-log-sessions/spec.md
+++ b/openspec/changes/add-usage-log-split-status/specs/usage-log-sessions/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Split Equipment Status Tracking
+
+The system SHALL record separate equipment condition values at the start and end of each usage session via `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` columns on `nhat_ky_su_dung`.
+
+#### Scenario: Start session with initial status
+- **WHEN** a user calls `usage_session_start` with a valid `p_tinh_trang_ban_dau` value
+- **THEN** the system writes the value to `tinh_trang_ban_dau`
+- **AND** includes `tinh_trang_ban_dau` in the JSON response
+
+#### Scenario: Start session without initial status
+- **WHEN** a user calls `usage_session_start` without `p_tinh_trang_ban_dau` or with an empty string
+- **THEN** the system raises an exception with error code `22023`
+
+#### Scenario: End session with final status
+- **WHEN** a user calls `usage_session_end` with a valid `p_tinh_trang_ket_thuc` value
+- **THEN** the system writes the value to `tinh_trang_ket_thuc`
+- **AND** includes `tinh_trang_ket_thuc` in the JSON response
+
+#### Scenario: End session without final status
+- **WHEN** a user calls `usage_session_end` without `p_tinh_trang_ket_thuc` or with an empty string
+- **THEN** the system raises an exception with error code `22023`
+
+### Requirement: Legacy Column Backward Compatibility
+
+During the transition period, the system SHALL continue writing `tinh_trang_thiet_bi` alongside the new split columns so that consumers not yet updated can still read the legacy field. The strict validation (`RAISE EXCEPTION`) applies only when the updated frontend explicitly sends the new params as empty; old callers omitting the param entirely receive `DEFAULT NULL` and the RPC writes only the legacy column without error.
+
+#### Scenario: Old caller omits new param entirely
+- **WHEN** an existing consumer calls `usage_session_start` without providing `p_tinh_trang_ban_dau` at all (param defaults to NULL)
+- **AND** the consumer provides `p_tinh_trang_thiet_bi`
+- **THEN** the system writes `tinh_trang_thiet_bi` as before
+- **AND** `tinh_trang_ban_dau` remains NULL
+- **AND** no exception is raised
+
+#### Scenario: New caller sends empty string
+- **WHEN** an updated consumer calls `usage_session_start` with `p_tinh_trang_ban_dau = ''`
+- **THEN** the system raises an exception with error code `22023`
+
+### Requirement: Split Status Display in Usage History
+
+The system SHALL display `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` separately in the usage history view, with a fallback to the legacy `tinh_trang_thiet_bi` column for records that predate the split.
+
+#### Scenario: Display split status for new records
+- **WHEN** a usage log has both `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` populated
+- **THEN** the history view displays both values in separate fields
+
+#### Scenario: Fallback to legacy status for old records
+- **WHEN** a usage log has `tinh_trang_ban_dau` or `tinh_trang_ket_thuc` as null
+- **AND** `tinh_trang_thiet_bi` is populated
+- **THEN** the history view displays the legacy value as a combined fallback
+
+### Requirement: Split Status in Print and Export
+
+The system SHALL include `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` as separate columns in print templates and CSV exports.
+
+#### Scenario: Print template includes both status columns
+- **WHEN** a user prints usage logs
+- **THEN** the print output contains separate "Tình trạng ban đầu" and "Tình trạng kết thúc" columns
+
+#### Scenario: CSV export includes both status columns
+- **WHEN** a user exports usage logs to CSV
+- **THEN** the CSV contains separate header columns for initial and final status
+
+### Requirement: Usage Log List RPC Projects Split Status
+
+Both `usage_log_list` overloads SHALL include `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` in their JSON response objects.
+
+#### Scenario: 8-param overload returns split status
+- **WHEN** a consumer calls the 8-param `usage_log_list`
+- **THEN** each returned JSON object includes `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` fields
+
+#### Scenario: 7-param overload returns split status
+- **WHEN** a consumer calls the 7-param `usage_log_list`
+- **THEN** each returned JSON object includes `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` fields
+
+### Requirement: Historical Data Backfill
+
+The migration SHALL backfill `tinh_trang_ban_dau` from `tinh_trang_thiet_bi` for all existing rows where the new column is NULL, and backfill `tinh_trang_ket_thuc` only for completed sessions (`trang_thai = 'hoan_thanh'`).
+
+#### Scenario: Backfill initial status from legacy
+- **GIVEN** an existing row with `tinh_trang_thiet_bi` populated and `tinh_trang_ban_dau` NULL
+- **WHEN** the migration runs
+- **THEN** `tinh_trang_ban_dau` is set to the legacy `tinh_trang_thiet_bi` value
+
+#### Scenario: Backfill final status for completed sessions
+- **GIVEN** an existing row with `trang_thai = 'hoan_thanh'` and `tinh_trang_thiet_bi` populated and `tinh_trang_ket_thuc` NULL
+- **WHEN** the migration runs
+- **THEN** `tinh_trang_ket_thuc` is set to the legacy `tinh_trang_thiet_bi` value
+
+#### Scenario: Active sessions are not backfilled for final status
+- **GIVEN** an existing row with `trang_thai = 'dang_su_dung'`
+- **WHEN** the migration runs
+- **THEN** `tinh_trang_ket_thuc` remains NULL
+
+### Requirement: Security Hardening for usage_session_end
+
+The `usage_session_end` RPC SHALL have DDL-level `SET search_path = public, pg_temp` and SHALL treat `admin` role equivalently to `global` in tenant bypass guards.
+
+#### Scenario: DDL-level search_path enforced
+- **WHEN** `usage_session_end` is introspected via `pg_proc`
+- **THEN** `proconfig` contains `search_path=public, pg_temp`
+
+#### Scenario: Admin role bypasses tenant guard
+- **WHEN** a user with `app_role = 'admin'` calls `usage_session_end`
+- **THEN** the system does NOT enforce the tenant guard (same as `global` role)

--- a/openspec/changes/add-usage-log-split-status/tasks.md
+++ b/openspec/changes/add-usage-log-split-status/tasks.md
@@ -1,0 +1,77 @@
+## Batch 1: Backend (can deploy independently)
+
+Backend is fully backward-compatible. Old frontend continues working after backend deploy because new RPC params default to NULL → validation skipped → legacy column written as before.
+
+### 1. SQL Smoke Tests (RED)
+
+- [ ] 1.1 Create `supabase/tests/usage_log_split_status_smoke.sql` with assertions:
+  - Columns `tinh_trang_ban_dau`, `tinh_trang_ket_thuc` exist.
+  - `usage_session_start` fails when `p_tinh_trang_ban_dau = ''` (empty string).
+  - `usage_session_start` succeeds and writes `tinh_trang_ban_dau`.
+  - `usage_session_end` fails when `p_tinh_trang_ket_thuc = ''` (empty string).
+  - `usage_session_end` succeeds and writes `tinh_trang_ket_thuc`.
+  - Both `usage_log_list` overloads return the 2 new fields.
+  - `usage_session_end` has DDL-level `search_path = public, pg_temp`.
+  - Backfill: legacy rows populate `tinh_trang_ban_dau`.
+  - Backfill: completed sessions populate `tinh_trang_ket_thuc`.
+  - JSON response of `usage_session_start` includes `tinh_trang_ban_dau`.
+  - JSON response of `usage_session_end` includes `tinh_trang_ket_thuc`.
+  - Backward compat: `usage_session_start` with `p_tinh_trang_ban_dau = NULL` (old caller) does NOT raise exception.
+  - Admin role: `usage_session_end` tenant guard treats `admin` same as `global`.
+- [ ] 1.2 Run smoke test and confirm RED (expected: fail because columns/params don't exist yet).
+
+### 2. Migration (GREEN)
+
+- [ ] 2.1 Create `supabase/migrations/YYYYMMDDHHMMSS_usage_log_split_status_columns.sql` with:
+  - `ALTER TABLE` adding 2 new columns.
+  - Backfill from `tinh_trang_thiet_bi` (approximation for historical data).
+  - Updated `usage_session_start` with new param, validation (skip when NULL, raise when empty), INSERT writing both new + legacy columns, and response.
+  - Updated `usage_session_end` with new param, validation, UPDATE, response, DDL-level `SET search_path`, and fixed admin role guard (`NOT v_is_global`).
+  - Updated both `usage_log_list` overloads projecting 2 new fields.
+  - Proper `GRANT EXECUTE` statements.
+- [ ] 2.2 Run smoke test and confirm GREEN.
+- [ ] 2.3 Run `supabase-get_advisors(type='security')` to verify no regressions.
+
+### 3. Backend Verification
+
+- [ ] 3.1 All SQL smoke tests pass.
+- [ ] 3.2 Security advisors clean.
+- [ ] 3.3 Commit: `feat: add usage log split status columns and RPC updates`
+
+---
+
+## Batch 2: Frontend (deploy after Batch 1 is on production)
+
+Start this batch only after Batch 1 migration is deployed. The pre-requisite refactor and frontend changes depend on the new RPC params being available.
+
+### 4. Pre-requisite Refactor
+
+- [ ] 4.1 Extract HTML builder from `usage-log-print.tsx` into `usage-log-print-html-builder.ts` (file is 491 lines, exceeds 350-line ceiling).
+- [ ] 4.2 Extract CSV builder from `usage-log-print.tsx` into `usage-log-print-csv-builder.ts`.
+- [ ] 4.3 Verify `usage-log-print.tsx` is under 350 lines after extraction; run `typecheck` and focused tests.
+
+### 5. Frontend Tests (RED)
+
+- [ ] 5.1 Create `start-usage-dialog.validation.test.tsx`: block submit when missing initial status; allow when valid.
+- [ ] 5.2 Create `end-usage-dialog.validation.test.tsx`: block submit when missing final status; allow when valid.
+- [ ] 5.3 Create `usage-log-print.columns.test.tsx`: print HTML + CSV include 2 status columns.
+- [ ] 5.4 Run focused tests and confirm RED.
+
+### 6. Frontend Implementation (GREEN)
+
+- [ ] 6.1 Update `database.ts` types: add `tinh_trang_ban_dau?: string | null` and `tinh_trang_ket_thuc?: string | null`.
+- [ ] 6.2 Update `use-usage-logs.ts`: mutation payloads and response parsing for start/end.
+- [ ] 6.3 Update `start-usage-dialog.tsx`: new `tinh_trang_ban_dau` field (free-text + datalist), Zod validation.
+- [ ] 6.4 Update `end-usage-dialog.tsx`: new `tinh_trang_ket_thuc` field (required), Zod validation.
+- [ ] 6.5 Update `usage-history-tab.tsx`: display split status with legacy fallback.
+- [ ] 6.6 Update `usage-log-print.tsx` + extracted builders: 2 status columns in print table and CSV.
+- [ ] 6.7 Run focused tests and confirm GREEN.
+
+### 7. Frontend Verification
+
+- [ ] 7.1 Run `node scripts/npm-run.js run verify:no-explicit-any`
+- [ ] 7.2 Run `node scripts/npm-run.js run typecheck`
+- [ ] 7.3 Run focused tests: `npm test -- --testPathPattern="usage|print"`
+- [ ] 7.4 Run `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
+- [ ] 7.5 Run `openspec validate add-usage-log-split-status --strict`
+- [ ] 7.6 Commit: `feat: add split status UI for usage log sessions`

--- a/openspec/changes/add-usage-log-split-status/tasks.md
+++ b/openspec/changes/add-usage-log-split-status/tasks.md
@@ -4,7 +4,7 @@ Backend is fully backward-compatible. Old frontend continues working after backe
 
 ### 1. SQL Smoke Tests (RED)
 
-- [ ] 1.1 Create `supabase/tests/usage_log_split_status_smoke.sql` with assertions:
+- [x] 1.1 Create `supabase/tests/usage_log_split_status_smoke.sql` with assertions:
   - Columns `tinh_trang_ban_dau`, `tinh_trang_ket_thuc` exist.
   - `usage_session_start` fails when `p_tinh_trang_ban_dau = ''` (empty string).
   - `usage_session_start` succeeds and writes `tinh_trang_ban_dau`.
@@ -19,23 +19,26 @@ Backend is fully backward-compatible. Old frontend continues working after backe
   - Backward compat: `usage_session_start` with `p_tinh_trang_ban_dau = NULL` (old caller) does NOT raise exception.
   - Admin role: `usage_session_end` tenant guard treats `admin` same as `global`.
 - [ ] 1.2 Run smoke test and confirm RED (expected: fail because columns/params don't exist yet).
+  Note: skipped after backend implementation was already in place; later GREEN smoke run was executed against the applied migration instead.
 
 ### 2. Migration (GREEN)
 
-- [ ] 2.1 Create `supabase/migrations/YYYYMMDDHHMMSS_usage_log_split_status_columns.sql` with:
+- [x] 2.1 Create `supabase/migrations/YYYYMMDDHHMMSS_usage_log_split_status_columns.sql` with:
   - `ALTER TABLE` adding 2 new columns.
   - Backfill from `tinh_trang_thiet_bi` (approximation for historical data).
   - Updated `usage_session_start` with new param, validation (skip when NULL, raise when empty), INSERT writing both new + legacy columns, and response.
   - Updated `usage_session_end` with new param, validation, UPDATE, response, DDL-level `SET search_path`, and fixed admin role guard (`NOT v_is_global`).
   - Updated both `usage_log_list` overloads projecting 2 new fields.
   - Proper `GRANT EXECUTE` statements.
-- [ ] 2.2 Run smoke test and confirm GREEN.
-- [ ] 2.3 Run `supabase-get_advisors(type='security')` to verify no regressions.
+- [x] 2.2 Run smoke test and confirm GREEN.
+- [x] 2.3 Run `supabase-get_advisors(type='security')` to verify no regressions.
+  Note: advisor output still contains pre-existing repo-wide findings, but no new lint was introduced for the split-status migration/functions.
 
 ### 3. Backend Verification
 
-- [ ] 3.1 All SQL smoke tests pass.
+- [x] 3.1 All SQL smoke tests pass.
 - [ ] 3.2 Security advisors clean.
+  Note: not clean at project level because the Supabase advisor still reports pre-existing issues outside this change; verification confirmed no new regression tied to the applied migration.
 - [ ] 3.3 Commit: `feat: add usage log split status columns and RPC updates`
 
 ---

--- a/supabase/migrations/20260414130000_usage_log_split_status_columns.sql
+++ b/supabase/migrations/20260414130000_usage_log_split_status_columns.sql
@@ -1,0 +1,408 @@
+-- Migration: usage_log_split_status_columns
+-- Purpose: Split tinh_trang_thiet_bi into tinh_trang_ban_dau + tinh_trang_ket_thuc
+-- Security fixes: usage_session_end DDL search_path + admin role guard
+
+-- =============================================================================
+-- 1. Schema: add new columns
+-- =============================================================================
+
+ALTER TABLE public.nhat_ky_su_dung
+  ADD COLUMN IF NOT EXISTS tinh_trang_ban_dau text,
+  ADD COLUMN IF NOT EXISTS tinh_trang_ket_thuc text;
+
+-- =============================================================================
+-- 2. Backfill from legacy tinh_trang_thiet_bi (approximation for historical data)
+-- =============================================================================
+
+UPDATE public.nhat_ky_su_dung
+SET tinh_trang_ban_dau = tinh_trang_thiet_bi
+WHERE tinh_trang_ban_dau IS NULL
+  AND tinh_trang_thiet_bi IS NOT NULL;
+
+UPDATE public.nhat_ky_su_dung
+SET tinh_trang_ket_thuc = tinh_trang_thiet_bi
+WHERE tinh_trang_ket_thuc IS NULL
+  AND tinh_trang_thiet_bi IS NOT NULL
+  AND trang_thai = 'hoan_thanh';
+
+-- =============================================================================
+-- 3. usage_session_start: add p_tinh_trang_ban_dau param
+--    DROP old signature first to avoid overload ambiguity
+-- =============================================================================
+
+DROP FUNCTION IF EXISTS public.usage_session_start(bigint, bigint, text, text, bigint);
+
+CREATE OR REPLACE FUNCTION public.usage_session_start(
+  p_thiet_bi_id bigint,
+  p_nguoi_su_dung_id bigint DEFAULT NULL::bigint,
+  p_tinh_trang_thiet_bi text DEFAULT NULL::text,
+  p_ghi_chu text DEFAULT NULL::text,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_tinh_trang_ban_dau text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_is_global boolean := false;
+  v_allowed bigint[] := null;
+  v_user_id bigint := nullif(public._get_jwt_claim('user_id'), '')::bigint;
+  v_target_user bigint;
+  v_equipment_don_vi bigint;
+  v_new_id bigint;
+  result jsonb;
+BEGIN
+  v_is_global := v_role in ('global', 'admin');
+
+  if p_thiet_bi_id is null then
+    raise exception 'Equipment ID is required' using errcode = '22023';
+  end if;
+
+  -- Validate new param: NULL = skip (backward compat), empty = reject
+  if p_tinh_trang_ban_dau is not null and trim(p_tinh_trang_ban_dau) = '' then
+    raise exception 'Initial equipment status cannot be empty' using errcode = '22023';
+  end if;
+
+  if v_role = 'regional_leader' then
+    raise exception 'Permission denied' using errcode = '42501';
+  end if;
+
+  if v_user_id is null then
+    raise exception 'Authenticated user required' using errcode = '42501';
+  end if;
+
+  v_target_user := coalesce(p_nguoi_su_dung_id, v_user_id);
+
+  if not (v_is_global or v_role in ('to_qltb', 'technician', 'qltb_khoa'))
+     and v_target_user <> v_user_id then
+    raise exception 'Cannot start session for another user' using errcode = '42501';
+  end if;
+
+  select tb.don_vi into v_equipment_don_vi
+  from public.thiet_bi tb
+  where tb.id = p_thiet_bi_id
+    and tb.is_deleted = false
+  for update;
+
+  if not found then
+    raise exception 'Equipment not found' using errcode = 'P0002';
+  end if;
+
+  if not v_is_global then
+    v_allowed := public.allowed_don_vi_for_session();
+    if v_allowed is null or array_length(v_allowed, 1) is null or not v_equipment_don_vi = any(v_allowed) then
+      raise exception 'Access denied for equipment tenant' using errcode = '42501';
+    end if;
+  else
+    if p_don_vi is not null then
+      v_equipment_don_vi := p_don_vi;
+    end if;
+  end if;
+
+  perform 1
+  from public.nhat_ky_su_dung nk
+  where nk.thiet_bi_id = p_thiet_bi_id
+    and nk.trang_thai = 'dang_su_dung';
+
+  if found then
+    raise exception 'Thiết bị đang được sử dụng bởi người khác' using errcode = 'P0001';
+  end if;
+
+  insert into public.nhat_ky_su_dung (
+    thiet_bi_id,
+    nguoi_su_dung_id,
+    thoi_gian_bat_dau,
+    tinh_trang_thiet_bi,
+    tinh_trang_ban_dau,
+    ghi_chu,
+    trang_thai,
+    created_at,
+    updated_at
+  )
+  values (
+    p_thiet_bi_id,
+    v_target_user,
+    timezone('utc', now()),
+    coalesce(p_tinh_trang_ban_dau, p_tinh_trang_thiet_bi),
+    p_tinh_trang_ban_dau,
+    p_ghi_chu,
+    'dang_su_dung',
+    timezone('utc', now()),
+    timezone('utc', now())
+  )
+  returning id into v_new_id;
+
+  select jsonb_build_object(
+    'id', nk.id,
+    'thiet_bi_id', nk.thiet_bi_id,
+    'nguoi_su_dung_id', nk.nguoi_su_dung_id,
+    'thoi_gian_bat_dau', nk.thoi_gian_bat_dau,
+    'thoi_gian_ket_thuc', nk.thoi_gian_ket_thuc,
+    'tinh_trang_thiet_bi', nk.tinh_trang_thiet_bi,
+    'tinh_trang_ban_dau', nk.tinh_trang_ban_dau,
+    'tinh_trang_ket_thuc', nk.tinh_trang_ket_thuc,
+    'ghi_chu', nk.ghi_chu,
+    'trang_thai', nk.trang_thai,
+    'created_at', nk.created_at,
+    'updated_at', nk.updated_at,
+    'thiet_bi', jsonb_build_object(
+      'id', tb.id,
+      'ma_thiet_bi', tb.ma_thiet_bi,
+      'ten_thiet_bi', tb.ten_thiet_bi,
+      'khoa_phong_quan_ly', tb.khoa_phong_quan_ly,
+      'don_vi', tb.don_vi
+    ),
+    'nguoi_su_dung', case
+      when nv.id is not null then jsonb_build_object(
+        'id', nv.id,
+        'full_name', nv.full_name,
+        'khoa_phong', nv.khoa_phong
+      )
+      else null
+    end
+  )
+  into result
+  from public.nhat_ky_su_dung nk
+  join public.thiet_bi tb on tb.id = nk.thiet_bi_id
+  left join public.nhan_vien nv on nv.id = nk.nguoi_su_dung_id
+  where nk.id = v_new_id;
+
+  return result;
+END;
+$function$;
+
+-- =============================================================================
+-- 4. usage_session_end: add p_tinh_trang_ket_thuc + fix search_path + admin guard
+--    DROP old signature first to avoid overload ambiguity
+-- =============================================================================
+
+DROP FUNCTION IF EXISTS public.usage_session_end(bigint, text, text, bigint);
+
+CREATE OR REPLACE FUNCTION public.usage_session_end(
+  p_usage_log_id bigint,
+  p_tinh_trang_thiet_bi text DEFAULT NULL::text,
+  p_ghi_chu text DEFAULT NULL::text,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_tinh_trang_ket_thuc text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_is_global boolean := false;
+  v_allowed bigint[] := public.allowed_don_vi_for_session();
+  v_user_id bigint := nullif(public._get_jwt_claim('user_id'), '')::bigint;
+  rec record;
+  result jsonb;
+BEGIN
+  v_is_global := v_role in ('global', 'admin');
+
+  if p_usage_log_id is null then
+    raise exception 'Usage log ID is required' using errcode = '22023';
+  end if;
+
+  -- Validate new param: NULL = skip (backward compat), empty = reject
+  if p_tinh_trang_ket_thuc is not null and trim(p_tinh_trang_ket_thuc) = '' then
+    raise exception 'Final equipment status cannot be empty' using errcode = '22023';
+  end if;
+
+  if v_role = 'regional_leader' then
+    raise exception 'Permission denied' using errcode = '42501';
+  end if;
+
+  select nk.*, tb.don_vi as equipment_don_vi
+  into rec
+  from public.nhat_ky_su_dung nk
+  join public.thiet_bi tb on tb.id = nk.thiet_bi_id
+  where nk.id = p_usage_log_id
+  for update;
+
+  if not found then
+    raise exception 'Usage session not found' using errcode = 'P0002';
+  end if;
+
+  if rec.trang_thai != 'dang_su_dung' then
+    raise exception 'Usage session already closed' using errcode = 'P0001';
+  end if;
+
+  -- FIX: use v_is_global instead of v_role <> 'global' (includes admin)
+  if not v_is_global then
+    if v_allowed is null or array_length(v_allowed, 1) is null or not rec.equipment_don_vi = any(v_allowed) then
+      raise exception 'Access denied for equipment tenant' using errcode = '42501';
+    end if;
+  else
+    if p_don_vi is not null then
+      rec.equipment_don_vi := p_don_vi;
+    end if;
+  end if;
+
+  if v_role in ('user', 'qltb_khoa') and rec.nguoi_su_dung_id is distinct from v_user_id then
+    raise exception 'Cannot close session for another user' using errcode = '42501';
+  end if;
+
+  update public.nhat_ky_su_dung
+  set thoi_gian_ket_thuc = timezone('utc', now()),
+      tinh_trang_thiet_bi = coalesce(p_tinh_trang_ket_thuc, p_tinh_trang_thiet_bi, rec.tinh_trang_thiet_bi),
+      tinh_trang_ket_thuc = p_tinh_trang_ket_thuc,
+      ghi_chu = coalesce(p_ghi_chu, rec.ghi_chu),
+      trang_thai = 'hoan_thanh',
+      updated_at = timezone('utc', now())
+  where id = p_usage_log_id;
+
+  select jsonb_build_object(
+    'id', nk.id,
+    'thiet_bi_id', nk.thiet_bi_id,
+    'nguoi_su_dung_id', nk.nguoi_su_dung_id,
+    'thoi_gian_bat_dau', nk.thoi_gian_bat_dau,
+    'thoi_gian_ket_thuc', nk.thoi_gian_ket_thuc,
+    'tinh_trang_thiet_bi', nk.tinh_trang_thiet_bi,
+    'tinh_trang_ban_dau', nk.tinh_trang_ban_dau,
+    'tinh_trang_ket_thuc', nk.tinh_trang_ket_thuc,
+    'ghi_chu', nk.ghi_chu,
+    'trang_thai', nk.trang_thai,
+    'created_at', nk.created_at,
+    'updated_at', nk.updated_at,
+    'thiet_bi', jsonb_build_object(
+      'id', tb.id,
+      'ma_thiet_bi', tb.ma_thiet_bi,
+      'ten_thiet_bi', tb.ten_thiet_bi,
+      'khoa_phong_quan_ly', tb.khoa_phong_quan_ly,
+      'don_vi', tb.don_vi
+    ),
+    'nguoi_su_dung', case
+      when nv.id is not null then jsonb_build_object(
+        'id', nv.id,
+        'full_name', nv.full_name,
+        'khoa_phong', nv.khoa_phong
+      )
+      else null
+    end
+  )
+  into result
+  from public.nhat_ky_su_dung nk
+  join public.thiet_bi tb on tb.id = nk.thiet_bi_id
+  left join public.nhan_vien nv on nv.id = nk.nguoi_su_dung_id
+  where nk.id = p_usage_log_id;
+
+  return result;
+END;
+$function$;
+
+-- =============================================================================
+-- 5. usage_log_list (8-param): add new fields to JSON projection
+--    Signature unchanged - CREATE OR REPLACE is safe
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.usage_log_list(
+  p_thiet_bi_id bigint DEFAULT NULL::bigint,
+  p_trang_thai text DEFAULT NULL::text,
+  p_active_only boolean DEFAULT false,
+  p_started_from timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_started_to timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_limit integer DEFAULT 200,
+  p_offset integer DEFAULT 0,
+  p_don_vi bigint DEFAULT NULL::bigint
+)
+RETURNS SETOF jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_is_global BOOLEAN := false;
+  v_allowed BIGINT[] := public.allowed_don_vi_for_session();
+  v_effective BIGINT[] := NULL;
+  v_limit INT := GREATEST(p_limit, 1);
+  v_offset INT := GREATEST(p_offset, 0);
+BEGIN
+  v_is_global := v_role IN ('global', 'admin');
+
+  PERFORM set_config('search_path', 'public', true);
+
+  IF p_trang_thai IS NOT NULL AND p_trang_thai NOT IN ('dang_su_dung', 'hoan_thanh') THEN
+    RAISE EXCEPTION 'Invalid status filter' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_is_global THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    END IF;
+  ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN;
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF NOT p_don_vi = ANY(v_allowed) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'id', nk.id,
+    'thiet_bi_id', nk.thiet_bi_id,
+    'nguoi_su_dung_id', nk.nguoi_su_dung_id,
+    'thoi_gian_bat_dau', nk.thoi_gian_bat_dau,
+    'thoi_gian_ket_thuc', nk.thoi_gian_ket_thuc,
+    'tinh_trang_thiet_bi', nk.tinh_trang_thiet_bi,
+    'tinh_trang_ban_dau', nk.tinh_trang_ban_dau,
+    'tinh_trang_ket_thuc', nk.tinh_trang_ket_thuc,
+    'ghi_chu', nk.ghi_chu,
+    'trang_thai', nk.trang_thai,
+    'created_at', nk.created_at,
+    'updated_at', nk.updated_at,
+    'equipment_is_deleted', tb.is_deleted,
+    'thiet_bi', jsonb_build_object(
+      'id', tb.id,
+      'ma_thiet_bi', tb.ma_thiet_bi,
+      'ten_thiet_bi', tb.ten_thiet_bi,
+      'khoa_phong_quan_ly', tb.khoa_phong_quan_ly,
+      'don_vi', tb.don_vi,
+      'is_deleted', tb.is_deleted
+    ),
+    'nguoi_su_dung', CASE
+      WHEN nv.id IS NOT NULL THEN jsonb_build_object(
+        'id', nv.id,
+        'full_name', nv.full_name,
+        'khoa_phong', nv.khoa_phong
+      )
+      ELSE NULL
+    END
+  )
+  FROM public.nhat_ky_su_dung nk
+  LEFT JOIN public.thiet_bi tb ON tb.id = nk.thiet_bi_id
+  LEFT JOIN public.nhan_vien nv ON nv.id = nk.nguoi_su_dung_id
+  WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+    AND (p_thiet_bi_id IS NULL OR nk.thiet_bi_id = p_thiet_bi_id)
+    AND (NOT p_active_only OR nk.trang_thai = 'dang_su_dung')
+    AND (p_trang_thai IS NULL OR nk.trang_thai = p_trang_thai)
+    AND (p_started_from IS NULL OR nk.thoi_gian_bat_dau >= p_started_from)
+    AND (p_started_to IS NULL OR nk.thoi_gian_bat_dau <= p_started_to)
+  ORDER BY nk.thoi_gian_bat_dau DESC
+  OFFSET v_offset
+  LIMIT v_limit;
+END;
+$function$;
+
+-- NOTE: The 7-param usage_log_list overload uses to_jsonb(nk)
+-- which auto-includes all columns. No code change needed for it.
+
+-- =============================================================================
+-- 6. Grant execute on updated functions
+-- =============================================================================
+
+GRANT EXECUTE ON FUNCTION public.usage_session_start(bigint, bigint, text, text, bigint, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.usage_session_end(bigint, text, text, bigint, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.usage_log_list(bigint, text, boolean, timestamptz, timestamptz, integer, integer, bigint) TO authenticated;

--- a/supabase/migrations/20260414130000_usage_log_split_status_columns.sql
+++ b/supabase/migrations/20260414130000_usage_log_split_status_columns.sql
@@ -1,6 +1,18 @@
 -- Migration: usage_log_split_status_columns
 -- Purpose: Split tinh_trang_thiet_bi into tinh_trang_ban_dau + tinh_trang_ket_thuc
 -- Security fixes: usage_session_end DDL search_path + admin role guard
+-- Rollback note (forward-only): restore prior RPC bodies from
+--   - 20260219032645_fix_workflow_guard_security_and_race.sql (usage_session_start)
+--   - 20250927_usage_log_rpcs.sql (usage_session_end)
+--   - 20260213100500_equipment_soft_delete_historical_read_policy.sql
+--     plus 20260216141000_fix_report_and_historical_rpc_security_and_types.sql
+--     (usage_log_list hardening)
+-- Reverse the function definitions before touching the split-status columns.
+-- Dropping tinh_trang_ban_dau / tinh_trang_ket_thuc, or removing legacy
+-- tinh_trang_thiet_bi, is only safe before production data is written into the
+-- new columns.
+
+BEGIN;
 
 -- =============================================================================
 -- 1. Schema: add new columns
@@ -216,6 +228,14 @@ BEGIN
     raise exception 'Permission denied' using errcode = '42501';
   end if;
 
+  if v_role is null or v_role = '' then
+    raise exception 'Missing role claim' using errcode = '42501';
+  end if;
+
+  if v_user_id is null then
+    raise exception 'Missing user_id claim' using errcode = '42501';
+  end if;
+
   select nk.*, tb.don_vi as equipment_don_vi
   into rec
   from public.nhat_ky_su_dung nk
@@ -324,8 +344,6 @@ DECLARE
 BEGIN
   v_is_global := v_role IN ('global', 'admin');
 
-  PERFORM set_config('search_path', 'public', true);
-
   IF p_trang_thai IS NOT NULL AND p_trang_thai NOT IN ('dang_su_dung', 'hoan_thanh') THEN
     RAISE EXCEPTION 'Invalid status filter' USING ERRCODE = '22023';
   END IF;
@@ -406,3 +424,9 @@ $function$;
 GRANT EXECUTE ON FUNCTION public.usage_session_start(bigint, bigint, text, text, bigint, text) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.usage_session_end(bigint, text, text, bigint, text) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.usage_log_list(bigint, text, boolean, timestamptz, timestamptz, integer, integer, bigint) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.usage_session_start(bigint, bigint, text, text, bigint, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.usage_session_end(bigint, text, text, bigint, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.usage_log_list(bigint, text, boolean, timestamptz, timestamptz, integer, integer, bigint) FROM PUBLIC;
+
+COMMIT;

--- a/supabase/migrations/20260414130000_usage_log_split_status_columns.sql
+++ b/supabase/migrations/20260414130000_usage_log_split_status_columns.sql
@@ -69,6 +69,10 @@ DECLARE
 BEGIN
   v_is_global := v_role in ('global', 'admin');
 
+  if v_role is null or v_role = '' then
+    raise exception 'Missing role claim' using errcode = '42501';
+  end if;
+
   if p_thiet_bi_id is null then
     raise exception 'Equipment ID is required' using errcode = '22023';
   end if;

--- a/supabase/migrations/20260415040000_fix_usage_session_end_admin_guard.sql
+++ b/supabase/migrations/20260415040000_fix_usage_session_end_admin_guard.sql
@@ -1,0 +1,131 @@
+-- Fix usage_session_end admin/global bypass to avoid eager tenant-scope resolution
+-- The split-status migration left v_allowed initialized from allowed_don_vi_for_session()
+-- in the DECLARE block. Raw admin JWTs without don_vi can fail there before the
+-- function body reaches the v_is_global bypass branch.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.usage_session_end(
+  p_usage_log_id bigint,
+  p_tinh_trang_thiet_bi text DEFAULT NULL::text,
+  p_ghi_chu text DEFAULT NULL::text,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_tinh_trang_ket_thuc text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_is_global boolean := false;
+  v_allowed bigint[] := null;
+  v_user_id bigint := nullif(public._get_jwt_claim('user_id'), '')::bigint;
+  rec record;
+  result jsonb;
+BEGIN
+  v_is_global := v_role in ('global', 'admin');
+
+  if p_usage_log_id is null then
+    raise exception 'Usage log ID is required' using errcode = '22023';
+  end if;
+
+  if p_tinh_trang_ket_thuc is not null and trim(p_tinh_trang_ket_thuc) = '' then
+    raise exception 'Final equipment status cannot be empty' using errcode = '22023';
+  end if;
+
+  if v_role = 'regional_leader' then
+    raise exception 'Permission denied' using errcode = '42501';
+  end if;
+
+  if v_role is null or v_role = '' then
+    raise exception 'Missing role claim' using errcode = '42501';
+  end if;
+
+  if v_user_id is null then
+    raise exception 'Missing user_id claim' using errcode = '42501';
+  end if;
+
+  select nk.*, tb.don_vi as equipment_don_vi
+  into rec
+  from public.nhat_ky_su_dung nk
+  join public.thiet_bi tb on tb.id = nk.thiet_bi_id
+  where nk.id = p_usage_log_id
+  for update;
+
+  if not found then
+    raise exception 'Usage session not found' using errcode = 'P0002';
+  end if;
+
+  if rec.trang_thai != 'dang_su_dung' then
+    raise exception 'Usage session already closed' using errcode = 'P0001';
+  end if;
+
+  if not v_is_global then
+    v_allowed := public.allowed_don_vi_for_session();
+    if v_allowed is null or array_length(v_allowed, 1) is null or not rec.equipment_don_vi = any(v_allowed) then
+      raise exception 'Access denied for equipment tenant' using errcode = '42501';
+    end if;
+  else
+    if p_don_vi is not null then
+      rec.equipment_don_vi := p_don_vi;
+    end if;
+  end if;
+
+  if v_role in ('user', 'qltb_khoa') and rec.nguoi_su_dung_id is distinct from v_user_id then
+    raise exception 'Cannot close session for another user' using errcode = '42501';
+  end if;
+
+  update public.nhat_ky_su_dung
+  set thoi_gian_ket_thuc = timezone('utc', now()),
+      tinh_trang_thiet_bi = coalesce(p_tinh_trang_ket_thuc, p_tinh_trang_thiet_bi, rec.tinh_trang_thiet_bi),
+      tinh_trang_ket_thuc = p_tinh_trang_ket_thuc,
+      ghi_chu = coalesce(p_ghi_chu, rec.ghi_chu),
+      trang_thai = 'hoan_thanh',
+      updated_at = timezone('utc', now())
+  where id = p_usage_log_id;
+
+  select jsonb_build_object(
+    'id', nk.id,
+    'thiet_bi_id', nk.thiet_bi_id,
+    'nguoi_su_dung_id', nk.nguoi_su_dung_id,
+    'thoi_gian_bat_dau', nk.thoi_gian_bat_dau,
+    'thoi_gian_ket_thuc', nk.thoi_gian_ket_thuc,
+    'tinh_trang_thiet_bi', nk.tinh_trang_thiet_bi,
+    'tinh_trang_ban_dau', nk.tinh_trang_ban_dau,
+    'tinh_trang_ket_thuc', nk.tinh_trang_ket_thuc,
+    'ghi_chu', nk.ghi_chu,
+    'trang_thai', nk.trang_thai,
+    'created_at', nk.created_at,
+    'updated_at', nk.updated_at,
+    'thiet_bi', jsonb_build_object(
+      'id', tb.id,
+      'ma_thiet_bi', tb.ma_thiet_bi,
+      'ten_thiet_bi', tb.ten_thiet_bi,
+      'khoa_phong_quan_ly', tb.khoa_phong_quan_ly,
+      'don_vi', tb.don_vi
+    ),
+    'nguoi_su_dung', case
+      when nv.id is not null then jsonb_build_object(
+        'id', nv.id,
+        'full_name', nv.full_name,
+        'khoa_phong', nv.khoa_phong
+      )
+      else null
+    end
+  )
+  into result
+  from public.nhat_ky_su_dung nk
+  join public.thiet_bi tb on tb.id = nk.thiet_bi_id
+  left join public.nhan_vien nv on nv.id = nk.nguoi_su_dung_id
+  where nk.id = p_usage_log_id;
+
+  return result;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.usage_session_end(bigint, text, text, bigint, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.usage_session_end(bigint, text, text, bigint, text) FROM PUBLIC;
+
+COMMIT;

--- a/supabase/tests/usage_log_split_status_smoke.sql
+++ b/supabase/tests/usage_log_split_status_smoke.sql
@@ -1,0 +1,545 @@
+-- supabase/tests/usage_log_split_status_smoke.sql
+-- Purpose: validate split status columns, RPC params, backward compat, security fixes
+-- How to run: docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/usage_log_split_status_smoke.sql
+-- Non-destructive: wrapped in transaction and rolled back
+
+BEGIN;
+
+-- 1) Schema: columns tinh_trang_ban_dau and tinh_trang_ket_thuc exist
+DO $$
+DECLARE
+  v_count int;
+BEGIN
+  SELECT COUNT(*)
+  INTO v_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'nhat_ky_su_dung'
+    AND column_name IN ('tinh_trang_ban_dau', 'tinh_trang_ket_thuc');
+
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'Expected 2 new columns (tinh_trang_ban_dau, tinh_trang_ket_thuc), found %', v_count;
+  END IF;
+
+  RAISE NOTICE 'OK: schema columns exist';
+END $$;
+
+-- 2) usage_session_start: happy path with p_tinh_trang_ban_dau
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'UL-SPLIT-START-HP-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_result jsonb;
+  v_row record;
+BEGIN
+  SELECT id INTO v_tenant
+  FROM public.don_vi WHERE active = true
+  ORDER BY id LIMIT 1;
+
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'No active tenant found';
+  END IF;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (v_code, 'smoke', 'Split Start HP', 'to_qltb', v_tenant, v_tenant)
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (v_code, 'Split start happy path', v_tenant)
+  RETURNING id INTO v_thiet_bi_id;
+
+  PERFORM set_config('request.jwt.claims', json_build_object(
+    'app_role', 'to_qltb', 'role', 'authenticated',
+    'user_id', v_user_id::text, 'sub', v_user_id::text,
+    'don_vi', v_tenant::text
+  )::text, true);
+
+  v_result := public.usage_session_start(
+    p_thiet_bi_id := v_thiet_bi_id,
+    p_nguoi_su_dung_id := v_user_id,
+    p_tinh_trang_ban_dau := 'Hoạt động tốt',
+    p_ghi_chu := 'smoke test'
+  );
+
+  -- JSON response must include tinh_trang_ban_dau
+  IF v_result->>'tinh_trang_ban_dau' IS DISTINCT FROM 'Hoạt động tốt' THEN
+    RAISE EXCEPTION 'JSON response tinh_trang_ban_dau mismatch: %', v_result->>'tinh_trang_ban_dau';
+  END IF;
+
+  -- DB row must have tinh_trang_ban_dau written
+  SELECT tinh_trang_ban_dau, tinh_trang_thiet_bi
+  INTO v_row
+  FROM public.nhat_ky_su_dung
+  WHERE id = (v_result->>'id')::bigint;
+
+  IF v_row.tinh_trang_ban_dau IS DISTINCT FROM 'Hoạt động tốt' THEN
+    RAISE EXCEPTION 'DB tinh_trang_ban_dau mismatch: %', v_row.tinh_trang_ban_dau;
+  END IF;
+
+  -- Legacy column should also be written (backward compat for reads)
+  IF v_row.tinh_trang_thiet_bi IS DISTINCT FROM 'Hoạt động tốt' THEN
+    RAISE EXCEPTION 'Legacy tinh_trang_thiet_bi not written: %', v_row.tinh_trang_thiet_bi;
+  END IF;
+
+  RAISE NOTICE 'OK: usage_session_start happy path passed';
+END $$;
+
+-- 3) usage_session_start: backward compat — NULL param, no exception
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'UL-SPLIT-START-BC-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_result jsonb;
+  v_row record;
+BEGIN
+  SELECT id INTO v_tenant
+  FROM public.don_vi WHERE active = true
+  ORDER BY id LIMIT 1;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (v_code, 'smoke', 'Split Start BC', 'to_qltb', v_tenant, v_tenant)
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (v_code, 'Split start backward compat', v_tenant)
+  RETURNING id INTO v_thiet_bi_id;
+
+  PERFORM set_config('request.jwt.claims', json_build_object(
+    'app_role', 'to_qltb', 'role', 'authenticated',
+    'user_id', v_user_id::text, 'sub', v_user_id::text,
+    'don_vi', v_tenant::text
+  )::text, true);
+
+  -- Old caller: does NOT send p_tinh_trang_ban_dau at all
+  v_result := public.usage_session_start(
+    p_thiet_bi_id := v_thiet_bi_id,
+    p_nguoi_su_dung_id := v_user_id,
+    p_tinh_trang_thiet_bi := 'Hoạt động',
+    p_ghi_chu := 'old caller smoke'
+  );
+
+  -- Should NOT raise exception (we got here = success)
+
+  -- DB: tinh_trang_ban_dau should be NULL, legacy should be written
+  SELECT tinh_trang_ban_dau, tinh_trang_thiet_bi
+  INTO v_row
+  FROM public.nhat_ky_su_dung
+  WHERE id = (v_result->>'id')::bigint;
+
+  IF v_row.tinh_trang_ban_dau IS NOT NULL THEN
+    RAISE EXCEPTION 'Backward compat: tinh_trang_ban_dau should be NULL for old caller, got %', v_row.tinh_trang_ban_dau;
+  END IF;
+
+  IF v_row.tinh_trang_thiet_bi IS DISTINCT FROM 'Hoạt động' THEN
+    RAISE EXCEPTION 'Backward compat: legacy column not written: %', v_row.tinh_trang_thiet_bi;
+  END IF;
+
+  RAISE NOTICE 'OK: usage_session_start backward compat passed';
+END $$;
+
+-- 4) usage_session_start: empty string rejected
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'UL-SPLIT-START-VAL-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_error_raised boolean := false;
+BEGIN
+  SELECT id INTO v_tenant
+  FROM public.don_vi WHERE active = true
+  ORDER BY id LIMIT 1;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (v_code, 'smoke', 'Split Start Val', 'to_qltb', v_tenant, v_tenant)
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (v_code, 'Split start validation', v_tenant)
+  RETURNING id INTO v_thiet_bi_id;
+
+  PERFORM set_config('request.jwt.claims', json_build_object(
+    'app_role', 'to_qltb', 'role', 'authenticated',
+    'user_id', v_user_id::text, 'sub', v_user_id::text,
+    'don_vi', v_tenant::text
+  )::text, true);
+
+  BEGIN
+    PERFORM public.usage_session_start(
+      p_thiet_bi_id := v_thiet_bi_id,
+      p_nguoi_su_dung_id := v_user_id,
+      p_tinh_trang_ban_dau := '',
+      p_ghi_chu := 'should fail'
+    );
+  EXCEPTION
+    WHEN SQLSTATE '22023' THEN
+      v_error_raised := true;
+  END;
+
+  IF NOT v_error_raised THEN
+    RAISE EXCEPTION 'Expected empty p_tinh_trang_ban_dau to raise 22023';
+  END IF;
+
+  RAISE NOTICE 'OK: usage_session_start empty string rejected';
+END $$;
+
+-- 5) usage_session_end: happy path with p_tinh_trang_ket_thuc + DDL search_path
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'UL-SPLIT-END-HP-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_start_result jsonb;
+  v_end_result jsonb;
+  v_log_id bigint;
+  v_row record;
+  v_proconfig text[];
+BEGIN
+  SELECT id INTO v_tenant
+  FROM public.don_vi WHERE active = true
+  ORDER BY id LIMIT 1;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (v_code, 'smoke', 'Split End HP', 'to_qltb', v_tenant, v_tenant)
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (v_code, 'Split end happy path', v_tenant)
+  RETURNING id INTO v_thiet_bi_id;
+
+  PERFORM set_config('request.jwt.claims', json_build_object(
+    'app_role', 'to_qltb', 'role', 'authenticated',
+    'user_id', v_user_id::text, 'sub', v_user_id::text,
+    'don_vi', v_tenant::text
+  )::text, true);
+
+  -- Start a session first
+  v_start_result := public.usage_session_start(
+    p_thiet_bi_id := v_thiet_bi_id,
+    p_nguoi_su_dung_id := v_user_id,
+    p_tinh_trang_ban_dau := 'Bình thường'
+  );
+  v_log_id := (v_start_result->>'id')::bigint;
+
+  -- End with p_tinh_trang_ket_thuc
+  v_end_result := public.usage_session_end(
+    p_usage_log_id := v_log_id,
+    p_tinh_trang_ket_thuc := 'Hư hỏng nhẹ'
+  );
+
+  -- JSON response must include tinh_trang_ket_thuc
+  IF v_end_result->>'tinh_trang_ket_thuc' IS DISTINCT FROM 'Hư hỏng nhẹ' THEN
+    RAISE EXCEPTION 'End JSON tinh_trang_ket_thuc mismatch: %', v_end_result->>'tinh_trang_ket_thuc';
+  END IF;
+
+  -- JSON response must include tinh_trang_ban_dau (from start)
+  IF v_end_result->>'tinh_trang_ban_dau' IS DISTINCT FROM 'Bình thường' THEN
+    RAISE EXCEPTION 'End JSON tinh_trang_ban_dau mismatch: %', v_end_result->>'tinh_trang_ban_dau';
+  END IF;
+
+  -- DB row verification
+  SELECT tinh_trang_ban_dau, tinh_trang_ket_thuc, tinh_trang_thiet_bi, trang_thai
+  INTO v_row
+  FROM public.nhat_ky_su_dung WHERE id = v_log_id;
+
+  IF v_row.tinh_trang_ket_thuc IS DISTINCT FROM 'Hư hỏng nhẹ' THEN
+    RAISE EXCEPTION 'DB tinh_trang_ket_thuc mismatch: %', v_row.tinh_trang_ket_thuc;
+  END IF;
+
+  IF v_row.trang_thai IS DISTINCT FROM 'hoan_thanh' THEN
+    RAISE EXCEPTION 'Session should be completed, got %', v_row.trang_thai;
+  END IF;
+
+  -- Legacy column should be written with end status for backward readers
+  IF v_row.tinh_trang_thiet_bi IS DISTINCT FROM 'Hư hỏng nhẹ' THEN
+    RAISE EXCEPTION 'Legacy tinh_trang_thiet_bi not updated: %', v_row.tinh_trang_thiet_bi;
+  END IF;
+
+  -- DDL-level search_path must be set (not just body-level set_config)
+  SELECT p.proconfig
+  INTO v_proconfig
+  FROM pg_catalog.pg_proc p
+  JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'usage_session_end'
+  LIMIT 1;
+
+  IF v_proconfig IS NULL OR NOT EXISTS (
+    SELECT 1 FROM unnest(v_proconfig) c WHERE c ILIKE '%search_path%'
+  ) THEN
+    RAISE EXCEPTION 'usage_session_end missing DDL-level search_path, proconfig = %', v_proconfig;
+  END IF;
+
+  RAISE NOTICE 'OK: usage_session_end happy path + DDL search_path passed';
+END $$;
+
+-- 6) usage_session_end: admin role should bypass tenant guard (same as global)
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'UL-SPLIT-END-ADM-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_start_result jsonb;
+  v_end_result jsonb;
+  v_log_id bigint;
+BEGIN
+  SELECT id INTO v_tenant
+  FROM public.don_vi WHERE active = true
+  ORDER BY id LIMIT 1;
+
+  -- Pick a different tenant for the admin user to prove cross-tenant access
+  SELECT id INTO v_other_tenant
+  FROM public.don_vi WHERE active = true AND id <> v_tenant
+  ORDER BY id LIMIT 1;
+
+  -- If only one tenant exists, use same tenant (still tests admin path)
+  IF v_other_tenant IS NULL THEN
+    v_other_tenant := v_tenant;
+  END IF;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (v_code, 'smoke', 'Split End Admin', 'to_qltb', v_tenant, v_tenant)
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (v_code, 'Split end admin test', v_tenant)
+  RETURNING id INTO v_thiet_bi_id;
+
+  -- Start session as to_qltb (valid tenant)
+  PERFORM set_config('request.jwt.claims', json_build_object(
+    'app_role', 'to_qltb', 'role', 'authenticated',
+    'user_id', v_user_id::text, 'sub', v_user_id::text,
+    'don_vi', v_tenant::text
+  )::text, true);
+
+  v_start_result := public.usage_session_start(
+    p_thiet_bi_id := v_thiet_bi_id,
+    p_nguoi_su_dung_id := v_user_id,
+    p_tinh_trang_ban_dau := 'OK'
+  );
+  v_log_id := (v_start_result->>'id')::bigint;
+
+  -- Switch to admin role (different tenant) — should still be able to end session
+  PERFORM set_config('request.jwt.claims', json_build_object(
+    'app_role', 'admin', 'role', 'authenticated',
+    'user_id', v_user_id::text, 'sub', v_user_id::text,
+    'don_vi', v_other_tenant::text
+  )::text, true);
+
+  v_end_result := public.usage_session_end(
+    p_usage_log_id := v_log_id,
+    p_tinh_trang_ket_thuc := 'OK sau sử dụng'
+  );
+
+  -- If we reach here without exception, admin bypassed tenant guard
+  IF v_end_result->>'trang_thai' IS DISTINCT FROM 'hoan_thanh' THEN
+    RAISE EXCEPTION 'Admin end session should succeed, got trang_thai=%', v_end_result->>'trang_thai';
+  END IF;
+
+  RAISE NOTICE 'OK: usage_session_end admin role guard bypass passed';
+END $$;
+
+-- 7) usage_log_list: both overloads return tinh_trang_ban_dau + tinh_trang_ket_thuc
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'UL-SPLIT-LIST-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_start_result jsonb;
+  v_log_id bigint;
+  v_row_8p jsonb;
+  v_row_7p jsonb;
+BEGIN
+  SELECT id INTO v_tenant
+  FROM public.don_vi WHERE active = true
+  ORDER BY id LIMIT 1;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (v_code, 'smoke', 'Split List Test', 'to_qltb', v_tenant, v_tenant)
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (v_code, 'Split list test equip', v_tenant)
+  RETURNING id INTO v_thiet_bi_id;
+
+  PERFORM set_config('request.jwt.claims', json_build_object(
+    'app_role', 'to_qltb', 'role', 'authenticated',
+    'user_id', v_user_id::text, 'sub', v_user_id::text,
+    'don_vi', v_tenant::text
+  )::text, true);
+
+  v_start_result := public.usage_session_start(
+    p_thiet_bi_id := v_thiet_bi_id,
+    p_nguoi_su_dung_id := v_user_id,
+    p_tinh_trang_ban_dau := 'Tốt'
+  );
+  v_log_id := (v_start_result->>'id')::bigint;
+
+  -- End session to populate tinh_trang_ket_thuc
+  PERFORM public.usage_session_end(
+    p_usage_log_id := v_log_id,
+    p_tinh_trang_ket_thuc := 'Vẫn tốt'
+  );
+
+  -- 8-param overload
+  SELECT r INTO v_row_8p
+  FROM public.usage_log_list(
+    p_thiet_bi_id := v_thiet_bi_id,
+    p_limit := 1
+  ) r
+  LIMIT 1;
+
+  IF v_row_8p IS NULL THEN
+    RAISE EXCEPTION '8-param usage_log_list returned no rows';
+  END IF;
+
+  IF NOT v_row_8p ? 'tinh_trang_ban_dau' THEN
+    RAISE EXCEPTION '8-param overload missing tinh_trang_ban_dau key';
+  END IF;
+
+  IF NOT v_row_8p ? 'tinh_trang_ket_thuc' THEN
+    RAISE EXCEPTION '8-param overload missing tinh_trang_ket_thuc key';
+  END IF;
+
+  IF v_row_8p->>'tinh_trang_ban_dau' IS DISTINCT FROM 'Tốt' THEN
+    RAISE EXCEPTION '8-param tinh_trang_ban_dau value mismatch: %', v_row_8p->>'tinh_trang_ban_dau';
+  END IF;
+
+  IF v_row_8p->>'tinh_trang_ket_thuc' IS DISTINCT FROM 'Vẫn tốt' THEN
+    RAISE EXCEPTION '8-param tinh_trang_ket_thuc value mismatch: %', v_row_8p->>'tinh_trang_ket_thuc';
+  END IF;
+
+  -- 7-param overload (uses to_jsonb → auto-includes new columns)
+  SELECT r INTO v_row_7p
+  FROM public.usage_log_list(
+    p_q := v_code,
+    p_page := 1,
+    p_page_size := 1
+  ) r
+  LIMIT 1;
+
+  IF v_row_7p IS NULL THEN
+    RAISE EXCEPTION '7-param usage_log_list returned no rows';
+  END IF;
+
+  IF NOT v_row_7p ? 'tinh_trang_ban_dau' THEN
+    RAISE EXCEPTION '7-param overload missing tinh_trang_ban_dau key';
+  END IF;
+
+  IF NOT v_row_7p ? 'tinh_trang_ket_thuc' THEN
+    RAISE EXCEPTION '7-param overload missing tinh_trang_ket_thuc key';
+  END IF;
+
+  IF v_row_7p->>'tinh_trang_ban_dau' IS DISTINCT FROM 'Tốt' THEN
+    RAISE EXCEPTION '7-param tinh_trang_ban_dau value mismatch: %', v_row_7p->>'tinh_trang_ban_dau';
+  END IF;
+
+  RAISE NOTICE 'OK: usage_log_list both overloads return split status fields';
+END $$;
+
+-- 8) Backfill: legacy tinh_trang_thiet_bi → new columns
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'UL-SPLIT-BKFILL-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_row record;
+BEGIN
+  SELECT id INTO v_tenant
+  FROM public.don_vi WHERE active = true
+  ORDER BY id LIMIT 1;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (v_code, 'smoke', 'Split Backfill', 'to_qltb', v_tenant, v_tenant)
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (v_code, 'Split backfill test', v_tenant)
+  RETURNING id INTO v_thiet_bi_id;
+
+  -- Insert a legacy-style row directly (simulating pre-migration data)
+  INSERT INTO public.nhat_ky_su_dung (
+    thiet_bi_id, nguoi_su_dung_id, thoi_gian_bat_dau,
+    tinh_trang_thiet_bi, trang_thai, created_at, updated_at
+  ) VALUES (
+    v_thiet_bi_id, v_user_id, timezone('utc', now()),
+    'Legacy Status', 'hoan_thanh', timezone('utc', now()), timezone('utc', now())
+  );
+
+  -- Manually run backfill logic (same as migration does)
+  UPDATE public.nhat_ky_su_dung
+  SET tinh_trang_ban_dau = tinh_trang_thiet_bi
+  WHERE thiet_bi_id = v_thiet_bi_id
+    AND tinh_trang_ban_dau IS NULL
+    AND tinh_trang_thiet_bi IS NOT NULL;
+
+  UPDATE public.nhat_ky_su_dung
+  SET tinh_trang_ket_thuc = tinh_trang_thiet_bi
+  WHERE thiet_bi_id = v_thiet_bi_id
+    AND tinh_trang_ket_thuc IS NULL
+    AND tinh_trang_thiet_bi IS NOT NULL
+    AND trang_thai = 'hoan_thanh';
+
+  SELECT tinh_trang_ban_dau, tinh_trang_ket_thuc, tinh_trang_thiet_bi
+  INTO v_row
+  FROM public.nhat_ky_su_dung
+  WHERE thiet_bi_id = v_thiet_bi_id
+  LIMIT 1;
+
+  IF v_row.tinh_trang_ban_dau IS DISTINCT FROM 'Legacy Status' THEN
+    RAISE EXCEPTION 'Backfill tinh_trang_ban_dau mismatch: %', v_row.tinh_trang_ban_dau;
+  END IF;
+
+  IF v_row.tinh_trang_ket_thuc IS DISTINCT FROM 'Legacy Status' THEN
+    RAISE EXCEPTION 'Backfill tinh_trang_ket_thuc for completed session mismatch: %', v_row.tinh_trang_ket_thuc;
+  END IF;
+
+  -- Test active session: tinh_trang_ket_thuc should NOT be backfilled
+  INSERT INTO public.nhat_ky_su_dung (
+    thiet_bi_id, nguoi_su_dung_id, thoi_gian_bat_dau,
+    tinh_trang_thiet_bi, trang_thai, created_at, updated_at
+  ) VALUES (
+    v_thiet_bi_id, v_user_id, timezone('utc', now()),
+    'Active Legacy', 'dang_su_dung', timezone('utc', now()), timezone('utc', now())
+  );
+
+  UPDATE public.nhat_ky_su_dung
+  SET tinh_trang_ban_dau = tinh_trang_thiet_bi
+  WHERE thiet_bi_id = v_thiet_bi_id
+    AND tinh_trang_ban_dau IS NULL
+    AND tinh_trang_thiet_bi IS NOT NULL;
+
+  UPDATE public.nhat_ky_su_dung
+  SET tinh_trang_ket_thuc = tinh_trang_thiet_bi
+  WHERE thiet_bi_id = v_thiet_bi_id
+    AND tinh_trang_ket_thuc IS NULL
+    AND tinh_trang_thiet_bi IS NOT NULL
+    AND trang_thai = 'hoan_thanh';
+
+  SELECT tinh_trang_ban_dau, tinh_trang_ket_thuc
+  INTO v_row
+  FROM public.nhat_ky_su_dung
+  WHERE thiet_bi_id = v_thiet_bi_id
+    AND trang_thai = 'dang_su_dung'
+  LIMIT 1;
+
+  IF v_row.tinh_trang_ban_dau IS DISTINCT FROM 'Active Legacy' THEN
+    RAISE EXCEPTION 'Backfill active session tinh_trang_ban_dau mismatch: %', v_row.tinh_trang_ban_dau;
+  END IF;
+
+  IF v_row.tinh_trang_ket_thuc IS NOT NULL THEN
+    RAISE EXCEPTION 'Backfill should NOT fill tinh_trang_ket_thuc for active sessions, got %', v_row.tinh_trang_ket_thuc;
+  END IF;
+
+  RAISE NOTICE 'OK: backfill verification passed';
+END $$;
+
+ROLLBACK;

--- a/supabase/tests/usage_log_split_status_smoke.sql
+++ b/supabase/tests/usage_log_split_status_smoke.sql
@@ -265,11 +265,15 @@ BEGIN
   INTO v_proconfig
   FROM pg_catalog.pg_proc p
   JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-  WHERE n.nspname = 'public' AND p.proname = 'usage_session_end'
+  WHERE n.nspname = 'public'
+    AND p.proname = 'usage_session_end'
+    AND pg_get_function_identity_arguments(p.oid) = 'p_usage_log_id bigint, p_tinh_trang_thiet_bi text, p_ghi_chu text, p_don_vi bigint, p_tinh_trang_ket_thuc text'
   LIMIT 1;
 
   IF v_proconfig IS NULL OR NOT EXISTS (
-    SELECT 1 FROM unnest(v_proconfig) c WHERE c ILIKE '%search_path%'
+    SELECT 1
+    FROM unnest(COALESCE(v_proconfig, ARRAY[]::text[])) AS c
+    WHERE lower(c) = 'search_path=public, pg_temp'
   ) THEN
     RAISE EXCEPTION 'usage_session_end missing DDL-level search_path, proconfig = %', v_proconfig;
   END IF;
@@ -277,7 +281,60 @@ BEGIN
   RAISE NOTICE 'OK: usage_session_end happy path + DDL search_path passed';
 END $$;
 
--- 6) usage_session_end: admin role should bypass tenant guard (same as global)
+-- 6) usage_session_end: empty string rejected
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'UL-SPLIT-END-VAL-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_start_result jsonb;
+  v_log_id bigint;
+  v_error_raised boolean := false;
+BEGIN
+  SELECT id INTO v_tenant
+  FROM public.don_vi WHERE active = true
+  ORDER BY id LIMIT 1;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (v_code, 'smoke', 'Split End Val', 'to_qltb', v_tenant, v_tenant)
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
+  VALUES (v_code, 'Split end validation', v_tenant)
+  RETURNING id INTO v_thiet_bi_id;
+
+  PERFORM set_config('request.jwt.claims', json_build_object(
+    'app_role', 'to_qltb', 'role', 'authenticated',
+    'user_id', v_user_id::text, 'sub', v_user_id::text,
+    'don_vi', v_tenant::text
+  )::text, true);
+
+  v_start_result := public.usage_session_start(
+    p_thiet_bi_id := v_thiet_bi_id,
+    p_nguoi_su_dung_id := v_user_id,
+    p_tinh_trang_ban_dau := 'Tốt'
+  );
+  v_log_id := (v_start_result->>'id')::bigint;
+
+  BEGIN
+    PERFORM public.usage_session_end(
+      p_usage_log_id := v_log_id,
+      p_tinh_trang_ket_thuc := ''
+    );
+  EXCEPTION
+    WHEN SQLSTATE '22023' THEN
+      v_error_raised := true;
+  END;
+
+  IF NOT v_error_raised THEN
+    RAISE EXCEPTION 'Expected empty p_tinh_trang_ket_thuc to raise 22023';
+  END IF;
+
+  RAISE NOTICE 'OK: usage_session_end empty string rejected';
+END $$;
+
+-- 7) usage_session_end: admin role should bypass tenant guard (same as global)
 DO $$
 DECLARE
   v_tenant bigint;
@@ -298,9 +355,10 @@ BEGIN
   FROM public.don_vi WHERE active = true AND id <> v_tenant
   ORDER BY id LIMIT 1;
 
-  -- If only one tenant exists, use same tenant (still tests admin path)
   IF v_other_tenant IS NULL THEN
-    v_other_tenant := v_tenant;
+    INSERT INTO public.don_vi(name, active)
+    VALUES ('Smoke split admin tenant ' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS'), true)
+    RETURNING id INTO v_other_tenant;
   END IF;
 
   INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
@@ -345,7 +403,7 @@ BEGIN
   RAISE NOTICE 'OK: usage_session_end admin role guard bypass passed';
 END $$;
 
--- 7) usage_log_list: both overloads return tinh_trang_ban_dau + tinh_trang_ket_thuc
+-- 8) usage_log_list: both overloads return tinh_trang_ban_dau + tinh_trang_ket_thuc
 DO $$
 DECLARE
   v_tenant bigint;

--- a/supabase/tests/usage_log_split_status_smoke.sql
+++ b/supabase/tests/usage_log_split_status_smoke.sql
@@ -338,7 +338,6 @@ END $$;
 DO $$
 DECLARE
   v_tenant bigint;
-  v_other_tenant bigint;
   v_user_id bigint;
   v_thiet_bi_id bigint;
   v_code text := 'UL-SPLIT-END-ADM-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
@@ -349,17 +348,6 @@ BEGIN
   SELECT id INTO v_tenant
   FROM public.don_vi WHERE active = true
   ORDER BY id LIMIT 1;
-
-  -- Pick a different tenant for the admin user to prove cross-tenant access
-  SELECT id INTO v_other_tenant
-  FROM public.don_vi WHERE active = true AND id <> v_tenant
-  ORDER BY id LIMIT 1;
-
-  IF v_other_tenant IS NULL THEN
-    INSERT INTO public.don_vi(name, active)
-    VALUES ('Smoke split admin tenant ' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS'), true)
-    RETURNING id INTO v_other_tenant;
-  END IF;
 
   INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
   VALUES (v_code, 'smoke', 'Split End Admin', 'to_qltb', v_tenant, v_tenant)
@@ -383,11 +371,11 @@ BEGIN
   );
   v_log_id := (v_start_result->>'id')::bigint;
 
-  -- Switch to admin role (different tenant) — should still be able to end session
+  -- Switch to raw admin role without don_vi. This must still pass so the SQL
+  -- function does not depend on proxy-side admin -> global normalization.
   PERFORM set_config('request.jwt.claims', json_build_object(
     'app_role', 'admin', 'role', 'authenticated',
-    'user_id', v_user_id::text, 'sub', v_user_id::text,
-    'don_vi', v_other_tenant::text
+    'user_id', v_user_id::text, 'sub', v_user_id::text
   )::text, true);
 
   v_end_result := public.usage_session_end(


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds split equipment status to usage logs with new initial and final status fields, keeping backward compatibility. Fixes and hardens RPC security (DDL-level `search_path`, role guard), and patches `usage_session_end` so admin bypass works even without `don_vi`; ships SQL smoke tests and OpenSpec docs/tasks.

- **New Features**
  - Added `tinh_trang_ban_dau` and `tinh_trang_ket_thuc` columns.
  - Updated `usage_session_start` and `usage_session_end` to accept/return the new fields.
  - Updated `usage_log_list` to return both fields (both overloads).
  - Backfilled from `tinh_trang_thiet_bi` (final only for completed sessions) and kept writing the legacy column; validation skips when new params are NULL for backward compatibility.

- **Bug Fixes**
  - Set DDL-level `search_path = public, pg_temp` on updated RPCs (`usage_session_start`, `usage_session_end`, and 8‑param `usage_log_list`).
  - Fixed `usage_session_end` tenant guard: treat `admin` like `global` and avoid eager tenant-scope lookup so admin bypass works without `don_vi`.
  - Added missing role guard for usage sessions (blocks disallowed roles and cross-user actions where not permitted).

<sup>Written for commit 97a19f6dcc623432afb255637b9a19629abbe705. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Record equipment condition separately at session start and end; UI, logs, and CSV/print output show both fields with legacy fallback.
* **Bug Fixes**
  * Hardened session-end security/tenant handling and fixed admin-role guard.
* **Refactor**
  * Split print/export builder to support added columns.
* **Tests**
  * Added smoke tests covering migration, validation, responses, and backfill.
* **Chores**
  * Database migration adds and backfills the new status columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->