### PR TITLE
feat(#338 PR-2a): types/strings + useResolveActiveRepair hook + LinkedRequestContext

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -583,3 +583,12 @@ If the repo is already up to date and you are enabling embeddings for the first 
 - Running `gitnexus analyze` without `--embeddings` will drop existing embeddings.
 
 <!-- gitnexus:end -->
+
+---
+
+## SonarCloud Policy
+
+- **Ignore `new_duplicated_lines_density` (Duplication on New Code) warnings.** Do NOT extract shared helpers, inline `// NOSONAR`, or otherwise change code purely to reduce the duplication ratio. Project owner directive 2026-04-27.
+- React Query / Vitest test boilerplate (createQueryClient, createWrapper, vi.mock for rpc-client) is intentionally repeated per test file for readability and per-file mock isolation. SonarCloud will keep flagging it; that is acceptable.
+- Other SonarCloud findings (security hotspots, real bugs, code smells with concrete remediation, coverage on new code) are still in scope and should be addressed normally.
+- If a SonarCloud Quality Gate fails ONLY on duplication, treat it the same as the persistent Preview Build & Test billing-block: merge with `--admin` once all bot reviewers and human approvals are clear.

--- a/docs/superpowers/plans/2026-04-26-issue-207-phase1-equipment-deeplink-active-repair.md
+++ b/docs/superpowers/plans/2026-04-26-issue-207-phase1-equipment-deeplink-active-repair.md
@@ -74,18 +74,24 @@ import {
 } from '../repair-request-deep-link'
 
 describe('repair-request-deep-link :: active resolver query key', () => {
-  it('returns a stable tuple keyed by equipmentId', () => {
-    expect(buildActiveRepairRequestQueryKey(7)).toEqual([
-      'repair_request_active_for_equipment',
-      { equipmentId: 7 },
-    ])
+  it('returns a stable tuple prefixed by repairKeys.all so mutations invalidate it', () => {
+    expect(buildActiveRepairRequestQueryKey(7)).toEqual(['repair', 'active', 7])
   })
 
   it('encodes a null equipmentId verbatim so callers can disable the query without losing key shape', () => {
     expect(buildActiveRepairRequestQueryKey(null)).toEqual([
-      'repair_request_active_for_equipment',
-      { equipmentId: null },
+      'repair',
+      'active',
+      null,
     ])
+  })
+
+  it('keeps the leading "repair" element identical to repairKeys.all to preserve the invalidation contract', () => {
+    // repairKeys.all is `['repair'] as const` in src/hooks/use-cached-repair.ts.
+    // Mutations call invalidateQueries({ queryKey: ['repair'] }), which prefix-matches
+    // any tuple whose first element is exactly 'repair'.
+    expect(buildActiveRepairRequestQueryKey(7)[0]).toBe('repair')
+    expect(buildActiveRepairRequestQueryKey(null)[0]).toBe('repair')
   })
 })
 
@@ -120,8 +126,16 @@ Expected: 4 new tests fail; the existing tests for `buildRepairRequestCreateInte
 
 export const REPAIR_REQUEST_VIEW_ACTION = 'view'
 
+/**
+ * Canonical TanStack Query key for the active repair request resolver.
+ *
+ * Shape: `["repair", "active", equipmentId]`. The leading `"repair"` element
+ * is intentional — it matches `repairKeys.all` from `@/hooks/use-cached-repair`
+ * so that mutations invalidating `repairKeys.all` (create/update/assign/
+ * complete/delete) automatically invalidate this query family by prefix.
+ */
 export function buildActiveRepairRequestQueryKey(equipmentId: number | null) {
-  return ['repair_request_active_for_equipment', { equipmentId }] as const
+  return ['repair', 'active', equipmentId] as const
 }
 
 export function buildRepairRequestViewHref(requestId: number) {

--- a/docs/superpowers/specs/2026-04-26-issue-207-phase1-equipment-deeplink-active-repair-design.md
+++ b/docs/superpowers/specs/2026-04-26-issue-207-phase1-equipment-deeplink-active-repair-design.md
@@ -80,8 +80,12 @@ src/components/equipment-linked-request/  (new shared package)
 ```ts
 export const REPAIR_REQUEST_VIEW_ACTION = 'view'
 
+// Shape: ['repair', 'active', equipmentId]. Leading 'repair' element matches
+// repairKeys.all from @/hooks/use-cached-repair so existing mutation
+// invalidations subsume this query family by prefix-match (TanStack Query v5
+// compares array elements element-wise via Object.is).
 export function buildActiveRepairRequestQueryKey(equipmentId: number | null) {
-  return ['repair_request_active_for_equipment', { equipmentId }] as const
+  return ['repair', 'active', equipmentId] as const
 }
 
 // Phase 1: not consumed by route sync yet, but stable for future bookmarkable URL story.
@@ -422,7 +426,7 @@ All tests are written before the implementation per Ralph contract. Tools: `vite
 `src/lib/__tests__/repair-request-deep-link.test.ts`
 
 - `buildRepairRequestCreateIntentHref` — back-compat with renamed file (existing assertions preserved).
-- `buildActiveRepairRequestQueryKey` — shape `['repair_request_active_for_equipment', { equipmentId }]`; null equipmentId case.
+- `buildActiveRepairRequestQueryKey` — shape `['repair', 'active', equipmentId]` (prefix-match against `repairKeys.all`); null equipmentId case + leading-prefix invariant.
 - `buildRepairRequestViewHref` — query string format, integer requestId only.
 
 `src/components/equipment-linked-request/__tests__/strings.test.ts`

--- a/src/components/equipment-linked-request/LinkedRequestContext.tsx
+++ b/src/components/equipment-linked-request/LinkedRequestContext.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import * as React from 'react'
+import { EquipmentDialogContext } from '@/app/(app)/equipment/_components/EquipmentDialogContext'
+import type { LinkedRequestKind, LinkedRequestState } from './types'
+
+export interface LinkedRequestContextValue {
+  state: LinkedRequestState
+  openRepair: (equipmentId: number) => void
+  close: () => void
+}
+
+const Context = React.createContext<LinkedRequestContextValue | null>(null)
+
+const CLOSED_STATE: LinkedRequestState = {
+  open: false,
+  kind: null,
+  equipmentId: null,
+}
+
+export function LinkedRequestProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = React.useState<LinkedRequestState>(CLOSED_STATE)
+
+  // Idempotent setters: bail out when the next state is structurally equal so
+  // callers can safely invoke openRepair/close from effects without triggering
+  // re-render loops (React useState only short-circuits on Object.is identity).
+  const openRepair = React.useCallback((equipmentId: number) => {
+    setState((prev) =>
+      prev.open && prev.kind === 'repair' && prev.equipmentId === equipmentId
+        ? prev
+        : { open: true, kind: 'repair', equipmentId },
+    )
+  }, [])
+
+  const close = React.useCallback(() => {
+    setState((prev) => (prev.open ? CLOSED_STATE : prev))
+  }, [])
+
+  // Auto-close when the parent Equipment Detail dialog closes.
+  // Subscribing via an effect keeps the provider usable outside the equipment
+  // page (the EquipmentDialogContext is `null` there); we just skip the effect.
+  const equipmentDialog = React.useContext(EquipmentDialogContext)
+  const isDetailOpen = equipmentDialog?.dialogState.isDetailOpen ?? false
+
+  React.useEffect(() => {
+    if (!isDetailOpen) {
+      setState((prev) => (prev.open ? CLOSED_STATE : prev))
+    }
+  }, [isDetailOpen])
+
+  const value = React.useMemo<LinkedRequestContextValue>(
+    () => ({ state, openRepair, close }),
+    [state, openRepair, close],
+  )
+
+  return <Context.Provider value={value}>{children}</Context.Provider>
+}
+
+export function useLinkedRequest(): LinkedRequestContextValue {
+  const value = React.useContext(Context)
+  if (!value) {
+    throw new Error('useLinkedRequest must be used within a LinkedRequestProvider')
+  }
+  return value
+}
+
+// Phase 2/3 may reuse these types/aliases without the kind union widening;
+// re-export so consumers don't import from ./types directly.
+export type { LinkedRequestKind, LinkedRequestState }

--- a/src/components/equipment-linked-request/__tests__/LinkedRequestContext.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/LinkedRequestContext.test.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react'
+import { act, render, renderHook, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  LinkedRequestProvider,
+  useLinkedRequest,
+} from '../LinkedRequestContext'
+import {
+  EquipmentDialogContext,
+  type EquipmentDialogContextValue,
+} from '@/app/(app)/equipment/_components/EquipmentDialogContext'
+
+function createEquipmentDialogContextStub(
+  overrides: Partial<EquipmentDialogContextValue> = {}
+): EquipmentDialogContextValue {
+  return {
+    user: null,
+    isGlobal: false,
+    isRegionalLeader: false,
+    dialogState: {
+      isAddOpen: false,
+      isImportOpen: false,
+      isColumnsOpen: false,
+      isDetailOpen: false,
+      isStartUsageOpen: false,
+      isEndUsageOpen: false,
+      isDeleteOpen: false,
+      detailEquipment: null,
+      startUsageEquipment: null,
+      endUsageLog: null,
+      deleteTarget: null,
+      deleteSource: null,
+    },
+    openAddDialog: vi.fn(),
+    openImportDialog: vi.fn(),
+    openColumnsDialog: vi.fn(),
+    openDetailDialog: vi.fn(),
+    openStartUsageDialog: vi.fn(),
+    openEndUsageDialog: vi.fn(),
+    openDeleteDialog: vi.fn(),
+    closeAddDialog: vi.fn(),
+    closeImportDialog: vi.fn(),
+    closeColumnsDialog: vi.fn(),
+    closeDetailDialog: vi.fn(),
+    closeStartUsageDialog: vi.fn(),
+    closeEndUsageDialog: vi.fn(),
+    closeDeleteDialog: vi.fn(),
+    closeAllDialogs: vi.fn(),
+    onDataMutationSuccess: vi.fn(),
+    ...overrides,
+  }
+}
+
+function wrap(
+  equipmentDialogValue: EquipmentDialogContextValue,
+): React.FC<{ children: React.ReactNode }> {
+  return function Wrapper({ children }) {
+    return (
+      <EquipmentDialogContext.Provider value={equipmentDialogValue}>
+        <LinkedRequestProvider>{children}</LinkedRequestProvider>
+      </EquipmentDialogContext.Provider>
+    )
+  }
+}
+
+describe('LinkedRequestProvider', () => {
+  it('starts in the closed state', () => {
+    const ctx = createEquipmentDialogContextStub()
+    const { result } = renderHook(() => useLinkedRequest(), { wrapper: wrap(ctx) })
+    expect(result.current.state).toEqual({ open: false, kind: null, equipmentId: null })
+  })
+
+  it('opens with kind="repair" and the given equipmentId', () => {
+    const ctx = createEquipmentDialogContextStub({
+      dialogState: { ...createEquipmentDialogContextStub().dialogState, isDetailOpen: true },
+    })
+    const { result } = renderHook(() => useLinkedRequest(), { wrapper: wrap(ctx) })
+    act(() => result.current.openRepair(11))
+    expect(result.current.state).toEqual({ open: true, kind: 'repair', equipmentId: 11 })
+  })
+
+  it('close() returns to the closed state', () => {
+    const ctx = createEquipmentDialogContextStub({
+      dialogState: { ...createEquipmentDialogContextStub().dialogState, isDetailOpen: true },
+    })
+    const { result } = renderHook(() => useLinkedRequest(), { wrapper: wrap(ctx) })
+    act(() => result.current.openRepair(7))
+    act(() => result.current.close())
+    expect(result.current.state.open).toBe(false)
+  })
+
+  it('throws if used outside the provider', () => {
+    expect(() => renderHook(() => useLinkedRequest())).toThrow(
+      /LinkedRequestProvider/,
+    )
+  })
+
+  it('auto-closes when EquipmentDialogContext.dialogState.isDetailOpen flips to false', () => {
+    const dialogStateOpen = {
+      ...createEquipmentDialogContextStub().dialogState,
+      isDetailOpen: true,
+    }
+    const dialogStateClosed = {
+      ...createEquipmentDialogContextStub().dialogState,
+      isDetailOpen: false,
+    }
+    const initialCtx = createEquipmentDialogContextStub({ dialogState: dialogStateOpen })
+
+    function Harness() {
+      const linked = useLinkedRequest()
+      return <span data-testid="open">{linked.state.open ? 'yes' : 'no'}</span>
+    }
+
+    function Opener() {
+      const linked = useLinkedRequest()
+      React.useEffect(() => {
+        linked.openRepair(99)
+      }, [linked])
+      return null
+    }
+
+    const { rerender } = render(
+      <EquipmentDialogContext.Provider value={initialCtx}>
+        <LinkedRequestProvider>
+          <Harness />
+          <Opener />
+        </LinkedRequestProvider>
+      </EquipmentDialogContext.Provider>,
+    )
+
+    expect(screen.getByTestId('open').textContent).toBe('yes')
+
+    // Detail dialog now closes — provider must auto-close the sheet.
+    rerender(
+      <EquipmentDialogContext.Provider
+        value={createEquipmentDialogContextStub({ dialogState: dialogStateClosed })}
+      >
+        <LinkedRequestProvider>
+          <Harness />
+        </LinkedRequestProvider>
+      </EquipmentDialogContext.Provider>,
+    )
+
+    expect(screen.getByTestId('open').textContent).toBe('no')
+  })
+})

--- a/src/components/equipment-linked-request/resolvers/__tests__/useResolveActiveRepair.test.ts
+++ b/src/components/equipment-linked-request/resolvers/__tests__/useResolveActiveRepair.test.ts
@@ -1,0 +1,116 @@
+import * as React from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCallRpc = vi.fn()
+
+vi.mock('@/lib/rpc-client', () => ({
+  callRpc: (...args: unknown[]) => mockCallRpc(...args),
+}))
+
+import { useResolveActiveRepair } from '../useResolveActiveRepair'
+import { buildActiveRepairRequestQueryKey } from '@/lib/repair-request-deep-link'
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe('useResolveActiveRepair', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCallRpc.mockReset()
+  })
+
+  it('does not fetch when enabled is false', async () => {
+    const queryClient = createQueryClient()
+    renderHook(
+      () => useResolveActiveRepair({ equipmentId: 7, enabled: false }),
+      { wrapper: createWrapper(queryClient) },
+    )
+    // give microtasks a chance to flush
+    await act(async () => {})
+    expect(mockCallRpc).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when equipmentId is null even if enabled is true', async () => {
+    const queryClient = createQueryClient()
+    renderHook(
+      () => useResolveActiveRepair({ equipmentId: null, enabled: true }),
+      { wrapper: createWrapper(queryClient) },
+    )
+    await act(async () => {})
+    expect(mockCallRpc).not.toHaveBeenCalled()
+  })
+
+  it('fetches via callRpc with the correct fn name and args when enabled', async () => {
+    mockCallRpc.mockResolvedValueOnce({ active_count: 0, request: null })
+    const queryClient = createQueryClient()
+    const { result } = renderHook(
+      () => useResolveActiveRepair({ equipmentId: 42, enabled: true }),
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockCallRpc).toHaveBeenCalledTimes(1)
+    const callArg = mockCallRpc.mock.calls[0]![0]
+    expect(callArg.fn).toBe('repair_request_active_for_equipment')
+    expect(callArg.args).toEqual({ p_thiet_bi_id: 42 })
+    expect(callArg.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('uses the canonical query key from repair-request-deep-link', async () => {
+    mockCallRpc.mockResolvedValue({ active_count: 0, request: null })
+    const queryClient = createQueryClient()
+    renderHook(
+      () => useResolveActiveRepair({ equipmentId: 5, enabled: true }),
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    await waitFor(() => {
+      expect(mockCallRpc).toHaveBeenCalled()
+    })
+
+    const expectedKey = buildActiveRepairRequestQueryKey(5)
+    const cached = queryClient.getQueryData(expectedKey)
+    expect(cached).toEqual({ active_count: 0, request: null })
+  })
+
+  it('isolates caches between two equipmentIds', async () => {
+    mockCallRpc
+      .mockResolvedValueOnce({ active_count: 1, request: { id: 100 } })
+      .mockResolvedValueOnce({ active_count: 2, request: { id: 200 } })
+
+    const queryClient = createQueryClient()
+    const { result: r1 } = renderHook(
+      () => useResolveActiveRepair({ equipmentId: 1, enabled: true }),
+      { wrapper: createWrapper(queryClient) },
+    )
+    const { result: r2 } = renderHook(
+      () => useResolveActiveRepair({ equipmentId: 2, enabled: true }),
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    await waitFor(() => {
+      expect(r1.current.isSuccess).toBe(true)
+      expect(r2.current.isSuccess).toBe(true)
+    })
+
+    expect(r1.current.data).toEqual({ active_count: 1, request: { id: 100 } })
+    expect(r2.current.data).toEqual({ active_count: 2, request: { id: 200 } })
+  })
+})

--- a/src/components/equipment-linked-request/resolvers/__tests__/useResolveActiveRepair.test.ts
+++ b/src/components/equipment-linked-request/resolvers/__tests__/useResolveActiveRepair.test.ts
@@ -1,6 +1,4 @@
-import * as React from 'react'
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockCallRpc = vi.fn()
@@ -11,21 +9,10 @@ vi.mock('@/lib/rpc-client', () => ({
 
 import { useResolveActiveRepair } from '../useResolveActiveRepair'
 import { buildActiveRepairRequestQueryKey } from '@/lib/repair-request-deep-link'
-
-function createQueryClient(): QueryClient {
-  return new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-}
-
-function createWrapper(queryClient: QueryClient) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(QueryClientProvider, { client: queryClient }, children)
-  }
-}
+import {
+  createReactQueryWrapper,
+  createTestQueryClient,
+} from '@/test-utils/react-query'
 
 describe('useResolveActiveRepair', () => {
   beforeEach(() => {
@@ -34,10 +21,10 @@ describe('useResolveActiveRepair', () => {
   })
 
   it('does not fetch when enabled is false', async () => {
-    const queryClient = createQueryClient()
+    const queryClient = createTestQueryClient()
     renderHook(
       () => useResolveActiveRepair({ equipmentId: 7, enabled: false }),
-      { wrapper: createWrapper(queryClient) },
+      { wrapper: createReactQueryWrapper(queryClient) },
     )
     // give microtasks a chance to flush
     await act(async () => {})
@@ -45,10 +32,10 @@ describe('useResolveActiveRepair', () => {
   })
 
   it('does not fetch when equipmentId is null even if enabled is true', async () => {
-    const queryClient = createQueryClient()
+    const queryClient = createTestQueryClient()
     renderHook(
       () => useResolveActiveRepair({ equipmentId: null, enabled: true }),
-      { wrapper: createWrapper(queryClient) },
+      { wrapper: createReactQueryWrapper(queryClient) },
     )
     await act(async () => {})
     expect(mockCallRpc).not.toHaveBeenCalled()
@@ -56,10 +43,10 @@ describe('useResolveActiveRepair', () => {
 
   it('fetches via callRpc with the correct fn name and args when enabled', async () => {
     mockCallRpc.mockResolvedValueOnce({ active_count: 0, request: null })
-    const queryClient = createQueryClient()
+    const queryClient = createTestQueryClient()
     const { result } = renderHook(
       () => useResolveActiveRepair({ equipmentId: 42, enabled: true }),
-      { wrapper: createWrapper(queryClient) },
+      { wrapper: createReactQueryWrapper(queryClient) },
     )
 
     await waitFor(() => {
@@ -75,10 +62,10 @@ describe('useResolveActiveRepair', () => {
 
   it('uses the canonical query key from repair-request-deep-link', async () => {
     mockCallRpc.mockResolvedValue({ active_count: 0, request: null })
-    const queryClient = createQueryClient()
+    const queryClient = createTestQueryClient()
     renderHook(
       () => useResolveActiveRepair({ equipmentId: 5, enabled: true }),
-      { wrapper: createWrapper(queryClient) },
+      { wrapper: createReactQueryWrapper(queryClient) },
     )
 
     await waitFor(() => {
@@ -95,14 +82,14 @@ describe('useResolveActiveRepair', () => {
       .mockResolvedValueOnce({ active_count: 1, request: { id: 100 } })
       .mockResolvedValueOnce({ active_count: 2, request: { id: 200 } })
 
-    const queryClient = createQueryClient()
+    const queryClient = createTestQueryClient()
     const { result: r1 } = renderHook(
       () => useResolveActiveRepair({ equipmentId: 1, enabled: true }),
-      { wrapper: createWrapper(queryClient) },
+      { wrapper: createReactQueryWrapper(queryClient) },
     )
     const { result: r2 } = renderHook(
       () => useResolveActiveRepair({ equipmentId: 2, enabled: true }),
-      { wrapper: createWrapper(queryClient) },
+      { wrapper: createReactQueryWrapper(queryClient) },
     )
 
     await waitFor(() => {

--- a/src/components/equipment-linked-request/resolvers/useResolveActiveRepair.ts
+++ b/src/components/equipment-linked-request/resolvers/useResolveActiveRepair.ts
@@ -13,8 +13,16 @@ export type UseResolveActiveRepairOptions = {
  * the dedicated RPC. Caller is responsible for status-gating; this hook only
  * checks the trivial `equipmentId != null` precondition.
  *
- * Mutations elsewhere (create/update/assign/complete/delete) all invalidate
- * `repairKeys.all`, which subsumes this query's key.
+ * Cache invalidation contract: the query key is built by
+ * `buildActiveRepairRequestQueryKey`, which returns `["repair", "active", id]`.
+ * That tuple is prefix-matched by `repairKeys.all = ["repair"]`, so the five
+ * existing repair mutations (create, update, assign, complete, delete) which
+ * call `invalidateQueries({ queryKey: repairKeys.all })` automatically
+ * invalidate this hook's cache without any per-key wiring. The contract is
+ * pinned by the prefix tests in
+ * `src/lib/__tests__/repair-request-deep-link.test.ts` and the mutation
+ * invalidation suite in
+ * `src/hooks/__tests__/use-cached-repair.invalidation.test.ts`.
  */
 export function useResolveActiveRepair(opts: UseResolveActiveRepairOptions) {
   return useQuery<ActiveRepairResult>({

--- a/src/components/equipment-linked-request/resolvers/useResolveActiveRepair.ts
+++ b/src/components/equipment-linked-request/resolvers/useResolveActiveRepair.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query'
+import { callRpc } from '@/lib/rpc-client'
+import { buildActiveRepairRequestQueryKey } from '@/lib/repair-request-deep-link'
+import type { ActiveRepairResult } from '../types'
+
+export type UseResolveActiveRepairOptions = {
+  equipmentId: number | null
+  enabled: boolean
+}
+
+/**
+ * Phase 1 resolver — fetches the active repair request for one equipment via
+ * the dedicated RPC. Caller is responsible for status-gating; this hook only
+ * checks the trivial `equipmentId != null` precondition.
+ *
+ * Mutations elsewhere (create/update/assign/complete/delete) all invalidate
+ * `repairKeys.all`, which subsumes this query's key.
+ */
+export function useResolveActiveRepair(opts: UseResolveActiveRepairOptions) {
+  return useQuery<ActiveRepairResult>({
+    queryKey: buildActiveRepairRequestQueryKey(opts.equipmentId),
+    queryFn: ({ signal }) =>
+      callRpc<ActiveRepairResult>({
+        fn: 'repair_request_active_for_equipment',
+        args: { p_thiet_bi_id: opts.equipmentId! },
+        signal,
+      }),
+    enabled: opts.enabled && opts.equipmentId !== null,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  })
+}

--- a/src/components/equipment-linked-request/strings.ts
+++ b/src/components/equipment-linked-request/strings.ts
@@ -1,0 +1,11 @@
+export const STRINGS = {
+  buttonSingleActive: 'Yêu cầu sửa chữa hiện tại',
+  buttonMultiActive: (count: number) =>
+    `${count} yêu cầu sửa chữa active — mở bản mới nhất`,
+  buttonAriaLabel: (maThietBi: string) =>
+    `Yêu cầu sửa chữa hiện tại của thiết bị ${maThietBi}`,
+  multiActiveAlert: (count: number) =>
+    `Phát hiện ${count} yêu cầu active. Đang hiển thị bản cập nhật mới nhất. Để xem tất cả, mở danh sách trên trang Yêu cầu sửa chữa.`,
+  footerOpenInRepairRequests: 'Mở trong trang Yêu cầu sửa chữa',
+  autoCloseToastTitle: 'Yêu cầu đã được hoàn thành',
+} as const

--- a/src/components/equipment-linked-request/types.ts
+++ b/src/components/equipment-linked-request/types.ts
@@ -1,0 +1,17 @@
+import type { RepairRequestWithEquipment } from '@/app/(app)/repair-requests/types'
+
+/**
+ * Phase 1: only 'repair' is implemented. Phase 2/3 will add 'transfer' and
+ * 'maintenance' (or split the latter into 'calibration' / 'inspection') without
+ * changing the surrounding shape.
+ */
+export type LinkedRequestKind = 'repair'
+
+export type ActiveRepairResult = {
+  active_count: number
+  request: RepairRequestWithEquipment | null
+}
+
+export type LinkedRequestState =
+  | { open: false; kind: null; equipmentId: null }
+  | { open: true; kind: LinkedRequestKind; equipmentId: number }

--- a/src/lib/__tests__/repair-request-deep-link.test.ts
+++ b/src/lib/__tests__/repair-request-deep-link.test.ts
@@ -32,18 +32,25 @@ describe('buildRepairRequestsByEquipmentHref', () => {
 })
 
 describe('repair-request-deep-link :: active resolver query key', () => {
-  it('returns a stable tuple keyed by equipmentId', () => {
-    expect(buildActiveRepairRequestQueryKey(7)).toEqual([
-      'repair_request_active_for_equipment',
-      { equipmentId: 7 },
-    ])
+  it('returns a stable tuple prefixed by repairKeys.all so mutations invalidate it', () => {
+    expect(buildActiveRepairRequestQueryKey(7)).toEqual(['repair', 'active', 7])
   })
 
   it('encodes a null equipmentId verbatim so callers can disable the query without losing key shape', () => {
     expect(buildActiveRepairRequestQueryKey(null)).toEqual([
-      'repair_request_active_for_equipment',
-      { equipmentId: null },
+      'repair',
+      'active',
+      null,
     ])
+  })
+
+  it('keeps the leading "repair" element identical to repairKeys.all to preserve the invalidation contract', () => {
+    // repairKeys.all is `['repair'] as const` in src/hooks/use-cached-repair.ts.
+    // Mutations call invalidateQueries({ queryKey: ['repair'] }), which prefix-matches
+    // any tuple whose first element is exactly 'repair'. Hard-pin the prefix here so
+    // a regression in either file is caught by this test family alone.
+    expect(buildActiveRepairRequestQueryKey(7)[0]).toBe('repair')
+    expect(buildActiveRepairRequestQueryKey(null)[0]).toBe('repair')
   })
 })
 

--- a/src/lib/repair-request-deep-link.ts
+++ b/src/lib/repair-request-deep-link.ts
@@ -31,8 +31,19 @@ export function buildRepairRequestsByEquipmentHref(equipmentId: number) {
 
 export const REPAIR_REQUEST_VIEW_ACTION = "view"
 
+/**
+ * Canonical TanStack Query key for the active repair request resolver.
+ *
+ * Shape: `["repair", "active", equipmentId]`. The leading `"repair"` element
+ * is intentional — it matches `repairKeys.all` from `@/hooks/use-cached-repair`
+ * so that mutations invalidating `repairKeys.all` (create/update/assign/
+ * complete/delete) automatically invalidate this query family by prefix.
+ *
+ * Do not change the leading prefix without updating `repairKeys.all` and the
+ * invalidation contract test in `src/hooks/__tests__/use-cached-repair.invalidation.test.ts`.
+ */
 export function buildActiveRepairRequestQueryKey(equipmentId: number | null) {
-  return ["repair_request_active_for_equipment", { equipmentId }] as const
+  return ["repair", "active", equipmentId] as const
 }
 
 export function buildRepairRequestViewHref(requestId: number) {

--- a/src/test-utils/react-query.ts
+++ b/src/test-utils/react-query.ts
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+/**
+ * Vitest-friendly QueryClient factory: zero retry, zero gc-time so each test
+ * starts from a clean cache and async assertions don't race against background
+ * retries. Use as `wrapper: createReactQueryWrapper(createTestQueryClient())`
+ * inside `renderHook` / `render` calls.
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+/**
+ * Returns a `wrapper` component that provides the given QueryClient to the
+ * tree under test. Pure helper — no JSX so the file can stay `.ts`.
+ */
+export function createReactQueryWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of #338 (umbrella #207). Slice **PR-2a of 5** per `docs/superpowers/plans/2026-04-27-issue-338-execution-slices.md`. Foundations of the new \`src/components/equipment-linked-request/\` package: type/string scaffolding, the \`useResolveActiveRepair\` TanStack Query hook (calls \`repair_request_active_for_equipment\` RPC introduced in PR-1b), and the \`LinkedRequestProvider\`/\`useLinkedRequest\` context. **No** UI surface; no production code imports the new package yet — that lands in PR-2b (button/host/adapter) and PR-3 (mount on Equipment page).

## Tasks delivered (from plan d27b8bb)

- [x] Task 2.1 — Types and strings (foundation)
- [x] Task 2.2 — Resolver hook \`useResolveActiveRepair\` (TDD)
- [x] Task 2.3 — \`LinkedRequestContext\` Provider (TDD)

## Test plan

- [x] verify:no-explicit-any green
- [x] typecheck green (\`tsc --noEmit\`)
- [x] focused test:run green: 22/22 pass across 4 files
  - \`src/components/equipment-linked-request/resolvers/__tests__/useResolveActiveRepair.test.ts\` (5/5)
  - \`src/components/equipment-linked-request/__tests__/LinkedRequestContext.test.tsx\` (5/5)
  - \`src/lib/__tests__/repair-request-deep-link.test.ts\` (7/7) — re-run as smoke for stable foundation
  - \`src/lib/__tests__/repair-request-deep-link.adoption.test.ts\` (5/5) — re-run as smoke
- [x] react-doctor \`--diff main\` green: **100/100**, "No issues found!" on 6 changed source files

## Deploy-safety reasoning

**Pure additive.** \`grep -r "equipment-linked-request"\` outside the new directory returns zero matches: no production component, page, or test imports anything from this package. The bundle size delta is therefore zero on every existing route — Next.js tree-shakes the unused module out. Reverting this PR is a clean \`git revert\` with no downstream cleanup.

## Notable implementation detail

\`LinkedRequestProvider\` uses **idempotent functional setState** for \`openRepair\` / \`close\` / the auto-close effect (returns \`prev\` when next state is structurally equal). React's default \`Object.is\` short-circuit doesn't help with object literals; without the bail-out, callers invoking \`openRepair\` from inside a \`useEffect\` (Task 2.3 contract test does exactly this) would loop forever. This is the canonical React pattern for state-mutating callbacks reachable from effects.

## Refs

- Refs #338 (umbrella #207)
- Plan: \`docs/superpowers/plans/2026-04-26-issue-207-phase1-equipment-deeplink-active-repair.md\`
- Slices: \`docs/superpowers/plans/2026-04-27-issue-338-execution-slices.md\`
- Builds on PR #343 (PR-1a, helper rename) + PR #345 (PR-1b, RPC + index)
- Unblocks PR-2b (button/host/adapter, depends on \`useLinkedRequest\`)

Generated with [Devin](https://cli.devin.ai/docs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added linked repair request functionality for equipment with automatic state synchronization.
  * Enabled fetching and display of active repair requests associated with equipment.
  * Integrated automatic state closure when equipment detail view is dismissed.
  * Added Vietnamese localization for repair request interface elements and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded the new `src/components/equipment-linked-request/` package with types/strings, a `useResolveActiveRepair` hook, and a `LinkedRequestProvider`/`useLinkedRequest` context for equipment‑linked repair requests. Also fixed the active repair query key to `['repair','active',id]` so existing mutations invalidate it; additive only and not mounted yet — supports #338.

- **New Features**
  - `useResolveActiveRepair`: wraps `repair_request_active_for_equipment` via TanStack Query; uses `buildActiveRepairRequestQueryKey`; supports `enabled`; per‑equipment caches.
  - `LinkedRequestProvider`/`useLinkedRequest`: manages open/close; exposes `openRepair` and `close`; idempotent updates; auto‑closes with `EquipmentDialogContext`.
  - Types/strings: `LinkedRequestKind = 'repair'`, `ActiveRepairResult`, Vietnamese copy in `strings.ts`.

- **Refactors**
  - Extracted React Query test helpers to `src/test-utils/react-query.ts`; documented SonarCloud duplication policy in `AGENTS.md` (ignore duplication‑only gates).

<sup>Written for commit 6faea1387df92c56b34c53a0aadb040d06befedc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

