### PR TITLE
[Equipment] Phase 2 - user department prefilter for workflow guards (#302)

### DIFF
--- a/supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql
+++ b/supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql
@@ -195,8 +195,16 @@ BEGIN
     RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
   END IF;
 
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
   IF v_role = 'regional_leader' THEN
     RAISE EXCEPTION 'Regional leaders have read-only access to transfers' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
   END IF;
 
   IF v_role = 'user' THEN
@@ -214,7 +222,7 @@ BEGIN
     RAISE EXCEPTION 'Thiết bị không tồn tại' USING errcode = 'P0002';
   END IF;
 
-  IF NOT v_is_global AND v_don_vi IS NOT NULL AND v_tb.don_vi::text IS DISTINCT FROM v_don_vi THEN
+  IF NOT v_is_global AND v_tb.don_vi::text IS DISTINCT FROM v_don_vi THEN
     RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
   END IF;
 
@@ -265,13 +273,15 @@ BEGIN
   )
   RETURNING id INTO v_id;
 
-  PERFORM public.audit_log(
+  IF NOT public.audit_log(
     'transfer_request_create',
     'transfer_request',
     v_id,
     NULL,
     p_data - 'created_by' - 'updated_by' - 'nguoi_yeu_cau_id'
-  );
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for transfer_request %', v_id;
+  END IF;
 
   RETURN v_id;
 END;
@@ -369,5 +379,6 @@ END;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.maintenance_tasks_bulk_insert(JSONB) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.maintenance_tasks_bulk_insert(JSONB) FROM PUBLIC;
 
 COMMIT;

--- a/supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql
+++ b/supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql
@@ -298,12 +298,21 @@ SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_role TEXT := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id BIGINT := NULLIF(public._get_jwt_claim('user_id'), '')::BIGINT;
   v_allowed BIGINT[] := NULL;
   v_department_scope TEXT := NULL;
   v_item JSONB;
   v_thiet_bi_id BIGINT;
   v_equipment_scope TEXT;
 BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING ERRCODE = '42501';
+  END IF;
+
   IF v_role = 'regional_leader' THEN
     RAISE EXCEPTION 'Permission denied' USING ERRCODE = '42501';
   END IF;

--- a/supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql
+++ b/supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql
@@ -1,0 +1,373 @@
+-- Migration: add role=user department scope to workflow guard RPCs
+-- Date: 2026-04-22
+-- Scope: Issue #302 workflow-family only
+--
+-- Notes:
+-- - Reuse public._normalize_department_scope(text) introduced by Issue #301.
+-- - Preserve current tenant guards and non-user behavior.
+-- - Keep existing row-lock, audit, and P0002 behavior unchanged where already established.
+-- Rollback:
+-- - Forward-only. Restore the prior RPC bodies in a new timestamped migration
+--   if this batch must be reverted.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.repair_request_create(
+  p_thiet_bi_id integer,
+  p_mo_ta_su_co text,
+  p_hang_muc_sua_chua text,
+  p_ngay_mong_muon_hoan_thanh date,
+  p_nguoi_yeu_cau text,
+  p_don_vi_thuc_hien text,
+  p_ten_don_vi_thue text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_id integer;
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_department_scope text;
+  v_tb record;
+  v_snapshot_status text;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_claims->>'khoa_phong');
+  END IF;
+
+  SELECT tb.id, tb.don_vi, tb.khoa_phong_quan_ly, tb.tinh_trang_hien_tai
+  INTO v_tb
+  FROM public.thiet_bi tb
+  WHERE tb.id = p_thiet_bi_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Thiết bị không tồn tại' USING errcode = 'P0002';
+  END IF;
+
+  IF NOT v_is_global AND v_tb.don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'user'
+     AND (
+       v_department_scope IS NULL
+       OR public._normalize_department_scope(v_tb.khoa_phong_quan_ly) IS DISTINCT FROM v_department_scope
+     ) THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc khoa/phòng khác' USING errcode = '42501';
+  END IF;
+
+  v_snapshot_status := v_tb.tinh_trang_hien_tai;
+
+  IF v_tb.tinh_trang_hien_tai = 'Chờ sửa chữa' THEN
+    SELECT ycss.tinh_trang_thiet_bi_truoc_yeu_cau
+    INTO v_snapshot_status
+    FROM public.yeu_cau_sua_chua ycss
+    WHERE ycss.thiet_bi_id = p_thiet_bi_id
+      AND ycss.trang_thai IN ('Chờ xử lý', 'Đã duyệt', 'Không HT')
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau IS NOT NULL
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau <> 'Chờ sửa chữa'
+    ORDER BY ycss.id DESC
+    LIMIT 1;
+
+    v_snapshot_status := coalesce(
+      v_snapshot_status,
+      nullif(v_tb.tinh_trang_hien_tai, 'Chờ sửa chữa'),
+      'Hoạt động'
+    );
+  END IF;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien,
+    ten_don_vi_thue,
+    tinh_trang_thiet_bi_truoc_yeu_cau
+  )
+  VALUES (
+    p_thiet_bi_id,
+    p_mo_ta_su_co,
+    p_hang_muc_sua_chua,
+    p_ngay_mong_muon_hoan_thanh,
+    p_nguoi_yeu_cau,
+    'Chờ xử lý',
+    p_don_vi_thuc_hien,
+    p_ten_don_vi_thue,
+    v_snapshot_status
+  )
+  RETURNING id INTO v_id;
+
+  PERFORM public.repair_request_sync_equipment_status(p_thiet_bi_id::bigint);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    p_thiet_bi_id,
+    'Sửa chữa',
+    'Tạo yêu cầu sửa chữa',
+    jsonb_build_object(
+      'mo_ta_su_co', p_mo_ta_su_co,
+      'hang_muc', p_hang_muc_sua_chua,
+      'ngay_mong_muon_hoan_thanh', p_ngay_mong_muon_hoan_thanh,
+      'don_vi_thuc_hien', p_don_vi_thuc_hien,
+      'ten_don_vi_thue', p_ten_don_vi_thue
+    ),
+    v_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_create',
+    'repair_request',
+    v_id,
+    NULL,
+    jsonb_build_object(
+      'thiet_bi_id', p_thiet_bi_id,
+      'mo_ta_su_co', p_mo_ta_su_co
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', v_id;
+  END IF;
+
+  RETURN v_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.transfer_request_create(
+  p_data jsonb
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_id int;
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_don_vi text;
+  v_user_id int;
+  v_department_scope text;
+  v_tb record;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}')::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_don_vi := nullif(v_claims->>'don_vi', '');
+  v_user_id := nullif(v_claims->>'user_id', '')::int;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Regional leaders have read-only access to transfers' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_claims->>'khoa_phong');
+  END IF;
+
+  SELECT id, don_vi, khoa_phong_quan_ly
+  INTO v_tb
+  FROM public.thiet_bi
+  WHERE id = (p_data->>'thiet_bi_id')::int
+    AND is_deleted = false
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Thiết bị không tồn tại' USING errcode = 'P0002';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NOT NULL AND v_tb.don_vi::text IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'user'
+     AND (
+       v_department_scope IS NULL
+       OR public._normalize_department_scope(v_tb.khoa_phong_quan_ly) IS DISTINCT FROM v_department_scope
+     ) THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc khoa/phòng khác' USING errcode = '42501';
+  END IF;
+
+  INSERT INTO public.yeu_cau_luan_chuyen(
+    thiet_bi_id,
+    loai_hinh,
+    ly_do_luan_chuyen,
+    khoa_phong_hien_tai,
+    khoa_phong_nhan,
+    muc_dich,
+    don_vi_nhan,
+    dia_chi_don_vi,
+    nguoi_lien_he,
+    so_dien_thoai,
+    ngay_du_kien_tra,
+    nguoi_yeu_cau_id,
+    trang_thai,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    (p_data->>'thiet_bi_id')::int,
+    p_data->>'loai_hinh',
+    nullif(p_data->>'ly_do_luan_chuyen', ''),
+    nullif(p_data->>'khoa_phong_hien_tai', ''),
+    nullif(p_data->>'khoa_phong_nhan', ''),
+    nullif(p_data->>'muc_dich', ''),
+    nullif(p_data->>'don_vi_nhan', ''),
+    nullif(p_data->>'dia_chi_don_vi', ''),
+    nullif(p_data->>'nguoi_lien_he', ''),
+    nullif(p_data->>'so_dien_thoai', ''),
+    CASE
+      WHEN coalesce(p_data->>'ngay_du_kien_tra', '') <> '' THEN (p_data->>'ngay_du_kien_tra')::date
+      ELSE NULL
+    END,
+    v_user_id,
+    'cho_duyet',
+    v_user_id,
+    v_user_id
+  )
+  RETURNING id INTO v_id;
+
+  PERFORM public.audit_log(
+    'transfer_request_create',
+    'transfer_request',
+    v_id,
+    NULL,
+    p_data - 'created_by' - 'updated_by' - 'nguoi_yeu_cau_id'
+  );
+
+  RETURN v_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.transfer_request_create(jsonb) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.transfer_request_create(jsonb) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.maintenance_tasks_bulk_insert(p_tasks JSONB)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role TEXT := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_allowed BIGINT[] := NULL;
+  v_department_scope TEXT := NULL;
+  v_item JSONB;
+  v_thiet_bi_id BIGINT;
+  v_equipment_scope TEXT;
+BEGIN
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role <> 'global' THEN
+    v_allowed := public.allowed_don_vi_for_session();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RAISE EXCEPTION 'Không có quyền thêm công việc bảo trì' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(public._get_jwt_claim('khoa_phong'));
+    IF v_department_scope IS NULL THEN
+      RAISE EXCEPTION 'Không có quyền thêm công việc bảo trì' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF p_tasks IS NULL OR jsonb_array_length(p_tasks) = 0 THEN
+    RETURN;
+  END IF;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(p_tasks) AS value LOOP
+    v_thiet_bi_id := NULLIF(v_item->>'thiet_bi_id', '')::BIGINT;
+
+    IF v_role <> 'global' AND v_thiet_bi_id IS NOT NULL THEN
+      SELECT public._normalize_department_scope(tb.khoa_phong_quan_ly)
+      INTO v_equipment_scope
+      FROM public.thiet_bi tb
+      WHERE tb.id = v_thiet_bi_id
+        AND tb.don_vi = ANY(v_allowed);
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING ERRCODE = '42501';
+      END IF;
+
+      IF v_role = 'user' AND v_equipment_scope IS DISTINCT FROM v_department_scope THEN
+        RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc khoa/phòng khác' USING ERRCODE = '42501';
+      END IF;
+    END IF;
+  END LOOP;
+
+  INSERT INTO public.cong_viec_bao_tri (
+    ke_hoach_id,
+    thiet_bi_id,
+    loai_cong_viec,
+    diem_hieu_chuan,
+    don_vi_thuc_hien,
+    thang_1, thang_2, thang_3, thang_4, thang_5, thang_6, thang_7, thang_8, thang_9, thang_10, thang_11, thang_12,
+    ghi_chu
+  )
+  SELECT
+    (t->>'ke_hoach_id')::BIGINT,
+    NULLIF(t->>'thiet_bi_id', '')::BIGINT,
+    t->>'loai_cong_viec',
+    t->>'diem_hieu_chuan',
+    t->>'don_vi_thuc_hien',
+    COALESCE((t->>'thang_1')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_2')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_3')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_4')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_5')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_6')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_7')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_8')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_9')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_10')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_11')::BOOLEAN, FALSE),
+    COALESCE((t->>'thang_12')::BOOLEAN, FALSE),
+    t->>'ghi_chu'
+  FROM jsonb_array_elements(p_tasks) AS t;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.maintenance_tasks_bulk_insert(JSONB) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql
+++ b/supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql
@@ -297,14 +297,21 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_role TEXT := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
-  v_user_id BIGINT := NULLIF(public._get_jwt_claim('user_id'), '')::BIGINT;
+  v_role TEXT;
+  v_is_global BOOLEAN := false;
+  v_user_id BIGINT;
   v_allowed BIGINT[] := NULL;
   v_department_scope TEXT := NULL;
   v_item JSONB;
