### PR TITLE
[Issue #315][Batch 4] Final hardening and closeout for AI provider/model switching

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -1,3 +1,42 @@
 ## Codebase Patterns
 
+- AI provider/model selection lives behind a single resolver in `src/lib/ai/config.ts`. Production callers must consume `getChatModel()`, `getKeyPoolSize()`, and `handleProviderQuotaError(keyIndex)` from `src/lib/ai/provider.ts`. The chat route (`src/app/api/chat/route.ts`) holds zero direct `process.env.AI_*` reads and zero `@ai-sdk/*` provider-factory imports — keep it that way.
+- Non-rotating transports (`gateway`, `openai-compatible`) MUST report `getKeyPoolSize() === 1`, `handleProviderQuotaError() === false`, and never mutate the Google rotation pool's `_internals.exhaustedIndices` / `_internals.firstExhaustedAt`. Tests pinning this contract live in `src/lib/ai/__tests__/provider.test.ts` under "Closeout invariants".
+- `readEnv()` in `src/lib/ai/config.ts` trims values, so whitespace-only env vars are treated as missing. Closeout tests in `src/lib/ai/__tests__/config.test.ts` ("Closeout fail-fast invariants") pin this for `AI_DEFAULT_CHAT_PROVIDER`, `AI_GATEWAY_API_KEY`, `AI_OPENAI_COMPATIBLE_API_KEY`, and `AI_OPENAI_COMPATIBLE_BASE_URL`.
+
 ## Progress Log
+
+## 2026-04-26 - Issue #327 Story 1 (Audit & blast-radius)
+- Used GitNexus + code-review-graph + ripgrep to confirm AI provider/model centralization.
+- Findings:
+  - `route.ts` has zero direct AI env reads / no `@ai-sdk/*` factory imports — passes AC1 cleanly.
+  - All AI config helpers are only consumed inside `src/lib/ai/` and their tests.
+  - `provider.ts:77` reads `process.env.AI_GATEWAY_API_KEY` inline — minor symmetry issue vs openai-compatible helpers; tracked as follow-up Issue #334 (out of #327 scope per "no new runtime behavior" rule).
+  - `src/lib/ai/sql/client.ts` (`AI_DATABASE_URL`) and `src/lib/ai/limits.ts` (rate-limit knobs) read env directly, but both are out of #315 scope.
+- Tools: gitnexus index re-confirmed fresh at main HEAD `76562f8` before audit.
+- Learnings: GitNexus call graph occasionally misses cross-module export references; cross-validate with grep when verifying centralization claims.
+---
+
+## 2026-04-26 - Issue #327 Story 2 (Quota semantics regression)
+- Added 6 closeout-invariant tests in `src/lib/ai/__tests__/provider.test.ts`:
+  - Gateway / openai-compatible quota errors do NOT mutate `_internals.exhaustedIndices` or `_internals.firstExhaustedAt`.
+  - Gateway / openai-compatible report `getKeyPoolSize() === 1` even when stray `GOOGLE_GENERATIVE_AI_API_KEYS` is present (env-mixing protection).
+  - `getChatModel()` returns `keyIndex: 0` for gateway / openai-compatible regardless of `_internals.currentIndex`.
+- File line count after edit: 371 (well under 450 ceiling).
+- Verification: focused vitest 26/26 green.
+---
+
+## 2026-04-26 - Issue #327 Story 3 (Fail-fast config error coverage)
+- Added 6 closeout-invariant tests in `src/lib/ai/__tests__/config.test.ts`:
+  - Whitespace-only `AI_DEFAULT_CHAT_PROVIDER` falls back to gateway default.
+  - Whitespace-only `AI_GATEWAY_API_KEY`, `AI_OPENAI_COMPATIBLE_API_KEY`, `AI_OPENAI_COMPATIBLE_BASE_URL` all throw fail-fast errors.
+  - Unsupported provider rejection works via `AI_DEFAULT_CHAT_PROVIDER`, not just legacy `AI_PROVIDER`.
+  - Provider name is normalized to lowercase before validation (`GATEWAY` → `gateway`).
+- File line count after edit: 333 (under 450 ceiling).
+- Verification: focused vitest 23/23 green.
+- Full gate run on branch `issue-327-ai-config-closeout`:
+  - `verify:no-explicit-any`: pass
+  - `typecheck`: pass
+  - 6 focused vitest files (config, config.docs-contract, provider, provider-options, route.key-rotation, route.limits): 81/81 pass
+  - `react-doctor --diff main`: 100/100
+---

--- a/src/lib/ai/__tests__/config.test.ts
+++ b/src/lib/ai/__tests__/config.test.ts
@@ -235,4 +235,99 @@ describe('AI default chat config resolver', () => {
       ),
     ).toEqual(['KEY_A', 'KEY_B'])
   })
