### PR TITLE
feat(auth): add batch-2 auth event emission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,15 @@ Bash is ONLY for short-output ops: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm 
 
 For the `verify:no-explicit-any` → `typecheck` → focused vitest → `react-doctor` chain, gather them all in **one** `ctx_batch_execute` so failures are searchable via `ctx_search`.
 
+### RTK vs Context-Mode Convention
+
+Use this repo-level split consistently:
+
+- **Shell / RTK-style short git ops:** `git status`, `git checkout`, `git add`, `git commit`, `git push`, `git pull --rebase`, `git fetch`, `git branch`
+- **Always route through `context-mode`:** `gh`, test runners, `git diff`, `git log`, `react-doctor`, large `rg`, and any command likely to emit more than ~20 lines
+
+Do not run `gh` directly in plain bash when `context-mode` can carry the command.
+
 ### Read / Grep redirected for analysis
 
 - Reading a file to **edit** it → `read` is correct (Edit needs content in context).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,15 @@ npm run n:test        # Tests
 
 **Why:** `.cmd` batch files and some `.exe` files don't return stdout in certain shell contexts (Claude Code's Bash tool). These helpers use Node's `child_process.execSync` to properly capture output.
 
+### RTK vs Context-Mode Convention
+
+Use this split consistently for repo work:
+
+- **Shell / RTK-style short git ops:** `git status`, `git checkout`, `git add`, `git commit`, `git push`, `git pull --rebase`, `git fetch`, `git branch`
+- **Always route through `context-mode`:** `gh`, test runners, `git diff`, `git log`, `react-doctor`, large `rg`, and any command likely to emit more than ~20 lines
+
+Do not run `gh` directly in plain bash when `context-mode` can carry the command.
+
 ### Verification Order (MANDATORY for `.ts` / `.tsx` changes)
 
 Run verification in this order before claiming success, committing, or updating a PR:

--- a/src/auth/__tests__/auth-config.authorize-events.test.ts
+++ b/src/auth/__tests__/auth-config.authorize-events.test.ts
@@ -266,6 +266,39 @@ describe("authOptions authorize + auth lifecycle events", () => {
     ])
   })
 
