### PR TITLE
feat: add AI config resolver

### DIFF
--- a/src/app/api/chat/__tests__/route.key-rotation.test.ts
+++ b/src/app/api/chat/__tests__/route.key-rotation.test.ts
@@ -18,6 +18,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // Mock setup — hoisted above all imports
 // ---------------------------------------------------------------------------
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()

--- a/src/lib/ai/__tests__/config.test.ts
+++ b/src/lib/ai/__tests__/config.test.ts
@@ -79,6 +79,34 @@ describe('AI default chat config resolver', () => {
     })
   })
 
+  it('keeps legacy single Google API key config in direct Google mode', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          GOOGLE_GENERATIVE_AI_API_KEY: 'google-key',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'google',
+      model: 'gemini-3.1-flash-lite-preview',
+    })
+  })
+
+  it('keeps legacy pooled Google API key config in direct Google mode', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          GOOGLE_GENERATIVE_AI_API_KEYS: 'google-key-a,google-key-b',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'google',
+      model: 'gemini-3.1-flash-lite-preview',
+    })
+  })
+
   it('rejects gateway model ids without a provider prefix', () => {
     expect(() =>
       resolveDefaultChatConfig(

--- a/src/lib/ai/__tests__/config.test.ts
+++ b/src/lib/ai/__tests__/config.test.ts
@@ -51,6 +51,34 @@ describe('AI default chat config resolver', () => {
     })
   })
 
+  it('keeps legacy AI_MODEL-only config in direct Google mode', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          AI_MODEL: 'gemini-3.1-flash-lite-preview',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'google',
+      model: 'gemini-3.1-flash-lite-preview',
+    })
+  })
+
+  it('uses an unprefixed Google model default when only legacy provider is set', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          AI_PROVIDER: 'google',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'google',
+      model: 'gemini-3.1-flash-lite-preview',
+    })
+  })
+
   it('rejects gateway model ids without a provider prefix', () => {
     expect(() =>
       resolveDefaultChatConfig(

--- a/src/lib/ai/__tests__/config.test.ts
+++ b/src/lib/ai/__tests__/config.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertDefaultChatCredentials,
+  loadGoogleApiKeys,
+  resolveDefaultChatConfig,
+} from '../config'
+
+function env(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...overrides }
+}
+
+describe('AI default chat config resolver', () => {
+  it('uses gateway and the hard default model when no env is configured', () => {
+    expect(resolveDefaultChatConfig(env())).toEqual({
+      capability: 'default_chat',
+      provider: 'gateway',
+      model: 'google/gemini-3.1-flash-lite-preview',
+    })
+  })
+
+  it('prefers capability-specific provider and model env vars', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          AI_DEFAULT_CHAT_PROVIDER: 'gateway',
+          AI_DEFAULT_CHAT_MODEL: 'mistral/mistral-large-3',
+          AI_PROVIDER: 'google',
+          AI_MODEL: 'gemini-3-flash',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'gateway',
+      model: 'mistral/mistral-large-3',
+    })
+  })
+
+  it('falls back to legacy Google provider and model env vars', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          AI_PROVIDER: 'google',
+          AI_MODEL: 'gemini-3-flash',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'google',
+      model: 'gemini-3-flash',
+    })
+  })
+
+  it('rejects gateway model ids without a provider prefix', () => {
+    expect(() =>
+      resolveDefaultChatConfig(
+        env({
+          AI_DEFAULT_CHAT_PROVIDER: 'gateway',
+          AI_DEFAULT_CHAT_MODEL: 'gemini-3-flash',
+        }),
+      ),
+    ).toThrow('AI_DEFAULT_CHAT_MODEL must be a provider-prefixed model id when provider is gateway')
+  })
+
+  it('rejects unsupported direct providers and points to gateway mode', () => {
+    expect(() =>
+      resolveDefaultChatConfig(
+        env({
+          AI_PROVIDER: 'openai',
+          AI_MODEL: 'gpt-5.2',
+        }),
+      ),
+    ).toThrow('Unsupported direct AI provider: openai. Use AI_DEFAULT_CHAT_PROVIDER=gateway')
+  })
+
+  it('requires an AI Gateway API key in gateway mode', () => {
+    const config = resolveDefaultChatConfig(
+      env({
+        AI_DEFAULT_CHAT_PROVIDER: 'gateway',
+        AI_DEFAULT_CHAT_MODEL: 'openai/gpt-5.2',
+      }),
+    )
+
+    expect(() => assertDefaultChatCredentials(config, env())).toThrow(
+      'AI_GATEWAY_API_KEY is required for AI gateway mode',
+    )
+  })
+
+  it('requires at least one Google API key in direct Google mode', () => {
+    const config = resolveDefaultChatConfig(
+      env({
+        AI_PROVIDER: 'google',
+        AI_MODEL: 'gemini-3-flash',
+      }),
+    )
+
+    expect(() => assertDefaultChatCredentials(config, env())).toThrow(
+      'GOOGLE_GENERATIVE_AI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEYS is required for direct Google mode',
+    )
+  })
+
+  it('loads comma-separated Google keys before the single-key fallback', () => {
+    expect(
+      loadGoogleApiKeys(
+        env({
+          GOOGLE_GENERATIVE_AI_API_KEYS: ' KEY_A, ,KEY_B ',
+          GOOGLE_GENERATIVE_AI_API_KEY: 'SINGLE',
+        }),
+      ),
+    ).toEqual(['KEY_A', 'KEY_B'])
+  })
+})

