### PR TITLE
refactor(linked-request): extract shared linked sheet shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,6 +531,8 @@ git pull --rebase && git push
 
 Per-row indicators that depend on aggregated business state must be backed by aggregate columns on `equipment_list_enhanced`, never by per-row resolver RPCs. `LinkedRequestRowIndicator` is the reference pattern: it reads `equipment.active_repair_request_id` from row data and renders synchronously without calling `callRpc` or `useResolveActiveRepair`. The resolver hook is reserved for click-time fetches in `LinkedRequestSheetHost`, where only one linked request can be open at a time.
 
+For linked-request side sheets, the host owns the modal/sheet shell. Loading, error, and resolved states must render inside the same shared shell (`LinkedRequestSheetShell`) so first-open transitions do not unmount one sheet and mount another. Embedded detail views such as `RepairRequestsDetailView` must support content-only rendering when used inside that host-owned shell.
+
 ## SQL Code Generation Checklist
 
 Before finalizing any data-access code, verify each item:

--- a/src/components/equipment-linked-request/LinkedRequestSheetHost.tsx
+++ b/src/components/equipment-linked-request/LinkedRequestSheetHost.tsx
@@ -3,16 +3,12 @@
 import * as React from 'react'
 import dynamic from 'next/dynamic'
 import { Button } from '@/components/ui/button'
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetTitle,
-} from '@/components/ui/sheet'
+import { SheetDescription, SheetTitle } from '@/components/ui/sheet'
 import { toast } from '@/hooks/use-toast'
 import { useLinkedRequest } from './LinkedRequestContext'
 import { useResolveActiveRepair } from './resolvers/useResolveActiveRepair'
 import type { RepairRequestSheetAdapterProps } from './adapters/repairRequestSheetAdapter'
+import { LinkedRequestSheetShell } from './LinkedRequestSheetShell'
 import { STRINGS } from './strings'
 
 const RepairRequestSheetAdapter = dynamic<RepairRequestSheetAdapterProps>(
@@ -94,10 +90,8 @@ export function LinkedRequestSheetHost() {
     )
 
   return (
-    <Sheet open={enabled} onOpenChange={(open) => !open && close()}>
-      <SheetContent side="right" className="w-full sm:max-w-xl md:max-w-2xl lg:max-w-3xl p-0">
-        {content}
-      </SheetContent>
-    </Sheet>
+    <LinkedRequestSheetShell open={enabled} onClose={close}>
+      {content}
+    </LinkedRequestSheetShell>
   )
 }

--- a/src/components/equipment-linked-request/LinkedRequestSheetShell.tsx
+++ b/src/components/equipment-linked-request/LinkedRequestSheetShell.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import * as React from 'react'
+
+import { Sheet, SheetContent } from '@/components/ui/sheet'
+
+interface LinkedRequestSheetShellProps {
+  open: boolean
+  onClose: () => void
+  children: React.ReactNode
+}
+
+export function LinkedRequestSheetShell({
+  open,
+  onClose,
+  children,
+}: LinkedRequestSheetShellProps) {
+  return (
+    <Sheet open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+      <SheetContent side="right" className="w-full sm:max-w-xl md:max-w-2xl lg:max-w-3xl p-0">
+        {children}
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/equipment-linked-request/__tests__/LinkedRequestSheetShell.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/LinkedRequestSheetShell.test.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let sheetInstanceCounter = 0
+
+vi.mock('@/components/ui/sheet', () => ({
+  Sheet: ({
+    open,
+    children,
+    onOpenChange,
+  }: {
+    open: boolean
+    children: React.ReactNode
+    onOpenChange?: (open: boolean) => void
+  }) => {
+    const instanceId = React.useRef(++sheetInstanceCounter)
+    if (!open) return null
+
+    return (
+      <div
+        data-testid="sheet-root"
+        data-sheet-instance={String(instanceId.current)}
+        onClick={() => onOpenChange?.(false)}
+      >
+        {children}
+      </div>
+    )
+  },
+  SheetContent: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & { children: React.ReactNode }) => (
+    <div data-testid="sheet-content" {...props}>
+      {children}
+    </div>
+  ),
+}))
+
+import { LinkedRequestSheetShell } from '../LinkedRequestSheetShell'
+
+describe('LinkedRequestSheetShell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sheetInstanceCounter = 0
+  })
+
+  it('renders one shared sheet shell with the standard equipment linked-request sizing', () => {
+    render(
+      <LinkedRequestSheetShell open={true} onClose={vi.fn()}>
+        <div>shell content</div>
+      </LinkedRequestSheetShell>,
+    )
+
+    expect(screen.getByTestId('sheet-root')).toBeInTheDocument()
+    expect(screen.getByTestId('sheet-content').className).toContain('w-full')
+    expect(screen.getByTestId('sheet-content').className).toContain('sm:max-w-xl')
+    expect(screen.getByTestId('sheet-content').className).toContain('md:max-w-2xl')
+    expect(screen.getByTestId('sheet-content').className).toContain('lg:max-w-3xl')
+  })
+
+  it('calls onClose when the sheet requests close', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <LinkedRequestSheetShell open={true} onClose={onClose}>
+        <div>shell content</div>
+      </LinkedRequestSheetShell>,
+    )
+
+    await user.click(screen.getByTestId('sheet-root'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the same sheet instance mounted while children change from loading to resolved content', () => {
+    const { rerender } = render(
+      <LinkedRequestSheetShell open={true} onClose={vi.fn()}>
+        <div>loading content</div>
+      </LinkedRequestSheetShell>,
+    )
+
+    const initialInstanceId = screen
+      .getByTestId('sheet-root')
+      .getAttribute('data-sheet-instance')
+
+    rerender(
+      <LinkedRequestSheetShell open={true} onClose={vi.fn()}>
+        <div>resolved content</div>
+      </LinkedRequestSheetShell>,
+    )
+
+    expect(screen.getByText('resolved content')).toBeInTheDocument()
+    expect(screen.getByTestId('sheet-root')).toHaveAttribute(
+      'data-sheet-instance',
+      initialInstanceId,
+    )
+  })
+
+  it('renders nothing when closed', () => {
+    render(
+      <LinkedRequestSheetShell open={false} onClose={vi.fn()}>
+        <div>hidden content</div>
+      </LinkedRequestSheetShell>,
+    )
+
+    expect(screen.queryByTestId('sheet-root')).toBeNull()
+  })
+})

