### PR TITLE
feat: add issue 271 batch 3 dormant SQL executor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "lucide-react": "^0.475.0",
         "next": "^15.5.9",
         "next-auth": "^4.24.13",
+        "postgres": "^3.4.9",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -58,6 +59,7 @@
         "react-window": "^2.2.0",
         "recharts": "^2.15.1",
         "remark-gfm": "^4.0.1",
+        "server-only": "^0.0.1",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.24.2"
@@ -12180,6 +12182,19 @@
       "version": "4.2.0",
       "license": "MIT"
     },
+    "node_modules/postgres": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
+      "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
     "node_modules/preact": {
       "version": "10.28.2",
       "license": "MIT",
@@ -13031,6 +13046,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/serwist": {
       "version": "9.5.6",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lucide-react": "^0.475.0",
     "next": "^15.5.9",
     "next-auth": "^4.24.13",
+    "postgres": "^3.4.9",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
@@ -83,6 +84,7 @@
     "react-window": "^2.2.0",
     "recharts": "^2.15.1",
     "remark-gfm": "^4.0.1",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.2"

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -28,11 +28,12 @@ import { getChatModel, getKeyPoolSize, handleProviderQuotaError } from '@/lib/ai
 import { buildSystemPrompt } from '@/lib/ai/prompts/system'
 import type { SystemPromptContext } from '@/lib/ai/prompts/types'
 import { routeChatIntent } from '@/lib/ai/intent-routing'
+import { resolveAssistantScope } from '@/lib/ai/sql/scope'
 import { extractEquipmentLookupHints } from '@/lib/ai/tools/equipment-lookup-identifiers'
 import { buildToolRegistry, validateRequestedTools } from '@/lib/ai/tools/registry'
 import { checkUsageLimits, confirmUsage, recordUsage } from '@/lib/ai/usage-metering'
 import { isProviderQuotaError, sanitizeErrorForClient } from '@/lib/ai/errors'
-import { isPrivilegedRole, ROLES } from '@/lib/rbac'
+import { ROLES } from '@/lib/rbac'
 
 export const runtime = 'nodejs'
 export const maxDuration = 60
@@ -88,26 +89,6 @@ function hasAllowedChatRole(value: unknown): boolean {
   }
 
   return ALLOWED_CHAT_ROLES.has(value.trim().toLowerCase())
-}
-
-function toFacilityId(value: unknown): number | undefined {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value
-  }
-
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) {
-      return undefined
-    }
-
-    const parsed = Number(trimmed)
-    if (Number.isFinite(parsed)) {
-      return parsed
-    }
-  }
-
-  return undefined
 }
 
 export async function POST(request: Request) {
@@ -170,30 +151,19 @@ export async function POST(request: Request) {
   }
 
   const role = typeof user.role === 'string' ? user.role : undefined
-  const sessionFacilityId = toFacilityId(user.don_vi)
-  const requestedFacilityId = parsedRequest.data.selectedFacilityId
-  let selectedFacilityId = sessionFacilityId
-
-  if (isPrivilegedRole(role)) {
-    if (effectiveRequestedTools.length > 0 && requestedFacilityId === undefined) {
-      return plainError(
-        'Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.',
-        400,
-      )
-    }
-    if (requestedFacilityId !== undefined) {
-      selectedFacilityId = requestedFacilityId
-    }
+  const scopeResolution = resolveAssistantScope({
+    user,
+    requestedFacilityId: parsedRequest.data.selectedFacilityId,
+    requireFacilityScope: effectiveRequestedTools.length > 0,
+  })
+  if (!scopeResolution.ok) {
+    return plainError(scopeResolution.message, 400)
   }
-
-  if (effectiveRequestedTools.length > 0 && selectedFacilityId === undefined) {
-    return plainError('Unable to resolve facility context for tool execution.', 400)
-  }
-  const promptUserId =
-    typeof user.id === 'string' || typeof user.id === 'number'
-      ? String(user.id)
-      : undefined
-  const usageUserId = promptUserId ?? 'unknown-session'
+  const {
+    promptUserId,
+    selectedFacilityId,
+    usageUserId,
+  } = scopeResolution
   const usageLimit = checkUsageLimits({
     userId: usageUserId,
     tenantId: selectedFacilityId,

--- a/src/lib/ai/sql/__tests__/query-database-dormant.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-dormant.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { POST as rpcPost } from '@/app/api/rpc/[fn]/route'
+import { QUERY_DATABASE_TOOL_NAME } from '@/lib/ai/tools/query-database'
+import { getAllowedToolNamesForTest, getToolRpcMapping, validateRequestedTools } from '@/lib/ai/tools/registry'
+
+async function invokeRpcProxy(fn: string) {
+  const req = new Request(`http://localhost/api/rpc/${fn}`, { method: 'POST' })
+  return rpcPost(req as never, { params: Promise.resolve({ fn }) })
+}
+
+describe('query_database dormant Batch 3 contract', () => {
+  it('defines the dormant tool name without adding it to the assistant registry', () => {
+    expect(QUERY_DATABASE_TOOL_NAME).toBe('query_database')
+    expect(getAllowedToolNamesForTest()).not.toContain(QUERY_DATABASE_TOOL_NAME)
+    expect(validateRequestedTools([QUERY_DATABASE_TOOL_NAME])).toEqual({
+      ok: false,
+      message: 'Unknown tool requested: query_database',
+    })
+  })
+
+  it('does not expose SQL execution through the RPC proxy mapping', async () => {
+    expect(getToolRpcMapping()).not.toHaveProperty(QUERY_DATABASE_TOOL_NAME)
+    expect(Object.values(getToolRpcMapping())).not.toContain('ai_query_database')
+
+    const res = await invokeRpcProxy('ai_query_database')
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Function not allowed' })
+  })
+})

--- a/src/lib/ai/sql/__tests__/query-database-executor.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-executor.test.ts
@@ -1,7 +1,143 @@
-import { describe, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+import { AssistantSqlError } from '../errors'
+import { executeAssistantSql, type AssistantSqlDb } from '../executor'
+import type { AssistantSqlScope } from '../scope'
+
+const scope: AssistantSqlScope = {
+  effectiveFacilityId: 2,
+  facilitySource: 'session',
+  normalizedRole: 'technician',
+  rawRole: 'technician',
+  sessionFacilityId: 2,
+  selectedFacilityId: undefined,
+  userId: 'u1',
+}
+
+function createDb(rows: Array<Record<string, unknown>>): {
+  db: AssistantSqlDb
+  settings: Array<{ name: string; value: string }>
+  statements: string[]
+} {
+  const settings: Array<{ name: string; value: string }> = []
+  const statements: string[] = []
+  const db: AssistantSqlDb = {
+    begin: async callback =>
+      callback({
+        setLocal: async (name, value) => {
+          settings.push({ name, value })
+        },
+        unsafe: async statement => {
+          statements.push(statement)
+          return rows
+        },
+      }),
+  }
+
+  return { db, settings, statements }
+}
+
+async function expectAssistantSqlError(
+  action: () => Promise<unknown>,
+  code: string,
+) {
+  await expect(action()).rejects.toBeInstanceOf(AssistantSqlError)
+  try {
+    await action()
+  } catch (error) {
+    expect(error).toBeInstanceOf(AssistantSqlError)
+    expect((error as AssistantSqlError).code).toBe(code)
+  }
+}
 
 describe('query_database executor contract', () => {
-  it.todo('applies transaction-local settings for timeout and search_path')
-  it.todo('requires server-injected single-facility scope before execution')
-  it.todo('keeps the tool dormant and unreachable from /api/chat in Batch 1')
+  it('applies transaction-local settings for timeout, search_path, and facility scope', async () => {
+    const { db, settings, statements } = createDb([{ equipment_id: 1 }])
+
+    const result = await executeAssistantSql({
+      db,
+      scope,
+      sql: 'select equipment_id from ai_readonly.equipment_search',
+    })
+
+    expect(result).toEqual({
+      rowCount: 1,
+      rows: [{ equipment_id: 1 }],
+      payloadBytes: expect.any(Number),
+      sqlShape: 'select equipment_id from ai_readonly.equipment_search',
+    })
+    expect(settings).toEqual([
+      { name: 'statement_timeout', value: '5000ms' },
+      { name: 'search_path', value: 'ai_readonly, pg_catalog' },
+      { name: 'app.current_role', value: 'technician' },
+      { name: 'app.current_user_id', value: 'u1' },
+      { name: 'app.current_facility_id', value: '2' },
+    ])
+    expect(statements).toEqual([
+      'select * from (select equipment_id from ai_readonly.equipment_search) as assistant_sql_result limit 101',
+    ])
+  })
+
+  it('requires server-injected single-facility scope before execution', async () => {
+    const { db } = createDb([])
+
+    await expectAssistantSqlError(
+      () =>
+        executeAssistantSql({
+          db,
+          scope: undefined as unknown as AssistantSqlScope,
+          sql: 'select 1',
+        }),
+      'scope_required',
+    )
+  })
+
+  it('maps row and payload limits to safe error classes', async () => {
+    const tooManyRows = Array.from({ length: 101 }, (_, index) => ({ id: index + 1 }))
+    await expectAssistantSqlError(
+      () =>
+        executeAssistantSql({
+          db: createDb(tooManyRows).db,
+          scope,
+          sql: 'select id from ai_readonly.equipment_search',
+        }),
+      'row_limit_exceeded',
+    )
+
+    await expectAssistantSqlError(
+      () =>
+        executeAssistantSql({
+          db: createDb([{ value: 'x'.repeat(65 * 1024) }]).db,
+          scope,
+          sql: 'select value from ai_readonly.equipment_search',
+        }),
+      'payload_limit_exceeded',
+    )
+  })
+
+  it('maps database statement timeout failures to a safe error class', async () => {
+    const db: AssistantSqlDb = {
+      begin: async callback =>
+        callback({
+          setLocal: async () => {},
+          unsafe: async () => {
+            throw Object.assign(new Error('canceling statement due to statement timeout'), {
+              code: '57014',
+            })
+          },
+        }),
+    }
+
+    await expectAssistantSqlError(
+      () =>
+        executeAssistantSql({
+          db,
+          scope,
+          sql: 'select 1',
+        }),
+      'timeout',
+    )
+  })
 })

--- a/src/lib/ai/sql/__tests__/query-database-executor.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-executor.test.ts
@@ -11,8 +11,8 @@ const scope: AssistantSqlScope = {
   facilitySource: 'session',
   normalizedRole: 'technician',
   rawRole: 'technician',
+  requestedFacilityId: undefined,
   sessionFacilityId: 2,
-  selectedFacilityId: undefined,
   userId: 'u1',
 }
 
@@ -43,7 +43,6 @@ async function expectAssistantSqlError(
   action: () => Promise<unknown>,
   code: string,
 ) {
-  await expect(action()).rejects.toBeInstanceOf(AssistantSqlError)
   try {
     await action()
   } catch (error) {

--- a/src/lib/ai/sql/__tests__/query-database-executor.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-executor.test.ts
@@ -48,10 +48,19 @@ async function expectAssistantSqlError(
   } catch (error) {
     expect(error).toBeInstanceOf(AssistantSqlError)
     expect((error as AssistantSqlError).code).toBe(code)
+    return
   }
+
+  throw new Error(`Expected AssistantSqlError with code '${code}'`)
 }
 
 describe('query_database executor contract', () => {
+  it('fails the assertion helper when no assistant SQL error is thrown', async () => {
+    await expect(
+      expectAssistantSqlError(async () => undefined, 'scope_required'),
+    ).rejects.toThrow('Expected AssistantSqlError')
+  })
+
   it('applies transaction-local settings for timeout, search_path, and facility scope', async () => {
     const { db, settings, statements } = createDb([{ equipment_id: 1 }])
 

--- a/src/lib/ai/sql/__tests__/query-database-guard.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-guard.test.ts
@@ -82,4 +82,17 @@ describe('query_database guardrails contract', () => {
   it('rejects PostgreSQL E-strings instead of parsing backslash escapes', () => {
     expectSqlError("select E'x\\'' from public.thiet_bi", 'invalid_statement')
   })
+
+  it('does not reject plain string literals that contain E-quote text', () => {
+    expect(
+      validateAssistantSql(
+        "select 'contains E'' marker' as note from ai_readonly.equipment_search",
+      ),
+    ).toEqual({
+      statement:
+        "select 'contains E'' marker' as note from ai_readonly.equipment_search",
+      sqlShape:
+        "select 'contains E'' marker' as note from ai_readonly.equipment_search",
+    })
+  })
 })

--- a/src/lib/ai/sql/__tests__/query-database-guard.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-guard.test.ts
@@ -1,9 +1,60 @@
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
+
+import { AssistantSqlError } from '../errors'
+import { validateAssistantSql } from '../guardrails'
+
+function expectSqlError(sql: string, code: string) {
+  expect(() => validateAssistantSql(sql)).toThrow(AssistantSqlError)
+  try {
+    validateAssistantSql(sql)
+  } catch (error) {
+    expect(error).toBeInstanceOf(AssistantSqlError)
+    expect((error as AssistantSqlError).code).toBe(code)
+    return
+  }
+
+  throw new Error('Expected SQL validation to fail')
+}
 
 describe('query_database guardrails contract', () => {
-  it.todo('rejects multi-statement SQL before execution')
-  it.todo('rejects statements outside SELECT / WITH ... SELECT')
-  it.todo('rejects forbidden schema access outside ai_readonly')
-  it.todo('rejects comment-obfuscated mutation attempts')
-  it.todo('maps timeout, row, and payload limits to safe error classes')
+  it('normalizes a single SELECT statement for execution', () => {
+    expect(validateAssistantSql(' select equipment_id from ai_readonly.equipment_search; ')).toEqual({
+      statement: 'select equipment_id from ai_readonly.equipment_search',
+      sqlShape: 'select equipment_id from ai_readonly.equipment_search',
+    })
+  })
+
+  it('allows WITH queries that resolve to SELECT', () => {
+    expect(
+      validateAssistantSql(`
+        with recent_repairs as (
+          select equipment_id from ai_readonly.repair_facts limit 5
+        )
+        select equipment_id from recent_repairs
+      `).statement,
+    ).toMatch(/^with recent_repairs as/i)
+  })
+
+  it('rejects multi-statement SQL before execution', () => {
+    expectSqlError('select 1; select 2', 'invalid_statement')
+    expectSqlError("select ';'; select 2", 'invalid_statement')
+  })
+
+  it('rejects statements outside SELECT / WITH ... SELECT', () => {
+    expectSqlError('update ai_readonly.equipment_search set status = null', 'invalid_statement')
+    expectSqlError('explain analyze select 1', 'invalid_statement')
+    expectSqlError('copy ai_readonly.equipment_search to stdout', 'invalid_statement')
+  })
+
+  it('rejects forbidden schema access outside ai_readonly', () => {
+    expectSqlError('select id from public.thiet_bi', 'forbidden_schema')
+    expectSqlError('select id from auth.users', 'forbidden_schema')
+    expectSqlError('select pg_catalog.set_config(\'app.current_facility_id\', \'2\', true)', 'forbidden_function')
+  })
+
+  it('rejects comment-obfuscated mutation attempts', () => {
+    expectSqlError('select 1 /* hidden update public.users */', 'forbidden_keyword')
+    expectSqlError('with x as (delete from ai_readonly.equipment_search returning *) select * from x', 'forbidden_keyword')
+    expectSqlError('select 1 where set_config(\'app.current_facility_id\', \'2\', true) is not null', 'forbidden_function')
+  })
 })

--- a/src/lib/ai/sql/__tests__/query-database-guard.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-guard.test.ts
@@ -4,7 +4,6 @@ import { AssistantSqlError } from '../errors'
 import { validateAssistantSql } from '../guardrails'
 
 function expectSqlError(sql: string, code: string) {
-  expect(() => validateAssistantSql(sql)).toThrow(AssistantSqlError)
   try {
     validateAssistantSql(sql)
   } catch (error) {
@@ -21,6 +20,19 @@ describe('query_database guardrails contract', () => {
     expect(validateAssistantSql(' select equipment_id from ai_readonly.equipment_search; ')).toEqual({
       statement: 'select equipment_id from ai_readonly.equipment_search',
       sqlShape: 'select equipment_id from ai_readonly.equipment_search',
+    })
+  })
+
+  it('allows table aliases while enforcing ai_readonly table references', () => {
+    expect(
+      validateAssistantSql(
+        'select equipment.equipment_id from ai_readonly.equipment_search equipment',
+      ),
+    ).toEqual({
+      statement:
+        'select equipment.equipment_id from ai_readonly.equipment_search equipment',
+      sqlShape:
+        'select equipment.equipment_id from ai_readonly.equipment_search equipment',
     })
   })
 
@@ -49,12 +61,21 @@ describe('query_database guardrails contract', () => {
   it('rejects forbidden schema access outside ai_readonly', () => {
     expectSqlError('select id from public.thiet_bi', 'forbidden_schema')
     expectSqlError('select id from auth.users', 'forbidden_schema')
+    expectSqlError('select id from some_other_schema.equipment', 'forbidden_schema')
     expectSqlError('select pg_catalog.set_config(\'app.current_facility_id\', \'2\', true)', 'forbidden_function')
   })
 
   it('rejects comment-obfuscated mutation attempts', () => {
     expectSqlError('select 1 /* hidden update public.users */', 'forbidden_keyword')
+    expectSqlError(
+      "select * from ai_readonly.equipment_search --'\nwhere set_config('app.current_facility_id', '2', true) is not null",
+      'forbidden_function',
+    )
     expectSqlError('with x as (delete from ai_readonly.equipment_search returning *) select * from x', 'forbidden_keyword')
     expectSqlError('select 1 where set_config(\'app.current_facility_id\', \'2\', true) is not null', 'forbidden_function')
+  })
+
+  it('rejects dollar-quoted strings instead of trying to parse them', () => {
+    expectSqlError("select $$'$$ || set_config('app.current_facility_id', '2', true)", 'invalid_statement')
   })
 })

--- a/src/lib/ai/sql/__tests__/query-database-guard.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-guard.test.ts
@@ -78,4 +78,8 @@ describe('query_database guardrails contract', () => {
   it('rejects dollar-quoted strings instead of trying to parse them', () => {
     expectSqlError("select $$'$$ || set_config('app.current_facility_id', '2', true)", 'invalid_statement')
   })
+
+  it('rejects PostgreSQL E-strings instead of parsing backslash escapes', () => {
+    expectSqlError("select E'x\\'' from public.thiet_bi", 'invalid_statement')
+  })
 })

--- a/src/lib/ai/sql/__tests__/scope.test.ts
+++ b/src/lib/ai/sql/__tests__/scope.test.ts
@@ -23,8 +23,8 @@ describe('AssistantSqlScope resolver', () => {
         facilitySource: 'session',
         normalizedRole: 'technician',
         rawRole: 'technician',
+        requestedFacilityId: 999,
         sessionFacilityId: 2,
-        selectedFacilityId: 999,
         userId: 'u1',
       },
     })
@@ -58,7 +58,7 @@ describe('AssistantSqlScope resolver', () => {
           effectiveFacilityId: 7,
           facilitySource: 'selected',
           normalizedRole: 'regional_leader',
-          selectedFacilityId: 7,
+          requestedFacilityId: 7,
           userId: 'u1',
         }),
       }),
@@ -98,6 +98,30 @@ describe('AssistantSqlScope resolver', () => {
       usageUserId: 'u1',
       selectedFacilityId: undefined,
       assistantSqlScope: undefined,
+    })
+  })
+
+  it('keeps the session facility for privileged no-tool chat when one exists', () => {
+    const result = resolveAssistantScope({
+      user: { id: 'u1', role: 'admin', don_vi: 3 },
+      requestedFacilityId: undefined,
+      requireFacilityScope: false,
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      promptUserId: 'u1',
+      usageUserId: 'u1',
+      selectedFacilityId: 3,
+      assistantSqlScope: {
+        effectiveFacilityId: 3,
+        facilitySource: 'session',
+        normalizedRole: 'global',
+        rawRole: 'admin',
+        requestedFacilityId: undefined,
+        sessionFacilityId: 3,
+        userId: 'u1',
+      },
     })
   })
 })

--- a/src/lib/ai/sql/__tests__/scope.test.ts
+++ b/src/lib/ai/sql/__tests__/scope.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveAssistantScope } from '../scope'
+
+const FACILITY_REQUIRED_MESSAGE =
+  'Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.'
+
+describe('AssistantSqlScope resolver', () => {
+  it('pins non-privileged roles to the session facility and ignores selected facility overrides', () => {
+    const result = resolveAssistantScope({
+      user: { id: 'u1', role: 'technician', don_vi: 2 },
+      requestedFacilityId: 999,
+      requireFacilityScope: true,
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      promptUserId: 'u1',
+      usageUserId: 'u1',
+      selectedFacilityId: 2,
+      assistantSqlScope: {
+        effectiveFacilityId: 2,
+        facilitySource: 'session',
+        normalizedRole: 'technician',
+        rawRole: 'technician',
+        sessionFacilityId: 2,
+        selectedFacilityId: 999,
+        userId: 'u1',
+      },
+    })
+  })
+
+  it('requires privileged roles to choose a facility before scoped tool execution', () => {
+    const result = resolveAssistantScope({
+      user: { id: 'u1', role: 'global', don_vi: null },
+      requestedFacilityId: undefined,
+      requireFacilityScope: true,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      message: FACILITY_REQUIRED_MESSAGE,
+    })
+  })
+
+  it('uses selected facility provenance for privileged roles', () => {
+    const result = resolveAssistantScope({
+      user: { id: 'u1', role: 'regional_leader', don_vi: null },
+      requestedFacilityId: 7,
+      requireFacilityScope: true,
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        selectedFacilityId: 7,
+        assistantSqlScope: expect.objectContaining({
+          effectiveFacilityId: 7,
+          facilitySource: 'selected',
+          normalizedRole: 'regional_leader',
+          selectedFacilityId: 7,
+          userId: 'u1',
+        }),
+      }),
+    )
+  })
+
+  it('normalizes raw admin sessions to global semantics without losing raw role', () => {
+    const result = resolveAssistantScope({
+      user: { id: 'u1', role: 'admin', don_vi: null },
+      requestedFacilityId: 11,
+      requireFacilityScope: true,
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        selectedFacilityId: 11,
+        assistantSqlScope: expect.objectContaining({
+          effectiveFacilityId: 11,
+          normalizedRole: 'global',
+          rawRole: 'admin',
+        }),
+      }),
+    )
+  })
+
+  it('does not require a facility when no scoped tool execution is requested', () => {
+    const result = resolveAssistantScope({
+      user: { id: 'u1', role: 'global', don_vi: null },
+      requestedFacilityId: undefined,
+      requireFacilityScope: false,
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      promptUserId: 'u1',
+      usageUserId: 'u1',
+      selectedFacilityId: undefined,
+      assistantSqlScope: undefined,
+    })
+  })
+})

--- a/src/lib/ai/sql/__tests__/scope.test.ts
+++ b/src/lib/ai/sql/__tests__/scope.test.ts
@@ -65,6 +65,19 @@ describe('AssistantSqlScope resolver', () => {
     )
   })
 
+  it('rejects invalid privileged selected facility overrides before tool execution', () => {
+    const result = resolveAssistantScope({
+      user: { id: 'u1', role: 'global', don_vi: null },
+      requestedFacilityId: Number.NaN,
+      requireFacilityScope: true,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      message: FACILITY_REQUIRED_MESSAGE,
+    })
+  })
+
   it('normalizes raw admin sessions to global semantics without losing raw role', () => {
     const result = resolveAssistantScope({
       user: { id: 'u1', role: 'admin', don_vi: null },

--- a/src/lib/ai/sql/client.ts
+++ b/src/lib/ai/sql/client.ts
@@ -53,7 +53,7 @@ function wrapTransaction(tx: PostgresTransaction): AssistantSqlTransaction {
 export function getAssistantSqlDb(): AssistantSqlDb {
   return {
     begin: async callback => {
-      const [result] = await getClient().begin(async tx => [
+      const [result] = await getClient().begin('read only', async tx => [
         await callback(wrapTransaction(tx)),
       ])
       return result

--- a/src/lib/ai/sql/client.ts
+++ b/src/lib/ai/sql/client.ts
@@ -1,0 +1,62 @@
+import 'server-only'
+
+import postgres from 'postgres'
+
+import type { AssistantSqlDb, AssistantSqlTransaction } from './executor'
+import { AssistantSqlError } from './errors'
+
+type PostgresClient = ReturnType<typeof postgres>
+type PostgresTransaction = postgres.TransactionSql<Record<string, unknown>>
+
+const globalForAssistantSql = globalThis as typeof globalThis & {
+  __assistantSqlClient?: PostgresClient
+}
+
+function createAssistantSqlClient(): PostgresClient {
+  const databaseUrl = process.env.AI_DATABASE_URL
+  if (!databaseUrl) {
+    throw new AssistantSqlError(
+      'configuration_error',
+      'AI_DATABASE_URL is required for assistant SQL execution.',
+    )
+  }
+
+  return postgres(databaseUrl, {
+    connect_timeout: 10,
+    idle_timeout: 5,
+    max: 1,
+    prepare: false,
+    ssl: 'require',
+  })
+}
+
+function getClient(): PostgresClient {
+  if (globalForAssistantSql.__assistantSqlClient === undefined) {
+    globalForAssistantSql.__assistantSqlClient = createAssistantSqlClient()
+  }
+
+  return globalForAssistantSql.__assistantSqlClient
+}
+
+function wrapTransaction(tx: PostgresTransaction): AssistantSqlTransaction {
+  return {
+    setLocal: async (name, value) => {
+      await tx`select set_config(${name}, ${value}, true)`
+    },
+    unsafe: async statement => {
+      const rows = await tx.unsafe<Array<Record<string, unknown>>>(statement)
+      return [...rows] as Array<Record<string, unknown>>
+    },
+  }
+}
+
+export function getAssistantSqlDb(): AssistantSqlDb {
+  return {
+    begin: async callback => {
+      const [result] = await getClient().begin(async tx => [
+        await callback(wrapTransaction(tx)),
+      ])
+      return result
+    },
+  }
+}

--- a/src/lib/ai/sql/constants.ts
+++ b/src/lib/ai/sql/constants.ts
@@ -1,0 +1,6 @@
+export const ASSISTANT_SQL_STATEMENT_TIMEOUT_MS = 5_000
+export const ASSISTANT_SQL_MAX_ROWS = 100
+export const ASSISTANT_SQL_MAX_PAYLOAD_BYTES = 64 * 1024
+export const ASSISTANT_SQL_SEARCH_PATH = 'ai_readonly, pg_catalog'
+export const ASSISTANT_SQL_TOOL_NAME = 'query_database'
+

--- a/src/lib/ai/sql/errors.ts
+++ b/src/lib/ai/sql/errors.ts
@@ -1,0 +1,26 @@
+export type AssistantSqlErrorCode =
+  | 'configuration_error'
+  | 'execution_error'
+  | 'forbidden_function'
+  | 'forbidden_keyword'
+  | 'forbidden_schema'
+  | 'invalid_statement'
+  | 'payload_limit_exceeded'
+  | 'row_limit_exceeded'
+  | 'scope_required'
+  | 'timeout'
+
+export class AssistantSqlError extends Error {
+  readonly code: AssistantSqlErrorCode
+
+  constructor(code: AssistantSqlErrorCode, message: string) {
+    super(message)
+    this.name = 'AssistantSqlError'
+    this.code = code
+  }
+}
+
+export function isAssistantSqlError(error: unknown): error is AssistantSqlError {
+  return error instanceof AssistantSqlError
+}
+

--- a/src/lib/ai/sql/executor.ts
+++ b/src/lib/ai/sql/executor.ts
@@ -1,0 +1,121 @@
+import { Buffer } from 'node:buffer'
+
+import { ASSISTANT_SQL_MAX_PAYLOAD_BYTES, ASSISTANT_SQL_MAX_ROWS, ASSISTANT_SQL_SEARCH_PATH, ASSISTANT_SQL_STATEMENT_TIMEOUT_MS } from './constants'
+import { getAssistantSqlDb } from './client'
+import { AssistantSqlError, isAssistantSqlError } from './errors'
+import { validateAssistantSql } from './guardrails'
+import type { AssistantSqlScope } from './scope'
+
+export interface AssistantSqlTransaction {
+  setLocal(name: string, value: string): Promise<void>
+  unsafe(statement: string): Promise<Array<Record<string, unknown>>>
+}
+
+export interface AssistantSqlDb {
+  begin(
+    callback: (tx: AssistantSqlTransaction) => Promise<Array<Record<string, unknown>>>,
+  ): Promise<Array<Record<string, unknown>>>
+}
+
+export interface ExecuteAssistantSqlParams {
+  db?: AssistantSqlDb
+  maxPayloadBytes?: number
+  maxRows?: number
+  scope: AssistantSqlScope
+  sql: string
+}
+
+export interface AssistantSqlResult {
+  payloadBytes: number
+  rowCount: number
+  rows: Array<Record<string, unknown>>
+  sqlShape: string
+}
+
+function assertScope(scope: AssistantSqlScope | undefined): AssistantSqlScope {
+  if (
+    scope === undefined ||
+    !Number.isFinite(scope.effectiveFacilityId) ||
+    !scope.userId
+  ) {
+    throw new AssistantSqlError(
+      'scope_required',
+      'Server-injected assistant SQL scope is required.',
+    )
+  }
+
+  return scope
+}
+
+function mapExecutionError(error: unknown): AssistantSqlError {
+  if (isAssistantSqlError(error)) {
+    return error
+  }
+
+  const errorRecord = error as { code?: unknown; message?: unknown }
+  const code = typeof errorRecord.code === 'string' ? errorRecord.code : undefined
+  const message = typeof errorRecord.message === 'string' ? errorRecord.message : ''
+
+  if (code === '57014' || /statement timeout/i.test(message)) {
+    return new AssistantSqlError('timeout', 'Assistant SQL query timed out.')
+  }
+
+  return new AssistantSqlError('execution_error', 'Assistant SQL query failed.')
+}
+
+function buildLimitedStatement(statement: string, maxRows: number): string {
+  return `select * from (${statement}) as assistant_sql_result limit ${maxRows + 1}`
+}
+
+async function applyTransactionSettings(
+  tx: AssistantSqlTransaction,
+  scope: AssistantSqlScope,
+) {
+  await tx.setLocal('statement_timeout', `${ASSISTANT_SQL_STATEMENT_TIMEOUT_MS}ms`)
+  await tx.setLocal('search_path', ASSISTANT_SQL_SEARCH_PATH)
+  await tx.setLocal('app.current_role', scope.normalizedRole ?? scope.rawRole ?? 'unknown')
+  await tx.setLocal('app.current_user_id', scope.userId)
+  await tx.setLocal('app.current_facility_id', String(scope.effectiveFacilityId))
+}
+
+export async function executeAssistantSql({
+  db = getAssistantSqlDb(),
+  maxPayloadBytes = ASSISTANT_SQL_MAX_PAYLOAD_BYTES,
+  maxRows = ASSISTANT_SQL_MAX_ROWS,
+  scope,
+  sql,
+}: ExecuteAssistantSqlParams): Promise<AssistantSqlResult> {
+  const resolvedScope = assertScope(scope)
+  const validated = validateAssistantSql(sql)
+
+  try {
+    const rows = await db.begin(async tx => {
+      await applyTransactionSettings(tx, resolvedScope)
+      return tx.unsafe(buildLimitedStatement(validated.statement, maxRows))
+    })
+
+    if (rows.length > maxRows) {
+      throw new AssistantSqlError(
+        'row_limit_exceeded',
+        'Assistant SQL query returned too many rows.',
+      )
+    }
+
+    const payloadBytes = Buffer.byteLength(JSON.stringify(rows), 'utf8')
+    if (payloadBytes > maxPayloadBytes) {
+      throw new AssistantSqlError(
+        'payload_limit_exceeded',
+        'Assistant SQL query returned too much data.',
+      )
+    }
+
+    return {
+      payloadBytes,
+      rowCount: rows.length,
+      rows,
+      sqlShape: validated.sqlShape,
+    }
+  } catch (error) {
+    throw mapExecutionError(error)
+  }
+}

--- a/src/lib/ai/sql/executor.ts
+++ b/src/lib/ai/sql/executor.ts
@@ -1,6 +1,11 @@
 import { Buffer } from 'node:buffer'
 
-import { ASSISTANT_SQL_MAX_PAYLOAD_BYTES, ASSISTANT_SQL_MAX_ROWS, ASSISTANT_SQL_SEARCH_PATH, ASSISTANT_SQL_STATEMENT_TIMEOUT_MS } from './constants'
+import {
+  ASSISTANT_SQL_MAX_PAYLOAD_BYTES,
+  ASSISTANT_SQL_MAX_ROWS,
+  ASSISTANT_SQL_SEARCH_PATH,
+  ASSISTANT_SQL_STATEMENT_TIMEOUT_MS,
+} from './constants'
 import { getAssistantSqlDb } from './client'
 import { AssistantSqlError, isAssistantSqlError } from './errors'
 import { validateAssistantSql } from './guardrails'
@@ -67,6 +72,29 @@ function buildLimitedStatement(statement: string, maxRows: number): string {
   return `select * from (${statement}) as assistant_sql_result limit ${maxRows + 1}`
 }
 
+function measurePayloadBytes(
+  rows: Array<Record<string, unknown>>,
+  maxPayloadBytes: number,
+): number {
+  let payloadBytes = Buffer.byteLength('[', 'utf8')
+
+  for (const [index, row] of rows.entries()) {
+    if (index > 0) {
+      payloadBytes += Buffer.byteLength(',', 'utf8')
+    }
+
+    payloadBytes += Buffer.byteLength(JSON.stringify(row), 'utf8')
+    if (payloadBytes + Buffer.byteLength(']', 'utf8') > maxPayloadBytes) {
+      throw new AssistantSqlError(
+        'payload_limit_exceeded',
+        'Assistant SQL query returned too much data.',
+      )
+    }
+  }
+
+  return payloadBytes + Buffer.byteLength(']', 'utf8')
+}
+
 async function applyTransactionSettings(
   tx: AssistantSqlTransaction,
   scope: AssistantSqlScope,
@@ -101,13 +129,7 @@ export async function executeAssistantSql({
       )
     }
 
-    const payloadBytes = Buffer.byteLength(JSON.stringify(rows), 'utf8')
-    if (payloadBytes > maxPayloadBytes) {
-      throw new AssistantSqlError(
-        'payload_limit_exceeded',
-        'Assistant SQL query returned too much data.',
-      )
-    }
+    const payloadBytes = measurePayloadBytes(rows, maxPayloadBytes)
 
     return {
       payloadBytes,

--- a/src/lib/ai/sql/guardrails.ts
+++ b/src/lib/ai/sql/guardrails.ts
@@ -25,7 +25,9 @@ const FORBIDDEN_KEYWORDS = [
   'vacuum',
 ] as const
 
-const FORBIDDEN_SCHEMAS = [
+const ALLOWED_SCHEMA = 'ai_readonly'
+
+const KNOWN_FORBIDDEN_SCHEMAS = [
   'auth',
   'extensions',
   'graphql_public',
@@ -37,10 +39,40 @@ const FORBIDDEN_SCHEMAS = [
 ] as const
 
 const FORBIDDEN_FUNCTIONS = ['set_config'] as const
+const DOLLAR_QUOTED_STRING_PATTERN = /\$[A-Za-z_][\w$]*\$|\$\$/
+const FORBIDDEN_KEYWORD_PATTERN = new RegExp(
+  String.raw`\b(?:${FORBIDDEN_KEYWORDS.join('|')})\b`,
+  'i',
+)
+const FORBIDDEN_FUNCTION_PATTERN = new RegExp(
+  String.raw`\b(?:${FORBIDDEN_FUNCTIONS.join('|')})\s*\(`,
+  'i',
+)
+const KNOWN_FORBIDDEN_SCHEMA_PATTERN = new RegExp(
+  String.raw`\b(?:${KNOWN_FORBIDDEN_SCHEMAS.join('|')})\s*\.`,
+  'i',
+)
+const TABLE_REFERENCE_SCHEMA_PATTERN =
+  /\b(?:from|join)\s+([A-Za-z_][\w$]*)\s*\./gi
+const FUNCTION_SCHEMA_PATTERN = /\b([A-Za-z_][\w$]*)\s*\.\s*[A-Za-z_][\w$]*\s*\(/gi
 
 export interface ValidatedAssistantSql {
   statement: string
   sqlShape: string
+}
+
+function extractCommentText(sql: string): string {
+  const comments: string[] = []
+
+  for (const match of sql.matchAll(/\/\*([\s\S]*?)\*\//g)) {
+    comments.push(match[1] ?? '')
+  }
+
+  for (const match of sql.matchAll(/--([^\n\r]*)/g)) {
+    comments.push(match[1] ?? '')
+  }
+
+  return comments.join(' ')
 }
 
 function stripComments(sql: string): string {
@@ -93,6 +125,15 @@ function countSemicolons(sql: string): number {
   return (sql.match(/;/g) ?? []).length
 }
 
+function assertNoDollarQuotedStrings(sql: string) {
+  if (DOLLAR_QUOTED_STRING_PATTERN.test(sql)) {
+    throw new AssistantSqlError(
+      'invalid_statement',
+      'Dollar-quoted strings are not allowed.',
+    )
+  }
+}
+
 function assertSingleStatement(normalized: string, masked: string) {
   const semicolonCount = countSemicolons(masked)
   if (semicolonCount > 1 || (semicolonCount === 1 && !normalized.endsWith(';'))) {
@@ -113,21 +154,33 @@ function assertSelectOnly(statement: string) {
 }
 
 function assertNoForbiddenKeywords(maskedStatement: string) {
-  for (const keyword of FORBIDDEN_KEYWORDS) {
-    const keywordPattern = new RegExp(`\\b${keyword}\\b`, 'i')
-    if (keywordPattern.test(maskedStatement)) {
-      throw new AssistantSqlError(
-        'forbidden_keyword',
-        'Forbidden SQL keyword detected.',
-      )
-    }
+  if (FORBIDDEN_KEYWORD_PATTERN.test(maskedStatement)) {
+    throw new AssistantSqlError(
+      'forbidden_keyword',
+      'Forbidden SQL keyword detected.',
+    )
   }
 }
 
 function assertNoForbiddenSchemas(maskedStatement: string) {
-  for (const schema of FORBIDDEN_SCHEMAS) {
-    const schemaPattern = new RegExp(`\\b${schema}\\s*\\.`, 'i')
-    if (schemaPattern.test(maskedStatement)) {
+  if (KNOWN_FORBIDDEN_SCHEMA_PATTERN.test(maskedStatement)) {
+    throw new AssistantSqlError(
+      'forbidden_schema',
+      'Only the ai_readonly schema is queryable.',
+    )
+  }
+
+  for (const match of maskedStatement.matchAll(TABLE_REFERENCE_SCHEMA_PATTERN)) {
+    if (match[1]?.toLowerCase() !== ALLOWED_SCHEMA) {
+      throw new AssistantSqlError(
+        'forbidden_schema',
+        'Only the ai_readonly schema is queryable.',
+      )
+    }
+  }
+
+  for (const match of maskedStatement.matchAll(FUNCTION_SCHEMA_PATTERN)) {
+    if (match[1]?.toLowerCase() !== ALLOWED_SCHEMA) {
       throw new AssistantSqlError(
         'forbidden_schema',
         'Only the ai_readonly schema is queryable.',
@@ -137,22 +190,21 @@ function assertNoForbiddenSchemas(maskedStatement: string) {
 }
 
 function assertNoForbiddenFunctions(maskedStatement: string) {
-  for (const functionName of FORBIDDEN_FUNCTIONS) {
-    const functionPattern = new RegExp(`\\b${functionName}\\s*\\(`, 'i')
-    if (functionPattern.test(maskedStatement)) {
-      throw new AssistantSqlError(
-        'forbidden_function',
-        'Forbidden SQL function detected.',
-      )
-    }
+  if (FORBIDDEN_FUNCTION_PATTERN.test(maskedStatement)) {
+    throw new AssistantSqlError(
+      'forbidden_function',
+      'Forbidden SQL function detected.',
+    )
   }
 }
 
 export function validateAssistantSql(sql: string): ValidatedAssistantSql {
+  assertNoDollarQuotedStrings(sql)
+
+  const commentText = normalizeWhitespace(extractCommentText(sql))
   const withoutComments = stripComments(sql)
   const normalized = normalizeWhitespace(withoutComments)
   const masked = normalizeWhitespace(maskQuotedText(withoutComments))
-  const maskedForForbiddenScan = normalizeWhitespace(maskQuotedText(sql))
 
   if (!normalized) {
     throw new AssistantSqlError('invalid_statement', 'SQL is required.')
@@ -163,9 +215,12 @@ export function validateAssistantSql(sql: string): ValidatedAssistantSql {
   const statement = withoutTrailingSemicolon(normalized)
 
   assertSelectOnly(statement)
-  assertNoForbiddenFunctions(maskedForForbiddenScan)
-  assertNoForbiddenKeywords(maskedForForbiddenScan)
-  assertNoForbiddenSchemas(maskedForForbiddenScan)
+  assertNoForbiddenFunctions(commentText)
+  assertNoForbiddenKeywords(commentText)
+  assertNoForbiddenSchemas(commentText)
+  assertNoForbiddenFunctions(masked)
+  assertNoForbiddenKeywords(masked)
+  assertNoForbiddenSchemas(masked)
 
   return {
     statement,

--- a/src/lib/ai/sql/guardrails.ts
+++ b/src/lib/ai/sql/guardrails.ts
@@ -1,0 +1,174 @@
+import { AssistantSqlError } from './errors'
+
+const FORBIDDEN_KEYWORDS = [
+  'alter',
+  'analyze',
+  'call',
+  'cluster',
+  'comment',
+  'copy',
+  'create',
+  'delete',
+  'drop',
+  'execute',
+  'grant',
+  'insert',
+  'listen',
+  'merge',
+  'notify',
+  'refresh',
+  'reindex',
+  'revoke',
+  'set',
+  'truncate',
+  'update',
+  'vacuum',
+] as const
+
+const FORBIDDEN_SCHEMAS = [
+  'auth',
+  'extensions',
+  'graphql_public',
+  'information_schema',
+  'pg_catalog',
+  'pg_temp',
+  'public',
+  'storage',
+] as const
+
+const FORBIDDEN_FUNCTIONS = ['set_config'] as const
+
+export interface ValidatedAssistantSql {
+  statement: string
+  sqlShape: string
+}
+
+function stripComments(sql: string): string {
+  return sql
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/--[^\n\r]*/g, ' ')
+}
+
+function maskQuotedText(sql: string): string {
+  let masked = ''
+  let quote: "'" | '"' | null = null
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index]
+    const next = sql[index + 1]
+
+    if (quote === null) {
+      if (char === "'" || char === '"') {
+        quote = char
+        masked += ' '
+      } else {
+        masked += char
+      }
+      continue
+    }
+
+    if (char === quote) {
+      if (quote === "'" && next === "'") {
+        masked += '  '
+        index += 1
+        continue
+      }
+      quote = null
+    }
+    masked += ' '
+  }
+
+  return masked
+}
+
+function normalizeWhitespace(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+function withoutTrailingSemicolon(statement: string): string {
+  return statement.endsWith(';') ? statement.slice(0, -1).trim() : statement
+}
+
+function countSemicolons(sql: string): number {
+  return (sql.match(/;/g) ?? []).length
+}
+
+function assertSingleStatement(normalized: string, masked: string) {
+  const semicolonCount = countSemicolons(masked)
+  if (semicolonCount > 1 || (semicolonCount === 1 && !normalized.endsWith(';'))) {
+    throw new AssistantSqlError(
+      'invalid_statement',
+      'Only one SQL statement is allowed.',
+    )
+  }
+}
+
+function assertSelectOnly(statement: string) {
+  if (!/^(select|with)\b/i.test(statement)) {
+    throw new AssistantSqlError(
+      'invalid_statement',
+      'Only SELECT statements are allowed.',
+    )
+  }
+}
+
+function assertNoForbiddenKeywords(maskedStatement: string) {
+  for (const keyword of FORBIDDEN_KEYWORDS) {
+    const keywordPattern = new RegExp(`\\b${keyword}\\b`, 'i')
+    if (keywordPattern.test(maskedStatement)) {
+      throw new AssistantSqlError(
+        'forbidden_keyword',
+        'Forbidden SQL keyword detected.',
+      )
+    }
+  }
+}
+
+function assertNoForbiddenSchemas(maskedStatement: string) {
+  for (const schema of FORBIDDEN_SCHEMAS) {
+    const schemaPattern = new RegExp(`\\b${schema}\\s*\\.`, 'i')
+    if (schemaPattern.test(maskedStatement)) {
+      throw new AssistantSqlError(
+        'forbidden_schema',
+        'Only the ai_readonly schema is queryable.',
+      )
+    }
+  }
+}
+
+function assertNoForbiddenFunctions(maskedStatement: string) {
+  for (const functionName of FORBIDDEN_FUNCTIONS) {
+    const functionPattern = new RegExp(`\\b${functionName}\\s*\\(`, 'i')
+    if (functionPattern.test(maskedStatement)) {
+      throw new AssistantSqlError(
+        'forbidden_function',
+        'Forbidden SQL function detected.',
+      )
+    }
+  }
+}
+
+export function validateAssistantSql(sql: string): ValidatedAssistantSql {
+  const withoutComments = stripComments(sql)
+  const normalized = normalizeWhitespace(withoutComments)
+  const masked = normalizeWhitespace(maskQuotedText(withoutComments))
+  const maskedForForbiddenScan = normalizeWhitespace(maskQuotedText(sql))
+
+  if (!normalized) {
+    throw new AssistantSqlError('invalid_statement', 'SQL is required.')
+  }
+
+  assertSingleStatement(normalized, masked)
+
+  const statement = withoutTrailingSemicolon(normalized)
+
+  assertSelectOnly(statement)
+  assertNoForbiddenFunctions(maskedForForbiddenScan)
+  assertNoForbiddenKeywords(maskedForForbiddenScan)
+  assertNoForbiddenSchemas(maskedForForbiddenScan)
+
+  return {
+    statement,
+    sqlShape: statement,
+  }
+}

--- a/src/lib/ai/sql/guardrails.ts
+++ b/src/lib/ai/sql/guardrails.ts
@@ -40,7 +40,6 @@ const KNOWN_FORBIDDEN_SCHEMAS = [
 
 const FORBIDDEN_FUNCTIONS = ['set_config'] as const
 const DOLLAR_QUOTED_STRING_PATTERN = /\$[A-Za-z_][\w$]*\$|\$\$/
-const ESCAPE_STRING_PATTERN = /\bE\s*'/i
 const FORBIDDEN_KEYWORD_PATTERN = new RegExp(
   String.raw`\b(?:${FORBIDDEN_KEYWORDS.join('|')})\b`,
   'i',
@@ -126,6 +125,52 @@ function countSemicolons(sql: string): number {
   return (sql.match(/;/g) ?? []).length
 }
 
+function isIdentifierChar(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z0-9_$]/.test(char)
+}
+
+function hasEscapeStringOutsideQuotedText(sql: string): boolean {
+  let quote: "'" | '"' | null = null
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index]
+    const next = sql[index + 1]
+
+    if (quote === null) {
+      if (char === "'" || char === '"') {
+        quote = char
+        continue
+      }
+
+      if (
+        (char === 'E' || char === 'e') &&
+        !isIdentifierChar(sql[index - 1])
+      ) {
+        let nextNonSpaceIndex = index + 1
+        while (/\s/.test(sql[nextNonSpaceIndex] ?? '')) {
+          nextNonSpaceIndex += 1
+        }
+
+        if (sql[nextNonSpaceIndex] === "'") {
+          return true
+        }
+      }
+
+      continue
+    }
+
+    if (char === quote) {
+      if (quote === "'" && next === "'") {
+        index += 1
+        continue
+      }
+      quote = null
+    }
+  }
+
+  return false
+}
+
 function assertNoDollarQuotedStrings(sql: string) {
   if (DOLLAR_QUOTED_STRING_PATTERN.test(sql)) {
     throw new AssistantSqlError(
@@ -136,7 +181,7 @@ function assertNoDollarQuotedStrings(sql: string) {
 }
 
 function assertNoEscapeStrings(sql: string) {
-  if (ESCAPE_STRING_PATTERN.test(sql)) {
+  if (hasEscapeStringOutsideQuotedText(sql)) {
     throw new AssistantSqlError(
       'invalid_statement',
       'PostgreSQL escape strings are not allowed.',
@@ -210,7 +255,6 @@ function assertNoForbiddenFunctions(maskedStatement: string) {
 
 export function validateAssistantSql(sql: string): ValidatedAssistantSql {
   assertNoDollarQuotedStrings(sql)
-  assertNoEscapeStrings(sql)
 
   const commentText = normalizeWhitespace(extractCommentText(sql))
   const withoutComments = stripComments(sql)
@@ -222,6 +266,7 @@ export function validateAssistantSql(sql: string): ValidatedAssistantSql {
   }
 
   assertSingleStatement(normalized, masked)
+  assertNoEscapeStrings(withoutComments)
 
   const statement = withoutTrailingSemicolon(normalized)
 

--- a/src/lib/ai/sql/guardrails.ts
+++ b/src/lib/ai/sql/guardrails.ts
@@ -40,6 +40,7 @@ const KNOWN_FORBIDDEN_SCHEMAS = [
 
 const FORBIDDEN_FUNCTIONS = ['set_config'] as const
 const DOLLAR_QUOTED_STRING_PATTERN = /\$[A-Za-z_][\w$]*\$|\$\$/
+const ESCAPE_STRING_PATTERN = /\bE\s*'/i
 const FORBIDDEN_KEYWORD_PATTERN = new RegExp(
   String.raw`\b(?:${FORBIDDEN_KEYWORDS.join('|')})\b`,
   'i',
@@ -134,6 +135,15 @@ function assertNoDollarQuotedStrings(sql: string) {
   }
 }
 
+function assertNoEscapeStrings(sql: string) {
+  if (ESCAPE_STRING_PATTERN.test(sql)) {
+    throw new AssistantSqlError(
+      'invalid_statement',
+      'PostgreSQL escape strings are not allowed.',
+    )
+  }
+}
+
 function assertSingleStatement(normalized: string, masked: string) {
   const semicolonCount = countSemicolons(masked)
   if (semicolonCount > 1 || (semicolonCount === 1 && !normalized.endsWith(';'))) {
@@ -200,6 +210,7 @@ function assertNoForbiddenFunctions(maskedStatement: string) {
 
 export function validateAssistantSql(sql: string): ValidatedAssistantSql {
   assertNoDollarQuotedStrings(sql)
+  assertNoEscapeStrings(sql)
 
   const commentText = normalizeWhitespace(extractCommentText(sql))
   const withoutComments = stripComments(sql)

--- a/src/lib/ai/sql/scope.ts
+++ b/src/lib/ai/sql/scope.ts
@@ -1,0 +1,142 @@
+import { isGlobalRole, isPrivilegedRole, ROLES, type Role } from '@/lib/rbac'
+
+const DEFAULT_FACILITY_REQUIRED_MESSAGE =
+  'Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.'
+const DEFAULT_UNRESOLVED_FACILITY_MESSAGE =
+  'Unable to resolve facility context for tool execution.'
+
+export type AssistantSqlFacilitySource = 'selected' | 'session'
+
+export interface AssistantSqlScope {
+  effectiveFacilityId: number
+  facilitySource: AssistantSqlFacilitySource
+  normalizedRole?: Role
+  rawRole?: string
+  selectedFacilityId?: number
+  sessionFacilityId?: number
+  userId: string
+}
+
+export interface ResolveAssistantScopeParams {
+  facilityRequiredMessage?: string
+  requireFacilityScope: boolean
+  requestedFacilityId: number | undefined
+  unresolvedFacilityMessage?: string
+  user: Record<string, unknown>
+}
+
+export type AssistantScopeResolutionResult =
+  | {
+      ok: true
+      assistantSqlScope: AssistantSqlScope | undefined
+      promptUserId: string | undefined
+      selectedFacilityId: number | undefined
+      usageUserId: string
+    }
+  | {
+      ok: false
+      message: string
+    }
+
+function toFacilityId(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      return undefined
+    }
+
+    const parsed = Number(trimmed)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return undefined
+}
+
+function toUserId(value: unknown): string | undefined {
+  return typeof value === 'string' || typeof value === 'number'
+    ? String(value)
+    : undefined
+}
+
+function normalizeAssistantRole(role: string | undefined): Role | undefined {
+  if (role === undefined) {
+    return undefined
+  }
+
+  const normalized = role.trim().toLowerCase()
+  if (!normalized) {
+    return undefined
+  }
+
+  if (isGlobalRole(normalized)) {
+    return ROLES.GLOBAL
+  }
+
+  if (Object.values(ROLES).includes(normalized as Role)) {
+    return normalized as Role
+  }
+
+  return undefined
+}
+
+export function resolveAssistantScope({
+  facilityRequiredMessage = DEFAULT_FACILITY_REQUIRED_MESSAGE,
+  requireFacilityScope,
+  requestedFacilityId,
+  unresolvedFacilityMessage = DEFAULT_UNRESOLVED_FACILITY_MESSAGE,
+  user,
+}: ResolveAssistantScopeParams): AssistantScopeResolutionResult {
+  const rawRole = typeof user.role === 'string' ? user.role : undefined
+  const normalizedRole = normalizeAssistantRole(rawRole)
+  const sessionFacilityId = toFacilityId(user.don_vi)
+  const promptUserId = toUserId(user.id)
+  const usageUserId = promptUserId ?? 'unknown-session'
+  const privileged = isPrivilegedRole(rawRole)
+  let selectedFacilityId = sessionFacilityId
+  let facilitySource: AssistantSqlFacilitySource = 'session'
+
+  if (privileged) {
+    if (requireFacilityScope && requestedFacilityId === undefined) {
+      return { ok: false, message: facilityRequiredMessage }
+    }
+
+    if (requestedFacilityId !== undefined) {
+      selectedFacilityId = requestedFacilityId
+      facilitySource = 'selected'
+    } else {
+      selectedFacilityId = undefined
+    }
+  }
+
+  if (requireFacilityScope && selectedFacilityId === undefined) {
+    return { ok: false, message: unresolvedFacilityMessage }
+  }
+
+  const assistantSqlScope =
+    selectedFacilityId === undefined
+      ? undefined
+      : {
+          effectiveFacilityId: selectedFacilityId,
+          facilitySource,
+          normalizedRole,
+          rawRole,
+          selectedFacilityId: requestedFacilityId,
+          sessionFacilityId,
+          userId: usageUserId,
+        }
+
+  return {
+    ok: true,
+    assistantSqlScope,
+    promptUserId,
+    selectedFacilityId,
+    usageUserId,
+  }
+}
+

--- a/src/lib/ai/sql/scope.ts
+++ b/src/lib/ai/sql/scope.ts
@@ -12,7 +12,7 @@ export interface AssistantSqlScope {
   facilitySource: AssistantSqlFacilitySource
   normalizedRole?: Role
   rawRole?: string
-  selectedFacilityId?: number
+  requestedFacilityId?: number
   sessionFacilityId?: number
   userId: string
 }
@@ -109,8 +109,6 @@ export function resolveAssistantScope({
     if (requestedFacilityId !== undefined) {
       selectedFacilityId = requestedFacilityId
       facilitySource = 'selected'
-    } else {
-      selectedFacilityId = undefined
     }
   }
 
@@ -126,7 +124,7 @@ export function resolveAssistantScope({
           facilitySource,
           normalizedRole,
           rawRole,
-          selectedFacilityId: requestedFacilityId,
+          requestedFacilityId,
           sessionFacilityId,
           userId: usageUserId,
         }
@@ -139,4 +137,3 @@ export function resolveAssistantScope({
     usageUserId,
   }
 }
-

--- a/src/lib/ai/sql/scope.ts
+++ b/src/lib/ai/sql/scope.ts
@@ -95,6 +95,7 @@ export function resolveAssistantScope({
   const rawRole = typeof user.role === 'string' ? user.role : undefined
   const normalizedRole = normalizeAssistantRole(rawRole)
   const sessionFacilityId = toFacilityId(user.don_vi)
+  const normalizedRequestedFacilityId = toFacilityId(requestedFacilityId)
   const promptUserId = toUserId(user.id)
   const usageUserId = promptUserId ?? 'unknown-session'
   const privileged = isPrivilegedRole(rawRole)
@@ -102,12 +103,12 @@ export function resolveAssistantScope({
   let facilitySource: AssistantSqlFacilitySource = 'session'
 
   if (privileged) {
-    if (requireFacilityScope && requestedFacilityId === undefined) {
+    if (requireFacilityScope && normalizedRequestedFacilityId === undefined) {
       return { ok: false, message: facilityRequiredMessage }
     }
 
-    if (requestedFacilityId !== undefined) {
-      selectedFacilityId = requestedFacilityId
+    if (normalizedRequestedFacilityId !== undefined) {
+      selectedFacilityId = normalizedRequestedFacilityId
       facilitySource = 'selected'
     }
   }
@@ -124,7 +125,7 @@ export function resolveAssistantScope({
           facilitySource,
           normalizedRole,
           rawRole,
-          requestedFacilityId,
+          requestedFacilityId: normalizedRequestedFacilityId,
           sessionFacilityId,
           userId: usageUserId,
         }

--- a/src/lib/ai/tools/query-database.ts
+++ b/src/lib/ai/tools/query-database.ts
@@ -1,0 +1,44 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+import { ASSISTANT_SQL_TOOL_NAME } from '@/lib/ai/sql/constants'
+import { executeAssistantSql, type AssistantSqlResult } from '@/lib/ai/sql/executor'
+import type { AssistantSqlScope } from '@/lib/ai/sql/scope'
+
+export const QUERY_DATABASE_TOOL_NAME = ASSISTANT_SQL_TOOL_NAME
+
+const queryDatabaseInputSchema = z
+  .object({
+    reasoning: z.string().trim().min(1).max(500),
+    sql: z.string().trim().min(1).max(20_000),
+  })
+  .strict()
+
+export interface QueryDatabaseToolParams {
+  execute?: (params: {
+    scope: AssistantSqlScope
+    sql: string
+  }) => Promise<AssistantSqlResult>
+  scope: AssistantSqlScope
+}
+
+export function queryDatabaseTool({
+  execute = executeAssistantSql,
+  scope,
+}: QueryDatabaseToolParams) {
+  return tool({
+    description:
+      'Run one read-only SQL query against the ai_readonly semantic layer for the server-injected facility scope.',
+    inputSchema: queryDatabaseInputSchema,
+    execute: async ({ reasoning, sql }) => {
+      const result = await execute({ scope, sql })
+
+      return {
+        reasoning,
+        rowCount: result.rowCount,
+        rows: result.rows,
+      }
+    },
+  })
+}
+

--- a/src/lib/ai/tools/query-database.ts
+++ b/src/lib/ai/tools/query-database.ts
@@ -1,11 +1,11 @@
-import { tool } from 'ai'
+import { tool, type Tool } from 'ai'
 import { z } from 'zod'
 
 import { ASSISTANT_SQL_TOOL_NAME } from '@/lib/ai/sql/constants'
 import { executeAssistantSql, type AssistantSqlResult } from '@/lib/ai/sql/executor'
 import type { AssistantSqlScope } from '@/lib/ai/sql/scope'
 
-export const QUERY_DATABASE_TOOL_NAME = ASSISTANT_SQL_TOOL_NAME
+export { ASSISTANT_SQL_TOOL_NAME as QUERY_DATABASE_TOOL_NAME }
 
 const queryDatabaseInputSchema = z
   .object({
@@ -13,6 +13,14 @@ const queryDatabaseInputSchema = z
     sql: z.string().trim().min(1).max(20_000),
   })
   .strict()
+
+type QueryDatabaseToolInput = z.infer<typeof queryDatabaseInputSchema>
+
+interface QueryDatabaseToolOutput {
+  reasoning: string
+  rowCount: number
+  rows: Array<Record<string, unknown>>
+}
 
 export interface QueryDatabaseToolParams {
   execute?: (params: {
@@ -25,12 +33,15 @@ export interface QueryDatabaseToolParams {
 export function queryDatabaseTool({
   execute = executeAssistantSql,
   scope,
-}: QueryDatabaseToolParams) {
-  return tool({
+}: QueryDatabaseToolParams): Tool<QueryDatabaseToolInput, QueryDatabaseToolOutput> {
+  return tool<QueryDatabaseToolInput, QueryDatabaseToolOutput>({
     description:
       'Run one read-only SQL query against the ai_readonly semantic layer for the server-injected facility scope.',
     inputSchema: queryDatabaseInputSchema,
-    execute: async ({ reasoning, sql }) => {
+    execute: async ({
+      reasoning,
+      sql,
+    }: QueryDatabaseToolInput): Promise<QueryDatabaseToolOutput> => {
       const result = await execute({ scope, sql })
 
       return {
@@ -41,4 +52,3 @@ export function queryDatabaseTool({
     },
   })
 }
-


### PR DESCRIPTION
## Summary
- Implements Issue #271 Batch 3 shared AssistantSqlScope resolver and refactors /api/chat scope resolution through it without changing runtime tool exposure.
- Adds dormant server-only query_database foundation: postgres.js client, SQL guardrails, executor caps/timeouts, error classes, and dormant tool module.
- Keeps query_database unregistered in /api/chat and keeps ai_query_database rejected by the RPC proxy; no migrations were created or applied.

## Test Plan
- [x] node scripts/npm-run.js run verify:no-explicit-any
- [x] node scripts/npm-run.js run typecheck
- [x] node scripts/npm-run.js run test:run -- src/lib/ai/sql/__tests__/query-database-guard.test.ts src/lib/ai/sql/__tests__/query-database-executor.test.ts src/lib/ai/sql/__tests__/scope.test.ts src/lib/ai/sql/__tests__/query-database-dormant.test.ts src/app/api/chat/__tests__/route.tenant-policy.test.ts src/app/api/chat/__tests__/route.tools-allowlist.test.ts src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts src/lib/ai/tools/__tests__/registry.allowlist.test.ts
- [x] node scripts/npm-run.js run test:run -- src/lib/ai/sql/__tests__
- [x] node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
- [x] git diff --check

## Notes
- Related: #271
- Batch 4 audit seam remains pending.
- GitHub Preview Build & Test may still be affected by the known external billing/account issue noted on #271.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-only, dormant SQL executor with strict guardrails and a shared scope resolver now used by `/api/chat`. Delivers Batch 3 of Issue #271 without enabling the `query_database` tool or any new runtime capabilities.

- **Bug Fixes**
  - Hardened SQL guardrails: reject dollar-quoted strings; reject PostgreSQL E-strings only when used as escape literals; scan comments and masked SQL for forbidden keywords/functions; enforce `ai_readonly` for all table/function references.
  - Safer execution: map Postgres timeout (`57014`) to a `timeout` error; enforce row and payload limits with typed errors; keep transaction-local settings (`statement_timeout`, `search_path`, role/user/facility).
  - Scope resolution: `/api/chat` uses `resolveAssistantScope` with selected-facility normalization for privileged roles, session-facility pinning for non-privileged roles, and `admin` normalized to `global`; clear message when a facility is required; the `query_database` tool stays unregistered and `ai_query_database` remains blocked via RPC.

<sup>Written for commit 7a124fd80e777814eb9875ef4d53ea2f48e6be65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI assistant can run read-only database queries with per-request facility and user scoping.
* **Safety & Validation**
  * Strong SQL guardrails reject non-SELECT, multi-statement, forbidden schemas/functions, and unsafe string forms.
  * Enforced limits on rows, payload size, and statement timeouts with clear error codes.
* **Behavior Changes**
  * Facility selection rules refined for privileged and non-privileged users to determine query scope.
* **Tests**
  * Expanded test coverage for SQL validation, execution limits, scope resolution, and tool exposure.
* **Chores**
  * Added runtime dependencies for database connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->