--- a/src/lib/ai/__tests__/provider.test.ts
+++ b/src/lib/ai/__tests__/provider.test.ts
@@ -213,6 +213,17 @@ describe('provider — API key rotation', () => {
     expect(keyIndex).toBe(0)
   })
 
+  it('trims the gateway API key before constructing the provider', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'gateway'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'openai/gpt-5.2'
+    process.env.AI_GATEWAY_API_KEY = ' GATEWAY_KEY\n'
+
+    const { model } = getChatModel()
+    const m = model as unknown as { apiKey: string }
+
+    expect(m.apiKey).toBe('GATEWAY_KEY')
+  })
+
   it('reports a single non-rotating key slot for gateway mode', () => {
     process.env.AI_DEFAULT_CHAT_PROVIDER = 'gateway'
     process.env.AI_DEFAULT_CHAT_MODEL = 'openai/gpt-5.2'

--- a/src/lib/ai/__tests__/provider.test.ts
+++ b/src/lib/ai/__tests__/provider.test.ts
@@ -22,6 +22,18 @@ vi.mock('@ai-sdk/google', () => ({
   }),
 }))
 
+vi.mock('ai', () => ({
+  createGateway: vi.fn((opts?: { apiKey?: string }) => {
+    const provider = (modelId: string) => ({
+      __testModel: true,
+      transport: 'gateway',
+      modelId,
+      apiKey: opts?.apiKey ?? 'DEFAULT_GATEWAY_KEY',
+    })
+    return provider
+  }),
+}))
+
 describe('provider — API key rotation', () => {
   const ORIGINAL_ENV = { ...process.env }
 
@@ -170,6 +182,43 @@ describe('provider — API key rotation', () => {
 
   it('throws on unsupported provider', () => {
     process.env.AI_PROVIDER = 'openai'
-    expect(() => getChatModel()).toThrow('Unsupported AI provider: openai')
+    expect(() => getChatModel()).toThrow('Unsupported direct AI provider: openai')
+  })
+
+  it('keeps key pool sizing available when model construction would reject config', () => {
+    process.env.AI_PROVIDER = 'openai'
+
+    expect(getKeyPoolSize()).toBe(3)
+  })
+
+  // -------------------------------------------------------------------
+  // Gateway provider contract
+  // -------------------------------------------------------------------
+
+  it('returns a gateway model for provider-prefixed default chat config', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'gateway'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'mistral/mistral-large-3'
+    process.env.AI_GATEWAY_API_KEY = 'GATEWAY_KEY'
+
+    const { model, keyIndex } = getChatModel()
+    const m = model as unknown as {
+      apiKey: string
+      modelId: string
+      transport: string
+    }
+
+    expect(m.transport).toBe('gateway')
+    expect(m.apiKey).toBe('GATEWAY_KEY')
+    expect(m.modelId).toBe('mistral/mistral-large-3')
+    expect(keyIndex).toBe(0)
+  })
+
+  it('reports a single non-rotating key slot for gateway mode', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'gateway'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'openai/gpt-5.2'
+    process.env.AI_GATEWAY_API_KEY = 'GATEWAY_KEY'
+
+    expect(getKeyPoolSize()).toBe(1)
+    expect(handleProviderQuotaError(0)).toBe(false)
   })
 })

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -30,6 +30,12 @@ export function resolveDefaultChatProvider(env: NodeJS.ProcessEnv = process.env)
     return 'google'
   }
 