+  it("falls back to augmented session fields when signOut token no longer carries auth claims", async () => {
+    const signOutEvent = getSignOutEventHandler()
+
+    await signOutEvent({
+      token: {
+        loginTime: Date.now() - 60_000,
+      } as never,
+      session: {
+        user: {
+          id: "42",
+          username: "NQMinh",
+          don_vi: 17,
+          name: "Nguyen Quang Minh",
+        },
+      } as never,
+    })
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
+      expect.objectContaining({
+        event: "forced_signout",
+        source: "events_signout",
+        signout_reason: "session_expired",
+        user_id: "42",
+        username: "nqminh",
+        tenant_id: "17",
+        request_id: "req-123",
+        metadata: expect.objectContaining({
+          session_duration_ms: 60000,
+        }),
+      }),
+    ])
+  })
+
   it("skips signOut emission for probe traffic with no token identity or reason", async () => {
     const signOutEvent = getSignOutEventHandler()
 

--- a/src/auth/__tests__/auth-config.authorize-events.test.ts
+++ b/src/auth/__tests__/auth-config.authorize-events.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const requestHeadersState = vi.hoisted(() => ({
+  values: new Map<string, string>(),
+}))
+
+const supabaseState = vi.hoisted(() => ({
+  rpcRows: [] as unknown[],
+  rpcError: null as unknown,
+}))
+
+const supabaseClient = vi.hoisted(() => ({
+  rpc: vi.fn(async () => ({
+    data: supabaseState.rpcError ? null : supabaseState.rpcRows,
+    error: supabaseState.rpcError,
+  })),
+}))
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => supabaseClient),
+}))
+
+vi.mock("next/headers", () => ({
+  headers: () => ({
+    get(name: string) {
+      return requestHeadersState.values.get(name.toLowerCase()) ?? null
+    },
+  }),
+}))
+
+import { authOptions } from "@/auth/config"
+
+type AuthorizeFn = (credentials?: Record<string, unknown>, req?: Request) => Promise<unknown>
+type SignInEvent = NonNullable<NonNullable<typeof authOptions.events>["signIn"]>
+type SignOutEvent = NonNullable<NonNullable<typeof authOptions.events>["signOut"]>
+
+type AuthLifecycleLog = {
+  scope: string
+  event: string
+  source: string
+  reason_code?: string
+  signout_reason?: string
+  user_id?: string
+  username?: string
+  tenant_id?: string
+  request_id?: string | null
+  ip_address?: string | null
+  user_agent?: string | null
+  metadata?: Record<string, unknown>
+}
+
+function getAuthorizeHandler(): AuthorizeFn {
+  const provider = authOptions.providers.find(
+    (
+      candidate
+    ): candidate is { options?: { authorize?: AuthorizeFn } } =>
+      "options" in candidate && typeof candidate.options?.authorize === "function"
+  )
+
+  if (!provider) {
+    throw new Error("credentials authorize handler not configured")
+  }
+
+  return provider.options!.authorize!
+}
+
+function getSignInEventHandler(): SignInEvent {
+  const handler = authOptions.events?.signIn
+  if (!handler) {
+    throw new Error("signIn event handler not configured")
+  }
+
+  return handler
+}
+
+function getSignOutEventHandler(): SignOutEvent {
+  const handler = authOptions.events?.signOut
+  if (!handler) {
+    throw new Error("signOut event handler not configured")
+  }
+
+  return handler
+}
+
+function authLifecycleLogs(infoSpy: ReturnType<typeof vi.spyOn>): AuthLifecycleLog[] {
+  return infoSpy.mock.calls
+    .map(([message]) => (typeof message === "string" ? message : ""))
+    .filter((message) => message.includes("\"scope\":\"auth.lifecycle\""))
+    .map((message) => JSON.parse(message) as AuthLifecycleLog)
+}
+
+function buildAuthorizeRequest() {
+  return new Request("http://localhost/api/auth/callback/credentials", {
+    headers: {
+      "x-request-id": "req-123",
+      "x-forwarded-for": "203.0.113.1, 10.0.0.1",
+      "user-agent": "VitestBrowser/1.0",
+    },
+  })
+}
+
+describe("authOptions authorize + auth lifecycle events", () => {
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-05-04T03:00:00Z"))
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined)
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co")
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key")
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key")
+    requestHeadersState.values = new Map([
+      ["x-request-id", "req-123"],
+      ["x-forwarded-for", "203.0.113.1, 10.0.0.1"],
+      ["user-agent", "VitestBrowser/1.0"],
+    ])
+    supabaseState.rpcRows = []
+    supabaseState.rpcError = null
+    supabaseClient.rpc.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+    consoleInfoSpy.mockRestore()
+    consoleErrorSpy.mockRestore()
+    consoleWarnSpy.mockRestore()
+  })
+
+  it("emits login_failure/config_error when auth env is missing", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "")
+
+    const authorize = getAuthorizeHandler()
+    const result = await authorize({
+      username: "NQMinh",
+      password: "super-secret",
+    }, buildAuthorizeRequest())
+
+    expect(result).toBeNull()
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
+      expect.objectContaining({
+        event: "login_failure",
+        source: "authorize",
+        reason_code: "config_error",
+        username: "nqminh",
+        request_id: "req-123",
+        ip_address: "203.0.113.1",
+        user_agent: "VitestBrowser/1.0",
+      }),
+    ])
+    expect(JSON.stringify(authLifecycleLogs(consoleInfoSpy))).not.toContain("super-secret")
+  })
+
+  it("emits tenant_inactive when rpc auth says tenant is inactive", async () => {
+    supabaseState.rpcRows = [{
+      is_authenticated: false,
+      authentication_mode: "tenant_inactive",
+    }]
+
+    const authorize = getAuthorizeHandler()
+
+    await expect(authorize({
+      username: "LOCKED.USER",
+      password: "secret",
+    }, buildAuthorizeRequest())).rejects.toThrow("tenant_inactive")
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
+      expect.objectContaining({
+        event: "tenant_inactive",
+        source: "authorize",
+        reason_code: "tenant_inactive",
+        username: "locked.user",
+        request_id: "req-123",
+      }),
+    ])
+  })
+
+  it("emits login_success from events.signIn with lowercased username and no secrets", async () => {
+    const signInEvent = getSignInEventHandler()
+
+    await signInEvent({
+      user: {
+        id: "42",
+        username: "NQMinh",
+        don_vi: 17,
+        password: "super-secret",
+      } as never,
+      account: null,
+      isNewUser: false,
+    })
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
+      expect.objectContaining({
+        event: "login_success",
+        source: "events_signin",
+        user_id: "42",
+        username: "nqminh",
+        tenant_id: "17",
+        request_id: "req-123",
+        ip_address: "203.0.113.1",
+        user_agent: "VitestBrowser/1.0",
+      }),
+    ])
+    expect(JSON.stringify(authLifecycleLogs(consoleInfoSpy))).not.toContain("super-secret")
+  })
+
+  it("emits forced_signout/session_expired on signOut fallback and computes session duration", async () => {
+    const signOutEvent = getSignOutEventHandler()
+
+    await signOutEvent({
+      token: {
+        id: "42",
+        username: "nqminh",
+        don_vi: 17,
+        loginTime: Date.now() - 120_000,
+      } as never,
+      session: undefined as never,
+    })
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
+      expect.objectContaining({
+        event: "forced_signout",
+        source: "events_signout",
+        signout_reason: "session_expired",
+        user_id: "42",
+        username: "nqminh",
+        tenant_id: "17",
+        request_id: "req-123",
+        metadata: expect.objectContaining({
+          session_duration_ms: 120000,
+        }),
+      }),
+    ])
+  })
+
+  it("skips signOut emission for probe traffic with no token identity or reason", async () => {
+    const signOutEvent = getSignOutEventHandler()
+
+    await signOutEvent({
+      token: {} as never,
+      session: undefined as never,
+    })
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([])
+  })
+})

