### PR TITLE
[Issue #366][Batch 4] Wire frontend signout observability

### DIFF
--- a/scripts/test_session_management.md
+++ b/scripts/test_session_management.md
@@ -1,92 +1,88 @@
-# 🔧 TEST SESSION MANAGEMENT MỚI
+# Test Session Management va Signout Wiring
 
-## ✅ **Những gì đã thay đổi:**
+Tai lieu nay dung de test Batch 4 cua Issue #366/#379 sau khi backend auth observability da co san.
 
-### 1. **Token thật được lưu trong localStorage**
-- Token chứa thông tin user và thời gian hết hạn
-- Format: Base64 encoded JSON với:
-  ```json
-  {
-    "user_id": 1,
-    "username": "admin", 
-    "role": "admin",
-    "khoa_phong": "IT",
-    "full_name": "Admin User",
-    "created_at": 1640995200000,
-    "expires_at": 1641006000000  // 3 tiếng sau
-  }
-  ```
+## Muc tieu
 
-### 2. **Session validation mỗi phút**
-- Kiểm tra token local mỗi phút (không cần gọi server)
-- Cảnh báo khi còn 5 phút
-- Auto-logout khi hết hạn với thông báo rõ ràng
+- Xac nhan user bam `Dang xuat` thi frontend seed `pending_signout_reason=user_initiated` truoc khi `signOut()`.
+- Xac nhan doi mat khau thanh cong thi frontend seed `pending_signout_reason=forced_password_change`, giu toast thanh cong trong thoi gian ngan, roi moi `signOut()`.
+- Ghi ro hanh vi cross-tab:
+  - tab khoi tao doi mat khau se phat `forced_signout/forced_password_change`
+  - tab khac co the phat `forced_signout/session_expired`
+  - backend correlate bang `token_invalidated_password_change`
 
-### 3. **Thông báo cho user**
-- **Cảnh báo:** "Phiên làm việc sẽ hết hạn trong X phút"
-- **Auto-logout:** "Phiên làm việc đã hết hạn. Bạn đã được đăng xuất tự động sau 3 tiếng"
+## Verification nhanh trong local
 
-## 🚀 **Cách test:**
+### 1. Chay cac gate bat buoc
 
-### **BƯỚC 1: Restart ứng dụng**
 ```bash
-# Dừng server (Ctrl+C)
-npm run dev
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run test:run -- src/app/'(app)'/__tests__/AppLayoutShell.test.tsx
+node scripts/npm-run.js run test:run -- src/components/__tests__/change-password-dialog.signout.test.tsx
+node scripts/npm-run.js run test:run -- src/lib/__tests__/auth-signout.test.ts
+node scripts/npm-run.js run test:run -- src/auth/__tests__/auth-config.authorize-events.test.ts
+node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
 ```
 
-### **BƯỚC 2: Test login**
-1. Đăng nhập vào ứng dụng
-2. Kiểm tra localStorage có token mới (F12 → Application → Local Storage)
-3. Token sẽ có format dài (Base64)
+### 2. Test `Dang xuat` tu user menu
 
-### **BƯỚC 3: Test session persistence**
-1. Refresh trang nhiều lần → không bị logout
-2. Đóng browser và mở lại → vẫn đăng nhập
-3. Session sẽ tồn tại đúng 3 tiếng
+1. Dang nhap vao app.
+2. Mo user menu o header.
+3. Bam `Dang xuat`.
+4. Ky vong:
+   - session bi xoa va quay ve `/`
+   - chi co mot signout flow cho tab khoi tao
+   - backend log event `signout` voi `signout_reason=user_initiated`
 
-### **BƯỚC 4: Test auto-logout (optional)**
-Để test nhanh, có thể tạm thời giảm thời gian session:
+Neu can kiem tra bang test tu dong, xem:
+- `src/app/(app)/__tests__/AppLayoutShell.test.tsx`
+- `src/lib/__tests__/auth-signout.test.ts`
+- `src/auth/__tests__/auth-config.authorize-events.test.ts`
 
-```javascript
-// Trong auth-context.tsx, dòng 141, thay:
-expires_at: Date.now() + (3 * 60 * 60 * 1000) // 3 hours
-// Thành:
-expires_at: Date.now() + (2 * 60 * 1000) // 2 phút để test
-```
+### 3. Test doi mat khau thanh cong
 
-## 📊 **Debug session:**
+1. Dang nhap vao app.
+2. Mo user menu va chon `Thay doi mat khau`.
+3. Nhap mat khau hien tai, mat khau moi, xac nhan mat khau moi.
+4. Submit khi RPC `change_password` thanh cong.
+5. Ky vong:
+   - hien toast thanh cong
+   - dialog dong lai
+   - toast van con hien khoang 1.5 giay truoc khi bi logout
+   - sau do app quay ve `/`
+   - backend log `forced_signout` voi `signout_reason=forced_password_change`
+   - khong co ghost `session_expired` tren tab khoi tao
 
-### **Xem thông tin session hiện tại:**
-```javascript
-// Chạy trong Console (F12)
-const token = localStorage.getItem('auth_session_token');
-if (token) {
-  const sessionData = JSON.parse(atob(token));
-  console.log('Session data:', sessionData);
-  console.log('Expires at:', new Date(sessionData.expires_at));
-  console.log('Time left:', Math.round((sessionData.expires_at - Date.now()) / 1000 / 60), 'minutes');
-}
-```
+Neu can kiem tra bang test tu dong, xem:
+- `src/components/__tests__/change-password-dialog.signout.test.tsx`
+- `src/lib/__tests__/auth-signout.test.ts`
+- `src/auth/__tests__/auth-config.authorize-events.test.ts`
 
-### **Kiểm tra session validation:**
-- Mở Console (F12)
-- Mỗi phút sẽ thấy session được check
-- Khi còn 5 phút sẽ có cảnh báo
-- Khi hết hạn sẽ có thông báo logout
+### 4. Test cross-tab sau doi mat khau
 
-## ✅ **Kết quả mong đợi:**
+1. Mo cung mot tai khoan o 2 tab.
+2. O tab A, doi mat khau thanh cong.
+3. Quan sat tab B.
+4. Ky vong:
+   - tab A phat `forced_signout/forced_password_change`
+   - tab B co the roi vao `session_expired` khi session bi vo hieu hoa
+   - backend da co `token_invalidated_password_change` de correlate 2 su kien nay
 
-1. ✅ **Không còn logout sau 5 phút**
-2. ✅ **Session tồn tại đúng 3 tiếng**  
-3. ✅ **Thông báo rõ ràng khi auto-logout**
-4. ✅ **Cảnh báo trước khi hết hạn**
-5. ✅ **Không cần gọi server để validate**
+Ghi chu:
+- `session_expired` o tab khong khoi tao la hanh vi du kien, khong coi la bug cua Batch 4.
+- Muc tieu cua Batch 4 la loai bo ghost `session_expired` tren tab khoi tao doi mat khau.
 
-## 🔒 **Bảo mật:**
+## Kiem tra log / audit sink
 
-- Token được Base64 encode (không phải encryption)
-- Chấp nhận rủi ro như bạn yêu cầu
-- Đơn giản và hiệu quả
-- Không ảnh hưởng performance
+Neu Batch 3 da duoc apply, co the kiem tra them bang log hoac `auth_audit_log`:
 
-Giải pháp này đơn giản, hiệu quả và giải quyết được vấn đề auto-logout không mong muốn!
+- `signout` + `user_initiated`
+- `forced_signout` + `forced_password_change`
+- `forced_signout` + `session_expired` chi xuat hien o fallback/cross-tab path
+- `token_invalidated_password_change` de correlate invalidation
+
+Can doi chieu them voi:
+- `src/auth/config.ts`
+- `src/auth/logging.ts`
+- `src/auth/persistence.ts`

--- a/src/app/(app)/__tests__/AppLayoutShell.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   clearAllEquipmentFilters: vi.fn(),
   signOut: vi.fn(),
   useSession: vi.fn(),
+  updateSession: vi.fn(),
   usePathname: vi.fn(),
   useTenantSelection: vi.fn(),
   useTenantBranding: vi.fn(),
@@ -137,9 +138,11 @@ import { AppLayoutShell } from "@/app/(app)/_components/AppLayoutShell"
 describe("AppLayoutShell", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.updateSession.mockResolvedValue(undefined)
     mocks.useSession.mockReturnValue({
       data: { user: { id: "u1" } },
       status: "authenticated",
+      update: mocks.updateSession,
     })
     mocks.usePathname.mockReturnValue("/dashboard")
     mocks.useTenantSelection.mockReturnValue({
@@ -184,7 +187,7 @@ describe("AppLayoutShell", () => {
     })
   })
 
-  it("clears equipment filters before signing out from the user menu", async () => {
+  it("persists a user-initiated signout reason before signing out from the user menu", async () => {
     const user = userEvent.setup()
 
     render(
@@ -203,8 +206,14 @@ describe("AppLayoutShell", () => {
     await user.click(screen.getByRole("button", { name: /đăng xuất/i }))
 
     expect(mocks.clearAllEquipmentFilters).toHaveBeenCalledTimes(1)
+    expect(mocks.updateSession).toHaveBeenCalledWith({
+      pending_signout_reason: "user_initiated",
+    })
     expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
     expect(mocks.clearAllEquipmentFilters.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.updateSession.mock.invocationCallOrder[0]
+    )
+    expect(mocks.updateSession.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.signOut.mock.invocationCallOrder[0]
     )
   })

--- a/src/app/(app)/__tests__/AppLayoutShell.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.test.tsx
@@ -218,6 +218,38 @@ describe("AppLayoutShell", () => {
     )
   })
 
+  it("allows retrying user-menu signout after a signOut failure", async () => {
+    const user = userEvent.setup()
+    mocks.signOut
+      .mockRejectedValueOnce(new Error("redirect failed"))
+      .mockResolvedValueOnce(undefined)
+
+    render(
+      <AppLayoutShell
+        user={{
+          role: "global",
+          full_name: "Test User",
+          username: "tester",
+          khoa_phong: "IT",
+        }}
+      >
+        <div>Child Content</div>
+      </AppLayoutShell>
+    )
+
+    const signOutButton = screen.getByRole("button", { name: /đăng xuất/i })
+
+    await user.click(signOutButton)
+    await vi.waitFor(() => {
+      expect(mocks.signOut).toHaveBeenCalledTimes(1)
+    })
+
+    await user.click(signOutButton)
+    await vi.waitFor(() => {
+      expect(mocks.signOut).toHaveBeenCalledTimes(2)
+    })
+  })
+
   it("redirects through signOut when the session becomes unauthenticated", () => {
     const sessionState = {
       data: { user: { id: "u1" } },

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -119,6 +119,8 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
     void signOutWithReason({
       updateSession: update,
       reason: "user_initiated",
+    }).catch(() => {
+      hasHandledSessionExitRef.current = false
     })
   }, [update])
 

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -36,6 +36,7 @@ import { EquipmentFilterProvider, clearAllEquipmentFilters } from "@/contexts/Eq
 import { AppSidebarNav } from "@/components/app-sidebar-nav"
 import { getAppNavigationItems } from "@/components/app-navigation"
 import { useAppNotificationCounts } from "@/hooks/useAppNotificationCounts"
+import { signOutWithReason } from "@/lib/auth-signout"
 
 const AssistantTriggerButton = dynamic(
   () => import("@/components/assistant/AssistantTriggerButton").then(m => m.AssistantTriggerButton),
@@ -70,7 +71,7 @@ export function AppLayoutShell({ children, user }: AppLayoutShellProps) {
 
 function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
   const pathname = usePathname()
-  const { status } = useSession()
+  const { status, update } = useSession()
   const { selectedFacilityId, shouldFetchData } = useTenantSelection()
   const hasHandledSessionExitRef = React.useRef(false)
   const [isSidebarOpen, setSidebarOpen] = React.useState(true)
@@ -109,8 +110,17 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
   }, [])
 
   const handleSignOut = React.useCallback(() => {
-    redirectToSignedOutHome()
-  }, [redirectToSignedOutHome])
+    if (hasHandledSessionExitRef.current) {
+      return
+    }
+
+    hasHandledSessionExitRef.current = true
+    clearAllEquipmentFilters()
+    void signOutWithReason({
+      updateSession: update,
+      reason: "user_initiated",
+    })
+  }, [update])
 
   React.useEffect(() => {
     if (status === "unauthenticated") {

--- a/src/auth/__tests__/auth-config.authorize-events.test.ts
+++ b/src/auth/__tests__/auth-config.authorize-events.test.ts
@@ -344,6 +344,49 @@ describe("authOptions authorize + auth lifecycle events", () => {
     )
   })
 
+  it("emits signout/user_initiated when signOut receives a persisted user intent", async () => {
+    const signOutEvent = getSignOutEventHandler()
+
+    await signOutEvent({
+      token: {
+        id: "42",
+        username: "nqminh",
+        don_vi: 17,
+        loginTime: Date.now() - 30_000,
+        pending_signout_reason: "user_initiated",
+      } as never,
+      session: undefined as never,
+    })
+
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
+      expect.objectContaining({
+        event: "signout",
+        source: "events_signout",
+        signout_reason: "user_initiated",
+        user_id: "42",
+        username: "nqminh",
+        tenant_id: "17",
+        request_id: "req-123",
+        metadata: expect.objectContaining({
+          session_duration_ms: 30000,
+        }),
+      }),
+    ])
+    expect(supabaseState.rpcCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fn: "auth_audit_log_insert",
+          args: expect.objectContaining({
+            p_event: "signout",
+            p_source: "events_signout",
+            p_signout_reason: "user_initiated",
+            p_user_id: "42",
+          }),
+        }),
+      ])
+    )
+  })
+
   it("falls back to augmented session fields when signOut token no longer carries auth claims", async () => {
     const signOutEvent = getSignOutEventHandler()
 

--- a/src/components/__tests__/change-password-dialog.signout.test.tsx
+++ b/src/components/__tests__/change-password-dialog.signout.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   toast: vi.fn(),
@@ -116,6 +116,10 @@ describe("ChangePasswordDialog forced signout", () => {
     })
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it("persists the forced password-change signout reason after a successful password change", async () => {
     const onOpenChange = vi.fn()
 
@@ -144,5 +148,44 @@ describe("ChangePasswordDialog forced signout", () => {
     expect(mocks.updateSession).toHaveBeenCalledWith({
       pending_signout_reason: "forced_password_change",
     })
+  })
+
+  it("shows a logout-specific error if post-change signout fails after the password update succeeds", async () => {
+    vi.useFakeTimers()
+    mocks.signOut.mockRejectedValueOnce(new Error("redirect failed"))
+
+    render(<ChangePasswordDialog open onOpenChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText("Mật khẩu hiện tại *"), {
+      target: { value: "old-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Xác nhận mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Thay đổi mật khẩu" }))
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500)
+    })
+    await Promise.resolve()
+
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Thành công",
+      }),
+    )
+    expect(mocks.toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "destructive",
+        title: "Đăng xuất chưa hoàn tất",
+        description: "Mật khẩu đã được thay đổi. Vui lòng đăng xuất thủ công hoặc tải lại trang.",
+      }),
+    )
   })
 })

