### PR TITLE
feat: rollout query_database for assistant reporting

### DIFF
--- a/src/app/api/chat/__tests__/route.intent-routing.test.ts
+++ b/src/app/api/chat/__tests__/route.intent-routing.test.ts
@@ -8,6 +8,7 @@ const buildSystemPromptMock = vi.fn()
 const checkUsageLimitsMock = vi.fn()
 const recordUsageMock = vi.fn()
 const confirmUsageMock = vi.fn()
+const executeAuditedAssistantSqlMock = vi.fn()
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -27,6 +28,11 @@ vi.mock('@/lib/ai/usage-metering', () => ({
   checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
   recordUsage: (...args: unknown[]) => recordUsageMock(...args),
   confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+}))
+
+vi.mock('@/lib/ai/sql/audited-executor', () => ({
+  executeAuditedAssistantSql: (...args: unknown[]) =>
+    executeAuditedAssistantSqlMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -71,6 +77,11 @@ describe('/api/chat intent routing + clarification guard', () => {
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
+    executeAuditedAssistantSqlMock.mockResolvedValue({
+      rowCount: 1,
+      rows: [{ total: 3 }],
+      sqlShape: 'select total from ai_readonly.reporting_summary',
+    })
   })
 
   it('routes equipment repair-status questions to equipmentLookup instead of repairSummary', async () => {
@@ -189,6 +200,7 @@ describe('/api/chat intent routing + clarification guard', () => {
     expect(streamArgs.tools).not.toHaveProperty('usageHistory')
     expect(streamArgs.tools).not.toHaveProperty('attachmentLookup')
     expect(streamArgs.tools).not.toHaveProperty('deviceQuotaLookup')
+    expect(streamArgs.tools).not.toHaveProperty('query_database')
   })
 
   it('returns clarification instead of 400 when privileged user has no facility and intent is ambiguous', async () => {
@@ -210,5 +222,97 @@ describe('/api/chat intent routing + clarification guard', () => {
     expect(res.headers.get('content-type')).toContain('text/event-stream')
     expect(streamTextMock).not.toHaveBeenCalled()
     expect(text).toContain('trạng thái thiết bị')
+  })
+
+  it('routes narrow reporting prompts to query_database only', async () => {
+    const res = await POST(
+      buildRequest({
+        selectedFacilityId: 17,
+        messages: buildMessages(
+          'Báo cáo tổng hợp số lượng thiết bị theo trạng thái của đơn vị hiện tại',
+        ),
+        requestedTools: [
+          'equipmentLookup',
+          'maintenanceSummary',
+          'repairSummary',
+          'usageHistory',
+          'query_database',
+        ],
+      }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+
+    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
+      tools?: Record<string, unknown>
+    }
+    expect(streamArgs.tools).toHaveProperty('query_database')
+    expect(streamArgs.tools).not.toHaveProperty('equipmentLookup')
+    expect(streamArgs.tools).not.toHaveProperty('maintenanceSummary')
+    expect(streamArgs.tools).not.toHaveProperty('repairSummary')
+    expect(streamArgs.tools).not.toHaveProperty('usageHistory')
+  })
+
+  it('fails closed for query_database when a privileged user has not selected a facility', async () => {
+    getServerSessionMock.mockResolvedValue({
+      user: { id: 'u1', role: 'admin', don_vi: undefined },
+    })
+
+    const res = await POST(
+      buildRequest({
+        messages: buildMessages(
+          'Báo cáo tổng hợp số lượng thiết bị theo trạng thái của đơn vị hiện tại',
+        ),
+        requestedTools: ['query_database'],
+      }) as never,
+    )
+    const text = await res.text()
+
+    expect(res.status).toBe(400)
+    expect(text).toContain('vui lòng chọn cơ sở y tế')
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the server-injected facility scope when query_database executes', async () => {
+    getServerSessionMock.mockResolvedValue({
+      user: { id: 'u1', role: 'to_qltb', don_vi: 17 },
+    })
+
+    const res = await POST(
+      buildRequest({
+        selectedFacilityId: 999,
+        messages: buildMessages('Cho tôi báo cáo tổng hợp số lượng thiết bị theo trạng thái'),
+        requestedTools: ['query_database'],
+      }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+
+    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
+      tools?: Record<
+        string,
+        {
+          execute?: (input: Record<string, unknown>) => Promise<unknown>
+        }
+      >
+    }
+    await streamArgs.tools?.query_database?.execute?.({
+      reasoning: 'Need a facility-scoped status summary.',
+      sql: 'select total from ai_readonly.reporting_summary',
+    })
+
+    expect(executeAuditedAssistantSqlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: expect.objectContaining({
+          effectiveFacilityId: 17,
+          facilitySource: 'session',
+          requestedFacilityId: 999,
+          sessionFacilityId: 17,
+          userId: 'u1',
+        }),
+      }),
+    )
   })
 })

--- a/src/app/api/chat/__tests__/route.intent-routing.test.ts
+++ b/src/app/api/chat/__tests__/route.intent-routing.test.ts
@@ -120,6 +120,7 @@ describe('/api/chat intent routing + clarification guard', () => {
     }
     expect(streamArgs.tools).toHaveProperty('repairSummary')
     expect(streamArgs.tools).not.toHaveProperty('equipmentLookup')
+    expect(streamArgs.tools).not.toHaveProperty('query_database')
   })
 
   it('asks a clarification question before calling tools for ambiguous repair intents', async () => {
@@ -153,6 +154,26 @@ describe('/api/chat intent routing + clarification guard', () => {
     expect(streamTextMock).not.toHaveBeenCalled()
     expect(text).toContain('một thiết bị cụ thể')
     expect(text).toContain('tổng quan định mức của đơn vị')
+  })
+
+  it('keeps query_database out of quota-summary routing decisions', async () => {
+    const res = await POST(
+      buildRequest({
+        selectedFacilityId: 17,
+        messages: buildMessages('Tổng quan định mức của đơn vị hiện tại thế nào?'),
+        requestedTools: ['deviceQuotaLookup', 'quotaComplianceSummary', 'query_database'],
+      }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+
+    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
+      tools?: Record<string, unknown>
+    }
+    expect(streamArgs.tools).toHaveProperty('quotaComplianceSummary')
+    expect(streamArgs.tools).not.toHaveProperty('deviceQuotaLookup')
+    expect(streamArgs.tools).not.toHaveProperty('query_database')
   })
 
   it('asks for a concrete equipment identifier before calling equipmentLookup on ambiguous device lookup prompts', async () => {
@@ -230,6 +251,36 @@ describe('/api/chat intent routing + clarification guard', () => {
         selectedFacilityId: 17,
         messages: buildMessages(
           'Báo cáo tổng hợp số lượng thiết bị theo trạng thái của đơn vị hiện tại',
+        ),
+        requestedTools: [
+          'equipmentLookup',
+          'maintenanceSummary',
+          'repairSummary',
+          'usageHistory',
+          'query_database',
+        ],
+      }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+
+    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
+      tools?: Record<string, unknown>
+    }
+    expect(streamArgs.tools).toHaveProperty('query_database')
+    expect(streamArgs.tools).not.toHaveProperty('equipmentLookup')
+    expect(streamArgs.tools).not.toHaveProperty('maintenanceSummary')
+    expect(streamArgs.tools).not.toHaveProperty('repairSummary')
+    expect(streamArgs.tools).not.toHaveProperty('usageHistory')
+  })
+
+  it('routes detailed reporting prompts with chi tiết to query_database only', async () => {
+    const res = await POST(
+      buildRequest({
+        selectedFacilityId: 17,
+        messages: buildMessages(
+          'Báo cáo chi tiết tình trạng thiết bị theo khoa trong đơn vị hiện tại',
         ),
         requestedTools: [
           'equipmentLookup',

--- a/src/app/api/chat/__tests__/route.tool-rpc-mapping.test.ts
+++ b/src/app/api/chat/__tests__/route.tool-rpc-mapping.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 import { getToolRpcMapping } from '@/lib/ai/tools/registry'
 

--- a/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
+++ b/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
@@ -85,18 +87,21 @@ describe('/api/chat tools allowlist policy', () => {
     expect(streamTextMock).not.toHaveBeenCalled()
   })
 
-  it('blocks query_database before rollout', async () => {
+  it('allows query_database when it is explicitly requested for the rollout path', async () => {
     const res = await POST(
       buildRequest({
         messages: VALID_MESSAGES,
         requestedTools: ['query_database'],
       }) as never,
     )
-    const text = await res.text()
 
-    expect(res.status).toBe(400)
-    expect(text).toBe('Unknown tool requested: query_database')
-    expect(streamTextMock).not.toHaveBeenCalled()
+    expect(res.status).toBe(200)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+
+    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
+      tools?: Record<string, unknown>
+    }
+    expect(streamArgs.tools).toHaveProperty('query_database')
   })
 
   it('blocks queryDatabase before rollout', async () => {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -160,6 +160,7 @@ export async function POST(request: Request) {
     return plainError(scopeResolution.message, 400)
   }
   const {
+    assistantSqlScope,
     promptUserId,
     selectedFacilityId,
     usageUserId,
@@ -187,6 +188,7 @@ export async function POST(request: Request) {
   const tools =
     effectiveRequestedTools.length > 0 && selectedFacilityId !== undefined
       ? buildToolRegistry({
+          assistantSqlScope,
           request,
           tenantId: selectedFacilityId,
           userId: usageUserId,

--- a/src/components/assistant/AssistantPanel.tsx
+++ b/src/components/assistant/AssistantPanel.tsx
@@ -37,6 +37,7 @@ const REQUESTED_TOOLS = [
     "attachmentLookup",
     "deviceQuotaLookup",
     "quotaComplianceSummary",
+    "query_database",
     "generateTroubleshootingDraft",
     "generateRepairRequestDraft",
     "categorySuggestion",

--- a/src/lib/ai/__tests__/intent-routing.test.ts
+++ b/src/lib/ai/__tests__/intent-routing.test.ts
@@ -236,6 +236,37 @@ describe('routeChatIntent', () => {
       })
     })
 
+    it('strips query_database from repair-summary routing decisions', () => {
+      const result = routeChatIntent({
+        messages: [makeUserMessage('Có bao nhiêu phiếu sửa chữa đang chờ xử lý?')],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ALL_CHAT_TOOLS.filter(
+          toolName =>
+            toolName !== 'equipmentLookup' && toolName !== 'query_database',
+        ),
+      })
+    })
+
+    it('routes detailed reporting prompts with chi tiết to query_database when they are not specific-item lookups', () => {
+      const result = routeChatIntent({
+        messages: [
+          makeUserMessage(
+            'Báo cáo chi tiết tình trạng thiết bị theo khoa trong đơn vị hiện tại',
+          ),
+        ],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ['query_database'],
+      })
+    })
+
     it('holds query_database out of generic prompts when the request is not a reporting fallback', () => {
       const result = routeChatIntent({
         messages: [makeUserMessage('Xin chào, bạn giúp được gì?')],

--- a/src/lib/ai/__tests__/intent-routing.test.ts
+++ b/src/lib/ai/__tests__/intent-routing.test.ts
@@ -12,6 +12,17 @@ function makeUserMessage(text: string): UIMessage {
 
 const ALL_REPAIR_TOOLS = ['equipmentLookup', 'repairSummary']
 const ALL_QUOTA_TOOLS = ['deviceQuotaLookup', 'quotaComplianceSummary']
+const ALL_CHAT_TOOLS = [
+  'equipmentLookup',
+  'maintenanceSummary',
+  'maintenancePlanLookup',
+  'repairSummary',
+  'usageHistory',
+  'attachmentLookup',
+  'deviceQuotaLookup',
+  'quotaComplianceSummary',
+  'query_database',
+]
 
 describe('routeChatIntent', () => {
   // ──────────────────────────────────────────────────────
@@ -196,6 +207,56 @@ describe('routeChatIntent', () => {
       expect(result).toEqual({
         kind: 'proceed',
         requestedTools: [...ALL_REPAIR_TOOLS],
+      })
+    })
+  })
+
+  describe('Issue #272 — query_database curated-first fallback', () => {
+    it('routes narrow reporting prompts to query_database when curated tools do not match', () => {
+      const result = routeChatIntent({
+        messages: [makeUserMessage('Báo cáo tổng hợp số lượng thiết bị theo trạng thái của đơn vị hiện tại')],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ['query_database'],
+      })
+    })
+
+    it('keeps curated lookup prompts off the SQL fallback path', () => {
+      const result = routeChatIntent({
+        messages: [makeUserMessage('Tra cứu thông tin thiết bị monitor CMS8000')],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ['equipmentLookup'],
+      })
+    })
+
+    it('holds query_database out of generic prompts when the request is not a reporting fallback', () => {
+      const result = routeChatIntent({
+        messages: [makeUserMessage('Xin chào, bạn giúp được gì?')],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ALL_CHAT_TOOLS.filter(toolName => toolName !== 'query_database'),
+      })
+    })
+
+    it('keeps query_database available when it is the only explicitly requested tool', () => {
+      const result = routeChatIntent({
+        messages: [makeUserMessage('Xin chào')],
+        requestedTools: ['query_database'],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ['query_database'],
       })
     })
   })

--- a/src/lib/ai/intent-routing.ts
+++ b/src/lib/ai/intent-routing.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from 'ai'
+import { ASSISTANT_SQL_TOOL_NAME } from './sql/constants'
 import { getLatestUserText } from './tools/equipment-lookup-identifiers'
 import { hasRepairRequestDraftStartIntent } from './draft/repair-request-draft-session'
 
@@ -35,7 +36,10 @@ export function routeChatIntent({
 }): ChatIntentRoutingResult {
   const latestUserText = getLatestUserText(messages)
   if (!latestUserText) {
-    return { kind: 'proceed', requestedTools }
+    return {
+      kind: 'proceed',
+      requestedTools: holdBackQueryDatabase(requestedTools),
+    }
   }
 
   const repairDecision = classifyRepairIntent(latestUserText, requestedTools)
@@ -53,7 +57,18 @@ export function routeChatIntent({
     return equipmentLookupDecision
   }
 
-  return { kind: 'proceed', requestedTools }
+  const sqlReportingDecision = classifyAssistantSqlReportingIntent(
+    latestUserText,
+    requestedTools,
+  )
+  if (sqlReportingDecision) {
+    return sqlReportingDecision
+  }
+
+  return {
+    kind: 'proceed',
+    requestedTools: holdBackQueryDatabase(requestedTools),
+  }
 }
 
 function classifyRepairIntent(
@@ -185,6 +200,45 @@ function classifyEquipmentLookupIntent(
   }
 }
 
+function classifyAssistantSqlReportingIntent(
+  text: string,
+  requestedTools: string[],
+): ChatIntentRoutingResult | null {
+  if (
+    !requestedTools.includes(ASSISTANT_SQL_TOOL_NAME) ||
+    requestedTools.every(toolName => toolName === ASSISTANT_SQL_TOOL_NAME)
+  ) {
+    return null
+  }
+
+  if (hasEquipmentIdentifier(text)) {
+    return null
+  }
+
+  const normalized = normalizeIntentText(text)
+  const mentionsReportingIntent =
+    /\b(bao cao|thong ke|tong hop|phan bo|top|xep hang|xu huong|ty le)\b/.test(
+      normalized,
+    )
+  const mentionsReportingSubject =
+    /\b(thiet bi|bao tri|hieu chuan|kiem dinh|sua chua|su dung|dinh muc|trang thai|don vi|co so|khoa|phong)\b/.test(
+      normalized,
+    )
+  const mentionsSpecificItem =
+    /\b(ma thiet bi|serial|model|chi tiet|thiet bi nay|may nay|mot thiet bi cu the)\b/.test(
+      normalized,
+    )
+
+  if (!mentionsReportingIntent || !mentionsReportingSubject || mentionsSpecificItem) {
+    return null
+  }
+
+  return {
+    kind: 'proceed',
+    requestedTools: [ASSISTANT_SQL_TOOL_NAME],
+  }
+}
+
 function normalizeIntentText(text: string): string {
   return text
     .normalize('NFD')
@@ -279,4 +333,15 @@ function removeTool(requestedTools: string[], toolName: string): string[] {
 
 function keepOnlyTool(requestedTools: string[], toolName: string): string[] {
   return requestedTools.filter(requestedTool => requestedTool === toolName)
+}
+
+function holdBackQueryDatabase(requestedTools: string[]): string[] {
+  if (
+    !requestedTools.includes(ASSISTANT_SQL_TOOL_NAME) ||
+    requestedTools.every(toolName => toolName === ASSISTANT_SQL_TOOL_NAME)
+  ) {
+    return requestedTools
+  }
+
+  return removeTool(requestedTools, ASSISTANT_SQL_TOOL_NAME)
 }

--- a/src/lib/ai/intent-routing.ts
+++ b/src/lib/ai/intent-routing.ts
@@ -34,25 +34,29 @@ export function routeChatIntent({
   messages: UIMessage[]
   requestedTools: string[]
 }): ChatIntentRoutingResult {
+  const nonSqlRequestedTools = holdBackQueryDatabase(requestedTools)
   const latestUserText = getLatestUserText(messages)
   if (!latestUserText) {
     return {
       kind: 'proceed',
-      requestedTools: holdBackQueryDatabase(requestedTools),
+      requestedTools: nonSqlRequestedTools,
     }
   }
 
-  const repairDecision = classifyRepairIntent(latestUserText, requestedTools)
+  const repairDecision = classifyRepairIntent(latestUserText, nonSqlRequestedTools)
   if (repairDecision) {
     return repairDecision
   }
 
-  const quotaDecision = classifyQuotaIntent(latestUserText, requestedTools)
+  const quotaDecision = classifyQuotaIntent(latestUserText, nonSqlRequestedTools)
   if (quotaDecision) {
     return quotaDecision
   }
 
-  const equipmentLookupDecision = classifyEquipmentLookupIntent(latestUserText, requestedTools)
+  const equipmentLookupDecision = classifyEquipmentLookupIntent(
+    latestUserText,
+    nonSqlRequestedTools,
+  )
   if (equipmentLookupDecision) {
     return equipmentLookupDecision
   }
@@ -225,7 +229,7 @@ function classifyAssistantSqlReportingIntent(
       normalized,
     )
   const mentionsSpecificItem =
-    /\b(ma thiet bi|serial|model|chi tiet|thiet bi nay|may nay|mot thiet bi cu the)\b/.test(
+    /\b(ma thiet bi|serial|model|thiet bi nay|may nay|mot thiet bi cu the)\b/.test(
       normalized,
     )
 
@@ -316,6 +320,10 @@ function shouldNarrowToEquipmentLookup(
   const mentionsUsage = /\b(lich su su dung|su dung)\b/.test(normalizedText)
   const mentionsAttachment = /\b(tai lieu|dinh kem|file|huong dan)\b/.test(normalizedText)
   const mentionsQuota = /\b(dinh muc|quota)\b/.test(normalizedText)
+  const mentionsReporting =
+    /\b(bao cao|thong ke|tong hop|phan bo|top|xep hang|xu huong|ty le)\b/.test(
+      normalizedText,
+    )
 
   return (
     mentionsLookupIntent &&
@@ -323,7 +331,8 @@ function shouldNarrowToEquipmentLookup(
     !mentionsRepair &&
     !mentionsUsage &&
     !mentionsAttachment &&
-    !mentionsQuota
+    !mentionsQuota &&
+    !mentionsReporting
   )
 }
 

--- a/src/lib/ai/prompts/system.ts
+++ b/src/lib/ai/prompts/system.ts
@@ -119,6 +119,8 @@ export function buildSystemPrompt(context: SystemPromptContext = {}): string {
       '- KHÔNG bao giờ gọi công cụ có tính chất create/update/delete.',
       '- KHÔNG chấp nhận file upload hoặc nội dung multimodal từ người dùng.',
       '- Tra cứu file đính kèm được hỗ trợ qua công cụ `attachmentLookup` – chỉ trả metadata (tên file, liên kết).',
+      '- `query_database` chỉ là fallback hẹp cho câu hỏi báo cáo/tổng hợp ad-hoc trong phạm vi một cơ sở.',
+      '- Khi dùng `query_database`, chỉ được viết đúng một câu lệnh `SELECT` trên semantic layer `ai_readonly`; không truy vấn schema production khác và không giả định quyền cross-facility.',
       '',
       '**📦 Định dạng kết quả tool (Tool Response Envelope):**',
       '- Mỗi tool read-only trả về kết quả dạng `{ modelSummary, followUpContext?, uiArtifact? }`.',

--- a/src/lib/ai/sql/__tests__/query-database-dormant.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-dormant.test.ts
@@ -1,23 +1,78 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('server-only', () => ({}))
 
+const executeAuditedAssistantSqlMock = vi.fn()
+
+vi.mock('@/lib/ai/sql/audited-executor', () => ({
+  executeAuditedAssistantSql: (...args: unknown[]) =>
+    executeAuditedAssistantSqlMock(...args),
+}))
+
 import { POST as rpcPost } from '@/app/api/rpc/[fn]/route'
 import { QUERY_DATABASE_TOOL_NAME } from '@/lib/ai/tools/query-database'
-import { getAllowedToolNamesForTest, getToolRpcMapping, validateRequestedTools } from '@/lib/ai/tools/registry'
+import { buildToolRegistry, getAllowedToolNamesForTest, getToolRpcMapping, validateRequestedTools } from '@/lib/ai/tools/registry'
+import type { AssistantSqlScope } from '@/lib/ai/sql/scope'
 
 async function invokeRpcProxy(fn: string) {
   const req = new Request(`http://localhost/api/rpc/${fn}`, { method: 'POST' })
   return rpcPost(req as never, { params: Promise.resolve({ fn }) })
 }
 
-describe('query_database dormant Batch 3 contract', () => {
-  it('defines the dormant tool name without adding it to the assistant registry', () => {
+type ExecutableTool = {
+  execute: (input: Record<string, unknown>) => Promise<unknown>
+}
+
+describe('query_database runtime rollout contract', () => {
+  beforeEach(() => {
+    executeAuditedAssistantSqlMock.mockReset()
+    executeAuditedAssistantSqlMock.mockResolvedValue({
+      rowCount: 1,
+      rows: [{ total: 5 }],
+      reasoning: 'unused',
+    })
+  })
+
+  it('defines the rollout tool name and accepts it in the assistant registry', () => {
     expect(QUERY_DATABASE_TOOL_NAME).toBe('query_database')
-    expect(getAllowedToolNamesForTest()).not.toContain(QUERY_DATABASE_TOOL_NAME)
+    expect(getAllowedToolNamesForTest()).toContain(QUERY_DATABASE_TOOL_NAME)
     expect(validateRequestedTools([QUERY_DATABASE_TOOL_NAME])).toEqual({
-      ok: false,
-      message: 'Unknown tool requested: query_database',
+      ok: true,
+      requestedTools: [QUERY_DATABASE_TOOL_NAME],
+    })
+  })
+
+  it('wires query_database with the server-injected assistant SQL scope', async () => {
+    const scope: AssistantSqlScope = {
+      effectiveFacilityId: 17,
+      facilitySource: 'selected',
+      normalizedRole: 'global',
+      rawRole: 'admin',
+      requestedFacilityId: 17,
+      sessionFacilityId: undefined,
+      userId: 'u-admin',
+    }
+    const request = new Request('http://localhost/api/chat', { method: 'POST' })
+
+    const registry = buildToolRegistry({
+      request,
+      tenantId: 17,
+      userId: 'u-admin',
+      requestedTools: ['query_database'],
+      assistantSqlScope: scope,
+    })
+
+    const queryDatabaseTool = registry.query_database as unknown as ExecutableTool
+    await queryDatabaseTool.execute({
+      reasoning: 'Need a reporting summary.',
+      sql: 'select total from ai_readonly.reporting_summary',
+    })
+
+    expect(executeAuditedAssistantSqlMock).toHaveBeenCalledWith({
+      request,
+      scope,
+      sql: 'select total from ai_readonly.reporting_summary',
+      execute: undefined,
     })
   })
 

--- a/src/lib/ai/tools/__tests__/category-suggestion-envelope.test.ts
+++ b/src/lib/ai/tools/__tests__/category-suggestion-envelope.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const executeRpcToolMock = vi.fn()
 
 vi.mock('@/lib/ai/tools/rpc-tool-executor', () => ({

--- a/src/lib/ai/tools/__tests__/category-suggestion-registry.test.ts
+++ b/src/lib/ai/tools/__tests__/category-suggestion-registry.test.ts
@@ -3,6 +3,8 @@ import path from 'node:path'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const executeRpcToolMock = vi.fn()
 
 vi.mock('@/lib/ai/tools/rpc-tool-executor', () => ({

--- a/src/lib/ai/tools/__tests__/registry.allowlist.test.ts
+++ b/src/lib/ai/tools/__tests__/registry.allowlist.test.ts
@@ -1,19 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 import { getAllowedToolNamesForTest, validateRequestedTools } from '../registry'
 
 describe('registry allowlist contract', () => {
-  it('does not expose query_database in the current assistant allowlist', () => {
+  it('exposes query_database in the assistant allowlist', () => {
     const allowedToolNames = getAllowedToolNamesForTest()
 
-    expect(allowedToolNames).not.toContain('query_database')
+    expect(allowedToolNames).toContain('query_database')
     expect(allowedToolNames).not.toContain('queryDatabase')
   })
 
-  it('rejects query_database before runtime rollout exists', () => {
+  it('accepts query_database for the runtime rollout', () => {
     expect(validateRequestedTools(['query_database'])).toEqual({
-      ok: false,
-      message: 'Unknown tool requested: query_database',
+      ok: true,
+      requestedTools: ['query_database'],
     })
   })
 

--- a/src/lib/ai/tools/__tests__/registry.equipment-lookup-identifiers.test.ts
+++ b/src/lib/ai/tools/__tests__/registry.equipment-lookup-identifiers.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const executeRpcToolMock = vi.fn()
 
 vi.mock('@/lib/ai/tools/rpc-tool-executor', () => ({

--- a/src/lib/ai/tools/registry.ts
+++ b/src/lib/ai/tools/registry.ts
@@ -1,10 +1,13 @@
 import { tool, type ToolSet } from 'ai'
 
 import { generateTroubleshootingDraft } from '@/lib/ai/draft/troubleshooting-tool'
+import { ASSISTANT_SQL_TOOL_NAME } from '@/lib/ai/sql/constants'
+import type { AssistantSqlScope } from '@/lib/ai/sql/scope'
 import {
   type EquipmentLookupHints,
   normalizeEquipmentLookupArgs,
 } from '@/lib/ai/tools/equipment-lookup-identifiers'
+import { queryDatabaseTool } from '@/lib/ai/tools/query-database'
 import {
   QUERY_CATALOG,
   QUERY_CATALOG_PENDING_TOOL_NAMES,
@@ -59,6 +62,7 @@ const KNOWN_BUT_BLOCKED_TOOLS = new Set(['systemDiagnostics'])
 const ALLOWED_TOOL_NAMES = new Set([
   ...QUERY_CATALOG_TOOL_NAMES,
   ...DRAFT_TOOL_NAMES,
+  ASSISTANT_SQL_TOOL_NAME,
 ])
 
 /** Exposed for contract tests only. Do NOT import in production code. */
@@ -101,6 +105,7 @@ const KNOWN_TOOL_NAMES = new Set([
   ...QUERY_CATALOG_TOOL_NAMES,
   ...KNOWN_BUT_BLOCKED_TOOLS,
   ...DRAFT_TOOL_NAMES,
+  ASSISTANT_SQL_TOOL_NAME,
 ])
 
 function normalizeToolNames(toolNames: string[]): string[] {
@@ -145,6 +150,7 @@ export function validateRequestedTools(
 }
 
 export interface BuildToolRegistryParams {
+  assistantSqlScope?: AssistantSqlScope
   request: Request
   tenantId: number
   userId: string
@@ -153,6 +159,7 @@ export interface BuildToolRegistryParams {
 }
 
 export function buildToolRegistry({
+  assistantSqlScope,
   request,
   tenantId,
   userId,
@@ -166,6 +173,16 @@ export function buildToolRegistry({
   const tools: ToolSet = {}
 
   for (const toolName of allowedRequestedTools) {
+    if (toolName === ASSISTANT_SQL_TOOL_NAME) {
+      if (assistantSqlScope) {
+        tools[toolName] = queryDatabaseTool({
+          request,
+          scope: assistantSqlScope,
+        })
+      }
+      continue
+    }
+
     // Draft tools: wire directly (no RPC proxy)
     const draftDef = DRAFT_TOOL_DEFINITIONS[toolName]
     if (draftDef) {


### PR DESCRIPTION
## Summary
- roll out `query_database` in the assistant runtime for single-facility ad-hoc reporting
- keep curated tools as the primary path and only fall back to `query_database` for narrow reporting prompts
- preserve the private SQL execution boundary by keeping `ai_query_database` blocked from the public RPC proxy

## What Changed
- added `query_database` to the assistant allowlist and runtime registry with server-injected `AssistantSqlScope`
- updated chat intent routing so mixed tool requests hold back SQL unless a reporting-specific fallback matches
- passed assistant SQL scope from `/api/chat` into the runtime tool registry and added concise `ai_readonly` guidance to the system prompt
- included `query_database` in the assistant panel tool request list so the backend can choose it when appropriate
- replaced dormant rollout tests with runtime contract coverage and added regression tests for curated-first fallback, facility enforcement, and scope injection
- added `server-only` mocks where registry tests now import SQL runtime wiring

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js test src/lib/ai/tools/__tests__/registry.allowlist.test.ts src/lib/ai/tools/__tests__/registry.equipment-lookup-identifiers.test.ts src/lib/ai/tools/__tests__/category-suggestion-envelope.test.ts src/lib/ai/tools/__tests__/category-suggestion-registry.test.ts src/lib/ai/sql/__tests__/query-database-executor.test.ts src/lib/ai/sql/__tests__/query-database-guard.test.ts src/lib/ai/sql/__tests__/query-database-audit.test.ts src/lib/ai/sql/__tests__/query-database-dormant.test.ts src/lib/ai/__tests__/intent-routing.test.ts src/app/api/chat/__tests__/route.tools-allowlist.test.ts src/app/api/chat/__tests__/route.intent-routing.test.ts src/app/api/chat/__tests__/route.tool-rpc-mapping.test.ts src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

Closes Issue #272
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls out `query_database` as a narrow, single‑facility reporting fallback with stricter intent routing that keeps it out of non‑reporting flows. Injects server SQL scope and uses audited execution to enforce facility boundaries while keeping SQL off the public RPC.

- **New Features**
  - Added `query_database` to the allowlist and tool registry, wired with server‑injected `AssistantSqlScope`.
  - Tightened intent routing: strip `query_database` from repair/quota/equipment decisions; only select it for reporting keywords; require a selected facility and fail closed if missing.
  - Passed assistant SQL scope from `/api/chat` into the registry; updated system prompt to allow a single `SELECT` on `ai_readonly` only.
  - Included `query_database` in the Assistant Panel’s requested tools so the backend can choose it when appropriate; execution remains behind the audited executor and off the public RPC proxy; tests updated for routing, allowlist, scope injection, and facility enforcement.

Linked to Linear Issue #272.

<sup>Written for commit 89a8677d11d1c6bea171351fd0ba4159830f3282. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `query_database` tool for generating facility-scoped reports and summaries.
  * Implemented intelligent intent routing to automatically use the database query tool for reporting questions.

* **Tests**
  * Added comprehensive test coverage for the new database query tool, intent routing, and tool allowlisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->