### PR TITLE
fix(auth): harden password change flow

### DIFF
--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -93,6 +93,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'get_facilities_with_equipment_count',
   'get_accessible_facilities',
   'user_create',
+  'change_password',
   'user_membership_add',
   'user_membership_remove',
   'user_set_current_don_vi',

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -43,6 +43,13 @@ describe('RPC proxy whitelist', () => {
     await expect(res.json()).resolves.toEqual({ error: 'Content-Length header required' })
   })
 
+  it('allows change_password through whitelist checks', async () => {
+    const res = await invokeRpcProxy('change_password')
+
+    expect(res.status).toBe(411)
+    await expect(res.json()).resolves.toEqual({ error: 'Content-Length header required' })
+  })
+
   it.each([
     'equipment_filter_buckets',
     'dashboard_kpi_summary',

--- a/src/components/__tests__/change-password-dialog.security-source.test.ts
+++ b/src/components/__tests__/change-password-dialog.security-source.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+describe("ChangePasswordDialog password-change security posture", () => {
+  it("does not include the legacy client-side password fallback", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/components/change-password-dialog.tsx"),
+      "utf8",
+    )
+
+    expect(source).not.toContain("hashed_password")
+    expect(source).not.toContain(".from('nhan_vien')")
+    expect(source).not.toContain('.from("nhan_vien")')
+    expect(source).not.toContain(".update({ password")
+    expect(source).not.toContain("temporary fallback")
+  })
+})

--- a/src/components/__tests__/change-password-dialog.signout.test.tsx
+++ b/src/components/__tests__/change-password-dialog.signout.test.tsx
@@ -223,6 +223,7 @@ describe("ChangePasswordDialog forced signout", () => {
 
   it("fails closed when the password-change RPC is unavailable", async () => {
     const onOpenChange = vi.fn()
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     mocks.rpc.mockRejectedValueOnce(new Error("Could not find the function public.change_password"))
 
     render(<ChangePasswordDialog open onOpenChange={onOpenChange} />)
@@ -243,13 +244,18 @@ describe("ChangePasswordDialog forced signout", () => {
         expect.objectContaining({
           variant: "destructive",
           title: "Lỗi",
-          description: "Could not find the function public.change_password",
+          description: "Dịch vụ đổi mật khẩu tạm thời không khả dụng. Vui lòng thử lại sau.",
         }),
       )
     })
 
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Password change RPC unavailable:",
+      expect.any(Error),
+    )
     expect(onOpenChange).not.toHaveBeenCalled()
     expect(mocks.updateSession).not.toHaveBeenCalled()
     expect(mocks.signOut).not.toHaveBeenCalled()
+    consoleErrorSpy.mockRestore()
   })
 })

--- a/src/components/__tests__/change-password-dialog.signout.test.tsx
+++ b/src/components/__tests__/change-password-dialog.signout.test.tsx
@@ -20,10 +20,8 @@ vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: mocks.toast }),
 }))
 
-vi.mock("@/lib/supabase", () => ({
-  supabase: {
-    rpc: (...args: unknown[]) => mocks.rpc(...args),
-  },
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: (...args: unknown[]) => mocks.rpc(...args),
 }))
 
 vi.mock("@/components/ui/dialog", () => ({
@@ -98,11 +96,8 @@ describe("ChangePasswordDialog forced signout", () => {
     vi.clearAllMocks()
     mocks.updateSession.mockResolvedValue(undefined)
     mocks.rpc.mockResolvedValue({
-      data: {
-        success: true,
-        message: "Đã thay đổi mật khẩu thành công với mã hóa bảo mật.",
-      },
-      error: null,
+      success: true,
+      message: "Đã thay đổi mật khẩu thành công với mã hóa bảo mật.",
     })
     mocks.useSession.mockReturnValue({
       data: {
@@ -144,6 +139,14 @@ describe("ChangePasswordDialog forced signout", () => {
       )
     })
 
+    expect(mocks.rpc).toHaveBeenCalledWith({
+      fn: "change_password",
+      args: {
+        p_user_id: 42,
+        p_old_password: "old-password",
+        p_new_password: "new-password",
+      },
+    })
     expect(onOpenChange).toHaveBeenCalledWith(false)
     expect(mocks.updateSession).toHaveBeenCalledWith({
       pending_signout_reason: "forced_password_change",
@@ -216,5 +219,37 @@ describe("ChangePasswordDialog forced signout", () => {
         }),
       )
     })
+  })
+
+  it("fails closed when the password-change RPC is unavailable", async () => {
+    const onOpenChange = vi.fn()
+    mocks.rpc.mockRejectedValueOnce(new Error("Could not find the function public.change_password"))
+
+    render(<ChangePasswordDialog open onOpenChange={onOpenChange} />)
+
+    fireEvent.change(screen.getByLabelText("Mật khẩu hiện tại *"), {
+      target: { value: "old-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Xác nhận mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Thay đổi mật khẩu" }))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: "Lỗi",
+          description: "Could not find the function public.change_password",
+        }),
+      )
+    })
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+    expect(mocks.updateSession).not.toHaveBeenCalled()
+    expect(mocks.signOut).not.toHaveBeenCalled()
   })
 })

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -17,12 +17,17 @@ import { Label } from "@/components/ui/label"
 import { useToast } from "@/hooks/use-toast"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
 import { signOutWithReason } from "@/lib/auth-signout"
