### PR TITLE
fix(auth): jwt-callback profile refresh cooldown + update-trigger gate (Phase 1 of #365)

### DIFF
--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -22,7 +22,10 @@ const profileRowDefault: ProfileRow = {
 const supabaseState = vi.hoisted(() => ({
   fromCalls: [] as string[],
   profileRow: null as unknown,
+  donViRows: [] as unknown[],
+  donViError: null as unknown,
   diaBanMaRows: [] as unknown[],
+  diaBanError: null as unknown,
 }))
 
 const supabaseClient = vi.hoisted(() => ({
@@ -40,13 +43,25 @@ const supabaseClient = vi.hoisted(() => ({
         }),
       }
     }
+    if (table === "don_vi") {
+      return {
+        select: () => ({
+          eq: () => ({
+            limit: vi.fn(async () => ({
+              data: supabaseState.donViError ? null : supabaseState.donViRows,
+              error: supabaseState.donViError,
+            })),
+          }),
+        }),
+      }
+    }
     if (table === "dia_ban") {
       return {
         select: () => ({
           eq: () => ({
             limit: vi.fn(async () => ({
-              data: supabaseState.diaBanMaRows,
-              error: null,
+              data: supabaseState.diaBanError ? null : supabaseState.diaBanMaRows,
+              error: supabaseState.diaBanError,
             })),
           }),
         }),
@@ -104,7 +119,10 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key")
     supabaseState.fromCalls = []
     supabaseState.profileRow = { ...profileRowDefault }
+    supabaseState.donViRows = [{ dia_ban_id: 9 }]
+    supabaseState.donViError = null
     supabaseState.diaBanMaRows = [{ ma_dia_ban: "HN-01" }]
+    supabaseState.diaBanError = null
     supabaseClient.from.mockClear()
   })
 
@@ -231,5 +249,68 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
       id: "42",
       lastRefreshAt: now - 5 * 60_000, // still the old value
     })
+  })
+
+  it("logs and skips lastRefreshAt stamp when don_vi secondary lookup returns an error", async () => {
+    const now = Date.now()
+    // Primary row forces the don_vi lookup: dia_ban_id null but don_vi set
+    supabaseState.profileRow = {
+      ...profileRowDefault,
+      dia_ban_id: null,
+      current_don_vi: 17,
+      don_vi: 17,
+    }
+    supabaseState.donViError = { message: "don_vi table boom" }
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const prevRefresh = now - 5 * 60_000
+
+    const token = {
+      ...baseToken,
+      dia_ban_id: null,
+      loginTime: now - 60 * 60_000,
+      lastRefreshAt: prevRefresh,
+    }
+
+    const result = await runJwt({ token })
+
+    expect(supabaseState.fromCalls).toContain("don_vi")
+    expect(warnSpy).toHaveBeenCalled()
+    const logged = warnSpy.mock.calls
+      .map((args) => args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "))
+      .join("\n")
+    expect(logged).toMatch(/don_vi/)
+    expect(result).toMatchObject({
+      id: "42",
+      lastRefreshAt: prevRefresh, // not advanced
+    })
+    warnSpy.mockRestore()
+  })
+
+  it("logs and skips lastRefreshAt stamp when dia_ban secondary lookup returns an error", async () => {
+    const now = Date.now()
+    supabaseState.diaBanError = { message: "dia_ban table boom" }
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const prevRefresh = now - 5 * 60_000
+
+    const token = {
+      ...baseToken,
+      dia_ban_ma: null, // ensure the dia_ban lookup runs
+      loginTime: now - 60 * 60_000,
+      lastRefreshAt: prevRefresh,
+    }
+
+    const result = await runJwt({ token })
+
+    expect(supabaseState.fromCalls).toContain("dia_ban")
+    expect(warnSpy).toHaveBeenCalled()
+    const logged = warnSpy.mock.calls
+      .map((args) => args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "))
+      .join("\n")
+    expect(logged).toMatch(/dia_ban/)
+    expect(result).toMatchObject({
+      id: "42",
+      lastRefreshAt: prevRefresh, // not advanced
+    })
+    warnSpy.mockRestore()
   })
 })

