### PR TITLE
feat: [287] centralize protected page session boundary

### DIFF
--- a/src/app/(app)/__tests__/AuthenticatedPageBoundary.test.tsx
+++ b/src/app/(app)/__tests__/AuthenticatedPageBoundary.test.tsx
@@ -1,0 +1,85 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+
+describe("AuthenticatedPageBoundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the fallback while the session is loading", () => {
+    mocks.useSession.mockReturnValue({
+      status: "loading",
+      data: null,
+    })
+
+    const children = vi.fn(() => <div data-testid="protected-content">Protected</div>)
+
+    render(
+      <AuthenticatedPageBoundary fallback={<div data-testid="boundary-fallback">Loading</div>}>
+        {children}
+      </AuthenticatedPageBoundary>
+    )
+
+    expect(screen.getByTestId("boundary-fallback")).toBeInTheDocument()
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument()
+    expect(children).not.toHaveBeenCalled()
+  })
+
+  it("renders the fallback without invoking children when the user is unauthenticated", () => {
+    mocks.useSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    })
+
+    const children = vi.fn(() => <div data-testid="protected-content">Protected</div>)
+
+    render(
+      <AuthenticatedPageBoundary fallback={<div data-testid="boundary-fallback">Loading</div>}>
+        {children}
+      </AuthenticatedPageBoundary>
+    )
+
+    expect(screen.getByTestId("boundary-fallback")).toBeInTheDocument()
+    expect(screen.queryByTestId("protected-content")).not.toBeInTheDocument()
+    expect(children).not.toHaveBeenCalled()
+  })
+
+  it("renders children with the authenticated session user", () => {
+    const user = {
+      id: "user-1",
+      role: "to_qltb",
+      username: "tester",
+    }
+
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user },
+    })
+
+    const children = vi.fn((sessionUser: typeof user) => (
+      <div data-testid="protected-content">{sessionUser.username}</div>
+    ))
+
+    render(
+      <AuthenticatedPageBoundary fallback={<div data-testid="boundary-fallback">Loading</div>}>
+        {children}
+      </AuthenticatedPageBoundary>
+    )
+
+    expect(screen.queryByTestId("boundary-fallback")).not.toBeInTheDocument()
+    expect(screen.getByTestId("protected-content")).toHaveTextContent("tester")
+    expect(children).toHaveBeenCalledWith(user)
+  })
+})

--- a/src/app/(app)/_components/AuthenticatedPageBoundary.tsx
+++ b/src/app/(app)/_components/AuthenticatedPageBoundary.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import * as React from "react"
+import { useSession } from "next-auth/react"
+import type { Session } from "next-auth"
+
+type AuthenticatedPageBoundaryProps = {
+  fallback: React.ReactNode
+  children: (user: Session["user"]) => React.ReactNode
+}
+
+export function AuthenticatedPageBoundary({
+  fallback,
+  children,
+}: AuthenticatedPageBoundaryProps) {
+  const { data: session, status } = useSession()
+
+  if (status !== "authenticated" || !session?.user) {
+    return <>{fallback}</>
+  }
+
+  return <>{children(session.user)}</>
+}

--- a/src/app/(app)/_components/AuthenticatedPageFallbacks.tsx
+++ b/src/app/(app)/_components/AuthenticatedPageFallbacks.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import { Loader2 } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function AuthenticatedPageSkeletonFallback() {
+  return (
+    <div
+      className="flex items-center justify-center min-h-[50vh]"
+      data-testid="authenticated-page-skeleton-fallback"
+    >
+      <div className="text-center space-y-2">
+        <Skeleton className="h-8 w-32 mx-auto" />
+        <Skeleton className="h-4 w-48 mx-auto" />
+      </div>
+    </div>
+  )
+}
+
+export function AuthenticatedPageSpinnerFallback() {
+  return (
+    <div
+      className="flex min-h-[50vh] items-center justify-center"
+      data-testid="authenticated-page-spinner-fallback"
+    >
+      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+    </div>
+  )
+}