+  // Preserve the old minimal setup where a deployment only provided Google API
+  // key env vars and relied on the implicit Google provider.
+  if (loadGoogleApiKeys(env).length > 0 && !readEnv(env, 'AI_DEFAULT_CHAT_MODEL')) {
+    return 'google'
+  }
+
   return DEFAULT_PROVIDER
     .toLowerCase()
 }

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,0 +1,91 @@
+export type AiChatCapability = 'default_chat'
+export type AiProviderTransport = 'gateway' | 'google'
+
+export interface ResolvedDefaultChatConfig {
+  capability: AiChatCapability
+  provider: AiProviderTransport
+  model: string
+}
+
+const DEFAULT_PROVIDER: AiProviderTransport = 'gateway'
+const DEFAULT_MODEL = 'google/gemini-3.1-flash-lite-preview'
+
+function readEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key]?.trim()
+  return value ? value : undefined
+}
+
+function hasProviderPrefix(model: string): boolean {
+  return /^[a-z0-9][a-z0-9-]*\/.+$/i.test(model)
+}
+
+export function resolveDefaultChatProvider(env: NodeJS.ProcessEnv = process.env): string {
+  return (readEnv(env, 'AI_DEFAULT_CHAT_PROVIDER') ?? readEnv(env, 'AI_PROVIDER') ?? DEFAULT_PROVIDER)
+    .toLowerCase()
+}
+
+function resolveModel(env: NodeJS.ProcessEnv): string {
+  return readEnv(env, 'AI_DEFAULT_CHAT_MODEL') ?? readEnv(env, 'AI_MODEL') ?? DEFAULT_MODEL
+}
+
+export function loadGoogleApiKeys(env: NodeJS.ProcessEnv = process.env): string[] {
+  const pool = readEnv(env, 'GOOGLE_GENERATIVE_AI_API_KEYS')
+  if (pool) {
+    const keys = pool
+      .split(',')
+      .map(key => key.trim())
+      .filter(Boolean)
+    if (keys.length > 0) return keys
+  }
+
+  const single = readEnv(env, 'GOOGLE_GENERATIVE_AI_API_KEY')
+  return single ? [single] : []
+}
+
+export function resolveDefaultChatConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedDefaultChatConfig {
+  const provider = resolveDefaultChatProvider(env)
+  const model = resolveModel(env)
+
+  if (provider === 'gateway') {
+    if (!hasProviderPrefix(model)) {
+      throw new Error(
+        'AI_DEFAULT_CHAT_MODEL must be a provider-prefixed model id when provider is gateway',
+      )
+    }
+
+    return {
+      capability: 'default_chat',
+      provider,
+      model,
+    }
+  }
+
+  if (provider === 'google') {
+    return {
+      capability: 'default_chat',
+      provider,
+      model,
+    }
+  }
+
+  throw new Error(
+    `Unsupported direct AI provider: ${provider}. Use AI_DEFAULT_CHAT_PROVIDER=gateway with a provider-prefixed model id.`,
+  )
+}
+
+export function assertDefaultChatCredentials(
+  config: ResolvedDefaultChatConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (config.provider === 'gateway' && !readEnv(env, 'AI_GATEWAY_API_KEY')) {
+    throw new Error('AI_GATEWAY_API_KEY is required for AI gateway mode')
+  }
+
+  if (config.provider === 'google' && loadGoogleApiKeys(env).length === 0) {
+    throw new Error(
+      'GOOGLE_GENERATIVE_AI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEYS is required for direct Google mode',
+    )
+  }
+}

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -8,7 +8,8 @@ export interface ResolvedDefaultChatConfig {
 }
 
 const DEFAULT_PROVIDER: AiProviderTransport = 'gateway'
-const DEFAULT_MODEL = 'google/gemini-3.1-flash-lite-preview'
+const DEFAULT_GATEWAY_MODEL = 'google/gemini-3.1-flash-lite-preview'
+const DEFAULT_GOOGLE_MODEL = 'gemini-3.1-flash-lite-preview'
 
 function readEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
   const value = env[key]?.trim()
