### PR TITLE
Fix maintenance audit logging and missing-task update errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,14 @@ QUERY REVIEW CHECKLIST
 
 ## SQL Migration Safety Rules (MANDATORY)
 
+### Migration Source Order
+
+Before creating, renaming, or applying a Supabase migration, compare the new filename timestamp against all existing local migrations that touch the same tables, functions, triggers, policies, or grants. The local migration filename order is the source of truth for fresh DB/reset behavior.
+
+- A migration that `CREATE OR REPLACE`s an existing function MUST sort after the latest local migration that also redefines that function.
+- Do not name a local migration only to match a Supabase MCP-applied live version if that places it before existing local migrations that can overwrite it.
+- If a bad-order migration has already been applied via MCP, fix the repo by adding/renaming to a correctly ordered local migration and apply a new idempotent superseding migration. Do not keep the bad-order local file and do not manually edit `supabase_migrations.schema_migrations` unless the team explicitly approves a metadata repair.
+
 ### LIKE/ILIKE Sanitization
 
 **NEVER concatenate user input directly into LIKE/ILIKE patterns.** Always use `_sanitize_ilike_pattern()`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,6 +489,14 @@ QUERY REVIEW CHECKLIST
 
 ## SQL Migration Safety Rules (MANDATORY)
 
+### Migration Source Order
+
+Before creating, renaming, or applying a Supabase migration, compare the new filename timestamp against all existing local migrations that touch the same tables, functions, triggers, policies, or grants. The local migration filename order is the source of truth for fresh DB/reset behavior.
+
+- A migration that `CREATE OR REPLACE`s an existing function MUST sort after the latest local migration that also redefines that function.
+- Do not name a local migration only to match a Supabase MCP-applied live version if that places it before existing local migrations that can overwrite it.
+- If a bad-order migration has already been applied via MCP, fix the repo by adding/renaming to a correctly ordered local migration and apply a new idempotent superseding migration. Do not keep the bad-order local file and do not manually edit `supabase_migrations.schema_migrations` unless the team explicitly approves a metadata repair.
+
 ### LIKE/ILIKE Sanitization
 
 **NEVER concatenate user input directly into LIKE/ILIKE patterns.** Always use `_sanitize_ilike_pattern()`:

