### PR TITLE
fix: lock repair request equipment status invariant

### DIFF
--- a/docs/superpowers/plans/2026-04-15-repair-request-equipment-status-invariant-plan.md
+++ b/docs/superpowers/plans/2026-04-15-repair-request-equipment-status-invariant-plan.md
@@ -79,10 +79,10 @@ This prevents over-correcting `delete` to always restore `Hoạt động`.
 - [ ] **Step 4: Add the pre-request snapshot restore case**
 
 In the same smoke file, add a third test that:
-- inserts equipment with a non-default status such as `Chờ bảo trì`
+- inserts equipment with a non-default status such as `Ngưng sử dụng`
 - creates a repair request for that equipment
 - deletes the only request
-- expects the equipment status to return to `Chờ bảo trì`
+- expects the equipment status to return to `Ngưng sử dụng`
 
 This is the forward-looking guard that prevents future variants of the same bug on non-`Hoạt động` equipment.
 

--- a/docs/superpowers/plans/2026-04-15-repair-request-equipment-status-invariant-plan.md
+++ b/docs/superpowers/plans/2026-04-15-repair-request-equipment-status-invariant-plan.md
@@ -1,0 +1,341 @@
+# Repair Request Equipment Status Invariant Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `thiet_bi.tinh_trang_hien_tai` a consistent, test-backed invariant across the repair-request lifecycle so sequences like `complete -> create another request -> delete that request` cannot leave stale equipment status behind.
+
+**Architecture:** Treat equipment-status sync as a database invariant, not a per-RPC side effect. Add an explicit pre-request status snapshot on `yeu_cau_sua_chua`, introduce one PL/pgSQL helper that resolves the correct equipment status from the set of surviving repair requests plus the deleted request fallback snapshot, then route `repair_request_create`, `repair_request_approve`, `repair_request_complete`, and `repair_request_delete` through that helper. Drive the whole change from failing SQL smoke tests that reproduce the current bug and adjacent multi-request edge cases before adding the migration and safe legacy-data reconciliation.
+
+**Tech Stack:** Supabase Postgres, PL/pgSQL migrations, SQL smoke tests, GitHub CLI, Supabase MCP
+
+---
+
+## Scope And Assumptions
+
+- This plan fixes the equipment-status invariant only.
+- Follow-up UI validation issue for blank completion results is tracked separately in GitHub issue `#262`.
+- Assumption: if a repair request reaches `Hoàn thành` and no other repair request for the same equipment is still active, the equipment status should be `Hoạt động`.
+- Assumption: deleting the last active repair request should restore the deleted request's pre-request equipment status snapshot when available.
+- Decision gate: if product wants special handling for `Không HT` when no active request remains, lock that rule before implementing Task 2. Do not silently invent a new rule mid-migration.
+
+## File Map
+
+**Files to create**
+- `supabase/tests/repair_request_equipment_status_invariant_smoke.sql`
+- `supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql`
+
+**Files to modify**
+- `supabase/tests/repair_request_lifecycle_audit_smoke.sql`
+- `progress.txt`
+
+**External references**
+- GitHub issue `#262` for the blank completion-result follow-up
+- Deployed RPCs inspected via Supabase MCP:
+  - `public.repair_request_create(integer, text, text, date, text, text, text)`
+  - `public.repair_request_complete(integer, text, text, numeric)`
+  - `public.repair_request_delete(integer)`
+
+## Chunk 1: Reproduce The Invariant Failures First
+
+### Task 1: Freeze the current bug and the adjacent edge cases with failing SQL smoke tests
+
+**Files:**
+- Create: `supabase/tests/repair_request_equipment_status_invariant_smoke.sql`
+- Modify: `supabase/tests/repair_request_lifecycle_audit_smoke.sql`
+
+- [ ] **Step 1: Write the primary failing repro for the current production bug**
+
+In `supabase/tests/repair_request_equipment_status_invariant_smoke.sql`, add a transaction-wrapped test that:
+- creates request `A` for one equipment
+- approves and completes request `A`
+- asserts equipment is `Hoạt động`
+- creates request `B` on the same equipment
+- deletes request `B`
+- expects equipment to return to `Hoạt động`
+
+Use explicit `RAISE EXCEPTION` messages naming each intermediate status.
+
+- [ ] **Step 2: Run the new smoke file to verify RED**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+```
+
+Expected:
+- FAIL on the `delete B` assertion because current `repair_request_delete` leaves `thiet_bi.tinh_trang_hien_tai = 'Chờ sửa chữa'`
+
+- [ ] **Step 3: Add the active-sibling guard case**
+
+In the same smoke file, add a second test that:
+- creates request `A`
+- leaves `A` active
+- creates request `B`
+- deletes request `B`
+- expects equipment to remain `Chờ sửa chữa` because request `A` is still active
+
+This prevents over-correcting `delete` to always restore `Hoạt động`.
+
+- [ ] **Step 4: Add the pre-request snapshot restore case**
+
+In the same smoke file, add a third test that:
+- inserts equipment with a non-default status such as `Chờ bảo trì`
+- creates a repair request for that equipment
+- deletes the only request
+- expects the equipment status to return to `Chờ bảo trì`
+
+This is the forward-looking guard that prevents future variants of the same bug on non-`Hoạt động` equipment.
+
+- [ ] **Step 5: Run the smoke file again to verify RED still reflects the intended gaps**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+```
+
+Expected:
+- FAIL on current implementation
+- failure messages point to missing status recomputation or missing snapshot support, not to fixture/setup mistakes
+
+- [ ] **Step 6: Tighten the existing lifecycle smoke around delete**
+
+Modify `supabase/tests/repair_request_lifecycle_audit_smoke.sql` delete coverage so the delete path also asserts the equipment status after delete, not just audit/history.
+
+Keep the existing audit assertions intact; add one explicit status assertion only.
+
+- [ ] **Step 7: Run the lifecycle smoke to verify RED on the delete-status assertion**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_lifecycle_audit_smoke.sql
+```
+
+Expected:
+- FAIL in the delete section on equipment-status recomputation
+
+- [ ] **Step 8: Commit the red test slice**
+
+Run:
+```bash
+git add supabase/tests/repair_request_equipment_status_invariant_smoke.sql supabase/tests/repair_request_lifecycle_audit_smoke.sql
+git commit -m "test: capture repair request equipment status invariant regressions"
+```
+
+## Chunk 2: Centralize Equipment Status Resolution In The Database
+
+### Task 2: Add snapshot support and one helper that owns repair-driven equipment status
+
+**Files:**
+- Create: `supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql`
+- Read only: `supabase/migrations/20260219223500_fix_repair_request_toctou_race.sql`
+- Read only: `supabase/migrations/20260412100000_add_repair_request_cost_statistics.sql`
+- Read only: `supabase/migrations/20260406082000_fix_request_lifecycle_review_followups.sql`
+
+- [ ] **Step 1: Write the failing migration-facing expectations into comments before code**
+
+At the top of the new migration, document the invariant the helper must implement:
+- active request exists -> `Chờ sửa chữa`
+- no active request, surviving completed request exists -> `Hoạt động`
+- no surviving active/completed request after a delete -> restore deleted request snapshot if provided
+- otherwise leave status unchanged
+
+This comment is a design lock. Do not start coding before the invariant is written down.
+
+- [ ] **Step 2: Add the schema support for snapshot-based restoration**
+
+In `supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql`, add:
+- nullable column `tinh_trang_thiet_bi_truoc_yeu_cau text` to `public.yeu_cau_sua_chua`
+
+Do not backfill speculative values into this column for old rows. New rows are the authoritative forward fix.
+
+- [ ] **Step 3: Implement a single helper that resolves equipment status**
+
+In the same migration, create:
+- `public.repair_request_sync_equipment_status(p_thiet_bi_id bigint, p_deleted_request_previous_status text DEFAULT NULL)`
+
+Keep it `SECURITY DEFINER` with `SET search_path = public, pg_temp`.
+
+Implementation shape:
+- lock or read surviving requests for `p_thiet_bi_id`
+- if any request is `Chờ xử lý` or `Đã duyệt`, set equipment to `Chờ sửa chữa`
+- else if any surviving request is `Hoàn thành`, set equipment to `Hoạt động`
+- else if `p_deleted_request_previous_status` is non-empty, restore that snapshot
+- else leave `thiet_bi.tinh_trang_hien_tai` unchanged
+
+- [ ] **Step 4: Override `repair_request_create` to capture snapshot and call the helper**
+
+Replace the inline status update in `public.repair_request_create(...)` so it:
+- captures the locked equipment status into `tinh_trang_thiet_bi_truoc_yeu_cau`
+- inserts the request row
+- calls `public.repair_request_sync_equipment_status(...)`
+
+Preserve the existing row lock, claim guards, audit log, and history behavior.
+
+- [ ] **Step 5: Override `repair_request_approve` and `repair_request_complete` to use the helper**
+
+Replace their direct `UPDATE public.thiet_bi` logic with calls to `public.repair_request_sync_equipment_status(...)` after the request row is updated.
+
+Preserve:
+- row locking
+- idempotency guards
+- cost handling
+- audit/history fail-closed behavior
+
+- [ ] **Step 6: Override `repair_request_delete` to restore from the deleted-row snapshot**
+
+Change `public.repair_request_delete(...)` so it:
+- reads and locks the request plus equipment
+- stores `v_locked.tinh_trang_thiet_bi_truoc_yeu_cau`
+- deletes the row
+- calls `public.repair_request_sync_equipment_status(v_locked.thiet_bi_id, v_locked.tinh_trang_thiet_bi_truoc_yeu_cau)`
+
+Do not skip the helper when the deleted request was still `Chờ xử lý`.
+
+- [ ] **Step 7: Run the new invariant smoke file to verify GREEN**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 8: Run the lifecycle smoke to verify GREEN**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_lifecycle_audit_smoke.sql
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 9: Commit the invariant-helper slice**
+
+Run:
+```bash
+git add supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql supabase/tests/repair_request_equipment_status_invariant_smoke.sql supabase/tests/repair_request_lifecycle_audit_smoke.sql
+git commit -m "fix: centralize repair request equipment status sync"
+```
+
+## Chunk 3: Reconcile Legacy Data And Prove The Repair Query Stays Clean
+
+### Task 3: Add safe backfill and prove the known mismatch query goes to zero
+
+**Files:**
+- Modify: `supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql`
+- Test: `supabase/tests/repair_request_equipment_status_invariant_smoke.sql`
+
+- [ ] **Step 1: Add a safe reconciliation update for the already-bad legacy rows**
+
+Extend the new migration with a data-fix statement that sets equipment to `Hoạt động` only when:
+- there exists at least one `Hoàn thành` repair request for the equipment
+- there are no surviving active repair requests (`Chờ xử lý`, `Đã duyệt`) for that equipment
+- current equipment status is not already `Hoạt động`
+
+This is the migrationized form of the manual backfill already validated on production data.
+
+- [ ] **Step 2: Add a smoke assertion for the reconciliation query**
+
+In `supabase/tests/repair_request_equipment_status_invariant_smoke.sql`, add a final assertion that the mismatch query:
+- `completed request` joined to equipment with non-`Hoạt động` status
+returns zero rows for the test fixtures after the migration logic runs.
+
+- [ ] **Step 3: Run the invariant smoke again to verify GREEN**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 4: Verify the real reconciliation query on the target database**
+
+Run via Supabase MCP or `psql`:
+```sql
+SELECT yc.id AS repair_request_id, yc.thiet_bi_id, yc.trang_thai, tb.tinh_trang_hien_tai
+FROM public.yeu_cau_sua_chua yc
+JOIN public.thiet_bi tb ON tb.id = yc.thiet_bi_id
+WHERE yc.trang_thai = 'Hoàn thành'
+  AND COALESCE(tb.tinh_trang_hien_tai, '') <> 'Hoạt động';
+```
+
+Expected:
+- zero rows after the migration/backfill is applied
+
+- [ ] **Step 5: Run Supabase security advisors after the migration**
+
+Use Supabase MCP:
+- `get_advisors(security)`
+
+Expected:
+- no new advisor findings caused by the migration
+
+- [ ] **Step 6: Commit the reconciliation slice**
+
+Run:
+```bash
+git add supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+git commit -m "fix: reconcile legacy repair equipment status mismatches"
+```
+
+## Chunk 4: Final Verification, Documentation, And Session Handoff
+
+### Task 4: Close with evidence and durable notes
+
+**Files:**
+- Modify: `progress.txt`
+- External: GitHub issue `#262`
+
+- [ ] **Step 1: Run the full focused verification set**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_lifecycle_audit_smoke.sql
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_cost_smoke.sql
+```
+
+Expected:
+- PASS on all three smoke files
+
+- [ ] **Step 2: Record the implementation outcome in `progress.txt`**
+
+Append a progress entry summarizing:
+- the invariant helper
+- the snapshot column
+- the delete regression fix
+- the legacy-data reconciliation
+- the open follow-up in issue `#262`
+
+- [ ] **Step 3: Verify the git diff is scoped**
+
+Run:
+```bash
+git diff --stat
+git diff -- supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql supabase/tests/repair_request_equipment_status_invariant_smoke.sql supabase/tests/repair_request_lifecycle_audit_smoke.sql progress.txt
+```
+
+Expected:
+- only the planned files changed
+- no UI code mixed into this invariant fix
+
+- [ ] **Step 4: Land the work using the repo’s mandatory verification/push workflow**
+
+Run:
+```bash
+git pull --rebase
+git push
+git status
+```
+
+Expected:
+- push succeeds
+- `git status` reports the branch is up to date with `origin`
+
+- [ ] **Step 5: Hand off the remaining explicit follow-up**
+
+Reference GitHub issue `#262` in the final session handoff as the intentionally deferred UI/DB contract cleanup for blank completion results.