-import { supabase } from "@/lib/supabase"
+import { callRpc } from "@/lib/rpc-client"
 import { useSession } from "next-auth/react"
 
 interface ChangePasswordDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+}
+
+type ChangePasswordRpcResult = {
+  success?: boolean
+  message?: string
 }
 
 export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
@@ -117,15 +122,6 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
       return
     }
 
-    if (!supabase) {
-      toast({
-        variant: "destructive",
-        title: "Lỗi",
-        description: "Không thể kết nối đến cơ sở dữ liệu."
-      })
-      return
-    }
-
     setIsLoading(true)
     let passwordChanged = false
 
@@ -140,86 +136,29 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
         return
       }
 
-      // Try to use the secure change_password function first
-      const { data, error } = await supabase.rpc('change_password', {
-        p_user_id: currentUserId,
-        p_old_password: formData.currentPassword,
-        p_new_password: formData.newPassword
+      const data = await callRpc<ChangePasswordRpcResult>({
+        fn: "change_password",
+        args: {
+          p_user_id: currentUserId,
+          p_old_password: formData.currentPassword,
+          p_new_password: formData.newPassword,
+        },
       })
 
-      // If function doesn't exist, fall back to direct update (temporary)
-      if (error && (
-        error.message?.includes('Could not find the function') ||
-        error.message?.includes('function change_password') ||
-        error.code === '42883' // Function does not exist error code
-      )) {
-        console.log('change_password function not found, using temporary fallback method')
-        console.log('Error details:', error)
-
-        // Verify current password manually
-        const { data: currentUser, error: fetchError } = await supabase
-          .from('nhan_vien')
-          .select('password, hashed_password')
-          .eq('id', currentUserId)
-          .single()
-
-        if (fetchError) {
-          throw fetchError
-        }
-
-        // Check password (try hashed first, then plain text)
-        let passwordValid = false
-        if (currentUser.hashed_password && currentUser.hashed_password !== '') {
-          // Try to verify with hashed password (this won't work client-side, so we'll use plain text comparison)
-          passwordValid = currentUser.password === formData.currentPassword
-        } else {
-          passwordValid = currentUser.password === formData.currentPassword
-        }
-
-        if (!passwordValid) {
-          toast({
-            variant: "destructive",
-            title: "Lỗi",
-            description: "Mật khẩu hiện tại không đúng."
-          })
-          setIsLoading(false)
-          return
-        }
-
-        // Update password directly
-        const { error: updateError } = await supabase
-          .from('nhan_vien')
-          .update({ password: formData.newPassword })
-          .eq('id', currentUserId)
-
-        if (updateError) {
-          throw updateError
-        }
-
+      if (!data?.success) {
         toast({
-          title: "Thành công",
-          description: "Đã thay đổi mật khẩu thành công. (Chế độ tạm thời - vui lòng chạy script SQL để kích hoạt mã hóa mật khẩu)"
+          variant: "destructive",
+          title: "Lỗi",
+          description: data?.message || "Mật khẩu hiện tại không đúng."
         })
-      } else if (error) {
-        console.error('Error from change_password function:', error)
-        throw error
-      } else {
-        // Check if password change was successful (new JSON response format)
-        if (!data || !data.success) {
-          toast({
-            variant: "destructive",
-            title: "Lỗi",
-            description: data?.message || "Mật khẩu hiện tại không đúng."
-          })
-          setIsLoading(false)
-          return
-        }
-
-        toast({
-          title: "Thành công",
-          description: data.message || "Đã thay đổi mật khẩu thành công với mã hóa bảo mật."
-        })
+        setIsLoading(false)
+        return
       }
+
+      toast({
+        title: "Thành công",
+        description: data.message || "Đã thay đổi mật khẩu thành công với mã hóa bảo mật."
+      })
 
       onOpenChange(false)
       passwordChanged = true

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -30,6 +30,27 @@ type ChangePasswordRpcResult = {
   message?: string
 }
 
+const PASSWORD_CHANGE_UNAVAILABLE_MESSAGE =
+  "Dịch vụ đổi mật khẩu tạm thời không khả dụng. Vui lòng thử lại sau."
+
+function isPasswordChangeUnavailableError(error: unknown): boolean {
+  const message = getUnknownErrorMessage(error, "").toLowerCase()
+  return (
+    message.includes("could not find the function") ||
+    message.includes("function change_password") ||
+    message.includes("rpc change_password failed") ||
+    message.includes("function not allowed")
+  )
+}
+
+function getPasswordChangeErrorMessage(error: unknown): string {
+  if (isPasswordChangeUnavailableError(error)) {
+    return PASSWORD_CHANGE_UNAVAILABLE_MESSAGE
+  }
+
+  return getUnknownErrorMessage(error, "Có lỗi xảy ra khi thay đổi mật khẩu.")
+}
+
 export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
   const { toast } = useToast()
   const { data: session, update } = useSession()
@@ -163,10 +184,15 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
       onOpenChange(false)
       passwordChanged = true
     } catch (error: unknown) {
+      if (isPasswordChangeUnavailableError(error)) {
+        try {
+          console.error("Password change RPC unavailable:", error)
+        } catch {}
+      }
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: getUnknownErrorMessage(error, "Có lỗi xảy ra khi thay đổi mật khẩu."),
+        description: getPasswordChangeErrorMessage(error),
       })
     } finally {
       setIsLoading(false)

--- a/supabase/migrations/20260505144500_harden_change_password_rpc.sql
+++ b/supabase/migrations/20260505144500_harden_change_password_rpc.sql
@@ -8,12 +8,16 @@ CREATE OR REPLACE FUNCTION public.change_password(
 ) RETURNS jsonb
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public, extensions, pg_temp
+SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_claims JSONB := COALESCE(current_setting('request.jwt.claims', true), '{}')::jsonb;
   v_role TEXT := LOWER(COALESCE(NULLIF(v_claims->>'app_role', ''), NULLIF(v_claims->>'role', '')));
   v_claim_user_id INTEGER;
+  v_user_agent TEXT := COALESCE(
+    NULLIF((COALESCE(NULLIF(current_setting('request.headers', true), ''), '{}')::jsonb)->>'user-agent', ''),
+    'unknown'
+  );
   user_record RECORD;
   password_valid BOOLEAN := FALSE;
 BEGIN
@@ -35,6 +39,14 @@ BEGIN
     RAISE EXCEPTION 'user_id claim mismatch' USING ERRCODE = '42501';
   END IF;
 
+  IF NULLIF(p_old_password, '') IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'message', 'Current password is incorrect');
+  END IF;
+
+  IF NULLIF(p_new_password, '') IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'message', 'New password is required');
+  END IF;
+
   SELECT id, username, password, hashed_password
   INTO user_record
   FROM public.nhan_vien
