### PR TITLE
[Repair Requests] Add bookmarkable view-sheet deep link (#341)

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts
@@ -391,6 +391,51 @@ describe('useRepairRequestsDeepLink', () => {
     expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests?foo=bar', { scroll: false })
   })
 
+  it('opens the detail sheet with thiet_bi null when equipment_get is denied after request resolution', async () => {
+    mocks.callRpc
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        id: 77,
+        thiet_bi_id: 42,
+        ngay_yeu_cau: '2026-04-28',
+        trang_thai: 'Chờ xử lý',
+        mo_ta_su_co: 'Mất nguồn',
+        hang_muc_sua_chua: null,
+        ngay_mong_muon_hoan_thanh: null,
+        nguoi_yeu_cau: 'Nguyen Van A',
+        ngay_duyet: null,
+        ngay_hoan_thanh: null,
+        nguoi_duyet: null,
+        nguoi_xac_nhan: null,
+        chi_phi_sua_chua: null,
+        don_vi_thuc_hien: null,
+        ten_don_vi_thue: null,
+        ket_qua_sua_chua: null,
+        ly_do_khong_hoan_thanh: null,
+      })
+      .mockRejectedValueOnce(new Error('Equipment not found or access denied'))
+
+    const sp = createSearchParams({ action: 'view', requestId: '77', foo: 'bar' })
+
+    renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+    await waitFor(() => {
+      expect(mocks.openViewDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 77,
+          thiet_bi_id: 42,
+          thiet_bi: null,
+        }),
+      )
+    })
+    expect(mocks.toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: expect.stringContaining('Không thể mở chi tiết yêu cầu sửa chữa'),
+      }),
+    )
+    expect(mocks.routerReplace).not.toHaveBeenCalled()
+  })
+
   it('cleans only action/requestId after the URL-driven detail sheet closes', async () => {
     mocks.callRpc
       .mockResolvedValueOnce([])

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts
@@ -21,16 +21,22 @@ const mocks = vi.hoisted(() => ({
   callRpc: vi.fn(),
   toast: vi.fn(),
   openCreateSheet: vi.fn(),
+  openViewDialog: vi.fn(),
   applyAssistantDraft: vi.fn(),
   routerReplace: vi.fn(),
   searchParamsGet: vi.fn() as ReturnType<typeof vi.fn>,
   searchParamsToString: vi.fn().mockReturnValue(''),
   queryClientGetQueryData: vi.fn(),
   queryClientRemoveQueries: vi.fn(),
+  useRepairRequestsContext: vi.fn(),
 }))
 
 vi.mock('@/lib/rpc-client', () => ({
   callRpc: mocks.callRpc,
+}))
+
+vi.mock('../_hooks/useRepairRequestsContext', () => ({
+  useRepairRequestsContext: () => mocks.useRepairRequestsContext(),
 }))
 
 // ── Import AFTER mocks ────────────────────────────────────────────
@@ -72,6 +78,10 @@ describe('useRepairRequestsDeepLink', () => {
     vi.clearAllMocks()
     mocks.callRpc.mockResolvedValue([])
     mocks.queryClientGetQueryData.mockReturnValue(undefined)
+    mocks.useRepairRequestsContext.mockReturnValue({
+      dialogState: { requestToView: null },
+      openViewDialog: mocks.openViewDialog,
+    })
   })
 
   afterEach(() => {
@@ -287,14 +297,212 @@ describe('useRepairRequestsDeepLink', () => {
     expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
   })
 
+  it('opens the detail sheet for action=view and a valid requestId without cleaning the URL on open', async () => {
+    mocks.callRpc
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        id: 77,
+        thiet_bi_id: 42,
+        ngay_yeu_cau: '2026-04-28',
+        trang_thai: 'Chờ xử lý',
+        mo_ta_su_co: 'Mất nguồn',
+        hang_muc_sua_chua: null,
+        ngay_mong_muon_hoan_thanh: null,
+        nguoi_yeu_cau: 'Nguyen Van A',
+        ngay_duyet: null,
+        ngay_hoan_thanh: null,
+        nguoi_duyet: null,
+        nguoi_xac_nhan: null,
+        chi_phi_sua_chua: null,
+        don_vi_thuc_hien: null,
+        ten_don_vi_thue: null,
+        ket_qua_sua_chua: null,
+        ly_do_khong_hoan_thanh: null,
+      })
+      .mockResolvedValueOnce({
+        id: 42,
+        ma_thiet_bi: 'TB042',
+        ten_thiet_bi: 'Máy B',
+        model: 'Model X',
+        serial: 'SER-42',
+        khoa_phong_quan_ly: 'Khoa 2',
+        don_vi: 9,
+      })
+
+    const sp = createSearchParams({ action: 'view', requestId: '77', foo: 'bar' })
+
+    renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+    await waitFor(() => {
+      expect(mocks.openViewDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 77,
+          thiet_bi_id: 42,
+          thiet_bi: expect.objectContaining({
+            ma_thiet_bi: 'TB042',
+            model: 'Model X',
+            serial: 'SER-42',
+            khoa_phong_quan_ly: 'Khoa 2',
+            facility_id: 9,
+          }),
+        }),
+      )
+    })
+    expect(mocks.routerReplace).not.toHaveBeenCalled()
+  })
+
+  it('toasts and cleans only action/requestId when action=view has an invalid requestId', async () => {
+    const sp = createSearchParams({ action: 'view', requestId: 'abc', foo: 'bar' })
+
+    renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          title: 'Lỗi',
+          description: expect.stringContaining('Không thể mở chi tiết yêu cầu sửa chữa'),
+        }),
+      )
+    })
+    expect(mocks.openViewDialog).not.toHaveBeenCalled()
+    expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests?foo=bar', { scroll: false })
+  })
+
+  it('toasts and cleans only action/requestId when action=view cannot resolve the request', async () => {
+    mocks.callRpc
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('Yêu cầu sửa chữa không tồn tại hoặc bạn không có quyền truy cập'))
+
+    const sp = createSearchParams({ action: 'view', requestId: '999', foo: 'bar' })
+
+    renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'destructive',
+          title: 'Lỗi',
+          description: expect.stringContaining('Không thể mở chi tiết yêu cầu sửa chữa'),
+        }),
+      )
+    })
+    expect(mocks.openViewDialog).not.toHaveBeenCalled()
+    expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests?foo=bar', { scroll: false })
+  })
+
+  it('cleans only action/requestId after the URL-driven detail sheet closes', async () => {
+    mocks.callRpc
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        id: 77,
+        thiet_bi_id: 42,
+        ngay_yeu_cau: '2026-04-28',
+        trang_thai: 'Chờ xử lý',
+        mo_ta_su_co: 'Mất nguồn',
+        hang_muc_sua_chua: null,
+        ngay_mong_muon_hoan_thanh: null,
+        nguoi_yeu_cau: 'Nguyen Van A',
+        ngay_duyet: null,
+        ngay_hoan_thanh: null,
+        nguoi_duyet: null,
+        nguoi_xac_nhan: null,
+        chi_phi_sua_chua: null,
+        don_vi_thuc_hien: null,
+        ten_don_vi_thue: null,
+        ket_qua_sua_chua: null,
+        ly_do_khong_hoan_thanh: null,
+      })
+      .mockResolvedValueOnce({
+        id: 42,
+        ma_thiet_bi: 'TB042',
+        ten_thiet_bi: 'Máy B',
+        model: 'Model X',
+        serial: 'SER-42',
+        khoa_phong_quan_ly: 'Khoa 2',
+        don_vi: 9,
+      })
+
+    const baseOpts = createDefaultOptions()
+    const requestToView = {
+      id: 77,
+      thiet_bi_id: 42,
+      ngay_yeu_cau: '2026-04-28',
+      trang_thai: 'Chờ xử lý',
+      mo_ta_su_co: 'Mất nguồn',
+      hang_muc_sua_chua: null,
+      ngay_mong_muon_hoan_thanh: null,
+      nguoi_yeu_cau: 'Nguyen Van A',
+      ngay_duyet: null,
+      ngay_hoan_thanh: null,
+      nguoi_duyet: null,
+      nguoi_xac_nhan: null,
+      chi_phi_sua_chua: null,
+      don_vi_thuc_hien: null,
+      ten_don_vi_thue: null,
+      ket_qua_sua_chua: null,
+      ly_do_khong_hoan_thanh: null,
+      thiet_bi: {
+        ma_thiet_bi: 'TB042',
+        ten_thiet_bi: 'Máy B',
+        model: 'Model X',
+        serial: 'SER-42',
+        khoa_phong_quan_ly: 'Khoa 2',
+        facility_name: null,
+        facility_id: 9,
+      },
+    }
+
+    const { rerender } = renderHook(
+      ({ currentSearchParams }) => useRepairRequestsDeepLink({
+        ...baseOpts,
+        searchParams: currentSearchParams,
+      }),
+      {
+        initialProps: {
+          currentSearchParams: createSearchParams({ action: 'view', requestId: '77', foo: 'bar' }),
+        },
+      },
+    )
+
+    await waitFor(() => {
+      expect(mocks.openViewDialog).toHaveBeenCalled()
+    })
+    expect(mocks.routerReplace).not.toHaveBeenCalled()
+
+    mocks.useRepairRequestsContext.mockReturnValue({
+      dialogState: { requestToView },
+      openViewDialog: mocks.openViewDialog,
+    })
+
+    rerender({ currentSearchParams: createSearchParams({ action: 'view', requestId: '77', foo: 'bar' }) })
+
+    mocks.useRepairRequestsContext.mockReturnValue({
+      dialogState: { requestToView: null },
+      openViewDialog: mocks.openViewDialog,
+    })
+
+    rerender({ currentSearchParams: createSearchParams({ action: 'view', requestId: '77', foo: 'bar' }) })
+
+    await waitFor(() => {
+      expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests?foo=bar', { scroll: false })
+    })
+  })
+
   it('reuses the shared create-action constant instead of hardcoding the action value', () => {
     const source = readFileSync(
       resolve(process.cwd(), 'src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts'),
       'utf8',
     )
+    const viewSource = readFileSync(
+      resolve(process.cwd(), 'src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts'),
+      'utf8',
+    )
 
     expect(source).toContain('REPAIR_REQUEST_CREATE_ACTION')
     expect(source).not.toContain("searchParams.get('action') !== 'create'")
+    expect(viewSource).toContain('REPAIR_REQUEST_VIEW_ACTION')
+    expect(viewSource).not.toContain("searchParams.get('action') === 'view'")
   })
 
   registerUseRepairRequestsDeepLinkRaceCases({

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts
@@ -10,6 +10,9 @@ import {
   fetchRepairRequestEquipmentById,
   fetchRepairRequestEquipmentList,
 } from "../repair-requests-equipment-rpc"
+import {
+  useRepairRequestViewDeepLink,
+} from "./useRepairRequestsDeepLinkView"
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -236,6 +239,13 @@ export function useRepairRequestsDeepLink(
     run()
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, allEquipment])
+
+  useRepairRequestViewDeepLink({
+    searchParams,
+    pathname,
+    router,
+    toast,
+  })
 
   // Handle action=create param with equipment pre-selection.
   // For action=create&equipmentId, gates on terminal resolution state

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts
@@ -1,0 +1,195 @@
+"use client"
+
+import * as React from "react"
+import type { RepairRequestWithEquipment } from "../types"
+import { callRpc } from "@/lib/rpc-client"
+import { getUnknownErrorMessage } from "@/lib/error-utils"
+import { REPAIR_REQUEST_VIEW_ACTION } from "@/lib/repair-request-deep-link"
+import { useRepairRequestsContext } from "./useRepairRequestsContext"
+
+type RepairRequestRecord = Omit<RepairRequestWithEquipment, "thiet_bi"> & {
+  thiet_bi?: unknown
+}
+
+type EquipmentDetailRecord = {
+  id: number
+  ma_thiet_bi: string | null
+  ten_thiet_bi: string | null
+  model?: string | null
+  serial?: string | null
+  khoa_phong_quan_ly?: string | null
+  don_vi?: number | null
+}
+
+function toPositiveInt(value: string | null) {
+  if (!value) return null
+
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function toNullableString(value: unknown) {
+  return typeof value === "string" ? value : null
+}
+
+function toNullableNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+export function parseRepairRequestIdParam(value: string | null) {
+  return toPositiveInt(value)
+}
+
+export function buildRepairRequestViewCleanupPath(
+  pathname: string,
+  searchParams: URLSearchParams,
+) {
+  const params = new URLSearchParams(searchParams.toString())
+  params.delete("action")
+  params.delete("requestId")
+
+  return params.size ? `${pathname}?${params.toString()}` : pathname
+}
+
+export async function resolveRepairRequestView(
+  requestId: number,
+): Promise<RepairRequestWithEquipment | null> {
+  const request = await callRpc<RepairRequestRecord | null>({
+    fn: "repair_request_get",
+    args: { p_id: requestId },
+  })
+
+  if (!request) return null
+
+  const equipment = await callRpc<EquipmentDetailRecord | null>({
+    fn: "equipment_get",
+    args: { p_id: request.thiet_bi_id },
+  })
+
+  if (!equipment) return null
+
+  return {
+    ...request,
+    thiet_bi: {
+      ten_thiet_bi: equipment.ten_thiet_bi ?? "",
+      ma_thiet_bi: equipment.ma_thiet_bi ?? "",
+      model: toNullableString(equipment.model),
+      serial: toNullableString(equipment.serial),
+      khoa_phong_quan_ly: toNullableString(equipment.khoa_phong_quan_ly),
+      facility_name: null,
+      facility_id: toNullableNumber(equipment.don_vi),
+    },
+  }
+}
+
+const VIEW_INTENT_FAILURE_DESCRIPTION =
+  "Không thể mở chi tiết yêu cầu sửa chữa."
+
+interface UseRepairRequestViewDeepLinkOptions {
+  searchParams: URLSearchParams
+  pathname: string
+  router: { replace: (path: string, opts?: { scroll?: boolean }) => void }
+  toast: (opts: { variant?: "default" | "destructive" | null; title: string; description: string }) => void
+}
+
+export function useRepairRequestViewDeepLink({
+  searchParams,
+  pathname,
+  router,
+  toast,
+}: UseRepairRequestViewDeepLinkOptions) {
+  const { dialogState, openViewDialog } = useRepairRequestsContext()
+  const lastHandledViewRequestIdRef = React.useRef<number | null>(null)
+  const lastUrlDrivenViewRequestIdRef = React.useRef<number | null>(null)
+  const hasObservedOpenUrlDrivenViewRef = React.useRef(false)
+
+  React.useEffect(() => {
+    if (searchParams.get("action") !== REPAIR_REQUEST_VIEW_ACTION) {
+      lastHandledViewRequestIdRef.current = null
+      lastUrlDrivenViewRequestIdRef.current = null
+      hasObservedOpenUrlDrivenViewRef.current = false
+      return
+    }
+
+    const requestId = parseRepairRequestIdParam(searchParams.get("requestId"))
+    const cleanViewIntentUrl = () => {
+      router.replace(
+        buildRepairRequestViewCleanupPath(pathname, searchParams),
+        { scroll: false },
+      )
+    }
+    const denyViewIntent = (message: string | null) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi",
+        description: message
+          ? `${VIEW_INTENT_FAILURE_DESCRIPTION} ${message}`
+          : VIEW_INTENT_FAILURE_DESCRIPTION,
+      })
+      cleanViewIntentUrl()
+    }
+
+    if (requestId === null) {
+      denyViewIntent(null)
+      return
+    }
+
+    if (lastHandledViewRequestIdRef.current === requestId) return
+    lastHandledViewRequestIdRef.current = requestId
+
+    let isCancelled = false
+
+    const run = async () => {
+      try {
+        const request = await resolveRepairRequestView(requestId)
+        if (isCancelled) return
+
+        if (!request) {
+          denyViewIntent(null)
+          return
+        }
+
+        lastUrlDrivenViewRequestIdRef.current = requestId
+        openViewDialog(request)
+      } catch (error: unknown) {
+        if (isCancelled) return
+        denyViewIntent(getUnknownErrorMessage(error))
+      }
+    }
+
+    run()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [openViewDialog, pathname, router, searchParams, toast])
+
+  React.useEffect(() => {
+    if (searchParams.get("action") !== REPAIR_REQUEST_VIEW_ACTION) return
+
+    const requestId = parseRepairRequestIdParam(searchParams.get("requestId"))
+    if (
+      requestId === null ||
+      lastUrlDrivenViewRequestIdRef.current !== requestId ||
+      !hasObservedOpenUrlDrivenViewRef.current
+    ) {
+      if (dialogState.requestToView?.id === requestId) {
+        hasObservedOpenUrlDrivenViewRef.current = true
+      }
+      return
+    }
+
+    if (dialogState.requestToView?.id === requestId) {
+      hasObservedOpenUrlDrivenViewRef.current = true
+      return
+    }
+
+    router.replace(
+      buildRepairRequestViewCleanupPath(pathname, searchParams),
+      { scroll: false },
+    )
+    lastHandledViewRequestIdRef.current = null
+    lastUrlDrivenViewRequestIdRef.current = null
+    hasObservedOpenUrlDrivenViewRef.current = false
+  }, [dialogState.requestToView, pathname, router, searchParams])
+}

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts
@@ -61,24 +61,29 @@ export async function resolveRepairRequestView(
 
   if (!request) return null
 
-  const equipment = await callRpc<EquipmentDetailRecord | null>({
-    fn: "equipment_get",
-    args: { p_id: request.thiet_bi_id },
-  })
-
-  if (!equipment) return null
+  let equipment: EquipmentDetailRecord | null = null
+  try {
+    equipment = await callRpc<EquipmentDetailRecord | null>({
+      fn: "equipment_get",
+      args: { p_id: request.thiet_bi_id },
+    })
+  } catch {
+    equipment = null
+  }
 
   return {
     ...request,
-    thiet_bi: {
-      ten_thiet_bi: equipment.ten_thiet_bi ?? "",
-      ma_thiet_bi: equipment.ma_thiet_bi ?? "",
-      model: toNullableString(equipment.model),
-      serial: toNullableString(equipment.serial),
-      khoa_phong_quan_ly: toNullableString(equipment.khoa_phong_quan_ly),
-      facility_name: null,
-      facility_id: toNullableNumber(equipment.don_vi),
-    },
+    thiet_bi: equipment
+      ? {
+          ten_thiet_bi: equipment.ten_thiet_bi ?? "",
+          ma_thiet_bi: equipment.ma_thiet_bi ?? "",
+          model: toNullableString(equipment.model),
+          serial: toNullableString(equipment.serial),
+          khoa_phong_quan_ly: toNullableString(equipment.khoa_phong_quan_ly),
+          facility_name: null,
+          facility_id: toNullableNumber(equipment.don_vi),
+        }
+      : null,
   }
 }
 

