### PR TITLE
feat(338): PR-2b — LinkedRequest shell (adapter + SheetHost + barrel)

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsDetailView.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsDetailView.test.tsx
@@ -2,6 +2,7 @@
  * TDD RED phase: Tests for the unified RepairRequestsDetailView shell.
  */
 import * as React from "react"
+import Link from "next/link"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -199,6 +200,21 @@ describe("RepairRequestsDetailView", () => {
       historyErrorMessage: null,
       activeTab: "details",
     })
+  })
+
+  it("renders extension content inside the dialog portal", () => {
+    render(
+      <RepairRequestsDetailView
+        requestToView={mockRequest}
+        onClose={vi.fn()}
+        contentHeader={<div data-testid="linked-request-header">Header extension</div>}
+        footerContent={<Link href="/repair-requests?equipmentId=100">Footer extension</Link>}
+      />,
+    )
+
+    const dialogEl = screen.getByRole("dialog")
+    expect(dialogEl).toContainElement(screen.getByTestId("linked-request-header"))
+    expect(dialogEl).toContainElement(screen.getByRole("link", { name: "Footer extension" }))
   })
 
   it("replaces raw RPC errors with a friendly Vietnamese message and logs the original error", () => {

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsDetailView.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsDetailView.test.tsx
@@ -217,6 +217,15 @@ describe("RepairRequestsDetailView", () => {
     expect(dialogEl).toContainElement(screen.getByRole("link", { name: "Footer extension" }))
   })
 
+  it("renders footerContent when it is zero", () => {
+    render(
+      <RepairRequestsDetailView requestToView={mockRequest} onClose={vi.fn()} footerContent={0} />,
+    )
+
+    const dialogEl = screen.getByRole("dialog")
+    expect(dialogEl).toHaveTextContent("0")
+  })
+
   it("replaces raw RPC errors with a friendly Vietnamese message and logs the original error", () => {
     mockUseRepairRequestHistory.mockReturnValue({
       data: undefined,

--- a/src/app/(app)/repair-requests/_components/RepairRequestsDetailView.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsDetailView.tsx
@@ -15,6 +15,8 @@ import { RepairRequestsDetailTabs } from "./RepairRequestsDetailTabs"
 interface RepairRequestsDetailViewProps {
   requestToView: RepairRequestWithEquipment | null
   onClose: () => void
+  contentHeader?: React.ReactNode
+  footerContent?: React.ReactNode
 }
 
 const SAFE_HISTORY_ERROR_MESSAGE = "Không thể tải lịch sử thay đổi lúc này. Vui lòng thử lại sau."
@@ -41,6 +43,8 @@ function getSafeHistoryErrorMessage(error: unknown) {
 export const RepairRequestsDetailView = React.memo(function RepairRequestsDetailView({
   requestToView,
   onClose,
+  contentHeader,
+  footerContent,
 }: RepairRequestsDetailViewProps) {
   const [activeTab, setActiveTab] = React.useState("details")
 
@@ -88,6 +92,7 @@ export const RepairRequestsDetailView = React.memo(function RepairRequestsDetail
               Thông tin chi tiết và lịch sử của yêu cầu sửa chữa thiết bị
             </SheetDescription>
           </div>
+          {contentHeader}
           <RepairRequestsDetailTabs
             request={requestToView}
             historyEntries={historyEntries}
@@ -97,7 +102,14 @@ export const RepairRequestsDetailView = React.memo(function RepairRequestsDetail
             activeTab={activeTab}
             onTabChange={setActiveTab}
           />
-          <div className="p-4 border-t flex justify-end">
+          <div
+            className={
+              footerContent
+                ? "p-4 border-t flex items-center justify-between gap-3"
+                : "p-4 border-t flex justify-end"
+            }
+          >
+            {footerContent ? <div className="min-w-0">{footerContent}</div> : null}
             <Button variant="outline" onClick={onClose}>
               Đóng
             </Button>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsDetailView.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsDetailView.tsx
@@ -46,6 +46,7 @@ export const RepairRequestsDetailView = React.memo(function RepairRequestsDetail
   contentHeader,
   footerContent,
 }: RepairRequestsDetailViewProps) {
+  const hasFooterContent = footerContent !== null && footerContent !== undefined
   const [activeTab, setActiveTab] = React.useState("details")
 
   // Reset to details tab when viewing a different request
@@ -104,12 +105,12 @@ export const RepairRequestsDetailView = React.memo(function RepairRequestsDetail
           />
           <div
             className={
-              footerContent
+              hasFooterContent
                 ? "p-4 border-t flex items-center justify-between gap-3"
                 : "p-4 border-t flex justify-end"
             }
           >
-            {footerContent ? <div className="min-w-0">{footerContent}</div> : null}
+            {hasFooterContent ? <div className="min-w-0">{footerContent}</div> : null}
             <Button variant="outline" onClick={onClose}>
               Đóng
             </Button>

--- a/src/components/equipment-linked-request/LinkedRequestSheetHost.tsx
+++ b/src/components/equipment-linked-request/LinkedRequestSheetHost.tsx
@@ -2,6 +2,13 @@
 
 import * as React from 'react'
 import dynamic from 'next/dynamic'
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+} from '@/components/ui/sheet'
 import { toast } from '@/hooks/use-toast'
 import { useLinkedRequest } from './LinkedRequestContext'
 import { useResolveActiveRepair } from './resolvers/useResolveActiveRepair'
@@ -12,6 +19,38 @@ const RepairRequestSheetAdapter = dynamic<RepairRequestSheetAdapterProps>(
   () => import('./adapters/repairRequestSheetAdapter'),
   { ssr: false },
 )
+
+function LinkedRequestResolverSheet({
+  state,
+  onClose,
+}: {
+  state: 'loading' | 'error'
+  onClose: () => void
+}) {
+  const isError = state === 'error'
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && onClose()}>
+      <SheetContent side="right" className="w-full sm:max-w-md p-0">
+        <div className="flex h-full flex-col">
+          <div className="p-4 border-b" role={isError ? 'alert' : 'status'} aria-live="polite">
+            <SheetTitle>
+              {isError ? STRINGS.resolveErrorTitle : STRINGS.resolveLoadingTitle}
+            </SheetTitle>
+            <SheetDescription>
+              {isError ? STRINGS.resolveErrorDescription : STRINGS.resolveLoadingDescription}
+            </SheetDescription>
+          </div>
+          <div className="mt-auto p-4 border-t flex justify-end">
+            <Button variant="outline" onClick={onClose}>
+              Đóng
+            </Button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}
 
 /**
  * Mounts the active-request side sheet at page level (sibling of
@@ -41,6 +80,14 @@ export function LinkedRequestSheetHost() {
   }, [enabled, data, close])
 
   if (!enabled || !data || data.active_count === 0 || !data.request) {
+    if (enabled && query.isError) {
+      return <LinkedRequestResolverSheet state="error" onClose={close} />
+    }
+
+    if (enabled && (query.isLoading || !data)) {
+      return <LinkedRequestResolverSheet state="loading" onClose={close} />
+    }
+
     return null
   }
 

--- a/src/components/equipment-linked-request/LinkedRequestSheetHost.tsx
+++ b/src/components/equipment-linked-request/LinkedRequestSheetHost.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import * as React from 'react'
+import dynamic from 'next/dynamic'
+import { toast } from '@/hooks/use-toast'
+import { useLinkedRequest } from './LinkedRequestContext'
+import { useResolveActiveRepair } from './resolvers/useResolveActiveRepair'
+import type { RepairRequestSheetAdapterProps } from './adapters/repairRequestSheetAdapter'
+import { STRINGS } from './strings'
+
+const RepairRequestSheetAdapter = dynamic<RepairRequestSheetAdapterProps>(
+  () => import('./adapters/repairRequestSheetAdapter'),
+  { ssr: false },
+)
+
+/**
+ * Mounts the active-request side sheet at page level (sibling of
+ * EquipmentDetailDialog). Keeps the sheet detached from Equipment Detail's
+ * internal tree so the in-row icon (post 2026-04-27 pivot) can open the
+ * sheet from anywhere on the equipment page.
+ *
+ * Auto-close-on-stale (active_count flips to 0) lives here because it
+ * depends on the resolver result. The resolver fires only when state.open
+ * becomes true (i.e., user clicks the row icon).
+ */
+export function LinkedRequestSheetHost() {
+  const { state, close } = useLinkedRequest()
+
+  const enabled = state.open && state.kind === 'repair'
+  const equipmentId = enabled ? state.equipmentId : null
+  const query = useResolveActiveRepair({ equipmentId, enabled })
+
+  // Auto-close when the resolver settles with no active record.
+  const data = query.data
+  React.useEffect(() => {
+    if (!enabled) return
+    if (data && data.active_count === 0) {
+      close()
+      toast({ title: STRINGS.autoCloseToastTitle })
+    }
+  }, [enabled, data, close])
+
+  if (!enabled || !data || data.active_count === 0 || !data.request) {
+    return null
+  }
+
+  return (
+    <RepairRequestSheetAdapter
+      request={data.request}
+      activeCount={data.active_count}
+      onClose={close}
+    />
+  )
+}

--- a/src/components/equipment-linked-request/__tests__/LinkedRequestSheetHost.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/LinkedRequestSheetHost.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/hooks/use-toast', () => ({
 }))
 
 // Stub the lazy adapter to a synchronous component so we can read its props.
-vi.mock('../adapters/repairRequestSheetAdapter', () => ({
+vi.mock('@/components/equipment-linked-request/adapters/repairRequestSheetAdapter', () => ({
   default: ({ request, activeCount, onClose }: {
     request: { id: number }
     activeCount: number
@@ -49,9 +49,12 @@ vi.mock('next/dynamic', () => ({
   },
 }))
 
-import { LinkedRequestProvider, useLinkedRequest } from '../LinkedRequestContext'
-import { LinkedRequestSheetHost } from '../LinkedRequestSheetHost'
 import { EquipmentDialogContext } from '@/app/(app)/equipment/_components/EquipmentDialogContext'
+import {
+  LinkedRequestProvider,
+  useLinkedRequest,
+} from '@/components/equipment-linked-request/LinkedRequestContext'
+import { LinkedRequestSheetHost } from '@/components/equipment-linked-request/LinkedRequestSheetHost'
 
 function makeEquipmentDialogStub(isDetailOpen = true) {
   return {

--- a/src/components/equipment-linked-request/__tests__/LinkedRequestSheetHost.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/LinkedRequestSheetHost.test.tsx
@@ -152,6 +152,24 @@ describe('LinkedRequestSheetHost', () => {
     expect(screen.getByTestId('adapter-active-count').textContent).toBe('3')
   })
 
+  it('renders an explicit loading sheet while resolving the active repair request', async () => {
+    mockCallRpc.mockImplementationOnce(() => new Promise(() => {}))
+
+    renderHost({ equipmentId: 11 })
+
+    expect(await screen.findByText('Đang mở yêu cầu sửa chữa')).toBeInTheDocument()
+    expect(screen.getByText('Vui lòng chờ trong giây lát.')).toBeInTheDocument()
+  })
+
+  it('renders an explicit error sheet when the active repair resolver fails', async () => {
+    mockCallRpc.mockRejectedValueOnce(new Error('RPC failed'))
+
+    renderHost({ equipmentId: 11 })
+
+    expect(await screen.findByText('Không thể mở yêu cầu sửa chữa')).toBeInTheDocument()
+    expect(screen.getByText('Vui lòng thử lại từ danh sách thiết bị.')).toBeInTheDocument()
+  })
+
   it('auto-closes and toasts when resolver returns active_count: 0 while open', async () => {
     mockCallRpc.mockResolvedValueOnce({ active_count: 0, request: null })
     renderHost({ equipmentId: 11 })

--- a/src/components/equipment-linked-request/__tests__/LinkedRequestSheetHost.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/LinkedRequestSheetHost.test.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCallRpc = vi.fn()
+const mockToast = vi.fn()
+
+vi.mock('@/lib/rpc-client', () => ({
+  callRpc: (...args: unknown[]) => mockCallRpc(...args),
+}))
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: (args: unknown) => mockToast(args),
+}))
+
+// Stub the lazy adapter to a synchronous component so we can read its props.
+vi.mock('../adapters/repairRequestSheetAdapter', () => ({
+  default: ({ request, activeCount, onClose }: {
+    request: { id: number }
+    activeCount: number
+    onClose: () => void
+  }) => (
+    <div data-testid="adapter-stub">
+      <span data-testid="adapter-request-id">{request.id}</span>
+      <span data-testid="adapter-active-count">{activeCount}</span>
+      <button type="button" onClick={onClose}>stub-close</button>
+    </div>
+  ),
+}))
+
+// Force next/dynamic to resolve synchronously to the mocked module.
+vi.mock('next/dynamic', () => ({
+  default: (loader: () => Promise<{ default: React.ComponentType<unknown> }>) => {
+    let Component: React.ComponentType<unknown> | null = null
+    let pending = true
+    let promise: Promise<unknown> | null = null
+    return function Dynamic(props: Record<string, unknown>) {
+      if (Component) return <Component {...props} />
+      if (!promise) {
+        promise = loader().then((mod) => {
+          Component = mod.default
+          pending = false
+        })
+      }
+      if (pending) throw promise
+      return null
+    }
+  },
+}))
+
+import { LinkedRequestProvider, useLinkedRequest } from '../LinkedRequestContext'
+import { LinkedRequestSheetHost } from '../LinkedRequestSheetHost'
+import { EquipmentDialogContext } from '@/app/(app)/equipment/_components/EquipmentDialogContext'
+
+function makeEquipmentDialogStub(isDetailOpen = true) {
+  return {
+    user: null,
+    isGlobal: false,
+    isRegionalLeader: false,
+    dialogState: {
+      isAddOpen: false,
+      isImportOpen: false,
+      isColumnsOpen: false,
+      isDetailOpen,
+      isStartUsageOpen: false,
+      isEndUsageOpen: false,
+      isDeleteOpen: false,
+      detailEquipment: null,
+      startUsageEquipment: null,
+      endUsageLog: null,
+      deleteTarget: null,
+      deleteSource: null,
+    },
+    openAddDialog: vi.fn(),
+    openImportDialog: vi.fn(),
+    openColumnsDialog: vi.fn(),
+    openDetailDialog: vi.fn(),
+    openStartUsageDialog: vi.fn(),
+    openEndUsageDialog: vi.fn(),
+    openDeleteDialog: vi.fn(),
+    closeAddDialog: vi.fn(),
+    closeImportDialog: vi.fn(),
+    closeColumnsDialog: vi.fn(),
+    closeDetailDialog: vi.fn(),
+    closeStartUsageDialog: vi.fn(),
+    closeEndUsageDialog: vi.fn(),
+    closeDeleteDialog: vi.fn(),
+    closeAllDialogs: vi.fn(),
+    onDataMutationSuccess: vi.fn(),
+  }
+}
+
+function Renderer({ equipmentId }: { equipmentId: number | null }) {
+  const linked = useLinkedRequest()
+  React.useEffect(() => {
+    if (equipmentId !== null) linked.openRepair(equipmentId)
+  }, [linked, equipmentId])
+  return <LinkedRequestSheetHost />
+}
+
+function renderHost({ equipmentId = 11 }: { equipmentId?: number | null } = {}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <EquipmentDialogContext.Provider value={makeEquipmentDialogStub()}>
+        <LinkedRequestProvider>
+          <React.Suspense fallback={<div data-testid="suspense" />}>
+            <Renderer equipmentId={equipmentId} />
+          </React.Suspense>
+        </LinkedRequestProvider>
+      </EquipmentDialogContext.Provider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('LinkedRequestSheetHost', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCallRpc.mockReset()
+    mockToast.mockReset()
+  })
+
+  it('renders nothing when state is closed', () => {
+    renderHost({ equipmentId: null })
+    expect(screen.queryByTestId('adapter-stub')).toBeNull()
+    expect(mockCallRpc).not.toHaveBeenCalled()
+  })
+
+  it('renders the adapter with the resolved request when active_count >= 1', async () => {
+    mockCallRpc.mockResolvedValueOnce({
+      active_count: 1,
+      request: { id: 555, thiet_bi_id: 11 },
+    })
+    renderHost({ equipmentId: 11 })
+
+    const adapter = await screen.findByTestId('adapter-stub')
+    expect(adapter).toBeInTheDocument()
+    expect(screen.getByTestId('adapter-request-id').textContent).toBe('555')
+    expect(screen.getByTestId('adapter-active-count').textContent).toBe('1')
+  })
+
+  it('passes activeCount through to the adapter for multi-active', async () => {
+    mockCallRpc.mockResolvedValueOnce({
+      active_count: 3,
+      request: { id: 999, thiet_bi_id: 11 },
+    })
+    renderHost({ equipmentId: 11 })
+    await screen.findByTestId('adapter-stub')
+    expect(screen.getByTestId('adapter-active-count').textContent).toBe('3')
+  })
+
+  it('auto-closes and toasts when resolver returns active_count: 0 while open', async () => {
+    mockCallRpc.mockResolvedValueOnce({ active_count: 0, request: null })
+    renderHost({ equipmentId: 11 })
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({ title: 'Yêu cầu đã được hoàn thành' })
+    })
+    expect(screen.queryByTestId('adapter-stub')).toBeNull()
+  })
+})

--- a/src/components/equipment-linked-request/__tests__/repairRequestSheetAdapter.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/repairRequestSheetAdapter.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { RepairRequestWithEquipment } from '@/app/(app)/repair-requests/types'
+import { STRINGS } from '@/components/equipment-linked-request/strings'
+
+const mocks = vi.hoisted(() => ({
+  detailView: vi.fn(),
+}))
+
+vi.mock('@/app/(app)/repair-requests/_components/RepairRequestsDetailView', () => ({
+  RepairRequestsDetailView: ({
+    requestToView,
+    onClose,
+    contentHeader,
+    footerContent,
+  }: {
+    requestToView: RepairRequestWithEquipment | null
+    onClose: () => void
+    contentHeader?: React.ReactNode
+    footerContent?: React.ReactNode
+  }) => {
+    mocks.detailView({ requestToView, onClose, contentHeader, footerContent })
+    return (
+      <div role="dialog" data-testid="detail-view">
+        <div data-testid="content-header">{contentHeader}</div>
+        <div data-testid="footer-content">{footerContent}</div>
+      </div>
+    )
+  },
+}))
+
+import RepairRequestSheetAdapter from '../adapters/repairRequestSheetAdapter'
+
+const mockRequest = {
+  id: 9001,
+  thiet_bi_id: 42,
+} as RepairRequestWithEquipment
+
+describe('RepairRequestSheetAdapter', () => {
+  it('injects the multi-active alert and repair-requests link into the detail sheet slots', () => {
+    render(<RepairRequestSheetAdapter request={mockRequest} activeCount={3} onClose={vi.fn()} />)
+
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).getByRole('alert')).toHaveTextContent(STRINGS.multiActiveAlert(3))
+    expect(
+      within(dialog).getByRole('link', { name: STRINGS.footerOpenInRepairRequests }),
+    ).toHaveAttribute('href', '/repair-requests?equipmentId=42')
+  })
+})

--- a/src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx
+++ b/src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import * as React from 'react'
+import Link from 'next/link'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { buildRepairRequestsByEquipmentHref } from '@/lib/repair-request-deep-link'
 import { RepairRequestsDetailView } from '@/app/(app)/repair-requests/_components/RepairRequestsDetailView'
 import type { RepairRequestWithEquipment } from '@/app/(app)/repair-requests/types'
-import { STRINGS } from '../strings'
+import { STRINGS } from '@/components/equipment-linked-request/strings'
 
 export interface RepairRequestSheetAdapterProps {
   request: RepairRequestWithEquipment
@@ -29,23 +30,26 @@ export default function RepairRequestSheetAdapter({
 }: RepairRequestSheetAdapterProps) {
   const showMultiActiveAlert = activeCount > 1
   const openInRepairRequestsHref = buildRepairRequestsByEquipmentHref(request.thiet_bi_id)
+  const contentHeader = showMultiActiveAlert ? (
+    <Alert role="alert" variant="destructive" className="mx-4 mt-3">
+      <AlertDescription>{STRINGS.multiActiveAlert(activeCount)}</AlertDescription>
+    </Alert>
+  ) : null
+  const footerContent = (
+    <Link
+      href={openInRepairRequestsHref}
+      className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+    >
+      {STRINGS.footerOpenInRepairRequests}
+    </Link>
+  )
 
   return (
-    <>
-      {showMultiActiveAlert ? (
-        <Alert role="alert" variant="destructive" className="mx-4 mt-3">
-          <AlertDescription>{STRINGS.multiActiveAlert(activeCount)}</AlertDescription>
-        </Alert>
-      ) : null}
-      <RepairRequestsDetailView requestToView={request} onClose={onClose} />
-      <div className="px-4 pb-4 -mt-1">
-        <a
-          href={openInRepairRequestsHref}
-          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
-        >
-          {STRINGS.footerOpenInRepairRequests}
-        </a>
-      </div>
-    </>
+    <RepairRequestsDetailView
+      requestToView={request}
+      onClose={onClose}
+      contentHeader={contentHeader}
+      footerContent={footerContent}
+    />
   )
 }

--- a/src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx
+++ b/src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import * as React from 'react'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { buildRepairRequestsByEquipmentHref } from '@/lib/repair-request-deep-link'
+import { RepairRequestsDetailView } from '@/app/(app)/repair-requests/_components/RepairRequestsDetailView'
+import type { RepairRequestWithEquipment } from '@/app/(app)/repair-requests/types'
+import { STRINGS } from '../strings'
+
+export interface RepairRequestSheetAdapterProps {
+  request: RepairRequestWithEquipment
+  activeCount: number
+  onClose: () => void
+}
+
+/**
+ * Phase 1 read/detail parity adapter. Wraps the existing repair-requests
+ * detail sheet so it can be opened from Equipment list (#338) without
+ * surfacing any mutation actions (those still live on the /repair-requests
+ * page).
+ *
+ * Loaded lazily via next/dynamic from LinkedRequestSheetHost so its
+ * dependencies do not ship in the equipment route initial chunk.
+ */
+export default function RepairRequestSheetAdapter({
+  request,
+  activeCount,
+  onClose,
+}: RepairRequestSheetAdapterProps) {
+  const showMultiActiveAlert = activeCount > 1
+  const openInRepairRequestsHref = buildRepairRequestsByEquipmentHref(request.thiet_bi_id)
+
+  return (
+    <>
+      {showMultiActiveAlert ? (
+        <Alert role="alert" variant="destructive" className="mx-4 mt-3">
+          <AlertDescription>{STRINGS.multiActiveAlert(activeCount)}</AlertDescription>
+        </Alert>
+      ) : null}
+      <RepairRequestsDetailView requestToView={request} onClose={onClose} />
+      <div className="px-4 pb-4 -mt-1">
+        <a
+          href={openInRepairRequestsHref}
+          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+        >
+          {STRINGS.footerOpenInRepairRequests}
+        </a>
+      </div>
+    </>
+  )
+}

--- a/src/components/equipment-linked-request/index.ts
+++ b/src/components/equipment-linked-request/index.ts
@@ -1,0 +1,14 @@
+/**
+ * equipment-linked-request package barrel.
+ *
+ * Phase 1 of #338. Consumers import via '@/components/equipment-linked-request'.
+ *
+ * After the 2026-04-27 in-row icon pivot, the chip-style `LinkedRequestButton`
+ * is no longer part of this package — its role is taken over by
+ * `LinkedRequestRowIndicator`, added in PR-3b.
+ */
+
+export { LinkedRequestProvider, useLinkedRequest } from './LinkedRequestContext'
+export type { LinkedRequestContextValue } from './LinkedRequestContext'
+export { LinkedRequestSheetHost } from './LinkedRequestSheetHost'
+export type { LinkedRequestKind, LinkedRequestState, ActiveRepairResult } from './types'

--- a/src/components/equipment-linked-request/strings.ts
+++ b/src/components/equipment-linked-request/strings.ts
@@ -8,4 +8,8 @@ export const STRINGS = {
     `Phát hiện ${count} yêu cầu active. Đang hiển thị bản cập nhật mới nhất. Để xem tất cả, mở danh sách trên trang Yêu cầu sửa chữa.`,
   footerOpenInRepairRequests: 'Mở trong trang Yêu cầu sửa chữa',
   autoCloseToastTitle: 'Yêu cầu đã được hoàn thành',
+  resolveLoadingTitle: 'Đang mở yêu cầu sửa chữa',
+  resolveLoadingDescription: 'Vui lòng chờ trong giây lát.',
+  resolveErrorTitle: 'Không thể mở yêu cầu sửa chữa',
+  resolveErrorDescription: 'Vui lòng thử lại từ danh sách thiết bị.',
 } as const


### PR DESCRIPTION
## Summary
Adds the UI shell for the equipment-to-repair deep-link feature (Issue #338 Phase 1). Ships `repairRequestSheetAdapter` (converts a resolved repair request into a Sheet-compatible payload), `LinkedRequestSheetHost` (renders a read-only `RepairRequestsDetailView` inside a Sheet when an active repair is resolved), and the `index.ts` barrel so PR-3b can import the package cleanly. No production surface imports this package yet — the feature remains unlit until PR-3b.

## Tasks delivered (from plan d27b8bb)
- [x] Task 2.5 — `repairRequestSheetAdapter` (no test file per plan; covered by SheetHost integration tests)
- [x] Task 2.6 — `LinkedRequestSheetHost` component + unit tests (4/4 pass)
- [x] Task 2.7 — Barrel `index.ts` (no `LinkedRequestButton` export; Task 2.4 dropped per 2026-04-27 pivot)

## Test plan
- [x] `verify:no-explicit-any` green
- [x] `typecheck` green
- [x] Focused `test:run` green (`LinkedRequestContext.test.tsx`, `useResolveActiveRepair.test.ts`, `LinkedRequestSheetHost.test.tsx`) — 14/14 pass
- [x] `react-doctor --diff main` green (100/100)

## Deploy-safety reasoning
All files are additive and not imported by any production UI surface (`equipment-table-columns`, `mobile-equipment-list-item`, `EquipmentPageClient`, etc.). The package is tree-shakable; merging this PR ships zero user-visible change. Feature lights up only in PR-3b when the barrel is imported and `LinkedRequestRowIndicator` is wired into table/mobile rows.

## Refs
- Refs #338 (PR-3b will close)
- Refs #207 (umbrella)
- Plan: `docs/superpowers/plans/2026-04-26-issue-207-phase1-equipment-deeplink-active-repair.md`
- Slices: `docs/superpowers/plans/2026-04-27-issue-338-execution-slices.md`

**Label:** `do-not-merge` — waiting for PR-3a (backend migration) before PR-3b frontend integration.

Generated with [Devin](https://cli.devin.ai/docs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the UI shell for the equipment-to-repair deep link (Phase 1 of #338). Provides a read-only side sheet for an equipment’s active repair, with explicit loading/error states; the package is exported via `@/components/equipment-linked-request` and remains off until PR‑3b wires it in.

- New Features
  - LinkedRequestSheetHost: mounts a page-level side sheet, resolves the active repair on open, shows loading/error sheets with localized text, auto-closes with a toast when none remain, and lazy-loads the adapter via `next/dynamic`.
  - repairRequestSheetAdapter: wraps `RepairRequestsDetailView` in read-only mode, injects a multi-active alert, and adds an “Open in Repair Requests” link built with `buildRepairRequestsByEquipmentHref` via the new `contentHeader`/`footerContent` slots.
  - RepairRequestsDetailView: adds optional `contentHeader` and `footerContent` slots (supports zero values) and updated layout to host the adapter’s injected UI.
  - Barrel `index.ts`: exposes provider/hooks/host for clean imports from `@/components/equipment-linked-request`.

<sup>Written for commit a51d94596f241ee3a8200ae8cd01f6d292d97ded. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a repair-request sheet when equipment has linked active repairs, with loading and error states.
  * Auto-closes the sheet and shows a toast when no active repairs remain.
  * Displays an alert for multiple active repairs and a footer link to the repair requests page.
* **Tests**
  * Added tests covering render flows: closed, loading, error, multiple/zero active counts, and toast emission.
* **Localization**
  * Added Vietnamese strings for loading/error UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->