### PR TITLE
Fix transfer kanban infinite scroll trigger

### DIFF
--- a/src/components/transfers/TransfersKanbanView.tsx
+++ b/src/components/transfers/TransfersKanbanView.tsx
@@ -50,61 +50,26 @@ function KanbanColumnWithInfiniteScroll({
   renderRowActions: (item: TransferListItem) => React.ReactNode
   referenceDate: Date
 }) {
-  const [infiniteScrollEnabled, setInfiniteScrollEnabled] = React.useState(false)
-
-  // Track if we've done the initial fetch after enabling infinite scroll
-  const didInitialFetchRef = React.useRef(false)
-
-  // Create a stable key from filters to detect changes
-  const filtersKey = React.useMemo(() => JSON.stringify(filters), [filters])
-
-  // Reset infinite scroll state when filters change (prevents auto-fetching after filter change)
-  React.useEffect(() => {
-    setInfiniteScrollEnabled(false)
-    didInitialFetchRef.current = false
-  }, [filtersKey])
-
-  // Infinite scroll for this specific column (disabled until user scrolls near bottom)
+  // Keep the query disabled until the column asks for more rows; manual fetch starts at page 2.
   const {
     data: infiniteData,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useTransferColumnInfiniteScroll(filters, status, infiniteScrollEnabled)
-
-  // One-time fetch when infinite scroll is first enabled
-  // This handles the case where user scrolls, we enable the query, but fetchNextPage
-  // wasn't called because hasNextPage was undefined during the initial scroll trigger
-  React.useEffect(() => {
-    if (
-      infiniteScrollEnabled &&
-      hasNextPage &&
-      !isFetchingNextPage &&
-      !didInitialFetchRef.current
-    ) {
-      didInitialFetchRef.current = true
-      fetchNextPage()
-    }
-  }, [infiniteScrollEnabled, hasNextPage, isFetchingNextPage, fetchNextPage])
+  } = useTransferColumnInfiniteScroll(filters, status, false)
 
   // Merge initial kanban data with infinite scroll pages
-  const { tasks, hasMore, isLoadingMore } = useMergedColumnData(
+  const { tasks, hasMore } = useMergedColumnData(
     initialTasks,
     infiniteData?.pages,
     false
   )
 
   const handleLoadMore = React.useCallback(() => {
-    // Enable infinite scroll on first trigger (loads page 2)
-    if (!infiniteScrollEnabled) {
-      setInfiniteScrollEnabled(true)
-      return // useEffect above will handle the fetch once query is enabled
-    }
-
-    if (hasNextPage && !isFetchingNextPage) {
+    if (!isFetchingNextPage && hasNextPage !== false) {
       fetchNextPage()
     }
-  }, [infiniteScrollEnabled, hasNextPage, isFetchingNextPage, fetchNextPage])
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   return (
     <TransfersKanbanColumn

--- a/src/components/transfers/__tests__/TransfersKanbanView.infinite-scroll.test.tsx
+++ b/src/components/transfers/__tests__/TransfersKanbanView.infinite-scroll.test.tsx
@@ -1,0 +1,213 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TransfersKanbanView } from "@/components/transfers/TransfersKanbanView"
+import type {
+  TransferKanbanResponse,
+  TransferListFilters,
+  TransferListItem,
+  TransferStatus,
+} from "@/types/transfers-data-grid"
+
+const mocks = vi.hoisted(() => ({
+  fetchNextPage: vi.fn(),
+  renderColumn: vi.fn(),
+  useTransferColumnInfiniteScroll: vi.fn(),
+  useTransfersKanban: vi.fn(),
+}))
+
+vi.mock("@/hooks/useTransferDataGrid", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/useTransferDataGrid")>()
+
+  return {
+    ...actual,
+    useTransferColumnInfiniteScroll: mocks.useTransferColumnInfiniteScroll,
+    useTransfersKanban: mocks.useTransfersKanban,
+  }
+})
+
+interface MockKanbanColumnProps {
+  status: TransferStatus
+  tasks: TransferListItem[]
+  total: number
+  hasMore: boolean
+  onLoadMore?: () => void
+}
+
+vi.mock("@/components/transfers/TransfersKanbanColumn", () => ({
+  TransfersKanbanColumn: ({
+    status,
+    tasks,
+    total,
+  hasMore,
+  onLoadMore,
+}: MockKanbanColumnProps) => (
+    mocks.renderColumn({ status, tasks, total, hasMore, onLoadMore }) ?? (
+      <section data-testid={`kanban-column-${status}`}>
+        <div data-testid={`kanban-total-${status}`}>{total}</div>
+        {tasks.map((task) => (
+          <div key={task.id}>{task.ma_yeu_cau}</div>
+        ))}
+        <button
+          type="button"
+          data-testid={`load-more-${status}`}
+          disabled={!hasMore}
+          onClick={onLoadMore}
+        >
+          Load more
+        </button>
+      </section>
+    )
+  ),
+}))
+
+function makeTransferItem(
+  overrides: Partial<TransferListItem> = {},
+): TransferListItem {
+  return {
+    id: overrides.id ?? 1,
+    ma_yeu_cau: overrides.ma_yeu_cau ?? "LC-0001",
+    thiet_bi_id: overrides.thiet_bi_id ?? 1,
+    loai_hinh: overrides.loai_hinh ?? "noi_bo",
+    trang_thai: overrides.trang_thai ?? "cho_duyet",
+    nguoi_yeu_cau_id: overrides.nguoi_yeu_cau_id ?? 1,
+    ly_do_luan_chuyen: overrides.ly_do_luan_chuyen ?? "Transfer",
+    khoa_phong_hien_tai: overrides.khoa_phong_hien_tai ?? "Dept A",
+    khoa_phong_nhan: overrides.khoa_phong_nhan ?? "Dept B",
+    muc_dich: overrides.muc_dich ?? null,
+    don_vi_nhan: overrides.don_vi_nhan ?? null,
+    dia_chi_don_vi: overrides.dia_chi_don_vi ?? null,
+    nguoi_lien_he: overrides.nguoi_lien_he ?? null,
+    so_dien_thoai: overrides.so_dien_thoai ?? null,
+    ngay_du_kien_tra: overrides.ngay_du_kien_tra ?? null,
+    ngay_ban_giao: overrides.ngay_ban_giao ?? null,
+    ngay_hoan_tra: overrides.ngay_hoan_tra ?? null,
+    ngay_hoan_thanh: overrides.ngay_hoan_thanh ?? null,
+    nguoi_duyet_id: overrides.nguoi_duyet_id ?? null,
+    ngay_duyet: overrides.ngay_duyet ?? null,
+    ghi_chu_duyet: overrides.ghi_chu_duyet ?? null,
+    created_at: overrides.created_at ?? "2026-05-01T00:00:00.000Z",
+    updated_at: overrides.updated_at ?? null,
+    created_by: overrides.created_by ?? 1,
+    updated_by: overrides.updated_by ?? null,
+    thiet_bi: overrides.thiet_bi ?? {
+      ten_thiet_bi: "Device",
+      ma_thiet_bi: "TB-001",
+      model: "Model",
+      serial: "SER-001",
+      khoa_phong_quan_ly: "Dept A",
+      facility_name: "Facility",
+      facility_id: 1,
+    },
+  }
+}
+
+function makeKanbanResponse(tasks: TransferListItem[]): TransferKanbanResponse {
+  return {
+    columns: {
+      cho_duyet: { tasks, total: tasks.length + 1, hasMore: true },
+      da_duyet: { tasks: [], total: 0, hasMore: false },
+      dang_luan_chuyen: { tasks: [], total: 0, hasMore: false },
+      da_ban_giao: { tasks: [], total: 0, hasMore: false },
+      hoan_thanh: { tasks: [], total: 0, hasMore: false },
+    },
+    totalCount: tasks.length + 1,
+  }
+}
+
+function makeInitialPageTasks(): TransferListItem[] {
+  return Array.from({ length: 30 }, (_, index) =>
+    makeTransferItem({
+      id: index + 1,
+      ma_yeu_cau: `LC-PAGE-1-${index + 1}`,
+    }),
+  )
+}
+
+function renderKanbanView(filters: TransferListFilters = { types: ["noi_bo"] }) {
+  return render(
+    <TransfersKanbanView
+      filters={filters}
+      initialData={null}
+      onViewTransfer={vi.fn()}
+      renderRowActions={() => null}
+      statusCounts={undefined}
+      userRole="to_qltb"
+    />,
+  )
+}
+
+describe("TransfersKanbanView infinite scroll", () => {
+  beforeEach(() => {
+    mocks.fetchNextPage.mockReset()
+    mocks.renderColumn.mockReset()
+    mocks.useTransferColumnInfiniteScroll.mockReset()
+    mocks.useTransfersKanban.mockReset()
+    mocks.useTransfersKanban.mockReturnValue({
+      data: makeKanbanResponse(makeInitialPageTasks()),
+      isFetching: false,
+      isLoading: false,
+    })
+    mocks.useTransferColumnInfiniteScroll.mockReturnValue({
+      data: undefined,
+      fetchNextPage: mocks.fetchNextPage,
+      hasNextPage: undefined,
+      isFetchingNextPage: false,
+    })
+  })
+
+  it("fetches page 2 on the first load-more trigger without enabling auto-fetch", async () => {
+    const user = userEvent.setup()
+
+    renderKanbanView()
+
+    expect(mocks.useTransferColumnInfiniteScroll).toHaveBeenCalledWith(
+      expect.objectContaining({ types: ["noi_bo"] }),
+      "cho_duyet",
+      false,
+    )
+
+    await user.click(screen.getAllByTestId("load-more-cho_duyet")[0])
+
+    expect(mocks.fetchNextPage).toHaveBeenCalledTimes(1)
+    expect(mocks.useTransferColumnInfiniteScroll).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "cho_duyet",
+      true,
+    )
+  })
+
+  it("merges initial kanban tasks with page 2 tasks without duplicating page 1", () => {
+    const page2Task = makeTransferItem({
+      id: 31,
+      ma_yeu_cau: "LC-PAGE-2-1",
+    })
+    mocks.useTransferColumnInfiniteScroll.mockImplementation(
+      (_filters: TransferListFilters, status: TransferStatus) => ({
+        data:
+          status === "cho_duyet"
+            ? { pages: [{ data: [page2Task], hasMore: false }] }
+            : undefined,
+        fetchNextPage: mocks.fetchNextPage,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+      }),
+    )
+
+    renderKanbanView()
+
+    const choDuyetColumn = mocks.renderColumn.mock.calls
+      .map((call) => call[0] as MockKanbanColumnProps)
+      .find((props) => props.status === "cho_duyet")
+
+    expect(choDuyetColumn).toBeDefined()
+    const taskCodes = choDuyetColumn?.tasks.map((task) => task.ma_yeu_cau) ?? []
+
+    expect(taskCodes).toContain("LC-PAGE-1-1")
+    expect(taskCodes).toContain("LC-PAGE-2-1")
+    expect(taskCodes.filter((code) => code === "LC-PAGE-1-1")).toHaveLength(1)
+    expect(taskCodes).toHaveLength(31)
+  })
+})

--- a/src/hooks/__tests__/useTransfersKanban.test.tsx
+++ b/src/hooks/__tests__/useTransfersKanban.test.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import type { TransferKanbanResponse } from "@/types/transfers-data-grid"
+import type { TransferKanbanResponse, TransferListItem } from "@/types/transfers-data-grid"
 
 const mocks = vi.hoisted(() => ({
   callRpc: vi.fn(),
@@ -13,7 +13,11 @@ vi.mock("@/lib/rpc-client", () => ({
   callRpc: mocks.callRpc,
 }))
 
-import { transferKanbanKeys, useTransfersKanban } from "../useTransfersKanban"
+import {
+  transferKanbanKeys,
+  useTransferColumnInfiniteScroll,
+  useTransfersKanban,
+} from "../useTransfersKanban"
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
@@ -42,6 +46,47 @@ function makeKanbanResponse(totalCount: number): TransferKanbanResponse {
       hoan_thanh: { tasks: [], total: 0, hasMore: false },
     },
     totalCount,
+  }
+}
+
+function makeTransferListItem(
+  overrides: Partial<TransferListItem> = {},
+): TransferListItem {
+  return {
+    id: overrides.id ?? 42,
+    ma_yeu_cau: overrides.ma_yeu_cau ?? "LC-0042",
+    thiet_bi_id: overrides.thiet_bi_id ?? 7,
+    loai_hinh: overrides.loai_hinh ?? "noi_bo",
+    trang_thai: overrides.trang_thai ?? "cho_duyet",
+    nguoi_yeu_cau_id: overrides.nguoi_yeu_cau_id ?? 1,
+    ly_do_luan_chuyen: overrides.ly_do_luan_chuyen ?? "Transfer",
+    khoa_phong_hien_tai: overrides.khoa_phong_hien_tai ?? "Dept A",
+    khoa_phong_nhan: overrides.khoa_phong_nhan ?? "Dept B",
+    muc_dich: overrides.muc_dich ?? null,
+    don_vi_nhan: overrides.don_vi_nhan ?? null,
+    dia_chi_don_vi: overrides.dia_chi_don_vi ?? null,
+    nguoi_lien_he: overrides.nguoi_lien_he ?? null,
+    so_dien_thoai: overrides.so_dien_thoai ?? null,
+    ngay_du_kien_tra: overrides.ngay_du_kien_tra ?? null,
+    ngay_ban_giao: overrides.ngay_ban_giao ?? null,
+    ngay_hoan_tra: overrides.ngay_hoan_tra ?? null,
+    ngay_hoan_thanh: overrides.ngay_hoan_thanh ?? null,
+    nguoi_duyet_id: overrides.nguoi_duyet_id ?? null,
+    ngay_duyet: overrides.ngay_duyet ?? null,
+    ghi_chu_duyet: overrides.ghi_chu_duyet ?? null,
+    created_at: overrides.created_at ?? "2026-05-01T00:00:00.000Z",
+    updated_at: overrides.updated_at ?? null,
+    created_by: overrides.created_by ?? 1,
+    updated_by: overrides.updated_by ?? null,
+    thiet_bi: overrides.thiet_bi ?? {
+      ten_thiet_bi: "Device",
+      ma_thiet_bi: "TB-007",
+      model: "Model",
+      serial: "SER-007",
+      khoa_phong_quan_ly: "Dept A",
+      facility_name: "Facility",
+      facility_id: 7,
+    },
   }
 }
 
@@ -79,5 +124,37 @@ describe("useTransfersKanban", () => {
 
     expect(query?.options.refetchInterval).toBe(60_000)
     expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+
+  it("fetches page 2 first when column infinite scroll is triggered manually", async () => {
+    mocks.callRpc.mockResolvedValue({
+      data: [makeTransferListItem()],
+      total: 31,
+      page: 2,
+      pageSize: 30,
+    })
+
+    const queryClient = createQueryClient()
+    const filters = { types: ["noi_bo"] as const, facilityId: 7 }
+    const { result } = renderHook(
+      () => useTransferColumnInfiniteScroll(filters, "cho_duyet", false),
+      { wrapper: createWrapper(queryClient) },
+    )
+
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+
+    await result.current.fetchNextPage()
+
+    await waitFor(() => {
+      expect(mocks.callRpc).toHaveBeenCalledWith({
+        fn: "transfer_request_list",
+        args: expect.objectContaining({
+          p_page: 2,
+          p_page_size: 30,
+          p_statuses: ["cho_duyet"],
+          p_view_mode: "table",
+        }),
+      })
+    })
   })
 })


### PR DESCRIPTION
## Summary
- remove the `infiniteScrollEnabled` state/effect handoff in `TransfersKanbanView`
- keep the per-column infinite query disabled and fetch page 2 manually from the load-more trigger
- add focused regression coverage for first trigger behavior, page-2 RPC args, and no duplicate page-1 merge

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/transfers/__tests__/TransfersKanbanView.infinite-scroll.test.tsx src/hooks/__tests__/useTransfersKanban.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

Closes #362

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Transfers Kanban infinite scroll: the first “Load more” now fetches page 2 per column, and we removed the auto-enable handoff to prevent missed fetches and duplicate page-1 merges. Aligns with #362.

- **Bug Fixes**
  - Removed `infiniteScrollEnabled` state/effect from `TransfersKanbanView`.
  - Kept per-column infinite query disabled and triggered `fetchNextPage()` on click when not fetching and `hasNextPage !== false`.
  - Ensured merge combines initial tasks with later pages without duplicating page 1; added tests for first trigger and correct RPC args (page 2).

<sup>Written for commit cdabcd509c1be8c19f47c86bbbc20066c9d8a5a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

