### PR TITLE
feat: start issue 271 safe sql foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,10 @@ AI_RATE_LIMIT_MAX_REQUESTS=10
 # Daily quota (cost control) — adjust per org size
 AI_DAILY_USER_QUOTA_REQUESTS=150
 AI_DAILY_TENANT_QUOTA_REQUESTS=1500
+
+# Assistant SQL foundation (Issue #271, dormant until runtime rollout)
+# Dedicated transaction-pooler URL for the passworded login role that inherits
+# ai_query_reader. Do not reuse anon/service-role credentials here.
+# Example format:
+# postgresql://ai_query_tool:<PASSWORD>@db.<project-ref>.supabase.co:6543/postgres?sslmode=require
+AI_DATABASE_URL=

--- a/docs/ai/assistant-sql-foundation-runbook.md
+++ b/docs/ai/assistant-sql-foundation-runbook.md
@@ -16,13 +16,23 @@ The migration does **not** create a passworded login role, because credentials m
 
 ## Manual Role Provisioning
 
-After the migration is applied to the target Supabase project, create the passworded login role manually in SQL editor or via a privileged database session:
+After the migration is applied to the target Supabase project, create the passworded login role manually from a privileged database session. On hosted Supabase, that means using the SQL editor or a direct `psql`/admin session with enough privileges to run `CREATE ROLE`; do not try to create this role through `service_role` or an app-facing API.
 
 ```sql
-create role ai_query_tool
-  login
-  password 'REPLACE_WITH_A_LONG_RANDOM_PASSWORD'
-  in role ai_query_reader;
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_roles
+    where rolname = 'ai_query_tool'
+  ) then
+    create role ai_query_tool
+      login
+      password 'REPLACE_WITH_A_LONG_RANDOM_PASSWORD'
+      in role ai_query_reader;
+  end if;
+end
+$$;
 
 grant connect on database postgres to ai_query_tool;
 
@@ -35,19 +45,21 @@ alter role ai_query_tool set search_path = ai_readonly, pg_catalog;
 Notes:
 - keep `ai_query_tool` dedicated to assistant SQL only
 - never reuse `service_role`, `anon`, or app-user credentials
+- store the password in the team secret manager and rotate it there before updating `AI_DATABASE_URL`
 - runtime code should still issue `SET LOCAL search_path = ai_readonly, pg_catalog` per transaction as defense in depth
 
 ## Environment Contract
 
-Set `AI_DATABASE_URL` to the Supabase transaction-pooler URL for `ai_query_tool`:
+Set `AI_DATABASE_URL` to the exact Supabase transaction-pooler connection string shown in the project dashboard (`Connect` -> `Transaction pooler`), then swap in the dedicated `ai_query_tool` credentials:
 
 ```text
-postgresql://ai_query_tool:<PASSWORD>@db.<project-ref>.supabase.co:6543/postgres?sslmode=require
+postgresql://ai_query_tool:<PASSWORD>@<transaction-pooler-host>:6543/postgres?sslmode=require
 ```
 
 Use:
 - transaction pooler (`:6543`) for serverless runtime
 - SSL required
+- copy the exact hostname/username format from the Supabase dashboard instead of assuming a single pooler host pattern
 - prepared statements disabled in the future executor (`prepare: false`)
 
 ## Local Verification

--- a/docs/ai/assistant-sql-foundation-runbook.md
+++ b/docs/ai/assistant-sql-foundation-runbook.md
@@ -34,6 +34,7 @@ begin
 end
 $$;
 
+grant ai_query_reader to ai_query_tool;
 grant connect on database postgres to ai_query_tool;
 
 alter role ai_query_tool set default_transaction_read_only = on;

--- a/docs/ai/assistant-sql-foundation-runbook.md
+++ b/docs/ai/assistant-sql-foundation-runbook.md
@@ -1,0 +1,75 @@
+# Assistant SQL Foundation Runbook
+
+This runbook covers the manual provisioning steps for the dormant assistant SQL foundation introduced by Issue `#271`.
+
+## Purpose
+
+The application stays RPC-first. This SQL foundation exists only for a future server-only assistant path and is intentionally not wired into `/api/chat` yet.
+
+The migration creates:
+- `ai_readonly` schema
+- facility-scope helper functions
+- approved read-only semantic views
+- `ai_query_reader` grant role
+
+The migration does **not** create a passworded login role, because credentials must not live in git.
+
+## Manual Role Provisioning
+
+After the migration is applied to the target Supabase project, create the passworded login role manually in SQL editor or via a privileged database session:
+
+```sql
+create role ai_query_tool
+  login
+  password 'REPLACE_WITH_A_LONG_RANDOM_PASSWORD'
+  in role ai_query_reader;
+
+grant connect on database postgres to ai_query_tool;
+
+alter role ai_query_tool set default_transaction_read_only = on;
+alter role ai_query_tool set statement_timeout = '5s';
+alter role ai_query_tool set idle_in_transaction_session_timeout = '5s';
+alter role ai_query_tool set search_path = ai_readonly, pg_catalog;
+```
+
+Notes:
+- keep `ai_query_tool` dedicated to assistant SQL only
+- never reuse `service_role`, `anon`, or app-user credentials
+- runtime code should still issue `SET LOCAL search_path = ai_readonly, pg_catalog` per transaction as defense in depth
+
+## Environment Contract
+
+Set `AI_DATABASE_URL` to the Supabase transaction-pooler URL for `ai_query_tool`:
+
+```text
+postgresql://ai_query_tool:<PASSWORD>@db.<project-ref>.supabase.co:6543/postgres?sslmode=require
+```
+
+Use:
+- transaction pooler (`:6543`) for serverless runtime
+- SSL required
+- prepared statements disabled in the future executor (`prepare: false`)
+
+## Local Verification
+
+After applying the migration and creating the login role, run:
+
+```bash
+psql "$SUPABASE_DB_URL" -f supabase/tests/assistant_sql_foundation_smoke.sql
+```
+
+That smoke script verifies:
+- `ai_readonly` schema and approved views exist
+- `ai_query_reader` can read only the semantic layer
+- raw `public` table access is not granted
+- missing `app.current_facility_id` fails closed
+- semantic views are queryable when a facility scope is injected
+
+## Rollout Boundary
+
+This foundation remains dormant until later batches:
+- no runtime `query_database` registration in `/api/chat`
+- no planner selection changes
+- no audit-execution path yet
+
+Those steps belong to later implementation batches and should not be mixed into the migration rollout.

--- a/docs/plans/2026-04-18-issue-271-safe-sql-foundation-plan.md
+++ b/docs/plans/2026-04-18-issue-271-safe-sql-foundation-plan.md
@@ -2,40 +2,40 @@
 
 ## Summary
 - Repo state: local branch `plan/issue-271-safe-sql-foundation` already exists and currently points at the same commit as `main` / `origin/main` (`8496584`); this plan assumes implementation starts from that base.
-- Current production-safe assistant path is `[chat route](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:113) -> [tool registry](/root/qltbyt-nam-phong/src/lib/ai/tools/registry.ts:150) -> [RPC executor](/root/qltbyt-nam-phong/src/lib/ai/tools/rpc-tool-executor.ts:189) -> [RPC proxy](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239) -> SQL RPCs`. That path already enforces auth, facility selection, JWT claim injection, allowlists, quotas, and error sanitization.
+- Current production-safe assistant path is `[chat route](src/app/api/chat/route.ts#L113) -> [tool registry](src/lib/ai/tools/registry.ts#L150) -> [RPC executor](src/lib/ai/tools/rpc-tool-executor.ts#L189) -> [RPC proxy](src/app/api/rpc/[fn]/route.ts#L239) -> SQL RPCs`. That path already enforces auth, facility selection, JWT claim injection, allowlists, quotas, and error sanitization.
 - Scope split is clear from GitHub: `#271` is pre-rollout foundation only; `#272` is runtime `query_database` rollout; `#273` is planner/router hardening. `#271` should therefore land a dormant end-to-end SQL foundation, but must not register `query_database` in `/api/chat` yet.
 - Explicit reconciliation with the repo’s RPC-only rule: keep RPC-only as the default app-data rule. The new SQL path is a narrow server-only assistant exception that can read only `ai_readonly` views through a dedicated read-only DB identity. Curated tools stay on the existing RPC path. Any audit write for the SQL path stays on the existing JWT/RPC boundary instead of the read-only DB role.
 
 ## Repo Reconnaissance
 - Required docs align on the same baseline: assistant reads must remain tenant-safe, server-enforced, and read-only. Relevant references were `docs/PRD-Vercel-AI-SDK.md`, `tasks/prd-vercel-ai-sdk-strategic-spec.md`, `openspec/project.md`, and `docs/RBAC.md`.
