### PR TITLE
fix: consolidate transfer dialog state management

### DIFF
--- a/src/components/__tests__/transfer-dialog.state.test.tsx
+++ b/src/components/__tests__/transfer-dialog.state.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+
+import type { TransferRequest } from "@/types/database"
+import type { TransferEquipmentOption } from "@/components/transfer-dialog.shared"
+import {
+  createEmptyTransferDialogState,
+  createTransferDialogStateFromTransfer,
+  transferDialogStateReducer,
+} from "@/components/transfer-dialog.shared"
+
+const equipment: TransferEquipmentOption = {
+  id: 11,
+  ma_thiet_bi: "TB-11",
+  ten_thiet_bi: "Máy siêu âm",
+  khoa_phong_quan_ly: "Khoa A",
+}
+
+const transfer: TransferRequest = {
+  id: 7,
+  ma_yeu_cau: "LC-0007",
+  thiet_bi_id: 11,
+  loai_hinh: "ben_ngoai",
+  trang_thai: "cho_duyet",
+  ly_do_luan_chuyen: "Điều phối",
+  khoa_phong_hien_tai: "Khoa A",
+  khoa_phong_nhan: "",
+  muc_dich: "sua_chua",
+  don_vi_nhan: "Bệnh viện B",
+  dia_chi_don_vi: "12 Nguyễn Trãi",
+  nguoi_lien_he: "Nguyễn Văn B",
+  so_dien_thoai: "0900000000",
+  ngay_du_kien_tra: "2026-05-01",
+  created_at: "2026-04-01T00:00:00.000Z",
+  updated_at: "2026-04-01T00:00:00.000Z",
+  thiet_bi: {
+    id: 11,
+    ma_thiet_bi: "TB-11",
+    ten_thiet_bi: "Máy siêu âm",
+    khoa_phong_quan_ly: "Khoa A",
+  },
+}
+
+describe("transfer dialog shared reducer", () => {
+  it("resets dirty add-dialog state back to the empty baseline", () => {
+    const dirtyState = transferDialogStateReducer(createEmptyTransferDialogState(), {
+      type: "EQUIPMENT_SELECTED",
+      equipment,
+    })
+
+    const resetState = transferDialogStateReducer(dirtyState, {
+      type: "RESET",
+    })
+
+    expect(resetState).toEqual(createEmptyTransferDialogState())
+  })
+
+  it("hydrates edit-dialog state from an existing transfer in one transition", () => {
+    expect(createTransferDialogStateFromTransfer(transfer)).toEqual({
+      formData: {
+        thiet_bi_id: 11,
+        loai_hinh: "ben_ngoai",
+        ly_do_luan_chuyen: "Điều phối",
+        khoa_phong_hien_tai: "Khoa A",
+        khoa_phong_nhan: "",
+        muc_dich: "sua_chua",
+        don_vi_nhan: "Bệnh viện B",
+        dia_chi_don_vi: "12 Nguyễn Trãi",
+        nguoi_lien_he: "Nguyễn Văn B",
+        so_dien_thoai: "0900000000",
+        ngay_du_kien_tra: "2026-05-01",
+      },
+      searchTerm: "Máy siêu âm (TB-11)",
+      selectedEquipment: equipment,
+      isSubmitting: false,
+    })
+  })
+
+  it("clears the selected equipment link when a new search term diverges", () => {
+    const selectedState = transferDialogStateReducer(createEmptyTransferDialogState(), {
+      type: "EQUIPMENT_SELECTED",
+      equipment,
+    })
+
+    const searchedState = transferDialogStateReducer(selectedState, {
+      type: "SEARCH_CHANGED",
+      value: "Máy khác",
+    })
+
+    expect(searchedState).toMatchObject({
+      searchTerm: "Máy khác",
+      selectedEquipment: null,
+      formData: expect.objectContaining({
+        thiet_bi_id: 0,
+        khoa_phong_hien_tai: "",
+      }),
+    })
+  })
+})