--- a/src/app/(app)/maintenance/__tests__/MaintenancePage.auth.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenancePage.auth.test.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}))
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="maintenance-page-skeleton" {...props} />
+  ),
+}))
+
+vi.mock("../_components/MaintenanceContext", () => ({
+  MaintenanceProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="maintenance-provider">{children}</div>
+  ),
+}))
+
+vi.mock("../_components/MaintenancePageClient", () => ({
+  MaintenancePageClient: () => <div data-testid="maintenance-page-client">Maintenance Page Client</div>,
+}))
+
+import MaintenancePage from "../page"
+
+describe("MaintenancePage auth wrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps the loading fallback visible without redirecting unauthenticated users", () => {
+    mocks.useSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    })
+
+    render(<MaintenancePage />)
+
+    expect(screen.getAllByTestId("maintenance-page-skeleton").length).toBeGreaterThan(0)
+    expect(screen.queryByTestId("maintenance-provider")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("maintenance-page-client")).not.toBeInTheDocument()
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+
+  it("mounts the maintenance wrapper once the session is authenticated", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: { user: { id: "user-1", role: "to_qltb" } },
+    })
+
+    render(<MaintenancePage />)
+
+    expect(screen.getByTestId("maintenance-provider")).toBeInTheDocument()
+    expect(screen.getByTestId("maintenance-page-client")).toBeInTheDocument()
+    expect(screen.queryByTestId("maintenance-page-skeleton")).not.toBeInTheDocument()
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/maintenance/page.tsx
+++ b/src/app/(app)/maintenance/page.tsx
@@ -2,36 +2,17 @@
 
 import * as React from "react"
 import type { RowSelectionState } from "@tanstack/react-table"
-import { useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
 import { Skeleton } from "@/components/ui/skeleton"
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
 import { MaintenanceProvider } from "./_components/MaintenanceContext"
 import { MaintenancePageClient } from "./_components/MaintenancePageClient"
 
 export default function MaintenancePage() {
-  const { status } = useSession()
-  const router = useRouter()
-
-  // Handle unauthenticated redirect in useEffect (not during render)
-  React.useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push("/")
-    }
-  }, [status, router])
-
-  // Show loading state for both loading and unauthenticated (while redirecting)
-  if (status === "loading" || status === "unauthenticated") {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="text-center space-y-2">
-          <Skeleton className="h-8 w-32 mx-auto" />
-          <Skeleton className="h-4 w-48 mx-auto" />
-        </div>
-      </div>
-    )
-  }
-
-  return <MaintenancePageWrapper />
+  return (
+    <AuthenticatedPageBoundary fallback={<MaintenancePageClientFallback />}>
+      {() => <MaintenancePageWrapper />}
+    </AuthenticatedPageBoundary>
+  )
 }
 
 function MaintenancePageWrapper() {

--- a/src/app/(app)/maintenance/page.tsx
+++ b/src/app/(app)/maintenance/page.tsx
@@ -2,14 +2,14 @@
 
 import * as React from "react"
 import type { RowSelectionState } from "@tanstack/react-table"
-import { Skeleton } from "@/components/ui/skeleton"
 import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSkeletonFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { MaintenanceProvider } from "./_components/MaintenanceContext"
 import { MaintenancePageClient } from "./_components/MaintenancePageClient"
 
 export default function MaintenancePage() {
   return (
-    <AuthenticatedPageBoundary fallback={<MaintenancePageClientFallback />}>
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSkeletonFallback />}>
       {() => <MaintenancePageWrapper />}
     </AuthenticatedPageBoundary>
   )
@@ -23,20 +23,9 @@ function MaintenancePageWrapper() {
       taskRowSelection={taskRowSelection}
       setTaskRowSelection={setTaskRowSelection}
     >
-      <React.Suspense fallback={<MaintenancePageClientFallback />}>
+      <React.Suspense fallback={<AuthenticatedPageSkeletonFallback />}>
         <MaintenancePageClient />
       </React.Suspense>
     </MaintenanceProvider>
-  )
-}
-
-function MaintenancePageClientFallback() {
-  return (
-    <div className="flex items-center justify-center min-h-[50vh]">
-      <div className="text-center space-y-2">
-        <Skeleton className="h-8 w-32 mx-auto" />
-        <Skeleton className="h-4 w-48 mx-auto" />
-      </div>
-    </div>
   )
 }

--- a/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
+++ b/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
@@ -83,7 +83,7 @@ describe("ReportsPage auth gate", () => {
     state.shouldFetchData = false
   })
 