+
+  // -------------------------------------------------------------------
+  // Closeout fail-fast invariants (Issue #327 / #315 Batch 4)
+  //
+  // These tests pin the contract that whitespace-only env values are
+  // treated as missing — preventing accidental "blank string" deployments
+  // from silently passing credential validation.
+  // -------------------------------------------------------------------
+
+  it('treats whitespace-only AI_DEFAULT_CHAT_PROVIDER as missing and falls back to gateway default', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          AI_DEFAULT_CHAT_PROVIDER: '   ',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'gateway',
+      model: 'google/gemini-3.1-flash-lite-preview',
+    })
+  })
+
+  it('treats whitespace-only AI_GATEWAY_API_KEY as missing in gateway mode', () => {
+    const config = resolveDefaultChatConfig(
+      env({
+        AI_DEFAULT_CHAT_PROVIDER: 'gateway',
+        AI_DEFAULT_CHAT_MODEL: 'openai/gpt-5.2',
+      }),
+    )
+
+    expect(() =>
+      assertDefaultChatCredentials(
+        config,
+        env({
+          AI_GATEWAY_API_KEY: '   ',
+        }),
+      ),
+    ).toThrow('AI_GATEWAY_API_KEY is required for AI gateway mode')
+  })
+
+  it('treats whitespace-only AI_OPENAI_COMPATIBLE_API_KEY as missing in openai-compatible mode', () => {
+    const envVars = env({
+      AI_DEFAULT_CHAT_PROVIDER: 'openai-compatible',
+      AI_DEFAULT_CHAT_MODEL: 'qwen3.5-plus-2026-04-20',
+      AI_OPENAI_COMPATIBLE_BASE_URL:
+        'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+      AI_OPENAI_COMPATIBLE_API_KEY: '   ',
+    })
+    const config = resolveDefaultChatConfig(envVars)
+
+    expect(() => assertDefaultChatCredentials(config, envVars)).toThrow(
+      'AI_OPENAI_COMPATIBLE_API_KEY is required for openai-compatible mode',
+    )
+  })
+
+  it('treats whitespace-only AI_OPENAI_COMPATIBLE_BASE_URL as missing in openai-compatible mode', () => {
+    const envVars = env({
+      AI_DEFAULT_CHAT_PROVIDER: 'openai-compatible',
+      AI_DEFAULT_CHAT_MODEL: 'qwen3.5-plus-2026-04-20',
+      AI_OPENAI_COMPATIBLE_BASE_URL: '   ',
+      AI_OPENAI_COMPATIBLE_API_KEY: 'DASHSCOPE_KEY',
+    })
+    const config = resolveDefaultChatConfig(envVars)
+
+    expect(() => assertDefaultChatCredentials(config, envVars)).toThrow(
+      'AI_OPENAI_COMPATIBLE_BASE_URL is required for openai-compatible mode',
+    )
+  })
+
+  it('rejects unsupported direct provider supplied via AI_DEFAULT_CHAT_PROVIDER, not just legacy AI_PROVIDER', () => {
+    expect(() =>
+      resolveDefaultChatConfig(
+        env({
+          AI_DEFAULT_CHAT_PROVIDER: 'anthropic',
+          AI_DEFAULT_CHAT_MODEL: 'claude-3.5-sonnet',
+        }),
+      ),
+    ).toThrow('Unsupported direct AI provider: anthropic. Use AI_DEFAULT_CHAT_PROVIDER=gateway')
+  })
+
+  it('normalizes the provider name to lowercase before validation', () => {
+    expect(
+      resolveDefaultChatConfig(
+        env({
+          AI_DEFAULT_CHAT_PROVIDER: 'GATEWAY',
+          AI_DEFAULT_CHAT_MODEL: 'openai/gpt-5.2',
+        }),
+      ),
+    ).toEqual({
+      capability: 'default_chat',
+      provider: 'gateway',
+      model: 'openai/gpt-5.2',
+    })
+  })
 })

--- a/src/lib/ai/__tests__/provider.test.ts
+++ b/src/lib/ai/__tests__/provider.test.ts
@@ -282,4 +282,90 @@ describe('provider — API key rotation', () => {
     expect(getKeyPoolSize()).toBe(1)
     expect(handleProviderQuotaError(0)).toBe(false)
   })