+  v_ke_hoach_id BIGINT;
   v_thiet_bi_id BIGINT;
+  v_plan_scope TEXT;
   v_equipment_scope TEXT;
 BEGIN
+  v_role := lower(COALESCE(NULLIF(public._get_jwt_claim('app_role'), ''), NULLIF(public._get_jwt_claim('role'), '')));
+  v_is_global := v_role IN ('global', 'admin');
+  v_user_id := NULLIF(public._get_jwt_claim('user_id'), '')::BIGINT;
+
   IF v_role IS NULL OR v_role = '' THEN
     RAISE EXCEPTION 'Missing role claim in JWT' USING ERRCODE = '42501';
   END IF;
@@ -317,7 +324,7 @@ BEGIN
     RAISE EXCEPTION 'Permission denied' USING ERRCODE = '42501';
   END IF;
 
-  IF v_role <> 'global' THEN
+  IF NOT v_is_global THEN
     v_allowed := public.allowed_don_vi_for_session();
     IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
       RAISE EXCEPTION 'Không có quyền thêm công việc bảo trì' USING ERRCODE = '42501';
@@ -336,9 +343,26 @@ BEGIN
   END IF;
 
   FOR v_item IN SELECT value FROM jsonb_array_elements(p_tasks) AS value LOOP
