### PR TITLE
feat(338): PR-3a — sync active repair equipment list backend

### DIFF
--- a/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/hooks/use-usage-logs', () => ({
 
 // Import after mocking
 import { useEquipmentData } from '../_hooks/useEquipmentData'
+import type { Equipment } from '@/types/database'
 import type { UseEquipmentDataParams } from '../_hooks/useEquipmentData'
 
 // Default params for tests - now includes context values that were previously from useFacilityFilter
@@ -120,6 +121,40 @@ describe('useEquipmentData', () => {
 
       expect(result.current.data).toEqual(mockEquipment)
       expect(result.current.total).toBe(2)
+    })
+
+    it('should preserve active repair request id returned by equipment_list_enhanced', async () => {
+      const mockEquipment = [
+        {
+          id: 1,
+          ma_thiet_bi: 'EQ-001',
+          ten_thiet_bi: 'Test Equipment 1',
+          active_repair_request_id: 33801,
+        } satisfies Equipment,
+        {
+          id: 2,
+          ma_thiet_bi: 'EQ-002',
+          ten_thiet_bi: 'Test Equipment 2',
+          active_repair_request_id: null,
+        } satisfies Equipment,
+      ]
+      mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
+        if (fn === 'equipment_list_enhanced') {
+          return Promise.resolve({ data: mockEquipment, total: 2 })
+        }
+        return Promise.resolve([])
+      })
+
+      const { result } = renderHook(() => useEquipmentData(createDefaultParams()), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
+
+      expect(result.current.data[0]?.active_repair_request_id).toBe(33801)
+      expect(result.current.data[1]?.active_repair_request_id).toBeNull()
     })
 
     it('should reflect active-only server contract (deleted fixtures excluded upstream)', async () => {
@@ -706,4 +741,3 @@ describe('useEquipmentData', () => {
     })
   })
 })
-

--- a/src/contexts/__tests__/realtime-context.invalidation.test.tsx
+++ b/src/contexts/__tests__/realtime-context.invalidation.test.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react'
+import { act, render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { repairKeys } from '@/hooks/use-cached-repair'
+
+type RealtimeCallback = (payload: {
+  table: string
+  eventType: 'INSERT' | 'UPDATE' | 'DELETE'
+  new: Record<string, unknown>
+  old: Record<string, unknown>
+}) => void
+
+const mockRealtime = vi.hoisted(() => {
+  const postgresCallbacks = new Map<string, RealtimeCallback>()
+  const channel = {
+    on: vi.fn((event: string, filter: { table?: string }, callback: RealtimeCallback) => {
+      if (event === 'postgres_changes' && filter.table) {
+        postgresCallbacks.set(filter.table, callback)
+      }
+      return channel
+    }),
+    subscribe: vi.fn((callback: (status: string) => void) => {
+      callback('SUBSCRIBED')
+      return channel
+    }),
+  }
+  const removeChannel = vi.fn()
+
+  return {
+    postgresCallbacks,
+    channel,
+    removeChannel,
+  }
+})
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    channel: vi.fn(() => mockRealtime.channel),
+    removeChannel: mockRealtime.removeChannel,
+  },
+}))
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: vi.fn(),
+}))
+
+import { RealtimeProvider } from '../realtime-context'
+
+function renderWithQueryClient(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RealtimeProvider>
+        <div />
+      </RealtimeProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('RealtimeProvider invalidation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockRealtime.postgresCallbacks.clear()
+    mockRealtime.channel.on.mockClear()
+    mockRealtime.channel.subscribe.mockClear()
+    mockRealtime.removeChannel.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('invalidates repair and equipment-list queries when repair requests change', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+    const refetchSpy = vi.spyOn(queryClient, 'refetchQueries')
+
+    const view = renderWithQueryClient(queryClient)
+
+    const callback = mockRealtime.postgresCallbacks.get('yeu_cau_sua_chua')
+    expect(callback).toBeDefined()
+
+    act(() => {
+      callback?.({
+        table: 'yeu_cau_sua_chua',
+        eventType: 'UPDATE',
+        new: { id: 1 },
+        old: { id: 1 },
+      })
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(150)
+      await Promise.resolve()
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: repairKeys.all,
+      refetchType: 'active',
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['equipment_list_enhanced'],
+      refetchType: 'active',
+    })
+
+    expect(refetchSpy).toHaveBeenCalledWith({
+      queryKey: ['equipment_list_enhanced'],
+      type: 'active',
+    })
+
+    view.unmount()
+  })
+})

