### PR TITLE
[Repair Requests] Prevent out-of-scope create deep-link blank sheet (#303)

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.race-cases.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.race-cases.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import type { useRepairRequestsDeepLink as useRepairRequestsDeepLinkType } from '../_hooks/useRepairRequestsDeepLink'
+
+interface DeepLinkRaceCaseDeps {
+  useRepairRequestsDeepLink: typeof useRepairRequestsDeepLinkType
+  mocks: {
+    callRpc: ReturnType<typeof import('vitest').vi.fn>
+    openCreateSheet: ReturnType<typeof import('vitest').vi.fn>
+    routerReplace: ReturnType<typeof import('vitest').vi.fn>
+    toast: ReturnType<typeof import('vitest').vi.fn>
+  }
+  createDefaultOptions: (searchParams?: URLSearchParams) => Parameters<typeof useRepairRequestsDeepLinkType>[0]
+  createSearchParams: (params?: Record<string, string>) => URLSearchParams
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+const VALID_EQUIPMENT = {
+  id: 42,
+  ma_thiet_bi: 'TB042',
+  ten_thiet_bi: 'Máy B',
+  khoa_phong_quan_ly: 'Khoa 2',
+}
+
+export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCaseDeps) {
+  const { useRepairRequestsDeepLink, mocks, createDefaultOptions, createSearchParams } = deps
+
+  describe('race: equipment resolution timing', () => {
+    it('waits for targeted equipment_get before opening sheet when list settles first', async () => {
+      const equipmentGetDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
+
+      mocks.callRpc
+        .mockResolvedValueOnce([])              // equipment_list: resolves immediately
+        .mockReturnValueOnce(equipmentGetDeferred.promise) // equipment_get: deferred
+
+      const sp = createSearchParams({ action: 'create', equipmentId: '42' })
+      renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+      // Wait for list to settle
+      await waitFor(() => {
+        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
+      })
+
+      // Sheet must NOT have opened yet while equipment_get is still pending
+      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+
+      // Now resolve equipment_get
+      await act(async () => {
+        equipmentGetDeferred.resolve(VALID_EQUIPMENT)
+      })
+
+      // Sheet should now open WITH equipment
+      await waitFor(() => {
+        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
+        )
+      })
+      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
+    })
+
+    it('opens with prefill when targeted equipment_get resolves before list is useful', async () => {
+      const listDeferred = createDeferred<Array<typeof VALID_EQUIPMENT>>()
+
+      mocks.callRpc
+        .mockReturnValueOnce(listDeferred.promise)        // equipment_list: deferred (slow)
+        .mockResolvedValueOnce(VALID_EQUIPMENT)            // equipment_get: resolves immediately
+
+      const sp = createSearchParams({ action: 'create', equipmentId: '42' })
+      renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+      // equipment_get resolves quickly; sheet should open with prefill
+      await waitFor(() => {
+        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
+        )
+      })
+
+      // Cleanup: resolve the list to avoid dangling promise
+      await act(async () => {
+        listDeferred.resolve([])
+      })
+    })
+
+    it('does not reopen the create sheet when the initial list settles after the intent is consumed', async () => {
+      const listDeferred = createDeferred<Array<typeof VALID_EQUIPMENT>>()
+
+      mocks.callRpc
+        .mockReturnValueOnce(listDeferred.promise)
+        .mockResolvedValueOnce(VALID_EQUIPMENT)
+
+      const sp = createSearchParams({ action: 'create', equipmentId: '42' })
+      const opts = createDefaultOptions(sp)
+      renderHook(() => useRepairRequestsDeepLink(opts))
+
+      await waitFor(() => {
+        expect(mocks.openCreateSheet).toHaveBeenCalledTimes(1)
+        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
+        )
+      })
+
+      await act(async () => {
+        listDeferred.resolve([VALID_EQUIPMENT])
+      })
+
+      await waitFor(() => {
+        expect(mocks.openCreateSheet).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('does not open a blank sheet after equipment_get reaches terminal missing state', async () => {
+      const equipmentGetDeferred = createDeferred<null>()
+
+      mocks.callRpc
+        .mockResolvedValueOnce([])                          // equipment_list: immediate
+        .mockReturnValueOnce(equipmentGetDeferred.promise)  // equipment_get: deferred
+
+      const sp = createSearchParams({ action: 'create', equipmentId: '999' })
+      renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+      // Wait for list
+      await waitFor(() => {
+        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
+      })
+
+      // Sheet must NOT open while equipment_get is pending
+      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+
+      // Resolve as missing
+      await act(async () => {
+        equipmentGetDeferred.resolve(null)
+      })
+
+      await waitFor(() => {
+        expect(mocks.toast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: 'destructive',
+            title: 'Lỗi',
+            description: expect.stringContaining('Không thể mở phiếu sửa chữa'),
+          })
+        )
+      })
+      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
+    })
+
+    it('waits for the latest equipmentId when the URL changes mid-flight', async () => {
+      const firstEquipmentDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
+      const secondEquipmentDeferred = createDeferred<{
+        id: 99
+        ma_thiet_bi: string
+        ten_thiet_bi: string
+        khoa_phong_quan_ly: string
+      } | null>()
+      const nextEquipment = {
+        id: 99 as const,
+        ma_thiet_bi: 'TB099',
+        ten_thiet_bi: 'Máy C',
+        khoa_phong_quan_ly: 'Khoa 3',
+      }
+      const baseOpts = createDefaultOptions()
+
+      mocks.callRpc
+        .mockResolvedValueOnce([])
+        .mockReturnValueOnce(firstEquipmentDeferred.promise)
+        .mockReturnValueOnce(secondEquipmentDeferred.promise)
+
+      const { rerender } = renderHook(
+        ({ currentSearchParams }) => useRepairRequestsDeepLink({
+          ...baseOpts,
+          searchParams: currentSearchParams,
+        }),
+        {
+          initialProps: {
+            currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
+      })
+
+      act(() => {
+        rerender({
+          currentSearchParams: createSearchParams({ action: 'create', equipmentId: '99' }),
+        })
+      })
+
+      await waitFor(() => {
+        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
+      })
+
+      await act(async () => {
+        firstEquipmentDeferred.resolve(VALID_EQUIPMENT)
+        await Promise.resolve()
+      })
+
+      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+      expect(mocks.routerReplace).not.toHaveBeenCalled()
+
+      await act(async () => {
+        secondEquipmentDeferred.resolve(nextEquipment)
+      })
+
+      await waitFor(() => {
+        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 99, ma_thiet_bi: 'TB099' })
+        )
+      })
+      expect(mocks.openCreateSheet).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: 42 })
+      )
+      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
+    })
+
+    it('keeps isEquipmentFetchPending true while a newer equipment fetch is still in flight', async () => {
+      const firstEquipmentDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
+      const secondEquipmentDeferred = createDeferred<{
+        id: 99
+        ma_thiet_bi: string
+        ten_thiet_bi: string
+        khoa_phong_quan_ly: string
+      } | null>()
+      const nextEquipment = {
+        id: 99 as const,
+        ma_thiet_bi: 'TB099',
+        ten_thiet_bi: 'Máy C',
+        khoa_phong_quan_ly: 'Khoa 3',
+      }
+      const baseOpts = createDefaultOptions()
+
+      mocks.callRpc
+        .mockResolvedValueOnce([])
+        .mockReturnValueOnce(firstEquipmentDeferred.promise)
+        .mockReturnValueOnce(secondEquipmentDeferred.promise)
+
+      const { result, rerender } = renderHook(
+        ({ currentSearchParams }) => useRepairRequestsDeepLink({
+          ...baseOpts,
+          searchParams: currentSearchParams,
+        }),
+        {
+          initialProps: {
+            currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(result.current.isEquipmentFetchPending).toBe(true)
+      })
+
+      act(() => {
+        rerender({
+          currentSearchParams: createSearchParams({ action: 'create', equipmentId: '99' }),
+        })
+      })
+
+      await waitFor(() => {
+        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
+      })
+
+      await act(async () => {
+        firstEquipmentDeferred.resolve(VALID_EQUIPMENT)
+        await Promise.resolve()
+      })
+
+      expect(result.current.isEquipmentFetchPending).toBe(true)
+
+      await act(async () => {
+        secondEquipmentDeferred.resolve(nextEquipment)
+      })
+
+      await waitFor(() => {
+        expect(result.current.isEquipmentFetchPending).toBe(false)
+      })
+    })
+
+  })
+}

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.race-cases.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.race-cases.ts
@@ -87,6 +87,53 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       })
     })
 
