### PR TITLE
feat: add split status UI for usage log sessions

### DIFF
--- a/openspec/changes/add-usage-log-split-status/tasks.md
+++ b/openspec/changes/add-usage-log-split-status/tasks.md
@@ -49,32 +49,34 @@ Start this batch only after Batch 1 migration is deployed. The pre-requisite ref
 
 ### 4. Pre-requisite Refactor
 
-- [ ] 4.1 Extract HTML builder from `usage-log-print.tsx` into `usage-log-print-html-builder.ts` (file is 491 lines, exceeds 350-line ceiling).
-- [ ] 4.2 Extract CSV builder from `usage-log-print.tsx` into `usage-log-print-csv-builder.ts`.
-- [ ] 4.3 Verify `usage-log-print.tsx` is under 350 lines after extraction; run `typecheck` and focused tests.
+- [x] 4.1 Extract HTML builder from `usage-log-print.tsx` into `usage-log-print-html-builder.ts` (file is 491 lines, exceeds 350-line ceiling).
+- [x] 4.2 Extract CSV builder from `usage-log-print.tsx` into `usage-log-print-csv-builder.ts`.
+- [x] 4.3 Verify `usage-log-print.tsx` is under 350 lines after extraction; run `typecheck` and focused tests.
 
 ### 5. Frontend Tests (RED)
 
-- [ ] 5.1 Create `start-usage-dialog.validation.test.tsx`: block submit when missing initial status; allow when valid.
-- [ ] 5.2 Create `end-usage-dialog.validation.test.tsx`: block submit when missing final status; allow when valid.
-- [ ] 5.3 Create `usage-log-print.columns.test.tsx`: print HTML + CSV include 2 status columns.
-- [ ] 5.4 Run focused tests and confirm RED.
+- [x] 5.1 Create `start-usage-dialog.validation.test.tsx`: block submit when missing initial status; allow when valid.
+- [x] 5.2 Create `end-usage-dialog.validation.test.tsx`: block submit when missing final status; allow when valid.
+- [x] 5.3 Create `usage-log-print.columns.test.tsx`: print HTML + CSV include 2 status columns.
+- [x] 5.4 Run focused tests and confirm RED.
 
 ### 6. Frontend Implementation (GREEN)
 
-- [ ] 6.1 Update `database.ts` types: add `tinh_trang_ban_dau?: string | null` and `tinh_trang_ket_thuc?: string | null`.
-- [ ] 6.2 Update `use-usage-logs.ts`: mutation payloads and response parsing for start/end.
-- [ ] 6.3 Update `start-usage-dialog.tsx`: new `tinh_trang_ban_dau` field (free-text + datalist), Zod validation.
-- [ ] 6.4 Update `end-usage-dialog.tsx`: new `tinh_trang_ket_thuc` field (required), Zod validation.
-- [ ] 6.5 Update `usage-history-tab.tsx`: display split status with legacy fallback.
-- [ ] 6.6 Update `usage-log-print.tsx` + extracted builders: 2 status columns in print table and CSV.
-- [ ] 6.7 Run focused tests and confirm GREEN.
+- [x] 6.1 Update `database.ts` types: add `tinh_trang_ban_dau?: string | null` and `tinh_trang_ket_thuc?: string | null`.
+- [x] 6.2 Update `use-usage-logs.ts`: mutation payloads and response parsing for start/end.
+- [x] 6.3 Update `start-usage-dialog.tsx`: new `tinh_trang_ban_dau` field (free-text + datalist), Zod validation.
+- [x] 6.4 Update `end-usage-dialog.tsx`: new `tinh_trang_ket_thuc` field (required), Zod validation.
+- [x] 6.5 Update `usage-history-tab.tsx`: display split status with legacy fallback.
+- [x] 6.6 Update `usage-log-print.tsx` + extracted builders: 2 status columns in print table and CSV.
+- [x] 6.7 Run focused tests and confirm GREEN.
 
 ### 7. Frontend Verification
 
-- [ ] 7.1 Run `node scripts/npm-run.js run verify:no-explicit-any`
-- [ ] 7.2 Run `node scripts/npm-run.js run typecheck`
-- [ ] 7.3 Run focused tests: `npm test -- --testPathPattern="usage|print"`
-- [ ] 7.4 Run `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
-- [ ] 7.5 Run `openspec validate add-usage-log-split-status --strict`
-- [ ] 7.6 Commit: `feat: add split status UI for usage log sessions`
+- [x] 7.1 Run `node scripts/npm-run.js run verify:no-explicit-any`
+- [x] 7.2 Run `node scripts/npm-run.js run typecheck`
+- [x] 7.3 Run focused tests: `npm test -- --testPathPattern="usage|print"`
+  Note: used exact targeted Vitest files covering hooks, dialogs, usage history, print/export, log-template, and fallback helper.
+- [x] 7.4 Run `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
+  Note: React Doctor score `99/100`; residual warnings are one `styled-jsx` false positive on `log-template.tsx` and one non-blocking file-length suggestion for `usage-history-tab.tsx`.
+- [x] 7.5 Run `openspec validate add-usage-log-split-status --strict`
+- [x] 7.6 Commit: `feat: add split status UI for usage log sessions`

--- a/src/app/(app)/forms/log-template/page.tsx
+++ b/src/app/(app)/forms/log-template/page.tsx
@@ -12,19 +12,22 @@ const mockData = {
     {
       dateTime: "08:30 - 12/07/2025",
       user: "BS. Nguyễn Thị Bình",
-      condition: "Tốt",
+      initialCondition: "Tốt",
+      finalCondition: "Tốt",
       note: "Xét nghiệm máu thường quy"
     },
     {
       dateTime: "14:00 - 12/07/2025",
       user: "KTV. Trần Văn Cường",
-      condition: "Tốt",
+      initialCondition: "Tốt",
+      finalCondition: "Theo dõi thêm",
       note: "Xét nghiệm nước tiểu"
     },
     {
       dateTime: "09:15 - 13/07/2025",
       user: "BS. Lê Thị Dung",
-      condition: "Tốt",
+      initialCondition: "Ổn định",
+      finalCondition: "Ổn định",
       note: "Quan sát tế bào"
     }
   ]

--- a/src/components/__tests__/end-usage-dialog.validation.test.tsx
+++ b/src/components/__tests__/end-usage-dialog.validation.test.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  mutateAsync: vi.fn(),
+  useEndUsageSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/hooks/use-usage-logs", () => ({
+  useEndUsageSession: () => mocks.useEndUsageSession(),
+}))
+
+import { EndUsageDialog } from "../end-usage-dialog"
+
+describe("EndUsageDialog validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        media: "(max-width: 767px)",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: 7,
+          role: "to_qltb",
+          full_name: "Nguyễn Văn A",
+        },
+      },
+    })
+
+    mocks.mutateAsync.mockResolvedValue({ id: 1, thiet_bi_id: 99 })
+    mocks.useEndUsageSession.mockReturnValue({
+      mutateAsync: mocks.mutateAsync,
+      isPending: false,
+    })
+  })
+
+  it("blocks submit when the final status is empty", async () => {
+    render(
+      <EndUsageDialog
+        open
+        onOpenChange={vi.fn()}
+        usageLog={{
+          id: 1,
+          thiet_bi_id: 99,
+          thoi_gian_bat_dau: "2026-04-15T01:00:00Z",
+          trang_thai: "dang_su_dung",
+          created_at: "2026-04-15T01:00:00Z",
+          updated_at: "2026-04-15T01:00:00Z",
+          tinh_trang_thiet_bi: null,
+          ghi_chu: null,
+          thiet_bi: { ten_thiet_bi: "Monitor", ma_thiet_bi: "TB-99", id: 99 },
+          nguoi_su_dung: { id: 7, username: "user", password: "", full_name: "Nguyễn Văn A", role: "to_qltb", created_at: "2026-04-15T01:00:00Z" },
+        }}
+      />
+    )
+
+    const input = screen.getByLabelText("Tình trạng kết thúc")
+    fireEvent.change(input, { target: { value: " " } })
+    fireEvent.click(screen.getByRole("button", { name: "Kết thúc sử dụng" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Vui lòng nhập tình trạng kết thúc")).toBeInTheDocument()
+    })
+
+    expect(mocks.mutateAsync).not.toHaveBeenCalled()
+  })
+
+  it("submits both final status fields when the input is valid", async () => {
+    render(
+      <EndUsageDialog
+        open
+        onOpenChange={vi.fn()}
+        usageLog={{
+          id: 1,
+          thiet_bi_id: 99,
+          thoi_gian_bat_dau: "2026-04-15T01:00:00Z",
+          trang_thai: "dang_su_dung",
+          created_at: "2026-04-15T01:00:00Z",
+          updated_at: "2026-04-15T01:00:00Z",
+          tinh_trang_thiet_bi: "Tốt",
+          ghi_chu: "",
+          thiet_bi: { ten_thiet_bi: "Monitor", ma_thiet_bi: "TB-99", id: 99 },
+          nguoi_su_dung: { id: 7, username: "user", password: "", full_name: "Nguyễn Văn A", role: "to_qltb", created_at: "2026-04-15T01:00:00Z" },
+        }}
+      />
+    )
+
+    const input = screen.getByLabelText("Tình trạng kết thúc")
+    fireEvent.change(input, { target: { value: "Cần bảo trì" } })
+    fireEvent.click(screen.getByRole("button", { name: "Kết thúc sử dụng" }))
+
+    await waitFor(() => {
+      expect(mocks.mutateAsync).toHaveBeenCalledWith({
+        id: 1,
+        tinh_trang_thiet_bi: "Cần bảo trì",
+        tinh_trang_ket_thuc: "Cần bảo trì",
+        ghi_chu: "",
+      })
+    })
+  })
+})

--- a/src/components/__tests__/log-template.columns.test.tsx
+++ b/src/components/__tests__/log-template.columns.test.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { render, screen, within } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/components/form-branding-header", () => ({
+  FormBrandingHeader: () => <div data-testid="branding-header" />,
+}))
+
+import { LogTemplate } from "../log-template"
+
+describe("LogTemplate", () => {
+  it("renders split status columns with narrower existing widths for print layout", () => {
+    render(
+      <LogTemplate
+        usageLogs={[
+          {
+            dateTime: "08:30 - 12/07/2025",
+            user: "BS. Nguyễn Thị Bình",
+            initialCondition: "Tốt",
+            finalCondition: "Cần theo dõi",
+            note: "Xét nghiệm máu thường quy",
+          },
+        ]}
+      />
+    )
+
+    const headerRow = screen.getAllByRole("row")[0]
+    const headers = within(headerRow).getAllByRole("columnheader")
+
+    expect(headers).toHaveLength(5)
+    expect(headers[0]).toHaveTextContent("Ngày, giờ sử dụng")
+    expect(headers[0]).toHaveStyle({ width: "18%" })
+    expect(headers[1]).toHaveTextContent("Người sử dụng")
+    expect(headers[1]).toHaveStyle({ width: "18%" })
+    expect(headers[2]).toHaveTextContent("Tình trạng bắt đầu")
+    expect(headers[2]).toHaveStyle({ width: "16%" })
+    expect(headers[3]).toHaveTextContent("Tình trạng kết thúc")
+    expect(headers[3]).toHaveStyle({ width: "16%" })
+    expect(headers[4]).toHaveTextContent("Ghi chú")
+    expect(headers[4]).toHaveStyle({ width: "32%" })
+
+    expect(screen.getByText("Tốt")).toBeInTheDocument()
+    expect(screen.getByText("Cần theo dõi")).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/start-usage-dialog.validation.test.tsx
+++ b/src/components/__tests__/start-usage-dialog.validation.test.tsx
@@ -1,0 +1,105 @@
+import * as React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  mutateAsync: vi.fn(),
+  useStartUsageSession: vi.fn(),
+  useToast: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/hooks/use-usage-logs", () => ({
+  useStartUsageSession: () => mocks.useStartUsageSession(),
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => mocks.useToast(),
+}))
+
+import { StartUsageDialog } from "../start-usage-dialog"
+
+describe("StartUsageDialog validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        media: "(max-width: 767px)",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: 7,
+          role: "to_qltb",
+          full_name: "Nguyễn Văn A",
+        },
+      },
+    })
+
+    mocks.mutateAsync.mockResolvedValue({ id: 1, thiet_bi_id: 99 })
+    mocks.useStartUsageSession.mockReturnValue({
+      mutateAsync: mocks.mutateAsync,
+      isPending: false,
+    })
+    mocks.useToast.mockReturnValue({ toast: vi.fn() })
+  })
+
+  it("blocks submit when the initial status is empty", async () => {
+    render(
+      <StartUsageDialog
+        open
+        onOpenChange={vi.fn()}
+        equipment={{ id: 99, ten_thiet_bi: "Monitor", ma_thiet_bi: "TB-99", tinh_trang_hien_tai: null }}
+      />
+    )
+
+    const input = screen.getByLabelText("Tình trạng ban đầu")
+    fireEvent.change(input, { target: { value: "   " } })
+    fireEvent.click(screen.getByRole("button", { name: "Bắt đầu sử dụng" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Vui lòng nhập tình trạng ban đầu")).toBeInTheDocument()
+    })
+
+    expect(mocks.mutateAsync).not.toHaveBeenCalled()
+  })
+
+  it("submits both initial status fields when the input is valid", async () => {
+    render(
+      <StartUsageDialog
+        open
+        onOpenChange={vi.fn()}
+        equipment={{ id: 99, ten_thiet_bi: "Monitor", ma_thiet_bi: "TB-99", tinh_trang_hien_tai: "Tốt" }}
+      />
+    )
+
+    const input = screen.getByLabelText("Tình trạng ban đầu")
+    fireEvent.change(input, { target: { value: "Hoạt động tốt" } })
+    fireEvent.click(screen.getByRole("button", { name: "Bắt đầu sử dụng" }))
+
+    await waitFor(() => {
+      expect(mocks.mutateAsync).toHaveBeenCalledWith({
+        thiet_bi_id: 99,
+        nguoi_su_dung_id: 7,
+        tinh_trang_thiet_bi: "Hoạt động tốt",
+        tinh_trang_ban_dau: "Hoạt động tốt",
+        ghi_chu: "",
+      })
+    })
+  })
+})

