### PR TITLE
perf(dashboard): dedupe post-login bootstrap after session hydrate

### DIFF
--- a/src/app/(app)/__tests__/AppLayoutShell.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.test.tsx
@@ -187,6 +187,32 @@ describe("AppLayoutShell", () => {
     })
   })
 
+  it("keeps notification bootstrap disabled while session hydration is still loading", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1" } },
+      status: "loading",
+      update: mocks.updateSession,
+    })
+
+    render(
+      <AppLayoutShell
+        user={{
+          role: "global",
+          full_name: "Test User",
+          username: "tester",
+          khoa_phong: "IT",
+        }}
+      >
+        <div>Child Content</div>
+      </AppLayoutShell>
+    )
+
+    expect(mocks.useAppNotificationCounts).toHaveBeenCalledWith({
+      enabled: false,
+      facilityId: null,
+    })
+  })
+
   it("persists a user-initiated signout reason before signing out from the user menu", async () => {
     const user = userEvent.setup()
 

--- a/src/app/(app)/__tests__/layout.auth.test.tsx
+++ b/src/app/(app)/__tests__/layout.auth.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   redirect: vi.fn((path: string) => {
     throw new Error(`NEXT_REDIRECT:${path}`)
   }),
+  sessionProvider: vi.fn(({ children }: { children: React.ReactNode }) => <>{children}</>),
   shell: vi.fn(
     ({
       user,
@@ -30,6 +31,13 @@ vi.mock("next-auth", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: (path: string) => mocks.redirect(path),
+}))
+
+vi.mock("@/providers/session-provider", () => ({
+  NextAuthSessionProvider: (props: {
+    session?: unknown
+    children: React.ReactNode
+  }) => mocks.sessionProvider(props),
 }))
 
 vi.mock("@/app/(app)/_components/AppLayoutShell", () => ({
@@ -58,7 +66,7 @@ describe("AppLayout auth gate", () => {
   })
 
   it("renders the app shell for authenticated users", async () => {
-    mocks.getServerSession.mockResolvedValue({
+    const session = {
       user: {
         id: "1",
         role: "global",
@@ -66,12 +74,17 @@ describe("AppLayout auth gate", () => {
         username: "auth-user",
         khoa_phong: "IT",
       },
-    })
+    }
+    mocks.getServerSession.mockResolvedValue(session)
 
     render(await AppLayout({ children: <div>Protected Child</div> }))
 
     expect(mocks.getServerSession).toHaveBeenCalledWith(authOptions)
     expect(mocks.redirect).not.toHaveBeenCalled()
+    expect(mocks.sessionProvider).toHaveBeenCalledWith({
+      session,
+      children: expect.anything(),
+    })
     expect(screen.getByTestId("shell-user")).toHaveTextContent("Authenticated User")
     expect(screen.getByTestId("shell-children")).toHaveTextContent("Protected Child")
   })

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -80,7 +80,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
   const [isAssistantOpen, setIsAssistantOpen] = React.useState(false)
   const branding = useTenantBranding()
   const { counts: notificationCounts } = useAppNotificationCounts({
-    enabled: shouldFetchData,
+    enabled: status === "authenticated" && shouldFetchData,
     facilityId: selectedFacilityId,
   })
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation"
 
 import { authOptions } from "@/auth/config"
 import { AppLayoutShell } from "@/app/(app)/_components/AppLayoutShell"
+import { NextAuthSessionProvider } from "@/providers/session-provider"
 
 type AppLayoutProps = {
   children: ReactNode
@@ -17,5 +18,9 @@ export default async function AppLayout({ children }: AppLayoutProps) {
     redirect("/")
   }
 
-  return <AppLayoutShell user={session.user}>{children}</AppLayoutShell>
+  return (
+    <NextAuthSessionProvider session={session}>
+      <AppLayoutShell user={session.user}>{children}</AppLayoutShell>
+    </NextAuthSessionProvider>
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type {Metadata, Viewport} from 'next';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster"
-import { NextAuthSessionProvider } from '@/providers/session-provider';
 import { LanguageProvider } from '@/contexts/language-context';
 import { QueryProvider } from '@/providers/query-provider';
 import { RealtimeProvider } from '@/contexts/realtime-context';
@@ -30,13 +29,11 @@ export default function RootLayout({
         <QueryProvider>
           <RealtimeProvider>
             <LanguageProvider>
-            <NextAuthSessionProvider>
-                {children}
-                <Toaster />
-                <PWAInstallPrompt />
-                {process.env.NODE_ENV === 'development' && <PWAStatus />}
-                <ThemeColorManager />
-            </NextAuthSessionProvider>
+              {children}
+              <Toaster />
+              <PWAInstallPrompt />
+              {process.env.NODE_ENV === 'development' && <PWAStatus />}
+              <ThemeColorManager />
             </LanguageProvider>
           </RealtimeProvider>
         </QueryProvider>

--- a/src/components/dashboard/__tests__/kpi-cards.test.tsx
+++ b/src/components/dashboard/__tests__/kpi-cards.test.tsx
@@ -75,17 +75,34 @@ describe("KPICards", () => {
     })
   })
 
-  it("shows loading state instead of zero KPI values while session is resolving", () => {
-    mockUseSession.mockReturnValue({
-      data: null,
+  it("waits for an authenticated session before bootstrapping the shared dashboard summary RPC", async () => {
+    const sessionState = {
+      data: { user: { id: 1, role: "global" } },
       status: "loading",
+    }
+    mockUseSession.mockImplementation(() => sessionState)
+    mockCallRpc.mockResolvedValue({
+      totalEquipment: 12,
+      maintenanceCount: 3,
+      repairRequests: { total: 2, pending: 1, approved: 1, completed: 0 },
+      maintenancePlans: {
+        total: 4,
+        draft: 2,
+        approved: 2,
+        plans: [],
+      },
     })
-    mockCallRpc.mockReturnValue(new Promise(() => undefined))
 
-    render(<KPICards />, { wrapper: createWrapper() })
+    const { rerender } = render(<KPICards />, { wrapper: createWrapper() })
 
-    expect(screen.queryByLabelText("0 thiết bị")).not.toBeInTheDocument()
-    expect(screen.queryByLabelText("0 thiết bị cần bảo trì")).not.toBeInTheDocument()
+    expect(mockCallRpc).not.toHaveBeenCalled()
+
+    sessionState.status = "authenticated"
+    rerender(<KPICards />)
+
+    await waitFor(() => {
+      expect(mockCallRpc).toHaveBeenCalledTimes(1)
+    })
     expect(mockCallRpc).toHaveBeenCalledWith({
       fn: "dashboard_kpi_summary",
     })

--- a/src/contexts/TenantSelectionContext.tsx
+++ b/src/contexts/TenantSelectionContext.tsx
@@ -116,12 +116,13 @@ export function TenantSelectionProvider({ children }: { children: React.ReactNod
   // Non-privileged users can always fetch (server enforces their don_vi)
   // Privileged users must select a facility first (undefined = not selected, null = "all", number = specific)
   const shouldFetchData = React.useMemo(() => {
+    if (status !== "authenticated") return false
     if (!showSelector) return true
     // undefined = not selected yet, block fetching
     // null = "all facilities" selected, allow fetching
     // number = specific facility selected, allow fetching
     return selectedFacilityId !== undefined
-  }, [showSelector, selectedFacilityId])
+  }, [selectedFacilityId, showSelector, status])
 
   // Memoize context value to prevent unnecessary re-renders
   const value = React.useMemo<TenantSelectionContextValue>(() => ({

--- a/src/contexts/__tests__/TenantSelectionContext.test.tsx
+++ b/src/contexts/__tests__/TenantSelectionContext.test.tsx
@@ -1,0 +1,105 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  callRpc: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: (...args: unknown[]) => mocks.callRpc(...args),
+}))
+
+import { TenantSelectionProvider, useTenantSelection } from "@/contexts/TenantSelectionContext"
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function TenantSelectionProbe() {
+  const { showSelector, shouldFetchData, selectedFacilityId } = useTenantSelection()
+
+  return (
+    <>
+      <div data-testid="show-selector">{String(showSelector)}</div>
+      <div data-testid="should-fetch-data">{String(shouldFetchData)}</div>
+      <div data-testid="selected-facility-id">{String(selectedFacilityId)}</div>
+    </>
+  )
+}
+
+describe("TenantSelectionProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sessionStorage.clear()
+    mocks.callRpc.mockResolvedValue([])
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1", role: "user" } },
+      status: "authenticated",
+    })
+  })
+
+  it("blocks data bootstrap while the session is still loading for non-privileged users", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1", role: "user" } },
+      status: "loading",
+    })
+
+    render(
+      <TenantSelectionProvider>
+        <TenantSelectionProbe />
+      </TenantSelectionProvider>,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByTestId("show-selector")).toHaveTextContent("false")
+    expect(screen.getByTestId("should-fetch-data")).toHaveTextContent("false")
+  })
+
+  it("unblocks data bootstrap once a non-privileged session is authenticated", () => {
+    render(
+      <TenantSelectionProvider>
+        <TenantSelectionProbe />
+      </TenantSelectionProvider>,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByTestId("show-selector")).toHaveTextContent("false")
+    expect(screen.getByTestId("should-fetch-data")).toHaveTextContent("true")
+  })
+
+  it("keeps privileged users blocked until facility selection is resolved", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1", role: "global" } },
+      status: "authenticated",
+    })
+
+    render(
+      <TenantSelectionProvider>
+        <TenantSelectionProbe />
+      </TenantSelectionProvider>,
+      { wrapper: createWrapper() }
+    )
+
+    expect(screen.getByTestId("show-selector")).toHaveTextContent("true")
+    expect(screen.getByTestId("selected-facility-id")).toHaveTextContent("undefined")
+    expect(screen.getByTestId("should-fetch-data")).toHaveTextContent("false")
+  })
+})

--- a/src/hooks/__tests__/use-dashboard-stats.session-gating.test.ts
+++ b/src/hooks/__tests__/use-dashboard-stats.session-gating.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: mocks.useQuery,
+}))
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+import {
+  useEquipmentAttention,
+  useEquipmentAttentionPaginated,
+} from "@/hooks/use-dashboard-stats"
+
+describe("use-dashboard-stats session gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useQuery.mockImplementation((options: unknown) => options)
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1", role: "global", dia_ban_id: 12 } },
+      status: "authenticated",
+    })
+  })
+
+  it("keeps equipment attention disabled while session hydration is loading", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1", role: "global", dia_ban_id: 12 } },
+      status: "loading",
+    })
+
+    renderHook(() => useEquipmentAttention())
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["dashboard-stats", "equipment-attention", "global", "12"],
+        enabled: false,
+      })
+    )
+  })
+
+  it("keeps paginated equipment attention disabled while session hydration is loading", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1", role: "global", dia_ban_id: 12 } },
+      status: "loading",
+    })
+
+    renderHook(() =>
+      useEquipmentAttentionPaginated({
+        page: 2,
+        pageSize: 25,
+        enabled: true,
+      })
+    )
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["dashboard-stats", "equipment-attention", "global", "12", 2, 25],
+        enabled: false,
+      })
+    )
+  })
+
+  it("enables paginated equipment attention only after authenticated session is ready", () => {
+    renderHook(() =>
+      useEquipmentAttentionPaginated({
+        page: 2,
+        pageSize: 25,
+        enabled: true,
+      })
+    )
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["dashboard-stats", "equipment-attention", "global", "12", 2, 25],
+        enabled: true,
+      })
+    )
+  })
+})

