### PR TITLE
feat: add nav notification badges

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,25 +5,15 @@ import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import { MainContentTransition } from "@/components/page-transition-wrapper"
 import {
-  Bell,
   HardHat,
   Home,
-  LineChart,
-  ListOrdered,
   LogOut,
   Package,
   QrCode,
-  Settings,
   User,
-  Users,
-  Wrench,
   Menu,
   Copyright,
   KeyRound,
-  ArrowLeftRight,
-  BarChart3,
-  Activity,
-  Calculator,
 } from "lucide-react"
 
 import {
@@ -51,10 +41,12 @@ import { RealtimeStatus } from "@/components/realtime-status"
 import { MobileFooterNav } from "@/components/mobile-footer-nav"
 import { HelpButton } from "@/components/onboarding/HelpButton"
 import { USER_ROLES } from "@/types/database"
-import { callRpc } from "@/lib/rpc-client"
 import { TenantSelectionProvider } from "@/contexts/TenantSelectionContext"
 import { EquipmentFilterProvider, clearAllEquipmentFilters } from "@/contexts/EquipmentFilterContext"
 import dynamic from "next/dynamic"
+import { AppSidebarNav } from "@/components/app-sidebar-nav"
+import { getAppNavigationItems } from "@/components/app-navigation"
+import { useAppNotificationCounts } from "@/hooks/useAppNotificationCounts"
 // Tenant switcher removed in favor of per-page tenant filters
 
 // Lazy-load assistant components (bundle-dynamic-imports)
@@ -77,31 +69,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const { data: session, status } = useSession()
   const user = session?.user as { role?: string; full_name?: string; username?: string; khoa_phong?: string } | undefined
   const branding = useTenantBranding()
-
-  // Header notification counts (tenant-scoped via RPC)
-  const [repairCount, setRepairCount] = React.useState<number>(0)
-  const [transferCount, setTransferCount] = React.useState<number>(0)
-
-  React.useEffect(() => {
-    let cancelled = false
-    const fetchSummary = async () => {
-      try {
-        if (!user) return
-        const summary = await callRpc<{ pending_repairs: number; pending_transfers: number }, { p_don_vi?: number | null }>({
-          fn: 'header_notifications_summary',
-          args: { p_don_vi: null },
-        })
-        if (!cancelled) {
-          setRepairCount(summary?.pending_repairs || 0)
-          setTransferCount(summary?.pending_transfers || 0)
-        }
-      } catch (err) {
-        console.error('Header notifications error:', err)
-      }
-    }
-    fetchSummary()
-    return () => { cancelled = true }
-  }, [user])
+  const { counts: notificationCounts } = useAppNotificationCounts({ enabled: Boolean(user) })
 
   // Tour attribute mapping for Driver.js sidebar navigation tour
   const tourAttributes: Record<string, string> = {
@@ -117,24 +85,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
   // Dynamic nav items based on user role
   const navItems = React.useMemo(() => {
-    const baseItems = [
-      { href: "/dashboard", icon: Home, label: "Tổng quan" },
-      { href: "/equipment", icon: Package, label: "Thiết bị" },
-      { href: "/repair-requests", icon: Wrench, label: "Yêu cầu sửa chữa" },
-      { href: "/maintenance", icon: HardHat, label: "Bảo trì" },
-      { href: "/transfers", icon: ArrowLeftRight, label: "Luân chuyển" },
-      { href: "/device-quota", icon: Calculator, label: "Định mức" },
-      { href: "/reports", icon: BarChart3, label: "Báo cáo" },
-      { href: "/qr-scanner", icon: QrCode, label: "Quét QR" },
-    ]
-
-    // Add admin/global-only pages
-    if (isGlobalRole(user?.role)) {
-      baseItems.push({ href: "/users", icon: Users, label: "Người dùng" })
-      baseItems.push({ href: "/activity-logs", icon: Activity, label: "Nhật ký hoạt động" })
-    }
-
-    return baseItems
+    return getAppNavigationItems(user?.role)
   }, [user?.role])
 
   React.useEffect(() => {
@@ -183,30 +134,14 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 </Link>
               </div>
               <div className="flex-1 overflow-auto py-4">
-                <nav className={cn("grid items-start text-sm font-medium gap-1", isSidebarOpen ? "px-3" : "justify-items-center")}>
-                  {navItems.map(({ href, icon: Icon, label }) => (
-                    <Link
-                      key={label}
-                      href={href}
-                      className={cn(
-                        "flex items-center rounded-xl py-2.5 transition-all duration-200",
-                        pathname === href || pathname.startsWith(href)
-                          ? "bg-gradient-to-r from-primary to-primary/90 text-white font-semibold shadow-lg shadow-primary/25"
-                          : "text-slate-600 hover:bg-slate-50 hover:text-primary",
-                        isSidebarOpen ? "px-3 gap-3" : "h-11 w-11 justify-center"
-                      )}
-                      title={!isSidebarOpen ? label : ""}
-                      aria-label={label}
-                      data-tour={tourAttributes[href]}
-                    >
-                      <Icon className={cn(
-                        "h-5 w-5 transition-colors",
-                        pathname === href || pathname.startsWith(href) ? "text-white" : "text-slate-500"
-                      )} />
-                      {isSidebarOpen && <span>{label}</span>}
-                    </Link>
-                  ))}
-                </nav>
+                <AppSidebarNav
+                  items={navItems}
+                  pathname={pathname}
+                  isSidebarOpen={isSidebarOpen}
+                  notificationCounts={notificationCounts}
+                  tourAttributes={tourAttributes}
+                  className={cn("px-3", !isSidebarOpen && "justify-items-center px-0")}
+                />
               </div>
             </div>
           </div>
@@ -239,27 +174,15 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                       <span className="text-center heading-responsive-h3">QUẢN LÝ TBYT - CDC</span>
                     </Link>
                   </div>
-                  <nav className="grid gap-1 body-responsive font-medium p-3">
-                    {navItems.map(({ href, icon: Icon, label }) => (
-                      <Link
-                        key={label}
-                        href={href}
-                        className={cn(
-                          "flex items-center gap-3 rounded-xl mobile-interactive transition-all duration-200 touch-target px-3 py-2.5",
-                          pathname === href || pathname.startsWith(href)
-                            ? "bg-gradient-to-r from-primary to-primary/90 text-white font-semibold shadow-lg shadow-primary/25"
-                            : "text-slate-600 hover:bg-slate-50 hover:text-primary"
-                        )}
-                        onClick={() => setIsMobileSheetOpen(false)}
-                      >
-                        <Icon className={cn(
-                          "h-5 w-5",
-                          pathname === href || pathname.startsWith(href) ? "text-white" : "text-slate-500"
-                        )} />
-                        {label}
-                      </Link>
-                    ))}
-                  </nav>
+                  <AppSidebarNav
+                    items={navItems}
+                    pathname={pathname}
+                    isSidebarOpen
+                    notificationCounts={notificationCounts}
+                    variant="sheet"
+                    className="p-3"
+                    onNavigate={() => setIsMobileSheetOpen(false)}
+                  />
                 </SheetContent>
               </Sheet>
               <Button
@@ -301,8 +224,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
               {/* Notification Bell */}
               <NotificationBellDialog
-                repairCount={repairCount}
-                transferCount={transferCount}
+                repairCount={notificationCounts.repair}
+                transferCount={notificationCounts.transfer}
+                maintenanceCount={notificationCounts.maintenance}
               />
 
               <DropdownMenu>
@@ -351,7 +275,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             </main>
 
             {/* Mobile Footer Navigation - replaces offcanvas sidebar on mobile */}
-            <MobileFooterNav />
+            <MobileFooterNav notificationCounts={notificationCounts} />
 
             {/* AI Assistant FAB + Panel */}
             <AssistantTriggerButton

--- a/src/components/__tests__/app-sidebar-nav.test.tsx
+++ b/src/components/__tests__/app-sidebar-nav.test.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen, within } from "@testing-library/react"
+import { ArrowLeftRight, HardHat, Home, Wrench } from "lucide-react"
+import { describe, expect, it } from "vitest"
+
+import { AppSidebarNav } from "../app-sidebar-nav"
+
+describe("AppSidebarNav", () => {
+  it("renders per-type badges on matching navigation items only", () => {
+    render(
+      <AppSidebarNav
+        items={[
+          { href: "/dashboard", icon: Home, label: "Tổng quan" },
+          { href: "/repair-requests", icon: Wrench, label: "Yêu cầu sửa chữa", badgeKey: "repair" },
+          { href: "/maintenance", icon: HardHat, label: "Bảo trì", badgeKey: "maintenance" },
+          { href: "/transfers", icon: ArrowLeftRight, label: "Luân chuyển", badgeKey: "transfer" },
+        ]}
+        pathname="/dashboard"
+        isSidebarOpen
+        notificationCounts={{
+          repair: 2,
+          transfer: 4,
+          maintenance: 12,
+        }}
+        tourAttributes={{
+          "/dashboard": "sidebar-nav-dashboard",
+          "/repair-requests": "sidebar-nav-repairs",
+          "/maintenance": "sidebar-nav-maintenance",
+          "/transfers": "sidebar-nav-transfers",
+        }}
+      />
+    )
+
+    const repairLink = screen.getByText("Yêu cầu sửa chữa").closest("a")
+    const maintenanceLink = screen.getByText("Bảo trì").closest("a")
+    const transferLink = screen.getByText("Luân chuyển").closest("a")
+    const dashboardLink = screen.getByText("Tổng quan").closest("a")
+
+    expect(repairLink).not.toBeNull()
+    expect(maintenanceLink).not.toBeNull()
+    expect(transferLink).not.toBeNull()
+    expect(dashboardLink).not.toBeNull()
+
+    expect(within(repairLink!).getByText("2")).toBeInTheDocument()
+    expect(within(transferLink!).getByText("4")).toBeInTheDocument()
+    expect(within(maintenanceLink!).getByText("9+")).toBeInTheDocument()
+    expect(within(dashboardLink!).queryByText("2")).not.toBeInTheDocument()
+    expect(within(dashboardLink!).queryByText("4")).not.toBeInTheDocument()
+    expect(within(dashboardLink!).queryByText("9+")).not.toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/mobile-footer-nav.test.tsx
+++ b/src/components/__tests__/mobile-footer-nav.test.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  usePathname: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.usePathname(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+import { MobileFooterNav } from "../mobile-footer-nav"
+
+describe("MobileFooterNav", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.usePathname.mockReturnValue("/dashboard")
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          role: "global",
+        },
+      },
+    })
+  })
+
+  it("shows repair badge on the tab and aggregates hidden counts on the more button", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MobileFooterNav
+        notificationCounts={{
+          repair: 2,
+          transfer: 4,
+          maintenance: 8,
+        }}
+      />
+    )
+
+    const repairLink = screen.getByText("Sửa chữa").closest("a")
+    const moreButton = screen.getByRole("button", { name: /thêm tùy chọn/i })
+
+    expect(repairLink).not.toBeNull()
+    expect(within(repairLink!).getByText("2")).toBeInTheDocument()
+    expect(within(moreButton).getByText("9+")).toBeInTheDocument()
+
+    await user.click(moreButton)
+
+    const transferLink = screen.getByText("Luân chuyển").closest("a")
+    const maintenanceLink = screen.getByText("Bảo trì").closest("a")
+
+    expect(transferLink).not.toBeNull()
+    expect(maintenanceLink).not.toBeNull()
+    expect(within(transferLink!).getByText("4")).toBeInTheDocument()
+    expect(within(maintenanceLink!).getByText("8")).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/mobile-footer-nav.test.tsx
+++ b/src/components/__tests__/mobile-footer-nav.test.tsx
@@ -17,7 +17,7 @@ vi.mock("next-auth/react", () => ({
   useSession: () => mocks.useSession(),
 }))
 
-import { MobileFooterNav } from "../mobile-footer-nav"
+import { MobileFooterNav } from "@/components/mobile-footer-nav"
 
 describe("MobileFooterNav", () => {
   beforeEach(() => {
@@ -51,6 +51,8 @@ describe("MobileFooterNav", () => {
     expect(repairLink).not.toBeNull()
     expect(within(repairLink!).getByText("2")).toBeInTheDocument()
     expect(within(moreButton).getByText("9+")).toBeInTheDocument()
+    expect(moreButton).toHaveClass("relative")
+    expect(moreButton).toHaveAttribute("aria-expanded", "false")
 
     await user.click(moreButton)
 
@@ -61,5 +63,6 @@ describe("MobileFooterNav", () => {
     expect(maintenanceLink).not.toBeNull()
     expect(within(transferLink!).getByText("4")).toBeInTheDocument()
     expect(within(maintenanceLink!).getByText("8")).toBeInTheDocument()
+    expect(moreButton).toHaveAttribute("aria-expanded", "true")
   })
 })

--- a/src/components/__tests__/notification-bell-dialog.test.tsx
+++ b/src/components/__tests__/notification-bell-dialog.test.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { NotificationBellDialog } from "../notification-bell-dialog"
+
+describe("NotificationBellDialog", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation(() => ({
+        matches: false,
+        media: "",
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+
+  it("includes maintenance count in the total badge and dialog content", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <NotificationBellDialog
+        repairCount={2}
+        transferCount={3}
+        maintenanceCount={4}
+      />
+    )
+
+    expect(screen.getByText("9")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /mở thông báo/i }))
+
+    expect(screen.getByText("Thông báo và Cảnh báo (9)")).toBeInTheDocument()
+    const maintenanceSection = screen.getByText("Yêu cầu Bảo trì (4)").closest("section")
+
+    expect(maintenanceSection).not.toBeNull()
+    expect(
+      within(maintenanceSection!).getByText("Có 4 kế hoạch bảo trì đã được duyệt đang chờ triển khai.")
+    ).toBeInTheDocument()
+    expect(within(maintenanceSection!).getByRole("link", { name: "Xem chi tiết →" })).toHaveAttribute(
+      "href",
+      "/maintenance"
+    )
+  })
+
+  it("caps the total badge at 9+", () => {
+    render(
+      <NotificationBellDialog
+        repairCount={4}
+        transferCount={4}
+        maintenanceCount={4}
+      />
+    )
+
+    expect(screen.getByText("9+")).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/notification-bell-dialog.test.tsx
+++ b/src/components/__tests__/notification-bell-dialog.test.tsx
@@ -1,13 +1,19 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
-import { render, screen, within } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { NotificationBellDialog } from "../notification-bell-dialog"
+import { NotificationBellDialog } from "@/components/notification-bell-dialog"
 
 describe("NotificationBellDialog", () => {
   beforeEach(() => {
+    class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: vi.fn().mockImplementation(() => ({
@@ -20,6 +26,14 @@ describe("NotificationBellDialog", () => {
         removeEventListener: vi.fn(),
         dispatchEvent: vi.fn(),
       })),
+    })
+    Object.defineProperty(window, "ResizeObserver", {
+      writable: true,
+      value: ResizeObserverMock,
+    })
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      writable: true,
+      value: ResizeObserverMock,
     })
   })
 
@@ -61,5 +75,26 @@ describe("NotificationBellDialog", () => {
     )
 
     expect(screen.getByText("9+")).toBeInTheDocument()
+  })
+
+  it("closes the dialog after clicking a detail link", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <NotificationBellDialog
+        repairCount={2}
+        transferCount={0}
+        maintenanceCount={0}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /mở thông báo/i }))
+    expect(screen.getByText("Thông báo và Cảnh báo (2)")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("link", { name: "Xem chi tiết →" }))
+
+    await waitFor(() =>
+      expect(screen.queryByText("Thông báo và Cảnh báo (2)")).not.toBeInTheDocument()
+    )
   })
 })

--- a/src/components/app-navigation.tsx
+++ b/src/components/app-navigation.tsx
@@ -1,0 +1,84 @@
+import {
+  Activity,
+  ArrowLeftRight,
+  BarChart3,
+  Calculator,
+  HardHat,
+  Home,
+  Package,
+  QrCode,
+  Users,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react"
+
+import { isGlobalRole } from "@/lib/rbac"
+import type { AppNotificationBadgeKey } from "@/lib/app-notification-counts"
+
+export interface AppNavItem {
+  href: string
+  icon: LucideIcon
+  label: string
+  mobileLabel?: string
+  mobileSection: "main" | "more"
+  badgeKey?: AppNotificationBadgeKey
+  requiresGlobal?: boolean
+}
+
+const APP_NAV_ITEMS: AppNavItem[] = [
+  { href: "/dashboard", icon: Home, label: "Tổng quan", mobileSection: "main" },
+  { href: "/equipment", icon: Package, label: "Thiết bị", mobileSection: "main" },
+  {
+    href: "/repair-requests",
+    icon: Wrench,
+    label: "Yêu cầu sửa chữa",
+    mobileLabel: "Sửa chữa",
+    mobileSection: "main",
+    badgeKey: "repair",
+  },
+  {
+    href: "/transfers",
+    icon: ArrowLeftRight,
+    label: "Luân chuyển",
+    mobileSection: "more",
+    badgeKey: "transfer",
+  },
+  {
+    href: "/maintenance",
+    icon: HardHat,
+    label: "Bảo trì",
+    mobileSection: "more",
+    badgeKey: "maintenance",
+  },
+  { href: "/device-quota", icon: Calculator, label: "Định mức", mobileSection: "more" },
+  { href: "/reports", icon: BarChart3, label: "Báo cáo", mobileSection: "more" },
+  { href: "/qr-scanner", icon: QrCode, label: "Quét QR", mobileSection: "more" },
+  { href: "/users", icon: Users, label: "Người dùng", mobileSection: "more", requiresGlobal: true },
+  {
+    href: "/activity-logs",
+    icon: Activity,
+    label: "Nhật ký hoạt động",
+    mobileSection: "more",
+    requiresGlobal: true,
+  },
+]
+
+export function getAppNavigationItems(role?: string): AppNavItem[] {
+  return APP_NAV_ITEMS.filter((item) => !item.requiresGlobal || isGlobalRole(role))
+}
+
+export function getMobileFooterMainNavItems(role?: string): AppNavItem[] {
+  return getAppNavigationItems(role).filter((item) => item.mobileSection === "main")
+}
+
+export function getMobileFooterMoreNavItems(role?: string): AppNavItem[] {
+  return getAppNavigationItems(role).filter((item) => item.mobileSection === "more")
+}
+
+export function isAppNavItemActive(pathname: string, href: string): boolean {
+  if (href === "/dashboard") {
+    return pathname === href
+  }
+
+  return pathname === href || pathname.startsWith(`${href}/`)
+}

--- a/src/components/app-notification-badge.tsx
+++ b/src/components/app-notification-badge.tsx
@@ -1,0 +1,41 @@
+import * as React from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { formatNotificationBadgeCount } from "@/lib/app-notification-counts"
+import { cn } from "@/lib/utils"
+
+interface AppNotificationBadgeProps {
+  count: number
+  active?: boolean
+  mode?: "inline" | "floating"
+  className?: string
+}
+
+export function AppNotificationBadge({
+  count,
+  active = false,
+  mode = "inline",
+  className,
+}: Readonly<AppNotificationBadgeProps>): React.JSX.Element | null {
+  const label = formatNotificationBadgeCount(count)
+
+  if (!label) {
+    return null
+  }
+
+  return (
+    <Badge
+      variant="destructive"
+      className={cn(
+        "border-transparent text-[11px] font-semibold leading-none",
+        mode === "inline"
+          ? "ml-auto h-5 min-w-[1.25rem] justify-center rounded-full px-1.5"
+          : "absolute right-1 top-1 h-5 min-w-[1.25rem] justify-center rounded-full px-1.5",
+        active ? "ring-2 ring-white/30" : null,
+        className
+      )}
+    >
+      {label}
+    </Badge>
+  )
+}

--- a/src/components/app-sidebar-nav.tsx
+++ b/src/components/app-sidebar-nav.tsx
@@ -1,0 +1,85 @@
+import * as React from "react"
+import Link from "next/link"
+
+import type { AppNotificationCounts } from "@/lib/app-notification-counts"
+import { cn } from "@/lib/utils"
+
+import { AppNotificationBadge } from "./app-notification-badge"
+import { isAppNavItemActive, type AppNavItem } from "./app-navigation"
+
+interface AppSidebarNavProps {
+  items: AppNavItem[]
+  pathname: string
+  isSidebarOpen: boolean
+  notificationCounts: AppNotificationCounts
+  tourAttributes?: Record<string, string>
+  variant?: "sidebar" | "sheet"
+  className?: string
+  onNavigate?: () => void
+}
+
+export function AppSidebarNav({
+  items,
+  pathname,
+  isSidebarOpen,
+  notificationCounts,
+  tourAttributes = {},
+  variant = "sidebar",
+  className,
+  onNavigate,
+}: Readonly<AppSidebarNavProps>): React.JSX.Element {
+  const isSheetVariant = variant === "sheet"
+
+  return (
+    <nav
+      className={cn(
+        isSheetVariant
+          ? "grid gap-1 body-responsive font-medium"
+          : "grid items-start text-sm font-medium gap-1",
+        className
+      )}
+    >
+      {items.map(({ href, icon: Icon, label, badgeKey }) => {
+        const isActive = isAppNavItemActive(pathname, href)
+        const badgeCount = badgeKey ? notificationCounts[badgeKey] : 0
+        const usesFloatingBadge = !isSheetVariant && !isSidebarOpen
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={cn(
+              "rounded-xl transition-all duration-200",
+              isSheetVariant
+                ? "flex items-center gap-3 px-3 py-2.5 mobile-interactive touch-target"
+                : "flex items-center py-2.5",
+              isActive
+                ? "bg-gradient-to-r from-primary to-primary/90 text-white font-semibold shadow-lg shadow-primary/25"
+                : "text-slate-600 hover:bg-slate-50 hover:text-primary",
+              !isSheetVariant && isSidebarOpen ? "px-3 gap-3" : null,
+              !isSheetVariant && !isSidebarOpen ? "relative h-11 w-11 justify-center" : null
+            )}
+            title={!isSheetVariant && !isSidebarOpen ? label : ""}
+            aria-label={label}
+            aria-current={isActive ? "page" : undefined}
+            data-tour={tourAttributes[href]}
+            onClick={onNavigate}
+          >
+            <Icon
+              className={cn(
+                "h-5 w-5 transition-colors",
+                isActive ? "text-white" : "text-slate-500"
+              )}
+            />
+            {(isSheetVariant || isSidebarOpen) && <span>{label}</span>}
+            <AppNotificationBadge
+              count={badgeCount}
+              active={isActive}
+              mode={usesFloatingBadge ? "floating" : "inline"}
+            />
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/app-sidebar-nav.tsx
+++ b/src/components/app-sidebar-nav.tsx
@@ -7,6 +7,8 @@ import { cn } from "@/lib/utils"
 import { AppNotificationBadge } from "./app-notification-badge"
 import { isAppNavItemActive, type AppNavItem } from "./app-navigation"
 
+const EMPTY_TOUR_ATTRIBUTES: Record<string, string> = {}
+
 interface AppSidebarNavProps {
   items: AppNavItem[]
   pathname: string
@@ -23,7 +25,7 @@ export function AppSidebarNav({
   pathname,
   isSidebarOpen,
   notificationCounts,
-  tourAttributes = {},
+  tourAttributes = EMPTY_TOUR_ATTRIBUTES,
   variant = "sidebar",
   className,
   onNavigate,

--- a/src/components/mobile-footer-nav.tsx
+++ b/src/components/mobile-footer-nav.tsx
@@ -4,17 +4,7 @@ import * as React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import {
-  Home,
-  Package,
-  Wrench,
-  ArrowLeftRight,
   MoreHorizontal,
-  HardHat,
-  BarChart3,
-  QrCode,
-  Users,
-  Activity,
-  Calculator,
 } from "lucide-react"
 
 import {
@@ -24,87 +14,79 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { useSession } from "next-auth/react"
+import {
+  EMPTY_APP_NOTIFICATION_COUNTS,
+  sumNotificationBadgeCounts,
+  type AppNotificationCounts,
+} from "@/lib/app-notification-counts"
 import { cn } from "@/lib/utils"
-import { isGlobalRole } from "@/lib/rbac"
 
-export function MobileFooterNav() {
+import { AppNotificationBadge } from "./app-notification-badge"
+import {
+  getMobileFooterMainNavItems,
+  getMobileFooterMoreNavItems,
+  isAppNavItemActive,
+} from "./app-navigation"
+
+interface MobileFooterNavProps {
+  notificationCounts?: AppNotificationCounts
+}
+
+export function MobileFooterNav({
+  notificationCounts = EMPTY_APP_NOTIFICATION_COUNTS,
+}: Readonly<MobileFooterNavProps>) {
   const pathname = usePathname()
   const { data: session } = useSession()
-  const user = session?.user as any
+  const user = session?.user as { role?: string } | undefined
 
-  // Primary navigation items for footer tabs
-  const mainNavItems = [
-    { href: "/dashboard", icon: Home, label: "Tổng quan" },
-    { href: "/equipment", icon: Package, label: "Thiết bị" },
-    { href: "/repair-requests", icon: Wrench, label: "Sửa chữa" },
-  ]
-
-  // Secondary navigation items for "More" dropdown
-  const moreNavItems = React.useMemo(() => {
-    const baseItems = [
-      { href: "/transfers", icon: ArrowLeftRight, label: "Luân chuyển" },
-      { href: "/maintenance", icon: HardHat, label: "Bảo trì" },
-      { href: "/device-quota", icon: Calculator, label: "Định mức" },
-      { href: "/reports", icon: BarChart3, label: "Báo cáo" },
-      { href: "/qr-scanner", icon: QrCode, label: "Quét QR" },
-    ]
-
-    // Add admin-only items with role-based permissions
-  if (isGlobalRole(user?.role)) {
-      baseItems.push({ href: "/users", icon: Users, label: "Người dùng" })
-      baseItems.push({ href: "/activity-logs", icon: Activity, label: "Nhật ký hoạt động" })
-    }
-
-    return baseItems
-  }, [user?.role])
+  const mainNavItems = React.useMemo(() => getMobileFooterMainNavItems(user?.role), [user?.role])
+  const moreNavItems = React.useMemo(() => getMobileFooterMoreNavItems(user?.role), [user?.role])
 
   // Check if any item in "More" dropdown is active
   const isMoreActive = React.useMemo(() => {
-    return moreNavItems.some(item =>
-      pathname === item.href || pathname.startsWith(item.href + '/')
-    )
+    return moreNavItems.some((item) => isAppNavItemActive(pathname, item.href))
   }, [pathname, moreNavItems])
 
-  // Enhanced active state detection for better UX
-  const isItemActive = React.useCallback((href: string) => {
-    if (href === "/dashboard") {
-      return pathname === href
-    }
-    return pathname === href || pathname.startsWith(href + '/')
-  }, [pathname])
+  const moreBadgeCount = React.useMemo(
+    () =>
+      sumNotificationBadgeCounts(
+        moreNavItems
+          .map((item) => item.badgeKey)
+          .filter((badgeKey): badgeKey is keyof AppNotificationCounts => Boolean(badgeKey)),
+        notificationCounts
+      ),
+    [moreNavItems, notificationCounts]
+  )
 
   return (
     <div className="fixed bottom-0 left-0 right-0 mobile-footer-z border-t border-slate-200 bg-white shadow-[0_-2px_10px_rgba(0,0,0,0.08)] md:hidden lg:hidden">
-      <nav
-        className="grid h-16 grid-cols-4 items-center px-2"
-        role="navigation"
-        aria-label="Điều hướng chính"
-      >
-        {mainNavItems.map(({ href, icon: Icon, label }) => {
-          const isActive = isItemActive(href)
+      <nav className="grid h-16 grid-cols-4 items-center px-2" aria-label="Điều hướng chính">
+        {mainNavItems.map(({ href, icon: Icon, label, mobileLabel, badgeKey }) => {
+          const isActive = isAppNavItemActive(pathname, href)
+          const badgeCount = badgeKey ? notificationCounts[badgeKey] : 0
           return (
             <Link
-              key={label}
+              key={href}
               href={href}
               className={cn(
-                "flex flex-col items-center justify-center gap-1 rounded-xl mx-1 py-2 transition-all duration-200 touch-target focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                "relative flex flex-col items-center justify-center gap-1 rounded-xl mx-1 py-2 transition-all duration-200 touch-target focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                 isActive
                   ? "bg-gradient-to-br from-primary to-primary/90 text-white shadow-lg shadow-primary/20"
                   : "text-slate-600 hover:bg-slate-50 active:bg-slate-100"
               )}
-              aria-label={label}
+              aria-label={mobileLabel ?? label}
               aria-current={isActive ? "page" : undefined}
             >
               <Icon className={cn(
                 "h-5 w-5 transition-colors",
                 isActive ? "text-white" : "text-slate-500"
               )} />
+              <AppNotificationBadge count={badgeCount} active={isActive} mode="floating" />
               <span className={cn(
                 "text-xs font-medium transition-colors",
                 isActive ? "text-white" : "text-slate-600"
-              )}>{label}</span>
+              )}>{mobileLabel ?? label}</span>
             </Link>
           )
         })}
@@ -126,6 +108,7 @@ export function MobileFooterNav() {
                 "h-5 w-5 transition-colors",
                 isMoreActive ? "text-white" : "text-slate-500"
               )} />
+              <AppNotificationBadge count={moreBadgeCount} active={isMoreActive} mode="floating" />
               <span className={cn(
                 "text-xs font-medium transition-colors",
                 isMoreActive ? "text-white" : "text-slate-600"
@@ -137,8 +120,9 @@ export function MobileFooterNav() {
             className="mb-3 min-w-[200px] bg-white border border-slate-200 shadow-xl rounded-xl p-2"
             sideOffset={12}
           >
-            {moreNavItems.map(({ href, icon: Icon, label }) => {
-              const isActive = isItemActive(href)
+            {moreNavItems.map(({ href, icon: Icon, label, mobileLabel, badgeKey }) => {
+              const isActive = isAppNavItemActive(pathname, href)
+              const badgeCount = badgeKey ? notificationCounts[badgeKey] : 0
               return (
                 <DropdownMenuItem key={label} asChild>
                   <Link
@@ -155,7 +139,8 @@ export function MobileFooterNav() {
                       "h-5 w-5 transition-colors",
                       isActive ? "text-white" : "text-slate-500"
                     )} />
-                    <span className="text-sm">{label}</span>
+                    <span className="text-sm">{mobileLabel ?? label}</span>
+                    <AppNotificationBadge count={badgeCount} active={isActive} />
                   </Link>
                 </DropdownMenuItem>
               )

--- a/src/components/mobile-footer-nav.tsx
+++ b/src/components/mobile-footer-nav.tsx
@@ -96,13 +96,12 @@ export function MobileFooterNav({
             <Button
               variant="ghost"
               className={cn(
-                "flex flex-col items-center justify-center gap-1 rounded-xl mx-1 py-2 transition-all duration-200 touch-target h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                "relative flex flex-col items-center justify-center gap-1 rounded-xl mx-1 py-2 transition-all duration-200 touch-target h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                 isMoreActive
                   ? "bg-gradient-to-br from-primary to-primary/90 text-white shadow-lg shadow-primary/20"
                   : "text-slate-600 hover:bg-slate-50 active:bg-slate-100"
               )}
               aria-label="Thêm tùy chọn"
-              aria-expanded="false"
             >
               <MoreHorizontal className={cn(
                 "h-5 w-5 transition-colors",

--- a/src/components/notification-bell-dialog.tsx
+++ b/src/components/notification-bell-dialog.tsx
@@ -32,6 +32,9 @@ export function NotificationBellDialog({
   maintenanceCount: maintenanceCountProp = 0,
 }: NotificationBellDialogProps) {
   const [isOpen, setIsOpen] = React.useState(false);
+  const handleDetailClick = React.useCallback(() => {
+    setIsOpen(false)
+  }, [])
 
   // Support either direct counts or fallback to array-based counting for backward compatibility
   const repairCount =
@@ -93,7 +96,7 @@ export function NotificationBellDialog({
                       Có {repairCount} yêu cầu sửa chữa đang chờ xử lý hoặc đã được duyệt.
                     </p>
                     <Button variant="link" className="p-0 h-auto text-sm" asChild>
-                      <Link href="/repair-requests">Xem chi tiết →</Link>
+                      <Link href="/repair-requests" onClick={handleDetailClick}>Xem chi tiết →</Link>
                     </Button>
                   </div>
                 </section>
@@ -110,7 +113,7 @@ export function NotificationBellDialog({
                       Có {transferCount} yêu cầu luân chuyển đang chờ duyệt hoặc đã được duyệt.
                     </p>
                     <Button variant="link" className="p-0 h-auto text-sm" asChild>
-                      <Link href="/transfers">Xem chi tiết →</Link>
+                      <Link href="/transfers" onClick={handleDetailClick}>Xem chi tiết →</Link>
                     </Button>
                   </div>
                 </section>
@@ -127,7 +130,7 @@ export function NotificationBellDialog({
                       Có {maintenanceCount} kế hoạch bảo trì đã được duyệt đang chờ triển khai.
                     </p>
                     <Button variant="link" className="p-0 h-auto text-sm" asChild>
-                      <Link href="/maintenance">Xem chi tiết →</Link>
+                      <Link href="/maintenance" onClick={handleDetailClick}>Xem chi tiết →</Link>
                     </Button>
                   </div>
                 </section>

--- a/src/components/notification-bell-dialog.tsx
+++ b/src/components/notification-bell-dialog.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import * as React from "react"
-import { Bell, ArrowLeftRight, Wrench } from "lucide-react"
+import Link from "next/link"
+import { Bell, ArrowLeftRight, HardHat, Wrench } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -11,15 +12,16 @@ import {
   DialogTrigger,
   DialogDescription,
 } from "@/components/ui/dialog"
-import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { AppNotificationBadge } from "@/components/app-notification-badge"
 
 interface NotificationBellDialogProps {
-  allRepairRequests?: any;
-  allTransferRequests?: any;
+  allRepairRequests?: Array<{ trang_thai?: string }>;
+  allTransferRequests?: Array<{ trang_thai?: string }>;
   // Optional direct counts (preferred). When provided, component won't re-count from arrays
   repairCount?: number;
   transferCount?: number;
+  maintenanceCount?: number;
 }
 
 export function NotificationBellDialog({
@@ -27,6 +29,7 @@ export function NotificationBellDialog({
   allTransferRequests,
   repairCount: repairCountProp,
   transferCount: transferCountProp,
+  maintenanceCount: maintenanceCountProp = 0,
 }: NotificationBellDialogProps) {
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -34,18 +37,21 @@ export function NotificationBellDialog({
   const repairCount =
     typeof repairCountProp === 'number'
       ? repairCountProp
-      : (allRepairRequests?.filter((req: any) =>
+      : (allRepairRequests?.filter((req) =>
           req.trang_thai === 'Chờ xử lý' || req.trang_thai === 'Đã duyệt'
         )?.length || 0);
   
   const transferCount =
     typeof transferCountProp === 'number'
       ? transferCountProp
-      : (allTransferRequests?.filter((req: any) =>
+      : (allTransferRequests?.filter((req) =>
           req.trang_thai === 'cho_duyet' || req.trang_thai === 'da_duyet'
         )?.length || 0);
-  
-  const totalAlertsCount = repairCount + transferCount;
+
+  const maintenanceCount =
+    typeof maintenanceCountProp === "number" ? maintenanceCountProp : 0
+
+  const totalAlertsCount = repairCount + transferCount + maintenanceCount;
 
   
 
@@ -54,14 +60,11 @@ export function NotificationBellDialog({
       <DialogTrigger asChild>
         <Button variant="ghost" size="icon" className="relative rounded-full">
           <Bell className="h-5 w-5" />
-          {totalAlertsCount > 0 && (
-            <Badge
-              variant="destructive"
-              className="absolute -top-1 -right-1 h-4 w-4 min-w-[1rem] p-0.5 text-xs flex items-center justify-center rounded-full"
-            >
-              {totalAlertsCount > 9 ? "9+" : totalAlertsCount}
-            </Badge>
-          )}
+          <AppNotificationBadge
+            count={totalAlertsCount}
+            mode="floating"
+            className="-right-1 -top-1 h-4 min-w-[1rem] px-1 text-xs"
+          />
           <span className="sr-only">Mở thông báo</span>
         </Button>
       </DialogTrigger>
@@ -90,7 +93,7 @@ export function NotificationBellDialog({
                       Có {repairCount} yêu cầu sửa chữa đang chờ xử lý hoặc đã được duyệt.
                     </p>
                     <Button variant="link" className="p-0 h-auto text-sm" asChild>
-                      <a href="/repair-requests">Xem chi tiết →</a>
+                      <Link href="/repair-requests">Xem chi tiết →</Link>
                     </Button>
                   </div>
                 </section>
@@ -107,7 +110,24 @@ export function NotificationBellDialog({
                       Có {transferCount} yêu cầu luân chuyển đang chờ duyệt hoặc đã được duyệt.
                     </p>
                     <Button variant="link" className="p-0 h-auto text-sm" asChild>
-                      <a href="/transfers">Xem chi tiết →</a>
+                      <Link href="/transfers">Xem chi tiết →</Link>
+                    </Button>
+                  </div>
+                </section>
+              )}
+
+              {maintenanceCount > 0 && (
+                <section>
+                  <h3 className="text-md font-semibold mb-2 flex items-center">
+                    <HardHat className="h-4 w-4 mr-2 text-emerald-600" />
+                    Yêu cầu Bảo trì ({maintenanceCount})
+                  </h3>
+                  <div className="p-3 border rounded-md">
+                    <p className="text-sm text-muted-foreground">
+                      Có {maintenanceCount} kế hoạch bảo trì đã được duyệt đang chờ triển khai.
+                    </p>
+                    <Button variant="link" className="p-0 h-auto text-sm" asChild>
+                      <Link href="/maintenance">Xem chi tiết →</Link>
                     </Button>
                   </div>
                 </section>

--- a/src/hooks/__tests__/useAppNotificationCounts.test.tsx
+++ b/src/hooks/__tests__/useAppNotificationCounts.test.tsx
@@ -1,0 +1,97 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+}))
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: mocks.callRpc,
+}))
+
+import { useAppNotificationCounts } from "../useAppNotificationCounts"
+
+describe("useAppNotificationCounts", () => {
+  beforeEach(() => {
+    mocks.callRpc.mockReset()
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    consoleErrorSpy.mockRestore()
+  })
+
+  it("merges header notifications with approved maintenance counts", async () => {
+    mocks.callRpc
+      .mockResolvedValueOnce({
+        pending_repairs: 2,
+        pending_transfers: 3,
+      })
+      .mockResolvedValueOnce({
+        "Bản nháp": 5,
+        "Đã duyệt": 4,
+        "Không duyệt": 1,
+      })
+
+    const { result } = renderHook(() => useAppNotificationCounts({ enabled: true }))
+
+    await waitFor(() =>
+      expect(result.current.counts).toEqual({
+        repair: 2,
+        transfer: 3,
+        maintenance: 4,
+      })
+    )
+
+    expect(mocks.callRpc).toHaveBeenNthCalledWith(1, {
+      fn: "header_notifications_summary",
+      args: { p_don_vi: null },
+    })
+    expect(mocks.callRpc).toHaveBeenNthCalledWith(2, {
+      fn: "maintenance_plan_status_counts",
+      args: {},
+    })
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("falls back maintenance to zero when maintenance counts fail", async () => {
+    mocks.callRpc
+      .mockResolvedValueOnce({
+        pending_repairs: 1,
+        pending_transfers: 2,
+      })
+      .mockRejectedValueOnce(new Error("unstable maintenance counts"))
+
+    const { result } = renderHook(() => useAppNotificationCounts({ enabled: true }))
+
+    await waitFor(() =>
+      expect(result.current.counts).toEqual({
+        repair: 1,
+        transfer: 2,
+        maintenance: 0,
+      })
+    )
+
+    expect(result.current.isLoading).toBe(false)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Maintenance notification counts error:",
+      expect.any(Error)
+    )
+  })
+
+  it("does not fetch when disabled", async () => {
+    const { result } = renderHook(() => useAppNotificationCounts({ enabled: false }))
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+    expect(result.current.counts).toEqual({
+      repair: 0,
+      transfer: 0,
+      maintenance: 0,
+    })
+  })
+})

--- a/src/hooks/__tests__/useAppNotificationCounts.test.tsx
+++ b/src/hooks/__tests__/useAppNotificationCounts.test.tsx
@@ -1,3 +1,5 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -12,6 +14,12 @@ vi.mock("@/lib/rpc-client", () => ({
 }))
 
 import { useAppNotificationCounts } from "../useAppNotificationCounts"
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
 
 describe("useAppNotificationCounts", () => {
   beforeEach(() => {
@@ -36,7 +44,17 @@ describe("useAppNotificationCounts", () => {
         "Không duyệt": 1,
       })
 
-    const { result } = renderHook(() => useAppNotificationCounts({ enabled: true }))
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useAppNotificationCounts({ enabled: true }), {
+      wrapper: createWrapper(queryClient),
+    })
 
     await waitFor(() =>
       expect(result.current.counts).toEqual({
@@ -46,14 +64,22 @@ describe("useAppNotificationCounts", () => {
       })
     )
 
-    expect(mocks.callRpc).toHaveBeenNthCalledWith(1, {
-      fn: "header_notifications_summary",
-      args: { p_don_vi: null },
-    })
-    expect(mocks.callRpc).toHaveBeenNthCalledWith(2, {
-      fn: "maintenance_plan_status_counts",
-      args: {},
-    })
+    const [headerCall, maintenanceCall] = mocks.callRpc.mock.calls.map(([call]) => call)
+
+    expect(headerCall).toEqual(
+      expect.objectContaining({
+        fn: "header_notifications_summary",
+        signal: expect.any(AbortSignal),
+      })
+    )
+    expect(headerCall).not.toHaveProperty("args")
+    expect(maintenanceCall).toEqual(
+      expect.objectContaining({
+        fn: "maintenance_plan_status_counts",
+        args: {},
+        signal: expect.any(AbortSignal),
+      })
+    )
     expect(result.current.isLoading).toBe(false)
   })
 
@@ -65,7 +91,17 @@ describe("useAppNotificationCounts", () => {
       })
       .mockRejectedValueOnce(new Error("unstable maintenance counts"))
 
-    const { result } = renderHook(() => useAppNotificationCounts({ enabled: true }))
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useAppNotificationCounts({ enabled: true }), {
+      wrapper: createWrapper(queryClient),
+    })
 
     await waitFor(() =>
       expect(result.current.counts).toEqual({
@@ -83,7 +119,17 @@ describe("useAppNotificationCounts", () => {
   })
 
   it("does not fetch when disabled", async () => {
-    const { result } = renderHook(() => useAppNotificationCounts({ enabled: false }))
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useAppNotificationCounts({ enabled: false }), {
+      wrapper: createWrapper(queryClient),
+    })
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
@@ -93,5 +139,45 @@ describe("useAppNotificationCounts", () => {
       transfer: 0,
       maintenance: 0,
     })
+  })
+
+  it("dedupes concurrent consumers through the shared query cache", async () => {
+    mocks.callRpc
+      .mockResolvedValueOnce({
+        pending_repairs: 6,
+        pending_transfers: 1,
+      })
+      .mockResolvedValueOnce({
+        "Đã duyệt": 2,
+      })
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const wrapper = createWrapper(queryClient)
+    const firstHook = renderHook(() => useAppNotificationCounts({ enabled: true }), { wrapper })
+    const secondHook = renderHook(() => useAppNotificationCounts({ enabled: true }), { wrapper })
+
+    await waitFor(() =>
+      expect(firstHook.result.current.counts).toEqual({
+        repair: 6,
+        transfer: 1,
+        maintenance: 2,
+      })
+    )
+    await waitFor(() =>
+      expect(secondHook.result.current.counts).toEqual({
+        repair: 6,
+        transfer: 1,
+        maintenance: 2,
+      })
+    )
+
+    expect(mocks.callRpc).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/hooks/useAppNotificationCounts.ts
+++ b/src/hooks/useAppNotificationCounts.ts
@@ -1,0 +1,104 @@
+"use client"
+
+import * as React from "react"
+
+import { callRpc } from "@/lib/rpc-client"
+import {
+  EMPTY_APP_NOTIFICATION_COUNTS,
+  normalizeNotificationCount,
+  type AppNotificationCounts,
+} from "@/lib/app-notification-counts"
+
+interface HeaderNotificationsSummary {
+  pending_repairs?: number
+  pending_transfers?: number
+}
+
+interface MaintenancePlanStatusCounts {
+  "Bản nháp"?: number
+  "Đã duyệt"?: number
+  "Không duyệt"?: number
+}
+
+interface UseAppNotificationCountsOptions {
+  enabled?: boolean
+}
+
+interface UseAppNotificationCountsResult {
+  counts: AppNotificationCounts
+  isLoading: boolean
+}
+
+export function useAppNotificationCounts(
+  options: UseAppNotificationCountsOptions = {}
+): UseAppNotificationCountsResult {
+  const { enabled = true } = options
+  const [counts, setCounts] = React.useState<AppNotificationCounts>(EMPTY_APP_NOTIFICATION_COUNTS)
+  const [isLoading, setIsLoading] = React.useState<boolean>(enabled)
+
+  React.useEffect(() => {
+    if (!enabled) {
+      setCounts(EMPTY_APP_NOTIFICATION_COUNTS)
+      setIsLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    const fetchCounts = async () => {
+      setIsLoading(true)
+
+      const [headerSummaryResult, maintenanceCountsResult] = await Promise.allSettled([
+        callRpc<HeaderNotificationsSummary, { p_don_vi?: number | null }>({
+          fn: "header_notifications_summary",
+          args: { p_don_vi: null },
+        }),
+        callRpc<MaintenancePlanStatusCounts | null, Record<string, never>>({
+          fn: "maintenance_plan_status_counts",
+          args: {},
+        }),
+      ])
+
+      if (cancelled) {
+        return
+      }
+
+      if (headerSummaryResult.status === "rejected") {
+        console.error("Header notifications error:", headerSummaryResult.reason)
+      }
+
+      if (maintenanceCountsResult.status === "rejected") {
+        console.error("Maintenance notification counts error:", maintenanceCountsResult.reason)
+      }
+
+      const nextCounts: AppNotificationCounts = {
+        repair:
+          headerSummaryResult.status === "fulfilled"
+            ? normalizeNotificationCount(headerSummaryResult.value?.pending_repairs)
+            : 0,
+        transfer:
+          headerSummaryResult.status === "fulfilled"
+            ? normalizeNotificationCount(headerSummaryResult.value?.pending_transfers)
+            : 0,
+        maintenance:
+          maintenanceCountsResult.status === "fulfilled"
+            ? normalizeNotificationCount(maintenanceCountsResult.value?.["Đã duyệt"])
+            : 0,
+      }
+
+      setCounts(nextCounts)
+      setIsLoading(false)
+    }
+
+    void fetchCounts()
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return {
+    counts,
+    isLoading,
+  }
+}

--- a/src/hooks/useAppNotificationCounts.ts
+++ b/src/hooks/useAppNotificationCounts.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import * as React from "react"
+import { useQuery } from "@tanstack/react-query"
 
 import { callRpc } from "@/lib/rpc-client"
 import {
@@ -29,39 +29,26 @@ interface UseAppNotificationCountsResult {
   isLoading: boolean
 }
 
+const APP_NOTIFICATION_COUNTS_QUERY_KEY = ["app-notification-counts"] as const
+
 export function useAppNotificationCounts(
   options: UseAppNotificationCountsOptions = {}
 ): UseAppNotificationCountsResult {
   const { enabled = true } = options
-  const [counts, setCounts] = React.useState<AppNotificationCounts>(EMPTY_APP_NOTIFICATION_COUNTS)
-  const [isLoading, setIsLoading] = React.useState<boolean>(enabled)
-
-  React.useEffect(() => {
-    if (!enabled) {
-      setCounts(EMPTY_APP_NOTIFICATION_COUNTS)
-      setIsLoading(false)
-      return
-    }
-
-    let cancelled = false
-
-    const fetchCounts = async () => {
-      setIsLoading(true)
-
+  const { data, isLoading } = useQuery<AppNotificationCounts>({
+    queryKey: APP_NOTIFICATION_COUNTS_QUERY_KEY,
+    queryFn: async ({ signal }) => {
       const [headerSummaryResult, maintenanceCountsResult] = await Promise.allSettled([
-        callRpc<HeaderNotificationsSummary, { p_don_vi?: number | null }>({
+        callRpc<HeaderNotificationsSummary>({
           fn: "header_notifications_summary",
-          args: { p_don_vi: null },
+          signal,
         }),
         callRpc<MaintenancePlanStatusCounts | null, Record<string, never>>({
           fn: "maintenance_plan_status_counts",
           args: {},
+          signal,
         }),
       ])
-
-      if (cancelled) {
-        return
-      }
 
       if (headerSummaryResult.status === "rejected") {
         console.error("Header notifications error:", headerSummaryResult.reason)
@@ -71,7 +58,7 @@ export function useAppNotificationCounts(
         console.error("Maintenance notification counts error:", maintenanceCountsResult.reason)
       }
 
-      const nextCounts: AppNotificationCounts = {
+      return {
         repair:
           headerSummaryResult.status === "fulfilled"
             ? normalizeNotificationCount(headerSummaryResult.value?.pending_repairs)
@@ -85,20 +72,14 @@ export function useAppNotificationCounts(
             ? normalizeNotificationCount(maintenanceCountsResult.value?.["Đã duyệt"])
             : 0,
       }
-
-      setCounts(nextCounts)
-      setIsLoading(false)
-    }
-
-    void fetchCounts()
-
-    return () => {
-      cancelled = true
-    }
-  }, [enabled])
+    },
+    enabled,
+    staleTime: 30_000,
+    gcTime: 10 * 60 * 1000,
+  })
 
   return {
-    counts,
-    isLoading,
+    counts: enabled ? (data ?? EMPTY_APP_NOTIFICATION_COUNTS) : EMPTY_APP_NOTIFICATION_COUNTS,
+    isLoading: enabled ? isLoading : false,
   }
 }

--- a/src/lib/app-notification-counts.ts
+++ b/src/lib/app-notification-counts.ts
@@ -1,0 +1,36 @@
+export interface AppNotificationCounts {
+  repair: number
+  transfer: number
+  maintenance: number
+}
+
+export type AppNotificationBadgeKey = keyof AppNotificationCounts
+
+export const EMPTY_APP_NOTIFICATION_COUNTS: AppNotificationCounts = {
+  repair: 0,
+  transfer: 0,
+  maintenance: 0,
+}
+
+const BADGE_CAP = 9
+
+export function normalizeNotificationCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}
+
+export function formatNotificationBadgeCount(count: number): string | null {
+  const normalizedCount = normalizeNotificationCount(count)
+
+  if (normalizedCount <= 0) {
+    return null
+  }
+
+  return normalizedCount > BADGE_CAP ? "9+" : String(normalizedCount)
+}
+
+export function sumNotificationBadgeCounts(
+  keys: readonly AppNotificationBadgeKey[],
+  counts: AppNotificationCounts
+): number {
+  return keys.reduce((total, key) => total + normalizeNotificationCount(counts[key]), 0)
+}


### PR DESCRIPTION
## Summary
- add a shared notification-count hook that merges repair, transfer, and approved maintenance counts for the app shell
- reuse shared navigation config and badge components so desktop sidebar, mobile footer, mobile sheet, and header bell stay in sync without duplicating badge logic
- extend the notification bell to include maintenance and keep the total badge aligned with the per-menu workload badges

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/hooks/__tests__/useAppNotificationCounts.test.tsx src/components/__tests__/notification-bell-dialog.test.tsx src/components/__tests__/app-sidebar-nav.test.tsx src/components/__tests__/mobile-footer-nav.test.tsx`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Notes
- `maintenance_plan_status_counts` behaved stably during implementation, so no follow-up issue was created.
- React Doctor still reports one pre-existing client redirect warning in `src/app/(app)/layout.tsx` (`router.push()` inside `useEffect`).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds notification badges across the app so users can see pending work at a glance. Counts combine pending repairs, transfers, and approved maintenance, and show in the sidebar, header bell, mobile footer, and mobile sheet.

- **New Features**
  - Badges on nav items and the bell via `AppNotificationBadge`, capped at 9+; floating on collapsed sidebar and mobile tabs/“More”.
  - `useAppNotificationCounts` merges `header_notifications_summary` and `maintenance_plan_status_counts` into `repair`, `transfer`, and `maintenance`, with fallback to 0 on errors.
  - Bell dialog includes maintenance in the total and closes after clicking detail links.

- **Refactors**
  - Centralized nav in `app-navigation` and rendering in `AppSidebarNav` to keep desktop, mobile sheet, and footer in sync.
  - Shared count utils live in `app-notification-counts`; removed inline logic from `layout.tsx` which now uses `getAppNavigationItems` and `next/link` in the bell.

<sup>Written for commit 4421d57b101e1ef17e5b09e56ae8def03c7fee27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Notification badges now appear on navigation items, displaying counts for pending repairs, transfers, and maintenance requests.

* **Refactor**
  * Reorganized navigation system to use a composable architecture, improving modularity and maintainability.

* **Tests**
  * Added comprehensive test coverage for navigation, footer navigation, and notification components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->