--- a/src/components/__tests__/usage-history-tab.loadmore.test.tsx
+++ b/src/components/__tests__/usage-history-tab.loadmore.test.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 
 const mocks = vi.hoisted(() => ({
   useSession: vi.fn(),
@@ -38,7 +38,7 @@ vi.mock("../end-usage-dialog", () => ({
 
 import { UsageHistoryTab } from "../usage-history-tab"
 
-function createUsageLog(id: number) {
+function createUsageLog(id: number, overrides: Record<string, unknown> = {}) {
   return {
     id,
     thoi_gian_bat_dau: `2026-03-${String((id % 28) + 1).padStart(2, "0")}T08:00:00Z`,
@@ -52,6 +52,7 @@ function createUsageLog(id: number) {
       ten_thiet_bi: "Test Equipment",
       ma_thiet_bi: "TB-001",
     },
+    ...overrides,
   }
 }
 
@@ -106,5 +107,47 @@ describe("UsageHistoryTab load more", () => {
 
     const lastOffset = mocks.useEquipmentUsageLogsMore.mock.calls.at(-1)?.[1]
     expect(lastOffset).toBe(150)
+  })
+
+  it("removes deleted historical logs from accumulated pages", async () => {
+    const deleteUsageLog = vi.fn().mockResolvedValue(undefined)
+    const historicalLog = createUsageLog(51, {
+      trang_thai: "hoan_thanh",
+      thoi_gian_ket_thuc: "2026-03-24T09:00:00Z",
+      nguoi_su_dung: {
+        full_name: "Loaded User 51",
+      },
+    })
+
+    mocks.useEquipmentUsageLogsMore.mockImplementation((_equipmentId: string, offset: number) => ({
+      data: offset > 0 ? [historicalLog] : EMPTY_MORE_USAGE_LOGS,
+      isLoading: false,
+      isFetching: false,
+      offset,
+    }))
+    mocks.useDeleteUsageLog.mockReturnValue({
+      mutateAsync: deleteUsageLog,
+      isPending: false,
+    })
+
+    render(
+      <UsageHistoryTab
+        equipment={{ id: 42, ten_thiet_bi: "Test Equipment", ma_thiet_bi: "TB-001" }}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole("button", { name: "Tải thêm lịch sử" }))
+
+    expect(await screen.findByText("Loaded User 51")).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("button", { name: "Xóa nhật ký sử dụng 51" }))
+    fireEvent.click(await screen.findByRole("button", { name: "Xóa" }))
+
+    await waitFor(() => {
+      expect(deleteUsageLog).toHaveBeenCalledWith(51)
+    })
+    await waitFor(() => {
+      expect(screen.queryByText("Loaded User 51")).toBeNull()
+    })
   })
 })

--- a/src/components/__tests__/usage-history-tab.split-status.test.tsx
+++ b/src/components/__tests__/usage-history-tab.split-status.test.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  useIsMobile: vi.fn(),
+  useEquipmentUsageLogs: vi.fn(),
+  useEquipmentUsageLogsMore: vi.fn(),
+  useDeleteUsageLog: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mocks.useIsMobile(),
+}))
+
+vi.mock("@/hooks/use-usage-logs", () => ({
+  useEquipmentUsageLogs: (...args: unknown[]) => mocks.useEquipmentUsageLogs(...args),
+  useEquipmentUsageLogsMore: (...args: unknown[]) => mocks.useEquipmentUsageLogsMore(...args),
+  useDeleteUsageLog: () => mocks.useDeleteUsageLog(),
+}))
+
+vi.mock("../usage-log-print", () => ({
+  UsageLogPrint: () => <div data-testid="usage-log-print" />,
+}))
+
+vi.mock("../end-usage-dialog", () => ({
+  EndUsageDialog: () => null,
+}))
+
+import { UsageHistoryTab } from "../usage-history-tab"
+
+const usageLogs = [
+  {
+    id: 1,
+    thiet_bi_id: 99,
+    thoi_gian_bat_dau: "2026-04-15T01:00:00Z",
+    thoi_gian_ket_thuc: "2026-04-15T02:00:00Z",
+    trang_thai: "hoan_thanh" as const,
+    created_at: "2026-04-15T01:00:00Z",
+    updated_at: "2026-04-15T02:00:00Z",
+    nguoi_su_dung_id: 7,
+    tinh_trang_ban_dau: "Tốt",
+    tinh_trang_ket_thuc: "Cần theo dõi",
+    tinh_trang_thiet_bi: "Legacy",
+    ghi_chu: "Có thay đổi nhẹ",
+    nguoi_su_dung: { full_name: "Nguyễn Văn A" },
+    thiet_bi: { ten_thiet_bi: "Monitor", ma_thiet_bi: "TB-99" },
+  },
+  {
+    id: 2,
+    thiet_bi_id: 99,
+    thoi_gian_bat_dau: "2026-04-16T01:00:00Z",
+    thoi_gian_ket_thuc: "2026-04-16T02:00:00Z",
+    trang_thai: "hoan_thanh" as const,
+    created_at: "2026-04-16T01:00:00Z",
+    updated_at: "2026-04-16T02:00:00Z",
+    nguoi_su_dung_id: 7,
+    tinh_trang_ban_dau: null,
+    tinh_trang_ket_thuc: null,
+    tinh_trang_thiet_bi: "Fallback legacy",
+    ghi_chu: null,
+    nguoi_su_dung: { full_name: "Trần Thị B" },
+    thiet_bi: { ten_thiet_bi: "Monitor", ma_thiet_bi: "TB-99" },
+  },
+]
+
+describe("UsageHistoryTab split status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: 7,
+          role: "global",
+        },
+      },
+    })
+
+    mocks.useEquipmentUsageLogs.mockReturnValue({
+      data: usageLogs,
+      isLoading: false,
+    })
+
+    mocks.useEquipmentUsageLogsMore.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+    })
+
+    mocks.useDeleteUsageLog.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })
+  })
+
+  it("renders separate initial and final status columns on desktop with legacy fallback", () => {
+    mocks.useIsMobile.mockReturnValue(false)
+
+    render(
+      <UsageHistoryTab
+        equipment={{ id: 99, ten_thiet_bi: "Monitor", ma_thiet_bi: "TB-99" }}
+      />
+    )
+
+    expect(screen.getByRole("columnheader", { name: "Tình trạng ban đầu" })).toBeInTheDocument()
+    expect(screen.getByRole("columnheader", { name: "Tình trạng kết thúc" })).toBeInTheDocument()
+    expect(screen.getByText("Tốt")).toBeInTheDocument()
+    expect(screen.getByText("Cần theo dõi")).toBeInTheDocument()
+    expect(screen.getAllByText("Fallback legacy")).toHaveLength(2)
+  })
+
+  it("renders separate mobile labels for initial and final status", () => {
+    mocks.useIsMobile.mockReturnValue(true)
+
+    render(
+      <UsageHistoryTab
+        equipment={{ id: 99, ten_thiet_bi: "Monitor", ma_thiet_bi: "TB-99" }}
+      />
+    )
+
+    expect(screen.getAllByText(/Tình trạng ban đầu:/)[0]).toBeInTheDocument()
+    expect(screen.getAllByText(/Tình trạng kết thúc:/)[0]).toBeInTheDocument()
+    expect(screen.getAllByText("Fallback legacy")).toHaveLength(2)
+  })
+})

--- a/src/components/__tests__/usage-history-tab.split-status.test.tsx
+++ b/src/components/__tests__/usage-history-tab.split-status.test.tsx
@@ -112,6 +112,7 @@ describe("UsageHistoryTab split status", () => {
 
     expect(screen.getByRole("columnheader", { name: "Tình trạng ban đầu" })).toBeInTheDocument()
     expect(screen.getByRole("columnheader", { name: "Tình trạng kết thúc" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Xóa nhật ký sử dụng 1" })).toBeInTheDocument()
     expect(screen.getByText("Tốt")).toBeInTheDocument()
     expect(screen.getByText("Cần theo dõi")).toBeInTheDocument()
     expect(screen.getAllByText("Fallback legacy")).toHaveLength(2)

--- a/src/components/__tests__/usage-log-print.columns.test.ts
+++ b/src/components/__tests__/usage-log-print.columns.test.ts
@@ -114,4 +114,21 @@ describe("usage log print builders", () => {
 
     expect(html).toContain('<img src="" alt="Logo"')
   })
+
+  it("escapes manipulated date range values in print HTML", () => {
+    const html = buildUsageLogPrintHtml({
+      equipment,
+      filteredLogs: usageLogs,
+      tenantName: "QLTBYT",
+      tenantLogoUrl: "https://example.com/logo.png",
+      dateFrom: "2026-04-15<script>",
+      dateTo: "2026-04-16<img src=x onerror=alert(1)>",
+      now: new Date("2026-04-15T03:00:00Z"),
+    })
+
+    expect(html).not.toContain("<script>")
+    expect(html).not.toContain("<img src=x onerror=alert(1)>")
+    expect(html).toContain("15&lt;script&gt;/04/2026")
+    expect(html).toContain("16&lt;img src=x onerror=alert(1)&gt;/04/2026")
+  })
 })

--- a/src/components/__tests__/usage-log-print.columns.test.ts
+++ b/src/components/__tests__/usage-log-print.columns.test.ts
@@ -100,4 +100,18 @@ describe("usage log print builders", () => {
       process.env.TZ = originalTz
     }
   })
+
+  it("rejects unsafe non-image data URIs for the printed tenant logo", () => {
+    const html = buildUsageLogPrintHtml({
+      equipment,
+      filteredLogs: usageLogs,
+      tenantName: "QLTBYT",
+      tenantLogoUrl: "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+      dateFrom: "",
+      dateTo: "",
+      now: new Date("2026-04-15T03:00:00Z"),
+    })
+
+    expect(html).toContain('<img src="" alt="Logo"')
+  })
 })

--- a/src/components/__tests__/usage-log-print.columns.test.ts
+++ b/src/components/__tests__/usage-log-print.columns.test.ts
@@ -62,4 +62,42 @@ describe("usage log print builders", () => {
     expect(csv).toContain("Tốt")
     expect(csv).toContain("Fallback legacy")
   })
+
+  it("escapes CSV quotes and neutralizes spreadsheet formulas in free-text cells", () => {
+    const csv = buildUsageLogCsv({
+      equipment,
+      filteredLogs: [
+        {
+          ...usageLogs[0],
+          tinh_trang_ban_dau: 'Kiểm tra "ABC"',
+          ghi_chu: '=1+1 "quoted"',
+        },
+      ],
+      now: new Date("2026-04-15T03:00:00Z"),
+    })
+
+    expect(csv).toContain(`"Kiểm tra ""ABC"""`)
+    expect(csv).toContain(`"'=1+1 ""quoted"""`)
+  })
+
+  it("formats date-only print ranges without UTC day shifts", () => {
+    const originalTz = process.env.TZ
+    process.env.TZ = "America/Los_Angeles"
+
+    try {
+      const html = buildUsageLogPrintHtml({
+        equipment,
+        filteredLogs: usageLogs,
+        tenantName: "QLTBYT",
+        tenantLogoUrl: "https://example.com/logo.png",
+        dateFrom: "2026-04-15",
+        dateTo: "2026-04-16",
+        now: new Date("2026-04-15T03:00:00Z"),
+      })
+
+      expect(html).toContain("(15/04/2026 - 16/04/2026)")
+    } finally {
+      process.env.TZ = originalTz
+    }
+  })
 })

