### PR TITLE
fix(equipment): repaint multi-selection for admin/global

### DIFF
--- a/src/app/(app)/equipment/__tests__/EquipmentBulkDeleteBar.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentBulkDeleteBar.test.tsx
@@ -176,4 +176,28 @@ describe("EquipmentBulkDeleteBar", () => {
 
     expect(tableRef?.getState().rowSelection).toEqual({})
   })
+
+  it("renders selected actions out of normal document flow to avoid shifting the table", async () => {
+    let tableRef: Table<Equipment> | null = null
+    const Harness = createTableHarness((table) => {
+      tableRef = table
+    })
+
+    render(<Harness canBulkSelect={true} isCardView={false} />)
+
+    await waitFor(() => {
+      expect(tableRef).not.toBeNull()
+    })
+
+    act(() => {
+      tableRef?.getRow("101").toggleSelected(true)
+    })
+
+    const floatingBar = screen.getByTestId("equipment-bulk-delete-bar")
+
+    expect(floatingBar).toHaveClass("absolute")
+    expect(floatingBar).toHaveClass("pointer-events-none")
+    expect(floatingBar).toHaveClass("z-20")
+    expect(screen.getByText(/^Đã chọn/i)).toHaveTextContent("1")
+  })
 })

--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx
@@ -1,0 +1,184 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { useEquipmentPage } from "../use-equipment-page"
+
+type EquipmentPageState = ReturnType<typeof useEquipmentPage>
+
+interface TestTable {
+  selectedCount: number
+  selectOne: () => void
+  getFilteredRowModel: () => { rows: unknown[] }
+}
+
+const state = vi.hoisted(() => ({
+  pageState: null as EquipmentPageState | null,
+}))
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  setColumnFilters: vi.fn(),
+  clearPendingAction: vi.fn(),
+  openAddDialog: vi.fn(),
+  openImportDialog: vi.fn(),
+  openColumnsDialog: vi.fn(),
+  openDetailDialog: vi.fn(),
+  openEditDialog: vi.fn(),
+}))
+
+vi.mock("../use-equipment-page", () => ({
+  useEquipmentPage: () => state.pageState,
+}))
+
+vi.mock("../_hooks/useEquipmentContext", () => ({
+  useEquipmentContext: () => ({
+    openAddDialog: mocks.openAddDialog,
+    openImportDialog: mocks.openImportDialog,
+    openColumnsDialog: mocks.openColumnsDialog,
+    openDetailDialog: mocks.openDetailDialog,
+    openEditDialog: mocks.openEditDialog,
+  }),
+}))
+
+vi.mock("../_components/EquipmentDialogContext", () => ({
+  EquipmentDialogProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("../equipment-content", () => ({
+  EquipmentContent: ({ table }: { table: TestTable }) => (
+    <section aria-label="equipment content">
+      <output aria-label="selected count">{table.selectedCount}</output>
+      <button type="button" onClick={table.selectOne}>
+        Chọn dòng
+      </button>
+    </section>
+  ),
+}))
+
+vi.mock("../equipment-dialogs", () => ({
+  EquipmentDialogs: () => null,
+}))
+
+vi.mock("../_components/EquipmentColumnsDialog", () => ({
+  EquipmentColumnsDialog: () => null,
+}))
+
+vi.mock("../_components/EquipmentBulkDeleteBar", () => ({
+  EquipmentBulkDeleteBar: () => null,
+}))
+
+vi.mock("@/components/equipment/equipment-toolbar", () => ({
+  EquipmentToolbar: () => null,
+}))
+
+vi.mock("@/components/equipment/filter-bottom-sheet", () => ({
+  FilterBottomSheet: () => null,
+}))
+
+vi.mock("@/components/shared/DataTablePagination", () => ({
+  DataTablePagination: () => null,
+}))
+
+vi.mock("@/components/shared/TenantSelector", () => ({
+  TenantSelector: () => null,
+}))
+
+import { EquipmentPageClient } from "../_components/EquipmentPageClient"
+
+function createTable(): TestTable {
+  const table: TestTable = {
+    selectedCount: 0,
+    selectOne() {
+      table.selectedCount = 1
+    },
+    getFilteredRowModel: () => ({ rows: [{ id: 202 }] }),
+  }
+  return table
+}
+
+function createPageState(table: TestTable): EquipmentPageState {
+  return {
+    status: "authenticated",
+    router: { push: mocks.push, replace: vi.fn() },
+    effectiveTenantKey: "5",
+    user: { id: 1, role: "admin" },
+    pendingAction: null,
+    clearPendingAction: mocks.clearPendingAction,
+    isGlobal: true,
+    isRegionalLeader: false,
+    total: 1,
+    isLoading: false,
+    isFetching: false,
+    shouldFetchEquipment: true,
+    table,
+    columns: [],
+    pagination: { pageIndex: 0, pageSize: 20 },
+    setPagination: vi.fn(),
+    searchTerm: "",
+    setSearchTerm: vi.fn(),
+    columnFilters: [],
+    setColumnFilters: mocks.setColumnFilters,
+    isFiltered: false,
+    departments: [],
+    users: [],
+    locations: [],
+    statuses: [],
+    classifications: [],
+    fundingSources: [],
+    filterData: {
+      status: [],
+      department: [],
+      location: [],
+      user: [],
+      classification: [],
+      fundingSource: [],
+    },
+    showFacilityFilter: true,
+    facilities: [],
+    selectedFacilityId: 5,
+    setSelectedFacilityId: vi.fn(),
+    activeFacility: null,
+    hasFacilityFilter: true,
+    isFacilitiesLoading: false,
+    handleFacilityClear: vi.fn(),
+    isFilterSheetOpen: false,
+    setIsFilterSheetOpen: vi.fn(),
+    handleExportData: vi.fn(),
+    handleDownloadTemplate: vi.fn(),
+    handleGenerateProfileSheet: vi.fn(),
+    handleGenerateDeviceLabel: vi.fn(),
+    onDataMutationSuccess: vi.fn(),
+    onDataMutationSuccessWithStatePreservation: vi.fn(),
+    isMobile: false,
+    isCardView: false,
+    useTabletFilters: false,
+    canBulkSelect: true,
+    isExporting: false,
+    tenantBranding: undefined,
+  } as unknown as EquipmentPageState
+}
+
+describe("EquipmentPageClient selection render boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.pageState = null
+  })
+
+  it("re-renders equipment content when stable table state changes row selection", async () => {
+    const user = userEvent.setup()
+    const table = createTable()
+    state.pageState = createPageState(table)
+
+    const { rerender } = render(<EquipmentPageClient />)
+
+    expect(screen.getByLabelText("selected count")).toHaveTextContent("0")
+
+    await user.click(screen.getByRole("button", { name: "Chọn dòng" }))
+    rerender(<EquipmentPageClient />)
+
+    expect(screen.getByLabelText("selected count")).toHaveTextContent("1")
+  })
+})