@@ -20,12 +21,24 @@ function hasProviderPrefix(model: string): boolean {
 }
 
 export function resolveDefaultChatProvider(env: NodeJS.ProcessEnv = process.env): string {
-  return (readEnv(env, 'AI_DEFAULT_CHAT_PROVIDER') ?? readEnv(env, 'AI_PROVIDER') ?? DEFAULT_PROVIDER)
+  const explicitProvider = readEnv(env, 'AI_DEFAULT_CHAT_PROVIDER') ?? readEnv(env, 'AI_PROVIDER')
+  if (explicitProvider) return explicitProvider.toLowerCase()
+
+  // Preserve legacy deployments that only configured AI_MODEL under the old
+  // implicit Google provider contract.
+  if (readEnv(env, 'AI_MODEL') && !readEnv(env, 'AI_DEFAULT_CHAT_MODEL')) {
+    return 'google'
+  }
+
+  return DEFAULT_PROVIDER
     .toLowerCase()
 }
 
-function resolveModel(env: NodeJS.ProcessEnv): string {
-  return readEnv(env, 'AI_DEFAULT_CHAT_MODEL') ?? readEnv(env, 'AI_MODEL') ?? DEFAULT_MODEL
+function resolveModel(env: NodeJS.ProcessEnv, provider: string): string {
+  const explicitModel = readEnv(env, 'AI_DEFAULT_CHAT_MODEL') ?? readEnv(env, 'AI_MODEL')
+  if (explicitModel) return explicitModel
+
+  return provider === 'google' ? DEFAULT_GOOGLE_MODEL : DEFAULT_GATEWAY_MODEL
 }
 
 export function loadGoogleApiKeys(env: NodeJS.ProcessEnv = process.env): string[] {
@@ -46,7 +59,7 @@ export function resolveDefaultChatConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedDefaultChatConfig {
   const provider = resolveDefaultChatProvider(env)
-  const model = resolveModel(env)
+  const model = resolveModel(env, provider)
 
   if (provider === 'gateway') {
     if (!hasProviderPrefix(model)) {

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -1,28 +1,19 @@
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
-import type { LanguageModel } from 'ai'
+import { createGateway, type LanguageModel } from 'ai'
 
-const DEFAULT_PROVIDER = 'google'
-const DEFAULT_MODEL = 'gemini-3.1-flash-lite-preview'
+import {
+  assertDefaultChatCredentials,
+  resolveDefaultChatProvider,
+  loadGoogleApiKeys,
+  resolveDefaultChatConfig,
+} from './config'
 
 // ---------------------------------------------------------------------------
 // API-key pool & round-robin rotation
 // ---------------------------------------------------------------------------
 
 function loadApiKeys(): string[] {
-  const pool = process.env.GOOGLE_GENERATIVE_AI_API_KEYS
-  if (pool) {
-    const keys = pool
-      .split(',')
-      .map((k) => k.trim())
-      .filter(Boolean)
-    if (keys.length > 0) return keys
-  }
-
-  // Fallback: single-key env var (read by @ai-sdk/google by default)
-  const single = process.env.GOOGLE_GENERATIVE_AI_API_KEY
-  if (single?.trim()) return [single.trim()]
-
-  return []
+  return loadGoogleApiKeys()
 }
 
 /** Visible for testing — do NOT use directly outside tests. */
@@ -68,10 +59,17 @@ export interface ChatModelWithKeyIndex {
  * the correct key is marked as exhausted even under concurrent requests.
  */
 export function getChatModel(): ChatModelWithKeyIndex {
-  const provider = (process.env.AI_PROVIDER ?? DEFAULT_PROVIDER).toLowerCase()
-  const model = process.env.AI_MODEL ?? DEFAULT_MODEL
+  const config = resolveDefaultChatConfig()
+  assertDefaultChatCredentials(config)
 
-  switch (provider) {
+  switch (config.provider) {
+    case 'gateway': {
+      const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY })
+      return {
+        model: gateway(config.model as Parameters<typeof gateway>[0]),
+        keyIndex: 0,
+      }
+    }
     case 'google': {
       const keyIndex = _internals.currentIndex
       const key = _internals.keys[keyIndex]
@@ -79,12 +77,10 @@ export function getChatModel(): ChatModelWithKeyIndex {
       // Otherwise fall through to the default (reads GOOGLE_GENERATIVE_AI_API_KEY).
       const google = createGoogleGenerativeAI(key ? { apiKey: key } : undefined)
       return {
-        model: google(model as Parameters<typeof google>[0]),
+        model: google(config.model as Parameters<typeof google>[0]),
         keyIndex,
       }
     }
-    default:
-      throw new Error(`Unsupported AI provider: ${provider}`)
   }
 }
 
@@ -98,6 +94,8 @@ export function getChatModel(): ChatModelWithKeyIndex {
  *          pool are exhausted (caller should surface the quota error to the user).
  */
 export function handleProviderQuotaError(failedKeyIndex: number): boolean {
+  if (resolveDefaultChatProvider() === 'gateway') return false
+
   maybeResetExhausted()
 
   const { keys, exhaustedIndices } = _internals
@@ -131,5 +129,7 @@ export function handleProviderQuotaError(failedKeyIndex: number): boolean {
  * Used by the route to cap retry attempts.
  */
 export function getKeyPoolSize(): number {
+  if (resolveDefaultChatProvider() === 'gateway') return 1
+
   return _internals.keys.length
 }

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -64,7 +64,7 @@ export function getChatModel(): ChatModelWithKeyIndex {
 
   switch (config.provider) {
     case 'gateway': {
-      const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY })
+      const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY?.trim() })
       return {
         model: gateway(config.model as Parameters<typeof gateway>[0]),
         keyIndex: 0,


### PR DESCRIPTION
## Summary
- Add a central default_chat AI config resolver with capability-specific env precedence and legacy fallback.
- Add Gateway provider factory support via AI SDK createGateway while preserving direct Google key-pool rotation.
- Keep /api/chat route integration for Batch #325 and preserve quota rotation compatibility.

## Test Plan
- [x] node scripts/npm-run.js run verify:no-explicit-any
- [x] node scripts/npm-run.js run typecheck
- [x] node scripts/npm-run.js run test:run -- src/lib/ai/__tests__/config.test.ts src/lib/ai/__tests__/provider.test.ts src/app/api/chat/__tests__/route.key-rotation.test.ts

Closes #324
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a central resolver for default chat config with gateway‑first defaults, strict env validation, and legacy compatibility per #324. Preserves legacy Google setups, including `AI_MODEL`‑only and key‑only configs, and keeps `/api/chat` quota behavior.

- **New Features**
  - Central `default_chat` resolver in `src/lib/ai/config.ts`; `AI_DEFAULT_CHAT_*` overrides legacy `AI_*`.
  - Defaults to `gateway` with `google/gemini-3.1-flash-lite-preview`; legacy `AI_MODEL` or just Google keys imply direct `google` with a sensible default.
  - Gateway via `ai` `createGateway`; requires provider‑prefixed models (e.g., `openai/gpt-4o`) and `AI_GATEWAY_API_KEY` (trimmed); single‑slot pool, no rotation.
  - Direct `google` via `@ai-sdk/google`; rotates `GOOGLE_GENERATIVE_AI_API_KEYS` with `GOOGLE_GENERATIVE_AI_API_KEY` fallback; keeps retry/rotation.
  - Clear errors for unprefixed gateway models and unsupported direct providers (guides to `AI_DEFAULT_CHAT_PROVIDER=gateway`); tests cover resolver, provider, and route key rotation.

- **Migration**
  - Gateway: set `AI_DEFAULT_CHAT_PROVIDER=gateway`, `AI_DEFAULT_CHAT_MODEL=<provider>/<model>`, and `AI_GATEWAY_API_KEY`.
  - Direct Google: either set `AI_PROVIDER=google` (optional `AI_MODEL`) with keys, or just set Google keys (`GOOGLE_GENERATIVE_AI_API_KEYS` or `GOOGLE_GENERATIVE_AI_API_KEY`).

<sup>Written for commit 40628db7ad48dde87fa39239cafb34af88ee0964. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an AI gateway provider as an alternative to direct providers
  * Introduced environment-based configuration for default chat settings with provider and model selection
  * Implemented credential validation to ensure required API keys are present for the selected provider mode

* **Tests**
  * Added comprehensive test suites for AI configuration resolution and provider behavior
  * Added mock for gateway transport testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->