--- a/src/auth/__tests__/auth-config.authorize-events.test.ts
+++ b/src/auth/__tests__/auth-config.authorize-events.test.ts
@@ -179,6 +179,35 @@ describe("authOptions authorize + auth lifecycle events", () => {
     ])
   })
 
+  it("emits authorize_exception for unexpected runtime errors before rethrowing", async () => {
+    const runtimeError = new Error("database exploded")
+    supabaseClient.rpc.mockImplementationOnce(async () => {
+      throw runtimeError
+    })
+
+    const authorize = getAuthorizeHandler()
+
+    await expect(authorize({
+      username: "NQMinh",
+      password: "secret",
+    }, buildAuthorizeRequest())).rejects.toThrow("database exploded")
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
+      expect.objectContaining({
+        event: "login_failure",
+        source: "authorize",
+        reason_code: "authorize_exception",
+        username: "nqminh",
+        request_id: "req-123",
+        ip_address: "203.0.113.1",
+        user_agent: "VitestBrowser/1.0",
+        metadata: expect.objectContaining({
+          error_message: "database exploded",
+        }),
+      }),
+    ])
+  })
+
   it("emits login_success from events.signIn with lowercased username and no secrets", async () => {
     const signInEvent = getSignInEventHandler()
 

--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -262,7 +262,9 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     const result = await runJwt({ token })
 
     expect(supabaseClient.rpc).toHaveBeenCalled()
-    expect(result).toEqual({})
+    expect(result).toEqual({
+      loginTime,
+    })
   })
 
   it("persists pending_signout_reason from session.update payloads into the JWT", async () => {
@@ -323,6 +325,7 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     })
 
     expect(result).toMatchObject({
+      loginTime: now - 10_000,
       pending_signout_reason: "forced_password_change",
     })
     expect(result).not.toHaveProperty("id")

--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -308,6 +308,9 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     expect(result).toMatchObject({
       pending_signout_reason: "forced_password_change",
     })
+    expect(result).not.toHaveProperty("id")
+    expect(result).not.toHaveProperty("username")
+    expect(result).not.toHaveProperty("role")
 
     expect(authLifecycleLogs(consoleInfoSpy)).toEqual(
       expect.arrayContaining([

--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -45,6 +45,10 @@ const supabaseClient = vi.hoisted(() => ({
   })),
 }))
 
+const requestHeadersState = vi.hoisted(() => ({
+  values: new Map<string, string>(),
+}))
+
 type AuthJwtTelemetryLog = {
   scope: string
   event: string
@@ -57,8 +61,30 @@ type AuthJwtTelemetryLog = {
   password?: string
 }
 
+type AuthLifecycleLog = {
+  scope: string
+  event: string
+  source: string
+  signout_reason?: string
+  user_id?: string
+  username?: string
+  tenant_id?: string
+  request_id?: string | null
+  ip_address?: string | null
+  user_agent?: string | null
+  metadata?: Record<string, unknown>
+}
+
 vi.mock("@supabase/supabase-js", () => ({
   createClient: vi.fn(() => supabaseClient),
+}))
+
+vi.mock("next/headers", () => ({
+  headers: () => ({
+    get(name: string) {
+      return requestHeadersState.values.get(name.toLowerCase()) ?? null
+    },
+  }),
 }))
 
 import { authOptions } from "@/auth/config"
@@ -97,6 +123,13 @@ function authJwtTelemetryLogs(infoSpy: ReturnType<typeof vi.spyOn>): AuthJwtTele
     .map((message) => JSON.parse(message) as AuthJwtTelemetryLog)
 }
 
+function authLifecycleLogs(infoSpy: ReturnType<typeof vi.spyOn>): AuthLifecycleLog[] {
+  return infoSpy.mock.calls
+    .map(([message]) => (typeof message === "string" ? message : ""))
+    .filter((message) => message.includes("\"scope\":\"auth.lifecycle\""))
+    .map((message) => JSON.parse(message) as AuthLifecycleLog)
+}
+
 describe("authOptions.jwt cooldown + trigger gate", () => {
   let consoleInfoSpy: ReturnType<typeof vi.spyOn>
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>
@@ -110,6 +143,11 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key")
     vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-service-role-key")
     vi.stubEnv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+    requestHeadersState.values = new Map([
+      ["x-request-id", "jwt-req-42"],
+      ["x-forwarded-for", "198.51.100.9"],
+      ["user-agent", "VitestJwt/1.0"],
+    ])
     supabaseState.fromCalls = []
     supabaseState.rpcRows = [{ ...profileRowDefault }]
     supabaseState.rpcError = null
@@ -227,6 +265,67 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     expect(result).toEqual({})
   })
 