--- a/src/components/__tests__/change-password-dialog.signout.test.tsx
+++ b/src/components/__tests__/change-password-dialog.signout.test.tsx
@@ -188,4 +188,33 @@ describe("ChangePasswordDialog forced signout", () => {
       }),
     )
   })
+
+  it("preserves message details from non-Error password-change failures", async () => {
+    mocks.rpc.mockRejectedValueOnce({
+      message: "Supabase RPC failed",
+    })
+
+    render(<ChangePasswordDialog open onOpenChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText("Mật khẩu hiện tại *"), {
+      target: { value: "old-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Xác nhận mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Thay đổi mật khẩu" }))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: "Lỗi",
+          description: "Supabase RPC failed",
+        }),
+      )
+    })
+  })
 })

--- a/src/components/__tests__/change-password-dialog.signout.test.tsx
+++ b/src/components/__tests__/change-password-dialog.signout.test.tsx
@@ -1,0 +1,148 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  toast: vi.fn(),
+  useSession: vi.fn(),
+  signOut: vi.fn(),
+  updateSession: vi.fn(),
+  rpc: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  signOut: (...args: unknown[]) => mocks.signOut(...args),
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}))
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => mocks.rpc(...args),
+  },
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    type,
+    disabled,
+  }: {
+    children: React.ReactNode
+    onClick?: React.MouseEventHandler<HTMLButtonElement>
+    type?: "button" | "submit" | "reset"
+    disabled?: boolean
+  }) => (
+    <button type={type} onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/input", () => ({
+  Input: ({
+    id,
+    value,
+    onChange,
+    type,
+    disabled,
+    placeholder,
+  }: {
+    id: string
+    value?: string
+    onChange?: React.ChangeEventHandler<HTMLInputElement>
+    type?: string
+    disabled?: boolean
+    placeholder?: string
+  }) => (
+    <input
+      id={id}
+      value={value}
+      onChange={onChange}
+      type={type}
+      disabled={disabled}
+      placeholder={placeholder}
+    />
+  ),
+}))
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({
+    children,
+    htmlFor,
+  }: {
+    children: React.ReactNode
+    htmlFor?: string
+  }) => <label htmlFor={htmlFor}>{children}</label>,
+}))
+
+import { ChangePasswordDialog } from "../change-password-dialog"
+
+describe("ChangePasswordDialog forced signout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.updateSession.mockResolvedValue(undefined)
+    mocks.rpc.mockResolvedValue({
+      data: {
+        success: true,
+        message: "Đã thay đổi mật khẩu thành công với mã hóa bảo mật.",
+      },
+      error: null,
+    })
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: "42",
+          username: "tester",
+        },
+      },
+      status: "authenticated",
+      update: mocks.updateSession,
+    })
+  })
+
+  it("persists the forced password-change signout reason after a successful password change", async () => {
+    const onOpenChange = vi.fn()
+
+    render(<ChangePasswordDialog open onOpenChange={onOpenChange} />)
+
+    fireEvent.change(screen.getByLabelText("Mật khẩu hiện tại *"), {
+      target: { value: "old-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Xác nhận mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Thay đổi mật khẩu" }))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Thành công",
+        }),
+      )
+    })
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(mocks.updateSession).toHaveBeenCalledWith({
+      pending_signout_reason: "forced_password_change",
+    })
+  })
+})

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -15,6 +15,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/use-toast"
+import { signOutWithReason } from "@/lib/auth-signout"
 import { supabase } from "@/lib/supabase"
 import { useSession } from "next-auth/react"
 