+    it('requires equipment_get even when targeted equipment is already cached from the list', async () => {
+      const equipmentGetDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
+      const baseOpts = createDefaultOptions()
+
+      mocks.callRpc
+        .mockResolvedValueOnce([VALID_EQUIPMENT])
+        .mockReturnValueOnce(equipmentGetDeferred.promise)
+
+      const { result, rerender } = renderHook(
+        ({ currentSearchParams }) => useRepairRequestsDeepLink({
+          ...baseOpts,
+          searchParams: currentSearchParams,
+        }),
+        {
+          initialProps: {
+            currentSearchParams: createSearchParams(),
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(result.current.hasLoadedEquipment).toBe(true)
+      })
+      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        rerender({
+          currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
+        })
+      })
+
+      await waitFor(() => {
+        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
+      })
+      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+
+      await act(async () => {
+        equipmentGetDeferred.resolve(VALID_EQUIPMENT)
+      })
+
+      await waitFor(() => {
+        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
+        )
+      })
+    })
+
     it('does not reopen the create sheet when the initial list settles after the intent is consumed', async () => {
       const listDeferred = createDeferred<Array<typeof VALID_EQUIPMENT>>()
 

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.retry-cases.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.retry-cases.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import type { useRepairRequestsDeepLink as useRepairRequestsDeepLinkType } from '../_hooks/useRepairRequestsDeepLink'
+
+interface DeepLinkRetryCaseDeps {
+  useRepairRequestsDeepLink: typeof useRepairRequestsDeepLinkType
+  mocks: {
+    callRpc: ReturnType<typeof import('vitest').vi.fn>
+    openCreateSheet: ReturnType<typeof import('vitest').vi.fn>
+    routerReplace: ReturnType<typeof import('vitest').vi.fn>
+    toast: ReturnType<typeof import('vitest').vi.fn>
+  }
+  createDefaultOptions: (searchParams?: URLSearchParams) => Parameters<typeof useRepairRequestsDeepLinkType>[0]
+  createSearchParams: (params?: Record<string, string>) => URLSearchParams
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+const VALID_EQUIPMENT = {
+  id: 42,
+  ma_thiet_bi: 'TB042',
+  ten_thiet_bi: 'Máy B',
+  khoa_phong_quan_ly: 'Khoa 2',
+}
+
+export function registerUseRepairRequestsDeepLinkRetryCases(deps: DeepLinkRetryCaseDeps) {
+  const { useRepairRequestsDeepLink, mocks, createDefaultOptions, createSearchParams } = deps
+
+  describe('retry and plain create timing', () => {
+    it('resets same-id missing resolution to pending before retrying create intent', async () => {
+      const retryEquipmentDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
+      const baseOpts = createDefaultOptions()
+
+      mocks.callRpc
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(null)
+        .mockReturnValueOnce(retryEquipmentDeferred.promise)
+
+      const { rerender } = renderHook(
+        ({ currentSearchParams }) => useRepairRequestsDeepLink({
+          ...baseOpts,
+          searchParams: currentSearchParams,
+        }),
+        {
+          initialProps: {
+            currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(mocks.toast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: 'destructive',
+            title: 'Lỗi',
+            description: expect.stringContaining('Không thể mở phiếu sửa chữa'),
+          })
+        )
+      })
+      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+
+      mocks.openCreateSheet.mockClear()
+      mocks.toast.mockClear()
+      mocks.routerReplace.mockClear()
+
+      act(() => {
+        rerender({ currentSearchParams: createSearchParams() })
+      })
+
+      act(() => {
+        rerender({
+          currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
+        })
+      })
+
+      await waitFor(() => {
+        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
+      })
+
+      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+      expect(mocks.routerReplace).not.toHaveBeenCalled()
+
+      await act(async () => {
+        retryEquipmentDeferred.resolve(VALID_EQUIPMENT)
+      })
+
+      await waitFor(() => {
+        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
+        )
+      })
+    })
+
+    it('does not delay action=create without equipmentId due to resolution gating', async () => {
+      mocks.callRpc.mockResolvedValueOnce([]) // equipment_list
+
+      const sp = createSearchParams({ action: 'create' })
+      renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+      // Should open immediately — no equipment resolution gating
+      await waitFor(() => {
+        expect(mocks.openCreateSheet).toHaveBeenCalledWith()
+      })
+
+      // Only 1 RPC call (equipment_list), no equipment_get
+      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
+    })
+  })
+}

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts
@@ -34,8 +34,10 @@ vi.mock('@/lib/rpc-client', () => ({
 }))
 
 // ── Import AFTER mocks ────────────────────────────────────────────
-import { useRepairRequestsDeepLink } from '../_hooks/useRepairRequestsDeepLink'
 import type { UiFilters } from '@/lib/rr-prefs'
+import { registerUseRepairRequestsDeepLinkRaceCases } from './useRepairRequestsDeepLink.race-cases'
+import { registerUseRepairRequestsDeepLinkRetryCases } from './useRepairRequestsDeepLink.retry-cases'
+import { useRepairRequestsDeepLink } from '../_hooks/useRepairRequestsDeepLink'
 
 // ── Helpers ───────────────────────────────────────────────────────
 function createSearchParams(params: Record<string, string> = {}): URLSearchParams {
@@ -222,7 +224,7 @@ describe('useRepairRequestsDeepLink', () => {
     expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
   })
 
-  it('degrades gracefully when action=create has an unresolved equipmentId', async () => {
+  it('does not open the create sheet when action=create has an unresolved equipmentId', async () => {
     mocks.callRpc
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce(null)
@@ -232,11 +234,56 @@ describe('useRepairRequestsDeepLink', () => {
     renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
 
     await waitFor(() => {
-      expect(mocks.openCreateSheet).toHaveBeenCalledWith()
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          title: 'Lỗi',
+          description: expect.stringContaining('Không thể mở phiếu sửa chữa'),
+        })
+      )
     })
-    expect(mocks.openCreateSheet).not.toHaveBeenCalledWith(
-      expect.objectContaining({ id: 999 })
-    )
+    expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+    expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
+  })
+
+  it('does not open the create sheet when equipment_get denies access', async () => {
+    mocks.callRpc
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce({ message: 'Equipment not found or access denied' })
+
+    const sp = createSearchParams({ action: 'create', equipmentId: '999' })
+
+    renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          title: 'Lỗi',
+          description: expect.stringContaining('Equipment not found or access denied'),
+        })
+      )
+    })
+    expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+    expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
+  })
+
+  it('does not treat an invalid equipmentId as a blank create intent', async () => {
+    const sp = createSearchParams({ action: 'create', equipmentId: 'abc' })
+
+    renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          title: 'Lỗi',
+          description: expect.stringContaining('Không thể mở phiếu sửa chữa'),
+        })
+      )
+    })
+    expect(mocks.openCreateSheet).not.toHaveBeenCalled()
+    expect(mocks.callRpc).toHaveBeenCalledTimes(1)
     expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
   })
 