+  it("persists pending_signout_reason from session.update payloads into the JWT", async () => {
+    const now = Date.now()
+
+    const result = await runJwt({
+      token: {
+        ...baseToken,
+        loginTime: now - 10_000,
+        lastRefreshAt: now - 10_000,
+      },
+      trigger: "update",
+      session: {
+        pending_signout_reason: "user_initiated",
+      } as JwtArgs["session"],
+    })
+
+    expect(result).toMatchObject({
+      id: "42",
+      pending_signout_reason: "user_initiated",
+    })
+  })
+
+  it("preserves pending_signout_reason when update-trigger invalidation would otherwise empty the token", async () => {
+    const now = Date.now()
+    supabaseState.rpcRows = [{
+      ...profileRowDefault,
+      password_changed_at: new Date(now - 5_000).toISOString(),
+    }]
+
+    const result = await runJwt({
+      token: {
+        ...baseToken,
+        loginTime: now - 10_000,
+        lastRefreshAt: now - 10_000,
+      },
+      trigger: "update",
+      session: {
+        pending_signout_reason: "forced_password_change",
+      } as JwtArgs["session"],
+    })
+
+    expect(result).toMatchObject({
+      pending_signout_reason: "forced_password_change",
+    })
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "token_invalidated_password_change",
+          source: "jwt_callback",
+          user_id: "42",
+          username: "nqminh",
+          tenant_id: "17",
+          signout_reason: "forced_password_change",
+          request_id: "jwt-req-42",
+          ip_address: "198.51.100.9",
+          user_agent: "VitestJwt/1.0",
+        }),
+      ])
+    )
+  })
+
   it("does not advance lastRefreshAt when the profile fetch fails", async () => {
     const now = Date.now()
     supabaseState.rpcRows = []
@@ -245,6 +344,35 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
       id: "42",
       lastRefreshAt: now - 5 * 60_000, // still the old value
     })
+  })
+
+  it("emits profile_refresh_failed lifecycle log when the profile RPC fails", async () => {
+    const now = Date.now()
+    supabaseState.rpcRows = []
+    supabaseState.rpcError = { message: "rpc boom" }
+
+    await runJwt({
+      token: {
+        ...baseToken,
+        loginTime: now - 5 * 60_000,
+        lastRefreshAt: now - 5 * 60_000,
+      },
+    })
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "profile_refresh_failed",
+          source: "jwt_callback",
+          user_id: "42",
+          username: "nqminh",
+          tenant_id: "17",
+          request_id: "jwt-req-42",
+          ip_address: "198.51.100.9",
+          user_agent: "VitestJwt/1.0",
+        }),
+      ])
+    )
   })
 
   it("keeps steady-session profile refreshes at or below 0.05 RPC calls per jwt callback", async () => {

--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -286,6 +286,23 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     })
   })
 
