### PR TITLE
[Equipment] Phase 4 - QR contract and final verification for department prefilter (#304)

### DIFF
--- a/src/components/__tests__/qr-action-sheet.test.tsx
+++ b/src/components/__tests__/qr-action-sheet.test.tsx
@@ -75,9 +75,20 @@ const mockEquipment = {
   phan_loai_theo_nd98: 'Loại B',
 }
 
+function renderQRActionSheet(qrCode = 'TB-001') {
+  return render(
+    <QRActionSheet
+      qrCode={qrCode}
+      onClose={mockOnClose}
+      onAction={mockOnAction}
+    />
+  )
+}
+
+const mockOnClose = vi.fn()
+const mockOnAction = vi.fn()
+
 describe('QRActionSheet', () => {
-  const mockOnClose = vi.fn()
-  const mockOnAction = vi.fn()
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
@@ -99,13 +110,7 @@ describe('QRActionSheet', () => {
     it('should display the scanned QR code', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       expect(screen.getByText('TB-001')).toBeInTheDocument()
 
@@ -122,13 +127,7 @@ describe('QRActionSheet', () => {
       })
       mockCallRpc.mockReturnValueOnce(pendingPromise)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       expect(screen.getByText('Đang tìm kiếm thiết bị...')).toBeInTheDocument()
 
@@ -145,13 +144,7 @@ describe('QRActionSheet', () => {
     it('should display equipment details after successful fetch', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Máy siêu âm')).toBeInTheDocument()
@@ -167,13 +160,7 @@ describe('QRActionSheet', () => {
         gia_goc: 0,
       })
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Giá gốc:')).toBeInTheDocument()
@@ -187,13 +174,7 @@ describe('QRActionSheet', () => {
     it('should display error message when equipment not found', async () => {
       mockCallRpc.mockResolvedValueOnce(null)
 
-      render(
-        <QRActionSheet
-          qrCode="INVALID-CODE"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet('INVALID-CODE')
 
       await waitFor(() => {
         expect(screen.getByText('Không tìm thấy thiết bị')).toBeInTheDocument()
@@ -207,13 +188,7 @@ describe('QRActionSheet', () => {
     it('should call equipment_get_by_code RPC (not direct table access)', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(mockCallRpc).toHaveBeenCalledWith({
@@ -226,13 +201,7 @@ describe('QRActionSheet', () => {
     it('should trim QR code before sending to RPC', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="  TB-001  "
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet('  TB-001  ')
 
       await waitFor(() => {
         expect(mockCallRpc).toHaveBeenCalledWith({
@@ -245,13 +214,7 @@ describe('QRActionSheet', () => {
     it('should NOT pass p_don_vi parameter (tenant is enforced server-side)', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         const callArgs = mockCallRpc.mock.calls[0][0]
@@ -264,7 +227,28 @@ describe('QRActionSheet', () => {
     it('should display access denied error when RPC throws access denied', async () => {
       mockCallRpc.mockRejectedValueOnce(new Error('Equipment not found or access denied'))
 
-      render(
+      renderQRActionSheet('TB-FORBIDDEN')
+
+      await waitFor(() => {
+        expect(screen.getByText('Không có quyền truy cập')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText(/không thuộc quyền quản lý của bạn/)).toBeInTheDocument()
+    })
+
+    it('should clear equipment details and remove action paths after an access denied lookup', async () => {
+      mockCallRpc
+        .mockResolvedValueOnce(mockEquipment)
+        .mockRejectedValueOnce(new Error('Equipment not found or access denied'))
+
+      const { rerender } = renderQRActionSheet()
+
+      await waitFor(() => {
+        expect(screen.getByText('Máy siêu âm')).toBeInTheDocument()
+        expect(screen.getByText('Xem thông tin chi tiết')).toBeInTheDocument()
+      })
+
+      rerender(
         <QRActionSheet
           qrCode="TB-FORBIDDEN"
           onClose={mockOnClose}
@@ -276,19 +260,20 @@ describe('QRActionSheet', () => {
         expect(screen.getByText('Không có quyền truy cập')).toBeInTheDocument()
       })
 
-      expect(screen.getByText(/không thuộc quyền quản lý của bạn/)).toBeInTheDocument()
+      expect(screen.queryByText('Máy siêu âm')).not.toBeInTheDocument()
+      expect(screen.queryByText('SU-500 • GE Healthcare')).not.toBeInTheDocument()
+      expect(screen.queryByText('Ghi nhật ký sử dụng thiết bị')).not.toBeInTheDocument()
+      expect(screen.queryByText('Xem thông tin chi tiết')).not.toBeInTheDocument()
+      expect(screen.queryByText('Lịch sử bảo trì & sửa chữa')).not.toBeInTheDocument()
+      expect(screen.queryByText('Tạo yêu cầu sửa chữa')).not.toBeInTheDocument()
+      expect(screen.queryByText('Cập nhật trạng thái')).not.toBeInTheDocument()
+      expect(mockOnAction).not.toHaveBeenCalled()
     })
 
     it('should display not found error when equipment does not exist', async () => {
       mockCallRpc.mockRejectedValueOnce(new Error('Equipment not found'))
 
-      render(
-        <QRActionSheet
-          qrCode="TB-NONEXISTENT"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet('TB-NONEXISTENT')
 
       await waitFor(() => {
         expect(screen.getByText('Không tìm thấy thiết bị')).toBeInTheDocument()
@@ -298,13 +283,7 @@ describe('QRActionSheet', () => {
     it('should display network error when connection fails', async () => {
       mockCallRpc.mockRejectedValueOnce(new Error('Network request failed'))
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Lỗi kết nối mạng')).toBeInTheDocument()
@@ -314,13 +293,7 @@ describe('QRActionSheet', () => {
     it('should display network error when RPC rejects with a network string', async () => {
       mockCallRpc.mockRejectedValueOnce('Network request failed')
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Lỗi kết nối mạng')).toBeInTheDocument()
@@ -330,13 +303,7 @@ describe('QRActionSheet', () => {
     it('should show retry button on error', async () => {
       mockCallRpc.mockRejectedValueOnce(new Error('Equipment not found'))
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Thử lại')).toBeInTheDocument()
@@ -346,13 +313,7 @@ describe('QRActionSheet', () => {
     it('should retry search when retry button clicked', async () => {
       mockCallRpc.mockRejectedValueOnce(new Error('Network request failed'))
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Thử lại')).toBeInTheDocument()
@@ -374,13 +335,7 @@ describe('QRActionSheet', () => {
     it('should call onAction with equipment when action button clicked', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Máy siêu âm')).toBeInTheDocument()
@@ -395,13 +350,7 @@ describe('QRActionSheet', () => {
     it('should render all action buttons when equipment is found', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Ghi nhật ký sử dụng thiết bị')).toBeInTheDocument()
@@ -417,13 +366,7 @@ describe('QRActionSheet', () => {
     it('should expose an accessible close button label in the header', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       await waitFor(() => {
         expect(screen.getByText('Máy siêu âm')).toBeInTheDocument()
@@ -437,13 +380,7 @@ describe('QRActionSheet', () => {
     it('should call onClose when close button is clicked', async () => {
       mockCallRpc.mockResolvedValueOnce(mockEquipment)
 
-      render(
-        <QRActionSheet
-          qrCode="TB-001"
-          onClose={mockOnClose}
-          onAction={mockOnAction}
-        />
-      )
+      renderQRActionSheet()
 
       // Wait for equipment to load
       await waitFor(() => {

--- a/supabase/migrations/20260423033000_pin_department_scope_helper_search_path.sql
+++ b/supabase/migrations/20260423033000_pin_department_scope_helper_search_path.sql
@@ -1,0 +1,35 @@
+-- Pin search_path for the user department scope helper introduced in batch #301.
+-- Keeps helper behavior unchanged while removing the mutable search_path advisor regression.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._normalize_department_scope(p_value text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_normalized text;
+BEGIN
+  IF p_value IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_normalized := replace(p_value, chr(160), ' ');
+  v_normalized := replace(v_normalized, E'\r', ' ');
+  v_normalized := replace(v_normalized, E'\n', ' ');
+  v_normalized := replace(v_normalized, E'\t', ' ');
+  v_normalized := regexp_replace(v_normalized, '[-]+', ' ', 'g');
+  v_normalized := regexp_replace(v_normalized, '\s+', ' ', 'g');
+  v_normalized := lower(trim(v_normalized));
+
+  IF v_normalized = '' THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN v_normalized;
+END;
+$function$;
+
+COMMIT;

--- a/supabase/tests/equipment_department_scope_reads_smoke.sql
+++ b/supabase/tests/equipment_department_scope_reads_smoke.sql
@@ -20,6 +20,7 @@ DECLARE
   v_sqlstate text;
   v_sqlerrm text;
   v_names text[];
+  v_proconfig text[];
 BEGIN
   INSERT INTO public.don_vi(name, active)
   VALUES ('Smoke Department Scope Tenant ' || v_suffix, true)
@@ -415,6 +416,19 @@ BEGIN
 
   IF COALESCE((v_payload->>'total')::integer, 0) <> 2 THEN
     RAISE EXCEPTION 'Admin/global control should still see both same-tenant rows, got %', v_payload->>'total';
+  END IF;
+
+  SELECT p.proconfig
+  INTO v_proconfig
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = '_normalize_department_scope'
+  LIMIT 1;
+
+  IF v_proconfig IS NULL
+     OR array_position(v_proconfig, 'search_path=public, pg_temp') IS NULL THEN
+    RAISE EXCEPTION '_normalize_department_scope must pin search_path to public, pg_temp';
   END IF;
 
   RAISE NOTICE 'OK: equipment department scope read smoke checks passed';


### PR DESCRIPTION
## Summary
- tighten QR access-denied contract coverage without changing QR UI behavior
- add final read smoke coverage for `_normalize_department_scope` search_path pinning
- add a narrow migration to pin helper `search_path = public, pg_temp` and clear the rollout advisor regression

## Verification
- Supabase MCP `execute_sql`: `supabase/tests/equipment_department_scope_reads_smoke.sql`
- Supabase MCP `execute_sql`: `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/qr-action-sheet.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- Supabase MCP `get_advisors(type: "security")` (no remaining `_normalize_department_scope` finding)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored QR action sheet test suite with improved helper functions and expanded coverage for access-denied scenarios.
  * Enhanced smoke testing to validate database function configurations and consistency.

* **Chores**
  * Added database helper function for normalizing department scope data with explicit configuration constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes the QR equipment lookup contract and department prefilter verification. Pins `_normalize_department_scope` to a safe `search_path` and tightens access-denied handling in tests. No UI changes.

- **Bug Fixes**
  - Pin `_normalize_department_scope` with `IMMUTABLE` and `search_path = public, pg_temp` to clear the mutable `search_path` advisor regression.
  - Add a smoke check that asserts the function’s `proconfig` includes the pin.

- **Refactors**
  - Deduplicate `QRActionSheet` tests with `renderQRActionSheet`; behavior unchanged.
  - Strengthen contract coverage: trim QR before RPC, call `equipment_get_by_code`, never pass `p_don_vi`, handle access denied/not found/network errors, clear details and actions after access denied, and verify retry/close flows.

<sup>Written for commit d6ee0d26d4fb2fb9bf60b947e1555378f69c6cc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

