### PR TITLE
perf: optimize equipment and dashboard data loading

### DIFF
--- a/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
@@ -74,18 +74,8 @@ describe('useEquipmentData', () => {
           return Promise.resolve({ data: [], total: 0 })
         case 'tenant_list':
           return Promise.resolve([])
-        case 'departments_list_for_tenant':
-          return Promise.resolve([])
-        case 'equipment_users_list_for_tenant':
-          return Promise.resolve([])
-        case 'equipment_locations_list_for_tenant':
-          return Promise.resolve([])
-        case 'equipment_statuses_list_for_tenant':
-          return Promise.resolve([])
-        case 'equipment_classifications_list_for_tenant':
-          return Promise.resolve([])
-        case 'equipment_funding_sources_list_for_tenant':
-          return Promise.resolve([])
+        case 'equipment_filter_buckets':
+          return Promise.resolve({})
         case 'get_facilities_with_equipment_count':
           return Promise.resolve([])
         default:
@@ -337,14 +327,71 @@ describe('useEquipmentData', () => {
   })
 
   describe('Filter Options Queries', () => {
-    it('should fetch departments for tenant', async () => {
+    it('should fetch all filter option buckets with a single RPC', async () => {
+      mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
+        if (fn === 'equipment_list_enhanced') {
+          return Promise.resolve({ data: [], total: 0 })
+        }
+        if (fn === 'equipment_filter_buckets') {
+          return Promise.resolve({
+            department: [{ name: 'Khoa A', count: 5 }],
+            user: [{ name: 'Nguyen Van A', count: 3 }],
+            location: [{ name: 'Phong 101', count: 2 }],
+            status: [{ name: 'Hoat dong', count: 10 }],
+            classification: [{ name: 'Loai B', count: 7 }],
+            fundingSource: [{ name: 'Ngân sách nhà nước', count: 4 }],
+          })
+        }
+        return Promise.resolve([])
+      })
+
+      const { result } = renderHook(() => useEquipmentData(createDefaultParams()), {
+        wrapper: createWrapper(),
+      })
+
+      await waitFor(() => {
+        expect(result.current.filterData.department).toEqual([
+          { id: 'Khoa A', label: 'Khoa A', count: 5 },
+        ])
+      })
+
+      expect(result.current.departments).toEqual(['Khoa A'])
+      expect(result.current.users).toEqual(['Nguyen Van A'])
+      expect(result.current.locations).toEqual(['Phong 101'])
+      expect(result.current.statuses).toEqual(['Hoat dong'])
+      expect(result.current.classifications).toEqual(['Loai B'])
+      expect(result.current.fundingSources).toEqual(['Ngân sách nhà nước'])
+
+      expect(mockCallRpc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fn: 'equipment_filter_buckets',
+          args: expect.objectContaining({ p_don_vi: 5 }),
+        })
+      )
+
+      const facetRpcNames = [
+        'departments_list_for_tenant',
+        'equipment_users_list_for_tenant',
+        'equipment_locations_list_for_tenant',
+        'equipment_statuses_list_for_tenant',
+        'equipment_classifications_list_for_tenant',
+        'equipment_funding_sources_list_for_tenant',
+      ]
+      const calledFacetRpcs = mockCallRpc.mock.calls
+        .map((call) => call[0].fn)
+        .filter((fn) => facetRpcNames.includes(fn))
+
+      expect(calledFacetRpcs).toEqual([])
+    })
+
+    it('should expose department buckets for tenant', async () => {
       const mockDepartments = [
         { name: 'Khoa Noi', count: 10 },
         { name: 'Khoa Ngoai', count: 5 },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'departments_list_for_tenant') {
-          return Promise.resolve(mockDepartments)
+        if (fn === 'equipment_filter_buckets') {
+          return Promise.resolve({ department: mockDepartments })
         }
         if (fn === 'equipment_list_enhanced') {
           return Promise.resolve({ data: [], total: 0 })
@@ -361,14 +408,14 @@ describe('useEquipmentData', () => {
       })
     })
 
-    it('should fetch users for tenant', async () => {
+    it('should expose user buckets for tenant', async () => {
       const mockUsers = [
         { name: 'Nguyen Van A', count: 3 },
         { name: 'Tran Thi B', count: 2 },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_users_list_for_tenant') {
-          return Promise.resolve(mockUsers)
+        if (fn === 'equipment_filter_buckets') {
+          return Promise.resolve({ user: mockUsers })
         }
         if (fn === 'equipment_list_enhanced') {
           return Promise.resolve({ data: [], total: 0 })
@@ -385,14 +432,14 @@ describe('useEquipmentData', () => {
       })
     })
 
-    it('should fetch statuses for tenant', async () => {
+    it('should expose status buckets for tenant', async () => {
       const mockStatuses = [
         { name: 'Hoat dong', count: 50 },
         { name: 'Cho sua chua', count: 10 },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_statuses_list_for_tenant') {
-          return Promise.resolve(mockStatuses)
+        if (fn === 'equipment_filter_buckets') {
+          return Promise.resolve({ status: mockStatuses })
         }
         if (fn === 'equipment_list_enhanced') {
           return Promise.resolve({ data: [], total: 0 })
@@ -414,12 +461,12 @@ describe('useEquipmentData', () => {
         switch (fn) {
           case 'equipment_list_enhanced':
             return Promise.resolve({ data: [], total: 0 })
-          case 'departments_list_for_tenant':
-            return Promise.resolve([{ name: 'Khoa A', count: 5 }])
-          case 'equipment_statuses_list_for_tenant':
-            return Promise.resolve([{ name: 'Hoat dong', count: 10 }])
-          case 'equipment_locations_list_for_tenant':
-            return Promise.resolve([{ name: 'Phong 101', count: 3 }])
+          case 'equipment_filter_buckets':
+            return Promise.resolve({
+              department: [{ name: 'Khoa A', count: 5 }],
+              status: [{ name: 'Hoat dong', count: 10 }],
+              location: [{ name: 'Phong 101', count: 3 }],
+            })
           default:
             return Promise.resolve([])
         }
@@ -696,14 +743,14 @@ describe('useEquipmentData', () => {
   })
 
   describe('Funding Source Filter', () => {
-    it('should fetch funding sources for tenant', async () => {
+    it('should expose funding source buckets for tenant', async () => {
       const mockFundingSources = [
         { name: 'Ngân sách nhà nước', count: 42 },
         { name: 'Chưa có', count: 15 },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_funding_sources_list_for_tenant') {
-          return Promise.resolve(mockFundingSources)
+        if (fn === 'equipment_filter_buckets') {
+          return Promise.resolve({ fundingSource: mockFundingSources })
         }
         if (fn === 'equipment_list_enhanced') {
           return Promise.resolve({ data: [], total: 0 })

--- a/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
@@ -517,11 +517,13 @@ describe('useEquipmentData', () => {
     })
 
     it('should not fetch tenant list for non-global users', async () => {
-      renderHook(() => useEquipmentData(createDefaultParams({ isGlobal: false })), {
+      const { result } = renderHook(() => useEquipmentData(createDefaultParams({ isGlobal: false })), {
         wrapper: createWrapper(),
       })
 
-      await new Promise((r) => setTimeout(r, 100))
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false)
+      })
 
       expect(mockCallRpc).not.toHaveBeenCalledWith(
         expect.objectContaining({ fn: 'tenant_list' })

--- a/src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx
+++ b/src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx
@@ -339,4 +339,25 @@ describe('useEquipmentPage tenant switching', () => {
       })
     )
   })
+
+  it('resets pagination in the same action when filters change', () => {
+    const { result } = renderHook(() => useEquipmentPage())
+
+    act(() => {
+      result.current.setColumnFilters([{ id: 'tinh_trang_hien_tai', value: ['Chờ sửa chữa'] }])
+    })
+
+    expect(mocks.setPagination).toHaveBeenCalledWith(expect.any(Function))
+
+    const resetUpdater = mocks.setPagination.mock.calls[0][0] as (
+      value: { pageIndex: number; pageSize: number }
+    ) => { pageIndex: number; pageSize: number }
+    expect(resetUpdater({ pageIndex: 3, pageSize: 20 })).toEqual({
+      pageIndex: 0,
+      pageSize: 20,
+    })
+    expect(mocks.setColumnFilters).toHaveBeenCalledWith([
+      { id: 'tinh_trang_hien_tai', value: ['Chờ sửa chữa'] },
+    ])
+  })
 })

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -70,6 +70,23 @@ export interface UseEquipmentDataReturn {
   invalidateEquipmentForCurrentTenant: () => void
 }
 
+type FilterBucketItem = { name: string; count: number }
+
+type EquipmentFilterBucketsResponse = Partial<{
+  department: FilterBucketItem[]
+  user: FilterBucketItem[]
+  location: FilterBucketItem[]
+  status: FilterBucketItem[]
+  classification: FilterBucketItem[]
+  fundingSource: FilterBucketItem[]
+}>
+
+const EMPTY_FILTER_BUCKET: FilterBucketItem[] = []
+
+function normalizeBucket(data: EquipmentFilterBucketsResponse | undefined, key: keyof EquipmentFilterBucketsResponse) {
+  return data?.[key] ?? EMPTY_FILTER_BUCKET
+}
+
 export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDataReturn {
   const {
     isGlobal,
@@ -214,126 +231,36 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
 
   const isFetching = isEqFetching
 
-  // Filter options queries - updated with role/diaBan in query key
-  const { data: departmentsData } = useQuery<{ name: string; count: number }[]>({
-    queryKey: ["departments_list_for_tenant", { tenant: effectiveTenantKey, role: userRole, diaBan: userDiaBanId, donVi: effectiveSelectedDonVi }],
+  // Filter buckets are bundled into one RPC to avoid six parallel cold-start calls.
+  const { data: filterBucketsData } = useQuery<EquipmentFilterBucketsResponse>({
+    queryKey: ["equipment_filter_buckets", { tenant: effectiveTenantKey, role: userRole, diaBan: userDiaBanId, donVi: effectiveSelectedDonVi }],
     queryFn: async ({ signal }) => {
-      const result = await callRpc<{ name: string; count: number }[]>({
-        fn: "departments_list_for_tenant",
+      const result = await callRpc<EquipmentFilterBucketsResponse>({
+        fn: "equipment_filter_buckets",
         args: { p_don_vi: effectiveSelectedDonVi },
         signal,
       })
-      return result || []
+      return result ?? {}
     },
     enabled: shouldFetchData,
     staleTime: 300_000,
     gcTime: 10 * 60_000,
     refetchOnWindowFocus: false,
   })
-  const departments = React.useMemo(
-    () => (departmentsData || []).map((x) => x.name).filter(Boolean),
-    [departmentsData]
-  )
 
-  const { data: usersData } = useQuery<{ name: string; count: number }[]>({
-    queryKey: ["equipment_users_list_for_tenant", { tenant: effectiveTenantKey, role: userRole, diaBan: userDiaBanId, donVi: effectiveSelectedDonVi }],
-    queryFn: async ({ signal }) => {
-      const result = await callRpc<{ name: string; count: number }[]>({
-        fn: "equipment_users_list_for_tenant",
-        args: { p_don_vi: effectiveSelectedDonVi },
-        signal,
-      })
-      return result || []
-    },
-    enabled: shouldFetchData,
-    staleTime: 300_000,
-    gcTime: 10 * 60_000,
-    refetchOnWindowFocus: false,
-  })
-  const users = React.useMemo(
-    () => (usersData || []).map((x) => x.name).filter(Boolean),
-    [usersData]
-  )
+  const departmentsData = normalizeBucket(filterBucketsData, "department")
+  const usersData = normalizeBucket(filterBucketsData, "user")
+  const locationsData = normalizeBucket(filterBucketsData, "location")
+  const classificationsData = normalizeBucket(filterBucketsData, "classification")
+  const statusesData = normalizeBucket(filterBucketsData, "status")
+  const fundingSourcesData = normalizeBucket(filterBucketsData, "fundingSource")
 
-  const { data: locationsData } = useQuery<{ name: string; count: number }[]>({
-    queryKey: ["equipment_locations_list_for_tenant", { tenant: effectiveTenantKey, role: userRole, diaBan: userDiaBanId, donVi: effectiveSelectedDonVi }],
-    queryFn: async ({ signal }) => {
-      const result = await callRpc<{ name: string; count: number }[]>({
-        fn: "equipment_locations_list_for_tenant",
-        args: { p_don_vi: effectiveSelectedDonVi },
-        signal,
-      })
-      return result || []
-    },
-    enabled: shouldFetchData,
-    staleTime: 300_000,
-    gcTime: 10 * 60_000,
-    refetchOnWindowFocus: false,
-  })
-  const locations = React.useMemo(
-    () => (locationsData || []).map((x) => x.name).filter(Boolean),
-    [locationsData]
-  )
-
-  const { data: classificationsData } = useQuery<{ name: string; count: number }[]>({
-    queryKey: ["equipment_classifications_list_for_tenant", { tenant: effectiveTenantKey, role: userRole, diaBan: userDiaBanId, donVi: effectiveSelectedDonVi }],
-    queryFn: async ({ signal }) => {
-      const result = await callRpc<{ name: string; count: number }[]>({
-        fn: "equipment_classifications_list_for_tenant",
-        args: { p_don_vi: effectiveSelectedDonVi },
-        signal,
-      })
-      return result || []
-    },
-    enabled: shouldFetchData,
-    staleTime: 300_000,
-    gcTime: 10 * 60_000,
-    refetchOnWindowFocus: false,
-  })
-  const classifications = React.useMemo(
-    () => (classificationsData || []).map((x) => x.name).filter(Boolean),
-    [classificationsData]
-  )
-
-  const { data: statusesData } = useQuery<{ name: string; count: number }[]>({
-    queryKey: ["equipment_statuses_list_for_tenant", { tenant: effectiveTenantKey, role: userRole, diaBan: userDiaBanId, donVi: effectiveSelectedDonVi }],
-    queryFn: async ({ signal }) => {
-      const result = await callRpc<{ name: string; count: number }[]>({
-        fn: "equipment_statuses_list_for_tenant",
-        args: { p_don_vi: effectiveSelectedDonVi },
-        signal,
-      })
-      return result || []
-    },
-    enabled: shouldFetchData,
-    staleTime: 300_000,
-    gcTime: 10 * 60_000,
-    refetchOnWindowFocus: false,
-  })
-  const statuses = React.useMemo(
-    () => (statusesData || []).map((x) => x.name).filter(Boolean),
-    [statusesData]
-  )
-
-  const { data: fundingSourcesData } = useQuery<{ name: string; count: number }[]>({
-    queryKey: ["equipment_funding_sources_list_for_tenant", { tenant: effectiveTenantKey, role: userRole, diaBan: userDiaBanId, donVi: effectiveSelectedDonVi }],
-    queryFn: async ({ signal }) => {
-      const result = await callRpc<{ name: string; count: number }[]>({
-        fn: "equipment_funding_sources_list_for_tenant",
-        args: { p_don_vi: effectiveSelectedDonVi },
-        signal,
-      })
-      return result || []
-    },
-    enabled: shouldFetchData,
-    staleTime: 300_000,
-    gcTime: 10 * 60_000,
-    refetchOnWindowFocus: false,
-  })
-  const fundingSources = React.useMemo(
-    () => (fundingSourcesData || []).map((x) => x.name).filter(Boolean),
-    [fundingSourcesData]
-  )
+  const departments = React.useMemo(() => departmentsData.map((x) => x.name).filter(Boolean), [departmentsData])
+  const users = React.useMemo(() => usersData.map((x) => x.name).filter(Boolean), [usersData])
+  const locations = React.useMemo(() => locationsData.map((x) => x.name).filter(Boolean), [locationsData])
+  const classifications = React.useMemo(() => classificationsData.map((x) => x.name).filter(Boolean), [classificationsData])
+  const statuses = React.useMemo(() => statusesData.map((x) => x.name).filter(Boolean), [statusesData])
+  const fundingSources = React.useMemo(() => fundingSourcesData.map((x) => x.name).filter(Boolean), [fundingSourcesData])
 
   // Filter data for bottom sheet
   const filterData: FilterBottomSheetData = React.useMemo(

--- a/src/app/(app)/equipment/use-equipment-page.tsx
+++ b/src/app/(app)/equipment/use-equipment-page.tsx
@@ -146,6 +146,28 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
     selectedFacilityId: data.selectedFacilityId,
   })
 
+  const resetPaginationForFilterChange = React.useCallback(() => {
+    table.setPagination((current) =>
+      current.pageIndex === 0 ? current : { ...current, pageIndex: 0 }
+    )
+  }, [table.setPagination])
+
+  const setSearchTermAndReset = React.useCallback<React.Dispatch<React.SetStateAction<string>>>(
+    (value) => {
+      resetPaginationForFilterChange()
+      filters.setSearchTerm(value)
+    },
+    [filters.setSearchTerm, resetPaginationForFilterChange]
+  )
+
+  const setColumnFiltersAndReset = React.useCallback<React.Dispatch<React.SetStateAction<typeof filters.columnFilters>>>(
+    (value) => {
+      resetPaginationForFilterChange()
+      filters.setColumnFilters(value)
+    },
+    [filters.setColumnFilters, resetPaginationForFilterChange]
+  )
+
   // Effective don_vi for export (same logic as useEquipmentData)
   const effectiveSelectedDonVi = React.useMemo(() => {
     if (auth.isRegionalLeader) {
@@ -272,9 +294,9 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
 
       // Filters
       searchTerm: filters.searchTerm,
-      setSearchTerm: filters.setSearchTerm,
+      setSearchTerm: setSearchTermAndReset,
       columnFilters: filters.columnFilters,
-      setColumnFilters: filters.setColumnFilters,
+      setColumnFilters: setColumnFiltersAndReset,
       isFiltered: table.isFiltered,
 
       // Filter options
@@ -328,6 +350,8 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
       table,
       columns,
       filters,
+      setSearchTermAndReset,
+      setColumnFiltersAndReset,
       hasFacilityFilter,
       handleFacilityClear,
       isFilterSheetOpen,

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -27,6 +27,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'equipment_classifications_list_for_tenant',
   'equipment_statuses_list_for_tenant',
   'equipment_funding_sources_list_for_tenant',
+  'equipment_filter_buckets',
   'equipment_bulk_import',
   // Repairs
   'repair_request_list',
@@ -73,6 +74,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'maintenance_stats_for_reports',
   'get_maintenance_report_data',
   'maintenance_plan_status_counts',
+  'dashboard_kpi_summary',
   // AI Assistant (read-only)
   'ai_equipment_lookup',
   'ai_maintenance_plan_lookup',

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -44,6 +44,16 @@ describe('RPC proxy whitelist', () => {
   })
 
   it.each([
+    'equipment_filter_buckets',
+    'dashboard_kpi_summary',
+  ])('allows performance RPC "%s" through whitelist checks', async (fn) => {
+    const res = await invokeRpcProxy(fn)
+
+    expect(res.status).toBe(411)
+    await expect(res.json()).resolves.toEqual({ error: 'Content-Length header required' })
+  })
+
+  it.each([
     'ai_equipment_lookup',
     'ai_maintenance_summary',
     'ai_maintenance_plan_lookup',

--- a/src/components/dashboard/__tests__/kpi-cards.test.tsx
+++ b/src/components/dashboard/__tests__/kpi-cards.test.tsx
@@ -4,16 +4,14 @@ import { render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockCallRpc = vi.fn()
+const mockUseSession = vi.fn()
 
 vi.mock("@/lib/rpc-client", () => ({
   callRpc: (...args: unknown[]) => mockCallRpc(...args),
 }))
 
 vi.mock("next-auth/react", () => ({
-  useSession: () => ({
-    data: { user: { id: "42", role: "global", dia_ban_id: null } },
-    status: "authenticated",
-  }),
+  useSession: () => mockUseSession(),
 }))
 
 import { KPICards } from "@/components/dashboard/kpi-cards"
@@ -35,6 +33,10 @@ describe("KPICards", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubGlobal("React", React)
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "42", role: "global", dia_ban_id: null } },
+      status: "authenticated",
+    })
     mockCallRpc.mockResolvedValue({
       totalEquipment: 12,
       maintenanceCount: 3,
@@ -68,6 +70,22 @@ describe("KPICards", () => {
     })
 
     expect(mockCallRpc).toHaveBeenCalledTimes(1)
+    expect(mockCallRpc).toHaveBeenCalledWith({
+      fn: "dashboard_kpi_summary",
+    })
+  })
+
+  it("shows loading state instead of zero KPI values while session is resolving", () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: "loading",
+    })
+    mockCallRpc.mockReturnValue(new Promise(() => undefined))
+
+    render(<KPICards />, { wrapper: createWrapper() })
+
+    expect(screen.queryByLabelText("0 thiết bị")).not.toBeInTheDocument()
+    expect(screen.queryByLabelText("0 thiết bị cần bảo trì")).not.toBeInTheDocument()
     expect(mockCallRpc).toHaveBeenCalledWith({
       fn: "dashboard_kpi_summary",
     })

--- a/src/components/dashboard/__tests__/kpi-cards.test.tsx
+++ b/src/components/dashboard/__tests__/kpi-cards.test.tsx
@@ -1,0 +1,75 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockCallRpc = vi.fn()
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: (...args: unknown[]) => mockCallRpc(...args),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({
+    data: { user: { id: "42", role: "global", dia_ban_id: null } },
+    status: "authenticated",
+  }),
+}))
+
+import { KPICards } from "@/components/dashboard/kpi-cards"
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+describe("KPICards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal("React", React)
+    mockCallRpc.mockResolvedValue({
+      totalEquipment: 12,
+      maintenanceCount: 3,
+      repairRequests: {
+        total: 2,
+        pending: 1,
+        approved: 1,
+        completed: 5,
+      },
+      maintenancePlans: {
+        total: 4,
+        draft: 2,
+        approved: 2,
+        plans: [],
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("loads all KPI cards through one dashboard summary RPC", async () => {
+    render(<KPICards />, { wrapper: createWrapper() })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("12 thiết bị")).toBeInTheDocument()
+      expect(screen.getByLabelText("3 thiết bị cần bảo trì")).toBeInTheDocument()
+      expect(screen.getByLabelText("2 yêu cầu sửa chữa")).toBeInTheDocument()
+      expect(screen.getByLabelText("4 kế hoạch bảo trì, hiệu chuẩn, kiểm định")).toBeInTheDocument()
+    })
+
+    expect(mockCallRpc).toHaveBeenCalledTimes(1)
+    expect(mockCallRpc).toHaveBeenCalledWith({
+      fn: "dashboard_kpi_summary",
+    })
+  })
+})

--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -1,5 +1,6 @@
 ﻿"use client"
 
+import * as React from "react"
 import { Package, HardHat, Wrench, Calendar } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"

--- a/src/hooks/use-dashboard-stats.ts
+++ b/src/hooks/use-dashboard-stats.ts
@@ -15,6 +15,8 @@ export type { EquipmentAttention, EquipmentAttentionPage } from './use-dashboard
 // Query keys for dashboard statistics
 export const dashboardStatsKeys = {
   all: ['dashboard-stats'] as const,
+  kpiSummaryRoot: () => [...dashboardStatsKeys.all, 'kpi-summary'] as const,
+  kpiSummary: (userRole?: string, diaBanId?: string | null) => [...dashboardStatsKeys.kpiSummaryRoot(), userRole, diaBanId] as const,
   totalEquipment: (userRole?: string, diaBanId?: string | null) => [...dashboardStatsKeys.all, 'total-equipment', userRole, diaBanId] as const,
   maintenanceCount: (userRole?: string, diaBanId?: string | null) => [...dashboardStatsKeys.all, 'maintenance-count', userRole, diaBanId] as const,
   repairRequests: (userRole?: string, diaBanId?: string | null) => [...dashboardStatsKeys.all, 'repair-requests', userRole, diaBanId] as const,
@@ -36,40 +38,14 @@ function getDashboardUserScope(
 
 // Hook to get total equipment count (tenant-filtered)
 export function useTotalEquipment() {
-  const { data: session } = useSession()
-  const user: DashboardSessionUser | undefined = session?.user
-  const scope = getDashboardUserScope(user)
-  
-  return useQuery({
-    queryKey: dashboardStatsKeys.totalEquipment(scope.role, scope.diaBanId),
-    queryFn: async (): Promise<number> => {
-      const data = await callRpc<number>({ fn: 'dashboard_equipment_total' })
-      return data ?? 0
-    },
-    staleTime: 2 * 60 * 1000, // 2 minutes - equipment count changes less frequently
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnWindowFocus: true,
-    refetchInterval: 5 * 60 * 1000, // Refetch every 5 minutes
-  })
+  const query = useDashboardKpiSummary()
+  return { ...query, data: query.data?.totalEquipment ?? (query.data ? 0 : undefined) }
 }
 
 // Hook to get equipment needing maintenance/calibration count (tenant-filtered)
 export function useMaintenanceCount() {
-  const { data: session } = useSession()
-  const user: DashboardSessionUser | undefined = session?.user
-  const scope = getDashboardUserScope(user)
-  
-  return useQuery({
-    queryKey: dashboardStatsKeys.maintenanceCount(scope.role, scope.diaBanId),
-    queryFn: async (): Promise<number> => {
-      const data = await callRpc<number>({ fn: 'dashboard_maintenance_count' })
-      return data ?? 0
-    },
-    staleTime: 2 * 60 * 1000, // 2 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnWindowFocus: true,
-    refetchInterval: 5 * 60 * 1000, // Refetch every 5 minutes
-  })
+  const query = useDashboardKpiSummary()
+  return { ...query, data: query.data?.maintenanceCount ?? (query.data ? 0 : undefined) }
 }
 
 // Interface for repair request statistics
@@ -82,26 +58,8 @@ export interface RepairRequestStats {
 
 // Hook to get repair request statistics (tenant-filtered)
 export function useRepairRequestStats() {
-  const { data: session } = useSession()
-  const user: DashboardSessionUser | undefined = session?.user
-  const scope = getDashboardUserScope(user)
-  
-  return useQuery({
-    queryKey: dashboardStatsKeys.repairRequests(scope.role, scope.diaBanId),
-    queryFn: async (): Promise<RepairRequestStats> => {
-      const data = await callRpc<RepairRequestStats>({ fn: 'dashboard_repair_request_stats' })
-      return data ?? {
-        total: 0,
-        pending: 0,
-        approved: 0,
-        completed: 0
-      }
-    },
-    staleTime: 1 * 60 * 1000, // 1 minute - repair requests change more frequently
-    gcTime: 5 * 60 * 1000, // 5 minutes
-    refetchOnWindowFocus: true,
-    refetchInterval: 3 * 60 * 1000, // Refetch every 3 minutes
-  })
+  const query = useDashboardKpiSummary()
+  return { ...query, data: query.data?.repairRequests ?? (query.data ? EMPTY_REPAIR_REQUEST_STATS : undefined) }
 }
 
 // Interface for maintenance plan statistics
@@ -120,28 +78,65 @@ export interface MaintenancePlanStats {
   }>
 }
 
-// Hook to get maintenance plan statistics (tenant-filtered)
-export function useMaintenancePlanStats() {
+export interface DashboardKpiSummary {
+  totalEquipment: number
+  maintenanceCount: number
+  repairRequests: RepairRequestStats
+  maintenancePlans: MaintenancePlanStats
+}
+
+const EMPTY_REPAIR_REQUEST_STATS: RepairRequestStats = {
+  total: 0,
+  pending: 0,
+  approved: 0,
+  completed: 0,
+}
+
+const EMPTY_MAINTENANCE_PLAN_STATS: MaintenancePlanStats = {
+  total: 0,
+  draft: 0,
+  approved: 0,
+  plans: [],
+}
+
+function normalizeDashboardKpiSummary(data: Partial<DashboardKpiSummary> | null | undefined): DashboardKpiSummary {
+  return {
+    totalEquipment: data?.totalEquipment ?? 0,
+    maintenanceCount: data?.maintenanceCount ?? 0,
+    repairRequests: {
+      ...EMPTY_REPAIR_REQUEST_STATS,
+      ...(data?.repairRequests ?? {}),
+    },
+    maintenancePlans: {
+      ...EMPTY_MAINTENANCE_PLAN_STATS,
+      ...(data?.maintenancePlans ?? {}),
+      plans: data?.maintenancePlans?.plans ?? [],
+    },
+  }
+}
+
+export function useDashboardKpiSummary() {
   const { data: session } = useSession()
   const user: DashboardSessionUser | undefined = session?.user
   const scope = getDashboardUserScope(user)
-  
+
   return useQuery({
-    queryKey: dashboardStatsKeys.maintenancePlans(scope.role, scope.diaBanId),
-    queryFn: async (): Promise<MaintenancePlanStats> => {
-      const data = await callRpc<MaintenancePlanStats>({ fn: 'dashboard_maintenance_plan_stats' })
-      return data ?? {
-        total: 0,
-        draft: 0,
-        approved: 0,
-        plans: []
-      }
+    queryKey: dashboardStatsKeys.kpiSummary(scope.role, scope.diaBanId),
+    queryFn: async (): Promise<DashboardKpiSummary> => {
+      const data = await callRpc<Partial<DashboardKpiSummary>>({ fn: 'dashboard_kpi_summary' })
+      return normalizeDashboardKpiSummary(data)
     },
-    staleTime: 3 * 60 * 1000, // 3 minutes - maintenance plans change less frequently
-    gcTime: 10 * 60 * 1000, // 10 minutes
-    refetchOnWindowFocus: true,
-    refetchInterval: 5 * 60 * 1000, // Refetch every 5 minutes
+    enabled: Boolean(user),
+    staleTime: 2 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
   })
+}
+
+// Hook to get maintenance plan statistics (tenant-filtered)
+export function useMaintenancePlanStats() {
+  const query = useDashboardKpiSummary()
+  return { ...query, data: query.data?.maintenancePlans ?? (query.data ? EMPTY_MAINTENANCE_PLAN_STATS : undefined) }
 }
 
 // Hook to get equipment needing attention

--- a/src/hooks/use-dashboard-stats.ts
+++ b/src/hooks/use-dashboard-stats.ts
@@ -126,7 +126,6 @@ export function useDashboardKpiSummary() {
       const data = await callRpc<Partial<DashboardKpiSummary>>({ fn: 'dashboard_kpi_summary' })
       return normalizeDashboardKpiSummary(data)
     },
-    enabled: Boolean(user),
     staleTime: 2 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,

--- a/supabase/migrations/20260501090000_add_equipment_dashboard_perf_rpcs.sql
+++ b/supabase/migrations/20260501090000_add_equipment_dashboard_perf_rpcs.sql
@@ -1,0 +1,235 @@
+-- Migration: add bundled equipment filters and dashboard KPI summary RPCs
+-- Date: 2026-05-01
+-- Scope: performance-only read RPCs for Equipment and Dashboard initial loads
+--
+-- Notes:
+-- - Repo-only until explicitly applied via Supabase MCP.
+-- - Keep access semantics aligned with the current tenant and department-scoped
+--   equipment read functions.
+-- - Reduce browser initial-load fan-out without changing page-visible data.
+--
+-- Rollback:
+-- - Forward-only. Drop the new RPCs and index in a later timestamped migration
+--   if this batch must be reverted.
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_ycsc_active_equipment_status_requested_desc
+ON public.yeu_cau_sua_chua (thiet_bi_id, trang_thai, ngay_yeu_cau DESC, id DESC)
+WHERE trang_thai IN ('Chờ xử lý', 'Đã duyệt');
+
+CREATE OR REPLACE FUNCTION public.equipment_filter_buckets(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_allowed bigint[];
+  v_effective bigint[];
+  v_department_scope text;
+  v_jwt_claims jsonb;
+  v_result jsonb;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object(
+        'department', '[]'::jsonb,
+        'user', '[]'::jsonb,
+        'location', '[]'::jsonb,
+        'status', '[]'::jsonb,
+        'classification', '[]'::jsonb,
+        'fundingSource', '[]'::jsonb
+      );
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object(
+        'department', '[]'::jsonb,
+        'user', '[]'::jsonb,
+        'location', '[]'::jsonb,
+        'status', '[]'::jsonb,
+        'classification', '[]'::jsonb,
+        'fundingSource', '[]'::jsonb
+      );
+    END IF;
+  END IF;
+
+  WITH scoped_equipment AS MATERIALIZED (
+    SELECT
+      COALESCE(NULLIF(TRIM(tb.khoa_phong_quan_ly), ''), 'Chưa phân loại') AS department_name,
+      COALESCE(NULLIF(TRIM(tb.nguoi_dang_truc_tiep_quan_ly), ''), 'Chưa có người sử dụng') AS user_name,
+      COALESCE(NULLIF(TRIM(tb.vi_tri_lap_dat), ''), 'Chưa có vị trí') AS location_name,
+      COALESCE(NULLIF(TRIM(tb.tinh_trang_hien_tai), ''), 'Chưa phân loại') AS status_name,
+      COALESCE(NULLIF(TRIM(tb.phan_loai_theo_nd98), ''), 'Chưa phân loại') AS classification_name,
+      COALESCE(NULLIF(TRIM(tb.nguon_kinh_phi), ''), 'Chưa có') AS funding_source_name
+    FROM public.thiet_bi tb
+    WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+      AND tb.is_deleted = false
+      AND (
+        v_role <> 'user'
+        OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+      )
+  )
+  SELECT jsonb_build_object(
+    'department', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT department_name AS name, COUNT(*)::integer AS count
+        FROM scoped_equipment
+        GROUP BY department_name
+      ) bucket
+    ), '[]'::jsonb),
+    'user', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT user_name AS name, COUNT(*)::integer AS count
+        FROM scoped_equipment
+        GROUP BY user_name
+      ) bucket
+    ), '[]'::jsonb),
+    'location', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT location_name AS name, COUNT(*)::integer AS count
+        FROM scoped_equipment
+        GROUP BY location_name
+      ) bucket
+    ), '[]'::jsonb),
+    'status', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT status_name AS name, COUNT(*)::integer AS count
+        FROM scoped_equipment
+        GROUP BY status_name
+      ) bucket
+    ), '[]'::jsonb),
+    'classification', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT classification_name AS name, COUNT(*)::integer AS count
+        FROM scoped_equipment
+        GROUP BY classification_name
+      ) bucket
+    ), '[]'::jsonb),
+    'fundingSource', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT funding_source_name AS name, COUNT(*)::integer AS count
+        FROM scoped_equipment
+        GROUP BY funding_source_name
+      ) bucket
+    ), '[]'::jsonb)
+  )
+  INTO v_result;
+
+  RETURN COALESCE(v_result, jsonb_build_object(
+    'department', '[]'::jsonb,
+    'user', '[]'::jsonb,
+    'location', '[]'::jsonb,
+    'status', '[]'::jsonb,
+    'classification', '[]'::jsonb,
+    'fundingSource', '[]'::jsonb
+  ));
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.dashboard_kpi_summary()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_jwt_claims jsonb;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'totalEquipment', public.dashboard_equipment_total(),
+    'maintenanceCount', public.dashboard_maintenance_count(),
+    'repairRequests', public.dashboard_repair_request_stats(),
+    'maintenancePlans', public.dashboard_maintenance_plan_stats()
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.equipment_filter_buckets(bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.equipment_filter_buckets(bigint) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.equipment_filter_buckets(bigint) TO service_role;
+
+REVOKE ALL ON FUNCTION public.dashboard_kpi_summary() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dashboard_kpi_summary() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.dashboard_kpi_summary() TO service_role;
+
+COMMENT ON FUNCTION public.equipment_filter_buckets(bigint) IS
+  'Returns all equipment filter option buckets in one scoped RPC for faster Equipment initial load.';
+
+COMMENT ON FUNCTION public.dashboard_kpi_summary() IS
+  'Returns Dashboard KPI card payload in one scoped RPC for faster Dashboard initial load.';
+
+COMMIT;

--- a/supabase/tests/dashboard_kpi_summary_smoke.sql
+++ b/supabase/tests/dashboard_kpi_summary_smoke.sql
@@ -1,0 +1,109 @@
+-- supabase/tests/dashboard_kpi_summary_smoke.sql
+-- Purpose: smoke-test dashboard_kpi_summary after the migration is applied.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_equipment_id bigint;
+  v_payload jsonb;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Dashboard KPI Tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-KPI-EQ-' || v_suffix,
+    'Smoke Dashboard KPI Equipment ' || v_suffix,
+    v_tenant,
+    'Khoa KPI ' || v_suffix,
+    'Chờ bảo trì',
+    false
+  )
+  RETURNING id INTO v_equipment_id;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    ngay_yeu_cau,
+    trang_thai,
+    mo_ta_su_co
+  )
+  VALUES (
+    v_equipment_id,
+    now(),
+    'Chờ xử lý',
+    'Smoke KPI repair request ' || v_suffix
+  );
+
+  INSERT INTO public.ke_hoach_bao_tri(
+    ten_ke_hoach,
+    nam,
+    don_vi,
+    khoa_phong,
+    loai_cong_viec,
+    trang_thai
+  )
+  VALUES (
+    'Smoke KPI Plan ' || v_suffix,
+    EXTRACT(YEAR FROM current_date)::integer,
+    v_tenant,
+    'Khoa KPI ' || v_suffix,
+    'Bảo trì',
+    'Bản nháp'
+  );
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'to_qltb',
+      'user_id', '900002',
+      'don_vi', v_tenant
+    )::text,
+    true
+  );
+
+  v_payload := public.dashboard_kpi_summary();
+
+  IF jsonb_typeof(v_payload) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'dashboard_kpi_summary must return an object: %', v_payload;
+  END IF;
+
+  IF NOT (v_payload ? 'totalEquipment')
+     OR NOT (v_payload ? 'maintenanceCount')
+     OR NOT (v_payload ? 'repairRequests')
+     OR NOT (v_payload ? 'maintenancePlans') THEN
+    RAISE EXCEPTION 'dashboard_kpi_summary missing expected keys: %', v_payload;
+  END IF;
+
+  IF COALESCE((v_payload->>'totalEquipment')::integer, 0) < 1 THEN
+    RAISE EXCEPTION 'dashboard_kpi_summary totalEquipment should include smoke equipment: %', v_payload;
+  END IF;
+
+  IF COALESCE((v_payload->>'maintenanceCount')::integer, 0) < 1 THEN
+    RAISE EXCEPTION 'dashboard_kpi_summary maintenanceCount should include smoke equipment: %', v_payload;
+  END IF;
+
+  IF COALESCE((v_payload->'repairRequests'->>'pending')::integer, 0) < 1 THEN
+    RAISE EXCEPTION 'dashboard_kpi_summary repairRequests.pending should include smoke request: %', v_payload;
+  END IF;
+
+  IF COALESCE((v_payload->'maintenancePlans'->>'draft')::integer, 0) < 1 THEN
+    RAISE EXCEPTION 'dashboard_kpi_summary maintenancePlans.draft should include smoke plan: %', v_payload;
+  END IF;
+
+  RAISE NOTICE 'dashboard_kpi_summary smoke: PASSED';
+END;
+$$;
+
+ROLLBACK;

--- a/supabase/tests/equipment_filter_buckets_smoke.sql
+++ b/supabase/tests/equipment_filter_buckets_smoke.sql
@@ -1,0 +1,106 @@
+-- supabase/tests/equipment_filter_buckets_smoke.sql
+-- Purpose: smoke-test equipment_filter_buckets after the migration is applied.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_payload jsonb;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Filter Buckets Tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Filter Buckets Other Tenant ' || v_suffix, true)
+  RETURNING id INTO v_other_tenant;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    nguoi_dang_truc_tiep_quan_ly,
+    vi_tri_lap_dat,
+    phan_loai_theo_nd98,
+    nguon_kinh_phi,
+    is_deleted
+  )
+  VALUES
+    (
+      'SMK-BUCKET-ALLOW-' || v_suffix,
+      'Smoke Bucket Allowed ' || v_suffix,
+      v_tenant,
+      'Khoa Bucket ' || v_suffix,
+      'Hoat dong',
+      'User Bucket ' || v_suffix,
+      'Room Bucket ' || v_suffix,
+      'Class Bucket ' || v_suffix,
+      'Fund Bucket ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-BUCKET-OTHER-' || v_suffix,
+      'Smoke Bucket Other ' || v_suffix,
+      v_other_tenant,
+      'Khoa Other ' || v_suffix,
+      'Hoat dong',
+      'User Other ' || v_suffix,
+      'Room Other ' || v_suffix,
+      'Class Other ' || v_suffix,
+      'Fund Other ' || v_suffix,
+      false
+    );
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'to_qltb',
+      'user_id', '900001',
+      'don_vi', v_tenant
+    )::text,
+    true
+  );
+
+  v_payload := public.equipment_filter_buckets(v_tenant);
+
+  IF jsonb_typeof(v_payload->'department') IS DISTINCT FROM 'array' THEN
+    RAISE EXCEPTION 'equipment_filter_buckets.department must be an array: %', v_payload;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'department') entry
+    WHERE entry->>'name' = 'Khoa Bucket ' || v_suffix
+      AND (entry->>'count')::integer = 1
+  ) THEN
+    RAISE EXCEPTION 'equipment_filter_buckets missing scoped department bucket: %', v_payload;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'department') entry
+    WHERE entry->>'name' = 'Khoa Other ' || v_suffix
+  ) THEN
+    RAISE EXCEPTION 'equipment_filter_buckets leaked cross-tenant department bucket: %', v_payload;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'fundingSource') entry
+    WHERE entry->>'name' = 'Fund Bucket ' || v_suffix
+      AND (entry->>'count')::integer = 1
+  ) THEN
+    RAISE EXCEPTION 'equipment_filter_buckets missing fundingSource bucket: %', v_payload;
+  END IF;
+
+  RAISE NOTICE 'equipment_filter_buckets smoke: PASSED';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