@@ -250,340 +297,17 @@ describe('useRepairRequestsDeepLink', () => {
     expect(source).not.toContain("searchParams.get('action') !== 'create'")
   })
 
-  // ── Race condition tests ────────────────────────────────────────
-  // These use deferred promises to control timing between equipment_list
-  // and equipment_get, exposing the race in the current implementation.
+  registerUseRepairRequestsDeepLinkRaceCases({
+    useRepairRequestsDeepLink,
+    mocks,
+    createDefaultOptions,
+    createSearchParams,
+  })
 
-  function createDeferred<T>() {
-    let resolve!: (value: T) => void
-    let reject!: (reason?: unknown) => void
-    const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
-    return { promise, resolve, reject }
-  }
-
-  const VALID_EQUIPMENT = {
-    id: 42,
-    ma_thiet_bi: 'TB042',
-    ten_thiet_bi: 'Máy B',
-    khoa_phong_quan_ly: 'Khoa 2',
-  }
-
-  describe('race: equipment resolution timing', () => {
-    it('waits for targeted equipment_get before opening sheet when list settles first', async () => {
-      const equipmentGetDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
-
-      mocks.callRpc
-        .mockResolvedValueOnce([])              // equipment_list: resolves immediately
-        .mockReturnValueOnce(equipmentGetDeferred.promise) // equipment_get: deferred
-
-      const sp = createSearchParams({ action: 'create', equipmentId: '42' })
-      renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
-
-      // Wait for list to settle
-      await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
-      })
-
-      // Sheet must NOT have opened yet while equipment_get is still pending
-      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
-
-      // Now resolve equipment_get
-      await act(async () => {
-        equipmentGetDeferred.resolve(VALID_EQUIPMENT)
-      })
-
-      // Sheet should now open WITH equipment
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
-          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
-        )
-      })
-      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
-    })
-
-    it('opens with prefill when targeted equipment_get resolves before list is useful', async () => {
-      const listDeferred = createDeferred<Array<typeof VALID_EQUIPMENT>>()
-
-      mocks.callRpc
-        .mockReturnValueOnce(listDeferred.promise)        // equipment_list: deferred (slow)
-        .mockResolvedValueOnce(VALID_EQUIPMENT)            // equipment_get: resolves immediately
-
-      const sp = createSearchParams({ action: 'create', equipmentId: '42' })
-      renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
-
-      // equipment_get resolves quickly; sheet should open with prefill
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
-          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
-        )
-      })
-
-      // Cleanup: resolve the list to avoid dangling promise
-      await act(async () => {
-        listDeferred.resolve([])
-      })
-    })
-
-    it('does not reopen the create sheet when the initial list settles after the intent is consumed', async () => {
-      const listDeferred = createDeferred<Array<typeof VALID_EQUIPMENT>>()
-
-      mocks.callRpc
-        .mockReturnValueOnce(listDeferred.promise)
-        .mockResolvedValueOnce(VALID_EQUIPMENT)
-
-      const sp = createSearchParams({ action: 'create', equipmentId: '42' })
-      const opts = createDefaultOptions(sp)
-      renderHook(() => useRepairRequestsDeepLink(opts))
-
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledTimes(1)
-        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
-          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
-        )
-      })
-
-      await act(async () => {
-        listDeferred.resolve([VALID_EQUIPMENT])
-      })
-
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledTimes(1)
-      })
-    })
-
-    it('opens blank sheet only after equipment_get reaches terminal missing state', async () => {
-      const equipmentGetDeferred = createDeferred<null>()
-
-      mocks.callRpc
-        .mockResolvedValueOnce([])                          // equipment_list: immediate
-        .mockReturnValueOnce(equipmentGetDeferred.promise)  // equipment_get: deferred
-
-      const sp = createSearchParams({ action: 'create', equipmentId: '999' })
-      renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
-
-      // Wait for list
-      await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
-      })
-
-      // Sheet must NOT open while equipment_get is pending
-      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
-
-      // Resolve as missing
-      await act(async () => {
-        equipmentGetDeferred.resolve(null)
-      })
-
-      // Now sheet should open blank (graceful degradation)
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledWith()
-      })
-      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
-    })
-
-    it('waits for the latest equipmentId when the URL changes mid-flight', async () => {
-      const firstEquipmentDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
-      const secondEquipmentDeferred = createDeferred<{
-        id: 99
-        ma_thiet_bi: string
-        ten_thiet_bi: string
-        khoa_phong_quan_ly: string
-      } | null>()
-      const nextEquipment = {
-        id: 99 as const,
-        ma_thiet_bi: 'TB099',
-        ten_thiet_bi: 'Máy C',
-        khoa_phong_quan_ly: 'Khoa 3',
-      }
-      const baseOpts = createDefaultOptions()
-
-      mocks.callRpc
-        .mockResolvedValueOnce([])
-        .mockReturnValueOnce(firstEquipmentDeferred.promise)
-        .mockReturnValueOnce(secondEquipmentDeferred.promise)
-
-      const { rerender } = renderHook(
-        ({ currentSearchParams }) => useRepairRequestsDeepLink({
-          ...baseOpts,
-          searchParams: currentSearchParams,
-        }),
-        {
-          initialProps: {
-            currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
-          },
-        },
-      )
-
-      await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
-      })
-
-      act(() => {
-        rerender({
-          currentSearchParams: createSearchParams({ action: 'create', equipmentId: '99' }),
-        })
-      })
-
-      await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
-      })
-
-      await act(async () => {
-        firstEquipmentDeferred.resolve(VALID_EQUIPMENT)
-        await Promise.resolve()
-      })
-
-      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
-      expect(mocks.routerReplace).not.toHaveBeenCalled()
-
-      await act(async () => {
-        secondEquipmentDeferred.resolve(nextEquipment)
-      })
-
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
-          expect.objectContaining({ id: 99, ma_thiet_bi: 'TB099' })
-        )
-      })
-      expect(mocks.openCreateSheet).not.toHaveBeenCalledWith(
-        expect.objectContaining({ id: 42 })
-      )
-      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
-    })
-
-    it('keeps isEquipmentFetchPending true while a newer equipment fetch is still in flight', async () => {
-      const firstEquipmentDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
-      const secondEquipmentDeferred = createDeferred<{
-        id: 99
-        ma_thiet_bi: string
-        ten_thiet_bi: string
-        khoa_phong_quan_ly: string
-      } | null>()
-      const nextEquipment = {
-        id: 99 as const,
-        ma_thiet_bi: 'TB099',
-        ten_thiet_bi: 'Máy C',
-        khoa_phong_quan_ly: 'Khoa 3',
-      }
-      const baseOpts = createDefaultOptions()
-
-      mocks.callRpc
-        .mockResolvedValueOnce([])
-        .mockReturnValueOnce(firstEquipmentDeferred.promise)
-        .mockReturnValueOnce(secondEquipmentDeferred.promise)
-
-      const { result, rerender } = renderHook(
-        ({ currentSearchParams }) => useRepairRequestsDeepLink({
-          ...baseOpts,
-          searchParams: currentSearchParams,
-        }),
-        {
-          initialProps: {
-            currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
-          },
-        },
-      )
-
-      await waitFor(() => {
-        expect(result.current.isEquipmentFetchPending).toBe(true)
-      })
-
-      act(() => {
-        rerender({
-          currentSearchParams: createSearchParams({ action: 'create', equipmentId: '99' }),
-        })
-      })
-
-      await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
-      })
-
-      await act(async () => {
-        firstEquipmentDeferred.resolve(VALID_EQUIPMENT)
-        await Promise.resolve()
-      })
-
-      expect(result.current.isEquipmentFetchPending).toBe(true)
-
-      await act(async () => {
-        secondEquipmentDeferred.resolve(nextEquipment)
-      })
-
-      await waitFor(() => {
-        expect(result.current.isEquipmentFetchPending).toBe(false)
-      })
-    })
-
-    it('resets same-id missing resolution to pending before retrying create intent', async () => {
-      const retryEquipmentDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
-      const baseOpts = createDefaultOptions()
-
-      mocks.callRpc
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce(null)
-        .mockReturnValueOnce(retryEquipmentDeferred.promise)
-
-      const { rerender } = renderHook(
-        ({ currentSearchParams }) => useRepairRequestsDeepLink({
-          ...baseOpts,
-          searchParams: currentSearchParams,
-        }),
-        {
-          initialProps: {
-            currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
-          },
-        },
-      )
-
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledWith()
-      })
-
-      mocks.openCreateSheet.mockClear()
-      mocks.routerReplace.mockClear()
-
-      act(() => {
-        rerender({ currentSearchParams: createSearchParams() })
-      })
-
-      act(() => {
-        rerender({
-          currentSearchParams: createSearchParams({ action: 'create', equipmentId: '42' }),
-        })
-      })
-
-      await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
-      })
-
-      expect(mocks.openCreateSheet).not.toHaveBeenCalled()
-      expect(mocks.routerReplace).not.toHaveBeenCalled()
-
-      await act(async () => {
-        retryEquipmentDeferred.resolve(VALID_EQUIPMENT)
-      })
-
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledWith(
-          expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
-        )
-      })
-    })
-
-    it('does not delay action=create without equipmentId due to resolution gating', async () => {
-      mocks.callRpc.mockResolvedValueOnce([]) // equipment_list
-
-      const sp = createSearchParams({ action: 'create' })
-      renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
-
-      // Should open immediately — no equipment resolution gating
-      await waitFor(() => {
-        expect(mocks.openCreateSheet).toHaveBeenCalledWith()
-      })
-
-      // Only 1 RPC call (equipment_list), no equipment_get
-      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
-      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
-    })
+  registerUseRepairRequestsDeepLinkRetryCases({
+    useRepairRequestsDeepLink,
+    mocks,
+    createDefaultOptions,
+    createSearchParams,
   })
 })

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts
@@ -176,16 +176,7 @@ export function useRepairRequestsDeepLink(
       activeCreateEquipmentIdRef.current = idNum
     }
     const existing = allEquipment.find(eq => eq.id === idNum)
