### PR TITLE
fix: align inventory report count with user department scope

### DIFF
--- a/supabase/migrations/20260423103000_fix_equipment_count_enhanced_user_department_scope.sql
+++ b/supabase/migrations/20260423103000_fix_equipment_count_enhanced_user_department_scope.sql
@@ -70,15 +70,23 @@ BEGIN
         RETURN 0;
       END IF;
     END IF;
-  ELSE
+  ELSIF v_role IN ('to_qltb', 'qltb_khoa', 'technician', 'user') THEN
     v_effective_donvi := NULLIF(public._get_jwt_claim('don_vi'), '')::bigint;
     IF v_effective_donvi IS NULL THEN
       RAISE EXCEPTION 'Missing don_vi claim for role %', v_role USING ERRCODE = '42501';
     END IF;
 
+    IF v_allowed IS NULL
+       OR array_length(v_allowed, 1) IS NULL
+       OR NOT (v_effective_donvi = ANY(v_allowed)) THEN
+      RAISE EXCEPTION 'Access denied for role %', v_role USING ERRCODE = '42501';
+    END IF;
+
     IF p_don_vi IS NOT NULL AND p_don_vi <> v_effective_donvi THEN
       RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING ERRCODE = '42501';
     END IF;
+  ELSE
+    RAISE EXCEPTION 'Access denied for role %', v_role USING ERRCODE = '42501';
   END IF;
 
   IF v_role = 'user' THEN
@@ -119,5 +127,6 @@ END;
 $function$;
 
 GRANT EXECUTE ON FUNCTION public.equipment_count_enhanced(TEXT[], TEXT, BIGINT, TEXT) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.equipment_count_enhanced(TEXT[], TEXT, BIGINT, TEXT) FROM PUBLIC;
 
 COMMIT;

--- a/supabase/migrations/20260423103000_fix_equipment_count_enhanced_user_department_scope.sql
+++ b/supabase/migrations/20260423103000_fix_equipment_count_enhanced_user_department_scope.sql
@@ -1,0 +1,123 @@
+-- Migration: align equipment_count_enhanced with role=user department scope
+-- Date: 2026-04-23
+-- Issue: #306
+--
+-- Notes:
+-- - Keep the public.equipment_count_enhanced(TEXT[], TEXT, BIGINT, TEXT)
+--   signature unchanged.
+-- - Preserve existing non-user behavior for global/admin/regional_leader.
+-- - Reuse public._normalize_department_scope(text) to match the read/filter
+--   RPC contract introduced in Issue #301.
+-- - Fail closed for role=user when khoa_phong claim is missing/blank or when
+--   the requested department does not match the user's normalized scope.
+--
+-- Rollback:
+-- - Forward-only. Restore the previous function body in a new timestamped
+--   migration if this behavior must be reverted.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.equipment_count_enhanced(
+  p_statuses text[] DEFAULT NULL::text[],
+  p_q text DEFAULT NULL::text,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_allowed bigint[];
+  v_effective_donvi bigint;
+  v_cnt bigint;
+  v_sanitized_q text;
+  v_department_scope text;
+  v_requested_department_scope text;
+BEGIN
+  v_role := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id := NULLIF(public._get_jwt_claim('user_id'), '');
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    v_effective_donvi := p_don_vi;
+  ELSIF v_role = 'regional_leader' THEN
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN 0;
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective_donvi := p_don_vi;
+      ELSE
+        RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+    ELSE
+      v_effective_donvi := NULLIF(public._get_jwt_claim('don_vi'), '')::bigint;
+      IF v_effective_donvi IS NULL THEN
+        RETURN 0;
+      END IF;
+    END IF;
+  ELSE
+    v_effective_donvi := NULLIF(public._get_jwt_claim('don_vi'), '')::bigint;
+    IF v_effective_donvi IS NULL THEN
+      RAISE EXCEPTION 'Missing don_vi claim for role %', v_role USING ERRCODE = '42501';
+    END IF;
+
+    IF p_don_vi IS NOT NULL AND p_don_vi <> v_effective_donvi THEN
+      RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(public._get_jwt_claim('khoa_phong'));
+    IF v_department_scope IS NULL THEN
+      RETURN 0;
+    END IF;
+
+    IF p_khoa_phong IS NOT NULL THEN
+      v_requested_department_scope := public._normalize_department_scope(p_khoa_phong);
+      IF v_requested_department_scope IS DISTINCT FROM v_department_scope THEN
+        RETURN 0;
+      END IF;
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  SELECT COUNT(*)
+  INTO v_cnt
+  FROM public.thiet_bi tb
+  WHERE tb.is_deleted = false
+    AND (v_effective_donvi IS NULL OR tb.don_vi = v_effective_donvi)
+    AND (
+      (v_role = 'user' AND public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope)
+      OR
+      (v_role <> 'user' AND (p_khoa_phong IS NULL OR tb.khoa_phong_quan_ly = p_khoa_phong))
+    )
+    AND (
+      v_sanitized_q IS NULL
+      OR tb.ten_thiet_bi ILIKE ('%' || v_sanitized_q || '%')
+      OR tb.ma_thiet_bi ILIKE ('%' || v_sanitized_q || '%')
+    )
+    AND (p_statuses IS NULL OR tb.tinh_trang_hien_tai = ANY(p_statuses));
+
+  RETURN COALESCE(v_cnt, 0);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.equipment_count_enhanced(TEXT[], TEXT, BIGINT, TEXT) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/equipment_soft_delete_reports_smoke.sql
+++ b/supabase/tests/equipment_soft_delete_reports_smoke.sql
@@ -385,6 +385,33 @@ BEGIN
       v_count_enhanced;
   END IF;
 
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'auditor',
+      'role', 'authenticated',
+      'user_id', '3',
+      'sub', '3',
+      'don_vi', v_tenant_user
+    )::text,
+    true
+  );
+
+  BEGIN
+    PERFORM public.equipment_count_enhanced(
+      p_statuses => NULL,
+      p_q => v_user_prefix,
+      p_don_vi => v_tenant_user,
+      p_khoa_phong => NULL
+    );
+
+    RAISE EXCEPTION
+      'unsupported role should have raised 42501 for equipment_count_enhanced';
+  EXCEPTION
+    WHEN SQLSTATE '42501' THEN
+      NULL;
+  END;
+
   RAISE NOTICE 'OK: equipment report soft-delete smoke checks passed';
 END $$;
 

