### PR TITLE
refactor: extract assistant query catalog

### DIFF
--- a/src/lib/ai/tools/__tests__/query-catalog.test.ts
+++ b/src/lib/ai/tools/__tests__/query-catalog.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+const EXPECTED_TOOL_NAMES = [
+  'attachmentLookup',
+  'categorySuggestion',
+  'departmentList',
+  'deviceQuotaLookup',
+  'equipmentLookup',
+  'maintenancePlanLookup',
+  'maintenanceSummary',
+  'quotaComplianceSummary',
+  'repairSummary',
+  'usageHistory',
+]
+
+const EXPECTED_RPC_MAPPING: Record<string, string> = {
+  equipmentLookup: 'ai_equipment_lookup',
+  maintenanceSummary: 'ai_maintenance_summary',
+  maintenancePlanLookup: 'ai_maintenance_plan_lookup',
+  repairSummary: 'ai_repair_summary',
+  usageHistory: 'ai_usage_summary',
+  attachmentLookup: 'ai_attachment_metadata',
+  deviceQuotaLookup: 'ai_device_quota_lookup',
+  quotaComplianceSummary: 'ai_quota_compliance_summary',
+  categorySuggestion: 'ai_category_suggestion',
+  departmentList: 'ai_department_list',
+}
+
+const EXPECTED_MIGRATION_STATUS: Record<string, 'migrated' | 'pending'> = {
+  categorySuggestion: 'migrated',
+  departmentList: 'migrated',
+  equipmentLookup: 'pending',
+  maintenanceSummary: 'pending',
+  maintenancePlanLookup: 'pending',
+  repairSummary: 'pending',
+  usageHistory: 'pending',
+  attachmentLookup: 'pending',
+  deviceQuotaLookup: 'pending',
+  quotaComplianceSummary: 'pending',
+}
+
+describe('query catalog', () => {
+  it('exports the exact curated read-only tool names', async () => {
+    const { QUERY_CATALOG } = await import('../query-catalog')
+
+    expect(Object.keys(QUERY_CATALOG).sort()).toEqual(EXPECTED_TOOL_NAMES)
+  })
+
+  it('exports the exact tool to RPC mapping', async () => {
+    const { getQueryCatalogToolRpcMapping } = await import('../query-catalog')
+
+    expect(getQueryCatalogToolRpcMapping()).toEqual(EXPECTED_RPC_MAPPING)
+  })
+
+  it('exports the exact migration status map', async () => {
+    const { getQueryCatalogMigrationStatusMap } = await import('../query-catalog')
+
+    expect(getQueryCatalogMigrationStatusMap()).toEqual(EXPECTED_MIGRATION_STATUS)
+  })
+
+  it('marks migrated tools with a model budget', async () => {
+    const { QUERY_CATALOG } = await import('../query-catalog')
+
+    const migratedToolNames = Object.entries(EXPECTED_MIGRATION_STATUS)
+      .filter(([, status]) => status === 'migrated')
+      .map(([name]) => name)
+
+    for (const toolName of migratedToolNames) {
+      expect(QUERY_CATALOG[toolName]?.modelBudget, `${toolName} must define modelBudget`).toBeDefined()
+    }
+  })
+})

