### PR TITLE
fix: validate blank repair completion payload

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsCompleteDialog.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsCompleteDialog.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RepairRequestsCompleteDialog } from "../_components/RepairRequestsCompleteDialog"
 import type { RepairRequestWithEquipment } from "../types"
@@ -109,6 +109,70 @@ function setupContext(overrides?: Partial<ReturnType<typeof mockContext.useRepai
 }
 
 describe("RepairRequestsCompleteDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps Hoàn thành disabled for blank or whitespace-only repair results", async () => {
+    const user = userEvent.setup()
+    setupContext()
+
+    render(<RepairRequestsCompleteDialog />)
+
+    const confirmButton = screen.getByRole("button", { name: "Xác nhận hoàn thành" })
+    expect(confirmButton).toBeDisabled()
+
+    await user.type(screen.getByLabelText("Kết quả sửa chữa"), "   ")
+    expect(confirmButton).toBeDisabled()
+
+    await user.click(confirmButton)
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
+  it("enables Hoàn thành after a non-empty repair result and submits a trimmed payload", async () => {
+    const user = userEvent.setup()
+    setupContext()
+
+    render(<RepairRequestsCompleteDialog />)
+
+    await user.type(screen.getByLabelText("Kết quả sửa chữa"), "  Đã thay bộ nguồn  ")
+    const confirmButton = screen.getByRole("button", { name: "Xác nhận hoàn thành" })
+
+    expect(confirmButton).toBeEnabled()
+
+    await user.click(confirmButton)
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 7,
+        completion: "Đã thay bộ nguồn",
+        reason: null,
+      }),
+      { onSuccess: mockCloseAllDialogs }
+    )
+  })
+
+  it("keeps Không HT disabled for blank or whitespace-only reasons", async () => {
+    const user = userEvent.setup()
+    setupContext({
+      dialogState: {
+        requestToComplete,
+        completionType: "Không HT",
+      },
+    })
+
+    render(<RepairRequestsCompleteDialog />)
+
+    const confirmButton = screen.getByRole("button", { name: "Xác nhận không hoàn thành" })
+    expect(confirmButton).toBeDisabled()
+
+    await user.type(screen.getByLabelText("Lý do không hoàn thành"), "   ")
+    expect(confirmButton).toBeDisabled()
+
+    await user.click(confirmButton)
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
   it("shows the optional repair cost field for Hoàn thành and submits a parsed numeric payload", async () => {
     const user = userEvent.setup()
     setupContext()

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsContext.completeMutation.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsContext.completeMutation.test.tsx
@@ -136,7 +136,7 @@ describe("RepairRequestsContext complete mutation", () => {
         <MutationHarnessWithPayload
           payload={{
             id: 99,
-            completion: "",
+            completion: "   ",
             reason: null,
             repairCost: null,
           }}

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsContext.completeMutation.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsContext.completeMutation.test.tsx
@@ -51,6 +51,28 @@ function createWrapper(queryClient: QueryClient) {
 }
 
 function MutationHarness() {
+  return (
+    <MutationHarnessWithPayload
+      payload={{
+        id: 99,
+        completion: "Đã sửa xong",
+        reason: null,
+        repairCost: 1234567,
+      }}
+    />
+  )
+}
+
+function MutationHarnessWithPayload({
+  payload,
+}: {
+  payload: {
+    id: number
+    completion: string | null
+    reason: string | null
+    repairCost: number | null
+  }
+}) {
   const context = React.useContext(RepairRequestsContext)
   const hasTriggeredRef = React.useRef(false)
 
@@ -61,13 +83,8 @@ function MutationHarness() {
 
     hasTriggeredRef.current = true
 
-    context.completeMutation.mutate({
-      id: 99,
-      completion: "Đã sửa xong",
-      reason: null,
-      repairCost: 1234567,
-    })
-  }, [context])
+    context.completeMutation.mutate(payload)
+  }, [context, payload])
 
   return null
 }
@@ -103,6 +120,40 @@ describe("RepairRequestsContext complete mutation", () => {
           p_chi_phi_sua_chua: 1234567,
         },
       })
+    })
+  })
+
+  it("rejects blank completion before calling RPC", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+
+    render(
+      <RepairRequestsProvider>
+        <MutationHarnessWithPayload
+          payload={{
+            id: 99,
+            completion: "",
+            reason: null,
+            repairCost: null,
+          }}
+        />
+      </RepairRequestsProvider>,
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await waitFor(() => {
+      expect(mockCallRpc).not.toHaveBeenCalled()
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: "Lỗi cập nhật yêu cầu",
+          description: "Phải nhập kết quả sửa chữa hoặc lý do không hoàn thành",
+        })
+      )
     })
   })
 })

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx
@@ -42,6 +42,9 @@ function CompleteDialogForm({
   const [completionResult, setCompletionResult] = React.useState("")
   const [nonCompletionReason, setNonCompletionReason] = React.useState("")
   const [repairCostInput, setRepairCostInput] = React.useState("")
+  const activeCompletionText =
+    completionType === "Hoàn thành" ? completionResult : nonCompletionReason
+  const isConfirmDisabled = isPending || activeCompletionText.trim().length === 0
 
   const handleRepairCostChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const digitsOnly = event.target.value.replace(/\D/g, "")
@@ -129,7 +132,7 @@ function CompleteDialogForm({
         <Button variant="outline" onClick={onCancel} disabled={isPending}>
           Hủy
         </Button>
-        <Button onClick={handleConfirm} disabled={isPending}>
+        <Button onClick={handleConfirm} disabled={isConfirmDisabled}>
           {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {completionType === "Hoàn thành" ? "Xác nhận hoàn thành" : "Xác nhận không hoàn thành"}
         </Button>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx
@@ -216,12 +216,19 @@ function useCompleteMutation(
       reason: string | null
       repairCost: number | null
     }) => {
+      const completion = data.completion?.trim() ?? ""
+      const reason = data.reason?.trim() ?? ""
+
+      if (completion.length === 0 && reason.length === 0) {
+        throw new Error("Phải nhập kết quả sửa chữa hoặc lý do không hoàn thành")
+      }
+
       return callRpc({
         fn: 'repair_request_complete',
         args: {
           p_id: data.id,
-          p_completion: data.completion,
-          p_reason: data.reason,
+          p_completion: completion.length > 0 ? completion : null,
+          p_reason: reason.length > 0 ? reason : null,
           p_chi_phi_sua_chua: data.repairCost,
         }
       })

--- a/supabase/migrations/20260416015100_fix_repair_request_complete_empty_payload.sql
+++ b/supabase/migrations/20260416015100_fix_repair_request_complete_empty_payload.sql
@@ -1,0 +1,132 @@
+CREATE OR REPLACE FUNCTION public.repair_request_complete(
+  p_id integer,
+  p_completion text DEFAULT NULL,
+  p_reason text DEFAULT NULL,
+  p_chi_phi_sua_chua numeric DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_thiet_bi_id bigint;
+  v_tb_don_vi bigint;
+  v_locked_status text;
+  v_locked_completed_at timestamptz;
+  v_status text;
+  v_result text;
+  v_reason text;
+  v_cost numeric(14,2);
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  SELECT ycss.thiet_bi_id, ycss.trang_thai, ycss.ngay_hoan_thanh, tb.don_vi
+  INTO v_thiet_bi_id, v_locked_status, v_locked_completed_at, v_tb_don_vi
+  FROM public.yeu_cau_sua_chua ycss
+  JOIN public.thiet_bi tb ON tb.id = ycss.thiet_bi_id
+  WHERE ycss.id = p_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF ycss, tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Yêu cầu không tồn tại';
+  END IF;
+
+  IF NOT v_is_global AND v_tb_don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  IF v_locked_completed_at IS NOT NULL OR v_locked_status IN ('Hoàn thành', 'Không HT') THEN
+    RAISE EXCEPTION 'Không thể hoàn thành lại yêu cầu đã hoàn thành' USING errcode = '22023';
+  END IF;
+
+  IF p_chi_phi_sua_chua IS NOT NULL AND p_chi_phi_sua_chua < 0 THEN
+    RAISE EXCEPTION 'Chi phí sửa chữa không được âm' USING errcode = '22023';
+  END IF;
+
+  IF coalesce(trim(p_completion), '') = ''
+     AND coalesce(trim(p_reason), '') = '' THEN
+    RAISE EXCEPTION 'Phải nhập kết quả sửa chữa hoặc lý do không hoàn thành'
+      USING errcode = '22023';
+  END IF;
+
+  IF p_completion IS NOT NULL AND trim(p_completion) <> '' THEN
+    v_status := 'Hoàn thành';
+    v_result := p_completion;
+    v_reason := NULL;
+    v_cost := p_chi_phi_sua_chua;
+  ELSE
+    v_status := 'Không HT';
+    v_result := NULL;
+    v_reason := p_reason;
+    v_cost := NULL;
+  END IF;
+
+  UPDATE public.yeu_cau_sua_chua
+  SET trang_thai = v_status,
+      ngay_hoan_thanh = now(),
+      ket_qua_sua_chua = v_result,
+      ly_do_khong_hoan_thanh = v_reason,
+      chi_phi_sua_chua = v_cost
+  WHERE id = p_id;
+
+  PERFORM public.repair_request_sync_equipment_status(v_thiet_bi_id);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    v_thiet_bi_id,
+    'Sửa chữa',
+    'Yêu cầu sửa chữa cập nhật trạng thái',
+    jsonb_build_object(
+      'ket_qua', coalesce(v_result, v_reason),
+      'trang_thai', v_status,
+      'chi_phi_sua_chua', v_cost
+    ),
+    p_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_complete',
+    'repair_request',
+    p_id,
+    NULL,
+    jsonb_build_object(
+      'trang_thai', v_status,
+      'ket_qua_sua_chua', v_result,
+      'ly_do_khong_hoan_thanh', v_reason,
+      'chi_phi_sua_chua', v_cost
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', p_id;
+  END IF;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_complete(integer, text, text, numeric) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_complete(integer, text, text, numeric) FROM PUBLIC;

--- a/supabase/migrations/20260416021800_fix_repair_request_complete_control_char_whitespace.sql
+++ b/supabase/migrations/20260416021800_fix_repair_request_complete_control_char_whitespace.sql
@@ -1,8 +1,10 @@
 -- Follow-up to 20260416015100_fix_repair_request_complete_empty_payload.sql.
 -- Forward-only migration: do not roll back by editing/deleting applied history.
--- If rollback is ever required before first production write of this follow-up,
--- restore public.repair_request_complete(...) from
--- 20260416015100_fix_repair_request_complete_empty_payload.sql.
+-- Do not restore public.repair_request_complete(...) from
+-- 20260416015100_fix_repair_request_complete_empty_payload.sql, because that
+-- earlier body validates with trim() but persists raw padded text.
+-- If this follow-up ever needs to be reverted, ship a new forward-only
+-- migration with an explicit replacement body instead of reusing the older one.
 -- Normalize all leading/trailing whitespace in repair_request_complete terminal
 -- payloads before validation so tabs/newlines cannot bypass the empty-payload
 -- guard, and persisted completion/reason text is stored trimmed.

--- a/supabase/migrations/20260416021800_fix_repair_request_complete_control_char_whitespace.sql
+++ b/supabase/migrations/20260416021800_fix_repair_request_complete_control_char_whitespace.sql
@@ -1,0 +1,156 @@
+-- Follow-up to 20260416015100_fix_repair_request_complete_empty_payload.sql.
+-- Forward-only migration: do not roll back by editing/deleting applied history.
+-- If rollback is ever required before first production write of this follow-up,
+-- restore public.repair_request_complete(...) from
+-- 20260416015100_fix_repair_request_complete_empty_payload.sql.
+-- Normalize all leading/trailing whitespace in repair_request_complete terminal
+-- payloads before validation so tabs/newlines cannot bypass the empty-payload
+-- guard, and persisted completion/reason text is stored trimmed.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.repair_request_complete(
+  p_id integer,
+  p_completion text DEFAULT NULL,
+  p_reason text DEFAULT NULL,
+  p_chi_phi_sua_chua numeric DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_thiet_bi_id bigint;
+  v_tb_don_vi bigint;
+  v_locked_status text;
+  v_locked_completed_at timestamptz;
+  v_status text;
+  v_result text;
+  v_reason text;
+  v_cost numeric(14,2);
+  v_normalized_completion text;
+  v_normalized_reason text;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  SELECT ycss.thiet_bi_id, ycss.trang_thai, ycss.ngay_hoan_thanh, tb.don_vi
+  INTO v_thiet_bi_id, v_locked_status, v_locked_completed_at, v_tb_don_vi
+  FROM public.yeu_cau_sua_chua ycss
+  JOIN public.thiet_bi tb ON tb.id = ycss.thiet_bi_id
+  WHERE ycss.id = p_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF ycss, tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Yêu cầu không tồn tại';
+  END IF;
+
+  IF NOT v_is_global AND v_tb_don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  IF v_locked_completed_at IS NOT NULL OR v_locked_status IN ('Hoàn thành', 'Không HT') THEN
+    RAISE EXCEPTION 'Không thể hoàn thành lại yêu cầu đã hoàn thành' USING errcode = '22023';
+  END IF;
+
+  IF p_chi_phi_sua_chua IS NOT NULL AND p_chi_phi_sua_chua < 0 THEN
+    RAISE EXCEPTION 'Chi phí sửa chữa không được âm' USING errcode = '22023';
+  END IF;
+
+  v_normalized_completion := nullif(
+    regexp_replace(coalesce(p_completion, ''), '^[[:space:]]+|[[:space:]]+$', '', 'g'),
+    ''
+  );
+  v_normalized_reason := nullif(
+    regexp_replace(coalesce(p_reason, ''), '^[[:space:]]+|[[:space:]]+$', '', 'g'),
+    ''
+  );
+
+  IF v_normalized_completion IS NULL
+     AND v_normalized_reason IS NULL THEN
+    RAISE EXCEPTION 'Phải nhập kết quả sửa chữa hoặc lý do không hoàn thành'
+      USING errcode = '22023';
+  END IF;
+
+  IF v_normalized_completion IS NOT NULL THEN
+    v_status := 'Hoàn thành';
+    v_result := v_normalized_completion;
+    v_reason := NULL;
+    v_cost := p_chi_phi_sua_chua;
+  ELSE
+    v_status := 'Không HT';
+    v_result := NULL;
+    v_reason := v_normalized_reason;
+    v_cost := NULL;
+  END IF;
+
+  UPDATE public.yeu_cau_sua_chua
+  SET trang_thai = v_status,
+      ngay_hoan_thanh = now(),
+      ket_qua_sua_chua = v_result,
+      ly_do_khong_hoan_thanh = v_reason,
+      chi_phi_sua_chua = v_cost
+  WHERE id = p_id;
+
+  PERFORM public.repair_request_sync_equipment_status(v_thiet_bi_id);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    v_thiet_bi_id,
+    'Sửa chữa',
+    'Yêu cầu sửa chữa cập nhật trạng thái',
+    jsonb_build_object(
+      'ket_qua', coalesce(v_result, v_reason),
+      'trang_thai', v_status,
+      'chi_phi_sua_chua', v_cost
+    ),
+    p_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_complete',
+    'repair_request',
+    p_id,
+    NULL,
+    jsonb_build_object(
+      'trang_thai', v_status,
+      'ket_qua_sua_chua', v_result,
+      'ly_do_khong_hoan_thanh', v_reason,
+      'chi_phi_sua_chua', v_cost
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', p_id;
+  END IF;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_complete(integer, text, text, numeric) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_complete(integer, text, text, numeric) FROM PUBLIC;
+
+COMMIT;

--- a/supabase/tests/repair_request_cost_smoke.sql
+++ b/supabase/tests/repair_request_cost_smoke.sql
@@ -527,4 +527,85 @@ BEGIN
   RAISE NOTICE 'OK: empty completion payload guard passed';
 END $$;
 
+-- 7) Non-space whitespace payloads must raise and leave the request approved.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_completion_request_id bigint;
+  v_reason_request_id bigint;
+  v_status text;
+  v_completed_at timestamptz;
+  v_completion text;
+  v_reason text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair control-char smoke tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_control_char_smoke_' || v_suffix,
+    'smoke-password',
+    'Repair Control Char Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  v_completion_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-COMP');
+  v_reason_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix || '-REASON');
+  PERFORM pg_temp._rr_cost_set_claims('to_qltb', v_user_id, v_tenant);
+
+  BEGIN
+    PERFORM public.repair_request_complete(v_completion_request_id::integer, E'\n\t', NULL, NULL);
+    RAISE EXCEPTION 'Expected newline/tab-only completion to raise';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLSTATE <> '22023' THEN
+      RAISE EXCEPTION 'Expected SQLSTATE 22023 for control-char completion, got [%] %', SQLSTATE, SQLERRM;
+    END IF;
+  END;
+
+  SELECT trang_thai, ngay_hoan_thanh, ket_qua_sua_chua, ly_do_khong_hoan_thanh
+  INTO v_status, v_completed_at, v_completion, v_reason
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_completion_request_id;
+
+  IF v_status <> 'Đã duyệt'
+     OR v_completed_at IS NOT NULL
+     OR v_completion IS NOT NULL
+     OR v_reason IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Control-char completion must not mutate request; got status=%, completed_at=%, completion=%, reason=%',
+      v_status, v_completed_at, v_completion, v_reason;
+  END IF;
+
+  BEGIN
+    PERFORM public.repair_request_complete(v_reason_request_id::integer, NULL, E'\n\t', NULL);
+    RAISE EXCEPTION 'Expected newline/tab-only reason to raise';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLSTATE <> '22023' THEN
+      RAISE EXCEPTION 'Expected SQLSTATE 22023 for control-char reason, got [%] %', SQLSTATE, SQLERRM;
+    END IF;
+  END;
+
+  SELECT trang_thai, ngay_hoan_thanh, ket_qua_sua_chua, ly_do_khong_hoan_thanh
+  INTO v_status, v_completed_at, v_completion, v_reason
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_reason_request_id;
+
+  IF v_status <> 'Đã duyệt'
+     OR v_completed_at IS NOT NULL
+     OR v_completion IS NOT NULL
+     OR v_reason IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Control-char reason must not mutate request; got status=%, completed_at=%, completion=%, reason=%',
+      v_status, v_completed_at, v_completion, v_reason;
+  END IF;
+
+  RAISE NOTICE 'OK: control-char completion and reason guards passed';
+END $$;
+
 ROLLBACK;

--- a/supabase/tests/repair_request_cost_smoke.sql
+++ b/supabase/tests/repair_request_cost_smoke.sql
@@ -471,4 +471,60 @@ BEGIN
   RAISE NOTICE 'OK: repair cost list/detail/report payloads passed';
 END $$;
 
+-- 6) Empty completion payload must raise and leave the request approved.
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_user_id bigint;
+  v_request_id bigint;
+  v_status text;
+  v_completed_at timestamptz;
+  v_completion text;
+  v_reason text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair empty smoke tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_empty_smoke_' || v_suffix,
+    'smoke-password',
+    'Repair Empty Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  v_request_id := pg_temp._rr_cost_create_approved_request(v_tenant, v_user_id, v_suffix);
+  PERFORM pg_temp._rr_cost_set_claims('to_qltb', v_user_id, v_tenant);
+
+  BEGIN
+    PERFORM public.repair_request_complete(v_request_id::integer, '   ', NULL, NULL);
+    RAISE EXCEPTION 'Expected whitespace-only completion to raise';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLSTATE <> '22023' THEN
+      RAISE EXCEPTION 'Expected SQLSTATE 22023 for whitespace completion, got [%] %', SQLSTATE, SQLERRM;
+    END IF;
+  END;
+
+  SELECT trang_thai, ngay_hoan_thanh, ket_qua_sua_chua, ly_do_khong_hoan_thanh
+  INTO v_status, v_completed_at, v_completion, v_reason
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_request_id;
+
+  IF v_status <> 'Đã duyệt'
+     OR v_completed_at IS NOT NULL
+     OR v_completion IS NOT NULL
+     OR v_reason IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Blank completion must not mutate request; got status=%, completed_at=%, completion=%, reason=%',
+      v_status, v_completed_at, v_completion, v_reason;
+  END IF;
+
+  RAISE NOTICE 'OK: empty completion payload guard passed';
+END $$;
+
 ROLLBACK;


### PR DESCRIPTION
## Summary
Fixes #262.

This PR closes the UI/DB contract gap where a user could choose `Hoàn thành`, leave `Kết quả sửa chữa` blank, and still submit a payload that the database interpreted as `Không HT`.

## What Changed
- disabled the complete-dialog confirm button when the active completion field is blank or whitespace-only
- normalized and guarded `useCompleteMutation` so blank completion/reason payloads are rejected before `repair_request_complete` is called
- added a Supabase migration that makes `public.repair_request_complete(integer, text, text, numeric)` raise `22023` when both terminal payload fields are blank
- extended `supabase/tests/repair_request_cost_smoke.sql` with a regression case that proves blank completion no longer mutates the request to a terminal state
- added focused Vitest coverage for both the dialog behavior and the context mutation guard

## Files
- `src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx`
- `src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx`
- `src/app/(app)/repair-requests/__tests__/RepairRequestsCompleteDialog.test.tsx`
- `src/app/(app)/repair-requests/__tests__/RepairRequestsContext.completeMutation.test.tsx`
- `supabase/tests/repair_request_cost_smoke.sql`
- `supabase/migrations/20260416015100_fix_repair_request_complete_empty_payload.sql`

## Verification
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- "src/app/(app)/repair-requests/__tests__/RepairRequestsCompleteDialog.test.tsx" "src/app/(app)/repair-requests/__tests__/RepairRequestsContext.completeMutation.test.tsx"`
- [x] full `supabase/tests/repair_request_cost_smoke.sql` executed against the linked Supabase project after applying the migration
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Notes
- The local `lims-postgres` container is stale for this smoke test path because it is missing `yeu_cau_sua_chua.chi_phi_sua_chua`, so SQL red/green verification had to run against the linked Supabase project.
- The linked Supabase project migration was applied during verification in this session.
- React Doctor reported only the existing file-level `useMutation` invalidation warnings in `RepairRequestsContext.tsx`; no new issue specific to this change.

## Follow-up
- Manual browser verification is tracked separately in #264 because this session did not have browser automation attached.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents blank or whitespace-only repair completion submissions (spaces, tabs, newlines) so requests aren’t mis-set to “Không HT.” The dialog blocks empty input, the mutation trims values and nulls empties, and the DB normalizes, rejects empty payloads, and saves trimmed text.

- **Bug Fixes**
  - Dialog: disable confirm when `Kết quả sửa chữa` or `Lý do không hoàn thành` is blank/whitespace; submit trimmed completion.
  - Mutation: trim `completion`/`reason`, reject when both empty, and send nulls for emptied fields before calling `repair_request_complete`.
  - DB: replace `public.repair_request_complete(integer, text, text, numeric)` to regex-trim leading/trailing whitespace (incl. tabs/newlines), reject when both are empty (raise `22023`), and persist trimmed text; adds a forward-only follow-up migration with rollback notes.
  - Tests: add Vitest cases for disabled states and trimmed payload; extend SQL smoke tests for space-only and control-char whitespace guards with no state change.

<sup>Written for commit b3b09549915de9afdaf54cf476147b01c7cf6692. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Confirm button now stays disabled until the completion result or non-completion reason contains non-whitespace text, preventing blank submissions.
  * Server-side validation now trims inputs and rejects whitespace-only completion/reason values, returning clearer error feedback and ensuring requests are not updated with empty payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->