@@ -50,7 +62,7 @@ BEGIN
     password_valid := (user_record.password = p_old_password);
   END IF;
 
-  IF NOT password_valid THEN
+  IF password_valid IS DISTINCT FROM TRUE THEN
     RETURN jsonb_build_object('success', false, 'message', 'Current password is incorrect');
   END IF;
 
@@ -78,7 +90,7 @@ BEGIN
       user_record.username,
       'User changed password',
       COALESCE(pg_catalog.inet_client_addr(), '0.0.0.0'::INET),
-      COALESCE(current_setting('request.headers', true), 'unknown')
+      v_user_agent
     );
   EXCEPTION WHEN others THEN
     RAISE WARNING 'Failed to log password change: %', SQLERRM;

--- a/supabase/migrations/20260505144500_harden_change_password_rpc.sql
+++ b/supabase/migrations/20260505144500_harden_change_password_rpc.sql
@@ -1,0 +1,96 @@
+-- Harden password changes behind session-signed JWT claims.
+-- Do not trust p_user_id from the client; it must match request.jwt.claims.user_id.
+
+CREATE OR REPLACE FUNCTION public.change_password(
+  p_user_id INTEGER,
+  p_old_password TEXT,
+  p_new_password TEXT
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_claims JSONB := COALESCE(current_setting('request.jwt.claims', true), '{}')::jsonb;
+  v_role TEXT := LOWER(COALESCE(NULLIF(v_claims->>'app_role', ''), NULLIF(v_claims->>'role', '')));
+  v_claim_user_id INTEGER;
+  user_record RECORD;
+  password_valid BOOLEAN := FALSE;
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF NULLIF(v_claims->>'user_id', '') IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  BEGIN
+    v_claim_user_id := (v_claims->>'user_id')::INTEGER;
+  EXCEPTION WHEN invalid_text_representation THEN
+    RAISE EXCEPTION 'Invalid user_id claim' USING ERRCODE = '42501';
+  END;
+
+  IF p_user_id IS NULL OR p_user_id <> v_claim_user_id THEN
+    RAISE EXCEPTION 'user_id claim mismatch' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT id, username, password, hashed_password
+  INTO user_record
+  FROM public.nhan_vien
+  WHERE id = p_user_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'message', 'User not found');
+  END IF;
+
+  IF user_record.hashed_password IS NOT NULL AND user_record.hashed_password <> '' THEN
+    password_valid := (extensions.crypt(p_old_password, user_record.hashed_password) = user_record.hashed_password);
+  ELSE
+    password_valid := (user_record.password = p_old_password);
+  END IF;
+
+  IF NOT password_valid THEN
+    RETURN jsonb_build_object('success', false, 'message', 'Current password is incorrect');
+  END IF;
+
+  UPDATE public.nhan_vien
+  SET hashed_password = extensions.crypt(p_new_password, extensions.gen_salt('bf', 12)),
+      password = 'hashed password',
+      password_changed_at = NOW()
+  WHERE id = p_user_id;
+
+  BEGIN
+    INSERT INTO public.audit_logs (
+      admin_user_id,
+      admin_username,
+      action_type,
+      target_user_id,
+      target_username,
+      action_details,
+      ip_address,
+      user_agent
+    ) VALUES (
+      p_user_id,
+      user_record.username,
+      'password_change',
+      p_user_id,
+      user_record.username,
+      'User changed password',
+      COALESCE(pg_catalog.inet_client_addr(), '0.0.0.0'::INET),
+      COALESCE(current_setting('request.headers', true), 'unknown')
+    );
+  EXCEPTION WHEN others THEN
+    RAISE WARNING 'Failed to log password change: %', SQLERRM;
+  END;
+
+  RETURN jsonb_build_object('success', true, 'message', 'Password updated successfully');
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.change_password(INTEGER, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.change_password(INTEGER, TEXT, TEXT) FROM anon;
+GRANT EXECUTE ON FUNCTION public.change_password(INTEGER, TEXT, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.change_password(INTEGER, TEXT, TEXT)
+IS 'Allows the current authenticated session user to change only their own password with hashed storage, audit logging, and JWT claim guard.';

--- a/supabase/tests/change_password_hardening_smoke.sql
+++ b/supabase/tests/change_password_hardening_smoke.sql
@@ -1,0 +1,47 @@
+-- Smoke test for Issue #393 password-change hardening.
+-- Expected to pass only after applying 20260505144500_harden_change_password_rpc.sql.
+
+DO $$
+DECLARE
+  v_can_anon BOOLEAN;
+  v_can_authenticated BOOLEAN;
+  v_function_def TEXT;
+BEGIN
+  SELECT has_function_privilege('anon', 'public.change_password(integer, text, text)', 'EXECUTE')
+  INTO v_can_anon;
+
+  IF v_can_anon THEN
+    RAISE EXCEPTION 'anon must not execute public.change_password';
+  END IF;
+
+  SELECT has_function_privilege('authenticated', 'public.change_password(integer, text, text)', 'EXECUTE')
+  INTO v_can_authenticated;
+
+  IF NOT v_can_authenticated THEN
+    RAISE EXCEPTION 'authenticated must execute public.change_password';
+  END IF;
+
+  SELECT pg_get_functiondef('public.change_password(integer, text, text)'::regprocedure)
+  INTO v_function_def;
+
+  IF v_function_def NOT LIKE '%user_id claim mismatch%' THEN
+    RAISE EXCEPTION 'change_password must reject p_user_id values that do not match JWT user_id';
+  END IF;
+
+  PERFORM set_config('request.jwt.claims', '{}', true);
+  BEGIN
+    PERFORM public.change_password(1, 'old-password', 'new-password');
+    RAISE EXCEPTION 'change_password must fail closed without user_id claim';
+  EXCEPTION WHEN SQLSTATE '42501' THEN
+    NULL;
+  END;
+
+  PERFORM set_config('request.jwt.claims', '{"app_role":"to_qltb","user_id":"1"}', true);
+  BEGIN
+    PERFORM public.change_password(2, 'old-password', 'new-password');
+    RAISE EXCEPTION 'change_password must fail closed when p_user_id mismatches JWT user_id';
+  EXCEPTION WHEN SQLSTATE '42501' THEN
+    NULL;
+  END;
+END;
+$$;

--- a/supabase/tests/change_password_hardening_smoke.sql
+++ b/supabase/tests/change_password_hardening_smoke.sql
@@ -5,7 +5,8 @@ DO $$
 DECLARE
   v_can_anon BOOLEAN;
   v_can_authenticated BOOLEAN;
-  v_function_def TEXT;
+  v_is_security_definer BOOLEAN;
+  v_has_narrow_search_path BOOLEAN;
 BEGIN
   SELECT has_function_privilege('anon', 'public.change_password(integer, text, text)', 'EXECUTE')
   INTO v_can_anon;
@@ -21,11 +22,32 @@ BEGIN
     RAISE EXCEPTION 'authenticated must execute public.change_password';
   END IF;
 
-  SELECT pg_get_functiondef('public.change_password(integer, text, text)'::regprocedure)
-  INTO v_function_def;
+  SELECT p.prosecdef
+  INTO v_is_security_definer
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'change_password'
+    AND pg_get_function_identity_arguments(p.oid) = 'p_user_id integer, p_old_password text, p_new_password text';
 
-  IF v_function_def NOT LIKE '%user_id claim mismatch%' THEN
-    RAISE EXCEPTION 'change_password must reject p_user_id values that do not match JWT user_id';
+  IF v_is_security_definer IS DISTINCT FROM TRUE THEN
+    RAISE EXCEPTION 'change_password must be SECURITY DEFINER';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    CROSS JOIN LATERAL unnest(p.proconfig) AS config(value)
+    WHERE n.nspname = 'public'
+      AND p.proname = 'change_password'
+      AND pg_get_function_identity_arguments(p.oid) = 'p_user_id integer, p_old_password text, p_new_password text'
+      AND config.value = 'search_path=public, pg_temp'
+  )
+  INTO v_has_narrow_search_path;
+
+  IF NOT v_has_narrow_search_path THEN
+    RAISE EXCEPTION 'change_password must use search_path=public, pg_temp';
   END IF;
 
   PERFORM set_config('request.jwt.claims', '{}', true);


### PR DESCRIPTION
## Summary
- Remove the legacy client-side password-change fallback from `ChangePasswordDialog`
- Route password changes through the session-signed `/api/rpc/change_password` proxy path
- Add local SQL migration and smoke test to harden `change_password` with JWT user matching and revoke anon execution
- Split broader `nhan_vien` table privilege/RLS cleanup into follow-up #405

## Verification
- RED focused app/proxy tests failed before implementation for the intended reasons
- Live SQL RED failed before migration apply: `anon must not execute public.change_password`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js test -- src/components/__tests__/change-password-dialog.signout.test.tsx src/components/__tests__/change-password-dialog.security-source.test.ts src/lib/__tests__/auth-signout.test.ts src/auth/__tests__/auth-config.jwt-cooldown.test.ts src/auth/__tests__/auth-config.jwt-rpc.test.ts src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` → 99/100, existing #390 `isLoading` warning remains

## Migration status
Migration is included but intentionally not applied yet per owner instruction. Post-apply SQL smoke and Supabase advisors should run after explicit approval to apply.

Fixes #393

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the password change flow by removing the client-side fallback and routing all updates through the session-signed RPC proxy. Adds a secure `public.change_password` with JWT user matching to prevent impersonation. Fixes #393.

- **Bug Fixes**
  - `ChangePasswordDialog` now calls `/api/rpc/change_password` via `callRpc`; removed direct `nhan_vien` updates and legacy fallback.
  - Whitelisted `change_password` in the RPC proxy.
  - Improved error handling with a friendly message when the RPC is unavailable; added tests for whitelist, dialog security posture, success path, and fail-closed behavior.

- **Migration**
  - Introduces `public.change_password(p_user_id, p_old_password, p_new_password)` with JWT claim guard (p_user_id must match JWT `user_id`), bcrypt hashing, and audit logging.
  - Uses `SECURITY DEFINER` and `search_path=public, pg_temp`; revokes execute from `anon`, grants to `authenticated`. Smoke test verifies permissions, claim checks, and these safeguards.
  - Migration is included but not applied yet; apply it and run the smoke test after approval.

<sup>Written for commit 4b422c7b1001255d70ee28cffc46e4c2ccac4fb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Password changes now processed through a secure RPC endpoint with comprehensive security hardening and audit logging.

* **Tests**
  * Added comprehensive test coverage for password change functionality, including security validation and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->