### PR TITLE
[Issue #315] Document AI env flow and support custom OpenAI-compatible endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ AI_MODEL=gemini-3.1-flash-lite-preview
 GOOGLE_GENERATIVE_AI_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEYS=
 
+# Custom OpenAI-compatible endpoint path for providers that require a base URL.
+# Set AI_DEFAULT_CHAT_PROVIDER=openai-compatible to use this transport.
+AI_OPENAI_COMPATIBLE_BASE_URL=
+AI_OPENAI_COMPATIBLE_API_KEY=
+
 # Optional provider-specific placeholders used outside the default_chat contract.
 ANTHROPIC_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -15,12 +15,22 @@ AUTH_MIDDLEWARE_ENABLED=true
 NEXT_PUBLIC_AUTH_LEGACY_BRIDGE=true
 
 # AI assistant (Vercel AI SDK)
-AI_PROVIDER=google
-AI_MODEL=gemini-3-flash-preview
-GOOGLE_GENERATIVE_AI_API_KEY=
-# Optional future provider placeholders
-ANTHROPIC_API_KEY=
+# Preferred default_chat contract: switch model/provider by changing the
+# provider-prefixed gateway model id and redeploy.
+AI_DEFAULT_CHAT_MODEL=google/gemini-3.1-flash-lite-preview
 AI_GATEWAY_API_KEY=
+# Optional explicit pin. Resolver already defaults to gateway when a
+# provider-prefixed AI_DEFAULT_CHAT_MODEL is set and legacy Google envs are absent.
+AI_DEFAULT_CHAT_PROVIDER=gateway
+
+# Compatibility path for legacy direct Google deployments.
+AI_PROVIDER=google
+AI_MODEL=gemini-3.1-flash-lite-preview
+GOOGLE_GENERATIVE_AI_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEYS=
+
+# Optional provider-specific placeholders used outside the default_chat contract.
+ANTHROPIC_API_KEY=
 
 # AI guardrails (Task 1B)
 # Output quality

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory contains technical documentation, architectural decisions, and im
 
 ### Architecture & Design
 - [Transfers Kanban Scalability Plan (Deferred)](./transfers-kanban-scalability-plan.md) - Performance and UX improvements for handling 100+ transfer requests
+- [Default Chat Config Runbook](./ai/default-chat-config-runbook.md) - Env-based AI provider/model switching for the primary chat flow
 
 ### Audits & Reports
 - [Explicit `any` Audit Report (2026-03-28)](./explicit-any-audit-2026-03-28.md) - Full-repo `explicit any` inventory, root-cause analysis, and low-risk remediation shortlist

--- a/docs/ai/default-chat-config-runbook.md
+++ b/docs/ai/default-chat-config-runbook.md
@@ -1,0 +1,83 @@
+# Default Chat Config Runbook
+
+This runbook documents the env contract for switching the primary `default_chat` AI provider/model without editing route or business-logic code.
+
+## Preferred Gateway Flow
+
+Use Vercel AI Gateway as the preferred transport for `default_chat`.
+
+Required env vars:
+
+```env
+AI_DEFAULT_CHAT_MODEL=google/gemini-3.1-flash-lite-preview
+AI_GATEWAY_API_KEY=your_gateway_key
+```
+
+Optional explicit pin:
+
+```env
+AI_DEFAULT_CHAT_PROVIDER=gateway
+```
+
+`AI_DEFAULT_CHAT_PROVIDER` is an optional explicit pin. The current resolver already defaults to gateway when `AI_DEFAULT_CHAT_MODEL` is provider-prefixed and legacy Google env vars are not steering resolution into compatibility mode.
+
+Model ids must use the format `<provider>/<model>`, for example:
+
+- `google/gemini-3.1-flash-lite-preview`
+- `openai/gpt-5.2`
+- `anthropic/claude-sonnet-4`
+- `mistral/mistral-large-3`
+
+No AI base URL env var is required by the current implementation. Gateway transport is created internally and only needs `AI_GATEWAY_API_KEY`.
+
+## Compatibility Flow: Direct Google
+
+Keep the legacy direct Google path only for compatibility with older deployments or if you explicitly want Google API-key pool rotation.
+
+Direct Google env vars:
+
+```env
+AI_PROVIDER=google
+AI_MODEL=gemini-3.1-flash-lite-preview
+GOOGLE_GENERATIVE_AI_API_KEY=your_google_key
+GOOGLE_GENERATIVE_AI_API_KEYS=key_a,key_b,key_c
+```
+
+Notes:
+
+- `GOOGLE_GENERATIVE_AI_API_KEY` is the single-key path.
+- `GOOGLE_GENERATIVE_AI_API_KEYS` enables the direct Google key pool.
+- Key-pool quota rotation applies only to direct Google mode, not gateway mode.
+- Leaving legacy Google env vars in place can keep a deployment on the compatibility path instead of the preferred gateway path.
+
+## Deployment Switch Flow
+
+To switch the primary provider/model for `default_chat`:
+
+1. Update `AI_DEFAULT_CHAT_MODEL` to the new provider-prefixed model id.
+2. Ensure `AI_GATEWAY_API_KEY` is set for the target environment.
+3. Remove or stop relying on legacy direct Google env vars if you want the deployment to resolve cleanly to gateway mode.
+4. Redeploy.
+
+You should not need to edit `src/app/api/chat/route.ts` or any business-logic file for a normal provider/model switch.
+
+## Validation Failures And Fixes
+
+| Error | Meaning | Fix |
+|---|---|---|
+| `AI_DEFAULT_CHAT_MODEL must be a provider-prefixed model id when provider is gateway` | Gateway mode was selected but the model id is missing the provider prefix. | Change the model to `<provider>/<model>`, for example `openai/gpt-5.2`. |
+| `AI_GATEWAY_API_KEY is required for AI gateway mode` | Gateway mode resolved successfully but the gateway key is missing. | Set `AI_GATEWAY_API_KEY` in the deployment environment and redeploy. |
+| `Unsupported direct AI provider: ... Use AI_DEFAULT_CHAT_PROVIDER=gateway with a provider-prefixed model id.` | A direct provider other than Google was configured via legacy env vars. | Move to the preferred gateway flow and use a provider-prefixed `AI_DEFAULT_CHAT_MODEL`. |
+| `GOOGLE_GENERATIVE_AI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEYS is required for direct Google mode` | Direct Google compatibility mode resolved, but no Google API key is available. | Set one of the Google key env vars or remove the legacy direct Google settings so the deployment uses gateway mode instead. |
+
+## Operational Default
+
+For new or cleaned-up deployments, prefer:
+
+```env
+AI_DEFAULT_CHAT_MODEL=google/gemini-3.1-flash-lite-preview
+AI_GATEWAY_API_KEY=your_gateway_key
+AI_DEFAULT_CHAT_PROVIDER=gateway
+```
+
+Use the direct Google compatibility flow only when you intentionally need the old key-rotation path.

--- a/docs/ai/default-chat-config-runbook.md
+++ b/docs/ai/default-chat-config-runbook.md
@@ -28,7 +28,27 @@ Model ids must use the format `<provider>/<model>`, for example:
 - `anthropic/claude-sonnet-4`
 - `mistral/mistral-large-3`
 
-No AI base URL env var is required by the current implementation. Gateway transport is created internally and only needs `AI_GATEWAY_API_KEY`.
+No AI base URL env var is required for gateway mode. Gateway transport is created internally and only needs `AI_GATEWAY_API_KEY`.
+
+## Custom OpenAI-Compatible Endpoint Flow
+
+Use this path for providers that expose an OpenAI-compatible API behind a custom base URL, such as DashScope.
+
+Required env vars:
+
+```env
+AI_DEFAULT_CHAT_PROVIDER=openai-compatible
+AI_DEFAULT_CHAT_MODEL=qwen3.5-plus-2026-04-20
+AI_OPENAI_COMPATIBLE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+AI_OPENAI_COMPATIBLE_API_KEY=your_provider_key
+```
+
+Notes:
+
+- This path does not use Vercel AI Gateway.
+- Model ids do not need the gateway `<provider>/<model>` prefix here. Use the model id expected by the target provider.
+- Key rotation does not apply to this path.
+- DashScope is a working example of this contract because it exposes an OpenAI-compatible API behind a custom base URL.
 
 ## Compatibility Flow: Direct Google
 
@@ -61,6 +81,14 @@ To switch the primary provider/model for `default_chat`:
 
 You should not need to edit `src/app/api/chat/route.ts` or any business-logic file for a normal provider/model switch.
 
+For a custom OpenAI-compatible endpoint:
+
+1. Set `AI_DEFAULT_CHAT_PROVIDER=openai-compatible`.
+2. Set `AI_DEFAULT_CHAT_MODEL` to the model id expected by the provider.
+3. Set `AI_OPENAI_COMPATIBLE_BASE_URL`.
+4. Set `AI_OPENAI_COMPATIBLE_API_KEY`.
+5. Redeploy.
+
 ## Validation Failures And Fixes
 
 | Error | Meaning | Fix |
@@ -69,6 +97,8 @@ You should not need to edit `src/app/api/chat/route.ts` or any business-logic fi
 | `AI_GATEWAY_API_KEY is required for AI gateway mode` | Gateway mode resolved successfully but the gateway key is missing. | Set `AI_GATEWAY_API_KEY` in the deployment environment and redeploy. |
 | `Unsupported direct AI provider: ... Use AI_DEFAULT_CHAT_PROVIDER=gateway with a provider-prefixed model id.` | A direct provider other than Google was configured via legacy env vars. | Move to the preferred gateway flow and use a provider-prefixed `AI_DEFAULT_CHAT_MODEL`. |
 | `GOOGLE_GENERATIVE_AI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEYS is required for direct Google mode` | Direct Google compatibility mode resolved, but no Google API key is available. | Set one of the Google key env vars or remove the legacy direct Google settings so the deployment uses gateway mode instead. |
+| `AI_OPENAI_COMPATIBLE_BASE_URL is required for openai-compatible mode` | Custom OpenAI-compatible mode was selected without a base URL. | Set `AI_OPENAI_COMPATIBLE_BASE_URL` to the provider's OpenAI-compatible API root. |
+| `AI_OPENAI_COMPATIBLE_API_KEY is required for openai-compatible mode` | Custom OpenAI-compatible mode was selected without an API key. | Set `AI_OPENAI_COMPATIBLE_API_KEY` in the deployment environment and redeploy. |
 
 ## Operational Default
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/google": "^3.0.34",
+        "@ai-sdk/openai-compatible": "^2.0.41",
         "@ai-sdk/react": "^3.0.107",
         "@hookform/resolvers": "^4.1.3",
         "@morphllm/morphmcp": "^0.8.57",
@@ -127,6 +128,39 @@
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.16"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "2.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.41.tgz",
+      "integrity": "sha512-kNAGINk71AlOXx10Dq/PXw4t/9XjdK8uxfpVElRwtSFMdeSiLVt58p9TPx4/FJD+hxZuVhvxYj9r42osxWq79g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.34",
+    "@ai-sdk/openai-compatible": "^2.0.41",
     "@ai-sdk/react": "^3.0.107",
     "@hookform/resolvers": "^4.1.3",
     "@morphllm/morphmcp": "^0.8.57",

--- a/src/lib/ai/__tests__/config.docs-contract.test.ts
+++ b/src/lib/ai/__tests__/config.docs-contract.test.ts
@@ -14,7 +14,8 @@ describe('AI config docs contract', () => {
     expect(envExample).toContain('AI_MODEL=gemini-3.1-flash-lite-preview')
     expect(envExample).toContain('GOOGLE_GENERATIVE_AI_API_KEY=')
     expect(envExample).toContain('GOOGLE_GENERATIVE_AI_API_KEYS=')
-    expect(envExample).not.toContain('AI_BASE_URL=')
+    expect(envExample).toContain('AI_OPENAI_COMPATIBLE_BASE_URL=')
+    expect(envExample).toContain('AI_OPENAI_COMPATIBLE_API_KEY=')
   })
 
   it('provides a runbook for switching providers by env and redeploy', () => {
@@ -32,7 +33,9 @@ describe('AI config docs contract', () => {
     expect(runbook).toContain('mistral/')
     expect(runbook).toContain('GOOGLE_GENERATIVE_AI_API_KEYS')
     expect(runbook).toContain('redeploy')
-    expect(runbook).not.toContain('AI_BASE_URL')
+    expect(runbook).toContain('AI_OPENAI_COMPATIBLE_BASE_URL')
+    expect(runbook).toContain('AI_OPENAI_COMPATIBLE_API_KEY')
+    expect(runbook).toContain('DashScope')
     expect(runbook).toContain(
       'AI_DEFAULT_CHAT_MODEL must be a provider-prefixed model id when provider is gateway',
     )

--- a/src/lib/ai/__tests__/config.docs-contract.test.ts
+++ b/src/lib/ai/__tests__/config.docs-contract.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+describe('AI config docs contract', () => {
+  it('documents the preferred gateway env contract without requiring a base URL', () => {
+    const envExample = readFileSync(path.resolve(process.cwd(), '.env.example'), 'utf8')
+
+    expect(envExample).toContain('AI_DEFAULT_CHAT_MODEL=google/gemini-3.1-flash-lite-preview')
+    expect(envExample).toContain('AI_GATEWAY_API_KEY=')
+    expect(envExample).toContain('AI_DEFAULT_CHAT_PROVIDER=gateway')
+    expect(envExample).toContain('AI_PROVIDER=google')
+    expect(envExample).toContain('AI_MODEL=gemini-3.1-flash-lite-preview')
+    expect(envExample).toContain('GOOGLE_GENERATIVE_AI_API_KEY=')
+    expect(envExample).toContain('GOOGLE_GENERATIVE_AI_API_KEYS=')
+    expect(envExample).not.toContain('AI_BASE_URL=')
+  })
+
+  it('provides a runbook for switching providers by env and redeploy', () => {
+    const runbookPath = path.resolve(process.cwd(), 'docs/ai/default-chat-config-runbook.md')
+    const runbook = readFileSync(runbookPath, 'utf8')
+
+    expect(runbook).toContain('AI_DEFAULT_CHAT_MODEL')
+    expect(runbook).toContain('AI_GATEWAY_API_KEY')
+    expect(runbook).toContain('AI_DEFAULT_CHAT_PROVIDER')
+    expect(runbook).toContain('optional explicit pin')
+    expect(runbook).toContain('<provider>/<model>')
+    expect(runbook).toContain('google/')
+    expect(runbook).toContain('openai/')
+    expect(runbook).toContain('anthropic/')
+    expect(runbook).toContain('mistral/')
+    expect(runbook).toContain('GOOGLE_GENERATIVE_AI_API_KEYS')
+    expect(runbook).toContain('redeploy')
+    expect(runbook).not.toContain('AI_BASE_URL')
+    expect(runbook).toContain(
+      'AI_DEFAULT_CHAT_MODEL must be a provider-prefixed model id when provider is gateway',
+    )
+    expect(runbook).toContain('AI_GATEWAY_API_KEY is required for AI gateway mode')
+    expect(runbook).toContain('Unsupported direct AI provider:')
+  })
+})

--- a/src/lib/ai/__tests__/config.test.ts
+++ b/src/lib/ai/__tests__/config.test.ts
@@ -65,6 +65,23 @@ describe('AI default chat config resolver', () => {
     })
   })
 
+  it('supports an explicit openai-compatible provider with a custom base URL', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          AI_DEFAULT_CHAT_PROVIDER: 'openai-compatible',
+          AI_DEFAULT_CHAT_MODEL: 'qwen3.5-plus-2026-04-20',
+          AI_OPENAI_COMPATIBLE_BASE_URL:
+            'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'openai-compatible',
+      model: 'qwen3.5-plus-2026-04-20',
+    })
+  })
+
   it('keeps legacy AI_MODEL-only config in direct Google mode', () => {
     expect(
       resolveDefaultChatConfig(
@@ -166,6 +183,33 @@ describe('AI default chat config resolver', () => {
 
     expect(() => assertDefaultChatCredentials(config, env())).toThrow(
       'GOOGLE_GENERATIVE_AI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEYS is required for direct Google mode',
+    )
+  })
+
+  it('requires a base URL in openai-compatible mode', () => {
+    const config = resolveDefaultChatConfig(
+      env({
+        AI_DEFAULT_CHAT_PROVIDER: 'openai-compatible',
+        AI_DEFAULT_CHAT_MODEL: 'qwen3.5-plus-2026-04-20',
+      }),
+    )
+
+    expect(() => assertDefaultChatCredentials(config, env())).toThrow(
+      'AI_OPENAI_COMPATIBLE_BASE_URL is required for openai-compatible mode',
+    )
+  })
+
+  it('requires an API key in openai-compatible mode', () => {
+    const envVars = env({
+      AI_DEFAULT_CHAT_PROVIDER: 'openai-compatible',
+      AI_DEFAULT_CHAT_MODEL: 'qwen3.5-plus-2026-04-20',
+      AI_OPENAI_COMPATIBLE_BASE_URL:
+        'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+    })
+    const config = resolveDefaultChatConfig(envVars)
+
+    expect(() => assertDefaultChatCredentials(config, envVars)).toThrow(
+      'AI_OPENAI_COMPATIBLE_API_KEY is required for openai-compatible mode',
     )
   })
 

--- a/src/lib/ai/__tests__/config.test.ts
+++ b/src/lib/ai/__tests__/config.test.ts
@@ -36,6 +36,20 @@ describe('AI default chat config resolver', () => {
     })
   })
 
+  it('defaults to gateway when only a provider-prefixed AI_DEFAULT_CHAT_MODEL is configured', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          AI_DEFAULT_CHAT_MODEL: 'openai/gpt-5.2',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'gateway',
+      model: 'openai/gpt-5.2',
+    })
+  })
+
   it('falls back to legacy Google provider and model env vars', () => {
     expect(
       resolveDefaultChatConfig(

--- a/src/lib/ai/__tests__/provider.test.ts
+++ b/src/lib/ai/__tests__/provider.test.ts
@@ -22,6 +22,20 @@ vi.mock('@ai-sdk/google', () => ({
   }),
 }))
 
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: vi.fn((opts?: { apiKey?: string; baseURL?: string; name?: string }) => {
+    const provider = (modelId: string) => ({
+      __testModel: true,
+      transport: 'openai-compatible',
+      providerName: opts?.name ?? 'openai-compatible',
+      modelId,
+      apiKey: opts?.apiKey ?? 'DEFAULT_OPENAI_COMPATIBLE_KEY',
+      baseURL: opts?.baseURL ?? 'https://example.invalid/v1',
+    })
+    return provider
+  }),
+}))
+
 vi.mock('ai', () => ({
   createGateway: vi.fn((opts?: { apiKey?: string }) => {
     const provider = (modelId: string) => ({
@@ -185,10 +199,11 @@ describe('provider — API key rotation', () => {
     expect(() => getChatModel()).toThrow('Unsupported direct AI provider: openai')
   })
 
-  it('keeps key pool sizing available when model construction would reject config', () => {
+  it('treats unsupported direct providers as non-rotating while config validation fails elsewhere', () => {
     process.env.AI_PROVIDER = 'openai'
 
-    expect(getKeyPoolSize()).toBe(3)
+    expect(getKeyPoolSize()).toBe(1)
+    expect(handleProviderQuotaError(0)).toBe(false)
   })
 
   // -------------------------------------------------------------------
@@ -228,6 +243,41 @@ describe('provider — API key rotation', () => {
     process.env.AI_DEFAULT_CHAT_PROVIDER = 'gateway'
     process.env.AI_DEFAULT_CHAT_MODEL = 'openai/gpt-5.2'
     process.env.AI_GATEWAY_API_KEY = 'GATEWAY_KEY'
+
+    expect(getKeyPoolSize()).toBe(1)
+    expect(handleProviderQuotaError(0)).toBe(false)
+  })
+
+  it('returns an openai-compatible model for a custom base URL provider', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'openai-compatible'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'qwen3.5-plus-2026-04-20'
+    process.env.AI_OPENAI_COMPATIBLE_BASE_URL =
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
+    process.env.AI_OPENAI_COMPATIBLE_API_KEY = 'DASHSCOPE_KEY'
+
+    const { model, keyIndex } = getChatModel()
+    const m = model as unknown as {
+      apiKey: string
+      baseURL: string
+      modelId: string
+      transport: string
+      providerName: string
+    }
+
+    expect(m.transport).toBe('openai-compatible')
+    expect(m.providerName).toBe('openai-compatible')
+    expect(m.apiKey).toBe('DASHSCOPE_KEY')
+    expect(m.baseURL).toBe('https://dashscope-intl.aliyuncs.com/compatible-mode/v1')
+    expect(m.modelId).toBe('qwen3.5-plus-2026-04-20')
+    expect(keyIndex).toBe(0)
+  })
+
+  it('reports a single non-rotating key slot for openai-compatible mode', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'openai-compatible'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'qwen3.5-plus-2026-04-20'
+    process.env.AI_OPENAI_COMPATIBLE_BASE_URL =
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
+    process.env.AI_OPENAI_COMPATIBLE_API_KEY = 'DASHSCOPE_KEY'
 
     expect(getKeyPoolSize()).toBe(1)
     expect(handleProviderQuotaError(0)).toBe(false)

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,5 +1,5 @@
 export type AiChatCapability = 'default_chat'
-export type AiProviderTransport = 'gateway' | 'google'
+export type AiProviderTransport = 'gateway' | 'google' | 'openai-compatible'
 
 export interface ResolvedDefaultChatConfig {
   capability: AiChatCapability
@@ -14,6 +14,18 @@ const DEFAULT_GOOGLE_MODEL = 'gemini-3.1-flash-lite-preview'
 function readEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
   const value = env[key]?.trim()
   return value ? value : undefined
+}
+
+export function readOpenAICompatibleBaseUrl(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return readEnv(env, 'AI_OPENAI_COMPATIBLE_BASE_URL')
+}
+
+export function readOpenAICompatibleApiKey(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return readEnv(env, 'AI_OPENAI_COMPATIBLE_API_KEY')
 }
 
 function hasProviderPrefix(model: string): boolean {
@@ -89,6 +101,14 @@ export function resolveDefaultChatConfig(
     }
   }
 
+  if (provider === 'openai-compatible') {
+    return {
+      capability: 'default_chat',
+      provider,
+      model,
+    }
+  }
+
   throw new Error(
     `Unsupported direct AI provider: ${provider}. Use AI_DEFAULT_CHAT_PROVIDER=gateway with a provider-prefixed model id.`,
   )
@@ -106,5 +126,13 @@ export function assertDefaultChatCredentials(
     throw new Error(
       'GOOGLE_GENERATIVE_AI_API_KEY or GOOGLE_GENERATIVE_AI_API_KEYS is required for direct Google mode',
     )
+  }
+
+  if (config.provider === 'openai-compatible' && !readOpenAICompatibleBaseUrl(env)) {
+    throw new Error('AI_OPENAI_COMPATIBLE_BASE_URL is required for openai-compatible mode')
+  }
+
+  if (config.provider === 'openai-compatible' && !readOpenAICompatibleApiKey(env)) {
+    throw new Error('AI_OPENAI_COMPATIBLE_API_KEY is required for openai-compatible mode')
   }
 }

--- a/src/lib/ai/provider.ts
+++ b/src/lib/ai/provider.ts
@@ -1,9 +1,12 @@
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { createGateway, type LanguageModel } from 'ai'
 
 import {
   assertDefaultChatCredentials,
   type ResolvedDefaultChatConfig,
+  readOpenAICompatibleApiKey,
+  readOpenAICompatibleBaseUrl,
   resolveDefaultChatProvider,
   loadGoogleApiKeys,
   resolveDefaultChatConfig,
@@ -92,6 +95,24 @@ export function getChatModel(): ChatModelWithKeyIndex {
         keyIndex,
       }
     }
+    case 'openai-compatible': {
+      const apiKey = readOpenAICompatibleApiKey()
+      const baseURL = readOpenAICompatibleBaseUrl()
+      if (!apiKey || !baseURL) {
+        throw new Error('OpenAI-compatible credentials should have been validated before use')
+      }
+      const openAICompatible = createOpenAICompatible({
+        name: 'openai-compatible',
+        apiKey,
+        baseURL,
+      })
+      return {
+        model: openAICompatible(config.model as Parameters<typeof openAICompatible>[0]),
+        config,
+        providerOptions: resolveDefaultChatProviderOptions(config),
+        keyIndex: 0,
+      }
+    }
   }
 }
 
@@ -105,7 +126,8 @@ export function getChatModel(): ChatModelWithKeyIndex {
  *          pool are exhausted (caller should surface the quota error to the user).
  */
 export function handleProviderQuotaError(failedKeyIndex: number): boolean {
-  if (resolveDefaultChatProvider() === 'gateway') return false
+  const provider = resolveDefaultChatProvider()
+  if (provider !== 'google') return false
 
   maybeResetExhausted()
 
@@ -140,7 +162,7 @@ export function handleProviderQuotaError(failedKeyIndex: number): boolean {
  * Used by the route to cap retry attempts.
  */
 export function getKeyPoolSize(): number {
-  if (resolveDefaultChatProvider() === 'gateway') return 1
+  if (resolveDefaultChatProvider() !== 'google') return 1
 
   return _internals.keys.length
 }


### PR DESCRIPTION
## Summary
- document the preferred default_chat gateway env contract and direct Google compatibility path
- add support for custom OpenAI-compatible providers configured with `baseURL + apiKey + model`
- cover the new transport with resolver/provider/doc drift tests and verify `/api/chat` guardrails stay intact

## Testing
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- "src/lib/ai/__tests__/config.docs-contract.test.ts" "src/lib/ai/__tests__/config.test.ts" "src/lib/ai/__tests__/provider.test.ts" "src/app/api/chat/__tests__/route.limits.test.ts"`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- live smoke via `@ai-sdk/openai-compatible` against DashScope-compatible base URL returned `OK` with model `qwen3.5-plus-2026-04-20`

Closes #326
Closes #331