--- a/supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql
+++ b/supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql
@@ -1,0 +1,569 @@
+-- Lock the repair-request equipment-status invariant so device status is derived
+-- from the surviving repair requests instead of being updated ad hoc per RPC.
+-- Prepared for review only; do not apply automatically from the agent session.
+-- Rollback note: this forward-only migration adds a snapshot column and replaces
+-- several RPC bodies. If rollback is required, restore those RPC bodies from the
+-- immediately previous migrations before removing the snapshot column.
+
+BEGIN;
+
+ALTER TABLE public.yeu_cau_sua_chua
+  ADD COLUMN IF NOT EXISTS tinh_trang_thiet_bi_truoc_yeu_cau text NULL;
+
+COMMENT ON COLUMN public.yeu_cau_sua_chua.tinh_trang_thiet_bi_truoc_yeu_cau IS
+  'Equipment status snapshot captured when the repair request was created; used to restore status when the request is deleted and no repair requests remain.';
+
+CREATE OR REPLACE FUNCTION public.repair_request_sync_equipment_status(
+  p_thiet_bi_id bigint,
+  p_fallback_status text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_current_status text;
+  v_is_deleted boolean := false;
+  v_has_open_request boolean := false;
+  v_latest_status text;
+  v_next_status text;
+BEGIN
+  SELECT tb.tinh_trang_hien_tai, tb.is_deleted
+  INTO v_current_status, v_is_deleted
+  FROM public.thiet_bi tb
+  WHERE tb.id = p_thiet_bi_id
+  FOR UPDATE OF tb;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF v_is_deleted THEN
+    RETURN;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.yeu_cau_sua_chua ycss
+    WHERE ycss.thiet_bi_id = p_thiet_bi_id
+      AND ycss.trang_thai IN ('Chờ xử lý', 'Đã duyệt')
+  )
+  INTO v_has_open_request;
+
+  IF v_has_open_request THEN
+    v_next_status := 'Chờ sửa chữa';
+  ELSE
+    SELECT ycss.trang_thai
+    INTO v_latest_status
+    FROM public.yeu_cau_sua_chua ycss
+    WHERE ycss.thiet_bi_id = p_thiet_bi_id
+    ORDER BY ycss.id DESC
+    LIMIT 1;
+
+    IF FOUND THEN
+      IF v_latest_status = 'Hoàn thành' THEN
+        v_next_status := 'Hoạt động';
+      ELSE
+        v_next_status := 'Chờ sửa chữa';
+      END IF;
+    ELSE
+      v_next_status := coalesce(p_fallback_status, v_current_status);
+    END IF;
+  END IF;
+
+  IF v_next_status IS DISTINCT FROM v_current_status THEN
+    UPDATE public.thiet_bi
+    SET tinh_trang_hien_tai = v_next_status
+    WHERE id = p_thiet_bi_id;
+  END IF;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.repair_request_sync_equipment_status(bigint, text) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_create(
+  p_thiet_bi_id integer,
+  p_mo_ta_su_co text,
+  p_hang_muc_sua_chua text,
+  p_ngay_mong_muon_hoan_thanh date,
+  p_nguoi_yeu_cau text,
+  p_don_vi_thuc_hien text,
+  p_ten_don_vi_thue text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_id integer;
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_tb record;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  SELECT tb.id, tb.don_vi, tb.tinh_trang_hien_tai
+  INTO v_tb
+  FROM public.thiet_bi tb
+  WHERE tb.id = p_thiet_bi_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Thiết bị không tồn tại' USING errcode = 'P0002';
+  END IF;
+
+  IF NOT v_is_global AND v_tb.don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien,
+    ten_don_vi_thue,
+    tinh_trang_thiet_bi_truoc_yeu_cau
+  )
+  VALUES (
+    p_thiet_bi_id,
+    p_mo_ta_su_co,
+    p_hang_muc_sua_chua,
+    p_ngay_mong_muon_hoan_thanh,
+    p_nguoi_yeu_cau,
+    'Chờ xử lý',
+    p_don_vi_thuc_hien,
+    p_ten_don_vi_thue,
+    v_tb.tinh_trang_hien_tai
+  )
+  RETURNING id INTO v_id;
+
+  PERFORM public.repair_request_sync_equipment_status(p_thiet_bi_id::bigint);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    p_thiet_bi_id,
+    'Sửa chữa',
+    'Tạo yêu cầu sửa chữa',
+    jsonb_build_object(
+      'mo_ta_su_co', p_mo_ta_su_co,
+      'hang_muc', p_hang_muc_sua_chua,
+      'ngay_mong_muon_hoan_thanh', p_ngay_mong_muon_hoan_thanh,
+      'don_vi_thuc_hien', p_don_vi_thuc_hien,
+      'ten_don_vi_thue', p_ten_don_vi_thue
+    ),
+    v_id
+  );
+
+  PERFORM public.audit_log(
+    'repair_request_create',
+    'repair_request',
+    v_id,
+    NULL,
+    jsonb_build_object(
+      'thiet_bi_id', p_thiet_bi_id,
+      'mo_ta_su_co', p_mo_ta_su_co
+    )
+  );
+
+  RETURN v_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_approve(
+  p_id integer,
+  p_nguoi_duyet text,
+  p_don_vi_thuc_hien text,
+  p_ten_don_vi_thue text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_locked record;
+  v_req public.yeu_cau_sua_chua%ROWTYPE;
+  v_tb_don_vi bigint;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  SELECT ycss.*, tb.don_vi AS tb_don_vi
+  INTO v_locked
+  FROM public.yeu_cau_sua_chua ycss
+  JOIN public.thiet_bi tb ON tb.id = ycss.thiet_bi_id
+  WHERE ycss.id = p_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF ycss, tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Yêu cầu không tồn tại';
+  END IF;
+
+  v_tb_don_vi := v_locked.tb_don_vi;
+
+  IF NOT v_is_global AND v_tb_don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  IF v_locked.trang_thai IS DISTINCT FROM 'Chờ xử lý' THEN
+    RAISE EXCEPTION 'Chỉ có thể duyệt yêu cầu ở trạng thái Chờ xử lý' USING errcode = '22023';
+  END IF;
+
+  UPDATE public.yeu_cau_sua_chua
+  SET trang_thai = 'Đã duyệt',
+      ngay_duyet = now(),
+      nguoi_duyet = p_nguoi_duyet,
+      don_vi_thuc_hien = p_don_vi_thuc_hien,
+      ten_don_vi_thue = CASE
+        WHEN p_don_vi_thuc_hien = 'thue_ngoai' THEN p_ten_don_vi_thue
+        ELSE NULL
+      END
+  WHERE id = p_id
+  RETURNING * INTO v_req;
+
+  PERFORM public.repair_request_sync_equipment_status(v_req.thiet_bi_id);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    v_req.thiet_bi_id,
+    'Sửa chữa',
+    'Duyệt yêu cầu sửa chữa',
+    jsonb_build_object(
+      'nguoi_duyet', v_req.nguoi_duyet,
+      'ngay_duyet', v_req.ngay_duyet,
+      'don_vi_thuc_hien', v_req.don_vi_thuc_hien,
+      'ten_don_vi_thue', v_req.ten_don_vi_thue
+    ),
+    p_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_approve',
+    'repair_request',
+    p_id,
+    NULL,
+    jsonb_build_object(
+      'trang_thai', v_req.trang_thai,
+      'nguoi_duyet', v_req.nguoi_duyet,
+      'ngay_duyet', v_req.ngay_duyet,
+      'don_vi_thuc_hien', v_req.don_vi_thuc_hien,
+      'ten_don_vi_thue', v_req.ten_don_vi_thue
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', p_id;
+  END IF;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_approve(integer, text, text, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_approve(integer, text, text, text) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_complete(
+  p_id integer,
+  p_completion text DEFAULT NULL,
+  p_reason text DEFAULT NULL,
+  p_chi_phi_sua_chua numeric DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_thiet_bi_id bigint;
+  v_tb_don_vi bigint;
+  v_locked_status text;
+  v_locked_completed_at timestamptz;
+  v_status text;
+  v_result text;
+  v_reason text;
+  v_cost numeric(14,2);
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  SELECT ycss.thiet_bi_id, ycss.trang_thai, ycss.ngay_hoan_thanh, tb.don_vi
+  INTO v_thiet_bi_id, v_locked_status, v_locked_completed_at, v_tb_don_vi
+  FROM public.yeu_cau_sua_chua ycss
+  JOIN public.thiet_bi tb ON tb.id = ycss.thiet_bi_id
+  WHERE ycss.id = p_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF ycss, tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Yêu cầu không tồn tại';
+  END IF;
+
+  IF NOT v_is_global AND v_tb_don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  IF v_locked_completed_at IS NOT NULL OR v_locked_status IN ('Hoàn thành', 'Không HT') THEN
+    RAISE EXCEPTION 'Không thể hoàn thành lại yêu cầu đã hoàn thành' USING errcode = '22023';
+  END IF;
+
+  IF p_chi_phi_sua_chua IS NOT NULL AND p_chi_phi_sua_chua < 0 THEN
+    RAISE EXCEPTION 'Chi phí sửa chữa không được âm' USING errcode = '22023';
+  END IF;
+
+  IF p_completion IS NOT NULL AND trim(p_completion) <> '' THEN
+    v_status := 'Hoàn thành';
+    v_result := p_completion;
+    v_reason := NULL;
+    v_cost := p_chi_phi_sua_chua;
+  ELSE
+    v_status := 'Không HT';
+    v_result := NULL;
+    v_reason := p_reason;
+    v_cost := NULL;
+  END IF;
+
+  UPDATE public.yeu_cau_sua_chua
+  SET trang_thai = v_status,
+      ngay_hoan_thanh = now(),
+      ket_qua_sua_chua = v_result,
+      ly_do_khong_hoan_thanh = v_reason,
+      chi_phi_sua_chua = v_cost
+  WHERE id = p_id;
+
+  PERFORM public.repair_request_sync_equipment_status(v_thiet_bi_id);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    v_thiet_bi_id,
+    'Sửa chữa',
+    'Yêu cầu sửa chữa cập nhật trạng thái',
+    jsonb_build_object(
+      'ket_qua', coalesce(v_result, v_reason),
+      'trang_thai', v_status,
+      'chi_phi_sua_chua', v_cost
+    ),
+    p_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_complete',
+    'repair_request',
+    p_id,
+    NULL,
+    jsonb_build_object(
+      'trang_thai', v_status,
+      'ket_qua_sua_chua', v_result,
+      'ly_do_khong_hoan_thanh', v_reason,
+      'chi_phi_sua_chua', v_cost
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', p_id;
+  END IF;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_complete(integer, text, text, numeric) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_complete(integer, text, text, numeric) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_delete(
+  p_id integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_locked record;
+  v_fallback_status text;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  -- Intentionally allow delete cleanup even after equipment soft-delete.
+  -- Other repair RPCs block deleted equipment because they mutate active workflow state.
+  SELECT ycss.*, tb.don_vi AS tb_don_vi
+  INTO v_locked
+  FROM public.yeu_cau_sua_chua ycss
+  JOIN public.thiet_bi tb ON tb.id = ycss.thiet_bi_id
+  WHERE ycss.id = p_id
+  FOR UPDATE OF ycss, tb;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF NOT v_is_global AND v_locked.tb_don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  v_fallback_status := v_locked.tinh_trang_thiet_bi_truoc_yeu_cau;
+
+  IF NOT public.audit_log(
+    'repair_request_delete',
+    'repair_request',
+    p_id,
+    NULL,
+    jsonb_build_object(
+      'thiet_bi_id', v_locked.thiet_bi_id,
+      'trang_thai', v_locked.trang_thai
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', p_id;
+  END IF;
+
+  DELETE FROM public.yeu_cau_sua_chua
+  WHERE id = p_id;
+
+  PERFORM public.repair_request_sync_equipment_status(v_locked.thiet_bi_id, v_fallback_status);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet)
+  VALUES (
+    v_locked.thiet_bi_id,
+    'Sửa chữa',
+    'Xóa yêu cầu sửa chữa',
+    jsonb_build_object('yeu_cau_id', p_id)
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_delete(integer) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_delete(integer) FROM PUBLIC;
+
+DO $$
+DECLARE
+  v_thiet_bi_id bigint;
+BEGIN
+  -- Reconcile only the known-bad legacy class: equipment still stuck in
+  -- Chờ sửa chữa even though the latest surviving repair request completed and
+  -- there are no open repair requests left. Avoid broader rewrites because
+  -- equipment status can also change through non-repair workflows.
+  FOR v_thiet_bi_id IN
+    SELECT tb.id
+    FROM public.thiet_bi tb
+    WHERE tb.is_deleted = false
+      AND tb.tinh_trang_hien_tai = 'Chờ sửa chữa'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.yeu_cau_sua_chua y_open
+        WHERE y_open.thiet_bi_id = tb.id
+          AND y_open.trang_thai IN ('Chờ xử lý', 'Đã duyệt')
+      )
+      AND EXISTS (
+        SELECT 1
+        FROM public.yeu_cau_sua_chua y_latest
+        WHERE y_latest.thiet_bi_id = tb.id
+          AND y_latest.id = (
+            SELECT max(y2.id)
+            FROM public.yeu_cau_sua_chua y2
+            WHERE y2.thiet_bi_id = tb.id
+          )
+          AND y_latest.trang_thai = 'Hoàn thành'
+      )
+  LOOP
+    PERFORM public.repair_request_sync_equipment_status(v_thiet_bi_id, NULL);
+  END LOOP;
+END $$;
+
+COMMIT;

--- a/supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql
+++ b/supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql
@@ -199,7 +199,7 @@ BEGIN
     v_id
   );
 
-  PERFORM public.audit_log(
+  IF NOT public.audit_log(
     'repair_request_create',
     'repair_request',
     v_id,
@@ -208,7 +208,9 @@ BEGIN
       'thiet_bi_id', p_thiet_bi_id,
       'mo_ta_su_co', p_mo_ta_su_co
     )
-  );
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', v_id;
+  END IF;
 
   RETURN v_id;
 END;

--- a/supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql
+++ b/supabase/migrations/20260415113000_repair_request_equipment_status_invariant.sql
@@ -104,6 +104,7 @@ DECLARE
   v_user_id bigint;
   v_don_vi bigint;
   v_tb record;
+  v_snapshot_status text;
 BEGIN
   v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
   v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
@@ -142,6 +143,21 @@ BEGIN
     RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
   END IF;
 
+  v_snapshot_status := v_tb.tinh_trang_hien_tai;
+
+  IF v_tb.tinh_trang_hien_tai = 'Chờ sửa chữa' THEN
+    SELECT ycss.tinh_trang_thiet_bi_truoc_yeu_cau
+    INTO v_snapshot_status
+    FROM public.yeu_cau_sua_chua ycss
+    WHERE ycss.thiet_bi_id = p_thiet_bi_id
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau IS NOT NULL
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau <> 'Chờ sửa chữa'
+    ORDER BY ycss.id ASC
+    LIMIT 1;
+
+    v_snapshot_status := coalesce(v_snapshot_status, v_tb.tinh_trang_hien_tai);
+  END IF;
+
   INSERT INTO public.yeu_cau_sua_chua(
     thiet_bi_id,
     mo_ta_su_co,
@@ -162,7 +178,7 @@ BEGIN
     'Chờ xử lý',
     p_don_vi_thuc_hien,
     p_ten_don_vi_thue,
-    v_tb.tinh_trang_hien_tai
+    v_snapshot_status
   )
   RETURNING id INTO v_id;
 

--- a/supabase/migrations/20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql
+++ b/supabase/migrations/20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql
@@ -1,0 +1,262 @@
+-- Follow-up to 20260415113000_repair_request_equipment_status_invariant.sql.
+-- Forward-only migration: do not roll back by editing/deleting applied history.
+-- If rollback is ever required before first production write of this follow-up,
+-- restore RPC bodies from 20260415113000_repair_request_equipment_status_invariant.sql.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.repair_request_create(
+  p_thiet_bi_id integer,
+  p_mo_ta_su_co text,
+  p_hang_muc_sua_chua text,
+  p_ngay_mong_muon_hoan_thanh date,
+  p_nguoi_yeu_cau text,
+  p_don_vi_thuc_hien text,
+  p_ten_don_vi_thue text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_id integer;
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_tb record;
+  v_snapshot_status text;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  SELECT tb.id, tb.don_vi, tb.tinh_trang_hien_tai
+  INTO v_tb
+  FROM public.thiet_bi tb
+  WHERE tb.id = p_thiet_bi_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Thiết bị không tồn tại' USING errcode = 'P0002';
+  END IF;
+
+  IF NOT v_is_global AND v_tb.don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  v_snapshot_status := v_tb.tinh_trang_hien_tai;
+
+  IF v_tb.tinh_trang_hien_tai = 'Chờ sửa chữa' THEN
+    -- Only inherit from the currently open repair cluster. Historical completed
+    -- requests must not leak their old baseline into a newer cluster.
+    SELECT ycss.tinh_trang_thiet_bi_truoc_yeu_cau
+    INTO v_snapshot_status
+    FROM public.yeu_cau_sua_chua ycss
+    WHERE ycss.thiet_bi_id = p_thiet_bi_id
+      AND ycss.trang_thai IN ('Chờ xử lý', 'Đã duyệt')
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau IS NOT NULL
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau <> 'Chờ sửa chữa'
+    ORDER BY ycss.id DESC
+    LIMIT 1;
+
+    v_snapshot_status := coalesce(v_snapshot_status, v_tb.tinh_trang_hien_tai);
+  END IF;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien,
+    ten_don_vi_thue,
+    tinh_trang_thiet_bi_truoc_yeu_cau
+  )
+  VALUES (
+    p_thiet_bi_id,
+    p_mo_ta_su_co,
+    p_hang_muc_sua_chua,
+    p_ngay_mong_muon_hoan_thanh,
+    p_nguoi_yeu_cau,
+    'Chờ xử lý',
+    p_don_vi_thuc_hien,
+    p_ten_don_vi_thue,
+    v_snapshot_status
+  )
+  RETURNING id INTO v_id;
+
+  PERFORM public.repair_request_sync_equipment_status(p_thiet_bi_id::bigint);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    p_thiet_bi_id,
+    'Sửa chữa',
+    'Tạo yêu cầu sửa chữa',
+    jsonb_build_object(
+      'mo_ta_su_co', p_mo_ta_su_co,
+      'hang_muc', p_hang_muc_sua_chua,
+      'ngay_mong_muon_hoan_thanh', p_ngay_mong_muon_hoan_thanh,
+      'don_vi_thuc_hien', p_don_vi_thuc_hien,
+      'ten_don_vi_thue', p_ten_don_vi_thue
+    ),
+    v_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_create',
+    'repair_request',
+    v_id,
+    NULL,
+    jsonb_build_object(
+      'thiet_bi_id', p_thiet_bi_id,
+      'mo_ta_su_co', p_mo_ta_su_co
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', v_id;
+  END IF;
+
+  RETURN v_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_delete(p_id integer)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_locked record;
+  v_fallback_status text;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  -- Intentionally allow delete cleanup even after equipment soft-delete.
+  -- Other repair RPCs block deleted equipment because they mutate active workflow state.
+  SELECT ycss.*, tb.don_vi AS tb_don_vi, tb.tinh_trang_hien_tai AS tb_tinh_trang_hien_tai
+  INTO v_locked
+  FROM public.yeu_cau_sua_chua ycss
+  JOIN public.thiet_bi tb ON tb.id = ycss.thiet_bi_id
+  WHERE ycss.id = p_id
+  FOR UPDATE OF ycss, tb;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF NOT v_is_global AND v_locked.tb_don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  -- Legacy rows created before the snapshot column existed can only be repaired
+  -- best-effort here. Never feed a phantom Chờ sửa chữa status back into the
+  -- sync helper when the deleted row is the last surviving repair request.
+  v_fallback_status := coalesce(
+    v_locked.tinh_trang_thiet_bi_truoc_yeu_cau,
+    nullif(v_locked.tb_tinh_trang_hien_tai, 'Chờ sửa chữa'),
+    'Hoạt động'
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_delete',
+    'repair_request',
+    p_id,
+    NULL,
+    jsonb_build_object(
+      'thiet_bi_id', v_locked.thiet_bi_id,
+      'trang_thai', v_locked.trang_thai
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', p_id;
+  END IF;
+
+  DELETE FROM public.yeu_cau_sua_chua
+  WHERE id = p_id;
+
+  PERFORM public.repair_request_sync_equipment_status(v_locked.thiet_bi_id, v_fallback_status);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet)
+  VALUES (
+    v_locked.thiet_bi_id,
+    'Sửa chữa',
+    'Xóa yêu cầu sửa chữa',
+    jsonb_build_object('yeu_cau_id', p_id)
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_delete(integer) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_delete(integer) FROM PUBLIC;
+
+UPDATE public.yeu_cau_sua_chua AS y
+SET tinh_trang_thiet_bi_truoc_yeu_cau = coalesce(
+  (
+    SELECT y_open.tinh_trang_thiet_bi_truoc_yeu_cau
+    FROM public.yeu_cau_sua_chua AS y_open
+    WHERE y_open.thiet_bi_id = y.thiet_bi_id
+      AND y_open.id <> y.id
+      AND y_open.trang_thai IN ('Chờ xử lý', 'Đã duyệt')
+      AND y_open.tinh_trang_thiet_bi_truoc_yeu_cau IS NOT NULL
+      AND y_open.tinh_trang_thiet_bi_truoc_yeu_cau <> 'Chờ sửa chữa'
+    ORDER BY y_open.id DESC
+    LIMIT 1
+  ),
+  nullif(tb.tinh_trang_hien_tai, 'Chờ sửa chữa'),
+  'Hoạt động'
+)
+FROM public.thiet_bi AS tb
+WHERE y.thiet_bi_id = tb.id
+  AND y.tinh_trang_thiet_bi_truoc_yeu_cau IS NULL;
+
+COMMIT;

--- a/supabase/migrations/20260415132628_fix_repair_request_failed_followup_snapshot.sql
+++ b/supabase/migrations/20260415132628_fix_repair_request_failed_followup_snapshot.sql
@@ -1,0 +1,269 @@
+-- Follow-up to 20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql.
+-- Forward-only migration: do not roll back by editing/deleting applied history.
+-- If rollback is ever required before first production write of this follow-up,
+-- restore RPC bodies from 20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.repair_request_create(
+  p_thiet_bi_id integer,
+  p_mo_ta_su_co text,
+  p_hang_muc_sua_chua text,
+  p_ngay_mong_muon_hoan_thanh date,
+  p_nguoi_yeu_cau text,
+  p_don_vi_thuc_hien text,
+  p_ten_don_vi_thue text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_id integer;
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_tb record;
+  v_snapshot_status text;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  SELECT tb.id, tb.don_vi, tb.tinh_trang_hien_tai
+  INTO v_tb
+  FROM public.thiet_bi tb
+  WHERE tb.id = p_thiet_bi_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Thiết bị không tồn tại' USING errcode = 'P0002';
+  END IF;
+
+  IF NOT v_is_global AND v_tb.don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  v_snapshot_status := v_tb.tinh_trang_hien_tai;
+
+  IF v_tb.tinh_trang_hien_tai = 'Chờ sửa chữa' THEN
+    -- Inherit from the active repair context. This includes open requests and
+    -- the latest failed repair, because a Không HT result intentionally leaves
+    -- the equipment waiting for a follow-up repair.
+    SELECT ycss.tinh_trang_thiet_bi_truoc_yeu_cau
+    INTO v_snapshot_status
+    FROM public.yeu_cau_sua_chua ycss
+    WHERE ycss.thiet_bi_id = p_thiet_bi_id
+      AND ycss.trang_thai IN ('Chờ xử lý', 'Đã duyệt', 'Không HT')
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau IS NOT NULL
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau <> 'Chờ sửa chữa'
+    ORDER BY ycss.id DESC
+    LIMIT 1;
+
+    v_snapshot_status := coalesce(
+      v_snapshot_status,
+      nullif(v_tb.tinh_trang_hien_tai, 'Chờ sửa chữa'),
+      'Hoạt động'
+    );
+  END IF;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien,
+    ten_don_vi_thue,
+    tinh_trang_thiet_bi_truoc_yeu_cau
+  )
+  VALUES (
+    p_thiet_bi_id,
+    p_mo_ta_su_co,
+    p_hang_muc_sua_chua,
+    p_ngay_mong_muon_hoan_thanh,
+    p_nguoi_yeu_cau,
+    'Chờ xử lý',
+    p_don_vi_thuc_hien,
+    p_ten_don_vi_thue,
+    v_snapshot_status
+  )
+  RETURNING id INTO v_id;
+
+  PERFORM public.repair_request_sync_equipment_status(p_thiet_bi_id::bigint);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    p_thiet_bi_id,
+    'Sửa chữa',
+    'Tạo yêu cầu sửa chữa',
+    jsonb_build_object(
+      'mo_ta_su_co', p_mo_ta_su_co,
+      'hang_muc', p_hang_muc_sua_chua,
+      'ngay_mong_muon_hoan_thanh', p_ngay_mong_muon_hoan_thanh,
+      'don_vi_thuc_hien', p_don_vi_thuc_hien,
+      'ten_don_vi_thue', p_ten_don_vi_thue
+    ),
+    v_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_create',
+    'repair_request',
+    v_id,
+    NULL,
+    jsonb_build_object(
+      'thiet_bi_id', p_thiet_bi_id,
+      'mo_ta_su_co', p_mo_ta_su_co
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', v_id;
+  END IF;
+
+  RETURN v_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_delete(p_id integer)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_locked record;
+  v_fallback_status text;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  -- Intentionally allow delete cleanup even after equipment soft-delete.
+  -- Other repair RPCs block deleted equipment because they mutate active workflow state.
+  SELECT ycss.*, tb.don_vi AS tb_don_vi, tb.tinh_trang_hien_tai AS tb_tinh_trang_hien_tai
+  INTO v_locked
+  FROM public.yeu_cau_sua_chua ycss
+  JOIN public.thiet_bi tb ON tb.id = ycss.thiet_bi_id
+  WHERE ycss.id = p_id
+  FOR UPDATE OF ycss, tb;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF NOT v_is_global AND v_locked.tb_don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  -- Never feed a repair-driven intermediate status back into the sync helper
+  -- when the deleted row is the last surviving repair request.
+  v_fallback_status := coalesce(
+    nullif(v_locked.tinh_trang_thiet_bi_truoc_yeu_cau, 'Chờ sửa chữa'),
+    nullif(v_locked.tb_tinh_trang_hien_tai, 'Chờ sửa chữa'),
+    'Hoạt động'
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_delete',
+    'repair_request',
+    p_id,
+    NULL,
+    jsonb_build_object(
+      'thiet_bi_id', v_locked.thiet_bi_id,
+      'trang_thai', v_locked.trang_thai
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', p_id;
+  END IF;
+
+  DELETE FROM public.yeu_cau_sua_chua
+  WHERE id = p_id;
+
+  PERFORM public.repair_request_sync_equipment_status(v_locked.thiet_bi_id, v_fallback_status);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet)
+  VALUES (
+    v_locked.thiet_bi_id,
+    'Sửa chữa',
+    'Xóa yêu cầu sửa chữa',
+    jsonb_build_object('yeu_cau_id', p_id)
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_delete(integer) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_delete(integer) FROM PUBLIC;
+
+UPDATE public.yeu_cau_sua_chua AS y
+SET tinh_trang_thiet_bi_truoc_yeu_cau = coalesce(
+  (
+    SELECT y_ref.tinh_trang_thiet_bi_truoc_yeu_cau
+    FROM public.yeu_cau_sua_chua AS y_ref
+    WHERE y_ref.thiet_bi_id = y.thiet_bi_id
+      AND y_ref.id <> y.id
+      AND y_ref.trang_thai IN ('Chờ xử lý', 'Đã duyệt', 'Không HT')
+      AND y_ref.tinh_trang_thiet_bi_truoc_yeu_cau IS NOT NULL
+      AND y_ref.tinh_trang_thiet_bi_truoc_yeu_cau <> 'Chờ sửa chữa'
+    ORDER BY y_ref.id DESC
+    LIMIT 1
+  ),
+  nullif(tb.tinh_trang_hien_tai, 'Chờ sửa chữa'),
+  'Hoạt động'
+)
+FROM public.thiet_bi AS tb
+WHERE y.thiet_bi_id = tb.id
+  AND (
+    y.tinh_trang_thiet_bi_truoc_yeu_cau IS NULL
+    OR y.tinh_trang_thiet_bi_truoc_yeu_cau = 'Chờ sửa chữa'
+  );
+
+COMMIT;

--- a/supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+++ b/supabase/tests/repair_request_equipment_status_invariant_smoke.sql
@@ -681,4 +681,105 @@ BEGIN
   RAISE NOTICE 'OK: legacy NULL-snapshot delete does not leave phantom Chờ sửa chữa';
 END $$;
 
+-- 8) A follow-up request created after a failed repair must not capture the
+-- intermediate Chờ sửa chữa status as its restore snapshot.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_equipment_id bigint;
+  v_request_a bigint;
+  v_request_b bigint;
+  v_snapshot_b text;
+  v_status_after_delete_b text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair status failed followup tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_status_failed_followup_' || v_suffix,
+    'smoke-password',
+    'Repair Status Failed Followup',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (
+    'RR-FAILED-FOLLOWUP-' || v_suffix,
+    'Repair status failed followup equipment ' || v_suffix,
+    v_tenant,
+    'Ngưng sử dụng'
+  )
+  RETURNING id INTO v_equipment_id;
+
+  PERFORM pg_temp._rr_status_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_request_a := public.repair_request_create(
+    v_equipment_id::integer,
+    'Failed request A',
+    'Failed followup scope A',
+    CURRENT_DATE + 7,
+    'Requester A',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_approve(
+    v_request_a::integer,
+    'Approver A',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_complete(
+    v_request_a::integer,
+    NULL,
+    'Không sửa được',
+    NULL
+  );
+
+  v_request_b := public.repair_request_create(
+    v_equipment_id::integer,
+    'Follow-up request B after failed request A',
+    'Failed followup scope B',
+    CURRENT_DATE + 8,
+    'Requester B',
+    'noi_bo',
+    NULL
+  );
+
+  SELECT ycss.tinh_trang_thiet_bi_truoc_yeu_cau
+  INTO v_snapshot_b
+  FROM public.yeu_cau_sua_chua ycss
+  WHERE ycss.id = v_request_b;
+
+  IF v_snapshot_b IS DISTINCT FROM 'Ngưng sử dụng' THEN
+    RAISE EXCEPTION
+      'Invariant failed: follow-up request after failed repair should inherit Ngưng sử dụng, got %',
+      v_snapshot_b;
+  END IF;
+
+  PERFORM public.repair_request_delete(v_request_a::integer);
+  PERFORM public.repair_request_delete(v_request_b::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete_b
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete_b IS DISTINCT FROM 'Ngưng sử dụng' THEN
+    RAISE EXCEPTION
+      'Invariant failed: deleting failed repair follow-up cluster should restore Ngưng sử dụng, got %',
+      v_status_after_delete_b;
+  END IF;
+
+  RAISE NOTICE 'OK: failed repair follow-up does not capture phantom Chờ sửa chữa';
+END $$;
+
 ROLLBACK;

--- a/supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+++ b/supabase/tests/repair_request_equipment_status_invariant_smoke.sql
@@ -484,4 +484,201 @@ BEGIN
   RAISE NOTICE 'OK: FIFO delete order restores original equipment status';
 END $$;
 
+-- 6) A new repair cluster must inherit the baseline from the current open
+-- cluster, not from an older completed repair cycle on the same equipment.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_equipment_id bigint;
+  v_old_request bigint;
+  v_request_a bigint;
+  v_request_b bigint;
+  v_snapshot_b text;
+  v_status_after_delete_b text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair status cluster tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_status_cluster_' || v_suffix,
+    'smoke-password',
+    'Repair Status Cluster',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (
+    'RR-CLUSTER-' || v_suffix,
+    'Repair status cluster equipment ' || v_suffix,
+    v_tenant,
+    'Hoạt động'
+  )
+  RETURNING id INTO v_equipment_id;
+
+  PERFORM pg_temp._rr_status_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_old_request := public.repair_request_create(
+    v_equipment_id::integer,
+    'Old cluster request',
+    'Old cluster scope',
+    CURRENT_DATE + 1,
+    'Requester old',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_approve(
+    v_old_request::integer,
+    'Approver old',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_complete(
+    v_old_request::integer,
+    'Old cluster completed',
+    NULL,
+    NULL
+  );
+
+  UPDATE public.thiet_bi
+  SET tinh_trang_hien_tai = 'Ngưng sử dụng'
+  WHERE id = v_equipment_id;
+
+  v_request_a := public.repair_request_create(
+    v_equipment_id::integer,
+    'Current cluster A',
+    'Current cluster scope A',
+    CURRENT_DATE + 2,
+    'Requester A',
+    'noi_bo',
+    NULL
+  );
+
+  v_request_b := public.repair_request_create(
+    v_equipment_id::integer,
+    'Current cluster B',
+    'Current cluster scope B',
+    CURRENT_DATE + 3,
+    'Requester B',
+    'noi_bo',
+    NULL
+  );
+
+  SELECT ycss.tinh_trang_thiet_bi_truoc_yeu_cau
+  INTO v_snapshot_b
+  FROM public.yeu_cau_sua_chua ycss
+  WHERE ycss.id = v_request_b;
+
+  IF v_snapshot_b IS DISTINCT FROM 'Ngưng sử dụng' THEN
+    RAISE EXCEPTION
+      'Invariant failed: current cluster request B should inherit Ngưng sử dụng, got %',
+      v_snapshot_b;
+  END IF;
+
+  PERFORM public.repair_request_delete(v_old_request::integer);
+  PERFORM public.repair_request_delete(v_request_a::integer);
+  PERFORM public.repair_request_delete(v_request_b::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete_b
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete_b IS DISTINCT FROM 'Ngưng sử dụng' THEN
+    RAISE EXCEPTION
+      'Invariant failed: deleting the current cluster should restore Ngưng sử dụng, got %',
+      v_status_after_delete_b;
+  END IF;
+
+  RAISE NOTICE 'OK: current repair cluster does not inherit stale historical baseline';
+END $$;
+
+-- 7) Deleting a legacy request with NULL snapshot must not leave the device in
+-- a phantom Chờ sửa chữa state once no repair requests remain.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_equipment_id bigint;
+  v_request_id bigint;
+  v_status_after_delete text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair status legacy tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_status_legacy_' || v_suffix,
+    'smoke-password',
+    'Repair Status Legacy',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (
+    'RR-LEGACY-' || v_suffix,
+    'Repair status legacy equipment ' || v_suffix,
+    v_tenant,
+    'Hoạt động'
+  )
+  RETURNING id INTO v_equipment_id;
+
+  UPDATE public.thiet_bi
+  SET tinh_trang_hien_tai = 'Chờ sửa chữa'
+  WHERE id = v_equipment_id;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien,
+    ten_don_vi_thue,
+    tinh_trang_thiet_bi_truoc_yeu_cau
+  )
+  VALUES (
+    v_equipment_id,
+    'Legacy request without snapshot',
+    'Legacy scope without snapshot',
+    CURRENT_DATE + 7,
+    'Requester legacy',
+    'Chờ xử lý',
+    'noi_bo',
+    NULL,
+    NULL
+  )
+  RETURNING id INTO v_request_id;
+
+  PERFORM pg_temp._rr_status_set_claims('to_qltb', v_user_id, v_tenant);
+  PERFORM public.repair_request_delete(v_request_id::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete IS DISTINCT FROM 'Hoạt động' THEN
+    RAISE EXCEPTION
+      'Invariant failed: deleting legacy NULL-snapshot request should restore Hoạt động, got %',
+      v_status_after_delete;
+  END IF;
+
+  RAISE NOTICE 'OK: legacy NULL-snapshot delete does not leave phantom Chờ sửa chữa';
+END $$;
+
 ROLLBACK;

--- a/supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+++ b/supabase/tests/repair_request_equipment_status_invariant_smoke.sql
@@ -396,4 +396,92 @@ BEGIN
   RAISE NOTICE 'OK: failed repair delete restores latest completed status';
 END $$;
 
+-- 5) Deleting requests in FIFO order must still restore the original equipment
+-- status carried by the repair cluster, not the intermediate Chờ sửa chữa state.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_equipment_id bigint;
+  v_request_a bigint;
+  v_request_b bigint;
+  v_status_after_delete_a text;
+  v_status_after_delete_b text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair status fifo tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_status_fifo_' || v_suffix,
+    'smoke-password',
+    'Repair Status FIFO',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (
+    'RR-FIFO-' || v_suffix,
+    'Repair status fifo equipment ' || v_suffix,
+    v_tenant,
+    'Hoạt động'
+  )
+  RETURNING id INTO v_equipment_id;
+
+  PERFORM pg_temp._rr_status_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_request_a := public.repair_request_create(
+    v_equipment_id::integer,
+    'FIFO request A',
+    'FIFO scope A',
+    CURRENT_DATE + 7,
+    'Requester A',
+    'noi_bo',
+    NULL
+  );
+
+  v_request_b := public.repair_request_create(
+    v_equipment_id::integer,
+    'FIFO request B',
+    'FIFO scope B',
+    CURRENT_DATE + 8,
+    'Requester B',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_delete(v_request_a::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete_a
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete_a IS DISTINCT FROM 'Chờ sửa chữa' THEN
+    RAISE EXCEPTION
+      'Invariant failed: deleting request A first should keep Chờ sửa chữa while request B survives, got %',
+      v_status_after_delete_a;
+  END IF;
+
+  PERFORM public.repair_request_delete(v_request_b::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete_b
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete_b IS DISTINCT FROM 'Hoạt động' THEN
+    RAISE EXCEPTION
+      'Invariant failed: deleting requests in FIFO order should restore Hoạt động, got %',
+      v_status_after_delete_b;
+  END IF;
+
+  RAISE NOTICE 'OK: FIFO delete order restores original equipment status';
+END $$;
+
 ROLLBACK;

--- a/supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+++ b/supabase/tests/repair_request_equipment_status_invariant_smoke.sql
@@ -1,0 +1,399 @@
+-- supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+-- Purpose: lock the equipment-status invariant for repair-request lifecycle flows.
+-- How to run (psql): psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/repair_request_equipment_status_invariant_smoke.sql
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp._rr_status_set_claims(
+  p_role text,
+  p_user_id bigint,
+  p_don_vi bigint
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', p_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::text,
+      'sub', p_user_id::text,
+      'don_vi', p_don_vi::text
+    )::text,
+    true
+  );
+END;
+$$;
+
+-- 1) Repro the current production bug:
+-- complete request A -> equipment becomes Hoạt động
+-- create request B -> equipment becomes Chờ sửa chữa
+-- delete request B -> equipment should return to Hoạt động
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_equipment_id bigint;
+  v_request_a bigint;
+  v_request_b bigint;
+  v_status_after_complete text;
+  v_status_after_delete_b text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair status invariant tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_status_invariant_' || v_suffix,
+    'smoke-password',
+    'Repair Status Invariant',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (
+    'RR-STATUS-' || v_suffix,
+    'Repair status invariant equipment ' || v_suffix,
+    v_tenant,
+    'Hoạt động'
+  )
+  RETURNING id INTO v_equipment_id;
+
+  PERFORM pg_temp._rr_status_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_request_a := public.repair_request_create(
+    v_equipment_id::integer,
+    'Request A',
+    'Scope A',
+    CURRENT_DATE + 7,
+    'Requester A',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_approve(
+    v_request_a::integer,
+    'Approver A',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_complete(
+    v_request_a::integer,
+    'Completed A successfully',
+    NULL,
+    NULL
+  );
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_complete
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_complete IS DISTINCT FROM 'Hoạt động' THEN
+    RAISE EXCEPTION
+      'Setup failed: after completing request A expected Hoạt động, got %',
+      v_status_after_complete;
+  END IF;
+
+  v_request_b := public.repair_request_create(
+    v_equipment_id::integer,
+    'Request B',
+    'Scope B',
+    CURRENT_DATE + 14,
+    'Requester B',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_delete(v_request_b::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete_b
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete_b IS DISTINCT FROM 'Hoạt động' THEN
+    RAISE EXCEPTION
+      'Invariant failed: after deleting request B expected Hoạt động, got %',
+      v_status_after_delete_b;
+  END IF;
+
+  RAISE NOTICE 'OK: completed repair survives later request delete';
+END $$;
+
+-- 2) Deleting a newer request must not clear Chờ sửa chữa when another open
+-- repair request for the same equipment still exists.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_equipment_id bigint;
+  v_request_a bigint;
+  v_request_b bigint;
+  v_status_after_delete_b text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair status sibling tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_status_sibling_' || v_suffix,
+    'smoke-password',
+    'Repair Status Sibling',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (
+    'RR-SIBLING-' || v_suffix,
+    'Repair status sibling equipment ' || v_suffix,
+    v_tenant,
+    'Hoạt động'
+  )
+  RETURNING id INTO v_equipment_id;
+
+  PERFORM pg_temp._rr_status_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_request_a := public.repair_request_create(
+    v_equipment_id::integer,
+    'Request A still open',
+    'Scope A still open',
+    CURRENT_DATE + 7,
+    'Requester A',
+    'noi_bo',
+    NULL
+  );
+
+  v_request_b := public.repair_request_create(
+    v_equipment_id::integer,
+    'Request B deleted',
+    'Scope B deleted',
+    CURRENT_DATE + 8,
+    'Requester B',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_delete(v_request_b::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete_b
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete_b IS DISTINCT FROM 'Chờ sửa chữa' THEN
+    RAISE EXCEPTION
+      'Invariant failed: deleting request B while request A is open should keep Chờ sửa chữa, got %',
+      v_status_after_delete_b;
+  END IF;
+
+  PERFORM public.repair_request_delete(v_request_a::integer);
+
+  RAISE NOTICE 'OK: sibling open repair keeps Chờ sửa chữa';
+END $$;
+
+-- 3) Deleting the only repair request should restore the equipment status that
+-- existed before the request changed it to Chờ sửa chữa.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_equipment_id bigint;
+  v_request_id bigint;
+  v_status_after_create text;
+  v_status_after_delete text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair status restore tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_status_restore_' || v_suffix,
+    'smoke-password',
+    'Repair Status Restore',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (
+    'RR-RESTORE-' || v_suffix,
+    'Repair status restore equipment ' || v_suffix,
+    v_tenant,
+    'Ngưng sử dụng'
+  )
+  RETURNING id INTO v_equipment_id;
+
+  PERFORM pg_temp._rr_status_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_request_id := public.repair_request_create(
+    v_equipment_id::integer,
+    'Request restore baseline',
+    'Restore baseline scope',
+    CURRENT_DATE + 7,
+    'Requester restore',
+    'noi_bo',
+    NULL
+  );
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_create
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_create IS DISTINCT FROM 'Chờ sửa chữa' THEN
+    RAISE EXCEPTION
+      'Setup failed: creating the request should set Chờ sửa chữa, got %',
+      v_status_after_create;
+  END IF;
+
+  PERFORM public.repair_request_delete(v_request_id::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete IS DISTINCT FROM 'Ngưng sử dụng' THEN
+    RAISE EXCEPTION
+      'Invariant failed: deleting the only request should restore Ngưng sử dụng, got %',
+      v_status_after_delete;
+  END IF;
+
+  RAISE NOTICE 'OK: delete restores pre-request equipment status';
+END $$;
+
+-- 4) A failed repair should leave the device in Chờ sửa chữa, but deleting that
+-- failed request later must restore Hoạt động when the latest surviving request
+-- on the equipment is a completed repair.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_equipment_id bigint;
+  v_request_a bigint;
+  v_request_b bigint;
+  v_status_after_failed_b text;
+  v_status_after_delete_b text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair status failed tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_status_failed_' || v_suffix,
+    'smoke-password',
+    'Repair Status Failed',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (
+    'RR-FAILED-' || v_suffix,
+    'Repair status failed equipment ' || v_suffix,
+    v_tenant,
+    'Hoạt động'
+  )
+  RETURNING id INTO v_equipment_id;
+
+  PERFORM pg_temp._rr_status_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_request_a := public.repair_request_create(
+    v_equipment_id::integer,
+    'Completed request A',
+    'Completed scope A',
+    CURRENT_DATE + 7,
+    'Requester A',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_approve(
+    v_request_a::integer,
+    'Approver A',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_complete(
+    v_request_a::integer,
+    'Completed request A successfully',
+    NULL,
+    NULL
+  );
+
+  v_request_b := public.repair_request_create(
+    v_equipment_id::integer,
+    'Failed request B',
+    'Failed scope B',
+    CURRENT_DATE + 8,
+    'Requester B',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_approve(
+    v_request_b::integer,
+    'Approver B',
+    'noi_bo',
+    NULL
+  );
+
+  PERFORM public.repair_request_complete(
+    v_request_b::integer,
+    NULL,
+    'Thiếu vật tư thay thế',
+    NULL
+  );
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_failed_b
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_failed_b IS DISTINCT FROM 'Chờ sửa chữa' THEN
+    RAISE EXCEPTION
+      'Setup failed: failed repair B should leave Chờ sửa chữa, got %',
+      v_status_after_failed_b;
+  END IF;
+
+  PERFORM public.repair_request_delete(v_request_b::integer);
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status_after_delete_b
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_equipment_id;
+
+  IF v_status_after_delete_b IS DISTINCT FROM 'Hoạt động' THEN
+    RAISE EXCEPTION
+      'Invariant failed: deleting failed request B should restore Hoạt động from completed request A, got %',
+      v_status_after_delete_b;
+  END IF;
+
+  RAISE NOTICE 'OK: failed repair delete restores latest completed status';
+END $$;
+
+ROLLBACK;

--- a/supabase/tests/repair_request_lifecycle_audit_smoke.sql
+++ b/supabase/tests/repair_request_lifecycle_audit_smoke.sql
@@ -1141,4 +1141,105 @@ BEGIN
   RAISE NOTICE 'OK: repair_request_approve fails closed when audit_log returns FALSE';
 END $$;
 
+-- 9) create path should fail closed when audit_log returns FALSE
+DO $$
+DECLARE
+  v_tenant bigint;
+  v_user_id bigint;
+  v_thiet_bi_id bigint;
+  v_code text := 'RR-LIFECYCLE-CREATE-FAIL-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_error_raised boolean := false;
+  v_request_count bigint;
+  v_history_count bigint;
+  v_equipment_status text;
+BEGIN
+  SELECT id
+  INTO v_tenant
+  FROM public.don_vi
+  WHERE active = true
+  ORDER BY id
+  LIMIT 1;
+
+  IF v_tenant IS NULL THEN
+    RAISE EXCEPTION 'No active tenant found for create fail-closed smoke fixture';
+  END IF;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_create_fail_smoke_' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS'),
+    'smoke-password',
+    'Repair Create Fail-Closed Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (v_code, 'Repair lifecycle create fail-closed smoke', v_tenant, 'Ngưng sử dụng')
+  RETURNING id INTO v_thiet_bi_id;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text
+    )::text,
+    true
+  );
+
+  BEGIN
+    PERFORM public.repair_request_create(
+      v_thiet_bi_id::integer,
+      'Mô tả create fail-closed',
+      'Hạng mục create fail-closed',
+      current_date + 1,
+      'Người yêu cầu smoke',
+      'noi_bo',
+      NULL
+    );
+  EXCEPTION
+    WHEN OTHERS THEN
+      v_error_raised := true;
+  END;
+
+  IF NOT v_error_raised THEN
+    RAISE EXCEPTION 'Expected repair_request_create to fail closed when audit_log returns FALSE';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_request_count
+  FROM public.yeu_cau_sua_chua
+  WHERE thiet_bi_id = v_thiet_bi_id
+    AND mo_ta_su_co = 'Mô tả create fail-closed';
+
+  IF v_request_count <> 0 THEN
+    RAISE EXCEPTION 'repair_request_create fail-closed path should not persist request rows';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_history_count
+  FROM public.lich_su_thiet_bi
+  WHERE thiet_bi_id = v_thiet_bi_id
+    AND mo_ta = 'Tạo yêu cầu sửa chữa';
+
+  IF v_history_count <> 0 THEN
+    RAISE EXCEPTION 'repair_request_create fail-closed path should not persist equipment history rows';
+  END IF;
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_equipment_status
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_thiet_bi_id;
+
+  IF v_equipment_status IS DISTINCT FROM 'Ngưng sử dụng' THEN
+    RAISE EXCEPTION 'repair_request_create fail-closed path should preserve original equipment status, found %', v_equipment_status;
+  END IF;
+
+  RAISE NOTICE 'OK: repair_request_create fails closed when audit_log returns FALSE';
+END $$;
+
 ROLLBACK;

--- a/supabase/tests/repair_request_lifecycle_audit_smoke.sql
+++ b/supabase/tests/repair_request_lifecycle_audit_smoke.sql
@@ -787,11 +787,13 @@ DECLARE
   v_request_id bigint;
   v_code text := 'RR-LIFECYCLE-DEL-' || to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
   v_expected_status text;
+  v_expected_equipment_status text := 'Ngưng sử dụng';
   v_remaining bigint;
   v_audit_count bigint;
   v_audit_details jsonb;
   v_history_id bigint;
   v_history_details jsonb;
+  v_equipment_status_after_delete text;
 BEGIN
   SELECT id
   INTO v_tenant
@@ -815,8 +817,8 @@ BEGIN
   )
   RETURNING id INTO v_user_id;
 
-  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
-  VALUES (v_code, 'Repair lifecycle delete smoke', v_tenant)
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (v_code, 'Repair lifecycle delete smoke', v_tenant, v_expected_equipment_status)
   RETURNING id INTO v_thiet_bi_id;
 
   PERFORM set_config(
@@ -906,6 +908,18 @@ BEGIN
 
   IF (v_history_details->>'yeu_cau_id')::bigint IS DISTINCT FROM v_request_id THEN
     RAISE EXCEPTION 'repair_request_delete equipment history yeu_cau_id mismatch';
+  END IF;
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_equipment_status_after_delete
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_thiet_bi_id;
+
+  IF v_equipment_status_after_delete IS DISTINCT FROM v_expected_equipment_status THEN
+    RAISE EXCEPTION
+      'repair_request_delete should restore equipment status %, found %',
+      v_expected_equipment_status,
+      v_equipment_status_after_delete;
   END IF;
 
   RAISE NOTICE 'OK: repair_request_delete audit smoke passed';

--- a/supabase/tests/repair_request_lifecycle_audit_smoke.sql
+++ b/supabase/tests/repair_request_lifecycle_audit_smoke.sql
@@ -975,8 +975,8 @@ BEGIN
   )
   RETURNING id INTO v_user_id;
 
-  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
-  VALUES (v_code, 'Repair lifecycle update fail-closed smoke', v_tenant)
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (v_code, 'Repair lifecycle update fail-closed smoke', v_tenant, 'Hoạt động')
   RETURNING id INTO v_thiet_bi_id;
 
   PERFORM set_config(
@@ -991,15 +991,29 @@ BEGIN
     true
   );
 
-  v_request_id := public.repair_request_create(
-    v_thiet_bi_id::integer,
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien,
+    ten_don_vi_thue,
+    tinh_trang_thiet_bi_truoc_yeu_cau
+  )
+  VALUES (
+    v_thiet_bi_id,
     'Mô tả fail-closed',
     'Hạng mục fail-closed',
     current_date + 1,
     'Người yêu cầu smoke',
+    'Chờ xử lý',
     'noi_bo',
-    NULL
-  );
+    NULL,
+    'Hoạt động'
+  )
+  RETURNING id INTO v_request_id;
 
   BEGIN
     PERFORM public.repair_request_update(
@@ -1076,8 +1090,8 @@ BEGIN
   )
   RETURNING id INTO v_user_id;
 
-  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi)
-  VALUES (v_code, 'Repair lifecycle approve fail-closed smoke', v_tenant)
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai)
+  VALUES (v_code, 'Repair lifecycle approve fail-closed smoke', v_tenant, 'Hoạt động')
   RETURNING id INTO v_thiet_bi_id;
 
   PERFORM set_config(
@@ -1092,15 +1106,29 @@ BEGIN
     true
   );
 
-  v_request_id := public.repair_request_create(
-    v_thiet_bi_id::integer,
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien,
+    ten_don_vi_thue,
+    tinh_trang_thiet_bi_truoc_yeu_cau
+  )
+  VALUES (
+    v_thiet_bi_id,
     'Mô tả approve fail-closed',
     'Hạng mục approve fail-closed',
     current_date + 1,
     'Người yêu cầu smoke',
+    'Chờ xử lý',
     'noi_bo',
-    NULL
-  );
+    NULL,
+    'Hoạt động'
+  )
+  RETURNING id INTO v_request_id;
 
   BEGIN
     PERFORM public.repair_request_approve(


### PR DESCRIPTION
## Summary
- add a dedicated SQL smoke test for the repair-request equipment-status invariant
- tighten the existing repair lifecycle audit smoke test so delete must also restore the equipment status
- add review-only migration `20260415113000_repair_request_equipment_status_invariant.sql` that snapshots pre-request equipment status, centralizes status recomputation in `repair_request_sync_equipment_status(...)`, and routes `repair_request_create/approve/complete/delete` through that helper
- add a narrow legacy backfill for equipment stuck at `Chờ sửa chữa` even though the latest surviving repair request is `Hoàn thành`

## Notes
- no frontend changes in this PR
- per review-first instruction, the new migration has **not** been applied yet
- follow-up UI validation for empty completion payload remains tracked separately in issue #262

## Verification
- `git diff --check`
- live Supabase RED repro (transaction + rollback) confirms current bug still exists before applying the new migration:
  - `repair_request_delete should restore equipment status Ngưng sử dụng, found Chờ sửa chữa`
- GREEN migration verification and `get_advisors(security)` are intentionally deferred until after reviewer approval because the migration must stay unapplied in this session

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes devices getting stuck at 'Chờ sửa chữa' and prevents phantom follow-up snapshots after failed repairs by making equipment status a DB-computed invariant and tightening snapshot rules. Create now fails closed on audit errors with no partial state left behind.

- **Bug Fixes**
  - `repair_request_create` captures the pre-request status and, if the device is already 'Chờ sửa chữa', inherits the baseline from the current open cluster or the latest 'Không HT' follow-up only (never an old completed cycle).
  - Centralized status in `repair_request_sync_equipment_status(...)` and applied to create/approve/complete/delete; `repair_request_delete` restores the previous status when it’s the last request, keeps 'Chờ sửa chữa' if others remain, strips 'Chờ sửa chữa' from fallbacks, and covers legacy NULL-snapshot rows.
  - Added invariant smoke tests (failed-repair follow-ups, FIFO deletes); create fails closed when `audit_log` returns FALSE.

- **Migration**
  - Adds `yeu_cau_sua_chua.tinh_trang_thiet_bi_truoc_yeu_cau` and introduces `repair_request_sync_equipment_status(...)`.
  - Adds `20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql` and `20260415132628_fix_repair_request_failed_followup_snapshot.sql` to refine cluster snapshot capture (including 'Không HT'), harden delete fallbacks, and backfill NULL or 'Chờ sửa chữa' snapshots; includes a narrow reconciliation for devices stuck at 'Chờ sửa chữa' when the latest surviving request is 'Hoàn thành'. Migrations are review-only and not applied yet.

<sup>Written for commit 5bad8fc5387520ef4219b17aca0d259f47b3066c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Equipment status is now consistently maintained across repair request lifecycle actions; device status updates automatically when requests are created, approved, completed, or deleted.
  * Requests now store a prior-status snapshot to enable correct restoration when removed.

* **Bug Fixes**
  * Deleting repair requests restores equipment to the correct previous state.
  * Existing inconsistent equipment records were reconciled and corrected.

* **Tests**
  * Added end-to-end smoke tests covering create/approve/complete/delete scenarios and status invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->