### PR TITLE
perf: optimize repair request data loading

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsKpi.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsKpi.test.tsx
@@ -19,6 +19,8 @@ const mocks = vi.hoisted(() => ({
   useQuery: vi.fn(),
   useQueryClient: vi.fn(),
   toast: vi.fn(),
+  tableMount: vi.fn(),
+  tableUnmount: vi.fn(),
 }))
 
 // ── Module mocks ───────────────────────────────────────────────────────
@@ -125,7 +127,14 @@ vi.mock('../_components/RepairRequestsCreateSheet', () => ({
 }))
 
 vi.mock('../_components/RepairRequestsTable', () => ({
-  RepairRequestsTable: () => <div data-testid="repair-table">table</div>,
+  RepairRequestsTable: () => {
+    React.useEffect(() => {
+      mocks.tableMount()
+      return () => mocks.tableUnmount()
+    }, [])
+
+    return <div data-testid="repair-table">table</div>
+  },
 }))
 
 vi.mock('../_components/RepairRequestsToolbar', () => ({
@@ -200,7 +209,7 @@ vi.mock('@tanstack/react-query', () => ({
 
     if (key === 'repair_request_list') {
       return {
-        data: options.enabled ? { data: [], total: 0, page: 1, pageSize: 20 } : undefined,
+        data: options.enabled ? { data: mockListData, total: mockListData.length, page: 1, pageSize: 20 } : undefined,
         isLoading: false,
         isFetching: false,
         refetch: vi.fn(),
@@ -216,6 +225,7 @@ vi.mock('@tanstack/react-query', () => ({
 
 // ── Shared test state ──────────────────────────────────────────────────
 let mockStatusCounts: Record<string, number> | undefined
+let mockListData: Array<{ id: number }>
 
 // Import component AFTER mocks
 import RepairRequestsPageClient from '../_components/RepairRequestsPageClient'
@@ -277,6 +287,7 @@ describe('RepairRequests KPI Cards', () => {
       'Hoàn thành': 5,
       'Không HT': 1,
     }
+    mockListData = []
     mocks.callRpc.mockResolvedValue([])
   })
 
@@ -356,6 +367,27 @@ describe('RepairRequests KPI Cards', () => {
       )
       expect(listCall).toBeDefined()
       expect(listCall!.enabled).toBe(true)
+    })
+
+    it('should not remount the table when only row count changes', async () => {
+      setupTenantUser()
+      let view: ReturnType<typeof render> | undefined
+
+      await act(async () => {
+        view = render(<RepairRequestsPageClient />)
+      })
+
+      expect(mocks.tableMount).toHaveBeenCalledTimes(1)
+      expect(mocks.tableUnmount).not.toHaveBeenCalled()
+
+      mockListData = [{ id: 1 }]
+
+      await act(async () => {
+        view!.rerender(<RepairRequestsPageClient />)
+      })
+
+      expect(mocks.tableMount).toHaveBeenCalledTimes(1)
+      expect(mocks.tableUnmount).not.toHaveBeenCalled()
     })
   })
 

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.race-cases.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.race-cases.ts
@@ -35,16 +35,13 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
     it('waits for targeted equipment_get before opening sheet when list settles first', async () => {
       const equipmentGetDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
 
-      mocks.callRpc
-        .mockResolvedValueOnce([])              // equipment_list: resolves immediately
-        .mockReturnValueOnce(equipmentGetDeferred.promise) // equipment_get: deferred
+      mocks.callRpc.mockReturnValueOnce(equipmentGetDeferred.promise)
 
       const sp = createSearchParams({ action: 'create', equipmentId: '42' })
       renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
 
-      // Wait for list to settle
       await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
+        expect(mocks.callRpc).toHaveBeenCalledTimes(1)
       })
 
       // Sheet must NOT have opened yet while equipment_get is still pending
@@ -64,36 +61,25 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
     })
 
-    it('opens with prefill when targeted equipment_get resolves before list is useful', async () => {
-      const listDeferred = createDeferred<Array<typeof VALID_EQUIPMENT>>()
-
-      mocks.callRpc
-        .mockReturnValueOnce(listDeferred.promise)        // equipment_list: deferred (slow)
-        .mockResolvedValueOnce(VALID_EQUIPMENT)            // equipment_get: resolves immediately
+    it('opens with prefill when targeted equipment_get resolves', async () => {
+      mocks.callRpc.mockResolvedValueOnce(VALID_EQUIPMENT)
 
       const sp = createSearchParams({ action: 'create', equipmentId: '42' })
       renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
 
-      // equipment_get resolves quickly; sheet should open with prefill
       await waitFor(() => {
         expect(mocks.openCreateSheet).toHaveBeenCalledWith(
           expect.objectContaining({ id: 42, ma_thiet_bi: 'TB042' })
         )
       })
-
-      // Cleanup: resolve the list to avoid dangling promise
-      await act(async () => {
-        listDeferred.resolve([])
-      })
+      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
     })
 
-    it('requires equipment_get even when targeted equipment is already cached from the list', async () => {
+    it('requires equipment_get when navigating from a plain page load to create intent', async () => {
       const equipmentGetDeferred = createDeferred<typeof VALID_EQUIPMENT | null>()
       const baseOpts = createDefaultOptions()
 
-      mocks.callRpc
-        .mockResolvedValueOnce([VALID_EQUIPMENT])
-        .mockReturnValueOnce(equipmentGetDeferred.promise)
+      mocks.callRpc.mockReturnValueOnce(equipmentGetDeferred.promise)
 
       const { result, rerender } = renderHook(
         ({ currentSearchParams }) => useRepairRequestsDeepLink({
@@ -107,10 +93,8 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
         },
       )
 
-      await waitFor(() => {
-        expect(result.current.hasLoadedEquipment).toBe(true)
-      })
-      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+      expect(result.current.hasLoadedEquipment).toBe(true)
+      expect(mocks.callRpc).not.toHaveBeenCalled()
 
       act(() => {
         rerender({
@@ -119,7 +103,7 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       })
 
       await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
+        expect(mocks.callRpc).toHaveBeenCalledTimes(1)
       })
       expect(mocks.openCreateSheet).not.toHaveBeenCalled()
 
@@ -134,16 +118,12 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       })
     })
 
-    it('does not reopen the create sheet when the initial list settles after the intent is consumed', async () => {
-      const listDeferred = createDeferred<Array<typeof VALID_EQUIPMENT>>()
-
-      mocks.callRpc
-        .mockReturnValueOnce(listDeferred.promise)
-        .mockResolvedValueOnce(VALID_EQUIPMENT)
+    it('does not reopen the create sheet after the intent is consumed', async () => {
+      mocks.callRpc.mockResolvedValueOnce(VALID_EQUIPMENT)
 
       const sp = createSearchParams({ action: 'create', equipmentId: '42' })
       const opts = createDefaultOptions(sp)
-      renderHook(() => useRepairRequestsDeepLink(opts))
+      const { rerender } = renderHook(() => useRepairRequestsDeepLink(opts))
 
       await waitFor(() => {
         expect(mocks.openCreateSheet).toHaveBeenCalledTimes(1)
@@ -152,9 +132,7 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
         )
       })
 
-      await act(async () => {
-        listDeferred.resolve([VALID_EQUIPMENT])
-      })
+      rerender()
 
       await waitFor(() => {
         expect(mocks.openCreateSheet).toHaveBeenCalledTimes(1)
@@ -164,16 +142,13 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
     it('does not open a blank sheet after equipment_get reaches terminal missing state', async () => {
       const equipmentGetDeferred = createDeferred<null>()
 
-      mocks.callRpc
-        .mockResolvedValueOnce([])                          // equipment_list: immediate
-        .mockReturnValueOnce(equipmentGetDeferred.promise)  // equipment_get: deferred
+      mocks.callRpc.mockReturnValueOnce(equipmentGetDeferred.promise)
 
       const sp = createSearchParams({ action: 'create', equipmentId: '999' })
       renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
 
-      // Wait for list
       await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
+        expect(mocks.callRpc).toHaveBeenCalledTimes(1)
       })
 
       // Sheet must NOT open while equipment_get is pending
@@ -214,7 +189,6 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       const baseOpts = createDefaultOptions()
 
       mocks.callRpc
-        .mockResolvedValueOnce([])
         .mockReturnValueOnce(firstEquipmentDeferred.promise)
         .mockReturnValueOnce(secondEquipmentDeferred.promise)
 
@@ -231,7 +205,7 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       )
 
       await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
+        expect(mocks.callRpc).toHaveBeenCalledTimes(1)
       })
 
       act(() => {
@@ -241,7 +215,7 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       })
 
       await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
+        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
       })
 
       await act(async () => {
@@ -284,7 +258,6 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       const baseOpts = createDefaultOptions()
 
       mocks.callRpc
-        .mockResolvedValueOnce([])
         .mockReturnValueOnce(firstEquipmentDeferred.promise)
         .mockReturnValueOnce(secondEquipmentDeferred.promise)
 
@@ -311,7 +284,7 @@ export function registerUseRepairRequestsDeepLinkRaceCases(deps: DeepLinkRaceCas
       })
 
       await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
+        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
       })
 
       await act(async () => {

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.retry-cases.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.retry-cases.ts
@@ -37,7 +37,6 @@ export function registerUseRepairRequestsDeepLinkRetryCases(deps: DeepLinkRetryC
       const baseOpts = createDefaultOptions()
 
       mocks.callRpc
-        .mockResolvedValueOnce([])
         .mockResolvedValueOnce(null)
         .mockReturnValueOnce(retryEquipmentDeferred.promise)
 
@@ -79,7 +78,7 @@ export function registerUseRepairRequestsDeepLinkRetryCases(deps: DeepLinkRetryC
       })
 
       await waitFor(() => {
-        expect(mocks.callRpc).toHaveBeenCalledTimes(3)
+        expect(mocks.callRpc).toHaveBeenCalledTimes(2)
       })
 
       expect(mocks.openCreateSheet).not.toHaveBeenCalled()
@@ -97,8 +96,6 @@ export function registerUseRepairRequestsDeepLinkRetryCases(deps: DeepLinkRetryC
     })
 
     it('does not delay action=create without equipmentId due to resolution gating', async () => {
-      mocks.callRpc.mockResolvedValueOnce([]) // equipment_list
-
       const sp = createSearchParams({ action: 'create' })
       renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
 
@@ -107,8 +104,7 @@ export function registerUseRepairRequestsDeepLinkRetryCases(deps: DeepLinkRetryC
         expect(mocks.openCreateSheet).toHaveBeenCalledWith()
       })
 
-      // Only 1 RPC call (equipment_list), no equipment_get
-      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+      expect(mocks.callRpc).not.toHaveBeenCalled()
       expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
     })
   })

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts
@@ -3,7 +3,7 @@
  * Tests for useRepairRequestsDeepLink hook.
  *
  * Verifies:
- * - Equipment list fetch on mount
+ * - No eager equipment list fetch on mount
  * - Deep-link: ?equipmentId=X triggers equipment_get RPC
  * - Deep-link: ?status=X preselects status filter
  * - Deep-link: ?action=create opens create sheet
@@ -101,46 +101,31 @@ describe('useRepairRequestsDeepLink', () => {
     })
   })
 
-  it('fetches equipment list on mount', async () => {
-    mocks.callRpc.mockResolvedValueOnce([
-      { id: 1, ma_thiet_bi: 'TB001', ten_thiet_bi: 'Máy A', khoa_phong_quan_ly: 'Khoa 1' },
-    ])
-
+  it('does not fetch equipment options on plain page mount', () => {
     const { result } = renderHook(() =>
       useRepairRequestsDeepLink(createDefaultOptions())
     )
 
-    await waitFor(() => {
-      expect(result.current.hasLoadedEquipment).toBe(true)
-    })
-    expect(result.current.allEquipment).toHaveLength(1)
-    expect(result.current.allEquipment[0].ma_thiet_bi).toBe('TB001')
+    expect(result.current.hasLoadedEquipment).toBe(true)
+    expect(result.current.allEquipment).toEqual([])
+    expect(mocks.callRpc).not.toHaveBeenCalled()
   })
 
-  it('toasts error when equipment list fetch fails', async () => {
-    mocks.callRpc.mockRejectedValueOnce({ message: 'Network error' })
+  it('does not toast equipment option errors on plain page mount', () => {
+    mocks.callRpc.mockRejectedValue({ message: 'Network error' })
 
-    const { result } = renderHook(() =>
+    renderHook(() =>
       useRepairRequestsDeepLink(createDefaultOptions())
     )
 
-    await waitFor(() => {
-      expect(result.current.hasLoadedEquipment).toBe(true)
-    })
-    expect(mocks.toast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        variant: 'destructive',
-        description: 'Không thể tải danh sách thiết bị. Network error',
-      })
-    )
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+    expect(mocks.toast).not.toHaveBeenCalled()
   })
 
   it('fetches equipment by ID for deep-link preselect', async () => {
-    mocks.callRpc
-      .mockResolvedValueOnce([]) // equipment_list
-      .mockResolvedValueOnce({   // equipment_get
-        id: 42, ma_thiet_bi: 'TB042', ten_thiet_bi: 'Máy B', khoa_phong_quan_ly: 'Khoa 2',
-      })
+    mocks.callRpc.mockResolvedValueOnce({
+      id: 42, ma_thiet_bi: 'TB042', ten_thiet_bi: 'Máy B', khoa_phong_quan_ly: 'Khoa 2',
+    })
 
     const sp = createSearchParams({ equipmentId: '42' })
     const { result } = renderHook(() =>
@@ -150,6 +135,12 @@ describe('useRepairRequestsDeepLink', () => {
     await waitFor(() => {
       expect(result.current.allEquipment.some(eq => eq.id === 42)).toBe(true)
     })
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fn: 'equipment_get',
+        args: { p_id: 42 },
+      }),
+    )
   })
 
   it('preselects status filter from URL param', () => {
@@ -209,14 +200,12 @@ describe('useRepairRequestsDeepLink', () => {
   })
 
   it('opens the create sheet with the resolved equipment for action=create and valid equipmentId', async () => {
-    mocks.callRpc
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({
-        id: 42,
-        ma_thiet_bi: 'TB042',
-        ten_thiet_bi: 'Máy B',
-        khoa_phong_quan_ly: 'Khoa 2',
-      })
+    mocks.callRpc.mockResolvedValueOnce({
+      id: 42,
+      ma_thiet_bi: 'TB042',
+      ten_thiet_bi: 'Máy B',
+      khoa_phong_quan_ly: 'Khoa 2',
+    })
 
     const sp = createSearchParams({ action: 'create', equipmentId: '42' })
 
@@ -235,9 +224,7 @@ describe('useRepairRequestsDeepLink', () => {
   })
 
   it('does not open the create sheet when action=create has an unresolved equipmentId', async () => {
-    mocks.callRpc
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce(null)
+    mocks.callRpc.mockResolvedValueOnce(null)
 
     const sp = createSearchParams({ action: 'create', equipmentId: '999' })
 
@@ -257,9 +244,7 @@ describe('useRepairRequestsDeepLink', () => {
   })
 
   it('does not open the create sheet when equipment_get denies access', async () => {
-    mocks.callRpc
-      .mockResolvedValueOnce([])
-      .mockRejectedValueOnce({ message: 'Equipment not found or access denied' })
+    mocks.callRpc.mockRejectedValueOnce({ message: 'Equipment not found or access denied' })
 
     const sp = createSearchParams({ action: 'create', equipmentId: '999' })
 
@@ -293,13 +278,12 @@ describe('useRepairRequestsDeepLink', () => {
       )
     })
     expect(mocks.openCreateSheet).not.toHaveBeenCalled()
-    expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+    expect(mocks.callRpc).not.toHaveBeenCalled()
     expect(mocks.routerReplace).toHaveBeenCalledWith('/repair-requests', { scroll: false })
   })
 
   it('opens the detail sheet for action=view and a valid requestId without cleaning the URL on open', async () => {
     mocks.callRpc
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         id: 77,
         thiet_bi_id: 42,
@@ -351,6 +335,56 @@ describe('useRepairRequestsDeepLink', () => {
     expect(mocks.routerReplace).not.toHaveBeenCalled()
   })
 
+  it('does not fetch equipment_get for action=view when repair_request_get already includes equipment', async () => {
+    mocks.callRpc.mockResolvedValueOnce({
+      id: 77,
+      thiet_bi_id: 42,
+      ngay_yeu_cau: '2026-04-28',
+      trang_thai: 'Chờ xử lý',
+      mo_ta_su_co: 'Mất nguồn',
+      hang_muc_sua_chua: null,
+      ngay_mong_muon_hoan_thanh: null,
+      nguoi_yeu_cau: 'Nguyen Van A',
+      ngay_duyet: null,
+      ngay_hoan_thanh: null,
+      nguoi_duyet: null,
+      nguoi_xac_nhan: null,
+      chi_phi_sua_chua: null,
+      don_vi_thuc_hien: null,
+      ten_don_vi_thue: null,
+      ket_qua_sua_chua: null,
+      ly_do_khong_hoan_thanh: null,
+      thiet_bi: {
+        ma_thiet_bi: 'TB042',
+        ten_thiet_bi: 'Máy B',
+        model: 'Model X',
+        serial: 'SER-42',
+        khoa_phong_quan_ly: 'Khoa 2',
+        facility_id: 9,
+      },
+    })
+
+    const sp = createSearchParams({ action: 'view', requestId: '77' })
+
+    renderHook(() => useRepairRequestsDeepLink(createDefaultOptions(sp)))
+
+    await waitFor(() => {
+      expect(mocks.openViewDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 77,
+          thiet_bi: expect.objectContaining({
+            ma_thiet_bi: 'TB042',
+            facility_id: 9,
+          }),
+        }),
+      )
+    })
+    expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+    expect(mocks.callRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fn: 'equipment_get' }),
+    )
+  })
+
   it('toasts and cleans only action/requestId when action=view has an invalid requestId', async () => {
     const sp = createSearchParams({ action: 'view', requestId: 'abc', foo: 'bar' })
 
@@ -370,9 +404,7 @@ describe('useRepairRequestsDeepLink', () => {
   })
 
   it('toasts and cleans only action/requestId when action=view cannot resolve the request', async () => {
-    mocks.callRpc
-      .mockResolvedValueOnce([])
-      .mockRejectedValueOnce(new Error('Yêu cầu sửa chữa không tồn tại hoặc bạn không có quyền truy cập'))
+    mocks.callRpc.mockRejectedValueOnce(new Error('Yêu cầu sửa chữa không tồn tại hoặc bạn không có quyền truy cập'))
 
     const sp = createSearchParams({ action: 'view', requestId: '999', foo: 'bar' })
 
@@ -393,7 +425,6 @@ describe('useRepairRequestsDeepLink', () => {
 
   it('opens the detail sheet with thiet_bi null when equipment_get is denied after request resolution', async () => {
     mocks.callRpc
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         id: 77,
         thiet_bi_id: 42,
@@ -438,7 +469,6 @@ describe('useRepairRequestsDeepLink', () => {
 
   it('cleans only action/requestId after the URL-driven detail sheet closes', async () => {
     mocks.callRpc
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         id: 77,
         thiet_bi_id: 42,

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -191,10 +191,10 @@ function RepairRequestsPageClientInner() {
   const columns = useRepairRequestColumns(columnOptions)
   const tableData = requests;
 
-  // Stable key for table to force remount on filter changes
+  // Keep the table subtree stable across pagination/filter result-size changes.
   const tableKey = React.useMemo(() => {
-    return `${selectedFacilityId || 'all'}_${tableData.length}`;
-  }, [selectedFacilityId, tableData.length]);
+    return `${selectedFacilityId ?? 'all'}`;
+  }, [selectedFacilityId]);
 
   const pageCount = repairPagination.pageCount
 

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLink.ts
@@ -6,10 +6,7 @@ import type { RepairRequestDraftPayload } from "@/lib/ai/draft/repair-request-dr
 import type { UiFilters } from "@/lib/rr-prefs"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
 import { REPAIR_REQUEST_CREATE_ACTION } from "@/lib/repair-request-deep-link"
-import {
-  fetchRepairRequestEquipmentById,
-  fetchRepairRequestEquipmentList,
-} from "../repair-requests-equipment-rpc"
+import { fetchRepairRequestEquipmentById } from "../repair-requests-equipment-rpc"
 import {
   useRepairRequestViewDeepLink,
 } from "./useRepairRequestsDeepLinkView"
@@ -85,7 +82,7 @@ export function useRepairRequestsDeepLink(
   } = opts
 
   const [allEquipment, setAllEquipment] = React.useState<EquipmentSelectItem[]>([])
-  const [hasLoadedEquipment, setHasLoadedEquipment] = React.useState(false)
+  const hasLoadedEquipment = true
   const [isEquipmentFetchPending, setIsEquipmentFetchPending] = React.useState(false)
   const [resolution, setResolution] = React.useState<RequestedEquipmentResolution>(IDLE_RESOLUTION)
   // Track the last processed status value to prevent render loops while still
@@ -111,29 +108,6 @@ export function useRepairRequestsDeepLink(
     )
     setIsEquipmentFetchPending(inFlightEquipmentFetchCountRef.current > 0)
   }
-
-  // Initial load: fetch a small equipment list via RPC
-  React.useEffect(() => {
-    const fetchInitialData = async () => {
-      try {
-        const eq = await fetchRepairRequestEquipmentList(null, 50)
-        setAllEquipment(eq || [])
-      } catch (error: unknown) {
-        const errorMessage = getUnknownErrorMessage(error)
-        toast({
-          variant: 'destructive',
-          title: 'Lỗi',
-          description: errorMessage
-            ? `Không thể tải danh sách thiết bị. ${errorMessage}`
-            : 'Không thể tải danh sách thiết bị.',
-        })
-      } finally {
-        setHasLoadedEquipment(true)
-      }
-    }
-    fetchInitialData()
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [toast])
 
   // Handle ?status=X deep-link — separate effect to avoid competing with
   // equipmentId fetch or action=create URL cleanup.

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts
@@ -21,6 +21,8 @@ type EquipmentDetailRecord = {
   don_vi?: number | null
 }
 
+type RepairRequestEquipment = RepairRequestWithEquipment["thiet_bi"]
+
 function toPositiveInt(value: string | null) {
   if (!value) return null
 
@@ -34,6 +36,37 @@ function toNullableString(value: unknown) {
 
 function toNullableNumber(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function mapEquipmentRecord(equipment: EquipmentDetailRecord): RepairRequestEquipment {
+  return {
+    ten_thiet_bi: equipment.ten_thiet_bi ?? "",
+    ma_thiet_bi: equipment.ma_thiet_bi ?? "",
+    model: toNullableString(equipment.model),
+    serial: toNullableString(equipment.serial),
+    khoa_phong_quan_ly: toNullableString(equipment.khoa_phong_quan_ly),
+    facility_name: null,
+    facility_id: toNullableNumber(equipment.don_vi),
+  }
+}
+
+function mapEmbeddedEquipment(value: unknown): RepairRequestEquipment {
+  if (!value || typeof value !== "object") return null
+
+  const equipment = value as Record<string, unknown>
+  const maThietBi = toNullableString(equipment.ma_thiet_bi)
+  const tenThietBi = toNullableString(equipment.ten_thiet_bi)
+  if (maThietBi === null && tenThietBi === null) return null
+
+  return {
+    ten_thiet_bi: tenThietBi ?? "",
+    ma_thiet_bi: maThietBi ?? "",
+    model: toNullableString(equipment.model),
+    serial: toNullableString(equipment.serial),
+    khoa_phong_quan_ly: toNullableString(equipment.khoa_phong_quan_ly),
+    facility_name: toNullableString(equipment.facility_name),
+    facility_id: toNullableNumber(equipment.facility_id) ?? toNullableNumber(equipment.don_vi),
+  }
 }
 
 export function parseRepairRequestIdParam(value: string | null) {
@@ -61,6 +94,14 @@ export async function resolveRepairRequestView(
 
   if (!request) return null
 
+  const embeddedEquipment = mapEmbeddedEquipment(request.thiet_bi)
+  if (embeddedEquipment) {
+    return {
+      ...request,
+      thiet_bi: embeddedEquipment,
+    }
+  }
+
   let equipment: EquipmentDetailRecord | null = null
   try {
     equipment = await callRpc<EquipmentDetailRecord | null>({
@@ -73,17 +114,7 @@ export async function resolveRepairRequestView(
 
   return {
     ...request,
-    thiet_bi: equipment
-      ? {
-          ten_thiet_bi: equipment.ten_thiet_bi ?? "",
-          ma_thiet_bi: equipment.ma_thiet_bi ?? "",
-          model: toNullableString(equipment.model),
-          serial: toNullableString(equipment.serial),
-          khoa_phong_quan_ly: toNullableString(equipment.khoa_phong_quan_ly),
-          facility_name: null,
-          facility_id: toNullableNumber(equipment.don_vi),
-        }
-      : null,
+    thiet_bi: equipment ? mapEquipmentRecord(equipment) : null,
   }
 }
 


### PR DESCRIPTION
## Summary
- Removes the eager `equipment_list` RPC from plain Repair Request page mount so initial load no longer pays for equipment options until a create/equipment deep-link actually needs them.
- Reuses embedded `thiet_bi` from `repair_request_get` for `action=view&requestId=...` deep-links and only falls back to `equipment_get` when detail data is missing.
- Stabilizes the Repair Requests desktop table key so row-count changes from filtering/pagination do not remount the table subtree.

## Performance Impact
- Initial Repair Request page load drops one unnecessary RPC roundtrip: from list + counts + eager equipment options to list + counts.
- Detail deep-link flow avoids duplicate equipment fetches when the request payload already includes equipment data.
- Table interactions avoid remount churn when only the number of rows changes.

## TDD Evidence
- RED: focused tests first failed on eager equipment loading, duplicate view equipment fetch, and table remount behavior.
- GREEN: implementation updated only the covered seams after RED failures.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/useRepairRequestsDeepLink.test.ts' 'src/app/(app)/repair-requests/__tests__/RepairRequestsKpi.test.tsx'` -> 39 tests passed
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` -> 100/100, no issues

## DB / Migration Notes
- No migration was created or applied.
- Supabase MCP live DB survey showed the main opportunity for this slice was app-layer roundtrip reduction, not adding an index or bundled RPC.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes the Repair Requests page by removing eager equipment option fetches, reusing embedded equipment data on view deep-links, and stabilizing the table to avoid unnecessary remounts. This cuts initial RPCs and prevents duplicate calls for faster loads and smoother interactions.

- **Refactors**
  - Stop calling `equipment_list` on plain mounts; load equipment only for create/equipment deep-links. UI is not gated.
  - For `action=view&requestId`, use embedded `thiet_bi` from `repair_request_get`; call `equipment_get` only if details are missing.
  - Stabilize the table key (facility-based) so pagination/filter row-count changes don’t remount the table subtree.

<sup>Written for commit 3943b96fb31fd0d9e4d508eee348d1b6b2f158da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table stability—table no longer remounts during pagination or filtering, preventing unnecessary data reloads.

* **Tests**
  * Expanded coverage for deep-link navigation and equipment resolution edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->