+
+  // -------------------------------------------------------------------
+  // Closeout invariants (Issue #327 / #315 Batch 4)
+  //
+  // These tests pin the contract that gateway and openai-compatible
+  // transports MUST behave as non-rotating, single-slot providers and
+  // MUST NOT mutate the Google rotation pool's internal state.
+  // -------------------------------------------------------------------
+
+  it('keeps key-pool internals untouched after a gateway quota error', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'gateway'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'openai/gpt-5.2'
+    process.env.AI_GATEWAY_API_KEY = 'GATEWAY_KEY'
+
+    const exhaustedSnapshot = new Set(_internals.exhaustedIndices)
+    const firstExhaustedSnapshot = _internals.firstExhaustedAt
+
+    expect(handleProviderQuotaError(0)).toBe(false)
+
+    expect(_internals.exhaustedIndices).toEqual(exhaustedSnapshot)
+    expect(_internals.firstExhaustedAt).toBe(firstExhaustedSnapshot)
+  })
+
+  it('keeps key-pool internals untouched after an openai-compatible quota error', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'openai-compatible'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'qwen3.5-plus-2026-04-20'
+    process.env.AI_OPENAI_COMPATIBLE_BASE_URL =
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
+    process.env.AI_OPENAI_COMPATIBLE_API_KEY = 'DASHSCOPE_KEY'
+
+    const exhaustedSnapshot = new Set(_internals.exhaustedIndices)
+    const firstExhaustedSnapshot = _internals.firstExhaustedAt
+
+    expect(handleProviderQuotaError(0)).toBe(false)
+
+    expect(_internals.exhaustedIndices).toEqual(exhaustedSnapshot)
+    expect(_internals.firstExhaustedAt).toBe(firstExhaustedSnapshot)
+  })
+
+  it('reports a single key slot for gateway mode even when stray Google pool env vars are present', () => {
+    // Defends against accidental env mixing: a deployment that switches to
+    // gateway must not be mis-sized as a multi-key Google pool just because
+    // legacy GOOGLE_GENERATIVE_AI_API_KEYS is still defined in the same env.
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'gateway'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'openai/gpt-5.2'
+    process.env.AI_GATEWAY_API_KEY = 'GATEWAY_KEY'
+    process.env.GOOGLE_GENERATIVE_AI_API_KEYS = 'STRAY_A,STRAY_B,STRAY_C'
+
+    expect(getKeyPoolSize()).toBe(1)
+  })
+
+  it('reports a single key slot for openai-compatible mode even when stray Google pool env vars are present', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'openai-compatible'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'qwen3.5-plus-2026-04-20'
+    process.env.AI_OPENAI_COMPATIBLE_BASE_URL =
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
+    process.env.AI_OPENAI_COMPATIBLE_API_KEY = 'DASHSCOPE_KEY'
+    process.env.GOOGLE_GENERATIVE_AI_API_KEYS = 'STRAY_A,STRAY_B'
+
+    expect(getKeyPoolSize()).toBe(1)
+  })
+
+  it('returns keyIndex 0 from getChatModel in gateway mode regardless of pool currentIndex', () => {
+    // The Google pool tracks currentIndex across requests. Switching to gateway
+    // must report a fresh, non-pooled key slot (0) rather than leaking the
+    // Google pool position.
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'gateway'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'openai/gpt-5.2'
+    process.env.AI_GATEWAY_API_KEY = 'GATEWAY_KEY'
+    _internals.currentIndex = 2 // simulate prior Google pool activity
+
+    const { keyIndex } = getChatModel()
+    expect(keyIndex).toBe(0)
+  })
+
+  it('returns keyIndex 0 from getChatModel in openai-compatible mode regardless of pool currentIndex', () => {
+    process.env.AI_DEFAULT_CHAT_PROVIDER = 'openai-compatible'
+    process.env.AI_DEFAULT_CHAT_MODEL = 'qwen3.5-plus-2026-04-20'
+    process.env.AI_OPENAI_COMPATIBLE_BASE_URL =
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
+    process.env.AI_OPENAI_COMPATIBLE_API_KEY = 'DASHSCOPE_KEY'
+    _internals.currentIndex = 2
+
+    const { keyIndex } = getChatModel()
+    expect(keyIndex).toBe(0)
+  })
 })


### PR DESCRIPTION
## Summary

Closes #327 — the final hardening / closeout batch under umbrella Issue #315.

This PR contains **only test additions** plus a `progress.txt` log entry. It introduces **no runtime behavior changes**, in line with #327's explicit constraint:

> This batch must only harden and close out already-working behavior.

## What's in here

### Story 1 — Audit & blast-radius (no code changes)
Cross-validated centralization of AI provider/model selection with GitNexus, code-review-graph, and ripgrep. Findings:

- `src/app/api/chat/route.ts` has **zero** direct `process.env.AI_*` reads and **zero** `@ai-sdk/*` provider-factory imports — passes AC1 cleanly.
- All AI config helpers are only consumed inside `src/lib/ai/` and their tests.
- One minor symmetry issue (`provider.ts:77` reads `AI_GATEWAY_API_KEY` inline instead of via a `readAIGatewayApiKey()` helper) was tracked as follow-up Issue #334 since it is out of #327's scope.
- `src/lib/ai/sql/client.ts` (`AI_DATABASE_URL`) and `src/lib/ai/limits.ts` (rate-limit knobs) read env directly, but both are out of #315 scope.

### Story 2 — Pin closeout invariants for non-rotating providers
`src/lib/ai/__tests__/provider.test.ts` (+86 lines, +6 tests):

- Gateway / openai-compatible quota errors do NOT mutate `_internals.exhaustedIndices` or `_internals.firstExhaustedAt`.
- Gateway / openai-compatible report `getKeyPoolSize() === 1` even when stray `GOOGLE_GENERATIVE_AI_API_KEYS` is present (env-mixing protection).
- `getChatModel()` returns `keyIndex: 0` for gateway / openai-compatible regardless of `_internals.currentIndex`.

### Story 3 — Pin fail-fast invariants for AI config closeout
`src/lib/ai/__tests__/config.test.ts` (+95 lines, +6 tests):

- Whitespace-only `AI_DEFAULT_CHAT_PROVIDER` falls back to gateway default.
- Whitespace-only `AI_GATEWAY_API_KEY`, `AI_OPENAI_COMPATIBLE_API_KEY`, `AI_OPENAI_COMPATIBLE_BASE_URL` all throw fail-fast errors.
- Unsupported provider rejection works via `AI_DEFAULT_CHAT_PROVIDER`, not just legacy `AI_PROVIDER`.
- Provider name is normalized to lowercase before validation (`GATEWAY` → `gateway`).

### Bookkeeping
- `progress.txt` updated with Story 1/2/3 entries and reusable Codebase Patterns under the closeout contract.

## Verification

- `node scripts/npm-run.js run verify:no-explicit-any` → pass
- `node scripts/npm-run.js run typecheck` → pass
- `node scripts/npm-run.js run test:run -- "src/lib/ai/__tests__/config.test.ts" "src/lib/ai/__tests__/config.docs-contract.test.ts" "src/lib/ai/__tests__/provider.test.ts" "src/lib/ai/__tests__/provider-options.test.ts" "src/app/api/chat/__tests__/route.key-rotation.test.ts" "src/app/api/chat/__tests__/route.limits.test.ts"` → 81 / 81 tests pass
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` → 100 / 100

## Acceptance criteria (#327)

- [x] No primary chat flow hardcodes provider/model selection outside the central resolver — confirmed by Story 1 audit.
- [x] Invalid AI config fails fast with clear errors — pinned by Story 3.
- [x] Gateway mode works as a non-rotating provider path — pinned by Story 2.
- [x] Direct Google mode preserves key-pool rotation behavior — already covered by existing tests in `provider.test.ts` and `route.key-rotation.test.ts`.
- [x] #315 umbrella will be updated with final batch status and links to completed PRs/issues after this PR merges.

## Residual risks

- **None for primary chat flow.** Story 1 confirmed centralization is intact; Story 2 + 3 pin the contracts.
- Cosmetic / consistency refactor in `provider.ts:77` is tracked separately as Issue #334 and is safe to defer.

## Independent merge / deploy safety

This PR adds tests only — there is no runtime behavior change, no env var change, and no dependency change.

Closes #327
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests that harden provider/model switching: gateway and openai-compatible remain single-slot (no rotation, keyIndex 0), and config fails fast on blank or unsupported values with lowercase normalization; also updates `progress.txt`. No runtime or dependency changes; closes #327 under #315.

<sup>Written for commit e206875650e0b7b1566873b793e9841871908c73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for configuration validation when environment variables contain whitespace-only values
  * Extended provider validation tests for unsupported direct providers
  * Added tests for provider quota handling and key pool behavior in non-rotating transport modes

* **Documentation**
  * Updated progress tracking with architectural constraints for centralized AI provider/model selection
  * Added detailed verification outcomes and test coverage metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->