### PR TITLE
fix: harden repair request read scope

### DIFF
--- a/src/hooks/__tests__/useRepairRequestDetail.test.ts
+++ b/src/hooks/__tests__/useRepairRequestDetail.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCallRpc = vi.fn()
+
+vi.mock('@/lib/rpc-client', () => ({
+  callRpc: (...args: unknown[]) => mockCallRpc(...args),
+}))
+
+import { repairKeys, useRepairRequestDetail } from '../use-cached-repair'
+import {
+  createReactQueryWrapper,
+  createTestQueryClient,
+} from '@/test-utils/react-query'
+
+describe('useRepairRequestDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCallRpc.mockReset()
+  })
+
+  it('does not fetch when id is null', async () => {
+    const queryClient = createTestQueryClient()
+
+    renderHook(() => useRepairRequestDetail(null), {
+      wrapper: createReactQueryWrapper(queryClient),
+    })
+
+    await act(async () => {})
+    expect(mockCallRpc).not.toHaveBeenCalled()
+  })
+
+  it('fetches repair_request_get with an integer id', async () => {
+    mockCallRpc.mockResolvedValueOnce({ id: 7, mo_ta_su_co: 'Mất nguồn' })
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useRepairRequestDetail('7'), {
+      wrapper: createReactQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockCallRpc).toHaveBeenCalledTimes(1)
+    expect(mockCallRpc.mock.calls[0]?.[0]).toMatchObject({
+      fn: 'repair_request_get',
+      args: { p_id: 7 },
+    })
+    expect(result.current.data).toEqual({ id: 7, mo_ta_su_co: 'Mất nguồn' })
+  })
+
+  it('stores the result under the canonical repair detail key', async () => {
+    mockCallRpc.mockResolvedValueOnce({ id: 15, mo_ta_su_co: 'Lỗi cảm biến' })
+    const queryClient = createTestQueryClient()
+
+    renderHook(() => useRepairRequestDetail('15'), {
+      wrapper: createReactQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => {
+      expect(mockCallRpc).toHaveBeenCalledTimes(1)
+    })
+
+    expect(queryClient.getQueryData(repairKeys.detail('15'))).toEqual({
+      id: 15,
+      mo_ta_su_co: 'Lỗi cảm biến',
+    })
+  })
+})

--- a/src/hooks/__tests__/useRepairRequestDetail.test.ts
+++ b/src/hooks/__tests__/useRepairRequestDetail.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/lib/rpc-client', () => ({
   callRpc: (...args: unknown[]) => mockCallRpc(...args),
 }))
 