--- a/src/contexts/realtime-context.tsx
+++ b/src/contexts/realtime-context.tsx
@@ -82,7 +82,7 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
   }
 
   // Handle database changes
-  const handleDatabaseChange = (payload: RealtimePostgresChangesPayload<any>) => {
+  const handleDatabaseChange = (payload: RealtimePostgresChangesPayload<Record<string, unknown>>) => {
     const { table, eventType, new: newRecord, old: oldRecord } = payload
     
     console.log(`[Realtime] ${eventType} on ${table}:`, { newRecord, oldRecord })
@@ -99,8 +99,10 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
         break
 
       case 'yeu_cau_sua_chua':
-        // Repair request changes
+        // Repair request changes also affect equipment_list_enhanced.active_repair_request_id.
         debouncedInvalidate(repairKeys.all) // ['repair'] - invalidates all repair queries
+        debouncedInvalidate(['equipment_list_enhanced'])
+        debouncedInvalidate(['equipment'])
         debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats']
         debouncedInvalidate(['reports'])
         break

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -40,6 +40,7 @@ export interface Equipment {
   // tenant/organization
   don_vi?: number | null;
   google_drive_folder_url?: string | null;
+  active_repair_request_id?: number | null;
   // metadata
   created_at?: string;
   updated_at?: string;

--- a/supabase/migrations/20260427231232_extend_equipment_list_enhanced_active_repair.sql
+++ b/supabase/migrations/20260427231232_extend_equipment_list_enhanced_active_repair.sql
@@ -1,0 +1,245 @@
+-- Historical mirror of live-applied migration version 20260427231232.
+-- Source: closed PR #348 for Issue #338 PR-3a.
+--
+-- Important:
+-- - This version already exists in Supabase schema_migrations.
+-- - Do NOT apply this migration again via Supabase MCP.
+-- - If reviewers find a behavioral bug in this already-live function,
+--   fix it with a new forward-only superseding migration instead of editing
+--   this historical mirror to pretend live ran different SQL.
+--
+-- Reason: Issue #338 Phase 1 adds active_repair_request_id to each equipment
+-- row so PR-3b can display an in-row Wrench icon without per-row RPC calls.
+-- The LATERAL lookup reuses idx_yeu_cau_sua_chua_thiet_bi_status from PR-1b.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.equipment_list_enhanced(
+  p_q text DEFAULT NULL::text,
+  p_sort text DEFAULT 'id.asc'::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung text DEFAULT NULL::text,
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat text DEFAULT NULL::text,
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang text DEFAULT NULL::text,
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai text DEFAULT NULL::text,
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi text DEFAULT NULL::text,
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := '';
+  v_user_id TEXT := NULL;
+  v_claim_donvi BIGINT := NULL;
+  v_allowed_don_vi BIGINT[];
+  v_effective_donvi BIGINT := NULL;
+  v_department_scope TEXT;
+  v_sort_col TEXT := 'id';
+  v_sort_dir TEXT := 'ASC';
+  v_limit INT := GREATEST(p_page_size, 1);
+  v_offset INT := GREATEST(p_page - 1, 0) * GREATEST(p_page_size, 1);
+  v_where TEXT := '1=1 AND is_deleted = false';
+  v_total BIGINT := 0;
+  v_data JSONB := '[]'::jsonb;
+  v_jwt_claims JSONB;
+  v_sanitized_q TEXT;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := COALESCE(
+    v_jwt_claims ->>'app_role',
+    v_jwt_claims ->>'role',
+    ''
+  );
+  v_user_id := NULLIF(v_jwt_claims ->>'user_id', '');
+  v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
+  END IF;
+
+  IF p_sort IS NOT NULL AND p_sort != '' THEN
+    v_sort_col := split_part(p_sort, '.', 1);
+    v_sort_dir := UPPER(COALESCE(NULLIF(split_part(p_sort, '.', 2), ''), 'ASC'));
+    IF v_sort_dir NOT IN ('ASC', 'DESC') THEN
+      v_sort_dir := 'ASC';
+    END IF;
+    IF v_sort_col NOT IN (
+      'id', 'ma_thiet_bi', 'ten_thiet_bi', 'model', 'serial',
+      'khoa_phong_quan_ly', 'tinh_trang_hien_tai', 'vi_tri_lap_dat',
+      'nguoi_dang_truc_tiep_quan_ly', 'phan_loai_theo_nd98', 'nguon_kinh_phi', 'don_vi',
+      'gia_goc', 'ngay_nhap', 'ngay_dua_vao_su_dung', 'ngay_bt_tiep_theo',
+      'so_luu_hanh'
+    ) THEN
+      v_sort_col := 'id';
+    END IF;
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF lower(v_role) IN ('global', 'admin') THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective_donvi := p_don_vi;
+    ELSE
+      v_effective_donvi := NULL;
+    END IF;
+  ELSE
+    IF v_allowed_don_vi IS NOT NULL AND array_length(v_allowed_don_vi, 1) > 0 THEN
+      IF p_don_vi IS NOT NULL THEN
+        IF p_don_vi = ANY(v_allowed_don_vi) THEN
+          v_effective_donvi := p_don_vi;
+        ELSE
+          RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'Access denied for tenant');
+        END IF;
+      ELSE
+        v_effective_donvi := NULL;
+      END IF;
+    ELSE
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'No tenant access');
+    END IF;
+  END IF;
+
+  IF lower(v_role) = 'user' AND v_department_scope IS NULL THEN
+    RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+  END IF;
+
+  IF v_effective_donvi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ' || v_effective_donvi;
+  END IF;
+
+  IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin') AND v_allowed_don_vi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = '
+      || quote_literal(v_department_scope);
+  END IF;
+
+  IF p_khoa_phong_array IS NOT NULL AND array_length(p_khoa_phong_array, 1) > 0 THEN
+    v_where := v_where || ' AND khoa_phong_quan_ly = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_khoa_phong_array) AS x), ',') || '])';
+  ELSIF p_khoa_phong IS NOT NULL AND trim(p_khoa_phong) != '' THEN
+    v_where := v_where || ' AND khoa_phong_quan_ly = ' || quote_literal(p_khoa_phong);
+  END IF;
+
+  IF p_nguoi_su_dung_array IS NOT NULL AND array_length(p_nguoi_su_dung_array, 1) > 0 THEN
+    v_where := v_where || ' AND nguoi_dang_truc_tiep_quan_ly = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguoi_su_dung_array) AS x), ',') || '])';
+  ELSIF p_nguoi_su_dung IS NOT NULL AND trim(p_nguoi_su_dung) != '' THEN
+    v_where := v_where || ' AND nguoi_dang_truc_tiep_quan_ly = ' || quote_literal(p_nguoi_su_dung);
+  END IF;
+
+  IF p_vi_tri_lap_dat_array IS NOT NULL AND array_length(p_vi_tri_lap_dat_array, 1) > 0 THEN
+    v_where := v_where || ' AND vi_tri_lap_dat = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_vi_tri_lap_dat_array) AS x), ',') || '])';
+  ELSIF p_vi_tri_lap_dat IS NOT NULL AND trim(p_vi_tri_lap_dat) != '' THEN
+    v_where := v_where || ' AND vi_tri_lap_dat = ' || quote_literal(p_vi_tri_lap_dat);
+  END IF;
+
+  IF p_tinh_trang_array IS NOT NULL AND array_length(p_tinh_trang_array, 1) > 0 THEN
+    v_where := v_where || ' AND tinh_trang_hien_tai = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_tinh_trang_array) AS x), ',') || '])';
+  ELSIF p_tinh_trang IS NOT NULL AND trim(p_tinh_trang) != '' THEN
+    v_where := v_where || ' AND tinh_trang_hien_tai = ' || quote_literal(p_tinh_trang);
+  END IF;
+
+  IF p_phan_loai_array IS NOT NULL AND array_length(p_phan_loai_array, 1) > 0 THEN
+    v_where := v_where || ' AND phan_loai_theo_nd98 = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_phan_loai_array) AS x), ',') || '])';
+  ELSIF p_phan_loai IS NOT NULL AND trim(p_phan_loai) != '' THEN
+    v_where := v_where || ' AND phan_loai_theo_nd98 = ' || quote_literal(p_phan_loai);
+  END IF;
+
+  IF p_nguon_kinh_phi_array IS NOT NULL AND array_length(p_nguon_kinh_phi_array, 1) > 0 THEN
+    IF 'Chưa có' = ANY(p_nguon_kinh_phi_array) THEN
+      DECLARE v_non_empty_sources TEXT[];
+      BEGIN
+        SELECT ARRAY(SELECT x FROM unnest(p_nguon_kinh_phi_array) AS x WHERE x != 'Chưa có') INTO v_non_empty_sources;
+        IF v_non_empty_sources IS NOT NULL AND array_length(v_non_empty_sources, 1) > 0 THEN
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''' OR TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+            array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(v_non_empty_sources) AS x), ',') || ']))';
+        ELSE
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+        END IF;
+      END;
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+        array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguon_kinh_phi_array) AS x), ',') || '])';
+    END IF;
+  ELSIF p_nguon_kinh_phi IS NOT NULL AND trim(p_nguon_kinh_phi) != '' THEN
+    IF p_nguon_kinh_phi = 'Chưa có' THEN
+      v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ' || quote_literal(p_nguon_kinh_phi);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_where := v_where || ' AND (ten_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR ma_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR serial ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR so_luu_hanh ILIKE ' || quote_literal('%' || v_sanitized_q || '%') || ')';
+  END IF;
+
+  EXECUTE format('SELECT count(*) FROM public.thiet_bi WHERE %s', v_where) INTO v_total;
+
+  EXECUTE format(
+    'SELECT COALESCE(jsonb_agg(t), ''[]''::jsonb) FROM (
+       SELECT (to_jsonb(tb.*) || jsonb_build_object(
+         ''google_drive_folder_url'', dv.google_drive_folder_url,
+         ''don_vi_name'', dv.name,
+         ''active_repair_request_id'', ar.active_id
+       )) AS t
+       FROM public.thiet_bi tb
+       LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+       LEFT JOIN LATERAL (
+         SELECT r.id AS active_id
+         FROM public.yeu_cau_sua_chua r
+         WHERE r.thiet_bi_id = tb.id
+           AND r.trang_thai IN (''Chờ xử lý'', ''Đã duyệt'')
+         ORDER BY r.ngay_yeu_cau DESC, r.id DESC
+         LIMIT 1
+       ) ar ON TRUE
+       WHERE %s
+       ORDER BY tb.%I %s
+       OFFSET %s LIMIT %s
+     ) sub',
+    v_where, v_sort_col, v_sort_dir, v_offset, v_limit
+  ) INTO v_data;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'total', v_total,
+    'page', p_page,
+    'pageSize', p_page_size
+  );
+END;
+$function$;
+
+COMMIT;

--- a/supabase/migrations/20260428040500_fix_equipment_list_enhanced_active_repair_contract.sql
+++ b/supabase/migrations/20260428040500_fix_equipment_list_enhanced_active_repair_contract.sql
@@ -1,20 +1,16 @@
--- Historical mirror of live-applied migration version 20260427231232.
--- Source: closed PR #348 for Issue #338 PR-3a.
+-- Issue #338 PR-3a follow-up: reassert equipment_list_enhanced contract.
 --
--- Important:
--- - This version already exists in Supabase schema_migrations.
--- - Do NOT apply this migration again via Supabase MCP.
--- - If reviewers find a behavioral bug in this already-live function,
---   fix it with a new forward-only superseding migration instead of editing
---   this historical mirror to pretend live ran different SQL.
+-- This supersedes already-live migration version 20260427231232 after review
+-- found two contract gaps in that historical version:
+-- - payload used wildcard row serialization, silently expanding with future thiet_bi columns
+-- - SECURITY DEFINER grants were not explicitly restricted to authenticated
 --
--- Reason: Issue #338 Phase 1 adds active_repair_request_id to each equipment
--- row so PR-3b can display an in-row Wrench icon without per-row RPC calls.
--- The LATERAL lookup reuses idx_yeu_cau_sua_chua_thiet_bi_status from PR-1b.
+-- Do NOT apply this migration before PR review approval. When approved, apply
+-- it via Supabase MCP apply_migration and then run the smoke SQL in
+-- supabase/tests/equipment_list_enhanced_active_repair_smoke.sql.
 --
--- Rollback pointer: restore the previous equipment_list_enhanced body from
--- supabase/migrations/20260422123000_add_user_department_scope_reads.sql,
--- then re-apply later local migrations that supersede this function.
+-- Rollback: re-apply the previous function body from
+-- supabase/migrations/20260427231232_extend_equipment_list_enhanced_active_repair.sql.
 
 BEGIN;
 
@@ -215,7 +211,43 @@ BEGIN
 
   EXECUTE format(
     'SELECT COALESCE(jsonb_agg(t), ''[]''::jsonb) FROM (
-       SELECT (to_jsonb(tb.*) || jsonb_build_object(
+       SELECT (jsonb_build_object(
+         ''ma_thiet_bi'', tb.ma_thiet_bi,
+         ''ten_thiet_bi'', tb.ten_thiet_bi,
+         ''model'', tb.model,
+         ''serial'', tb.serial,
+         ''cau_hinh_thiet_bi'', tb.cau_hinh_thiet_bi,
+         ''phu_kien_kem_theo'', tb.phu_kien_kem_theo,
+         ''hang_san_xuat'', tb.hang_san_xuat,
+         ''noi_san_xuat'', tb.noi_san_xuat,
+         ''nam_san_xuat'', tb.nam_san_xuat,
+         ''ngay_nhap'', tb.ngay_nhap,
+         ''ngay_dua_vao_su_dung'', tb.ngay_dua_vao_su_dung,
+         ''nguon_kinh_phi'', tb.nguon_kinh_phi,
+         ''gia_goc'', tb.gia_goc,
+         ''nam_tinh_hao_mon'', tb.nam_tinh_hao_mon,
+         ''ty_le_hao_mon'', tb.ty_le_hao_mon,
+         ''han_bao_hanh'', tb.han_bao_hanh,
+         ''vi_tri_lap_dat'', tb.vi_tri_lap_dat,
+         ''nguoi_dang_truc_tiep_quan_ly'', tb.nguoi_dang_truc_tiep_quan_ly,
+         ''khoa_phong_quan_ly'', tb.khoa_phong_quan_ly,
+         ''tinh_trang_hien_tai'', tb.tinh_trang_hien_tai,
+         ''ghi_chu'', tb.ghi_chu,
+         ''chu_ky_bt_dinh_ky'', tb.chu_ky_bt_dinh_ky,
+         ''ngay_bt_tiep_theo'', tb.ngay_bt_tiep_theo,
+         ''chu_ky_hc_dinh_ky'', tb.chu_ky_hc_dinh_ky,
+         ''ngay_hc_tiep_theo'', tb.ngay_hc_tiep_theo,
+         ''chu_ky_kd_dinh_ky'', tb.chu_ky_kd_dinh_ky,
+         ''ngay_kd_tiep_theo'', tb.ngay_kd_tiep_theo,
+         ''phan_loai_theo_nd98'', tb.phan_loai_theo_nd98,
+         ''id'', tb.id,
+         ''created_at'', tb.created_at,
+         ''don_vi'', tb.don_vi,
+         ''nguon_nhap'', tb.nguon_nhap,
+         ''so_luu_hanh'', tb.so_luu_hanh,
+         ''nhom_thiet_bi_id'', tb.nhom_thiet_bi_id,
+         ''is_deleted'', tb.is_deleted,
+         ''ngay_ngung_su_dung'', tb.ngay_ngung_su_dung,
          ''google_drive_folder_url'', dv.google_drive_folder_url,
          ''don_vi_name'', dv.name,
          ''active_repair_request_id'', ar.active_id
@@ -245,5 +277,45 @@ BEGIN
   );
 END;
 $function$;
+
+REVOKE EXECUTE ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) TO authenticated;
 
 COMMIT;

--- a/supabase/tests/equipment_list_enhanced_active_repair_smoke.sql
+++ b/supabase/tests/equipment_list_enhanced_active_repair_smoke.sql
@@ -1,0 +1,177 @@
+-- supabase/tests/equipment_list_enhanced_active_repair_smoke.sql
+-- Purpose: smoke-test equipment_list_enhanced active_repair_request_id.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp._ele_set_claims(
+  p_role text,
+  p_user_id bigint,
+  p_don_vi bigint DEFAULT NULL,
+  p_khoa_phong text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_role,
+      'role', p_role,
+      'user_id', p_user_id::text,
+      'don_vi', COALESCE(p_don_vi::text, ''),
+      'khoa_phong', COALESCE(p_khoa_phong, '')
+    )::text,
+    true
+  );
+END;
+$$;
+
+DO $$
+DECLARE
+  v_tenant_a bigint;
+  v_tenant_b bigint;
+  v_user_id bigint := 3383001;
+  v_eq_no_history bigint;
+  v_eq_completed_only bigint;
+  v_eq_active bigint;
+  v_eq_multi bigint;
+  v_eq_soft_deleted bigint;
+  v_eq_b bigint;
+  v_req_active bigint;
+  v_req_multi_newer bigint;
+  v_req_b_active bigint;
+  v_payload jsonb;
+  v_row jsonb;
+BEGIN
+  INSERT INTO public.don_vi(name)
+  VALUES ('Tenant A ELE active repair smoke')
+  RETURNING id INTO v_tenant_a;
+
+  INSERT INTO public.don_vi(name)
+  VALUES ('Tenant B ELE active repair smoke')
+  RETURNING id INTO v_tenant_b;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-AR-A1', 'eq no history', v_tenant_a, 'Khoa A1', 'Hoạt động')
+  RETURNING id INTO v_eq_no_history;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-AR-A2', 'eq completed only', v_tenant_a, 'Khoa A1', 'Hoạt động')
+  RETURNING id INTO v_eq_completed_only;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-AR-A3', 'eq active', v_tenant_a, 'Khoa A1', 'Chờ sửa chữa')
+  RETURNING id INTO v_eq_active;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-AR-A4', 'eq multi active', v_tenant_a, 'Khoa A1', 'Chờ sửa chữa')
+  RETURNING id INTO v_eq_multi;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai, is_deleted)
+  VALUES ('ELE-AR-A5', 'eq soft deleted', v_tenant_a, 'Khoa A1', 'Chờ sửa chữa', true)
+  RETURNING id INTO v_eq_soft_deleted;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai)
+  VALUES ('ELE-AR-B1', 'eq tenant B active', v_tenant_b, 'Khoa B1', 'Chờ sửa chữa')
+  RETURNING id INTO v_eq_b;
+
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co, ngay_hoan_thanh)
+  VALUES (v_eq_completed_only, now() - interval '5 days', 'Hoàn thành', 'Completed only', now() - interval '4 days');
+
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co)
+  VALUES (v_eq_active, now() - interval '3 days', 'Chờ xử lý', 'Single active')
+  RETURNING id INTO v_req_active;
+
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co)
+  VALUES (v_eq_multi, now() - interval '7 days', 'Chờ xử lý', 'Older active');
+
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co, ngay_duyet)
+  VALUES (v_eq_multi, now() - interval '1 day', 'Đã duyệt', 'Newer active', now() - interval '12 hours')
+  RETURNING id INTO v_req_multi_newer;
+
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co)
+  VALUES (v_eq_soft_deleted, now() - interval '1 day', 'Chờ xử lý', 'Active but equipment soft deleted');
+
+  INSERT INTO public.yeu_cau_sua_chua(thiet_bi_id, ngay_yeu_cau, trang_thai, mo_ta_su_co)
+  VALUES (v_eq_b, now() - interval '2 days', 'Chờ xử lý', 'Tenant B active')
+  RETURNING id INTO v_req_b_active;
+
+  PERFORM pg_temp._ele_set_claims('to_qltb', v_user_id, v_tenant_a);
+  v_payload := public.equipment_list_enhanced(NULL, 'id.asc', 1, 100, v_tenant_a, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+  v_row := (
+    SELECT row_value
+    FROM jsonb_array_elements(v_payload->'data') AS row_value
+    WHERE row_value->>'ma_thiet_bi' = 'ELE-AR-A1'
+  );
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'Scenario A failed: no-history equipment not found';
+  END IF;
+  IF v_row->>'active_repair_request_id' IS NOT NULL THEN
+    RAISE EXCEPTION 'Scenario A failed: expected null for no-history equipment, got %', v_row->>'active_repair_request_id';
+  END IF;
+
+  v_row := (
+    SELECT row_value
+    FROM jsonb_array_elements(v_payload->'data') AS row_value
+    WHERE row_value->>'ma_thiet_bi' = 'ELE-AR-A2'
+  );
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'Scenario B failed: completed-only equipment not found';
+  END IF;
+  IF v_row->>'active_repair_request_id' IS NOT NULL THEN
+    RAISE EXCEPTION 'Scenario B failed: expected null for completed-only equipment, got %', v_row->>'active_repair_request_id';
+  END IF;
+
+  v_row := (
+    SELECT row_value
+    FROM jsonb_array_elements(v_payload->'data') AS row_value
+    WHERE row_value->>'ma_thiet_bi' = 'ELE-AR-A3'
+  );
+  IF (v_row->>'active_repair_request_id')::bigint IS DISTINCT FROM v_req_active THEN
+    RAISE EXCEPTION 'Scenario C failed: expected %, got %', v_req_active, v_row->>'active_repair_request_id';
+  END IF;
+
+  v_row := (
+    SELECT row_value
+    FROM jsonb_array_elements(v_payload->'data') AS row_value
+    WHERE row_value->>'ma_thiet_bi' = 'ELE-AR-A4'
+  );
+  IF (v_row->>'active_repair_request_id')::bigint IS DISTINCT FROM v_req_multi_newer THEN
+    RAISE EXCEPTION 'Scenario D failed: expected latest active %, got %', v_req_multi_newer, v_row->>'active_repair_request_id';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'data') AS row_value
+    WHERE row_value->>'ma_thiet_bi' = 'ELE-AR-A5'
+  ) THEN
+    RAISE EXCEPTION 'Scenario E failed: soft-deleted equipment should be excluded';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'data') AS row_value
+    WHERE row_value->>'ma_thiet_bi' = 'ELE-AR-B1'
+  ) THEN
+    RAISE EXCEPTION 'Scenario F failed: cross-tenant equipment leaked';
+  END IF;
+
+  PERFORM pg_temp._ele_set_claims('global', v_user_id);
+  v_payload := public.equipment_list_enhanced(NULL, 'id.asc', 1, 100, v_tenant_b, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+  v_row := (
+    SELECT row_value
+    FROM jsonb_array_elements(v_payload->'data') AS row_value
+    WHERE row_value->>'ma_thiet_bi' = 'ELE-AR-B1'
+  );
+  IF (v_row->>'active_repair_request_id')::bigint IS DISTINCT FROM v_req_b_active THEN
+    RAISE EXCEPTION 'Scenario G failed: global expected tenant B active %, got %', v_req_b_active, v_row->>'active_repair_request_id';
+  END IF;
+
+  RAISE NOTICE 'equipment_list_enhanced_active_repair smoke: ALL SCENARIOS PASSED';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
Refs #338

## Summary

PR-3a reconciles the active-repair equipment-list backend/realtime slice after PR-2b merged.

Important context: closed PR #348 had already applied Supabase migration version `20260427231232` (`extend_equipment_list_enhanced_active_repair`) to live DB, but the branch was closed and never merged. This PR restores repo source-of-truth by adding a local historical mirror of that already-live migration.

## Migration handling

- Adds `supabase/migrations/20260427231232_extend_equipment_list_enhanced_active_repair.sql` as a historical mirror of the live-applied version.
- Does **not** run `apply_migration` for that file in this PR round because `schema_migrations` already contains version `20260427231232`.
- Adds `supabase/migrations/20260428040500_fix_equipment_list_enhanced_active_repair_contract.sql` as a forward-only follow-up for reviewer findings.
- The follow-up was applied to Supabase via MCP after reviewer feedback and user approval. Smoke SQL passed on live DB; transaction rolled back.
- Any further behavioral fix must also be forward-only; do not rewrite the historical mirror to pretend live ran different SQL.

Live checks performed before opening this PR:

- `list_migrations`: version `20260427231232 / extend_equipment_list_enhanced_active_repair` exists.
- `pg_get_functiondef`: `equipment_list_enhanced` has `active_repair_request_id`, `LEFT JOIN LATERAL`, `SECURITY DEFINER`, `search_path=public, pg_temp`, `allowed_don_vi_for_session_safe`, and expected ordering `ngay_yeu_cau DESC, r.id DESC`.
- Post-follow-up live routine privileges are `authenticated`, `postgres`, and `service_role`; `PUBLIC`/`anon` no longer have `EXECUTE`.

## Changes

- Adds non-destructive smoke SQL for `equipment_list_enhanced.active_repair_request_id` covering:
  - no history
  - completed-only history
  - single active request
  - multiple active requests deterministic latest
  - soft-deleted equipment excluded
  - cross-tenant isolation plus global access
- Adds forward-only SQL contract follow-up:
  - replaces wildcard row serialization with explicit `jsonb_build_object` column list
  - revokes execute from `PUBLIC, anon`
  - grants execute to `authenticated`
- Adds `active_repair_request_id?: number | null` to `Equipment`.
- Adds realtime regression coverage and invalidates `['equipment_list_enhanced']` on `yeu_cau_sua_chua` changes so the list row data refreshes when active repairs change.
- Keeps UI wiring out of scope; PR-3b will add the row indicator and provider/sheet integration.

## TDD / verification

- Scratch type RED: `Equipment` rejected `active_repair_request_id` before type update.
- Realtime RED: focused test failed before `['equipment_list_enhanced']` invalidation.
- Supabase MCP smoke SQL: executed successfully on live DB after follow-up apply; transaction rolled back.
- Supabase MCP live contract check: `SECURITY DEFINER`, `search_path=public, pg_temp`, no `to_jsonb(tb.*)`, explicit `jsonb_build_object`, `active_repair_request_id` present, `PUBLIC`/`anon` execute revoked.
- Supabase MCP advisors: security/performance advisors rerun after apply; remaining findings are existing broad DB lints, not a blocker for this PR contract.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/contexts/__tests__/realtime-context.invalidation.test.tsx src/app/'(app)'/equipment/__tests__/useEquipmentData.test.ts` — 27/27 pass
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` — 100/100
- `git diff --check`

## Out of scope

- No `LinkedRequestRowIndicator`.
- No `EquipmentPageClient` provider hoist.
- No `LinkedRequestSheetHost` mount in equipment dialogs.
- No `useEquipmentData` staleTime change; this stays with PR-3b where UI wiring and integration tests can cover the blast radius.