--- a/src/components/__tests__/usage-log-print.columns.test.ts
+++ b/src/components/__tests__/usage-log-print.columns.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildUsageLogCsv,
+  buildUsageLogPrintHtml,
+} from "../usage-log-print-builders"
+
+const equipment = {
+  id: 99,
+  ten_thiet_bi: "Monitor",
+  ma_thiet_bi: "TB-99",
+  khoa_phong_quan_ly: "Khoa Xét nghiệm",
+  hang_san_xuat: "Olympus",
+  model: "CX-23",
+  tinh_trang_hien_tai: "Hoạt động",
+}
+
+const usageLogs = [
+  {
+    id: 1,
+    thiet_bi_id: 99,
+    thoi_gian_bat_dau: "2026-04-15T01:00:00Z",
+    thoi_gian_ket_thuc: "2026-04-15T02:00:00Z",
+    trang_thai: "hoan_thanh" as const,
+    created_at: "2026-04-15T01:00:00Z",
+    updated_at: "2026-04-15T02:00:00Z",
+    nguoi_su_dung: { full_name: "Nguyễn Văn A", khoa_phong: "Khoa Xét nghiệm" },
+    tinh_trang_ban_dau: "Tốt",
+    tinh_trang_ket_thuc: null,
+    tinh_trang_thiet_bi: "Fallback legacy",
+    ghi_chu: "Có thay đổi nhẹ",
+  },
+]
+
+describe("usage log print builders", () => {
+  it("includes split status columns in print HTML with fallback values", () => {
+    const html = buildUsageLogPrintHtml({
+      equipment,
+      filteredLogs: usageLogs,
+      tenantName: "QLTBYT",
+      tenantLogoUrl: "https://example.com/logo.png",
+      dateFrom: "",
+      dateTo: "",
+      now: new Date("2026-04-15T03:00:00Z"),
+    })
+
+    expect(html).toContain("Tình trạng ban đầu")
+    expect(html).toContain("Tình trạng kết thúc")
+    expect(html).toContain("Tốt")
+    expect(html).toContain("Fallback legacy")
+  })
+
+  it("includes split status columns in CSV export with fallback values", () => {
+    const csv = buildUsageLogCsv({
+      equipment,
+      filteredLogs: usageLogs,
+      now: new Date("2026-04-15T03:00:00Z"),
+    })
+
+    expect(csv).toContain("Tình trạng ban đầu")
+    expect(csv).toContain("Tình trạng kết thúc")
+    expect(csv).toContain("Tốt")
+    expect(csv).toContain("Fallback legacy")
+  })
+})

--- a/src/components/__tests__/usage-session-flow.integration.test.tsx
+++ b/src/components/__tests__/usage-session-flow.integration.test.tsx
@@ -1,0 +1,250 @@
+import * as React from "react"
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import "@testing-library/jest-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { StartUsageDialog } from "../start-usage-dialog"
+import { UsageHistoryTab } from "../usage-history-tab"
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  useToast: vi.fn(),
+  useIsMobile: vi.fn(),
+  useEquipmentUsageLogs: vi.fn(),
+  useEquipmentUsageLogsMore: vi.fn(),
+  useDeleteUsageLog: vi.fn(),
+  useStartUsageSession: vi.fn(),
+  useEndUsageSession: vi.fn(),
+}))
+
+type UsageLogRecord = {
+  id: number
+  thiet_bi_id: number
+  nguoi_su_dung_id: number
+  thoi_gian_bat_dau: string
+  thoi_gian_ket_thuc?: string
+  trang_thai: "dang_su_dung" | "hoan_thanh"
+  created_at: string
+  updated_at: string
+  tinh_trang_thiet_bi?: string | null
+  tinh_trang_ban_dau?: string | null
+  tinh_trang_ket_thuc?: string | null
+  ghi_chu?: string | null
+  nguoi_su_dung?: { full_name: string }
+  thiet_bi?: { id: number; ten_thiet_bi: string; ma_thiet_bi: string }
+}
+
+const equipment = {
+  id: 99,
+  ten_thiet_bi: "Monitor xét nghiệm",
+  ma_thiet_bi: "TB-99",
+  tinh_trang_hien_tai: "Sẵn sàng",
+}
+
+let usageLogsState: UsageLogRecord[] = []
+let notifyStoreChange: (() => void) | null = null
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => mocks.useToast(),
+}))
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mocks.useIsMobile(),
+}))
+
+vi.mock("@/hooks/use-usage-logs", () => ({
+  useEquipmentUsageLogs: (...args: unknown[]) => mocks.useEquipmentUsageLogs(...args),
+  useEquipmentUsageLogsMore: (...args: unknown[]) => mocks.useEquipmentUsageLogsMore(...args),
+  useDeleteUsageLog: () => mocks.useDeleteUsageLog(),
+  useStartUsageSession: () => mocks.useStartUsageSession(),
+  useEndUsageSession: () => mocks.useEndUsageSession(),
+}))
+
+vi.mock("../usage-log-print", () => ({
+  UsageLogPrint: () => <div data-testid="usage-log-print" />,
+}))
+
+function UsageSessionFlowHarness() {
+  const [isStartDialogOpen, setIsStartDialogOpen] = React.useState(false)
+  const [, forceRender] = React.useState(0)
+
+  React.useEffect(() => {
+    notifyStoreChange = () => {
+      forceRender((value) => value + 1)
+    }
+
+    return () => {
+      notifyStoreChange = null
+    }
+  }, [])
+
+  return (
+    <div>
+      <button type="button" onClick={() => setIsStartDialogOpen(true)}>
+        Mở bắt đầu sử dụng
+      </button>
+      <StartUsageDialog
+        open={isStartDialogOpen}
+        onOpenChange={setIsStartDialogOpen}
+        equipment={equipment}
+      />
+      <UsageHistoryTab equipment={equipment} />
+    </div>
+  )
+}
+
+describe("usage session flow integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    usageLogsState = []
+    notifyStoreChange = null
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        media: "(max-width: 767px)",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: 7,
+          role: "to_qltb",
+          full_name: "Nguyễn Văn A",
+        },
+      },
+    })
+
+    mocks.useToast.mockReturnValue({ toast: vi.fn() })
+    mocks.useIsMobile.mockReturnValue(false)
+
+    mocks.useEquipmentUsageLogs.mockImplementation(() => ({
+      data: usageLogsState,
+      isLoading: false,
+    }))
+
+    mocks.useEquipmentUsageLogsMore.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+    })
+
+    mocks.useDeleteUsageLog.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    })
+
+    mocks.useStartUsageSession.mockReturnValue({
+      mutateAsync: vi.fn(async (payload: {
+        thiet_bi_id: number
+        nguoi_su_dung_id: number
+        tinh_trang_thiet_bi?: string
+        tinh_trang_ban_dau?: string
+        ghi_chu?: string
+      }) => {
+        usageLogsState = [
+          {
+            id: 1,
+            thiet_bi_id: payload.thiet_bi_id,
+            nguoi_su_dung_id: payload.nguoi_su_dung_id,
+            thoi_gian_bat_dau: "2026-04-15T05:00:00Z",
+            trang_thai: "dang_su_dung",
+            created_at: "2026-04-15T05:00:00Z",
+            updated_at: "2026-04-15T05:00:00Z",
+            tinh_trang_thiet_bi: payload.tinh_trang_thiet_bi ?? null,
+            tinh_trang_ban_dau: payload.tinh_trang_ban_dau ?? null,
+            tinh_trang_ket_thuc: null,
+            ghi_chu: payload.ghi_chu ?? "",
+            nguoi_su_dung: { full_name: "Nguyễn Văn A" },
+            thiet_bi: {
+              id: equipment.id,
+              ten_thiet_bi: equipment.ten_thiet_bi,
+              ma_thiet_bi: equipment.ma_thiet_bi,
+            },
+          },
+        ]
+        notifyStoreChange?.()
+
+        return usageLogsState[0]
+      }),
+      isPending: false,
+    })
+
+    mocks.useEndUsageSession.mockReturnValue({
+      mutateAsync: vi.fn(async (payload: {
+        id: number
+        tinh_trang_thiet_bi?: string
+        tinh_trang_ket_thuc?: string
+        ghi_chu?: string
+      }) => {
+        usageLogsState = usageLogsState.map((log) =>
+          log.id === payload.id
+            ? {
+                ...log,
+                thoi_gian_ket_thuc: "2026-04-15T06:30:00Z",
+                trang_thai: "hoan_thanh",
+                updated_at: "2026-04-15T06:30:00Z",
+                tinh_trang_thiet_bi: payload.tinh_trang_thiet_bi ?? log.tinh_trang_thiet_bi ?? null,
+                tinh_trang_ket_thuc: payload.tinh_trang_ket_thuc ?? null,
+                ghi_chu: payload.ghi_chu ?? log.ghi_chu ?? "",
+              }
+            : log
+        )
+        notifyStoreChange?.()
+
+        return usageLogsState[0]
+      }),
+      isPending: false,
+    })
+  })
+
+  it("lets the user start and then end usage while history shows split statuses", async () => {
+    const user = userEvent.setup()
+
+    render(<UsageSessionFlowHarness />)
+
+    expect(screen.getByText("Chưa có lịch sử sử dụng")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Mở bắt đầu sử dụng" }))
+    await user.clear(screen.getByLabelText("Tình trạng ban đầu"))
+    await user.type(screen.getByLabelText("Tình trạng ban đầu"), "Hoạt động ổn định")
+    await user.click(screen.getByRole("button", { name: "Bắt đầu sử dụng" }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Bạn đang sử dụng thiết bị này từ/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole("button", { name: "Kết thúc sử dụng" })).toBeInTheDocument()
+    expect(screen.getAllByText("Hoạt động ổn định")).toHaveLength(2)
+
+    await user.click(screen.getByRole("button", { name: "Kết thúc sử dụng" }))
+
+    const endDialog = await screen.findByRole("dialog")
+    await user.clear(within(endDialog).getByLabelText("Tình trạng kết thúc"))
+    await user.type(within(endDialog).getByLabelText("Tình trạng kết thúc"), "Cần vệ sinh")
+    await user.click(within(endDialog).getByRole("button", { name: "Kết thúc sử dụng" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Cần vệ sinh")).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText(/Bạn đang sử dụng thiết bị này từ/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Kết thúc sử dụng" })).not.toBeInTheDocument()
+    expect(screen.getByText("Hoàn thành")).toBeInTheDocument()
+    expect(screen.getByRole("columnheader", { name: "Tình trạng ban đầu" })).toBeInTheDocument()
+    expect(screen.getByRole("columnheader", { name: "Tình trạng kết thúc" })).toBeInTheDocument()
+  })
+})

--- a/src/components/end-usage-dialog.tsx
+++ b/src/components/end-usage-dialog.tsx
@@ -25,17 +25,11 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { useEndUsageSession } from "@/hooks/use-usage-logs"
 import { useSession } from "next-auth/react"
