### PR TITLE
fix: [288] remove device-quota wrapper auth redirects

### DIFF
--- a/src/app/(app)/device-quota/__tests__/DeviceQuotaPageAuth.test.tsx
+++ b/src/app/(app)/device-quota/__tests__/DeviceQuotaPageAuth.test.tsx
@@ -3,8 +3,10 @@ import "@testing-library/jest-dom"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const mockUseSession = vi.fn()
-const mockRouterPush = vi.fn()
+const { mockUseSession, mockRouterPush } = vi.hoisted(() => ({
+  mockUseSession: vi.fn(),
+  mockRouterPush: vi.fn(),
+}))
 
 vi.mock("next-auth/react", () => ({
   useSession: () => mockUseSession(),

--- a/src/app/(app)/device-quota/__tests__/DeviceQuotaPageAuth.test.tsx
+++ b/src/app/(app)/device-quota/__tests__/DeviceQuotaPageAuth.test.tsx
@@ -1,0 +1,215 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockUseSession = vi.fn()
+const mockRouterPush = vi.fn()
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+vi.mock("@/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext", () => ({
+  DeviceQuotaCategoryProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="categories-provider">{children}</div>
+  ),
+}))
+
+vi.mock("@/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryToolbar", () => ({
+  DeviceQuotaCategoryToolbar: () => <div data-testid="categories-toolbar">Toolbar</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryTree", () => ({
+  DeviceQuotaCategoryTree: () => <div data-testid="categories-tree">Tree</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDialog", () => ({
+  DeviceQuotaCategoryDialog: () => <div data-testid="categories-dialog">Dialog</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDeleteDialog", () => ({
+  DeviceQuotaCategoryDeleteDialog: () => <div data-testid="categories-delete-dialog">Delete</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog", () => ({
+  DeviceQuotaCategoryImportDialog: () => <div data-testid="categories-import-dialog">Import</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/dashboard/_components/DeviceQuotaDashboardContext", () => ({
+  DeviceQuotaDashboardProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dashboard-provider">{children}</div>
+  ),
+}))
+
+vi.mock("@/app/(app)/device-quota/dashboard/_components/DeviceQuotaComplianceCards", () => ({
+  DeviceQuotaComplianceCards: () => <div data-testid="dashboard-compliance-cards">Compliance</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/dashboard/_components/DeviceQuotaUnassignedAlert", () => ({
+  DeviceQuotaUnassignedAlert: () => <div data-testid="dashboard-unassigned-alert">Alert</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/dashboard/_components/DeviceQuotaActiveDecision", () => ({
+  DeviceQuotaActiveDecision: () => <div data-testid="dashboard-active-decision">Decision</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/dashboard/_components/DeviceQuotaReportDialog", () => ({
+  DeviceQuotaReportDialog: () => <div data-testid="dashboard-report-dialog">Dialog</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/dashboard/_hooks/useDeviceQuotaDashboardContext", () => ({
+  useDeviceQuotaDashboardContext: () => ({
+    complianceSummary: null,
+  }),
+}))
+
+vi.mock("@/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsContext", () => ({
+  DeviceQuotaDecisionsProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="decisions-provider">{children}</div>
+  ),
+}))
+
+vi.mock("@/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsToolbar", () => ({
+  DeviceQuotaDecisionsToolbar: () => <div data-testid="decisions-toolbar">Toolbar</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable", () => ({
+  DeviceQuotaDecisionsTable: () => <div data-testid="decisions-table">Table</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialog", () => ({
+  DeviceQuotaDecisionDialog: () => <div data-testid="decisions-dialog">Dialog</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext", () => ({
+  DeviceQuotaMappingProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="mapping-provider">{children}</div>
+  ),
+}))
+
+vi.mock("@/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingSplitView", () => ({
+  DeviceQuotaMappingSplitView: () => <div data-testid="mapping-split-view">Split view</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList", () => ({
+  DeviceQuotaUnassignedList: () => <div data-testid="mapping-unassigned-list">Unassigned</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/mapping/_components/DeviceQuotaCategoryTree", () => ({
+  DeviceQuotaCategoryTree: () => <div data-testid="mapping-category-tree">Tree</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingActions", () => ({
+  DeviceQuotaMappingActions: () => <div data-testid="mapping-actions">Actions</div>,
+}))
+
+vi.mock("@/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingGuide", () => ({
+  DeviceQuotaMappingGuide: () => <div data-testid="mapping-guide">Guide</div>,
+}))
+
+vi.mock("@/components/shared/TenantSelector", () => ({
+  TenantSelector: () => <div data-testid="tenant-selector">Tenant selector</div>,
+}))
+
+import DeviceQuotaCategoriesPage from "@/app/(app)/device-quota/categories/page"
+import DeviceQuotaDashboardPage from "@/app/(app)/device-quota/dashboard/page"
+import DeviceQuotaDecisionsPage from "@/app/(app)/device-quota/decisions/page"
+import DeviceQuotaMappingPage from "@/app/(app)/device-quota/mapping/page"
+
+type SessionState = {
+  status: "loading" | "unauthenticated" | "authenticated"
+  data: { user: { role: string; don_vi?: string } } | null
+}
+
+const authenticatedAdminSession: SessionState = {
+  status: "authenticated",
+  data: {
+    user: {
+      role: "admin",
+      don_vi: "1",
+    },
+  },
+}
+
+const pageCases = [
+  {
+    name: "categories",
+    Page: DeviceQuotaCategoriesPage,
+    protectedTestId: "categories-toolbar",
+    fallbackTestId: "authenticated-page-spinner-fallback",
+  },
+  {
+    name: "dashboard",
+    Page: DeviceQuotaDashboardPage,
+    protectedTestId: "dashboard-compliance-cards",
+    fallbackTestId: "authenticated-page-spinner-fallback",
+  },
+  {
+    name: "decisions",
+    Page: DeviceQuotaDecisionsPage,
+    protectedTestId: "decisions-table",
+    fallbackTestId: "device-quota-decisions-auth-fallback",
+  },
+  {
+    name: "mapping",
+    Page: DeviceQuotaMappingPage,
+    protectedTestId: "mapping-split-view",
+    fallbackTestId: "authenticated-page-spinner-fallback",
+  },
+] as const
+
+describe("DeviceQuota page auth wrappers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each(pageCases)(
+    "renders only the fallback for $name while the session is loading",
+    ({ Page, protectedTestId, fallbackTestId }) => {
+      mockUseSession.mockReturnValue({
+        status: "loading",
+        data: null,
+      })
+
+      render(<Page />)
+
+      expect(screen.getByTestId(fallbackTestId)).toBeInTheDocument()
+      expect(screen.queryByTestId(protectedTestId)).not.toBeInTheDocument()
+      expect(mockRouterPush).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(pageCases)(
+    "renders only the fallback for $name when unauthenticated",
+    ({ Page, protectedTestId, fallbackTestId }) => {
+      mockUseSession.mockReturnValue({
+        status: "unauthenticated",
+        data: null,
+      })
+
+      render(<Page />)
+
+      expect(screen.getByTestId(fallbackTestId)).toBeInTheDocument()
+      expect(screen.queryByTestId(protectedTestId)).not.toBeInTheDocument()
+      expect(mockRouterPush).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(pageCases)(
+    "renders protected content for $name when authenticated",
+    ({ Page, protectedTestId, fallbackTestId }) => {
+      mockUseSession.mockReturnValue(authenticatedAdminSession)
+
+      render(<Page />)
+
+      expect(screen.getByTestId(protectedTestId)).toBeInTheDocument()
+      expect(screen.queryByTestId(fallbackTestId)).not.toBeInTheDocument()
+      expect(mockRouterPush).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
@@ -56,6 +56,22 @@ describe('DeviceQuotaCategoriesPage', () => {
     vi.clearAllMocks()
   })
 
+  it('shows the restricted access state for authenticated users without category management permission', () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { role: 'user', don_vi: '1' } },
+      status: 'authenticated',
+    })
+
+    render(<DeviceQuotaCategoriesPage />, { wrapper: createWrapper() })
+
+    expect(screen.getByText('Truy cập bị hạn chế')).toBeInTheDocument()
+    expect(
+      screen.getByText(/chỉ dành cho quản trị viên hoặc bộ phận quản lý thiết bị/i)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Tạo danh mục' })).not.toBeInTheDocument()
+    expect(mockCallRpc).not.toHaveBeenCalled()
+  })
+
   it('renders toolbar and empty tree when authorized', async () => {
     mockUseSession.mockReturnValue({
       data: { user: { role: 'admin', don_vi: '1' } },

--- a/src/app/(app)/device-quota/categories/page.tsx
+++ b/src/app/(app)/device-quota/categories/page.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import * as React from "react"
-import { useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
-import { AlertTriangle, Loader2, Shield } from "lucide-react"
+import type { Session } from "next-auth"
+import { AlertTriangle, Shield } from "lucide-react"
 
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSpinnerFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { Card, CardContent } from "@/components/ui/card"
 import { isEquipmentManagerRole } from "@/lib/rbac"
 import { DeviceQuotaCategoryProvider } from "./_components/DeviceQuotaCategoryContext"
@@ -15,24 +16,21 @@ import { DeviceQuotaCategoryDeleteDialog } from "./_components/DeviceQuotaCatego
 import { DeviceQuotaCategoryImportDialog } from "./_components/DeviceQuotaCategoryImportDialog"
 
 export default function DeviceQuotaCategoriesPage() {
-  const { data: session, status } = useSession()
-  const router = useRouter()
+  return (
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSpinnerFallback />}>
+      {(user) => <DeviceQuotaCategoriesPageContent user={user} />}
+    </AuthenticatedPageBoundary>
+  )
+}
 
-  React.useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push("/")
-    }
-  }, [status, router])
+type DeviceQuotaCategoriesPageContentProps = {
+  user: Session["user"]
+}
 
-  if (status === "loading" || status === "unauthenticated") {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  const userRole = (session?.user as { role?: string } | undefined)?.role
+function DeviceQuotaCategoriesPageContent({
+  user,
+}: DeviceQuotaCategoriesPageContentProps) {
+  const userRole = user.role
   const canManageCategories = isEquipmentManagerRole(userRole)
 
   if (!canManageCategories) {

--- a/src/app/(app)/device-quota/dashboard/page.tsx
+++ b/src/app/(app)/device-quota/dashboard/page.tsx
@@ -1,10 +1,10 @@
 "use client"
 
 import * as React from "react"
-import { useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
-import { Loader2, FileText } from "lucide-react"
+import { FileText } from "lucide-react"
 
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSpinnerFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { DeviceQuotaDashboardProvider } from "./_components/DeviceQuotaDashboardContext"
 import { DeviceQuotaComplianceCards } from "./_components/DeviceQuotaComplianceCards"
 import { DeviceQuotaUnassignedAlert } from "./_components/DeviceQuotaUnassignedAlert"
@@ -29,31 +29,14 @@ import { Button } from "@/components/ui/button"
  * Pattern: Context provider wraps all child components
  */
 export default function DeviceQuotaDashboardPage() {
-  const { status } = useSession()
-  const router = useRouter()
-
-  React.useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push("/")
-    }
-  }, [status, router])
-
-  if (status === "loading") {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  if (status === "unauthenticated") {
-    return null
-  }
-
   return (
-    <DeviceQuotaDashboardProvider>
-      <DeviceQuotaDashboardPageContent />
-    </DeviceQuotaDashboardProvider>
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSpinnerFallback />}>
+      {() => (
+        <DeviceQuotaDashboardProvider>
+          <DeviceQuotaDashboardPageContent />
+        </DeviceQuotaDashboardProvider>
+      )}
+    </AuthenticatedPageBoundary>
   )
 }
 

--- a/src/app/(app)/device-quota/decisions/page.tsx
+++ b/src/app/(app)/device-quota/decisions/page.tsx
@@ -1,10 +1,9 @@
 "use client"
 
 import * as React from "react"
-import { useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
 import { Loader2 } from "lucide-react"
 
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
 import { DeviceQuotaDecisionsProvider } from "./_components/DeviceQuotaDecisionsContext"
 import { DeviceQuotaDecisionsToolbar } from "./_components/DeviceQuotaDecisionsToolbar"
 import { DeviceQuotaDecisionsTable } from "./_components/DeviceQuotaDecisionsTable"
@@ -28,47 +27,43 @@ import { DeviceQuotaDecisionDialog } from "./_components/DeviceQuotaDecisionDial
  * - RPC-only data access for security
  */
 export default function DeviceQuotaDecisionsPage() {
-  const { status } = useSession()
-  const router = useRouter()
-
-  // Handle unauthenticated redirect in useEffect (not during render)
-  React.useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push("/")
-    }
-  }, [status, router])
-
-  // Show loading state for both loading and unauthenticated (while redirecting)
-  if (status === "loading" || status === "unauthenticated") {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="text-center space-y-2">
-          <Loader2 className="h-8 w-8 mx-auto animate-spin text-muted-foreground" />
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <DeviceQuotaDecisionsProvider>
-      <div className="space-y-6">
-        {/* Page header */}
-        <div>
-          <h1 className="text-xl md:text-2xl font-semibold">Quyết định định mức</h1>
-          <p className="text-sm text-muted-foreground">
-            Quản lý các quyết định định mức thiết bị y tế
-          </p>
-        </div>
+    <AuthenticatedPageBoundary fallback={<DeviceQuotaDecisionsAuthFallback />}>
+      {() => (
+        <DeviceQuotaDecisionsProvider>
+          <div className="space-y-6">
+            {/* Page header */}
+            <div>
+              <h1 className="text-xl md:text-2xl font-semibold">Quyết định định mức</h1>
+              <p className="text-sm text-muted-foreground">
+                Quản lý các quyết định định mức thiết bị y tế
+              </p>
+            </div>
 
-        {/* Toolbar */}
-        <DeviceQuotaDecisionsToolbar />
+            {/* Toolbar */}
+            <DeviceQuotaDecisionsToolbar />
 
-        {/* Table */}
-        <DeviceQuotaDecisionsTable />
+            {/* Table */}
+            <DeviceQuotaDecisionsTable />
 
-        {/* Dialog (controlled by context) */}
-        <DeviceQuotaDecisionDialog />
+            {/* Dialog (controlled by context) */}
+            <DeviceQuotaDecisionDialog />
+          </div>
+        </DeviceQuotaDecisionsProvider>
+      )}
+    </AuthenticatedPageBoundary>
+  )
+}
+
+function DeviceQuotaDecisionsAuthFallback() {
+  return (
+    <div
+      className="flex items-center justify-center min-h-[50vh]"
+      data-testid="device-quota-decisions-auth-fallback"
+    >
+      <div className="text-center space-y-2">
+        <Loader2 className="h-8 w-8 mx-auto animate-spin text-muted-foreground" />
       </div>
-    </DeviceQuotaDecisionsProvider>
+    </div>
   )
 }

--- a/src/app/(app)/device-quota/mapping/page.tsx
+++ b/src/app/(app)/device-quota/mapping/page.tsx
@@ -1,10 +1,9 @@
 "use client"
 
 import * as React from "react"
-import { useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
-import { Loader2 } from "lucide-react"
 
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSpinnerFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { DeviceQuotaMappingProvider } from "./_components/DeviceQuotaMappingContext"
 import { DeviceQuotaMappingSplitView } from "./_components/DeviceQuotaMappingSplitView"
 import { DeviceQuotaUnassignedList } from "./_components/DeviceQuotaUnassignedList"
@@ -14,51 +13,36 @@ import { DeviceQuotaMappingGuide } from "./_components/DeviceQuotaMappingGuide"
 import { TenantSelector } from "@/components/shared/TenantSelector"
 
 export default function DeviceQuotaMappingPage() {
-  const { status } = useSession()
-  const router = useRouter()
-
-  // Handle unauthenticated redirect in useEffect (not during render)
-  React.useEffect(() => {
-    if (status === "unauthenticated") {
-      router.push("/")
-    }
-  }, [status, router])
-
-  // Show loading state for both loading and unauthenticated (while redirecting)
-  if (status === "loading" || status === "unauthenticated") {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
   return (
-    <DeviceQuotaMappingProvider>
-      <div className="container mx-auto py-6 space-y-6">
-        {/* Page header */}
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-bold">Phân loại thiết bị</h1>
-            <p className="text-muted-foreground">
-              Gán thiết bị vào các nhóm định mức
-            </p>
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSpinnerFallback />}>
+      {() => (
+        <DeviceQuotaMappingProvider>
+          <div className="container mx-auto py-6 space-y-6">
+            {/* Page header */}
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h1 className="text-2xl font-bold">Phân loại thiết bị</h1>
+                <p className="text-muted-foreground">
+                  Gán thiết bị vào các nhóm định mức
+                </p>
+              </div>
+              <TenantSelector hideAllOption />
+            </div>
+
+            {/* Manual mapping guide banner */}
+            <DeviceQuotaMappingGuide />
+
+            {/* Split view */}
+            <DeviceQuotaMappingSplitView
+              leftPanel={<DeviceQuotaUnassignedList />}
+              rightPanel={<DeviceQuotaCategoryTree />}
+            />
+
+            {/* Action bar (sticky footer) */}
+            <DeviceQuotaMappingActions />
           </div>
-          <TenantSelector hideAllOption />
-        </div>
-
-        {/* Manual mapping guide banner */}
-        <DeviceQuotaMappingGuide />
-
-        {/* Split view */}
-        <DeviceQuotaMappingSplitView
-          leftPanel={<DeviceQuotaUnassignedList />}
-          rightPanel={<DeviceQuotaCategoryTree />}
-        />
-
-        {/* Action bar (sticky footer) */}
-        <DeviceQuotaMappingActions />
-      </div>
-    </DeviceQuotaMappingProvider>
+        </DeviceQuotaMappingProvider>
+      )}
+    </AuthenticatedPageBoundary>
   )
 }


### PR DESCRIPTION
## Context
Issue #288 tracks the remaining wrapper-level unauthenticated redirects in the `device-quota` feature after the shared auth boundary work from #283/#287. The affected pages were still doing `useSession() + router.push("/")` in the page wrapper even though the `(app)` layout and middleware already gate unauthenticated access.

## What changed
- Replaced wrapper-level client redirects in these pages with `AuthenticatedPageBoundary`:
  - `src/app/(app)/device-quota/categories/page.tsx`
  - `src/app/(app)/device-quota/dashboard/page.tsx`
  - `src/app/(app)/device-quota/decisions/page.tsx`
  - `src/app/(app)/device-quota/mapping/page.tsx`
- Preserved feature-specific behavior while removing the redirect duplication:
  - `categories` still performs its role gate for non-manager/non-admin authenticated users
  - `decisions` keeps its existing loading UI shape via a local auth fallback component
  - `dashboard` and `mapping` now use the shared spinner fallback pattern already introduced for other protected page wrappers

## Tests
- Added focused auth-wrapper regression coverage for the 4 device-quota page wrappers in:
  - `src/app/(app)/device-quota/__tests__/DeviceQuotaPageAuth.test.tsx`
- Added a regression test to ensure authenticated users without category-management permission still see the restricted-access state in:
  - `src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx`

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js npx vitest run "src/app/(app)/device-quota/__tests__/DeviceQuotaPageAuth.test.tsx" "src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx"`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Notes
- This PR intentionally does not touch nested `device-quota` detail routes or other feature components that still use `useSession()` for tenant/role/data scoping rather than page-wrapper redirects.
- Manual browser verification of protected-route/session-expiry behavior is still recommended before merge, consistent with the #283/#287 auth-boundary work.

Closes #288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive authorization tests for Device Quota pages to validate authentication state handling across categories, dashboard, decisions, and mapping sections.
  * Added permission validation test to ensure restricted-access messaging displays correctly for users lacking category management permissions.

* **Refactor**
  * Consolidated authentication and loading state handling across Device Quota pages for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->