--- a/src/components/__tests__/transfer-dialogs.payload.test.tsx
+++ b/src/components/__tests__/transfer-dialogs.payload.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { TransferRequest } from "@/types/database"
 
 const mocks = vi.hoisted(() => ({
   callRpc: vi.fn(),
@@ -70,6 +71,7 @@ vi.mock("@/components/ui/select", () => ({
 }))
 
 import { AddTransferDialog } from "@/components/add-transfer-dialog"
+import { EditTransferDialog } from "@/components/edit-transfer-dialog"
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -81,6 +83,36 @@ function createWrapper() {
 
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function createTransfer(
+  overrides: Partial<TransferRequest> = {},
+): TransferRequest {
+  return {
+    id: overrides.id ?? 7,
+    ma_yeu_cau: overrides.ma_yeu_cau ?? "LC-0007",
+    thiet_bi_id: overrides.thiet_bi_id ?? 11,
+    loai_hinh: overrides.loai_hinh ?? "ben_ngoai",
+    trang_thai: overrides.trang_thai ?? "cho_duyet",
+    nguoi_yeu_cau_id: overrides.nguoi_yeu_cau_id ?? 42,
+    ly_do_luan_chuyen: overrides.ly_do_luan_chuyen ?? "Điều phối",
+    khoa_phong_hien_tai: overrides.khoa_phong_hien_tai ?? "Khoa A",
+    khoa_phong_nhan: overrides.khoa_phong_nhan ?? "",
+    muc_dich: overrides.muc_dich ?? "sua_chua",
+    don_vi_nhan: overrides.don_vi_nhan ?? "Bệnh viện B",
+    dia_chi_don_vi: overrides.dia_chi_don_vi ?? "12 Nguyễn Trãi",
+    nguoi_lien_he: overrides.nguoi_lien_he ?? "Nguyễn Văn B",
+    so_dien_thoai: overrides.so_dien_thoai ?? "0900000000",
+    ngay_du_kien_tra: overrides.ngay_du_kien_tra ?? "2026-05-01",
+    created_at: overrides.created_at ?? "2026-04-01T00:00:00.000Z",
+    updated_at: overrides.updated_at ?? "2026-04-01T00:00:00.000Z",
+    thiet_bi: overrides.thiet_bi ?? {
+      id: 11,
+      ma_thiet_bi: "TB-11",
+      ten_thiet_bi: "Máy siêu âm",
+      khoa_phong_quan_ly: "Khoa A",
+    },
   }
 }
 
@@ -168,6 +200,97 @@ describe("AddTransferDialog payload shaping", () => {
             ly_do_luan_chuyen: "Điều phối",
             nguoi_yeu_cau_id: 42,
             created_by: 42,
+            updated_by: 42,
+            khoa_phong_hien_tai: "Khoa A",
+            khoa_phong_nhan: "Khoa B",
+            muc_dich: null,
+            don_vi_nhan: null,
+            dia_chi_don_vi: null,
+            nguoi_lien_he: null,
+            so_dien_thoai: null,
+            ngay_du_kien_tra: null,
+          },
+        },
+      })
+    })
+
+    expect(onSuccess).toHaveBeenCalled()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})
+
+describe("EditTransferDialog payload shaping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: "42",
+          role: "to_qltb",
+        },
+      },
+      status: "authenticated",
+    })
+  })
+
+  it("drops stale external fields after switching from external to internal transfer", async () => {
+    mocks.callRpc.mockImplementation(async ({ fn }: { fn: string }) => {
+      if (fn === "equipment_list_enhanced") {
+        return {
+          data: [
+            {
+              id: 11,
+              ma_thiet_bi: "TB-11",
+              ten_thiet_bi: "Máy siêu âm",
+              khoa_phong_quan_ly: "Khoa A",
+            },
+          ],
+        }
+      }
+
+      if (fn === "transfer_request_update") {
+        return { id: 7 }
+      }
+
+      return []
+    })
+
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const onSuccess = vi.fn()
+
+    render(
+      <EditTransferDialog
+        open
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+        transfer={createTransfer()}
+      />,
+      { wrapper: createWrapper() },
+    )
+
+    let selects = screen.getAllByRole("combobox")
+    await user.selectOptions(selects[0], "noi_bo")
+
+    await user.clear(screen.getByLabelText("Khoa/Phòng hiện tại *"))
+    await user.type(screen.getByLabelText("Khoa/Phòng hiện tại *"), "Khoa A")
+    await user.clear(screen.getByLabelText("Khoa/Phòng nhận *"))
+    await user.type(screen.getByLabelText("Khoa/Phòng nhận *"), "Khoa B")
+    await user.clear(screen.getByLabelText(/Lý do/))
+    await user.type(screen.getByLabelText(/Lý do/), " Điều phối nội bộ ")
+
+    await user.click(screen.getByRole("button", { name: "Cập nhật" }))
+
+    await waitFor(() => {
+      expect(mocks.callRpc).toHaveBeenCalledWith({
+        fn: "transfer_request_update",
+        args: {
+          p_id: 7,
+          p_data: {
+            thiet_bi_id: 11,
+            loai_hinh: "noi_bo",
+            ly_do_luan_chuyen: "Điều phối nội bộ",
             updated_by: 42,
             khoa_phong_hien_tai: "Khoa A",
             khoa_phong_nhan: "Khoa B",

--- a/src/components/__tests__/transfer-dialogs.payload.test.tsx
+++ b/src/components/__tests__/transfer-dialogs.payload.test.tsx
@@ -308,4 +308,92 @@ describe("EditTransferDialog payload shaping", () => {
     expect(onSuccess).toHaveBeenCalled()
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
+
+  it("keeps the dialog state intact and re-enables submit after a failed update", async () => {
+    mocks.callRpc.mockImplementation(async ({ fn }: { fn: string }) => {
+      if (fn === "equipment_list_enhanced") {
+        return {
+          data: [
+            {
+              id: 11,
+              ma_thiet_bi: "TB-11",
+              ten_thiet_bi: "Máy siêu âm",
+              khoa_phong_quan_ly: "Khoa A",
+            },
+          ],
+        }
+      }
+
+      if (fn === "transfer_request_update") {
+        throw new Error("Update failed")
+      }
+
+      return []
+    })
+
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    const onSuccess = vi.fn()
+
+    render(
+      <EditTransferDialog
+        open
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+        transfer={createTransfer()}
+      />,
+      { wrapper: createWrapper() },
+    )
+
+    let selects = screen.getAllByRole("combobox")
+    await user.selectOptions(selects[0], "noi_bo")
+
+    const currentDepartmentInput = screen.getByLabelText("Khoa/Phòng hiện tại *")
+    const receivingDepartmentInput = screen.getByLabelText("Khoa/Phòng nhận *")
+    const reasonInput = screen.getByLabelText(/Lý do/)
+
+    await user.clear(currentDepartmentInput)
+    await user.type(currentDepartmentInput, "Khoa A")
+    await user.clear(receivingDepartmentInput)
+    await user.type(receivingDepartmentInput, "Khoa B")
+    await user.clear(reasonInput)
+    await user.type(reasonInput, " Điều phối lỗi ")
+
+    const submitButton = screen.getByRole("button", { name: "Cập nhật" })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mocks.callRpc).toHaveBeenCalledWith({
+        fn: "transfer_request_update",
+        args: {
+          p_id: 7,
+          p_data: {
+            thiet_bi_id: 11,
+            loai_hinh: "noi_bo",
+            ly_do_luan_chuyen: "Điều phối lỗi",
+            updated_by: 42,
+            khoa_phong_hien_tai: "Khoa A",
+            khoa_phong_nhan: "Khoa B",
+            muc_dich: null,
+            don_vi_nhan: null,
+            dia_chi_don_vi: null,
+            nguoi_lien_he: null,
+            so_dien_thoai: null,
+            ngay_du_kien_tra: null,
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Cập nhật" })).toBeEnabled()
+    })
+
+    expect(screen.getByTestId("dialog")).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(currentDepartmentInput).toHaveValue("Khoa A")
+    expect(receivingDepartmentInput).toHaveValue("Khoa B")
+    expect(reasonInput).toHaveValue(" Điều phối lỗi ")
+  })
 })

--- a/src/components/add-transfer-dialog.tsx
+++ b/src/components/add-transfer-dialog.tsx
@@ -23,8 +23,10 @@ import {
 import {
   buildCreateTransferPayload,
   createEmptyTransferDialogFormData,
+  createEmptyTransferDialogState,
   getTransferDialogErrorMessage,
   normalizeSessionUserId,
+  transferDialogStateReducer,
   type TransferEquipmentOption,
 } from "@/components/transfer-dialog.shared"
 import { TransferDialogEquipmentSearch } from "@/components/transfer-dialog.equipment-search"
@@ -46,23 +48,24 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
   const { data: session } = useSession()
   const currentUserId = normalizeSessionUserId(session?.user)
   const isRegionalLeader = isRegionalLeaderRole(session?.user?.role)
-  const [isLoading, setIsLoading] = React.useState(false)
-  const [searchTerm, setSearchTerm] = React.useState("")
-  const [selectedEquipment, setSelectedEquipment] = React.useState<TransferEquipmentOption | null>(null)
-  const [formData, setFormData] = React.useState(createEmptyTransferDialogFormData)
+  const [state, dispatch] = React.useReducer(
+    transferDialogStateReducer,
+    undefined,
+    createEmptyTransferDialogState,
+  )
+  const { formData, isSubmitting: isLoading, searchTerm, selectedEquipment } = state
 
-  const resetForm = React.useCallback(() => {
-    setFormData(createEmptyTransferDialogFormData())
-    setSelectedEquipment(null)
-    setSearchTerm("")
+  const setFormData = React.useCallback<
+    React.Dispatch<React.SetStateAction<ReturnType<typeof createEmptyTransferDialogFormData>>>
+  >((value) => {
+    dispatch({ type: "FORM_DATA_CHANGED", value })
   }, [])
 
   React.useEffect(() => {
     if (!open) {
-      resetForm()
-      return
+      dispatch({ type: "RESET" })
     }
-  }, [open, resetForm])
+  }, [open])
 
   const { departments, isLoadingDepartments } = useTransferDepartments({ open })
   const selectedValueLabel = selectedEquipment
@@ -102,25 +105,11 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     trimmedSearch.length > 0 && trimmedSearch.length < 2
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTerm(e.target.value)
-    if (selectedEquipment) {
-      setSelectedEquipment(null)
-      setFormData((prev) => ({
-        ...prev,
-        thiet_bi_id: 0,
-        khoa_phong_hien_tai: "",
-      }))
-    }
+    dispatch({ type: "SEARCH_CHANGED", value: e.target.value })
   }
 
   const handleSelectEquipment = (equipment: TransferEquipmentOption) => {
-    setSelectedEquipment(equipment)
-    setSearchTerm(`${equipment.ten_thiet_bi} (${equipment.ma_thiet_bi})`)
-    setFormData((prev) => ({
-      ...prev,
-      thiet_bi_id: equipment.id,
-      khoa_phong_hien_tai: equipment.khoa_phong_quan_ly || "",
-    }))
+    dispatch({ type: "EQUIPMENT_SELECTED", equipment })
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -166,7 +155,7 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
 
     // Thanh lý không cần validate thêm vì đã có default values
 
-    setIsLoading(true)
+    dispatch({ type: "SUBMIT_STARTED" })
 
     try {
       const payload = buildCreateTransferPayload({ formData, currentUserId })
@@ -191,7 +180,7 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
         ),
       })
     } finally {
-      setIsLoading(false)
+      dispatch({ type: "SUBMIT_FINISHED" })
     }
   }
 

--- a/src/components/edit-transfer-dialog.tsx
+++ b/src/components/edit-transfer-dialog.tsx
@@ -21,10 +21,10 @@ import { useTransferEquipmentSearch } from "@/components/transfer-dialog.data"
 import {
   buildUpdateTransferPayload,
   createEmptyTransferDialogFormData,
-  createTransferDialogFormDataFromTransfer,
-  getSelectedEquipmentFromTransfer,
+  createEmptyTransferDialogState,
   getTransferDialogErrorMessage,
   normalizeSessionUserId,
+  transferDialogStateReducer,
   type TransferEquipmentOption,
 } from "@/components/transfer-dialog.shared"
 import { TransferDialogEquipmentSearch } from "@/components/transfer-dialog.equipment-search"
@@ -47,36 +47,32 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
   const { data: session } = useSession()
   const currentUserId = normalizeSessionUserId(session?.user)
   const isRegionalLeader = isRegionalLeaderRole(session?.user?.role)
-  const [isLoading, setIsLoading] = React.useState(false)
-  const [searchTerm, setSearchTerm] = React.useState("")
-  const [selectedEquipment, setSelectedEquipment] = React.useState<TransferEquipmentOption | null>(null)
-  const [formData, setFormData] = React.useState(createEmptyTransferDialogFormData)
+  const [state, dispatch] = React.useReducer(
+    transferDialogStateReducer,
+    undefined,
+    createEmptyTransferDialogState,
+  )
+  const { formData, isSubmitting: isLoading, searchTerm, selectedEquipment } = state
+
+  const setFormData = React.useCallback<
+    React.Dispatch<React.SetStateAction<ReturnType<typeof createEmptyTransferDialogFormData>>>
+  >((value) => {
+    dispatch({ type: "FORM_DATA_CHANGED", value })
+  }, [])
 
   // Check if editing is allowed based on status
   const canEdit = Boolean(
     transfer && (transfer.trang_thai === 'cho_duyet' || transfer.trang_thai === 'da_duyet')
   )
 
-  const resetForm = React.useCallback(() => {
-    setFormData(createEmptyTransferDialogFormData())
-    setSelectedEquipment(null)
-    setSearchTerm("")
-  }, [])
-
   // Load transfer data when dialog opens
   React.useEffect(() => {
     if (open && transfer) {
-      setFormData(createTransferDialogFormDataFromTransfer(transfer))
-
-      const equipment = getSelectedEquipmentFromTransfer(transfer)
-      setSelectedEquipment(equipment)
-      if (equipment) {
-        setSearchTerm(`${equipment.ten_thiet_bi} (${equipment.ma_thiet_bi})`)
-      }
+      dispatch({ type: "LOAD_TRANSFER", transfer })
     } else if (!open) {
-      resetForm()
+      dispatch({ type: "RESET" })
     }
-  }, [open, transfer, resetForm])
+  }, [open, transfer])
 
   const selectedValueLabel = selectedEquipment
     ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
@@ -131,15 +127,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
     }
 
     const value = e.target.value
-    setSearchTerm(value)
-    if (selectedEquipment && value !== selectedValueLabel) {
-      setSelectedEquipment(null)
-      setFormData((prev) => ({
-        ...prev,
-        thiet_bi_id: 0,
-        khoa_phong_hien_tai: "",
-      }))
-    }
+    dispatch({ type: "SEARCH_CHANGED", value })
   }
 
   const handleSelectEquipment = (equipment: TransferEquipmentOption) => {
@@ -147,13 +135,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
       return
     }
 
-    setSelectedEquipment(equipment)
-    setSearchTerm(`${equipment.ten_thiet_bi} (${equipment.ma_thiet_bi})`)
-    setFormData((prev) => ({
-      ...prev,
-      thiet_bi_id: equipment.id,
-      khoa_phong_hien_tai: equipment.khoa_phong_quan_ly || "",
-    }))
+    dispatch({ type: "EQUIPMENT_SELECTED", equipment })
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -206,7 +188,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
       return
     }
 
-    setIsLoading(true)
+    dispatch({ type: "SUBMIT_STARTED" })
 
     try {
       const payload = buildUpdateTransferPayload({ formData, currentUserId })
@@ -229,7 +211,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
         ),
       })
     } finally {
-      setIsLoading(false)
+      dispatch({ type: "SUBMIT_FINISHED" })
     }
   }
 

