### PR TITLE
fix: guard equipment create flow for role user

### DIFF
--- a/src/app/(app)/equipment/__tests__/EquipmentDialogContext.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentDialogContext.test.tsx
@@ -4,19 +4,11 @@ import * as React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { Equipment, UsageLog } from '../types'
 
+const mockUseSession = vi.fn()
+
 // Mock next-auth
 vi.mock('next-auth/react', () => ({
-  useSession: () => ({
-    data: {
-      user: {
-        id: 1,
-        role: 'user',
-        don_vi: 5,
-        name: 'Test User',
-      },
-    },
-    status: 'authenticated',
-  }),
+  useSession: () => mockUseSession(),
 }))
 
 // Mock query client
@@ -57,6 +49,17 @@ const createWrapper = () => {
 describe('EquipmentDialogContext', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: 1,
+          role: 'admin',
+          don_vi: 5,
+          name: 'Test User',
+        },
+      },
+      status: 'authenticated',
+    })
   })
 
   describe('Initial State', () => {
@@ -101,6 +104,30 @@ describe('EquipmentDialogContext', () => {
       expect(result.current.dialogState.isAddOpen).toBe(true)
     })
 
+    it('does not open add dialog for role user', () => {
+      mockUseSession.mockReturnValue({
+        data: {
+          user: {
+            id: 1,
+            role: 'user',
+            don_vi: 5,
+            name: 'Test User',
+          },
+        },
+        status: 'authenticated',
+      })
+
+      const { result } = renderHook(() => useEquipmentContext(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.openAddDialog()
+      })
+
+      expect(result.current.dialogState.isAddOpen).toBe(false)
+    })
+
     it('should close add dialog', () => {
       const { result } = renderHook(() => useEquipmentContext(), {
         wrapper: createWrapper(),
@@ -129,6 +156,30 @@ describe('EquipmentDialogContext', () => {
       })
 
       expect(result.current.dialogState.isImportOpen).toBe(true)
+    })
+
+    it('does not open import dialog for role user', () => {
+      mockUseSession.mockReturnValue({
+        data: {
+          user: {
+            id: 1,
+            role: 'user',
+            don_vi: 5,
+            name: 'Test User',
+          },
+        },
+        status: 'authenticated',
+      })
+
+      const { result } = renderHook(() => useEquipmentContext(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.openImportDialog()
+      })
+
+      expect(result.current.dialogState.isImportOpen).toBe(false)
     })
 
     it('should close import dialog', () => {
@@ -388,7 +439,7 @@ describe('EquipmentDialogContext', () => {
         wrapper: createWrapper(),
       })
 
-      expect(result.current.isGlobal).toBe(false)
+      expect(result.current.isGlobal).toBe(true)
       expect(result.current.isRegionalLeader).toBe(false)
     })
   })

--- a/src/app/(app)/equipment/_components/EquipmentDialogContext.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDialogContext.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
-import { isGlobalRole, isRegionalLeaderRole } from "@/lib/rbac"
+import { isGlobalRole, isRegionalLeaderRole, ROLES } from "@/lib/rbac"
 import type { Equipment, UsageLog, SessionUser } from "../types"
 
 // ============================================
@@ -99,6 +99,7 @@ export function EquipmentDialogProvider({
   // Computed permissions
   const isGlobal = isGlobalRole(user?.role)
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
+  const isUserRole = user?.role?.toLowerCase().trim() === ROLES.USER
 
   // Dialog state
   const [dialogState, setDialogState] = React.useState<DialogState>({
@@ -138,12 +139,18 @@ export function EquipmentDialogProvider({
 
   // Dialog open actions
   const openAddDialog = React.useCallback(() => {
+    if (isUserRole) {
+      return
+    }
     setDialogState((prev) => ({ ...prev, isAddOpen: true }))
-  }, [])
+  }, [isUserRole])
 
   const openImportDialog = React.useCallback(() => {
+    if (isUserRole) {
+      return
+    }
     setDialogState((prev) => ({ ...prev, isImportOpen: true }))
-  }, [])
+  }, [isUserRole])
 
   const openColumnsDialog = React.useCallback(() => {
     setDialogState((prev) => ({ ...prev, isColumnsOpen: true }))

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -26,6 +26,7 @@ import type { DisplayContext } from "@/components/shared/DataTablePagination/typ
 import { EquipmentToolbar } from "@/components/equipment/equipment-toolbar"
 import { TenantSelector } from "@/components/shared/TenantSelector"
 import { applyAttentionStatusPresetFilters } from "@/lib/equipment-attention-preset"
+import { ROLES } from "@/lib/rbac"
 
 import { useEquipmentPage } from "../use-equipment-page"
 import { EquipmentContent } from "../equipment-content"
@@ -102,9 +103,11 @@ const EquipmentPageContent = React.memo(function EquipmentPageContent({
     openImportDialog,
     openColumnsDialog,
     openDetailDialog,
+    user: dialogUser,
   } = useEquipmentContext()
 
   const {
+    user,
     // Session/Auth
     isGlobal,
     isRegionalLeader,
@@ -165,6 +168,11 @@ const EquipmentPageContent = React.memo(function EquipmentPageContent({
     // Branding
     tenantBranding,
   } = pageState
+
+  const canCreateEquipment = React.useMemo(() => {
+    const role = (dialogUser?.role ?? user?.role ?? "").toLowerCase().trim()
+    return role !== ROLES.USER && !isRegionalLeader
+  }, [dialogUser?.role, user?.role, isRegionalLeader])
 
   // Handle route sync pending actions using context
   React.useEffect(() => {
@@ -241,6 +249,7 @@ const EquipmentPageContent = React.memo(function EquipmentPageContent({
             isMobile={isMobile}
             useTabletFilters={useTabletFilters}
             isRegionalLeader={isRegionalLeader}
+            canCreateEquipment={canCreateEquipment}
             hasFacilityFilter={hasFacilityFilter}
             isExporting={isExporting}
             onOpenFilterSheet={() => setIsFilterSheetOpen(true)}
@@ -306,7 +315,7 @@ const EquipmentPageContent = React.memo(function EquipmentPageContent({
       </Card>
 
       {/* Floating Add Button - Mobile only */}
-      {!isRegionalLeader ? (
+      {canCreateEquipment ? (
         <div className="fixed bottom-20 right-6 md:hidden z-[100]">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -248,7 +248,6 @@ const EquipmentPageContent = React.memo(function EquipmentPageContent({
             fundingSources={fundingSources}
             isMobile={isMobile}
             useTabletFilters={useTabletFilters}
-            isRegionalLeader={isRegionalLeader}
             canCreateEquipment={canCreateEquipment}
             hasFacilityFilter={hasFacilityFilter}
             isExporting={isExporting}

--- a/src/components/__tests__/equipment-dialogs.crud.test.tsx
+++ b/src/components/__tests__/equipment-dialogs.crud.test.tsx
@@ -260,6 +260,8 @@ describe('Equipment Dialogs CRUD', () => {
         { wrapper: createWrapper() }
       )
 
+      expect(screen.getByRole('button', { name: 'Lưu' })).toBeDisabled()
+
       fillRequiredAddFields()
       fireEvent.change(screen.getByRole('combobox'), {
         target: { value: 'Hoạt động' },

--- a/src/components/__tests__/equipment-dialogs.crud.test.tsx
+++ b/src/components/__tests__/equipment-dialogs.crud.test.tsx
@@ -237,6 +237,44 @@ describe('Equipment Dialogs CRUD', () => {
       })
     })
 
+    it('blocks create for role user even if the dialog is opened directly', async () => {
+      mockUseSession.mockReturnValue({
+        data: { user: { role: 'user', don_vi: 5 } },
+        status: 'authenticated',
+      })
+      mockCallRpc.mockImplementation(async ({ fn }) => {
+        if (fn === 'departments_list') {
+          return [{ name: 'Khoa Nội' }]
+        }
+        if (fn === 'tenant_list') {
+          return [{ id: 5, code: 'DV5', name: 'Đơn vị 5' }]
+        }
+        if (fn === 'equipment_create') {
+          return { id: 99 }
+        }
+        return []
+      })
+
+      render(
+        <AddEquipmentDialog open onOpenChange={vi.fn()} onSuccess={vi.fn()} />,
+        { wrapper: createWrapper() }
+      )
+
+      fillRequiredAddFields()
+      fireEvent.change(screen.getByRole('combobox'), {
+        target: { value: 'Hoạt động' },
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: 'Lưu' }))
+
+      await waitFor(() => {
+        const createCalls = mockCallRpc.mock.calls.filter(
+          ([args]) => (args as { fn?: string })?.fn === 'equipment_create'
+        )
+        expect(createCalls).toHaveLength(0)
+      })
+    })
+
     it('auto-fills decommission date only after status transitions to Ngưng sử dụng', async () => {
       const dateNowSpy = vi
         .spyOn(Date, 'now')

--- a/src/components/add-equipment-dialog.tsx
+++ b/src/components/add-equipment-dialog.tsx
@@ -61,6 +61,7 @@ export function AddEquipmentDialog({
   const { data: session } = useSession()
   const user = session?.user
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
+  const isUserRole = user?.role?.toLowerCase().trim() === ROLES.USER
 
   const { data: departments = [] } = useQuery({
     queryKey: ["departments_list"],
@@ -131,12 +132,12 @@ export function AddEquipmentDialog({
   })
 
   async function onSubmit(values: AddEquipmentFormValues) {
-    if (isRegionalLeader || user?.role === ROLES.USER) {
+    if (isRegionalLeader || isUserRole) {
       toast({
         variant: "destructive",
         title: "Không có quyền",
         description:
-          user?.role === ROLES.USER
+          isUserRole
             ? "Tài khoản người dùng không được phép thêm thiết bị."
             : "Tài khoản khu vực chỉ được phép xem dữ liệu thiết bị.",
       })
@@ -178,7 +179,10 @@ export function AddEquipmentDialog({
               >
                 Hủy
               </Button>
-              <Button type="submit" disabled={createMutation.isPending || isRegionalLeader}>
+              <Button
+                type="submit"
+                disabled={createMutation.isPending || isRegionalLeader || isUserRole}
+              >
                 {createMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 Lưu
               </Button>

--- a/src/components/add-equipment-dialog.tsx
+++ b/src/components/add-equipment-dialog.tsx
@@ -21,7 +21,7 @@ import { Form } from "@/components/ui/form"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { useToast } from "@/hooks/use-toast"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
-import { isRegionalLeaderRole } from "@/lib/rbac"
+import { isRegionalLeaderRole, ROLES } from "@/lib/rbac"
 import { callRpc } from "@/lib/rpc-client"
 
 import {
@@ -131,11 +131,14 @@ export function AddEquipmentDialog({
   })
 
   async function onSubmit(values: AddEquipmentFormValues) {
-    if (isRegionalLeader) {
+    if (isRegionalLeader || user?.role === ROLES.USER) {
       toast({
         variant: "destructive",
         title: "Không có quyền",
-        description: "Tài khoản khu vực chỉ được phép xem dữ liệu thiết bị.",
+        description:
+          user?.role === ROLES.USER
+            ? "Tài khoản người dùng không được phép thêm thiết bị."
+            : "Tài khoản khu vực chỉ được phép xem dữ liệu thiết bị.",
       })
       return
     }

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -9,6 +9,20 @@ import * as React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import "@testing-library/jest-dom"
 import { render, screen, fireEvent } from '@testing-library/react'
+import type { Table } from '@tanstack/react-table'
+import type { Equipment } from '@/types/database'
+
+type DropdownStateProps = {
+    open?: boolean
+    setOpen?: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+type DropdownChildProps = DropdownStateProps & Record<string, unknown>
+
+type DropdownWithChildrenProps = DropdownStateProps & {
+    children: React.ReactNode
+}
+
 /**
  * Mock dynamic imports (QR scanner components) to avoid SSR issues in tests
  */
@@ -21,36 +35,37 @@ vi.mock('next/dynamic', () => ({
  */
 vi.mock('@/components/ui/dropdown-menu', () => {
     return {
-        DropdownMenu: ({ children }: any) => {
+        DropdownMenu: ({ children }: { children: React.ReactNode }) => {
             const [open, setOpen] = React.useState(false)
             return (
                 <div data-testid="dropdown-menu">
-                    {React.Children.map(children, (child: any) =>
+                    {React.Children.map(children, (child) =>
                         React.isValidElement(child)
-                            ? React.cloneElement(child as React.ReactElement<any>, { open, setOpen })
+                            ? React.cloneElement(child as React.ReactElement<DropdownChildProps>, { open, setOpen })
                             : child
                     )}
                 </div>
             )
         },
-        DropdownMenuTrigger: ({ children, asChild, open, setOpen, ...rest }: any) => {
+        DropdownMenuTrigger: ({ children, asChild, open, setOpen, ...rest }: DropdownWithChildrenProps & { asChild?: boolean }) => {
             const handleClick = () => setOpen?.(!open)
             if (asChild && React.isValidElement(children)) {
-                return React.cloneElement(children as React.ReactElement<any>, {
+                const childElement = children as React.ReactElement<{ onClick?: (...args: unknown[]) => void }>
+                return React.cloneElement(childElement, {
                     ...rest,
-                    onClick: (...args: any[]) => {
+                    onClick: (...args: unknown[]) => {
                         handleClick()
-                            ; (children as any).props?.onClick?.(...args)
+                            ; childElement.props.onClick?.(...args)
                     },
                 })
             }
             return <button {...rest} onClick={handleClick}>{children}</button>
         },
-        DropdownMenuContent: ({ children, open, ...rest }: any) => {
+        DropdownMenuContent: ({ children, open, ...rest }: DropdownWithChildrenProps) => {
             if (!open) return null
             return <div data-testid="dropdown-content" {...rest}>{children}</div>
         },
-        DropdownMenuItem: ({ children, onSelect, ...rest }: any) => (
+        DropdownMenuItem: ({ children, onSelect, ...rest }: { children: React.ReactNode; onSelect?: () => void } & Record<string, unknown>) => (
             <button {...rest} onClick={onSelect}>{children}</button>
         ),
     }
@@ -75,7 +90,7 @@ function createMockTable() {
         getAllColumns: () => [],
         getState: () => ({ columnFilters: [] }),
     }
-    return table as any
+    return table as unknown as Table<Equipment>
 }
 
 describe('EquipmentToolbar with shared filters', () => {
@@ -93,6 +108,7 @@ describe('EquipmentToolbar with shared filters', () => {
         isMobile: false,
         useTabletFilters: false,
         isRegionalLeader: false,
+        canCreateEquipment: true,
         hasFacilityFilter: false,
         onOpenFilterSheet: vi.fn(),
         onOpenColumnsDialog: vi.fn(),
@@ -134,4 +150,11 @@ describe('EquipmentToolbar with shared filters', () => {
 
         expect(screen.getByText('Xóa tất cả')).toBeInTheDocument()
     })
+
+    it('hides add actions when create permission is disabled', () => {
+        render(<EquipmentToolbar {...baseProps} canCreateEquipment={false} />)
+
+        expect(screen.queryByText('Thêm thiết bị')).not.toBeInTheDocument()
+    })
+
 })

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -107,7 +107,6 @@ describe('EquipmentToolbar with shared filters', () => {
         fundingSources: ['Ngân sách'],
         isMobile: false,
         useTabletFilters: false,
-        isRegionalLeader: false,
         canCreateEquipment: true,
         hasFacilityFilter: false,
         onOpenFilterSheet: vi.fn(),

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -49,6 +49,7 @@ export interface EquipmentToolbarProps {
   isMobile: boolean
   useTabletFilters: boolean
   isRegionalLeader: boolean
+  canCreateEquipment: boolean
   hasFacilityFilter: boolean
   /** Whether export is currently in progress */
   isExporting?: boolean
@@ -76,6 +77,7 @@ export function EquipmentToolbar({
   isMobile,
   useTabletFilters,
   isRegionalLeader,
+  canCreateEquipment,
   hasFacilityFilter,
   isExporting = false,
   onOpenFilterSheet,
@@ -240,7 +242,7 @@ export function EquipmentToolbar({
 
           {/* Right: actions */}
           <div className="order-3 w-full md:order-2 md:w-auto flex items-center gap-2 justify-between md:justify-end">
-            {!isRegionalLeader && (
+            {canCreateEquipment && !isRegionalLeader && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button size="sm" className="hidden md:flex h-8 gap-1 touch-target-sm md:h-8">

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -48,7 +48,6 @@ export interface EquipmentToolbarProps {
   fundingSources: string[]
   isMobile: boolean
   useTabletFilters: boolean
-  isRegionalLeader: boolean
   canCreateEquipment: boolean
   hasFacilityFilter: boolean
   /** Whether export is currently in progress */
@@ -76,7 +75,6 @@ export function EquipmentToolbar({
   fundingSources,
   isMobile,
   useTabletFilters,
-  isRegionalLeader,
   canCreateEquipment,
   hasFacilityFilter,
   isExporting = false,

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -242,7 +242,7 @@ export function EquipmentToolbar({
 
           {/* Right: actions */}
           <div className="order-3 w-full md:order-2 md:w-auto flex items-center gap-2 justify-between md:justify-end">
-            {canCreateEquipment && !isRegionalLeader && (
+            {canCreateEquipment && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button size="sm" className="hidden md:flex h-8 gap-1 touch-target-sm md:h-8">


### PR DESCRIPTION
## Summary
- block role `user` from opening equipment add/import dialogs through page affordances and dialog context
- keep `AddEquipmentDialog` fail-closed for role `user` even if the dialog is opened directly
- add regression coverage for context guards, toolbar visibility, and direct dialog submit behavior

## Test Plan
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/app/'(app)'/equipment/__tests__/EquipmentDialogContext.test.tsx src/components/__tests__/equipment-dialogs.crud.test.tsx src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx --reporter=dot`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block users with role `user` from creating or importing equipment across the app. Add/import dialogs don’t open, submits are disabled with a clear toast, no RPC calls are made, and add actions are hidden via a single toolbar permission.

- **Bug Fixes**
  - Guard `openAddDialog` and `openImportDialog` in `EquipmentDialogContext` for role `user`.
  - Harden `AddEquipmentDialog`: disable submit and early-return with role-specific toast; keep regional leader restriction.
  - Compute `canCreateEquipment` on the page and pass to `EquipmentToolbar` and the mobile FAB; add tests for context guards, toolbar visibility, and blocking direct submits without RPC calls.

- **Refactors**
  - Drop unused toolbar role prop and use a single `canCreateEquipment` guard for add actions.

<sup>Written for commit 4e1816e0c47042e3f6b7e11a7cd10545d55fd63d. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/355?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented proper role-based access control for equipment operations. Users without appropriate permissions can no longer create or import equipment. Creation options are now hidden from the interface.

* **Tests**
  * Added tests to verify role-based equipment creation restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->