### PR TITLE
refactor(transfers): group TransfersPagePanel boolean-like props (#361)

### DIFF
--- a/src/app/(app)/transfers/_components/TransfersPageContent.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPageContent.tsx
@@ -99,11 +99,13 @@ export function TransfersPageContent({ user }: TransfersPageContentProps) {
           onTabChange={controller.setActiveTab}
           transferCounts={controller.transferCounts}
           totalCount={controller.totalCount}
-          showFacilityFilter={controller.showFacilityFilter}
+          permissions={{
+            showFacilityFilter: controller.showFacilityFilter,
+            isRegionalLeader: controller.isRegionalLeader,
+          }}
           activeFilterCount={controller.filtersState.activeFilterCount}
           onOpenFilterModal={() => controller.filtersState.setIsFilterModalOpen(true)}
           onOpenAddDialog={() => controller.setIsAddDialogOpen(true)}
-          isRegionalLeader={controller.isRegionalLeader}
           filterChipsValue={controller.filterChipsValue}
           onRemoveFilter={controller.filtersState.handleRemoveFilter}
           onClearAllFilters={controller.filtersState.handleClearAllFilters}
@@ -111,9 +113,11 @@ export function TransfersPageContent({ user }: TransfersPageContentProps) {
           onSearchTermChange={controller.filtersState.setSearchTerm}
           onClearSearch={controller.filtersState.clearSearch}
           viewMode={controller.viewMode}
-          shouldFetchData={controller.shouldFetchData}
-          isListLoading={controller.isListLoading}
-          isListFetching={controller.isListFetching}
+          dataState={{
+            shouldFetch: controller.shouldFetchData,
+            isLoading: controller.isListLoading,
+            isFetching: controller.isListFetching,
+          }}
           tableData={controller.tableData}
           referenceDate={controller.referenceDate}
           onViewTransfer={controller.rowActions.handleViewDetail}

--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -33,16 +33,26 @@ import type {
 
 import type { TransferUserRole } from "./TransfersTypes"
 
+export type TransfersPagePanelPermissions = Readonly<{
+  showFacilityFilter: boolean
+  isRegionalLeader: boolean
+}>
+
+export type TransfersPagePanelDataState = Readonly<{
+  shouldFetch: boolean
+  isLoading: boolean
+  isFetching: boolean
+}>
+
 type TransfersPagePanelProps = Readonly<{
   activeTab: TransferType
   onTabChange: (tab: TransferType) => void
   transferCounts: TransferCountsResponse | null | undefined
   totalCount: number
-  showFacilityFilter: boolean
+  permissions: TransfersPagePanelPermissions
   activeFilterCount: number
   onOpenFilterModal: () => void
   onOpenAddDialog: () => void
-  isRegionalLeader: boolean
   filterChipsValue: FilterChipsValue
   onRemoveFilter: (key: keyof FilterChipsValue, subkey?: string) => void
   onClearAllFilters: () => void
@@ -50,9 +60,7 @@ type TransfersPagePanelProps = Readonly<{
   onSearchTermChange: (value: string) => void
   onClearSearch: () => void
   viewMode: "table" | "kanban"
-  shouldFetchData: boolean
-  isListLoading: boolean
-  isListFetching: boolean
+  dataState: TransfersPagePanelDataState
   tableData: TransferListItem[]
   referenceDate: Date
   onViewTransfer: (item: TransferListItem) => void
@@ -89,11 +97,10 @@ export function TransfersPagePanel({
   onTabChange,
   transferCounts,
   totalCount,
-  showFacilityFilter,
+  permissions,
   activeFilterCount,
   onOpenFilterModal,
   onOpenAddDialog,
-  isRegionalLeader,
   filterChipsValue,
   onRemoveFilter,
   onClearAllFilters,
@@ -101,9 +108,7 @@ export function TransfersPagePanel({
   onSearchTermChange,
   onClearSearch,
   viewMode,
-  shouldFetchData,
-  isListLoading,
-  isListFetching,
+  dataState,
   tableData,
   referenceDate,
   onViewTransfer,
@@ -120,6 +125,8 @@ export function TransfersPagePanel({
   transferEntity,
   transferDisplayFormat,
 }: TransfersPagePanelProps) {
+  const { showFacilityFilter, isRegionalLeader } = permissions
+  const { shouldFetch, isLoading: isListLoading, isFetching: isListFetching } = dataState
   const transferTypeCounts = getTransferTypeCounts(activeTab, transferCounts, totalCount)
 
   return (
@@ -185,7 +192,7 @@ export function TransfersPagePanel({
               />
 
               {viewMode === "kanban" ? (
-                shouldFetchData ? (
+                shouldFetch ? (
                   <TransfersKanbanView
                     filters={filters}
                     onViewTransfer={onViewTransfer}
@@ -197,7 +204,7 @@ export function TransfersPagePanel({
                 ) : (
                   <TransfersTenantSelectionPlaceholder />
                 )
-              ) : shouldFetchData ? (
+              ) : shouldFetch ? (
                 <>
                   <div className="space-y-3 lg:hidden">
                     {isListLoading ? (
@@ -250,7 +257,7 @@ export function TransfersPagePanel({
         </TransfersSearchParamsBoundary>
       </CardContent>
 
-      {viewMode === "table" && shouldFetchData && (
+      {viewMode === "table" && shouldFetch && (
         <CardFooter className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <DataTablePagination
             table={table}

--- a/src/components/transfers/__tests__/TransfersKanbanView.infinite-scroll.test.tsx
+++ b/src/components/transfers/__tests__/TransfersKanbanView.infinite-scroll.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TransfersKanbanView } from "@/components/transfers/TransfersKanbanView"
+import { makeTransferItem } from "@/test-utils/transfers-fixtures"
 import type {
   TransferKanbanResponse,
   TransferListFilters,
@@ -62,47 +63,6 @@ vi.mock("@/components/transfers/TransfersKanbanColumn", () => ({
     )
   ),
 }))
-
-function makeTransferItem(
-  overrides: Partial<TransferListItem> = {},
-): TransferListItem {
-  return {
-    id: overrides.id ?? 1,
-    ma_yeu_cau: overrides.ma_yeu_cau ?? "LC-0001",
-    thiet_bi_id: overrides.thiet_bi_id ?? 1,
-    loai_hinh: overrides.loai_hinh ?? "noi_bo",
-    trang_thai: overrides.trang_thai ?? "cho_duyet",
-    nguoi_yeu_cau_id: overrides.nguoi_yeu_cau_id ?? 1,
-    ly_do_luan_chuyen: overrides.ly_do_luan_chuyen ?? "Transfer",
-    khoa_phong_hien_tai: overrides.khoa_phong_hien_tai ?? "Dept A",
-    khoa_phong_nhan: overrides.khoa_phong_nhan ?? "Dept B",
-    muc_dich: overrides.muc_dich ?? null,
-    don_vi_nhan: overrides.don_vi_nhan ?? null,
-    dia_chi_don_vi: overrides.dia_chi_don_vi ?? null,
-    nguoi_lien_he: overrides.nguoi_lien_he ?? null,
-    so_dien_thoai: overrides.so_dien_thoai ?? null,
-    ngay_du_kien_tra: overrides.ngay_du_kien_tra ?? null,
-    ngay_ban_giao: overrides.ngay_ban_giao ?? null,
-    ngay_hoan_tra: overrides.ngay_hoan_tra ?? null,
-    ngay_hoan_thanh: overrides.ngay_hoan_thanh ?? null,
-    nguoi_duyet_id: overrides.nguoi_duyet_id ?? null,
-    ngay_duyet: overrides.ngay_duyet ?? null,
-    ghi_chu_duyet: overrides.ghi_chu_duyet ?? null,
-    created_at: overrides.created_at ?? "2026-05-01T00:00:00.000Z",
-    updated_at: overrides.updated_at ?? null,
-    created_by: overrides.created_by ?? 1,
-    updated_by: overrides.updated_by ?? null,
-    thiet_bi: overrides.thiet_bi ?? {
-      ten_thiet_bi: "Device",
-      ma_thiet_bi: "TB-001",
-      model: "Model",
-      serial: "SER-001",
-      khoa_phong_quan_ly: "Dept A",
-      facility_name: "Facility",
-      facility_id: 1,
-    },
-  }
-}
 
 function makeKanbanResponse(tasks: TransferListItem[]): TransferKanbanResponse {
   return {

--- a/src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx
+++ b/src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx
@@ -1,10 +1,11 @@
 import * as React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 import type { Table as ReactTable } from "@tanstack/react-table"
 
 import { TransfersPagePanel } from "@/app/(app)/transfers/_components/TransfersPagePanel"
+import { makeTransferItem } from "@/test-utils/transfers-fixtures"
 import type {
   TransferListFilters,
   TransferListItem,
@@ -94,47 +95,6 @@ vi.mock("@/components/transfers/TransfersViewToggle", () => ({
 }))
 
 // --- Helpers ------------------------------------------------------------
-
-function makeTransferItem(
-  overrides: Partial<TransferListItem> = {},
-): TransferListItem {
-  return {
-    id: overrides.id ?? 1,
-    ma_yeu_cau: overrides.ma_yeu_cau ?? "LC-0001",
-    thiet_bi_id: overrides.thiet_bi_id ?? 1,
-    loai_hinh: overrides.loai_hinh ?? "noi_bo",
-    trang_thai: overrides.trang_thai ?? "cho_duyet",
-    nguoi_yeu_cau_id: overrides.nguoi_yeu_cau_id ?? 1,
-    ly_do_luan_chuyen: overrides.ly_do_luan_chuyen ?? "Reason",
-    khoa_phong_hien_tai: overrides.khoa_phong_hien_tai ?? "Dept A",
-    khoa_phong_nhan: overrides.khoa_phong_nhan ?? "Dept B",
-    muc_dich: overrides.muc_dich ?? null,
-    don_vi_nhan: overrides.don_vi_nhan ?? null,
-    dia_chi_don_vi: overrides.dia_chi_don_vi ?? null,
-    nguoi_lien_he: overrides.nguoi_lien_he ?? null,
-    so_dien_thoai: overrides.so_dien_thoai ?? null,
-    ngay_du_kien_tra: overrides.ngay_du_kien_tra ?? null,
-    ngay_ban_giao: overrides.ngay_ban_giao ?? null,
-    ngay_hoan_tra: overrides.ngay_hoan_tra ?? null,
-    ngay_hoan_thanh: overrides.ngay_hoan_thanh ?? null,
-    nguoi_duyet_id: overrides.nguoi_duyet_id ?? null,
-    ngay_duyet: overrides.ngay_duyet ?? null,
-    ghi_chu_duyet: overrides.ghi_chu_duyet ?? null,
-    created_at: overrides.created_at ?? "2026-05-01T00:00:00.000Z",
-    updated_at: overrides.updated_at ?? null,
-    created_by: overrides.created_by ?? 1,
-    updated_by: overrides.updated_by ?? null,
-    thiet_bi: overrides.thiet_bi ?? {
-      ten_thiet_bi: "Device",
-      ma_thiet_bi: "TB-001",
-      model: "Model",
-      serial: "SER-001",
-      khoa_phong_quan_ly: "Dept A",
-      facility_name: "Facility",
-      facility_id: 1,
-    },
-  }
-}
 
 type PanelProps = React.ComponentProps<typeof TransfersPagePanel>
 
@@ -283,14 +243,16 @@ describe("TransfersPagePanel grouped props", () => {
 
   it("shows sync indicator when isFetching=true and isLoading=false", () => {
     renderPanel({
+      viewMode: "table",
       dataState: { shouldFetch: true, isLoading: false, isFetching: true },
     })
     expect(screen.getByText(/Đang đồng bộ dữ liệu/)).toBeInTheDocument()
   })
 
   it("renders activeFilterCount badge when greater than zero", () => {
-    renderPanel({ activeFilterCount: 3 })
-    expect(screen.getByText("3")).toBeInTheDocument()
+    renderPanel({ viewMode: "table", activeFilterCount: 3 })
+    const filterButton = screen.getByRole("button", { name: /Bộ lọc/ })
+    expect(within(filterButton).getByText("3")).toBeInTheDocument()
   })
 
   it("invokes onOpenFilterModal when filter button is clicked", async () => {

--- a/src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx
+++ b/src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx
@@ -1,0 +1,304 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import type { Table as ReactTable } from "@tanstack/react-table"
+
+import { TransfersPagePanel } from "@/app/(app)/transfers/_components/TransfersPagePanel"
+import type {
+  TransferListFilters,
+  TransferListItem,
+  TransferType,
+} from "@/types/transfers-data-grid"
+
+// --- Heavy children: replaced with simple sentinels ---------------------
+
+vi.mock("@/components/shared/TenantSelector", () => ({
+  TenantSelector: () => <div data-testid="tenant-selector" />,
+}))
+
+vi.mock("@/components/shared/SearchInput", () => ({
+  SearchInput: ({
+    value,
+    onChange,
+    onClear,
+  }: {
+    value: string
+    onChange: (v: string) => void
+    onClear: () => void
+  }) => (
+    <div data-testid="search-input">
+      <input
+        aria-label="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <button type="button" onClick={onClear}>
+        clear
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock("@/components/shared/DataTablePagination", () => ({
+  DataTablePagination: () => <div data-testid="data-table-pagination" />,
+}))
+
+vi.mock("@/components/transfers/TransferCard", () => ({
+  TransferCard: ({ transfer }: { transfer: TransferListItem }) => (
+    <div data-testid={`transfer-card-${transfer.id}`}>{transfer.ma_yeu_cau}</div>
+  ),
+}))
+
+vi.mock("@/components/transfers/FilterChips", () => ({
+  FilterChips: () => <div data-testid="filter-chips" />,
+}))
+
+vi.mock("@/components/transfers/TransferTypeTabs", () => ({
+  TransferTypeTabs: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="transfer-type-tabs">{children}</div>
+  ),
+}))
+
+vi.mock("@/components/transfers/TransfersKanbanView", () => ({
+  TransfersKanbanView: ({
+    initialData,
+  }: {
+    initialData: unknown
+  }) => (
+    <div
+      data-testid="transfers-kanban-view"
+      data-initial={initialData === null ? "null" : "data"}
+    />
+  ),
+}))
+
+vi.mock("@/components/transfers/TransfersSearchParamsBoundary", () => ({
+  TransfersSearchParamsBoundary: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="search-params-boundary">{children}</div>
+  ),
+}))
+
+vi.mock("@/components/transfers/TransfersTableView", () => ({
+  TransfersTableView: () => <div data-testid="transfers-table-view" />,
+}))
+
+vi.mock("@/components/transfers/TransfersTenantSelectionPlaceholder", () => ({
+  TransfersTenantSelectionPlaceholder: () => (
+    <div data-testid="tenant-placeholder" />
+  ),
+}))
+
+vi.mock("@/components/transfers/TransfersViewToggle", () => ({
+  TransfersViewToggle: () => <div data-testid="view-toggle" />,
+}))
+
+// --- Helpers ------------------------------------------------------------
+
+function makeTransferItem(
+  overrides: Partial<TransferListItem> = {},
+): TransferListItem {
+  return {
+    id: overrides.id ?? 1,
+    ma_yeu_cau: overrides.ma_yeu_cau ?? "LC-0001",
+    thiet_bi_id: overrides.thiet_bi_id ?? 1,
+    loai_hinh: overrides.loai_hinh ?? "noi_bo",
+    trang_thai: overrides.trang_thai ?? "cho_duyet",
+    nguoi_yeu_cau_id: overrides.nguoi_yeu_cau_id ?? 1,
+    ly_do_luan_chuyen: overrides.ly_do_luan_chuyen ?? "Reason",
+    khoa_phong_hien_tai: overrides.khoa_phong_hien_tai ?? "Dept A",
+    khoa_phong_nhan: overrides.khoa_phong_nhan ?? "Dept B",
+    muc_dich: overrides.muc_dich ?? null,
+    don_vi_nhan: overrides.don_vi_nhan ?? null,
+    dia_chi_don_vi: overrides.dia_chi_don_vi ?? null,
+    nguoi_lien_he: overrides.nguoi_lien_he ?? null,
+    so_dien_thoai: overrides.so_dien_thoai ?? null,
+    ngay_du_kien_tra: overrides.ngay_du_kien_tra ?? null,
+    ngay_ban_giao: overrides.ngay_ban_giao ?? null,
+    ngay_hoan_tra: overrides.ngay_hoan_tra ?? null,
+    ngay_hoan_thanh: overrides.ngay_hoan_thanh ?? null,
+    nguoi_duyet_id: overrides.nguoi_duyet_id ?? null,
+    ngay_duyet: overrides.ngay_duyet ?? null,
+    ghi_chu_duyet: overrides.ghi_chu_duyet ?? null,
+    created_at: overrides.created_at ?? "2026-05-01T00:00:00.000Z",
+    updated_at: overrides.updated_at ?? null,
+    created_by: overrides.created_by ?? 1,
+    updated_by: overrides.updated_by ?? null,
+    thiet_bi: overrides.thiet_bi ?? {
+      ten_thiet_bi: "Device",
+      ma_thiet_bi: "TB-001",
+      model: "Model",
+      serial: "SER-001",
+      khoa_phong_quan_ly: "Dept A",
+      facility_name: "Facility",
+      facility_id: 1,
+    },
+  }
+}
+
+type PanelProps = React.ComponentProps<typeof TransfersPagePanel>
+
+function buildProps(overrides: Partial<PanelProps> = {}): PanelProps {
+  const filters: TransferListFilters = { types: ["noi_bo"] }
+  const tableStub = {} as unknown as ReactTable<TransferListItem>
+  const RowActions: PanelProps["RowActions"] = () => null
+
+  const base: PanelProps = {
+    activeTab: "noi_bo" as TransferType,
+    onTabChange: vi.fn(),
+    transferCounts: null,
+    totalCount: 0,
+    activeFilterCount: 0,
+    onOpenFilterModal: vi.fn(),
+    onOpenAddDialog: vi.fn(),
+    permissions: {
+      showFacilityFilter: false,
+      isRegionalLeader: false,
+    },
+    dataState: {
+      shouldFetch: true,
+      isLoading: false,
+      isFetching: false,
+    },
+    filterChipsValue: {} as PanelProps["filterChipsValue"],
+    onRemoveFilter: vi.fn(),
+    onClearAllFilters: vi.fn(),
+    searchTerm: "",
+    onSearchTermChange: vi.fn(),
+    onClearSearch: vi.fn(),
+    viewMode: "table",
+    tableData: [],
+    referenceDate: new Date("2026-05-01T00:00:00.000Z"),
+    onViewTransfer: vi.fn(),
+    RowActions,
+    renderRowActions: () => null,
+    filters,
+    kanbanData: null,
+    userRole: "to_qltb",
+    columns: [],
+    pagination: { pageIndex: 0, pageSize: 10 },
+    onPaginationChange: vi.fn(),
+    pageCount: 1,
+    table: tableStub,
+    transferEntity: { singular: "yêu cầu" },
+    transferDisplayFormat: () => null,
+  }
+
+  return { ...base, ...overrides }
+}
+
+function renderPanel(overrides: Partial<PanelProps> = {}) {
+  return render(<TransfersPagePanel {...buildProps(overrides)} />)
+}
+
+// --- Tests --------------------------------------------------------------
+
+describe("TransfersPagePanel grouped props", () => {
+  it("renders TenantSelector when permissions.showFacilityFilter=true", () => {
+    renderPanel({
+      permissions: { showFacilityFilter: true, isRegionalLeader: false },
+    })
+    expect(screen.getByTestId("tenant-selector")).toBeInTheDocument()
+  })
+
+  it("hides TenantSelector when permissions.showFacilityFilter=false", () => {
+    renderPanel()
+    expect(screen.queryByTestId("tenant-selector")).not.toBeInTheDocument()
+  })
+
+  it("hides 'Tạo yêu cầu mới' when permissions.isRegionalLeader=true", () => {
+    renderPanel({
+      permissions: { showFacilityFilter: false, isRegionalLeader: true },
+    })
+    expect(screen.queryByRole("button", { name: /Tạo yêu cầu mới/ })).toBeNull()
+  })
+
+  it("invokes onOpenAddDialog when create button is clicked (non-regional leader)", async () => {
+    const onOpenAddDialog = vi.fn()
+    renderPanel({ onOpenAddDialog })
+    await userEvent.setup().click(
+      screen.getByRole("button", { name: /Tạo yêu cầu mới/ }),
+    )
+    expect(onOpenAddDialog).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders tenant placeholder when dataState.shouldFetch=false (table mode)", () => {
+    renderPanel({
+      viewMode: "table",
+      dataState: { shouldFetch: false, isLoading: false, isFetching: false },
+    })
+    expect(screen.getByTestId("tenant-placeholder")).toBeInTheDocument()
+    expect(screen.queryByTestId("transfers-table-view")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("data-table-pagination")).not.toBeInTheDocument()
+  })
+
+  it("renders tenant placeholder when dataState.shouldFetch=false (kanban mode)", () => {
+    renderPanel({
+      viewMode: "kanban",
+      dataState: { shouldFetch: false, isLoading: false, isFetching: false },
+    })
+    expect(screen.getByTestId("tenant-placeholder")).toBeInTheDocument()
+    expect(screen.queryByTestId("transfers-kanban-view")).not.toBeInTheDocument()
+  })
+
+  it("renders kanban view with initialData=null while isFetching is true", () => {
+    renderPanel({
+      viewMode: "kanban",
+      dataState: { shouldFetch: true, isLoading: false, isFetching: true },
+      kanbanData: { columns: {}, totalCount: 0 } as PanelProps["kanbanData"],
+    })
+    const kanban = screen.getByTestId("transfers-kanban-view")
+    expect(kanban).toHaveAttribute("data-initial", "null")
+  })
+
+  it("renders kanban view with provided kanbanData when not fetching", () => {
+    renderPanel({
+      viewMode: "kanban",
+      dataState: { shouldFetch: true, isLoading: false, isFetching: false },
+      kanbanData: { columns: {}, totalCount: 0 } as PanelProps["kanbanData"],
+    })
+    expect(screen.getByTestId("transfers-kanban-view")).toHaveAttribute(
+      "data-initial",
+      "data",
+    )
+  })
+
+  it("renders table view + footer pagination in table mode when shouldFetch=true", () => {
+    renderPanel({
+      viewMode: "table",
+      dataState: { shouldFetch: true, isLoading: false, isFetching: false },
+      tableData: [makeTransferItem()],
+    })
+    expect(screen.getByTestId("transfers-table-view")).toBeInTheDocument()
+    expect(screen.getByTestId("data-table-pagination")).toBeInTheDocument()
+  })
+
+  it("shows mobile loading indicator when dataState.isLoading=true", () => {
+    renderPanel({
+      viewMode: "table",
+      dataState: { shouldFetch: true, isLoading: true, isFetching: false },
+    })
+    expect(screen.getByText(/Đang tải dữ liệu/)).toBeInTheDocument()
+  })
+
+  it("shows sync indicator when isFetching=true and isLoading=false", () => {
+    renderPanel({
+      dataState: { shouldFetch: true, isLoading: false, isFetching: true },
+    })
+    expect(screen.getByText(/Đang đồng bộ dữ liệu/)).toBeInTheDocument()
+  })
+
+  it("renders activeFilterCount badge when greater than zero", () => {
+    renderPanel({ activeFilterCount: 3 })
+    expect(screen.getByText("3")).toBeInTheDocument()
+  })
+
+  it("invokes onOpenFilterModal when filter button is clicked", async () => {
+    const onOpenFilterModal = vi.fn()
+    renderPanel({ onOpenFilterModal })
+    await userEvent.setup().click(
+      screen.getByRole("button", { name: /Bộ lọc/ }),
+    )
+    expect(onOpenFilterModal).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/test-utils/transfers-fixtures.ts
+++ b/src/test-utils/transfers-fixtures.ts
@@ -1,0 +1,46 @@
+import type { TransferListItem } from "@/types/transfers-data-grid"
+
+/**
+ * Shared test fixture for a TransferListItem with sensible defaults.
+ * Use from vitest test files to avoid duplicating the long list of fields.
+ */
+export function makeTransferItem(
+  overrides: Partial<TransferListItem> = {},
+): TransferListItem {
+  return {
+    id: overrides.id ?? 1,
+    ma_yeu_cau: overrides.ma_yeu_cau ?? "LC-0001",
+    thiet_bi_id: overrides.thiet_bi_id ?? 1,
+    loai_hinh: overrides.loai_hinh ?? "noi_bo",
+    trang_thai: overrides.trang_thai ?? "cho_duyet",
+    nguoi_yeu_cau_id: overrides.nguoi_yeu_cau_id ?? 1,
+    ly_do_luan_chuyen: overrides.ly_do_luan_chuyen ?? "Transfer",
+    khoa_phong_hien_tai: overrides.khoa_phong_hien_tai ?? "Dept A",
+    khoa_phong_nhan: overrides.khoa_phong_nhan ?? "Dept B",
+    muc_dich: overrides.muc_dich ?? null,
+    don_vi_nhan: overrides.don_vi_nhan ?? null,
+    dia_chi_don_vi: overrides.dia_chi_don_vi ?? null,
+    nguoi_lien_he: overrides.nguoi_lien_he ?? null,
+    so_dien_thoai: overrides.so_dien_thoai ?? null,
+    ngay_du_kien_tra: overrides.ngay_du_kien_tra ?? null,
+    ngay_ban_giao: overrides.ngay_ban_giao ?? null,
+    ngay_hoan_tra: overrides.ngay_hoan_tra ?? null,
+    ngay_hoan_thanh: overrides.ngay_hoan_thanh ?? null,
+    nguoi_duyet_id: overrides.nguoi_duyet_id ?? null,
+    ngay_duyet: overrides.ngay_duyet ?? null,
+    ghi_chu_duyet: overrides.ghi_chu_duyet ?? null,
+    created_at: overrides.created_at ?? "2026-05-01T00:00:00.000Z",
+    updated_at: overrides.updated_at ?? null,
+    created_by: overrides.created_by ?? 1,
+    updated_by: overrides.updated_by ?? null,
+    thiet_bi: overrides.thiet_bi ?? {
+      ten_thiet_bi: "Device",
+      ma_thiet_bi: "TB-001",
+      model: "Model",
+      serial: "SER-001",
+      khoa_phong_quan_ly: "Dept A",
+      facility_name: "Facility",
+      facility_id: 1,
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Closes #361.

Collapse 5 boolean-like props on `TransfersPagePanel` into two cohesive config objects to clear the React Doctor heuristic warning while keeping behavior unchanged:

- `permissions: { showFacilityFilter, isRegionalLeader }`
- `dataState:   { shouldFetch, isLoading, isFetching }`

Single consumer (`TransfersPageContent.tsx`) updated to pass the grouped objects.

## Why this approach

Issue suggested either grouping booleans into config objects or splitting into smaller view sections. Grouping is the smallest, surgical change and mirrors the existing grouping style already in this file (`transferEntity`, `transferDisplayFormat`, `pagination`). Avoids refactoring only to satisfy heuristic noise per the issue's acceptance criteria.

## Tests (TDD)

New render-level spec `src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx` (13 tests) locks in current behavior:

- TenantSelector visibility via `permissions.showFacilityFilter`
- "Tạo yêu cầu mới" button gated by `permissions.isRegionalLeader` (+ click handler)
- Tenant placeholder rendered in both kanban + table modes when `dataState.shouldFetch=false`
- Kanban `initialData` toggling between `null` and provided data based on `isFetching`
- Table view + footer pagination only when `viewMode==="table" && shouldFetch`
- Mobile loading branch when `isLoading=true`
- Sync indicator when `isFetching && !isLoading`
- Active filter count badge + filter modal trigger

Existing `TransfersPagePanel.search-params-boundary.test.ts` remains valid.

## Verification

- [x] `verify:no-explicit-any` — clean
- [x] `typecheck` — passes
- [x] Focused transfers tests — 71/71 passing across 16 files
- [x] `react-doctor --diff main` — score 100/100, the boolean-like-props warning on `TransfersPagePanel` is cleared

## Acceptance Criteria (Issue #361)

- [x] Existing Transfers behavior remains unchanged for table and kanban modes (locked in by render tests)
- [x] Prop shape is clearer (5 booleans → 2 grouped config objects)
- [x] App-layer gates run for TS/React change

## Manual Verification Notes

Behavior is fully covered by the new render tests; manual browser smoke recommended for global / regional_leader / to_qltb roles across table + kanban modes after deploy.

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grouped 5 boolean-like props on `TransfersPagePanel` into `permissions` and `dataState` to clear the React Doctor warning with no behavior changes. Updated the sole consumer and refined tests to lock current behavior per #361.

- **Refactors**
  - `TransfersPagePanel`: replaced booleans with `permissions: { showFacilityFilter, isRegionalLeader }` and `dataState: { shouldFetch, isLoading, isFetching }`.
  - `TransfersPageContent`: passes the new grouped props.
  - Tests: added render suite; extracted shared `makeTransferItem` fixture to `src/test-utils/transfers-fixtures.ts`; updated `TransfersKanbanView.infinite-scroll.test.tsx` to use it; tightened panel test assertions (explicit `viewMode`, scoped badge check).

<sup>Written for commit d243ec797108f0eccb012255ab9e1337183e6605. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized transfer management component property structure for improved code organization.

* **Tests**
  * Added comprehensive test coverage for transfer page panel functionality, validating UI rendering, conditional display logic, filter operations, view switching, and user interactions across different modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->