--- a/src/components/transfer-dialog.shared.ts
+++ b/src/components/transfer-dialog.shared.ts
@@ -19,6 +19,26 @@ export type TransferEquipmentOption = Pick<
   "id" | "ma_thiet_bi" | "ten_thiet_bi" | "model" | "serial" | "khoa_phong_quan_ly"
 >
 
+export type TransferDialogState = {
+  formData: TransferDialogFormData
+  searchTerm: string
+  selectedEquipment: TransferEquipmentOption | null
+  isSubmitting: boolean
+}
+
+type TransferDialogFormDataUpdate =
+  | TransferDialogFormData
+  | ((previous: TransferDialogFormData) => TransferDialogFormData)
+
+type TransferDialogStateAction =
+  | { type: "RESET" }
+  | { type: "LOAD_TRANSFER"; transfer: TransferRequest }
+  | { type: "FORM_DATA_CHANGED"; value: TransferDialogFormDataUpdate }
+  | { type: "SEARCH_CHANGED"; value: string }
+  | { type: "EQUIPMENT_SELECTED"; equipment: TransferEquipmentOption }
+  | { type: "SUBMIT_STARTED" }
+  | { type: "SUBMIT_FINISHED" }
+
 type TransferDialogPayload = {
   thiet_bi_id: number
   loai_hinh: TransferType
@@ -151,6 +171,15 @@ export function createEmptyTransferDialogFormData(): TransferDialogFormData {
   return { ...EMPTY_FORM_DATA }
 }
 
+export function createEmptyTransferDialogState(): TransferDialogState {
+  return {
+    formData: createEmptyTransferDialogFormData(),
+    searchTerm: "",
+    selectedEquipment: null,
+    isSubmitting: false,
+  }
+}
+
 export function normalizeSessionUserId(user: { id?: unknown } | null | undefined): number | null {
   const rawId = user?.id
 
@@ -254,6 +283,93 @@ export function getSelectedEquipmentFromTransfer(
     model: equipment.model ?? undefined,
     serial: (equipment.serial ?? equipment.serial_number) ?? undefined,
     khoa_phong_quan_ly: equipment.khoa_phong_quan_ly ?? undefined,
+  }
+}
+
+export function createTransferDialogStateFromTransfer(
+  transfer: TransferRequest,
+): TransferDialogState {
+  const selectedEquipment = getSelectedEquipmentFromTransfer(transfer)
+
+  return {
+    formData: createTransferDialogFormDataFromTransfer(transfer),
+    searchTerm: selectedEquipment
+      ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
+      : "",
+    selectedEquipment,
+    isSubmitting: false,
+  }
+}
+
+function updateTransferDialogFormData(
+  previous: TransferDialogFormData,
+  value: TransferDialogFormDataUpdate,
+): TransferDialogFormData {
+  return typeof value === "function" ? value(previous) : value
+}
+
+export function transferDialogStateReducer(
+  state: TransferDialogState,
+  action: TransferDialogStateAction,
+): TransferDialogState {
+  switch (action.type) {
+    case "RESET":
+      return createEmptyTransferDialogState()
+    case "LOAD_TRANSFER":
+      return createTransferDialogStateFromTransfer(action.transfer)
+    case "FORM_DATA_CHANGED":
+      return {
+        ...state,
+        formData: updateTransferDialogFormData(state.formData, action.value),
+      }
+    case "SEARCH_CHANGED": {
+      const selectedValueLabel = state.selectedEquipment
+        ? `${state.selectedEquipment.ten_thiet_bi} (${state.selectedEquipment.ma_thiet_bi})`
+        : ""
+      const shouldClearSelectedEquipment =
+        state.selectedEquipment !== null && action.value !== selectedValueLabel
+
+      if (!shouldClearSelectedEquipment) {
+        return {
+          ...state,
+          searchTerm: action.value,
+        }
+      }
+
+      return {
+        ...state,
+        searchTerm: action.value,
+        selectedEquipment: null,
+        formData: {
+          ...state.formData,
+          thiet_bi_id: 0,
+          khoa_phong_hien_tai: "",
+        },
+      }
+    }
+    case "EQUIPMENT_SELECTED":
+      return {
+        ...state,
+        searchTerm: `${action.equipment.ten_thiet_bi} (${action.equipment.ma_thiet_bi})`,
+        selectedEquipment: action.equipment,
+        formData: {
+          ...state.formData,
+          thiet_bi_id: action.equipment.id,
+          khoa_phong_hien_tai: action.equipment.khoa_phong_quan_ly || "",
+        },
+      }
+    case "SUBMIT_STARTED":
+      return {
+        ...state,
+        isSubmitting: true,
+      }
+    case "SUBMIT_FINISHED":
+      return {
+        ...state,
+        isSubmitting: false,
+      }
+    default:
+      return state
   }
 }
 


### PR DESCRIPTION
## Summary
- consolidate `AddTransferDialog` and `EditTransferDialog` state handling onto one shared reducer implementation in `src/components/transfer-dialog.shared.ts`
- replace multi-`useState` orchestration and multi-setter open/load/reset/search flows with reducer dispatches while keeping dialog props, RPC contracts, child component props, and UX unchanged
- add focused reducer-state coverage in `src/components/__tests__/transfer-dialog.state.test.tsx` and extend payload-shaping coverage for the edit flow in `src/components/__tests__/transfer-dialogs.payload.test.tsx`

## Problem
Issue #251 tracked React Doctor warnings in the transfer dialogs caused by fragmented local state (`formData`, `searchTerm`, `selectedEquipment`, submit loading) plus multiple `setState` calls inside a single `useEffect`, especially in the edit dialog load/reset path.

## What Changed
- added a shared `TransferDialogState` model, reducer, and state factory helpers for empty add-dialog state and hydrated edit-dialog state
- wired both dialogs to `useReducer`, including reducer-backed transitions for reset, load-from-transfer, search changes, equipment selection, form updates, and submit lifecycle
- preserved existing validation, toast copy, submit payload builders, TanStack Query data hooks, and rendered UI structure
- kept the compatibility boundary intact by adapting reducer dispatch to the existing `setFormData` callback shape used by `TransferTypeField`, `TransferInternalSelectFields`, `TransferInternalInputFields`, `TransferExternalFields`, and `TransferReasonField`

## Blast Radius
- direct importer confirmed by GitNexus: `src/app/(app)/transfers/_components/TransfersDialogs.tsx`
- broader regression surface is in shared transfer-dialog helpers and tests, not page integration
- focused regression coverage kept green for shared payload shaping, query/data hooks, and shared child components

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/components/__tests__/transfer-dialog.state.test.tsx src/components/__tests__/transfer-dialogs.payload.test.tsx src/components/__tests__/transfer-dialog.shared.test.ts src/components/__tests__/transfer-dialog.data.test.tsx src/components/__tests__/transfer-dialog.data-fetching.test.tsx src/components/__tests__/transfer-dialog.query-options.test.tsx src/components/__tests__/transfer-dialog.components.test.tsx`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Result
- React Doctor diff scan finished at `100/100` with no issues
- transfer dialog state transitions now have explicit reducer-level coverage for reset, load, and search-selection behavior
- payload-shaping guarantees from #235 remain covered for both create and update flows

Closes Issue #251
Closes #251
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated state for `AddTransferDialog` and `EditTransferDialog` into a shared reducer to remove React Doctor warnings and make transitions predictable. UX, RPC contracts, and child props remain unchanged; added tests, including the failed update path. Fixes #251.

- **Refactors**
  - Introduced `TransferDialogState` and reducer in `transfer-dialog.shared.ts`, with helpers for empty and hydrated state.
  - Moved both dialogs to `useReducer` with dispatches for reset, load-from-transfer, search, selection, form updates, and submit lifecycle.
  - Kept the `setFormData` callback shape for child fields; added tests in `transfer-dialog.state.test.tsx` and extended `transfer-dialogs.payload.test.tsx` (covers failed update resilience).

- **Bug Fixes**
  - Eliminates React Doctor warnings from fragmented state and multi-`setState` flows (issue #251).
  - Clears selected equipment when search diverges; ensures reliable reset behavior.
  - In edit mode, drops external-only fields when switching to internal transfers.
  - Keeps the dialog open and re-enables submit after a failed update.

<sup>Written for commit 80ea11e6c5ffc487c24fe79a65edce54b15c740c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for transfer dialog state management and payload handling to ensure reliability of transfer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->