### PR TITLE
perf: combine transfers page data loading

### DIFF
--- a/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
@@ -558,6 +558,34 @@ describe("Transfers KPI", () => {
     expect(mocks.useTransferCounts).not.toHaveBeenCalled()
   })
 
+  it("does not seed kanban initial data from a fetching page-data placeholder", () => {
+    mocks.rawViewMode = "kanban"
+    mocks.useTransferPageData.mockReturnValue({
+      data: {
+        list: null,
+        counts: {
+          totalCount: 20,
+          columnCounts: mockColumnCounts,
+        },
+        kanban: {
+          totalCount: 20,
+          columns: {},
+        },
+      },
+      isLoading: false,
+      isFetching: true,
+      isError: false,
+    })
+
+    render(<TransfersPage />)
+
+    expect(mocks.TransfersKanbanView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialData: null,
+      }),
+    )
+  })
+
   it("propagates the selected date range into the combined page-data filters", () => {
     mocks.useTransfersFilters.mockReturnValue({
       searchTerm: "",

--- a/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
@@ -472,10 +472,49 @@ describe("Transfers KPI", () => {
       expect.objectContaining({
         viewMode: "table",
         enabled: true,
+        includeCounts: true,
       }),
     )
     expect(mocks.useTransferList).not.toHaveBeenCalled()
     expect(mocks.useTransferCounts).not.toHaveBeenCalled()
+  })
+
+  it("skips page-invariant counts when only table pagination changes", () => {
+    mocks.useServerPagination
+      .mockReturnValueOnce({
+        page: 1,
+        pageSize: 10,
+        pagination: {
+          pageIndex: 0,
+          pageSize: 10,
+        },
+        setPagination: vi.fn(),
+        pageCount: 2,
+      })
+      .mockReturnValueOnce({
+        page: 2,
+        pageSize: 10,
+        pagination: {
+          pageIndex: 1,
+          pageSize: 10,
+        },
+        setPagination: vi.fn(),
+        pageCount: 2,
+      })
+
+    const { rerender } = render(<TransfersPage />)
+    rerender(<TransfersPage />)
+
+    expect(mocks.useTransferPageData).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ page: 1, pageSize: 10 }),
+      expect.objectContaining({ includeCounts: true }),
+    )
+    expect(mocks.useTransferPageData).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ page: 2, pageSize: 10 }),
+      expect.objectContaining({ includeCounts: false }),
+    )
   })
 
   it("does not fire the table list query when kanban is the active view", () => {

--- a/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
@@ -23,6 +23,8 @@ const mocks = vi.hoisted(() => ({
   useRouter: vi.fn(),
   useQueryClient: vi.fn(),
   useTenantSelection: vi.fn(),
+  rawViewMode: "table" as "table" | "kanban",
+  useTransferPageData: vi.fn(),
   useTransferList: vi.fn(),
   useTransferCounts: vi.fn(),
   useTransferActions: vi.fn(),
@@ -34,6 +36,7 @@ const mocks = vi.hoisted(() => ({
   OverdueTransfersAlert: vi.fn(),
   TransferDetailDialog: vi.fn(),
   TransfersTableView: vi.fn(),
+  TransfersKanbanView: vi.fn(),
 }))
 
 vi.mock("next-auth/react", () => ({
@@ -85,6 +88,7 @@ vi.mock("@/app/(app)/transfers/_components/useTransfersFilters", () => ({
 }))
 
 vi.mock("@/hooks/useTransferDataGrid", () => ({
+  useTransferPageData: (...args: unknown[]) => mocks.useTransferPageData(...args),
   useTransferList: (...args: unknown[]) => mocks.useTransferList(...args),
   useTransferCounts: (...args: unknown[]) => mocks.useTransferCounts(...args),
   transferDataGridKeys: {
@@ -164,12 +168,15 @@ vi.mock("@/components/transfers/TransfersTableView", () => ({
 }))
 
 vi.mock("@/components/transfers/TransfersKanbanView", () => ({
-  TransfersKanbanView: () => <div data-testid="transfers-kanban-view" />,
+  TransfersKanbanView: (props: unknown) => {
+    mocks.TransfersKanbanView(props)
+    return <div data-testid="transfers-kanban-view" />
+  },
 }))
 
 vi.mock("@/components/transfers/TransfersViewToggle", () => ({
   TransfersViewToggle: () => <div data-testid="transfers-view-toggle" />,
-  useTransfersViewMode: () => ["table", vi.fn()],
+  useTransfersViewMode: () => [mocks.rawViewMode, vi.fn()],
 }))
 
 vi.mock("@/components/transfers/TransfersTenantSelectionPlaceholder", () => ({
@@ -181,6 +188,7 @@ import TransfersPage from "@/app/(app)/transfers/page"
 describe("Transfers KPI", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.rawViewMode = "table"
 
     mocks.useSession.mockReturnValue({
       data: {
@@ -237,6 +245,25 @@ describe("Transfers KPI", () => {
       handleClearAllFilters: vi.fn(),
       handleRemoveFilter: vi.fn(),
       activeFilterCount: 0,
+    })
+
+    mocks.useTransferPageData.mockReturnValue({
+      data: {
+        list: {
+          data: [],
+          total: 20,
+          page: 1,
+          pageSize: 10,
+        },
+        counts: {
+          totalCount: 20,
+          columnCounts: mockColumnCounts,
+        },
+        kanban: null,
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
     })
 
     mocks.useTransferList.mockReturnValue({
@@ -347,9 +374,11 @@ describe("Transfers KPI", () => {
   })
 
   it("passes loading state", () => {
-    mocks.useTransferCounts.mockReturnValue({
+    mocks.useTransferPageData.mockReturnValue({
       data: undefined,
       isLoading: true,
+      isFetching: false,
+      isError: false,
     })
 
     render(<TransfersPage />)
@@ -362,9 +391,19 @@ describe("Transfers KPI", () => {
   })
 
   it("handles undefined statusCounts", () => {
-    mocks.useTransferCounts.mockReturnValue({
-      data: undefined,
+    mocks.useTransferPageData.mockReturnValue({
+      data: {
+        list: {
+          data: [],
+          total: 0,
+          page: 1,
+          pageSize: 10,
+        },
+        counts: undefined,
+        kanban: null,
+      },
       isLoading: false,
+      isFetching: false,
       isError: false,
     })
 
@@ -378,9 +417,10 @@ describe("Transfers KPI", () => {
   })
 
   it("passes error state when transfer counts query fails", () => {
-    mocks.useTransferCounts.mockReturnValue({
+    mocks.useTransferPageData.mockReturnValue({
       data: undefined,
       isLoading: false,
+      isFetching: false,
       isError: true,
     })
 
@@ -420,7 +460,66 @@ describe("Transfers KPI", () => {
     expect(tableProps).not.toHaveProperty("onSortingChange")
   })
 
-  it("propagates the selected date range into transfer list filters", () => {
+  it("uses the combined page-data query instead of separate list and count queries", () => {
+    render(<TransfersPage />)
+
+    expect(mocks.useTransferPageData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        types: ["noi_bo"],
+        page: 1,
+        pageSize: 10,
+      }),
+      expect.objectContaining({
+        viewMode: "table",
+        enabled: true,
+      }),
+    )
+    expect(mocks.useTransferList).not.toHaveBeenCalled()
+    expect(mocks.useTransferCounts).not.toHaveBeenCalled()
+  })
+
+  it("does not fire the table list query when kanban is the active view", () => {
+    mocks.rawViewMode = "kanban"
+    mocks.useTransferPageData.mockReturnValue({
+      data: {
+        list: null,
+        counts: {
+          totalCount: 20,
+          columnCounts: mockColumnCounts,
+        },
+        kanban: {
+          totalCount: 20,
+          columns: {},
+        },
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    })
+
+    render(<TransfersPage />)
+
+    expect(screen.getByTestId("transfers-kanban-view")).toBeInTheDocument()
+    expect(mocks.TransfersKanbanView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialData: {
+          totalCount: 20,
+          columns: {},
+        },
+      }),
+    )
+    expect(mocks.useTransferPageData).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        viewMode: "kanban",
+        enabled: true,
+      }),
+    )
+    expect(mocks.useTransferList).not.toHaveBeenCalled()
+    expect(mocks.useTransferCounts).not.toHaveBeenCalled()
+  })
+
+  it("propagates the selected date range into the combined page-data filters", () => {
     mocks.useTransfersFilters.mockReturnValue({
       searchTerm: "",
       setSearchTerm: vi.fn(),
@@ -442,12 +541,13 @@ describe("Transfers KPI", () => {
 
     render(<TransfersPage />)
 
-    expect(mocks.useTransferList).toHaveBeenCalledWith(
+    expect(mocks.useTransferPageData).toHaveBeenCalledWith(
       expect.objectContaining({
         dateFrom: "2026-04-02",
         dateTo: "2026-04-05",
       }),
       expect.objectContaining({
+        viewMode: "table",
         enabled: true,
       }),
     )

--- a/src/app/(app)/transfers/_components/TransfersPageContent.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPageContent.tsx
@@ -120,6 +120,7 @@ export function TransfersPageContent({ user }: TransfersPageContentProps) {
           RowActions={controller.rowActions.RowActions}
           renderRowActions={controller.rowActions.renderRowActions}
           filters={controller.filters}
+          kanbanData={controller.kanbanData}
           userRole={controller.userRole}
           columns={controller.columns}
           pagination={controller.transferPagination.pagination}

--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -25,6 +25,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import type { DisplayContext } from "@/components/shared/DataTablePagination/types"
 import type {
   TransferCountsResponse,
+  TransferKanbanResponse,
   TransferListFilters,
   TransferListItem,
   TransferType,
@@ -35,7 +36,7 @@ import type { TransferUserRole } from "./TransfersTypes"
 type TransfersPagePanelProps = Readonly<{
   activeTab: TransferType
   onTabChange: (tab: TransferType) => void
-  transferCounts: TransferCountsResponse | undefined
+  transferCounts: TransferCountsResponse | null | undefined
   totalCount: number
   showFacilityFilter: boolean
   activeFilterCount: number
@@ -58,6 +59,7 @@ type TransfersPagePanelProps = Readonly<{
   RowActions: (props: { item: TransferListItem }) => React.ReactNode
   renderRowActions: (item: TransferListItem) => React.ReactNode
   filters: TransferListFilters
+  kanbanData?: TransferKanbanResponse | null
   userRole?: TransferUserRole
   columns: ColumnDef<TransferListItem>[]
   pagination: PaginationState
@@ -70,7 +72,7 @@ type TransfersPagePanelProps = Readonly<{
 
 function getTransferTypeCounts(
   activeTab: TransferType,
-  transferCounts: TransferCountsResponse | undefined,
+  transferCounts: TransferCountsResponse | null | undefined,
   totalCount: number,
 ) {
   const activeCount = transferCounts?.totalCount ?? totalCount
@@ -108,6 +110,7 @@ export function TransfersPagePanel({
   RowActions,
   renderRowActions,
   filters,
+  kanbanData,
   userRole,
   columns,
   pagination,
@@ -188,6 +191,7 @@ export function TransfersPagePanel({
                     onViewTransfer={onViewTransfer}
                     renderRowActions={renderRowActions}
                     statusCounts={transferCounts?.columnCounts}
+                    initialData={kanbanData}
                     userRole={userRole}
                   />
                 ) : (

--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -191,7 +191,7 @@ export function TransfersPagePanel({
                     onViewTransfer={onViewTransfer}
                     renderRowActions={renderRowActions}
                     statusCounts={transferCounts?.columnCounts}
-                    initialData={kanbanData}
+                    initialData={isListFetching ? null : kanbanData}
                     userRole={userRole}
                   />
                 ) : (

--- a/src/app/(app)/transfers/_components/useTransfersPageController.ts
+++ b/src/app/(app)/transfers/_components/useTransfersPageController.ts
@@ -180,6 +180,36 @@ export function useTransfersPageController(
     ],
   )
 
+  const countsFilterKey = React.useMemo(
+    () =>
+      JSON.stringify({
+        q: filters.q ?? null,
+        types: [...(filters.types ?? [])].sort(),
+        facilityId: filters.facilityId ?? null,
+        dateFrom: filters.dateFrom ?? null,
+        dateTo: filters.dateTo ?? null,
+        assigneeIds: [...(filters.assigneeIds ?? [])].sort((a, b) => a - b),
+        role: filters._role ?? null,
+        diaBan: filters._diaBan ?? null,
+        tenantKey: filters._tenantKey ?? null,
+      }),
+    [
+      filters._diaBan,
+      filters._role,
+      filters._tenantKey,
+      filters.assigneeIds,
+      filters.dateFrom,
+      filters.dateTo,
+      filters.facilityId,
+      filters.q,
+      filters.types,
+    ],
+  )
+  const lastCountsFilterKeyRef = React.useRef<string | null>(null)
+  const [cachedTransferCounts, setCachedTransferCounts] =
+    React.useState<TransferCountsResponse | null>(null)
+  const includeCounts = lastCountsFilterKeyRef.current !== countsFilterKey
+
   const {
     data: transferPageData,
     isLoading: isPageDataLoading,
@@ -188,14 +218,23 @@ export function useTransfersPageController(
   } = useTransferPageData(filters, {
     viewMode,
     excludeCompleted: viewMode === "kanban",
+    includeCounts,
     perColumnLimit: 30,
     placeholderData: (previous) => previous,
     enabled: shouldFetchData,
   })
 
   const transferList = transferPageData?.list
-  const transferCounts = transferPageData?.counts
+  const latestTransferCounts = transferPageData?.counts
+  const transferCounts = latestTransferCounts ?? cachedTransferCounts
   const kanbanData = transferPageData?.kanban
+
+  React.useEffect(() => {
+    if (!latestTransferCounts) return
+
+    lastCountsFilterKeyRef.current = countsFilterKey
+    setCachedTransferCounts(latestTransferCounts)
+  }, [countsFilterKey, latestTransferCounts])
 
   React.useEffect(() => {
     setTotalCount(transferList?.total ?? kanbanData?.totalCount ?? transferCounts?.totalCount ?? 0)

--- a/src/app/(app)/transfers/_components/useTransfersPageController.ts
+++ b/src/app/(app)/transfers/_components/useTransfersPageController.ts
@@ -184,7 +184,7 @@ export function useTransfersPageController(
     () =>
       JSON.stringify({
         q: filters.q ?? null,
-        types: [...(filters.types ?? [])].sort(),
+        types: [...(filters.types ?? [])].sort((left, right) => left.localeCompare(right)),
         facilityId: filters.facilityId ?? null,
         dateFrom: filters.dateFrom ?? null,
         dateTo: filters.dateTo ?? null,

--- a/src/app/(app)/transfers/_components/useTransfersPageController.ts
+++ b/src/app/(app)/transfers/_components/useTransfersPageController.ts
@@ -17,8 +17,7 @@ import { useToast } from "@/hooks/use-toast"
 import { useTransferActions } from "@/hooks/useTransferActions"
 import {
   transferDataGridKeys,
-  useTransferCounts,
-  useTransferList,
+  useTransferPageData,
 } from "@/hooks/useTransferDataGrid"
 import { useTransferTypeTab } from "@/components/transfers/TransferTypeTabs"
 import { useTransfersViewMode } from "@/components/transfers/TransfersViewToggle"
@@ -30,6 +29,8 @@ import type { TransferRequest } from "@/types/database"
 import type {
   TransferListFilters,
   TransferListItem,
+  TransferCountsResponse,
+  TransferKanbanResponse,
 } from "@/types/transfers-data-grid"
 
 import type { TransferUserRole } from "./TransfersTypes"
@@ -41,7 +42,8 @@ export type TransfersPageUser = NonNullable<ReturnType<typeof useSession>["data"
 export interface TransfersPageControllerResult {
   activeTab: ReturnType<typeof useTransferTypeTab>[0]
   setActiveTab: ReturnType<typeof useTransferTypeTab>[1]
-  transferCounts: ReturnType<typeof useTransferCounts>["data"]
+  transferCounts: TransferCountsResponse | null | undefined
+  kanbanData: TransferKanbanResponse | null | undefined
   isCountsLoading: boolean
   isCountsError: boolean
   filtersState: ReturnType<typeof useTransfersFilters>
@@ -178,31 +180,26 @@ export function useTransfersPageController(
     ],
   )
 
-  const countsFilters = React.useMemo(() => {
-    const { statuses: _statuses, page: _page, pageSize: _pageSize, ...rest } = filters
-    return rest
-  }, [filters])
-
   const {
-    data: transferList,
-    isLoading: isListLoading,
-    isFetching: isListFetching,
-  } = useTransferList(filters, {
+    data: transferPageData,
+    isLoading: isPageDataLoading,
+    isFetching: isPageDataFetching,
+    isError: isPageDataError,
+  } = useTransferPageData(filters, {
+    viewMode,
+    excludeCompleted: viewMode === "kanban",
+    perColumnLimit: 30,
     placeholderData: (previous) => previous,
     enabled: shouldFetchData,
   })
 
-  const {
-    data: transferCounts,
-    isLoading: isCountsLoading,
-    isError: isCountsError,
-  } = useTransferCounts(countsFilters, {
-    enabled: shouldFetchData,
-  })
+  const transferList = transferPageData?.list
+  const transferCounts = transferPageData?.counts
+  const kanbanData = transferPageData?.kanban
 
   React.useEffect(() => {
-    setTotalCount(transferList?.total ?? 0)
-  }, [transferList?.total])
+    setTotalCount(transferList?.total ?? kanbanData?.totalCount ?? transferCounts?.totalCount ?? 0)
+  }, [kanbanData?.totalCount, transferCounts?.totalCount, transferList?.total])
 
   const {
     approveTransfer,
@@ -298,8 +295,9 @@ export function useTransfersPageController(
     activeTab,
     setActiveTab,
     transferCounts,
-    isCountsLoading,
-    isCountsError,
+    kanbanData,
+    isCountsLoading: isPageDataLoading,
+    isCountsError: isPageDataError,
     filtersState,
     filterChipsValue,
     filterModalValue,
@@ -317,8 +315,8 @@ export function useTransfersPageController(
     showFacilityFilter,
     shouldFetchData,
     tableData,
-    isListLoading,
-    isListFetching,
+    isListLoading: isPageDataLoading,
+    isListFetching: isPageDataFetching,
     totalCount,
     referenceDate,
     filters,

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -43,6 +43,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'repair_request_active_for_equipment',
   // Transfers
   'transfer_request_list',
+  'transfer_request_page_data',
   'transfer_request_list_enhanced',
   'transfer_request_get',
   'transfer_request_create',

--- a/src/components/transfers/TransfersKanbanView.tsx
+++ b/src/components/transfers/TransfersKanbanView.tsx
@@ -13,6 +13,7 @@ import type {
   TransferListItem,
   TransferStatusCounts,
   TransferStatus,
+  TransferKanbanResponse,
 } from '@/types/transfers-data-grid'
 import { ACTIVE_TRANSFER_STATUSES, TRANSFER_STATUS_LABELS } from '@/types/transfers-data-grid'
 
@@ -21,6 +22,7 @@ interface TransfersKanbanViewProps {
   onViewTransfer: (item: TransferListItem) => void
   renderRowActions: (item: TransferListItem) => React.ReactNode
   statusCounts: TransferStatusCounts | undefined
+  initialData?: TransferKanbanResponse | null
   /**
    * User role - determines if tenant selection is required before loading.
    * Global and regional_leader users must select a facility first.
@@ -124,39 +126,99 @@ export function TransfersKanbanView({
   onViewTransfer,
   renderRowActions,
   statusCounts,
+  initialData,
   userRole,
 }: TransfersKanbanViewProps) {
   const [showCompleted, setShowCompleted] = React.useState(false)
-  // Mobile: track selected status tab
-  const [mobileSelectedStatus, setMobileSelectedStatus] = React.useState<TransferStatus>('cho_duyet')
 
-  // Reference date for overdue calculation, refreshes every minute
-  const [referenceDate, setReferenceDate] = React.useState(() => new Date())
-  React.useEffect(() => {
-    const interval = setInterval(() => {
-      setReferenceDate(new Date())
-    }, 60_000) // Refresh every minute
-    return () => clearInterval(interval)
-  }, [])
+  if (initialData && !showCompleted) {
+    return (
+      <TransfersKanbanBoard
+        data={initialData}
+        filters={filters}
+        isFetching={false}
+        isLoading={false}
+        onViewTransfer={onViewTransfer}
+        renderRowActions={renderRowActions}
+        setShowCompleted={setShowCompleted}
+        showCompleted={showCompleted}
+      />
+    )
+  }
 
-  // Initial kanban load (30 items per column)
-  // NOTE: Tenant selection check is handled by parent (page.tsx)
-  // This component assumes data fetching is already authorized
+  return (
+    <FetchedTransfersKanbanBoard
+      filters={filters}
+      onViewTransfer={onViewTransfer}
+      renderRowActions={renderRowActions}
+      setShowCompleted={setShowCompleted}
+      showCompleted={showCompleted}
+      userRole={userRole}
+    />
+  )
+}
+
+function FetchedTransfersKanbanBoard({
+  filters,
+  onViewTransfer,
+  renderRowActions,
+  setShowCompleted,
+  showCompleted,
+  userRole,
+}: Pick<TransfersKanbanViewProps, "filters" | "onViewTransfer" | "renderRowActions" | "userRole"> & {
+  setShowCompleted: React.Dispatch<React.SetStateAction<boolean>>
+  showCompleted: boolean
+}) {
   const { data, isLoading, isFetching } = useTransfersKanban(filters, {
     excludeCompleted: !showCompleted,
     perColumnLimit: 30,
     userRole,
   })
 
-  const columns = data?.columns || {}
+  return (
+    <TransfersKanbanBoard
+      data={data}
+      filters={filters}
+      isFetching={isFetching}
+      isLoading={isLoading}
+      onViewTransfer={onViewTransfer}
+      renderRowActions={renderRowActions}
+      setShowCompleted={setShowCompleted}
+      showCompleted={showCompleted}
+    />
+  )
+}
 
-  // Columns to display
+function TransfersKanbanBoard({
+  data,
+  filters,
+  isFetching,
+  isLoading,
+  onViewTransfer,
+  renderRowActions,
+  setShowCompleted,
+  showCompleted,
+}: Pick<TransfersKanbanViewProps, "filters" | "onViewTransfer" | "renderRowActions"> & {
+  data: TransferKanbanResponse | undefined
+  isFetching: boolean
+  isLoading: boolean
+  setShowCompleted: React.Dispatch<React.SetStateAction<boolean>>
+  showCompleted: boolean
+}) {
+  const [mobileSelectedStatus, setMobileSelectedStatus] = React.useState<TransferStatus>('cho_duyet')
+  const [referenceDate, setReferenceDate] = React.useState(() => new Date())
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setReferenceDate(new Date())
+    }, 60_000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const columns = data?.columns || {}
   const activeColumns: TransferStatus[] = ACTIVE_TRANSFER_STATUSES
   const allColumns = showCompleted
     ? ([...activeColumns, 'hoan_thanh'] as TransferStatus[])
     : activeColumns
-
-  // Mobile navigation helpers
   const currentMobileIndex = allColumns.indexOf(mobileSelectedStatus)
   const canGoPrev = currentMobileIndex > 0
   const canGoNext = currentMobileIndex < allColumns.length - 1
@@ -173,7 +235,6 @@ export function TransfersKanbanView({
     }
   }, [canGoNext, allColumns, currentMobileIndex])
 
-  // Reset mobile selection if current status is no longer in columns
   React.useEffect(() => {
     if (!allColumns.includes(mobileSelectedStatus)) {
       setMobileSelectedStatus(allColumns[0])
@@ -193,7 +254,6 @@ export function TransfersKanbanView({
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Header: Show Completed toggle */}
       <div className="flex justify-end">
         <Button
           variant="outline"
@@ -204,15 +264,13 @@ export function TransfersKanbanView({
         </Button>
       </div>
 
-      {/* Mobile: Status tabs with swipe navigation */}
       <div className="lg:hidden">
-        {/* Status tab bar */}
         <div className="flex items-center gap-1 mb-3 overflow-x-auto pb-2 -mx-1 px-1">
           {allColumns.map((status) => {
             const columnData = columns[status] ?? { tasks: [], total: 0 }
             const count = columnData.total || 0
             const isActive = status === mobileSelectedStatus
-            
+
             return (
               <button
                 key={status}
@@ -239,9 +297,7 @@ export function TransfersKanbanView({
           })}
         </div>
 
-        {/* Navigation arrows + single column */}
         <div className="relative">
-          {/* Left arrow */}
           <button
             onClick={goToPrevColumn}
             disabled={!canGoPrev}
@@ -256,7 +312,6 @@ export function TransfersKanbanView({
             <ChevronLeft className="h-4 w-4" />
           </button>
 
-          {/* Right arrow */}
           <button
             onClick={goToNextColumn}
             disabled={!canGoNext}
@@ -271,7 +326,6 @@ export function TransfersKanbanView({
             <ChevronRight className="h-4 w-4" />
           </button>
 
-          {/* Single column for mobile - full width */}
           <div className="min-h-[calc(100vh-380px)]">
             {(() => {
               const columnData = columns[mobileSelectedStatus] ?? { tasks: [], total: 0, hasMore: false }
@@ -290,7 +344,6 @@ export function TransfersKanbanView({
             })()}
           </div>
 
-          {/* Dot indicators */}
           <div className="flex justify-center gap-1.5 mt-3">
             {allColumns.map((status, index) => (
               <button
@@ -309,13 +362,10 @@ export function TransfersKanbanView({
         </div>
       </div>
 
-      {/* Desktop: Horizontal kanban columns */}
       <div className="hidden lg:flex gap-3 overflow-x-auto pb-4 h-[calc(100vh-300px)]" style={{
         WebkitOverflowScrolling: 'touch'
       }}>
         {allColumns.map((status) => {
-          // Handle empty columns: Backend may omit statuses with 0 items
-          // Provide defaults to ensure all columns render correctly
           const columnData = columns[status] ?? { tasks: [], total: 0, hasMore: false }
           const initialTasks = columnData.tasks || []
           const initialTotal = columnData.total || 0
@@ -335,7 +385,6 @@ export function TransfersKanbanView({
         })}
       </div>
 
-      {/* Fetching indicator */}
       {isFetching && !isLoading && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/components/transfers/TransfersKanbanView.tsx
+++ b/src/components/transfers/TransfersKanbanView.tsx
@@ -131,46 +131,9 @@ export function TransfersKanbanView({
 }: TransfersKanbanViewProps) {
   const [showCompleted, setShowCompleted] = React.useState(false)
 
-  if (initialData && !showCompleted) {
-    return (
-      <TransfersKanbanBoard
-        data={initialData}
-        filters={filters}
-        isFetching={false}
-        isLoading={false}
-        onViewTransfer={onViewTransfer}
-        renderRowActions={renderRowActions}
-        setShowCompleted={setShowCompleted}
-        showCompleted={showCompleted}
-      />
-    )
-  }
-
-  return (
-    <FetchedTransfersKanbanBoard
-      filters={filters}
-      onViewTransfer={onViewTransfer}
-      renderRowActions={renderRowActions}
-      setShowCompleted={setShowCompleted}
-      showCompleted={showCompleted}
-      userRole={userRole}
-    />
-  )
-}
-
-function FetchedTransfersKanbanBoard({
-  filters,
-  onViewTransfer,
-  renderRowActions,
-  setShowCompleted,
-  showCompleted,
-  userRole,
-}: Pick<TransfersKanbanViewProps, "filters" | "onViewTransfer" | "renderRowActions" | "userRole"> & {
-  setShowCompleted: React.Dispatch<React.SetStateAction<boolean>>
-  showCompleted: boolean
-}) {
   const { data, isLoading, isFetching } = useTransfersKanban(filters, {
     excludeCompleted: !showCompleted,
+    initialData: !showCompleted ? initialData : null,
     perColumnLimit: 30,
     userRole,
   })

--- a/src/hooks/__tests__/useTransferPageData.test.tsx
+++ b/src/hooks/__tests__/useTransferPageData.test.tsx
@@ -1,0 +1,115 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: mocks.callRpc,
+}))
+
+import { useTransferPageData } from "../useTransferDataGrid"
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe("useTransferPageData", () => {
+  beforeEach(() => {
+    mocks.callRpc.mockReset()
+  })
+
+  it("calls the combined page-data RPC with table filters", async () => {
+    mocks.callRpc.mockResolvedValueOnce({
+      viewMode: "table",
+      list: {
+        data: [],
+        total: 0,
+        page: 2,
+        pageSize: 20,
+      },
+      counts: {
+        totalCount: 0,
+        columnCounts: {
+          cho_duyet: 0,
+          da_duyet: 0,
+          dang_luan_chuyen: 0,
+          da_ban_giao: 0,
+          hoan_thanh: 0,
+        },
+      },
+      kanban: null,
+    })
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const { result } = renderHook(
+      () =>
+        useTransferPageData(
+          {
+            q: "may tho",
+            statuses: ["da_duyet", "cho_duyet"],
+            types: ["noi_bo"],
+            page: 2,
+            pageSize: 20,
+            facilityId: 7,
+            dateFrom: "2026-04-01",
+            dateTo: "2026-04-30",
+            assigneeIds: [5, 3],
+          },
+          { viewMode: "table", enabled: true },
+        ),
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.data?.viewMode).toBe("table"))
+
+    expect(mocks.callRpc).toHaveBeenCalledWith({
+      fn: "transfer_request_page_data",
+      args: {
+        p_q: "may tho",
+        p_statuses: ["cho_duyet", "da_duyet"],
+        p_types: ["noi_bo"],
+        p_page: 2,
+        p_page_size: 20,
+        p_don_vi: 7,
+        p_date_from: "2026-04-01",
+        p_date_to: "2026-04-30",
+        p_assignee_ids: [3, 5],
+        p_view_mode: "table",
+        p_per_column_limit: 30,
+        p_exclude_completed: false,
+      },
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it("does not call the combined RPC when disabled", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    renderHook(() => useTransferPageData({}, { viewMode: "kanban", enabled: false }), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await Promise.resolve()
+
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/__tests__/useTransferPageData.test.tsx
+++ b/src/hooks/__tests__/useTransferPageData.test.tsx
@@ -90,7 +90,53 @@ describe("useTransferPageData", () => {
         p_view_mode: "table",
         p_per_column_limit: 30,
         p_exclude_completed: false,
+        p_include_counts: true,
       },
+      signal: expect.any(AbortSignal),
+    })
+  })
+
+  it("can skip counts when only page data is needed", async () => {
+    mocks.callRpc.mockResolvedValueOnce({
+      viewMode: "table",
+      list: {
+        data: [],
+        total: 20,
+        page: 2,
+        pageSize: 20,
+      },
+      counts: null,
+      kanban: null,
+    })
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const { result } = renderHook(
+      () =>
+        useTransferPageData(
+          {
+            types: ["noi_bo"],
+            page: 2,
+            pageSize: 20,
+          },
+          { viewMode: "table", enabled: true, includeCounts: false },
+        ),
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    await waitFor(() => expect(result.current.data?.counts).toBeNull())
+
+    expect(mocks.callRpc).toHaveBeenCalledWith({
+      fn: "transfer_request_page_data",
+      args: expect.objectContaining({
+        p_include_counts: false,
+      }),
       signal: expect.any(AbortSignal),
     })
   })

--- a/src/hooks/__tests__/useTransfersKanban.test.tsx
+++ b/src/hooks/__tests__/useTransfersKanban.test.tsx
@@ -1,0 +1,83 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { TransferKanbanResponse } from "@/types/transfers-data-grid"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: mocks.callRpc,
+}))
+
+import { transferKanbanKeys, useTransfersKanban } from "../useTransfersKanban"
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: 0,
+        retry: false,
+      },
+    },
+  })
+}
+
+function makeKanbanResponse(totalCount: number): TransferKanbanResponse {
+  return {
+    columns: {
+      cho_duyet: { tasks: [], total: totalCount, hasMore: false },
+      da_duyet: { tasks: [], total: 0, hasMore: false },
+      dang_luan_chuyen: { tasks: [], total: 0, hasMore: false },
+      da_ban_giao: { tasks: [], total: 0, hasMore: false },
+      hoan_thanh: { tasks: [], total: 0, hasMore: false },
+    },
+    totalCount,
+  }
+}
+
+describe("useTransfersKanban", () => {
+  beforeEach(() => {
+    mocks.callRpc.mockReset()
+  })
+
+  it("uses initial page data without disabling background refresh", async () => {
+    mocks.callRpc.mockResolvedValue(makeKanbanResponse(2))
+
+    const queryClient = createQueryClient()
+    const filters = { types: ["noi_bo"] as const, facilityId: 7 }
+    const { result } = renderHook(
+      () =>
+        useTransfersKanban(
+          filters,
+          {
+            initialData: makeKanbanResponse(1),
+            perColumnLimit: 30,
+            userRole: "to_qltb",
+          },
+        ),
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    expect(result.current.data?.totalCount).toBe(1)
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: transferKanbanKeys.filtered(filters, {
+        excludeCompleted: true,
+        perColumnLimit: 30,
+      }),
+    })
+
+    expect(query?.options.refetchInterval).toBe(60_000)
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useTransferDataGrid.ts
+++ b/src/hooks/useTransferDataGrid.ts
@@ -31,6 +31,7 @@ type TransferPageDataQueryOptions = Omit<
   viewMode: ViewMode
   perColumnLimit?: number
   excludeCompleted?: boolean
+  includeCounts?: boolean
 }
 
 const sanitizeFilters = (filters: TransferListFilters = {}) => {
@@ -150,6 +151,7 @@ const fetchTransferPageData = async (
   viewMode: ViewMode,
   perColumnLimit: number,
   excludeCompleted: boolean,
+  includeCounts: boolean,
   signal?: AbortSignal,
 ): Promise<TransferPageDataResponse> => {
   const sanitized = sanitizeFilters(filters)
@@ -168,6 +170,7 @@ const fetchTransferPageData = async (
       p_view_mode: viewMode,
       p_per_column_limit: perColumnLimit,
       p_exclude_completed: excludeCompleted,
+      p_include_counts: includeCounts,
     },
     signal,
   })
@@ -184,7 +187,12 @@ export const transferDataGridKeys = {
     [...transferDataGridKeys.all, 'counts', sanitizeFilters(filters)] as const,
   pageData: (
     filters: TransferListFilters,
-    options: { viewMode: ViewMode; perColumnLimit: number; excludeCompleted: boolean },
+    options: {
+      viewMode: ViewMode
+      perColumnLimit: number
+      excludeCompleted: boolean
+      includeCounts: boolean
+    },
   ) => [...transferDataGridKeys.all, 'page-data', sanitizeFilters(filters), options] as const,
 }
 
@@ -236,6 +244,7 @@ export const useTransferPageData = (
     viewMode,
     perColumnLimit = 30,
     excludeCompleted = false,
+    includeCounts = true,
     ...queryOptions
   } = options
 
@@ -244,9 +253,10 @@ export const useTransferPageData = (
       viewMode,
       perColumnLimit,
       excludeCompleted,
+      includeCounts,
     }),
     queryFn: ({ signal }) =>
-      fetchTransferPageData(filters, viewMode, perColumnLimit, excludeCompleted, signal),
+      fetchTransferPageData(filters, viewMode, perColumnLimit, excludeCompleted, includeCounts, signal),
     staleTime: 30_000,
     gcTime: 5 * 60_000,
     refetchOnWindowFocus: false,

--- a/src/hooks/useTransferDataGrid.ts
+++ b/src/hooks/useTransferDataGrid.ts
@@ -1,10 +1,14 @@
 import { useQuery, type UseQueryOptions, useQueryClient } from "@tanstack/react-query"
 
+import { callRpc } from "@/lib/rpc-client"
 import {
   type TransferCountsResponse,
   type TransferListFilters,
   type TransferListItem,
+  type TransferPageDataResponse,
   type TransferListResponse,
+  TransferPageDataResponseSchema,
+  type ViewMode,
 } from "@/types/transfers-data-grid"
 
 const DEFAULT_PAGE = 1
@@ -19,6 +23,15 @@ type TransferCountsQueryOptions = Omit<
   UseQueryOptions<TransferCountsResponse, Error>,
   "queryKey" | "queryFn"
 >
+
+type TransferPageDataQueryOptions = Omit<
+  UseQueryOptions<TransferPageDataResponse, Error>,
+  "queryKey" | "queryFn"
+> & {
+  viewMode: ViewMode
+  perColumnLimit?: number
+  excludeCompleted?: boolean
+}
 
 const sanitizeFilters = (filters: TransferListFilters = {}) => {
   const {
@@ -132,6 +145,36 @@ const fetchTransferCounts = async (
   return (await response.json()) as TransferCountsResponse
 }
 
+const fetchTransferPageData = async (
+  filters: TransferListFilters = {},
+  viewMode: ViewMode,
+  perColumnLimit: number,
+  excludeCompleted: boolean,
+  signal?: AbortSignal,
+): Promise<TransferPageDataResponse> => {
+  const sanitized = sanitizeFilters(filters)
+  const result = await callRpc({
+    fn: "transfer_request_page_data",
+    args: {
+      p_q: sanitized.q,
+      p_statuses: sanitized.statuses.length > 0 ? sanitized.statuses : null,
+      p_types: sanitized.types.length > 0 ? sanitized.types : null,
+      p_page: sanitized.page,
+      p_page_size: sanitized.pageSize,
+      p_don_vi: sanitized.facilityId,
+      p_date_from: sanitized.dateFrom,
+      p_date_to: sanitized.dateTo,
+      p_assignee_ids: sanitized.assigneeIds.length > 0 ? sanitized.assigneeIds : null,
+      p_view_mode: viewMode,
+      p_per_column_limit: perColumnLimit,
+      p_exclude_completed: excludeCompleted,
+    },
+    signal,
+  })
+
+  return TransferPageDataResponseSchema.parse(result)
+}
+
 export const transferDataGridKeys = {
   all: ['transfers-data-grid'] as const,
   lists: () => [...transferDataGridKeys.all, 'list'] as const,
@@ -139,6 +182,10 @@ export const transferDataGridKeys = {
     [...transferDataGridKeys.lists(), sanitizeFilters(filters)] as const,
   counts: (filters: TransferListFilters) =>
     [...transferDataGridKeys.all, 'counts', sanitizeFilters(filters)] as const,
+  pageData: (
+    filters: TransferListFilters,
+    options: { viewMode: ViewMode; perColumnLimit: number; excludeCompleted: boolean },
+  ) => [...transferDataGridKeys.all, 'page-data', sanitizeFilters(filters), options] as const,
 }
 
 export {
@@ -178,6 +225,34 @@ export const useTransferCounts = (
     refetchOnWindowFocus: true,
     retry: 2,
     ...options,
+  })
+}
+
+export const useTransferPageData = (
+  filters: TransferListFilters = {},
+  options: TransferPageDataQueryOptions,
+) => {
+  const {
+    viewMode,
+    perColumnLimit = 30,
+    excludeCompleted = false,
+    ...queryOptions
+  } = options
+
+  return useQuery<TransferPageDataResponse, Error>({
+    queryKey: transferDataGridKeys.pageData(filters, {
+      viewMode,
+      perColumnLimit,
+      excludeCompleted,
+    }),
+    queryFn: ({ signal }) =>
+      fetchTransferPageData(filters, viewMode, perColumnLimit, excludeCompleted, signal),
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    placeholderData: (previousData) => previousData,
+    retry: 2,
+    ...queryOptions,
   })
 }
 

--- a/src/hooks/useTransfersKanban.ts
+++ b/src/hooks/useTransfersKanban.ts
@@ -19,6 +19,7 @@ export const transferKanbanKeys = {
 
 interface UseTransfersKanbanOptions {
   excludeCompleted?: boolean
+  initialData?: TransferKanbanResponse | null
   perColumnLimit?: number
   /**
    * For global/regional users who can access multiple tenants:
@@ -39,7 +40,7 @@ export function useTransfersKanban(
   filters: TransferListFilters,
   options: UseTransfersKanbanOptions = {}
 ) {
-  const { excludeCompleted = true, perColumnLimit = 30, userRole } = options
+  const { excludeCompleted = true, initialData, perColumnLimit = 30, userRole } = options
 
   // Multi-tenant users must select a specific tenant before fetching
   const isMultiTenantUser = isGlobalRole(userRole) || isRegionalLeaderRole(userRole)
@@ -71,6 +72,7 @@ export function useTransfersKanban(
     staleTime: 30000, // 30 seconds
     refetchInterval: 60000, // Poll every 60 seconds
     gcTime: 5 * 60 * 1000, // Garbage collect after 5 minutes of inactivity
+    initialData: initialData ?? undefined,
     // Require types AND (single-tenant user OR multi-tenant user with facility selected)
     enabled: !!filters.types && filters.types.length > 0 && shouldFetch,
   })

--- a/src/types/transfers-data-grid.ts
+++ b/src/types/transfers-data-grid.ts
@@ -95,6 +95,13 @@ export interface TransferCountsResponse {
   columnCounts: TransferStatusCounts
 }
 
+export interface TransferPageDataResponse {
+  viewMode: ViewMode
+  list: TransferListResponse | null
+  counts: TransferCountsResponse | null
+  kanban: TransferKanbanResponse | null
+}
+
 // Zod schema for equipment info validation
 export const TransferEquipmentInfoSchema = z.object({
   ten_thiet_bi: z.string().nullable(),
@@ -156,6 +163,24 @@ export const TransferKanbanResponseSchema = z.object({
     TransferKanbanColumnDataSchema
   ),
   totalCount: z.number().int().nonnegative(),
+})
+
+export const TransferCountsResponseSchema = z.object({
+  totalCount: z.number().int().nonnegative(),
+  columnCounts: z.object({
+    cho_duyet: z.number().int().nonnegative(),
+    da_duyet: z.number().int().nonnegative(),
+    dang_luan_chuyen: z.number().int().nonnegative(),
+    da_ban_giao: z.number().int().nonnegative(),
+    hoan_thanh: z.number().int().nonnegative(),
+  }),
+})
+
+export const TransferPageDataResponseSchema = z.object({
+  viewMode: z.enum(['table', 'kanban']),
+  list: TransferTableModeResponseSchema.nullable(),
+  counts: TransferCountsResponseSchema.nullable(),
+  kanban: TransferKanbanResponseSchema.nullable(),
 })
 
 // TypeScript types inferred from Zod schemas

--- a/supabase/migrations/20260502040000_add_transfer_request_page_data_rpc.sql
+++ b/supabase/migrations/20260502040000_add_transfer_request_page_data_rpc.sql
@@ -13,7 +13,8 @@ CREATE OR REPLACE FUNCTION public.transfer_request_page_data(
   p_assignee_ids bigint[] DEFAULT NULL::bigint[],
   p_view_mode text DEFAULT 'table'::text,
   p_per_column_limit integer DEFAULT 30,
-  p_exclude_completed boolean DEFAULT false
+  p_exclude_completed boolean DEFAULT false,
+  p_include_counts boolean DEFAULT true
 )
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -44,32 +45,34 @@ BEGIN
 
   p_per_column_limit := LEAST(GREATEST(COALESCE(p_per_column_limit, 30), 1), 100);
 
-  v_counts_raw := public.transfer_request_counts(
-    p_q,
-    p_don_vi,
-    p_date_from,
-    p_date_to,
-    p_types,
-    p_assignee_ids
-  );
+  IF p_include_counts THEN
+    v_counts_raw := public.transfer_request_counts(
+      p_q,
+      p_don_vi,
+      p_date_from,
+      p_date_to,
+      p_types,
+      p_assignee_ids
+    );
 
-  v_total_count :=
-    COALESCE((v_counts_raw->>'cho_duyet')::bigint, 0) +
-    COALESCE((v_counts_raw->>'da_duyet')::bigint, 0) +
-    COALESCE((v_counts_raw->>'dang_luan_chuyen')::bigint, 0) +
-    COALESCE((v_counts_raw->>'da_ban_giao')::bigint, 0) +
-    COALESCE((v_counts_raw->>'hoan_thanh')::bigint, 0);
+    v_total_count :=
+      COALESCE((v_counts_raw->>'cho_duyet')::bigint, 0) +
+      COALESCE((v_counts_raw->>'da_duyet')::bigint, 0) +
+      COALESCE((v_counts_raw->>'dang_luan_chuyen')::bigint, 0) +
+      COALESCE((v_counts_raw->>'da_ban_giao')::bigint, 0) +
+      COALESCE((v_counts_raw->>'hoan_thanh')::bigint, 0);
 
-  v_counts := jsonb_build_object(
-    'totalCount', v_total_count,
-    'columnCounts', jsonb_build_object(
-      'cho_duyet', COALESCE((v_counts_raw->>'cho_duyet')::integer, 0),
-      'da_duyet', COALESCE((v_counts_raw->>'da_duyet')::integer, 0),
-      'dang_luan_chuyen', COALESCE((v_counts_raw->>'dang_luan_chuyen')::integer, 0),
-      'da_ban_giao', COALESCE((v_counts_raw->>'da_ban_giao')::integer, 0),
-      'hoan_thanh', COALESCE((v_counts_raw->>'hoan_thanh')::integer, 0)
-    )
-  );
+    v_counts := jsonb_build_object(
+      'totalCount', v_total_count,
+      'columnCounts', jsonb_build_object(
+        'cho_duyet', COALESCE((v_counts_raw->>'cho_duyet')::integer, 0),
+        'da_duyet', COALESCE((v_counts_raw->>'da_duyet')::integer, 0),
+        'dang_luan_chuyen', COALESCE((v_counts_raw->>'dang_luan_chuyen')::integer, 0),
+        'da_ban_giao', COALESCE((v_counts_raw->>'da_ban_giao')::integer, 0),
+        'hoan_thanh', COALESCE((v_counts_raw->>'hoan_thanh')::integer, 0)
+      )
+    );
+  END IF;
 
   IF v_view_mode = 'kanban' THEN
     v_kanban := public.transfer_request_list(
@@ -124,6 +127,7 @@ GRANT EXECUTE ON FUNCTION public.transfer_request_page_data(
   bigint[],
   text,
   integer,
+  boolean,
   boolean
 ) TO authenticated;
 
@@ -139,5 +143,6 @@ REVOKE EXECUTE ON FUNCTION public.transfer_request_page_data(
   bigint[],
   text,
   integer,
+  boolean,
   boolean
 ) FROM PUBLIC;

--- a/supabase/migrations/20260502040000_add_transfer_request_page_data_rpc.sql
+++ b/supabase/migrations/20260502040000_add_transfer_request_page_data_rpc.sql
@@ -1,0 +1,143 @@
+-- Combine Transfers page list/kanban data and status counts into one client RPC.
+-- This migration is intentionally local-only until reviewed and applied via Supabase MCP.
+
+CREATE OR REPLACE FUNCTION public.transfer_request_page_data(
+  p_q text DEFAULT NULL::text,
+  p_statuses text[] DEFAULT NULL::text[],
+  p_types text[] DEFAULT NULL::text[],
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_date_from date DEFAULT NULL::date,
+  p_date_to date DEFAULT NULL::date,
+  p_assignee_ids bigint[] DEFAULT NULL::bigint[],
+  p_view_mode text DEFAULT 'table'::text,
+  p_per_column_limit integer DEFAULT 30,
+  p_exclude_completed boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role text := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id text := NULLIF(COALESCE(public._get_jwt_claim('user_id'), public._get_jwt_claim('sub')), '');
+  v_view_mode text := COALESCE(p_view_mode, 'table');
+  v_list jsonb := NULL;
+  v_kanban jsonb := NULL;
+  v_counts_raw jsonb := NULL;
+  v_counts jsonb := NULL;
+  v_total_count bigint := 0;
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_view_mode NOT IN ('table', 'kanban') THEN
+    RAISE EXCEPTION 'Invalid view mode: %', v_view_mode USING ERRCODE = '22023';
+  END IF;
+
+  p_per_column_limit := LEAST(GREATEST(COALESCE(p_per_column_limit, 30), 1), 100);
+
+  v_counts_raw := public.transfer_request_counts(
+    p_q,
+    p_don_vi,
+    p_date_from,
+    p_date_to,
+    p_types,
+    p_assignee_ids
+  );
+
+  v_total_count :=
+    COALESCE((v_counts_raw->>'cho_duyet')::bigint, 0) +
+    COALESCE((v_counts_raw->>'da_duyet')::bigint, 0) +
+    COALESCE((v_counts_raw->>'dang_luan_chuyen')::bigint, 0) +
+    COALESCE((v_counts_raw->>'da_ban_giao')::bigint, 0) +
+    COALESCE((v_counts_raw->>'hoan_thanh')::bigint, 0);
+
+  v_counts := jsonb_build_object(
+    'totalCount', v_total_count,
+    'columnCounts', jsonb_build_object(
+      'cho_duyet', COALESCE((v_counts_raw->>'cho_duyet')::integer, 0),
+      'da_duyet', COALESCE((v_counts_raw->>'da_duyet')::integer, 0),
+      'dang_luan_chuyen', COALESCE((v_counts_raw->>'dang_luan_chuyen')::integer, 0),
+      'da_ban_giao', COALESCE((v_counts_raw->>'da_ban_giao')::integer, 0),
+      'hoan_thanh', COALESCE((v_counts_raw->>'hoan_thanh')::integer, 0)
+    )
+  );
+
+  IF v_view_mode = 'kanban' THEN
+    v_kanban := public.transfer_request_list(
+      p_q,
+      NULL,
+      p_types,
+      p_page,
+      p_page_size,
+      p_don_vi,
+      p_date_from,
+      p_date_to,
+      p_assignee_ids,
+      'kanban',
+      p_per_column_limit,
+      p_exclude_completed
+    );
+  ELSE
+    v_list := public.transfer_request_list(
+      p_q,
+      p_statuses,
+      p_types,
+      p_page,
+      p_page_size,
+      p_don_vi,
+      p_date_from,
+      p_date_to,
+      p_assignee_ids,
+      'table',
+      p_per_column_limit,
+      p_exclude_completed
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'viewMode', v_view_mode,
+    'list', v_list,
+    'counts', v_counts,
+    'kanban', v_kanban
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.transfer_request_page_data(
+  text,
+  text[],
+  text[],
+  integer,
+  integer,
+  bigint,
+  date,
+  date,
+  bigint[],
+  text,
+  integer,
+  boolean
+) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.transfer_request_page_data(
+  text,
+  text[],
+  text[],
+  integer,
+  integer,
+  bigint,
+  date,
+  date,
+  bigint[],
+  text,
+  integer,
+  boolean
+) FROM PUBLIC;

--- a/supabase/tests/transfer_request_page_data_smoke.sql
+++ b/supabase/tests/transfer_request_page_data_smoke.sql
@@ -58,15 +58,19 @@ BEGIN
     NULL
   );
 
-  IF v_page->>'viewMode' <> 'table' THEN
+  IF v_page->>'viewMode' IS DISTINCT FROM 'table' THEN
     RAISE EXCEPTION 'Expected table viewMode, got %', v_page->>'viewMode';
   END IF;
 
-  IF v_page->'list' <> v_old_list THEN
+  IF NOT (v_page ? 'list') OR v_page->'list' IS DISTINCT FROM v_old_list THEN
     RAISE EXCEPTION 'Combined page list does not match transfer_request_list';
   END IF;
 
-  IF v_page->'counts'->'columnCounts' <> v_old_counts THEN
+  IF NOT (v_page ? 'counts') OR NOT (v_page->'counts' ? 'columnCounts') THEN
+    RAISE EXCEPTION 'Combined page counts payload is missing columnCounts';
+  END IF;
+
+  IF v_page->'counts'->'columnCounts' IS DISTINCT FROM v_old_counts THEN
     RAISE EXCEPTION 'Combined page counts do not match transfer_request_counts';
   END IF;
 
@@ -77,7 +81,7 @@ BEGIN
     COALESCE((v_old_counts->>'da_ban_giao')::integer, 0) +
     COALESCE((v_old_counts->>'hoan_thanh')::integer, 0);
 
-  IF COALESCE((v_page->'counts'->>'totalCount')::integer, -1) <> v_total_count THEN
+  IF COALESCE((v_page->'counts'->>'totalCount')::integer, -1) IS DISTINCT FROM v_total_count THEN
     RAISE EXCEPTION 'Combined page totalCount mismatch';
   END IF;
 END $$;
@@ -112,15 +116,19 @@ BEGIN
     true
   );
 
-  IF v_page->>'viewMode' <> 'kanban' THEN
+  IF v_page->>'viewMode' IS DISTINCT FROM 'kanban' THEN
     RAISE EXCEPTION 'Expected kanban viewMode, got %', v_page->>'viewMode';
   END IF;
 
-  IF v_page->'list' <> 'null'::jsonb THEN
+  IF NOT (v_page ? 'list') OR v_page->'list' IS DISTINCT FROM 'null'::jsonb THEN
     RAISE EXCEPTION 'Kanban page data should not include table list payload';
   END IF;
 
-  IF jsonb_typeof(v_page->'kanban'->'columns') <> 'object' THEN
+  IF NOT (v_page ? 'kanban') OR NOT (v_page->'kanban' ? 'columns') THEN
+    RAISE EXCEPTION 'Kanban page data should include kanban.columns';
+  END IF;
+
+  IF jsonb_typeof(v_page->'kanban'->'columns') IS DISTINCT FROM 'object' THEN
     RAISE EXCEPTION 'Kanban page data should include columns object';
   END IF;
 END $$;

--- a/supabase/tests/transfer_request_page_data_smoke.sql
+++ b/supabase/tests/transfer_request_page_data_smoke.sql
@@ -1,0 +1,139 @@
+-- Smoke tests for transfer_request_page_data.
+-- Run only after applying 20260502040000_add_transfer_request_page_data_rpc.sql.
+
+DO $$
+DECLARE
+  v_page jsonb;
+  v_old_list jsonb;
+  v_old_counts jsonb;
+  v_total_count integer;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'global',
+      'role', 'global',
+      'user_id', 'transfer-page-data-smoke',
+      'sub', 'transfer-page-data-smoke'
+    )::text,
+    true
+  );
+
+  v_page := public.transfer_request_page_data(
+    NULL,
+    ARRAY['cho_duyet', 'da_duyet'],
+    ARRAY['noi_bo'],
+    1,
+    10,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    'table',
+    30,
+    false
+  );
+
+  v_old_list := public.transfer_request_list(
+    NULL,
+    ARRAY['cho_duyet', 'da_duyet'],
+    ARRAY['noi_bo'],
+    1,
+    10,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    'table',
+    30,
+    false
+  );
+
+  v_old_counts := public.transfer_request_counts(
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    ARRAY['noi_bo'],
+    NULL
+  );
+
+  IF v_page->>'viewMode' <> 'table' THEN
+    RAISE EXCEPTION 'Expected table viewMode, got %', v_page->>'viewMode';
+  END IF;
+
+  IF v_page->'list' <> v_old_list THEN
+    RAISE EXCEPTION 'Combined page list does not match transfer_request_list';
+  END IF;
+
+  IF v_page->'counts'->'columnCounts' <> v_old_counts THEN
+    RAISE EXCEPTION 'Combined page counts do not match transfer_request_counts';
+  END IF;
+
+  v_total_count :=
+    COALESCE((v_old_counts->>'cho_duyet')::integer, 0) +
+    COALESCE((v_old_counts->>'da_duyet')::integer, 0) +
+    COALESCE((v_old_counts->>'dang_luan_chuyen')::integer, 0) +
+    COALESCE((v_old_counts->>'da_ban_giao')::integer, 0) +
+    COALESCE((v_old_counts->>'hoan_thanh')::integer, 0);
+
+  IF COALESCE((v_page->'counts'->>'totalCount')::integer, -1) <> v_total_count THEN
+    RAISE EXCEPTION 'Combined page totalCount mismatch';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_page jsonb;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'global',
+      'role', 'global',
+      'user_id', 'transfer-page-data-smoke',
+      'sub', 'transfer-page-data-smoke'
+    )::text,
+    true
+  );
+
+  v_page := public.transfer_request_page_data(
+    NULL,
+    NULL,
+    ARRAY['noi_bo'],
+    1,
+    10,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    'kanban',
+    5,
+    true
+  );
+
+  IF v_page->>'viewMode' <> 'kanban' THEN
+    RAISE EXCEPTION 'Expected kanban viewMode, got %', v_page->>'viewMode';
+  END IF;
+
+  IF v_page->'list' <> 'null'::jsonb THEN
+    RAISE EXCEPTION 'Kanban page data should not include table list payload';
+  END IF;
+
+  IF jsonb_typeof(v_page->'kanban'->'columns') <> 'object' THEN
+    RAISE EXCEPTION 'Kanban page data should include columns object';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  PERFORM set_config('request.jwt.claims', '{}'::text, true);
+
+  BEGIN
+    PERFORM public.transfer_request_page_data();
+    RAISE EXCEPTION 'Expected transfer_request_page_data to fail without JWT claims';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+END $$;

--- a/supabase/tests/transfer_request_page_data_smoke.sql
+++ b/supabase/tests/transfer_request_page_data_smoke.sql
@@ -134,6 +134,46 @@ BEGIN
 END $$;
 
 DO $$
+DECLARE
+  v_page jsonb;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'global',
+      'role', 'global',
+      'user_id', 'transfer-page-data-smoke',
+      'sub', 'transfer-page-data-smoke'
+    )::text,
+    true
+  );
+
+  v_page := public.transfer_request_page_data(
+    NULL,
+    ARRAY['cho_duyet'],
+    ARRAY['noi_bo'],
+    2,
+    10,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    'table',
+    30,
+    false,
+    false
+  );
+
+  IF NOT (v_page ? 'counts') OR v_page->'counts' IS DISTINCT FROM 'null'::jsonb THEN
+    RAISE EXCEPTION 'Counts should be null when p_include_counts is false';
+  END IF;
+
+  IF NOT (v_page ? 'list') OR jsonb_typeof(v_page->'list') IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'Table page data should still include list when counts are skipped';
+  END IF;
+END $$;
+
+DO $$
 BEGIN
   PERFORM set_config('request.jwt.claims', '{}'::text, true);
 


### PR DESCRIPTION
## Summary
- Add a combined Transfers page RPC contract, `transfer_request_page_data`, to return list/kanban payload plus status counts in one response.
- Update Transfers page data loading to use `useTransferPageData` instead of separate list/count hooks.
- Pass initial kanban data into `TransfersKanbanView` so the active Kanban view does not fire the extra initial `transfer_request_list` request.
- Keep legacy `/api/transfers/list`, `/api/transfers/counts`, and existing RPCs intact for compatibility.

## Performance impact
- Table mode page load moves from `transfer_request_list` + `transfer_request_counts` to one `transfer_request_page_data` call.
- Kanban mode avoids the previous table-list call from the page controller and avoids a duplicate initial kanban fetch when combined page data is present.
- Per-column infinite scroll remains lazy and still starts only after user load-more intent.

## Migration note
- Added local migration `supabase/migrations/20260502040000_add_transfer_request_page_data_rpc.sql` for review.
- Added smoke test `supabase/tests/transfer_request_page_data_smoke.sql`.
- Migration has **not** been applied to Supabase yet by request. SQL smoke test has not been run yet and should run only after explicit apply approval.

## TDD evidence
- RED focused tests failed first because `useTransferPageData` did not exist and the controller still used separate list/count queries.
- GREEN focused tests now pass and assert the combined hook contract, no separate list/count hooks from the page controller, date filter propagation, and initial Kanban payload handoff.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any` passed.
- `node scripts/npm-run.js run typecheck` passed.
- `node scripts/npm-run.js run test:run -- 'src/hooks/__tests__/useTransferPageData.test.tsx' 'src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx'` passed: 13 tests.
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` exited 0 with score 99/100; remaining warnings are heuristic: existing boolean-prop density in `TransfersPagePanel` and existing `infiniteScrollEnabled` state pattern.

## Post-apply verification still pending
- Apply migration via Supabase MCP only after explicit approval.
- Then run `supabase/tests/transfer_request_page_data_smoke.sql` via Supabase MCP `execute_sql`.
- Then run Supabase MCP advisors: security and performance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combine Transfers page data loading into one RPC and hook to cut API calls for table and kanban. Normalize transfer type ordering and cache counts to skip re-fetches on pagination; keep Kanban fast with initial data and a 60s refresh.

- **Performance**
  - Added `transfer_request_page_data` RPC returning list, status counts, and kanban in one response; allowed in `ALLOWED_FUNCTIONS`.
  - Switched to `useTransferPageData`; passed `initialData` to `TransfersKanbanView` and updated `useTransfersKanban` to accept it while keeping the 60s refresh; don’t seed when the combined query is fetching.
  - Skip counts when only table pagination changes by caching the last counts filter and toggling `includeCounts`; sort `types` with an explicit comparator for stable cache keys.

- **Migration**
  - New SQL: `supabase/migrations/20260502040000_add_transfer_request_page_data_rpc.sql` (not applied yet).
  - After approval: apply the migration, run `supabase/tests/transfer_request_page_data_smoke.sql` (includes counts-skip case), then run Supabase advisors.

<sup>Written for commit 728c5787a2474e5cdf6f75ab9c903ffadeb8bbbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single page-data fetch combining table, counts, and kanban payloads.
  * Kanban view accepts optional initial data for faster first render.

* **Improvements**
  * Fewer redundant queries; improved caching and loading state across views.
  * More consistent KPI/tab counts and correct date-range propagation across page data.
  * Kanban no longer seeds list/count queries while page-level data is loading.

* **Tests**
  * Added unit and smoke tests covering the new page-data path and kanban behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->