@@ -25,10 +26,10 @@ interface ChangePasswordDialogProps {
 
 export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
   const { toast } = useToast()
-  const { data: session } = useSession()
-  const user = session?.user as any // Cast NextAuth user to our User type
+  const { data: session, update } = useSession()
+  const user = session?.user
   const currentUserId = React.useMemo(() => {
-    const rawId = user?.id
+    const rawId: unknown = user?.id
     if (typeof rawId === "number" && Number.isFinite(rawId)) {
       return rawId
     }
@@ -203,11 +204,17 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
       }
 
       onOpenChange(false)
-    } catch (error: any) {
+      await signOutWithReason({
+        updateSession: update,
+        reason: "forced_password_change",
+        delayMs: 1_500,
+      })
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : null
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: error.message || "Có lỗi xảy ra khi thay đổi mật khẩu."
+        description: errorMessage || "Có lỗi xảy ra khi thay đổi mật khẩu."
       })
     } finally {
       setIsLoading(false)

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -70,6 +70,22 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
     }
   }, [open, resetForm])
 
+  const handlePostChangeSignOut = React.useCallback(async () => {
+    try {
+      await signOutWithReason({
+        updateSession: update,
+        reason: "forced_password_change",
+        delayMs: 1_500,
+      })
+    } catch {
+      toast({
+        variant: "destructive",
+        title: "Đăng xuất chưa hoàn tất",
+        description: "Mật khẩu đã được thay đổi. Vui lòng đăng xuất thủ công hoặc tải lại trang.",
+      })
+    }
+  }, [toast, update])
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     
@@ -110,6 +126,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
     }
 
     setIsLoading(true)
