### PR TITLE
[Issue #315][Batch 2] Route chat through resolved AI config

### DIFF
--- a/src/app/api/chat/__tests__/route.attachment-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.attachment-tools.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
@@ -39,7 +41,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 const VALID_MESSAGES = [
   {
@@ -64,7 +69,7 @@ describe('/api/chat attachmentLookup tool', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'to_qltb', don_vi: 2 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-3-flash-preview', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-3-flash-preview'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')

--- a/src/app/api/chat/__tests__/route.auth-and-schema.test.ts
+++ b/src/app/api/chat/__tests__/route.auth-and-schema.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const getChatModelMock = vi.fn()
@@ -28,7 +30,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 const VALID_MESSAGES = [
   {
@@ -50,7 +55,7 @@ describe('/api/chat auth + schema', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
   })

--- a/src/app/api/chat/__tests__/route.error-safety.test.ts
+++ b/src/app/api/chat/__tests__/route.error-safety.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
@@ -41,7 +43,10 @@ vi.mock('ai', async () => {
 import { simulateReadableStream } from 'ai'
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 const VALID_MESSAGES = [
   {
@@ -63,7 +68,7 @@ describe('/api/chat error safety — non-stream contract', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
@@ -155,7 +160,7 @@ describe('/api/chat error safety — sanitization', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'admin', don_vi: 2 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')

--- a/src/app/api/chat/__tests__/route.intent-routing.test.ts
+++ b/src/app/api/chat/__tests__/route.intent-routing.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
@@ -45,7 +47,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 function buildRequest(body: unknown) {
   return new Request('http://localhost/api/chat', {
@@ -98,7 +103,7 @@ describe('/api/chat intent routing + clarification guard', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'to_qltb', don_vi: 17 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')

--- a/src/app/api/chat/__tests__/route.key-rotation.test.ts
+++ b/src/app/api/chat/__tests__/route.key-rotation.test.ts
@@ -96,6 +96,34 @@ function makeQuotaError(message = 'You exceeded your current quota') {
   return new Error(message)
 }
 
+function makeChatModel(model: string, keyIndex: number) {
+  return {
+    model,
+    keyIndex,
+    config: {
+      capability: 'default_chat',
+      provider: 'google',
+      model,
+    },
+    providerOptions: model.includes('gemini')
+      ? { google: { thinkingConfig: { thinkingLevel: 'medium' } } }
+      : undefined,
+  }
+}
+
+function makeGatewayChatModel(model: string) {
+  return {
+    model,
+    keyIndex: 0,
+    config: {
+      capability: 'default_chat',
+      provider: 'gateway',
+      model,
+    },
+    providerOptions: undefined,
+  }
+}
+
 function makeStreamResult(
   parts: Array<{ type: string; error?: unknown }>,
   options?: {
@@ -187,7 +215,7 @@ describe('/api/chat — API key rotation integration', () => {
   it('should succeed on the first attempt when no quota error occurs', async () => {
     // Given: a single-key pool and a working stream
     getKeyPoolSizeMock.mockReturnValue(1)
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-flash', 0))
     streamTextMock.mockReturnValue(makeOKStream())
 
     // When: the route is called
@@ -209,8 +237,8 @@ describe('/api/chat — API key rotation integration', () => {
 
     // getChatModel returns key 0 first, then key 1 after rotation
     getChatModelMock
-      .mockReturnValueOnce({ model: 'model-with-key-0', keyIndex: 0 })
-      .mockReturnValueOnce({ model: 'model-with-key-1', keyIndex: 1 })
+      .mockReturnValueOnce(makeChatModel('model-with-key-0', 0))
+      .mockReturnValueOnce(makeChatModel('model-with-key-1', 1))
 
     // streamText: emits quota error on first call (key 0), succeeds on second (key 1)
     streamTextMock
@@ -240,8 +268,8 @@ describe('/api/chat — API key rotation integration', () => {
     getKeyPoolSizeMock.mockReturnValue(2)
 
     getChatModelMock
-      .mockReturnValueOnce({ model: 'model-key-0', keyIndex: 0 })
-      .mockReturnValueOnce({ model: 'model-key-1', keyIndex: 1 })
+      .mockReturnValueOnce(makeChatModel('model-key-0', 0))
+      .mockReturnValueOnce(makeChatModel('model-key-1', 1))
 
     const firstReturnSpy = vi.fn(async () => ({ done: true, value: undefined }))
     const secondReturnSpy = vi.fn(async () => ({ done: true, value: undefined }))
@@ -263,7 +291,7 @@ describe('/api/chat — API key rotation integration', () => {
 
   it('rotates future requests when onError receives a quota error after preflight success', async () => {
     getKeyPoolSizeMock.mockReturnValue(1)
-    getChatModelMock.mockReturnValue({ model: 'model-key-0', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('model-key-0', 0))
 
     streamTextMock.mockReturnValue(
       makeStreamResult(
@@ -285,7 +313,7 @@ describe('/api/chat — API key rotation integration', () => {
 
   it('preflight ignores leading start and succeeds on first meaningful part', async () => {
     getKeyPoolSizeMock.mockReturnValue(1)
-    getChatModelMock.mockReturnValue({ model: 'model-key-0', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('model-key-0', 0))
 
     const returnSpy = vi.fn(async () => ({
       done: true,
@@ -305,8 +333,8 @@ describe('/api/chat — API key rotation integration', () => {
     getKeyPoolSizeMock.mockReturnValue(2)
 
     getChatModelMock
-      .mockReturnValueOnce({ model: 'model-key-0', keyIndex: 0 })
-      .mockReturnValueOnce({ model: 'model-key-1', keyIndex: 1 })
+      .mockReturnValueOnce(makeChatModel('model-key-0', 0))
+      .mockReturnValueOnce(makeChatModel('model-key-1', 1))
 
     const firstReturnSpy = vi.fn(async () => ({
       done: true,
@@ -338,7 +366,7 @@ describe('/api/chat — API key rotation integration', () => {
 
   it('preflight preserves stream responses for non-quota error parts', async () => {
     getKeyPoolSizeMock.mockReturnValue(2)
-    getChatModelMock.mockReturnValue({ model: 'model-key-0', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('model-key-0', 0))
 
     streamTextMock.mockReturnValue(
       makeStreamResult([
@@ -363,9 +391,9 @@ describe('/api/chat — API key rotation integration', () => {
     getKeyPoolSizeMock.mockReturnValue(3)
 
     getChatModelMock
-      .mockReturnValueOnce({ model: 'model-key-0', keyIndex: 0 })
-      .mockReturnValueOnce({ model: 'model-key-1', keyIndex: 1 })
-      .mockReturnValueOnce({ model: 'model-key-2', keyIndex: 2 })
+      .mockReturnValueOnce(makeChatModel('model-key-0', 0))
+      .mockReturnValueOnce(makeChatModel('model-key-1', 1))
+      .mockReturnValueOnce(makeChatModel('model-key-2', 2))
 
     streamTextMock
       .mockReturnValueOnce(makeQuotaStream())
@@ -396,8 +424,8 @@ describe('/api/chat — API key rotation integration', () => {
     getKeyPoolSizeMock.mockReturnValue(2)
 
     getChatModelMock
-      .mockReturnValueOnce({ model: 'model-key-0', keyIndex: 0 })
-      .mockReturnValueOnce({ model: 'model-key-1', keyIndex: 1 })
+      .mockReturnValueOnce(makeChatModel('model-key-0', 0))
+      .mockReturnValueOnce(makeChatModel('model-key-1', 1))
 
     streamTextMock
       .mockReturnValueOnce(makeQuotaStream())
@@ -426,7 +454,7 @@ describe('/api/chat — API key rotation integration', () => {
   it('should NOT rotate keys on non-quota errors (e.g. network timeout)', async () => {
     // Given: a 3-key pool, streamText throws a non-quota error
     getKeyPoolSizeMock.mockReturnValue(3)
-    getChatModelMock.mockReturnValue({ model: 'model-key-0', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('model-key-0', 0))
     streamTextMock.mockImplementation(() => { throw new Error('Network timeout') })
 
     // When
@@ -447,8 +475,8 @@ describe('/api/chat — API key rotation integration', () => {
     getKeyPoolSizeMock.mockReturnValue(2)
 
     getChatModelMock
-      .mockReturnValueOnce({ model: 'model-key-0', keyIndex: 0 })
-      .mockReturnValueOnce({ model: 'model-key-1', keyIndex: 1 })
+      .mockReturnValueOnce(makeChatModel('model-key-0', 0))
+      .mockReturnValueOnce(makeChatModel('model-key-1', 1))
 
     streamTextMock
       .mockImplementationOnce(() => { throw makeQuotaError() })
@@ -494,7 +522,7 @@ describe('/api/chat — API key rotation integration', () => {
   it('should surface quota error directly when pool has only one key', async () => {
     // Given: a single-key pool
     getKeyPoolSizeMock.mockReturnValue(1)
-    getChatModelMock.mockReturnValue({ model: 'model-only-key', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('model-only-key', 0))
     streamTextMock.mockReturnValue(makeQuotaStream())
 
     // handleProviderQuotaError returns false (no other keys)
@@ -506,6 +534,21 @@ describe('/api/chat — API key rotation integration', () => {
     // Then: 500 error, only 1 attempt, key still marked
     expect(res.status).toBe(500)
     expect(streamTextMock).toHaveBeenCalledOnce()
+    expect(handleProviderQuotaErrorMock).toHaveBeenCalledOnce()
+    expect(handleProviderQuotaErrorMock).toHaveBeenCalledWith(0)
+  })
+
+  it('should attempt a non-rotating Gateway model only once', async () => {
+    getKeyPoolSizeMock.mockReturnValue(1)
+    getChatModelMock.mockReturnValue(makeGatewayChatModel('openai/gpt-5.2'))
+    streamTextMock.mockReturnValue(makeQuotaStream())
+    handleProviderQuotaErrorMock.mockReturnValue(false)
+
+    const res = await POST(buildValidRequest() as never)
+
+    expect(res.status).toBe(500)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+    expect(getChatModelMock).toHaveBeenCalledOnce()
     expect(handleProviderQuotaErrorMock).toHaveBeenCalledOnce()
     expect(handleProviderQuotaErrorMock).toHaveBeenCalledWith(0)
   })

--- a/src/app/api/chat/__tests__/route.limits.test.ts
+++ b/src/app/api/chat/__tests__/route.limits.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
@@ -9,6 +9,27 @@ const buildSystemPromptMock = vi.fn()
 const checkUsageLimitsMock = vi.fn()
 const recordUsageMock = vi.fn()
 const confirmUsageMock = vi.fn()
+
+const ORIGINAL_ENV = { ...process.env }
+
+function mockChatModelResult(model: string, providerOptions?: unknown) {
+  const provider = model.startsWith('google/') || model.startsWith('openai/')
+    ? 'gateway'
+    : 'google'
+
+  return {
+    model,
+    keyIndex: 0,
+    config: {
+      capability: 'default_chat',
+      provider,
+      model,
+    },
+    providerOptions,
+  }
+}
+
+vi.mock('server-only', () => ({}))
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -74,12 +95,19 @@ function buildMessage(id: string, text = 'Xin chao') {
 
 describe('/api/chat limits', () => {
   beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV }
     vi.clearAllMocks()
 
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'admin', don_vi: 2 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(
+      mockChatModelResult('gemini-2.5-flash', {
+        google: {
+          thinkingConfig: { thinkingLevel: 'medium' },
+        },
+      }),
+    )
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
@@ -87,6 +115,10 @@ describe('/api/chat limits', () => {
       { role: 'user', content: 'converted-message-sentinel' },
     ])
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
   })
 
   it('applies maxOutputTokens and stopWhen guardrails to streamText', async () => {
@@ -105,7 +137,9 @@ describe('/api/chat limits', () => {
   })
 
   it('omits thinkingConfig for gemma models that do not support thinking levels', async () => {
-    getChatModelMock.mockReturnValue({ model: 'google:gemma-4-26b-a4b-it', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(
+      mockChatModelResult('gemma-4-26b-a4b-it'),
+    )
 
     const res = await POST(
       buildRequest({ messages: [buildMessage('m1')] }) as never,
@@ -124,7 +158,79 @@ describe('/api/chat limits', () => {
   })
 
   it('keeps thinkingConfig for gemini models that support thinking levels', async () => {
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(
+      mockChatModelResult('gemini-2.5-flash', {
+        google: {
+          thinkingConfig: { thinkingLevel: 'medium' },
+        },
+      }),
+    )
+
+    const res = await POST(
+      buildRequest({ messages: [buildMessage('m1')] }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as {
+      providerOptions?: {
+        google?: {
+          thinkingConfig?: {
+            thinkingLevel?: string
+          }
+        }
+      }
+    }
+
+    expect(streamTextArgs?.providerOptions?.google?.thinkingConfig).toEqual({
+      thinkingLevel: 'medium',
+    })
+  })
+
+  it('uses resolved Gateway provider options instead of legacy AI_MODEL for non-Google models', async () => {
+    process.env.AI_MODEL = 'gemini-3.1-flash-lite-preview'
+    getChatModelMock.mockReturnValue({
+      model: 'gateway-openai-model',
+      keyIndex: 0,
+      config: {
+        capability: 'default_chat',
+        provider: 'gateway',
+        model: 'openai/gpt-5.2',
+      },
+      providerOptions: undefined,
+    })
+
+    const res = await POST(
+      buildRequest({ messages: [buildMessage('m1')] }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as {
+      providerOptions?: {
+        google?: {
+          thinkingConfig?: unknown
+        }
+      }
+    }
+
+    expect(streamTextArgs?.providerOptions?.google?.thinkingConfig).toBeUndefined()
+  })
+
+  it('uses resolved Gateway Google provider options even when legacy AI_MODEL is non-Google', async () => {
+    process.env.AI_MODEL = 'openai/gpt-5.2'
+    getChatModelMock.mockReturnValue({
+      model: 'gateway-google-model',
+      keyIndex: 0,
+      config: {
+        capability: 'default_chat',
+        provider: 'gateway',
+        model: 'google/gemini-3.1-flash-lite-preview',
+      },
+      providerOptions: {
+        google: {
+          thinkingConfig: { thinkingLevel: 'medium' },
+        },
+      },
+    })
 
     const res = await POST(
       buildRequest({ messages: [buildMessage('m1')] }) as never,

--- a/src/app/api/chat/__tests__/route.quota-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.quota-tools.test.ts
@@ -3,6 +3,8 @@ import path from 'node:path'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
@@ -42,7 +44,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 const VALID_MESSAGES = [
   {
@@ -67,7 +72,7 @@ describe('/api/chat quota tools', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'to_qltb', don_vi: 2 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-3-flash-preview', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-3-flash-preview'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V2')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')

--- a/src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts
+++ b/src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
@@ -48,7 +50,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 function buildRequest(body: unknown) {
   return new Request('http://localhost/api/chat', {
@@ -73,7 +78,7 @@ describe('/api/chat rate limit and quota', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'admin', don_vi: 2 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })

--- a/src/app/api/chat/__tests__/route.repair-request-draft-orchestration.test.ts
+++ b/src/app/api/chat/__tests__/route.repair-request-draft-orchestration.test.ts
@@ -10,6 +10,8 @@ const recordUsageMock = vi.fn()
 const confirmUsageMock = vi.fn()
 const generateObjectMock = vi.fn()
 
+vi.mock('server-only', () => ({}))
+
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
 }))
@@ -64,6 +66,23 @@ function buildMessages(text: string) {
   ]
 }
 
+function makeChatModel(model: string) {
+  return {
+    model,
+    keyIndex: 0,
+    config: {
+      capability: 'default_chat',
+      provider: 'google',
+      model,
+    },
+    providerOptions: {
+      google: {
+        thinkingConfig: { thinkingLevel: 'medium' },
+      },
+    },
+  }
+}
+
 function getToolChunks(payload: string) {
   return parseSseJsonChunks(payload).filter(
     chunk =>
@@ -79,7 +98,7 @@ describe('/api/chat repair-request draft orchestration', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'to_qltb', don_vi: 17 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')

--- a/src/app/api/chat/__tests__/route.tenant-policy.test.ts
+++ b/src/app/api/chat/__tests__/route.tenant-policy.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
@@ -39,7 +41,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 const VALID_MESSAGES = [
   {
@@ -61,7 +66,7 @@ describe('/api/chat tenant policy', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')

--- a/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
+++ b/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
@@ -41,7 +41,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 const VALID_MESSAGES = [
   {
@@ -66,7 +69,7 @@ describe('/api/chat tools allowlist policy', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'to_qltb', don_vi: 2 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-2.5-flash', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')

--- a/src/app/api/chat/__tests__/route.usage-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.usage-tools.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
@@ -39,7 +41,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+import {
+  makeChatModel,
+  makeReadyStreamTextResult,
+} from './stream-text-result-test-helpers'
 
 const VALID_MESSAGES = [
   {
@@ -64,7 +69,7 @@ describe('/api/chat usageHistory tool', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'to_qltb', don_vi: 2 },
     })
-    getChatModelMock.mockReturnValue({ model: 'google:gemini-3-flash-preview', keyIndex: 0 })
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-3-flash-preview'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')

--- a/src/app/api/chat/__tests__/stream-text-result-test-helpers.ts
+++ b/src/app/api/chat/__tests__/stream-text-result-test-helpers.ts
@@ -1,5 +1,26 @@
 import { simulateReadableStream } from 'ai'
 
+export function makeChatModel(
+  model: string,
+  providerOptions?: unknown,
+) {
+  const isGatewayModel = model.startsWith('google/') || model.startsWith('openai/')
+  const resolvedModel = model.startsWith('google:')
+    ? model.slice('google:'.length)
+    : model
+
+  return {
+    model,
+    keyIndex: 0,
+    config: {
+      capability: 'default_chat' as const,
+      provider: isGatewayModel ? 'gateway' as const : 'google' as const,
+      model: resolvedModel,
+    },
+    providerOptions,
+  }
+}
+
 export function makeReadyStreamTextResult(options?: {
   uiChunks?: Array<Record<string, unknown>>
   steps?: Array<{
@@ -50,4 +71,3 @@ export function parseSseJsonChunks(payload: string): Array<Record<string, unknow
     .filter(line => line && line !== '[DONE]')
     .map(line => JSON.parse(line) as Record<string, unknown>)
 }
-

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -7,7 +7,6 @@ import {
   type UIMessage,
   validateUIMessages,
 } from 'ai'
-import type { GoogleLanguageModelOptions } from '@ai-sdk/google'
 import { getServerSession } from 'next-auth'
 
 import { authOptions } from '@/auth/config'
@@ -64,24 +63,6 @@ function clarificationResponse(message: string, originalMessages: UIMessage[]) {
 }
 
 const ALLOWED_CHAT_ROLES = new Set<string>(Object.values(ROLES))
-
-function normalizeGoogleModelId(modelId: string): string {
-  return modelId.startsWith('google:') ? modelId.slice('google:'.length) : modelId
-}
-
-function getGoogleProviderOptions(modelId: string): { google?: GoogleLanguageModelOptions } {
-  const normalizedModelId = normalizeGoogleModelId(modelId)
-
-  if (!normalizedModelId.startsWith('gemini-')) {
-    return {}
-  }
-
-  return {
-    google: {
-      thinkingConfig: { thinkingLevel: 'medium' },
-    } satisfies GoogleLanguageModelOptions,
-  }
-}
 
 function hasAllowedChatRole(value: unknown): boolean {
   if (typeof value !== 'string') {
@@ -209,24 +190,21 @@ export async function POST(request: Request) {
   }
 
   const maxAttempts = getKeyPoolSize()
-  const configuredModel = process.env.AI_MODEL ?? 'gemini-3.1-flash-lite-preview'
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     let keyIndex = 0
+    let configuredModel = 'unknown'
 
     try {
       const chatModel = getChatModel()
-      const resolvedModelId =
-        process.env.AI_MODEL ??
-        (typeof chatModel.model === 'string' ? chatModel.model : configuredModel)
       keyIndex = chatModel.keyIndex
+      configuredModel = chatModel.config.model
       console.info('[chat] Model attempt start', {
         attempt,
         maxAttempts,
         keyIndex,
         model: configuredModel,
       })
-      const googleProviderOptions = getGoogleProviderOptions(resolvedModelId)
 
       const result = streamText({
         model: chatModel.model,
@@ -235,7 +213,7 @@ export async function POST(request: Request) {
         stopWhen: stepCountIs(AI_MAX_TOOL_STEPS),
         messages: modelMessages,
         tools,
-        providerOptions: googleProviderOptions,
+        providerOptions: chatModel.providerOptions,
         onFinish({ usage, finishReason }) {
           // Only increment daily quotas after a successful completion.
           if (finishReason !== 'error') {
@@ -291,7 +269,7 @@ export async function POST(request: Request) {
                   output: toolResult.output,
                 })),
               })),
-              providerOptions: googleProviderOptions,
+              providerOptions: chatModel.providerOptions,
             })
 
             if (repairDraftArtifact) {

--- a/src/lib/ai/__tests__/provider-options.test.ts
+++ b/src/lib/ai/__tests__/provider-options.test.ts
@@ -50,4 +50,18 @@ describe('default chat provider options', () => {
       },
     })
   })
+
+  it('normalizes a google-prefixed model id in direct Google mode', () => {
+    expect(
+      resolveDefaultChatProviderOptions({
+        capability: 'default_chat',
+        provider: 'google',
+        model: 'google/gemini-3.1-flash-lite-preview',
+      }),
+    ).toEqual({
+      google: {
+        thinkingConfig: { thinkingLevel: 'medium' },
+      },
+    })
+  })
 })

--- a/src/lib/ai/__tests__/provider-options.test.ts
+++ b/src/lib/ai/__tests__/provider-options.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveDefaultChatProviderOptions } from '../provider-options'
+
+describe('default chat provider options', () => {
+  it('omits provider options for non-Google Gateway models', () => {
+    expect(
+      resolveDefaultChatProviderOptions({
+        capability: 'default_chat',
+        provider: 'gateway',
+        model: 'openai/gpt-5.2',
+      }),
+    ).toBeUndefined()
+  })
+
+  it('keeps Google thinking config for Gateway Gemini models', () => {
+    expect(
+      resolveDefaultChatProviderOptions({
+        capability: 'default_chat',
+        provider: 'gateway',
+        model: 'google/gemini-3.1-flash-lite-preview',
+      }),
+    ).toEqual({
+      google: {
+        thinkingConfig: { thinkingLevel: 'medium' },
+      },
+    })
+  })
+
+  it('omits Google thinking config for Gateway Gemma models', () => {
+    expect(
+      resolveDefaultChatProviderOptions({
+        capability: 'default_chat',
+        provider: 'gateway',
+        model: 'google/gemma-4-26b-a4b-it',
+      }),
+    ).toBeUndefined()
+  })
+
+  it('keeps Google thinking config for direct Google Gemini models', () => {
+    expect(
+      resolveDefaultChatProviderOptions({
+        capability: 'default_chat',
+        provider: 'google',
+        model: 'gemini-3.1-flash-lite-preview',
+      }),
+    ).toEqual({
+      google: {
+        thinkingConfig: { thinkingLevel: 'medium' },
+      },
+    })
+  })
+})

--- a/src/lib/ai/draft/repair-request-draft-extraction.ts
+++ b/src/lib/ai/draft/repair-request-draft-extraction.ts
@@ -1,8 +1,8 @@
 import type { LanguageModel, UIMessage } from 'ai'
 import { generateObject } from 'ai'
-import type { GoogleLanguageModelOptions } from '@ai-sdk/google'
 import { z } from 'zod'
 
+import type { DefaultChatProviderOptions } from '../provider-options'
 import type { RepairRequestDraftEquipmentContext } from './repair-request-draft-evidence'
 import type { RepairRequestDraftInput } from './repair-request-draft-tool'
 
@@ -151,9 +151,7 @@ export async function extractRepairRequestDraftFields({
   model: LanguageModel
   messages: UIMessage[]
   equipment: RepairRequestDraftEquipmentContext
-  providerOptions?: {
-    google?: GoogleLanguageModelOptions
-  }
+  providerOptions?: DefaultChatProviderOptions
 }): Promise<RepairRequestDraftExtractionResult> {
   const conversationTranscript =
     buildRepairRequestDraftConversationTranscript(messages)

--- a/src/lib/ai/draft/repair-request-draft-orchestrator.ts
+++ b/src/lib/ai/draft/repair-request-draft-orchestrator.ts
@@ -1,6 +1,6 @@
 import type { LanguageModel, UIMessage } from 'ai'
-import type { GoogleLanguageModelOptions } from '@ai-sdk/google'
 
+import type { DefaultChatProviderOptions } from '../provider-options'
 import { buildRepairRequestDraft } from './repair-request-draft-tool'
 import { collectRepairRequestDraftEvidence } from './repair-request-draft-evidence'
 import {
@@ -27,9 +27,7 @@ export async function maybeBuildRepairRequestDraftArtifact({
   model: LanguageModel
   messages: UIMessage[]
   steps: Array<{ toolResults: Array<{ toolName: string; output: unknown }> }>
-  providerOptions?: {
-    google?: GoogleLanguageModelOptions
-  }
+  providerOptions?: DefaultChatProviderOptions
 }): Promise<RepairRequestDraftOrchestrationResult | null> {
   const session = getRepairRequestDraftSessionState(messages)
   if (session.status !== 'active' || session.startMessageIndex === undefined) {
@@ -67,4 +65,3 @@ export async function maybeBuildRepairRequestDraftArtifact({
     output: buildRepairRequestDraft(input),
   }
 }
-

--- a/src/lib/ai/provider-options.ts
+++ b/src/lib/ai/provider-options.ts
@@ -1,0 +1,33 @@
+import type { GoogleLanguageModelOptions } from '@ai-sdk/google'
+import type { ProviderOptions } from '@ai-sdk/provider-utils'
+
+import type { ResolvedDefaultChatConfig } from './config'
+
+export type DefaultChatProviderOptions = ProviderOptions
+
+function normalizeGoogleModelId(config: ResolvedDefaultChatConfig): string | null {
+  if (config.provider === 'google') {
+    return config.model
+  }
+
+  if (config.model.startsWith('google/')) {
+    return config.model.slice('google/'.length)
+  }
+
+  return null
+}
+
+export function resolveDefaultChatProviderOptions(
+  config: ResolvedDefaultChatConfig,
+): DefaultChatProviderOptions | undefined {
+  const googleModelId = normalizeGoogleModelId(config)
+  if (googleModelId === null || !googleModelId.startsWith('gemini-')) {
+    return undefined
+  }
+
+  return {
+    google: {
+      thinkingConfig: { thinkingLevel: 'medium' },
+    } satisfies GoogleLanguageModelOptions,
+  }
+}

--- a/src/lib/ai/provider-options.ts
+++ b/src/lib/ai/provider-options.ts
@@ -5,13 +5,17 @@ import type { ResolvedDefaultChatConfig } from './config'
 
 export type DefaultChatProviderOptions = ProviderOptions
 
+function stripGooglePrefix(model: string): string {
+  return model.startsWith('google/') ? model.slice('google/'.length) : model
+}
+
 function normalizeGoogleModelId(config: ResolvedDefaultChatConfig): string | null {
   if (config.provider === 'google') {
-    return config.model
+    return stripGooglePrefix(config.model)
   }
 
   if (config.model.startsWith('google/')) {
-    return config.model.slice('google/'.length)
+    return stripGooglePrefix(config.model)
   }
 
   return null

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -3,10 +3,15 @@ import { createGateway, type LanguageModel } from 'ai'
 
 import {
   assertDefaultChatCredentials,
+  type ResolvedDefaultChatConfig,
   resolveDefaultChatProvider,
   loadGoogleApiKeys,
   resolveDefaultChatConfig,
 } from './config'
+import {
+  resolveDefaultChatProviderOptions,
+  type DefaultChatProviderOptions,
+} from './provider-options'
 
 // ---------------------------------------------------------------------------
 // API-key pool & round-robin rotation
@@ -47,6 +52,8 @@ function maybeResetExhausted(): void {
 
 export interface ChatModelWithKeyIndex {
   model: LanguageModel
+  config: ResolvedDefaultChatConfig
+  providerOptions?: DefaultChatProviderOptions
   /** The pool index of the API key bound to this model instance. */
   keyIndex: number
 }
@@ -67,6 +74,8 @@ export function getChatModel(): ChatModelWithKeyIndex {
       const gateway = createGateway({ apiKey: process.env.AI_GATEWAY_API_KEY?.trim() })
       return {
         model: gateway(config.model as Parameters<typeof gateway>[0]),
+        config,
+        providerOptions: resolveDefaultChatProviderOptions(config),
         keyIndex: 0,
       }
     }
@@ -78,6 +87,8 @@ export function getChatModel(): ChatModelWithKeyIndex {
       const google = createGoogleGenerativeAI(key ? { apiKey: key } : undefined)
       return {
         model: google(config.model as Parameters<typeof google>[0]),
+        config,
+        providerOptions: resolveDefaultChatProviderOptions(config),
         keyIndex,
       }
     }


### PR DESCRIPTION
## Summary

- Route `/api/chat` model labels and `providerOptions` through the resolved chat model contract instead of route-local `process.env.AI_MODEL` reads.
- Add shared default-chat provider options so Gateway non-Google models omit Google thinking config while Gateway/direct Google Gemini keeps it.
- Pass resolved provider options through repair-request draft extraction without importing Google-specific option types in draft orchestration.

## Verification

- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/lib/ai/__tests__/config.test.ts src/lib/ai/__tests__/provider.test.ts src/lib/ai/__tests__/provider-options.test.ts src/app/api/chat/__tests__/route.limits.test.ts src/app/api/chat/__tests__/route.key-rotation.test.ts src/app/api/chat/__tests__/route.repair-request-draft-orchestration.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` (100/100)
- `rg -n "process\.env\.AI_MODEL|process\.env\.AI_PROVIDER|GoogleLanguageModelOptions|getGoogleProviderOptions|normalizeGoogleModelId" src/app/api/chat src/lib/ai/draft src/lib/ai/provider.ts -S --glob '!**/__tests__/**'` (no production matches)

Closes #325

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced provider-specific configuration resolution to consistently apply AI model settings across different providers.

* **Bug Fixes**
  * Improved handling of model-specific options, ensuring proper application of provider configurations without unnecessary defaults.

* **Tests**
  * Added comprehensive test coverage for provider options and key rotation scenarios, including validation of non-rotating gateway models and provider-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `/api/chat` through the resolved default chat config and passes provider-specific options end to end. Applies Gemini thinking config only for eligible Google models and normalizes `google/`-prefixed IDs to align with #325.

- New Features
  - Use resolved chat config for model selection and `providerOptions` instead of `process.env.AI_MODEL`.
  - Apply default Google `thinkingConfig` for Gemini models (direct Google and Gateway Google); omit for Gemma and non-Google Gateway models.
  - Propagate resolved `providerOptions` into repair-request draft extraction/orchestration.

- Refactors
  - Removed route-local env reads; use `chatModel.config.model` and `chatModel.providerOptions`.
  - Added `resolveDefaultChatProviderOptions` and `DefaultChatProviderOptions` in `src/lib/ai/provider-options.ts`; avoided Google-specific option types in draft modules.
  - Normalized `google/`-prefixed direct Google model IDs so Gemini options apply; preserved non-rotating behavior for Gateway models.

<sup>Written for commit d0a8b2193932f426d86f4573b3dfbe0591a17227. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

