### PR TITLE
fix: enforce maintenance write role guards

### DIFF
--- a/supabase/migrations/20260424120000_enforce_maintenance_write_role_guards.sql
+++ b/supabase/migrations/20260424120000_enforce_maintenance_write_role_guards.sql
@@ -141,7 +141,7 @@ BEGIN
   SET ten_ke_hoach = COALESCE(p_ten_ke_hoach, ten_ke_hoach),
       nam = COALESCE(p_nam, nam),
       loai_cong_viec = COALESCE(p_loai_cong_viec, loai_cong_viec),
-      khoa_phong = NULLIF(p_khoa_phong, '')
+      khoa_phong = COALESCE(NULLIF(p_khoa_phong, ''), khoa_phong)
   WHERE id = p_id;
 END;
 $$;
@@ -482,14 +482,16 @@ BEGIN
   EXECUTE format('UPDATE public.cong_viec_bao_tri SET %I = true, %I = $1, updated_at = $1 WHERE id = $2', v_month_col, v_month_date_col)
     USING v_date, p_task_id;
 
-  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, ngay_thuc_hien)
-  VALUES (
-    v_task.thiet_bi_id,
-    v_task.loai_cong_viec,
-    format('Hoàn thành %s tháng %s/%s theo kế hoạch "%s"', v_task.loai_cong_viec, p_month, v_plan.nam, v_plan.ten_ke_hoach),
-    jsonb_build_object('cong_viec_id', p_task_id, 'thang', p_month, 'ten_ke_hoach', v_plan.ten_ke_hoach, 'khoa_phong', v_plan.khoa_phong, 'nam', v_plan.nam),
-    v_date
-  );
+  IF v_task.thiet_bi_id IS NOT NULL THEN
+    INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, ngay_thuc_hien)
+    VALUES (
+      v_task.thiet_bi_id,
+      v_task.loai_cong_viec,
+      format('Hoàn thành %s tháng %s/%s theo kế hoạch "%s"', v_task.loai_cong_viec, p_month, v_plan.nam, v_plan.ten_ke_hoach),
+      jsonb_build_object('cong_viec_id', p_task_id, 'thang', p_month, 'ten_ke_hoach', v_plan.ten_ke_hoach, 'khoa_phong', v_plan.khoa_phong, 'nam', v_plan.nam),
+      v_date
+    );
+  END IF;
 END;
 $$;
 
@@ -510,12 +512,32 @@ BEGIN
   END IF;
 
   IF NOT v_guard.is_global THEN
+    PERFORM 1
+    FROM public.cong_viec_bao_tri cv
+    JOIN public.ke_hoach_bao_tri kh ON kh.id = cv.ke_hoach_id
+    WHERE cv.id = ANY(p_ids)
+    FOR UPDATE OF cv, kh;
+
+    PERFORM 1
+    FROM public.cong_viec_bao_tri cv
+    JOIN public.thiet_bi tb ON tb.id = cv.thiet_bi_id
+    WHERE cv.id = ANY(p_ids)
+    FOR UPDATE OF tb;
+
     SELECT count(*)
     INTO v_denied_count
     FROM public.cong_viec_bao_tri cv
     JOIN public.ke_hoach_bao_tri kh ON kh.id = cv.ke_hoach_id
+    LEFT JOIN public.thiet_bi tb ON tb.id = cv.thiet_bi_id
     WHERE cv.id = ANY(p_ids)
-      AND (kh.don_vi IS NULL OR NOT kh.don_vi = ANY(v_guard.allowed_don_vi));
+      AND (
+        kh.don_vi IS NULL
+        OR NOT kh.don_vi = ANY(v_guard.allowed_don_vi)
+        OR (
+          cv.thiet_bi_id IS NOT NULL
+          AND (tb.id IS NULL OR tb.don_vi IS NULL OR NOT tb.don_vi = ANY(v_guard.allowed_don_vi))
+        )
+      );
 
     IF v_denied_count > 0 THEN
       RAISE EXCEPTION 'Không có quyền xóa công việc bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';