-    if (existing) {
-      // Equipment already in list — mark as resolved for create-intent gating
-      if (hasCreateAction) {
-        setResolution({
-          equipmentId: idNum,
-          phase: 'resolved',
-          equipment: existing,
-          failureMessage: null,
-        })
-      }
+    if (existing && !hasCreateAction) {
       return
     }
 
@@ -257,7 +248,7 @@ export function useRepairRequestsDeepLink(
       return
     }
 
-    const cleanCreateIntentUrl = () => {
+    const cleanCreateIntentUrl = (): void => {
       const params = new URLSearchParams(searchParams.toString())
       params.delete('action')
       params.delete('equipmentId')
@@ -266,7 +257,7 @@ export function useRepairRequestsDeepLink(
       router.replace(nextPath, { scroll: false })
     }
 
-    const denyCreateIntent = (message: string | null) => {
+    const denyCreateIntent = (message: string | null): void => {
       toast({
         variant: 'destructive',
         title: 'Lỗi',

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts
@@ -50,13 +50,18 @@ interface RequestedEquipmentResolution {
   equipmentId: number | null
   phase: RequestedEquipmentPhase
   equipment: EquipmentSelectItem | null
+  failureMessage: string | null
 }
 
 const IDLE_RESOLUTION: RequestedEquipmentResolution = {
   equipmentId: null,
   phase: 'idle',
   equipment: null,
+  failureMessage: null,
 }
+
+const CREATE_INTENT_FAILURE_DESCRIPTION =
+  'Không thể mở phiếu sửa chữa cho thiết bị này.'
 
 // ── Hook ─────────────────────────────────────────────────────────
 
@@ -156,9 +161,6 @@ export function useRepairRequestsDeepLink(
     if (idNum === null) return
 
     const hasCreateAction = searchParams.get('action') === REPAIR_REQUEST_CREATE_ACTION
-    if (hasCreateAction) {
-      activeCreateEquipmentIdRef.current = idNum
-    }
 
     // Skip when fetch is in flight OR when resolution is already progressing
     // (setResolution triggers re-render before async run() sets isEquipmentFetchPending)
@@ -166,13 +168,23 @@ export function useRepairRequestsDeepLink(
     if (
       hasCreateAction &&
       resolution.equipmentId === idNum &&
-      (resolution.phase === 'pending' || resolution.phase === 'resolved')
+      (resolution.phase === 'pending' ||
+        resolution.phase === 'resolved' ||
+        resolution.phase === 'missing')
     ) return
+    if (hasCreateAction) {
+      activeCreateEquipmentIdRef.current = idNum
+    }
     const existing = allEquipment.find(eq => eq.id === idNum)
     if (existing) {
       // Equipment already in list — mark as resolved for create-intent gating
       if (hasCreateAction) {
-        setResolution({ equipmentId: idNum, phase: 'resolved', equipment: existing })
+        setResolution({
+          equipmentId: idNum,
+          phase: 'resolved',
+          equipment: existing,
+          failureMessage: null,
+        })
       }
       return
     }
@@ -184,7 +196,12 @@ export function useRepairRequestsDeepLink(
       hasCreateAction &&
       (resolution.equipmentId !== idNum || resolution.phase === 'missing')
     ) {
-      setResolution({ equipmentId: idNum, phase: 'pending', equipment: null })
+      setResolution({
+        equipmentId: idNum,
+        phase: 'pending',
+        equipment: null,
+        failureMessage: null,
+      })
     }
 
     const run = async () => {
@@ -195,16 +212,31 @@ export function useRepairRequestsDeepLink(
           setAllEquipment(prev => [row, ...prev.filter(x => x.id !== row.id)])
           if (hasCreateAction) {
             if (activeCreateEquipmentIdRef.current !== idNum) return
-            setResolution({ equipmentId: idNum, phase: 'resolved', equipment: row })
+            setResolution({
+              equipmentId: idNum,
+              phase: 'resolved',
+              equipment: row,
+              failureMessage: null,
+            })
           }
         } else if (hasCreateAction) {
           if (activeCreateEquipmentIdRef.current !== idNum) return
-          setResolution({ equipmentId: idNum, phase: 'missing', equipment: null })
+          setResolution({
+            equipmentId: idNum,
+            phase: 'missing',
+            equipment: null,
+            failureMessage: null,
+          })
         }
-      } catch {
+      } catch (error: unknown) {
         if (hasCreateAction) {
           if (activeCreateEquipmentIdRef.current !== idNum) return
-          setResolution({ equipmentId: idNum, phase: 'missing', equipment: null })
+          setResolution({
+            equipmentId: idNum,
+            phase: 'missing',
+            equipment: null,
+            failureMessage: getUnknownErrorMessage(error),
+          })
         }
       } finally {
         decrementEquipmentFetchPending()
@@ -218,11 +250,47 @@ export function useRepairRequestsDeepLink(
   // For action=create&equipmentId, gates on terminal resolution state
   // instead of coarse hasLoadedEquipment + isEquipmentFetchPending.
   React.useEffect(() => {
-    if (searchParams.get('action') !== REPAIR_REQUEST_CREATE_ACTION) return
+    if (searchParams.get('action') !== REPAIR_REQUEST_CREATE_ACTION) {
+      if (resolution.phase === 'missing') {
+        setResolution(IDLE_RESOLUTION)
+      }
+      return
+    }
+
+    const cleanCreateIntentUrl = () => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete('action')
+      params.delete('equipmentId')
+      params.delete('status')
+      const nextPath = params.size ? `${pathname}?${params.toString()}` : pathname
+      router.replace(nextPath, { scroll: false })
+    }
+
+    const denyCreateIntent = (message: string | null) => {
+      toast({
+        variant: 'destructive',
+        title: 'Lỗi',
+        description: message
+          ? `${CREATE_INTENT_FAILURE_DESCRIPTION} ${message}`
+          : CREATE_INTENT_FAILURE_DESCRIPTION,
+      })
+      cleanCreateIntentUrl()
+      activeCreateEquipmentIdRef.current = null
+    }
+
+    const equipmentIdParam = searchParams.get('equipmentId')
+    const hasEquipmentIdParam = equipmentIdParam !== null
+    const equipmentId = parseEquipmentIdParam(equipmentIdParam)
+
+    if (hasEquipmentIdParam && equipmentId === null) {
+      denyCreateIntent(null)
+      return
+    }
 
     // Assistant-draft fast path — takes precedence over equipment resolution
     const cachedAssistantDraft = queryClient.getQueryData(["assistant-draft"])
     if (
+      !hasEquipmentIdParam &&
       cachedAssistantDraft &&
       typeof cachedAssistantDraft === "object" &&
       "equipment" in cachedAssistantDraft &&
@@ -232,16 +300,9 @@ export function useRepairRequestsDeepLink(
       openCreateSheet()
       queryClient.removeQueries({ queryKey: ["assistant-draft"] })
 
-      const params = new URLSearchParams(searchParams.toString())
-      params.delete('action')
-      params.delete('equipmentId')
-      params.delete('status')
-      const nextPath = params.size ? `${pathname}?${params.toString()}` : pathname
-      router.replace(nextPath, { scroll: false })
+      cleanCreateIntentUrl()
       return
     }
-
-    const equipmentId = parseEquipmentIdParam(searchParams.get('equipmentId'))
 
     if (equipmentId) {
       // Ignore stale resolutions from superseded equipmentId requests.
@@ -257,23 +318,18 @@ export function useRepairRequestsDeepLink(
       ) {
         openCreateSheet(resolution.equipment)
       } else {
-        // phase === 'missing' — graceful degradation
-        openCreateSheet()
+        denyCreateIntent(resolution.failureMessage)
+        return
       }
     } else {
       // No equipmentId — open immediately
       openCreateSheet()
     }
 
-    const params = new URLSearchParams(searchParams.toString())
-    params.delete('action')
-    params.delete('equipmentId')
-    params.delete('status')
-    const nextPath = params.size ? `${pathname}?${params.toString()}` : pathname
-    router.replace(nextPath, { scroll: false })
+    cleanCreateIntentUrl()
     activeCreateEquipmentIdRef.current = null
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams, router, pathname, openCreateSheet, resolution, queryClient, applyAssistantDraft])
+  }, [searchParams, router, pathname, openCreateSheet, resolution, queryClient, applyAssistantDraft, toast])
 
   return { allEquipment, hasLoadedEquipment, isEquipmentFetchPending }
 }


### PR DESCRIPTION
## Summary
- Closes #303
- Prevent `?action=create&equipmentId=...` from opening a blank repair request sheet when equipment resolution is denied, missing, invalid, or otherwise unresolved
- Keep plain `?action=create` and valid resolved equipment prefill behavior unchanged
- Split the oversized deep-link test file into focused registrars before changing behavior

## TDD Evidence
- Mechanical split GREEN: `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts'` -> 18 passed\n- RED before hook implementation: same focused suite -> 5 failed / 15 passed on the new no-open expectations\n- Final GREEN: same focused suite -> 20 passed\n\n## Verification\n- `node scripts/npm-run.js run verify:no-explicit-any`\n- `node scripts/npm-run.js run typecheck`\n- `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts'`\n- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` -> 100 / 100, no issues\n\n## Notes\n- No SQL migration or Supabase DDL in this batch; #301/#302 already provide the server-side deny behavior.\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop opening a blank repair request sheet for `?action=create&equipmentId=...` when the equipment is invalid, missing, or access is denied. Now we also require a targeted equipment fetch before opening (even if it’s already in the list); plain `?action=create` and valid equipment prefill still work. Closes #303.

- **Bug Fixes**
  - Gate deep-link create on targeted `equipment_get`; require this fetch even if the item is cached, ignore stale IDs, and prevent double-opens.
  - On invalid/missing/denied IDs, show a destructive toast (including the server message when available), clean the URL, and do not open the sheet.
  - Validate `equipmentId`; non-numeric values are treated as errors (not blank create).

- **Refactors**
  - Split deep-link tests into `useRepairRequestsDeepLink.race-cases.ts` and `useRepairRequestsDeepLink.retry-cases.ts`.
  - Use `REPAIR_REQUEST_CREATE_ACTION` and reset resolution state when the create intent is cleared.

<sup>Written for commit aad857ef394682dbfa5aebc4b22eb60854c7cd04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and validation in repair request creation with clearer error messages when equipment cannot be found or accessed.
  * Enhanced robustness of the create sheet workflow to prevent unexpected behavior during concurrent requests.

* **Tests**
  * Added comprehensive test coverage for race-condition scenarios and edge cases.
  * Added retry scenario tests to ensure proper behavior during equipment resolution retry flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->