### PR TITLE
perf(auth): reduce auth hot path on login

### DIFF
--- a/src/auth/__tests__/auth-config.authorize-events.test.ts
+++ b/src/auth/__tests__/auth-config.authorize-events.test.ts
@@ -133,6 +133,12 @@ function createDeferredRpcResult(): DeferredRpcResult {
   return { promise, resolve }
 }
 
+async function flushMicrotasks(count = 3) {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve()
+  }
+}
+
 describe("authOptions authorize + auth lifecycle events", () => {
   let consoleInfoSpy: ReturnType<typeof vi.spyOn>
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>
@@ -280,7 +286,7 @@ describe("authOptions authorize + auth lifecycle events", () => {
       account: null,
       isNewUser: false,
     })
-    await Promise.resolve()
+    await flushMicrotasks()
 
     expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
       expect.objectContaining({
@@ -344,11 +350,10 @@ describe("authOptions authorize + auth lifecycle events", () => {
     const settled = vi.fn()
     void signInPromise.then(settled)
     await Promise.resolve()
+    expect(settled).toHaveBeenCalledTimes(1)
 
     deferredAuditInsert.resolve({ data: true, error: null })
     await signInPromise
-
-    expect(settled).toHaveBeenCalledTimes(1)
   })
 
   it("emits forced_signout/session_expired on signOut fallback and computes session duration", async () => {

--- a/src/auth/__tests__/auth-config.authorize-events.test.ts
+++ b/src/auth/__tests__/auth-config.authorize-events.test.ts
@@ -69,6 +69,11 @@ type AuthLifecycleLog = {
   metadata?: Record<string, unknown>
 }
 
+type DeferredRpcResult = {
+  promise: Promise<{ data: boolean | null; error: unknown }>
+  resolve: (result: { data: boolean | null; error: unknown }) => void
+}
+
 function getAuthorizeHandler(): AuthorizeFn {
   const provider = authOptions.providers.find(
     (
@@ -117,6 +122,15 @@ function buildAuthorizeRequest() {
       "user-agent": "VitestBrowser/1.0",
     },
   })
+}
+
+function createDeferredRpcResult(): DeferredRpcResult {
+  let resolve!: DeferredRpcResult["resolve"]
+  const promise = new Promise<{ data: boolean | null; error: unknown }>((innerResolve) => {
+    resolve = innerResolve
+  })
+
+  return { promise, resolve }
 }
 
 describe("authOptions authorize + auth lifecycle events", () => {
@@ -266,6 +280,7 @@ describe("authOptions authorize + auth lifecycle events", () => {
       account: null,
       isNewUser: false,
     })
+    await Promise.resolve()
 
     expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
       expect.objectContaining({
@@ -297,6 +312,43 @@ describe("authOptions authorize + auth lifecycle events", () => {
       ])
     )
     expect(JSON.stringify(authLifecycleLogs(consoleInfoSpy))).not.toContain("super-secret")
+  })
+
+  it("does not block signIn completion on auth audit persistence", async () => {
+    const signInEvent = getSignInEventHandler()
+    const deferredAuditInsert = createDeferredRpcResult()
+
+    supabaseClient.rpc.mockImplementationOnce(async (fn: string, args: Record<string, unknown>) => {
+      supabaseState.rpcCalls.push({ fn, args })
+
+      if (fn === "auth_audit_log_insert") {
+        return deferredAuditInsert.promise
+      }
+
+      return {
+        data: null,
+        error: { message: `unexpected rpc ${fn}` },
+      }
+    })
+
+    const signInPromise = signInEvent({
+      user: {
+        id: "42",
+        username: "NQMinh",
+        don_vi: 17,
+      } as never,
+      account: null,
+      isNewUser: false,
+    })
+
+    const settled = vi.fn()
+    void signInPromise.then(settled)
+    await Promise.resolve()
+
+    deferredAuditInsert.resolve({ data: true, error: null })
+    await signInPromise
+
+    expect(settled).toHaveBeenCalledTimes(1)
   })
 
   it("emits forced_signout/session_expired on signOut fallback and computes session duration", async () => {

--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -187,13 +187,13 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     consoleWarnSpy.mockRestore()
   })
 
-  it("fetches profile on sign-in and stamps lastRefreshAt + loginTime", async () => {
+  it("skips profile refresh RPC on sign-in and still stamps lastRefreshAt + loginTime", async () => {
     const result = await runJwt({
       token: { ...baseToken },
       user: { ...baseToken } as JwtArgs["user"],
     })
 
-    expect(supabaseClient.rpc).toHaveBeenCalledWith("get_session_profile_for_jwt", { p_user_id: "42" })
+    expect(supabaseClient.rpc).not.toHaveBeenCalled()
     expect(supabaseClient.from).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       id: "42",

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -305,6 +305,7 @@ export const authOptions: NextAuthOptions = {
         token = {
           ...applyAuthUserToJwt(token, user),
           loginTime: now, // Track when user logged in
+          lastRefreshAt: now,
         }
       }
 
@@ -323,7 +324,7 @@ export const authOptions: NextAuthOptions = {
       // Force a refresh when NextAuth indicates an explicit update (e.g.
       // tenant switch via session.update()).
       const lastRefreshAt = typeof token.lastRefreshAt === "number" ? token.lastRefreshAt : null
-      const isExplicitUpdate = trigger === "update" || Boolean(user)
+      const isExplicitUpdate = trigger === "update"
       const refreshReason = user
         ? "sign_in"
         : trigger === "update"
@@ -530,16 +531,20 @@ export const authOptions: NextAuthOptions = {
   },
   events: {
     async signIn({ user }) {
-      const requestContext = await readRuntimeRequestContext()
+      const userId = typeof user.id === "string" ? user.id : user.id != null ? String(user.id) : undefined
+      const username = normalizeUsernameForLog(user.username ?? user.name)
+      const tenantId = coerceTenantId(user.don_vi)
 
-      await recordAuthLifecycleEvent({
-        event: "login_success",
-        source: "events_signin",
-        user_id: typeof user.id === "string" ? user.id : user.id != null ? String(user.id) : undefined,
-        username: normalizeUsernameForLog(user.username ?? user.name),
-        tenant_id: coerceTenantId(user.don_vi),
-        ...requestContext,
-      })
+      void readRuntimeRequestContext().then((requestContext) =>
+        recordAuthLifecycleEvent({
+          event: "login_success",
+          source: "events_signin",
+          user_id: userId,
+          username,
+          tenant_id: tenantId,
+          ...requestContext,
+        })
+      )
     },
     async signOut({ token, session }) {
       const pendingReason = isPendingSignoutReason(token?.pending_signout_reason)


### PR DESCRIPTION
## Summary

Implements Batch 1 of #394 by shortening the blocking login path before the user reaches the app shell.

## Changes

- stop forcing `get_session_profile_for_jwt` during sign-in when `authorize()` already returned the first-render fields
- stamp `lastRefreshAt` from the sign-in payload so later refreshes still flow through cooldown / `trigger === "update"`
- move `login_success` auth audit persistence off the blocking `events.signIn` path
- add focused regression coverage for both behaviors

## Verification

- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/auth/__tests__/auth-config.jwt-cooldown.test.ts src/auth/__tests__/auth-config.authorize-events.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Tracker

- Refs #394
- Follow-up Batch 2: #398

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up login by removing blocking work on the auth hot path, improving time to first render. Implements Batch 1 for #394.

- **Refactors**
  - Skip profile refresh RPC on sign-in when `authorize()` already provides first-render fields.
  - Stamp `lastRefreshAt` at login; only treat `trigger === "update"` as an explicit update for refresh gating.
  - Fully defer `login_success` audit logging (including request context read) so sign-in isn’t blocked; added a regression test to ensure sign-in completes even if audit insert is pending.

<sup>Written for commit eec7eff0afcfa57fde571dd0b1293febccffd597. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in now completes without blocking on background operations, improving responsiveness.
  * Profile refresh is deferred on sign-in when cooldown interval hasn't elapsed, reducing unnecessary API calls.

* **Tests**
  * Added test coverage ensuring sign-in resolves even with pending async operations.
  * Updated sign-in behavior tests to reflect new flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->