--- a/supabase/migrations/20260424120000_enforce_maintenance_write_role_guards.sql
+++ b/supabase/migrations/20260424120000_enforce_maintenance_write_role_guards.sql
@@ -1,0 +1,553 @@
+-- 20260424120000_enforce_maintenance_write_role_guards.sql
+-- Purpose: Enforce Issue #309 server-side role guards for maintenance plan/task write RPCs.
+-- Policy: role=user and regional_leader are read-only for maintenance writes; existing allowed
+-- roles keep same-tenant write behavior.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._assert_maintenance_write_allowed()
+RETURNS TABLE (
+  role_name text,
+  is_global boolean,
+  allowed_don_vi bigint[],
+  default_don_vi bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_allowed bigint[] := ARRAY[]::bigint[];
+BEGIN
+  v_role := lower(COALESCE(NULLIF(public._get_jwt_claim('app_role'), ''), NULLIF(public._get_jwt_claim('role'), '')));
+  v_user_id := NULLIF(COALESCE(public._get_jwt_claim('user_id'), public._get_jwt_claim('sub')), '');
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role IN ('user', 'regional_leader') THEN
+    RAISE EXCEPTION 'Không có quyền ghi dữ liệu bảo trì' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'global' THEN
+    role_name := v_role;
+    is_global := true;
+    allowed_don_vi := NULL;
+    default_don_vi := NULL;
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+  IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+    RAISE EXCEPTION 'Không có quyền ghi dữ liệu bảo trì' USING ERRCODE = '42501';
+  END IF;
+
+  role_name := v_role;
+  is_global := false;
+  allowed_don_vi := v_allowed;
+  default_don_vi := v_allowed[1];
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public._assert_maintenance_write_allowed() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._assert_maintenance_write_allowed() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.maintenance_plan_create(
+  p_ten_ke_hoach text,
+  p_nam integer,
+  p_loai_cong_viec text,
+  p_khoa_phong text,
+  p_nguoi_lap_ke_hoach text
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_new_id integer;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  INSERT INTO public.ke_hoach_bao_tri(
+    ten_ke_hoach,
+    nam,
+    loai_cong_viec,
+    khoa_phong,
+    nguoi_lap_ke_hoach,
+    trang_thai,
+    don_vi
+  )
+  VALUES (
+    p_ten_ke_hoach,
+    p_nam,
+    p_loai_cong_viec,
+    NULLIF(p_khoa_phong, ''),
+    p_nguoi_lap_ke_hoach,
+    'Bản nháp',
+    v_guard.default_don_vi
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_plan_update(
+  p_id bigint,
+  p_ten_ke_hoach text,
+  p_nam integer,
+  p_loai_cong_viec text,
+  p_khoa_phong text
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_plan public.ke_hoach_bao_tri;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  SELECT *
+  INTO v_plan
+  FROM public.ke_hoach_bao_tri
+  WHERE id = p_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Kế hoạch không tồn tại' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT v_guard.is_global AND (v_plan.don_vi IS NULL OR NOT v_plan.don_vi = ANY(v_guard.allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Không có quyền trên kế hoạch bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.ke_hoach_bao_tri
+  SET ten_ke_hoach = COALESCE(p_ten_ke_hoach, ten_ke_hoach),
+      nam = COALESCE(p_nam, nam),
+      loai_cong_viec = COALESCE(p_loai_cong_viec, loai_cong_viec),
+      khoa_phong = NULLIF(p_khoa_phong, '')
+  WHERE id = p_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_plan_delete(p_id bigint)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_plan public.ke_hoach_bao_tri;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  SELECT *
+  INTO v_plan
+  FROM public.ke_hoach_bao_tri
+  WHERE id = p_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF NOT v_guard.is_global AND (v_plan.don_vi IS NULL OR NOT v_plan.don_vi = ANY(v_guard.allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Không có quyền trên kế hoạch bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.ke_hoach_bao_tri WHERE id = p_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_plan_approve(p_id bigint, p_nguoi_duyet text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_plan public.ke_hoach_bao_tri;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  SELECT *
+  INTO v_plan
+  FROM public.ke_hoach_bao_tri
+  WHERE id = p_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF NOT v_guard.is_global AND (v_plan.don_vi IS NULL OR NOT v_plan.don_vi = ANY(v_guard.allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Không có quyền trên kế hoạch bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.ke_hoach_bao_tri
+  SET trang_thai = 'Đã duyệt',
+      ngay_phe_duyet = now(),
+      nguoi_duyet = p_nguoi_duyet
+  WHERE id = p_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_plan_reject(p_id bigint, p_nguoi_duyet text, p_ly_do text)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_plan public.ke_hoach_bao_tri;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  SELECT *
+  INTO v_plan
+  FROM public.ke_hoach_bao_tri
+  WHERE id = p_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF NOT v_guard.is_global AND (v_plan.don_vi IS NULL OR NOT v_plan.don_vi = ANY(v_guard.allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Không có quyền trên kế hoạch bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.ke_hoach_bao_tri
+  SET trang_thai = 'Không duyệt',
+      ngay_phe_duyet = now(),
+      nguoi_duyet = p_nguoi_duyet,
+      ly_do_khong_duyet = p_ly_do
+  WHERE id = p_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_tasks_bulk_insert(p_tasks jsonb)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_item jsonb;
+  v_ke_hoach_id bigint;
+  v_thiet_bi_id bigint;
+  v_plan public.ke_hoach_bao_tri;
+  v_equipment_don_vi bigint;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  IF p_tasks IS NULL OR jsonb_array_length(p_tasks) = 0 THEN
+    RETURN;
+  END IF;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(p_tasks) AS value LOOP
+    v_ke_hoach_id := NULLIF(v_item->>'ke_hoach_id', '')::bigint;
+    v_thiet_bi_id := NULLIF(v_item->>'thiet_bi_id', '')::bigint;
+
+    SELECT *
+    INTO v_plan
+    FROM public.ke_hoach_bao_tri
+    WHERE id = v_ke_hoach_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Kế hoạch bảo trì không tồn tại' USING ERRCODE = 'P0002';
+    END IF;
+
+    IF NOT v_guard.is_global AND (v_plan.don_vi IS NULL OR NOT v_plan.don_vi = ANY(v_guard.allowed_don_vi)) THEN
+      RAISE EXCEPTION 'Không có quyền thêm công việc bảo trì cho kế hoạch thuộc đơn vị khác' USING ERRCODE = '42501';
+    END IF;
+
+    IF v_thiet_bi_id IS NOT NULL THEN
+      SELECT don_vi
+      INTO v_equipment_don_vi
+      FROM public.thiet_bi
+      WHERE id = v_thiet_bi_id
+        AND is_deleted = false
+      FOR UPDATE;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'Thiết bị không tồn tại' USING ERRCODE = 'P0002';
+      END IF;
+
+      IF NOT v_guard.is_global AND (v_equipment_don_vi IS NULL OR NOT v_equipment_don_vi = ANY(v_guard.allowed_don_vi)) THEN
+        RAISE EXCEPTION 'Không có quyền thêm công việc bảo trì cho thiết bị thuộc đơn vị khác' USING ERRCODE = '42501';
+      END IF;
+    END IF;
+  END LOOP;
+
+  INSERT INTO public.cong_viec_bao_tri (
+    ke_hoach_id, thiet_bi_id, loai_cong_viec, diem_hieu_chuan, don_vi_thuc_hien,
+    thang_1, thang_2, thang_3, thang_4, thang_5, thang_6,
+    thang_7, thang_8, thang_9, thang_10, thang_11, thang_12, ghi_chu
+  )
+  SELECT
+    (t->>'ke_hoach_id')::bigint, NULLIF(t->>'thiet_bi_id', '')::bigint,
+    t->>'loai_cong_viec', t->>'diem_hieu_chuan', t->>'don_vi_thuc_hien',
+    COALESCE((t->>'thang_1')::boolean, false), COALESCE((t->>'thang_2')::boolean, false),
+    COALESCE((t->>'thang_3')::boolean, false), COALESCE((t->>'thang_4')::boolean, false),
+    COALESCE((t->>'thang_5')::boolean, false), COALESCE((t->>'thang_6')::boolean, false),
+    COALESCE((t->>'thang_7')::boolean, false), COALESCE((t->>'thang_8')::boolean, false),
+    COALESCE((t->>'thang_9')::boolean, false), COALESCE((t->>'thang_10')::boolean, false),
+    COALESCE((t->>'thang_11')::boolean, false), COALESCE((t->>'thang_12')::boolean, false),
+    t->>'ghi_chu'
+  FROM jsonb_array_elements(p_tasks) AS t;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_task_update(p_id bigint, p_task jsonb)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_task public.cong_viec_bao_tri;
+  v_plan_don_vi bigint;
+  v_new_plan_don_vi bigint;
+  v_new_equipment_don_vi bigint;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  SELECT *
+  INTO v_task
+  FROM public.cong_viec_bao_tri
+  WHERE id = p_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  SELECT don_vi
+  INTO v_plan_don_vi
+  FROM public.ke_hoach_bao_tri
+  WHERE id = v_task.ke_hoach_id
+  FOR UPDATE;
+
+  IF NOT v_guard.is_global AND (v_plan_don_vi IS NULL OR NOT v_plan_don_vi = ANY(v_guard.allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Không có quyền cập nhật công việc bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';
+  END IF;
+
+  IF NULLIF(p_task->>'ke_hoach_id', '') IS NOT NULL THEN
+    SELECT don_vi
+    INTO v_new_plan_don_vi
+    FROM public.ke_hoach_bao_tri
+    WHERE id = NULLIF(p_task->>'ke_hoach_id', '')::bigint
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Kế hoạch bảo trì không tồn tại' USING ERRCODE = 'P0002';
+    END IF;
+
+    IF NOT v_guard.is_global AND (v_new_plan_don_vi IS NULL OR NOT v_new_plan_don_vi = ANY(v_guard.allowed_don_vi)) THEN
+      RAISE EXCEPTION 'Không có quyền chuyển công việc bảo trì sang kế hoạch thuộc đơn vị khác' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF NULLIF(p_task->>'thiet_bi_id', '') IS NOT NULL THEN
+    SELECT don_vi
+    INTO v_new_equipment_don_vi
+    FROM public.thiet_bi
+    WHERE id = NULLIF(p_task->>'thiet_bi_id', '')::bigint
+      AND is_deleted = false
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Thiết bị không tồn tại' USING ERRCODE = 'P0002';
+    END IF;
+
+    IF NOT v_guard.is_global AND (v_new_equipment_don_vi IS NULL OR NOT v_new_equipment_don_vi = ANY(v_guard.allowed_don_vi)) THEN
+      RAISE EXCEPTION 'Không có quyền gán công việc bảo trì cho thiết bị thuộc đơn vị khác' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  UPDATE public.cong_viec_bao_tri
+  SET ke_hoach_id = COALESCE(NULLIF(p_task->>'ke_hoach_id', '')::bigint, ke_hoach_id),
+      thiet_bi_id = COALESCE(NULLIF(p_task->>'thiet_bi_id', '')::bigint, thiet_bi_id),
+      loai_cong_viec = COALESCE(p_task->>'loai_cong_viec', loai_cong_viec),
+      diem_hieu_chuan = COALESCE(p_task->>'diem_hieu_chuan', diem_hieu_chuan),
+      don_vi_thuc_hien = COALESCE(p_task->>'don_vi_thuc_hien', don_vi_thuc_hien),
+      thang_1 = COALESCE((p_task->>'thang_1')::boolean, thang_1), thang_2 = COALESCE((p_task->>'thang_2')::boolean, thang_2),
+      thang_3 = COALESCE((p_task->>'thang_3')::boolean, thang_3), thang_4 = COALESCE((p_task->>'thang_4')::boolean, thang_4),
+      thang_5 = COALESCE((p_task->>'thang_5')::boolean, thang_5), thang_6 = COALESCE((p_task->>'thang_6')::boolean, thang_6),
+      thang_7 = COALESCE((p_task->>'thang_7')::boolean, thang_7), thang_8 = COALESCE((p_task->>'thang_8')::boolean, thang_8),
+      thang_9 = COALESCE((p_task->>'thang_9')::boolean, thang_9), thang_10 = COALESCE((p_task->>'thang_10')::boolean, thang_10),
+      thang_11 = COALESCE((p_task->>'thang_11')::boolean, thang_11), thang_12 = COALESCE((p_task->>'thang_12')::boolean, thang_12),
+      thang_1_hoan_thanh = COALESCE((p_task->>'thang_1_hoan_thanh')::boolean, thang_1_hoan_thanh), thang_2_hoan_thanh = COALESCE((p_task->>'thang_2_hoan_thanh')::boolean, thang_2_hoan_thanh),
+      thang_3_hoan_thanh = COALESCE((p_task->>'thang_3_hoan_thanh')::boolean, thang_3_hoan_thanh), thang_4_hoan_thanh = COALESCE((p_task->>'thang_4_hoan_thanh')::boolean, thang_4_hoan_thanh),
+      thang_5_hoan_thanh = COALESCE((p_task->>'thang_5_hoan_thanh')::boolean, thang_5_hoan_thanh), thang_6_hoan_thanh = COALESCE((p_task->>'thang_6_hoan_thanh')::boolean, thang_6_hoan_thanh),
+      thang_7_hoan_thanh = COALESCE((p_task->>'thang_7_hoan_thanh')::boolean, thang_7_hoan_thanh), thang_8_hoan_thanh = COALESCE((p_task->>'thang_8_hoan_thanh')::boolean, thang_8_hoan_thanh),
+      thang_9_hoan_thanh = COALESCE((p_task->>'thang_9_hoan_thanh')::boolean, thang_9_hoan_thanh), thang_10_hoan_thanh = COALESCE((p_task->>'thang_10_hoan_thanh')::boolean, thang_10_hoan_thanh),
+      thang_11_hoan_thanh = COALESCE((p_task->>'thang_11_hoan_thanh')::boolean, thang_11_hoan_thanh), thang_12_hoan_thanh = COALESCE((p_task->>'thang_12_hoan_thanh')::boolean, thang_12_hoan_thanh),
+      ngay_hoan_thanh_1 = COALESCE((p_task->>'ngay_hoan_thanh_1')::timestamptz, ngay_hoan_thanh_1), ngay_hoan_thanh_2 = COALESCE((p_task->>'ngay_hoan_thanh_2')::timestamptz, ngay_hoan_thanh_2),
+      ngay_hoan_thanh_3 = COALESCE((p_task->>'ngay_hoan_thanh_3')::timestamptz, ngay_hoan_thanh_3), ngay_hoan_thanh_4 = COALESCE((p_task->>'ngay_hoan_thanh_4')::timestamptz, ngay_hoan_thanh_4),
+      ngay_hoan_thanh_5 = COALESCE((p_task->>'ngay_hoan_thanh_5')::timestamptz, ngay_hoan_thanh_5), ngay_hoan_thanh_6 = COALESCE((p_task->>'ngay_hoan_thanh_6')::timestamptz, ngay_hoan_thanh_6),
+      ngay_hoan_thanh_7 = COALESCE((p_task->>'ngay_hoan_thanh_7')::timestamptz, ngay_hoan_thanh_7), ngay_hoan_thanh_8 = COALESCE((p_task->>'ngay_hoan_thanh_8')::timestamptz, ngay_hoan_thanh_8),
+      ngay_hoan_thanh_9 = COALESCE((p_task->>'ngay_hoan_thanh_9')::timestamptz, ngay_hoan_thanh_9), ngay_hoan_thanh_10 = COALESCE((p_task->>'ngay_hoan_thanh_10')::timestamptz, ngay_hoan_thanh_10),
+      ngay_hoan_thanh_11 = COALESCE((p_task->>'ngay_hoan_thanh_11')::timestamptz, ngay_hoan_thanh_11), ngay_hoan_thanh_12 = COALESCE((p_task->>'ngay_hoan_thanh_12')::timestamptz, ngay_hoan_thanh_12),
+      ghi_chu = COALESCE(p_task->>'ghi_chu', ghi_chu),
+      updated_at = now()
+  WHERE id = p_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_task_complete(p_task_id bigint, p_month integer)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_task public.cong_viec_bao_tri;
+  v_plan public.ke_hoach_bao_tri;
+  v_equipment_don_vi bigint;
+  v_date timestamptz := now();
+  v_month_col text;
+  v_month_date_col text;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  IF p_month IS NULL OR p_month < 1 OR p_month > 12 THEN
+    RAISE EXCEPTION 'Tháng hoàn thành không hợp lệ' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT *
+  INTO v_task
+  FROM public.cong_viec_bao_tri
+  WHERE id = p_task_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  SELECT *
+  INTO v_plan
+  FROM public.ke_hoach_bao_tri
+  WHERE id = v_task.ke_hoach_id
+  FOR UPDATE;
+
+  IF NOT v_guard.is_global AND (v_plan.don_vi IS NULL OR NOT v_plan.don_vi = ANY(v_guard.allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Không có quyền hoàn thành công việc bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_task.thiet_bi_id IS NOT NULL THEN
+    SELECT don_vi
+    INTO v_equipment_don_vi
+    FROM public.thiet_bi
+    WHERE id = v_task.thiet_bi_id
+      AND is_deleted = false
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Thiết bị không tồn tại' USING ERRCODE = 'P0002';
+    END IF;
+
+    IF NOT v_guard.is_global AND (v_equipment_don_vi IS NULL OR NOT v_equipment_don_vi = ANY(v_guard.allowed_don_vi)) THEN
+      RAISE EXCEPTION 'Không có quyền hoàn thành công việc bảo trì cho thiết bị thuộc đơn vị khác' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  v_month_col := format('thang_%s_hoan_thanh', p_month);
+  v_month_date_col := format('ngay_hoan_thanh_%s', p_month);
+
+  EXECUTE format('UPDATE public.cong_viec_bao_tri SET %I = true, %I = $1, updated_at = $1 WHERE id = $2', v_month_col, v_month_date_col)
+    USING v_date, p_task_id;
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, ngay_thuc_hien)
+  VALUES (
+    v_task.thiet_bi_id,
+    v_task.loai_cong_viec,
+    format('Hoàn thành %s tháng %s/%s theo kế hoạch "%s"', v_task.loai_cong_viec, p_month, v_plan.nam, v_plan.ten_ke_hoach),
+    jsonb_build_object('cong_viec_id', p_task_id, 'thang', p_month, 'ten_ke_hoach', v_plan.ten_ke_hoach, 'khoa_phong', v_plan.khoa_phong, 'nam', v_plan.nam),
+    v_date
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_tasks_delete(p_ids bigint[])
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_denied_count bigint;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  IF p_ids IS NULL OR array_length(p_ids, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF NOT v_guard.is_global THEN
+    SELECT count(*)
+    INTO v_denied_count
+    FROM public.cong_viec_bao_tri cv
+    JOIN public.ke_hoach_bao_tri kh ON kh.id = cv.ke_hoach_id
+    WHERE cv.id = ANY(p_ids)
+      AND (kh.don_vi IS NULL OR NOT kh.don_vi = ANY(v_guard.allowed_don_vi));
+
+    IF v_denied_count > 0 THEN
+      RAISE EXCEPTION 'Không có quyền xóa công việc bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  DELETE FROM public.cong_viec_bao_tri WHERE id = ANY(p_ids);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.maintenance_plan_create(text, integer, text, text, text),
+  public.maintenance_plan_update(bigint, text, integer, text, text),
+  public.maintenance_plan_delete(bigint),
+  public.maintenance_plan_approve(bigint, text),
+  public.maintenance_plan_reject(bigint, text, text),
+  public.maintenance_tasks_bulk_insert(jsonb),
+  public.maintenance_task_update(bigint, jsonb),
+  public.maintenance_task_complete(bigint, integer),
+  public.maintenance_tasks_delete(bigint[])
+TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION
+  public.maintenance_plan_create(text, integer, text, text, text),
+  public.maintenance_plan_update(bigint, text, integer, text, text),
+  public.maintenance_plan_delete(bigint),
+  public.maintenance_plan_approve(bigint, text),
+  public.maintenance_plan_reject(bigint, text, text),
+  public.maintenance_tasks_bulk_insert(jsonb),
+  public.maintenance_task_update(bigint, jsonb),
+  public.maintenance_task_complete(bigint, integer),
+  public.maintenance_tasks_delete(bigint[])
+FROM PUBLIC;
+
+COMMIT;

--- a/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
+++ b/supabase/tests/equipment_department_scope_workflow_guards_smoke.sql
@@ -192,28 +192,45 @@ BEGIN
     RAISE EXCEPTION 'transfer_request_create should persist exactly 1 allowed row, got %', v_count;
   END IF;
 
-  PERFORM public.maintenance_tasks_bulk_insert(
-    jsonb_build_array(
-      jsonb_build_object(
-        'ke_hoach_id', v_plan_id,
-        'thiet_bi_id', v_allowed_equipment,
-        'loai_cong_viec', 'kiem_tra',
-        'diem_hieu_chuan', 'Smoke allowed maintenance ' || v_suffix,
-        'don_vi_thuc_hien', 'noi_bo',
-        'thang_1', true,
-        'ghi_chu', 'Smoke allowed maintenance ' || v_suffix
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.maintenance_tasks_bulk_insert(
+      jsonb_build_array(
+        jsonb_build_object(
+          'ke_hoach_id', v_plan_id,
+          'thiet_bi_id', v_allowed_equipment,
+          'loai_cong_viec', 'kiem_tra',
+          'diem_hieu_chuan', 'Smoke same-department user maintenance ' || v_suffix,
+          'don_vi_thuc_hien', 'noi_bo',
+          'thang_1', true,
+          'ghi_chu', 'Smoke same-department user maintenance ' || v_suffix
+        )
       )
-    )
-  );
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to deny role user maintenance writes';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected role user maintenance_tasks_bulk_insert deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
 
   SELECT COUNT(*)
   INTO v_count
   FROM public.cong_viec_bao_tri
   WHERE thiet_bi_id = v_allowed_equipment
-    AND ghi_chu = 'Smoke allowed maintenance ' || v_suffix;
+    AND ghi_chu = 'Smoke same-department user maintenance ' || v_suffix;
 
-  IF v_count <> 1 THEN
-    RAISE EXCEPTION 'maintenance_tasks_bulk_insert should persist exactly 1 allowed row, got %', v_count;
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Role user maintenance deny should not persist task rows';
   END IF;
 
   PERFORM set_config(
@@ -707,12 +724,12 @@ BEGIN
     RAISE EXCEPTION 'Blank-claim maintenance deny should not persist task rows';
   END IF;
 
-  IF position('missing role claim in jwt' in lower(pg_get_functiondef('public.maintenance_tasks_bulk_insert(jsonb)'::regprocedure))) = 0 THEN
-    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to guard missing role claim';
+  IF position('missing role claim in jwt' in lower(pg_get_functiondef('public._assert_maintenance_write_allowed()'::regprocedure))) = 0 THEN
+    RAISE EXCEPTION 'Expected maintenance write helper to guard missing role claim';
   END IF;
 
-  IF position('v_user_id is null' in lower(pg_get_functiondef('public.maintenance_tasks_bulk_insert(jsonb)'::regprocedure))) = 0 THEN
-    RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert to guard missing user_id claim';
+  IF position('missing user_id claim in jwt' in lower(pg_get_functiondef('public._assert_maintenance_write_allowed()'::regprocedure))) = 0 THEN
+    RAISE EXCEPTION 'Expected maintenance write helper to guard missing user_id claim';
   END IF;
 
   RAISE NOTICE 'OK: equipment department workflow guard smoke setup completed';

--- a/supabase/tests/maintenance_write_role_guards_smoke.sql
+++ b/supabase/tests/maintenance_write_role_guards_smoke.sql
@@ -14,11 +14,14 @@ DECLARE
   v_plan_id bigint;
   v_other_plan_id bigint;
   v_admin_plan_id bigint;
+  v_admin_plan_don_vi bigint;
   v_task_id bigint;
   v_other_task_id bigint;
+  v_other_equipment_id bigint;
+  v_mismatched_task_id bigint;
   v_count bigint;
   v_failed boolean;
-  v_sqlstate text;
+  v_denied_role text;
 BEGIN
   INSERT INTO public.dia_ban(ma_dia_ban, ten_dia_ban, active)
   VALUES ('SMK-MW-' || v_suffix, 'Smoke Maintenance Write Region ' || v_suffix, true)
@@ -106,6 +109,37 @@ BEGIN
     RAISE EXCEPTION 'Expected to_qltb maintenance_plan_create to return a plan id';
   END IF;
 
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai, is_deleted)
+  VALUES (
+    'SMK-MW-OTHER-EQ-' || v_suffix,
+    'Smoke Maintenance Other Equipment ' || v_suffix,
+    v_other_tenant,
+    'Smoke Other Department',
+    'Hoat dong',
+    false
+  )
+  RETURNING id INTO v_other_equipment_id;
+
+  INSERT INTO public.cong_viec_bao_tri(
+    ke_hoach_id,
+    thiet_bi_id,
+    loai_cong_viec,
+    diem_hieu_chuan,
+    don_vi_thuc_hien,
+    thang_1,
+    ghi_chu
+  )
+  VALUES (
+    v_plan_id,
+    v_other_equipment_id,
+    'kiem_tra',
+    'Smoke mismatched equipment task ' || v_suffix,
+    'noi_bo',
+    true,
+    'Smoke mismatched equipment task ' || v_suffix
+  )
+  RETURNING id INTO v_mismatched_task_id;
+
   PERFORM public.maintenance_plan_update(
     v_plan_id,
     'Smoke Maintenance Updated Plan ' || v_suffix,
@@ -179,6 +213,15 @@ BEGIN
     RAISE EXCEPTION 'Expected admin maintenance_plan_create without don_vi claim to remain allowed';
   END IF;
 
+  SELECT don_vi
+  INTO v_admin_plan_don_vi
+  FROM public.ke_hoach_bao_tri
+  WHERE id = v_admin_plan_id;
+
+  IF v_admin_plan_don_vi IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected admin-created plan without don_vi claim to persist NULL don_vi, got %', v_admin_plan_don_vi;
+  END IF;
+
   PERFORM public.maintenance_plan_delete(v_admin_plan_id);
 
   SELECT count(*)
@@ -190,13 +233,13 @@ BEGIN
     RAISE EXCEPTION 'Expected admin maintenance_plan_delete to remove admin-created plan';
   END IF;
 
-  FOREACH v_sqlstate IN ARRAY ARRAY['user', 'regional_leader'] LOOP
+  FOREACH v_denied_role IN ARRAY ARRAY['user', 'regional_leader'] LOOP
     PERFORM set_config(
       'request.jwt.claims',
       CASE
-        WHEN v_sqlstate = 'regional_leader' THEN
+        WHEN v_denied_role = 'regional_leader' THEN
           json_build_object(
-            'app_role', v_sqlstate,
+            'app_role', v_denied_role,
             'role', 'authenticated',
             'user_id', v_user_id::text,
             'sub', v_user_id::text,
@@ -204,7 +247,7 @@ BEGIN
           )::text
         ELSE
           json_build_object(
-            'app_role', v_sqlstate,
+            'app_role', v_denied_role,
             'role', 'authenticated',
             'user_id', v_user_id::text,
             'sub', v_user_id::text,
@@ -217,7 +260,7 @@ BEGIN
     v_failed := false;
     BEGIN
       PERFORM public.maintenance_plan_create(
-        'Smoke denied plan ' || v_sqlstate || ' ' || v_suffix,
+        'Smoke denied plan ' || v_denied_role || ' ' || v_suffix,
         EXTRACT(YEAR FROM current_date)::integer,
         'kiem_tra',
         'Smoke Denied Department',
@@ -226,18 +269,18 @@ BEGIN
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_plan_create for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_plan_create for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_plan_create for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_plan_create for % to deny with 42501', v_denied_role;
     END IF;
 
     v_failed := false;
     BEGIN
       PERFORM public.maintenance_plan_update(
         v_plan_id,
-        'Smoke denied update ' || v_sqlstate || ' ' || v_suffix,
+        'Smoke denied update ' || v_denied_role || ' ' || v_suffix,
         EXTRACT(YEAR FROM current_date)::integer,
         'bao_tri',
         'Smoke Denied Department'
@@ -245,11 +288,11 @@ BEGIN
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_plan_update for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_plan_update for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_plan_update for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_plan_update for % to deny with 42501', v_denied_role;
     END IF;
 
     v_failed := false;
@@ -258,11 +301,11 @@ BEGIN
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_plan_approve for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_plan_approve for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_plan_approve for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_plan_approve for % to deny with 42501', v_denied_role;
     END IF;
 
     v_failed := false;
@@ -271,11 +314,11 @@ BEGIN
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_plan_reject for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_plan_reject for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_plan_reject for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_plan_reject for % to deny with 42501', v_denied_role;
     END IF;
 
     v_failed := false;
@@ -285,37 +328,37 @@ BEGIN
           jsonb_build_object(
             'ke_hoach_id', v_plan_id,
             'loai_cong_viec', 'kiem_tra',
-            'diem_hieu_chuan', 'Smoke denied task ' || v_sqlstate || ' ' || v_suffix,
+            'diem_hieu_chuan', 'Smoke denied task ' || v_denied_role || ' ' || v_suffix,
             'don_vi_thuc_hien', 'noi_bo',
             'thang_3', true,
-            'ghi_chu', 'Smoke denied task ' || v_sqlstate || ' ' || v_suffix
+            'ghi_chu', 'Smoke denied task ' || v_denied_role || ' ' || v_suffix
           )
         )
       );
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert for % to deny with 42501', v_denied_role;
     END IF;
 
     v_failed := false;
     BEGIN
       PERFORM public.maintenance_task_update(
         v_other_task_id,
-        jsonb_build_object('ghi_chu', 'Smoke denied update task ' || v_sqlstate || ' ' || v_suffix)
+        jsonb_build_object('ghi_chu', 'Smoke denied update task ' || v_denied_role || ' ' || v_suffix)
       );
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_task_update for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_task_update for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_task_update for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_task_update for % to deny with 42501', v_denied_role;
     END IF;
 
     v_failed := false;
@@ -324,11 +367,11 @@ BEGIN
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_task_complete for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_task_complete for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_task_complete for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_task_complete for % to deny with 42501', v_denied_role;
     END IF;
 
     v_failed := false;
@@ -337,11 +380,11 @@ BEGIN
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_tasks_delete for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_tasks_delete for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_tasks_delete for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_tasks_delete for % to deny with 42501', v_denied_role;
     END IF;
 
     v_failed := false;
@@ -350,11 +393,11 @@ BEGIN
     EXCEPTION WHEN OTHERS THEN
       v_failed := true;
       IF SQLSTATE IS DISTINCT FROM '42501' THEN
-        RAISE EXCEPTION 'Expected maintenance_plan_delete for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+        RAISE EXCEPTION 'Expected maintenance_plan_delete for % to deny with 42501, got %', v_denied_role, SQLSTATE;
       END IF;
     END;
     IF NOT v_failed THEN
-      RAISE EXCEPTION 'Expected maintenance_plan_delete for % to deny with 42501', v_sqlstate;
+      RAISE EXCEPTION 'Expected maintenance_plan_delete for % to deny with 42501', v_denied_role;
     END IF;
   END LOOP;
 
@@ -416,6 +459,19 @@ BEGIN
   END;
   IF NOT v_failed THEN
     RAISE EXCEPTION 'Expected cross-tenant maintenance_tasks_delete to deny with 42501';
+  END IF;
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.maintenance_tasks_delete(ARRAY[v_mismatched_task_id]);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    IF SQLSTATE IS DISTINCT FROM '42501' THEN
+      RAISE EXCEPTION 'Expected mismatched-equipment maintenance_tasks_delete to deny with 42501, got %', SQLSTATE;
+    END IF;
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected mismatched-equipment maintenance_tasks_delete to deny with 42501';
   END IF;
 
   RAISE NOTICE 'OK: maintenance write role guard smoke completed';

--- a/supabase/tests/maintenance_write_role_guards_smoke.sql
+++ b/supabase/tests/maintenance_write_role_guards_smoke.sql
@@ -1,0 +1,424 @@
+-- supabase/tests/maintenance_write_role_guards_smoke.sql
+-- Purpose: lock Issue #309 maintenance write role guards.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_region_id bigint;
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_user_id bigint;
+  v_plan_id bigint;
+  v_other_plan_id bigint;
+  v_admin_plan_id bigint;
+  v_task_id bigint;
+  v_other_task_id bigint;
+  v_count bigint;
+  v_failed boolean;
+  v_sqlstate text;
+BEGIN
+  INSERT INTO public.dia_ban(ma_dia_ban, ten_dia_ban, active)
+  VALUES ('SMK-MW-' || v_suffix, 'Smoke Maintenance Write Region ' || v_suffix, true)
+  RETURNING id INTO v_region_id;
+
+  INSERT INTO public.don_vi(code, name, active, dia_ban_id)
+  VALUES ('SMK-MW-A-' || v_suffix, 'Smoke Maintenance Write Tenant A ' || v_suffix, true, v_region_id)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.don_vi(code, name, active, dia_ban_id)
+  VALUES ('SMK-MW-B-' || v_suffix, 'Smoke Maintenance Write Tenant B ' || v_suffix, true, v_region_id)
+  RETURNING id INTO v_other_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi, dia_ban_id)
+  VALUES (
+    'maintenance_write_smoke_' || v_suffix,
+    'smoke-password',
+    'Maintenance Write Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant,
+    v_region_id
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.ke_hoach_bao_tri(
+    ten_ke_hoach,
+    nam,
+    loai_cong_viec,
+    khoa_phong,
+    nguoi_lap_ke_hoach,
+    trang_thai,
+    don_vi
+  )
+  VALUES (
+    'Smoke Maintenance Other Tenant Plan ' || v_suffix,
+    EXTRACT(YEAR FROM current_date)::integer,
+    'kiem_tra',
+    'Smoke Other Department',
+    'Maintenance Write Smoke',
+    'Bản nháp',
+    v_other_tenant
+  )
+  RETURNING id INTO v_other_plan_id;
+
+  INSERT INTO public.cong_viec_bao_tri(
+    ke_hoach_id,
+    loai_cong_viec,
+    diem_hieu_chuan,
+    don_vi_thuc_hien,
+    thang_1,
+    ghi_chu
+  )
+  VALUES (
+    v_other_plan_id,
+    'kiem_tra',
+    'Smoke other tenant task ' || v_suffix,
+    'noi_bo',
+    true,
+    'Smoke other tenant task ' || v_suffix
+  )
+  RETURNING id INTO v_other_task_id;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text
+    )::text,
+    true
+  );
+
+  v_plan_id := public.maintenance_plan_create(
+    'Smoke Maintenance Allowed Plan ' || v_suffix,
+    EXTRACT(YEAR FROM current_date)::integer,
+    'kiem_tra',
+    'Smoke Department',
+    'Maintenance Write Smoke'
+  );
+
+  IF v_plan_id IS NULL THEN
+    RAISE EXCEPTION 'Expected to_qltb maintenance_plan_create to return a plan id';
+  END IF;
+
+  PERFORM public.maintenance_plan_update(
+    v_plan_id,
+    'Smoke Maintenance Updated Plan ' || v_suffix,
+    EXTRACT(YEAR FROM current_date)::integer,
+    'bao_tri',
+    'Smoke Department Updated'
+  );
+
+  PERFORM public.maintenance_plan_approve(v_plan_id, 'Maintenance Write Approver');
+  PERFORM public.maintenance_plan_reject(v_plan_id, 'Maintenance Write Approver', 'Smoke reject reason');
+
+  PERFORM public.maintenance_tasks_bulk_insert(
+    jsonb_build_array(
+      jsonb_build_object(
+        'ke_hoach_id', v_plan_id,
+        'loai_cong_viec', 'kiem_tra',
+        'diem_hieu_chuan', 'Smoke allowed task ' || v_suffix,
+        'don_vi_thuc_hien', 'noi_bo',
+        'thang_1', true,
+        'ghi_chu', 'Smoke allowed task ' || v_suffix
+      )
+    )
+  );
+
+  SELECT id
+  INTO v_task_id
+  FROM public.cong_viec_bao_tri
+  WHERE ke_hoach_id = v_plan_id
+    AND ghi_chu = 'Smoke allowed task ' || v_suffix;
+
+  IF v_task_id IS NULL THEN
+    RAISE EXCEPTION 'Expected to_qltb maintenance_tasks_bulk_insert to persist a task';
+  END IF;
+
+  PERFORM public.maintenance_task_update(
+    v_task_id,
+    jsonb_build_object('ghi_chu', 'Smoke updated task ' || v_suffix, 'thang_2', true)
+  );
+  PERFORM public.maintenance_task_complete(v_task_id, 1);
+  PERFORM public.maintenance_tasks_delete(ARRAY[v_task_id]);
+
+  SELECT count(*)
+  INTO v_count
+  FROM public.cong_viec_bao_tri
+  WHERE id = v_task_id;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Expected to_qltb maintenance_tasks_delete to remove allowed task';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'admin',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text
+    )::text,
+    true
+  );
+
+  v_admin_plan_id := public.maintenance_plan_create(
+    'Smoke Maintenance Admin Plan ' || v_suffix,
+    EXTRACT(YEAR FROM current_date)::integer,
+    'kiem_tra',
+    'Smoke Admin Department',
+    'Maintenance Write Smoke Admin'
+  );
+
+  IF v_admin_plan_id IS NULL THEN
+    RAISE EXCEPTION 'Expected admin maintenance_plan_create without don_vi claim to remain allowed';
+  END IF;
+
+  PERFORM public.maintenance_plan_delete(v_admin_plan_id);
+
+  SELECT count(*)
+  INTO v_count
+  FROM public.ke_hoach_bao_tri
+  WHERE id = v_admin_plan_id;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Expected admin maintenance_plan_delete to remove admin-created plan';
+  END IF;
+
+  FOREACH v_sqlstate IN ARRAY ARRAY['user', 'regional_leader'] LOOP
+    PERFORM set_config(
+      'request.jwt.claims',
+      CASE
+        WHEN v_sqlstate = 'regional_leader' THEN
+          json_build_object(
+            'app_role', v_sqlstate,
+            'role', 'authenticated',
+            'user_id', v_user_id::text,
+            'sub', v_user_id::text,
+            'dia_ban', v_region_id::text
+          )::text
+        ELSE
+          json_build_object(
+            'app_role', v_sqlstate,
+            'role', 'authenticated',
+            'user_id', v_user_id::text,
+            'sub', v_user_id::text,
+            'don_vi', v_tenant::text
+          )::text
+      END,
+      true
+    );
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_plan_create(
+        'Smoke denied plan ' || v_sqlstate || ' ' || v_suffix,
+        EXTRACT(YEAR FROM current_date)::integer,
+        'kiem_tra',
+        'Smoke Denied Department',
+        'Maintenance Write Smoke'
+      );
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_plan_create for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_plan_create for % to deny with 42501', v_sqlstate;
+    END IF;
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_plan_update(
+        v_plan_id,
+        'Smoke denied update ' || v_sqlstate || ' ' || v_suffix,
+        EXTRACT(YEAR FROM current_date)::integer,
+        'bao_tri',
+        'Smoke Denied Department'
+      );
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_plan_update for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_plan_update for % to deny with 42501', v_sqlstate;
+    END IF;
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_plan_approve(v_plan_id, 'Denied Approver');
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_plan_approve for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_plan_approve for % to deny with 42501', v_sqlstate;
+    END IF;
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_plan_reject(v_plan_id, 'Denied Approver', 'Denied reason');
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_plan_reject for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_plan_reject for % to deny with 42501', v_sqlstate;
+    END IF;
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_tasks_bulk_insert(
+        jsonb_build_array(
+          jsonb_build_object(
+            'ke_hoach_id', v_plan_id,
+            'loai_cong_viec', 'kiem_tra',
+            'diem_hieu_chuan', 'Smoke denied task ' || v_sqlstate || ' ' || v_suffix,
+            'don_vi_thuc_hien', 'noi_bo',
+            'thang_3', true,
+            'ghi_chu', 'Smoke denied task ' || v_sqlstate || ' ' || v_suffix
+          )
+        )
+      );
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_tasks_bulk_insert for % to deny with 42501', v_sqlstate;
+    END IF;
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_task_update(
+        v_other_task_id,
+        jsonb_build_object('ghi_chu', 'Smoke denied update task ' || v_sqlstate || ' ' || v_suffix)
+      );
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_task_update for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_task_update for % to deny with 42501', v_sqlstate;
+    END IF;
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_task_complete(v_other_task_id, 1);
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_task_complete for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_task_complete for % to deny with 42501', v_sqlstate;
+    END IF;
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_tasks_delete(ARRAY[v_other_task_id]);
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_tasks_delete for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_tasks_delete for % to deny with 42501', v_sqlstate;
+    END IF;
+
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_plan_delete(v_plan_id);
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_plan_delete for % to deny with 42501, got %', v_sqlstate, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_plan_delete for % to deny with 42501', v_sqlstate;
+    END IF;
+  END LOOP;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.maintenance_plan_update(
+      v_other_plan_id,
+      'Smoke cross-tenant update ' || v_suffix,
+      EXTRACT(YEAR FROM current_date)::integer,
+      'bao_tri',
+      'Smoke Cross Tenant'
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    IF SQLSTATE IS DISTINCT FROM '42501' THEN
+      RAISE EXCEPTION 'Expected cross-tenant maintenance_plan_update to deny with 42501, got %', SQLSTATE;
+    END IF;
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected cross-tenant maintenance_plan_update to deny with 42501';
+  END IF;
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.maintenance_task_update(
+      v_other_task_id,
+      jsonb_build_object('ghi_chu', 'Smoke cross-tenant task update ' || v_suffix)
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    IF SQLSTATE IS DISTINCT FROM '42501' THEN
+      RAISE EXCEPTION 'Expected cross-tenant maintenance_task_update to deny with 42501, got %', SQLSTATE;
+    END IF;
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected cross-tenant maintenance_task_update to deny with 42501';
+  END IF;
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.maintenance_tasks_delete(ARRAY[v_other_task_id]);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    IF SQLSTATE IS DISTINCT FROM '42501' THEN
+      RAISE EXCEPTION 'Expected cross-tenant maintenance_tasks_delete to deny with 42501, got %', SQLSTATE;
+    END IF;
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected cross-tenant maintenance_tasks_delete to deny with 42501';
+  END IF;
+
+  RAISE NOTICE 'OK: maintenance write role guard smoke completed';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Adds a forward-only Supabase migration that enforces server-side role/user guards on maintenance plan/task write RPCs.
- Denies `user` and `regional_leader` maintenance writes with `42501`, normalizes `admin` to `global`, and preserves same-tenant write behavior for other roles.
- Adds a post-apply maintenance write smoke test and aligns the workflow guard smoke test with the #309 policy.

## Test Plan
- [x] Supabase MCP RED probe: confirmed `role=user` can currently call `maintenance_plan_update` directly, proving the gap before migration.
- [x] `git diff --check`
- [x] Static migration scan: all 10 patched functions include `SECURITY DEFINER` and `SET search_path = public, pg_temp`.
- [ ] Apply migration via Supabase MCP.
- [ ] Run `supabase/tests/maintenance_write_role_guards_smoke.sql` via Supabase MCP.
- [ ] Run updated `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql` via Supabase MCP.
- [ ] Run Supabase MCP `get_advisors(security)` after apply.

## Notes
- Migration was intentionally not applied in this branch per maintainer instruction.
- GREEN smoke verification is prepared but should run only after migration apply.

Closes #309

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces server-side guards for all maintenance plan/task writes to close the permission gap in Issue #309. Denies `user` and `regional_leader` with 42501, normalizes `admin` to `global`, and enforces same-tenant scope on plans, tasks, and equipment. Closes #309

- **Bug Fixes**
  - Adds a forward-only Supabase migration securing maintenance write RPCs via a shared `_assert_maintenance_write_allowed()` with SECURITY DEFINER + search_path, and revokes PUBLIC execute (granting only `authenticated`).
  - Applies guards to plan create/update/delete/approve/reject and task bulk insert/update/complete/delete, including cross-tenant and mismatched-equipment denials; preserves admin-as-global behavior (no `don_vi` claim).
  - Adds `maintenance_write_role_guards_smoke.sql` and updates the equipment workflow smoke test to assert role `user` denies with 42501 and to validate missing role/user_id claims via the helper.

- **Migration**
  - Apply the migration in Supabase.
  - Run `supabase/tests/maintenance_write_role_guards_smoke.sql` and `supabase/tests/equipment_department_scope_workflow_guards_smoke.sql`.
  - Optionally run `get_advisors(security)` to verify posture.

<sup>Written for commit 62cc2a5ad45fe0ed5ec6a556c577376efac5f110. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added role-based authorization controls for maintenance plan operations, including creation, updates, deletion, and approval workflows.
  * Added role-based authorization controls for maintenance task management, including bulk operations, updates, and completion tracking.
  * Enhanced security validation to enforce organizational hierarchy and scope restrictions on all maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->