-- The repo already contains an earlier design document for `query_database` at [docs/plans/2026-03-24-ai-query-database-refactor-plan.md](/root/qltbyt-nam-phong/docs/plans/2026-03-24-ai-query-database-refactor-plan.md:1), but that document mixes foundation and rollout. Issue `#271` should take only the foundation pieces and leave runtime registration to `#272`.
+- The repo already contains an earlier design document for `query_database` at [docs/plans/2026-03-24-ai-query-database-refactor-plan.md](docs/plans/2026-03-24-ai-query-database-refactor-plan.md#L1), but that document mixes foundation and rollout. Issue `#271` should take only the foundation pieces and leave runtime registration to `#272`.
 - Existing assistant query-catalog extraction was merged in PR `#274`, which intentionally split follow-up work into `#271`, `#272`, `#273`, and kept charts separate in `#270`.
 - Current assistant safety seams to preserve:
-  - auth/session gate in [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:113)
-  - RBAC normalization in [src/lib/rbac.ts](/root/qltbyt-nam-phong/src/lib/rbac.ts:75)
-  - facility selection model in [src/contexts/TenantSelectionContext.tsx](/root/qltbyt-nam-phong/src/contexts/TenantSelectionContext.tsx:29)
-  - RPC whitelist/JWT signing in [src/app/api/rpc/[fn]/route.ts](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239)
+  - auth/session gate in [src/app/api/chat/route.ts](src/app/api/chat/route.ts#L113)
+  - RBAC normalization in [src/lib/rbac.ts](src/lib/rbac.ts#L75)
+  - facility selection model in [src/contexts/TenantSelectionContext.tsx](src/contexts/TenantSelectionContext.tsx#L29)
+  - RPC whitelist/JWT signing in [src/app/api/rpc/[fn]/route.ts](src/app/api/rpc/[fn]/route.ts#L239)
   - audit helper `public.audit_log(...)` in `supabase/migrations/2025-09-29/20250925_audit_logs_v2_entities_and_helper.sql`
 
 ## GitNexus Blast Radius
 
 ### Exact Files / Modules / Migrations / Tests Likely Affected
 - Assistant orchestration:
-  - [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:113)
-  - [src/lib/ai/prompts/system.ts](/root/qltbyt-nam-phong/src/lib/ai/prompts/system.ts:37)
-  - [src/components/assistant/AssistantPanel.tsx](/root/qltbyt-nam-phong/src/components/assistant/AssistantPanel.tsx:30)
+  - [src/app/api/chat/route.ts](src/app/api/chat/route.ts#L113)
+  - [src/lib/ai/prompts/system.ts](src/lib/ai/prompts/system.ts#L37)
+  - [src/components/assistant/AssistantPanel.tsx](src/components/assistant/AssistantPanel.tsx#L30)
 - Assistant tool boundary:
-  - [src/lib/ai/tools/registry.ts](/root/qltbyt-nam-phong/src/lib/ai/tools/registry.ts:150)
-  - [src/lib/ai/tools/rpc-tool-executor.ts](/root/qltbyt-nam-phong/src/lib/ai/tools/rpc-tool-executor.ts:189)
+  - [src/lib/ai/tools/registry.ts](src/lib/ai/tools/registry.ts#L150)
+  - [src/lib/ai/tools/rpc-tool-executor.ts](src/lib/ai/tools/rpc-tool-executor.ts#L189)
   - new `src/lib/ai/sql/*` modules for dormant SQL foundation
 - Auth / RBAC / scope:
-  - [src/lib/rbac.ts](/root/qltbyt-nam-phong/src/lib/rbac.ts:75)
-  - [src/contexts/TenantSelectionContext.tsx](/root/qltbyt-nam-phong/src/contexts/TenantSelectionContext.tsx:29)
-  - [src/auth/config.ts](/root/qltbyt-nam-phong/src/auth/config.ts:78)
+  - [src/lib/rbac.ts](src/lib/rbac.ts#L75)
+  - [src/contexts/TenantSelectionContext.tsx](src/contexts/TenantSelectionContext.tsx#L29)
+  - [src/auth/config.ts](src/auth/config.ts#L78)
 - RPC boundary / audit reuse:
-  - [src/app/api/rpc/[fn]/route.ts](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239)
-  - [src/hooks/use-audit-logs.ts](/root/qltbyt-nam-phong/src/hooks/use-audit-logs.ts:1)
-  - [src/lib/rpc-client.ts](/root/qltbyt-nam-phong/src/lib/rpc-client.ts:1)
+  - [src/app/api/rpc/[fn]/route.ts](src/app/api/rpc/[fn]/route.ts#L239)
+  - [src/hooks/use-audit-logs.ts](src/hooks/use-audit-logs.ts#L1)
+  - [src/lib/rpc-client.ts](src/lib/rpc-client.ts#L1)
 - Likely new migrations:
   - one migration for `ai_readonly` schema/helpers/views/privileges
   - one migration for assistant SQL audit RPC wrapper or related observability support
@@ -47,17 +47,17 @@
   - `20250927_regional_leader_schema_foundation.sql`
   - `2025-09-29/20250925_audit_logs_v2_entities_and_helper.sql`
 - Tests likely affected:
-  - [src/app/api/chat/__tests__/route.tools-allowlist.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tools-allowlist.test.ts:1)
-  - [src/app/api/chat/__tests__/route.tenant-policy.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tenant-policy.test.ts:1)
-  - [src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts](/root/qltbyt-nam-phong/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts:1)
-  - [src/lib/ai/tools/__tests__/rpc-tool-executor.test.ts](/root/qltbyt-nam-phong/src/lib/ai/tools/__tests__/rpc-tool-executor.test.ts:1)
+  - [src/app/api/chat/__tests__/route.tools-allowlist.test.ts](src/app/api/chat/__tests__/route.tools-allowlist.test.ts#L1)
+  - [src/app/api/chat/__tests__/route.tenant-policy.test.ts](src/app/api/chat/__tests__/route.tenant-policy.test.ts#L1)
+  - [src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts](src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts#L1)
+  - [src/lib/ai/tools/__tests__/rpc-tool-executor.test.ts](src/lib/ai/tools/__tests__/rpc-tool-executor.test.ts#L1)
   - new `src/lib/ai/sql/__tests__/*`
   - new `supabase/tests/assistant_sql_foundation_smoke.sql`
 
 ### Upstream / Downstream Dependencies
 - GitNexus upstream impact on `buildToolRegistry` is low and direct only from chat route. That means the current tool-registration surface is concentrated and safe to keep unchanged in `#271`.
 - GitNexus upstream impact on `executeRpcTool` is also low and limited to `registry.ts` and then chat route. That confirms the existing curated tool path can remain untouched while the dormant SQL path is built separately.
-- GitNexus upstream impact on `isPrivilegedRole` shows it is shared by both [chat route](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:177) and [TenantSelectionProvider](/root/qltbyt-nam-phong/src/contexts/TenantSelectionContext.tsx:35). Any single-facility scope contract should therefore reuse current role resolution instead of inventing a parallel privilege model.
+- GitNexus upstream impact on `isPrivilegedRole` shows it is shared by both [chat route](src/app/api/chat/route.ts#L177) and [TenantSelectionProvider](src/contexts/TenantSelectionContext.tsx#L35). Any single-facility scope contract should therefore reuse current role resolution instead of inventing a parallel privilege model.
 - SQL function names are not indexed by GitNexus in this repo; SQL blast radius must continue to use grep/manual review for migrations and smoke tests.
 
 ### Trust Boundaries And Security-Sensitive Integration Points
@@ -68,8 +68,8 @@
 - `isGlobalRole()` / `isPrivilegedRole()` remain mandatory for admin/global normalization; direct string checks against `'global'` would be a regression.
 
 ### Existing Abstractions To Reuse Instead Of Bypassing
-- Reuse current facility-selection semantics from [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:172) for privileged vs local roles.
-- Reuse `sanitizeErrorForClient()` from [src/lib/ai/errors.ts](/root/qltbyt-nam-phong/src/lib/ai/errors.ts:101) for surfaced SQL path failures.
+- Reuse current facility-selection semantics from [src/app/api/chat/route.ts](src/app/api/chat/route.ts#L172) for privileged vs local roles.
+- Reuse `sanitizeErrorForClient()` from [src/lib/ai/errors.ts](src/lib/ai/errors.ts#L101) for surfaced SQL path failures.
 - Reuse query-catalog as the source of truth for curated tools; `#271` should not merge SQL capability into catalog metadata yet unless needed for dormant contract tests.
 - Reuse `public.allowed_don_vi_for_session()` / `allowed_don_vi_for_session_safe()` patterns as the model for future richer scope, but keep `#271` single-facility only.
 - Reuse audit-log UI/read paths rather than adding dedicated assistant-observability UI in this issue.
@@ -83,11 +83,11 @@
 
 ## Phase 0: Discovery / Invariants
 - Target files:
-  - [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:113)
-  - [src/app/api/rpc/[fn]/route.ts](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239)
-  - [src/lib/rbac.ts](/root/qltbyt-nam-phong/src/lib/rbac.ts:75)
-  - [src/contexts/TenantSelectionContext.tsx](/root/qltbyt-nam-phong/src/contexts/TenantSelectionContext.tsx:29)
-  - [docs/plans/2026-03-24-ai-query-database-refactor-plan.md](/root/qltbyt-nam-phong/docs/plans/2026-03-24-ai-query-database-refactor-plan.md:1)
+  - [src/app/api/chat/route.ts](src/app/api/chat/route.ts#L113)
+  - [src/app/api/rpc/[fn]/route.ts](src/app/api/rpc/[fn]/route.ts#L239)
+  - [src/lib/rbac.ts](src/lib/rbac.ts#L75)
+  - [src/contexts/TenantSelectionContext.tsx](src/contexts/TenantSelectionContext.tsx#L29)
+  - [docs/plans/2026-03-24-ai-query-database-refactor-plan.md](docs/plans/2026-03-24-ai-query-database-refactor-plan.md#L1)
 - Test strategy:
   - Add a red regression test proving `#271` does not expose `query_database` in `/api/chat`.
   - Add a red regression test proving the RPC proxy allowlist still excludes any direct SQL execution entrypoint.
@@ -102,9 +102,9 @@
   - new `src/lib/ai/sql/__tests__/query-database-guard.test.ts`
   - new `src/lib/ai/sql/__tests__/query-database-executor.test.ts`
   - new `src/lib/ai/sql/__tests__/query-database-audit.test.ts`
-  - [src/app/api/chat/__tests__/route.tools-allowlist.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tools-allowlist.test.ts:1)
-  - [src/app/api/chat/__tests__/route.tenant-policy.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tenant-policy.test.ts:1)
-  - [src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts](/root/qltbyt-nam-phong/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts:1)
+  - [src/app/api/chat/__tests__/route.tools-allowlist.test.ts](src/app/api/chat/__tests__/route.tools-allowlist.test.ts#L1)
+  - [src/app/api/chat/__tests__/route.tenant-policy.test.ts](src/app/api/chat/__tests__/route.tenant-policy.test.ts#L1)
+  - [src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts](src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts#L1)
   - new `supabase/tests/assistant_sql_foundation_smoke.sql`
 - Test strategy:
   - Write failing tests first for:
@@ -186,10 +186,10 @@
 
 ## Phase 4: Scoped Server Contract
 - Target files:
-  - extract shared scope resolution from [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:172)
+  - extract shared scope resolution from [src/app/api/chat/route.ts](src/app/api/chat/route.ts#L172)
   - small shared helper module in `src/lib/ai/` or `src/lib/ai/sql/`
 - Test strategy:
-  - preserve existing [route.tenant-policy.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tenant-policy.test.ts:1)
+  - preserve existing [route.tenant-policy.test.ts](src/app/api/chat/__tests__/route.tenant-policy.test.ts#L1)
   - add unit tests for:
     - local roles use session `don_vi`
     - privileged roles require selected facility
@@ -208,9 +208,9 @@
 ## Phase 5: Audit / Observability
 - Target files:
   - one new migration for assistant SQL audit wrapper or helper RPC
-  - [src/app/api/rpc/[fn]/route.ts](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239)
+  - [src/app/api/rpc/[fn]/route.ts](src/app/api/rpc/[fn]/route.ts#L239)
   - new server helper for audit writes
-  - [src/hooks/use-audit-logs.ts](/root/qltbyt-nam-phong/src/hooks/use-audit-logs.ts:1) for label/entity typing
+  - [src/hooks/use-audit-logs.ts](src/hooks/use-audit-logs.ts#L1) for label/entity typing
 - Test strategy:
   - red tests for:
     - sanitized SQL audit payload

--- a/docs/plans/2026-04-18-issue-271-safe-sql-foundation-plan.md
+++ b/docs/plans/2026-04-18-issue-271-safe-sql-foundation-plan.md
@@ -1,0 +1,376 @@
+# Issue #271: Safe SQL Foundation For Assistant Read-Only Semantic Layer
+
+## Summary
+- Repo state: local branch `plan/issue-271-safe-sql-foundation` already exists and currently points at the same commit as `main` / `origin/main` (`8496584`); this plan assumes implementation starts from that base.
+- Current production-safe assistant path is `[chat route](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:113) -> [tool registry](/root/qltbyt-nam-phong/src/lib/ai/tools/registry.ts:150) -> [RPC executor](/root/qltbyt-nam-phong/src/lib/ai/tools/rpc-tool-executor.ts:189) -> [RPC proxy](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239) -> SQL RPCs`. That path already enforces auth, facility selection, JWT claim injection, allowlists, quotas, and error sanitization.
+- Scope split is clear from GitHub: `#271` is pre-rollout foundation only; `#272` is runtime `query_database` rollout; `#273` is planner/router hardening. `#271` should therefore land a dormant end-to-end SQL foundation, but must not register `query_database` in `/api/chat` yet.
+- Explicit reconciliation with the repo’s RPC-only rule: keep RPC-only as the default app-data rule. The new SQL path is a narrow server-only assistant exception that can read only `ai_readonly` views through a dedicated read-only DB identity. Curated tools stay on the existing RPC path. Any audit write for the SQL path stays on the existing JWT/RPC boundary instead of the read-only DB role.
+
+## Repo Reconnaissance
+- Required docs align on the same baseline: assistant reads must remain tenant-safe, server-enforced, and read-only. Relevant references were `docs/PRD-Vercel-AI-SDK.md`, `tasks/prd-vercel-ai-sdk-strategic-spec.md`, `openspec/project.md`, and `docs/RBAC.md`.
+- The repo already contains an earlier design document for `query_database` at [docs/plans/2026-03-24-ai-query-database-refactor-plan.md](/root/qltbyt-nam-phong/docs/plans/2026-03-24-ai-query-database-refactor-plan.md:1), but that document mixes foundation and rollout. Issue `#271` should take only the foundation pieces and leave runtime registration to `#272`.
+- Existing assistant query-catalog extraction was merged in PR `#274`, which intentionally split follow-up work into `#271`, `#272`, `#273`, and kept charts separate in `#270`.
+- Current assistant safety seams to preserve:
+  - auth/session gate in [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:113)
+  - RBAC normalization in [src/lib/rbac.ts](/root/qltbyt-nam-phong/src/lib/rbac.ts:75)
+  - facility selection model in [src/contexts/TenantSelectionContext.tsx](/root/qltbyt-nam-phong/src/contexts/TenantSelectionContext.tsx:29)
+  - RPC whitelist/JWT signing in [src/app/api/rpc/[fn]/route.ts](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239)
+  - audit helper `public.audit_log(...)` in `supabase/migrations/2025-09-29/20250925_audit_logs_v2_entities_and_helper.sql`
+
+## GitNexus Blast Radius
+
+### Exact Files / Modules / Migrations / Tests Likely Affected
+- Assistant orchestration:
+  - [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:113)
+  - [src/lib/ai/prompts/system.ts](/root/qltbyt-nam-phong/src/lib/ai/prompts/system.ts:37)
+  - [src/components/assistant/AssistantPanel.tsx](/root/qltbyt-nam-phong/src/components/assistant/AssistantPanel.tsx:30)
+- Assistant tool boundary:
+  - [src/lib/ai/tools/registry.ts](/root/qltbyt-nam-phong/src/lib/ai/tools/registry.ts:150)
+  - [src/lib/ai/tools/rpc-tool-executor.ts](/root/qltbyt-nam-phong/src/lib/ai/tools/rpc-tool-executor.ts:189)
+  - new `src/lib/ai/sql/*` modules for dormant SQL foundation
+- Auth / RBAC / scope:
+  - [src/lib/rbac.ts](/root/qltbyt-nam-phong/src/lib/rbac.ts:75)
+  - [src/contexts/TenantSelectionContext.tsx](/root/qltbyt-nam-phong/src/contexts/TenantSelectionContext.tsx:29)
+  - [src/auth/config.ts](/root/qltbyt-nam-phong/src/auth/config.ts:78)
+- RPC boundary / audit reuse:
+  - [src/app/api/rpc/[fn]/route.ts](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239)
+  - [src/hooks/use-audit-logs.ts](/root/qltbyt-nam-phong/src/hooks/use-audit-logs.ts:1)
+  - [src/lib/rpc-client.ts](/root/qltbyt-nam-phong/src/lib/rpc-client.ts:1)
+- Likely new migrations:
+  - one migration for `ai_readonly` schema/helpers/views/privileges
+  - one migration for assistant SQL audit RPC wrapper or related observability support
+- Existing migrations/patterns to reuse:
+  - `20260303113000_add_ai_assistant_readonly_rpcs.sql`
+  - `20260310145700_add_ai_usage_summary_rpc.sql`
+  - `20260310173500_add_ai_attachment_metadata_rpc.sql`
+  - `20260328113000_add_ai_category_suggestion_rpc.sql`
+  - `20250927_regional_leader_schema_foundation.sql`
+  - `2025-09-29/20250925_audit_logs_v2_entities_and_helper.sql`
+- Tests likely affected:
+  - [src/app/api/chat/__tests__/route.tools-allowlist.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tools-allowlist.test.ts:1)
+  - [src/app/api/chat/__tests__/route.tenant-policy.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tenant-policy.test.ts:1)
+  - [src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts](/root/qltbyt-nam-phong/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts:1)
+  - [src/lib/ai/tools/__tests__/rpc-tool-executor.test.ts](/root/qltbyt-nam-phong/src/lib/ai/tools/__tests__/rpc-tool-executor.test.ts:1)
+  - new `src/lib/ai/sql/__tests__/*`
+  - new `supabase/tests/assistant_sql_foundation_smoke.sql`
+
+### Upstream / Downstream Dependencies
+- GitNexus upstream impact on `buildToolRegistry` is low and direct only from chat route. That means the current tool-registration surface is concentrated and safe to keep unchanged in `#271`.
+- GitNexus upstream impact on `executeRpcTool` is also low and limited to `registry.ts` and then chat route. That confirms the existing curated tool path can remain untouched while the dormant SQL path is built separately.
+- GitNexus upstream impact on `isPrivilegedRole` shows it is shared by both [chat route](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:177) and [TenantSelectionProvider](/root/qltbyt-nam-phong/src/contexts/TenantSelectionContext.tsx:35). Any single-facility scope contract should therefore reuse current role resolution instead of inventing a parallel privilege model.
+- SQL function names are not indexed by GitNexus in this repo; SQL blast radius must continue to use grep/manual review for migrations and smoke tests.
+
+### Trust Boundaries And Security-Sensitive Integration Points
+- `/api/chat` is the assistant request boundary. It already owns session validation, facility resolution, quota checks, and safe error handling. `#271` may extract reusable scope resolution, but must not change public behavior.
+- `/api/rpc/[fn]` is the current trusted JWT-signing boundary. The new SQL execution path must not be allowed to look like just another unvetted RPC call.
+- Supabase migrations are the data boundary. `ai_readonly` must be the only surface exposed to the SQL identity.
+- `public.audit_log(...)` is the established audit write seam. The SQL path should reuse it through an authenticated server-side wrapper, not invent a second audit table or write through the read-only DB role.
+- `isGlobalRole()` / `isPrivilegedRole()` remain mandatory for admin/global normalization; direct string checks against `'global'` would be a regression.
+
+### Existing Abstractions To Reuse Instead Of Bypassing
+- Reuse current facility-selection semantics from [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:172) for privileged vs local roles.
+- Reuse `sanitizeErrorForClient()` from [src/lib/ai/errors.ts](/root/qltbyt-nam-phong/src/lib/ai/errors.ts:101) for surfaced SQL path failures.
+- Reuse query-catalog as the source of truth for curated tools; `#271` should not merge SQL capability into catalog metadata yet unless needed for dormant contract tests.
+- Reuse `public.allowed_don_vi_for_session()` / `allowed_don_vi_for_session_safe()` patterns as the model for future richer scope, but keep `#271` single-facility only.
+- Reuse audit-log UI/read paths rather than adding dedicated assistant-observability UI in this issue.
+
+## Risks / Open Questions / Architectural Conflicts
+- Main architectural conflict: the repo rule is “RPC-only / no direct table access in app code,” while `query_database` requires direct SQL execution. Resolution: treat assistant SQL as a server-only exception with its own identity and semantic layer, while preserving RPC-only as the default rule for all app/business reads and writes.
+- `#271` must not silently absorb `#272`. If `/api/chat` exposes `query_database` in this issue, the scope boundary between issues is broken.
+- Dedicated login credentials for the SQL role cannot be fully encoded in git migrations; the migration can create grants/roles, but login password creation and `AI_DATABASE_URL` provisioning remain an ops step that must be documented.
+- Audit writes cannot be performed by the read-only SQL identity. This requires a separate server-side audit write path, ideally via a thin RPC wrapper over `public.audit_log(...)`.
+- Future cross-facility SQL is intentionally out of scope. Do not design the single-facility v1 contract as if it already solves `regional_leader` multi-facility ad-hoc access.
+
+## Phase 0: Discovery / Invariants
+- Target files:
+  - [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:113)
+  - [src/app/api/rpc/[fn]/route.ts](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239)
+  - [src/lib/rbac.ts](/root/qltbyt-nam-phong/src/lib/rbac.ts:75)
+  - [src/contexts/TenantSelectionContext.tsx](/root/qltbyt-nam-phong/src/contexts/TenantSelectionContext.tsx:29)
+  - [docs/plans/2026-03-24-ai-query-database-refactor-plan.md](/root/qltbyt-nam-phong/docs/plans/2026-03-24-ai-query-database-refactor-plan.md:1)
+- Test strategy:
+  - Add a red regression test proving `#271` does not expose `query_database` in `/api/chat`.
+  - Add a red regression test proving the RPC proxy allowlist still excludes any direct SQL execution entrypoint.
+- Expected artifacts:
+  - one short architecture note or plan note codifying the assistant-only SQL exception
+  - frozen invariants for single-facility scope, no runtime registration, and audit fail-closed behavior
+- Dependency ordering:
+  - must happen first so later phases do not accidentally turn `#271` into `#272`
+
+## Phase 1: Tests / Verification Harness
+- Target files:
+  - new `src/lib/ai/sql/__tests__/query-database-guard.test.ts`
+  - new `src/lib/ai/sql/__tests__/query-database-executor.test.ts`
+  - new `src/lib/ai/sql/__tests__/query-database-audit.test.ts`
+  - [src/app/api/chat/__tests__/route.tools-allowlist.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tools-allowlist.test.ts:1)
+  - [src/app/api/chat/__tests__/route.tenant-policy.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tenant-policy.test.ts:1)
+  - [src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts](/root/qltbyt-nam-phong/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts:1)
+  - new `supabase/tests/assistant_sql_foundation_smoke.sql`
+- Test strategy:
+  - Write failing tests first for:
+    - single-statement enforcement
+    - `SELECT` / `WITH ... SELECT` only
+    - forbidden schema access
+    - row limit and payload limit
+    - timeout mapping to a safe error class
+    - facility scope injection contract
+    - audit logging on success/failure
+    - non-registration in current assistant runtime
+- Expected artifacts:
+  - unit-level harness for SQL guardrails
+  - DB smoke harness for semantic-layer and role permissions
+  - explicit note that `assistant_sql_foundation_smoke.sql` is a local/DB-admin verification artifact, not a CI gate
+- Dependency ordering:
+  - all implementation phases should advance these tests from red to green incrementally
+
+## Phase 2: DB Semantic Layer + Identity
+- Target files:
+  - one new migration for `ai_readonly` schema, scope helpers, and first approved views
+  - docs/env/runbook update for `AI_DATABASE_URL` and role provisioning
+- Test strategy:
+  - DB smoke verifies:
+    - `ai_readonly` views can be selected by the assistant SQL identity
+    - raw schemas cannot be read
+    - mutation attempts fail under the read-only role
+    - missing session scope fails
+- Expected artifacts:
+  - `ai_readonly` schema
+  - helper functions like `ai_readonly.current_facility_id()` or equivalent fail-closed scope resolver
+  - security-barrier views for first approved semantic surface
+  - `ai_query_reader` role/grants/default privileges
+  - documented manual step for the passworded login role and env var provisioning
+- Dependency ordering:
+  - before executor implementation, because TS code should target a fixed DB contract
+- Default semantic seed:
+  - provisional until Phase 3 executor validation confirms the query contract; freeze the approved view list before Phase 4
+  - include facility-scoped views for:
+    - `equipment_search`
+    - `maintenance_facts`
+    - `repair_facts`
+    - `usage_facts`
+    - `quota_facts`
+  - keep `attachmentLookup`, `categorySuggestion`, and `departmentList` on curated RPCs because their current contracts are intentionally bespoke
+
+## Phase 3: Execution Guardrails
+- Target files:
+  - new `src/lib/ai/sql/client.ts`
+  - new `src/lib/ai/sql/constants.ts`
+  - new `src/lib/ai/sql/guardrails.ts`
+  - new `src/lib/ai/sql/executor.ts`
+  - new dormant `src/lib/ai/tools/query-database.ts`
+  - `.env.example`
+  - `package.json`
+- Test strategy:
+  - unit tests first for lexical guards and normalization
+  - mocked executor tests for transaction-local settings and result caps
+  - assert `prepare: false` and server-only import discipline
+- Expected artifacts:
+  - server-only `postgres` / postgres.js client
+  - `AI_DATABASE_URL` contract documented as Supabase transaction-pooler connection for serverless runtime:
+    - port `6543`
+    - SSL required
+    - dedicated login role password supplied outside git
+  - prepared statements disabled with `prepare: false`
+  - transaction-local hardening includes `SET LOCAL search_path = ai_readonly, pg_catalog`
+  - executor with these defaults:
+    - `statement_timeout = 5s`
+    - `maxRows = 100`
+    - `maxPayloadBytes = 64 KiB`
+    - one statement only
+    - `SELECT` / `WITH ... SELECT` only
+    - explicit forbidden keyword/schema checks
+    - sanitized SQL shape for logs
+  - dormant tool wrapper that is not yet registered into `/api/chat`
+- Dependency ordering:
+  - after Phase 2 because the executor depends on the semantic-layer contract
+
+## Phase 4: Scoped Server Contract
+- Target files:
+  - extract shared scope resolution from [src/app/api/chat/route.ts](/root/qltbyt-nam-phong/src/app/api/chat/route.ts:172)
+  - small shared helper module in `src/lib/ai/` or `src/lib/ai/sql/`
+- Test strategy:
+  - preserve existing [route.tenant-policy.test.ts](/root/qltbyt-nam-phong/src/app/api/chat/__tests__/route.tenant-policy.test.ts:1)
+  - add unit tests for:
+    - local roles use session `don_vi`
+    - privileged roles require selected facility
+    - `admin` normalizes to global semantics
+    - no caller/model-provided tenant override is accepted
+- Expected artifacts:
+  - one typed `AssistantSqlScope` contract carrying:
+    - `effectiveFacilityId`
+    - normalized role
+    - user id
+    - selected facility provenance
+  - no duplicated privilege logic between current chat route and future SQL rollout
+- Dependency ordering:
+  - before future runtime registration, but included in `#271` so scope semantics are fixed before `#272`
+
+## Phase 5: Audit / Observability
+- Target files:
+  - one new migration for assistant SQL audit wrapper or helper RPC
+  - [src/app/api/rpc/[fn]/route.ts](/root/qltbyt-nam-phong/src/app/api/rpc/[fn]/route.ts:239)
+  - new server helper for audit writes
+  - [src/hooks/use-audit-logs.ts](/root/qltbyt-nam-phong/src/hooks/use-audit-logs.ts:1) for label/entity typing
+- Test strategy:
+  - red tests for:
+    - sanitized SQL audit payload
+    - latency capture
+    - row count capture
+    - effective scope capture
+    - error-class capture
+    - audit failure causing SQL path failure
+  - SQL smoke proves logs show up through `audit_logs_list_v2`
+- Expected artifacts:
+  - dedicated authenticated audit write RPC for assistant SQL path, wrapping `public.audit_log(...)`
+  - new audit action type such as `assistant_query_database`
+  - structured `action_details` like:
+    - `tool_path`
+    - `sql_shape`
+    - `latency_ms`
+    - `row_count`
+    - `payload_bytes`
+    - `effective_facility_id`
+    - `error_class`
+- Dependency ordering:
+  - after executor contract exists, because audit payload depends on executor outcomes
+
+## Test Matrix
+- Read-only enforcement:
+  - assistant SQL identity cannot `INSERT/UPDATE/DELETE/ALTER/DROP`
+  - read-only transaction default remains active even if lexical guards miss something
+- Schema boundary enforcement:
+  - `ai_readonly.*` succeeds
+  - `public.*`, `auth.*`, `storage.*`, `graphql_public.*`, `extensions.*`, `pg_temp.*` fail before execution
+- Timeout / row / payload limits:
+  - long-running query maps to timeout error class
+  - queries returning more than `100` rows fail with `row_limit_exceeded`
+  - oversized JSON payload fails with `payload_limit_exceeded`
+- Facility scope injection:
+  - missing scope fails
+  - local roles are pinned to session `don_vi`
+  - privileged roles require selected facility
+  - model/caller tenant overrides are ignored or rejected
+- Forbidden statements / multi-statement rejection:
+  - `select 1; select 2`
+  - `set ...`
+  - `copy`
+  - `explain analyze`
+  - `with x as (delete ...)`
+  - comment-obfuscated mutations
+  - all must fail guard tests
+- Audit logging:
+  - successful queries and rejected executions both emit sanitized audit records
+  - audit record includes scope, row count, latency, and error class
+  - audit failure aborts the SQL path
+
+## Execution Batches
+This plan should be executed as four small sequential batches under the same umbrella issue `#271`.
+
+Do not open more follow-up issues unless one batch is blocked by an external dependency. Use the batches below as the working order and review checkpoints.
+
+### Batch 1: Lock Scope And Red Tests
+- Includes:
+  - Phase 0
+  - Phase 1, but only the regression and red-test harness portions
+- Goal:
+  - prove `#271` does not change current `/api/chat` runtime exposure
+  - lock the safety invariants in tests before any SQL implementation begins
+- Deliverables:
+  - regression tests showing `query_database` is not registered
+  - RPC-whitelist tests proving no accidental SQL runtime path was exposed
+  - red unit tests for statement/schema/limit/scope/audit guardrails
+  - placeholder or first version of `assistant_sql_foundation_smoke.sql`
+- Stop condition:
+  - the team can point to failing tests that define the contract, while runtime behavior is still unchanged
+- Why this batch stands alone:
+  - if this batch is skipped or mixed with implementation, review becomes noisy and scope drift becomes easy
+
+### Batch 2: DB Semantic Layer And Identity
+- Includes:
+  - Phase 2
+- Goal:
+  - establish the only approved SQL-readable surface before any executor code is allowed to use it
+- Deliverables:
+  - migration for `ai_readonly` schema, scope helpers, grants, and first approved views
+  - documented provisioning steps for the dedicated login role and `AI_DATABASE_URL`
+  - local DB smoke proving read-only behavior, schema boundary enforcement, and fail-closed scope
+- Stop condition:
+  - the read-only SQL identity can query only the semantic layer and cannot touch raw schemas or mutate data
+- Why this batch stands alone:
+  - DB safety needs isolated review; mixing it with TS executor code makes privilege mistakes harder to spot
+
+### Batch 3: Dormant Executor And Shared Scope Contract
+- Includes:
+  - Phase 3
+  - Phase 4
+- Goal:
+  - build the server-side SQL executor and the shared `AssistantSqlScope` contract, but keep the tool dormant
+- Deliverables:
+  - `postgres` / postgres.js client wired to Supabase transaction pooler contract
+  - lexical guards, result caps, timeout mapping, payload limit handling
+  - extracted shared scope resolver so SQL execution cannot drift from existing `/api/chat` semantics
+  - dormant `query_database` tool module that is still not registered into `/api/chat`
+- Stop condition:
+  - unit tests pass for guardrails and scope resolution, and the dormant tool remains unreachable from runtime chat
+- Why these phases stay together:
+  - splitting executor logic from scope extraction would create duplicate privilege logic and invite security drift
+
+### Batch 4: Audit Seam And Final Hardening
+- Includes:
+  - Phase 5
+  - final verification gates from this plan
+- Goal:
+  - make the dormant SQL path observable, fail-closed, and fully verified without rolling it out
+- Deliverables:
+  - authenticated audit RPC/helper wrapping `public.audit_log(...)`
+  - audit payload coverage for success/failure/scope/latency/row-count/error-class
+  - final verification proof that `#271` is still dormant at runtime and safe to hand off to `#272`
+- Stop condition:
+  - all non-rollout checks pass, audit behavior is covered, and runtime registration is still absent
+- Why this is last:
+  - audit payload shape depends on the executor outputs and final scope contract
+
+## Recommended Implementation Order
+1. Batch 1: lock scope and red tests.
+2. Batch 2: build the DB semantic layer and dedicated identity.
+3. Batch 3: build the dormant executor together with the shared scope contract.
+4. Batch 4: add audit seam and run final verification.
+
+## Suggested Review Rhythm
+- Review Batch 1 for scope discipline and non-rollout guarantees.
+- Review Batch 2 separately for grants, schema exposure, and fail-closed DB behavior.
+- Review Batch 3 for server/runtime boundaries, role normalization, and guardrail correctness.
+- Review Batch 4 for observability, audit completeness, and release gating into `#272`.
+
+## Issue/PR Mapping
+- Keep `#271` as the single umbrella implementation issue for these four batches.
+- `#272` should not start until Batch 4 is complete, because it depends on the dormant foundation being proven safe.
+- `#273` remains separate; planner/runtime selection work should not be mixed into these batches.
+- If implementation is split into PRs, prefer `3` or `4` PRs that map directly to these batches rather than creating more GitHub issues.
+
+## Do First Next
+- Batch 1:
+  - add route and RPC-whitelist regression tests proving `query_database` is still not live
+  - add red tests for forbidden statements, schema boundaries, limits, and scope contract
+- Batch 2:
+  - draft the migration that creates `ai_readonly` helpers/views plus the nologin grant role
+  - add the SQL smoke file before any TS executor code depends on it
+- Batch 3:
+  - freeze the first approved view list in tests/docs before implementing the executor
+  - add `postgres` dependency and the dormant server-only executor only after the DB contract is stable
+- Batch 4:
+  - add the audit RPC/helper only after executor result shape and scope contract are fixed
+
+## Must Validate Before Any Production Rollout
+- The dedicated SQL identity exists in the real Supabase project and cannot read raw schemas.
+- `assistant_sql_foundation_smoke.sql` passes against the linked DB.
+- `node scripts/npm-run.js run verify:no-explicit-any`, `node scripts/npm-run.js run typecheck`, targeted Vitest, and `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` all pass.
+- `get_advisors(security)` is clean after migrations.
+- `/api/chat` still uses curated tools only in `#271`; actual runtime registration waits for `#272`.
+
+## Sources
+- `gh issue view 271 --repo thienchi2109/qltbyt-nam-phong`
+- `gh issue view 223 --repo thienchi2109/qltbyt-nam-phong`
+- `gh issue view 272 --repo thienchi2109/qltbyt-nam-phong`
+- `gh issue view 273 --repo thienchi2109/qltbyt-nam-phong`
+- `gh pr view 274 --repo thienchi2109/qltbyt-nam-phong`

--- a/docs/plans/2026-04-18-issue-271-safe-sql-foundation-plan.md
+++ b/docs/plans/2026-04-18-issue-271-safe-sql-foundation-plan.md
@@ -253,6 +253,10 @@
 - Forbidden statements / multi-statement rejection:
   - `select 1; select 2`
   - `set ...`
+  - `select set_config('app.current_facility_id', '2', true)`
+  - `select pg_catalog.set_config('app.current_facility_id', '2', true)`
+  - `with scope_override as (select pg_catalog.set_config('app.current_facility_id', '2', true)) select * from ai_readonly.equipment_search`
+  - `select 1 where set_config('app.current_facility_id', '2', true) is not null`
   - `copy`
   - `explain analyze`
   - `with x as (delete ...)`

--- a/src/app/api/chat/__tests__/route.tenant-policy.test.ts
+++ b/src/app/api/chat/__tests__/route.tenant-policy.test.ts
@@ -133,4 +133,27 @@ describe('/api/chat tenant policy', () => {
     }
     expect(streamArgs?.tools).toHaveProperty('equipmentLookup')
   })
+
+  it('treats raw admin session role as privileged for facility-scoped tool execution', async () => {
+    getServerSessionMock.mockResolvedValue({
+      user: { id: 'u1', role: 'admin', don_vi: null },
+    })
+
+    const res = await POST(
+      buildRequest({
+        messages: VALID_MESSAGES,
+        requestedTools: ['equipmentLookup'],
+        selectedFacilityId: 11,
+      }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(buildSystemPromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'admin', selectedFacilityId: 11 }),
+    )
+    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
+      tools?: Record<string, unknown>
+    }
+    expect(streamArgs?.tools).toHaveProperty('equipmentLookup')
+  })
 })

--- a/src/app/api/chat/__tests__/route.tool-rpc-mapping.test.ts
+++ b/src/app/api/chat/__tests__/route.tool-rpc-mapping.test.ts
@@ -26,6 +26,14 @@ describe('AI tool → RPC mapping contract', () => {
     expect(Object.keys(mapping)).toHaveLength(Object.keys(EXPECTED_MAPPING).length)
   })
 
+  it('does not expose query_database or ai_query_database in the RPC mapping', () => {
+    const mapping = getToolRpcMapping()
+
+    expect(mapping).not.toHaveProperty('query_database')
+    expect(mapping).not.toHaveProperty('queryDatabase')
+    expect(Object.values(mapping)).not.toContain('ai_query_database')
+  })
+
   it.each(Object.entries({
     equipmentLookup: 'ai_equipment_lookup',
     maintenanceSummary: 'ai_maintenance_summary',

--- a/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
+++ b/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
@@ -85,6 +85,20 @@ describe('/api/chat tools allowlist policy', () => {
     expect(streamTextMock).not.toHaveBeenCalled()
   })
 
+  it('blocks query_database before rollout', async () => {
+    const res = await POST(
+      buildRequest({
+        messages: VALID_MESSAGES,
+        requestedTools: ['query_database'],
+      }) as never,
+    )
+    const text = await res.text()
+
+    expect(res.status).toBe(400)
+    expect(text).toBe('Unknown tool requested: query_database')
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
   it('blocks known tools that are not in the v1 allowlist', async () => {
     const res = await POST(
       buildRequest({

--- a/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
+++ b/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
@@ -99,6 +99,20 @@ describe('/api/chat tools allowlist policy', () => {
     expect(streamTextMock).not.toHaveBeenCalled()
   })
 
+  it('blocks queryDatabase before rollout', async () => {
+    const res = await POST(
+      buildRequest({
+        messages: VALID_MESSAGES,
+        requestedTools: ['queryDatabase'],
+      }) as never,
+    )
+    const text = await res.text()
+
+    expect(res.status).toBe(400)
+    expect(text).toBe('Unknown tool requested: queryDatabase')
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
   it('blocks known tools that are not in the v1 allowlist', async () => {
     const res = await POST(
       buildRequest({

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -68,6 +68,12 @@ describe('RPC proxy whitelist', () => {
     await expect(res.json()).resolves.toEqual({ error: 'Function not allowed' })
   })
 
+  it('rejects ai_query_database before any SQL runtime path is introduced', async () => {
+    const res = await invokeRpcProxy('ai_query_database')
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Function not allowed' })
+  })
+
   it('allows dinh_muc_unified_import through whitelist checks', async () => {
     const res = await invokeRpcProxy('dinh_muc_unified_import')
 

--- a/src/lib/ai/sql/__tests__/query-database-audit.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-audit.test.ts
@@ -1,0 +1,7 @@
+import { describe, it } from 'vitest'
+
+describe('query_database audit contract', () => {
+  it.todo('emits sanitized audit payloads for successful executions')
+  it.todo('emits sanitized audit payloads for rejected executions')
+  it.todo('fails closed when audit writing fails')
+})

--- a/src/lib/ai/sql/__tests__/query-database-executor.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-executor.test.ts
@@ -1,0 +1,7 @@
+import { describe, it } from 'vitest'
+
+describe('query_database executor contract', () => {
+  it.todo('applies transaction-local settings for timeout and search_path')
+  it.todo('requires server-injected single-facility scope before execution')
+  it.todo('keeps the tool dormant and unreachable from /api/chat in Batch 1')
+})

--- a/src/lib/ai/sql/__tests__/query-database-guard.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-guard.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest'
+
+describe('query_database guardrails contract', () => {
+  it.todo('rejects multi-statement SQL before execution')
+  it.todo('rejects statements outside SELECT / WITH ... SELECT')
+  it.todo('rejects forbidden schema access outside ai_readonly')
+  it.todo('rejects comment-obfuscated mutation attempts')
+  it.todo('maps timeout, row, and payload limits to safe error classes')
+})

--- a/src/lib/ai/tools/__tests__/query-catalog.test.ts
+++ b/src/lib/ai/tools/__tests__/query-catalog.test.ts
@@ -56,6 +56,12 @@ describe('query catalog', () => {
     expect(getQueryCatalogToolRpcMapping()).toEqual(EXPECTED_RPC_MAPPING)
   })
 
+  it('does not define query_database rollout artifacts in the current catalog', () => {
+    expect(EXPECTED_TOOL_NAMES).not.toContain('query_database')
+    expect(EXPECTED_TOOL_NAMES).not.toContain('queryDatabase')
+    expect(Object.values(EXPECTED_RPC_MAPPING)).not.toContain('ai_query_database')
+  })
+
   it('exports the exact migration status map', () => {
     expect(getQueryCatalogMigrationStatusMap()).toEqual(EXPECTED_MIGRATION_STATUS)
   })

--- a/src/lib/ai/tools/__tests__/query-catalog.test.ts
+++ b/src/lib/ai/tools/__tests__/query-catalog.test.ts
@@ -57,9 +57,11 @@ describe('query catalog', () => {
   })
 
   it('does not define query_database rollout artifacts in the current catalog', () => {
-    expect(EXPECTED_TOOL_NAMES).not.toContain('query_database')
-    expect(EXPECTED_TOOL_NAMES).not.toContain('queryDatabase')
-    expect(Object.values(EXPECTED_RPC_MAPPING)).not.toContain('ai_query_database')
+    const catalogToolNames = Object.keys(QUERY_CATALOG)
+
+    expect(catalogToolNames).not.toContain('query_database')
+    expect(catalogToolNames).not.toContain('queryDatabase')
+    expect(Object.values(getQueryCatalogToolRpcMapping())).not.toContain('ai_query_database')
   })
 
   it('exports the exact migration status map', () => {

--- a/src/lib/ai/tools/__tests__/registry.allowlist.test.ts
+++ b/src/lib/ai/tools/__tests__/registry.allowlist.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { getAllowedToolNamesForTest, validateRequestedTools } from '../registry'
+
+describe('registry allowlist contract', () => {
+  it('does not expose query_database in the current assistant allowlist', () => {
+    const allowedToolNames = getAllowedToolNamesForTest()
+
+    expect(allowedToolNames).not.toContain('query_database')
+    expect(allowedToolNames).not.toContain('queryDatabase')
+  })
+
+  it('rejects query_database before runtime rollout exists', () => {
+    expect(validateRequestedTools(['query_database'])).toEqual({
+      ok: false,
+      message: 'Unknown tool requested: query_database',
+    })
+  })
+})

--- a/src/lib/ai/tools/__tests__/registry.allowlist.test.ts
+++ b/src/lib/ai/tools/__tests__/registry.allowlist.test.ts
@@ -16,4 +16,11 @@ describe('registry allowlist contract', () => {
       message: 'Unknown tool requested: query_database',
     })
   })
+
+  it('rejects queryDatabase before runtime rollout exists', () => {
+    expect(validateRequestedTools(['queryDatabase'])).toEqual({
+      ok: false,
+      message: 'Unknown tool requested: queryDatabase',
+    })
+  })
 })

--- a/src/lib/ai/tools/registry.ts
+++ b/src/lib/ai/tools/registry.ts
@@ -61,6 +61,11 @@ const ALLOWED_TOOL_NAMES = new Set([
   ...DRAFT_TOOL_NAMES,
 ])
 
+/** Exposed for contract tests only. Do NOT import in production code. */
+export function getAllowedToolNamesForTest(): string[] {
+  return [...ALLOWED_TOOL_NAMES].sort()
+}
+
 /** Returns tool name → RPC function mapping for contract-locking tests. */
 export function getToolRpcMapping(): Record<string, string> {
   return getQueryCatalogToolRpcMapping()

--- a/supabase/migrations/20260418120000_add_ai_readonly_semantic_layer_foundation.sql
+++ b/supabase/migrations/20260418120000_add_ai_readonly_semantic_layer_foundation.sql
@@ -8,6 +8,21 @@
 --   - passworded login role creation
 --   - runtime SQL executor rollout
 --   - audit plumbing
+--
+-- Rollback (forward-only strategy):
+--   Safe only before any production data or assistant traffic has exercised
+--   this semantic layer, and before any dependent passworded login role is
+--   created from `ai_query_reader`.
+--   Reverse in that window with:
+--     DROP VIEW IF EXISTS ai_readonly.quota_facts;
+--     DROP VIEW IF EXISTS ai_readonly.usage_facts;
+--     DROP VIEW IF EXISTS ai_readonly.repair_facts;
+--     DROP VIEW IF EXISTS ai_readonly.maintenance_facts;
+--     DROP VIEW IF EXISTS ai_readonly.equipment_search;
+--     DROP FUNCTION IF EXISTS ai_readonly.require_single_facility_scope();
+--     DROP FUNCTION IF EXISTS ai_readonly.current_facility_id();
+--     DROP SCHEMA IF EXISTS ai_readonly;
+--     DROP ROLE IF EXISTS ai_query_reader;
 
 BEGIN;
 
@@ -132,6 +147,7 @@ SELECT
 FROM public.cong_viec_bao_tri cv
 JOIN public.ke_hoach_bao_tri kh
   ON kh.id = cv.ke_hoach_id
+ AND kh.don_vi = ai_readonly.require_single_facility_scope()
 JOIN public.thiet_bi tb
   ON tb.id = cv.thiet_bi_id
 WHERE tb.is_deleted = false

--- a/supabase/migrations/20260418120000_add_ai_readonly_semantic_layer_foundation.sql
+++ b/supabase/migrations/20260418120000_add_ai_readonly_semantic_layer_foundation.sql
@@ -188,7 +188,6 @@ AS
 SELECT
   nk.id AS usage_log_id,
   nk.thiet_bi_id AS equipment_id,
-  nk.nguoi_su_dung_id,
   nk.thoi_gian_bat_dau,
   nk.thoi_gian_ket_thuc,
   nk.trang_thai,
@@ -289,7 +288,7 @@ COMMENT ON VIEW ai_readonly.repair_facts IS
 'Facility-scoped repair request facts for assistant SQL.';
 
 COMMENT ON VIEW ai_readonly.usage_facts IS
-'Facility-scoped equipment usage log facts for assistant SQL.';
+'Facility-scoped equipment usage log facts for assistant SQL, excluding raw user identifiers.';
 
 COMMENT ON VIEW ai_readonly.quota_facts IS
 'Facility-scoped equipment-to-quota semantic surface for assistant SQL.';
@@ -297,13 +296,17 @@ COMMENT ON VIEW ai_readonly.quota_facts IS
 GRANT USAGE ON SCHEMA ai_readonly TO ai_query_reader;
 GRANT EXECUTE ON FUNCTION ai_readonly.current_facility_id() TO ai_query_reader;
 GRANT EXECUTE ON FUNCTION ai_readonly.require_single_facility_scope() TO ai_query_reader;
-GRANT SELECT ON ALL TABLES IN SCHEMA ai_readonly TO ai_query_reader;
+GRANT SELECT ON TABLE ai_readonly.equipment_search TO ai_query_reader;
+GRANT SELECT ON TABLE ai_readonly.maintenance_facts TO ai_query_reader;
+GRANT SELECT ON TABLE ai_readonly.repair_facts TO ai_query_reader;
+GRANT SELECT ON TABLE ai_readonly.usage_facts TO ai_query_reader;
+GRANT SELECT ON TABLE ai_readonly.quota_facts TO ai_query_reader;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA ai_readonly
-  GRANT SELECT ON TABLES TO ai_query_reader;
+  REVOKE ALL ON TABLES FROM PUBLIC;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA ai_readonly
-  GRANT EXECUTE ON FUNCTIONS TO ai_query_reader;
+  REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
 
 REVOKE ALL ON ALL TABLES IN SCHEMA ai_readonly FROM PUBLIC;
 REVOKE ALL ON ALL FUNCTIONS IN SCHEMA ai_readonly FROM PUBLIC;

--- a/supabase/migrations/20260418120000_add_ai_readonly_semantic_layer_foundation.sql
+++ b/supabase/migrations/20260418120000_add_ai_readonly_semantic_layer_foundation.sql
@@ -1,0 +1,295 @@
+-- Issue #271 Batch 2: assistant SQL semantic-layer foundation.
+-- Scope:
+--   - create ai_readonly schema and fail-closed facility-scope helpers
+--   - create approved facility-scoped semantic views
+--   - create read-only grant role for future assistant SQL login role
+--
+-- Out of scope:
+--   - passworded login role creation
+--   - runtime SQL executor rollout
+--   - audit plumbing
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS ai_readonly;
+
+REVOKE ALL ON SCHEMA ai_readonly FROM PUBLIC;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_roles
+    WHERE rolname = 'ai_query_reader'
+  ) THEN
+    CREATE ROLE ai_query_reader NOLOGIN;
+  END IF;
+END
+$$;
+
+COMMENT ON ROLE ai_query_reader IS
+'Grant-only role for the assistant SQL semantic layer. Passworded login role must be created manually outside git.';
+
+CREATE OR REPLACE FUNCTION ai_readonly.current_facility_id()
+RETURNS bigint
+LANGUAGE plpgsql
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_raw text;
+BEGIN
+  v_raw := nullif(current_setting('app.current_facility_id', true), '');
+
+  IF v_raw IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN v_raw::bigint;
+EXCEPTION
+  WHEN invalid_text_representation THEN
+    RAISE EXCEPTION 'Invalid app.current_facility_id session value'
+      USING ERRCODE = '42501';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION ai_readonly.require_single_facility_scope()
+RETURNS bigint
+LANGUAGE plpgsql
+STABLE
+SET search_path = pg_catalog, pg_temp
+AS $$
+DECLARE
+  v_facility_id bigint;
+BEGIN
+  v_facility_id := ai_readonly.current_facility_id();
+
+  IF v_facility_id IS NULL THEN
+    RAISE EXCEPTION 'Missing app.current_facility_id session scope'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN v_facility_id;
+END;
+$$;
+
+COMMENT ON FUNCTION ai_readonly.current_facility_id() IS
+'Reads the server-injected app.current_facility_id GUC for assistant SQL reads.';
+
+COMMENT ON FUNCTION ai_readonly.require_single_facility_scope() IS
+'Returns the active facility scope or raises fail-closed when assistant SQL scope was not injected.';
+
+CREATE OR REPLACE VIEW ai_readonly.equipment_search
+WITH (security_barrier = true)
+AS
+SELECT
+  tb.id AS equipment_id,
+  tb.ma_thiet_bi,
+  tb.ten_thiet_bi,
+  tb.model,
+  tb.serial,
+  tb.so_luu_hanh,
+  tb.phan_loai_theo_nd98,
+  tb.nhom_thiet_bi_id,
+  tb.tinh_trang_hien_tai,
+  tb.khoa_phong_quan_ly,
+  tb.vi_tri_lap_dat,
+  tb.ngay_bt_tiep_theo,
+  tb.ngay_hc_tiep_theo,
+  tb.ngay_kd_tiep_theo,
+  tb.don_vi AS facility_id,
+  dv.code AS facility_code,
+  dv.name AS facility_name,
+  tb.created_at
+FROM public.thiet_bi tb
+LEFT JOIN public.don_vi dv
+  ON dv.id = tb.don_vi
+WHERE tb.is_deleted = false
+  AND tb.don_vi = ai_readonly.require_single_facility_scope();
+
+CREATE OR REPLACE VIEW ai_readonly.maintenance_facts
+WITH (security_barrier = true)
+AS
+SELECT
+  cv.id AS maintenance_task_id,
+  cv.ke_hoach_id AS maintenance_plan_id,
+  cv.thiet_bi_id AS equipment_id,
+  cv.loai_cong_viec,
+  cv.don_vi_thuc_hien,
+  cv.diem_hieu_chuan,
+  cv.ghi_chu AS task_notes,
+  kh.ten_ke_hoach,
+  kh.nam AS plan_year,
+  kh.trang_thai AS plan_status,
+  kh.ngay_phe_duyet,
+  kh.don_vi AS plan_facility_id,
+  tb.ma_thiet_bi,
+  tb.ten_thiet_bi,
+  tb.model,
+  tb.khoa_phong_quan_ly,
+  tb.tinh_trang_hien_tai,
+  tb.don_vi AS facility_id
+FROM public.cong_viec_bao_tri cv
+JOIN public.ke_hoach_bao_tri kh
+  ON kh.id = cv.ke_hoach_id
+JOIN public.thiet_bi tb
+  ON tb.id = cv.thiet_bi_id
+WHERE tb.is_deleted = false
+  AND tb.don_vi = ai_readonly.require_single_facility_scope();
+
+CREATE OR REPLACE VIEW ai_readonly.repair_facts
+WITH (security_barrier = true)
+AS
+SELECT
+  r.id AS repair_request_id,
+  r.thiet_bi_id AS equipment_id,
+  r.trang_thai AS repair_status,
+  r.mo_ta_su_co,
+  r.hang_muc_sua_chua,
+  r.ngay_yeu_cau,
+  r.ngay_duyet,
+  r.ngay_hoan_thanh,
+  r.don_vi_thuc_hien,
+  r.ten_don_vi_thue,
+  r.chi_phi_sua_chua,
+  tb.ma_thiet_bi,
+  tb.ten_thiet_bi,
+  tb.model,
+  tb.khoa_phong_quan_ly,
+  tb.don_vi AS facility_id,
+  dv.name AS facility_name
+FROM public.yeu_cau_sua_chua r
+JOIN public.thiet_bi tb
+  ON tb.id = r.thiet_bi_id
+LEFT JOIN public.don_vi dv
+  ON dv.id = tb.don_vi
+WHERE tb.is_deleted = false
+  AND tb.don_vi = ai_readonly.require_single_facility_scope();
+
+CREATE OR REPLACE VIEW ai_readonly.usage_facts
+WITH (security_barrier = true)
+AS
+SELECT
+  nk.id AS usage_log_id,
+  nk.thiet_bi_id AS equipment_id,
+  nk.nguoi_su_dung_id,
+  nk.thoi_gian_bat_dau,
+  nk.thoi_gian_ket_thuc,
+  nk.trang_thai,
+  nk.tinh_trang_thiet_bi,
+  nk.tinh_trang_ban_dau,
+  nk.tinh_trang_ket_thuc,
+  nk.ghi_chu,
+  CASE
+    WHEN nk.thoi_gian_bat_dau IS NOT NULL AND nk.thoi_gian_ket_thuc IS NOT NULL
+      THEN extract(epoch FROM (nk.thoi_gian_ket_thuc - nk.thoi_gian_bat_dau)) / 3600.0
+    ELSE NULL
+  END AS duration_hours,
+  tb.ma_thiet_bi,
+  tb.ten_thiet_bi,
+  tb.model,
+  tb.khoa_phong_quan_ly,
+  tb.don_vi AS facility_id
+FROM public.nhat_ky_su_dung nk
+JOIN public.thiet_bi tb
+  ON tb.id = nk.thiet_bi_id
+WHERE tb.is_deleted = false
+  AND tb.don_vi = ai_readonly.require_single_facility_scope();
+
+CREATE OR REPLACE VIEW ai_readonly.quota_facts
+WITH (security_barrier = true)
+AS
+SELECT
+  tb.id AS equipment_id,
+  tb.ma_thiet_bi,
+  tb.ten_thiet_bi,
+  tb.model,
+  tb.nhom_thiet_bi_id AS category_id,
+  ntb.ma_nhom AS category_code,
+  ntb.ten_nhom AS category_name,
+  tb.don_vi AS facility_id,
+  dv.name AS facility_name,
+  qd.id AS decision_id,
+  qd.so_quyet_dinh,
+  qd.trang_thai AS decision_status,
+  qd.ngay_hieu_luc,
+  cd.so_luong_toi_thieu,
+  cd.so_luong_toi_da,
+  count(*) FILTER (
+    WHERE tb.nhom_thiet_bi_id IS NOT NULL
+  ) OVER (
+    PARTITION BY tb.don_vi, tb.nhom_thiet_bi_id
+  )::bigint AS category_device_count,
+  CASE
+    WHEN tb.nhom_thiet_bi_id IS NULL THEN 'notMapped'
+    WHEN qd.id IS NULL THEN 'insufficientEvidence'
+    WHEN cd.id IS NULL THEN 'notInApprovedCatalog'
+    ELSE 'inQuotaCatalog'
+  END AS quota_status,
+  CASE
+    WHEN cd.id IS NULL THEN NULL
+    ELSE greatest(
+      cd.so_luong_toi_da::bigint
+      - count(*) FILTER (
+          WHERE tb.nhom_thiet_bi_id IS NOT NULL
+        ) OVER (
+          PARTITION BY tb.don_vi, tb.nhom_thiet_bi_id
+        )::bigint,
+      0
+    )
+  END AS remaining_quota
+FROM public.thiet_bi tb
+LEFT JOIN public.don_vi dv
+  ON dv.id = tb.don_vi
+LEFT JOIN public.nhom_thiet_bi ntb
+  ON ntb.id = tb.nhom_thiet_bi_id
+ AND ntb.don_vi_id = tb.don_vi
+LEFT JOIN LATERAL (
+  SELECT
+    qd_inner.id,
+    qd_inner.so_quyet_dinh,
+    qd_inner.trang_thai,
+    qd_inner.ngay_hieu_luc
+  FROM public.quyet_dinh_dinh_muc qd_inner
+  WHERE qd_inner.don_vi_id = tb.don_vi
+    AND qd_inner.trang_thai = 'active'
+  ORDER BY qd_inner.ngay_hieu_luc DESC, qd_inner.id DESC
+  LIMIT 1
+) qd
+  ON true
+LEFT JOIN public.chi_tiet_dinh_muc cd
+  ON cd.quyet_dinh_id = qd.id
+ AND cd.nhom_thiet_bi_id = tb.nhom_thiet_bi_id
+WHERE tb.is_deleted = false
+  AND tb.don_vi = ai_readonly.require_single_facility_scope();
+
+COMMENT ON VIEW ai_readonly.equipment_search IS
+'Facility-scoped semantic surface for assistant equipment lookup SQL.';
+
+COMMENT ON VIEW ai_readonly.maintenance_facts IS
+'Facility-scoped maintenance task and plan facts for assistant SQL.';
+
+COMMENT ON VIEW ai_readonly.repair_facts IS
+'Facility-scoped repair request facts for assistant SQL.';
+
+COMMENT ON VIEW ai_readonly.usage_facts IS
+'Facility-scoped equipment usage log facts for assistant SQL.';
+
+COMMENT ON VIEW ai_readonly.quota_facts IS
+'Facility-scoped equipment-to-quota semantic surface for assistant SQL.';
+
+GRANT USAGE ON SCHEMA ai_readonly TO ai_query_reader;
+GRANT EXECUTE ON FUNCTION ai_readonly.current_facility_id() TO ai_query_reader;
+GRANT EXECUTE ON FUNCTION ai_readonly.require_single_facility_scope() TO ai_query_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA ai_readonly TO ai_query_reader;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA ai_readonly
+  GRANT SELECT ON TABLES TO ai_query_reader;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA ai_readonly
+  GRANT EXECUTE ON FUNCTIONS TO ai_query_reader;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA ai_readonly FROM PUBLIC;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA ai_readonly FROM PUBLIC;
+
+COMMIT;

--- a/supabase/tests/assistant_sql_foundation_smoke.sql
+++ b/supabase/tests/assistant_sql_foundation_smoke.sql
@@ -1,0 +1,7 @@
+-- Local/DB-admin verification artifact for Issue #271.
+-- Do not wire this file into CI; it requires a linked Supabase database and
+-- a dedicated assistant SQL identity that does not exist yet in Batch 1.
+--
+-- Batch 1 placeholder only:
+--   - keep the filename and local-only contract stable
+--   - future batches will fill this with semantic-layer and privilege checks

--- a/supabase/tests/assistant_sql_foundation_smoke.sql
+++ b/supabase/tests/assistant_sql_foundation_smoke.sql
@@ -1,7 +1,113 @@
--- Local/DB-admin verification artifact for Issue #271.
--- Do not wire this file into CI; it requires a linked Supabase database and
--- a dedicated assistant SQL identity that does not exist yet in Batch 1.
+-- Local/DB-admin verification artifact for Issue #271 Batch 2.
+-- How to run (after applying the migration on a linked Supabase DB):
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/assistant_sql_foundation_smoke.sql
 --
--- Batch 1 placeholder only:
---   - keep the filename and local-only contract stable
---   - future batches will fill this with semantic-layer and privilege checks
+-- This script is intentionally local-only and should not be wired into CI.
+
+-- 1) Existence checks: schema, role, helpers, and approved views.
+DO $$
+DECLARE
+  v_missing text[];
+BEGIN
+  SELECT array_remove(array[
+    CASE WHEN to_regnamespace('ai_readonly') IS NULL THEN 'schema ai_readonly' END,
+    CASE WHEN NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ai_query_reader') THEN 'role ai_query_reader' END,
+    CASE WHEN to_regprocedure('ai_readonly.current_facility_id()') IS NULL THEN 'function ai_readonly.current_facility_id()' END,
+    CASE WHEN to_regprocedure('ai_readonly.require_single_facility_scope()') IS NULL THEN 'function ai_readonly.require_single_facility_scope()' END,
+    CASE WHEN to_regclass('ai_readonly.equipment_search') IS NULL THEN 'view ai_readonly.equipment_search' END,
+    CASE WHEN to_regclass('ai_readonly.maintenance_facts') IS NULL THEN 'view ai_readonly.maintenance_facts' END,
+    CASE WHEN to_regclass('ai_readonly.repair_facts') IS NULL THEN 'view ai_readonly.repair_facts' END,
+    CASE WHEN to_regclass('ai_readonly.usage_facts') IS NULL THEN 'view ai_readonly.usage_facts' END,
+    CASE WHEN to_regclass('ai_readonly.quota_facts') IS NULL THEN 'view ai_readonly.quota_facts' END
+  ], NULL)
+  INTO v_missing;
+
+  IF coalesce(array_length(v_missing, 1), 0) > 0 THEN
+    RAISE EXCEPTION 'Missing assistant SQL foundation artifacts: %', array_to_string(v_missing, ', ');
+  END IF;
+
+  RAISE NOTICE 'OK: ai_readonly schema, helpers, role, and views exist';
+END $$;
+
+-- 2) Privilege checks: role can read semantic layer and cannot read/mutate base tables.
+DO $$
+BEGIN
+  IF NOT has_schema_privilege('ai_query_reader', 'ai_readonly', 'USAGE') THEN
+    RAISE EXCEPTION 'ai_query_reader is missing USAGE on ai_readonly';
+  END IF;
+
+  IF NOT has_table_privilege('ai_query_reader', 'ai_readonly.equipment_search', 'SELECT') THEN
+    RAISE EXCEPTION 'ai_query_reader is missing SELECT on ai_readonly.equipment_search';
+  END IF;
+
+  IF NOT has_table_privilege('ai_query_reader', 'ai_readonly.maintenance_facts', 'SELECT') THEN
+    RAISE EXCEPTION 'ai_query_reader is missing SELECT on ai_readonly.maintenance_facts';
+  END IF;
+
+  IF NOT has_table_privilege('ai_query_reader', 'ai_readonly.repair_facts', 'SELECT') THEN
+    RAISE EXCEPTION 'ai_query_reader is missing SELECT on ai_readonly.repair_facts';
+  END IF;
+
+  IF NOT has_table_privilege('ai_query_reader', 'ai_readonly.usage_facts', 'SELECT') THEN
+    RAISE EXCEPTION 'ai_query_reader is missing SELECT on ai_readonly.usage_facts';
+  END IF;
+
+  IF NOT has_table_privilege('ai_query_reader', 'ai_readonly.quota_facts', 'SELECT') THEN
+    RAISE EXCEPTION 'ai_query_reader is missing SELECT on ai_readonly.quota_facts';
+  END IF;
+
+  IF has_table_privilege('ai_query_reader', 'public.thiet_bi', 'SELECT') THEN
+    RAISE EXCEPTION 'ai_query_reader must not have SELECT on public.thiet_bi';
+  END IF;
+
+  IF has_table_privilege('ai_query_reader', 'public.thiet_bi', 'INSERT,UPDATE,DELETE') THEN
+    RAISE EXCEPTION 'ai_query_reader must not have write privileges on public.thiet_bi';
+  END IF;
+
+  RAISE NOTICE 'OK: ai_query_reader privileges are limited to ai_readonly views';
+END $$;
+
+-- 3) Missing scope must fail closed.
+DO $$
+BEGIN
+  PERFORM set_config('app.current_facility_id', '', true);
+
+  BEGIN
+    PERFORM 1 FROM ai_readonly.equipment_search LIMIT 1;
+    RAISE EXCEPTION 'Expected ai_readonly.equipment_search to fail without app.current_facility_id';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLSTATE = '42501' THEN
+      RAISE NOTICE 'OK: missing facility scope fails closed';
+    ELSE
+      RAISE;
+    END IF;
+  END;
+END $$;
+
+-- 4) With a real facility scope, the semantic layer should be queryable.
+DO $$
+DECLARE
+  v_facility_id bigint;
+  v_count bigint;
+BEGIN
+  SELECT id
+  INTO v_facility_id
+  FROM public.don_vi
+  WHERE active = true
+  ORDER BY id
+  LIMIT 1;
+
+  IF v_facility_id IS NULL THEN
+    RAISE EXCEPTION 'Cannot run smoke: no active don_vi rows found';
+  END IF;
+
+  PERFORM set_config('app.current_facility_id', v_facility_id::text, true);
+
+  SELECT count(*) INTO v_count FROM ai_readonly.equipment_search;
+  SELECT count(*) INTO v_count FROM ai_readonly.maintenance_facts;
+  SELECT count(*) INTO v_count FROM ai_readonly.repair_facts;
+  SELECT count(*) INTO v_count FROM ai_readonly.usage_facts;
+  SELECT count(*) INTO v_count FROM ai_readonly.quota_facts;
+
+  RAISE NOTICE 'OK: ai_readonly views are queryable with app.current_facility_id=%', v_facility_id;
+END $$;


### PR DESCRIPTION
## Summary
This draft PR starts Issue #271: safe SQL foundation for the assistant semantic layer.

Current scope in this PR:
- completes **Batch 1**: non-rollout + scope regression contracts
- completes **Batch 2 (repo-ready only)**: SQL semantic-layer migration, smoke contract, and runbook
- does **not** apply the migration to the linked Supabase project yet
- does **not** register `query_database` into `/api/chat`
- does **not** start planner/runtime selection work from #273

This keeps `#271` strictly on foundation work and preserves the boundary with:
- `#272` runtime rollout of `query_database`
- `#273` planner/router hardening

Refs #271

## Why This PR Exists Now
Batch 1 was the cleanest review checkpoint because it locked the non-rollout boundary before any DB work. I continued into Batch 2 on the same branch, but kept Batch 2 repo-only so reviewers can inspect the semantic layer and grant model before any DB apply happens.

This means the PR is reviewable now without risking drift in the linked Supabase project.

## What Landed
### Batch 1: Scope + Regression Contracts
- lock that `query_database` / `queryDatabase` are not exposed in the current tool allowlist
- lock that `ai_query_database` is not in the RPC whitelist
- lock that query catalog / tool→RPC mapping contain no SQL rollout artifacts yet
- add regression coverage for raw NextAuth `admin` session behavior in `/api/chat` tenant scoping
- add placeholder SQL test harness files for later batches

Main files:
- `src/lib/ai/tools/registry.ts`
- `src/lib/ai/tools/__tests__/registry.allowlist.test.ts`
- `src/lib/ai/tools/__tests__/query-catalog.test.ts`
- `src/app/api/chat/__tests__/route.tools-allowlist.test.ts`
- `src/app/api/chat/__tests__/route.tenant-policy.test.ts`
- `src/app/api/chat/__tests__/route.tool-rpc-mapping.test.ts`
- `src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts`
- `src/lib/ai/sql/__tests__/query-database-guard.test.ts`
- `src/lib/ai/sql/__tests__/query-database-executor.test.ts`
- `src/lib/ai/sql/__tests__/query-database-audit.test.ts`

### Batch 2: DB Semantic Layer + Identity Foundation
Added repo-tracked artifacts only:
- migration for `ai_readonly` schema, fail-closed scope helpers, approved semantic views, and `ai_query_reader` grant role
- local-only smoke SQL for post-apply verification
- runbook for manual `ai_query_tool` login-role creation and `AI_DATABASE_URL`
- env contract in `.env.example`

Main files:
- `supabase/migrations/20260418120000_add_ai_readonly_semantic_layer_foundation.sql`
- `supabase/tests/assistant_sql_foundation_smoke.sql`
- `docs/ai/assistant-sql-foundation-runbook.md`
- `.env.example`

## Important Non-Goals In This PR
Explicitly not done here:
- no migration apply to linked DB
- no `get_advisors(security)` yet, because migration has not been applied
- no passworded login role creation in SQL migration
- no dormant executor/client TS implementation yet
- no audit RPC/helper yet
- no `/api/chat` registration of `query_database`

## Review Focus
Please review in this order:
1. **Batch 1 contracts**
   - does the PR sufficiently prove `#271` is still non-rollout?
   - are there any missing seams where `query_database` could leak early?
2. **Batch 2 DB foundation**
   - is `ai_readonly` the right semantic boundary?
   - do the fail-closed helpers around `app.current_facility_id` look correct?
   - are the chosen initial views aligned with current AI RPC surfaces?
   - are there any privilege/grant issues before migration apply?
3. **Roadmap fit**
   - does this still preserve the intended split:
     - `#271` foundation only
     - `#272` runtime rollout
     - `#273` planner hardening

## Verification Run
Repo-side verification completed:
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- focused `vitest` covering Batch 1 contract files
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `git diff --check`

DB-side verification intentionally **not run yet**:
- `supabase/tests/assistant_sql_foundation_smoke.sql`
- `get_advisors(security)`

Those wait until after explicit migration apply approval.

## Progress / Roadmap
### Completed
- Batch 1: lock scope and red/non-rollout contracts
- Batch 2: add repo-ready semantic-layer migration + smoke + runbook

### Next: Batch 3
Build the dormant executor and shared scope contract:
- add `src/lib/ai/sql/client.ts`, `constants.ts`, `guardrails.ts`, `executor.ts`
- add dormant `src/lib/ai/tools/query-database.ts`
- extract shared `AssistantSqlScope` contract from current `/api/chat` semantics
- keep tool unregistered in `/api/chat`

### Then: Batch 4
Add audit seam and final hardening:
- assistant SQL audit RPC/helper wrapping `public.audit_log(...)`
- sanitize and log execution metadata
- verify fail-closed audit behavior
- prove foundation remains dormant and ready for `#272`

## Notes For Reviewer
- This PR is intentionally a **draft** because the migration is not yet applied.
- If review agrees with the DB contract, the next operational step is a separate manual migration-apply checkpoint, not an automatic rollout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up a dormant, read-only SQL path for the assistant per #271. Locks non-rollout with contract tests and introduces the `ai_readonly` schema, fail-closed helpers, security-barrier views, grants, a runbook, and an `AI_DATABASE_URL` stub.

- **New Features**
  - Blocks `query_database`/`queryDatabase` and rejects `ai_query_database` across the RPC whitelist, tool→RPC mapping, query catalog, and registry allowlist; adds targeted tests.
  - Treats raw `admin` sessions as privileged for facility-scoped execution in `/api/chat`.
  - Adds unit test stubs for SQL guardrails, executor, and audit; adds the foundation plan doc.

- **Migration**
  - Adds `ai_readonly` with `current_facility_id()`/`require_single_facility_scope()` and security-barrier views: `equipment_search`, `maintenance_facts`, `repair_facts`, `usage_facts`, `quota_facts`; grants `ai_query_reader` read-only access.
  - Provides runbook for manual `ai_query_tool` login-role creation and `AI_DATABASE_URL` setup (Supabase transaction pooler `:6543`, SSL); updates `.env.example`; includes local smoke SQL for post-apply checks.
  - Repo-only migration; not applied. No `/api/chat` registration of `query_database`.

<sup>Written for commit 385bcaf6cc000e29317505ca9eb5a9477439943c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a runbook and a detailed implementation plan for a dormant, server-only SQL foundation for the assistant.

* **Chores**
  * Added an example environment DB connection entry.
  * Created a read-only semantic DB layer with facility-scoped access controls (dormant; not exposed to runtime).

* **Tests**
  * Added tests enforcing tool/RPC disallowlists and guardrails.
  * Added a local DB smoke-test script.

Note: This groundwork is not yet active in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->