-it("shows the loading skeleton without redirecting unauthenticated users", () => {
+  it("shows the loading skeleton without redirecting unauthenticated users", () => {
     state.sessionStatus = "unauthenticated"
     state.sessionData = null
 

--- a/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
+++ b/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const state = vi.hoisted(() => ({
@@ -83,16 +83,14 @@ describe("ReportsPage auth gate", () => {
     state.shouldFetchData = false
   })
 
-  it("shows loading skeleton while redirecting unauthenticated users", async () => {
+it("shows the loading skeleton without redirecting unauthenticated users", () => {
     state.sessionStatus = "unauthenticated"
     state.sessionData = null
 
     render(<ReportsPage />)
 
     expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0)
-    await waitFor(() => {
-      expect(mocks.push).toHaveBeenCalledWith("/")
-    })
+    expect(mocks.push).not.toHaveBeenCalled()
   })
 
   it("does not read tenant selection when user is unauthenticated", () => {

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Skeleton } from "@/components/ui/skeleton"
 import { TenantSelector } from "@/components/shared/TenantSelector"
 import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSkeletonFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { TenantSelectionTip } from "./components/tenant-selection-tip"
 import { useTenantSelection } from "@/contexts/TenantSelectionContext"
 
@@ -72,7 +73,7 @@ function TabSkeleton() {
 
 export default function ReportsPage() {
   return (
-    <AuthenticatedPageBoundary fallback={<ReportsPageAuthFallback />}>
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSkeletonFallback />}>
       {(user) => <ReportsPageContent user={user} />}
     </AuthenticatedPageBoundary>
   )
@@ -110,8 +111,8 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
     if (selectedFacilityId !== undefined) {
       return selectedFacilityId === null ? "all" : String(selectedFacilityId)
     }
-    return user?.don_vi ? String(user.don_vi) : "none"
-  }, [selectedFacilityId, user?.don_vi])
+    return user.don_vi ? String(user.don_vi) : "none"
+  }, [selectedFacilityId, user.don_vi])
 
   return (
     <div className="flex-1 space-y-4 p-4 md:p-8 pt-6">
@@ -177,17 +178,6 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
           </>
         ) : null}
       </Tabs>
-    </div>
-  )
-}
-
-function ReportsPageAuthFallback() {
-  return (
-    <div className="flex items-center justify-center min-h-[50vh]">
-      <div className="text-center space-y-2">
-        <Skeleton className="h-8 w-32 mx-auto" />
-        <Skeleton className="h-4 w-48 mx-auto" />
-      </div>
     </div>
   )
 }

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -1,12 +1,12 @@
 "use client"
 
 import * as React from "react"
-import { useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
+import type { Session } from "next-auth"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Skeleton } from "@/components/ui/skeleton"
 import { TenantSelector } from "@/components/shared/TenantSelector"
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
 import { TenantSelectionTip } from "./components/tenant-selection-tip"
 import { useTenantSelection } from "@/contexts/TenantSelectionContext"
 
@@ -71,31 +71,15 @@ function TabSkeleton() {
 }
 
 export default function ReportsPage() {
-  const router = useRouter()
-  const { data: session, status } = useSession()
-
-  React.useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push("/")
-    }
-  }, [status, router])
-
-  if (status === "loading" || status === "unauthenticated" || !session?.user) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="text-center space-y-2">
-          <Skeleton className="h-8 w-32 mx-auto" />
-          <Skeleton className="h-4 w-48 mx-auto" />
-        </div>
-      </div>
-    )
-  }
-
-  return <ReportsPageContent user={session.user} />
+  return (
+    <AuthenticatedPageBoundary fallback={<ReportsPageAuthFallback />}>
+      {(user) => <ReportsPageContent user={user} />}
+    </AuthenticatedPageBoundary>
+  )
 }
 
 interface ReportsPageContentProps {
-  user: NonNullable<ReturnType<typeof useSession>["data"]>["user"]
+  user: Session["user"]
 }
 
 function ReportsPageContent({ user }: ReportsPageContentProps) {
@@ -193,6 +177,17 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
           </>
         ) : null}
       </Tabs>
+    </div>
+  )
+}
+
+function ReportsPageAuthFallback() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="text-center space-y-2">
+        <Skeleton className="h-8 w-32 mx-auto" />
+        <Skeleton className="h-4 w-48 mx-auto" />
+      </div>
     </div>
   )
 }

--- a/src/app/(app)/transfers/__tests__/TransfersPage.auth.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersPage.auth.test.tsx
@@ -37,9 +37,9 @@ describe("TransfersPage auth wrapper", () => {
       data: null,
     })
 
-    const { container } = render(<TransfersPage />)
+    render(<TransfersPage />)
 
-    expect(container.querySelector(".animate-spin")).toBeInTheDocument()
+    expect(screen.getByTestId("authenticated-page-spinner-fallback")).toBeInTheDocument()
     expect(screen.queryByTestId("transfers-page-content")).not.toBeInTheDocument()
     expect(mocks.push).not.toHaveBeenCalled()
   })

