### PR TITLE
fix: harden assistant intent routing

### DIFF
--- a/src/app/api/chat/__tests__/route.intent-routing.test.ts
+++ b/src/app/api/chat/__tests__/route.intent-routing.test.ts
@@ -65,6 +65,22 @@ function buildMessages(text: string) {
   ]
 }
 
+const FULL_PANEL_TOOLS = [
+  'equipmentLookup',
+  'maintenanceSummary',
+  'maintenancePlanLookup',
+  'repairSummary',
+  'usageHistory',
+  'attachmentLookup',
+  'deviceQuotaLookup',
+  'quotaComplianceSummary',
+  'query_database',
+  'generateTroubleshootingDraft',
+  'generateRepairRequestDraft',
+  'categorySuggestion',
+  'departmentList',
+]
+
 describe('/api/chat intent routing + clarification guard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -149,6 +165,29 @@ describe('/api/chat intent routing + clarification guard', () => {
     expect(text).toContain('định mức')
   })
 
+  it('preserves explicit repair-draft starts when quota words are also present', async () => {
+    const res = await POST(
+      buildRequest({
+        selectedFacilityId: 17,
+        messages: buildMessages(
+          'Tạo phiếu yêu cầu sửa chữa thiết bị máy thở ABC đang vượt định mức',
+        ),
+        requestedTools: FULL_PANEL_TOOLS,
+      }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+
+    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
+      tools?: Record<string, unknown>
+    }
+    expect(streamArgs.tools).toHaveProperty('equipmentLookup')
+    expect(streamArgs.tools).toHaveProperty('repairSummary')
+    expect(streamArgs.tools).not.toHaveProperty('query_database')
+    expect(streamArgs.tools).not.toHaveProperty('generateRepairRequestDraft')
+  })
+
   it('asks a clarification question before calling tools for ambiguous repair intents', async () => {
     const res = await POST(
       buildRequest({
@@ -207,17 +246,7 @@ describe('/api/chat intent routing + clarification guard', () => {
       buildRequest({
         selectedFacilityId: 17,
         messages: buildMessages('Có bao nhiêu phiếu sửa chữa đang chờ xử lý?'),
-        requestedTools: [
-          'equipmentLookup',
-          'maintenanceSummary',
-          'maintenancePlanLookup',
-          'repairSummary',
-          'usageHistory',
-          'attachmentLookup',
-          'deviceQuotaLookup',
-          'quotaComplianceSummary',
-          'query_database',
-        ],
+        requestedTools: FULL_PANEL_TOOLS,
       }) as never,
     )
 

--- a/src/app/api/chat/__tests__/route.intent-routing.test.ts
+++ b/src/app/api/chat/__tests__/route.intent-routing.test.ts
@@ -241,25 +241,6 @@ describe('/api/chat intent routing + clarification guard', () => {
     expect(streamArgs.tools).not.toHaveProperty('query_database')
   })
 
-  it('keeps clear repair prompts on curated tools when the panel sends the full tool list', async () => {
-    const res = await postChatWithTools(
-      'Có bao nhiêu phiếu sửa chữa đang chờ xử lý?',
-      FULL_PANEL_TOOLS,
-    )
-
-    expect(res.status).toBe(200)
-    expect(streamTextMock).toHaveBeenCalledOnce()
-
-    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
-      tools?: Record<string, unknown>
-    }
-    expect(streamArgs.tools).toHaveProperty('repairSummary')
-    expect(streamArgs.tools).toHaveProperty('maintenanceSummary')
-    expect(streamArgs.tools).toHaveProperty('quotaComplianceSummary')
-    expect(streamArgs.tools).not.toHaveProperty('equipmentLookup')
-    expect(streamArgs.tools).not.toHaveProperty('query_database')
-  })
-
   it('asks for a concrete equipment identifier before calling equipmentLookup on ambiguous device lookup prompts', async () => {
     const res = await POST(
       buildRequest({

--- a/src/app/api/chat/__tests__/route.intent-routing.test.ts
+++ b/src/app/api/chat/__tests__/route.intent-routing.test.ts
@@ -65,6 +65,16 @@ function buildMessages(text: string) {
   ]
 }
 
+function postChatWithTools(text: string, requestedTools: string[]) {
+  return POST(
+    buildRequest({
+      selectedFacilityId: 17,
+      messages: buildMessages(text),
+      requestedTools,
+    }) as never,
+  )
+}
+
 const FULL_PANEL_TOOLS = [
   'equipmentLookup',
   'maintenanceSummary',
@@ -140,20 +150,15 @@ describe('/api/chat intent routing + clarification guard', () => {
   })
 
   it('asks a clarification question for mixed repair and quota prompts before calling tools', async () => {
-    const res = await POST(
-      buildRequest({
-        selectedFacilityId: 17,
-        messages: buildMessages(
-          'Có bao nhiêu phiếu sửa chữa và thiết bị vượt định mức trong đơn vị hiện tại?',
-        ),
-        requestedTools: [
-          'equipmentLookup',
-          'repairSummary',
-          'deviceQuotaLookup',
-          'quotaComplianceSummary',
-          'query_database',
-        ],
-      }) as never,
+    const res = await postChatWithTools(
+      'Có bao nhiêu phiếu sửa chữa và thiết bị vượt định mức trong đơn vị hiện tại?',
+      [
+        'equipmentLookup',
+        'repairSummary',
+        'deviceQuotaLookup',
+        'quotaComplianceSummary',
+        'query_database',
+      ],
     )
     const text = await res.text()
 
@@ -166,14 +171,9 @@ describe('/api/chat intent routing + clarification guard', () => {
   })
 
   it('preserves explicit repair-draft starts when quota words are also present', async () => {
-    const res = await POST(
-      buildRequest({
-        selectedFacilityId: 17,
-        messages: buildMessages(
-          'Tạo phiếu yêu cầu sửa chữa thiết bị máy thở ABC đang vượt định mức',
-        ),
-        requestedTools: FULL_PANEL_TOOLS,
-      }) as never,
+    const res = await postChatWithTools(
+      'Tạo phiếu yêu cầu sửa chữa thiết bị máy thở ABC đang vượt định mức',
+      FULL_PANEL_TOOLS,
     )
 
     expect(res.status).toBe(200)
@@ -242,12 +242,9 @@ describe('/api/chat intent routing + clarification guard', () => {
   })
 
   it('keeps clear repair prompts on curated tools when the panel sends the full tool list', async () => {
-    const res = await POST(
-      buildRequest({
-        selectedFacilityId: 17,
-        messages: buildMessages('Có bao nhiêu phiếu sửa chữa đang chờ xử lý?'),
-        requestedTools: FULL_PANEL_TOOLS,
-      }) as never,
+    const res = await postChatWithTools(
+      'Có bao nhiêu phiếu sửa chữa đang chờ xử lý?',
+      FULL_PANEL_TOOLS,
     )
 
     expect(res.status).toBe(200)

--- a/src/app/api/chat/__tests__/route.intent-routing.test.ts
+++ b/src/app/api/chat/__tests__/route.intent-routing.test.ts
@@ -123,6 +123,32 @@ describe('/api/chat intent routing + clarification guard', () => {
     expect(streamArgs.tools).not.toHaveProperty('query_database')
   })
 
+  it('asks a clarification question for mixed repair and quota prompts before calling tools', async () => {
+    const res = await POST(
+      buildRequest({
+        selectedFacilityId: 17,
+        messages: buildMessages(
+          'Có bao nhiêu phiếu sửa chữa và thiết bị vượt định mức trong đơn vị hiện tại?',
+        ),
+        requestedTools: [
+          'equipmentLookup',
+          'repairSummary',
+          'deviceQuotaLookup',
+          'quotaComplianceSummary',
+          'query_database',
+        ],
+      }) as never,
+    )
+    const text = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/event-stream')
+    expect(streamTextMock).not.toHaveBeenCalled()
+    expect(text).toContain('ý chính')
+    expect(text).toContain('sửa chữa')
+    expect(text).toContain('định mức')
+  })
+
   it('asks a clarification question before calling tools for ambiguous repair intents', async () => {
     const res = await POST(
       buildRequest({
@@ -173,6 +199,38 @@ describe('/api/chat intent routing + clarification guard', () => {
     }
     expect(streamArgs.tools).toHaveProperty('quotaComplianceSummary')
     expect(streamArgs.tools).not.toHaveProperty('deviceQuotaLookup')
+    expect(streamArgs.tools).not.toHaveProperty('query_database')
+  })
+
+  it('keeps clear repair prompts on curated tools when the panel sends the full tool list', async () => {
+    const res = await POST(
+      buildRequest({
+        selectedFacilityId: 17,
+        messages: buildMessages('Có bao nhiêu phiếu sửa chữa đang chờ xử lý?'),
+        requestedTools: [
+          'equipmentLookup',
+          'maintenanceSummary',
+          'maintenancePlanLookup',
+          'repairSummary',
+          'usageHistory',
+          'attachmentLookup',
+          'deviceQuotaLookup',
+          'quotaComplianceSummary',
+          'query_database',
+        ],
+      }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+
+    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
+      tools?: Record<string, unknown>
+    }
+    expect(streamArgs.tools).toHaveProperty('repairSummary')
+    expect(streamArgs.tools).toHaveProperty('maintenanceSummary')
+    expect(streamArgs.tools).toHaveProperty('quotaComplianceSummary')
+    expect(streamArgs.tools).not.toHaveProperty('equipmentLookup')
     expect(streamArgs.tools).not.toHaveProperty('query_database')
   })
 

--- a/src/lib/ai/__tests__/intent-routing.test.ts
+++ b/src/lib/ai/__tests__/intent-routing.test.ts
@@ -98,33 +98,28 @@ describe('routeChatIntent', () => {
       })
     })
 
-    it('keeps clear repair-summary prompts on curated routing and out of SQL fallback', () => {
-      const result = routeText('Có bao nhiêu phiếu sửa chữa đang chờ xử lý?', [
-        ...ALL_CHAT_TOOLS,
-      ])
+    it.each([
+      {
+        text: 'Có bao nhiêu phiếu sửa chữa đang chờ xử lý?',
+        removedTools: ['equipmentLookup', 'query_database'],
+      },
+      {
+        text: 'Tổng quan định mức của đơn vị hiện tại thế nào?',
+        removedTools: ['deviceQuotaLookup', 'query_database'],
+      },
+    ])(
+      'keeps clear curated prompt "$text" out of SQL fallback',
+      ({ text, removedTools }) => {
+        const result = routeText(text, [...ALL_CHAT_TOOLS])
 
-      expect(result).toEqual({
-        kind: 'proceed',
-        requestedTools: ALL_CHAT_TOOLS.filter(
-          toolName =>
-            toolName !== 'equipmentLookup' && toolName !== 'query_database',
-        ),
-      })
-    })
-
-    it('keeps clear quota-summary prompts on curated routing and out of SQL fallback', () => {
-      const result = routeText('Tổng quan định mức của đơn vị hiện tại thế nào?', [
-        ...ALL_CHAT_TOOLS,
-      ])
-
-      expect(result).toEqual({
-        kind: 'proceed',
-        requestedTools: ALL_CHAT_TOOLS.filter(
-          toolName =>
-            toolName !== 'deviceQuotaLookup' && toolName !== 'query_database',
-        ),
-      })
-    })
+        expect(result).toEqual({
+          kind: 'proceed',
+          requestedTools: ALL_CHAT_TOOLS.filter(
+            toolName => !removedTools.includes(toolName),
+          ),
+        })
+      },
+    )
 
     it('keeps generic non-reporting prompts on the fail-closed non-SQL path', () => {
       const result = routeText('Xin chào, bạn giúp được gì?', [...ALL_CHAT_TOOLS])

--- a/src/lib/ai/__tests__/intent-routing.test.ts
+++ b/src/lib/ai/__tests__/intent-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { UIMessage } from 'ai'
 import { routeChatIntent } from '../intent-routing'
+import * as queryCatalog from '../tools/query-catalog'
 
 function makeUserMessage(text: string): UIMessage {
   return {
@@ -25,6 +26,107 @@ const ALL_CHAT_TOOLS = [
 ]
 
 describe('routeChatIntent', () => {
+  describe('Issue #273 — catalog-backed curated routing metadata', () => {
+    it('declares routing intent metadata for ambiguous curated tool pairs', () => {
+      expect(queryCatalog.QUERY_CATALOG.equipmentLookup.routingIntents).toEqual(
+        expect.arrayContaining([
+          { group: 'repair', role: 'equipment-status' },
+          { group: 'equipmentLookup', role: 'specific-item' },
+        ]),
+      )
+      expect(queryCatalog.QUERY_CATALOG.repairSummary.routingIntents).toEqual([
+        { group: 'repair', role: 'workflow-summary' },
+      ])
+      expect(queryCatalog.QUERY_CATALOG.deviceQuotaLookup.routingIntents).toEqual([
+        { group: 'quota', role: 'specific-item' },
+      ])
+      expect(
+        queryCatalog.QUERY_CATALOG.quotaComplianceSummary.routingIntents,
+      ).toEqual([{ group: 'quota', role: 'facility-summary' }])
+    })
+
+    it('exposes query catalog tool names by routing group', () => {
+      const getToolsByRoutingGroup = (
+        queryCatalog as Record<string, unknown>
+      ).getQueryCatalogToolsByRoutingGroup
+
+      expect(getToolsByRoutingGroup).toBeTypeOf('function')
+      if (typeof getToolsByRoutingGroup !== 'function') {
+        return
+      }
+
+      expect(getToolsByRoutingGroup('repair')).toEqual([
+        'equipmentLookup',
+        'repairSummary',
+      ])
+      expect(getToolsByRoutingGroup('quota')).toEqual([
+        'deviceQuotaLookup',
+        'quotaComplianceSummary',
+      ])
+    })
+  })
+
+  describe('Issue #273 — curated precedence hardening', () => {
+    it('clarifies mixed repair and quota prompts instead of choosing a hard-coded family', () => {
+      const result = routeChatIntent({
+        messages: [
+          makeUserMessage(
+            'Có bao nhiêu phiếu sửa chữa và thiết bị vượt định mức trong đơn vị hiện tại?',
+          ),
+        ],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result.kind).toBe('clarify')
+    })
+
+    it('keeps clear repair-summary prompts on curated routing and out of SQL fallback', () => {
+      const result = routeChatIntent({
+        messages: [makeUserMessage('Có bao nhiêu phiếu sửa chữa đang chờ xử lý?')],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ALL_CHAT_TOOLS.filter(
+          toolName =>
+            toolName !== 'equipmentLookup' && toolName !== 'query_database',
+        ),
+      })
+    })
+
+    it('keeps clear quota-summary prompts on curated routing and out of SQL fallback', () => {
+      const result = routeChatIntent({
+        messages: [
+          makeUserMessage('Tổng quan định mức của đơn vị hiện tại thế nào?'),
+        ],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ALL_CHAT_TOOLS.filter(
+          toolName =>
+            toolName !== 'deviceQuotaLookup' && toolName !== 'query_database',
+        ),
+      })
+    })
+
+    it('keeps generic non-reporting prompts on the fail-closed non-SQL path', () => {
+      const result = routeChatIntent({
+        messages: [makeUserMessage('Xin chào, bạn giúp được gì?')],
+        requestedTools: [...ALL_CHAT_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: ALL_CHAT_TOOLS.filter(
+          toolName => toolName !== 'query_database',
+        ),
+      })
+    })
+  })
+
   // ──────────────────────────────────────────────────────
   // V1: repair router should NOT drop repairSummary when
   //     the question is about a device's repair history

--- a/src/lib/ai/__tests__/intent-routing.test.ts
+++ b/src/lib/ai/__tests__/intent-routing.test.ts
@@ -24,6 +24,13 @@ const ALL_CHAT_TOOLS = [
   'quotaComplianceSummary',
   'query_database',
 ]
+const FULL_PANEL_TOOLS = [
+  ...ALL_CHAT_TOOLS,
+  'generateTroubleshootingDraft',
+  'generateRepairRequestDraft',
+  'categorySuggestion',
+  'departmentList',
+]
 
 describe('routeChatIntent', () => {
   describe('Issue #273 — catalog-backed curated routing metadata', () => {
@@ -78,6 +85,24 @@ describe('routeChatIntent', () => {
       })
 
       expect(result.kind).toBe('clarify')
+    })
+
+    it('preserves explicit repair-draft starts even when quota words are present', () => {
+      const result = routeChatIntent({
+        messages: [
+          makeUserMessage(
+            'Tạo phiếu yêu cầu sửa chữa thiết bị máy thở ABC đang vượt định mức',
+          ),
+        ],
+        requestedTools: [...FULL_PANEL_TOOLS],
+      })
+
+      expect(result).toEqual({
+        kind: 'proceed',
+        requestedTools: FULL_PANEL_TOOLS.filter(
+          toolName => toolName !== 'query_database',
+        ),
+      })
     })
 
     it('keeps clear repair-summary prompts on curated routing and out of SQL fallback', () => {

--- a/src/lib/ai/__tests__/intent-routing.test.ts
+++ b/src/lib/ai/__tests__/intent-routing.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { UIMessage } from 'ai'
 import { routeChatIntent } from '../intent-routing'
-import * as queryCatalog from '../tools/query-catalog'
+import {
+  QUERY_CATALOG,
+  getQueryCatalogToolsByRoutingGroup,
+} from '../tools/query-catalog'
 
 function makeUserMessage(text: string): UIMessage {
   return {
@@ -9,6 +12,13 @@ function makeUserMessage(text: string): UIMessage {
     role: 'user',
     parts: [{ type: 'text' as const, text }],
   } as UIMessage
+}
+
+function routeText(text: string, requestedTools: string[]) {
+  return routeChatIntent({
+    messages: [makeUserMessage(text)],
+    requestedTools,
+  })
 }
 
 const ALL_REPAIR_TOOLS = ['equipmentLookup', 'repairSummary']
@@ -35,38 +45,29 @@ const FULL_PANEL_TOOLS = [
 describe('routeChatIntent', () => {
   describe('Issue #273 — catalog-backed curated routing metadata', () => {
     it('declares routing intent metadata for ambiguous curated tool pairs', () => {
-      expect(queryCatalog.QUERY_CATALOG.equipmentLookup.routingIntents).toEqual(
+      expect(QUERY_CATALOG.equipmentLookup.routingIntents).toEqual(
         expect.arrayContaining([
           { group: 'repair', role: 'equipment-status' },
           { group: 'equipmentLookup', role: 'specific-item' },
         ]),
       )
-      expect(queryCatalog.QUERY_CATALOG.repairSummary.routingIntents).toEqual([
+      expect(QUERY_CATALOG.repairSummary.routingIntents).toEqual([
         { group: 'repair', role: 'workflow-summary' },
       ])
-      expect(queryCatalog.QUERY_CATALOG.deviceQuotaLookup.routingIntents).toEqual([
+      expect(QUERY_CATALOG.deviceQuotaLookup.routingIntents).toEqual([
         { group: 'quota', role: 'specific-item' },
       ])
-      expect(
-        queryCatalog.QUERY_CATALOG.quotaComplianceSummary.routingIntents,
-      ).toEqual([{ group: 'quota', role: 'facility-summary' }])
+      expect(QUERY_CATALOG.quotaComplianceSummary.routingIntents).toEqual([
+        { group: 'quota', role: 'facility-summary' },
+      ])
     })
 
     it('exposes query catalog tool names by routing group', () => {
-      const getToolsByRoutingGroup = (
-        queryCatalog as Record<string, unknown>
-      ).getQueryCatalogToolsByRoutingGroup
-
-      expect(getToolsByRoutingGroup).toBeTypeOf('function')
-      if (typeof getToolsByRoutingGroup !== 'function') {
-        return
-      }
-
-      expect(getToolsByRoutingGroup('repair')).toEqual([
+      expect(getQueryCatalogToolsByRoutingGroup('repair')).toEqual([
         'equipmentLookup',
         'repairSummary',
       ])
-      expect(getToolsByRoutingGroup('quota')).toEqual([
+      expect(getQueryCatalogToolsByRoutingGroup('quota')).toEqual([
         'deviceQuotaLookup',
         'quotaComplianceSummary',
       ])
@@ -75,27 +76,19 @@ describe('routeChatIntent', () => {
 
   describe('Issue #273 — curated precedence hardening', () => {
     it('clarifies mixed repair and quota prompts instead of choosing a hard-coded family', () => {
-      const result = routeChatIntent({
-        messages: [
-          makeUserMessage(
-            'Có bao nhiêu phiếu sửa chữa và thiết bị vượt định mức trong đơn vị hiện tại?',
-          ),
-        ],
-        requestedTools: [...ALL_CHAT_TOOLS],
-      })
+      const result = routeText(
+        'Có bao nhiêu phiếu sửa chữa và thiết bị vượt định mức trong đơn vị hiện tại?',
+        [...ALL_CHAT_TOOLS],
+      )
 
       expect(result.kind).toBe('clarify')
     })
 
     it('preserves explicit repair-draft starts even when quota words are present', () => {
-      const result = routeChatIntent({
-        messages: [
-          makeUserMessage(
-            'Tạo phiếu yêu cầu sửa chữa thiết bị máy thở ABC đang vượt định mức',
-          ),
-        ],
-        requestedTools: [...FULL_PANEL_TOOLS],
-      })
+      const result = routeText(
+        'Tạo phiếu yêu cầu sửa chữa thiết bị máy thở ABC đang vượt định mức',
+        [...FULL_PANEL_TOOLS],
+      )
 
       expect(result).toEqual({
         kind: 'proceed',
@@ -106,10 +99,9 @@ describe('routeChatIntent', () => {
     })
 
     it('keeps clear repair-summary prompts on curated routing and out of SQL fallback', () => {
-      const result = routeChatIntent({
-        messages: [makeUserMessage('Có bao nhiêu phiếu sửa chữa đang chờ xử lý?')],
-        requestedTools: [...ALL_CHAT_TOOLS],
-      })
+      const result = routeText('Có bao nhiêu phiếu sửa chữa đang chờ xử lý?', [
+        ...ALL_CHAT_TOOLS,
+      ])
 
       expect(result).toEqual({
         kind: 'proceed',
@@ -121,12 +113,9 @@ describe('routeChatIntent', () => {
     })
 
     it('keeps clear quota-summary prompts on curated routing and out of SQL fallback', () => {
-      const result = routeChatIntent({
-        messages: [
-          makeUserMessage('Tổng quan định mức của đơn vị hiện tại thế nào?'),
-        ],
-        requestedTools: [...ALL_CHAT_TOOLS],
-      })
+      const result = routeText('Tổng quan định mức của đơn vị hiện tại thế nào?', [
+        ...ALL_CHAT_TOOLS,
+      ])
 
       expect(result).toEqual({
         kind: 'proceed',
@@ -138,10 +127,7 @@ describe('routeChatIntent', () => {
     })
 
     it('keeps generic non-reporting prompts on the fail-closed non-SQL path', () => {
-      const result = routeChatIntent({
-        messages: [makeUserMessage('Xin chào, bạn giúp được gì?')],
-        requestedTools: [...ALL_CHAT_TOOLS],
-      })
+      const result = routeText('Xin chào, bạn giúp được gì?', [...ALL_CHAT_TOOLS])
 
       expect(result).toEqual({
         kind: 'proceed',

--- a/src/lib/ai/intent-routing.ts
+++ b/src/lib/ai/intent-routing.ts
@@ -2,11 +2,19 @@ import type { UIMessage } from 'ai'
 import { ASSISTANT_SQL_TOOL_NAME } from './sql/constants'
 import { getLatestUserText } from './tools/equipment-lookup-identifiers'
 import { hasRepairRequestDraftStartIntent } from './draft/repair-request-draft-session'
+import {
+  getQueryCatalogToolsByRoutingGroup,
+  type QueryCatalogToolName,
+} from './tools/query-catalog'
 
-const EQUIPMENT_LOOKUP_TOOL = 'equipmentLookup'
-const REPAIR_SUMMARY_TOOL = 'repairSummary'
-const DEVICE_QUOTA_LOOKUP_TOOL = 'deviceQuotaLookup'
-const QUOTA_COMPLIANCE_SUMMARY_TOOL = 'quotaComplianceSummary'
+const EQUIPMENT_LOOKUP_TOOL: QueryCatalogToolName = 'equipmentLookup'
+const REPAIR_SUMMARY_TOOL: QueryCatalogToolName = 'repairSummary'
+const DEVICE_QUOTA_LOOKUP_TOOL: QueryCatalogToolName = 'deviceQuotaLookup'
+const QUOTA_COMPLIANCE_SUMMARY_TOOL: QueryCatalogToolName =
+  'quotaComplianceSummary'
+
+const REPAIR_ROUTING_TOOLS = getQueryCatalogToolsByRoutingGroup('repair')
+const QUOTA_ROUTING_TOOLS = getQueryCatalogToolsByRoutingGroup('quota')
 
 const REPAIR_INTENT_CLARIFICATION =
   'Anh/chị muốn xem trạng thái thiết bị hay tình trạng các yêu cầu sửa chữa/phiếu sửa chữa?'
@@ -16,6 +24,9 @@ const QUOTA_INTENT_CLARIFICATION =
 
 const EQUIPMENT_LOOKUP_CLARIFICATION =
   'Anh/chị muốn tra cứu thiết bị nào? Vui lòng cung cấp tên thiết bị cụ thể, mã thiết bị, model hoặc số serial trước khi tôi tra cứu.'
+
+const MIXED_CURATED_INTENT_CLARIFICATION =
+  'Anh/chị muốn ưu tiên ý chính nào: sửa chữa, định mức, hay tra cứu thiết bị? Vui lòng chọn một nội dung trước để tôi dùng đúng công cụ.'
 
 export type ChatIntentRoutingResult =
   | {
@@ -43,22 +54,23 @@ export function routeChatIntent({
     }
   }
 
-  const repairDecision = classifyRepairIntent(latestUserText, nonSqlRequestedTools)
-  if (repairDecision) {
-    return repairDecision
+  const curatedDecisions = [
+    buildCuratedDecision(classifyRepairIntent(latestUserText, nonSqlRequestedTools)),
+    buildCuratedDecision(classifyQuotaIntent(latestUserText, nonSqlRequestedTools)),
+    buildCuratedDecision(
+      classifyEquipmentLookupIntent(latestUserText, nonSqlRequestedTools),
+    ),
+  ].filter((decision): decision is CuratedRoutingDecision => decision !== null)
+
+  if (curatedDecisions.length > 1) {
+    return {
+      kind: 'clarify',
+      message: MIXED_CURATED_INTENT_CLARIFICATION,
+    }
   }
 
-  const quotaDecision = classifyQuotaIntent(latestUserText, nonSqlRequestedTools)
-  if (quotaDecision) {
-    return quotaDecision
-  }
-
-  const equipmentLookupDecision = classifyEquipmentLookupIntent(
-    latestUserText,
-    nonSqlRequestedTools,
-  )
-  if (equipmentLookupDecision) {
-    return equipmentLookupDecision
+  if (curatedDecisions.length === 1) {
+    return curatedDecisions[0].result
   }
 
   const sqlReportingDecision = classifyAssistantSqlReportingIntent(
@@ -75,14 +87,21 @@ export function routeChatIntent({
   }
 }
 
+interface CuratedRoutingDecision {
+  result: ChatIntentRoutingResult
+}
+
+function buildCuratedDecision(
+  result: ChatIntentRoutingResult | null,
+): CuratedRoutingDecision | null {
+  return result ? { result } : null
+}
+
 function classifyRepairIntent(
   text: string,
   requestedTools: string[],
 ): ChatIntentRoutingResult | null {
-  if (
-    !requestedTools.includes(EQUIPMENT_LOOKUP_TOOL) ||
-    !requestedTools.includes(REPAIR_SUMMARY_TOOL)
-  ) {
+  if (!hasAllRequestedTools(requestedTools, REPAIR_ROUTING_TOOLS)) {
     return null
   }
 
@@ -129,10 +148,7 @@ function classifyQuotaIntent(
   text: string,
   requestedTools: string[],
 ): ChatIntentRoutingResult | null {
-  if (
-    !requestedTools.includes(DEVICE_QUOTA_LOOKUP_TOOL) ||
-    !requestedTools.includes(QUOTA_COMPLIANCE_SUMMARY_TOOL)
-  ) {
+  if (!hasAllRequestedTools(requestedTools, QUOTA_ROUTING_TOOLS)) {
     return null
   }
 
@@ -338,6 +354,13 @@ function shouldNarrowToEquipmentLookup(
 
 function removeTool(requestedTools: string[], toolName: string): string[] {
   return requestedTools.filter(requestedTool => requestedTool !== toolName)
+}
+
+function hasAllRequestedTools(
+  requestedTools: string[],
+  requiredTools: readonly string[],
+): boolean {
+  return requiredTools.every(toolName => requestedTools.includes(toolName))
 }
 
 function keepOnlyTool(requestedTools: string[], toolName: string): string[] {

--- a/src/lib/ai/intent-routing.ts
+++ b/src/lib/ai/intent-routing.ts
@@ -54,8 +54,13 @@ export function routeChatIntent({
     }
   }
 
+  const repairDecision = classifyRepairIntent(latestUserText, nonSqlRequestedTools)
+  if (hasRepairRequestDraftStartIntent(latestUserText) && repairDecision) {
+    return repairDecision
+  }
+
   const curatedDecisions = [
-    buildCuratedDecision(classifyRepairIntent(latestUserText, nonSqlRequestedTools)),
+    buildCuratedDecision(repairDecision),
     buildCuratedDecision(classifyQuotaIntent(latestUserText, nonSqlRequestedTools)),
     buildCuratedDecision(
       classifyEquipmentLookupIntent(latestUserText, nonSqlRequestedTools),

--- a/src/lib/ai/tools/query-catalog.ts
+++ b/src/lib/ai/tools/query-catalog.ts
@@ -8,10 +8,24 @@ export interface QueryCatalogModelBudget {
   modelVisibleFields?: string[]
 }
 
+export type QueryCatalogRoutingGroup = 'repair' | 'quota' | 'equipmentLookup'
+
+export type QueryCatalogRoutingRole =
+  | 'equipment-status'
+  | 'workflow-summary'
+  | 'specific-item'
+  | 'facility-summary'
+
+export interface QueryCatalogRoutingIntent {
+  group: QueryCatalogRoutingGroup
+  role: QueryCatalogRoutingRole
+}
+
 interface BaseQueryCatalogEntry {
   description: string
   rpcFunction: string
   inputSchema: z.ZodType<Record<string, unknown>>
+  routingIntents?: QueryCatalogRoutingIntent[]
 }
 
 interface MigratedQueryCatalogEntry extends BaseQueryCatalogEntry {
@@ -32,6 +46,10 @@ export const QUERY_CATALOG = {
       'Lookup equipment details using approved read-only RPC. Supports text search plus structured `filters` for exact `equipmentCode`, current status, department, location, classification, model, and serial; use the returned total for aggregate counts.',
     rpcFunction: 'ai_equipment_lookup',
     migrationStatus: 'pending',
+    routingIntents: [
+      { group: 'repair', role: 'equipment-status' },
+      { group: 'equipmentLookup', role: 'specific-item' },
+    ],
     inputSchema: z
       .object({
         query: z.string().trim().min(1).max(200).optional(),
@@ -79,6 +97,7 @@ export const QUERY_CATALOG = {
     description: 'Retrieve repair summary data via approved read-only RPC.',
     rpcFunction: 'ai_repair_summary',
     migrationStatus: 'pending',
+    routingIntents: [{ group: 'repair', role: 'workflow-summary' }],
     inputSchema: z
       .object({
         status: z.string().trim().min(1).max(50).optional(),
@@ -113,6 +132,7 @@ export const QUERY_CATALOG = {
       'Check quota status for a specific equipment item against the active quota decision.',
     rpcFunction: 'ai_device_quota_lookup',
     migrationStatus: 'pending',
+    routingIntents: [{ group: 'quota', role: 'specific-item' }],
     inputSchema: z
       .object({
         p_thiet_bi_id: z.number().int().positive(),
@@ -124,6 +144,7 @@ export const QUERY_CATALOG = {
       'Get facility-level device quota compliance overview from the active decision.',
     rpcFunction: 'ai_quota_compliance_summary',
     migrationStatus: 'pending',
+    routingIntents: [{ group: 'quota', role: 'facility-summary' }],
     inputSchema: z.object({}).strict(),
   },
   categorySuggestion: {
@@ -159,6 +180,17 @@ export type QueryCatalogToolName = keyof typeof QUERY_CATALOG
 export const QUERY_CATALOG_TOOL_NAMES = Object.keys(QUERY_CATALOG) as QueryCatalogToolName[]
 
 export const QUERY_CATALOG_TOOL_NAME_SET: ReadonlySet<string> = new Set(QUERY_CATALOG_TOOL_NAMES)
+
+export function getQueryCatalogToolsByRoutingGroup(
+  group: QueryCatalogRoutingGroup,
+): QueryCatalogToolName[] {
+  return QUERY_CATALOG_TOOL_NAMES.filter(toolName => {
+    const entry: QueryCatalogEntry = QUERY_CATALOG[toolName]
+    return entry.routingIntents?.some(
+      routingIntent => routingIntent.group === group,
+    )
+  })
+}
 
 export function getQueryCatalogToolRpcMapping(): Record<string, string> {
   return Object.fromEntries(Object.entries(QUERY_CATALOG).map(([k, v]) => [k, v.rpcFunction]))


### PR DESCRIPTION
## Summary
- Add query-catalog routing metadata for repair/quota/equipment curated intent groups
- Route curated intent decisions before SQL fallback and clarify mixed repair/quota prompts instead of choosing by hard-coded order
- Add unit and /api/chat regression coverage for catalog metadata, mixed clarification, and query_database withholding

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/lib/ai/__tests__/intent-routing.test.ts src/app/api/chat/__tests__/route.intent-routing.test.ts
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
- git diff --check

Closes #273
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced chat intent recognition to better handle mixed or unclear requests with clarification prompts.
  * Improved tool filtering to display only relevant tools based on detected intent context.
  * Refined routing logic to distinguish between repair, quota, and equipment-related queries for more accurate assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->