--- a/supabase/tests/equipment_soft_delete_reports_smoke.sql
+++ b/supabase/tests/equipment_soft_delete_reports_smoke.sql
@@ -12,12 +12,19 @@ DECLARE
   v_loc text := 'SMK-RPT-LOC-' || v_suffix;
   v_tenant_main bigint;
   v_tenant_other bigint;
+  v_tenant_user bigint;
   v_list_count bigint;
   v_count_enhanced bigint;
   v_dept_count bigint;
   v_agg jsonb;
   v_status jsonb;
   v_legacy_total bigint;
+  v_user_prefix text := 'SMK-RPT-USER-' || v_suffix;
+  v_user_allowed_display text := 'Nội thận - Tiết niệu ' || v_suffix;
+  v_user_allowed_claim text := 'nội thận tiết niệu ' || v_suffix;
+  v_user_blocked_display text := 'ICU Blocked ' || v_suffix;
+  v_user_department_options bigint;
+  v_user_department_count bigint;
 BEGIN
   INSERT INTO public.don_vi(name, active)
   VALUES ('Smoke Report Main ' || v_suffix, true)
@@ -26,6 +33,10 @@ BEGIN
   INSERT INTO public.don_vi(name, active)
   VALUES ('Smoke Report Other ' || v_suffix, true)
   RETURNING id INTO v_tenant_other;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Report User Scope ' || v_suffix, true)