+    let passwordChanged = false
 
     try {
       if (currentUserId == null) {
@@ -204,11 +221,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
       }
 
       onOpenChange(false)
-      await signOutWithReason({
-        updateSession: update,
-        reason: "forced_password_change",
-        delayMs: 1_500,
-      })
+      passwordChanged = true
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : null
       toast({
@@ -218,6 +231,10 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
       })
     } finally {
       setIsLoading(false)
+    }
+
+    if (passwordChanged) {
+      await handlePostChangeSignOut()
     }
   }
 

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -15,6 +15,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/use-toast"
+import { getUnknownErrorMessage } from "@/lib/error-utils"
 import { signOutWithReason } from "@/lib/auth-signout"
 import { supabase } from "@/lib/supabase"
 import { useSession } from "next-auth/react"
@@ -223,11 +224,10 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
       onOpenChange(false)
       passwordChanged = true
     } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : null
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: errorMessage || "Có lỗi xảy ra khi thay đổi mật khẩu."
+        description: getUnknownErrorMessage(error, "Có lỗi xảy ra khi thay đổi mật khẩu."),
       })
     } finally {
       setIsLoading(false)

--- a/src/lib/__tests__/auth-signout.test.ts
+++ b/src/lib/__tests__/auth-signout.test.ts
@@ -11,6 +11,17 @@ vi.mock("next-auth/react", () => ({
 
 import { signOutWithReason } from "../auth-signout"
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+
+  return { promise, resolve, reject }
+}
+
 describe("signOutWithReason", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -19,6 +30,9 @@ describe("signOutWithReason", () => {
   })
 
   it("awaits the session reason update before signing out", async () => {
+    const deferred = createDeferred<void>()
+    mocks.updateSession.mockReturnValueOnce(deferred.promise)
+
     const signOutPromise = signOutWithReason({
       updateSession: mocks.updateSession,
       reason: "user_initiated",
@@ -29,9 +43,12 @@ describe("signOutWithReason", () => {
     expect(mocks.updateSession).toHaveBeenCalledWith({
       pending_signout_reason: "user_initiated",
     })
-    expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+    expect(mocks.signOut).not.toHaveBeenCalled()
 
+    deferred.resolve()
     await signOutPromise
+
+    expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
   })
 
   it("waits the requested delay before signing out", async () => {
@@ -53,6 +70,39 @@ describe("signOutWithReason", () => {
       mocks.signOut.mock.invocationCallOrder[0]
     )
 
+    await signOutPromise
+  })
+
+  it("calls signOut even when updateSession rejects", async () => {
+    mocks.updateSession.mockRejectedValueOnce(new Error("session update failed"))
+
+    await signOutWithReason({
+      updateSession: mocks.updateSession,
+      reason: "user_initiated",
+    })
+
+    expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+  })
+
+  it("falls back to signOut when updateSession hangs", async () => {
+    const deferred = createDeferred<void>()
+    mocks.updateSession.mockReturnValueOnce(deferred.promise)
+
+    const signOutPromise = signOutWithReason({
+      updateSession: mocks.updateSession,
+      reason: "user_initiated",
+    })
+
+    await Promise.resolve()
+    expect(mocks.signOut).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(mocks.signOut).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+
+    deferred.resolve()
     await signOutPromise
   })
 })

--- a/src/lib/__tests__/auth-signout.test.ts
+++ b/src/lib/__tests__/auth-signout.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  signOut: vi.fn(),
+  updateSession: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  signOut: (...args: unknown[]) => mocks.signOut(...args),
+}))
+
+import { signOutWithReason } from "../auth-signout"
+
+describe("signOutWithReason", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    mocks.updateSession.mockResolvedValue(undefined)
+  })
+
+  it("awaits the session reason update before signing out", async () => {
+    const signOutPromise = signOutWithReason({
+      updateSession: mocks.updateSession,
+      reason: "user_initiated",
+    })
+
+    await Promise.resolve()
+
+    expect(mocks.updateSession).toHaveBeenCalledWith({
+      pending_signout_reason: "user_initiated",
+    })
+    expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+
+    await signOutPromise
+  })
+
+  it("waits the requested delay before signing out", async () => {
+    const signOutPromise = signOutWithReason({
+      updateSession: mocks.updateSession,
+      reason: "forced_password_change",
+      delayMs: 1_500,
+    })
+
+    await Promise.resolve()
+    expect(mocks.signOut).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_499)
+    expect(mocks.signOut).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+    expect(mocks.updateSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.signOut.mock.invocationCallOrder[0]
+    )
+
+    await signOutPromise
+  })
+})

