### PR TITLE
feat(338): PR-3a — extend equipment_list_enhanced with active_repair_request_id

### DIFF
--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -4,6 +4,7 @@ import * as React from "react"
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { callRpc } from "@/lib/rpc-client"
 import { useActiveUsageLogs } from "@/hooks/use-usage-logs"
+import { useIsLinkedRequestActive } from "@/components/equipment-linked-request/useIsLinkedRequestActive"
 import type { Equipment } from "../types"
 import type { FilterBottomSheetData, FacilityOption, EquipmentListResponse } from "../types"
 
@@ -97,6 +98,7 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
   } = params
 
   const queryClient = useQueryClient()
+  const isLinkedRequestActive = useIsLinkedRequestActive()
 
   // Computed: should we fetch data based on tenant/facility selection
   // For regional_leader, require facility selection before fetching
@@ -188,7 +190,9 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
       return result
     },
     placeholderData: keepPreviousData,
-    staleTime: 120_000,
+    // Tighten staleTime when linked-request feature is active so the Wrench
+    // icon appears/disappears quickly after repair request changes.
+    staleTime: isLinkedRequestActive ? 15_000 : 120_000,
     gcTime: 10 * 60_000,
     refetchOnWindowFocus: false,
   })

--- a/src/components/equipment-linked-request/useIsLinkedRequestActive.ts
+++ b/src/components/equipment-linked-request/useIsLinkedRequestActive.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns whether the linked-request feature is currently active.
+ * Currently always false; will be wired to LinkedRequestContext in PR-3b.
+ * Used by useEquipmentData to tighten staleTime when the feature is lit up.
+ */
+export function useIsLinkedRequestActive(): boolean {
+  return false
+}

--- a/src/contexts/realtime-context.tsx
+++ b/src/contexts/realtime-context.tsx
@@ -99,8 +99,10 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
         break
 
       case 'yeu_cau_sua_chua':
-        // Repair request changes
+        // Repair request changes — also invalidate equipment because active_repair_request_id
+        // is derived from yeu_cau_sua_chua (LATERAL JOIN in equipment_list_enhanced).
         debouncedInvalidate(repairKeys.all) // ['repair'] - invalidates all repair queries
+        debouncedInvalidate(equipmentKeys.all) // ['equipment'] - active_repair_request_id may change
         debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats']
         debouncedInvalidate(['reports'])
         break

--- a/src/contexts/realtime-context.tsx
+++ b/src/contexts/realtime-context.tsx
@@ -82,7 +82,7 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
   }
 
   // Handle database changes
