### PR TITLE
Fix #319: Block global maintenance plan creation

### DIFF
--- a/src/app/(app)/maintenance/__tests__/MaintenancePageDesktopContent.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenancePageDesktopContent.test.tsx
@@ -1,14 +1,11 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-vi.mock("@/components/kpi", () => ({
-  KpiStatusBar: () => <div data-testid="maintenance-kpi-bar" />,
-}))
-
-vi.mock("../_hooks/useMaintenanceContext", () => ({
-  useMaintenanceContext: () => ({
+const mockContext = vi.hoisted(() => ({
+  value: {
+    user: { role: "to_qltb" },
     activeTab: "plans",
     setActiveTab: vi.fn(),
     selectedPlan: null,
@@ -36,7 +33,15 @@ vi.mock("../_hooks/useMaintenanceContext", () => ({
     taskEditing: {
       editingTaskId: null,
     },
-  }),
+  },
+}))
+
+vi.mock("@/components/kpi", () => ({
+  KpiStatusBar: () => <div data-testid="maintenance-kpi-bar" />,
+}))
+
+vi.mock("../_hooks/useMaintenanceContext", () => ({
+  useMaintenanceContext: () => mockContext.value,
 }))
 
 vi.mock("../_components/plan-filters-bar", () => ({
@@ -53,37 +58,47 @@ vi.mock("../_components/tasks-table", () => ({
 
 import { MaintenancePageDesktopContent } from "../_components/maintenance-page-desktop-content"
 
+function renderDesktopContent() {
+  return render(
+    <MaintenancePageDesktopContent
+      statusCounts={{ "Bản nháp": 1 }}
+      isCountsLoading={false}
+      isCountsError={false}
+      showFacilityFilter={false}
+      facilities={[]}
+      selectedFacilityId={null}
+      onFacilityChange={vi.fn()}
+      isLoadingFacilities={false}
+      totalCount={0}
+      planSearchTerm=""
+      onPlanSearchChange={vi.fn()}
+      isMobile={false}
+      mobilePlanCards={null}
+      planTable={{} as never}
+      planColumns={[]}
+      currentPage={1}
+      totalPages={1}
+      pageSize={10}
+      plans={[]}
+      isLoadingPlans={false}
+      onPageChange={vi.fn()}
+      onPageSizeChange={vi.fn()}
+      isFiltered={false}
+      taskTable={{} as never}
+      taskColumns={[]}
+    />,
+  )
+}
+
 describe("MaintenancePageDesktopContent", () => {
+  beforeEach(() => {
+    mockContext.value.user.role = "to_qltb"
+    mockContext.value.canManagePlans = true
+    vi.clearAllMocks()
+  })
+
   it("renders page title above KpiStatusBar and content card", () => {
-    render(
-      <MaintenancePageDesktopContent
-        statusCounts={{ "Bản nháp": 1 }}
-        isCountsLoading={false}
-        isCountsError={false}
-        showFacilityFilter={false}
-        facilities={[]}
-        selectedFacilityId={null}
-        onFacilityChange={vi.fn()}
-        isLoadingFacilities={false}
-        totalCount={0}
-        planSearchTerm=""
-        onPlanSearchChange={vi.fn()}
-        isMobile={false}
-        mobilePlanCards={null}
-        planTable={{} as never}
-        planColumns={[]}
-        currentPage={1}
-        totalPages={1}
-        pageSize={10}
-        plans={[]}
-        isLoadingPlans={false}
-        onPageChange={vi.fn()}
-        onPageSizeChange={vi.fn()}
-        isFiltered={false}
-        taskTable={{} as never}
-        taskColumns={[]}
-      />,
-    )
+    renderDesktopContent()
 
     const pageTitle = screen.getByRole("heading", { name: "Kế hoạch bảo trì" })
     const kpiBar = screen.getByTestId("maintenance-kpi-bar")
@@ -95,5 +110,19 @@ describe("MaintenancePageDesktopContent", () => {
     expect(
       Boolean(kpiBar.compareDocumentPosition(cardTitle) & Node.DOCUMENT_POSITION_FOLLOWING),
     ).toBe(true)
+  })
+
+  it("shows the create-plan action for non-global maintenance managers", () => {
+    renderDesktopContent()
+
+    expect(screen.getByRole("button", { name: "Tạo kế hoạch mới" })).toBeInTheDocument()
+  })
+
+  it("hides the create-plan action for global/admin users", () => {
+    mockContext.value.user.role = "admin"
+
+    renderDesktopContent()
+
+    expect(screen.queryByRole("button", { name: "Tạo kế hoạch mới" })).not.toBeInTheDocument()
   })
 })

--- a/src/app/(app)/maintenance/__tests__/MaintenancePageDesktopContent.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenancePageDesktopContent.test.tsx
@@ -6,10 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mockContext = vi.hoisted(() => ({
   value: {
     user: { role: "to_qltb" },
+    isAuthLoading: false,
     activeTab: "plans",
     setActiveTab: vi.fn(),
     selectedPlan: null,
     canManagePlans: true,
+    canCreatePlans: true,
     setIsAddPlanDialogOpen: vi.fn(),
     handleSelectPlan: vi.fn(),
     isRegionalLeader: false,
@@ -94,6 +96,7 @@ describe("MaintenancePageDesktopContent", () => {
   beforeEach(() => {
     mockContext.value.user.role = "to_qltb"
     mockContext.value.canManagePlans = true
+    mockContext.value.canCreatePlans = true
     vi.clearAllMocks()
   })
 
@@ -118,8 +121,9 @@ describe("MaintenancePageDesktopContent", () => {
     expect(screen.getByRole("button", { name: "Tạo kế hoạch mới" })).toBeInTheDocument()
   })
 
-  it("hides the create-plan action for global/admin users", () => {
-    mockContext.value.user.role = "admin"
+  it.each(["admin", "global"])("hides the create-plan action for %s users", (role) => {
+    mockContext.value.user.role = role
+    mockContext.value.canCreatePlans = false
 
     renderDesktopContent()
 

--- a/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
@@ -6,10 +6,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   context: {
     user: { role: "global" },
+    isAuthLoading: false,
     activeTab: "plans",
     setActiveTab: vi.fn(),
     selectedPlan: null,
     canManagePlans: true,
+    canCreatePlans: false,
     setIsAddPlanDialogOpen: vi.fn(),
     handleSelectPlan: vi.fn(),
     operations: {
@@ -80,11 +82,14 @@ describe("MobileMaintenanceLayout create-plan entry points", () => {
     vi.clearAllMocks()
     mocks.context.user.role = "global"
     mocks.context.canManagePlans = true
+    mocks.context.canCreatePlans = false
     mocks.context.activeTab = "plans"
     mocks.lastPlanCardsProps = null
   })
 
-  it("hides create-plan controls for global/admin users", () => {
+  it.each(["global", "admin"])("hides create-plan controls for %s users", (role) => {
+    mocks.context.user.role = role
+
     renderMobileLayout()
 
     expect(screen.queryByRole("button", { name: "Tạo kế hoạch mới" })).not.toBeInTheDocument()
@@ -93,6 +98,7 @@ describe("MobileMaintenanceLayout create-plan entry points", () => {
 
   it("keeps create-plan controls available for non-global maintenance managers", () => {
     mocks.context.user.role = "to_qltb"
+    mocks.context.canCreatePlans = true
 
     renderMobileLayout()
 

--- a/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
@@ -1,0 +1,102 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  context: {
+    user: { role: "global" },
+    activeTab: "plans",
+    setActiveTab: vi.fn(),
+    selectedPlan: null,
+    canManagePlans: true,
+    setIsAddPlanDialogOpen: vi.fn(),
+    handleSelectPlan: vi.fn(),
+    operations: {
+      openApproveDialog: vi.fn(),
+      openRejectDialog: vi.fn(),
+      openDeleteDialog: vi.fn(),
+    },
+    setEditingPlan: vi.fn(),
+  },
+  lastPlanCardsProps: null as { canCreatePlans?: boolean } | null,
+}))
+
+vi.mock("@/components/kpi", () => ({
+  KpiStatusBar: () => <div data-testid="maintenance-kpi-bar" />,
+}))
+
+vi.mock("../_hooks/useMaintenanceContext", () => ({
+  useMaintenanceContext: () => mocks.context,
+}))
+
+vi.mock("../_components/maintenance-mobile-plan-cards", () => ({
+  MaintenanceMobilePlanCards: (props: { canCreatePlans?: boolean }) => {
+    mocks.lastPlanCardsProps = props
+    return <div data-testid="mobile-plan-cards" />
+  },
+}))
+
+vi.mock("../_components/maintenance-mobile-tasks-panel", () => ({
+  MaintenanceMobileTasksPanel: () => <div data-testid="mobile-tasks-panel" />,
+}))
+
+import { MobileMaintenanceLayout } from "../_components/mobile-maintenance-layout"
+
+function renderMobileLayout() {
+  return render(
+    <MobileMaintenanceLayout
+      statusCounts={{ "Bản nháp": 1 }}
+      isCountsLoading={false}
+      isCountsError={false}
+      plans={[]}
+      isLoadingPlans={false}
+      planSearchTerm=""
+      setPlanSearchTerm={vi.fn()}
+      onClearSearch={vi.fn()}
+      totalPages={1}
+      totalCount={0}
+      currentPage={1}
+      setCurrentPage={vi.fn()}
+      showFacilityFilter={false}
+      facilities={[]}
+      selectedFacilityId={null}
+      isLoadingFacilities={false}
+      isMobileFilterSheetOpen={false}
+      setIsMobileFilterSheetOpen={vi.fn()}
+      pendingFacilityFilter={null}
+      setPendingFacilityFilter={vi.fn()}
+      handleMobileFilterApply={vi.fn()}
+      handleMobileFilterClear={vi.fn()}
+      activeMobileFilterCount={0}
+      expandedTaskIds={{}}
+      toggleTaskExpansion={vi.fn()}
+    />,
+  )
+}
+
+describe("MobileMaintenanceLayout create-plan entry points", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.context.user.role = "global"
+    mocks.context.canManagePlans = true
+    mocks.context.activeTab = "plans"
+    mocks.lastPlanCardsProps = null
+  })
+
+  it("hides create-plan controls for global/admin users", () => {
+    renderMobileLayout()
+
+    expect(screen.queryByRole("button", { name: "Tạo kế hoạch mới" })).not.toBeInTheDocument()
+    expect(mocks.lastPlanCardsProps?.canCreatePlans).toBe(false)
+  })
+
+  it("keeps create-plan controls available for non-global maintenance managers", () => {
+    mocks.context.user.role = "to_qltb"
+
+    renderMobileLayout()
+
+    expect(screen.getByRole("button", { name: "Tạo kế hoạch mới" })).toBeInTheDocument()
+    expect(mocks.lastPlanCardsProps?.canCreatePlans).toBe(true)
+  })
+})

--- a/src/app/(app)/maintenance/__tests__/use-maintenance-deep-link.create.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/use-maintenance-deep-link.create.test.tsx
@@ -1,0 +1,68 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  replace: vi.fn(),
+  searchParamsKey: "action=create",
+}))
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({
+    toString: () => mocks.searchParamsKey,
+  }),
+  useRouter: () => ({
+    replace: mocks.replace,
+  }),
+  usePathname: () => "/maintenance",
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}))
+
+import { useMaintenanceDeepLink } from "../_hooks/use-maintenance-deep-link"
+
+describe("useMaintenanceDeepLink create action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.searchParamsKey = "action=create"
+  })
+
+  it("does not open the create-plan dialog when create is not allowed", async () => {
+    const setIsAddPlanDialogOpen = vi.fn()
+
+    renderHook(() =>
+      useMaintenanceDeepLink({
+        plans: [],
+        isLoadingPlans: false,
+        setIsAddPlanDialogOpen,
+        canCreatePlans: false,
+        setSelectedPlan: vi.fn(),
+        setActiveTab: vi.fn(),
+      })
+    )
+
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith("/maintenance", { scroll: false }))
+    expect(setIsAddPlanDialogOpen).not.toHaveBeenCalled()
+  })
+
+  it("opens the create-plan dialog when create is allowed", async () => {
+    const setIsAddPlanDialogOpen = vi.fn()
+
+    renderHook(() =>
+      useMaintenanceDeepLink({
+        plans: [],
+        isLoadingPlans: false,
+        setIsAddPlanDialogOpen,
+        canCreatePlans: true,
+        setSelectedPlan: vi.fn(),
+        setActiveTab: vi.fn(),
+      })
+    )
+
+    await waitFor(() => expect(setIsAddPlanDialogOpen).toHaveBeenCalledWith(true))
+    expect(mocks.replace).toHaveBeenCalledWith("/maintenance", { scroll: false })
+  })
+})

--- a/src/app/(app)/maintenance/__tests__/use-maintenance-deep-link.create.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/use-maintenance-deep-link.create.test.tsx
@@ -39,6 +39,7 @@ describe("useMaintenanceDeepLink create action", () => {
         isLoadingPlans: false,
         setIsAddPlanDialogOpen,
         canCreatePlans: false,
+        isCreatePermissionLoading: false,
         setSelectedPlan: vi.fn(),
         setActiveTab: vi.fn(),
       })
@@ -57,10 +58,39 @@ describe("useMaintenanceDeepLink create action", () => {
         isLoadingPlans: false,
         setIsAddPlanDialogOpen,
         canCreatePlans: true,
+        isCreatePermissionLoading: false,
         setSelectedPlan: vi.fn(),
         setActiveTab: vi.fn(),
       })
     )
+
+    await waitFor(() => expect(setIsAddPlanDialogOpen).toHaveBeenCalledWith(true))
+    expect(mocks.replace).toHaveBeenCalledWith("/maintenance", { scroll: false })
+  })
+
+  it("waits to consume the create action while create permission is loading", async () => {
+    const setIsAddPlanDialogOpen = vi.fn()
+    let isCreatePermissionLoading = true
+    let canCreatePlans = false
+
+    const { rerender } = renderHook(() =>
+      useMaintenanceDeepLink({
+        plans: [],
+        isLoadingPlans: false,
+        setIsAddPlanDialogOpen,
+        canCreatePlans,
+        isCreatePermissionLoading,
+        setSelectedPlan: vi.fn(),
+        setActiveTab: vi.fn(),
+      })
+    )
+
+    expect(setIsAddPlanDialogOpen).not.toHaveBeenCalled()
+    expect(mocks.replace).not.toHaveBeenCalled()
+
+    isCreatePermissionLoading = false
+    canCreatePlans = true
+    rerender()
 
     await waitFor(() => expect(setIsAddPlanDialogOpen).toHaveBeenCalledWith(true))
     expect(mocks.replace).toHaveBeenCalledWith("/maintenance", { scroll: false })

--- a/src/app/(app)/maintenance/_components/MaintenanceContext.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenanceContext.tsx
@@ -5,7 +5,7 @@ import type { RowSelectionState } from "@tanstack/react-table"
 import { useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
 import { useToast } from "@/hooks/use-toast"
-import { isEquipmentManagerRole, isRegionalLeaderRole } from "@/lib/rbac"
+import { isEquipmentManagerRole, isGlobalRole, isRegionalLeaderRole } from "@/lib/rbac"
 import type { MaintenancePlan } from "@/hooks/use-cached-maintenance"
 import { useMaintenanceOperations } from "../_hooks/use-maintenance-operations"
 import { useMaintenancePrint } from "../_hooks/use-maintenance-print"
@@ -35,11 +35,13 @@ export function MaintenanceProvider({
 }: MaintenanceProviderProps) {
   const { toast } = useToast()
   const queryClient = useQueryClient()
-  const { data: session } = useSession()
+  const { data: session, status: sessionStatus } = useSession()
   const user: AuthUser | null = session?.user ?? null
 
+  const isAuthLoading = sessionStatus === "loading"
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
   const canManagePlans = isEquipmentManagerRole(user?.role)
+  const canCreatePlans = canManagePlans && !isGlobalRole(user?.role) && !isRegionalLeader
   const canCompleteTask = !isRegionalLeader && isEquipmentManagerRole(user?.role)
 
   const [selectedPlan, setSelectedPlan] = React.useState<MaintenancePlan | null>(null)
@@ -220,8 +222,10 @@ export function MaintenanceProvider({
   const value: MaintenanceContextValue = React.useMemo(
     () => ({
       user,
+      isAuthLoading,
       isRegionalLeader,
       canManagePlans,
+      canCreatePlans,
       canCompleteTask,
 
       selectedPlan,
@@ -275,8 +279,10 @@ export function MaintenanceProvider({
     }),
     [
       user,
+      isAuthLoading,
       isRegionalLeader,
       canManagePlans,
+      canCreatePlans,
       canCompleteTask,
       selectedPlan,
       activeTab,

--- a/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
@@ -81,6 +81,7 @@ export function MaintenancePageClient() {
   const totalCount = paginatedResponse?.total ?? 0
   const totalPages = Math.ceil(totalCount / pageSize)
   const showFacilityFilter = isGlobalRole(ctx.user?.role) || isRegionalLeaderRole(ctx.user?.role)
+  const canCreatePlans = ctx.canManagePlans && !isGlobalRole(ctx.user?.role)
 
   const {
     data: facilities = [],
@@ -122,6 +123,7 @@ export function MaintenancePageClient() {
     plans,
     isLoadingPlans,
     setIsAddPlanDialogOpen,
+    canCreatePlans,
     setSelectedPlan,
     setActiveTab,
   })

--- a/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
@@ -81,7 +81,6 @@ export function MaintenancePageClient() {
   const totalCount = paginatedResponse?.total ?? 0
   const totalPages = Math.ceil(totalCount / pageSize)
   const showFacilityFilter = isGlobalRole(ctx.user?.role) || isRegionalLeaderRole(ctx.user?.role)
-  const canCreatePlans = ctx.canManagePlans && !isGlobalRole(ctx.user?.role)
 
   const {
     data: facilities = [],
@@ -123,7 +122,8 @@ export function MaintenancePageClient() {
     plans,
     isLoadingPlans,
     setIsAddPlanDialogOpen,
-    canCreatePlans,
+    canCreatePlans: ctx.canCreatePlans,
+    isCreatePermissionLoading: ctx.isAuthLoading,
     setSelectedPlan,
     setActiveTab,
   })

--- a/src/app/(app)/maintenance/_components/maintenance-context.types.ts
+++ b/src/app/(app)/maintenance/_components/maintenance-context.types.ts
@@ -23,8 +23,10 @@ export interface CompletionStatusEntry {
 
 export interface MaintenanceContextValue {
   user: AuthUser | null
+  isAuthLoading: boolean
   isRegionalLeader: boolean
   canManagePlans: boolean
+  canCreatePlans: boolean
   canCompleteTask: boolean
 
   selectedPlan: MaintenancePlan | null

--- a/src/app/(app)/maintenance/_components/maintenance-mobile-plan-cards.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-mobile-plan-cards.tsx
@@ -24,6 +24,7 @@ interface MaintenanceMobilePlanCardsProps {
   isLoadingPlans: boolean
   showFacilityFilter: boolean
   canManagePlans: boolean
+  canCreatePlans: boolean
   onOpenAddPlanDialog: () => void
   onSelectPlan: (plan: MaintenancePlan) => void
   onSetTasksTab: () => void
@@ -38,6 +39,7 @@ export function MaintenanceMobilePlanCards({
   isLoadingPlans,
   showFacilityFilter,
   canManagePlans,
+  canCreatePlans,
   onOpenAddPlanDialog,
   onSelectPlan,
   onSetTasksTab,
@@ -79,7 +81,7 @@ export function MaintenanceMobilePlanCards({
               Hãy tạo kế hoạch mới hoặc điều chỉnh bộ lọc để xem dữ liệu phù hợp.
             </p>
           </div>
-          {canManagePlans && (
+          {canCreatePlans && (
             <Button onClick={onOpenAddPlanDialog} className="h-11 px-6">
               <PlusCircle className="mr-2 h-4 w-4" />
               Tạo kế hoạch mới

--- a/src/app/(app)/maintenance/_components/maintenance-page-desktop-content.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-page-desktop-content.tsx
@@ -16,7 +16,6 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { isGlobalRole } from "@/lib/rbac"
 
 import { PlanFiltersBar } from "./plan-filters-bar"
 import { PlansTable } from "./plans-table"
@@ -87,7 +86,6 @@ export function MaintenancePageDesktopContent({
 }: MaintenancePageDesktopContentProps) {
   const ctx = useMaintenanceContext()
   const editingTaskId = ctx.taskEditing.editingTaskId
-  const canCreatePlans = ctx.canManagePlans && !isGlobalRole(ctx.user?.role)
 
   return (
     <div className="space-y-6">
@@ -117,7 +115,7 @@ export function MaintenancePageDesktopContent({
                   Quản lý các kế hoạch bảo trì, hiệu chuẩn, kiểm định. Nhấp vào một hàng để xem chi tiết.
                 </CardDescription>
               </div>
-              {canCreatePlans && (
+              {ctx.canCreatePlans && (
                 <Button size="sm" className="h-8 gap-1 ml-auto" onClick={() => ctx.setIsAddPlanDialogOpen(true)}>
                   <PlusCircle className="h-3.5 w-3.5" />
                   <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">Tạo kế hoạch mới</span>

--- a/src/app/(app)/maintenance/_components/maintenance-page-desktop-content.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-page-desktop-content.tsx
@@ -16,6 +16,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { isGlobalRole } from "@/lib/rbac"
 
 import { PlanFiltersBar } from "./plan-filters-bar"
 import { PlansTable } from "./plans-table"
@@ -86,6 +87,7 @@ export function MaintenancePageDesktopContent({
 }: MaintenancePageDesktopContentProps) {
   const ctx = useMaintenanceContext()
   const editingTaskId = ctx.taskEditing.editingTaskId
+  const canCreatePlans = ctx.canManagePlans && !isGlobalRole(ctx.user?.role)
 
   return (
     <div className="space-y-6">
@@ -115,7 +117,7 @@ export function MaintenancePageDesktopContent({
                   Quản lý các kế hoạch bảo trì, hiệu chuẩn, kiểm định. Nhấp vào một hàng để xem chi tiết.
                 </CardDescription>
               </div>
-              {ctx.canManagePlans && (
+              {canCreatePlans && (
                 <Button size="sm" className="h-8 gap-1 ml-auto" onClick={() => ctx.setIsAddPlanDialogOpen(true)}>
                   <PlusCircle className="h-3.5 w-3.5" />
                   <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">Tạo kế hoạch mới</span>

--- a/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
+++ b/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
@@ -17,6 +17,7 @@ import { MAINTENANCE_STATUS_CONFIGS } from "@/components/kpi/configs/maintenance
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
+import { isGlobalRole } from "@/lib/rbac"
 import {
   Sheet,
   SheetClose,
@@ -88,6 +89,7 @@ export function MobileMaintenanceLayout({
   toggleTaskExpansion,
 }: MobileMaintenanceLayoutProps) {
   const ctx = useMaintenanceContext()
+  const canCreatePlans = ctx.canManagePlans && !isGlobalRole(ctx.user?.role)
 
   const months = React.useMemo(() => Array.from({ length: 12 }, (_, index) => index + 1), [])
   const planTabActive = ctx.activeTab === "plans"
@@ -236,6 +238,7 @@ export function MobileMaintenanceLayout({
               isLoadingPlans={isLoadingPlans}
               showFacilityFilter={showFacilityFilter}
               canManagePlans={ctx.canManagePlans}
+              canCreatePlans={canCreatePlans}
               onOpenAddPlanDialog={() => ctx.setIsAddPlanDialogOpen(true)}
               onSelectPlan={ctx.handleSelectPlan}
               onSetTasksTab={() => ctx.setActiveTab("tasks")}
@@ -270,7 +273,7 @@ export function MobileMaintenanceLayout({
         </div>
       </main>
 
-      {ctx.canManagePlans && !ctx.isRegionalLeader && (
+      {canCreatePlans && !ctx.isRegionalLeader && (
         <Button
           onClick={() => ctx.setIsAddPlanDialogOpen(true)}
           className="fixed right-4 z-50 h-14 w-14 rounded-full shadow-xl transition-transform active:scale-95"

--- a/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
+++ b/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
@@ -17,7 +17,6 @@ import { MAINTENANCE_STATUS_CONFIGS } from "@/components/kpi/configs/maintenance
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
-import { isGlobalRole } from "@/lib/rbac"
 import {
   Sheet,
   SheetClose,
@@ -89,7 +88,6 @@ export function MobileMaintenanceLayout({
   toggleTaskExpansion,
 }: MobileMaintenanceLayoutProps) {
   const ctx = useMaintenanceContext()
-  const canCreatePlans = ctx.canManagePlans && !isGlobalRole(ctx.user?.role)
 
   const months = React.useMemo(() => Array.from({ length: 12 }, (_, index) => index + 1), [])
   const planTabActive = ctx.activeTab === "plans"
@@ -238,7 +236,7 @@ export function MobileMaintenanceLayout({
               isLoadingPlans={isLoadingPlans}
               showFacilityFilter={showFacilityFilter}
               canManagePlans={ctx.canManagePlans}
-              canCreatePlans={canCreatePlans}
+              canCreatePlans={ctx.canCreatePlans}
               onOpenAddPlanDialog={() => ctx.setIsAddPlanDialogOpen(true)}
               onSelectPlan={ctx.handleSelectPlan}
               onSetTasksTab={() => ctx.setActiveTab("tasks")}
@@ -273,7 +271,7 @@ export function MobileMaintenanceLayout({
         </div>
       </main>
 
-      {canCreatePlans && !ctx.isRegionalLeader && (
+      {ctx.canCreatePlans && (
         <Button
           onClick={() => ctx.setIsAddPlanDialogOpen(true)}
           className="fixed right-4 z-50 h-14 w-14 rounded-full shadow-xl transition-transform active:scale-95"

--- a/src/app/(app)/maintenance/_hooks/use-maintenance-deep-link.ts
+++ b/src/app/(app)/maintenance/_hooks/use-maintenance-deep-link.ts
@@ -13,6 +13,8 @@ interface UseMaintenanceDeepLinkOptions {
   setIsAddPlanDialogOpen: (open: boolean) => void
   /** Whether the current user may open tenant plan creation */
   canCreatePlans: boolean
+  /** Whether create permission is still waiting on session state */
+  isCreatePermissionLoading: boolean
   /** Select a plan (navigates context to that plan) */
   setSelectedPlan: (plan: MaintenancePlan) => void
   /** Switch the active tab */
@@ -35,6 +37,7 @@ export function useMaintenanceDeepLink({
   isLoadingPlans,
   setIsAddPlanDialogOpen,
   canCreatePlans,
+  isCreatePermissionLoading,
   setSelectedPlan,
   setActiveTab,
 }: UseMaintenanceDeepLinkOptions) {
@@ -59,6 +62,9 @@ export function useMaintenanceDeepLink({
       const actionParam = params.get("action")
 
       if (actionParam === "create") {
+        if (isCreatePermissionLoading) {
+          return
+        }
         lastHandledKeyRef.current = searchParamsKey
         if (canCreatePlans) {
           setIsAddPlanDialogOpen(true)
@@ -128,6 +134,7 @@ export function useMaintenanceDeepLink({
     isLoadingPlans,
     setIsAddPlanDialogOpen,
     canCreatePlans,
+    isCreatePermissionLoading,
     setSelectedPlan,
     setActiveTab,
     toast,

--- a/src/app/(app)/maintenance/_hooks/use-maintenance-deep-link.ts
+++ b/src/app/(app)/maintenance/_hooks/use-maintenance-deep-link.ts
@@ -11,6 +11,8 @@ interface UseMaintenanceDeepLinkOptions {
   isLoadingPlans: boolean
   /** Open the "create plan" dialog */
   setIsAddPlanDialogOpen: (open: boolean) => void
+  /** Whether the current user may open tenant plan creation */
+  canCreatePlans: boolean
   /** Select a plan (navigates context to that plan) */
   setSelectedPlan: (plan: MaintenancePlan) => void
   /** Switch the active tab */
@@ -32,6 +34,7 @@ export function useMaintenanceDeepLink({
   plans,
   isLoadingPlans,
   setIsAddPlanDialogOpen,
+  canCreatePlans,
   setSelectedPlan,
   setActiveTab,
 }: UseMaintenanceDeepLinkOptions) {
@@ -57,7 +60,9 @@ export function useMaintenanceDeepLink({
 
       if (actionParam === "create") {
         lastHandledKeyRef.current = searchParamsKey
-        setIsAddPlanDialogOpen(true)
+        if (canCreatePlans) {
+          setIsAddPlanDialogOpen(true)
+        }
         router.replace(pathname, { scroll: false })
         return
       }
@@ -122,6 +127,7 @@ export function useMaintenanceDeepLink({
     plans,
     isLoadingPlans,
     setIsAddPlanDialogOpen,
+    canCreatePlans,
     setSelectedPlan,
     setActiveTab,
     toast,

--- a/supabase/migrations/20260424132000_block_global_maintenance_plan_create.sql
+++ b/supabase/migrations/20260424132000_block_global_maintenance_plan_create.sql
@@ -1,5 +1,7 @@
 -- 20260424132000_block_global_maintenance_plan_create.sql
 -- Purpose: Block global/admin users from creating tenantless maintenance plans.
+-- Rollback: restore the previous RPC body from
+-- supabase/migrations/20260424120000_enforce_maintenance_write_role_guards.sql.
 
 BEGIN;
 

--- a/supabase/migrations/20260424132000_block_global_maintenance_plan_create.sql
+++ b/supabase/migrations/20260424132000_block_global_maintenance_plan_create.sql
@@ -1,0 +1,56 @@
+-- 20260424132000_block_global_maintenance_plan_create.sql
+-- Purpose: Block global/admin users from creating tenantless maintenance plans.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.maintenance_plan_create(
+  p_ten_ke_hoach text,
+  p_nam integer,
+  p_loai_cong_viec text,
+  p_khoa_phong text,
+  p_nguoi_lap_ke_hoach text
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_new_id integer;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  IF v_guard.is_global THEN
+    RAISE EXCEPTION 'global/admin cannot create tenant maintenance plans' USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.ke_hoach_bao_tri(
+    ten_ke_hoach,
+    nam,
+    loai_cong_viec,
+    khoa_phong,
+    nguoi_lap_ke_hoach,
+    trang_thai,
+    don_vi
+  )
+  VALUES (
+    p_ten_ke_hoach,
+    p_nam,
+    p_loai_cong_viec,
+    NULLIF(p_khoa_phong, ''),
+    p_nguoi_lap_ke_hoach,
+    'Bản nháp',
+    v_guard.default_don_vi
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN v_new_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.maintenance_plan_create(text, integer, text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.maintenance_plan_create(text, integer, text, text, text) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/tests/maintenance_write_role_guards_smoke.sql
+++ b/supabase/tests/maintenance_write_role_guards_smoke.sql
@@ -13,8 +13,6 @@ DECLARE
   v_user_id bigint;
   v_plan_id bigint;
   v_other_plan_id bigint;
-  v_admin_plan_id bigint;
-  v_admin_plan_don_vi bigint;
   v_task_id bigint;
   v_other_task_id bigint;
   v_other_equipment_id bigint;
@@ -190,48 +188,37 @@ BEGIN
     RAISE EXCEPTION 'Expected to_qltb maintenance_tasks_delete to remove allowed task';
   END IF;
 
-  PERFORM set_config(
-    'request.jwt.claims',
-    json_build_object(
-      'app_role', 'admin',
-      'role', 'authenticated',
-      'user_id', v_user_id::text,
-      'sub', v_user_id::text
-    )::text,
-    true
-  );
+  FOREACH v_denied_role IN ARRAY ARRAY['admin', 'global'] LOOP
+    PERFORM set_config(
+      'request.jwt.claims',
+      json_build_object(
+        'app_role', v_denied_role,
+        'role', 'authenticated',
+        'user_id', v_user_id::text,
+        'sub', v_user_id::text
+      )::text,
+      true
+    );
 
-  v_admin_plan_id := public.maintenance_plan_create(
-    'Smoke Maintenance Admin Plan ' || v_suffix,
-    EXTRACT(YEAR FROM current_date)::integer,
-    'kiem_tra',
-    'Smoke Admin Department',
-    'Maintenance Write Smoke Admin'
-  );
-
-  IF v_admin_plan_id IS NULL THEN
-    RAISE EXCEPTION 'Expected admin maintenance_plan_create without don_vi claim to remain allowed';
-  END IF;
-
-  SELECT don_vi
-  INTO v_admin_plan_don_vi
-  FROM public.ke_hoach_bao_tri
-  WHERE id = v_admin_plan_id;
-
-  IF v_admin_plan_don_vi IS NOT NULL THEN
-    RAISE EXCEPTION 'Expected admin-created plan without don_vi claim to persist NULL don_vi, got %', v_admin_plan_don_vi;
-  END IF;
-
-  PERFORM public.maintenance_plan_delete(v_admin_plan_id);
-
-  SELECT count(*)
-  INTO v_count
-  FROM public.ke_hoach_bao_tri
-  WHERE id = v_admin_plan_id;
-
-  IF v_count <> 0 THEN
-    RAISE EXCEPTION 'Expected admin maintenance_plan_delete to remove admin-created plan';
-  END IF;
+    v_failed := false;
+    BEGIN
+      PERFORM public.maintenance_plan_create(
+        'Smoke global denied plan ' || v_denied_role || ' ' || v_suffix,
+        EXTRACT(YEAR FROM current_date)::integer,
+        'kiem_tra',
+        'Smoke Global Denied Department',
+        'Maintenance Write Smoke Global'
+      );
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := true;
+      IF SQLSTATE IS DISTINCT FROM '42501' THEN
+        RAISE EXCEPTION 'Expected maintenance_plan_create for % to deny with 42501, got %', v_denied_role, SQLSTATE;
+      END IF;
+    END;
+    IF NOT v_failed THEN
+      RAISE EXCEPTION 'Expected maintenance_plan_create for % to deny with 42501', v_denied_role;
+    END IF;
+  END LOOP;
 
   FOREACH v_denied_role IN ARRAY ARRAY['user', 'regional_leader'] LOOP
     PERFORM set_config(


### PR DESCRIPTION
## Summary
- Add a forward-only Supabase migration that keeps `maintenance_plan_create(text, integer, text, text, text)` signature unchanged but rejects global/admin with SQLSTATE 42501.
- Hide maintenance create-plan entry points for global/admin users on desktop, mobile, and `action=create` deep links.
- Update smoke/UI coverage for global/admin denial and non-global manager access.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/app/(app)/maintenance/__tests__/MaintenancePageDesktopContent.test.tsx src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx src/app/(app)/maintenance/__tests__/use-maintenance-deep-link.create.test.tsx src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Notes
- Per request, the Supabase migration was not applied in this session. Supabase smoke SQL should be run after migration application.
- React Doctor exits 0 with one existing size warning for `MobileMaintenanceLayout`.

Fixes #319
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block global/admin users from creating maintenance plans and hide all create entry points (desktop, mobile, and deep links). Adds a forward‑only Supabase migration enforcing the rule. Closes #319.

- **Bug Fixes**
  - DB: `public.maintenance_plan_create(text, integer, text, text, text)` now denies global/admin with SQLSTATE 42501 (signature unchanged).
  - UI: Hide “Tạo kế hoạch mới” for global/admin on desktop and mobile; floating action button respects the same rule.
  - Deep links: `action=create` waits for auth/permission to load, opens only when allowed, and always cleans the URL.
  - Tests: Added/updated desktop, mobile, deep‑link tests; smoke SQL asserts 42501 for `admin` and `global`.

- **Migration**
  - Apply the new Supabase migration and reload schema.
  - Run the maintenance write role smoke tests to verify denial behavior.

<sup>Written for commit ed85c86539f671c24b6bff02c77f481de2f0b1bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Implemented role-based access control for maintenance plan creation. The "Create new plan" button is now restricted to non-global maintenance managers and hidden from admin and global users.

* **Improvements**
  * Enhanced permission handling with fine-grained plan creation permissions. Access controls are now enforced consistently across the application and database layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
