### PR TITLE
fix: remove client-side unauthenticated redirect from activity logs page

### DIFF
--- a/src/app/(app)/activity-logs/__tests__/ActivityLogsPage.auth.test.tsx
+++ b/src/app/(app)/activity-logs/__tests__/ActivityLogsPage.auth.test.tsx
@@ -1,0 +1,98 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mocks.replace,
+  }),
+}))
+
+vi.mock("@/components/activity-logs/activity-logs-viewer", () => ({
+  ActivityLogsViewer: () => <div data-testid="activity-logs-viewer">Activity Logs Viewer</div>,
+}))
+
+import ActivityLogsPage from "../page"
+
+describe("ActivityLogsPage auth wrapper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows the shared spinner while the session is loading", () => {
+    mocks.useSession.mockReturnValue({
+      status: "loading",
+      data: null,
+    })
+
+    render(<ActivityLogsPage />)
+
+    expect(screen.getByTestId("authenticated-page-spinner-fallback")).toBeInTheDocument()
+    expect(screen.queryByTestId("activity-logs-viewer")).not.toBeInTheDocument()
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+
+  it("shows the shared spinner without redirecting when unauthenticated", () => {
+    mocks.useSession.mockReturnValue({
+      status: "unauthenticated",
+      data: null,
+    })
+
+    render(<ActivityLogsPage />)
+
+    expect(screen.getByTestId("authenticated-page-spinner-fallback")).toBeInTheDocument()
+    expect(screen.queryByTestId("activity-logs-viewer")).not.toBeInTheDocument()
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+
+  it("shows the restricted access message for non-global users", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: {
+        user: {
+          id: "user-1",
+          username: "regular-user",
+          role: "to_qltb",
+        },
+      },
+    })
+
+    render(<ActivityLogsPage />)
+
+    expect(screen.getByText("Truy cập bị hạn chế")).toBeInTheDocument()
+    expect(screen.queryByTestId("activity-logs-viewer")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("authenticated-page-spinner-fallback")).not.toBeInTheDocument()
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+
+  it("renders the activity logs viewer for global users", () => {
+    mocks.useSession.mockReturnValue({
+      status: "authenticated",
+      data: {
+        user: {
+          id: "user-1",
+          username: "global-admin",
+          role: "admin",
+        },
+      },
+    })
+
+    render(<ActivityLogsPage />)
+
+    expect(screen.getByTestId("activity-logs-viewer")).toBeInTheDocument()
+    expect(screen.getByText("Nhật ký hoạt động")).toBeInTheDocument()
+    expect(screen.getByText(/Phiên của bạn:/)).toHaveTextContent("global-admin")
+    expect(screen.queryByTestId("authenticated-page-spinner-fallback")).not.toBeInTheDocument()
+    expect(mocks.replace).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/activity-logs/page.tsx
+++ b/src/app/(app)/activity-logs/page.tsx
@@ -1,43 +1,29 @@
 'use client'
 
-import React from 'react'
-import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/navigation'
-import { Activity, Shield, AlertTriangle } from 'lucide-react'
+import * as React from 'react'
+import type { Session } from 'next-auth'
+import { Activity, AlertTriangle, Shield } from 'lucide-react'
 
+import { AuthenticatedPageBoundary } from '@/app/(app)/_components/AuthenticatedPageBoundary'
+import { AuthenticatedPageSpinnerFallback } from '@/app/(app)/_components/AuthenticatedPageFallbacks'
 import { ActivityLogsViewer } from '@/components/activity-logs/activity-logs-viewer'
 import { Card, CardContent } from '@/components/ui/card'
 import { isGlobalRole } from '@/lib/rbac'
 
 export default function ActivityLogsPage() {
-  const { data: session, status } = useSession()
+  return (
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSpinnerFallback />}>
+      {(user) => <ActivityLogsPageContent user={user} />}
+    </AuthenticatedPageBoundary>
+  )
+}
 
-  const router = useRouter()
+type ActivityLogsPageContentProps = {
+  user: Session['user']
+}
 
-  React.useEffect(() => {
-    if (status !== 'loading' && !session) {
-      router.replace('/auth/signin')
-    }
-  }, [status, session, router])
-
-  // Redirect if not authenticated
-  if (status === 'loading') {
-    return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">Đang tải...</p>
-        </div>
-      </div>
-    )
-  }
-
-  if (!session) {
-    return null
-  }
-
-  // Check if user is global admin
-  const isGlobalUser = isGlobalRole((session.user as any)?.role)
+function ActivityLogsPageContent({ user }: ActivityLogsPageContentProps) {
+  const isGlobalUser = isGlobalRole(user.role)
 
   if (!isGlobalUser) {
     return (
@@ -95,7 +81,7 @@ export default function ActivityLogsPage() {
             <span>Chỉ dành cho quản trị viên hệ thống</span>
           </div>
           <div className="text-sm text-gray-500">
-            Phiên của bạn: {(session.user as any)?.username || 'N/A'}
+            Phiên của bạn: {user.username || 'N/A'}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- migrate the activity logs page to AuthenticatedPageBoundary
- replace the page-local loading gate with the shared AuthenticatedPageSpinnerFallback
- remove the client-side unauthenticated redirect effect and add focused auth wrapper coverage

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- 'src/app/(app)/activity-logs/__tests__/ActivityLogsPage.auth.test.tsx'\n- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main\n\nCloses #298
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Activity Logs page to the shared auth boundary and spinner fallback, removing the client-side unauthenticated redirect. This eliminates redirect flicker and standardizes auth handling across the app. Closes #298.

- **Bug Fixes**
  - Use `AuthenticatedPageBoundary` with `AuthenticatedPageSpinnerFallback` for loading/unauthenticated states.
  - Remove client-side redirect effect; rely on the boundary for unauthenticated handling.
  - Add focused auth tests covering loading, unauthenticated, non-global, and global user flows.

<sup>Written for commit 3d467a42d95751d58be07199801d31557a25ab1f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added authentication and role-based access control validation tests for the Activity Logs page.

* **Refactor**
  * Improved authentication handling architecture on the Activity Logs page while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->