### PR TITLE
feat: hide device quota for restricted roles

### DIFF
--- a/src/app/(app)/device-quota/__tests__/layout.auth.test.tsx
+++ b/src/app/(app)/device-quota/__tests__/layout.auth.test.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  redirect: vi.fn((path: string) => {
+    throw new Error(`NEXT_REDIRECT:${path}`)
+  }),
+}))
+
+vi.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mocks.getServerSession(...args),
+}))
+
+vi.mock("next/navigation", () => ({
+  redirect: (path: string) => mocks.redirect(path),
+}))
+
+vi.mock("@/app/(app)/device-quota/_components/DeviceQuotaSubNav", () => ({
+  DeviceQuotaSubNav: () => <div data-testid="device-quota-subnav" />,
+}))
+
+import DeviceQuotaLayout from "@/app/(app)/device-quota/layout"
+import { authOptions } from "@/auth/config"
+
+describe("DeviceQuotaLayout auth gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("redirects unauthenticated requests to the login page", async () => {
+    mocks.getServerSession.mockResolvedValue(null)
+
+    await expect(
+      DeviceQuotaLayout({ children: <div>Protected Child</div> })
+    ).rejects.toThrow("NEXT_REDIRECT:/")
+
+    expect(mocks.getServerSession).toHaveBeenCalledWith(authOptions)
+    expect(mocks.redirect).toHaveBeenCalledWith("/")
+  })
+
+  it.each(["user", "qltb_khoa", "technician"])(
+    "redirects %s away from the device quota module",
+    async (role) => {
+      mocks.getServerSession.mockResolvedValue({
+        user: {
+          role,
+        },
+      })
+
+      await expect(
+        DeviceQuotaLayout({ children: <div>Protected Child</div> })
+      ).rejects.toThrow("NEXT_REDIRECT:/dashboard")
+
+      expect(mocks.getServerSession).toHaveBeenCalledWith(authOptions)
+      expect(mocks.redirect).toHaveBeenCalledWith("/dashboard")
+    }
+  )
+
+  it("renders the device quota layout for allowed roles", async () => {
+    mocks.getServerSession.mockResolvedValue({
+      user: {
+        role: "to_qltb",
+      },
+    })
+
+    render(await DeviceQuotaLayout({ children: <div>Protected Child</div> }))
+
+    expect(mocks.getServerSession).toHaveBeenCalledWith(authOptions)
+    expect(mocks.redirect).not.toHaveBeenCalled()
+    expect(screen.getByTestId("device-quota-subnav")).toBeInTheDocument()
+    expect(screen.getByText("Protected Child")).toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
@@ -58,7 +58,7 @@ describe('DeviceQuotaCategoriesPage', () => {
 
   it('shows the restricted access state for authenticated users without category management permission', () => {
     mockUseSession.mockReturnValue({
-      data: { user: { role: 'user', don_vi: '1' } },
+      data: { user: { role: 'regional_leader', don_vi: '1' } },
       status: 'authenticated',
     })
 

--- a/src/app/(app)/device-quota/layout.tsx
+++ b/src/app/(app)/device-quota/layout.tsx
@@ -1,4 +1,11 @@
+import * as React from "react"
+import type { ReactNode } from "react"
 import type { Metadata } from "next"
+import { getServerSession } from "next-auth"
+import { redirect } from "next/navigation"
+
+import { authOptions } from "@/auth/config"
+import { canAccessDeviceQuotaModule } from "@/lib/rbac"
 import { DeviceQuotaSubNav } from "./_components/DeviceQuotaSubNav"
 
 export const metadata: Metadata = {
@@ -6,11 +13,21 @@ export const metadata: Metadata = {
   description: "Quản lý định mức thiết bị y tế theo quyết định của Bộ Y tế",
 }
 
-export default function DeviceQuotaLayout({
+export default async function DeviceQuotaLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: ReactNode
 }) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user) {
+    redirect("/")
+  }
+
+  if (!canAccessDeviceQuotaModule(session.user.role)) {
+    redirect("/dashboard")
+  }
+
   return (
     <>
       <DeviceQuotaSubNav />

--- a/src/components/__tests__/app-navigation.test.ts
+++ b/src/components/__tests__/app-navigation.test.ts
@@ -2,31 +2,37 @@ import { describe, expect, it } from "vitest"
 
 import { getAppNavigationItems, getMobileFooterMoreNavItems } from "@/components/app-navigation"
 
-function getHrefs(role: string) {
+const restrictedRoles = ["user", "qltb_khoa", "technician"] as const
+const allowedRoles = ["to_qltb", "regional_leader", "global", "admin"] as const
+
+function getHrefs(role: string): string[] {
   return getAppNavigationItems(role).map((item) => item.href)
 }
 
-function getMoreHrefs(role: string) {
+function getMoreHrefs(role: string): string[] {
   return getMobileFooterMoreNavItems(role).map((item) => item.href)
 }
 
 describe("app-navigation role filtering", () => {
   it("hides device quota from restricted roles in the main navigation", () => {
-    expect(getHrefs("user")).not.toContain("/device-quota")
-    expect(getHrefs("qltb_khoa")).not.toContain("/device-quota")
-    expect(getHrefs("technician")).not.toContain("/device-quota")
+    for (const role of restrictedRoles) {
+      expect(getHrefs(role)).not.toContain("/device-quota")
+    }
   })
 
   it("keeps device quota visible for allowed roles in the main navigation", () => {
-    expect(getHrefs("to_qltb")).toContain("/device-quota")
-    expect(getHrefs("regional_leader")).toContain("/device-quota")
-    expect(getHrefs("global")).toContain("/device-quota")
+    for (const role of allowedRoles) {
+      expect(getHrefs(role)).toContain("/device-quota")
+    }
   })
 
   it("applies the same device quota filtering to the mobile more menu", () => {
-    expect(getMoreHrefs("user")).not.toContain("/device-quota")
-    expect(getMoreHrefs("qltb_khoa")).not.toContain("/device-quota")
-    expect(getMoreHrefs("technician")).not.toContain("/device-quota")
-    expect(getMoreHrefs("to_qltb")).toContain("/device-quota")
+    for (const role of restrictedRoles) {
+      expect(getMoreHrefs(role)).not.toContain("/device-quota")
+    }
+
+    for (const role of allowedRoles) {
+      expect(getMoreHrefs(role)).toContain("/device-quota")
+    }
   })
 })

--- a/src/components/__tests__/app-navigation.test.ts
+++ b/src/components/__tests__/app-navigation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { getAppNavigationItems, getMobileFooterMoreNavItems } from "@/components/app-navigation"
+
+function getHrefs(role: string) {
+  return getAppNavigationItems(role).map((item) => item.href)
+}
+
+function getMoreHrefs(role: string) {
+  return getMobileFooterMoreNavItems(role).map((item) => item.href)
+}
+
+describe("app-navigation role filtering", () => {
+  it("hides device quota from restricted roles in the main navigation", () => {
+    expect(getHrefs("user")).not.toContain("/device-quota")
+    expect(getHrefs("qltb_khoa")).not.toContain("/device-quota")
+    expect(getHrefs("technician")).not.toContain("/device-quota")
+  })
+
+  it("keeps device quota visible for allowed roles in the main navigation", () => {
+    expect(getHrefs("to_qltb")).toContain("/device-quota")
+    expect(getHrefs("regional_leader")).toContain("/device-quota")
+    expect(getHrefs("global")).toContain("/device-quota")
+  })
+
+  it("applies the same device quota filtering to the mobile more menu", () => {
+    expect(getMoreHrefs("user")).not.toContain("/device-quota")
+    expect(getMoreHrefs("qltb_khoa")).not.toContain("/device-quota")
+    expect(getMoreHrefs("technician")).not.toContain("/device-quota")
+    expect(getMoreHrefs("to_qltb")).toContain("/device-quota")
+  })
+})

--- a/src/components/app-navigation.tsx
+++ b/src/components/app-navigation.tsx
@@ -12,7 +12,7 @@ import {
   type LucideIcon,
 } from "lucide-react"
 
-import { isGlobalRole } from "@/lib/rbac"
+import { canAccessDeviceQuotaModule, isGlobalRole } from "@/lib/rbac"
 import type { AppNotificationBadgeKey } from "@/lib/app-notification-counts"
 
 export interface AppNavItem {
@@ -23,6 +23,7 @@ export interface AppNavItem {
   mobileSection: "main" | "more"
   badgeKey?: AppNotificationBadgeKey
   requiresGlobal?: boolean
+  requiresDeviceQuotaAccess?: boolean
 }
 
 const APP_NAV_ITEMS: AppNavItem[] = [
@@ -50,7 +51,13 @@ const APP_NAV_ITEMS: AppNavItem[] = [
     mobileSection: "more",
     badgeKey: "maintenance",
   },
-  { href: "/device-quota", icon: Calculator, label: "Định mức", mobileSection: "more" },
+  {
+    href: "/device-quota",
+    icon: Calculator,
+    label: "Định mức",
+    mobileSection: "more",
+    requiresDeviceQuotaAccess: true,
+  },
   { href: "/reports", icon: BarChart3, label: "Báo cáo", mobileSection: "more" },
   { href: "/qr-scanner", icon: QrCode, label: "Quét QR", mobileSection: "more" },
   { href: "/users", icon: Users, label: "Người dùng", mobileSection: "more", requiresGlobal: true },
@@ -64,7 +71,17 @@ const APP_NAV_ITEMS: AppNavItem[] = [
 ]
 
 export function getAppNavigationItems(role?: string): AppNavItem[] {
-  return APP_NAV_ITEMS.filter((item) => !item.requiresGlobal || isGlobalRole(role))
+  return APP_NAV_ITEMS.filter((item) => {
+    if (item.requiresGlobal && !isGlobalRole(role)) {
+      return false
+    }
+
+    if (item.requiresDeviceQuotaAccess && !canAccessDeviceQuotaModule(role)) {
+      return false
+    }
+
+    return true
+  })
 }
 
 export function getMobileFooterMainNavItems(role?: string): AppNavItem[] {

--- a/src/lib/__tests__/rbac.test.ts
+++ b/src/lib/__tests__/rbac.test.ts
@@ -1,4 +1,5 @@
 import {
+  canAccessDeviceQuotaModule,
   isGlobalRole,
   isRegionalLeaderRole,
   isEquipmentManagerRole,
@@ -12,6 +13,7 @@ describe('RBAC Utilities', () => {
 
   it('should fail closed for null/undefined', () => {
     nullishValues.forEach(value => {
+      expect(canAccessDeviceQuotaModule(value)).toBe(false)
       expect(isGlobalRole(value)).toBe(false)
       expect(isRegionalLeaderRole(value)).toBe(false)
       expect(isEquipmentManagerRole(value)).toBe(false)
@@ -23,6 +25,7 @@ describe('RBAC Utilities', () => {
   it('should return false for empty or whitespace-only strings', () => {
     const values = ['', '   ', '\n', '\t']
     values.forEach(value => {
+      expect(canAccessDeviceQuotaModule(value)).toBe(false)
       expect(isGlobalRole(value)).toBe(false)
       expect(isRegionalLeaderRole(value)).toBe(false)
       expect(isEquipmentManagerRole(value)).toBe(false)
@@ -32,6 +35,9 @@ describe('RBAC Utilities', () => {
   })
 
   it('should handle case-insensitivity and whitespace', () => {
+    expect(canAccessDeviceQuotaModule(' Admin ')).toBe(true)
+    expect(canAccessDeviceQuotaModule(' regional_leader ')).toBe(true)
+    expect(canAccessDeviceQuotaModule('  To_QLTB ')).toBe(true)
     expect(isGlobalRole(' GLOBAL ')).toBe(true)
     expect(isGlobalRole('Admin')).toBe(true)
     expect(isEquipmentManagerRole('  To_QLTB ')).toBe(true)
@@ -120,6 +126,7 @@ describe('RBAC Utilities', () => {
   it('should return false for unknown roles', () => {
     const values = ['super_admin', 'unknown', 'manager']
     values.forEach(value => {
+      expect(canAccessDeviceQuotaModule(value)).toBe(false)
       expect(isGlobalRole(value)).toBe(false)
       expect(isRegionalLeaderRole(value)).toBe(false)
       expect(isEquipmentManagerRole(value)).toBe(false)
@@ -143,6 +150,19 @@ describe('RBAC Utilities', () => {
 
     denied.forEach(role => {
       expect(isPrivilegedRole(role)).toBe(false)
+    })
+  })
+
+  it('should identify device quota module access correctly', () => {
+    const allowed = [ROLES.GLOBAL, ROLES.ADMIN, ROLES.REGIONAL_LEADER, ROLES.TO_QLTB]
+    const denied = [ROLES.TECHNICIAN, ROLES.QLTB_KHOA, ROLES.USER]
+
+    allowed.forEach(role => {
+      expect(canAccessDeviceQuotaModule(role)).toBe(true)
+    })
+
+    denied.forEach(role => {
+      expect(canAccessDeviceQuotaModule(role)).toBe(false)
     })
   })
 })

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -104,6 +104,20 @@ export function isEquipmentManagerRole(role: string | null | undefined): boolean
 }
 
 /**
+ * Device quota module access check.
+ *
+ * Use for: top-level device quota navigation and route entry gating.
+ * Restricted roles should not see the module entry point or access it directly.
+ */
+export function canAccessDeviceQuotaModule(role: string | null | undefined): boolean {
+  const normalized = normalizeRole(role)
+
+  return normalized !== ROLES.USER
+    && normalized !== ROLES.QLTB_KHOA
+    && normalized !== ROLES.TECHNICIAN
+}
+
+/**
  * Department-scoped role check.
  *
  * Use for: determining if user needs khoa_phong filtering.

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -112,9 +112,9 @@ export function isEquipmentManagerRole(role: string | null | undefined): boolean
 export function canAccessDeviceQuotaModule(role: string | null | undefined): boolean {
   const normalized = normalizeRole(role)
 
-  return normalized !== ROLES.USER
-    && normalized !== ROLES.QLTB_KHOA
-    && normalized !== ROLES.TECHNICIAN
+  return isGlobalRole(role)
+    || normalized === ROLES.REGIONAL_LEADER
+    || normalized === ROLES.TO_QLTB
 }
 
 /**


### PR DESCRIPTION
## Summary
- hide the `Định mức` navigation item for `user`, `qltb_khoa`, and `technician`
- block direct access to `/device-quota/**` for those roles with a server-side redirect to `/dashboard`
- add focused regression tests for nav filtering and the device quota layout auth gate

## Why
`/device-quota` was still visible in shared app navigation for lower-privilege roles, and those roles could still enter the module directly by URL because the module layout only rendered sub-navigation without a role gate.

## Implementation
- add `canAccessDeviceQuotaModule()` in `src/lib/rbac.ts`
- use that helper in `src/components/app-navigation.tsx` so desktop sidebar, mobile sheet, and mobile footer all inherit the same filter from the shared nav source
- add a server-side auth gate in `src/app/(app)/device-quota/layout.tsx` using `getServerSession(authOptions)` + `redirect()`
- keep the narrower category-management restriction intact and update the categories test to use a still-reachable restricted role (`regional_leader`) for that page-level state

## Blast Radius Reviewed
- `getAppNavigationItems()` is the high-risk entry point because it feeds `AppLayoutShell` and `MobileFooterNav`
- `DeviceQuotaLayout` is the low-risk subtree gate for `/device-quota/**`
- diff is intentionally limited to shared RBAC/nav filtering and the module layout gate

## Tests
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/app-navigation.test.ts 'src/app/(app)/device-quota/__tests__/layout.auth.test.tsx' 'src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx' 'src/app/(app)/device-quota/__tests__/DeviceQuotaPageAuth.test.tsx'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Manual Verification
- confirm `user`, `qltb_khoa`, and `technician` no longer see `Định mức` in desktop and mobile navigation
- confirm direct visits to `/device-quota`, `/device-quota/dashboard`, `/device-quota/decisions`, and `/device-quota/mapping` redirect to `/dashboard` for those roles

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the `Định mức` device quota module for restricted roles and block direct access with a server-side auth gate. Tighten RBAC to fail closed and ensure consistent filtering across desktop and mobile navigation.

- **Bug Fixes**
  - Hardened `canAccessDeviceQuotaModule()` to be case-insensitive, whitespace-safe, and fail closed for null/unknown roles; expanded RBAC tests.
  - Applied a `requiresDeviceQuotaAccess` flag in shared navigation to hide `/device-quota` in both main and mobile “More” menus; added nav tests.
  - Made `DeviceQuotaLayout` async with `getServerSession(authOptions)` and redirects: unauthenticated → `/`, restricted roles → `/dashboard`; kept stricter categories restriction and updated that test to use `regional_leader`.

<sup>Written for commit acfaca4e78bc1b03842fa8eb457ace96bc9e045a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device quota module now requires proper authentication and role-based authorization. Users without appropriate permissions will be automatically redirected to the dashboard or login.
  * Navigation menu intelligently filters the device quota option based on user access permissions.

* **Tests**
  * Added comprehensive test coverage validating authentication gating and role-based access control across the device quota module and navigation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->