--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx
@@ -100,23 +100,28 @@ function createTable(): TestTable {
 }
 
 function createPageState(table: TestTable): EquipmentPageState {
-  return {
+  const pageState: EquipmentPageState = {
     status: "authenticated",
-    router: { push: mocks.push, replace: vi.fn() },
+    router: { push: mocks.push, replace: vi.fn() } as EquipmentPageState["router"],
     effectiveTenantKey: "5",
-    user: { id: 1, role: "admin" },
+    user: { id: 1, role: "admin" } as EquipmentPageState["user"],
     pendingAction: null,
     clearPendingAction: mocks.clearPendingAction,
+    isFetchingHighlight: false,
     isGlobal: true,
     isRegionalLeader: false,
+    data: [],
     total: 1,
     isLoading: false,
     isFetching: false,
     shouldFetchEquipment: true,
-    table,
+    table: table as EquipmentPageState["table"],
     columns: [],
     pagination: { pageIndex: 0, pageSize: 20 },
     setPagination: vi.fn(),
+    pageCount: 1,
+    columnVisibility: {},
+    setColumnVisibility: vi.fn(),
     searchTerm: "",
     setSearchTerm: vi.fn(),
     columnFilters: [],
@@ -158,7 +163,8 @@ function createPageState(table: TestTable): EquipmentPageState {
     canBulkSelect: true,
     isExporting: false,
     tenantBranding: undefined,
-  } as unknown as EquipmentPageState
+  }
+  return pageState
 }
 
 describe("EquipmentPageClient selection render boundary", () => {

--- a/src/app/(app)/equipment/__tests__/equipment-content.selection.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-content.selection.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Regression-lock test: multi-selection invariants ở Equipment data grid
+ * khi `canBulkSelect=true` (áp dụng cho role admin/global/to_qltb).
+ *
+ * Bug báo cáo (prod): Với role admin/global, user không tick chọn được từng
+ * hàng; click nhiều lần thì data grid "tự chọn tất cả" trong page scope.
+ * Role to_qltb thì tick chọn bình thường.
+ *
+ * Các invariant cần giữ (áp dụng cho mọi role khi canBulkSelect=true):
+ *   1. Click checkbox của 1 row → CHỈ row đó được chọn/bỏ chọn; KHÔNG
+ *      trigger select-all page.
+ *   2. Click liên tiếp vào cùng 1 checkbox → selection chỉ toggle row đó
+ *      (0 ↔ 1), không "drift" sang các row khác.
+ *   3. Click checkbox row không được gọi `onShowDetails` (stopPropagation).
+ *   4. Khi parent container re-render với prop đổi (mô phỏng luồng
+ *      global/admin, nơi isFetching/data/selectedFacilityId hay đổi giữa
+ *      các click), rowSelection đã chọn PHẢI được bảo toàn.
+ *
+ * Các scenario 1–3 là ràng buộc căn bản. Scenario 4 đặc biệt nhắm đến cơ
+ * chế reset selection trong `useEquipmentTable` (reset theo
+ * pageIndex/pageSize/sorting/filterKey) có thể kích hoạt sai trong luồng
+ * global/admin.
+ */
+
+import * as React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import {
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+  type RowSelectionState,
+} from "@tanstack/react-table"
+import { describe, expect, it, vi } from "vitest"
+
+import { LinkedRequestProvider } from "@/components/equipment-linked-request"
+import { createEquipmentColumns } from "@/components/equipment/equipment-table-columns"
+import type { Equipment } from "@/types/database"
+import { EquipmentContent } from "../equipment-content"
+
+vi.mock("@/components/ui/tooltip", async () => {
+  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock")
+  return tooltipMockModule
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+function makeEquipment(id: number, overrides: Partial<Equipment> = {}): Equipment {
+  return {
+    id,
+    ma_thiet_bi: `TB-${id}`,
+    ten_thiet_bi: `Thiết bị ${id}`,
+    tinh_trang_hien_tai: "Hoạt động",
+    ...overrides,
+  }
+}
+
+interface HarnessProps {
+  data: Equipment[]
+  onShowDetails?: (equipment: Equipment) => void
+  /**
+   * Mô phỏng parent re-render đổi ref giữa các lần click (luồng
+   * global/admin: selectedFacilityId/isFetching/... thay đổi). Tăng giá
+   * trị này giữa các assertion để kích hoạt parent re-render.
+   */
+  externalTick?: number
+  /**
+   * Emulate `canBulkSelect=true` (role admin/global/to_qltb).
+   */
+  canBulkSelect?: boolean
+}
+
+function EquipmentSelectionHarness({
+  data,
+  onShowDetails = vi.fn(),
+  externalTick = 0,
+  canBulkSelect = true,
+}: HarnessProps) {
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({})
+
+  const columns = React.useMemo(
+    () =>
+      createEquipmentColumns({
+        renderActions: () => null,
+        canBulkSelect,
+      }),
+    [canBulkSelect],
+  )
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { rowSelection },
+    onRowSelectionChange: setRowSelection,
+    enableRowSelection: true,
+    getRowId: (row) => String(row.id),
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  return (
+    <LinkedRequestProvider>
+      {/* externalTick được render để ép parent re-render khi prop đổi */}
+      <span data-testid="external-tick" hidden>
+        {externalTick}
+      </span>
+      <EquipmentContent
+        isGlobal={true}
+        isRegionalLeader={false}
+        shouldFetchEquipment={true}
+        isLoading={false}
+        isFetching={externalTick % 2 === 1}
+        isCardView={false}
+        table={table}
+        columns={columns}
+        onShowDetails={onShowDetails}
+      />
+      <output data-testid="selected-ids">
+        {table
+          .getFilteredSelectedRowModel()
+          .rows.map((row) => row.original.id)
+          .join(",")}
+      </output>
+      <output data-testid="selected-count">
+        {table.getFilteredSelectedRowModel().rows.length}
+      </output>
+    </LinkedRequestProvider>
+  )
+}
+
+function getRowCheckbox(rowId: number) {
+  const row = screen.getByRole("row", { name: new RegExp(`TB-${rowId}`) })
+  return within(row).getByRole("checkbox", { name: "Chọn dòng" })
+}
+
+describe("EquipmentContent multi-selection (canBulkSelect=true / admin+global)", () => {
+  it("toggling a single row checkbox only affects that row", () => {
+    const data = [makeEquipment(101), makeEquipment(202), makeEquipment(303)]
+    render(<EquipmentSelectionHarness data={data} />)
+
+    fireEvent.click(getRowCheckbox(202))
+
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("202")
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1")
+  })
+
+  it("clicking the same row checkbox repeatedly never auto-selects other rows", () => {
+    const data = [makeEquipment(101), makeEquipment(202), makeEquipment(303)]
+    render(<EquipmentSelectionHarness data={data} />)
+
+    const checkbox = getRowCheckbox(101)
+
+    fireEvent.click(checkbox) // select
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("101")
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1")
+
+    fireEvent.click(checkbox) // deselect
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("")
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("0")
+
+    fireEvent.click(checkbox) // select
+    fireEvent.click(checkbox) // deselect
+    fireEvent.click(checkbox) // select
+
+    // After odd number of clicks on the SAME row: exactly that row selected.
+    // Bug repro target: "click nhiều lần tự chọn tất cả" would set count to 3.
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("101")
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1")
+  })
+
+  it("row checkbox click does not bubble to row onClick (no detail dialog)", () => {
+    const data = [makeEquipment(101)]
+    const onShowDetails = vi.fn()
+    render(
+      <EquipmentSelectionHarness data={data} onShowDetails={onShowDetails} />,
+    )
+
+    fireEvent.click(getRowCheckbox(101))
+
+    expect(onShowDetails).not.toHaveBeenCalled()
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1")
+  })
+
+  it("selection is preserved across admin-like parent re-renders", () => {
+    const data = [makeEquipment(101), makeEquipment(202), makeEquipment(303)]
+
+    const { rerender } = render(
+      <EquipmentSelectionHarness data={data} externalTick={0} />,
+    )
+
+    fireEvent.click(getRowCheckbox(202))
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("202")
+
+    // Simulate admin-only re-renders (e.g. isFetching toggling from
+    // background refetch, or selectedFacilityId reference churn).
+    for (let tick = 1; tick <= 4; tick++) {
+      rerender(<EquipmentSelectionHarness data={data} externalTick={tick} />)
+    }
+
+    // Selection must survive purely presentational parent re-renders.
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("202")
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1")
+  })
+
+  it("selecting multiple distinct rows keeps only those rows selected", () => {
+    const data = [
+      makeEquipment(101),
+      makeEquipment(202),
+      makeEquipment(303),
+      makeEquipment(404),
+    ]
+    render(<EquipmentSelectionHarness data={data} />)
+
+    fireEvent.click(getRowCheckbox(101))
+    fireEvent.click(getRowCheckbox(303))
+
+    const selected = screen.getByTestId("selected-ids").textContent ?? ""
+    expect(selected.split(",").sort()).toEqual(["101", "303"])
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("2")
+  })
+})

--- a/src/app/(app)/equipment/__tests__/useEquipmentTable.rerender-proof.test.tsx
+++ b/src/app/(app)/equipment/__tests__/useEquipmentTable.rerender-proof.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Proof tests for issue #400 — root cause investigation.
+ *
+ * Background: Bug báo cáo là multi-selection ở Equipment data grid bị
+ * trễ rất lâu cho role admin/global (state cập nhật đúng nhưng UI
+ * mất vài giây mới phản hồi). Hypothesis ban đầu: chain memo vỡ ở
+ * `useReactTable` → `useEquipmentTable` → `useEquipmentPage` →
+ * `React.memo(EquipmentPageContent)` gây full subtree re-render mỗi click.
+ *
+ * KẾT QUẢ: Hypothesis trên đã được CHỨNG MINH SAI bằng các test bên dưới.
+ * `useReactTable` trả về `table` instance có identity ỔN ĐỊNH qua re-render,
+ * và `useEquipmentTable` memoize ĐÚNG return object qua selection toggle.
+ * → Chain memo từ `useEquipmentTable` không phải root cause.
+ *
+ * Các test này được giữ lại để:
+ *   1. Lock hành vi đúng (memo stability) — tránh regression sau này.
+ *   2. Là bằng chứng kiểm chứng được, lưu lại quá trình điều tra.
+ *
+ * Khi root cause thật được xác định, các test khác cần được viết để khóa
+ * mặt khác (vd: data size budget, render cost trong cell, listener leak).
+ */
+
+import * as React from "react"
+import { act, renderHook } from "@testing-library/react"
+import {
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from "@tanstack/react-table"
+import { describe, expect, it, vi } from "vitest"
+
+import { useEquipmentTable } from "../_hooks/useEquipmentTable"
+import { createSelectionColumn } from "@/components/ui/data-table-selection"
+import type { Equipment } from "@/types/database"
+
+vi.mock("@/hooks/use-media-query", () => ({
+  useMediaQuery: () => false,
+}))
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}))
+
+function makeEquipment(id: number): Equipment {
+  return {
+    id,
+    ma_thiet_bi: `TB-${id}`,
+    ten_thiet_bi: `Thiết bị ${id}`,
+    tinh_trang_hien_tai: "Hoạt động",
+  }
+}
+
+const ROWS: Equipment[] = [
+  makeEquipment(101),
+  makeEquipment(202),
+  makeEquipment(303),
+]
+
+// ============================================================================
+// Bằng chứng 1: useReactTable trả về table identity ỔN ĐỊNH qua render
+// ============================================================================
+
+describe("[issue #400] useReactTable instance identity is stable", () => {
+  it("returns the SAME table reference across no-op re-renders", () => {
+    const columns: ColumnDef<Equipment>[] = [
+      { accessorKey: "ma_thiet_bi", header: "Mã" },
+    ]
+
+    const { result, rerender } = renderHook(() =>
+      useReactTable({
+        data: ROWS,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+      }),
+    )
+
+    const t1 = result.current
+    rerender()
+    const t2 = result.current
+    rerender()
+    const t3 = result.current
+
+    // Khẳng định: table instance từ useReactTable KHÔNG đổi ref qua
+    // re-render khi options không đổi. Loại bỏ giả thuyết "table ref churn".
+    expect(t2).toBe(t1)
+    expect(t3).toBe(t1)
+  })
+})
+
+// ============================================================================
+// Bằng chứng 2: useEquipmentTable memoize return CHÍNH XÁC
+// ============================================================================
+
+function renderUseEquipmentTable(selectedFacilityId: number | null = 5) {
+  return renderHook(() => {
+    const [sorting, setSorting] = React.useState([])
+    const [columnFilters, setColumnFilters] = React.useState([])
+    const [searchTerm, setSearchTerm] = React.useState("")
+    const [pagination, setPagination] = React.useState({ pageIndex: 0, pageSize: 20 })
+
+    const columns = React.useMemo<ColumnDef<Equipment>[]>(
+      () => [
+        createSelectionColumn<Equipment>(),
+        { accessorKey: "ma_thiet_bi", header: "Mã" },
+      ],
+      [],
+    )
+
+    return useEquipmentTable({
+      data: ROWS,
+      total: ROWS.length,
+      columns,
+      sorting,
+      setSorting,
+      columnFilters,
+      setColumnFilters,
+      debouncedSearch: searchTerm,
+      setSearchTerm,
+      pagination,
+      setPagination,
+      selectedDonVi: selectedFacilityId,
+      selectedFacilityId,
+    })
+  })
+}
+
+describe("[issue #400] useEquipmentTable return identity is stable", () => {
+  it("returns the SAME object across no-op re-renders", () => {
+    const { result, rerender } = renderUseEquipmentTable(5)
+
+    const before = result.current
+    rerender()
+    const after = result.current
+
+    // Khẳng định: re-render không đổi gì → return ref không đổi.
+    // Loại bỏ giả thuyết "memo deps churn ngầm".
+    expect(after).toBe(before)
+  })
+
+  it("preserves the SAME `table` reference across selection toggles", () => {
+    const { result } = renderUseEquipmentTable(5)
+
+    const tableBefore = result.current.table
+    act(() => {
+      result.current.table.toggleAllPageRowsSelected(true)
+    })
+    const tableAfter = result.current.table
+
+    // Khẳng định: TanStack table instance giữ identity qua state change
+    // nội tại (rowSelection). Loại bỏ giả thuyết "selection toggle khiến
+    // table ref đổi → trigger downstream re-render".
+    expect(tableAfter).toBe(tableBefore)
+  })
+
+  it("returns the SAME memo object across selection toggles (selection state is internal)", () => {
+    const { result } = renderUseEquipmentTable(5)
+
+    const before = result.current
+    act(() => {
+      result.current.table.toggleAllPageRowsSelected(true)
+    })
+    const after = result.current
+
+    // Khẳng định cuối cùng: rowSelection thay đổi KHÔNG làm
+    // useEquipmentTable phát object mới ra ngoài. Đây là proof rằng
+    // chain memo từ useEquipmentTable đã đúng — root cause của lag
+    // KHÔNG nằm ở đây. Cần điều tra layer khác (data size, cell cost,
+    // subscriber, listener, hoặc ở tầng useEquipmentPage trở lên).
+    expect(after).toBe(before)
+  })
+})

--- a/src/app/(app)/equipment/__tests__/useEquipmentTable.selection.admin-flow.test.tsx
+++ b/src/app/(app)/equipment/__tests__/useEquipmentTable.selection.admin-flow.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Regression-lock test: multi-selection invariants ở `useEquipmentTable`
+ * hook khi chạy trong luồng admin/global (có `selectedFacilityId`).
+ *
+ * Bug báo cáo (prod):
+ *   - Role admin/global: tick chọn không phản hồi; click nhiều lần → tự
+ *     chọn tất cả trong page.
+ *   - Role to_qltb: tick chọn bình thường.
+ *
+ * Khác biệt giữa 2 role ở tầng này:
+ *   - to_qltb: `selectedFacilityId === undefined` cố định, `selectedDonVi`
+ *     cố định → `filterKey` trong useEquipmentTable ổn định → effect
+ *     `setRowSelection({})` không re-fire ngoài ý muốn.
+ *   - admin/global: `selectedFacilityId` đổi theo TenantSelector. Nếu bất
+ *     kỳ re-render admin-only nào làm ref của filterKey deps nhích →
+ *     selection bị reset ngay sau khi user tick.
+ *
+ * Các invariant cần giữ (áp dụng cho admin/global):
+ *   1. Click 1 row checkbox với `selectedFacilityId=number` ổn định → row
+ *      đó được chọn, tổng selection = 1, KHÔNG select-all page.
+ *   2. Parent re-render (isFetching toggle, data ref đổi) giữa các click
+ *      không làm mất selection đã chọn trước đó.
+ *   3. Khi admin chuyển facility (`selectedFacilityId` đổi value), việc
+ *      reset selection là mong muốn. Nhưng nếu `selectedFacilityId` giữ
+ *      nguyên value (chỉ ref đổi), selection phải được giữ.
+ */
+
+import * as React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import type { ColumnDef } from "@tanstack/react-table"
+import { flexRender } from "@tanstack/react-table"
+import { describe, expect, it, vi } from "vitest"
+
+import { useEquipmentTable } from "../_hooks/useEquipmentTable"
+import { createSelectionColumn } from "@/components/ui/data-table-selection"
+import type { Equipment } from "@/types/database"
+
+vi.mock("@/hooks/use-media-query", () => ({
+  useMediaQuery: () => false,
+}))
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}))
+
+function makeEquipment(id: number): Equipment {
+  return {
+    id,
+    ma_thiet_bi: `TB-${id}`,
+    ten_thiet_bi: `Thiết bị ${id}`,
+    tinh_trang_hien_tai: "Hoạt động",
+  }
+}
+
+const ROWS: Equipment[] = [
+  makeEquipment(101),
+  makeEquipment(202),
+  makeEquipment(303),
+]
+
+interface HarnessProps {
+  /**
+   * Admin/global: number (facility đã chọn).
+   * to_qltb: undefined (không đổi).
+   */
+  selectedFacilityId: number | null | undefined
+  /**
+   * Mô phỏng parent re-render giữa các click (admin thường gặp:
+   * isFetching toggle, activeUsageLogs refetch, branding load xong).
+   */
+  tick: number
+}
+
+function AdminTableHarness({ selectedFacilityId, tick }: HarnessProps) {
+  // Parent state do `useEquipmentPage` giữ
+  const [sorting, setSorting] = React.useState([])
+  const [columnFilters, setColumnFilters] = React.useState([])
+  const [searchTerm, setSearchTerm] = React.useState("")
+  const [pagination, setPagination] = React.useState({ pageIndex: 0, pageSize: 20 })
+
+  // Columns: chỉ cần selection + 1 data column cho test
+  const columns = React.useMemo<ColumnDef<Equipment>[]>(
+    () => [
+      createSelectionColumn<Equipment>(),
+      {
+        accessorKey: "ma_thiet_bi",
+        header: "Mã TB",
+        cell: ({ row }) => <span>{row.original.ma_thiet_bi}</span>,
+      },
+    ],
+    [],
+  )
+
+  // Admin scenario: selectedDonVi === selectedFacilityId khi showSelector
+  const selectedDonVi =
+    typeof selectedFacilityId === "number" ? selectedFacilityId : null
+
+  const { table } = useEquipmentTable({
+    data: ROWS,
+    total: ROWS.length,
+    columns,
+    sorting,
+    setSorting,
+    columnFilters,
+    setColumnFilters,
+    debouncedSearch: searchTerm,
+    setSearchTerm,
+    pagination,
+    setPagination,
+    selectedDonVi,
+    selectedFacilityId,
+  })
+
+  return (
+    <div>
+      <span data-testid="tick" hidden>
+        {tick}
+      </span>
+      <table>
+        <thead>
+          {table.getHeaderGroups().map((hg) => (
+            <tr key={hg.id}>
+              {hg.headers.map((h) => (
+                <th key={h.id}>
+                  {h.isPlaceholder
+                    ? null
+                    : flexRender(h.column.columnDef.header, h.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr
+              key={row.id}
+              aria-label={row.original.ma_thiet_bi}
+              onClick={() => {
+                // mimic EquipmentContent: open detail on row click
+              }}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <output data-testid="selected-ids">
+        {table
+          .getFilteredSelectedRowModel()
+          .rows.map((r) => r.original.id)
+          .join(",")}
+      </output>
+      <output data-testid="selected-count">
+        {table.getFilteredSelectedRowModel().rows.length}
+      </output>
+    </div>
+  )
+}
+
+function getRowCheckbox(code: string) {
+  const row = screen.getByRole("row", { name: code })
+  return within(row).getByRole("checkbox", { name: "Chọn dòng" })
+}
+
+describe("useEquipmentTable selection with admin/global facility flow", () => {
+  it("click 1 row checkbox with stable facility selection → only that row is selected", () => {
+    render(<AdminTableHarness selectedFacilityId={5} tick={0} />)
+
+    fireEvent.click(getRowCheckbox("TB-202"))
+
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("202")
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1")
+  })
+
+  it("same row checkbox clicked repeatedly never drifts to select-all", () => {
+    render(<AdminTableHarness selectedFacilityId={5} tick={0} />)
+    const cb = getRowCheckbox("TB-101")
+
+    for (let i = 0; i < 5; i++) {
+      fireEvent.click(cb)
+    }
+
+    // Odd number of toggles = that single row selected; NOT all 3 rows.
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1")
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("101")
+  })
+
+  it("parent re-renders between clicks do not wipe selection (admin-like)", () => {
+    const { rerender } = render(
+      <AdminTableHarness selectedFacilityId={5} tick={0} />,
+    )
+
+    fireEvent.click(getRowCheckbox("TB-202"))
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("202")
+
+    // Simulate admin-only parent re-renders (isFetching toggle, branding
+    // ref change, activeUsageLogs refetch) with SAME facility selection.
+    for (let tick = 1; tick <= 5; tick++) {
+      rerender(<AdminTableHarness selectedFacilityId={5} tick={tick} />)
+    }
+
+    expect(screen.getByTestId("selected-ids")).toHaveTextContent("202")
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("1")
+
+    // Then click another row → should ADD to selection (2), not reset.
+    fireEvent.click(getRowCheckbox("TB-303"))
+    const ids = (screen.getByTestId("selected-ids").textContent ?? "").split(
+      ",",
+    )
+    expect(ids.sort()).toEqual(["202", "303"])
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("2")
+  })
+
+  it("selecting 2 distinct rows in admin flow keeps only those rows selected", () => {
+    render(<AdminTableHarness selectedFacilityId={5} tick={0} />)
+
+    fireEvent.click(getRowCheckbox("TB-101"))
+    fireEvent.click(getRowCheckbox("TB-303"))
+
+    const ids = (screen.getByTestId("selected-ids").textContent ?? "").split(
+      ",",
+    )
+    expect(ids.sort()).toEqual(["101", "303"])
+    expect(screen.getByTestId("selected-count")).toHaveTextContent("2")
+  })
+})

--- a/src/app/(app)/equipment/_components/EquipmentBulkDeleteBar.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentBulkDeleteBar.tsx
@@ -35,13 +35,18 @@ export function EquipmentBulkDeleteBar({
   const { mutate: bulkDelete, isPending: isDeleting } = useBulkDeleteEquipment()
 
   const selectedRows = table.getFilteredSelectedRowModel().rows
-  const selectedIds = React.useMemo(
-    () =>
-      selectedRows
-        .map((row) => Number(row.original.id))
-        .filter((id) => Number.isFinite(id)),
-    [selectedRows]
-  )
+  const selectedIds = React.useMemo(() => {
+    const ids: number[] = []
+
+    for (const row of selectedRows) {
+      const id = Number(row.original.id)
+      if (Number.isFinite(id)) {
+        ids.push(id)
+      }
+    }
+
+    return ids
+  }, [selectedRows])
   const selectedCount = selectedIds.length
 
   React.useEffect(() => {
@@ -66,48 +71,55 @@ export function EquipmentBulkDeleteBar({
     [selectedIds, isDeleting, bulkDelete, table]
   )
 
-  if (!canBulkSelect || isCardView) {
+  if (!canBulkSelect || isCardView || selectedCount === 0) {
     return null
   }
 
   return (
-    <BulkActionBar
-      selectedCount={selectedCount}
-      onClearSelection={() => table.resetRowSelection()}
-      entityLabel="thiết bị"
+    <div
+      data-testid="equipment-bulk-delete-bar"
+      className="pointer-events-none absolute bottom-4 right-4 z-20 flex max-w-[calc(100%-2rem)] justify-end"
     >
-      <AlertDialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
-        <AlertDialogTrigger asChild>
-          <Button type="button" size="sm" variant="destructive" disabled={isDeleting}>
-            {EQUIPMENT_BULK_DELETE_LABEL}
-          </Button>
-        </AlertDialogTrigger>
-        <AlertDialogContent onClick={(event) => event.stopPropagation()}>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Bạn có chắc chắn muốn xóa các thiết bị đã chọn?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {`Hành động này sẽ xóa mềm ${selectedCount} thiết bị đã chọn. Bạn có thể khôi phục lại sau nếu cần.`}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel
-              onClick={(event) => {
-                event.stopPropagation()
-                setIsConfirmOpen(false)
-              }}
-            >
-              Hủy
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              disabled={selectedCount === 0 || isDeleting}
-            >
-              {isDeleting ? "Đang xóa..." : "Xóa"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </BulkActionBar>
+      <div className="pointer-events-auto max-w-full shadow-lg">
+        <BulkActionBar
+          selectedCount={selectedCount}
+          onClearSelection={() => table.resetRowSelection()}
+          entityLabel="thiết bị"
+        >
+          <AlertDialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+            <AlertDialogTrigger asChild>
+              <Button type="button" size="sm" variant="destructive" disabled={isDeleting}>
+                {EQUIPMENT_BULK_DELETE_LABEL}
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent onClick={(event) => event.stopPropagation()}>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Bạn có chắc chắn muốn xóa các thiết bị đã chọn?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {`Hành động này sẽ xóa mềm ${selectedCount} thiết bị đã chọn. Bạn có thể khôi phục lại sau nếu cần.`}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    setIsConfirmOpen(false)
+                  }}
+                >
+                  Hủy
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={handleConfirmDelete}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  disabled={selectedCount === 0 || isDeleting}
+                >
+                  {isDeleting ? "Đang xóa..." : "Xóa"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </BulkActionBar>
+      </div>
+    </div>
   )
 }

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -92,8 +92,11 @@ export function EquipmentPageClient() {
   )
 }
 
-// Separate component to use context inside provider - memoized to prevent re-renders
-const EquipmentPageContent = React.memo(function EquipmentPageContent({
+// Separate component to use context inside provider.
+// Do not memoize this boundary: TanStack Table keeps a stable table reference
+// while its internal row selection changes, so memoizing by pageState can leave
+// selection checkboxes visually stale until an unrelated parent render occurs.
+function EquipmentPageContent({
   pageState
 }: {
   pageState: ReturnType<typeof useEquipmentPage>
@@ -348,4 +351,4 @@ const EquipmentPageContent = React.memo(function EquipmentPageContent({
       />
     </>
   )
-})
+}

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -264,15 +264,14 @@ function EquipmentPageContent({
             onShowEquipmentDetails={(eq) => openDetailDialog(eq)}
           />
 
-          <EquipmentBulkDeleteBar
-            table={table}
-            canBulkSelect={canBulkSelect}
-            isCardView={isCardView}
-          />
-
           <EquipmentColumnsDialog table={table} />
 
-          <div className="mt-4">
+          <div className="relative mt-4">
+            <EquipmentBulkDeleteBar
+              table={table}
+              canBulkSelect={canBulkSelect}
+              isCardView={isCardView}
+            />
             <EquipmentContent
               isGlobal={isGlobal}
               isRegionalLeader={isRegionalLeader}


### PR DESCRIPTION
## Summary
- Fix Equipment grid multi-selection repaint for admin/global users.
- Root cause: `EquipmentPageContent` was memoized by a stable `pageState` object while TanStack Table row selection changes internally behind a stable table reference.
- Add a TDD regression at the `EquipmentPageClient` boundary that fails when selection state changes but content is not repainted.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx' 'src/app/(app)/equipment/__tests__/equipment-content.selection.test.tsx' 'src/app/(app)/equipment/__tests__/useEquipmentTable.selection.admin-flow.test.tsx' 'src/app/(app)/equipment/__tests__/useEquipmentTable.rerender-proof.test.tsx'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` (100/100)

Fixes #400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale multi-selection in the Equipment grid for admin/global users and stabilizes the bulk actions UI. Un-memoizes page content so checkbox changes repaint instantly and floats the bulk delete bar to prevent table shifting. Fixes #400.

- **Bug Fixes**
  - Un-memoized `EquipmentPageContent` so updates from `@tanstack/react-table` row selection repaint immediately under a stable table ref.
  - Floated `EquipmentBulkDeleteBar` inside a relative container (absolute positioning, pointer-events guard), render only when `selectedCount > 0`, and streamlined `selectedIds` mapping.
  - Added regression tests for selection invariants and admin-like re-renders, proof tests for stable `table` identity, and a layout test for the floating bulk bar.

<sup>Written for commit 7ebde603d60e9d4c2c03927f8bdf595965dfc79f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for equipment table row selection functionality, including multi-selection behavior, rendering stability, and component re-render consistency across various user interactions.

* **Refactor**
  * Simplified equipment page component implementation to improve rendering behavior and consistency with table state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->