--- a/src/components/equipment-linked-request/__tests__/LinkedRequestSheetShell.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/LinkedRequestSheetShell.test.tsx
@@ -19,13 +19,14 @@ vi.mock('@/components/ui/sheet', () => ({
     if (!open) return null
 
     return (
-      <div
+      <button
+        type="button"
         data-testid="sheet-root"
         data-sheet-instance={String(instanceId.current)}
         onClick={() => onOpenChange?.(false)}
       >
         {children}
-      </div>
+      </button>
     )
   },
   SheetContent: ({
@@ -38,7 +39,7 @@ vi.mock('@/components/ui/sheet', () => ({
   ),
 }))
 
-import { LinkedRequestSheetShell } from '../LinkedRequestSheetShell'
+import { LinkedRequestSheetShell } from '@/components/equipment-linked-request/LinkedRequestSheetShell'
 
 describe('LinkedRequestSheetShell', () => {
   beforeEach(() => {
@@ -84,7 +85,7 @@ describe('LinkedRequestSheetShell', () => {
 
     const initialInstanceId = screen
       .getByTestId('sheet-root')
-      .getAttribute('data-sheet-instance')
+      .dataset.sheetInstance
 
     rerender(
       <LinkedRequestSheetShell open={true} onClose={vi.fn()}>
@@ -93,10 +94,7 @@ describe('LinkedRequestSheetShell', () => {
     )
 
     expect(screen.getByText('resolved content')).toBeInTheDocument()
-    expect(screen.getByTestId('sheet-root')).toHaveAttribute(
-      'data-sheet-instance',
-      initialInstanceId,
-    )
+    expect(screen.getByTestId('sheet-root').dataset.sheetInstance).toBe(initialInstanceId)
   })
 
   it('renders nothing when closed', () => {

--- a/src/components/equipment-linked-request/index.ts
+++ b/src/components/equipment-linked-request/index.ts
@@ -10,5 +10,6 @@
 export { LinkedRequestProvider, useLinkedRequest } from './LinkedRequestContext'
 export type { LinkedRequestContextValue } from './LinkedRequestContext'
 export { LinkedRequestRowIndicator } from './LinkedRequestRowIndicator'
+export { LinkedRequestSheetShell } from './LinkedRequestSheetShell'
 export { LinkedRequestSheetHost } from './LinkedRequestSheetHost'
 export type { LinkedRequestKind, LinkedRequestState, ActiveRepairResult } from './types'


### PR DESCRIPTION
## Summary
- extract `LinkedRequestSheetShell` so linked-request hosts own a single shared sheet shell
- refactor `LinkedRequestSheetHost` to render loading, error, and resolved states inside that shared shell
- add contract coverage and document the host-owned shell rule for future linked domains (`#339`, `#340`)

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/components/equipment-linked-request/__tests__/LinkedRequestSheetShell.test.tsx`
- [x] `node scripts/npm-run.js run test:run -- src/components/equipment-linked-request/__tests__/LinkedRequestSheetHost.test.tsx`
- [x] `node scripts/npm-run.js run test:run -- src/components/equipment-linked-request/__tests__/repairRequestSheetAdapter.test.tsx`
- [x] `node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/__tests__/EquipmentRowLinkedRequest.integration.test.tsx'`
- [x] `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/RepairRequestsDetailView.test.tsx'`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- [x] `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `LinkedRequestSheetShell` and refactored `LinkedRequestSheetHost` to render loading/error/resolved states inside one host-owned sheet. This removes first-open flicker and standardizes side-sheet sizing for linked requests; supports Linear 338 with follow-ups for 339/340.

- **Refactors**
  - Added `LinkedRequestSheetShell` and exported it from `index.ts`; host now controls open/close and wraps all states in the same shell.
  - Updated `LinkedRequestSheetHost` to use the shell and keep content-only rendering for embedded views like `RepairRequestsDetailView`.
  - Added dedicated tests for `LinkedRequestSheetShell` (sizing, close behavior, instance stability) and aligned assertions; documented the host-owned shell rule in `CLAUDE.md`.

<sup>Written for commit ea4b960ffcb57b1345ba1818c8dfa793b56db002. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/352?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of linked-request side sheet transitions to prevent UI swapping on initial open.

* **Documentation**
  * Updated component patterns documentation for linked-request sheet lifecycle management.

* **Tests**
  * Added comprehensive test coverage for sheet component persistence and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->