--- a/src/app/(app)/transfers/__tests__/TransfersPage.auth.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersPage.auth.test.tsx
@@ -1,0 +1,64 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}))
+
+vi.mock("../_components/TransfersPageContent", () => ({
+  TransfersPageContent: ({ user }: { user: { username?: string | null } }) => (
+    <div data-testid="transfers-page-content">{user.username ?? "missing-user"}</div>
+  ),
+}))
+
+import TransfersPage from "../page"
+
+describe("TransfersPage auth wrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows the loading spinner without redirecting unauthenticated users", () => {
+    mocks.useSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    })
+
+    const { container } = render(<TransfersPage />)
+
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument()
+    expect(screen.queryByTestId("transfers-page-content")).not.toBeInTheDocument()
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+
+  it("renders the transfers content once the session is authenticated", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: {
+        user: {
+          id: "user-1",
+          username: "transfers-user",
+          role: "global",
+        },
+      },
+    })
+
+    render(<TransfersPage />)
+
+    expect(screen.getByTestId("transfers-page-content")).toHaveTextContent("transfers-user")
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/transfers/page.tsx
+++ b/src/app/(app)/transfers/page.tsx
@@ -2,9 +2,8 @@
 
 import * as React from "react"
 import { Loader2 } from "lucide-react"
-import { useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
 
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
 import { TransfersPageContent } from "./_components/TransfersPageContent"
 
 function TransfersSearchParamsFallback() {
@@ -16,30 +15,13 @@ function TransfersSearchParamsFallback() {
 }
 
 export default function TransfersPage() {
-  const { data: session, status } = useSession()
-  const router = useRouter()
-
-  React.useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push("/")
-    }
-  }, [status, router])
-
-  if (status === "loading") {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  if (status === "unauthenticated" || !session?.user) {
-    return null
-  }
-
   return (
-    <React.Suspense fallback={<TransfersSearchParamsFallback />}>
-      <TransfersPageContent user={session.user} />
-    </React.Suspense>
+    <AuthenticatedPageBoundary fallback={<TransfersSearchParamsFallback />}>
+      {(user) => (
+        <React.Suspense fallback={<TransfersSearchParamsFallback />}>
+          <TransfersPageContent user={user} />
+        </React.Suspense>
+      )}
+    </AuthenticatedPageBoundary>
   )
 }

--- a/src/app/(app)/transfers/page.tsx
+++ b/src/app/(app)/transfers/page.tsx
@@ -1,22 +1,18 @@
 "use client"
 
 import * as React from "react"
-import { Loader2 } from "lucide-react"
 
 import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSpinnerFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { TransfersPageContent } from "./_components/TransfersPageContent"
 
 function TransfersSearchParamsFallback() {
-  return (
-    <div className="flex min-h-[50vh] items-center justify-center">
-      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-    </div>
-  )
+  return <AuthenticatedPageSpinnerFallback />
 }
 
 export default function TransfersPage() {
   return (
-    <AuthenticatedPageBoundary fallback={<TransfersSearchParamsFallback />}>
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSpinnerFallback />}>
       {(user) => (
         <React.Suspense fallback={<TransfersSearchParamsFallback />}>
           <TransfersPageContent user={user} />


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/292" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized session gating for protected pages using a shared `AuthenticatedPageBoundary` and fallback components across Maintenance, Reports, and Transfers. Implements Linear 287 and keeps loading fallbacks visible without redirects until the session is authenticated.

- **New Features**
  - Added `AuthenticatedPageBoundary` that renders a `fallback` until `next-auth` is authenticated, then calls `children(session.user)`.
  - Added `AuthenticatedPageSkeletonFallback` and `AuthenticatedPageSpinnerFallback` for consistent loading UI.

- **Refactors**
  - Updated `maintenance/page.tsx`, `reports/page.tsx`, and `transfers/page.tsx` to use the boundary; removed client-side redirects and status checks.
  - Added tests for the boundary and page auth behavior (new Maintenance and Transfers auth tests); updated Reports tests to assert no redirect.

<sup>Written for commit e7450fe126aefa831f0afae072ad8a1f25ee244c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for authentication boundary component and multiple pages to ensure proper authentication state handling.

* **Refactor**
  * Introduced a unified authentication boundary component for consistent session management across pages, improving code maintainability and reducing duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->