### PR TITLE
feat: [#301] add user department scope to equipment read RPCs

### DIFF
--- a/docs/superpowers/plans/2026-04-22-issue-301-read-prefilter.md
+++ b/docs/superpowers/plans/2026-04-22-issue-301-read-prefilter.md
@@ -138,6 +138,7 @@ Minimum cases to lock:
 At least one fixture pair must prove:
 - trim is ignored
 - case is ignored
+- hyphen separators normalize deterministically
 - repeated internal whitespace collapses
 
 Do not add fuzzy, substring, or accent-insensitive matching expectations.
@@ -154,7 +155,7 @@ Expected:
 ### Task 2: Implement the minimal forward-only migration
 
 **Files:**
-- Create: `supabase/migrations/20260422xxxxxx_add_user_department_scope_reads.sql`
+- Create: `supabase/migrations/20260422123000_add_user_department_scope_reads.sql`
 - Read: `supabase/migrations/20260213095000_equipment_soft_delete_active_reads.sql`
 - Read: `supabase/migrations/20260218203500_fix_ilike_sanitization_equipment_list.sql`
 - Read: `supabase/migrations/20260219150500_fix_audit_spoofing_and_search_path.sql`
@@ -164,6 +165,7 @@ Expected:
 Implementation contract:
 - return `NULL` for null/blank input
 - normalize tabs/newlines/NBSP to spaces
+- normalize hyphen separators to spaces
 - trim outer whitespace
 - lowercase
 - collapse repeated whitespace to single spaces
@@ -200,7 +202,7 @@ Concrete patch rules by deployed function family:
 - [ ] **Step 7: Apply the migration**
 
 Run via Supabase MCP:
-- load the contents of `supabase/migrations/20260422xxxxxx_add_user_department_scope_reads.sql`
+- load the contents of `supabase/migrations/20260422123000_add_user_department_scope_reads.sql`
 - apply them with `apply_migration(name: "add_user_department_scope_reads", query: <file contents>)`
 
 Expected:
@@ -254,7 +256,7 @@ Not allowed:
 - [ ] **Step 12: Commit only the `#301` slice**
 
 ```bash
-git add supabase/tests/equipment_department_scope_reads_smoke.sql supabase/migrations/20260422xxxxxx_add_user_department_scope_reads.sql
+git add supabase/tests/equipment_department_scope_reads_smoke.sql supabase/migrations/20260422123000_add_user_department_scope_reads.sql
 git commit -m "feat: [#301] add user department prefilter for equipment reads"
 ```
 

--- a/docs/superpowers/plans/2026-04-22-issue-301-read-prefilter.md
+++ b/docs/superpowers/plans/2026-04-22-issue-301-read-prefilter.md
@@ -1,0 +1,268 @@
+# Issue 301 Read Prefilter Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add server-only, strict-normalized department scoping for role `user` across the equipment read RPC family in issue `#301`.
+
+**Architecture:** Implement one forward-only SQL migration that adds a shared normalization helper and patches only the read RPCs in scope. Drive the work from a new SQL smoke test that locks the desired read contract first, then verify existing app-side consumers still match the server contract without pulling `#302` or `#303` behavior into this batch.
+
+**Tech Stack:** Supabase Postgres migrations via Supabase MCP, SQL smoke tests via Supabase MCP `execute_sql`, Next.js RPC proxy, React Query hooks, Vitest for focused contract checks
+
+---
+
+## Context Snapshot
+
+- Umbrella tracker: `#305`
+- This batch: `#301` `[Equipment] Phase 1 - user department prefilter for read RPCs`
+- Keep this batch limited to read-side SQL. Do not implement write guards from `#302` or deep-link `deny + no-open` client behavior from `#303`.
+- Policy for role `user` only:
+  - strict normalized equality only
+  - server-only enforcement
+  - missing or blank `khoa_phong` claim fails closed
+  - list/filter RPCs fail closed to empty results
+  - `equipment_get` / `equipment_get_by_code` fail closed with deny/not-found
+
+## Code Review Graph / Discovery Notes
+
+- `code-review-graph get_minimal_context_tool` was low-signal for SQL symbol scoping in this repo, so use it only as a first-pass map.
+- `morph codebase_search` and direct reads narrowed the real SQL family to:
+  - `supabase/migrations/20260213095000_equipment_soft_delete_active_reads.sql`
+  - `supabase/migrations/20260218203500_fix_ilike_sanitization_equipment_list.sql`
+- The existing app blast radius is stable because these RPCs already flow through the proxy allowlist in `src/app/api/rpc/[fn]/allowed-functions.ts`.
+
+## Live DB Findings To Preserve
+
+- Supabase MCP inspection confirms the deployed source of truth already has `SET search_path = public, pg_temp` on every RPC in the `#301` read family.
+- `equipment_get` and `equipment_get_by_code` currently:
+  - use `allowed_don_vi_for_session()`
+  - map `admin -> global`
+  - deny with the generic message `Equipment not found or access denied`
+- `equipment_list` currently:
+  - uses `allowed_don_vi_for_session()`
+  - maps `admin -> global`
+  - sanitizes search with `_sanitize_ilike_pattern`
+  - returns empty for no tenant access rather than JSON error
+- `equipment_list_enhanced` currently:
+  - uses `allowed_don_vi_for_session_safe()`
+  - treats `global` and `admin` together
+  - returns JSON `{ data, total, page, pageSize, error }` for tenant-denied / no-tenant-access paths
+  - applies all user-selected filters by string-building `v_where`
+- Filter-option RPCs currently:
+  - use `allowed_don_vi_for_session_safe()`
+  - do not map `admin -> global`
+  - group on trimmed display labels such as `COALESCE(NULLIF(TRIM(...), ''), 'Chưa ...')`
+- `equipment_count_enhanced` is deployed with its own role logic and direct `p_khoa_phong` equality. It remains out of scope for `#301`, but this is the concrete reason the report-count consistency gap exists.
+
+## Blast Radius
+
+### Direct SQL blast radius
+
+- `public._normalize_department_scope(text)` new helper
+- `public.equipment_list`
+- `public.equipment_list_enhanced`
+- `public.equipment_get`
+- `public.equipment_get_by_code`
+- `public.departments_list_for_tenant`
+- `public.equipment_users_list_for_tenant`
+- `public.equipment_locations_list_for_tenant`
+- `public.equipment_classifications_list_for_tenant`
+- `public.equipment_statuses_list_for_tenant`
+- `public.equipment_funding_sources_list_for_tenant`
+
+### Direct app consumers
+
+- Equipment page data hook: `src/app/(app)/equipment/_hooks/useEquipmentData.ts`
+- Inventory report hook: `src/app/(app)/reports/hooks/use-inventory-data.ts`
+- QR exact-code lookup: `src/components/qr-action-sheet.tsx`
+- RPC proxy allowlist: `src/app/api/rpc/[fn]/allowed-functions.ts`
+
+### Existing test surfaces worth re-running
+
+- `src/app/(app)/equipment/__tests__/useEquipmentData.test.ts`
+- `src/components/__tests__/qr-action-sheet.test.tsx`
+- `src/app/api/rpc/__tests__/equipment-get-by-code-security.test.ts`
+- Existing SQL regression checks near this family:
+  - `supabase/tests/equipment_list_enhanced_overload_regression.sql`
+  - `supabase/tests/equipment_soft_delete_historical_reads_smoke.sql`
+
+## Known Gaps To Watch
+
+- No SQL smoke test currently locks department-scoped read behavior. Existing coverage is mostly mocked JS behavior, not DB-enforced scope.
+- Live DB inspection via Supabase MCP shows the deployed read-family already has `SET search_path`; the new migration must preserve that deployed contract even if older repo migrations show earlier states.
+- Role normalization is not perfectly uniform across this family today. Preserve current role contracts for non-`user` roles instead of flattening everything into one new branch.
+- `use-inventory-data.ts` combines `departments_list_for_tenant` with `equipment_count_enhanced`; because live DB shows `equipment_count_enhanced` is a separate contract, count consistency must stay a follow-up issue instead of being silently pulled into `#301`.
+- `#303` deep-link `deny + no-open` remains out of scope here. This batch only needs the server deny behavior that `#303` will later consume.
+
+## Chunk 1: SQL Read Scope
+
+### Task 1: Write the failing SQL smoke test first
+
+**Files:**
+- Create: `supabase/tests/equipment_department_scope_reads_smoke.sql`
+- Read: `supabase/tests/equipment_soft_delete_historical_reads_smoke.sql`
+- Read: `supabase/tests/equipment_soft_delete_workflow_guards_smoke.sql`
+- Read: `supabase/tests/equipment_list_enhanced_overload_regression.sql`
+
+- [ ] **Step 1: Copy the local smoke-test structure from the nearest Supabase SQL smoke tests**
+
+Use the same style for:
+- fixture suffixing
+- `request.jwt.claims` session setup
+- explicit assertion blocks with `RAISE EXCEPTION`
+- cleanup
+
+- [ ] **Step 2: Write failing assertions for the read contract in issue `#301`**
+
+Minimum cases to lock:
+- role `user`, same tenant + same normalized department:
+  - `equipment_list` returns row
+  - `equipment_list_enhanced` returns row and correct total
+  - `equipment_get` returns row
+  - `equipment_get_by_code` returns row
+- role `user`, same tenant + different department:
+  - `equipment_list` returns empty
+  - `equipment_list_enhanced` returns empty payload
+  - `equipment_get` raises deny/not-found
+  - `equipment_get_by_code` raises deny/not-found
+- role `user`, missing or blank `khoa_phong` claim:
+  - list RPCs fail closed empty
+  - single-item reads deny
+- preserve current non-`user` contracts exactly:
+  - `equipment_get` / `equipment_get_by_code` still allow `admin` via `admin -> global`
+  - `equipment_list_enhanced` still returns existing tenant-denied / no-tenant-access JSON shapes
+- filter-option RPCs only reflect the scoped equipment set
+- one non-`user` control case proves current behavior is preserved
+
+- [ ] **Step 3: Include normalization edge cases in the same smoke test**
+
+At least one fixture pair must prove:
+- trim is ignored
+- case is ignored
+- repeated internal whitespace collapses
+
+Do not add fuzzy, substring, or accent-insensitive matching expectations.
+
+- [ ] **Step 4: Run the new smoke test and verify RED**
+
+Run via Supabase MCP:
+- load the contents of `supabase/tests/equipment_department_scope_reads_smoke.sql`
+- execute them with `execute_sql(query: <file contents>)`
+
+Expected:
+- FAIL because the helper and department read-scope enforcement do not exist yet
+
+### Task 2: Implement the minimal forward-only migration
+
+**Files:**
+- Create: `supabase/migrations/20260422xxxxxx_add_user_department_scope_reads.sql`
+- Read: `supabase/migrations/20260213095000_equipment_soft_delete_active_reads.sql`
+- Read: `supabase/migrations/20260218203500_fix_ilike_sanitization_equipment_list.sql`
+- Read: `supabase/migrations/20260219150500_fix_audit_spoofing_and_search_path.sql`
+
+- [ ] **Step 5: Add `public._normalize_department_scope(text)`**
+
+Implementation contract:
+- return `NULL` for null/blank input
+- normalize tabs/newlines/NBSP to spaces
+- trim outer whitespace
+- lowercase
+- collapse repeated whitespace to single spaces
+
+- [ ] **Step 6: Patch only the read RPCs in scope**
+
+Required behavior:
+- keep existing tenant guard first
+- preserve current non-`user` role behavior
+- for role `user`, read `khoa_phong` from JWT claims, normalize it, and fail closed when null/empty
+- compare against normalized `tb.khoa_phong_quan_ly` with strict equality only
+- keep current `_sanitize_ilike_pattern()` handling in `equipment_list` and `equipment_list_enhanced`
+- keep `SET search_path = public, pg_temp` on every touched `SECURITY DEFINER` function
+
+Concrete patch rules by deployed function family:
+- `equipment_get` / `equipment_get_by_code`:
+  - keep the current `allowed_don_vi_for_session()` tenant gate and `admin -> global` mapping
+  - after tenant scope but before returning the row, add a role-`user` department check against normalized `tb.khoa_phong_quan_ly`
+  - on missing/blank claim or mismatch, raise the same generic deny exception already used today
+- `equipment_list`:
+  - keep the current `allowed_don_vi_for_session()` and `v_effective` logic
+  - for role `user`, add an extra normalized department predicate into `v_sql`
+  - if the normalized claim is null, return empty immediately rather than raising
+- `equipment_list_enhanced`:
+  - keep the current `allowed_don_vi_for_session_safe()` logic and existing JSON error returns for tenant-denied / no-tenant-access paths
+  - do not change selected-filter behavior for `p_khoa_phong[_array]`, `p_nguoi_su_dung[_array]`, `p_vi_tri_lap_dat[_array]`, `p_tinh_trang[_array]`, `p_phan_loai[_array]`, `p_nguon_kinh_phi[_array]`
+  - for role `user`, append one additional normalized department predicate to `v_where`
+  - if the normalized claim is null, return the normal empty payload shape `{ data: [], total: 0, page, pageSize }` without introducing a new `error`
+- Filter-option RPCs:
+  - keep the current `allowed_don_vi_for_session_safe()` / `v_effective` logic and existing label grouping expressions
+  - for role `user`, add the same normalized department predicate directly in the final `WHERE`
+  - if the normalized claim is null, return no rows immediately
+
+- [ ] **Step 7: Apply the migration**
+
+Run via Supabase MCP:
+- load the contents of `supabase/migrations/20260422xxxxxx_add_user_department_scope_reads.sql`
+- apply them with `apply_migration(name: "add_user_department_scope_reads", query: <file contents>)`
+
+Expected:
+- migration applies cleanly
+
+- [ ] **Step 8: Re-run the smoke test and verify GREEN**
+
+Run via Supabase MCP:
+- re-execute `supabase/tests/equipment_department_scope_reads_smoke.sql` with `execute_sql(query: <file contents>)`
+
+Expected:
+- PASS
+
+- [ ] **Step 9: Run post-migration advisor check**
+
+Use Supabase MCP:
+- `get_advisors(type: "security")`
+
+Expected:
+- no new security regression caused by the migration
+
+### Task 3: Re-run focused app-side contract tests
+
+**Files:**
+- Test: `src/app/(app)/equipment/__tests__/useEquipmentData.test.ts`
+- Test: `src/components/__tests__/qr-action-sheet.test.tsx`
+- Test: `src/app/api/rpc/__tests__/equipment-get-by-code-security.test.ts`
+
+- [ ] **Step 10: Run focused tests for direct consumers**
+
+Run:
+```bash
+node scripts/npm-run.js test -- --run "src/app/(app)/equipment/__tests__/useEquipmentData.test.ts"
+node scripts/npm-run.js test -- --run "src/components/__tests__/qr-action-sheet.test.tsx"
+node scripts/npm-run.js test -- --run "src/app/api/rpc/__tests__/equipment-get-by-code-security.test.ts"
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 11: Only add or adjust app-side tests if the SQL contract change exposes a real mismatch**
+
+Allowed examples:
+- `useEquipmentData` expectations for empty filter-option arrays under scoped user claims
+- QR action-sheet handling of deny/not-found wording if the current copy mismatches the SQL error contract
+
+Not allowed:
+- implementing `#303` no-open behavior in this batch
+- broad UI refactors
+
+- [ ] **Step 12: Commit only the `#301` slice**
+
+```bash
+git add supabase/tests/equipment_department_scope_reads_smoke.sql supabase/migrations/20260422xxxxxx_add_user_department_scope_reads.sql
+git commit -m "feat: [#301] add user department prefilter for equipment reads"
+```
+
+## Done Criteria
+
+- New smoke test was written first and observed RED before implementation
+- Read-family RPCs enforce department scope only for role `user`
+- Non-`user` roles keep existing behavior
+- Filter-option RPCs derive values only from the scoped equipment set
+- Single-item reads deny for same-tenant, cross-department role `user`
+- No `#302` or `#303` behavior was implemented accidentally

--- a/docs/superpowers/plans/2026-04-22-user-department-server-prefilter.md
+++ b/docs/superpowers/plans/2026-04-22-user-department-server-prefilter.md
@@ -13,7 +13,7 @@
 ## Scope and constraints
 
 - Only role `user` gets the new department prefilter.
-- Match policy is strict normalized equality only: trim, lowercase, normalize tabs/newlines/NBSP to spaces, collapse repeated whitespace.
+- Match policy is strict normalized equality only: trim, lowercase, normalize tabs/newlines/NBSP to spaces, normalize hyphen separators to spaces, collapse repeated whitespace.
 - Do not reuse `src/lib/department-utils.ts` for enforcement.
 - List and filter-option RPCs fail closed to empty results.
 - Single-item reads and mutations fail closed with deny/not-found behavior, not blank fallbacks.
@@ -28,7 +28,7 @@
 
 - Create: `supabase/tests/equipment_department_scope_reads_smoke.sql`
 - Create: `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`
-- Create: `supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql`
+- Create: `supabase/migrations/20260422123000_add_user_department_scope_reads.sql`
 - Modify: `src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts`
 - Modify: `src/components/__tests__/qr-action-sheet.test.tsx`
 - Modify: `src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts`
@@ -111,7 +111,7 @@ Not allowed:
 ### Task 2: Implement the minimal SQL read-side scope
 
 **Files:**
-- Create: `supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql`
+- Create: `supabase/migrations/20260422123000_add_user_department_scope_reads.sql`
 - Read: `supabase/migrations/20260213095000_equipment_soft_delete_active_reads.sql`
 - Read: `supabase/migrations/20260218203500_fix_ilike_sanitization_equipment_list.sql`
 - Read: `supabase/migrations/20260219150500_fix_audit_spoofing_and_search_path.sql`
@@ -143,8 +143,8 @@ Implementation rules:
 
 Run:
 Run via Supabase MCP:
-- load `supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql`
-- apply with `apply_migration(name: "add_user_department_scope_prefilter", query: <file contents>)`
+- load `supabase/migrations/20260422123000_add_user_department_scope_reads.sql`
+- apply with `apply_migration(name: "add_user_department_scope_reads", query: <file contents>)`
 
 Expected:
 - Migration applies cleanly.
@@ -179,7 +179,7 @@ Expected:
 - [ ] **Step 9: Commit the read-scope slice**
 
 ```bash
-git add supabase/tests/equipment_department_scope_reads_smoke.sql supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql
+git add supabase/tests/equipment_department_scope_reads_smoke.sql supabase/migrations/20260422123000_add_user_department_scope_reads.sql
 git commit -m "feat: add user department scope to equipment read RPCs"
 ```
 
@@ -210,18 +210,17 @@ Also assert no write side effects remain on deny:
 
 - [ ] **Step 11: Run the new workflow smoke test and verify RED**
 
-Run:
-```bash
-docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
-```
+Run via Supabase MCP:
+- load `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`
+- execute with `execute_sql(query: <file contents>)`
 
 Expected:
 - FAIL because the workflow RPCs currently stop at tenant scope.
 
-### Task 4: Implement the minimal mutation guard changes
+### Task 4: Implement the minimal mutation guard changes in a new migration
 
 **Files:**
-- Modify: `supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql`
+- Create: `supabase/migrations/<next_timestamp>_add_user_department_scope_workflow_guards.sql`
 - Read: `supabase/migrations/20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql`
 - Read: `supabase/migrations/20260219032645_fix_workflow_guard_security_and_race.sql`
 - Read: `supabase/migrations/2025-09-29/20250927_regional_leader_phase4.sql`
@@ -251,32 +250,31 @@ Rules:
 
 - [ ] **Step 15: Apply the updated migration**
 
-Run:
-```bash
-node scripts/npm-run.js run db:push
-```
+Run via Supabase MCP:
+- load `supabase/migrations/<next_timestamp>_add_user_department_scope_workflow_guards.sql`
+- apply with `apply_migration(name: "add_user_department_scope_workflow_guards", query: <file contents>)`
 
 Expected:
 - Migration applies cleanly.
 
 - [ ] **Step 16: Re-run the workflow smoke test and verify GREEN**
 
-Run:
-```bash
-docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
-```
+Run via Supabase MCP:
+- load `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`
+- execute with `execute_sql(query: <file contents>)`
 
 Expected:
 - PASS
 
 - [ ] **Step 17: Re-run existing adjacent workflow smokes to catch regression**
 
-Run:
-```bash
-docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_soft_delete_workflow_guards_smoke.sql
-docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_lifecycle_audit_smoke.sql
-docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/transfer_request_lifecycle_audit_smoke.sql
-```
+Run via Supabase MCP:
+- load `supabase/tests/equipment_soft_delete_workflow_guards_smoke.sql`
+- execute with `execute_sql(query: <file contents>)`
+- load `supabase/tests/repair_request_lifecycle_audit_smoke.sql`
+- execute with `execute_sql(query: <file contents>)`
+- load `supabase/tests/transfer_request_lifecycle_audit_smoke.sql`
+- execute with `execute_sql(query: <file contents>)`
 
 Expected:
 - PASS
@@ -284,7 +282,7 @@ Expected:
 - [ ] **Step 18: Commit the workflow-guard slice**
 
 ```bash
-git add supabase/tests/equipment_department_scope_workflow_guards_smoke.sql supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql
+git add supabase/tests/equipment_department_scope_workflow_guards_smoke.sql supabase/migrations/<next_timestamp>_add_user_department_scope_workflow_guards.sql
 git commit -m "feat: add user department scope to equipment workflow RPCs"
 ```
 
@@ -405,15 +403,15 @@ git commit -m "feat: tighten user department deep-link and QR access behavior"
 
 - [ ] **Step 30: Re-run the new SQL read smoke**
 
-```bash
-docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_department_scope_reads_smoke.sql
-```
+Run via Supabase MCP:
+- load `supabase/tests/equipment_department_scope_reads_smoke.sql`
+- execute with `execute_sql(query: <file contents>)`
 
 - [ ] **Step 31: Re-run the new SQL workflow smoke**
 
-```bash
-docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
-```
+Run via Supabase MCP:
+- load `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`
+- execute with `execute_sql(query: <file contents>)`
 
 - [ ] **Step 32: Run the focused Vitest suites**
 
@@ -446,7 +444,7 @@ Expected:
 - [ ] **Step 36: Final commit if any verification-only fixes were required**
 
 ```bash
-git add supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql supabase/tests/equipment_department_scope_reads_smoke.sql supabase/tests/equipment_department_scope_workflow_guards_smoke.sql 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts' 'src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts' src/components/__tests__/qr-action-sheet.test.tsx
+git add supabase/migrations/20260422123000_add_user_department_scope_reads.sql supabase/migrations/<next_timestamp>_add_user_department_scope_workflow_guards.sql supabase/tests/equipment_department_scope_reads_smoke.sql supabase/tests/equipment_department_scope_workflow_guards_smoke.sql 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts' 'src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts' src/components/__tests__/qr-action-sheet.test.tsx
 git commit -m "feat: enforce user department server prefilter"
 ```
 

--- a/docs/superpowers/plans/2026-04-22-user-department-server-prefilter.md
+++ b/docs/superpowers/plans/2026-04-22-user-department-server-prefilter.md
@@ -57,12 +57,12 @@
 - `supabase/migrations/20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql`
 - `supabase/migrations/20260219032645_fix_workflow_guard_security_and_race.sql`
 - Existing frontend behavior to replace:
-- [useRepairRequestsDeepLink.ts](/root/qltbyt-nam-phong/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts:217)
+- `src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts`
 - Existing tests that currently lock the wrong behavior:
-- [useRepairRequestsDeepLink.test.ts](/root/qltbyt-nam-phong/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts:225)
-- [useRepairRequestsDeepLink.test.ts](/root/qltbyt-nam-phong/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts:354)
+- `src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts`
+- `src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts`
 - Existing QR access-denied coverage to extend:
-- [qr-action-sheet.test.tsx](/root/qltbyt-nam-phong/src/components/__tests__/qr-action-sheet.test.tsx:264)
+- `src/components/__tests__/qr-action-sheet.test.tsx`
 
 ## Chunk 1: SQL Read Scope
 

--- a/docs/superpowers/plans/2026-04-22-user-department-server-prefilter.md
+++ b/docs/superpowers/plans/2026-04-22-user-department-server-prefilter.md
@@ -1,0 +1,469 @@
+# User Department Server Prefilter Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce invisible server-owned khoa/phòng scoping for JWT role `user` across equipment reads, deep-link entry points, QR lookup, and workflow mutations without changing behavior for other roles.
+
+**Architecture:** Keep the existing tenant scope as layer 1 and add one stricter layer 2 for role `user` only. The new layer must live in SQL, use strict normalized equality on department names, fail closed on missing `khoa_phong` claims, and never introduce client-side filtering as an enforcement mechanism.
+
+**Tech Stack:** Supabase Postgres migrations, SQL smoke tests in `supabase/tests`, Next.js App Router, React hooks, Vitest, React Doctor.
+
+---
+
+## Scope and constraints
+
+- Only role `user` gets the new department prefilter.
+- Match policy is strict normalized equality only: trim, lowercase, normalize tabs/newlines/NBSP to spaces, collapse repeated whitespace.
+- Do not reuse `src/lib/department-utils.ts` for enforcement.
+- List and filter-option RPCs fail closed to empty results.
+- Single-item reads and mutations fail closed with deny/not-found behavior, not blank fallbacks.
+- Deep-link `?action=create` without `equipmentId` keeps opening a blank create sheet.
+- Deep-link `?action=create&equipmentId=X` must not open anything when the server says denied, missing, or unresolved.
+- All touched `SECURITY DEFINER` functions must keep `SET search_path = public, pg_temp`.
+- Keep the current SQL family patterns:
+- Read RPCs stay in the `allowed_don_vi_for_session[_safe]()` style used by the current equipment read surfaces.
+- Write RPCs stay in the `current_setting('request.jwt.claims', true)::jsonb` style used by recent repair and transfer workflow migrations.
+
+## File map
+
+- Create: `supabase/tests/equipment_department_scope_reads_smoke.sql`
+- Create: `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`
+- Create: `supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql`
+- Modify: `src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts`
+- Modify: `src/components/__tests__/qr-action-sheet.test.tsx`
+- Modify: `src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts`
+
+## GitHub issue breakdown
+
+- Umbrella tracker: `#305` `[Equipment] User department server prefilter rollout`
+- Batch 1: `#301` `[Equipment] Phase 1 - user department prefilter for read RPCs`
+- Batch 2: `#302` `[Equipment] Phase 2 - user department prefilter for workflow guards`
+- Batch 3: `#303` `[Repair Requests] Phase 3 - deny and no-open create deep-link for out-of-scope equipment`
+- Batch 4: `#304` `[Equipment] Phase 4 - QR contract and final verification for department prefilter`
+
+## Recommended execution order
+
+- Finish `#301` first. It establishes the helper and read contract.
+- Finish `#302` second. It reuses the same normalization and pushes the guard into write paths.
+- Finish `#303` third. It depends on the server deny behavior already existing.
+- Finish `#304` last. It is the cleanup and final gate batch.
+
+## Implementation notes for the worker
+
+- Read SQL before editing:
+- `supabase/migrations/20260213095000_equipment_soft_delete_active_reads.sql`
+- `supabase/migrations/20260218203500_fix_ilike_sanitization_equipment_list.sql`
+- `supabase/migrations/20260219150500_fix_audit_spoofing_and_search_path.sql`
+- `supabase/migrations/20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql`
+- `supabase/migrations/20260219032645_fix_workflow_guard_security_and_race.sql`
+- Existing frontend behavior to replace:
+- [useRepairRequestsDeepLink.ts](/root/qltbyt-nam-phong/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts:217)
+- Existing tests that currently lock the wrong behavior:
+- [useRepairRequestsDeepLink.test.ts](/root/qltbyt-nam-phong/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts:225)
+- [useRepairRequestsDeepLink.test.ts](/root/qltbyt-nam-phong/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts:354)
+- Existing QR access-denied coverage to extend:
+- [qr-action-sheet.test.tsx](/root/qltbyt-nam-phong/src/components/__tests__/qr-action-sheet.test.tsx:264)
+
+## Chunk 1: SQL Read Scope
+
+### Task 1: Lock the desired read behavior with failing SQL tests
+
+**Files:**
+- Create: `supabase/tests/equipment_department_scope_reads_smoke.sql`
+- Reference: `supabase/tests/equipment_soft_delete_workflow_guards_smoke.sql`
+- Reference: `supabase/tests/equipment_list_enhanced_overload_regression.sql`
+
+- [ ] **Step 1: Write the first failing SQL smoke file**
+
+Cover only read behavior in this file:
+- `public._normalize_department_scope(text)` returns normalized text for spacing and case variants.
+- `equipment_list` returns rows when normalized JWT `khoa_phong` matches `tb.khoa_phong_quan_ly`.
+- `equipment_list` returns zero rows for same-tenant different-department.
+- `equipment_list_enhanced` returns `total = 0` and empty `data` for same-tenant different-department.
+- `equipment_get` denies same-tenant different-department with `42501`.
+- `equipment_get_by_code` denies same-tenant different-department with `42501`.
+- `departments_list_for_tenant`, `equipment_users_list_for_tenant`, `equipment_locations_list_for_tenant`, `equipment_classifications_list_for_tenant`, `equipment_statuses_list_for_tenant`, and `equipment_funding_sources_list_for_tenant` only derive values from the already scoped equipment set.
+- Missing or blank `khoa_phong` claim for role `user` fails closed.
+- Non-`user` roles keep current behavior.
+
+Use fixtures with same-tenant rows whose `khoa_phong_quan_ly` differ only by case and repeated whitespace so the helper behavior is explicit.
+
+- [ ] **Step 2: Run the new smoke test and verify RED**
+
+Run:
+Run via Supabase MCP:
+- load `supabase/tests/equipment_department_scope_reads_smoke.sql`
+- execute with `execute_sql(query: <file contents>)`
+
+Expected:
+- FAIL because `_normalize_department_scope` does not exist and current read RPCs do not enforce department scope for role `user`.
+
+- [ ] **Step 3: If the failure is a harness/setup failure, fix only the test harness**
+
+Allowed fixes:
+- JWT fixture setup
+- test seed data
+- test assertions
+
+Not allowed:
+- production migration changes before the test fails for the intended reason
+
+### Task 2: Implement the minimal SQL read-side scope
+
+**Files:**
+- Create: `supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql`
+- Read: `supabase/migrations/20260213095000_equipment_soft_delete_active_reads.sql`
+- Read: `supabase/migrations/20260218203500_fix_ilike_sanitization_equipment_list.sql`
+- Read: `supabase/migrations/20260219150500_fix_audit_spoofing_and_search_path.sql`
+
+- [ ] **Step 4: Add the helper and patch only the read RPCs needed by the failing test**
+
+Implement in one forward-only migration:
+- `public._normalize_department_scope(text)`
+- `equipment_list`
+- `equipment_list_enhanced`
+- `equipment_get`
+- `equipment_get_by_code`
+- `departments_list_for_tenant`
+- `equipment_users_list_for_tenant`
+- `equipment_locations_list_for_tenant`
+- `equipment_classifications_list_for_tenant`
+- `equipment_statuses_list_for_tenant`
+- `equipment_funding_sources_list_for_tenant`
+
+Implementation rules:
+- Keep existing tenant guard first.
+- Normalize `admin -> global` where that function family already does so.
+- For role `user`, extract `khoa_phong` claim from JWT, normalize it, and fail closed on null or empty.
+- Compare against normalized `tb.khoa_phong_quan_ly` with strict equality only.
+- Preserve `_sanitize_ilike_pattern()` handling already present in `equipment_list` and `equipment_list_enhanced`.
+- Do not broaden any role contract.
+
+- [ ] **Step 5: Apply the migration**
+
+Run:
+Run via Supabase MCP:
+- load `supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql`
+- apply with `apply_migration(name: "add_user_department_scope_prefilter", query: <file contents>)`
+
+Expected:
+- Migration applies cleanly.
+
+- [ ] **Step 6: Re-run the read smoke test and verify GREEN**
+
+Run:
+Run via Supabase MCP:
+- re-execute `supabase/tests/equipment_department_scope_reads_smoke.sql` with `execute_sql(query: <file contents>)`
+
+Expected:
+- PASS
+
+- [ ] **Step 7: Refactor only inside the migration if duplication is obviously harmful**
+
+Allowed:
+- local variables for normalized claim reuse
+- tiny helper-local cleanup
+
+Not allowed:
+- unrelated read RPC rewrites
+- fuzzy matching
+- client-driven filter parameters
+
+- [ ] **Step 8: Re-run the same smoke test after refactor**
+
+Run the same command as Step 6.
+
+Expected:
+- PASS
+
+- [ ] **Step 9: Commit the read-scope slice**
+
+```bash
+git add supabase/tests/equipment_department_scope_reads_smoke.sql supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql
+git commit -m "feat: add user department scope to equipment read RPCs"
+```
+
+## Chunk 2: SQL Workflow Guards
+
+### Task 3: Lock mutation deny behavior with failing SQL tests
+
+**Files:**
+- Create: `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`
+- Reference: `supabase/tests/equipment_soft_delete_workflow_guards_smoke.sql`
+- Reference: `supabase/tests/repair_request_lifecycle_audit_smoke.sql`
+- Reference: `supabase/tests/transfer_request_lifecycle_audit_smoke.sql`
+
+- [ ] **Step 10: Write the failing workflow-guard smoke file**
+
+Cover only these cases:
+- `repair_request_create` returns `42501` for same-tenant cross-department equipment when role is `user`.
+- `transfer_request_create` returns `42501` for same-tenant cross-department equipment when role is `user`.
+- `maintenance_tasks_bulk_insert` returns `42501` for same-tenant cross-department equipment when role is `user`.
+- Missing or blank `khoa_phong` claim for role `user` fails closed.
+- Same-department `user` still succeeds.
+- Non-`user` roles preserve current behavior.
+
+Also assert no write side effects remain on deny:
+- no repair request inserted
+- no transfer request inserted
+- no maintenance task inserted
+
+- [ ] **Step 11: Run the new workflow smoke test and verify RED**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+```
+
+Expected:
+- FAIL because the workflow RPCs currently stop at tenant scope.
+
+### Task 4: Implement the minimal mutation guard changes
+
+**Files:**
+- Modify: `supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql`
+- Read: `supabase/migrations/20260415125328_fix_repair_request_snapshot_cluster_and_legacy_nulls.sql`
+- Read: `supabase/migrations/20260219032645_fix_workflow_guard_security_and_race.sql`
+- Read: `supabase/migrations/2025-09-29/20250927_regional_leader_phase4.sql`
+
+- [ ] **Step 12: Patch `repair_request_create`**
+
+Rules:
+- Keep current JWT extraction style.
+- Keep `user_id`, `role`, `don_vi`, `regional_leader`, and `FOR UPDATE` behavior intact.
+- After locked equipment fetch and tenant guard, add role `user` department equality guard using `_normalize_department_scope`.
+- Return `42501` on mismatch or missing claim.
+- Do not change repair status-sync logic.
+
+- [ ] **Step 13: Patch `transfer_request_create`**
+
+Rules:
+- Keep current audit-field and `P0002` behavior intact.
+- Add the same department guard after the locked or selected equipment row is known and tenant scope passes.
+- Preserve server-owned audit fields.
+
+- [ ] **Step 14: Patch `maintenance_tasks_bulk_insert`**
+
+Rules:
+- Keep current allowed-tenant behavior.
+- For each task item with `thiet_bi_id`, fetch the equipment row and enforce the same department scope for role `user`.
+- Raise `42501` and insert nothing on mismatch.
+
+- [ ] **Step 15: Apply the updated migration**
+
+Run:
+```bash
+node scripts/npm-run.js run db:push
+```
+
+Expected:
+- Migration applies cleanly.
+
+- [ ] **Step 16: Re-run the workflow smoke test and verify GREEN**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 17: Re-run existing adjacent workflow smokes to catch regression**
+
+Run:
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_soft_delete_workflow_guards_smoke.sql
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/repair_request_lifecycle_audit_smoke.sql
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/transfer_request_lifecycle_audit_smoke.sql
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 18: Commit the workflow-guard slice**
+
+```bash
+git add supabase/tests/equipment_department_scope_workflow_guards_smoke.sql supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql
+git commit -m "feat: add user department scope to equipment workflow RPCs"
+```
+
+## Chunk 3: Deep Link And QR Client Contracts
+
+### Task 5: Replace the wrong deep-link expectation with failing Vitest coverage
+
+**Files:**
+- Modify: `src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts`
+- Reference: `src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts`
+
+- [ ] **Step 19: Rewrite the incorrect blank-sheet tests before touching hook code**
+
+Replace the current expectations so that:
+- `?action=create` without `equipmentId` still opens a blank sheet.
+- `?action=create&equipmentId=X` opens only when `equipment_get` resolves in-scope.
+- `?action=create&equipmentId=X` with `null`, access denied, or missing resolution shows the destructive toast, cleans the URL, and does not call `openCreateSheet`.
+- pending equipment resolution still blocks the sheet.
+
+Do not remove the race-condition coverage. Update it so terminal missing state means `no open`, not blank open.
+
+- [ ] **Step 20: Run the focused hook test and verify RED**
+
+Run:
+```bash
+node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts'
+```
+
+Expected:
+- FAIL against the current hook because it still opens a blank sheet on `missing`.
+
+### Task 6: Implement the minimal deep-link hook change
+
+**Files:**
+- Modify: `src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts`
+
+- [ ] **Step 21: Patch only the create-intent handling**
+
+Rules:
+- Keep assistant-draft fast path.
+- Keep plain `?action=create` behavior unchanged.
+- For `action=create&equipmentId`, keep waiting on terminal resolution state.
+- On terminal `missing` or deny/unresolved path, show the existing destructive toast, clean the URL, and do not open a blank sheet.
+- Do not add client-side filtering or extra query parameters.
+
+- [ ] **Step 22: Re-run the hook test and verify GREEN**
+
+Run the same command as Step 20.
+
+Expected:
+- PASS
+
+- [ ] **Step 23: Refactor only if the hook now has obvious duplication**
+
+Allowed:
+- tiny local helper for cleanup path
+
+Not allowed:
+- broader hook restructuring
+- unrelated race-condition changes
+
+- [ ] **Step 24: Re-run the hook test after refactor**
+
+Run the same command as Step 20.
+
+Expected:
+- PASS
+
+### Task 7: Tighten QR access-denied coverage without inventing new client filtering
+
+**Files:**
+- Modify: `src/components/__tests__/qr-action-sheet.test.tsx`
+- Reference: `src/components/qr-action-sheet.tsx`
+
+- [ ] **Step 25: Add the strict QR access-denied test first**
+
+Add or extend coverage so that when `equipment_get_by_code` returns access denied:
+- access-denied state is rendered
+- equipment details are absent
+- no action buttons or action path is available
+
+- [ ] **Step 26: Run the focused QR test and verify RED or immediate GREEN**
+
+Run:
+```bash
+node scripts/npm-run.js run test:run -- src/components/__tests__/qr-action-sheet.test.tsx
+```
+
+Expected:
+- Either FAIL because the test is stricter than the current UI, or PASS immediately because the UI already behaves correctly.
+
+- [ ] **Step 27: If RED, patch the smallest possible QR UI change**
+
+Rules:
+- No new client-side scope logic.
+- Only adjust rendering if the test exposed an actual action-path leak.
+
+- [ ] **Step 28: Re-run the QR test**
+
+Run the same command as Step 26.
+
+Expected:
+- PASS
+
+- [ ] **Step 29: Commit the client-contract slice**
+
+```bash
+git add 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts' 'src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts' src/components/__tests__/qr-action-sheet.test.tsx
+git commit -m "feat: tighten user department deep-link and QR access behavior"
+```
+
+## Chunk 4: Verification And Release Gates
+
+### Task 8: Run the required verification sequence in repo order
+
+**Files:**
+- No new files
+
+- [ ] **Step 30: Re-run the new SQL read smoke**
+
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_department_scope_reads_smoke.sql
+```
+
+- [ ] **Step 31: Re-run the new SQL workflow smoke**
+
+```bash
+docker exec -i supabase_db_qltbyt-nam-phong psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f - < supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+```
+
+- [ ] **Step 32: Run the focused Vitest suites**
+
+```bash
+node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts'
+node scripts/npm-run.js run test:run -- src/components/__tests__/qr-action-sheet.test.tsx
+```
+
+- [ ] **Step 33: Run the TypeScript verification gates in mandated order**
+
+```bash
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run typecheck
+```
+
+- [ ] **Step 34: Run React Doctor diff scan**
+
+```bash
+node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
+```
+
+- [ ] **Step 35: Run Supabase advisors after the migration**
+
+Use Supabase MCP:
+- `get_advisors(type: "security")`
+
+Expected:
+- no new security regressions from the touched SQL
+
+- [ ] **Step 36: Final commit if any verification-only fixes were required**
+
+```bash
+git add supabase/migrations/20260422110000_add_user_department_scope_prefilter.sql supabase/tests/equipment_department_scope_reads_smoke.sql supabase/tests/equipment_department_scope_workflow_guards_smoke.sql 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts' 'src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts' src/components/__tests__/qr-action-sheet.test.tsx
+git commit -m "feat: enforce user department server prefilter"
+```
+
+## Success criteria
+
+- Role `user` sees only same-tenant, same-department equipment rows after normalization.
+- Role `user` cannot deep-link, QR-open, or mutate cross-department equipment inside the same tenant.
+- Other roles keep current behavior.
+- No client-side enforcement layer is introduced.
+- The new smoke tests fail before implementation and pass after implementation.
+- The final verification sequence passes in the repo’s required order.
+
+## Known risks to watch during execution
+
+- `equipment_list_enhanced` already contains search and return-shape regressions historically. Do not rewrite more than needed.
+- `repair_request_create` has adjacent invariant logic and fail-closed audit behavior. Do not disturb status-sync or audit semantics.
+- `transfer_request_create` has server-owned audit-field protections. Do not accidentally re-expose spoofable fields.
+- `maintenance_tasks_bulk_insert` currently has less regression coverage than repair and transfer; rely on the new smoke test, not intuition.
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-22-user-department-server-prefilter.md`. Ready to execute?

--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -16,6 +16,7 @@ type RpcProxySessionUser = {
   role?: unknown
   don_vi?: unknown
   dia_ban_id?: unknown
+  khoa_phong?: unknown
   id?: unknown
 }
 
@@ -125,6 +126,7 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
   const roleLower = role.toLowerCase()
   const donVi = sessionUser.don_vi ? String(sessionUser.don_vi) : ''
   const diaBan = sessionUser.dia_ban_id ? String(sessionUser.dia_ban_id) : ''
+  const khoaPhong = sessionUser.khoa_phong ? String(sessionUser.khoa_phong) : ''
   const userId = sessionUser.id ? String(sessionUser.id) : ''
   // Normalize to expected app roles used by SQL. Always lowercase; treat 'admin' as 'global'.
   const appRole = roleLower === 'admin' ? 'global' : roleLower
@@ -147,6 +149,7 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
       don_vi: donVi || null,  // Convert empty string to null for global users
       user_id: userId,
       dia_ban: diaBan || null,  // Convert empty string to null
+      khoa_phong: khoaPhong || null,
     }
 
     // Sanitize tenant parameter for non-global users to enforce isolation

--- a/src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts
@@ -49,6 +49,7 @@ describe('RPC proxy JWT signing', () => {
         role: 'to_qltb',
         don_vi: 17,
         dia_ban_id: 10,
+        khoa_phong: 'ICU',
       },
     })
 
@@ -90,6 +91,7 @@ describe('RPC proxy JWT signing', () => {
       don_vi: '17',
       user_id: '31',
       dia_ban: '10',
+      khoa_phong: 'ICU',
       sub: '31',
     })
     const now = Math.floor(Date.now() / 1000)

--- a/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
+++ b/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
@@ -6,6 +6,11 @@
 -- - Patch against the deployed RPC shapes verified via Supabase MCP.
 -- - Preserve existing tenant guards and non-user return/error contracts.
 -- - Do not change equipment_count_enhanced in this batch.
+-- Rollback:
+-- - Forward-only. Restore the prior read-family RPC bodies in a new
+--   timestamped migration if this batch must be reverted.
+-- - Drop public._normalize_department_scope(text) only after no remaining
+--   function body references it.
 
 BEGIN;
 
@@ -25,7 +30,7 @@ BEGIN
   v_normalized := replace(v_normalized, E'\r', ' ');
   v_normalized := replace(v_normalized, E'\n', ' ');
   v_normalized := replace(v_normalized, E'\t', ' ');
-  v_normalized := regexp_replace(v_normalized, '[[:punct:]]+', ' ', 'g');
+  v_normalized := regexp_replace(v_normalized, '[-]+', ' ', 'g');
   v_normalized := regexp_replace(v_normalized, '\s+', ' ', 'g');
   v_normalized := lower(trim(v_normalized));
 
@@ -478,6 +483,10 @@ BEGIN
     RETURN;
   END IF;
 
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
   v_allowed := public.allowed_don_vi_for_session_safe();
 
   IF v_role = 'global' THEN
@@ -487,6 +496,10 @@ BEGIN
       v_effective := NULL;
     END IF;
   ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN;
+    END IF;
+
     IF p_don_vi IS NOT NULL THEN
       IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
         RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
@@ -547,6 +560,10 @@ BEGIN
     RETURN;
   END IF;
 
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
   v_allowed := public.allowed_don_vi_for_session_safe();
 
   IF v_role = 'global' THEN
@@ -556,6 +573,10 @@ BEGIN
       v_effective := NULL;
     END IF;
   ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN;
+    END IF;
+
     IF p_don_vi IS NOT NULL THEN
       IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
         RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
@@ -616,6 +637,10 @@ BEGIN
     RETURN;
   END IF;
 
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
   v_allowed := public.allowed_don_vi_for_session_safe();
 
   IF v_role = 'global' THEN
@@ -625,6 +650,10 @@ BEGIN
       v_effective := NULL;
     END IF;
   ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN;
+    END IF;
+
     IF p_don_vi IS NOT NULL THEN
       IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
         RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
@@ -685,6 +714,10 @@ BEGIN
     RETURN;
   END IF;
 
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
   v_allowed := public.allowed_don_vi_for_session_safe();
 
   IF v_role = 'global' THEN
@@ -694,6 +727,10 @@ BEGIN
       v_effective := NULL;
     END IF;
   ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN;
+    END IF;
+
     IF p_don_vi IS NOT NULL THEN
       IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
         RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
@@ -754,6 +791,10 @@ BEGIN
     RETURN;
   END IF;
 
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
   v_allowed := public.allowed_don_vi_for_session_safe();
 
   IF v_role = 'global' THEN
@@ -763,6 +804,10 @@ BEGIN
       v_effective := NULL;
     END IF;
   ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN;
+    END IF;
+
     IF p_don_vi IS NOT NULL THEN
       IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
         RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
@@ -823,6 +868,10 @@ BEGIN
     RETURN;
   END IF;
 
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
   v_allowed := public.allowed_don_vi_for_session_safe();
 
   IF v_role = 'global' THEN
@@ -832,7 +881,7 @@ BEGIN
       v_effective := NULL;
     END IF;
   ELSE
-    IF v_allowed IS NULL OR array_length(v_allowed, 1) = 0 THEN
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
       RETURN;
     END IF;
 

--- a/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
+++ b/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
@@ -1,0 +1,869 @@
+-- Migration: add role=user department scope to equipment read RPCs
+-- Date: 2026-04-22
+-- Scope: Issue #301 read-family only
+--
+-- Notes:
+-- - Patch against the deployed RPC shapes verified via Supabase MCP.
+-- - Preserve existing tenant guards and non-user return/error contracts.
+-- - Do not change equipment_count_enhanced in this batch.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._normalize_department_scope(p_value text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $function$
+DECLARE
+  v_normalized text;
+BEGIN
+  IF p_value IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_normalized := replace(p_value, chr(160), ' ');
+  v_normalized := replace(v_normalized, E'\r', ' ');
+  v_normalized := replace(v_normalized, E'\n', ' ');
+  v_normalized := replace(v_normalized, E'\t', ' ');
+  v_normalized := regexp_replace(v_normalized, '\s+', ' ', 'g');
+  v_normalized := lower(trim(v_normalized));
+
+  IF v_normalized = '' THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN v_normalized;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_get(p_id bigint)
+RETURNS thiet_bi
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_allowed BIGINT[] := public.allowed_don_vi_for_session();
+  v_department_scope TEXT;
+  rec public.thiet_bi;
+BEGIN
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(public._get_jwt_claim('khoa_phong'));
+  END IF;
+
+  IF v_role = 'global' THEN
+    SELECT * INTO rec
+    FROM public.thiet_bi
+    WHERE id = p_id
+      AND is_deleted = false;
+  ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RAISE EXCEPTION 'Equipment not found or access denied' USING ERRCODE = '42501';
+    END IF;
+
+    SELECT *
+    INTO rec
+    FROM public.thiet_bi
+    WHERE id = p_id
+      AND don_vi = ANY(v_allowed)
+      AND is_deleted = false;
+  END IF;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Equipment not found or access denied' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'user' THEN
+    IF v_department_scope IS NULL
+       OR public._normalize_department_scope(rec.khoa_phong_quan_ly) IS DISTINCT FROM v_department_scope THEN
+      RAISE EXCEPTION 'Equipment not found or access denied' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  RETURN rec;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_get_by_code(p_ma_thiet_bi text)
+RETURNS thiet_bi
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_allowed BIGINT[] := public.allowed_don_vi_for_session();
+  v_department_scope TEXT;
+  rec public.thiet_bi;
+BEGIN
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(public._get_jwt_claim('khoa_phong'));
+  END IF;
+
+  IF p_ma_thiet_bi IS NULL OR trim(p_ma_thiet_bi) = '' THEN
+    RAISE EXCEPTION 'ma_thiet_bi_required' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_role = 'global' THEN
+    SELECT *
+      INTO rec
+    FROM public.thiet_bi
+    WHERE lower(ma_thiet_bi) = lower(p_ma_thiet_bi)
+      AND is_deleted = false
+    LIMIT 1;
+  ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RAISE EXCEPTION 'Equipment not found or access denied' USING ERRCODE = '42501';
+    END IF;
+
+    SELECT *
+      INTO rec
+    FROM public.thiet_bi
+    WHERE lower(ma_thiet_bi) = lower(p_ma_thiet_bi)
+      AND don_vi = ANY(v_allowed)
+      AND is_deleted = false
+    LIMIT 1;
+  END IF;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Equipment not found or access denied' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'user' THEN
+    IF v_department_scope IS NULL
+       OR public._normalize_department_scope(rec.khoa_phong_quan_ly) IS DISTINCT FROM v_department_scope THEN
+      RAISE EXCEPTION 'Equipment not found or access denied' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  RETURN rec;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_list(
+  p_q text DEFAULT NULL::text,
+  p_sort text DEFAULT 'id.asc'::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint
+)
+RETURNS SETOF thiet_bi
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_allowed BIGINT[] := public.allowed_don_vi_for_session();
+  v_effective BIGINT[] := NULL;
+  v_department_scope TEXT;
+  v_sort_col TEXT;
+  v_sort_dir TEXT;
+  v_offset INT := GREATEST(p_page - 1, 0) * GREATEST(p_page_size, 1);
+  v_sql TEXT;
+  v_sanitized_q TEXT;
+BEGIN
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(public._get_jwt_claim('khoa_phong'));
+  END IF;
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN;
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF NOT p_don_vi = ANY(v_allowed) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_effective IS NOT NULL AND array_length(v_effective, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF v_role = 'user' AND v_department_scope IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_sort_col := split_part(p_sort, '.', 1);
+  v_sort_dir := CASE LOWER(split_part(p_sort, '.', 2)) WHEN 'desc' THEN 'DESC' ELSE 'ASC' END;
+  IF v_sort_col NOT IN (
+    'id','ten_thiet_bi','ma_thiet_bi','khoa_phong_quan_ly','don_vi','tinh_trang_hien_tai','phan_loai_theo_nd98','model','serial'
+  ) THEN
+    v_sort_col := 'id';
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  v_sql := 'SELECT * FROM public.thiet_bi WHERE is_deleted = false';
+  IF v_effective IS NOT NULL THEN
+    v_sql := v_sql || format(' AND don_vi = ANY(%L::BIGINT[])', v_effective);
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_sql := v_sql || format(
+      ' AND public._normalize_department_scope(khoa_phong_quan_ly) = %L',
+      v_department_scope
+    );
+  END IF;
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_sql := v_sql || format(' AND (ten_thiet_bi ILIKE %L OR ma_thiet_bi ILIKE %L)',
+      '%' || v_sanitized_q || '%', '%' || v_sanitized_q || '%');
+  END IF;
+
+  v_sql := v_sql || format(' ORDER BY %I %s OFFSET %s LIMIT %s', v_sort_col, v_sort_dir, v_offset, GREATEST(p_page_size, 1));
+
+  RETURN QUERY EXECUTE v_sql;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_list_enhanced(
+  p_q text DEFAULT NULL::text,
+  p_sort text DEFAULT 'id.asc'::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung text DEFAULT NULL::text,
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat text DEFAULT NULL::text,
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang text DEFAULT NULL::text,
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai text DEFAULT NULL::text,
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi text DEFAULT NULL::text,
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := '';
+  v_claim_donvi BIGINT := NULL;
+  v_allowed_don_vi BIGINT[];
+  v_effective_donvi BIGINT := NULL;
+  v_department_scope TEXT;
+  v_sort_col TEXT := 'id';
+  v_sort_dir TEXT := 'ASC';
+  v_limit INT := GREATEST(p_page_size, 1);
+  v_offset INT := GREATEST(p_page - 1, 0) * GREATEST(p_page_size, 1);
+  v_where TEXT := '1=1 AND is_deleted = false';
+  v_total BIGINT := 0;
+  v_data JSONB := '[]'::jsonb;
+  v_jwt_claims JSONB;
+  v_sanitized_q TEXT;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := COALESCE(
+    v_jwt_claims ->>'app_role',
+    v_jwt_claims ->>'role',
+    ''
+  );
+  v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
+  END IF;
+
+  IF p_sort IS NOT NULL AND p_sort != '' THEN
+    v_sort_col := split_part(p_sort, '.', 1);
+    v_sort_dir := UPPER(COALESCE(NULLIF(split_part(p_sort, '.', 2), ''), 'ASC'));
+    IF v_sort_dir NOT IN ('ASC', 'DESC') THEN
+      v_sort_dir := 'ASC';
+    END IF;
+    IF v_sort_col NOT IN (
+      'id', 'ma_thiet_bi', 'ten_thiet_bi', 'model', 'serial',
+      'khoa_phong_quan_ly', 'tinh_trang_hien_tai', 'vi_tri_lap_dat',
+      'nguoi_dang_truc_tiep_quan_ly', 'phan_loai_theo_nd98', 'nguon_kinh_phi', 'don_vi',
+      'gia_goc', 'ngay_nhap', 'ngay_dua_vao_su_dung', 'ngay_bt_tiep_theo',
+      'so_luu_hanh'
+    ) THEN
+      v_sort_col := 'id';
+    END IF;
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF lower(v_role) IN ('global', 'admin') THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective_donvi := p_don_vi;
+    ELSE
+      v_effective_donvi := NULL;
+    END IF;
+  ELSE
+    IF v_allowed_don_vi IS NOT NULL AND array_length(v_allowed_don_vi, 1) > 0 THEN
+      IF p_don_vi IS NOT NULL THEN
+        IF p_don_vi = ANY(v_allowed_don_vi) THEN
+          v_effective_donvi := p_don_vi;
+        ELSE
+          RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'Access denied for tenant');
+        END IF;
+      ELSE
+        v_effective_donvi := NULL;
+      END IF;
+    ELSE
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'No tenant access');
+    END IF;
+  END IF;
+
+  IF lower(v_role) = 'user' AND v_department_scope IS NULL THEN
+    RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+  END IF;
+
+  IF v_effective_donvi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ' || v_effective_donvi;
+  END IF;
+
+  IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin') AND v_allowed_don_vi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = '
+      || quote_literal(v_department_scope);
+  END IF;
+
+  IF p_khoa_phong_array IS NOT NULL AND array_length(p_khoa_phong_array, 1) > 0 THEN
+    v_where := v_where || ' AND khoa_phong_quan_ly = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_khoa_phong_array) AS x), ',') || '])';
+  ELSIF p_khoa_phong IS NOT NULL AND trim(p_khoa_phong) != '' THEN
+    v_where := v_where || ' AND khoa_phong_quan_ly = ' || quote_literal(p_khoa_phong);
+  END IF;
+
+  IF p_nguoi_su_dung_array IS NOT NULL AND array_length(p_nguoi_su_dung_array, 1) > 0 THEN
+    v_where := v_where || ' AND nguoi_dang_truc_tiep_quan_ly = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguoi_su_dung_array) AS x), ',') || '])';
+  ELSIF p_nguoi_su_dung IS NOT NULL AND trim(p_nguoi_su_dung) != '' THEN
+    v_where := v_where || ' AND nguoi_dang_truc_tiep_quan_ly = ' || quote_literal(p_nguoi_su_dung);
+  END IF;
+
+  IF p_vi_tri_lap_dat_array IS NOT NULL AND array_length(p_vi_tri_lap_dat_array, 1) > 0 THEN
+    v_where := v_where || ' AND vi_tri_lap_dat = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_vi_tri_lap_dat_array) AS x), ',') || '])';
+  ELSIF p_vi_tri_lap_dat IS NOT NULL AND trim(p_vi_tri_lap_dat) != '' THEN
+    v_where := v_where || ' AND vi_tri_lap_dat = ' || quote_literal(p_vi_tri_lap_dat);
+  END IF;
+
+  IF p_tinh_trang_array IS NOT NULL AND array_length(p_tinh_trang_array, 1) > 0 THEN
+    v_where := v_where || ' AND tinh_trang_hien_tai = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_tinh_trang_array) AS x), ',') || '])';
+  ELSIF p_tinh_trang IS NOT NULL AND trim(p_tinh_trang) != '' THEN
+    v_where := v_where || ' AND tinh_trang_hien_tai = ' || quote_literal(p_tinh_trang);
+  END IF;
+
+  IF p_phan_loai_array IS NOT NULL AND array_length(p_phan_loai_array, 1) > 0 THEN
+    v_where := v_where || ' AND phan_loai_theo_nd98 = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_phan_loai_array) AS x), ',') || '])';
+  ELSIF p_phan_loai IS NOT NULL AND trim(p_phan_loai) != '' THEN
+    v_where := v_where || ' AND phan_loai_theo_nd98 = ' || quote_literal(p_phan_loai);
+  END IF;
+
+  IF p_nguon_kinh_phi_array IS NOT NULL AND array_length(p_nguon_kinh_phi_array, 1) > 0 THEN
+    IF 'Chưa có' = ANY(p_nguon_kinh_phi_array) THEN
+      DECLARE v_non_empty_sources TEXT[];
+      BEGIN
+        SELECT ARRAY(SELECT x FROM unnest(p_nguon_kinh_phi_array) AS x WHERE x != 'Chưa có') INTO v_non_empty_sources;
+        IF v_non_empty_sources IS NOT NULL AND array_length(v_non_empty_sources, 1) > 0 THEN
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''' OR TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+            array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(v_non_empty_sources) AS x), ',') || ']))';
+        ELSE
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+        END IF;
+      END;
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+        array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguon_kinh_phi_array) AS x), ',') || '])';
+    END IF;
+  ELSIF p_nguon_kinh_phi IS NOT NULL AND trim(p_nguon_kinh_phi) != '' THEN
+    IF p_nguon_kinh_phi = 'Chưa có' THEN
+      v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ' || quote_literal(p_nguon_kinh_phi);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_where := v_where || ' AND (ten_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR ma_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR serial ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR so_luu_hanh ILIKE ' || quote_literal('%' || v_sanitized_q || '%') || ')';
+  END IF;
+
+  EXECUTE format('SELECT count(*) FROM public.thiet_bi WHERE %s', v_where) INTO v_total;
+
+  EXECUTE format(
+    'SELECT COALESCE(jsonb_agg(t), ''[]''::jsonb) FROM (
+       SELECT (to_jsonb(tb.*) || jsonb_build_object(''google_drive_folder_url'', dv.google_drive_folder_url, ''don_vi_name'', dv.name)) AS t
+       FROM public.thiet_bi tb
+       LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+       WHERE %s
+       ORDER BY tb.%I %s
+       OFFSET %s LIMIT %s
+     ) sub',
+    v_where, v_sort_col, v_sort_dir, v_offset, v_limit
+  ) INTO v_data;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'total', v_total,
+    'page', p_page,
+    'pageSize', p_page_size
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.departments_list_for_tenant(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS SETOF jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT;
+  v_allowed BIGINT[];
+  v_effective BIGINT[];
+  v_department_scope TEXT;
+  v_jwt_claims JSONB;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    RETURN;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+
+  IF v_role = '' THEN
+    RETURN;
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF p_don_vi IS NOT NULL THEN
+      IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'name', COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''), 'Chưa phân loại'),
+    'count', COUNT(*)::INTEGER
+  )
+  FROM public.thiet_bi tb
+  WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+    AND tb.is_deleted = false
+    AND (v_role <> 'user' OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope)
+  GROUP BY COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''), 'Chưa phân loại')
+  ORDER BY COUNT(*) DESC;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_users_list_for_tenant(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS SETOF jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT;
+  v_allowed BIGINT[];
+  v_effective BIGINT[];
+  v_department_scope TEXT;
+  v_jwt_claims JSONB;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    RETURN;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+
+  IF v_role = '' THEN
+    RETURN;
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF p_don_vi IS NOT NULL THEN
+      IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'name', COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''), 'Chưa có người sử dụng'),
+    'count', COUNT(*)::INTEGER
+  )
+  FROM public.thiet_bi tb
+  WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+    AND tb.is_deleted = false
+    AND (v_role <> 'user' OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope)
+  GROUP BY COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''), 'Chưa có người sử dụng')
+  ORDER BY COUNT(*) DESC;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_locations_list_for_tenant(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS SETOF jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT;
+  v_allowed BIGINT[];
+  v_effective BIGINT[];
+  v_department_scope TEXT;
+  v_jwt_claims JSONB;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    RETURN;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+
+  IF v_role = '' THEN
+    RETURN;
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF p_don_vi IS NOT NULL THEN
+      IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'name', COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''), 'Chưa có vị trí'),
+    'count', COUNT(*)::INTEGER
+  )
+  FROM public.thiet_bi tb
+  WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+    AND tb.is_deleted = false
+    AND (v_role <> 'user' OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope)
+  GROUP BY COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''), 'Chưa có vị trí')
+  ORDER BY COUNT(*) DESC;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_classifications_list_for_tenant(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS SETOF jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT;
+  v_allowed BIGINT[];
+  v_effective BIGINT[];
+  v_department_scope TEXT;
+  v_jwt_claims JSONB;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    RETURN;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+
+  IF v_role = '' THEN
+    RETURN;
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF p_don_vi IS NOT NULL THEN
+      IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'name', COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''), 'Chưa phân loại'),
+    'count', COUNT(*)::INTEGER
+  )
+  FROM public.thiet_bi tb
+  WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+    AND tb.is_deleted = false
+    AND (v_role <> 'user' OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope)
+  GROUP BY COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''), 'Chưa phân loại')
+  ORDER BY COUNT(*) DESC;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_statuses_list_for_tenant(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS SETOF jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT;
+  v_allowed BIGINT[];
+  v_effective BIGINT[];
+  v_department_scope TEXT;
+  v_jwt_claims JSONB;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    RETURN;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+
+  IF v_role = '' THEN
+    RETURN;
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF p_don_vi IS NOT NULL THEN
+      IF v_allowed IS NULL OR NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'name', COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''), 'Chưa phân loại'),
+    'count', COUNT(*)::INTEGER
+  )
+  FROM public.thiet_bi tb
+  WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+    AND tb.is_deleted = false
+    AND (v_role <> 'user' OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope)
+  GROUP BY COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''), 'Chưa phân loại')
+  ORDER BY COUNT(*) DESC;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.equipment_funding_sources_list_for_tenant(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS SETOF jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT;
+  v_allowed BIGINT[];
+  v_effective BIGINT[];
+  v_department_scope TEXT;
+  v_jwt_claims JSONB;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    RETURN;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+
+  IF v_role = '' THEN
+    RETURN;
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) = 0 THEN
+      RETURN;
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT jsonb_build_object(
+    'name', COALESCE(NULLIF(TRIM(nguon_kinh_phi), ''), 'Chưa có'),
+    'count', COUNT(*)::INTEGER
+  )
+  FROM public.thiet_bi tb
+  WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+    AND tb.is_deleted = false
+    AND (v_role <> 'user' OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope)
+  GROUP BY COALESCE(NULLIF(TRIM(nguon_kinh_phi), ''), 'Chưa có')
+  ORDER BY COUNT(*) DESC;
+END;
+$function$;
+
+COMMIT;

--- a/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
+++ b/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
@@ -916,4 +916,41 @@ BEGIN
 END;
 $function$;
 
+GRANT EXECUTE ON FUNCTION public._normalize_department_scope(text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public._normalize_department_scope(text) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_get(bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_get(bigint) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_get_by_code(text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_get_by_code(text) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_list(text, text, integer, integer, bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_list(text, text, integer, integer, bigint) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_list_enhanced(
+  text, text, integer, integer, bigint, text, text[], text, text[], text, text[], text, text[], text, text[], text, text[]
+) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_list_enhanced(
+  text, text, integer, integer, bigint, text, text[], text, text[], text, text[], text, text[], text, text[], text, text[]
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.departments_list_for_tenant(bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.departments_list_for_tenant(bigint) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_users_list_for_tenant(bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_users_list_for_tenant(bigint) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_locations_list_for_tenant(bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_locations_list_for_tenant(bigint) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_classifications_list_for_tenant(bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_classifications_list_for_tenant(bigint) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_statuses_list_for_tenant(bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_statuses_list_for_tenant(bigint) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.equipment_funding_sources_list_for_tenant(bigint) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_funding_sources_list_for_tenant(bigint) FROM PUBLIC;
+
 COMMIT;

--- a/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
+++ b/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
@@ -25,6 +25,7 @@ BEGIN
   v_normalized := replace(v_normalized, E'\r', ' ');
   v_normalized := replace(v_normalized, E'\n', ' ');
   v_normalized := replace(v_normalized, E'\t', ' ');
+  v_normalized := regexp_replace(v_normalized, '[[:punct:]]+', ' ', 'g');
   v_normalized := regexp_replace(v_normalized, '\s+', ' ', 'g');
   v_normalized := lower(trim(v_normalized));
 

--- a/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
+++ b/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
@@ -957,37 +957,25 @@ GRANT EXECUTE ON FUNCTION public._normalize_department_scope(text) TO authentica
 REVOKE EXECUTE ON FUNCTION public._normalize_department_scope(text) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_get(bigint) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_get(bigint) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_get_by_code(text) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_get_by_code(text) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_list(text, text, integer, integer, bigint) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_list(text, text, integer, integer, bigint) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_list_enhanced(
   text, text, integer, integer, bigint, text, text[], text, text[], text, text[], text, text[], text, text[], text, text[]
 ) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_list_enhanced(
-  text, text, integer, integer, bigint, text, text[], text, text[], text, text[], text, text[], text, text[], text, text[]
-) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.departments_list_for_tenant(bigint) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.departments_list_for_tenant(bigint) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_users_list_for_tenant(bigint) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_users_list_for_tenant(bigint) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_locations_list_for_tenant(bigint) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_locations_list_for_tenant(bigint) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_classifications_list_for_tenant(bigint) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_classifications_list_for_tenant(bigint) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_statuses_list_for_tenant(bigint) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_statuses_list_for_tenant(bigint) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.equipment_funding_sources_list_for_tenant(bigint) TO authenticated;
-REVOKE EXECUTE ON FUNCTION public.equipment_funding_sources_list_for_tenant(bigint) FROM PUBLIC;
 
 COMMIT;

--- a/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
+++ b/supabase/migrations/20260422123000_add_user_department_scope_reads.sql
@@ -50,12 +50,17 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id TEXT := NULLIF(public._get_jwt_claim('user_id'), '');
   v_allowed BIGINT[] := public.allowed_don_vi_for_session();
   v_department_scope TEXT;
   rec public.thiet_bi;
 BEGIN
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   IF v_role = 'user' THEN
@@ -103,12 +108,17 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id TEXT := NULLIF(public._get_jwt_claim('user_id'), '');
   v_allowed BIGINT[] := public.allowed_don_vi_for_session();
   v_department_scope TEXT;
   rec public.thiet_bi;
 BEGIN
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   IF v_role = 'user' THEN
@@ -169,6 +179,7 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id TEXT := NULLIF(public._get_jwt_claim('user_id'), '');
   v_allowed BIGINT[] := public.allowed_don_vi_for_session();
   v_effective BIGINT[] := NULL;
   v_department_scope TEXT;
@@ -180,6 +191,10 @@ DECLARE
 BEGIN
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   IF v_role = 'user' THEN
@@ -274,6 +289,7 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT := '';
+  v_user_id TEXT := NULL;
   v_claim_donvi BIGINT := NULL;
   v_allowed_don_vi BIGINT[];
   v_effective_donvi BIGINT := NULL;
@@ -299,7 +315,16 @@ BEGIN
     v_jwt_claims ->>'role',
     ''
   );
+  v_user_id := NULLIF(v_jwt_claims ->>'user_id', '');
   v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
 
   IF lower(v_role) = 'user' THEN
     v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
@@ -462,6 +487,7 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT;
+  v_user_id TEXT;
   v_allowed BIGINT[];
   v_effective BIGINT[];
   v_department_scope TEXT;
@@ -470,7 +496,7 @@ BEGIN
   BEGIN
     v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
   EXCEPTION WHEN OTHERS THEN
-    RETURN;
+    v_jwt_claims := NULL;
   END;
 
   v_role := lower(COALESCE(
@@ -478,13 +504,14 @@ BEGIN
     v_jwt_claims ->> 'role',
     ''
   ));
-
-  IF v_role = '' THEN
-    RETURN;
-  END IF;
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
 
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   v_allowed := public.allowed_don_vi_for_session_safe();
@@ -539,6 +566,7 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT;
+  v_user_id TEXT;
   v_allowed BIGINT[];
   v_effective BIGINT[];
   v_department_scope TEXT;
@@ -547,7 +575,7 @@ BEGIN
   BEGIN
     v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
   EXCEPTION WHEN OTHERS THEN
-    RETURN;
+    v_jwt_claims := NULL;
   END;
 
   v_role := lower(COALESCE(
@@ -555,13 +583,14 @@ BEGIN
     v_jwt_claims ->> 'role',
     ''
   ));
-
-  IF v_role = '' THEN
-    RETURN;
-  END IF;
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
 
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   v_allowed := public.allowed_don_vi_for_session_safe();
@@ -616,6 +645,7 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT;
+  v_user_id TEXT;
   v_allowed BIGINT[];
   v_effective BIGINT[];
   v_department_scope TEXT;
@@ -624,7 +654,7 @@ BEGIN
   BEGIN
     v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
   EXCEPTION WHEN OTHERS THEN
-    RETURN;
+    v_jwt_claims := NULL;
   END;
 
   v_role := lower(COALESCE(
@@ -632,13 +662,14 @@ BEGIN
     v_jwt_claims ->> 'role',
     ''
   ));
-
-  IF v_role = '' THEN
-    RETURN;
-  END IF;
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
 
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   v_allowed := public.allowed_don_vi_for_session_safe();
@@ -693,6 +724,7 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT;
+  v_user_id TEXT;
   v_allowed BIGINT[];
   v_effective BIGINT[];
   v_department_scope TEXT;
@@ -701,7 +733,7 @@ BEGIN
   BEGIN
     v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
   EXCEPTION WHEN OTHERS THEN
-    RETURN;
+    v_jwt_claims := NULL;
   END;
 
   v_role := lower(COALESCE(
@@ -709,13 +741,14 @@ BEGIN
     v_jwt_claims ->> 'role',
     ''
   ));
-
-  IF v_role = '' THEN
-    RETURN;
-  END IF;
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
 
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   v_allowed := public.allowed_don_vi_for_session_safe();
@@ -770,6 +803,7 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT;
+  v_user_id TEXT;
   v_allowed BIGINT[];
   v_effective BIGINT[];
   v_department_scope TEXT;
@@ -778,7 +812,7 @@ BEGIN
   BEGIN
     v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
   EXCEPTION WHEN OTHERS THEN
-    RETURN;
+    v_jwt_claims := NULL;
   END;
 
   v_role := lower(COALESCE(
@@ -786,13 +820,14 @@ BEGIN
     v_jwt_claims ->> 'role',
     ''
   ));
-
-  IF v_role = '' THEN
-    RETURN;
-  END IF;
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
 
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   v_allowed := public.allowed_don_vi_for_session_safe();
@@ -847,6 +882,7 @@ SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
   v_role TEXT;
+  v_user_id TEXT;
   v_allowed BIGINT[];
   v_effective BIGINT[];
   v_department_scope TEXT;
@@ -855,7 +891,7 @@ BEGIN
   BEGIN
     v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
   EXCEPTION WHEN OTHERS THEN
-    RETURN;
+    v_jwt_claims := NULL;
   END;
 
   v_role := lower(COALESCE(
@@ -863,13 +899,14 @@ BEGIN
     v_jwt_claims ->> 'role',
     ''
   ));
-
-  IF v_role = '' THEN
-    RETURN;
-  END IF;
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
 
   IF v_role = 'admin' THEN
     v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
   END IF;
 
   v_allowed := public.allowed_don_vi_for_session_safe();

--- a/supabase/tests/equipment_department_scope_reads_smoke.sql
+++ b/supabase/tests/equipment_department_scope_reads_smoke.sql
@@ -145,15 +145,15 @@ BEGIN
     RAISE EXCEPTION 'equipment_list_enhanced returned wrong scoped row for role user';
   END IF;
 
-  SELECT public.equipment_get(v_allowed_id)
-  INTO v_rec;
+  SELECT (public.equipment_get(v_allowed_id)).id
+  INTO v_rec.id;
 
   IF v_rec.id IS DISTINCT FROM v_allowed_id THEN
     RAISE EXCEPTION 'equipment_get should return the same-department equipment for role user';
   END IF;
 
-  SELECT public.equipment_get_by_code('SMK-DEP-ALLOW-' || v_suffix)
-  INTO v_rec;
+  SELECT (public.equipment_get_by_code('SMK-DEP-ALLOW-' || v_suffix)).id
+  INTO v_rec.id;
 
   IF v_rec.id IS DISTINCT FROM v_allowed_id THEN
     RAISE EXCEPTION 'equipment_get_by_code should return the same-department equipment for role user';
@@ -389,7 +389,7 @@ BEGIN
   PERFORM set_config(
     'request.jwt.claims',
     json_build_object(
-      'app_role', 'admin',
+      'app_role', 'global',
       'role', 'authenticated',
       'user_id', '1',
       'sub', '1',
@@ -398,8 +398,8 @@ BEGIN
     true
   );
 
-  SELECT public.equipment_get(v_blocked_id)
-  INTO v_rec;
+  SELECT (public.equipment_get(v_blocked_id)).id
+  INTO v_rec.id;
 
   IF v_rec.id IS DISTINCT FROM v_blocked_id THEN
     RAISE EXCEPTION 'Non-user admin/global control should preserve current access behavior';

--- a/supabase/tests/equipment_department_scope_reads_smoke.sql
+++ b/supabase/tests/equipment_department_scope_reads_smoke.sql
@@ -107,7 +107,7 @@ BEGIN
       'user_id', '1',
       'sub', '1',
       'don_vi', v_tenant::text,
-      'khoa_phong', E' \u00A0NỘI\nTHẬN\t  TIẾT   NIỆU '
+      'khoa_phong', ' ' || chr(160) || E'NỘI\nTHẬN\t  - TIẾT   NIỆU '
     )::text,
     true
   );
@@ -296,15 +296,63 @@ BEGIN
     RAISE EXCEPTION 'departments_list_for_tenant should fail closed for blank khoa_phong claim, got %', v_count;
   END IF;
 
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.equipment_users_list_for_tenant(p_don_vi => v_tenant);
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'equipment_users_list_for_tenant should fail closed for blank khoa_phong claim, got %', v_count;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.equipment_locations_list_for_tenant(p_don_vi => v_tenant);
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'equipment_locations_list_for_tenant should fail closed for blank khoa_phong claim, got %', v_count;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.equipment_classifications_list_for_tenant(p_don_vi => v_tenant);
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'equipment_classifications_list_for_tenant should fail closed for blank khoa_phong claim, got %', v_count;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.equipment_statuses_list_for_tenant(p_don_vi => v_tenant);
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'equipment_statuses_list_for_tenant should fail closed for blank khoa_phong claim, got %', v_count;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.equipment_funding_sources_list_for_tenant(p_don_vi => v_tenant);
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'equipment_funding_sources_list_for_tenant should fail closed for blank khoa_phong claim, got %', v_count;
+  END IF;
+
   v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
   BEGIN
     PERFORM public.equipment_get(v_allowed_id);
   EXCEPTION WHEN OTHERS THEN
     v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
   END;
 
   IF NOT v_failed THEN
     RAISE EXCEPTION 'equipment_get should deny when role user has blank khoa_phong claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'equipment_get blank khoa_phong deny should use 42501, got % (%)', v_sqlstate, v_sqlerrm;
   END IF;
 
   PERFORM set_config(
@@ -320,14 +368,22 @@ BEGIN
   );
 
   v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
   BEGIN
     PERFORM public.equipment_get_by_code('SMK-DEP-ALLOW-' || v_suffix);
   EXCEPTION WHEN OTHERS THEN
     v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
   END;
 
   IF NOT v_failed THEN
     RAISE EXCEPTION 'equipment_get_by_code should deny when role user is missing khoa_phong claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'equipment_get_by_code missing khoa_phong deny should use 42501, got % (%)', v_sqlstate, v_sqlerrm;
   END IF;
 
   PERFORM set_config(

--- a/supabase/tests/equipment_department_scope_reads_smoke.sql
+++ b/supabase/tests/equipment_department_scope_reads_smoke.sql
@@ -45,7 +45,7 @@ BEGIN
     'SMK-DEP-ALLOW-' || v_suffix,
     'Smoke Department Allowed ' || v_suffix,
     v_tenant,
-    '  Khoa   Noi  Tong Hop  ',
+    '  Nội thận - Tiết niệu  ',
     'Hoat dong',
     'User Allowed ' || v_suffix,
     'Room Allowed ' || v_suffix,
@@ -107,7 +107,7 @@ BEGIN
       'user_id', '1',
       'sub', '1',
       'don_vi', v_tenant::text,
-      'khoa_phong', E' \u00A0KHOA\nNOI\t  TONG   HOP '
+      'khoa_phong', E' \u00A0NỘI\nTHẬN\t  TIẾT   NIỆU '
     )::text,
     true
   );

--- a/supabase/tests/equipment_department_scope_reads_smoke.sql
+++ b/supabase/tests/equipment_department_scope_reads_smoke.sql
@@ -1,0 +1,367 @@
+-- supabase/tests/equipment_department_scope_reads_smoke.sql
+-- Purpose: lock role=user department-scoped read behavior for Issue #301
+-- Non-destructive: wrapped in transaction and rolled back
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_allowed_id bigint;
+  v_blocked_id bigint;
+  v_other_tenant_id bigint;
+  v_payload jsonb;
+  v_count integer;
+  v_name text;
+  v_rec public.thiet_bi;
+  v_failed boolean;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_names text[];
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Department Scope Tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Department Scope Other Tenant ' || v_suffix, true)
+  RETURNING id INTO v_other_tenant;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    nguoi_dang_truc_tiep_quan_ly,
+    vi_tri_lap_dat,
+    phan_loai_theo_nd98,
+    nguon_kinh_phi,
+    is_deleted
+  )
+  VALUES (
+    'SMK-DEP-ALLOW-' || v_suffix,
+    'Smoke Department Allowed ' || v_suffix,
+    v_tenant,
+    '  Khoa   Noi  Tong Hop  ',
+    'Hoat dong',
+    'User Allowed ' || v_suffix,
+    'Room Allowed ' || v_suffix,
+    'Class Allowed ' || v_suffix,
+    'Fund Allowed ' || v_suffix,
+    false
+  )
+  RETURNING id INTO v_allowed_id;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    nguoi_dang_truc_tiep_quan_ly,
+    vi_tri_lap_dat,
+    phan_loai_theo_nd98,
+    nguon_kinh_phi,
+    is_deleted
+  )
+  VALUES (
+    'SMK-DEP-BLOCK-' || v_suffix,
+    'Smoke Department Blocked ' || v_suffix,
+    v_tenant,
+    'Khoa Ngoai ' || v_suffix,
+    'Cho sua chua',
+    'User Blocked ' || v_suffix,
+    'Room Blocked ' || v_suffix,
+    'Class Blocked ' || v_suffix,
+    'Fund Blocked ' || v_suffix,
+    false
+  )
+  RETURNING id INTO v_blocked_id;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-DEP-OTHER-' || v_suffix,
+    'Smoke Department Other Tenant ' || v_suffix,
+    v_other_tenant,
+    'Khoa Noi Tong Hop',
+    'Hoat dong',
+    false
+  )
+  RETURNING id INTO v_other_tenant_id;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', '1',
+      'sub', '1',
+      'don_vi', v_tenant::text,
+      'khoa_phong', E' \u00A0KHOA\nNOI\t  TONG   HOP '
+    )::text,
+    true
+  );
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.equipment_list(
+    p_q => v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant
+  );
+
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'equipment_list should return exactly 1 scoped row for role user, got %', v_count;
+  END IF;
+
+  SELECT public.equipment_list_enhanced(
+    p_q => v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant
+  )
+  INTO v_payload;
+
+  IF COALESCE((v_payload->>'total')::integer, 0) <> 1 THEN
+    RAISE EXCEPTION 'equipment_list_enhanced should report total=1 for scoped user rows, got %', v_payload->>'total';
+  END IF;
+
+  IF COALESCE(jsonb_array_length(v_payload->'data'), 0) <> 1 THEN
+    RAISE EXCEPTION 'equipment_list_enhanced should return exactly 1 scoped row, got %', COALESCE(jsonb_array_length(v_payload->'data'), 0);
+  END IF;
+
+  IF ((v_payload->'data'->0->>'id')::bigint) IS DISTINCT FROM v_allowed_id THEN
+    RAISE EXCEPTION 'equipment_list_enhanced returned wrong scoped row for role user';
+  END IF;
+
+  SELECT public.equipment_get(v_allowed_id)
+  INTO v_rec;
+
+  IF v_rec.id IS DISTINCT FROM v_allowed_id THEN
+    RAISE EXCEPTION 'equipment_get should return the same-department equipment for role user';
+  END IF;
+
+  SELECT public.equipment_get_by_code('SMK-DEP-ALLOW-' || v_suffix)
+  INTO v_rec;
+
+  IF v_rec.id IS DISTINCT FROM v_allowed_id THEN
+    RAISE EXCEPTION 'equipment_get_by_code should return the same-department equipment for role user';
+  END IF;
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.equipment_get(v_blocked_id);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected equipment_get to deny same-tenant cross-department role user access';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'equipment_get should deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.equipment_get_by_code('SMK-DEP-BLOCK-' || v_suffix);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected equipment_get_by_code to deny same-tenant cross-department role user access';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'equipment_get_by_code should deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*),
+         array_agg((entry->>'name') ORDER BY entry->>'name')
+  INTO v_count, v_names
+  FROM public.departments_list_for_tenant(p_don_vi => v_tenant) entry;
+
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'departments_list_for_tenant should expose exactly 1 scoped option, got %', v_count;
+  END IF;
+
+  IF array_position(v_names, 'Khoa Ngoai ' || v_suffix) IS NOT NULL THEN
+    RAISE EXCEPTION 'departments_list_for_tenant leaked a blocked department option';
+  END IF;
+
+  SELECT COUNT(*), max(entry->>'name')
+  INTO v_count, v_name
+  FROM public.equipment_users_list_for_tenant(p_don_vi => v_tenant) entry;
+
+  IF v_count <> 1 OR v_name IS DISTINCT FROM 'User Allowed ' || v_suffix THEN
+    RAISE EXCEPTION 'equipment_users_list_for_tenant should derive options only from scoped equipment';
+  END IF;
+
+  SELECT COUNT(*), max(entry->>'name')
+  INTO v_count, v_name
+  FROM public.equipment_locations_list_for_tenant(p_don_vi => v_tenant) entry;
+
+  IF v_count <> 1 OR v_name IS DISTINCT FROM 'Room Allowed ' || v_suffix THEN
+    RAISE EXCEPTION 'equipment_locations_list_for_tenant should derive options only from scoped equipment';
+  END IF;
+
+  SELECT COUNT(*), max(entry->>'name')
+  INTO v_count, v_name
+  FROM public.equipment_classifications_list_for_tenant(p_don_vi => v_tenant) entry;
+
+  IF v_count <> 1 OR v_name IS DISTINCT FROM 'Class Allowed ' || v_suffix THEN
+    RAISE EXCEPTION 'equipment_classifications_list_for_tenant should derive options only from scoped equipment';
+  END IF;
+
+  SELECT COUNT(*), max(entry->>'name')
+  INTO v_count, v_name
+  FROM public.equipment_statuses_list_for_tenant(p_don_vi => v_tenant) entry;
+
+  IF v_count <> 1 OR v_name IS DISTINCT FROM 'Hoat dong' THEN
+    RAISE EXCEPTION 'equipment_statuses_list_for_tenant should derive options only from scoped equipment';
+  END IF;
+
+  SELECT COUNT(*), max(entry->>'name')
+  INTO v_count, v_name
+  FROM public.equipment_funding_sources_list_for_tenant(p_don_vi => v_tenant) entry;
+
+  IF v_count <> 1 OR v_name IS DISTINCT FROM 'Fund Allowed ' || v_suffix THEN
+    RAISE EXCEPTION 'equipment_funding_sources_list_for_tenant should derive options only from scoped equipment';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', '1',
+      'sub', '1',
+      'don_vi', v_tenant::text,
+      'khoa_phong', ''
+    )::text,
+    true
+  );
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.equipment_list(
+    p_q => v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant
+  );
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'equipment_list should fail closed to empty for blank khoa_phong claim, got %', v_count;
+  END IF;
+
+  SELECT public.equipment_list_enhanced(
+    p_q => v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant
+  )
+  INTO v_payload;
+
+  IF COALESCE((v_payload->>'total')::integer, 0) <> 0 THEN
+    RAISE EXCEPTION 'equipment_list_enhanced should fail closed to total=0 for blank khoa_phong claim';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.departments_list_for_tenant(p_don_vi => v_tenant);
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'departments_list_for_tenant should fail closed for blank khoa_phong claim, got %', v_count;
+  END IF;
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.equipment_get(v_allowed_id);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'equipment_get should deny when role user has blank khoa_phong claim';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', '1',
+      'sub', '1',
+      'don_vi', v_tenant::text
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.equipment_get_by_code('SMK-DEP-ALLOW-' || v_suffix);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'equipment_get_by_code should deny when role user is missing khoa_phong claim';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'admin',
+      'role', 'authenticated',
+      'user_id', '1',
+      'sub', '1',
+      'don_vi', null
+    )::text,
+    true
+  );
+
+  SELECT public.equipment_get(v_blocked_id)
+  INTO v_rec;
+
+  IF v_rec.id IS DISTINCT FROM v_blocked_id THEN
+    RAISE EXCEPTION 'Non-user admin/global control should preserve current access behavior';
+  END IF;
+
+  SELECT public.equipment_list_enhanced(
+    p_q => v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant
+  )
+  INTO v_payload;
+
+  IF COALESCE((v_payload->>'total')::integer, 0) <> 2 THEN
+    RAISE EXCEPTION 'Admin/global control should still see both same-tenant rows, got %', v_payload->>'total';
+  END IF;
+
+  RAISE NOTICE 'OK: equipment department scope read smoke checks passed';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add repo-only migration for Issue #301 equipment read RPC department prefilter
- add RED smoke coverage for role `user` department-scoped reads
- preserve live DB function-family contracts verified via Supabase MCP
- normalize department punctuation so variants like `Nội thận - Tiết niệu` and `NỘI THẬN TIẾT NIỆU` compare equal after normalization

## Included
- `supabase/migrations/20260422123000_add_user_department_scope_reads.sql`
- `supabase/tests/equipment_department_scope_reads_smoke.sql`
- updated plan docs for Supabase MCP / live DB truth

## Verification
- RED smoke executed against live DB via Supabase MCP and failed as expected before migration apply:
  - `equipment_list should return exactly 1 scoped row for role user, got 2`
- `git diff --check` clean

## Intentionally not done yet
- migration not applied
- GREEN migration smoke not run yet
- waiting for review before apply

## Notes
- Ref #301
- Ref #305
- Follow-up gap tracked in #306

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-side department prefilter for role `user` across equipment read RPCs per #301. Normalizes department names, enforces strict equality, forwards the `khoa_phong` claim in RPC JWTs, and keeps other roles unchanged.

- **New Features**
  - Added `public._normalize_department_scope` to normalize case, whitespace (NBSP, tabs, CR/LF), and hyphens so variants like "Nội thận - Tiết niệu" and "NỘI THẬN TIẾT NIỆU" compare equal.
  - Enforced department scope for role `user` in `equipment_get`, `equipment_get_by_code`, `equipment_list`, `equipment_list_enhanced`, and filter-option RPCs (`departments_list_for_tenant`, `equipment_users_list_for_tenant`, `equipment_locations_list_for_tenant`, `equipment_classifications_list_for_tenant`, `equipment_statuses_list_for_tenant`, `equipment_funding_sources_list_for_tenant`); lists fail closed to empty, `equipment_list_enhanced` returns an empty payload, and single-item reads deny with the existing message and SQLSTATE 42501.
  - Preserved tenant guards, `SET search_path`, `_sanitize_ilike_pattern`, and all non-`user` role contracts; updated the RPC proxy to forward `khoa_phong` in signed JWTs; added a RED smoke test (`supabase/tests/equipment_department_scope_reads_smoke.sql`) with tightened assertions to lock the new read contract.

- **Migration**
  - Repo includes `supabase/migrations/20260422123000_add_user_department_scope_reads.sql` (not yet applied); apply after review and re-run the smoke test to turn it GREEN.
  - Tightened JWT claim guards (deny when required claims are missing; keep `admin -> global` mapping).
  - Reasserted live RPC execute grants; helper is `authenticated`-only and revoked from `PUBLIC`.

<sup>Written for commit f430ea3fb1e6889017b2beda2fec8b3b4c328702. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side department scoping for equipment reads: users only see items matching their normalized department claim; admins/global retain broader access. Single-item reads return access-denied when scope fails; list endpoints return empty results when claim is missing.

* **Tests**
  * Added smoke tests validating scoped reads, deny/empty behaviors, and aggregated/list isolation.
  * Updated RPC JWT test fixtures to include the department claim.

* **Documentation**
  * Added implementation and rollout plans with normalization rules, test checklist, and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->