### PR TITLE
fix: remove redundant unauthenticated redirect from TenantsManagement

### DIFF
--- a/src/app/(app)/tenants/__tests__/TenantsPage.auth.test.tsx
+++ b/src/app/(app)/tenants/__tests__/TenantsPage.auth.test.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/components/tenants-management", () => ({
+  TenantsManagement: () => <div data-testid="tenants-management">Tenants Management</div>,
+}))
+
+import TenantsPage from "../page"
+
+describe("TenantsPage auth wrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows the auth fallback while the session is loading", () => {
+    mocks.useSession.mockReturnValue({
+      status: "loading",
+      data: null,
+    })
+
+    render(<TenantsPage />)
+
+    expect(screen.getByTestId("authenticated-page-skeleton-fallback")).toBeInTheDocument()
+    expect(screen.queryByTestId("tenants-management")).not.toBeInTheDocument()
+  })
+
+  it("shows the auth fallback without rendering tenants management when unauthenticated", () => {
+    mocks.useSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    })
+
+    render(<TenantsPage />)
+
+    expect(screen.getByTestId("authenticated-page-skeleton-fallback")).toBeInTheDocument()
+    expect(screen.queryByTestId("tenants-management")).not.toBeInTheDocument()
+  })
+
+  it("renders tenants management once the session is authenticated", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: {
+        user: {
+          id: "user-1",
+          role: "global",
+        },
+      },
+    })
+
+    render(<TenantsPage />)
+
+    expect(screen.getByTestId("tenants-management")).toBeInTheDocument()
+    expect(screen.queryByTestId("authenticated-page-skeleton-fallback")).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/tenants/page.tsx
+++ b/src/app/(app)/tenants/page.tsx
@@ -1,8 +1,14 @@
 "use client"
 
 import * as React from "react"
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSkeletonFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { TenantsManagement } from "@/components/tenants-management"
 
 export default function TenantsPage() {
-  return <TenantsManagement />
+  return (
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSkeletonFallback />}>
+      {() => <TenantsManagement />}
+    </AuthenticatedPageBoundary>
+  )
 }

--- a/src/components/__tests__/tenants-management.test.tsx
+++ b/src/components/__tests__/tenants-management.test.tsx
@@ -164,5 +164,6 @@ describe("TenantsManagement", () => {
 
     expect(screen.getByText("Không có quyền truy cập")).toBeInTheDocument()
     expect(push).not.toHaveBeenCalled()
+    expect(mocks.callRpc).not.toHaveBeenCalled()
   })
 })

--- a/src/components/__tests__/tenants-management.test.tsx
+++ b/src/components/__tests__/tenants-management.test.tsx
@@ -151,4 +151,18 @@ describe("TenantsManagement", () => {
       )
     })
   })
+
+  it("does not redirect unauthenticated users from the shared tenants management component", () => {
+    const push = vi.fn()
+    mocks.useRouter.mockReturnValue({ push })
+    mocks.useSession.mockReturnValue({
+      data: null,
+      status: "unauthenticated",
+    })
+
+    render(<TenantsManagement />, { wrapper: createWrapper() })
+
+    expect(screen.getByText("Không có quyền truy cập")).toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/tenants-management.tsx
+++ b/src/components/tenants-management.tsx
@@ -1,7 +1,6 @@
 ﻿"use client"
 
 import * as React from "react"
-import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 
@@ -43,7 +42,6 @@ type PreparedTenant = {
 }
 
 export function TenantsManagement() {
-  const router = useRouter()
   const { data: session, status } = useSession()
   const isGlobal = isGlobalRole(session?.user?.role)
   const { toast } = useToast()
@@ -56,10 +54,6 @@ export function TenantsManagement() {
   const [expandedTenants, setExpandedTenants] = React.useState<Record<number, boolean>>({})
 
   const collator = React.useMemo(() => new Intl.Collator("vi", { sensitivity: "base", usage: "sort" }), [])
-
-  React.useEffect(() => {
-    if (status === "unauthenticated") router.push("/")
-  }, [status, router])
 
   const query = useQuery<{ rows: TenantHierarchyRow[] }>({
     queryKey: ["don_vi", { q: debouncedQ }],

--- a/src/components/tenants-management.tsx
+++ b/src/components/tenants-management.tsx
@@ -80,6 +80,7 @@ export function TenantsManagement() {
     staleTime: 60_000,
     gcTime: 300_000,
     refetchOnWindowFocus: false,
+    enabled: status === "authenticated" && isGlobal,
   })
 
   const rows = query.data?.rows || []


### PR DESCRIPTION
## Summary
- wrap `/tenants` with `AuthenticatedPageBoundary` and the shared authenticated skeleton fallback
- remove the redundant `router.push("/")` redirect from `TenantsManagement` while preserving existing access-denied behavior
- add focused tests for the `/tenants` auth wrapper and the shared component unauthenticated no-redirect case

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/app/(app)/tenants/__tests__/TenantsPage.auth.test.tsx src/components/__tests__/tenants-management.test.tsx`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

Closes #291
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tenants page now displays authentication loading indicator during session verification instead of immediate navigation.

* **Tests**
  * Added comprehensive test coverage for authentication workflows, loading states, and access denial handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wraps the `/tenants` page in an `AuthenticatedPageBoundary` with a shared skeleton fallback, removes the unauthenticated redirect in `TenantsManagement`, and gates its data query behind auth + global role. This stops jarring home redirects and avoids unnecessary fetches when not allowed.

- **Bug Fixes**
  - Guard `/tenants` with `AuthenticatedPageBoundary`; only render `TenantsManagement` when authenticated.
  - Gate tenants query on `authenticated && global` so no RPCs run for unauthenticated or non-global users.
  - Remove `router.push("/")`; keep the existing "access denied" UI and add tests for loading/unauth fallbacks, no-redirect, and no fetch.

<sup>Written for commit c8af0240207eebfe9b702b3de0fc27717c8079fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