--- a/src/hooks/__tests__/use-recent-activities.test.ts
+++ b/src/hooks/__tests__/use-recent-activities.test.ts
@@ -54,6 +54,22 @@ describe("useRecentActivities", () => {
     })
   })
 
+  it("keeps the query disabled while session hydration is still loading", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: 1, role: "global" } },
+      status: "loading",
+    })
+
+    renderHook(() => useRecentActivities())
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["dashboard-recent-activities", "1", 15],
+        enabled: false,
+      }),
+    )
+  })
+
   it("disables the query when there is no authenticated session", () => {
     mocks.useSession.mockReturnValue({
       data: null,

--- a/src/hooks/__tests__/use-tenant-branding.test.ts
+++ b/src/hooks/__tests__/use-tenant-branding.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  useQueryClient: vi.fn(),
+  useSession: vi.fn(),
+  callRpc: vi.fn(),
+}))
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query")
+  return {
+    ...actual,
+    useQuery: mocks.useQuery,
+    useQueryClient: mocks.useQueryClient,
+  }
+})
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => mocks.useSession(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: (...args: unknown[]) => mocks.callRpc(...args),
+}))
+
+import { useTenantBranding } from "@/hooks/use-tenant-branding"
+
+describe("useTenantBranding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useQuery.mockImplementation((options: unknown) => options)
+    mocks.useQueryClient.mockReturnValue({
+      invalidateQueries: vi.fn(),
+    })
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1", role: "global", don_vi: null } },
+      status: "authenticated",
+    })
+  })
+
+  it("keeps branding bootstrap disabled while the session is loading", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "u1", role: "global", don_vi: null } },
+      status: "loading",
+    })
+
+    renderHook(() => useTenantBranding())
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["tenant_branding", { tenant: "none" }],
+        enabled: false,
+      })
+    )
+  })
+
+  it("enables branding fetch once the authenticated session is ready", async () => {
+    mocks.callRpc.mockResolvedValueOnce([{ id: 7, name: "CDC", logo_url: null }])
+
+    renderHook(() => useTenantBranding())
+
+    const firstCall = mocks.useQuery.mock.calls[0]?.[0]
+    expect(firstCall).toBeDefined()
+    expect(firstCall.enabled).toBe(true)
+
+    await expect(firstCall.queryFn({ signal: undefined })).resolves.toEqual({
+      id: 7,
+      name: "CDC",
+      logo_url: null,
+    })
+
+    expect(mocks.callRpc).toHaveBeenCalledWith({
+      fn: "don_vi_branding_get",
+      args: { p_id: null },
+      signal: undefined,
+    })
+  })
+})