-import { repairKeys, useRepairRequestDetail } from '../use-cached-repair'
+import { repairKeys, useRepairRequestDetail } from '@/hooks/use-cached-repair'
 import {
   createReactQueryWrapper,
   createTestQueryClient,

--- a/supabase/migrations/20260428132000_fix_repair_request_read_scope.sql
+++ b/supabase/migrations/20260428132000_fix_repair_request_read_scope.sql
@@ -1,0 +1,361 @@
+-- Issue #342: restore tenant guard on repair_request_get and add
+-- role=user fail-closed department scope across repair_request_get,
+-- repair_request_list, and repair_request_active_for_equipment.
+-- Rollback: restore the prior function definitions if needed.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.repair_request_get(p_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role text := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id text := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global boolean := false;
+  v_allowed bigint[] := NULL;
+  v_department_scope text := NULL;
+  v_result jsonb := NULL;
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  v_is_global := v_role IN ('global', 'admin');
+
+  IF NOT v_is_global THEN
+    v_allowed := public.allowed_don_vi_for_session();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RAISE EXCEPTION 'Yêu cầu sửa chữa không tồn tại hoặc bạn không có quyền truy cập' USING errcode = '42501';
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(public._get_jwt_claim('khoa_phong'));
+  END IF;
+
+  SELECT to_jsonb(r.*)
+  INTO v_result
+  FROM public.yeu_cau_sua_chua r
+  JOIN public.thiet_bi tb ON tb.id = r.thiet_bi_id
+  WHERE r.id = p_id
+    AND (
+      v_is_global
+      OR tb.don_vi = ANY(v_allowed)
+    )
+    AND (
+      v_role <> 'user'
+      OR (
+        v_department_scope IS NOT NULL
+        AND public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+      )
+    );
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Yêu cầu sửa chữa không tồn tại hoặc bạn không có quyền truy cập' USING errcode = '42501';
+  END IF;
+
+  RETURN v_result;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_get(integer) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_get(integer) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_list(
+  p_q text DEFAULT NULL::text,
+  p_status text DEFAULT NULL::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_date_from date DEFAULT NULL::date,
+  p_date_to date DEFAULT NULL::date,
+  p_statuses text[] DEFAULT NULL::text[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id text := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global boolean := false;
+  v_effective_donvi bigint := NULL;
+  v_allowed bigint[] := NULL;
+  v_limit integer := greatest(coalesce(p_page_size, 50), 1);
+  v_offset integer := greatest((coalesce(p_page, 1) - 1) * v_limit, 0);
+  v_page integer := (v_offset / v_limit)::integer + 1;
+  v_total bigint := 0;
+  v_data jsonb := '[]'::jsonb;
+  v_statuses text[] := NULL;
+  v_sanitized_q text := NULL;
+  v_department_scope text := NULL;
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  v_is_global := v_role IN ('global', 'admin');
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(public._get_jwt_claim('khoa_phong'));
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', v_page, 'pageSize', v_limit);
+    END IF;
+  END IF;
+
+  IF p_statuses IS NOT NULL AND array_length(p_statuses, 1) IS NOT NULL THEN
+    v_statuses := p_statuses;
+  ELSIF p_status IS NOT NULL AND p_status <> '' THEN
+    v_statuses := ARRAY[p_status];
+  END IF;
+
+  IF v_is_global THEN
+    v_effective_donvi := p_don_vi;
+  ELSE
+    v_allowed := public.allowed_don_vi_for_session();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', v_page, 'pageSize', v_limit);
+    END IF;
+    IF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective_donvi := p_don_vi;
+      ELSE
+        RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', v_page, 'pageSize', v_limit);
+      END IF;
+    END IF;
+  END IF;
+
+  SELECT count(*) INTO v_total
+  FROM public.yeu_cau_sua_chua r
+  LEFT JOIN public.thiet_bi tb ON tb.id = r.thiet_bi_id
+  WHERE (
+    (v_is_global AND (v_effective_donvi IS NULL OR tb.don_vi = v_effective_donvi)) OR
+    (NOT v_is_global AND ((v_effective_donvi IS NOT NULL AND tb.don_vi = v_effective_donvi) OR (v_effective_donvi IS NULL AND tb.don_vi = ANY(v_allowed))))
+  )
+  AND (
+    v_role <> 'user'
+    OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+  )
+  AND (v_statuses IS NULL OR r.trang_thai = ANY(v_statuses))
+  AND (
+    v_sanitized_q IS NULL OR
+    r.mo_ta_su_co ILIKE '%' || v_sanitized_q || '%' OR
+    r.hang_muc_sua_chua ILIKE '%' || v_sanitized_q || '%' OR
+    tb.ten_thiet_bi ILIKE '%' || v_sanitized_q || '%' OR
+    tb.ma_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+  )
+  AND (p_date_from IS NULL OR r.ngay_yeu_cau >= (p_date_from::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'))
+  AND (p_date_to IS NULL OR r.ngay_yeu_cau < ((p_date_to + interval '1 day')::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'));
+
+  SELECT coalesce(jsonb_agg(row_data ORDER BY ngay_yeu_cau DESC), '[]'::jsonb) INTO v_data
+  FROM (
+    SELECT
+      jsonb_build_object(
+        'id', r.id,
+        'thiet_bi_id', r.thiet_bi_id,
+        'ngay_yeu_cau', r.ngay_yeu_cau,
+        'trang_thai', r.trang_thai,
+        'mo_ta_su_co', r.mo_ta_su_co,
+        'hang_muc_sua_chua', r.hang_muc_sua_chua,
+        'ngay_mong_muon_hoan_thanh', r.ngay_mong_muon_hoan_thanh,
+        'nguoi_yeu_cau', r.nguoi_yeu_cau,
+        'ngay_duyet', r.ngay_duyet,
+        'ngay_hoan_thanh', r.ngay_hoan_thanh,
+        'nguoi_duyet', r.nguoi_duyet,
+        'nguoi_xac_nhan', r.nguoi_xac_nhan,
+        'don_vi_thuc_hien', r.don_vi_thuc_hien,
+        'ten_don_vi_thue', r.ten_don_vi_thue,
+        'ket_qua_sua_chua', r.ket_qua_sua_chua,
+        'ly_do_khong_hoan_thanh', r.ly_do_khong_hoan_thanh,
+        'chi_phi_sua_chua', r.chi_phi_sua_chua,
+        'equipment_is_deleted', tb.is_deleted,
+        'thiet_bi', jsonb_build_object(
+          'ten_thiet_bi', tb.ten_thiet_bi,
+          'ma_thiet_bi', tb.ma_thiet_bi,
+          'model', tb.model,
+          'serial', tb.serial,
+          'khoa_phong_quan_ly', tb.khoa_phong_quan_ly,
+          'facility_name', dv.name,
+          'facility_id', tb.don_vi,
+          'is_deleted', tb.is_deleted
+        )
+      ) AS row_data,
+      r.ngay_yeu_cau
+    FROM public.yeu_cau_sua_chua r
+    LEFT JOIN public.thiet_bi tb ON tb.id = r.thiet_bi_id
+    LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+    WHERE (
+      (v_is_global AND (v_effective_donvi IS NULL OR tb.don_vi = v_effective_donvi)) OR
+      (NOT v_is_global AND ((v_effective_donvi IS NOT NULL AND tb.don_vi = v_effective_donvi) OR (v_effective_donvi IS NULL AND tb.don_vi = ANY(v_allowed))))
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+    )
+    AND (v_statuses IS NULL OR r.trang_thai = ANY(v_statuses))
+    AND (
+      v_sanitized_q IS NULL OR
+      r.mo_ta_su_co ILIKE '%' || v_sanitized_q || '%' OR
+      r.hang_muc_sua_chua ILIKE '%' || v_sanitized_q || '%' OR
+      tb.ten_thiet_bi ILIKE '%' || v_sanitized_q || '%' OR
+      tb.ma_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+    )
+    AND (p_date_from IS NULL OR r.ngay_yeu_cau >= (p_date_from::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'))
+    AND (p_date_to IS NULL OR r.ngay_yeu_cau < ((p_date_to + interval '1 day')::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'))
+    ORDER BY r.ngay_yeu_cau DESC
+    OFFSET v_offset
+    LIMIT v_limit
+  ) subq;
+
+  RETURN jsonb_build_object('data', v_data, 'total', v_total, 'page', v_page, 'pageSize', v_limit);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_list(text, text, integer, integer, bigint, date, date, text[]) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_list(text, text, integer, integer, bigint, date, date, text[]) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.repair_request_active_for_equipment(p_thiet_bi_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id text := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global boolean := false;
+  v_allowed bigint[] := NULL;
+  v_request jsonb := NULL;
+  v_department_scope text := NULL;
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  v_is_global := v_role IN ('global', 'admin');
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(public._get_jwt_claim('khoa_phong'));
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('active_count', 0, 'request', NULL);
+    END IF;
+  END IF;
+
+  IF NOT v_is_global THEN
+    v_allowed := public.allowed_don_vi_for_session();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object('active_count', 0, 'request', NULL);
+    END IF;
+  END IF;
+
+  WITH active AS (
+    SELECT
+      r.id,
+      r.thiet_bi_id,
+      r.ngay_yeu_cau,
+      r.trang_thai,
+      r.mo_ta_su_co,
+      r.hang_muc_sua_chua,
+      r.ngay_mong_muon_hoan_thanh,
+      r.nguoi_yeu_cau,
+      r.ngay_duyet,
+      r.ngay_hoan_thanh,
+      r.nguoi_duyet,
+      r.nguoi_xac_nhan,
+      r.don_vi_thuc_hien,
+      r.ten_don_vi_thue,
+      r.ket_qua_sua_chua,
+      r.ly_do_khong_hoan_thanh,
+      r.chi_phi_sua_chua,
+      tb.ten_thiet_bi,
+      tb.ma_thiet_bi,
+      tb.model,
+      tb.serial,
+      tb.khoa_phong_quan_ly,
+      tb.don_vi AS thiet_bi_don_vi,
+      dv.name AS facility_name
+    FROM public.yeu_cau_sua_chua r
+    JOIN public.thiet_bi tb ON tb.id = r.thiet_bi_id
+    LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+    WHERE r.thiet_bi_id = p_thiet_bi_id
+      AND r.trang_thai IN ('Chờ xử lý', 'Đã duyệt')
+      AND coalesce(tb.is_deleted, false) = false
+      AND (v_is_global OR tb.don_vi = ANY(v_allowed))
+      AND (
+        v_role <> 'user'
+        OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+      )
+    ORDER BY coalesce(r.ngay_duyet, r.ngay_yeu_cau) DESC, r.id DESC
+  ),
+  counted AS (
+    SELECT count(*)::int AS c
+    FROM active
+  )
+  SELECT jsonb_build_object(
+    'active_count', counted.c,
+    'request',
+    CASE
+      WHEN counted.c = 0 THEN NULL
+      ELSE (
+        SELECT jsonb_build_object(
+          'id', a.id,
+          'thiet_bi_id', a.thiet_bi_id,
+          'ngay_yeu_cau', a.ngay_yeu_cau,
+          'trang_thai', a.trang_thai,
+          'mo_ta_su_co', a.mo_ta_su_co,
+          'hang_muc_sua_chua', a.hang_muc_sua_chua,
+          'ngay_mong_muon_hoan_thanh', a.ngay_mong_muon_hoan_thanh,
+          'nguoi_yeu_cau', a.nguoi_yeu_cau,
+          'ngay_duyet', a.ngay_duyet,
+          'ngay_hoan_thanh', a.ngay_hoan_thanh,
+          'nguoi_duyet', a.nguoi_duyet,
+          'nguoi_xac_nhan', a.nguoi_xac_nhan,
+          'don_vi_thuc_hien', a.don_vi_thuc_hien,
+          'ten_don_vi_thue', a.ten_don_vi_thue,
+          'ket_qua_sua_chua', a.ket_qua_sua_chua,
+          'ly_do_khong_hoan_thanh', a.ly_do_khong_hoan_thanh,
+          'chi_phi_sua_chua', a.chi_phi_sua_chua,
+          'thiet_bi', jsonb_build_object(
+            'ten_thiet_bi', a.ten_thiet_bi,
+            'ma_thiet_bi', a.ma_thiet_bi,
+            'model', a.model,
+            'serial', a.serial,
+            'khoa_phong_quan_ly', a.khoa_phong_quan_ly,
+            'facility_name', a.facility_name,
+            'facility_id', a.thiet_bi_don_vi
+          )
+        )
+        FROM active a
+        ORDER BY coalesce(a.ngay_duyet, a.ngay_yeu_cau) DESC, a.id DESC
+        LIMIT 1
+      )
+    END
+  )
+  INTO v_request
+  FROM counted;
+
+  RETURN v_request;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_active_for_equipment(integer) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_active_for_equipment(integer) FROM PUBLIC;
+
+COMMIT;

--- a/supabase/migrations/20260428132000_fix_repair_request_read_scope.sql
+++ b/supabase/migrations/20260428132000_fix_repair_request_read_scope.sql
@@ -1,7 +1,11 @@
 -- Issue #342: restore tenant guard on repair_request_get and add
 -- role=user fail-closed department scope across repair_request_get,
 -- repair_request_list, and repair_request_active_for_equipment.
--- Rollback: restore the prior function definitions if needed.
+-- Rollback source-of-truth:
+-- - repair_request_get: supabase/migrations/2025-09-15/20250915_ops_rpcs.sql
+--   and supabase/migrations/2025-09-29/20250927_regional_leader_phase4.sql
+-- - repair_request_list: supabase/migrations/20260216141000_fix_report_and_historical_rpc_security_and_types.sql
+-- - repair_request_active_for_equipment: supabase/migrations/20260427023000_add_repair_request_active_for_equipment.sql
 
 BEGIN;
 

--- a/supabase/tests/repair_request_read_scope_smoke.sql
+++ b/supabase/tests/repair_request_read_scope_smoke.sql
@@ -1,0 +1,441 @@
+-- supabase/tests/repair_request_read_scope_smoke.sql
+-- Purpose: lock tenant + role=user department scope across repair_request_get,
+-- repair_request_list, and repair_request_active_for_equipment for Issue #342.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp._rrrs_set_claims(
+  p_app_role text DEFAULT NULL,
+  p_user_id bigint DEFAULT NULL,
+  p_don_vi bigint DEFAULT NULL,
+  p_khoa_phong text DEFAULT NULL,
+  p_include_role_claim boolean DEFAULT false
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_claims jsonb := '{}'::jsonb;
+BEGIN
+  IF p_app_role IS NOT NULL THEN
+    v_claims := v_claims || jsonb_build_object('app_role', p_app_role);
+  END IF;
+
+  IF p_include_role_claim THEN
+    v_claims := v_claims || jsonb_build_object('role', coalesce(p_app_role, 'authenticated'));
+  END IF;
+
+  IF p_user_id IS NOT NULL THEN
+    v_claims := v_claims || jsonb_build_object(
+      'user_id', p_user_id::text,
+      'sub', p_user_id::text
+    );
+  END IF;
+
+  IF p_don_vi IS NOT NULL THEN
+    v_claims := v_claims || jsonb_build_object('don_vi', p_don_vi::text);
+  END IF;
+
+  IF p_khoa_phong IS NOT NULL THEN
+    v_claims := v_claims || jsonb_build_object('khoa_phong', p_khoa_phong);
+  END IF;
+
+  PERFORM set_config('request.jwt.claims', v_claims::text, true);
+END;
+$$;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant_a bigint;
+  v_tenant_b bigint;
+  v_user_id bigint := 990342;
+  v_eq_allowed bigint;
+  v_eq_blocked bigint;
+  v_eq_other_tenant bigint;
+  v_req_allowed bigint;
+  v_req_blocked bigint;
+  v_req_other_tenant bigint;
+  v_payload jsonb;
+  v_row jsonb;
+  v_failed boolean;
+  v_sqlstate text;
+  v_sqlerrm text;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Issue 342 tenant A ' || v_suffix, true)
+  RETURNING id INTO v_tenant_a;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Issue 342 tenant B ' || v_suffix, true)
+  RETURNING id INTO v_tenant_b;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'RRS-ALLOW-' || v_suffix,
+    'Repair request allowed ' || v_suffix,
+    v_tenant_a,
+    '  Nội thận - Tiết niệu  ',
+    'Chờ sửa chữa',
+    false
+  )
+  RETURNING id INTO v_eq_allowed;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'RRS-BLOCK-' || v_suffix,
+    'Repair request blocked ' || v_suffix,
+    v_tenant_a,
+    'Khoa Ngoại Tổng Hợp',
+    'Chờ sửa chữa',
+    false
+  )
+  RETURNING id INTO v_eq_blocked;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'RRS-OTHER-' || v_suffix,
+    'Repair request other tenant ' || v_suffix,
+    v_tenant_b,
+    'Khoa Nội Tổng Hợp',
+    'Chờ sửa chữa',
+    false
+  )
+  RETURNING id INTO v_eq_other_tenant;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    ngay_yeu_cau,
+    trang_thai,
+    mo_ta_su_co
+  )
+  VALUES (
+    v_eq_allowed,
+    now() - interval '1 day',
+    'Chờ xử lý',
+    'Issue 342 allowed ' || v_suffix
+  )
+  RETURNING id INTO v_req_allowed;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    ngay_yeu_cau,
+    trang_thai,
+    mo_ta_su_co
+  )
+  VALUES (
+    v_eq_blocked,
+    now() - interval '2 day',
+    'Chờ xử lý',
+    'Issue 342 blocked ' || v_suffix
+  )
+  RETURNING id INTO v_req_blocked;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    ngay_yeu_cau,
+    trang_thai,
+    mo_ta_su_co
+  )
+  VALUES (
+    v_eq_other_tenant,
+    now() - interval '3 day',
+    'Chờ xử lý',
+    'Issue 342 other tenant ' || v_suffix
+  )
+  RETURNING id INTO v_req_other_tenant;
+
+  ---------------------------------------------------------------------------
+  -- Scenario 1: role=user same tenant + normalized same department succeeds
+  ---------------------------------------------------------------------------
+  PERFORM pg_temp._rrrs_set_claims(
+    p_app_role => 'user',
+    p_user_id => v_user_id,
+    p_don_vi => v_tenant_a,
+    p_khoa_phong => ' ' || chr(160) || E'NỘI\nTHẬN\t  - TIẾT   NIỆU '
+  );
+
+  v_row := public.repair_request_get(v_req_allowed::int);
+  IF (v_row->>'id')::bigint IS DISTINCT FROM v_req_allowed THEN
+    RAISE EXCEPTION 'Scenario 1 failed: repair_request_get did not return the allowed row';
+  END IF;
+
+  v_payload := public.repair_request_list(
+    p_q => v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant_a
+  );
+  IF COALESCE((v_payload->>'total')::int, 0) <> 1 THEN
+    RAISE EXCEPTION 'Scenario 1 failed: repair_request_list total should be 1, got %', v_payload->>'total';
+  END IF;
+  IF COALESCE(jsonb_array_length(v_payload->'data'), 0) <> 1 THEN
+    RAISE EXCEPTION 'Scenario 1 failed: repair_request_list row count should be 1, got %', COALESCE(jsonb_array_length(v_payload->'data'), 0);
+  END IF;
+  IF ((v_payload->'data'->0->>'id')::bigint) IS DISTINCT FROM v_req_allowed THEN
+    RAISE EXCEPTION 'Scenario 1 failed: repair_request_list returned wrong row';
+  END IF;
+
+  v_payload := public.repair_request_active_for_equipment(v_eq_allowed::int);
+  IF (v_payload->>'active_count')::int <> 1 THEN
+    RAISE EXCEPTION 'Scenario 1 failed: active_count should be 1, got %', v_payload;
+  END IF;
+  IF ((v_payload->'request')->>'id')::bigint IS DISTINCT FROM v_req_allowed THEN
+    RAISE EXCEPTION 'Scenario 1 failed: active request row mismatch';
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario 2: role=user same tenant + different department is fail-closed
+  ---------------------------------------------------------------------------
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.repair_request_get(v_req_blocked::int);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed OR v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Scenario 2 failed: repair_request_get should deny cross-department access with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  v_payload := public.repair_request_list(
+    p_q => v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant_a
+  );
+  IF COALESCE((v_payload->>'total')::int, 0) <> 1 THEN
+    RAISE EXCEPTION 'Scenario 2 failed: list should still only expose the allowed row, got %', v_payload;
+  END IF;
+
+  v_payload := public.repair_request_active_for_equipment(v_eq_blocked::int);
+  IF (v_payload->>'active_count')::int <> 0 OR v_payload->'request' <> 'null'::jsonb THEN
+    RAISE EXCEPTION 'Scenario 2 failed: cross-department active lookup should be empty, got %', v_payload;
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario 3: role=user different tenant is fail-closed
+  ---------------------------------------------------------------------------
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.repair_request_get(v_req_other_tenant::int);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed OR v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Scenario 3 failed: repair_request_get should deny cross-tenant access with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  v_payload := public.repair_request_list(
+    p_q => 'other tenant ' || v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant_a
+  );
+  IF COALESCE((v_payload->>'total')::int, 0) <> 0 OR COALESCE(jsonb_array_length(v_payload->'data'), 0) <> 0 THEN
+    RAISE EXCEPTION 'Scenario 3 failed: cross-tenant list should be empty, got %', v_payload;
+  END IF;
+
+  v_payload := public.repair_request_active_for_equipment(v_eq_other_tenant::int);
+  IF (v_payload->>'active_count')::int <> 0 OR v_payload->'request' <> 'null'::jsonb THEN
+    RAISE EXCEPTION 'Scenario 3 failed: cross-tenant active lookup should be empty, got %', v_payload;
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario 4: role=user with missing khoa_phong claim is fail-closed
+  ---------------------------------------------------------------------------
+  PERFORM pg_temp._rrrs_set_claims(
+    p_app_role => 'user',
+    p_user_id => v_user_id,
+    p_don_vi => v_tenant_a,
+    p_khoa_phong => NULL
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.repair_request_get(v_req_allowed::int);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed OR v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Scenario 4 failed: repair_request_get should deny missing-department role user with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  v_payload := public.repair_request_list(
+    p_q => v_suffix,
+    p_page => 1,
+    p_page_size => 50,
+    p_don_vi => v_tenant_a
+  );
+  IF COALESCE((v_payload->>'total')::int, 0) <> 0 OR COALESCE(jsonb_array_length(v_payload->'data'), 0) <> 0 THEN
+    RAISE EXCEPTION 'Scenario 4 failed: missing-department list should be empty, got %', v_payload;
+  END IF;
+
+  v_payload := public.repair_request_active_for_equipment(v_eq_allowed::int);
+  IF (v_payload->>'active_count')::int <> 0 OR v_payload->'request' <> 'null'::jsonb THEN
+    RAISE EXCEPTION 'Scenario 4 failed: missing-department active lookup should be empty, got %', v_payload;
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario 5: non-user tenant role keeps same-tenant cross-department access
+  ---------------------------------------------------------------------------
+  PERFORM pg_temp._rrrs_set_claims(
+    p_app_role => 'to_qltb',
+    p_user_id => v_user_id,
+    p_don_vi => v_tenant_a
+  );
+
+  v_row := public.repair_request_get(v_req_blocked::int);
+  IF (v_row->>'id')::bigint IS DISTINCT FROM v_req_blocked THEN
+    RAISE EXCEPTION 'Scenario 5 failed: to_qltb should still read same-tenant cross-department row';
+  END IF;
+
+  v_payload := public.repair_request_active_for_equipment(v_eq_blocked::int);
+  IF (v_payload->>'active_count')::int <> 1 THEN
+    RAISE EXCEPTION 'Scenario 5 failed: to_qltb active lookup should remain visible, got %', v_payload;
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario 6: global can still read across tenants
+  ---------------------------------------------------------------------------
+  PERFORM pg_temp._rrrs_set_claims(
+    p_app_role => 'global',
+    p_user_id => v_user_id
+  );
+
+  v_row := public.repair_request_get(v_req_other_tenant::int);
+  IF (v_row->>'id')::bigint IS DISTINCT FROM v_req_other_tenant THEN
+    RAISE EXCEPTION 'Scenario 6 failed: global should still read cross-tenant row';
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario 7: missing role claim raises 42501 across the family
+  ---------------------------------------------------------------------------
+  PERFORM pg_temp._rrrs_set_claims(
+    p_app_role => NULL,
+    p_user_id => v_user_id,
+    p_don_vi => v_tenant_a,
+    p_khoa_phong => 'Nội thận',
+    p_include_role_claim => false
+  );
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.repair_request_get(v_req_allowed::int);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := SQLSTATE = '42501';
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Scenario 7 failed: repair_request_get should reject missing role claim';
+  END IF;
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.repair_request_list(
+      p_q => v_suffix,
+      p_page => 1,
+      p_page_size => 50,
+      p_don_vi => v_tenant_a
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := SQLSTATE = '42501';
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Scenario 7 failed: repair_request_list should reject missing role claim';
+  END IF;
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.repair_request_active_for_equipment(v_eq_allowed::int);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := SQLSTATE = '42501';
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Scenario 7 failed: repair_request_active_for_equipment should reject missing role claim';
+  END IF;
+
+  ---------------------------------------------------------------------------
+  -- Scenario 8: missing user_id claim raises 42501 across the family
+  ---------------------------------------------------------------------------
+  PERFORM pg_temp._rrrs_set_claims(
+    p_app_role => 'to_qltb',
+    p_user_id => NULL,
+    p_don_vi => v_tenant_a
+  );
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.repair_request_get(v_req_allowed::int);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := SQLSTATE = '42501';
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Scenario 8 failed: repair_request_get should reject missing user_id claim';
+  END IF;
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.repair_request_list(
+      p_q => v_suffix,
+      p_page => 1,
+      p_page_size => 50,
+      p_don_vi => v_tenant_a
+    );
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := SQLSTATE = '42501';
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Scenario 8 failed: repair_request_list should reject missing user_id claim';
+  END IF;
+
+  v_failed := false;
+  BEGIN
+    PERFORM public.repair_request_active_for_equipment(v_eq_allowed::int);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := SQLSTATE = '42501';
+  END;
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Scenario 8 failed: repair_request_active_for_equipment should reject missing user_id claim';
+  END IF;
+
+  RAISE NOTICE 'repair_request_read_scope_smoke: ALL SCENARIOS PASSED';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
Closes #342

## Summary
- restore JWT, search_path, tenant, and fail-closed department guards for `repair_request_get`
- add `role='user'` department-scope fail-closed behavior to `repair_request_list` and `repair_request_active_for_equipment`
- add focused regression coverage for the repair detail hook and a new family-wide Supabase smoke test

## Testing
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/hooks/__tests__/useRepairRequestDetail.test.ts src/components/equipment-linked-request/resolvers/__tests__/useResolveActiveRepair.test.ts 'src/app/(app)/repair-requests/__tests__/useRepairRequestsData.test.ts'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `git diff --check`

## Notes
- Migration file created but not applied yet, per request.
- New smoke SQL was not executed yet because it depends on the migration being applied first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened read access for repair requests by restoring JWT and tenant guards and adding fail-closed department scoping for `role='user'`. Resolves #342 and blocks cross-tenant or cross-department reads; adds targeted tests and a smoke script.

- **Bug Fixes**
  - Restored JWT checks, `search_path`, and tenant guard in `repair_request_get`; unauthorized reads fail with 42501.
  - Enforced department scope for `role='user'` across `repair_request_get`, `repair_request_list`, and `repair_request_active_for_equipment`; normalize `khoa_phong` and deny when claim is missing or mismatched.
  - Hardened filters and inputs: sanitized search patterns and tightened status filters; revoked PUBLIC execute and granted to `authenticated`.
  - Added regression coverage: `useRepairRequestDetail` hook test and a family-wide Supabase smoke test.

- **Migration**
  - Apply: `supabase/migrations/20260428132000_fix_repair_request_read_scope.sql`.
  - Then run: `supabase/tests/repair_request_read_scope_smoke.sql`.

<sup>Written for commit ae0fc5cfa7ccfdce60eca732b022748ec320449d. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/353?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Implemented strict tenant and department-level access controls on repair request endpoints. Users now see only repair requests appropriate to their role and assigned department.

* **Tests**
  * Added comprehensive authorization scope verification tests to ensure repair request access restrictions work correctly across all user roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