-import { type UsageLog } from "@/types/database"
+import { type SessionUser, type UsageLog } from "@/types/database"
 import { isRegionalLeaderRole } from "@/lib/rbac"
 
 const equipmentStatusOptions = [
@@ -48,7 +42,7 @@ const equipmentStatusOptions = [
 ] as const
 
 const endUsageSchema = z.object({
-  tinh_trang_thiet_bi: z.string().optional(),
+  tinh_trang_ket_thuc: z.string().trim().min(1, "Vui lòng nhập tình trạng kết thúc"),
   ghi_chu: z.string().optional(),
 })
 
@@ -66,13 +60,14 @@ export function EndUsageDialog({
   usageLog,
 }: EndUsageDialogProps) {
   const { data: session } = useSession()
-  const isRegionalLeader = isRegionalLeaderRole((session?.user as any)?.role)
+  const user = session?.user as SessionUser | undefined
+  const isRegionalLeader = isRegionalLeaderRole(user?.role)
   const endUsageMutation = useEndUsageSession()
 
   const form = useForm<EndUsageFormData>({
     resolver: zodResolver(endUsageSchema),
     defaultValues: {
-      tinh_trang_thiet_bi: usageLog?.tinh_trang_thiet_bi || "",
+      tinh_trang_ket_thuc: usageLog?.tinh_trang_ket_thuc ?? usageLog?.tinh_trang_thiet_bi ?? "",
       ghi_chu: usageLog?.ghi_chu || "",
     },
   })
@@ -80,7 +75,7 @@ export function EndUsageDialog({
   React.useEffect(() => {
     if (usageLog && open) {
       form.reset({
-        tinh_trang_thiet_bi: usageLog.tinh_trang_thiet_bi || "",
+        tinh_trang_ket_thuc: usageLog.tinh_trang_ket_thuc ?? usageLog.tinh_trang_thiet_bi ?? "",
         ghi_chu: usageLog.ghi_chu || "",
       })
     }
@@ -95,7 +90,8 @@ export function EndUsageDialog({
     try {
       await endUsageMutation.mutateAsync({
         id: usageLog.id,
-        tinh_trang_thiet_bi: data.tinh_trang_thiet_bi,
+        tinh_trang_thiet_bi: data.tinh_trang_ket_thuc,
+        tinh_trang_ket_thuc: data.tinh_trang_ket_thuc,
         ghi_chu: data.ghi_chu,
       })
       
@@ -137,28 +133,28 @@ export function EndUsageDialog({
             {/* Usage Info */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-4 bg-muted/50 rounded-lg">
               <div>
-                <label className="text-sm font-medium text-muted-foreground">Mã thiết bị</label>
+                <p className="text-sm font-medium text-muted-foreground">Mã thiết bị</p>
                 <p className="text-sm font-mono">{usageLog?.thiet_bi?.ma_thiet_bi}</p>
               </div>
               <div>
-                <label className="text-sm font-medium text-muted-foreground">Người sử dụng</label>
+                <p className="text-sm font-medium text-muted-foreground">Người sử dụng</p>
                 <p className="text-sm">{usageLog?.nguoi_su_dung?.full_name}</p>
               </div>
               <div>
-                <label className="text-sm font-medium text-muted-foreground">Thời gian bắt đầu</label>
+                <p className="text-sm font-medium text-muted-foreground">Thời gian bắt đầu</p>
                 <p className="text-sm">
                   {usageLog && format(new Date(usageLog.thoi_gian_bat_dau), "dd/MM/yyyy HH:mm", { locale: vi })}
                 </p>
               </div>
               <div>
-                <label className="text-sm font-medium text-muted-foreground">Thời gian kết thúc</label>
+                <p className="text-sm font-medium text-muted-foreground">Thời gian kết thúc</p>
                 <p className="text-sm">{format(new Date(), "dd/MM/yyyy HH:mm", { locale: vi })}</p>
               </div>
               <div className="col-span-1 sm:col-span-2">
-                <label className="text-sm font-medium text-muted-foreground flex items-center gap-1">
+                <p className="text-sm font-medium text-muted-foreground flex items-center gap-1">
                   <Clock className="h-4 w-4" />
                   Thời gian sử dụng
-                </label>
+                </p>
                 <p className="text-sm font-medium text-primary">{formatDuration(usageDuration)}</p>
               </div>
             </div>
@@ -166,24 +162,22 @@ export function EndUsageDialog({
             {/* Equipment Status */}
             <FormField
               control={form.control}
-              name="tinh_trang_thiet_bi"
+              name="tinh_trang_ket_thuc"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Tình trạng thiết bị sau khi sử dụng</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Chọn tình trạng thiết bị" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {equipmentStatusOptions.map((status) => (
-                        <SelectItem key={status} value={status}>
-                          {status}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <FormLabel>Tình trạng kết thúc</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      list="end-usage-status-options"
+                      placeholder="Nhập tình trạng thiết bị sau khi sử dụng"
+                    />
+                  </FormControl>
+                  <datalist id="end-usage-status-options">
+                    {equipmentStatusOptions.map((status) => (
+                      <option key={status} value={status} />
+                    ))}
+                  </datalist>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/components/log-template.tsx
+++ b/src/components/log-template.tsx
@@ -6,6 +6,8 @@ import { FormBrandingHeader } from "@/components/form-branding-header"
 interface UsageLogEntry {
   dateTime?: string
   user?: string
+  initialCondition?: string
+  finalCondition?: string
   condition?: string
   note?: string
 }
@@ -35,7 +37,7 @@ export function LogTemplate({
   serial = "",
   usageLogs = EMPTY_USAGE_LOGS
 }: LogTemplateProps) {
-  const formatValue = (value: any) => {
+  const formatValue = (value: unknown) => {
     if (value === null || value === undefined || value === '') {
       return ''
     }
@@ -49,8 +51,11 @@ export function LogTemplate({
       return `log-${dateTime || "unknown"}-${user || "unknown"}`
     }
 
-    const condition = formatValue(log.condition)
-    if (condition) return `condition-${condition}`
+    const initialCondition = formatValue(log.initialCondition ?? log.condition)
+    if (initialCondition) return `condition-${initialCondition}`
+
+    const finalCondition = formatValue(log.finalCondition ?? log.condition)
+    if (finalCondition) return `final-condition-${finalCondition}`
 
     const note = formatValue(log.note)
     if (note) return `note-${note}`
@@ -95,9 +100,10 @@ export function LogTemplate({
                   className="mb-2"
                 />
                 <div className="flex items-baseline justify-center mt-1">
-                  <label className="font-bold whitespace-nowrap">KHOA/PHÒNG:</label>
+                  <label className="font-bold whitespace-nowrap" htmlFor="log-template-department">KHOA/PHÒNG:</label>
                   <div className="w-1/2 ml-2">
                     <input 
+                      id="log-template-department"
                       type="text" 
                       className="form-input-line"
                       defaultValue={formatValue(department)}
@@ -115,16 +121,18 @@ export function LogTemplate({
           {/* Info Section */}
           <section className="space-y-2 mb-4">
             <div className="flex items-baseline">
-              <label className="whitespace-nowrap w-40">Người quản lý thiết bị:</label>
+              <label className="whitespace-nowrap w-40" htmlFor="log-template-device-manager">Người quản lý thiết bị:</label>
               <input 
+                id="log-template-device-manager"
                 type="text" 
                 className="form-input-line ml-2"
                 defaultValue={formatValue(deviceManager)}
               />
             </div>
             <div className="flex items-baseline">
-              <label className="whitespace-nowrap w-40">Tên thiết bị:</label>
+              <label className="whitespace-nowrap w-40" htmlFor="log-template-device-name">Tên thiết bị:</label>
               <input 
+                id="log-template-device-name"
                 type="text" 
                 className="form-input-line ml-2"
                 defaultValue={formatValue(deviceName)}
@@ -132,24 +140,27 @@ export function LogTemplate({
             </div>
             <div className="grid grid-cols-3 gap-x-8">
               <div className="flex items-baseline">
-                <label className="whitespace-nowrap">Mã thiết bị:</label>
+                <label className="whitespace-nowrap" htmlFor="log-template-device-code">Mã thiết bị:</label>
                 <input 
+                  id="log-template-device-code"
                   type="text" 
                   className="form-input-line ml-2"
                   defaultValue={formatValue(deviceCode)}
                 />
               </div>
               <div className="flex items-baseline">
-                <label className="whitespace-nowrap">Model:</label>
+                <label className="whitespace-nowrap" htmlFor="log-template-model">Model:</label>
                 <input 
+                  id="log-template-model"
                   type="text" 
                   className="form-input-line ml-2"
                   defaultValue={formatValue(model)}
                 />
               </div>
               <div className="flex items-baseline">
-                <label className="whitespace-nowrap">Serial N⁰:</label>
+                <label className="whitespace-nowrap" htmlFor="log-template-serial">Serial N⁰:</label>
                 <input 
+                  id="log-template-serial"
                   type="text" 
                   className="form-input-line ml-2"
                   defaultValue={formatValue(serial)}
@@ -163,10 +174,11 @@ export function LogTemplate({
             <table className="w-full data-table">
               <thead className="font-bold">
                 <tr>
-                  <th className="w-1/4">Ngày, giờ sử dụng</th>
-                  <th className="w-1/4">Người sử dụng</th>
-                  <th className="w-1/4">Tình trạng thiết bị</th>
-                  <th className="w-1/4">Ghi chú</th>
+                  <th style={{ width: "18%" }}>Ngày, giờ sử dụng</th>
+                  <th style={{ width: "18%" }}>Người sử dụng</th>
+                  <th style={{ width: "16%" }}>Tình trạng bắt đầu</th>
+                  <th style={{ width: "16%" }}>Tình trạng kết thúc</th>
+                  <th style={{ width: "32%" }}>Ghi chú</th>
                 </tr>
               </thead>
               <tbody>
@@ -174,7 +186,8 @@ export function LogTemplate({
                   <tr key={log._rowKey}>
                     <td>{formatValue(log.dateTime) || (index === 0 ? '\u00A0' : '')}</td>
                     <td>{formatValue(log.user)}</td>
-                    <td>{formatValue(log.condition)}</td>
+                    <td>{formatValue(log.initialCondition ?? log.condition)}</td>
+                    <td>{formatValue(log.finalCondition ?? log.condition)}</td>
                     <td>{formatValue(log.note)}</td>
                   </tr>
                 ))}

--- a/src/components/start-usage-dialog.tsx
+++ b/src/components/start-usage-dialog.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
-import { CalendarIcon, Loader2 } from "lucide-react"
+import { Loader2 } from "lucide-react"
 import { format } from "date-fns"
 import { vi } from "date-fns/locale"
 
@@ -27,17 +27,10 @@ import {
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { useSession } from "next-auth/react"
 import { useStartUsageSession } from "@/hooks/use-usage-logs"
 import { useToast } from "@/hooks/use-toast"
-import type { Equipment as DbEquipment } from "@/types/database"
+import type { Equipment as DbEquipment, SessionUser } from "@/types/database"
 import { isRegionalLeaderRole } from "@/lib/rbac"
 
 const equipmentStatusOptions = [
@@ -50,7 +43,7 @@ const equipmentStatusOptions = [
 ] as const
 
 const startUsageSchema = z.object({
-  tinh_trang_thiet_bi: z.string().optional(),
+  tinh_trang_ban_dau: z.string().trim().min(1, "Vui lòng nhập tình trạng ban đầu"),
   ghi_chu: z.string().optional(),
 })
 
@@ -70,7 +63,7 @@ export function StartUsageDialog({
   equipment,
 }: StartUsageDialogProps) {
   const { data: session } = useSession()
-  const user = session?.user as any
+  const user = session?.user as SessionUser | undefined
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
   const { toast } = useToast()
   const currentUserId = React.useMemo(() => {
@@ -88,7 +81,7 @@ export function StartUsageDialog({
   const form = useForm<StartUsageFormData>({
     resolver: zodResolver(startUsageSchema),
     defaultValues: {
-      tinh_trang_thiet_bi: equipment?.tinh_trang_hien_tai || "",
+      tinh_trang_ban_dau: equipment?.tinh_trang_hien_tai || "",
       ghi_chu: "",
     },
   })
@@ -96,7 +89,7 @@ export function StartUsageDialog({
   React.useEffect(() => {
     if (equipment && open) {
       form.reset({
-        tinh_trang_thiet_bi: equipment.tinh_trang_hien_tai || "",
+        tinh_trang_ban_dau: equipment.tinh_trang_hien_tai || "",
         ghi_chu: "",
       })
     }
@@ -122,7 +115,8 @@ export function StartUsageDialog({
       await startUsageMutation.mutateAsync({
         thiet_bi_id: equipment.id,
         nguoi_su_dung_id: requesterId,
-        tinh_trang_thiet_bi: data.tinh_trang_thiet_bi,
+        tinh_trang_thiet_bi: data.tinh_trang_ban_dau,
+        tinh_trang_ban_dau: data.tinh_trang_ban_dau,
         ghi_chu: data.ghi_chu,
       })
       
@@ -150,15 +144,15 @@ export function StartUsageDialog({
             {/* Equipment Info */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 p-4 bg-muted/50 rounded-lg">
               <div>
-                <label className="text-sm font-medium text-muted-foreground">Mã thiết bị</label>
+                <p className="text-sm font-medium text-muted-foreground">Mã thiết bị</p>
                 <p className="text-sm font-mono">{equipment?.ma_thiet_bi}</p>
               </div>
               <div>
-                <label className="text-sm font-medium text-muted-foreground">Người sử dụng</label>
+                <p className="text-sm font-medium text-muted-foreground">Người sử dụng</p>
                 <p className="text-sm">{user?.full_name}</p>
               </div>
               <div className="col-span-1 sm:col-span-2">
-                <label className="text-sm font-medium text-muted-foreground">Thời gian bắt đầu</label>
+                <p className="text-sm font-medium text-muted-foreground">Thời gian bắt đầu</p>
                 <p className="text-sm">{format(new Date(), "dd/MM/yyyy HH:mm", { locale: vi })}</p>
               </div>
             </div>
@@ -166,24 +160,22 @@ export function StartUsageDialog({
             {/* Equipment Status */}
             <FormField
               control={form.control}
-              name="tinh_trang_thiet_bi"
+              name="tinh_trang_ban_dau"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Tình trạng thiết bị</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Chọn tình trạng thiết bị" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {equipmentStatusOptions.map((status) => (
-                        <SelectItem key={status} value={status}>
-                          {status}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <FormLabel>Tình trạng ban đầu</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      list="start-usage-status-options"
+                      placeholder="Nhập tình trạng thiết bị trước khi sử dụng"
+                    />
+                  </FormControl>
+                  <datalist id="start-usage-status-options">
+                    {equipmentStatusOptions.map((status) => (
+                      <option key={status} value={status} />
+                    ))}
+                  </datalist>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/components/usage-history-tab.tsx
+++ b/src/components/usage-history-tab.tsx
@@ -32,7 +32,8 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { useEquipmentUsageLogs, useEquipmentUsageLogsMore, useDeleteUsageLog } from "@/hooks/use-usage-logs"
 import { useSession } from "next-auth/react"
 import { useIsMobile } from "@/hooks/use-mobile"
-import { type Equipment, type UsageLog, USAGE_STATUS } from "@/types/database"
+import { getUsageLogFinalStatus, getUsageLogInitialStatus } from "@/lib/usage-log-status"
+import { type Equipment, type SessionUser, type UsageLog, USAGE_STATUS } from "@/types/database"
 import { isGlobalRole } from "@/lib/rbac"
 import { EndUsageDialog } from "./end-usage-dialog"
 import { UsageLogPrint } from "./usage-log-print"
@@ -43,10 +44,10 @@ interface UsageHistoryTabProps {
 
 export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
   const { data: session } = useSession()
-  const user = session?.user as any
+  const user = session?.user as SessionUser | undefined
   const canDeleteUsageLogs = isGlobalRole(user?.role)
   const userId = React.useMemo(() => {
-    const uid = (user?.id as any)
+    const uid = user?.id
     const n = typeof uid === 'string' ? Number(uid) : uid
     return Number.isFinite(n) ? (n as number) : null
   }, [user?.id])
@@ -268,12 +269,15 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                       </span>
                     </div>
                     
-                    {log.tinh_trang_thiet_bi && (
-                      <div>
-                        <span className="text-muted-foreground">Tình trạng: </span>
-                        <span>{log.tinh_trang_thiet_bi}</span>
-                      </div>
-                    )}
+                    <div>
+                      <span className="text-muted-foreground">Tình trạng ban đầu: </span>
+                      <span>{getUsageLogInitialStatus(log) || '-'}</span>
+                    </div>
+
+                    <div>
+                      <span className="text-muted-foreground">Tình trạng kết thúc: </span>
+                      <span>{getUsageLogFinalStatus(log) || '-'}</span>
+                    </div>
                     
                     {log.ghi_chu && (
                       <div className="flex gap-2">
@@ -296,7 +300,8 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                   <TableHead>Thời gian bắt đầu</TableHead>
                   <TableHead>Thời gian kết thúc</TableHead>
                   <TableHead>Thời lượng</TableHead>
-                  <TableHead>Tình trạng TB</TableHead>
+                  <TableHead>Tình trạng ban đầu</TableHead>
+                  <TableHead>Tình trạng kết thúc</TableHead>
                   <TableHead>Trạng thái</TableHead>
                   <TableHead>Ghi chú</TableHead>
                   {canDeleteUsageLogs && <TableHead className="w-[50px]"></TableHead>}
@@ -320,7 +325,8 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                     <TableCell>
                       {formatDuration(log.thoi_gian_bat_dau, log.thoi_gian_ket_thuc)}
                     </TableCell>
-                    <TableCell>{log.tinh_trang_thiet_bi || '-'}</TableCell>
+                    <TableCell>{getUsageLogInitialStatus(log) || '-'}</TableCell>
+                    <TableCell>{getUsageLogFinalStatus(log) || '-'}</TableCell>
                     <TableCell>
                       <Badge variant={log.trang_thai === 'dang_su_dung' ? 'default' : 'secondary'}>
                         {USAGE_STATUS[log.trang_thai]}

--- a/src/components/usage-history-tab.tsx
+++ b/src/components/usage-history-tab.tsx
@@ -55,7 +55,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
   const [isEndDialogOpen, setIsEndDialogOpen] = React.useState(false)
   const [selectedUsageLog, setSelectedUsageLog] = React.useState<UsageLog | null>(null)
   const [loadMoreOffset, setLoadMoreOffset] = React.useState(0)
-  const [allUsageLogs, setAllUsageLogs] = React.useState<UsageLog[]>([])
+  const [loadedUsageLogPages, setLoadedUsageLogPages] = React.useState<Record<number, UsageLog[]>>({})
 
   // Initial load - recent usage logs (last 3 months, 50 records)
   const { data: recentUsageLogs, isLoading } = useEquipmentUsageLogs(equipment.id.toString(), {
@@ -73,19 +73,36 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
     }
   )
 
-  // Combine recent and additional usage logs
+  // Append each loaded page without dropping previously appended pages.
   React.useEffect(() => {
-    const combined = [...(recentUsageLogs || [])]
-    if (moreUsageLogs && moreUsageLogs.length > 0) {
-      // Add more logs, avoiding duplicates based on ID
-      const existingIds = new Set(combined.map(log => log.id))
-      const newLogs = moreUsageLogs.filter(log => !existingIds.has(log.id))
-      combined.push(...newLogs)
+    if (!moreUsageLogs || moreUsageLogs.length === 0) {
+      return
     }
-    setAllUsageLogs(combined)
-  }, [recentUsageLogs, moreUsageLogs])
 
-  const usageLogs = allUsageLogs
+    setLoadedUsageLogPages((previousPages) => {
+      const existingLogs = previousPages[equipment.id] || []
+      const existingIds = new Set(existingLogs.map((log) => log.id))
+      const newLogs = moreUsageLogs.filter((log) => !existingIds.has(log.id))
+
+      if (newLogs.length === 0) {
+        return previousPages
+      }
+
+      return {
+        ...previousPages,
+        [equipment.id]: [...existingLogs, ...newLogs],
+      }
+    })
+  }, [equipment.id, moreUsageLogs])
+
+  const usageLogs = React.useMemo(() => {
+    const recentLogs = recentUsageLogs || []
+    const loadedLogs = loadedUsageLogPages[equipment.id] || []
+    const existingIds = new Set(recentLogs.map((log) => log.id))
+    const uniqueLoadedLogs = loadedLogs.filter((log) => !existingIds.has(log.id))
+
+    return [...recentLogs, ...uniqueLoadedLogs]
+  }, [equipment.id, loadedUsageLogPages, recentUsageLogs])
   const deleteUsageLogMutation = useDeleteUsageLog()
 
   // Find active usage session for current user
@@ -225,7 +242,12 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                       {canDeleteUsageLogs && log.trang_thai === 'hoan_thanh' && (
                         <AlertDialog>
                           <AlertDialogTrigger asChild>
-                            <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0"
+                              aria-label={`Xóa nhật ký sử dụng ${log.id}`}
+                            >
                               <Trash2 className="h-4 w-4" />
                             </Button>
                           </AlertDialogTrigger>
@@ -340,7 +362,12 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                         {log.trang_thai === 'hoan_thanh' && (
                           <AlertDialog>
                             <AlertDialogTrigger asChild>
-                              <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-8 w-8 p-0"
+                                aria-label={`Xóa nhật ký sử dụng ${log.id}`}
+                              >
                                 <Trash2 className="h-4 w-4" />
                               </Button>
                             </AlertDialogTrigger>

--- a/src/components/usage-history-tab.tsx
+++ b/src/components/usage-history-tab.tsx
@@ -42,6 +42,19 @@ interface UsageHistoryTabProps {
   equipment: Pick<Equipment, 'id' | 'ten_thiet_bi' | 'ma_thiet_bi'> & Partial<Equipment>
 }
 
+function getUsageLogPageSignature(logs: UsageLog[]) {
+  return logs.map((log) => [
+    log.id,
+    log.updated_at,
+    log.trang_thai,
+    log.thoi_gian_ket_thuc ?? "",
+    log.tinh_trang_ban_dau ?? "",
+    log.tinh_trang_ket_thuc ?? "",
+    log.tinh_trang_thiet_bi ?? "",
+    log.ghi_chu ?? "",
+  ].join(":")).join("|")
+}
+
 export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
   const { data: session } = useSession()
   const user = session?.user as SessionUser | undefined
@@ -55,7 +68,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
   const [isEndDialogOpen, setIsEndDialogOpen] = React.useState(false)
   const [selectedUsageLog, setSelectedUsageLog] = React.useState<UsageLog | null>(null)
   const [loadMoreOffset, setLoadMoreOffset] = React.useState(0)
-  const [loadedUsageLogPages, setLoadedUsageLogPages] = React.useState<Record<number, UsageLog[]>>({})
+  const [loadedUsageLogPages, setLoadedUsageLogPages] = React.useState<Record<number, Record<number, UsageLog[]>>>({})
 
   // Initial load - recent usage logs (last 3 months, 50 records)
   const { data: recentUsageLogs, isLoading } = useEquipmentUsageLogs(equipment.id.toString(), {
@@ -73,31 +86,34 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
     }
   )
 
-  // Append each loaded page without dropping previously appended pages.
+  // Keep each loaded page by offset so refetches can replace stale rows.
   React.useEffect(() => {
-    if (!moreUsageLogs || moreUsageLogs.length === 0) {
+    if (!moreUsageLogs || loadMoreOffset === 0) {
       return
     }
 
     setLoadedUsageLogPages((previousPages) => {
-      const existingLogs = previousPages[equipment.id] || []
-      const existingIds = new Set(existingLogs.map((log) => log.id))
-      const newLogs = moreUsageLogs.filter((log) => !existingIds.has(log.id))
-
-      if (newLogs.length === 0) {
+      const equipmentPages = previousPages[equipment.id] || {}
+      const currentPage = equipmentPages[loadMoreOffset]
+      if (currentPage && getUsageLogPageSignature(currentPage) === getUsageLogPageSignature(moreUsageLogs)) {
         return previousPages
       }
 
       return {
         ...previousPages,
-        [equipment.id]: [...existingLogs, ...newLogs],
+        [equipment.id]: {
+          ...equipmentPages,
+          [loadMoreOffset]: moreUsageLogs,
+        },
       }
     })
-  }, [equipment.id, moreUsageLogs])
+  }, [equipment.id, loadMoreOffset, moreUsageLogs])
 
   const usageLogs = React.useMemo(() => {
     const recentLogs = recentUsageLogs || []
-    const loadedLogs = loadedUsageLogPages[equipment.id] || []
+    const loadedLogs = Object.entries(loadedUsageLogPages[equipment.id] || {})
+      .sort(([leftOffset], [rightOffset]) => Number(leftOffset) - Number(rightOffset))
+      .flatMap(([, logs]) => logs)
     const existingIds = new Set(recentLogs.map((log) => log.id))
     const uniqueLoadedLogs = loadedLogs.filter((log) => !existingIds.has(log.id))
 
@@ -137,6 +153,30 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
   const handleDeleteUsageLog = async (id: number) => {
     try {
       await deleteUsageLogMutation.mutateAsync(id)
+      setLoadedUsageLogPages((previousPages) => {
+        const equipmentPages = previousPages[equipment.id]
+        if (!equipmentPages) {
+          return previousPages
+        }
+
+        let removed = false
+        const nextEquipmentPages = Object.fromEntries(
+          Object.entries(equipmentPages).map(([offset, logs]) => {
+            const nextLogs = logs.filter((log) => log.id !== id)
+            removed ||= nextLogs.length !== logs.length
+            return [offset, nextLogs]
+          })
+        )
+
+        if (!removed) {
+          return previousPages
+        }
+
+        return {
+          ...previousPages,
+          [equipment.id]: nextEquipmentPages,
+        }
+      })
     } catch (error) {
       // Error handling is done in the mutation
     }

--- a/src/components/usage-log-print-builder-utils.ts
+++ b/src/components/usage-log-print-builder-utils.ts
@@ -34,9 +34,16 @@ export function escapeHtml(str: string | null | undefined): string {
 export function escapeUrl(url: string | null | undefined): string {
   if (url == null) return ""
   const trimmed = String(url).trim()
-  if (trimmed.startsWith("http://") || trimmed.startsWith("https://") || trimmed.startsWith("data:")) {
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
     return escapeHtml(trimmed)
   }
+
+  const safeDataImagePattern = /^data:image\/(?:png|jpeg|jpg|gif|webp);base64,[a-z0-9+/]+=*$/i
+  if (safeDataImagePattern.test(trimmed)) {
+    return escapeHtml(trimmed)
+  }
+
   return ""
 }
 

--- a/src/components/usage-log-print-builder-utils.ts
+++ b/src/components/usage-log-print-builder-utils.ts
@@ -1,0 +1,62 @@
+import { differenceInMinutes } from "date-fns"
+
+import { getUsageLogFinalStatus, getUsageLogInitialStatus } from "@/lib/usage-log-status"
+import { type Equipment, type UsageLog } from "@/types/database"
+
+export type PrintableEquipment = Pick<Equipment, "ma_thiet_bi" | "ten_thiet_bi"> & Partial<Equipment>
+
+export interface BuildUsageLogPrintHtmlArgs {
+  equipment: PrintableEquipment
+  filteredLogs: UsageLog[]
+  tenantName: string
+  tenantLogoUrl: string
+  dateFrom: string
+  dateTo: string
+  now: Date
+}
+
+export interface BuildUsageLogCsvArgs {
+  equipment: PrintableEquipment
+  filteredLogs: UsageLog[]
+  now: Date
+}
+
+export function escapeHtml(str: string | null | undefined): string {
+  if (str == null) return ""
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+export function escapeUrl(url: string | null | undefined): string {
+  if (url == null) return ""
+  const trimmed = String(url).trim()
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://") || trimmed.startsWith("data:")) {
+    return escapeHtml(trimmed)
+  }
+  return ""
+}
+
+export function formatUsageDuration(startTime: string, endTime?: string, now = new Date()) {
+  const start = new Date(startTime)
+  const end = endTime ? new Date(endTime) : now
+  const minutes = differenceInMinutes(end, start)
+  const hours = Math.floor(minutes / 60)
+  const mins = minutes % 60
+
+  if (hours > 0) {
+    return `${hours} giờ ${mins} phút`
+  }
+  return `${mins} phút`
+}
+
+export function getPrintableInitialStatus(log: UsageLog): string {
+  return getUsageLogInitialStatus(log) || ""
+}
+
+export function getPrintableFinalStatus(log: UsageLog): string {
+  return getUsageLogFinalStatus(log) || ""
+}

--- a/src/components/usage-log-print-builder-utils.ts
+++ b/src/components/usage-log-print-builder-utils.ts
@@ -40,6 +40,22 @@ export function escapeUrl(url: string | null | undefined): string {
   return ""
 }
 
+export function escapeCsvCell(value: unknown): string {
+  const raw = value == null ? "" : String(value)
+  const sanitized = /^[=+\-@]/.test(raw) ? `'${raw}` : raw
+  return `"${sanitized.replace(/"/g, '""')}"`
+}
+
+export function parseDateInputAsLocalDate(dateString: string): Date {
+  const [year, month, day] = dateString.split("-").map(Number)
+  return new Date(year, month - 1, day)
+}
+
+export function formatDateInputForPrint(dateString: string): string {
+  const [year, month, day] = dateString.split("-")
+  return `${day}/${month}/${year}`
+}
+
 export function formatUsageDuration(startTime: string, endTime?: string, now = new Date()) {
   const start = new Date(startTime)
   const end = endTime ? new Date(endTime) : now

--- a/src/components/usage-log-print-builders.ts
+++ b/src/components/usage-log-print-builders.ts
@@ -1,0 +1,2 @@
+export { buildUsageLogCsv } from "@/components/usage-log-print-csv-builder"
+export { buildUsageLogPrintHtml } from "@/components/usage-log-print-html-builder"

--- a/src/components/usage-log-print-csv-builder.ts
+++ b/src/components/usage-log-print-csv-builder.ts
@@ -3,6 +3,7 @@ import { vi } from "date-fns/locale"
 
 import {
   type BuildUsageLogCsvArgs,
+  escapeCsvCell,
   getPrintableFinalStatus,
   getPrintableInitialStatus,
 } from "@/components/usage-log-print-builder-utils"
@@ -39,12 +40,12 @@ export function buildUsageLogCsv({
   ])
 
   const csvContent = [
-    `"Nhật ký sử dụng thiết bị: ${equipment.ten_thiet_bi}"`,
-    `"Mã thiết bị: ${equipment.ma_thiet_bi}"`,
-    `"Xuất ngày: ${format(now, "dd/MM/yyyy HH:mm", { locale: vi })}"`,
+    escapeCsvCell(`Nhật ký sử dụng thiết bị: ${equipment.ten_thiet_bi}`),
+    escapeCsvCell(`Mã thiết bị: ${equipment.ma_thiet_bi}`),
+    escapeCsvCell(`Xuất ngày: ${format(now, "dd/MM/yyyy HH:mm", { locale: vi })}`),
     "",
-    headers.map((header) => `"${header}"`).join(","),
-    ...rows.map((row) => row.map((cell) => `"${cell}"`).join(",")),
+    headers.map((header) => escapeCsvCell(header)).join(","),
+    ...rows.map((row) => row.map((cell) => escapeCsvCell(cell)).join(",")),
   ].join("\n")
 
   return `\uFEFF${csvContent}`

--- a/src/components/usage-log-print-csv-builder.ts
+++ b/src/components/usage-log-print-csv-builder.ts
@@ -1,0 +1,51 @@
+import { differenceInMinutes, format } from "date-fns"
+import { vi } from "date-fns/locale"
+
+import {
+  type BuildUsageLogCsvArgs,
+  getPrintableFinalStatus,
+  getPrintableInitialStatus,
+} from "@/components/usage-log-print-builder-utils"
+
+export function buildUsageLogCsv({
+  equipment,
+  filteredLogs,
+  now,
+}: BuildUsageLogCsvArgs): string {
+  const headers = [
+    "STT",
+    "Người sử dụng",
+    "Khoa/Phòng",
+    "Thời gian bắt đầu",
+    "Thời gian kết thúc",
+    "Thời lượng (phút)",
+    "Tình trạng ban đầu",
+    "Tình trạng kết thúc",
+    "Trạng thái",
+    "Ghi chú",
+  ]
+
+  const rows = filteredLogs.map((log, index) => [
+    index + 1,
+    log.nguoi_su_dung?.full_name || "Không xác định",
+    log.nguoi_su_dung?.khoa_phong || "",
+    format(new Date(log.thoi_gian_bat_dau), "dd/MM/yyyy HH:mm", { locale: vi }),
+    log.thoi_gian_ket_thuc ? format(new Date(log.thoi_gian_ket_thuc), "dd/MM/yyyy HH:mm", { locale: vi }) : "",
+    differenceInMinutes(log.thoi_gian_ket_thuc ? new Date(log.thoi_gian_ket_thuc) : now, new Date(log.thoi_gian_bat_dau)),
+    getPrintableInitialStatus(log),
+    getPrintableFinalStatus(log),
+    log.trang_thai === "dang_su_dung" ? "Đang sử dụng" : "Hoàn thành",
+    log.ghi_chu || "",
+  ])
+
+  const csvContent = [
+    `"Nhật ký sử dụng thiết bị: ${equipment.ten_thiet_bi}"`,
+    `"Mã thiết bị: ${equipment.ma_thiet_bi}"`,
+    `"Xuất ngày: ${format(now, "dd/MM/yyyy HH:mm", { locale: vi })}"`,
+    "",
+    headers.map((header) => `"${header}"`).join(","),
+    ...rows.map((row) => row.map((cell) => `"${cell}"`).join(",")),
+  ].join("\n")
+
+  return `\uFEFF${csvContent}`
+}

--- a/src/components/usage-log-print-html-builder.ts
+++ b/src/components/usage-log-print-html-builder.ts
@@ -1,0 +1,242 @@
+import { format } from "date-fns"
+import { vi } from "date-fns/locale"
+
+import {
+  type BuildUsageLogPrintHtmlArgs,
+  escapeHtml,
+  escapeUrl,
+  formatUsageDuration,
+  getPrintableFinalStatus,
+  getPrintableInitialStatus,
+} from "@/components/usage-log-print-builder-utils"
+
+export function buildUsageLogPrintHtml({
+  equipment,
+  filteredLogs,
+  tenantName,
+  tenantLogoUrl,
+  dateFrom,
+  dateTo,
+  now,
+}: BuildUsageLogPrintHtmlArgs): string {
+  const currentDate = format(now, "dd/MM/yyyy HH:mm", { locale: vi })
+  const dateRange = dateFrom || dateTo
+    ? `(${dateFrom ? format(new Date(dateFrom), "dd/MM/yyyy", { locale: vi }) : "..."} - ${dateTo ? format(new Date(dateTo), "dd/MM/yyyy", { locale: vi }) : "..."})`
+    : ""
+
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <title>Nhật ký sử dụng thiết bị - ${escapeHtml(equipment.ten_thiet_bi)}</title>
+      <style>
+        @page {
+          size: A4 landscape;
+          margin: 1cm;
+        }
+        body {
+          font-family: 'Times New Roman', serif;
+          font-size: 13px;
+          line-height: 1.4;
+          margin: 0;
+          padding: 0;
+          color: #000;
+        }
+        .header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 20px;
+          border-bottom: 2px solid #000;
+          padding-bottom: 10px;
+        }
+        .header-content {
+          flex-grow: 1;
+          text-align: center;
+        }
+        .header-logo {
+          width: 80px;
+          height: 80px;
+        }
+        .header-spacer {
+          width: 80px;
+          height: 80px;
+        }
+        .content-body {
+          padding-bottom: 30px;
+        }
+        .header h1 {
+          font-size: 20px;
+          font-weight: bold;
+          margin: 0 0 5px 0;
+          text-transform: uppercase;
+        }
+        .header h2 {
+          font-size: 18px;
+          margin: 0 0 5px 0;
+        }
+        .equipment-info {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 20px;
+          margin-bottom: 20px;
+          padding: 10px;
+          border: 1px solid #ccc;
+          background-color: #f9f9f9;
+        }
+        .info-item {
+          display: flex;
+          margin-bottom: 5px;
+        }
+        .info-label {
+          font-weight: bold;
+          min-width: 120px;
+        }
+        .data-table {
+          width: 100%;
+          border-collapse: collapse;
+          margin-bottom: 20px;
+        }
+        .data-table th,
+        .data-table td {
+          border: 1px solid #000;
+          padding: 6px 4px;
+          text-align: left;
+          vertical-align: top;
+          font-size: 13px;
+        }
+        .data-table th {
+          background-color: #f0f0f0;
+          font-weight: bold;
+          text-align: center;
+        }
+        .data-table td:nth-child(1) { width: 5%; }
+        .data-table td:nth-child(2) { width: 14%; }
+        .data-table td:nth-child(3) { width: 11%; }
+        .data-table td:nth-child(4) { width: 11%; }
+        .data-table td:nth-child(5) { width: 9%; }
+        .data-table td:nth-child(6) { width: 14%; }
+        .data-table td:nth-child(7) { width: 14%; }
+        .data-table td:nth-child(8) { width: 8%; }
+        .data-table td:nth-child(9) { width: 14%; }
+        .footer {
+          margin-top: 30px;
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 50px;
+        }
+        .signature-section {
+          text-align: center;
+        }
+        .signature-title {
+          font-weight: bold;
+          margin-bottom: 50px;
+        }
+        .signature-line {
+          border-top: 1px solid #000;
+          margin-top: 50px;
+          padding-top: 5px;
+        }
+        .print-info {
+          font-size: 11px;
+          color: #666;
+          text-align: right;
+          margin-top: 20px;
+        }
+        .status-completed { color: #059669; }
+        .status-active { color: #dc2626; font-weight: bold; }
+      </style>
+    </head>
+    <body>
+      <div class="content-body">
+        <div class="header">
+          <img src="${escapeUrl(tenantLogoUrl)}" alt="Logo" class="header-logo" onerror="this.onerror=null;this.style.display='none';">
+          <div class="header-content">
+            <h2 style="font-size: 14px; font-weight: bold; margin: 0 0 5px 0; text-transform: uppercase;">${escapeHtml(tenantName)}</h2>
+            <h1>NHẬT KÝ SỬ DỤNG THIẾT BỊ</h1>
+            <h2>${escapeHtml(equipment.ten_thiet_bi)}</h2>
+            <div>Mã thiết bị: ${escapeHtml(equipment.ma_thiet_bi)} ${dateRange}</div>
+          </div>
+          <div class="header-spacer"></div>
+        </div>
+        <div class="equipment-info">
+          <div>
+            <div class="info-item">
+              <span class="info-label">Tên thiết bị:</span>
+              <span>${escapeHtml(equipment.ten_thiet_bi)}</span>
+            </div>
+            <div class="info-item">
+              <span class="info-label">Mã thiết bị:</span>
+              <span>${escapeHtml(equipment.ma_thiet_bi)}</span>
+            </div>
+            <div class="info-item">
+              <span class="info-label">Khoa/Phòng:</span>
+              <span>${escapeHtml(equipment.khoa_phong_quan_ly) || "Chưa xác định"}</span>
+            </div>
+          </div>
+          <div>
+            <div class="info-item">
+              <span class="info-label">Hãng sản xuất:</span>
+              <span>${escapeHtml(equipment.hang_san_xuat) || "Chưa có thông tin"}</span>
+            </div>
+            <div class="info-item">
+              <span class="info-label">Model:</span>
+              <span>${escapeHtml(equipment.model) || "Chưa có thông tin"}</span>
+            </div>
+            <div class="info-item">
+              <span class="info-label">Tình trạng hiện tại:</span>
+              <span>${escapeHtml(equipment.tinh_trang_hien_tai) || "Chưa xác định"}</span>
+            </div>
+          </div>
+        </div>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>STT</th>
+              <th>Người sử dụng</th>
+              <th>Thời gian bắt đầu</th>
+              <th>Thời gian kết thúc</th>
+              <th>Thời lượng</th>
+              <th>Tình trạng ban đầu</th>
+              <th>Tình trạng kết thúc</th>
+              <th>Trạng thái</th>
+              <th>Ghi chú</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${filteredLogs.map((log, index) => `
+              <tr>
+                <td style="text-align: center;">${index + 1}</td>
+                <td>${escapeHtml(log.nguoi_su_dung?.full_name) || "Không xác định"}</td>
+                <td>${format(new Date(log.thoi_gian_bat_dau), "dd/MM/yyyy HH:mm", { locale: vi })}</td>
+                <td>${log.thoi_gian_ket_thuc ? format(new Date(log.thoi_gian_ket_thuc), "dd/MM/yyyy HH:mm", { locale: vi }) : "-"}</td>
+                <td>${formatUsageDuration(log.thoi_gian_bat_dau, log.thoi_gian_ket_thuc, now)}</td>
+                <td>${escapeHtml(getPrintableInitialStatus(log)) || "-"}</td>
+                <td>${escapeHtml(getPrintableFinalStatus(log)) || "-"}</td>
+                <td class="${log.trang_thai === "dang_su_dung" ? "status-active" : "status-completed"}">
+                  ${log.trang_thai === "dang_su_dung" ? "Đang sử dụng" : "Hoàn thành"}
+                </td>
+                <td>${escapeHtml(log.ghi_chu) || "-"}</td>
+              </tr>
+            `).join("")}
+          </tbody>
+        </table>
+        <div class="footer">
+          <div class="signature-section">
+            <div class="signature-title">Người lập báo cáo</div>
+            <div class="signature-line">Ký tên</div>
+          </div>
+          <div class="signature-section">
+            <div class="signature-title">Phụ trách thiết bị</div>
+            <div class="signature-line">Ký tên</div>
+          </div>
+        </div>
+        <div class="print-info">
+          In ngày: ${currentDate} | Tổng số bản ghi: ${filteredLogs.length}
+        </div>
+      </div>
+    </body>
+    </html>
+  `
+}

--- a/src/components/usage-log-print-html-builder.ts
+++ b/src/components/usage-log-print-html-builder.ts
@@ -21,8 +21,10 @@ export function buildUsageLogPrintHtml({
   now,
 }: BuildUsageLogPrintHtmlArgs): string {
   const currentDate = format(now, "dd/MM/yyyy HH:mm", { locale: vi })
+  const printableDateFrom = dateFrom ? escapeHtml(formatDateInputForPrint(dateFrom)) : "..."
+  const printableDateTo = dateTo ? escapeHtml(formatDateInputForPrint(dateTo)) : "..."
   const dateRange = dateFrom || dateTo
-    ? `(${dateFrom ? formatDateInputForPrint(dateFrom) : "..."} - ${dateTo ? formatDateInputForPrint(dateTo) : "..."})`
+    ? `(${printableDateFrom} - ${printableDateTo})`
     : ""
 
   return `

--- a/src/components/usage-log-print-html-builder.ts
+++ b/src/components/usage-log-print-html-builder.ts
@@ -5,6 +5,7 @@ import {
   type BuildUsageLogPrintHtmlArgs,
   escapeHtml,
   escapeUrl,
+  formatDateInputForPrint,
   formatUsageDuration,
   getPrintableFinalStatus,
   getPrintableInitialStatus,
@@ -21,7 +22,7 @@ export function buildUsageLogPrintHtml({
 }: BuildUsageLogPrintHtmlArgs): string {
   const currentDate = format(now, "dd/MM/yyyy HH:mm", { locale: vi })
   const dateRange = dateFrom || dateTo
-    ? `(${dateFrom ? format(new Date(dateFrom), "dd/MM/yyyy", { locale: vi }) : "..."} - ${dateTo ? format(new Date(dateTo), "dd/MM/yyyy", { locale: vi }) : "..."})`
+    ? `(${dateFrom ? formatDateInputForPrint(dateFrom) : "..."} - ${dateTo ? formatDateInputForPrint(dateTo) : "..."})`
     : ""
 
   return `

--- a/src/components/usage-log-print.tsx
+++ b/src/components/usage-log-print.tsx
@@ -1,9 +1,8 @@
 "use client"
 
 import React from "react"
-import { format, differenceInMinutes } from "date-fns"
-import { vi } from "date-fns/locale"
-import { Printer, Download, Calendar, Filter } from "lucide-react"
+import { format } from "date-fns"
+import { Printer, Download } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -26,7 +25,8 @@ import {
 } from "@/components/ui/select"
 import { useEquipmentUsageLogs } from "@/hooks/use-usage-logs"
 import { useTenantBranding } from "@/hooks/use-tenant-branding"
-import { type Equipment, type UsageLog } from "@/types/database"
+import { buildUsageLogCsv, buildUsageLogPrintHtml } from "@/components/usage-log-print-builders"
+import { type Equipment } from "@/types/database"
 
 interface UsageLogPrintProps {
   equipment: Pick<Equipment, 'id' | 'ten_thiet_bi' | 'ma_thiet_bi'> & Partial<Equipment>
@@ -38,34 +38,6 @@ const STATUS_FILTER_OPTIONS = [
   { value: 'hoan_thanh', label: 'Hoàn thành' },
   { value: 'dang_su_dung', label: 'Đang sử dụng' },
 ] as const
-
-/**
- * Escapes HTML special characters to prevent XSS attacks.
- * Used when interpolating user-supplied data into HTML template strings.
- */
-function escapeHtml(str: string | null | undefined): string {
-  if (str == null) return ''
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
-
-/**
- * Escapes a URL for safe use in HTML attributes.
- * Only allows http, https, and data URLs to prevent javascript: injection.
- */
-function escapeUrl(url: string | null | undefined): string {
-  if (url == null) return ''
-  const trimmed = String(url).trim()
-  // Only allow safe URL protocols
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://') || trimmed.startsWith('data:')) {
-    return escapeHtml(trimmed)
-  }
-  return ''
-}
 
 export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
   const [isDialogOpen, setIsDialogOpen] = React.useState(false)
@@ -104,22 +76,16 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
     })
   }, [usageLogs, dateFrom, dateTo, statusFilter])
 
-  const formatDuration = (startTime: string, endTime?: string) => {
-    const start = new Date(startTime)
-    const end = endTime ? new Date(endTime) : new Date()
-    const minutes = differenceInMinutes(end, start)
-    
-    const hours = Math.floor(minutes / 60)
-    const mins = minutes % 60
-    
-    if (hours > 0) {
-      return `${hours} giờ ${mins} phút`
-    }
-    return `${mins} phút`
-  }
-
   const handlePrint = () => {
-    const printContent = generatePrintContent()
+    const printContent = buildUsageLogPrintHtml({
+      equipment,
+      filteredLogs,
+      tenantName,
+      tenantLogoUrl,
+      dateFrom,
+      dateTo,
+      now: new Date(),
+    })
     const printWindow = window.open('', '_blank')
 
     if (printWindow) {
@@ -134,7 +100,11 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
   }
 
   const handleExport = () => {
-    const csvContent = generateCSVContent()
+    const csvContent = buildUsageLogCsv({
+      equipment,
+      filteredLogs,
+      now: new Date(),
+    })
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
     const link = document.createElement('a')
     
@@ -149,301 +119,6 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
     }
     
     setIsDialogOpen(false)
-  }
-
-  const generatePrintContent = () => {
-    const currentDate = format(new Date(), 'dd/MM/yyyy HH:mm', { locale: vi })
-    const dateRange = dateFrom || dateTo 
-      ? `(${dateFrom ? format(new Date(dateFrom), 'dd/MM/yyyy', { locale: vi }) : '...'} - ${dateTo ? format(new Date(dateTo), 'dd/MM/yyyy', { locale: vi }) : '...'})`
-      : ''
-
-    return `
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <meta charset="utf-8">
-        <title>Nhật ký sử dụng thiết bị - ${escapeHtml(equipment.ten_thiet_bi)}</title>
-        <style>
-          @page {
-            size: A4 landscape;
-            margin: 1cm;
-          }
-          
-          body {
-            font-family: 'Times New Roman', serif;
-            font-size: 13px;
-            line-height: 1.4;
-            margin: 0;
-            padding: 0;
-            color: #000;
-          }
-          
-          .header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 20px;
-            border-bottom: 2px solid #000;
-            padding-bottom: 10px;
-          }
-
-          .header-content {
-            flex-grow: 1;
-            text-align: center;
-          }
-
-          .header-logo {
-            width: 80px;
-            height: 80px;
-          }
-
-          .header-spacer {
-            width: 80px;
-            height: 80px;
-          }
-
-          /* Print footer styles */
-          .print-footer {
-            position: fixed;
-            bottom: 1cm;
-            left: 2cm;
-            right: 2cm;
-            width: calc(100% - 4cm);
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            font-size: 11px;
-          }
-
-          .content-body {
-            padding-bottom: 30px; /* Space for footer */
-          }
-          
-          .header h1 {
-            font-size: 20px;
-            font-weight: bold;
-            margin: 0 0 5px 0;
-            text-transform: uppercase;
-          }
-          
-          .header h2 {
-            font-size: 18px;
-            margin: 0 0 5px 0;
-          }
-          
-          .equipment-info {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 20px;
-            margin-bottom: 20px;
-            padding: 10px;
-            border: 1px solid #ccc;
-            background-color: #f9f9f9;
-          }
-          
-          .info-item {
-            display: flex;
-            margin-bottom: 5px;
-          }
-          
-          .info-label {
-            font-weight: bold;
-            min-width: 120px;
-          }
-          
-          .data-table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-bottom: 20px;
-          }
-          
-          .data-table th,
-          .data-table td {
-            border: 1px solid #000;
-            padding: 6px 4px;
-            text-align: left;
-            vertical-align: top;
-            font-size: 13px;
-          }
-          
-          .data-table th {
-            background-color: #f0f0f0;
-            font-weight: bold;
-            text-align: center;
-          }
-          
-          .data-table td:nth-child(1) { width: 6%; } /* STT */
-          .data-table td:nth-child(2) { width: 20%; } /* Người sử dụng */
-          .data-table td:nth-child(3) { width: 15%; } /* Thời gian bắt đầu */
-          .data-table td:nth-child(4) { width: 15%; } /* Thời gian kết thúc */
-          .data-table td:nth-child(5) { width: 10%; } /* Thời lượng */
-          .data-table td:nth-child(6) { width: 14%; } /* Trạng thái */
-          .data-table td:nth-child(7) { width: 12%; } /* Ghi chú */
-          
-          .footer {
-            margin-top: 30px;
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 50px;
-          }
-          
-          .signature-section {
-            text-align: center;
-          }
-          
-          .signature-title {
-            font-weight: bold;
-            margin-bottom: 50px;
-          }
-          
-          .signature-line {
-            border-top: 1px solid #000;
-            margin-top: 50px;
-            padding-top: 5px;
-          }
-          
-          .print-info {
-            font-size: 11px;
-            color: #666;
-            text-align: right;
-            margin-top: 20px;
-          }
-          
-          .status-completed { color: #059669; }
-          .status-active { color: #dc2626; font-weight: bold; }
-        </style>
-      </head>
-      <body>
-        <div class="content-body">
-        <div class="header">
-          <img src="${escapeUrl(tenantLogoUrl)}" alt="Logo" class="header-logo" onerror="this.onerror=null;this.style.display='none';">
-          <div class="header-content">
-            <h2 style="font-size: 14px; font-weight: bold; margin: 0 0 5px 0; text-transform: uppercase;">${escapeHtml(tenantName)}</h2>
-            <h1>NHẬT KÝ SỬ DỤNG THIẾT BỊ</h1>
-            <h2>${escapeHtml(equipment.ten_thiet_bi)}</h2>
-            <div>Mã thiết bị: ${escapeHtml(equipment.ma_thiet_bi)} ${dateRange}</div>
-          </div>
-          <div class="header-spacer"></div>
-        </div>
-        
-        <div class="equipment-info">
-          <div>
-            <div class="info-item">
-              <span class="info-label">Tên thiết bị:</span>
-              <span>${escapeHtml(equipment.ten_thiet_bi)}</span>
-            </div>
-            <div class="info-item">
-              <span class="info-label">Mã thiết bị:</span>
-              <span>${escapeHtml(equipment.ma_thiet_bi)}</span>
-            </div>
-            <div class="info-item">
-              <span class="info-label">Khoa/Phòng:</span>
-              <span>${escapeHtml(equipment.khoa_phong_quan_ly) || 'Chưa xác định'}</span>
-            </div>
-          </div>
-          <div>
-            <div class="info-item">
-              <span class="info-label">Hãng sản xuất:</span>
-              <span>${escapeHtml(equipment.hang_san_xuat) || 'Chưa có thông tin'}</span>
-            </div>
-            <div class="info-item">
-              <span class="info-label">Model:</span>
-              <span>${escapeHtml(equipment.model) || 'Chưa có thông tin'}</span>
-            </div>
-            <div class="info-item">
-              <span class="info-label">Tình trạng hiện tại:</span>
-              <span>${escapeHtml(equipment.tinh_trang_hien_tai) || 'Chưa xác định'}</span>
-            </div>
-          </div>
-        </div>
-        
-        <table class="data-table">
-          <thead>
-            <tr>
-              <th>STT</th>
-              <th>Người sử dụng</th>
-              <th>Thời gian bắt đầu</th>
-              <th>Thời gian kết thúc</th>
-              <th>Thời lượng</th>
-              <th>Trạng thái</th>
-              <th>Ghi chú</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${filteredLogs.map((log, index) => `
-              <tr>
-                <td style="text-align: center;">${index + 1}</td>
-                <td>${escapeHtml(log.nguoi_su_dung?.full_name) || 'Không xác định'}</td>
-                <td>${format(new Date(log.thoi_gian_bat_dau), 'dd/MM/yyyy HH:mm', { locale: vi })}</td>
-                <td>${log.thoi_gian_ket_thuc ? format(new Date(log.thoi_gian_ket_thuc), 'dd/MM/yyyy HH:mm', { locale: vi }) : '-'}</td>
-                <td>${formatDuration(log.thoi_gian_bat_dau, log.thoi_gian_ket_thuc)}</td>
-                <td class="${log.trang_thai === 'dang_su_dung' ? 'status-active' : 'status-completed'}">
-                  ${log.trang_thai === 'dang_su_dung' ? 'Đang sử dụng' : 'Hoàn thành'}
-                </td>
-                <td>${escapeHtml(log.ghi_chu) || '-'}</td>
-              </tr>
-            `).join('')}
-          </tbody>
-        </table>
-        
-        <div class="footer">
-          <div class="signature-section">
-            <div class="signature-title">Người lập báo cáo</div>
-            <div class="signature-line">Ký tên</div>
-          </div>
-          <div class="signature-section">
-            <div class="signature-title">Phụ trách thiết bị</div>
-            <div class="signature-line">Ký tên</div>
-          </div>
-        </div>
-        
-        <div class="print-info">
-          In ngày: ${currentDate} | Tổng số bản ghi: ${filteredLogs.length}
-        </div>
-        </div>
-      </body>
-      </html>
-    `
-  }
-
-  const generateCSVContent = () => {
-    const headers = [
-      'STT',
-      'Người sử dụng',
-      'Khoa/Phòng',
-      'Thời gian bắt đầu',
-      'Thời gian kết thúc',
-      'Thời lượng (phút)',
-      'Tình trạng thiết bị',
-      'Trạng thái',
-      'Ghi chú'
-    ]
-
-    const rows = filteredLogs.map((log, index) => [
-      index + 1,
-      log.nguoi_su_dung?.full_name || 'Không xác định',
-      log.nguoi_su_dung?.khoa_phong || '',
-      format(new Date(log.thoi_gian_bat_dau), 'dd/MM/yyyy HH:mm', { locale: vi }),
-      log.thoi_gian_ket_thuc ? format(new Date(log.thoi_gian_ket_thuc), 'dd/MM/yyyy HH:mm', { locale: vi }) : '',
-      differenceInMinutes(
-        log.thoi_gian_ket_thuc ? new Date(log.thoi_gian_ket_thuc) : new Date(),
-        new Date(log.thoi_gian_bat_dau)
-      ),
-      log.tinh_trang_thiet_bi || '',
-      log.trang_thai === 'dang_su_dung' ? 'Đang sử dụng' : 'Hoàn thành',
-      log.ghi_chu || ''
-    ])
-
-    const csvContent = [
-      `"Nhật ký sử dụng thiết bị: ${equipment.ten_thiet_bi}"`,
-      `"Mã thiết bị: ${equipment.ma_thiet_bi}"`,
-      `"Xuất ngày: ${format(new Date(), 'dd/MM/yyyy HH:mm', { locale: vi })}"`,
-      '',
-      headers.map(h => `"${h}"`).join(','),
-      ...rows.map(row => row.map(cell => `"${cell}"`).join(','))
-    ].join('\n')
-
-    return '\uFEFF' + csvContent // Add BOM for UTF-8
   }
 
   return (

--- a/src/components/usage-log-print.tsx
+++ b/src/components/usage-log-print.tsx
@@ -90,8 +90,9 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
     const printWindow = window.open('', '_blank')
 
     if (printWindow) {
-      // Use modern approach to avoid deprecated document.write
-      printWindow.document.documentElement.innerHTML = printContent
+      printWindow.document.open()
+      printWindow.document.write(printContent)
+      printWindow.document.close()
       printWindow.focus()
       printWindow.print()
       printWindow.close()

--- a/src/components/usage-log-print.tsx
+++ b/src/components/usage-log-print.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/select"
 import { useEquipmentUsageLogs } from "@/hooks/use-usage-logs"
 import { useTenantBranding } from "@/hooks/use-tenant-branding"
+import { parseDateInputAsLocalDate } from "@/components/usage-log-print-builder-utils"
 import { buildUsageLogCsv, buildUsageLogPrintHtml } from "@/components/usage-log-print-builders"
 import { type Equipment } from "@/types/database"
 
@@ -55,9 +56,9 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
     if (!usageLogs) return []
 
     // Pre-calculate date boundaries to avoid creating Date objects in loop
-    const fromDate = dateFrom ? new Date(dateFrom) : null
+    const fromDate = dateFrom ? parseDateInputAsLocalDate(dateFrom) : null
     const toDate = dateTo ? (() => {
-      const date = new Date(dateTo)
+      const date = parseDateInputAsLocalDate(dateTo)
       date.setHours(23, 59, 59, 999) // End of day
       return date
     })() : null

--- a/src/hooks/__tests__/use-usage-logs.split-status.test.ts
+++ b/src/hooks/__tests__/use-usage-logs.split-status.test.ts
@@ -1,0 +1,110 @@
+import * as React from "react"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockCallRpc = vi.fn()
+const mockToast = vi.fn()
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: (args: unknown) => mockCallRpc(args),
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  toast: (args: unknown) => mockToast(args),
+}))
+
+import { useEndUsageSession, useStartUsageSession } from "../use-usage-logs"
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe("use-usage-logs split status payloads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCallRpc.mockReset()
+    mockCallRpc.mockResolvedValue({
+      id: 123,
+      thiet_bi_id: 456,
+      trang_thai: "dang_su_dung",
+    })
+  })
+
+  it("sends both the legacy and split initial status fields when starting usage", async () => {
+    const queryClient = createQueryClient()
+    const { result } = renderHook(() => useStartUsageSession(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    act(() => {
+      result.current.mutate({
+        thiet_bi_id: 456,
+        nguoi_su_dung_id: 789,
+        tinh_trang_thiet_bi: "Hoạt động tốt",
+        tinh_trang_ban_dau: "Hoạt động tốt",
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockCallRpc).toHaveBeenCalledWith({
+      fn: "usage_session_start",
+      args: {
+        p_thiet_bi_id: 456,
+        p_nguoi_su_dung_id: 789,
+        p_tinh_trang_thiet_bi: "Hoạt động tốt",
+        p_ghi_chu: null,
+        p_tinh_trang_ban_dau: "Hoạt động tốt",
+      },
+    })
+  })
+
+  it("sends both the legacy and split final status fields when ending usage", async () => {
+    mockCallRpc.mockResolvedValueOnce({
+      id: 123,
+      thiet_bi_id: 456,
+      trang_thai: "hoan_thanh",
+    })
+
+    const queryClient = createQueryClient()
+    const { result } = renderHook(() => useEndUsageSession(), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    act(() => {
+      result.current.mutate({
+        id: 123,
+        tinh_trang_thiet_bi: "Cần bảo trì",
+        tinh_trang_ket_thuc: "Cần bảo trì",
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockCallRpc).toHaveBeenCalledWith({
+      fn: "usage_session_end",
+      args: {
+        p_usage_log_id: 123,
+        p_tinh_trang_thiet_bi: "Cần bảo trì",
+        p_ghi_chu: null,
+        p_tinh_trang_ket_thuc: "Cần bảo trì",
+      },
+    })
+  })
+})

--- a/src/hooks/use-usage-logs.ts
+++ b/src/hooks/use-usage-logs.ts
@@ -155,6 +155,7 @@ export function useStartUsageSession() {
       thiet_bi_id: number
       nguoi_su_dung_id: number
       tinh_trang_thiet_bi?: string
+      tinh_trang_ban_dau?: string
       ghi_chu?: string
     }) => {
       const result = await callRpc<UsageLog>({
@@ -164,6 +165,7 @@ export function useStartUsageSession() {
           p_nguoi_su_dung_id: data.nguoi_su_dung_id,
           p_tinh_trang_thiet_bi: data.tinh_trang_thiet_bi ?? null,
           p_ghi_chu: data.ghi_chu ?? null,
+          p_tinh_trang_ban_dau: data.tinh_trang_ban_dau ?? null,
         },
       })
 
@@ -197,6 +199,7 @@ export function useEndUsageSession() {
     mutationFn: async (data: {
       id: number
       tinh_trang_thiet_bi?: string
+      tinh_trang_ket_thuc?: string
       ghi_chu?: string
     }) => {
       const result = await callRpc<UsageLog>({
@@ -205,6 +208,7 @@ export function useEndUsageSession() {
           p_usage_log_id: data.id,
           p_tinh_trang_thiet_bi: data.tinh_trang_thiet_bi ?? null,
           p_ghi_chu: data.ghi_chu ?? null,
+          p_tinh_trang_ket_thuc: data.tinh_trang_ket_thuc ?? null,
         },
       })
 

--- a/src/lib/__tests__/usage-log-status.test.ts
+++ b/src/lib/__tests__/usage-log-status.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getUsageLogFinalStatus,
+  getUsageLogInitialStatus,
+} from "../usage-log-status"
+
+describe("usage-log-status", () => {
+  it("prefers split status fields when present", () => {
+    const usageLog = {
+      tinh_trang_ban_dau: "Tốt",
+      tinh_trang_ket_thuc: "Cần kiểm tra",
+      tinh_trang_thiet_bi: "Legacy",
+    }
+
+    expect(getUsageLogInitialStatus(usageLog)).toBe("Tốt")
+    expect(getUsageLogFinalStatus(usageLog)).toBe("Cần kiểm tra")
+  })
+
+  it("falls back to legacy status when split fields are null", () => {
+    const usageLog = {
+      tinh_trang_ban_dau: null,
+      tinh_trang_ket_thuc: null,
+      tinh_trang_thiet_bi: "Tình trạng cũ",
+    }
+
+    expect(getUsageLogInitialStatus(usageLog)).toBe("Tình trạng cũ")
+    expect(getUsageLogFinalStatus(usageLog)).toBe("Tình trạng cũ")
+  })
+
+  it("returns null when no status field is available", () => {
+    expect(getUsageLogInitialStatus({})).toBeNull()
+    expect(getUsageLogFinalStatus({})).toBeNull()
+  })
+})

--- a/src/lib/usage-log-status.ts
+++ b/src/lib/usage-log-status.ts
@@ -1,0 +1,13 @@
+type UsageLogStatusLike = {
+  tinh_trang_ban_dau?: string | null
+  tinh_trang_ket_thuc?: string | null
+  tinh_trang_thiet_bi?: string | null
+}
+
+export function getUsageLogInitialStatus(log: UsageLogStatusLike): string | null {
+  return log.tinh_trang_ban_dau ?? log.tinh_trang_thiet_bi ?? null
+}
+
+export function getUsageLogFinalStatus(log: UsageLogStatusLike): string | null {
+  return log.tinh_trang_ket_thuc ?? log.tinh_trang_thiet_bi ?? null
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -93,6 +93,8 @@ export interface UsageLog {
   thoi_gian_bat_dau: string;
   thoi_gian_ket_thuc?: string;
   tinh_trang_thiet_bi?: string;
+  tinh_trang_ban_dau?: string | null;
+  tinh_trang_ket_thuc?: string | null;
   ghi_chu?: string;
   trang_thai: 'dang_su_dung' | 'hoan_thanh';
   created_at: string;


### PR DESCRIPTION
## Summary
- complete the remaining frontend batch for `openspec/changes/add-usage-log-split-status`
- add split status fields to start/end usage flows, usage history, print/export, and `LogTemplate`
- extract print builders from `usage-log-print.tsx` and add focused regression tests

## Context
- backend batch was merged in #259
- this PR contains the frontend half only, replayed onto current `main`

## Testing
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/lib/__tests__/usage-log-status.test.ts src/hooks/__tests__/use-usage-logs.split-status.test.ts src/components/__tests__/start-usage-dialog.validation.test.tsx src/components/__tests__/end-usage-dialog.validation.test.tsx src/components/__tests__/usage-history-tab.split-status.test.tsx src/components/__tests__/usage-log-print.columns.test.ts src/components/__tests__/log-template.columns.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `openspec validate add-usage-log-split-status --strict`

## Notes
- `react-doctor` score: `99/100`
- residual warnings are unchanged/non-blocking: one `styled-jsx` false positive in `log-template.tsx` and one file-length suggestion for `usage-history-tab.tsx`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds split initial/final status to usage log sessions across the app and in print/export, completing the frontend for `openspec/changes/add-usage-log-split-status`. Also fixes usage history pagination and escapes the print date range.

- **New Features**
  - Start/End usage: record initial and final status with clear validation.
  - Usage History, `LogTemplate`, and Print/Export (HTML/CSV): show both status columns; robust date/duration formatting; escape HTML/CSV and date range; fallback to legacy `tinh_trang_thiet_bi` when split fields are missing.
  - Hooks/helpers: `useStartUsageSession`/`useEndUsageSession` accept `tinh_trang_ban_dau`/`tinh_trang_ket_thuc`; helpers prefer split fields.

- **Refactors**
  - Extracted print builders into `usage-log-print-html-builder.ts`, `usage-log-print-csv-builder.ts`, and shared utils; `usage-log-print.tsx` is slimmer.
  - Added focused tests for dialog validation, history layout and pagination refresh, print columns, builder outputs, hook mutations, status fallbacks, and a start-to-end session integration test.

<sup>Written for commit 30bc1538916e23e167ff1e7f60f0138eff511e16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split equipment status tracking: record both initial and final status in logs; UI and history views show separate “start” and “end” status columns.
  * Improved print/export: HTML and CSV exports include split status columns, safer CSV escaping, and better date-range formatting.

* **Bug Fixes / UX**
  * Start/End dialogs switched to free-text with validation and clearer labels; accessibility improvements for form labels.

* **Tests**
  * Added extensive unit, column, integration, and export tests covering validation, flows, rendering, and CSV/HTML outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->