--- a/src/hooks/use-dashboard-stats.ts
+++ b/src/hooks/use-dashboard-stats.ts
@@ -116,7 +116,7 @@ function normalizeDashboardKpiSummary(data: Partial<DashboardKpiSummary> | null 
 }
 
 export function useDashboardKpiSummary() {
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
   const user: DashboardSessionUser | undefined = session?.user
   const scope = getDashboardUserScope(user)
 
@@ -126,6 +126,7 @@ export function useDashboardKpiSummary() {
       const data = await callRpc<Partial<DashboardKpiSummary>>({ fn: 'dashboard_kpi_summary' })
       return normalizeDashboardKpiSummary(data)
     },
+    enabled: status === "authenticated" && !!user?.id,
     staleTime: 2 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,

--- a/src/hooks/use-dashboard-stats.ts
+++ b/src/hooks/use-dashboard-stats.ts
@@ -141,7 +141,7 @@ export function useMaintenancePlanStats() {
 
 // Hook to get equipment needing attention
 export function useEquipmentAttention() {
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
   const user: DashboardSessionUser | undefined = session?.user
   const scope = getDashboardUserScope(user)
   
@@ -151,6 +151,7 @@ export function useEquipmentAttention() {
       const data = await callRpc<EquipmentAttentionRow[]>({ fn: 'equipment_attention_list', args: { p_limit: 5 } })
       return mapEquipmentAttentionRows(data)
     },
+    enabled: status === "authenticated" && !!user?.id,
     staleTime: 2 * 60 * 1000, // 2 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
     refetchOnWindowFocus: true,
@@ -160,7 +161,7 @@ export function useEquipmentAttention() {
 
 // Hook to get equipment needing attention with pagination (default 10 per page)
 export function useEquipmentAttentionPaginated(options?: { page?: number; pageSize?: number; enabled?: boolean }) {
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
   const user: DashboardSessionUser | undefined = session?.user
   const scope = getDashboardUserScope(user)
 
@@ -197,6 +198,6 @@ export function useEquipmentAttentionPaginated(options?: { page?: number; pageSi
     gcTime: 10 * 60 * 1000, // 10 minutes
     refetchOnWindowFocus: true,
     refetchInterval: 5 * 60 * 1000, // Refetch every 5 minutes
-    enabled: enabled && Boolean(user),
+    enabled: enabled && status === "authenticated" && !!user?.id,
   })
 }

--- a/src/hooks/use-recent-activities.ts
+++ b/src/hooks/use-recent-activities.ts
@@ -19,7 +19,7 @@ export interface RecentActivity {
  * Tenant-isolated server-side via JWT claims.
  */
 export function useRecentActivities(limit = 15) {
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
   const userId = session?.user?.id ? String(session.user.id) : 'anonymous'
 
   return useQuery<RecentActivity[]>({
@@ -29,7 +29,7 @@ export function useRecentActivities(limit = 15) {
         fn: 'dashboard_recent_activities',
         args: { p_limit: limit },
       }),
-    enabled: !!session,
+    enabled: status === "authenticated" && !!session?.user?.id,
     staleTime: 60_000,        // 1 minute
     gcTime: 5 * 60_000,       // 5 minutes
     refetchInterval: 120_000, // auto-refresh every 2 minutes

--- a/src/hooks/use-tenant-branding.ts
+++ b/src/hooks/use-tenant-branding.ts
@@ -11,12 +11,18 @@ export type TenantBranding = {
   logo_url: string | null
 }
 
+type TenantBrandingSessionUser = {
+  id?: string | number | null
+  role?: string | null
+  don_vi?: number | null
+}
+
 export function useTenantBranding(options?: {
   formTenantId?: number | null,
   useFormContext?: boolean
 }) {
-  const { data: session } = useSession()
-  const user = session?.user as any
+  const { data: session, status } = useSession()
+  const user = session?.user as TenantBrandingSessionUser | undefined
   const isPrivileged = isGlobalRole(user?.role)
   
   // Determine effective tenant ID based on user privilege and options
@@ -56,6 +62,7 @@ export function useTenantBranding(options?: {
         logo_url: row.logo_url ?? null 
       } : null
     },
+    enabled: status === "authenticated" && !!user?.id,
     placeholderData: keepPreviousData,
     staleTime: 5 * 60_000,
     gcTime: 15 * 60_000,

--- a/src/providers/session-provider.tsx
+++ b/src/providers/session-provider.tsx
@@ -1,12 +1,14 @@
 "use client"
 
+import type { Session } from "next-auth"
 import { SessionProvider } from "next-auth/react"
 import React from "react"
 
 type Props = {
   children: React.ReactNode
+  session?: Session | null
 }
 
-export function NextAuthSessionProvider({ children }: Props) {
-  return <SessionProvider>{children}</SessionProvider>
+export function NextAuthSessionProvider({ children, session }: Props) {
+  return <SessionProvider session={session}>{children}</SessionProvider>
 }


### PR DESCRIPTION
## Summary

Batch 2 of #394 reduces post-login bootstrap churn after client session hydrate.

## What changed

- hydrate the authenticated app subtree with the server session instead of mounting an empty root session provider
- gate tenant/bootstrap fetches on `status === "authenticated"` and a real session user id
- block notification, branding, KPI, and recent-activity bootstrap work during session loading
- add focused regressions for app layout hydration, tenant selection readiness, tenant branding, KPI bootstrap, recent activities, and shell notification gating

## Verification

- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/__tests__/layout.auth.test.tsx' 'src/app/(app)/__tests__/AppLayoutShell.test.tsx' 'src/components/dashboard/__tests__/kpi-cards.test.tsx' 'src/hooks/__tests__/use-recent-activities.test.ts' 'src/contexts/__tests__/TenantSelectionContext.test.tsx' 'src/hooks/__tests__/use-tenant-branding.test.ts'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Notes

- React Doctor score: `99/100`
- Remaining warnings are existing heuristics in `TenantSelectionContext` and were intentionally left out of this perf PR.

Fixes #398
Refs #394

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce post-login bootstrap churn by hydrating with the server session and deferring dashboard fetches until auth is ready, cutting duplicate RPCs and UI work. Fixes #398; follows #394.

- **Refactors**
  - Hydrate `NextAuthSessionProvider` with the server session in the authenticated app layout; remove the root-level provider.
  - Gate all dashboard queries on `status === "authenticated"` and a real `user.id` (notifications, branding, KPI summary, recent activities, equipment attention incl. paginated).
  - Update `TenantSelectionContext` to block fetches during auth loading and until facility selection is resolved.
  - Add tests for layout hydration and session-gated fetching across hooks and components, including equipment attention and branding.

<sup>Written for commit 2bbbb7f9f5c8a6eb2fe0bbe44ff7e48111c5daae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Data fetching operations now pause until session authentication completes, reducing errors during login transitions.

* **Tests**
  * Added comprehensive test coverage validating session-gated data operations across components, hooks, and context providers, including authentication state transitions.

* **Refactor**
  * Session provider initialization restructured for improved reliability and clearer data flow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->