### PR TITLE
Fix equipment unauthenticated redirect boundary

### DIFF
--- a/src/app/(app)/equipment/__tests__/EquipmentPage.auth.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPage.auth.test.tsx
@@ -1,0 +1,63 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}))
+
+vi.mock("../_components/EquipmentPageClient", () => ({
+  EquipmentPageClient: () => <div data-testid="equipment-page-client">Equipment</div>,
+}))
+
+import EquipmentPage from "../page"
+
+describe("EquipmentPage auth wrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal("React", React)
+  })
+
+  it("shows the skeleton fallback without redirecting unauthenticated users", () => {
+    mocks.useSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    })
+
+    render(<EquipmentPage />)
+
+    expect(screen.getByTestId("authenticated-page-skeleton-fallback")).toBeInTheDocument()
+    expect(screen.queryByTestId("equipment-page-client")).not.toBeInTheDocument()
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+
+  it("renders the equipment client once the session is authenticated", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: {
+        user: {
+          id: "user-1",
+          username: "equipment-user",
+          role: "global",
+        },
+      },
+    })
+
+    render(<EquipmentPage />)
+
+    expect(screen.getByTestId("equipment-page-client")).toHaveTextContent("Equipment")
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.auth.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.auth.test.tsx
@@ -1,0 +1,91 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest"
+
+const state = vi.hoisted(() => ({
+  pageState: null as null | {
+    status: "unauthenticated"
+    router: {
+      push: Mock
+      replace: Mock
+    }
+  },
+}))
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+}))
+
+vi.mock("../use-equipment-page", () => ({
+  useEquipmentPage: () => state.pageState,
+}))
+
+vi.mock("../_hooks/useEquipmentContext", () => ({
+  useEquipmentContext: () => ({
+    openAddDialog: vi.fn(),
+    openImportDialog: vi.fn(),
+    openColumnsDialog: vi.fn(),
+    openDetailDialog: vi.fn(),
+    openEditDialog: vi.fn(),
+  }),
+}))
+
+vi.mock("../_components/EquipmentDialogContext", () => ({
+  EquipmentDialogProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("../equipment-content", () => ({
+  EquipmentContent: () => null,
+}))
+
+vi.mock("../equipment-dialogs", () => ({
+  EquipmentDialogs: () => null,
+}))
+
+vi.mock("../_components/EquipmentColumnsDialog", () => ({
+  EquipmentColumnsDialog: () => null,
+}))
+
+vi.mock("../_components/EquipmentBulkDeleteBar", () => ({
+  EquipmentBulkDeleteBar: () => null,
+}))
+
+vi.mock("@/components/equipment/equipment-toolbar", () => ({
+  EquipmentToolbar: () => null,
+}))
+
+vi.mock("@/components/equipment/filter-bottom-sheet", () => ({
+  FilterBottomSheet: () => null,
+}))
+
+vi.mock("@/components/shared/DataTablePagination", () => ({
+  DataTablePagination: () => null,
+}))
+
+vi.mock("@/components/shared/TenantSelector", () => ({
+  TenantSelector: () => null,
+}))
+
+import { EquipmentPageClient } from "../_components/EquipmentPageClient"
+
+describe("EquipmentPageClient auth handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.pageState = {
+      status: "unauthenticated",
+      router: {
+        push: mocks.push,
+        replace: mocks.replace,
+      },
+    }
+  })
+
+  it("does not redirect unauthenticated users from the feature client", () => {
+    const { container } = render(<EquipmentPageClient />)
+
+    expect(container).toBeEmptyDOMElement()
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -64,13 +64,6 @@ const equipmentDisplayFormat = (ctx: DisplayContext) => {
 export function EquipmentPageClient() {
   const pageState = useEquipmentPage()
 
-  // Redirect unauthenticated users via useEffect to avoid side effects during render
-  React.useEffect(() => {
-    if (pageState.status === "unauthenticated") {
-      pageState.router.push("/")
-    }
-  }, [pageState.status, pageState.router])
-
   // Show loading state
   if (pageState.status === "loading") {
     return (
@@ -83,7 +76,7 @@ export function EquipmentPageClient() {
     )
   }
 
-  // Show nothing while redirecting unauthenticated users
+  // The page wrapper owns unauthenticated access; keep this as a defensive fallback.
   if (pageState.status === "unauthenticated") {
     return null
   }

--- a/src/app/(app)/equipment/page.tsx
+++ b/src/app/(app)/equipment/page.tsx
@@ -1,5 +1,16 @@
+"use client"
+
+import * as React from "react"
+
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSkeletonFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
+
 import { EquipmentPageClient } from "./_components/EquipmentPageClient"
 
 export default function EquipmentPage() {
-  return <EquipmentPageClient />
+  return (
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSkeletonFallback />}>
+      {() => <EquipmentPageClient />}
+    </AuthenticatedPageBoundary>
+  )
 }


### PR DESCRIPTION
## Summary
- Wrap the equipment page in the shared `AuthenticatedPageBoundary` + skeleton fallback pattern used by #287/#288.
- Remove the unauthenticated `router.push("/")` effect from `EquipmentPageClient` and keep only a defensive null fallback.
- Add focused auth tests for the equipment page wrapper and feature client redirect removal.

Closes #289

## Blast Radius
- GitNexus impact for `EquipmentPageClient`: LOW, 0 direct callers/processes affected.
- GitNexus impact for `EquipmentPage`: LOW, 0 direct callers/processes affected.
- GitNexus diff detection: low risk, no affected processes.
- Code Review Graph risk score: 0.65; flagged `EquipmentPage` and `EquipmentPageClient`, covered by new focused tests.

## Verification
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/__tests__/EquipmentPage.auth.test.tsx' 'src/app/(app)/equipment/__tests__/EquipmentPageClient.auth.test.tsx' 'src/app/(app)/equipment/__tests__/useEquipmentAuth.test.ts' 'src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx' 'src/app/(app)/equipment/__tests__/EquipmentPageClient.attention-preset.test.tsx' --reporter verbose`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` (100/100)

## Notes
- Manual browser verification was not run in this session.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the equipment page auth boundary by handling unauthenticated state in `AuthenticatedPageBoundary` and showing `AuthenticatedPageSkeletonFallback`. Removes the redirect effect from `EquipmentPageClient` to avoid side effects and adds focused auth tests for the wrapper and client.

<sup>Written for commit e117e03248f573e8f961b1b07678458ef5e09694. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication enforcement with proper loading states displayed during access verification on the Equipment page.

* **Tests**
  * Added authentication test coverage verifying correct behavior for both authenticated and unauthenticated users on the Equipment page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->