+    v_ke_hoach_id := NULLIF(v_item->>'ke_hoach_id', '')::BIGINT;
     v_thiet_bi_id := NULLIF(v_item->>'thiet_bi_id', '')::BIGINT;
 
-    IF v_role <> 'global' AND v_thiet_bi_id IS NOT NULL THEN
+    IF NOT v_is_global AND v_thiet_bi_id IS NULL THEN
+      SELECT public._normalize_department_scope(kh.khoa_phong)
+      INTO v_plan_scope
+      FROM public.ke_hoach_bao_tri kh
+      WHERE kh.id = v_ke_hoach_id
+        AND kh.don_vi = ANY(v_allowed);
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'Không có quyền thêm công việc bảo trì' USING ERRCODE = '42501';
+      END IF;
+
+      IF v_role = 'user' AND v_plan_scope IS DISTINCT FROM v_department_scope THEN
+        RAISE EXCEPTION 'Không có quyền thêm công việc bảo trì cho khoa/phòng khác' USING ERRCODE = '42501';
+      END IF;
+    END IF;
+
+    IF NOT v_is_global AND v_thiet_bi_id IS NOT NULL THEN
       SELECT public._normalize_department_scope(tb.khoa_phong_quan_ly)
       INTO v_equipment_scope
       FROM public.thiet_bi tb