--- a/src/components/equipment-linked-request/__tests__/repairRequestSheetAdapter.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/repairRequestSheetAdapter.test.tsx
@@ -39,6 +39,16 @@ const mockRequest = {
 } as RepairRequestWithEquipment
 
 describe('RepairRequestSheetAdapter', () => {
+  it('uses the direct repair-request view deep link when exactly one active request exists', () => {
+    render(<RepairRequestSheetAdapter request={mockRequest} activeCount={1} onClose={vi.fn()} />)
+
+    const dialog = screen.getByRole('dialog')
+    expect(
+      within(dialog).getByRole('link', { name: STRINGS.footerOpenInRepairRequests }),
+    ).toHaveAttribute('href', '/repair-requests?action=view&requestId=9001')
+    expect(within(dialog).queryByRole('alert')).not.toBeInTheDocument()
+  })
+
   it('injects the multi-active alert and repair-requests link into the detail sheet slots', () => {
     render(<RepairRequestSheetAdapter request={mockRequest} activeCount={3} onClose={vi.fn()} />)
 

--- a/src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx
+++ b/src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx
@@ -3,7 +3,10 @@
 import * as React from 'react'
 import Link from 'next/link'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { buildRepairRequestsByEquipmentHref } from '@/lib/repair-request-deep-link'
+import {
+  buildRepairRequestViewHref,
+  buildRepairRequestsByEquipmentHref,
+} from '@/lib/repair-request-deep-link'
 import { RepairRequestsDetailView } from '@/app/(app)/repair-requests/_components/RepairRequestsDetailView'
 import type { RepairRequestWithEquipment } from '@/app/(app)/repair-requests/types'
 import { STRINGS } from '@/components/equipment-linked-request/strings'
@@ -31,7 +34,9 @@ export default function RepairRequestSheetAdapter({
   renderSheetShell = true,
 }: RepairRequestSheetAdapterProps) {
   const showMultiActiveAlert = activeCount > 1
-  const openInRepairRequestsHref = buildRepairRequestsByEquipmentHref(request.thiet_bi_id)
+  const openInRepairRequestsHref = showMultiActiveAlert
+    ? buildRepairRequestsByEquipmentHref(request.thiet_bi_id)
+    : buildRepairRequestViewHref(request.id)
   const contentHeader = showMultiActiveAlert ? (
     <Alert role="alert" variant="destructive" className="mx-4 mt-3">
       <AlertDescription>{STRINGS.multiActiveAlert(activeCount)}</AlertDescription>

--- a/src/lib/__tests__/repair-request-deep-link.adoption.test.ts
+++ b/src/lib/__tests__/repair-request-deep-link.adoption.test.ts
@@ -9,6 +9,7 @@ const sourceFiles = [
   'src/components/mobile-equipment-list-item.tsx',
   'src/app/(app)/qr-scanner/page.tsx',
   'src/components/assistant/AssistantPanel.tsx',
+  'src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx',
 ] as const
 
 function readSource(filePath: string) {
@@ -53,6 +54,14 @@ describe('repair request create-intent source adoption', () => {
 
     expect(source).toContain('buildRepairRequestCreateIntentHref')
     expect(source).not.toContain('/repair-requests?action=create')
+  })
+
+  it('RepairRequestSheetAdapter uses shared repair-request helpers instead of hardcoded view hrefs', () => {
+    const source = readSource(sourceFiles[5])
+
+    expect(source).toContain('buildRepairRequestViewHref')
+    expect(source).toContain('buildRepairRequestsByEquipmentHref')
+    expect(source).not.toContain('/repair-requests?action=view&requestId=')
   })
 })
 


### PR DESCRIPTION
## Summary
- add `action=view&requestId=X` deep-link handling for `/repair-requests`
- resolve detail-sheet data via `repair_request_get` plus `equipment_get` and keep the URL until the sheet closes
- switch the equipment-linked-request footer to a hybrid link strategy: direct detail link for one active request, equipment-filtered list for multiple

## Testing
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts'
- node scripts/npm-run.js run test:run -- 'src/components/equipment-linked-request/__tests__/repairRequestSheetAdapter.test.tsx'
- node scripts/npm-run.js run test:run -- 'src/lib/__tests__/repair-request-deep-link.adoption.test.ts'
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

Fixes #341

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bookmarkable deep link to open a repair request detail in /repair-requests and updates the equipment-linked-request footer to link directly when there’s one active request. Gracefully handles cases where equipment details are unavailable. Fixes #341.

- **New Features**
  - Support `/repair-requests?action=view&requestId=<id>`; resolve the request, fetch equipment if available, open the detail dialog, keep the URL while open, and remove only `action`/`requestId` after close.
  - Show a clear error toast and clean just `action`/`requestId` when the ID is invalid or the request cannot be resolved.
  - New `useRepairRequestViewDeepLink` hook, integrated into the existing deep-link flow.
  - Footer strategy: direct view link for one active request; equipment-filtered list when multiple via `buildRepairRequestViewHref` and `buildRepairRequestsByEquipmentHref`.
  - Tests cover open/cleanup/error cases, equipment-unavailable degrade, and footer behavior.

<sup>Written for commit ac140e0040757f3488dc6f10c877e2189c8acb11. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/354?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deep-link support for viewing repair request details directly via URL.
  * Equipment sheet links now intelligently route to the repair request detail view when there's a single active request, or to the filtered list when multiple exist.
  * Improved error handling with user notifications for invalid or unavailable repair requests.

* **Tests**
  * Added comprehensive test coverage for deep-link resolution and URL parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->