-  const handleDatabaseChange = (payload: RealtimePostgresChangesPayload<any>) => {
+  const handleDatabaseChange = (payload: RealtimePostgresChangesPayload<Record<string, unknown>>) => {
     const { table, eventType, new: newRecord, old: oldRecord } = payload
     
     console.log(`[Realtime] ${eventType} on ${table}:`, { newRecord, oldRecord })
@@ -102,7 +102,7 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
         // Repair request changes — also invalidate equipment because active_repair_request_id
         // is derived from yeu_cau_sua_chua (LATERAL JOIN in equipment_list_enhanced).
         debouncedInvalidate(repairKeys.all) // ['repair'] - invalidates all repair queries
-        debouncedInvalidate(equipmentKeys.all) // ['equipment'] - active_repair_request_id may change
+        debouncedInvalidate(['equipment']) // active_repair_request_id derived from yeu_cau_sua_chua
         debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats']
         debouncedInvalidate(['reports'])
         break

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -40,6 +40,8 @@ export interface Equipment {
   // tenant/organization
   don_vi?: number | null;
   google_drive_folder_url?: string | null;
+  // linked active repair request (from equipment_list_enhanced LATERAL JOIN)
+  active_repair_request_id?: number | null;
   // metadata
   created_at?: string;
   updated_at?: string;

--- a/supabase/migrations/20260427100600_extend_equipment_list_enhanced_active_repair.sql
+++ b/supabase/migrations/20260427100600_extend_equipment_list_enhanced_active_repair.sql
@@ -1,0 +1,237 @@
+-- Migration: Extend equipment_list_enhanced with active_repair_request_id LATERAL join
+-- Date: 2026-04-27
+-- Reason: Issue #338 Phase 1 — Add active_repair_request_id to each equipment row
+--         so the frontend can display an in-row Wrench icon without per-row RPC.
+--         Reuses composite index idx_yeu_cau_sua_chua_thiet_bi_status from PR-1b.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.equipment_list_enhanced(
+  p_q text DEFAULT NULL::text,
+  p_sort text DEFAULT 'id.asc'::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung text DEFAULT NULL::text,
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat text DEFAULT NULL::text,
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang text DEFAULT NULL::text,
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai text DEFAULT NULL::text,
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi text DEFAULT NULL::text,
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := '';
+  v_user_id TEXT := NULL;
+  v_claim_donvi BIGINT := NULL;
+  v_allowed_don_vi BIGINT[];
+  v_effective_donvi BIGINT := NULL;
+  v_department_scope TEXT;
+  v_sort_col TEXT := 'id';
+  v_sort_dir TEXT := 'ASC';
+  v_limit INT := GREATEST(p_page_size, 1);
+  v_offset INT := GREATEST(p_page - 1, 0) * GREATEST(p_page_size, 1);
+  v_where TEXT := '1=1 AND is_deleted = false';
+  v_total BIGINT := 0;
+  v_data JSONB := '[]'::jsonb;
+  v_jwt_claims JSONB;
+  v_sanitized_q TEXT;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := COALESCE(
+    v_jwt_claims ->>'app_role',
+    v_jwt_claims ->>'role',
+    ''
+  );
+  v_user_id := NULLIF(v_jwt_claims ->>'user_id', '');
+  v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
+  END IF;
+
+  IF p_sort IS NOT NULL AND p_sort != '' THEN
+    v_sort_col := split_part(p_sort, '.', 1);
+    v_sort_dir := UPPER(COALESCE(NULLIF(split_part(p_sort, '.', 2), ''), 'ASC'));
+    IF v_sort_dir NOT IN ('ASC', 'DESC') THEN
+      v_sort_dir := 'ASC';
+    END IF;
+    IF v_sort_col NOT IN (
+      'id', 'ma_thiet_bi', 'ten_thiet_bi', 'model', 'serial',
+      'khoa_phong_quan_ly', 'tinh_trang_hien_tai', 'vi_tri_lap_dat',
+      'nguoi_dang_truc_tiep_quan_ly', 'phan_loai_theo_nd98', 'nguon_kinh_phi', 'don_vi',
+      'gia_goc', 'ngay_nhap', 'ngay_dua_vao_su_dung', 'ngay_bt_tiep_theo',
+      'so_luu_hanh'
+    ) THEN
+      v_sort_col := 'id';
+    END IF;
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF lower(v_role) IN ('global', 'admin') THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective_donvi := p_don_vi;
+    ELSE
+      v_effective_donvi := NULL;
+    END IF;
+  ELSE
+    IF v_allowed_don_vi IS NOT NULL AND array_length(v_allowed_don_vi, 1) > 0 THEN
+      IF p_don_vi IS NOT NULL THEN
+        IF p_don_vi = ANY(v_allowed_don_vi) THEN
+          v_effective_donvi := p_don_vi;
+        ELSE
+          RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'Access denied for tenant');
+        END IF;
+      ELSE
+        v_effective_donvi := NULL;
+      END IF;
+    ELSE
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'No tenant access');
+    END IF;
+  END IF;
+
+  IF lower(v_role) = 'user' AND v_department_scope IS NULL THEN
+    RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+  END IF;
+
+  IF v_effective_donvi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ' || v_effective_donvi;
+  END IF;
+
+  IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin') AND v_allowed_don_vi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = '
+      || quote_literal(v_department_scope);
+  END IF;
+
+  IF p_khoa_phong_array IS NOT NULL AND array_length(p_khoa_phong_array, 1) > 0 THEN
+    v_where := v_where || ' AND khoa_phong_quan_ly = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_khoa_phong_array) AS x), ',') || '])';
+  ELSIF p_khoa_phong IS NOT NULL AND trim(p_khoa_phong) != '' THEN
+    v_where := v_where || ' AND khoa_phong_quan_ly = ' || quote_literal(p_khoa_phong);
+  END IF;
+
+  IF p_nguoi_su_dung_array IS NOT NULL AND array_length(p_nguoi_su_dung_array, 1) > 0 THEN
+    v_where := v_where || ' AND nguoi_dang_truc_tiep_quan_ly = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguoi_su_dung_array) AS x), ',') || '])';
+  ELSIF p_nguoi_su_dung IS NOT NULL AND trim(p_nguoi_su_dung) != '' THEN
+    v_where := v_where || ' AND nguoi_dang_truc_tiep_quan_ly = ' || quote_literal(p_nguoi_su_dung);
+  END IF;
+
+  IF p_vi_tri_lap_dat_array IS NOT NULL AND array_length(p_vi_tri_lap_dat_array, 1) > 0 THEN
+    v_where := v_where || ' AND vi_tri_lap_dat = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_vi_tri_lap_dat_array) AS x), ',') || '])';
+  ELSIF p_vi_tri_lap_dat IS NOT NULL AND trim(p_vi_tri_lap_dat) != '' THEN
+    v_where := v_where || ' AND vi_tri_lap_dat = ' || quote_literal(p_vi_tri_lap_dat);
+  END IF;
+
+  IF p_tinh_trang_array IS NOT NULL AND array_length(p_tinh_trang_array, 1) > 0 THEN
+    v_where := v_where || ' AND tinh_trang_hien_tai = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_tinh_trang_array) AS x), ',') || '])';
+  ELSIF p_tinh_trang IS NOT NULL AND trim(p_tinh_trang) != '' THEN
+    v_where := v_where || ' AND tinh_trang_hien_tai = ' || quote_literal(p_tinh_trang);
+  END IF;
+
+  IF p_phan_loai_array IS NOT NULL AND array_length(p_phan_loai_array, 1) > 0 THEN
+    v_where := v_where || ' AND phan_loai_theo_nd98 = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_phan_loai_array) AS x), ',') || '])';
+  ELSIF p_phan_loai IS NOT NULL AND trim(p_phan_loai) != '' THEN
+    v_where := v_where || ' AND phan_loai_theo_nd98 = ' || quote_literal(p_phan_loai);
+  END IF;
+
+  IF p_nguon_kinh_phi_array IS NOT NULL AND array_length(p_nguon_kinh_phi_array, 1) > 0 THEN
+    IF 'Chưa có' = ANY(p_nguon_kinh_phi_array) THEN
+      DECLARE v_non_empty_sources TEXT[];
+      BEGIN
+        SELECT ARRAY(SELECT x FROM unnest(p_nguon_kinh_phi_array) AS x WHERE x != 'Chưa có') INTO v_non_empty_sources;
+        IF v_non_empty_sources IS NOT NULL AND array_length(v_non_empty_sources, 1) > 0 THEN
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''' OR TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+            array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(v_non_empty_sources) AS x), ',') || ']))';
+        ELSE
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+        END IF;
+      END;
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+        array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguon_kinh_phi_array) AS x), ',') || '])';
+    END IF;
+  ELSIF p_nguon_kinh_phi IS NOT NULL AND trim(p_nguon_kinh_phi) != '' THEN
+    IF p_nguon_kinh_phi = 'Chưa có' THEN
+      v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ' || quote_literal(p_nguon_kinh_phi);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_where := v_where || ' AND (ten_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR ma_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR serial ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR so_luu_hanh ILIKE ' || quote_literal('%' || v_sanitized_q || '%') || ')';
+  END IF;
+
+  EXECUTE format('SELECT count(*) FROM public.thiet_bi WHERE %s', v_where) INTO v_total;
+
+  EXECUTE format(
+    'SELECT COALESCE(jsonb_agg(t), ''[]''::jsonb) FROM (
+       SELECT (to_jsonb(tb.*) || jsonb_build_object(
+         ''google_drive_folder_url'', dv.google_drive_folder_url,
+         ''don_vi_name'', dv.name,
+         ''active_repair_request_id'', ar.active_id
+       )) AS t
+       FROM public.thiet_bi tb
+       LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+       LEFT JOIN LATERAL (
+         SELECT r.id AS active_id
+         FROM public.yeu_cau_sua_chua r
+         WHERE r.thiet_bi_id = tb.id
+           AND r.trang_thai IN (''Chờ xử lý'', ''Đã duyệt'')
+         ORDER BY r.ngay_yeu_cau DESC, r.id DESC
+         LIMIT 1
+       ) ar ON TRUE
+       WHERE %s
+       ORDER BY tb.%I %s
+       OFFSET %s LIMIT %s
+     ) sub',
+    v_where, v_sort_col, v_sort_dir, v_offset, v_limit
+  ) INTO v_data;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'total', v_total,
+    'page', p_page,
+    'pageSize', p_page_size
+  );
+END;
+$function$;
+
+COMMIT;

--- a/supabase/tests/equipment_list_enhanced_active_repair_smoke.sql
+++ b/supabase/tests/equipment_list_enhanced_active_repair_smoke.sql
@@ -1,0 +1,163 @@
+-- supabase/tests/equipment_list_enhanced_active_repair_smoke.sql
+-- Purpose: smoke-test equipment_list_enhanced active_repair_request_id after migration.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp._ele_set_claims(
+  p_role text,
+  p_user_id bigint,
+  p_don_vi bigint DEFAULT NULL,
+  p_khoa_phong text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', p_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::text,
+      'sub', p_user_id::text,
+      'don_vi', p_don_vi::text,
+      'khoa_phong', p_khoa_phong
+    )::text,
+    true
+  );
+END;
+$$;
+
+DO $$
+DECLARE
+  v_tenant_a bigint;
+  v_tenant_b bigint;
+  v_user_id bigint := 999002;
+  v_eq_active bigint;
+  v_eq_no_active bigint;
+  v_eq_multi bigint;
+  v_eq_soft_deleted bigint;
+  v_eq_b bigint;
+  v_req_active bigint;
+  v_req_approved bigint;
+  v_req_old_completed bigint;
+  v_req_b_active bigint;
+  v_result jsonb;
+  v_row jsonb;
+BEGIN
+  INSERT INTO public.don_vi(name) VALUES ('Tenant A ELE smoke') RETURNING id INTO v_tenant_a;
+  INSERT INTO public.don_vi(name) VALUES ('Tenant B ELE smoke') RETURNING id INTO v_tenant_b;
+
+  -- Equipment fixtures
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-A1', 'eq active', v_tenant_a, 'Khoa A1', 'Chờ sửa chữa') RETURNING id INTO v_eq_active;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-A2', 'eq no active', v_tenant_a, 'Khoa A1', 'Hoạt động') RETURNING id INTO v_eq_no_active;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-A3', 'eq multi', v_tenant_a, 'Khoa A1', 'Chờ sửa chữa') RETURNING id INTO v_eq_multi;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai, is_deleted)
+  VALUES ('ELE-A4', 'eq soft-deleted', v_tenant_a, 'Khoa A1', 'Chờ sửa chữa', true) RETURNING id INTO v_eq_soft_deleted;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-B1', 'eq B', v_tenant_b, 'Khoa B1', 'Chờ sửa chữa') RETURNING id INTO v_eq_b;
+
+  -- Repair request fixtures
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co)
+  VALUES (v_eq_active, now() - interval '3 days', 'Chờ xử lý', 'Active pending')
+  RETURNING id INTO v_req_active;
+
+  -- Multi: older pending + newer approved
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co)
+  VALUES (v_eq_multi, now() - interval '5 days', 'Chờ xử lý', 'Multi older')
+  RETURNING id INTO v_req_old_completed; -- reuse var name
+
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co, ngay_duyet)
+  VALUES (v_eq_multi, now() - interval '2 days', 'Đã duyệt', 'Multi newer', now() - interval '1 day')
+  RETURNING id INTO v_req_approved;
+
+  -- Non-active status (completed)
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co, ngay_hoan_thanh)
+  VALUES (v_eq_no_active, now() - interval '10 days', 'Hoàn thành', 'Completed only', now() - interval '5 days');
+
+  -- Soft-deleted equipment with active request
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co)
+  VALUES (v_eq_soft_deleted, now() - interval '1 day', 'Chờ xử lý', 'Active on deleted eq');
+
+  -- Tenant B active request
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co)
+  VALUES (v_eq_b, now() - interval '2 days', 'Chờ xử lý', 'Tenant B active')
+  RETURNING id INTO v_req_b_active;
+
+  ---------------------------------------------------------------------------
+  -- Scenario A: equipment with active repair → active_repair_request_id populated
+  ---------------------------------------------------------------------------
+  PERFORM pg_temp._ele_set_claims('to_qltb', v_user_id, v_tenant_a);
+  v_result := public.equipment_list_enhanced(NULL, 'id.asc', 1, 50, v_tenant_a, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+  SELECT t INTO v_row FROM jsonb_array_elements(v_result->'data') AS t WHERE t->>'ma_thiet_bi' = 'ELE-A1';
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'Scenario A failed: ELE-A1 not found';
+  END IF;
+  IF (v_row->>'active_repair_request_id')::bigint IS DISTINCT FROM v_req_active THEN
+    RAISE EXCEPTION 'Scenario A failed: expected %, got %', v_req_active, v_row->>'active_repair_request_id';
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario B: equipment with no active repair → active_repair_request_id null
+  ---------------------------------------------------------------------------
+  SELECT t INTO v_row FROM jsonb_array_elements(v_result->'data') AS t WHERE t->>'ma_thiet_bi' = 'ELE-A2';
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'Scenario B failed: ELE-A2 not found';
+  END IF;
+  IF v_row->>'active_repair_request_id' IS NOT NULL THEN
+    RAISE EXCEPTION 'Scenario B failed: expected null, got %', v_row->>'active_repair_request_id';
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario C: multiple active repairs → latest by ngay_yeu_cau DESC, id DESC wins
+  ---------------------------------------------------------------------------
+  SELECT t INTO v_row FROM jsonb_array_elements(v_result->'data') AS t WHERE t->>'ma_thiet_bi' = 'ELE-A3';
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'Scenario C failed: ELE-A3 not found';
+  END IF;
+  IF (v_row->>'active_repair_request_id')::bigint IS DISTINCT FROM v_req_approved THEN
+    RAISE EXCEPTION 'Scenario C failed: expected % (newer approved), got %', v_req_approved, v_row->>'active_repair_request_id';
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario D: soft-deleted equipment excluded → not in result
+  ---------------------------------------------------------------------------
+  SELECT t INTO v_row FROM jsonb_array_elements(v_result->'data') AS t WHERE t->>'ma_thiet_bi' = 'ELE-A4';
+  IF v_row IS NOT NULL THEN
+    RAISE EXCEPTION 'Scenario D failed: soft-deleted ELE-A4 should not appear';
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario E: cross-tenant user → cannot see tenant B equipment or its active_repair_request_id
+  ---------------------------------------------------------------------------
+  SELECT t INTO v_row FROM jsonb_array_elements(v_result->'data') AS t WHERE t->>'ma_thiet_bi' = 'ELE-B1';
+  IF v_row IS NOT NULL THEN
+    RAISE EXCEPTION 'Scenario E failed: cross-tenant ELE-B1 should not appear';
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario F: global role can see tenant B and its active_repair_request_id
+  ---------------------------------------------------------------------------
+  PERFORM pg_temp._ele_set_claims('global', v_user_id);
+  v_result := public.equipment_list_enhanced(NULL, 'id.asc', 1, 50, v_tenant_b, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+  SELECT t INTO v_row FROM jsonb_array_elements(v_result->'data') AS t WHERE t->>'ma_thiet_bi' = 'ELE-B1';
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'Scenario F failed: ELE-B1 not found for global';
+  END IF;
+  IF (v_row->>'active_repair_request_id')::bigint IS DISTINCT FROM v_req_b_active THEN
+    RAISE EXCEPTION 'Scenario F failed: expected %, got %', v_req_b_active, v_row->>'active_repair_request_id';
+  END IF;
+
+  RAISE NOTICE 'equipment_list_enhanced_active_repair smoke: ALL SCENARIOS PASSED';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
Backend-only PR extending `equipment_list_enhanced` with an `active_repair_request_id` LATERAL JOIN to `yeu_cau_sua_chua`, plus cross-cache invalidation in RealtimeProvider and preparatory frontend types. No UI changes — feature remains unlit until PR-3b.

## Tasks delivered (from plan d27b8bb)
- [x] Task 3.0a — Migration: extend `equipment_list_enhanced` with `active_repair_request_id` (LATERAL JOIN, reuses PR-1b composite index)
- [x] Task 3.0b — Smoke SQL: 6-scenario smoke test (A–F) executed via Supabase MCP, all pass
- [x] Task 3.0c — RealtimeProvider extension: invalidate `['equipment']` on `yeu_cau_sua_chua` events; Equipment type gains `active_repair_request_id?: number | null`; `useEquipmentData` staleTime prepared for 15s tightening when `LinkedRequestProvider` mounts in PR-3b

## Test plan
- [x] `verify:no-explicit-any` green
- [x] `typecheck` green
- [x] Focused `test:run` green (`useEquipmentData.test.ts`) — 25/25 pass
- [x] `react-doctor --diff main` green (100/100)
- [x] Smoke SQL passes 6/6 scenarios on live DB (via Supabase MCP)
- [x] Migration applied via Supabase MCP `apply_migration`

## Deploy-safety reasoning
Migration is additive: `active_repair_request_id` is projected into JSONB output as an extra key. Existing frontend consumers ignore unknown keys. RealtimeProvider extension invalidates `['equipment']` — a key family that already exists. No production UI imports or uses `active_repair_request_id` yet. Feature lights up only in PR-3b.

## Refs
- Refs #338 (PR-3b will close)
- Refs #207 (umbrella)
- Plan: `docs/superpowers/plans/2026-04-26-issue-207-phase1-equipment-deeplink-active-repair.md`
- Slices: `docs/superpowers/plans/2026-04-27-issue-338-execution-slices.md`

Generated with [Devin](https://cli.devin.ai/docs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `active_repair_request_id` to `equipment_list_enhanced` via a LATERAL join to `yeu_cau_sua_chua`, and wires realtime invalidation so equipment data refreshes when repair requests change. No UI changes; backend groundwork for #338 (UI lands in PR-3b).

- **New Features**
  - SQL: extend RPC to include `active_repair_request_id` from the latest active request (`Chờ xử lý`, `Đã duyệt`); additive output.
  - Realtime: invalidate `['equipment']` on `yeu_cau_sua_chua` events to keep the derived field fresh.
  - Types/hooks: add `active_repair_request_id?: number | null` to `Equipment`; add `useIsLinkedRequestActive` (stub for PR-3b); `useEquipmentData` tightens `staleTime` to 15s when the feature is on (defaults to 120s now).
  - Tests: add DB smoke test covering active, none, multiple, soft-deleted, cross-tenant, and global scenarios.

<sup>Written for commit b1037fd0c6d4b195bbf95ab9f15aa65e156f8c21. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/348?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