This PR optimizes the initial data-loading path for the Equipment page and Dashboard KPI cards.

### Equipment page
- Replaces six parallel filter-option RPC calls with one bundled `equipment_filter_buckets` RPC.
- Keeps tenant, regional-leader, and user department-scope semantics aligned with existing equipment read RPCs.
- Adds a composite partial index for active repair lookup used by `equipment_list_enhanced`.
- Resets Equipment pagination in the same filter-change action instead of relying only on a post-render effect.

### Dashboard
- Adds `dashboard_kpi_summary` RPC for KPI card data so the dashboard no longer starts four separate KPI queries.
- Keeps existing individual dashboard hook exports for component compatibility, backed by the shared summary query.
- Reduces KPI refetch aggressiveness by using a single cached summary query.

### API / tests
- Adds RPC whitelist entries for `equipment_filter_buckets` and `dashboard_kpi_summary`.
- Adds/updates focused regression tests for bundled Equipment filter buckets, same-action pagination reset, KPI summary query usage, and RPC whitelist coverage.
- Adds SQL smoke tests for the new RPCs.

## TDD / Verification Status

RED tests were created and run before implementation for:
- `src/app/(app)/equipment/__tests__/useEquipmentData.test.ts`
- `src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx`
- `src/components/dashboard/__tests__/kpi-cards.test.tsx`