--- a/src/lib/ai/tools/__tests__/query-catalog.test.ts
+++ b/src/lib/ai/tools/__tests__/query-catalog.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
+import {
+  QUERY_CATALOG,
+  getQueryCatalogMigrationStatusMap,
+  getQueryCatalogToolRpcMapping,
+} from '@/lib/ai/tools/query-catalog'
+
 const EXPECTED_TOOL_NAMES = [
   'attachmentLookup',
   'categorySuggestion',
@@ -40,27 +46,21 @@ const EXPECTED_MIGRATION_STATUS: Record<string, 'migrated' | 'pending'> = {
 }
 
 describe('query catalog', () => {
-  it('exports the exact curated read-only tool names', async () => {
-    const { QUERY_CATALOG } = await import('../query-catalog')
-
-    expect(Object.keys(QUERY_CATALOG).sort()).toEqual(EXPECTED_TOOL_NAMES)
+  it('exports the exact curated read-only tool names', () => {
+    expect(Object.keys(QUERY_CATALOG).sort((a, b) => a.localeCompare(b))).toEqual(
+      EXPECTED_TOOL_NAMES,
+    )
   })
 
-  it('exports the exact tool to RPC mapping', async () => {
-    const { getQueryCatalogToolRpcMapping } = await import('../query-catalog')
-
+  it('exports the exact tool to RPC mapping', () => {
     expect(getQueryCatalogToolRpcMapping()).toEqual(EXPECTED_RPC_MAPPING)
   })
 
-  it('exports the exact migration status map', async () => {
-    const { getQueryCatalogMigrationStatusMap } = await import('../query-catalog')
-
+  it('exports the exact migration status map', () => {
     expect(getQueryCatalogMigrationStatusMap()).toEqual(EXPECTED_MIGRATION_STATUS)
   })
 
-  it('marks migrated tools with a model budget', async () => {
-    const { QUERY_CATALOG } = await import('../query-catalog')
-
+  it('marks migrated tools with a model budget', () => {
     const migratedToolNames = Object.entries(EXPECTED_MIGRATION_STATUS)
       .filter(([, status]) => status === 'migrated')
       .map(([name]) => name)

--- a/src/lib/ai/tools/query-catalog.ts
+++ b/src/lib/ai/tools/query-catalog.ts
@@ -2,17 +2,29 @@ import { z } from 'zod'
 
 export type MigrationStatus = 'migrated' | 'pending'
 
-export type QueryCatalogEntry = {
+export interface QueryCatalogModelBudget {
+  maxItems?: number
+  maxBytes?: number
+  modelVisibleFields?: string[]
+}
+
+interface BaseQueryCatalogEntry {
   description: string
   rpcFunction: string
   inputSchema: z.ZodType<Record<string, unknown>>
-  migrationStatus: MigrationStatus
-  modelBudget?: {
-    maxItems?: number
-    maxBytes?: number
-    modelVisibleFields?: string[]
-  }
 }
+
+interface MigratedQueryCatalogEntry extends BaseQueryCatalogEntry {
+  migrationStatus: 'migrated'
+  modelBudget: QueryCatalogModelBudget
+}
+
+interface PendingQueryCatalogEntry extends BaseQueryCatalogEntry {
+  migrationStatus: 'pending'
+  modelBudget?: QueryCatalogModelBudget
+}
+
+export type QueryCatalogEntry = MigratedQueryCatalogEntry | PendingQueryCatalogEntry
 
 export const QUERY_CATALOG = {
   equipmentLookup: {

--- a/src/lib/ai/tools/query-catalog.ts
+++ b/src/lib/ai/tools/query-catalog.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod'
+
+export type MigrationStatus = 'migrated' | 'pending'
+
+export type QueryCatalogEntry = {
+  description: string
+  rpcFunction: string
+  inputSchema: z.ZodType<Record<string, unknown>>
+  migrationStatus: MigrationStatus
+  modelBudget?: {
+    maxItems?: number
+    maxBytes?: number
+    modelVisibleFields?: string[]
+  }
+}
+
+export const QUERY_CATALOG = {
+  equipmentLookup: {
+    description:
+      'Lookup equipment details using approved read-only RPC. Supports text search plus structured `filters` for exact `equipmentCode`, current status, department, location, classification, model, and serial; use the returned total for aggregate counts.',
+    rpcFunction: 'ai_equipment_lookup',
+    migrationStatus: 'pending',
+    inputSchema: z
+      .object({
+        query: z.string().trim().min(1).max(200).optional(),
+        limit: z.number().int().min(1).max(50).optional(),
+        status: z.string().trim().min(1).max(100).optional(),
+        filters: z
+          .object({
+            equipmentCode: z.string().trim().min(1).max(200).optional(),
+            status: z.string().trim().min(1).max(100).optional(),
+            department: z.string().trim().min(1).max(200).optional(),
+            location: z.string().trim().min(1).max(200).optional(),
+            classification: z.string().trim().min(1).max(50).optional(),
+            model: z.string().trim().min(1).max(200).optional(),
+            serial: z.string().trim().min(1).max(200).optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict(),
+  },
+  maintenanceSummary: {
+    description: 'Retrieve maintenance summary data via approved read-only RPC.',
+    rpcFunction: 'ai_maintenance_summary',
+    migrationStatus: 'pending',
+    inputSchema: z
+      .object({
+        fromDate: z.string().optional(),
+        toDate: z.string().optional(),
+      })
+      .strict(),
+  },
+  maintenancePlanLookup: {
+    description:
+      'Lookup maintenance, calibration, and inspection plans for a specific equipment item.',
+    rpcFunction: 'ai_maintenance_plan_lookup',
+    migrationStatus: 'pending',
+    inputSchema: z
+      .object({
+        p_thiet_bi_id: z.number().int().positive(),
+        p_nam: z.number().int().min(2000).max(2100).optional(),
+      })
+      .strict(),
+  },
+  repairSummary: {
+    description: 'Retrieve repair summary data via approved read-only RPC.',
+    rpcFunction: 'ai_repair_summary',
+    migrationStatus: 'pending',
+    inputSchema: z
+      .object({
+        status: z.string().trim().min(1).max(50).optional(),
+      })
+      .strict(),
+  },
+  usageHistory: {
+    description:
+      'Retrieve usage summary evidence for a specific equipment item from usage logs.',
+    rpcFunction: 'ai_usage_summary',
+    migrationStatus: 'pending',
+    inputSchema: z
+      .object({
+        p_thiet_bi_id: z.number().int().positive(),
+        p_months: z.number().int().min(1).max(24).optional(),
+      })
+      .strict(),
+  },
+  attachmentLookup: {
+    description:
+      'Lookup attachment metadata (file names, access types, URLs) for a specific equipment item. Returns normalized access contract.',
+    rpcFunction: 'ai_attachment_metadata',
+    migrationStatus: 'pending',
+    inputSchema: z
+      .object({
+        p_thiet_bi_id: z.number().int().positive(),
+      })
+      .strict(),
+  },
+  deviceQuotaLookup: {
+    description:
+      'Check quota status for a specific equipment item against the active quota decision.',
+    rpcFunction: 'ai_device_quota_lookup',
+    migrationStatus: 'pending',
+    inputSchema: z
+      .object({
+        p_thiet_bi_id: z.number().int().positive(),
+      })
+      .strict(),
+  },
+  quotaComplianceSummary: {
+    description:
+      'Get facility-level device quota compliance overview from the active decision.',
+    rpcFunction: 'ai_quota_compliance_summary',
+    migrationStatus: 'pending',
+    inputSchema: z.object({}).strict(),
+  },
+  categorySuggestion: {
+    description:
+      'Suggest the best matching equipment categories for a provided device name. Call this only after the user has given `device_name`; the RPC returns a bounded candidate set instead of the full category catalog.',
+    rpcFunction: 'ai_category_suggestion',
+    migrationStatus: 'migrated',
+    inputSchema: z
+      .object({
+        device_name: z.string().trim().min(1).max(200),
+      })
+      .strict(),
+    modelBudget: {
+      maxItems: 10,
+      modelVisibleFields: ['ma_nhom', 'ten_nhom', 'parent_name', 'phan_loai', 'match_reason'],
+    },
+  },
+  departmentList: {
+    description:
+      'List all departments (khoa/phòng) with equipment in the current facility. Call this BEFORE filtering equipmentLookup by department to get exact department names from the database.',
+    rpcFunction: 'ai_department_list',
+    migrationStatus: 'migrated',
+    inputSchema: z.object({}).strict(),
+    modelBudget: {
+      maxItems: 50,
+      modelVisibleFields: ['name', 'equipment_count'],
+    },
+  },
+} satisfies Record<string, QueryCatalogEntry>
+
+export type QueryCatalogToolName = keyof typeof QUERY_CATALOG
+
+export const QUERY_CATALOG_TOOL_NAMES = Object.keys(QUERY_CATALOG) as QueryCatalogToolName[]
+
+export const QUERY_CATALOG_TOOL_NAME_SET: ReadonlySet<string> = new Set(QUERY_CATALOG_TOOL_NAMES)
+
+export function getQueryCatalogToolRpcMapping(): Record<string, string> {
+  return Object.fromEntries(Object.entries(QUERY_CATALOG).map(([k, v]) => [k, v.rpcFunction]))
+}
+
+export function getQueryCatalogMigrationStatusMap(): Record<string, MigrationStatus> {
+  return Object.fromEntries(
+    Object.entries(QUERY_CATALOG).map(([k, v]) => [k, v.migrationStatus]),
+  )
+}
+
+export const QUERY_CATALOG_PENDING_TOOL_NAMES: ReadonlySet<string> = new Set(
+  Object.entries(QUERY_CATALOG)
+    .filter(([, def]) => def.migrationStatus === 'pending')
+    .map(([name]) => name),
+)

--- a/src/lib/ai/tools/query-catalog.types.assert.ts
+++ b/src/lib/ai/tools/query-catalog.types.assert.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+import type { MigrationStatus } from '@/lib/ai/tools/registry'
+import type { QueryCatalogEntry } from '@/lib/ai/tools/query-catalog'
+
+const migratedStatus: MigrationStatus = 'migrated'
+const pendingStatus: MigrationStatus = 'pending'
+
+void migratedStatus
+void pendingStatus
+
+const validMigratedEntry: QueryCatalogEntry = {
+  description: 'valid migrated tool',
+  rpcFunction: 'valid_rpc',
+  inputSchema: z.object({}).strict(),
+  migrationStatus: 'migrated',
+  modelBudget: {
+    maxItems: 10,
+  },
+}
+
+const validPendingEntry: QueryCatalogEntry = {
+  description: 'valid pending tool',
+  rpcFunction: 'valid_pending_rpc',
+  inputSchema: z.object({}).strict(),
+  migrationStatus: 'pending',
+}
+
+// @ts-expect-error migrated entries must define modelBudget
+const invalidMigratedEntry: QueryCatalogEntry = {
+  description: 'invalid migrated tool',
+  rpcFunction: 'invalid_rpc',
+  inputSchema: z.object({}).strict(),
+  migrationStatus: 'migrated',
+}
+
+void validMigratedEntry
+void validPendingEntry
+void invalidMigratedEntry

--- a/src/lib/ai/tools/registry.ts
+++ b/src/lib/ai/tools/registry.ts
@@ -17,6 +17,8 @@ import {
 } from '@/lib/ai/tools/query-catalog'
 import { executeRpcTool } from '@/lib/ai/tools/rpc-tool-executor'
 
+export type { MigrationStatus } from '@/lib/ai/tools/query-catalog'
+
 // ============================================
 // Draft Tool Definitions (non-RPC, advisory-only)
 // ============================================

--- a/src/lib/ai/tools/registry.ts
+++ b/src/lib/ai/tools/registry.ts
@@ -1,160 +1,21 @@
 import { tool, type ToolSet } from 'ai'
-import { z } from 'zod'
 
 import { generateTroubleshootingDraft } from '@/lib/ai/draft/troubleshooting-tool'
 import {
   type EquipmentLookupHints,
   normalizeEquipmentLookupArgs,
 } from '@/lib/ai/tools/equipment-lookup-identifiers'
+import {
+  QUERY_CATALOG,
+  QUERY_CATALOG_PENDING_TOOL_NAMES,
+  QUERY_CATALOG_TOOL_NAME_SET,
+  QUERY_CATALOG_TOOL_NAMES,
+  getQueryCatalogMigrationStatusMap,
+  getQueryCatalogToolRpcMapping,
+  type MigrationStatus,
+  type QueryCatalogToolName,
+} from '@/lib/ai/tools/query-catalog'
 import { executeRpcTool } from '@/lib/ai/tools/rpc-tool-executor'
-
-// ---------------------------------------------------------------------------
-// Migration status: tracks which tools have been migrated to the envelope
-// contract. Only 'migrated' tools produce a ToolResponseEnvelope with
-// importantFields / modelBudget; 'pending' tools still return raw payloads.
-// ---------------------------------------------------------------------------
-
-export type MigrationStatus = 'migrated' | 'pending'
-
-type ReadOnlyToolDefinition = {
-  description: string
-  rpcFunction: string
-  inputSchema: z.ZodType<Record<string, unknown>>
-  migrationStatus: MigrationStatus
-  modelBudget?: {
-    maxItems?: number
-    maxBytes?: number
-    modelVisibleFields?: string[]
-  }
-}
-
-const READ_ONLY_TOOL_DEFINITIONS: Record<string, ReadOnlyToolDefinition> = {
-  equipmentLookup: {
-    description:
-      'Lookup equipment details using approved read-only RPC. Supports text search plus structured `filters` for exact `equipmentCode`, current status, department, location, classification, model, and serial; use the returned total for aggregate counts.',
-    rpcFunction: 'ai_equipment_lookup',
-    migrationStatus: 'pending',
-    inputSchema: z
-      .object({
-        query: z.string().trim().min(1).max(200).optional(),
-        limit: z.number().int().min(1).max(50).optional(),
-        status: z.string().trim().min(1).max(100).optional(),
-        filters: z
-          .object({
-            equipmentCode: z.string().trim().min(1).max(200).optional(),
-            status: z.string().trim().min(1).max(100).optional(),
-            department: z.string().trim().min(1).max(200).optional(),
-            location: z.string().trim().min(1).max(200).optional(),
-            classification: z.string().trim().min(1).max(50).optional(),
-            model: z.string().trim().min(1).max(200).optional(),
-            serial: z.string().trim().min(1).max(200).optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict(),
-  },
-  maintenanceSummary: {
-    description: 'Retrieve maintenance summary data via approved read-only RPC.',
-    rpcFunction: 'ai_maintenance_summary',
-    migrationStatus: 'pending',
-    inputSchema: z
-      .object({
-        fromDate: z.string().optional(),
-        toDate: z.string().optional(),
-      })
-      .strict(),
-  },
-  maintenancePlanLookup: {
-    description:
-      'Lookup maintenance, calibration, and inspection plans for a specific equipment item.',
-    rpcFunction: 'ai_maintenance_plan_lookup',
-    migrationStatus: 'pending',
-    inputSchema: z
-      .object({
-        p_thiet_bi_id: z.number().int().positive(),
-        p_nam: z.number().int().min(2000).max(2100).optional(),
-      })
-      .strict(),
-  },
-  repairSummary: {
-    description: 'Retrieve repair summary data via approved read-only RPC.',
-    rpcFunction: 'ai_repair_summary',
-    migrationStatus: 'pending',
-    inputSchema: z
-      .object({
-        status: z.string().trim().min(1).max(50).optional(),
-      })
-      .strict(),
-  },
-  usageHistory: {
-    description:
-      'Retrieve usage summary evidence for a specific equipment item from usage logs.',
-    rpcFunction: 'ai_usage_summary',
-    migrationStatus: 'pending',
-    inputSchema: z
-      .object({
-        p_thiet_bi_id: z.number().int().positive(),
-        p_months: z.number().int().min(1).max(24).optional(),
-      })
-      .strict(),
-  },
-  attachmentLookup: {
-    description:
-      'Lookup attachment metadata (file names, access types, URLs) for a specific equipment item. Returns normalized access contract.',
-    rpcFunction: 'ai_attachment_metadata',
-    migrationStatus: 'pending',
-    inputSchema: z
-      .object({
-        p_thiet_bi_id: z.number().int().positive(),
-      })
-      .strict(),
-  },
-  deviceQuotaLookup: {
-    description:
-      'Check quota status for a specific equipment item against the active quota decision.',
-    rpcFunction: 'ai_device_quota_lookup',
-    migrationStatus: 'pending',
-    inputSchema: z
-      .object({
-        p_thiet_bi_id: z.number().int().positive(),
-      })
-      .strict(),
-  },
-  quotaComplianceSummary: {
-    description:
-      'Get facility-level device quota compliance overview from the active decision.',
-    rpcFunction: 'ai_quota_compliance_summary',
-    migrationStatus: 'pending',
-    inputSchema: z.object({}).strict(),
-  },
-  categorySuggestion: {
-    description:
-      'Suggest the best matching equipment categories for a provided device name. Call this only after the user has given `device_name`; the RPC returns a bounded candidate set instead of the full category catalog.',
-    rpcFunction: 'ai_category_suggestion',
-    migrationStatus: 'migrated',
-    inputSchema: z
-      .object({
-        device_name: z.string().trim().min(1).max(200),
-      })
-      .strict(),
-    modelBudget: {
-      maxItems: 10,
-      modelVisibleFields: ['ma_nhom', 'ten_nhom', 'parent_name', 'phan_loai', 'match_reason'],
-    },
-  },
-  departmentList: {
-    description:
-      'List all departments (khoa/phòng) with equipment in the current facility. Call this BEFORE filtering equipmentLookup by department to get exact department names from the database.',
-    rpcFunction: 'ai_department_list',
-    migrationStatus: 'migrated',
-    inputSchema: z.object({}).strict(),
-    modelBudget: {
-      maxItems: 50,
-      modelVisibleFields: ['name', 'equipment_count'],
-    },
-  },
-}
 
 // ============================================
 // Draft Tool Definitions (non-RPC, advisory-only)
@@ -194,22 +55,18 @@ const DRAFT_TOOL_NAMES = new Set(Object.keys(DRAFT_TOOL_DEFINITIONS))
 const KNOWN_BUT_BLOCKED_TOOLS = new Set(['systemDiagnostics'])
 
 const ALLOWED_TOOL_NAMES = new Set([
-  ...Object.keys(READ_ONLY_TOOL_DEFINITIONS),
+  ...QUERY_CATALOG_TOOL_NAMES,
   ...DRAFT_TOOL_NAMES,
 ])
 
 /** Returns tool name → RPC function mapping for contract-locking tests. */
 export function getToolRpcMapping(): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(READ_ONLY_TOOL_DEFINITIONS).map(([k, v]) => [k, v.rpcFunction]),
-  )
+  return getQueryCatalogToolRpcMapping()
 }
 
 /** Returns tool name → migrationStatus for contract-locking tests. */
 export function getMigrationStatusMap(): Record<string, MigrationStatus> {
-  return Object.fromEntries(
-    Object.entries(READ_ONLY_TOOL_DEFINITIONS).map(([k, v]) => [k, v.migrationStatus]),
-  )
+  return getQueryCatalogMigrationStatusMap()
 }
 
 /**
@@ -227,16 +84,14 @@ export function getMigrationStatusMap(): Record<string, MigrationStatus> {
  *   - quotaComplianceSummary — needs importantFields design
  */
 export const PENDING_TOOL_NAMES: ReadonlySet<string> = new Set(
-  Object.entries(READ_ONLY_TOOL_DEFINITIONS)
-    .filter(([, def]) => def.migrationStatus === 'pending')
-    .map(([name]) => name),
+  QUERY_CATALOG_PENDING_TOOL_NAMES,
 )
 
 /** Exposed for contract-shape tests only. Do NOT import in production code. */
-export const READ_ONLY_TOOL_DEFINITIONS_FOR_TEST = READ_ONLY_TOOL_DEFINITIONS
+export const READ_ONLY_TOOL_DEFINITIONS_FOR_TEST = QUERY_CATALOG
 
 const KNOWN_TOOL_NAMES = new Set([
-  ...Object.keys(READ_ONLY_TOOL_DEFINITIONS),
+  ...QUERY_CATALOG_TOOL_NAMES,
   ...KNOWN_BUT_BLOCKED_TOOLS,
   ...DRAFT_TOOL_NAMES,
 ])
@@ -244,6 +99,10 @@ const KNOWN_TOOL_NAMES = new Set([
 function normalizeToolNames(toolNames: string[]): string[] {
   const normalized = toolNames.map(name => name.trim()).filter(Boolean)
   return Array.from(new Set(normalized))
+}
+
+function isQueryCatalogToolName(toolName: string): toolName is QueryCatalogToolName {
+  return QUERY_CATALOG_TOOL_NAME_SET.has(toolName)
 }
 
 export function hasWriteIntentToolName(toolName: string): boolean {
@@ -310,10 +169,10 @@ export function buildToolRegistry({
     }
 
     // RPC-backed read-only tools
-    const rpcDef = READ_ONLY_TOOL_DEFINITIONS[toolName]
-    if (!rpcDef) {
+    if (!isQueryCatalogToolName(toolName)) {
       continue
     }
+    const rpcDef = QUERY_CATALOG[toolName]
 
     tools[toolName] = tool({
       description: rpcDef.description,


### PR DESCRIPTION
## Summary
- extract curated read-only assistant tool definitions into a dedicated `query-catalog` module
- keep `registry.ts` focused on validation and runtime tool wiring with compatibility exports preserved
- add catalog contract tests and split post-#223 follow-up tracking into #271, #272, #273 (with #270 kept separate for charts)

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/lib/ai/tools/__tests__ src/app/api/chat/__tests__/route.tool-rpc-mapping.test.ts src/app/api/chat/__tests__/route.equipment-tools.test.ts src/app/api/chat/__tests__/route.attachment-tools.test.ts src/app/api/chat/__tests__/route.troubleshooting.test.ts src/app/api/chat/__tests__/route.draft-output.test.ts`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Context
- Refs #223
- Follow-ups: #271, #272, #273
- Related UI/chart tracking: #270

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts the curated read-only assistant tool catalog into `query-catalog` and rewires `registry.ts` to consume it. Tightens the tool contract with type-checked budgets; step 1 for #223.

- **Refactors**
  - Added `query-catalog.ts` and `query-catalog.types.assert.ts`; expose the catalog and helpers (tool names, pending set, RPC map, migration map) and add TS checks requiring `modelBudget` for migrated tools.
  - Updated `registry.ts` to import from the catalog, re-export `MigrationStatus`, and keep compatibility exports (`getToolRpcMapping`, `getMigrationStatusMap`, `READ_ONLY_TOOL_DEFINITIONS_FOR_TEST`).
  - Added `query-catalog.test.ts` to assert exact tool names, RPC mapping, and migration statuses.

<sup>Written for commit 4e2569dd59d35a78ad5f4ed4bd97cbebb29deced. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized AI tool definitions and configuration management for improved code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for tool catalog validation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->