### PR TITLE
Fix repair requests unauthenticated redirect boundary

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPage.auth.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPage.auth.test.tsx
@@ -1,0 +1,64 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}))
+
+vi.mock("../_components/RepairRequestsPageClient", () => ({
+  default: () => <div data-testid="repair-requests-page-client">Repair requests</div>,
+}))
+
+import RepairRequestsPage from "../page"
+
+describe("RepairRequestsPage auth wrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows the skeleton fallback without redirecting unauthenticated users", () => {
+    mocks.useSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    })
+
+    render(<RepairRequestsPage />)
+
+    expect(screen.getByTestId("authenticated-page-skeleton-fallback")).toBeInTheDocument()
+    expect(screen.queryByTestId("repair-requests-page-client")).not.toBeInTheDocument()
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+
+  it("renders the repair requests client once the session is authenticated", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: {
+        user: {
+          id: "user-1",
+          username: "repair-user",
+          role: "global",
+        },
+      },
+    })
+
+    render(<RepairRequestsPage />)
+
+    expect(screen.getByTestId("repair-requests-page-client")).toHaveTextContent(
+      "Repair requests"
+    )
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.auth.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.auth.test.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/repair-requests",
+  useRouter: () => ({
+    push: mocks.push,
+    replace: mocks.replace,
+  }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-classname={className} data-testid="repair-requests-client-skeleton" />
+  ),
+}))
+
+import RepairRequestsPageClient from "../_components/RepairRequestsPageClient"
+
+describe("RepairRequestsPageClient auth handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("does not redirect unauthenticated users from the feature client", () => {
+    mocks.useSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    })
+
+    render(<RepairRequestsPageClient />)
+
+    expect(screen.getAllByTestId("repair-requests-client-skeleton")).toHaveLength(2)
+    expect(mocks.push).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -328,14 +328,8 @@ function RepairRequestsPageClientInner() {
 
 export default function RepairRequestsPageClient() {
   const { status } = useSession()
-  const router = useRouter()
 
-  // Handle unauthenticated redirect in useEffect (not during render)
-  React.useEffect(() => {
-    if (status === "unauthenticated") router.push("/")
-  }, [status, router])
-
-  // Show loading state for both loading and unauthenticated (while redirecting)
+  // The page wrapper owns unauthenticated access; keep the skeleton as a defensive fallback.
   if (status === "loading" || status === "unauthenticated") {
     return (
       <div className="flex items-center justify-center min-h-[50vh]">

--- a/src/app/(app)/repair-requests/page.tsx
+++ b/src/app/(app)/repair-requests/page.tsx
@@ -1,27 +1,22 @@
+"use client"
+
 import * as React from "react"
 
-import { Skeleton } from "@/components/ui/skeleton"
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSkeletonFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 
 import RepairRequestsPageClient from "./_components/RepairRequestsPageClient"
 
 export type { EquipmentSelectItem, RepairRequestWithEquipment, RepairUnit } from "./types"
 
-function RepairRequestsPageFallback() {
-  return (
-    <div className="flex items-center justify-center min-h-[50vh]">
-      <div className="text-center space-y-2">
-        <Skeleton className="h-8 w-32 mx-auto" />
-        <Skeleton className="h-4 w-48 mx-auto" />
-      </div>
-    </div>
-  )
-}
-
 export default function RepairRequestsPage() {
   return (
-    <React.Suspense fallback={<RepairRequestsPageFallback />}>
-      <RepairRequestsPageClient />
-    </React.Suspense>
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSkeletonFallback />}>
+      {() => (
+        <React.Suspense fallback={<AuthenticatedPageSkeletonFallback />}>
+          <RepairRequestsPageClient />
+        </React.Suspense>
+      )}
+    </AuthenticatedPageBoundary>
   )
 }
-


### PR DESCRIPTION
## Summary
- Wrap the repair requests page in the shared `AuthenticatedPageBoundary` + skeleton fallback pattern used by #287/#288.
- Preserve the page `Suspense` boundary for search-param suspension with the same skeleton fallback.
- Remove the unauthenticated `router.push("/")` effect from `RepairRequestsPageClient` and add focused auth coverage.

Closes #290

## Blast Radius
- GitNexus impact for `RepairRequestsPageClient`: LOW, 0 direct callers/processes affected.
- GitNexus impact for `RepairRequestsPageClientInner`: LOW, 0 direct callers/processes affected.
- GitNexus diff detection: medium risk because the changed file participates in `RepairRequestsPageClientInner → useToast → dispatch → listener`; no inner logic changed.
- Code Review Graph risk score: 0.60; flagged `RepairRequestsPage` and `RepairRequestsPageClient`, covered by new focused tests.

## Verification
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/RepairRequestsPage.auth.test.tsx' 'src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.auth.test.tsx' 'src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx' 'src/app/(app)/repair-requests/__tests__/RepairRequestsKpi.test.tsx' --reporter verbose`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` (100/100)

## Notes
- Manual browser verification was not run in this session.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unauthenticated redirects on the Repair Requests page by moving auth handling to the shared `AuthenticatedPageBoundary` with a consistent skeleton fallback. Keeps Suspense behavior for search params and removes client-side redirects. Closes #290.

- **Bug Fixes**
  - Wrapped page with `AuthenticatedPageBoundary` and `AuthenticatedPageSkeletonFallback`.
  - Preserved page `Suspense` with the same fallback for search-param loading.
  - Removed unauthenticated `router.push("/")` from `RepairRequestsPageClient`; boundary owns auth.
  - Added focused tests to confirm no redirects and correct skeleton rendering.

<sup>Written for commit e397314cf67f86d1422aba6e1b5ff98feda3020d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