--- a/src/lib/auth-signout.ts
+++ b/src/lib/auth-signout.ts
@@ -1,0 +1,43 @@
+import { signOut } from "next-auth/react"
+
+import type { AuthPendingSignoutReason } from "@/types/auth"
+
+type SignOutReasonUpdate = {
+  pending_signout_reason: AuthPendingSignoutReason
+}
+
+type UpdateSessionFn = ((data?: SignOutReasonUpdate) => Promise<unknown>) | null | undefined
+
+type SignOutWithReasonOptions = {
+  updateSession?: UpdateSessionFn
+  reason: AuthPendingSignoutReason
+  delayMs?: number
+  callbackUrl?: string
+}
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs)
+  })
+}
+
+export async function signOutWithReason({
+  updateSession,
+  reason,
+  delayMs = 0,
+  callbackUrl = "/",
+}: SignOutWithReasonOptions): Promise<void> {
+  if (updateSession) {
+    try {
+      await updateSession({ pending_signout_reason: reason })
+    } catch {
+      // Preserve logout UX even if the reason hint fails to persist.
+    }
+  }
+
+  if (delayMs > 0) {
+    await wait(delayMs)
+  }
+
+  await signOut({ callbackUrl })
+}

--- a/src/lib/auth-signout.ts
+++ b/src/lib/auth-signout.ts
@@ -15,10 +15,26 @@ type SignOutWithReasonOptions = {
   callbackUrl?: string
 }
 
