### PR TITLE
fix: ground query_database to ai_readonly schema

### DIFF
--- a/src/app/api/chat/__tests__/route.draft-output.test.ts
+++ b/src/app/api/chat/__tests__/route.draft-output.test.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 import {
   repairRequestDraftSchema,
@@ -316,8 +318,8 @@ describe('repairRequestDraft safety', () => {
     )
   })
 
-  it('system prompt version is v2.5.0', () => {
-    expect(SYSTEM_PROMPT_VERSION).toBe('v2.5.0')
+  it('system prompt version is v2.5.1', () => {
+    expect(SYSTEM_PROMPT_VERSION).toBe('v2.5.1')
   })
 
   it('prompt prevents auto-submission of repair requests', () => {

--- a/src/app/api/chat/__tests__/route.query-database-grounding.test.ts
+++ b/src/app/api/chat/__tests__/route.query-database-grounding.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+const getServerSessionMock = vi.fn()
+const streamTextMock = vi.fn()
+const stepCountIsMock = vi.fn()
+const getChatModelMock = vi.fn()
+const checkUsageLimitsMock = vi.fn()
+const recordUsageMock = vi.fn()
+const confirmUsageMock = vi.fn()
+
+vi.mock('next-auth', () => ({
+  getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
+}))
+
+vi.mock('@/lib/ai/provider', () => ({
+  getChatModel: (...args: unknown[]) => getChatModelMock(...args),
+  getKeyPoolSize: () => 1,
+  handleProviderQuotaError: () => false,
+}))
+
+vi.mock('@/lib/ai/usage-metering', () => ({
+  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
+  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
+  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+}))
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai')
+  return {
+    ...actual,
+    streamText: (...args: unknown[]) => streamTextMock(...args),
+    stepCountIs: (...args: unknown[]) => stepCountIsMock(...args),
+  }
+})
+
+import { POST } from '../route'
+import { QUERY_DATABASE_TOOL_DESCRIPTION } from '@/lib/ai/sql/schema-cheatsheet'
+import { makeChatModel, makeReadyStreamTextResult } from './stream-text-result-test-helpers'
+
+function buildRequest(body: unknown) {
+  return new Request('http://localhost/api/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/chat query_database grounding payload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    getServerSessionMock.mockResolvedValue({
+      user: { id: 'u1', role: 'to_qltb', don_vi: 17 },
+    })
+    getChatModelMock.mockReturnValue(makeChatModel('google/gemini-3.1-flash-lite-preview'))
+    checkUsageLimitsMock.mockReturnValue({ allowed: true })
+    stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
+    streamTextMock.mockReturnValue(makeReadyStreamTextResult())
+  })
+
+  it('sends the strengthened query_database grounding contract to streamText', async () => {
+    const res = await POST(
+      buildRequest({
+        selectedFacilityId: 17,
+        messages: [
+          {
+            id: 'msg_1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Thống kê số lượng thiết bị theo khoa' }],
+          },
+        ],
+        requestedTools: ['query_database'],
+      }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(streamTextMock).toHaveBeenCalledOnce()
+
+    const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as {
+      system?: string
+      tools?: Record<string, { description?: string }>
+    }
+
+    expect(streamTextArgs.system).toContain('equipment_search')
+    expect(streamTextArgs.system).toContain('maintenance_facts')
+    expect(streamTextArgs.system).toContain('repair_facts')
+    expect(streamTextArgs.system).toContain('usage_facts')
+    expect(streamTextArgs.system).toContain('quota_facts')
+    expect(streamTextArgs.system).toContain('khoa_phong_quan_ly')
+    expect(streamTextArgs.system).toContain('thiet_bi')
+    expect(streamTextArgs.system).toContain('khoa_phong')
+    expect(streamTextArgs.system).toContain('set_config')
+
+    expect(streamTextArgs.tools?.query_database?.description).toBe(
+      QUERY_DATABASE_TOOL_DESCRIPTION,
+    )
+    expect(streamTextArgs.tools?.query_database?.description).toContain(
+      'ai_readonly.equipment_search',
+    )
+  })
+})