Migration has now been applied via Supabase MCP and post-apply verification has been run. Supabase CLI was not used.

```bash
node scripts/npm-run.js run verify:no-explicit-any
node scripts/npm-run.js run typecheck
node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/__tests__/useEquipmentData.test.ts' 'src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx' 'src/components/dashboard/__tests__/kpi-cards.test.tsx' 'src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts'
node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
```

Current app-layer results:
- `verify:no-explicit-any`: passed, no explicit any in changed TypeScript files.
- `typecheck`: passed.
- Focused Vitest: 4 files passed, 55 tests passed. React act warning in `useEquipmentData.test.ts` was fixed and did not reappear. Added regression coverage for KPI loading while session is resolving.
- `react-doctor --diff main`: 100/100, no issues found.
- `git diff --check`: passed before commit.

## Migration / Post-Apply Verification

Applied via Supabase MCP:

```text
add_equipment_dashboard_perf_rpcs
live migration version: 20260501145857
local file: supabase/migrations/20260501090000_add_equipment_dashboard_perf_rpcs.sql
```

Post-apply Supabase MCP checks:
- `equipment_filter_buckets_smoke.sql`: passed.
- `dashboard_kpi_summary_smoke.sql`: passed.
- `get_advisors(security)`: ran; findings appear to be existing baseline warnings. New RPCs were separately verified with `SECURITY DEFINER` and `search_path=public, pg_temp`.
- `get_advisors(performance)`: ran; reported the new partial index as unused, expected immediately after creation before production workload uses it.