--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -19,6 +19,21 @@ const profileRowDefault: ProfileRow = {
   dia_ban_id: 9,
 }
 
+type QueryResult = { data: unknown; error: unknown }
+type Resolver = () => Promise<QueryResult>
+
+// Build the chain `from(table).select().eq(...).single|limit(...)` from a
+// single async resolver so the deepest user code sits at one level of nesting
+// instead of four. Tests configure responses through `supabaseState` below.
+function buildChain(resolver: Resolver, method: "single" | "limit") {
+  const terminal = vi.fn(resolver)
+  return {
+    select: () => ({
+      eq: () => ({ [method]: terminal }),
+    }),
+  }
+}
+
 const supabaseState = vi.hoisted(() => ({
   fromCalls: [] as string[],
   profileRow: null as unknown,
@@ -28,50 +43,34 @@ const supabaseState = vi.hoisted(() => ({
   diaBanError: null as unknown,
 }))
 
+const resolvers = vi.hoisted(() => ({
+  nhanVien: async () => ({
+    data: supabaseState.profileRow,
+    error: supabaseState.profileRow ? null : { message: "no row" },
+  }),
+  donVi: async () => ({
+    data: supabaseState.donViError ? null : supabaseState.donViRows,
+    error: supabaseState.donViError,
+  }),
+  diaBan: async () => ({
+    data: supabaseState.diaBanError ? null : supabaseState.diaBanMaRows,
+    error: supabaseState.diaBanError,
+  }),
+  unknownLimit: async () => ({ data: [], error: null }),
+  unknownSingle: async () => ({ data: null, error: null }),
+}))
+
 const supabaseClient = vi.hoisted(() => ({
   from: vi.fn((table: string) => {
     supabaseState.fromCalls.push(table)
-    if (table === "nhan_vien") {
-      return {
-        select: () => ({
-          eq: () => ({
-            single: vi.fn(async () => ({
-              data: supabaseState.profileRow,
-              error: supabaseState.profileRow ? null : { message: "no row" },
-            })),
-          }),
-        }),
-      }
-    }
-    if (table === "don_vi") {
-      return {
-        select: () => ({
-          eq: () => ({
-            limit: vi.fn(async () => ({
-              data: supabaseState.donViError ? null : supabaseState.donViRows,
-              error: supabaseState.donViError,
-            })),
-          }),
-        }),
-      }
-    }
-    if (table === "dia_ban") {
-      return {
-        select: () => ({
-          eq: () => ({
-            limit: vi.fn(async () => ({
-              data: supabaseState.diaBanError ? null : supabaseState.diaBanMaRows,
-              error: supabaseState.diaBanError,
-            })),
-          }),
-        }),
-      }
-    }
+    if (table === "nhan_vien") return buildChain(resolvers.nhanVien, "single")
+    if (table === "don_vi") return buildChain(resolvers.donVi, "limit")
+    if (table === "dia_ban") return buildChain(resolvers.diaBan, "limit")
     return {
       select: () => ({
         eq: () => ({
-          limit: vi.fn(async () => ({ data: [], error: null })),
-          single: vi.fn(async () => ({ data: null, error: null })),
+          limit: vi.fn(resolvers.unknownLimit),
+          single: vi.fn(resolvers.unknownSingle),
         }),
       }),
     }

--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// Build a chainable Supabase mock that records every .from() call.
+type ProfileRow = {
+  password_changed_at: string | null
+  current_don_vi: number | null
+  don_vi: number | null
+  khoa_phong: string | null
+  full_name: string | null
+  dia_ban_id: number | null
+}
+
+const profileRowDefault: ProfileRow = {
+  password_changed_at: null,
+  current_don_vi: 17,
+  don_vi: 17,
+  khoa_phong: "KT",
+  full_name: "Nguyen Quang Minh",
+  dia_ban_id: 9,
+}
+
+const supabaseState = vi.hoisted(() => ({
+  fromCalls: [] as string[],
+  profileRow: null as unknown,
+  diaBanMaRows: [] as unknown[],
+}))
+
+const supabaseClient = vi.hoisted(() => ({
+  from: vi.fn((table: string) => {
+    supabaseState.fromCalls.push(table)
+    if (table === "nhan_vien") {
+      return {
+        select: () => ({
+          eq: () => ({
+            single: vi.fn(async () => ({
+              data: supabaseState.profileRow,
+              error: supabaseState.profileRow ? null : { message: "no row" },
+            })),
+          }),
+        }),
+      }
+    }
+    if (table === "dia_ban") {
+      return {
+        select: () => ({
+          eq: () => ({
+            limit: vi.fn(async () => ({
+              data: supabaseState.diaBanMaRows,
+              error: null,
+            })),
+          }),
+        }),
+      }
+    }
+    return {
+      select: () => ({
+        eq: () => ({
+          limit: vi.fn(async () => ({ data: [], error: null })),
+          single: vi.fn(async () => ({ data: null, error: null })),
+        }),
+      }),
+    }
+  }),
+}))
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => supabaseClient),
+}))
+
+import { authOptions } from "@/auth/config"
+
+type JwtCb = NonNullable<NonNullable<typeof authOptions.callbacks>["jwt"]>
+type JwtArgs = Parameters<JwtCb>[0]
+
+const baseToken = {
+  id: "42",
+  username: "nqminh",
+  role: "to_qltb",
+  khoa_phong: "KT",
+  don_vi: 17,
+  dia_ban_id: 9,
+  full_name: "Nguyen Quang Minh",
+  auth_mode: "dual_mode",
+}
+
+async function runJwt(args: Partial<JwtArgs> & Pick<JwtArgs, "token">) {
+  const cb = authOptions.callbacks?.jwt
+  if (!cb) throw new Error("jwt callback not configured")
+  return cb({
+    account: null,
+    profile: undefined,
+    isNewUser: undefined,
+    session: undefined,
+    trigger: undefined,
+    ...args,
+  } as JwtArgs)
+}
+
+describe("authOptions.jwt cooldown + trigger gate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-05-02T12:00:00Z"))
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co")
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key")
+    supabaseState.fromCalls = []
+    supabaseState.profileRow = { ...profileRowDefault }
+    supabaseState.diaBanMaRows = [{ ma_dia_ban: "HN-01" }]
+    supabaseClient.from.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it("fetches profile on sign-in and stamps lastRefreshAt + loginTime", async () => {
+    const result = await runJwt({
+      token: { ...baseToken },
+      user: { ...baseToken } as JwtArgs["user"],
+    })
+
+    expect(supabaseState.fromCalls).toContain("nhan_vien")
+    expect(result).toMatchObject({
+      id: "42",
+      username: "nqminh",
+      loginTime: Date.now(),
+      lastRefreshAt: Date.now(),
+    })
+  })
+
+  it("skips DB fetch on subsequent calls within cooldown window", async () => {
+    const now = Date.now()
+    supabaseState.fromCalls = []
+    supabaseClient.from.mockClear()
+
+    const token = {
+      ...baseToken,
+      loginTime: now - 30_000, // 30s ago
+      lastRefreshAt: now - 30_000, // refreshed 30s ago, well inside cooldown
+    }
+
+    const result = await runJwt({ token })
+
+    expect(supabaseClient.from).not.toHaveBeenCalled()
+    expect(supabaseState.fromCalls).toEqual([])
+    expect(result).toMatchObject({
+      id: "42",
+      lastRefreshAt: now - 30_000, // unchanged
+    })
+  })
+
+  it("re-fetches when cooldown has elapsed", async () => {
+    const now = Date.now()
+    const token = {
+      ...baseToken,
+      loginTime: now - 5 * 60_000,
+      lastRefreshAt: now - 5 * 60_000, // 5 minutes ago
+    }
+
+    const result = await runJwt({ token })
+
+    expect(supabaseClient.from).toHaveBeenCalled()
+    expect(supabaseState.fromCalls).toContain("nhan_vien")
+    expect(result).toMatchObject({ lastRefreshAt: now })
+  })
+
+  it("force-refreshes when trigger === 'update' even within cooldown", async () => {
+    const now = Date.now()
+    supabaseState.profileRow = {
+      ...profileRowDefault,
+      current_don_vi: 99,
+      don_vi: 99,
+    }
+    const token = {
+      ...baseToken,
+      loginTime: now - 10_000,
+      lastRefreshAt: now - 10_000,
+    }
+
+    const result = await runJwt({ token, trigger: "update" })
+
+    expect(supabaseClient.from).toHaveBeenCalled()
+    expect(result).toMatchObject({
+      don_vi: 99,
+      lastRefreshAt: now,
+    })
+  })
+
+  it("returns the token untouched when token has no id (anonymous)", async () => {
+    const result = await runJwt({ token: { name: "anon" } as JwtArgs["token"] })
+
+    expect(supabaseClient.from).not.toHaveBeenCalled()
+    expect(result).toEqual({ name: "anon" })
+  })
+
+  it("invalidates token when password_changed_at is after loginTime (no cooldown bypass)", async () => {
+    const now = Date.now()
+    const loginTime = now - 60 * 60_000 // 1h ago
+    const passwordChangedAt = new Date(now - 5 * 60_000).toISOString() // 5min ago
+    supabaseState.profileRow = {
+      ...profileRowDefault,
+      password_changed_at: passwordChangedAt,
+    }
+
+    const token = {
+      ...baseToken,
+      loginTime,
+      lastRefreshAt: now - 5 * 60_000, // cooldown elapsed → fetch runs
+    }
+
+    const result = await runJwt({ token })
+
+    expect(supabaseClient.from).toHaveBeenCalled()
+    expect(result).toEqual({})
+  })
+
+  it("does not advance lastRefreshAt when the profile fetch fails", async () => {
+    const now = Date.now()
+    supabaseState.profileRow = null // forces error path
+
+    const token = {
+      ...baseToken,
+      loginTime: now - 5 * 60_000,
+      lastRefreshAt: now - 5 * 60_000,
+    }
+
+    const result = await runJwt({ token })
+
+    expect(supabaseClient.from).toHaveBeenCalled()
+    expect(result).toMatchObject({
+      id: "42",
+      lastRefreshAt: now - 5 * 60_000, // still the old value
+    })
+  })
+})

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -10,6 +10,18 @@ import {
   type AuthRpcUserRow,
 } from "./types"
 
+// Cooldown for the per-request profile refresh in the jwt callback.
+// Without this gate the callback issues 1-3 Supabase SELECTs on every
+// invocation (page render, getServerSession call, useSession poll, …),
+// which scales with traffic, not with auth-state changes. See issue #365.
+//
+// Trade-off: out-of-band invalidations (password change, tenant deactivation)
+// are visible only after the cooldown elapses or after an explicit
+// `trigger === 'update'` (e.g. tenant switch). 60s is intentionally short
+// enough to keep the password-change story acceptable while cutting DB
+// load to ~1 fetch / minute / active session.
+const PROFILE_REFRESH_INTERVAL_MS = 60_000
+
 export const authOptions: NextAuthOptions = {
   session: {
     strategy: "jwt",
@@ -76,83 +88,103 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger }) {
+      const now = Date.now()
+
       // On sign-in, persist extra fields in the JWT
       if (user) {
         token = {
           ...applyAuthUserToJwt(token, user),
-          loginTime: Date.now(), // Track when user logged in
+          loginTime: now, // Track when user logged in
         }
       }
 
-      // Refresh user-derived fields on every JWT callback
-      if (token.id) {
-        try {
-          const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-          const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-          if (supabaseUrl && serviceKey) {
-            const supabase = createClient(supabaseUrl, serviceKey)
-            const { data, error } = await supabase
-              .from("nhan_vien")
-              .select("password_changed_at, current_don_vi, don_vi, khoa_phong, full_name, dia_ban_id")
-              .eq("id", token.id)
-              .single()
+      if (!token.id) {
+        return token
+      }
 
-            if (!error && data) {
-              const profile = data as AuthProfileRow
-              // Password change invalidates session if changed after login
-              if (token.loginTime && profile.password_changed_at) {
-                const passwordChangedAt = new Date(profile.password_changed_at).getTime()
-                const tokenLoginTime = token.loginTime as number
-                if (passwordChangedAt > tokenLoginTime) {
-                  console.warn("Password changed after login - invalidating token")
-                  return {}
-                }
+      // Cooldown: skip the per-request profile fetch if we refreshed recently.
+      // Force a refresh when NextAuth indicates an explicit update (e.g.
+      // tenant switch via session.update()).
+      const lastRefreshAt = typeof token.lastRefreshAt === "number" ? token.lastRefreshAt : null
+      const isExplicitUpdate = trigger === "update" || Boolean(user)
+      if (
+        !isExplicitUpdate &&
+        lastRefreshAt !== null &&
+        now - lastRefreshAt < PROFILE_REFRESH_INTERVAL_MS
+      ) {
+        return token
+      }
+
+      // Refresh user-derived fields
+      try {
+        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+        const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+        if (supabaseUrl && serviceKey) {
+          const supabase = createClient(supabaseUrl, serviceKey)
+          const { data, error } = await supabase
+            .from("nhan_vien")
+            .select("password_changed_at, current_don_vi, don_vi, khoa_phong, full_name, dia_ban_id")
+            .eq("id", token.id)
+            .single()
+
+          if (!error && data) {
+            const profile = data as AuthProfileRow
+            // Password change invalidates session if changed after login
+            if (token.loginTime && profile.password_changed_at) {
+              const passwordChangedAt = new Date(profile.password_changed_at).getTime()
+              const tokenLoginTime = token.loginTime as number
+              if (passwordChangedAt > tokenLoginTime) {
+                console.warn("Password changed after login - invalidating token")
+                return {}
               }
-              // Keep JWT in sync with user profile for tenant-aware UI
-              const resolvedDonVi = profile.current_don_vi || profile.don_vi || null
-              let resolvedDiaBan: number | null = profile.dia_ban_id ?? null
-              let resolvedDiaBanMa: string | null = token.dia_ban_ma ?? null
-
-              if (!resolvedDiaBan && resolvedDonVi) {
-                try {
-                  const { data: donViRows, error: donViError } = await supabase
-                    .from("don_vi")
-                    .select("dia_ban_id")
-                    .eq("id", resolvedDonVi)
-                    .limit(1)
-
-                  if (!donViError && donViRows && donViRows.length > 0) {
-                    resolvedDiaBan = donViRows[0]?.dia_ban_id ?? null
-                  }
-                } catch (donViLookupError) {
-                  console.error("Failed to resolve dia_ban from don_vi", donViLookupError)
-                }
-              }
-
-              if (resolvedDiaBan && !resolvedDiaBanMa) {
-                try {
-                  const { data: diaBanRows, error: diaBanError } = await supabase
-                    .from("dia_ban")
-                    .select("ma_dia_ban")
-                    .eq("id", resolvedDiaBan)
-                    .limit(1)
-
-                  if (!diaBanError && diaBanRows && diaBanRows.length > 0) {
-                    resolvedDiaBanMa = diaBanRows[0]?.ma_dia_ban ?? null
-                  }
-                } catch (diaBanLookupError) {
-                  console.error("Failed to resolve dia_ban metadata", diaBanLookupError)
-                }
-              }
-
-              token = applyJwtProfileRefresh(token, profile, resolvedDonVi, resolvedDiaBan, resolvedDiaBanMa)
             }
+            // Keep JWT in sync with user profile for tenant-aware UI
+            const resolvedDonVi = profile.current_don_vi || profile.don_vi || null
+            let resolvedDiaBan: number | null = profile.dia_ban_id ?? null
+            let resolvedDiaBanMa: string | null = token.dia_ban_ma ?? null
+
+            if (!resolvedDiaBan && resolvedDonVi) {
+              try {
+                const { data: donViRows, error: donViError } = await supabase
+                  .from("don_vi")
+                  .select("dia_ban_id")
+                  .eq("id", resolvedDonVi)
+                  .limit(1)
+
+                if (!donViError && donViRows && donViRows.length > 0) {
+                  resolvedDiaBan = donViRows[0]?.dia_ban_id ?? null
+                }
+              } catch (donViLookupError) {
+                console.error("Failed to resolve dia_ban from don_vi", donViLookupError)
+              }
+            }
+
+            if (resolvedDiaBan && !resolvedDiaBanMa) {
+              try {
+                const { data: diaBanRows, error: diaBanError } = await supabase
+                  .from("dia_ban")
+                  .select("ma_dia_ban")
+                  .eq("id", resolvedDiaBan)
+                  .limit(1)
+
+                if (!diaBanError && diaBanRows && diaBanRows.length > 0) {
+                  resolvedDiaBanMa = diaBanRows[0]?.ma_dia_ban ?? null
+                }
+              } catch (diaBanLookupError) {
+                console.error("Failed to resolve dia_ban metadata", diaBanLookupError)
+              }
+            }
+
+            token = applyJwtProfileRefresh(token, profile, resolvedDonVi, resolvedDiaBan, resolvedDiaBanMa)
+            // Stamp lastRefreshAt only on a successful refresh so transient
+            // failures do not extend the cooldown beyond what they should.
+            token.lastRefreshAt = now
           }
-        } catch (e) {
-          // Log but don't break auth flow for database errors
-          console.error("Password change check failed:", e)
         }
+      } catch (e) {
+        // Log but don't break auth flow for database errors
+        console.error("Password change check failed:", e)
       }
 
       return token

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -143,6 +143,12 @@ export const authOptions: NextAuthOptions = {
             const resolvedDonVi = profile.current_don_vi || profile.don_vi || null
             let resolvedDiaBan: number | null = profile.dia_ban_id ?? null
             let resolvedDiaBanMa: string | null = token.dia_ban_ma ?? null
+            // Supabase v2 returns `{ data, error }` rather than throwing for
+            // failed table reads, so we must inspect `error` explicitly and
+            // only stamp lastRefreshAt when every required lookup succeeded.
+            // Otherwise a transient secondary failure would be frozen in
+            // for the entire cooldown window.
+            let secondaryLookupsOk = true
 
             if (!resolvedDiaBan && resolvedDonVi) {
               try {
@@ -152,11 +158,18 @@ export const authOptions: NextAuthOptions = {
                   .eq("id", resolvedDonVi)
                   .limit(1)
 
-                if (!donViError && donViRows && donViRows.length > 0) {
+                if (donViError) {
+                  console.warn("[jwt] don_vi lookup returned error", {
+                    message: donViError.message,
+                    don_vi: resolvedDonVi,
+                  })
+                  secondaryLookupsOk = false
+                } else if (donViRows && donViRows.length > 0) {
                   resolvedDiaBan = donViRows[0]?.dia_ban_id ?? null
                 }
               } catch (donViLookupError) {
-                console.error("Failed to resolve dia_ban from don_vi", donViLookupError)
+                console.error("[jwt] don_vi lookup threw", donViLookupError)
+                secondaryLookupsOk = false
               }
             }
 
@@ -168,18 +181,28 @@ export const authOptions: NextAuthOptions = {
                   .eq("id", resolvedDiaBan)
                   .limit(1)
 
-                if (!diaBanError && diaBanRows && diaBanRows.length > 0) {
+                if (diaBanError) {
+                  console.warn("[jwt] dia_ban lookup returned error", {
+                    message: diaBanError.message,
+                    dia_ban_id: resolvedDiaBan,
+                  })
+                  secondaryLookupsOk = false
+                } else if (diaBanRows && diaBanRows.length > 0) {
                   resolvedDiaBanMa = diaBanRows[0]?.ma_dia_ban ?? null
                 }
               } catch (diaBanLookupError) {
-                console.error("Failed to resolve dia_ban metadata", diaBanLookupError)
+                console.error("[jwt] dia_ban lookup threw", diaBanLookupError)
+                secondaryLookupsOk = false
               }
             }
 
             token = applyJwtProfileRefresh(token, profile, resolvedDonVi, resolvedDiaBan, resolvedDiaBanMa)
-            // Stamp lastRefreshAt only on a successful refresh so transient
-            // failures do not extend the cooldown beyond what they should.
-            token.lastRefreshAt = now
+            // Stamp lastRefreshAt only when every required lookup succeeded
+            // so transient failures do not extend the cooldown beyond what
+            // they should. A failing primary fetch never reaches this line.
+            if (secondaryLookupsOk) {
+              token.lastRefreshAt = now
+            }
           }
         }
       } catch (e) {

--- a/src/auth/next-auth-typing.types.assert.ts
+++ b/src/auth/next-auth-typing.types.assert.ts
@@ -37,6 +37,7 @@ type JwtHasDiaBanMa = Pick<JWT, "dia_ban_ma"> extends { dia_ban_ma?: string | nu
 type JwtHasFullName = Pick<JWT, "full_name"> extends { full_name?: string | null } ? true : false
 type JwtHasAuthMode = Pick<JWT, "auth_mode"> extends { auth_mode?: string | null } ? true : false
 type JwtHasLoginTime = Pick<JWT, "loginTime"> extends { loginTime?: number } ? true : false
+type JwtHasLastRefreshAt = Pick<JWT, "lastRefreshAt"> extends { lastRefreshAt?: number } ? true : false
 
 type _userHasId = Assert<UserHasId>
 type _userHasUsername = Assert<UserHasUsername>
@@ -71,3 +72,4 @@ type _jwtHasDiaBanMa = Assert<JwtHasDiaBanMa>
 type _jwtHasFullName = Assert<JwtHasFullName>
 type _jwtHasAuthMode = Assert<JwtHasAuthMode>
 type _jwtHasLoginTime = Assert<JwtHasLoginTime>
+type _jwtHasLastRefreshAt = Assert<JwtHasLastRefreshAt>

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -25,5 +25,6 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT extends DefaultJWT, Partial<NextAuthUserFields> {
     loginTime?: number
+    lastRefreshAt?: number
   }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #365. Adds a 60-second per-token cooldown to the NextAuth \`jwt\` callback so it stops issuing 1-3 Supabase SELECTs on every single invocation. Sign-in and explicit \`session.update()\` still refresh immediately; routine page renders / \`getServerSession\` calls within 60 s of the last successful refresh now skip the DB entirely.

Phase 2 (collapse the 1-3 SELECTs into one \`SECURITY DEFINER\` RPC and drop \`SUPABASE_SERVICE_ROLE_KEY\` from the hot path) requires a DB migration and is tracked separately in **#371**.

## What changes

- \`src/types/next-auth.d.ts\`: add \`lastRefreshAt?: number\` to the JWT augmentation. Mirrored in \`src/auth/next-auth-typing.types.assert.ts\`.
- \`src/auth/config.ts\`:
  - new \`PROFILE_REFRESH_INTERVAL_MS = 60_000\` constant with a comment block on the trade-off;
  - \`jwt\` callback now also reads \`trigger\`. Bails out before any DB work when the call is not a sign-in (no \`user\`), not an explicit \`'update'\`, and \`now - lastRefreshAt < PROFILE_REFRESH_INTERVAL_MS\`;
  - \`token.lastRefreshAt = now\` is stamped **only** after a successful profile refresh so transient errors do not extend the cooldown.
- \`src/auth/__tests__/auth-config.jwt-cooldown.test.ts\` (new, 7 cases): sign-in stamps \`lastRefreshAt\`; cooldown skips DB; cooldown elapsed re-fetches; \`trigger='update'\` force-refreshes; anonymous token no-op; password-change still invalidates; failed fetch does NOT advance \`lastRefreshAt\`. 4/7 fail against the pre-PR implementation, all 7 pass after the fix.

## Behavior

- Steady-state DB cost drops from "1-3 SELECTs per callback" to "1-3 SELECTs per cooldown window" (≤ ~1/min/active session).
- Sign-in latency unchanged (cooldown bypassed when \`user\` is present).
- Tenant switch via \`useSession().update()\` (\`trigger === 'update'\`) bypasses the cooldown so the new tenant becomes effective immediately.
- Out-of-band invalidations (password change, tenant deactivation) are visible after the cooldown elapses or at the next explicit update. This is the intended trade-off; #364 (cross-tab broadcast) handles the cross-device immediacy story.

## Test plan

- [x] \`node scripts/npm-run.js run verify:no-explicit-any\` — clean
- [x] \`node scripts/npm-run.js run typecheck\` — clean
- [x] \`node scripts/npm-run.js exec -- vitest run src/auth/__tests__/\` — 11/11 passing (7 new + 4 existing helper tests)
- [x] \`node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main\` — 100/100, no warnings

### Manual verification (recommended on preview)

- Sign in. Watch server logs while navigating between several /(app)/* routes within 60 s — there should be at most one batch of SELECTs against \`nhan_vien\` per minute, not per request.
- Trigger a tenant switch (calls \`useSession().update()\`) — observe an immediate re-fetch in the logs even within the cooldown.
- Change password from another device. Within ≤ 60 s the next page render should land on \`/?callbackUrl=…\` (jwt callback returns \`{}\` → middleware redirects).

## Out of scope

- The migration + RPC + service-role-key removal that closes the rest of #365 — tracked in **#371**.
- Cross-tab logout broadcast (#364), audit logging (#366), LoginForm refactor (#368), middleware kill switch (#363, already shipped in #369).

## Files

- \`src/auth/config.ts\` — new constant, cooldown gate, lastRefreshAt stamping.
- \`src/types/next-auth.d.ts\` — JWT field typing.
- \`src/auth/next-auth-typing.types.assert.ts\` — compile-time type assert for the new field.
- \`src/auth/__tests__/auth-config.jwt-cooldown.test.ts\` — new TDD coverage.

Refs #365. Phase 2 → #371.

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 60-second cooldown to the `next-auth` JWT callback with an update-trigger gate to stop redundant Supabase profile fetches. Sign-in and `session.update()` bypass the cooldown; steady-state reads drop to about one fetch per minute per active session. Phase 1 of #365.

- **Bug Fixes**
  - Added `lastRefreshAt` to JWT; stamped only after a successful refresh and only when secondary lookups succeed.
  - Gate refresh when not sign-in and not `trigger: 'update'` and within `PROFILE_REFRESH_INTERVAL_MS = 60_000`.
  - Explicitly handle `don_vi`/`dia_ban` lookup errors from `@supabase/supabase-js` v2: log warnings and do not advance `lastRefreshAt` on partial failures.
  - Keep password-change invalidation (returns `{}` when `password_changed_at` > `loginTime`); tests cover cooldown, trigger gate, elapsed refresh, anonymous tokens, and the new secondary-lookup error paths.

- **Refactors**
  - Flattened Supabase test mock chains with a `buildChain` helper to resolve Sonar S2004 nested-function violations; no behavior change.

<sup>Written for commit 4e1f8c70f72df567f68bb5182eb704410c889ce2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a profile refresh cooldown for JWTs, a forced-refresh on explicit updates, and tracking to only advance the refresh timestamp when required lookups succeed.

* **Tests**
  * Added thorough tests covering cooldown behavior, forced refreshes, anonymous/invalidation guards, secondary-lookup failures, and error handling during profile refresh.

* **Types**
  * JWT type updated to include an optional lastRefreshAt field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->