--- a/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+++ b/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
@@ -386,6 +386,46 @@ BEGIN
     RAISE EXCEPTION 'Cross-department maintenance deny should not persist task rows';
   END IF;
 
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.maintenance_tasks_bulk_insert(
+      jsonb_build_array(
+        jsonb_build_object(
+          'ke_hoach_id', v_plan_id,
+          'loai_cong_viec', 'kiem_tra',
+          'diem_hieu_chuan', 'Smoke null-equipment maintenance ' || v_suffix,
+          'don_vi_thuc_hien', 'noi_bo',
+          'thang_5', true,
+          'ghi_chu', 'Smoke null-equipment maintenance ' || v_suffix
+        )
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to deny unscoped NULL-equipment role user tasks';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected NULL-equipment maintenance task to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.cong_viec_bao_tri
+  WHERE thiet_bi_id IS NULL
+    AND ghi_chu = 'Smoke null-equipment maintenance ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'NULL-equipment maintenance deny should not persist task rows';
+  END IF;
+
   PERFORM set_config(
     'request.jwt.claims',
     json_build_object(

--- a/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+++ b/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
@@ -9,6 +9,7 @@ DECLARE
   v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
   v_tenant bigint;
   v_plan_id bigint;
+  v_blocked_plan_id bigint;
   v_user_id bigint;
   v_allowed_equipment bigint;
   v_blocked_equipment bigint;
@@ -21,19 +22,49 @@ DECLARE
   v_count bigint;
   v_status text;
 BEGIN
-  SELECT kh.id
-  INTO v_plan_id
-  FROM public.ke_hoach_bao_tri kh
-  ORDER BY kh.id
-  LIMIT 1;
-
-  IF v_plan_id IS NULL THEN
-    RAISE EXCEPTION 'Setup failed: no ke_hoach_bao_tri row found for maintenance workflow smoke test';
-  END IF;
-
   INSERT INTO public.don_vi(name, active)
   VALUES ('Smoke Workflow Department Tenant ' || v_suffix, true)
   RETURNING id INTO v_tenant;
+
+  INSERT INTO public.ke_hoach_bao_tri(
+    ten_ke_hoach,
+    nam,
+    loai_cong_viec,
+    khoa_phong,
+    nguoi_lap_ke_hoach,
+    trang_thai,
+    don_vi
+  )
+  VALUES (
+    'Smoke Workflow Allowed Plan ' || v_suffix,
+    EXTRACT(YEAR FROM current_date)::integer,
+    'kiem_tra',
+    'Nội thận - Tiết niệu',
+    'Workflow Department Smoke',
+    'Bản nháp',
+    v_tenant
+  )
+  RETURNING id INTO v_plan_id;
+
+  INSERT INTO public.ke_hoach_bao_tri(
+    ten_ke_hoach,
+    nam,
+    loai_cong_viec,
+    khoa_phong,
+    nguoi_lap_ke_hoach,
+    trang_thai,
+    don_vi
+  )
+  VALUES (
+    'Smoke Workflow Blocked Plan ' || v_suffix,
+    EXTRACT(YEAR FROM current_date)::integer,
+    'kiem_tra',
+    'Khoa Ngoai ' || v_suffix,
+    'Workflow Department Smoke',
+    'Bản nháp',
+    v_tenant
+  )
+  RETURNING id INTO v_blocked_plan_id;
 
   INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
   VALUES (
@@ -393,7 +424,7 @@ BEGIN
     PERFORM public.maintenance_tasks_bulk_insert(
       jsonb_build_array(
         jsonb_build_object(
-          'ke_hoach_id', v_plan_id,
+          'ke_hoach_id', v_blocked_plan_id,
           'loai_cong_viec', 'kiem_tra',
           'diem_hieu_chuan', 'Smoke null-equipment maintenance ' || v_suffix,
           'don_vi_thuc_hien', 'noi_bo',
@@ -409,7 +440,7 @@ BEGIN
   END;
 
   IF NOT v_failed THEN
-    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to deny unscoped NULL-equipment role user tasks';
+    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to deny out-of-department NULL-equipment role user tasks';
   END IF;
 
   IF v_sqlstate IS DISTINCT FROM '42501' THEN

--- a/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+++ b/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
@@ -1,0 +1,545 @@
+-- supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+-- Purpose: lock role=user department-scoped workflow guard behavior for Issue #302
+-- Non-destructive: wrapped in transaction and rolled back
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_plan_id bigint;
+  v_user_id bigint;
+  v_allowed_equipment bigint;
+  v_blocked_equipment bigint;
+  v_nonuser_equipment bigint;
+  v_request_id bigint;
+  v_transfer_id bigint;
+  v_failed boolean;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_count bigint;
+  v_status text;
+BEGIN
+  SELECT kh.id
+  INTO v_plan_id
+  FROM public.ke_hoach_bao_tri kh
+  ORDER BY kh.id
+  LIMIT 1;
+
+  IF v_plan_id IS NULL THEN
+    RAISE EXCEPTION 'Setup failed: no ke_hoach_bao_tri row found for maintenance workflow smoke test';
+  END IF;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Workflow Department Tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'workflow_department_smoke_' || v_suffix,
+    'smoke-password',
+    'Workflow Department Smoke',
+    'user',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-WF-ALLOW-' || v_suffix,
+    'Workflow Department Allowed ' || v_suffix,
+    v_tenant,
+    '  Nội thận - Tiết niệu  ',
+    'Hoat dong',
+    false
+  )
+  RETURNING id INTO v_allowed_equipment;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-WF-BLOCK-' || v_suffix,
+    'Workflow Department Blocked ' || v_suffix,
+    v_tenant,
+    'Khoa Ngoai ' || v_suffix,
+    'Hoat dong',
+    false
+  )
+  RETURNING id INTO v_blocked_equipment;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-WF-NONUSER-' || v_suffix,
+    'Workflow Department Non-user ' || v_suffix,
+    v_tenant,
+    'Khoa Khac ' || v_suffix,
+    'Hoat dong',
+    false
+  )
+  RETURNING id INTO v_nonuser_equipment;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text,
+      'khoa_phong', ' ' || chr(160) || E'NỘI\nTHẬN\t - TIẾT   NIỆU '
+    )::text,
+    true
+  );
+
+  v_request_id := public.repair_request_create(
+    v_allowed_equipment::integer,
+    'Smoke allowed repair ' || v_suffix,
+    'Allowed repair scope',
+    current_date + 1,
+    'Smoke user',
+    'noi_bo',
+    NULL
+  );
+
+  IF v_request_id IS NULL THEN
+    RAISE EXCEPTION 'Expected same-department role user repair_request_create to succeed';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.yeu_cau_sua_chua
+  WHERE id = v_request_id
+    AND thiet_bi_id = v_allowed_equipment;
+
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'repair_request_create should persist exactly 1 allowed request row, got %', v_count;
+  END IF;
+
+  v_transfer_id := public.transfer_request_create(
+    jsonb_build_object(
+      'thiet_bi_id', v_allowed_equipment,
+      'loai_hinh', 'noi_bo',
+      'ly_do_luan_chuyen', 'Smoke allowed transfer ' || v_suffix,
+      'khoa_phong_hien_tai', 'Nội thận - Tiết niệu',
+      'khoa_phong_nhan', 'Khoa Hoi suc ' || v_suffix
+    )
+  );
+
+  IF v_transfer_id IS NULL THEN
+    RAISE EXCEPTION 'Expected same-department role user transfer_request_create to succeed';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE id = v_transfer_id
+    AND thiet_bi_id = v_allowed_equipment;
+
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'transfer_request_create should persist exactly 1 allowed row, got %', v_count;
+  END IF;
+
+  PERFORM public.maintenance_tasks_bulk_insert(
+    jsonb_build_array(
+      jsonb_build_object(
+        'ke_hoach_id', v_plan_id,
+        'thiet_bi_id', v_allowed_equipment,
+        'loai_cong_viec', 'kiem_tra',
+        'diem_hieu_chuan', 'Smoke allowed maintenance ' || v_suffix,
+        'don_vi_thuc_hien', 'noi_bo',
+        'thang_1', true,
+        'ghi_chu', 'Smoke allowed maintenance ' || v_suffix
+      )
+    )
+  );
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.cong_viec_bao_tri
+  WHERE thiet_bi_id = v_allowed_equipment
+    AND ghi_chu = 'Smoke allowed maintenance ' || v_suffix;
+
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'maintenance_tasks_bulk_insert should persist exactly 1 allowed row, got %', v_count;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text
+    )::text,
+    true
+  );
+
+  v_request_id := public.repair_request_create(
+    v_nonuser_equipment::integer,
+    'Smoke non-user repair ' || v_suffix,
+    'Non-user cross department',
+    current_date + 2,
+    'Smoke operator',
+    'noi_bo',
+    NULL
+  );
+
+  IF v_request_id IS NULL THEN
+    RAISE EXCEPTION 'Expected non-user repair_request_create to preserve current same-tenant behavior';
+  END IF;
+
+  v_transfer_id := public.transfer_request_create(
+    jsonb_build_object(
+      'thiet_bi_id', v_nonuser_equipment,
+      'loai_hinh', 'noi_bo',
+      'ly_do_luan_chuyen', 'Smoke non-user transfer ' || v_suffix,
+      'khoa_phong_hien_tai', 'Khoa Khac ' || v_suffix,
+      'khoa_phong_nhan', 'Khoa Nhan non-user ' || v_suffix
+    )
+  );
+
+  IF v_transfer_id IS NULL THEN
+    RAISE EXCEPTION 'Expected non-user transfer_request_create to preserve current same-tenant behavior';
+  END IF;
+
+  PERFORM public.maintenance_tasks_bulk_insert(
+    jsonb_build_array(
+      jsonb_build_object(
+        'ke_hoach_id', v_plan_id,
+        'thiet_bi_id', v_nonuser_equipment,
+        'loai_cong_viec', 'kiem_tra',
+        'diem_hieu_chuan', 'Smoke non-user maintenance ' || v_suffix,
+        'don_vi_thuc_hien', 'noi_bo',
+        'thang_2', true,
+        'ghi_chu', 'Smoke non-user maintenance ' || v_suffix
+      )
+    )
+  );
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.cong_viec_bao_tri
+  WHERE thiet_bi_id = v_nonuser_equipment
+    AND ghi_chu = 'Smoke non-user maintenance ' || v_suffix;
+
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'Expected non-user maintenance_tasks_bulk_insert to preserve current same-tenant behavior';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text,
+      'khoa_phong', 'NỘI THẬN TIẾT NIỆU'
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.repair_request_create(
+      v_blocked_equipment::integer,
+      'Smoke blocked repair ' || v_suffix,
+      'Blocked repair scope',
+      current_date + 3,
+      'Smoke blocked user',
+      'noi_bo',
+      NULL
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected repair_request_create to deny same-tenant cross-department role user access';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected repair_request_create cross-department deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.yeu_cau_sua_chua
+  WHERE thiet_bi_id = v_blocked_equipment
+    AND mo_ta_su_co = 'Smoke blocked repair ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Cross-department repair deny should not persist request rows';
+  END IF;
+
+  SELECT tb.tinh_trang_hien_tai
+  INTO v_status
+  FROM public.thiet_bi tb
+  WHERE tb.id = v_blocked_equipment;
+
+  IF v_status IS DISTINCT FROM 'Hoat dong' THEN
+    RAISE EXCEPTION 'Cross-department repair deny should not change equipment status, found %', v_status;
+  END IF;
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.transfer_request_create(
+      jsonb_build_object(
+        'thiet_bi_id', v_blocked_equipment,
+        'loai_hinh', 'noi_bo',
+        'ly_do_luan_chuyen', 'Smoke blocked transfer ' || v_suffix,
+        'khoa_phong_hien_tai', 'Khoa Ngoai ' || v_suffix,
+        'khoa_phong_nhan', 'Khoa Nhan blocked ' || v_suffix
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected transfer_request_create to deny same-tenant cross-department role user access';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected transfer_request_create cross-department deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE thiet_bi_id = v_blocked_equipment
+    AND ly_do_luan_chuyen = 'Smoke blocked transfer ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Cross-department transfer deny should not persist request rows';
+  END IF;
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.maintenance_tasks_bulk_insert(
+      jsonb_build_array(
+        jsonb_build_object(
+          'ke_hoach_id', v_plan_id,
+          'thiet_bi_id', v_blocked_equipment,
+          'loai_cong_viec', 'kiem_tra',
+          'diem_hieu_chuan', 'Smoke blocked maintenance ' || v_suffix,
+          'don_vi_thuc_hien', 'noi_bo',
+          'thang_3', true,
+          'ghi_chu', 'Smoke blocked maintenance ' || v_suffix
+        )
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to deny same-tenant cross-department role user access';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert cross-department deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.cong_viec_bao_tri
+  WHERE thiet_bi_id = v_blocked_equipment
+    AND ghi_chu = 'Smoke blocked maintenance ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Cross-department maintenance deny should not persist task rows';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text,
+      'khoa_phong', '   '
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.repair_request_create(
+      v_allowed_equipment::integer,
+      'Smoke blank-claim repair ' || v_suffix,
+      'Blank claim repair scope',
+      current_date + 4,
+      'Smoke blank user',
+      'noi_bo',
+      NULL
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected repair_request_create to fail closed for blank khoa_phong claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected blank-claim repair_request_create to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.yeu_cau_sua_chua
+  WHERE thiet_bi_id = v_allowed_equipment
+    AND mo_ta_su_co = 'Smoke blank-claim repair ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Blank-claim repair deny should not persist request rows';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.transfer_request_create(
+      jsonb_build_object(
+        'thiet_bi_id', v_allowed_equipment,
+        'loai_hinh', 'noi_bo',
+        'ly_do_luan_chuyen', 'Smoke missing-claim transfer ' || v_suffix,
+        'khoa_phong_hien_tai', 'Nội thận - Tiết niệu',
+        'khoa_phong_nhan', 'Khoa Missing Claim ' || v_suffix
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected transfer_request_create to fail closed for missing khoa_phong claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected missing-claim transfer_request_create to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE thiet_bi_id = v_allowed_equipment
+    AND ly_do_luan_chuyen = 'Smoke missing-claim transfer ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Missing-claim transfer deny should not persist request rows';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text,
+      'khoa_phong', ''
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.maintenance_tasks_bulk_insert(
+      jsonb_build_array(
+        jsonb_build_object(
+          'ke_hoach_id', v_plan_id,
+          'thiet_bi_id', v_allowed_equipment,
+          'loai_cong_viec', 'kiem_tra',
+          'diem_hieu_chuan', 'Smoke blank-claim maintenance ' || v_suffix,
+          'don_vi_thuc_hien', 'noi_bo',
+          'thang_4', true,
+          'ghi_chu', 'Smoke blank-claim maintenance ' || v_suffix
+        )
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to fail closed for blank khoa_phong claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected blank-claim maintenance_tasks_bulk_insert to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.cong_viec_bao_tri
+  WHERE thiet_bi_id = v_allowed_equipment
+    AND ghi_chu = 'Smoke blank-claim maintenance ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Blank-claim maintenance deny should not persist task rows';
+  END IF;
+
+  RAISE NOTICE 'OK: equipment department workflow guard smoke setup completed';
+END $$;
+
+ROLLBACK;

--- a/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+++ b/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
@@ -636,6 +636,14 @@ BEGIN
     RAISE EXCEPTION 'Blank-claim maintenance deny should not persist task rows';
   END IF;
 
+  IF position('missing role claim in jwt' in lower(pg_get_functiondef('public.maintenance_tasks_bulk_insert(jsonb)'::regprocedure))) = 0 THEN
+    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to guard missing role claim';
+  END IF;
+
+  IF position('v_user_id is null' in lower(pg_get_functiondef('public.maintenance_tasks_bulk_insert(jsonb)'::regprocedure))) = 0 THEN
+    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to guard missing user_id claim';
+  END IF;
+
   RAISE NOTICE 'OK: equipment department workflow guard smoke setup completed';
 END $$;
 

--- a/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+++ b/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
@@ -490,6 +490,103 @@ BEGIN
     json_build_object(
       'app_role', 'user',
       'role', 'authenticated',
+      'don_vi', v_tenant::text,
+      'khoa_phong', 'nội thận - tiết niệu'
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.transfer_request_create(
+      jsonb_build_object(
+        'thiet_bi_id', v_allowed_equipment,
+        'loai_hinh', 'noi_bo',
+        'ly_do_luan_chuyen', 'Smoke missing-user-id transfer ' || v_suffix,
+        'khoa_phong_hien_tai', 'Nội thận - Tiết niệu',
+        'khoa_phong_nhan', 'Khoa Missing User ' || v_suffix
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected transfer_request_create to fail closed for missing user_id claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected missing-user transfer_request_create to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE thiet_bi_id = v_allowed_equipment
+    AND ly_do_luan_chuyen = 'Smoke missing-user-id transfer ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Missing-user transfer deny should not persist request rows';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'khoa_phong', 'nội thận - tiết niệu'
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.transfer_request_create(
+      jsonb_build_object(
+        'thiet_bi_id', v_allowed_equipment,
+        'loai_hinh', 'noi_bo',
+        'ly_do_luan_chuyen', 'Smoke missing-don-vi transfer ' || v_suffix,
+        'khoa_phong_hien_tai', 'Nội thận - Tiết niệu',
+        'khoa_phong_nhan', 'Khoa Missing Tenant ' || v_suffix
+      )
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected transfer_request_create to fail closed for missing don_vi claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected missing-don-vi transfer_request_create to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE thiet_bi_id = v_allowed_equipment
+    AND ly_do_luan_chuyen = 'Smoke missing-don-vi transfer ' || v_suffix;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Missing-don-vi transfer deny should not persist request rows';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
       'user_id', v_user_id::text,
       'sub', v_user_id::text,
       'don_vi', v_tenant::text,

--- a/supabase/tests/transfer_request_lifecycle_audit_smoke.sql
+++ b/supabase/tests/transfer_request_lifecycle_audit_smoke.sql
@@ -727,6 +727,57 @@ BEGIN
 END $$;
 
 -- 7) transfer_request_complete should fail closed when audit_log returns FALSE
+CREATE TEMP TABLE _transfer_complete_fail_closed_ctx (
+  request_id bigint NOT NULL
+) ON COMMIT DROP;
+
+DO $$
+DECLARE
+  v_ctx _transfer_lifecycle_ctx%ROWTYPE;
+  v_request_id bigint;
+BEGIN
+  SELECT *
+  INTO v_ctx
+  FROM _transfer_lifecycle_ctx
+  LIMIT 1;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_ctx.user_id::text,
+      'sub', v_ctx.user_id::text,
+      'don_vi', v_ctx.tenant_id::text
+    )::text,
+    true
+  );
+
+  UPDATE public.thiet_bi
+  SET khoa_phong_quan_ly = 'Khoa Cu Fail Closed ' || v_ctx.suffix
+  WHERE id = v_ctx.equipment_id;
+
+  v_request_id := public.transfer_request_create(
+    jsonb_build_object(
+      'thiet_bi_id', v_ctx.equipment_id,
+      'loai_hinh', 'noi_bo',
+      'ly_do_luan_chuyen', 'Smoke fail closed ' || v_ctx.suffix,
+      'khoa_phong_hien_tai', 'Khoa Cu Fail Closed ' || v_ctx.suffix,
+      'khoa_phong_nhan', 'Khoa Moi Fail Closed ' || v_ctx.suffix
+    )
+  );
+
+  UPDATE public.yeu_cau_luan_chuyen
+  SET trang_thai = 'da_ban_giao',
+      ngay_duyet = clock_timestamp(),
+      ngay_ban_giao = clock_timestamp(),
+      nguoi_duyet_id = v_ctx.user_id
+  WHERE id = v_request_id;
+
+  INSERT INTO _transfer_complete_fail_closed_ctx(request_id)
+  VALUES (v_request_id);
+END $$;
+
 CREATE OR REPLACE FUNCTION public.audit_log(
   p_action_type text,
   p_entity_type text DEFAULT NULL::text,
@@ -770,26 +821,14 @@ BEGIN
     true
   );
 
-  UPDATE public.thiet_bi
-  SET khoa_phong_quan_ly = 'Khoa Cu Fail Closed ' || v_ctx.suffix
-  WHERE id = v_ctx.equipment_id;
+  SELECT request_id
+  INTO v_request_id
+  FROM _transfer_complete_fail_closed_ctx
+  LIMIT 1;
 
-  v_request_id := public.transfer_request_create(
-    jsonb_build_object(
-      'thiet_bi_id', v_ctx.equipment_id,
-      'loai_hinh', 'noi_bo',
-      'ly_do_luan_chuyen', 'Smoke fail closed ' || v_ctx.suffix,
-      'khoa_phong_hien_tai', 'Khoa Cu Fail Closed ' || v_ctx.suffix,
-      'khoa_phong_nhan', 'Khoa Moi Fail Closed ' || v_ctx.suffix
-    )
-  );
-
-  UPDATE public.yeu_cau_luan_chuyen
-  SET trang_thai = 'da_ban_giao',
-      ngay_duyet = clock_timestamp(),
-      ngay_ban_giao = clock_timestamp(),
-      nguoi_duyet_id = v_ctx.user_id
-  WHERE id = v_request_id;
+  IF v_request_id IS NULL THEN
+    RAISE EXCEPTION 'Setup failed: no transfer request found for complete fail-closed smoke';
+  END IF;
 
   BEGIN
     PERFORM public.transfer_request_complete(
@@ -849,6 +888,62 @@ BEGIN
   END IF;
 
   RAISE NOTICE 'OK: transfer_request_complete fails closed when audit_log returns FALSE';
+END $$;
+
+-- 8) transfer_request_create should fail closed when audit_log returns FALSE
+DO $$
+DECLARE
+  v_ctx _transfer_lifecycle_ctx%ROWTYPE;
+  v_request_count bigint;
+  v_error_raised boolean := false;
+BEGIN
+  SELECT *
+  INTO v_ctx
+  FROM _transfer_lifecycle_ctx
+  LIMIT 1;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_ctx.user_id::text,
+      'sub', v_ctx.user_id::text,
+      'don_vi', v_ctx.tenant_id::text
+    )::text,
+    true
+  );
+
+  BEGIN
+    PERFORM public.transfer_request_create(
+      jsonb_build_object(
+        'thiet_bi_id', v_ctx.equipment_id,
+        'loai_hinh', 'noi_bo',
+        'ly_do_luan_chuyen', 'Smoke create fail closed ' || v_ctx.suffix,
+        'khoa_phong_hien_tai', 'Khoa Cu Fail Closed ' || v_ctx.suffix,
+        'khoa_phong_nhan', 'Khoa Create Fail Closed ' || v_ctx.suffix
+      )
+    );
+  EXCEPTION
+    WHEN OTHERS THEN
+      v_error_raised := true;
+  END;
+
+  IF NOT v_error_raised THEN
+    RAISE EXCEPTION 'Expected transfer_request_create to fail closed when audit_log returns FALSE';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_request_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE thiet_bi_id = v_ctx.equipment_id
+    AND ly_do_luan_chuyen = 'Smoke create fail closed ' || v_ctx.suffix;
+
+  IF v_request_count <> 0 THEN
+    RAISE EXCEPTION 'transfer_request_create fail-closed path should not persist request rows';
+  END IF;
+
+  RAISE NOTICE 'OK: transfer_request_create fails closed when audit_log returns FALSE';
 END $$;
 
 ROLLBACK;

--- a/supabase/tests/transfer_request_lifecycle_audit_smoke.sql
+++ b/supabase/tests/transfer_request_lifecycle_audit_smoke.sql
@@ -183,6 +183,7 @@ DECLARE
   v_req public.yeu_cau_luan_chuyen%ROWTYPE;
   v_log record;
   v_handover_at timestamptz := clock_timestamp();
+  v_approved_at timestamptz := clock_timestamp();
 BEGIN
   SELECT *
   INTO v_ctx
@@ -213,7 +214,16 @@ BEGIN
 
   PERFORM public.transfer_request_update_status(
     v_request_id::int,
-    'da_ban_giao',
+    'da_duyet',
+    jsonb_build_object(
+      'nguoi_duyet_id', v_ctx.user_id::text,
+      'ngay_duyet', v_approved_at
+    )
+  );
+
+  PERFORM public.transfer_request_update_status(
+    v_request_id::int,
+    'dang_luan_chuyen',
     jsonb_build_object(
       'ngay_ban_giao', v_handover_at
     )
@@ -240,8 +250,8 @@ BEGIN
     RAISE EXCEPTION 'Expected transfer_request_update_status audit row for in-progress transition';
   END IF;
 
-  IF v_req.trang_thai IS DISTINCT FROM 'da_ban_giao' THEN
-    RAISE EXCEPTION 'Setup failed: expected persisted status da_ban_giao, got %', v_req.trang_thai;
+  IF v_req.trang_thai IS DISTINCT FROM 'dang_luan_chuyen' THEN
+    RAISE EXCEPTION 'Setup failed: expected persisted status dang_luan_chuyen, got %', v_req.trang_thai;
   END IF;
 
   IF v_log.entity_label IS DISTINCT FROM v_req.ma_yeu_cau THEN
@@ -465,7 +475,7 @@ BEGIN
   );
 
   UPDATE public.yeu_cau_luan_chuyen
-  SET trang_thai = 'da_ban_giao',
+  SET trang_thai = 'dang_luan_chuyen',
       ngay_duyet = clock_timestamp(),
       ngay_ban_giao = clock_timestamp(),
       nguoi_duyet_id = v_ctx.user_id
@@ -627,7 +637,7 @@ BEGIN
   );
 
   UPDATE public.yeu_cau_luan_chuyen
-  SET trang_thai = 'da_ban_giao',
+  SET trang_thai = 'dang_luan_chuyen',
       ngay_duyet = clock_timestamp(),
       ngay_ban_giao = clock_timestamp(),
       nguoi_duyet_id = v_ctx.user_id
@@ -768,7 +778,7 @@ BEGIN
   );
 
   UPDATE public.yeu_cau_luan_chuyen
-  SET trang_thai = 'da_ban_giao',
+  SET trang_thai = 'dang_luan_chuyen',
       ngay_duyet = clock_timestamp(),
       ngay_ban_giao = clock_timestamp(),
       nguoi_duyet_id = v_ctx.user_id
@@ -867,8 +877,8 @@ BEGIN
     AND al.entity_id = v_request_id
     AND al.action_type = 'transfer_request_complete';
 
-  IF v_req.trang_thai IS DISTINCT FROM 'da_ban_giao' THEN
-    RAISE EXCEPTION 'Expected fail-closed path to preserve da_ban_giao status, found %', v_req.trang_thai;
+  IF v_req.trang_thai IS DISTINCT FROM 'dang_luan_chuyen' THEN
+    RAISE EXCEPTION 'Expected fail-closed path to preserve dang_luan_chuyen status, found %', v_req.trang_thai;
   END IF;
 
   IF v_req.ngay_hoan_thanh IS NOT NULL THEN


### PR DESCRIPTION
## Summary
- add `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`
- add forward-only migration `supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql`
- tighten workflow guards for role `user` on:
  - `repair_request_create`
  - `transfer_request_create`
  - `maintenance_tasks_bulk_insert`
- update Issue #302 verification language to Supabase MCP

## Status
- RED smoke reproduced via Supabase MCP `execute_sql(...)`
- failure is for the intended missing-guard reason: `repair_request_create` still allows same-tenant cross-department role `user` writes on the current DB
- migration has been written but not applied
- GREEN verification is intentionally deferred until migration apply, per current execution constraint

## Notes
- SQL-only batch
- follows recent repo migration patterns for `SECURITY DEFINER`, `SET search_path`, JWT fail-closed guards, row locks, and existing audit/P0002 behavior
- related issues: #302, #305

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds department-scoped guards for role `user` in equipment workflows to block same-tenant cross-department writes. Updates transfer lifecycle smoke tests to match the approve → in-progress flow and confirm fail-closed behavior, per #302.

- **New Features**
  - Enforce department match in `repair_request_create`, `transfer_request_create`, and `maintenance_tasks_bulk_insert` via `public._normalize_department_scope(...)`; deny with 42501 on blank/missing/mismatched `khoa_phong`.
  - Scope NULL-equipment in `maintenance_tasks_bulk_insert` by the plan’s department; require tenant via `public.allowed_don_vi_for_session()` and match when role `user`; keep global/admin behavior; continue to block `regional_leader`.

- **Migration**
  - Add forward-only migration: `supabase/migrations/20260422150000_add_user_department_scope_workflow_guards.sql`.
  - Add smoke tests: `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql` (includes deterministic NULL-equipment case).
  - Update `supabase/tests/transfer_request_lifecycle_audit_smoke.sql` to use `da_duyet` → `dang_luan_chuyen` transitions and verify fail-closed when `audit_log` returns FALSE on both create and complete.

<sup>Written for commit c9771093c9462d2649eecaafe5554bc0d7a1e0a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced department-scoped authorization and stricter claim checks for creating repair requests, transfer requests, and bulk maintenance task submissions; operations limited to authenticated users and blocked for unauthorized roles.
  * Operations now lock and validate equipment/plan scope and preserve correct equipment status on success.

* **Tests**
  * Added comprehensive smoke tests covering allowed/denied cross-department scenarios and malformed claims.
  * Added tests ensuring operations fail-safe (no partial persistence) when audit logging fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->