+  it("clears stale pending_signout_reason when a later session.update omits it", async () => {
+    const now = Date.now()
+
+    const result = await runJwt({
+      token: {
+        ...baseToken,
+        loginTime: now - 10_000,
+        lastRefreshAt: now - 10_000,
+        pending_signout_reason: "user_initiated",
+      } as JwtArgs["token"],
+      trigger: "update",
+      session: {} as JwtArgs["session"],
+    })
+
+    expect(result).not.toHaveProperty("pending_signout_reason")
+  })
+
   it("preserves pending_signout_reason when update-trigger invalidation would otherwise empty the token", async () => {
     const now = Date.now()
     supabaseState.rpcRows = [{

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -1,8 +1,11 @@
 import type { NextAuthOptions } from "next-auth"
+import { headers } from "next/headers"
 import Credentials from "next-auth/providers/credentials"
 import { createClient } from "@supabase/supabase-js"
 import jwt from "jsonwebtoken"
+import { emitAuthLifecycleLog } from "@/auth/logging"
 import { emitAuthJwtTelemetry } from "@/auth/telemetry"
+import type { AuthPendingSignoutReason } from "@/types/auth"
 import {
   applyAuthUserToJwt,
   applyJwtProfileRefresh,
@@ -31,6 +34,113 @@ class AuthRefreshConfigError extends Error {
     super(message)
     this.name = "AuthRefreshConfigError"
   }
+}
+
+type AuthRequestContext = {
+  request_id: string | null
+  ip_address: string | null
+  user_agent: string | null
+}
+
+type HeaderGetter = {
+  get(name: string): string | null
+}
+
+function normalizeUsernameForLog(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined
+  }
+
+  const normalized = value.trim().toLowerCase()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function coerceTenantId(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value)
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim()
+    return normalized.length > 0 ? normalized : undefined
+  }
+
+  return undefined
+}
+
+function readRequestContext(getHeader: (name: string) => string | null): AuthRequestContext {
+  const forwardedFor = getHeader("x-forwarded-for")
+  const requestId = getHeader("x-request-id") ?? getHeader("x-vercel-id")
+  const ipAddress = forwardedFor?.split(",")[0]?.trim() || null
+  const userAgent = getHeader("user-agent")
+
+  return {
+    request_id: requestId,
+    ip_address: ipAddress,
+    user_agent: userAgent,
+  }
+}
+
+function toHeaderGetter(rawHeaders: unknown): HeaderGetter | null {
+  if (!rawHeaders) {
+    return null
+  }
+
+  const maybeHeaderGetter = rawHeaders as { get?: unknown }
+  if (typeof rawHeaders === "object" && rawHeaders !== null && typeof maybeHeaderGetter.get === "function") {
+    const getHeader = (name: string) => (maybeHeaderGetter.get as (this: unknown, headerName: string) => unknown).call(rawHeaders, name)
+    return {
+      get(name: string) {
+        const value = getHeader(name)
+        return typeof value === "string" ? value : null
+      },
+    }
+  }
+
+  if (typeof rawHeaders === "object" && rawHeaders !== null) {
+    const headerMap = rawHeaders as Record<string, string | string[] | undefined>
+    return {
+      get(name: string) {
+        const value = headerMap[name] ?? headerMap[name.toLowerCase()]
+        if (Array.isArray(value)) {
+          return value[0] ?? null
+        }
+        return typeof value === "string" ? value : null
+      },
+    }
+  }
+
+  return null
+}
+
+function readAuthorizeRequestContext(req?: { headers?: unknown } | null): AuthRequestContext {
+  const headerGetter = toHeaderGetter(req?.headers)
+  if (!headerGetter) {
+    return {
+      request_id: null,
+      ip_address: null,
+      user_agent: null,
+    }
+  }
+
+  return readRequestContext((name) => headerGetter.get(name))
+}
+
+async function readRuntimeRequestContext(): Promise<AuthRequestContext> {
+  try {
+    const runtimeHeaders = await headers()
+    return readRequestContext((name) => runtimeHeaders.get(name))
+  } catch {
+    return {
+      request_id: null,
+      ip_address: null,
+      user_agent: null,
+    }
+  }
+}
+
+function isPendingSignoutReason(value: unknown): value is AuthPendingSignoutReason {
+  return value === "user_initiated" || value === "session_expired" || value === "forced_password_change"
 }
 
 function requireRefreshEnv(name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABASE_ANON_KEY" | "SUPABASE_JWT_SECRET"): string {
@@ -92,9 +202,11 @@ export const authOptions: NextAuthOptions = {
         username: { label: "Username", type: "text" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         const username = credentials?.username?.toString().trim()
         const password = credentials?.password?.toString() || ""
+        const requestContext = readAuthorizeRequestContext(req)
+        const normalizedUsername = normalizeUsernameForLog(username)
 
         if (!username || !password) return null
 
@@ -102,6 +214,12 @@ export const authOptions: NextAuthOptions = {
         const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
         if (!supabaseUrl || !serviceKey) {
           console.error("Supabase env not configured")
+          emitAuthLifecycleLog({
+            source: "authorize",
+            reason_code: "config_error",
+            username: normalizedUsername,
+            ...requestContext,
+          })
           return null
         }
 
@@ -115,6 +233,12 @@ export const authOptions: NextAuthOptions = {
 
           if (error) {
             console.error("RPC auth error:", error)
+            emitAuthLifecycleLog({
+              source: "authorize",
+              reason_code: "rpc_error",
+              username: normalizedUsername,
+              ...requestContext,
+            })
             throw new Error("rpc_error")
           }
 
@@ -126,24 +250,46 @@ export const authOptions: NextAuthOptions = {
 
             if (authResult?.authentication_mode === "tenant_inactive") {
               console.warn("Login blocked because tenant is inactive", { username })
+              emitAuthLifecycleLog({
+                source: "authorize",
+                reason_code: "tenant_inactive",
+                username: normalizedUsername,
+                ...requestContext,
+              })
               throw new Error("tenant_inactive")
             }
           }
 
+          emitAuthLifecycleLog({
+            source: "authorize",
+            reason_code: "invalid_credentials",
+            username: normalizedUsername,
+            ...requestContext,
+          })
           throw new Error("invalid_credentials")
         } catch (e) {
           if (e instanceof Error) {
             throw e
           }
           console.error("Authorize exception:", e)
+          emitAuthLifecycleLog({
+            source: "authorize",
+            reason_code: "authorize_exception",
+            username: normalizedUsername,
+            ...requestContext,
+          })
           throw new Error("authorize_exception")
         }
       },
     }),
   ],
   callbacks: {
-    async jwt({ token, user, trigger }) {
+    async jwt({ token, user, trigger, session }) {
       const now = Date.now()
+      const requestContext = await readRuntimeRequestContext()
+      const pendingSignoutReason = isPendingSignoutReason(session?.pending_signout_reason)
+        ? session.pending_signout_reason
+        : undefined
 
       // On sign-in, persist extra fields in the JWT
       if (user) {
@@ -151,6 +297,10 @@ export const authOptions: NextAuthOptions = {
           ...applyAuthUserToJwt(token, user),
           loginTime: now, // Track when user logged in
         }
+      }
+
+      if (pendingSignoutReason) {
+        token.pending_signout_reason = pendingSignoutReason
       }
 
       if (!token.id) {
@@ -230,6 +380,18 @@ export const authOptions: NextAuthOptions = {
           .rpc("get_session_profile_for_jwt", { p_user_id: userId })
 
         if (error) {
+          emitAuthLifecycleLog({
+            event: "profile_refresh_failed",
+            source: "jwt_callback",
+            user_id: userId,
+            username: normalizeUsernameForLog(token.username),
+            tenant_id: coerceTenantId(token.don_vi),
+            ...requestContext,
+            metadata: {
+              trigger,
+              refreshReason,
+            },
+          })
           emitAuthJwtTelemetry("jwt_refresh_failed", {
             userId,
             trigger,
@@ -242,6 +404,18 @@ export const authOptions: NextAuthOptions = {
         if (!error && data) {
           const profile = firstProfileRow(data)
           if (!profile) {
+            emitAuthLifecycleLog({
+              event: "profile_refresh_failed",
+              source: "jwt_callback",
+              user_id: userId,
+              username: normalizeUsernameForLog(token.username),
+              tenant_id: coerceTenantId(token.don_vi),
+              ...requestContext,
+              metadata: {
+                trigger,
+                refreshReason,
+              },
+            })
             emitAuthJwtTelemetry("jwt_refresh_failed", {
               userId,
               trigger,
@@ -256,6 +430,22 @@ export const authOptions: NextAuthOptions = {
             const passwordChangedAt = new Date(profile.password_changed_at).getTime()
             const tokenLoginTime = token.loginTime as number
             if (passwordChangedAt > tokenLoginTime) {
+              const signoutReason = isPendingSignoutReason(token.pending_signout_reason)
+                ? token.pending_signout_reason
+                : undefined
+              emitAuthLifecycleLog({
+                event: "token_invalidated_password_change",
+                source: "jwt_callback",
+                signout_reason: signoutReason,
+                user_id: userId,
+                username: normalizeUsernameForLog(token.username),
+                tenant_id: coerceTenantId(token.don_vi),
+                ...requestContext,
+                metadata: {
+                  trigger,
+                  refreshReason,
+                },
+              })
               emitAuthJwtTelemetry("jwt_token_invalidated_password_change", {
                 userId,
                 trigger,
@@ -265,7 +455,12 @@ export const authOptions: NextAuthOptions = {
                 invalidatedReason: "password_changed_after_login",
               })
               console.warn("Password changed after login - invalidating token")
-              return {}
+              return signoutReason
+                ? {
+                    ...token,
+                    pending_signout_reason: signoutReason,
+                  }
+                : {}
             }
           }
           // Keep JWT in sync with user profile for tenant-aware UI
@@ -284,6 +479,18 @@ export const authOptions: NextAuthOptions = {
           })
         }
       } catch (e) {
+        emitAuthLifecycleLog({
+          event: "profile_refresh_failed",
+          source: "jwt_callback",
+          user_id: userId,
+          username: normalizeUsernameForLog(token.username),
+          tenant_id: coerceTenantId(token.don_vi),
+          ...requestContext,
+          metadata: {
+            trigger,
+            refreshReason,
+          },
+        })
         emitAuthJwtTelemetry("jwt_refresh_failed", {
           userId,
           trigger,
@@ -303,6 +510,47 @@ export const authOptions: NextAuthOptions = {
     async session({ session, token }) {
       // Expose custom fields to the client session
       return applyJwtToSession(session, token)
+    },
+  },
+  events: {
+    async signIn({ user }) {
+      const requestContext = await readRuntimeRequestContext()
+
+      emitAuthLifecycleLog({
+        event: "login_success",
+        source: "events_signin",
+        user_id: typeof user.id === "string" ? user.id : user.id != null ? String(user.id) : undefined,
+        username: normalizeUsernameForLog(user.username ?? user.name),
+        tenant_id: coerceTenantId(user.don_vi),
+        ...requestContext,
+      })
+    },
+    async signOut({ token, session }) {
+      const pendingReason = isPendingSignoutReason(token?.pending_signout_reason)
+        ? token.pending_signout_reason
+        : undefined
+      const userId = typeof token?.id === "string" ? token.id : token?.id != null ? String(token.id) : undefined
+      const username = normalizeUsernameForLog(token?.username ?? session?.user?.name)
+      const tenantId = coerceTenantId(token?.don_vi)
+
+      if (!userId && !username && !tenantId && !pendingReason) {
+        return
+      }
+
+      const metadata: Record<string, unknown> = {}
+      if (typeof token?.loginTime === "number") {
+        metadata.session_duration_ms = Math.max(0, Date.now() - token.loginTime)
+      }
+
+      emitAuthLifecycleLog({
+        source: "events_signout",
+        signout_reason: pendingReason ?? "session_expired",
+        user_id: userId,
+        username,
+        tenant_id: tenantId,
+        ...(await readRuntimeRequestContext()),
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+      })
     },
   },
 }

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -466,11 +466,17 @@ export const authOptions: NextAuthOptions = {
                 invalidatedReason: "password_changed_after_login",
               })
               console.warn("Password changed after login - invalidating token")
-              return signoutReason
-                ? {
-                    pending_signout_reason: signoutReason,
-                  }
-                : {}
+              const invalidatedToken: {
+                loginTime?: number
+                pending_signout_reason?: AuthPendingSignoutReason
+              } = {}
+              if (typeof token.loginTime === "number") {
+                invalidatedToken.loginTime = token.loginTime
+              }
+              if (signoutReason) {
+                invalidatedToken.pending_signout_reason = signoutReason
+              }
+              return invalidatedToken
             }
           }
           // Keep JWT in sync with user profile for tenant-aware UI
@@ -539,9 +545,18 @@ export const authOptions: NextAuthOptions = {
       const pendingReason = isPendingSignoutReason(token?.pending_signout_reason)
         ? token.pending_signout_reason
         : undefined
-      const userId = typeof token?.id === "string" ? token.id : token?.id != null ? String(token.id) : undefined
-      const username = normalizeUsernameForLog(token?.username ?? session?.user?.name)
-      const tenantId = coerceTenantId(token?.don_vi)
+      const userId =
+        typeof token?.id === "string"
+          ? token.id
+          : token?.id != null
+            ? String(token.id)
+            : typeof session?.user?.id === "string"
+              ? session.user.id
+              : session?.user?.id != null
+                ? String(session.user.id)
+                : undefined
+      const username = normalizeUsernameForLog(token?.username ?? session?.user?.username ?? session?.user?.name)
+      const tenantId = coerceTenantId(token?.don_vi ?? session?.user?.don_vi)
 
       if (!userId && !username && !tenantId && !pendingReason) {
         return

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -310,6 +310,8 @@ export const authOptions: NextAuthOptions = {
 
       if (pendingSignoutReason) {
         token.pending_signout_reason = pendingSignoutReason
+      } else if (trigger === "update" && "pending_signout_reason" in token) {
+        delete token.pending_signout_reason
       }
 
       if (!token.id) {

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -268,17 +268,26 @@ export const authOptions: NextAuthOptions = {
           })
           throw new Error("invalid_credentials")
         } catch (e) {
-          if (e instanceof Error) {
+          if (
+            e instanceof Error &&
+            (e.message === "rpc_error" || e.message === "tenant_inactive" || e.message === "invalid_credentials")
+          ) {
             throw e
           }
+
           console.error("Authorize exception:", e)
           emitAuthLifecycleLog({
             source: "authorize",
             reason_code: "authorize_exception",
             username: normalizedUsername,
             ...requestContext,
+            metadata: e instanceof Error
+              ? {
+                  error_message: e.message,
+                }
+              : undefined,
           })
-          throw new Error("authorize_exception")
+          throw e instanceof Error ? e : new Error("authorize_exception")
         }
       },
     }),
@@ -457,7 +466,6 @@ export const authOptions: NextAuthOptions = {
               console.warn("Password changed after login - invalidating token")
               return signoutReason
                 ? {
-                    ...token,
                     pending_signout_reason: signoutReason,
                   }
                 : {}

--- a/src/auth/logging.ts
+++ b/src/auth/logging.ts
@@ -2,9 +2,13 @@ import { sanitizeForLog } from "@/lib/log-sanitizer"
 import type { AuthPendingSignoutReason } from "@/types/auth"
 
 export type AuthLifecycleEvent =
+  | "login_success"
   | "login_failure"
   | "tenant_inactive"
   | "profile_refresh_failed"
+  | "token_invalidated_password_change"
+  | "signout"
+  | "forced_signout"
 
 export type AuthLifecycleReasonCode =
   | "invalid_credentials"
@@ -23,9 +27,13 @@ export type AuthLifecycleLogInput = {
   event?: AuthLifecycleEvent
   source: AuthLogSource
   reason_code?: AuthLifecycleReasonCode
+  signout_reason?: AuthPendingSignoutReason
   user_id?: string
   username?: string
   tenant_id?: string
+  request_id?: string | null
+  ip_address?: string | null
+  user_agent?: string | null
   metadata?: Record<string, unknown>
 }
 
@@ -35,15 +43,23 @@ export type AuthLifecycleLogPayload = {
   event: AuthLifecycleEvent
   source: AuthLogSource
   reason_code?: AuthLifecycleReasonCode
+  signout_reason?: AuthPendingSignoutReason
   user_id?: string
   username?: string
   tenant_id?: string
+  request_id?: string | null
+  ip_address?: string | null
+  user_agent?: string | null
   metadata?: Record<string, unknown>
 }
 
 function deriveAuthLifecycleEvent(input: AuthLifecycleLogInput): AuthLifecycleEvent {
   if (input.event) {
     return input.event
+  }
+
+  if (input.signout_reason) {
+    return input.signout_reason === "user_initiated" ? "signout" : "forced_signout"
   }
 
   if (input.reason_code === "tenant_inactive") {
@@ -65,6 +81,10 @@ export function buildAuthLifecycleLog(input: AuthLifecycleLogInput): AuthLifecyc
     payload.reason_code = input.reason_code
   }
 
+  if (input.signout_reason !== undefined) {
+    payload.signout_reason = input.signout_reason
+  }
+
   if (input.user_id !== undefined) {
     payload.user_id = input.user_id
   }
@@ -75,6 +95,18 @@ export function buildAuthLifecycleLog(input: AuthLifecycleLogInput): AuthLifecyc
 
   if (input.tenant_id !== undefined) {
     payload.tenant_id = input.tenant_id
+  }
+
+  if (input.request_id !== undefined) {
+    payload.request_id = input.request_id
+  }
+
+  if (input.ip_address !== undefined) {
+    payload.ip_address = input.ip_address
+  }
+
+  if (input.user_agent !== undefined) {
+    payload.user_agent = input.user_agent
   }
 
   if (input.metadata !== undefined) {

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -87,6 +87,7 @@ export function applyJwtProfileRefresh(
 export function applyJwtToSession(session: Session, token: JWT): Session {
   return {
     ...session,
+    pending_signout_reason: token.pending_signout_reason ?? null,
     user: {
       ...session.user,
       id: token.id ?? session.user.id,


### PR DESCRIPTION
## Summary
- add server-side auth lifecycle emission for `authorize`, `jwt`, `events.signIn`, and `events.signOut`
- preserve `pending_signout_reason` through `session.update(...)` and password-change invalidation
- capture request correlation, IP, user-agent, and signout session duration in structured auth lifecycle logs

## Testing
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js exec vitest run src/auth/__tests__/auth-config.authorize-events.test.ts src/auth/__tests__/auth-config.jwt-cooldown.test.ts src/auth/__tests__/auth-lifecycle-logging.test.ts src/auth/__tests__/auth-types.test.ts
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

Closes #377
Refs #366
EOF 2>&1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured auth lifecycle events with request context across `authorize`, JWT callback, and `events.signIn`/`events.signOut`. Also clarifies agent docs on RTK vs context-mode command routing. Closes #377.

- **New Features**
  - Emits: login_success; login_failure (config_error, rpc_error, invalid_credentials, authorize_exception); tenant_inactive; profile_refresh_failed; token_invalidated_password_change; signout/forced_signout (from `pending_signout_reason`, with session duration).
  - Adds request context on all logs: `x-request-id`/`x-vercel-id`, IP from `x-forwarded-for`, and `user-agent`.
  - Persists `pending_signout_reason` from `session.update(...)` into JWT; clears stale values when later updates omit it; preserves it and `loginTime` on password-change invalidation; exposes on session; defaults to `session_expired` if absent; skips sign-out logs when no identity or reason.
  - Normalizes usernames, coerces tenant IDs, and avoids logging secrets; tests cover authorize emissions, JWT persistence/invalidation, and profile-refresh failure logging.

<sup>Written for commit 2e03fa5d39e8d604e07abe2441924f13715764e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication lifecycle logging with request context (request ID, IP, user-agent)
  * Added sign-out event tracking (forced sign-out, signout reasons) and session-duration metadata
  * JWT/session now preserve pending sign-out reason and can preserve loginTime during password-change invalidation; new lifecycle code for token invalidation

* **Tests**
  * Expanded tests covering credential authorize flows, sign-in/sign-out events, JWT cooldown/pending-signout behavior, tenant/config error cases, and telemetry emission

* **Documentation**
  * New guidance on RTK vs context-mode command conventions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->