+  RETURNING id INTO v_tenant_user;
 
   INSERT INTO public.thiet_bi (
     ma_thiet_bi,
@@ -40,6 +51,42 @@ BEGIN
     'Smoke report active equipment',
     v_tenant_main,
     v_dept,
+    v_loc,
+    'Hoạt động',
+    false
+  );
+
+  INSERT INTO public.thiet_bi (
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    vi_tri_lap_dat,
+    tinh_trang_hien_tai,
+    is_deleted
+  ) VALUES (
+    v_user_prefix || '-ALLOWED',
+    'Smoke report scoped allowed equipment',
+    v_tenant_user,
+    v_user_allowed_display,
+    v_loc,
+    'Hoạt động',
+    false
+  );
+
+  INSERT INTO public.thiet_bi (
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    vi_tri_lap_dat,
+    tinh_trang_hien_tai,
+    is_deleted
+  ) VALUES (
+    v_user_prefix || '-BLOCKED',
+    'Smoke report scoped blocked equipment',
+    v_tenant_user,
+    v_user_blocked_display,
     v_loc,
     'Hoạt động',
     false
@@ -230,6 +277,111 @@ BEGIN
   IF v_count_enhanced <> 1 THEN
     RAISE EXCEPTION
       'admin scope check for equipment_count_enhanced expected 1, got %',
+      v_count_enhanced;
+  END IF;
+
+  -- role=user should inherit the same normalized khoa/phong scope contract as
+  -- departments_list_for_tenant, including fail-closed behavior for blank scope.
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', '2',
+      'sub', '2',
+      'don_vi', v_tenant_user,
+      'khoa_phong', v_user_allowed_claim
+    )::text,
+    true
+  );
+
+  SELECT COUNT(*)
+  INTO v_user_department_options
+  FROM public.departments_list_for_tenant(p_don_vi => v_tenant_user);
+
+  IF v_user_department_options <> 1 THEN
+    RAISE EXCEPTION
+      'user scope departments_list_for_tenant expected 1 visible department, got %',
+      v_user_department_options;
+  END IF;
+
+  SELECT (d->>'count')::bigint
+  INTO v_user_department_count
+  FROM public.departments_list_for_tenant(p_don_vi => v_tenant_user) AS d
+  WHERE d->>'name' = v_user_allowed_display;
+
+  IF COALESCE(v_user_department_count, 0) <> 1 THEN
+    RAISE EXCEPTION
+      'user scope departments_list_for_tenant expected allowed department count 1, got %',
+      COALESCE(v_user_department_count, 0);
+  END IF;
+
+  SELECT public.equipment_count_enhanced(
+    p_statuses => NULL,
+    p_q => v_user_prefix,
+    p_don_vi => v_tenant_user,
+    p_khoa_phong => NULL
+  )
+  INTO v_count_enhanced;
+
+  IF v_count_enhanced <> 1 THEN
+    RAISE EXCEPTION
+      'user scope equipment_count_enhanced with NULL department expected 1, got %',
+      v_count_enhanced;
+  END IF;
+
+  SELECT public.equipment_count_enhanced(
+    p_statuses => NULL,
+    p_q => v_user_prefix,
+    p_don_vi => v_tenant_user,
+    p_khoa_phong => v_user_allowed_display
+  )
+  INTO v_count_enhanced;
+
+  IF v_count_enhanced <> 1 THEN
+    RAISE EXCEPTION
+      'user scope equipment_count_enhanced with matching department expected 1, got %',
+      v_count_enhanced;
+  END IF;
+
+  SELECT public.equipment_count_enhanced(
+    p_statuses => NULL,
+    p_q => v_user_prefix,
+    p_don_vi => v_tenant_user,
+    p_khoa_phong => v_user_blocked_display
+  )
+  INTO v_count_enhanced;
+
+  IF v_count_enhanced <> 0 THEN
+    RAISE EXCEPTION
+      'user scope equipment_count_enhanced with blocked department expected 0, got %',
+      v_count_enhanced;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', '2',
+      'sub', '2',
+      'don_vi', v_tenant_user,
+      'khoa_phong', ''
+    )::text,
+    true
+  );
+
+  SELECT public.equipment_count_enhanced(
+    p_statuses => NULL,
+    p_q => v_user_prefix,
+    p_don_vi => v_tenant_user,
+    p_khoa_phong => NULL
+  )
+  INTO v_count_enhanced;
+
+  IF v_count_enhanced <> 0 THEN
+    RAISE EXCEPTION
+      'user scope equipment_count_enhanced with blank claim expected 0, got %',
       v_count_enhanced;
   END IF;
 


### PR DESCRIPTION
## Summary
- align `equipment_count_enhanced` with the existing `role=user` normalized department scope contract
- add RED smoke coverage for report count consistency after department prefilter
- keep this change repo-only; the migration has not been applied to Supabase in this PR

## Verification
- ran updated `supabase/tests/equipment_soft_delete_reports_smoke.sql` against the current DB contract in a rollback-wrapped transaction
- confirmed RED on the intended gap: `equipment_count_enhanced(... p_khoa_phong => NULL)` returned `2` instead of scoped `1` for `role=user`
- after review feedback, reran a rollback-wrapped verification by loading the revised function body temporarily and confirming: scoped `role=user` counts pass, blank `khoa_phong` returns `0`, and unsupported roles raise `42501`
- ran `git diff --check`

## Notes
- this PR intentionally includes `REVOKE EXECUTE ... FROM PUBLIC` for the `SECURITY DEFINER` RPC to match the repo function security checklist in `REVIEW.md`
- codebase callers for `equipment_count_enhanced` are authenticated paths (`/api/rpc/[fn]` allowlist and reports hook usage); no anon/public app caller was found in repo search
- follow-up out of scope for this PR: `equipment_list_for_reports` user-scope gap tracked in #313

Closes #306