--- a/src/app/api/chat/__tests__/route.query-database-grounding.test.ts
+++ b/src/app/api/chat/__tests__/route.query-database-grounding.test.ts
@@ -36,7 +36,10 @@ vi.mock('ai', async () => {
 })
 
 import { POST } from '../route'
-import { QUERY_DATABASE_TOOL_DESCRIPTION } from '@/lib/ai/sql/schema-cheatsheet'
+import {
+  AI_READONLY_FORBIDDEN_REFERENCES,
+  QUERY_DATABASE_TOOL_DESCRIPTION,
+} from '@/lib/ai/sql/schema-cheatsheet'
 import { makeChatModel, makeReadyStreamTextResult } from './stream-text-result-test-helpers'
 
 function buildRequest(body: unknown) {
@@ -89,9 +92,10 @@ describe('/api/chat query_database grounding payload', () => {
     expect(streamTextArgs.system).toContain('usage_facts')
     expect(streamTextArgs.system).toContain('quota_facts')
     expect(streamTextArgs.system).toContain('khoa_phong_quan_ly')
-    expect(streamTextArgs.system).toContain('thiet_bi')
-    expect(streamTextArgs.system).toContain('khoa_phong')
-    expect(streamTextArgs.system).toContain('set_config')
+    expect(streamTextArgs.system).toContain('KHÔNG dùng raw schema/tên')
+    for (const ref of AI_READONLY_FORBIDDEN_REFERENCES) {
+      expect(streamTextArgs.system).toContain(ref)
+    }
 
     expect(streamTextArgs.tools?.query_database?.description).toBe(
       QUERY_DATABASE_TOOL_DESCRIPTION,

--- a/src/app/api/chat/__tests__/route.troubleshooting.test.ts
+++ b/src/app/api/chat/__tests__/route.troubleshooting.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 import {
   troubleshootingDraftSchema,
@@ -246,8 +248,8 @@ describe('troubleshooting draft safety', () => {
     }
   })
 
-  it('system prompt version is v2.5.0', () => {
-    expect(SYSTEM_PROMPT_VERSION).toBe('v2.5.0')
+  it('system prompt version is v2.5.1', () => {
+    expect(SYSTEM_PROMPT_VERSION).toBe('v2.5.1')
   })
 
   it('prompt labels troubleshooting output as Draft/Inference, never Fact', () => {

--- a/src/lib/ai/prompts/__tests__/system.test.ts
+++ b/src/lib/ai/prompts/__tests__/system.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
+import { AI_READONLY_FORBIDDEN_REFERENCES } from '@/lib/ai/sql/schema-cheatsheet'
 import { SYSTEM_PROMPT_VERSION, buildSystemPrompt } from '../system'
 
 describe('system prompt module', () => {
@@ -152,9 +153,10 @@ describe('system prompt module', () => {
     expect(prompt).toContain('usage_facts')
     expect(prompt).toContain('quota_facts')
     expect(prompt).toContain('khoa_phong_quan_ly')
-    expect(prompt).toContain('thiet_bi')
-    expect(prompt).toContain('khoa_phong')
-    expect(prompt).toContain('set_config')
+    expect(prompt).toContain('KHÔNG dùng raw schema/tên')
+    for (const ref of AI_READONLY_FORBIDDEN_REFERENCES) {
+      expect(prompt).toContain(ref)
+    }
   })
 
   it('includes § 10 troubleshooting drafts section', () => {

--- a/src/lib/ai/prompts/__tests__/system.test.ts
+++ b/src/lib/ai/prompts/__tests__/system.test.ts
@@ -135,8 +135,26 @@ describe('system prompt module', () => {
     expect(prompt).toContain('metadata')
   })
 
-  it('prompt version is v2.5.0 after Batch 2 envelope guidance updates', () => {
-    expect(SYSTEM_PROMPT_VERSION).toBe('v2.5.0')
+  it('prompt version is v2.5.1 after query_database grounding updates', () => {
+    expect(SYSTEM_PROMPT_VERSION).toBe('v2.5.1')
+  })
+
+  it('grounds query_database to the ai_readonly semantic surface', () => {
+    const prompt = buildSystemPrompt({
+      role: 'admin',
+      userId: 'u1',
+      selectedFacilityId: 2,
+    })
+
+    expect(prompt).toContain('equipment_search')
+    expect(prompt).toContain('maintenance_facts')
+    expect(prompt).toContain('repair_facts')
+    expect(prompt).toContain('usage_facts')
+    expect(prompt).toContain('quota_facts')
+    expect(prompt).toContain('khoa_phong_quan_ly')
+    expect(prompt).toContain('thiet_bi')
+    expect(prompt).toContain('khoa_phong')
+    expect(prompt).toContain('set_config')
   })
 
   it('includes § 10 troubleshooting drafts section', () => {

--- a/src/lib/ai/prompts/system.ts
+++ b/src/lib/ai/prompts/system.ts
@@ -1,7 +1,8 @@
 import { ROLES } from '@/lib/rbac'
+import { QUERY_DATABASE_PROMPT_POINTER } from '@/lib/ai/sql/schema-cheatsheet'
 import type { SystemPromptContext } from './types'
 
-export const SYSTEM_PROMPT_VERSION = 'v2.5.0'
+export const SYSTEM_PROMPT_VERSION = 'v2.5.1'
 
 const ALLOWED_ROLES: Set<string> = new Set(Object.values(ROLES))
 
@@ -120,7 +121,7 @@ export function buildSystemPrompt(context: SystemPromptContext = {}): string {
       '- KHÔNG chấp nhận file upload hoặc nội dung multimodal từ người dùng.',
       '- Tra cứu file đính kèm được hỗ trợ qua công cụ `attachmentLookup` – chỉ trả metadata (tên file, liên kết).',
       '- `query_database` chỉ là fallback hẹp cho câu hỏi báo cáo/tổng hợp ad-hoc trong phạm vi một cơ sở.',
-      '- Khi dùng `query_database`, chỉ được viết đúng một câu lệnh `SELECT` trên semantic layer `ai_readonly`; không truy vấn schema production khác và không giả định quyền cross-facility.',
+      `- ${QUERY_DATABASE_PROMPT_POINTER}`,
       '',
       '**📦 Định dạng kết quả tool (Tool Response Envelope):**',
       '- Mỗi tool read-only trả về kết quả dạng `{ modelSummary, followUpContext?, uiArtifact? }`.',

--- a/src/lib/ai/sql/__tests__/query-database-dormant.test.ts
+++ b/src/lib/ai/sql/__tests__/query-database-dormant.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/lib/ai/sql/audited-executor', () => ({
 }))
 
 import { POST as rpcPost } from '@/app/api/rpc/[fn]/route'
+import { QUERY_DATABASE_TOOL_DESCRIPTION } from '@/lib/ai/sql/schema-cheatsheet'
 import { QUERY_DATABASE_TOOL_NAME } from '@/lib/ai/tools/query-database'
 import { buildToolRegistry, getAllowedToolNamesForTest, getToolRpcMapping, validateRequestedTools } from '@/lib/ai/tools/registry'
 import type { AssistantSqlScope } from '@/lib/ai/sql/scope'
@@ -74,6 +75,33 @@ describe('query_database runtime rollout contract', () => {
       sql: 'select total from ai_readonly.reporting_summary',
       execute: undefined,
     })
+  })
+
+  it('exposes the canonical schema-grounded description', () => {
+    const scope: AssistantSqlScope = {
+      effectiveFacilityId: 17,
+      facilitySource: 'selected',
+      normalizedRole: 'global',
+      rawRole: 'admin',
+      requestedFacilityId: 17,
+      sessionFacilityId: undefined,
+      userId: 'u-admin',
+    }
+    const request = new Request('http://localhost/api/chat', { method: 'POST' })
+
+    const registry = buildToolRegistry({
+      request,
+      tenantId: 17,
+      userId: 'u-admin',
+      requestedTools: ['query_database'],
+      assistantSqlScope: scope,
+    })
+
+    const queryDatabaseTool = registry.query_database as unknown as {
+      description?: string
+    }
+
+    expect(queryDatabaseTool.description).toBe(QUERY_DATABASE_TOOL_DESCRIPTION)
   })
 
   it('does not expose SQL execution through the RPC proxy mapping', async () => {

--- a/src/lib/ai/sql/__tests__/schema-cheatsheet.test.ts
+++ b/src/lib/ai/sql/__tests__/schema-cheatsheet.test.ts
@@ -1,0 +1,157 @@
+import { Buffer } from 'node:buffer'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  AI_READONLY_FORBIDDEN_REFERENCES,
+  AI_READONLY_SCHEMA,
+  AI_READONLY_VIEW_NAMES,
+  QUERY_DATABASE_TOOL_DESCRIPTION,
+} from '../schema-cheatsheet'
+
+describe('query_database schema cheatsheet contract', () => {
+  it('exports the canonical ai_readonly view names', () => {
+    expect(AI_READONLY_VIEW_NAMES).toEqual([
+      'equipment_search',
+      'maintenance_facts',
+      'repair_facts',
+      'usage_facts',
+      'quota_facts',
+    ])
+  })
+
+  it('keeps the expected live columns for each ai_readonly view', () => {
+    expect(AI_READONLY_SCHEMA.equipment_search).toEqual([
+      'equipment_id',
+      'ma_thiet_bi',
+      'ten_thiet_bi',
+      'model',
+      'serial',
+      'so_luu_hanh',
+      'phan_loai_theo_nd98',
+      'nhom_thiet_bi_id',
+      'tinh_trang_hien_tai',
+      'khoa_phong_quan_ly',
+      'vi_tri_lap_dat',
+      'ngay_bt_tiep_theo',
+      'ngay_hc_tiep_theo',
+      'ngay_kd_tiep_theo',
+      'facility_id',
+      'facility_code',
+      'facility_name',
+      'created_at',
+    ])
+    expect(AI_READONLY_SCHEMA.maintenance_facts).toEqual([
+      'maintenance_task_id',
+      'maintenance_plan_id',
+      'equipment_id',
+      'loai_cong_viec',
+      'don_vi_thuc_hien',
+      'diem_hieu_chuan',
+      'task_notes',
+      'ten_ke_hoach',
+      'plan_year',
+      'plan_status',
+      'ngay_phe_duyet',
+      'plan_facility_id',
+      'ma_thiet_bi',
+      'ten_thiet_bi',
+      'model',
+      'khoa_phong_quan_ly',
+      'tinh_trang_hien_tai',
+      'facility_id',
+    ])
+    expect(AI_READONLY_SCHEMA.repair_facts).toEqual([
+      'repair_request_id',
+      'equipment_id',
+      'repair_status',
+      'mo_ta_su_co',
+      'hang_muc_sua_chua',
+      'ngay_yeu_cau',
+      'ngay_duyet',
+      'ngay_hoan_thanh',
+      'don_vi_thuc_hien',
+      'ten_don_vi_thue',
+      'chi_phi_sua_chua',
+      'ma_thiet_bi',
+      'ten_thiet_bi',
+      'model',
+      'khoa_phong_quan_ly',
+      'facility_id',
+      'facility_name',
+    ])
+    expect(AI_READONLY_SCHEMA.usage_facts).toEqual([
+      'usage_log_id',
+      'equipment_id',
+      'thoi_gian_bat_dau',
+      'thoi_gian_ket_thuc',
+      'trang_thai',
+      'tinh_trang_thiet_bi',
+      'tinh_trang_ban_dau',
+      'tinh_trang_ket_thuc',
+      'ghi_chu',
+      'duration_hours',
+      'ma_thiet_bi',
+      'ten_thiet_bi',
+      'model',
+      'khoa_phong_quan_ly',
+      'facility_id',
+    ])
+    expect(AI_READONLY_SCHEMA.quota_facts).toEqual([
+      'equipment_id',
+      'ma_thiet_bi',
+      'ten_thiet_bi',
+      'model',
+      'category_id',
+      'category_code',
+      'category_name',
+      'facility_id',
+      'facility_name',
+      'decision_id',
+      'so_quyet_dinh',
+      'decision_status',
+      'ngay_hieu_luc',
+      'so_luong_toi_thieu',
+      'so_luong_toi_da',
+      'category_device_count',
+      'quota_status',
+      'remaining_quota',
+    ])
+  })
+
+  it('embeds every view name and the canonical department column in the description', () => {
+    for (const viewName of AI_READONLY_VIEW_NAMES) {
+      expect(QUERY_DATABASE_TOOL_DESCRIPTION).toContain(`ai_readonly.${viewName}`)
+    }
+
+    expect(QUERY_DATABASE_TOOL_DESCRIPTION).toContain('khoa_phong_quan_ly')
+  })
+
+  it('includes the explicit forbidden raw-schema references', () => {
+    expect(AI_READONLY_FORBIDDEN_REFERENCES).toEqual([
+      'thiet_bi',
+      'khoa_phong',
+      'public.*',
+      'auth.*',
+      'pg_catalog.*',
+      'set_config',
+    ])
+
+    for (const ref of AI_READONLY_FORBIDDEN_REFERENCES) {
+      expect(QUERY_DATABASE_TOOL_DESCRIPTION).toContain(ref)
+    }
+  })
+
+  it('contains two ai_readonly SELECT examples', () => {
+    expect(QUERY_DATABASE_TOOL_DESCRIPTION).toContain(
+      'SELECT khoa_phong_quan_ly, COUNT(*) AS so_luong FROM ai_readonly.equipment_search',
+    )
+    expect(QUERY_DATABASE_TOOL_DESCRIPTION).toContain(
+      'SELECT ma_thiet_bi, ten_thiet_bi, ngay_bt_tiep_theo FROM ai_readonly.equipment_search',
+    )
+  })
+
+  it('stays within the documented byte budget', () => {
+    expect(Buffer.byteLength(QUERY_DATABASE_TOOL_DESCRIPTION, 'utf8')).toBeLessThanOrEqual(2600)
+  })
+})

--- a/src/lib/ai/sql/__tests__/schema-cheatsheet.test.ts
+++ b/src/lib/ai/sql/__tests__/schema-cheatsheet.test.ts
@@ -9,6 +9,8 @@ import {
   QUERY_DATABASE_TOOL_DESCRIPTION,
 } from '../schema-cheatsheet'
 
+const QUERY_DATABASE_TOOL_DESCRIPTION_BYTE_BUDGET = 2600
+
 describe('query_database schema cheatsheet contract', () => {
   it('exports the canonical ai_readonly view names', () => {
     expect(AI_READONLY_VIEW_NAMES).toEqual([
@@ -152,6 +154,9 @@ describe('query_database schema cheatsheet contract', () => {
   })
 
   it('stays within the documented byte budget', () => {
-    expect(Buffer.byteLength(QUERY_DATABASE_TOOL_DESCRIPTION, 'utf8')).toBeLessThanOrEqual(2600)
+    // Keep the tool description compact enough for the model-facing tool payload.
+    expect(Buffer.byteLength(QUERY_DATABASE_TOOL_DESCRIPTION, 'utf8')).toBeLessThanOrEqual(
+      QUERY_DATABASE_TOOL_DESCRIPTION_BYTE_BUDGET,
+    )
   })
 })

--- a/src/lib/ai/sql/schema-cheatsheet.ts
+++ b/src/lib/ai/sql/schema-cheatsheet.ts
@@ -1,0 +1,143 @@
+type AiReadonlyViewName =
+  | 'equipment_search'
+  | 'maintenance_facts'
+  | 'repair_facts'
+  | 'usage_facts'
+  | 'quota_facts'
+
+type AiReadonlySchema = Record<AiReadonlyViewName, readonly string[]>
+
+export const AI_READONLY_SCHEMA: AiReadonlySchema = {
+  equipment_search: [
+    'equipment_id',
+    'ma_thiet_bi',
+    'ten_thiet_bi',
+    'model',
+    'serial',
+    'so_luu_hanh',
+    'phan_loai_theo_nd98',
+    'nhom_thiet_bi_id',
+    'tinh_trang_hien_tai',
+    'khoa_phong_quan_ly',
+    'vi_tri_lap_dat',
+    'ngay_bt_tiep_theo',
+    'ngay_hc_tiep_theo',
+    'ngay_kd_tiep_theo',
+    'facility_id',
+    'facility_code',
+    'facility_name',
+    'created_at',
+  ],
+  maintenance_facts: [
+    'maintenance_task_id',
+    'maintenance_plan_id',
+    'equipment_id',
+    'loai_cong_viec',
+    'don_vi_thuc_hien',
+    'diem_hieu_chuan',
+    'task_notes',
+    'ten_ke_hoach',
+    'plan_year',
+    'plan_status',
+    'ngay_phe_duyet',
+    'plan_facility_id',
+    'ma_thiet_bi',
+    'ten_thiet_bi',
+    'model',
+    'khoa_phong_quan_ly',
+    'tinh_trang_hien_tai',
+    'facility_id',
+  ],
+  repair_facts: [
+    'repair_request_id',
+    'equipment_id',
+    'repair_status',
+    'mo_ta_su_co',
+    'hang_muc_sua_chua',
+    'ngay_yeu_cau',
+    'ngay_duyet',
+    'ngay_hoan_thanh',
+    'don_vi_thuc_hien',
+    'ten_don_vi_thue',
+    'chi_phi_sua_chua',
+    'ma_thiet_bi',
+    'ten_thiet_bi',
+    'model',
+    'khoa_phong_quan_ly',
+    'facility_id',
+    'facility_name',
+  ],
+  usage_facts: [
+    'usage_log_id',
+    'equipment_id',
+    'thoi_gian_bat_dau',
+    'thoi_gian_ket_thuc',
+    'trang_thai',
+    'tinh_trang_thiet_bi',
+    'tinh_trang_ban_dau',
+    'tinh_trang_ket_thuc',
+    'ghi_chu',
+    'duration_hours',
+    'ma_thiet_bi',
+    'ten_thiet_bi',
+    'model',
+    'khoa_phong_quan_ly',
+    'facility_id',
+  ],
+  quota_facts: [
+    'equipment_id',
+    'ma_thiet_bi',
+    'ten_thiet_bi',
+    'model',
+    'category_id',
+    'category_code',
+    'category_name',
+    'facility_id',
+    'facility_name',
+    'decision_id',
+    'so_quyet_dinh',
+    'decision_status',
+    'ngay_hieu_luc',
+    'so_luong_toi_thieu',
+    'so_luong_toi_da',
+    'category_device_count',
+    'quota_status',
+    'remaining_quota',
+  ],
+}
+
+export const AI_READONLY_VIEW_NAMES = Object.keys(
+  AI_READONLY_SCHEMA,
+) as AiReadonlyViewName[]
+
+export const AI_READONLY_FORBIDDEN_REFERENCES = [
+  'thiet_bi',
+  'khoa_phong',
+  'public.*',
+  'auth.*',
+  'pg_catalog.*',
+  'set_config',
+] as const
+
+function formatSchemaSurface(): string {
+  return AI_READONLY_VIEW_NAMES.map(
+    viewName =>
+      `ai_readonly.${viewName}(${AI_READONLY_SCHEMA[viewName].join(', ')})`,
+  ).join('; ')
+}
+
+export const QUERY_DATABASE_TOOL_DESCRIPTION = [
+  'Run exactly one read-only SQL SELECT on the ai_readonly semantic layer.',
+  'Scope is already injected for one facility, so do not call set_config and do not assume cross-facility access.',
+  `Allowed relations: ${formatSchemaSurface()}.`,
+  'Department/khoa is the text column khoa_phong_quan_ly on these views; there is no separate khoa_phong table in ai_readonly.',
+  `Never use raw relations or schemas: ${AI_READONLY_FORBIDDEN_REFERENCES.join(', ')}.`,
+  'Example 1: SELECT khoa_phong_quan_ly, COUNT(*) AS so_luong FROM ai_readonly.equipment_search GROUP BY khoa_phong_quan_ly ORDER BY so_luong DESC;',
+  'Example 2: SELECT ma_thiet_bi, ten_thiet_bi, ngay_bt_tiep_theo FROM ai_readonly.equipment_search WHERE ngay_bt_tiep_theo < CURRENT_DATE ORDER BY ngay_bt_tiep_theo;',
+].join(' ')
+
+export const QUERY_DATABASE_PROMPT_POINTER = [
+  `Khi dùng \`query_database\`: chỉ viết đúng một câu \`SELECT\` trên các view ${AI_READONLY_VIEW_NAMES.join(', ')}.`,
+  'Khoa/phòng nằm ở cột `khoa_phong_quan_ly`.',
+  `KHÔNG dùng raw schema/tên như ${AI_READONLY_FORBIDDEN_REFERENCES.join(', ')}.`,
+].join(' ')

--- a/src/lib/ai/sql/schema-cheatsheet.ts
+++ b/src/lib/ai/sql/schema-cheatsheet.ts
@@ -1,11 +1,11 @@
-type AiReadonlyViewName =
+export type AiReadonlyViewName =
   | 'equipment_search'
   | 'maintenance_facts'
   | 'repair_facts'
   | 'usage_facts'
   | 'quota_facts'
 
-type AiReadonlySchema = Record<AiReadonlyViewName, readonly string[]>
+export type AiReadonlySchema = Record<AiReadonlyViewName, readonly string[]>
 
 export const AI_READONLY_SCHEMA: AiReadonlySchema = {
   equipment_search: [

--- a/src/lib/ai/tools/query-database.ts
+++ b/src/lib/ai/tools/query-database.ts
@@ -2,6 +2,7 @@ import { tool, type Tool } from 'ai'
 import { z } from 'zod'
 
 import { ASSISTANT_SQL_TOOL_NAME } from '@/lib/ai/sql/constants'
+import { QUERY_DATABASE_TOOL_DESCRIPTION } from '@/lib/ai/sql/schema-cheatsheet'
 import {
   executeAuditedAssistantSql,
   type ExecuteAuditedAssistantSqlParams,
@@ -38,8 +39,7 @@ export function queryDatabaseTool({
   scope,
 }: QueryDatabaseToolParams): Tool<QueryDatabaseToolInput, QueryDatabaseToolOutput> {
   return tool<QueryDatabaseToolInput, QueryDatabaseToolOutput>({
-    description:
-      'Run one read-only SQL query against the ai_readonly semantic layer for the server-injected facility scope.',
+    description: QUERY_DATABASE_TOOL_DESCRIPTION,
     inputSchema: queryDatabaseInputSchema,
     execute: async ({
       reasoning,


### PR DESCRIPTION
Fixes #332

## Summary
- add a canonical ai_readonly schema cheatsheet for query_database
- wire the query_database tool description to the generated cheatsheet
- strengthen the system prompt pointer and add proxy-eval coverage for the model-facing payload

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js npx vitest run src/lib/ai/sql/__tests__/schema-cheatsheet.test.ts src/lib/ai/sql/__tests__/query-database-dormant.test.ts src/lib/ai/sql/__tests__/query-database-guard.test.ts src/app/api/chat/__tests__/route.query-database-grounding.test.ts src/app/api/chat/__tests__/route.intent-routing.test.ts src/app/api/chat/__tests__/route.tools-allowlist.test.ts src/lib/ai/prompts/__tests__/system.test.ts src/app/api/chat/__tests__/route.troubleshooting.test.ts src/app/api/chat/__tests__/route.draft-output.test.ts
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grounds the `query_database` tool to the `ai_readonly` schema with a canonical cheatsheet and a stricter system prompt. Fixes #332 by blocking raw schema access and keeping ad‑hoc `SELECT` queries scoped to one facility.

- **New Features**
  - Added a canonical `ai_readonly` schema cheatsheet (views: `equipment_search`, `maintenance_facts`, `repair_facts`, `usage_facts`, `quota_facts`) with column lists, two safe examples, and explicit forbidden references.
  - Wired the `query_database` tool description to the cheatsheet and updated the system prompt pointer; bumped prompt version to v2.5.1.
  - Tightened tests to validate stream payload grounding, the schema contract (forbidden refs and byte budget), and that the registry exposes the canonical description.

<sup>Written for commit 731ecc5b82915d1c68702ef978ae3edc1e460c01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * System prompt version bumped to v2.5.1 with refined AI instructions.
  * Database query functionality enhanced with schema-based constraints ensuring secure, read-only access to the appropriate data layer.
  * Improved documentation for the query database tool with clearer usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->