--- a/supabase/migrations/20260424143000_maintenance_audit_notfound.sql
+++ b/supabase/migrations/20260424143000_maintenance_audit_notfound.sql
@@ -1,0 +1,176 @@
+-- 20260424143000_maintenance_audit_notfound.sql
+-- Purpose:
+-- - Restore audit logging for maintenance_plan_create.
+-- - Make maintenance_task_update fail with P0002 when the target task is missing.
+-- Rollback: restore function bodies from
+-- supabase/migrations/20260424132000_block_global_maintenance_plan_create.sql and
+-- supabase/migrations/20260424120000_enforce_maintenance_write_role_guards.sql.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.maintenance_plan_create(
+  p_ten_ke_hoach text,
+  p_nam integer,
+  p_loai_cong_viec text,
+  p_khoa_phong text,
+  p_nguoi_lap_ke_hoach text
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_new_id integer;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  IF v_guard.is_global THEN
+    RAISE EXCEPTION 'global/admin cannot create tenant maintenance plans' USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.ke_hoach_bao_tri(
+    ten_ke_hoach,
+    nam,
+    loai_cong_viec,
+    khoa_phong,
+    nguoi_lap_ke_hoach,
+    trang_thai,
+    don_vi
+  )
+  VALUES (
+    p_ten_ke_hoach,
+    p_nam,
+    p_loai_cong_viec,
+    NULLIF(p_khoa_phong, ''),
+    p_nguoi_lap_ke_hoach,
+    'Bản nháp',
+    v_guard.default_don_vi
+  )
+  RETURNING id INTO v_new_id;
+
+  IF NOT public.audit_log(
+    'maintenance_plan_create',
+    'maintenance_plan',
+    v_new_id,
+    p_ten_ke_hoach,
+    jsonb_build_object(
+      'nam', p_nam,
+      'loai_cong_viec', p_loai_cong_viec,
+      'khoa_phong', NULLIF(p_khoa_phong, '')
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for maintenance_plan %', v_new_id;
+  END IF;
+
+  RETURN v_new_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_task_update(p_id bigint, p_task jsonb)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_guard record;
+  v_task public.cong_viec_bao_tri;
+  v_plan_don_vi bigint;
+  v_new_plan_don_vi bigint;
+  v_new_equipment_don_vi bigint;
+BEGIN
+  SELECT * INTO v_guard FROM public._assert_maintenance_write_allowed();
+
+  SELECT *
+  INTO v_task
+  FROM public.cong_viec_bao_tri
+  WHERE id = p_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Công việc bảo trì không tồn tại' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT don_vi
+  INTO v_plan_don_vi
+  FROM public.ke_hoach_bao_tri
+  WHERE id = v_task.ke_hoach_id
+  FOR UPDATE;
+
+  IF NOT v_guard.is_global AND (v_plan_don_vi IS NULL OR NOT v_plan_don_vi = ANY(v_guard.allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Không có quyền cập nhật công việc bảo trì thuộc đơn vị khác' USING ERRCODE = '42501';
+  END IF;
+
+  IF NULLIF(p_task->>'ke_hoach_id', '') IS NOT NULL THEN
+    SELECT don_vi
+    INTO v_new_plan_don_vi
+    FROM public.ke_hoach_bao_tri
+    WHERE id = NULLIF(p_task->>'ke_hoach_id', '')::bigint
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Kế hoạch bảo trì không tồn tại' USING ERRCODE = 'P0002';
+    END IF;
+
+    IF NOT v_guard.is_global AND (v_new_plan_don_vi IS NULL OR NOT v_new_plan_don_vi = ANY(v_guard.allowed_don_vi)) THEN
+      RAISE EXCEPTION 'Không có quyền chuyển công việc bảo trì sang kế hoạch thuộc đơn vị khác' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF NULLIF(p_task->>'thiet_bi_id', '') IS NOT NULL THEN
+    SELECT don_vi
+    INTO v_new_equipment_don_vi
+    FROM public.thiet_bi
+    WHERE id = NULLIF(p_task->>'thiet_bi_id', '')::bigint
+      AND is_deleted = false
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Thiết bị không tồn tại' USING ERRCODE = 'P0002';
+    END IF;
+
+    IF NOT v_guard.is_global AND (v_new_equipment_don_vi IS NULL OR NOT v_new_equipment_don_vi = ANY(v_guard.allowed_don_vi)) THEN
+      RAISE EXCEPTION 'Không có quyền gán công việc bảo trì cho thiết bị thuộc đơn vị khác' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  UPDATE public.cong_viec_bao_tri
+  SET ke_hoach_id = COALESCE(NULLIF(p_task->>'ke_hoach_id', '')::bigint, ke_hoach_id),
+      thiet_bi_id = COALESCE(NULLIF(p_task->>'thiet_bi_id', '')::bigint, thiet_bi_id),
+      loai_cong_viec = COALESCE(p_task->>'loai_cong_viec', loai_cong_viec),
+      diem_hieu_chuan = COALESCE(p_task->>'diem_hieu_chuan', diem_hieu_chuan),
+      don_vi_thuc_hien = COALESCE(p_task->>'don_vi_thuc_hien', don_vi_thuc_hien),
+      thang_1 = COALESCE((p_task->>'thang_1')::boolean, thang_1), thang_2 = COALESCE((p_task->>'thang_2')::boolean, thang_2),
+      thang_3 = COALESCE((p_task->>'thang_3')::boolean, thang_3), thang_4 = COALESCE((p_task->>'thang_4')::boolean, thang_4),
+      thang_5 = COALESCE((p_task->>'thang_5')::boolean, thang_5), thang_6 = COALESCE((p_task->>'thang_6')::boolean, thang_6),
+      thang_7 = COALESCE((p_task->>'thang_7')::boolean, thang_7), thang_8 = COALESCE((p_task->>'thang_8')::boolean, thang_8),
+      thang_9 = COALESCE((p_task->>'thang_9')::boolean, thang_9), thang_10 = COALESCE((p_task->>'thang_10')::boolean, thang_10),
+      thang_11 = COALESCE((p_task->>'thang_11')::boolean, thang_11), thang_12 = COALESCE((p_task->>'thang_12')::boolean, thang_12),
+      thang_1_hoan_thanh = COALESCE((p_task->>'thang_1_hoan_thanh')::boolean, thang_1_hoan_thanh), thang_2_hoan_thanh = COALESCE((p_task->>'thang_2_hoan_thanh')::boolean, thang_2_hoan_thanh),
+      thang_3_hoan_thanh = COALESCE((p_task->>'thang_3_hoan_thanh')::boolean, thang_3_hoan_thanh), thang_4_hoan_thanh = COALESCE((p_task->>'thang_4_hoan_thanh')::boolean, thang_4_hoan_thanh),
+      thang_5_hoan_thanh = COALESCE((p_task->>'thang_5_hoan_thanh')::boolean, thang_5_hoan_thanh), thang_6_hoan_thanh = COALESCE((p_task->>'thang_6_hoan_thanh')::boolean, thang_6_hoan_thanh),
+      thang_7_hoan_thanh = COALESCE((p_task->>'thang_7_hoan_thanh')::boolean, thang_7_hoan_thanh), thang_8_hoan_thanh = COALESCE((p_task->>'thang_8_hoan_thanh')::boolean, thang_8_hoan_thanh),
+      thang_9_hoan_thanh = COALESCE((p_task->>'thang_9_hoan_thanh')::boolean, thang_9_hoan_thanh), thang_10_hoan_thanh = COALESCE((p_task->>'thang_10_hoan_thanh')::boolean, thang_10_hoan_thanh),
+      thang_11_hoan_thanh = COALESCE((p_task->>'thang_11_hoan_thanh')::boolean, thang_11_hoan_thanh), thang_12_hoan_thanh = COALESCE((p_task->>'thang_12_hoan_thanh')::boolean, thang_12_hoan_thanh),
+      ngay_hoan_thanh_1 = COALESCE((p_task->>'ngay_hoan_thanh_1')::timestamptz, ngay_hoan_thanh_1), ngay_hoan_thanh_2 = COALESCE((p_task->>'ngay_hoan_thanh_2')::timestamptz, ngay_hoan_thanh_2),
+      ngay_hoan_thanh_3 = COALESCE((p_task->>'ngay_hoan_thanh_3')::timestamptz, ngay_hoan_thanh_3), ngay_hoan_thanh_4 = COALESCE((p_task->>'ngay_hoan_thanh_4')::timestamptz, ngay_hoan_thanh_4),
+      ngay_hoan_thanh_5 = COALESCE((p_task->>'ngay_hoan_thanh_5')::timestamptz, ngay_hoan_thanh_5), ngay_hoan_thanh_6 = COALESCE((p_task->>'ngay_hoan_thanh_6')::timestamptz, ngay_hoan_thanh_6),
+      ngay_hoan_thanh_7 = COALESCE((p_task->>'ngay_hoan_thanh_7')::timestamptz, ngay_hoan_thanh_7), ngay_hoan_thanh_8 = COALESCE((p_task->>'ngay_hoan_thanh_8')::timestamptz, ngay_hoan_thanh_8),
+      ngay_hoan_thanh_9 = COALESCE((p_task->>'ngay_hoan_thanh_9')::timestamptz, ngay_hoan_thanh_9), ngay_hoan_thanh_10 = COALESCE((p_task->>'ngay_hoan_thanh_10')::timestamptz, ngay_hoan_thanh_10),
+      ngay_hoan_thanh_11 = COALESCE((p_task->>'ngay_hoan_thanh_11')::timestamptz, ngay_hoan_thanh_11), ngay_hoan_thanh_12 = COALESCE((p_task->>'ngay_hoan_thanh_12')::timestamptz, ngay_hoan_thanh_12),
+      ghi_chu = COALESCE(p_task->>'ghi_chu', ghi_chu),
+      updated_at = now()
+  WHERE id = p_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.maintenance_plan_create(text, integer, text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.maintenance_plan_create(text, integer, text, text, text) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.maintenance_task_update(bigint, jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.maintenance_task_update(bigint, jsonb) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/tests/maintenance_audit_notfound_smoke.sql
+++ b/supabase/tests/maintenance_audit_notfound_smoke.sql
@@ -1,0 +1,147 @@
+-- supabase/tests/maintenance_audit_notfound_smoke.sql
+-- Purpose: lock maintenance plan-create audit logging and missing-task update errors.
+-- Non-destructive: wrapped in a transaction and rolled back.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_region_id bigint;
+  v_tenant bigint;
+  v_user_id bigint;
+  v_missing_task_id bigint := -987654321;
+  v_failed boolean := false;
+  v_sqlstate text;
+BEGIN
+  INSERT INTO public.dia_ban(ma_dia_ban, ten_dia_ban, active)
+  VALUES ('SMK-MANF-' || v_suffix, 'Smoke Maintenance Audit NotFound Region ' || v_suffix, true)
+  RETURNING id INTO v_region_id;
+
+  INSERT INTO public.don_vi(code, name, active, dia_ban_id)
+  VALUES ('SMK-MANF-' || v_suffix, 'Smoke Maintenance Audit NotFound Tenant ' || v_suffix, true, v_region_id)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi, dia_ban_id)
+  VALUES (
+    'maintenance_audit_notfound_smoke_' || v_suffix,
+    'smoke-password',
+    'Maintenance Audit NotFound Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant,
+    v_region_id
+  )
+  RETURNING id INTO v_user_id;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text
+    )::text,
+    true
+  );
+
+  BEGIN
+    PERFORM public.maintenance_task_update(
+      v_missing_task_id,
+      jsonb_build_object('ghi_chu', 'Smoke missing task update ' || v_suffix)
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected maintenance_task_update missing task to raise P0002';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM 'P0002' THEN
+    RAISE EXCEPTION 'Expected maintenance_task_update missing task to raise P0002, got %', v_sqlstate;
+  END IF;
+
+  RAISE NOTICE 'OK: maintenance_task_update missing task raises P0002';
+END $$;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_region_id bigint;
+  v_tenant bigint;
+  v_user_id bigint;
+  v_plan_id bigint;
+  v_log public.audit_logs%ROWTYPE;
+BEGIN
+  INSERT INTO public.dia_ban(ma_dia_ban, ten_dia_ban, active)
+  VALUES ('SMK-MAA-' || v_suffix, 'Smoke Maintenance Audit Region ' || v_suffix, true)
+  RETURNING id INTO v_region_id;
+
+  INSERT INTO public.don_vi(code, name, active, dia_ban_id)
+  VALUES ('SMK-MAA-' || v_suffix, 'Smoke Maintenance Audit Tenant ' || v_suffix, true, v_region_id)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi, dia_ban_id)
+  VALUES (
+    'maintenance_audit_smoke_' || v_suffix,
+    'smoke-password',
+    'Maintenance Audit Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant,
+    v_region_id
+  )
+  RETURNING id INTO v_user_id;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant::text
+    )::text,
+    true
+  );
+
+  v_plan_id := public.maintenance_plan_create(
+    'Smoke Maintenance Audit Plan ' || v_suffix,
+    EXTRACT(YEAR FROM current_date)::integer,
+    'kiem_tra',
+    'Smoke Audit Department',
+    'Maintenance Audit Smoke'
+  );
+
+  SELECT al.*
+  INTO v_log
+  FROM public.audit_logs al
+  WHERE al.action_type = 'maintenance_plan_create'
+    AND al.entity_type = 'maintenance_plan'
+    AND al.entity_id = v_plan_id
+  ORDER BY al.id DESC
+  LIMIT 1;
+
+  IF v_log.id IS NULL THEN
+    RAISE EXCEPTION 'Expected maintenance_plan_create to write an audit_logs row';
+  END IF;
+
+  IF v_log.entity_label IS DISTINCT FROM 'Smoke Maintenance Audit Plan ' || v_suffix THEN
+    RAISE EXCEPTION 'Expected audit entity_label to match plan name, got %', v_log.entity_label;
+  END IF;
+
+  IF v_log.action_details->>'loai_cong_viec' IS DISTINCT FROM 'kiem_tra' THEN
+    RAISE EXCEPTION 'Expected audit action_details.loai_cong_viec to be kiem_tra, got %', v_log.action_details->>'loai_cong_viec';
+  END IF;
+
+  IF v_log.action_details->>'khoa_phong' IS DISTINCT FROM 'Smoke Audit Department' THEN
+    RAISE EXCEPTION 'Expected audit action_details.khoa_phong to match input, got %', v_log.action_details->>'khoa_phong';
+  END IF;
+
+  RAISE NOTICE 'OK: maintenance_plan_create writes audit_logs row';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Fixes #318 by restoring fail-closed audit logging for `maintenance_plan_create`.
- Fixes #320 by making `maintenance_task_update` raise `P0002` when the target task is missing.
- Adds Supabase smoke coverage for both behaviors.

## Verification
- RED confirmed before migration: missing-task update smoke failed because live RPC returned success instead of `P0002`.
- Applied Supabase migration via MCP: `20260424082423 maintenance_audit_notfound`.
- Ran `maintenance_audit_notfound_smoke.sql` equivalent via Supabase MCP: passed.
- Ran maintenance write regression probe via Supabase MCP: allowed update passed; global create, user update, and cross-tenant update denied as expected.
- Verified live function definitions include `search_path`, audit fail-closed behavior, and `P0002` missing-task behavior.
- Ran Supabase security and performance advisors; remaining findings are pre-existing project-wide RLS/search_path/security-definer-view/unused-index findings.
- Ran `git diff --check`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores fail-closed audit logging on maintenance plan creation and makes missing maintenance-task updates return SQLSTATE P0002. Addresses #318 and #320 and adds Supabase smoke tests to lock both behaviors.

- **Bug Fixes**
  - `maintenance_plan_create`: audit logging is mandatory; runs as SECURITY DEFINER with explicit `search_path`; PUBLIC EXECUTE revoked and `authenticated` granted.
  - `maintenance_task_update`: raises `P0002` for missing task/plan/equipment and enforces tenant checks; runs as SECURITY DEFINER with explicit `search_path`; PUBLIC EXECUTE revoked and `authenticated` granted.

<sup>Written for commit 02684ff89fdf21e13254a8f9352e4d5e35131dfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Access controls for maintenance operations now enforced more strictly
  * Maintenance plans automatically logged for audit purposes
  * Improved error handling when maintenance records are not found

* **Tests**
  * Added test coverage for maintenance audit and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->