+const UPDATE_SESSION_TIMEOUT_MS = 1_000
+
 function wait(delayMs: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, delayMs)
   })
+}
+
+async function persistReasonWithTimeout(
+  updateSession: Exclude<UpdateSessionFn, null | undefined>,
+  reason: AuthPendingSignoutReason
+): Promise<void> {
+  try {
+    await Promise.race([
+      updateSession({ pending_signout_reason: reason }),
+      wait(UPDATE_SESSION_TIMEOUT_MS),
+    ])
+  } catch {
+    // Preserve logout UX even if the reason hint fails to persist.
+  }
 }
 
 export async function signOutWithReason({
@@ -28,11 +44,7 @@ export async function signOutWithReason({
   callbackUrl = "/",
 }: SignOutWithReasonOptions): Promise<void> {
   if (updateSession) {
-    try {
-      await updateSession({ pending_signout_reason: reason })
-    } catch {
-      // Preserve logout UX even if the reason hint fails to persist.
-    }
+    await persistReasonWithTimeout(updateSession, reason)
   }
 
   if (delayMs > 0) {


### PR DESCRIPTION
## Summary
- wire frontend signout reason propagation through a shared client helper
- seed `user_initiated` from `AppLayoutShell` and `forced_password_change` from `ChangePasswordDialog` before `signOut()`
- update auth event regression coverage and refresh `scripts/test_session_management.md` for the shipped signout flows

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/app/'(app)'/__tests__/AppLayoutShell.test.tsx src/components/__tests__/change-password-dialog.signout.test.tsx src/lib/__tests__/auth-signout.test.ts src/auth/__tests__/auth-config.authorize-events.test.ts`\n- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`\n\n## Links\nFixes #379\nRelated to #366\nFollow-up: #390\nFollow-up: #391

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates explicit signout reasons from the frontend so backend logs can attribute user-initiated and forced signouts. Implements Batch 4 of #366 and fixes #379 with a resilient helper, retry-safe app-shell logout, and a smoother forced logout after password changes.

- New Features
  - Added `signOutWithReason` (`src/lib/auth-signout.ts`): persists `pending_signout_reason` with a 1s timeout, optional delay, then calls `signOut` (default `callbackUrl: "/"`); falls back if the update fails or hangs.
  - `AppLayoutShell`: uses the helper, clears equipment filters first, persists `user_initiated` via `session.update`, prevents duplicate handling, and allows retry if `signOut` fails.
  - `ChangePasswordDialog`: persists `forced_password_change`, shows a success toast for ~1.5s before logout via the helper, shows a targeted error if logout fails, and preserves messages from non-Error failures.
  - Tests/docs: added update-order and retry coverage, helper timing/fallback tests, forced-signout tests (incl. non-Error failures), refreshed `scripts/test_session_management.md`, and auth event coverage for `signout_reason=user_initiated`.

<sup>Written for commit 4feeeb7c5920226cd7b3c601d6bf84394a6aceba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist explicit sign-out reasons and use them when signing out (including delayed/guaranteed attempts).
  * Trigger automatic sign-out after successful password changes; surface clear user feedback on failures.

* **Tests**
  * Added extensive tests for sign-out flows, retries, timing/fallbacks, and cross-tab synchronization.

* **Documentation**
  * Rewrote session-management test plan with concrete acceptance criteria, verification steps, and targeted scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->