## Review Notes

Please focus bot review on:
- RPC access-scope parity with existing equipment read functions.
- Whether `dashboard_kpi_summary` should continue delegating to existing KPI RPCs or inline the four queries in a later batch.
- Whether same-action pagination reset should also be pushed deeper into `useEquipmentTable` in a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up initial loads for Equipment and Dashboard by bundling many RPCs into two cached queries. Resets pagination on filter changes, adds an index for active repair lookups, and preserves KPI loading state to avoid zero-value flashes.

- **New Features**
  - Equipment: replaced six filter RPCs with `equipment_filter_buckets` (keeps tenant/regional-leader/user scoping); added a composite partial index for active repair lookup used by `equipment_list_enhanced`; reset pagination in the same filter-change action.
  - Dashboard: consolidated four KPI queries into `dashboard_kpi_summary`; existing hooks now read from a single cached summary via `useDashboardKpiSummary` and keep loading state until data arrives.
  - API/tests: whitelisted `equipment_filter_buckets` and `dashboard_kpi_summary`; added SQL smoke tests and a KPI cards test that asserts a single RPC and no zero-value flash during loading; removed a React act warning in `useEquipmentData` tests.

- **Migration**
  - Apply `supabase/migrations/20260501090000_add_equipment_dashboard_perf_rpcs.sql` via Supabase MCP.
  - Run smoke tests in `supabase/tests/` and targeted unit tests for equipment filters, KPI cards, and the RPC whitelist.

<sup>Written for commit cbe2d9d7711fde3396c09803b8e4809b15a5388e. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/358?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard KPI summary cards displaying key equipment metrics including total equipment count, maintenance activities, repair requests, and maintenance plans

* **Improvements**
  * Equipment filter options load with improved performance through optimized data retrieval
  * Table pagination automatically resets to the first page whenever filters or search terms are modified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



