### PR TITLE
feat(auth): add auth audit log retention cleanup

### DIFF
--- a/docs/runbooks/__tests__/auth-audit-log-retention.test.ts
+++ b/docs/runbooks/__tests__/auth-audit-log-retention.test.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('auth audit log retention runbook', () => {
+  it('does not tell operators to comment JSON cron config', () => {
+    const runbookPath = path.resolve(
+      process.cwd(),
+      'docs/runbooks/auth-audit-log-retention.md'
+    )
+    const runbook = fs.readFileSync(runbookPath, 'utf8')
+
+    expect(runbook).not.toMatch(/comment entry .*vercel\.json/i)
+  })
+})

--- a/docs/runbooks/auth-audit-log-retention.md
+++ b/docs/runbooks/auth-audit-log-retention.md
@@ -1,0 +1,85 @@
+# Auth audit log retention
+
+## Chính sách
+
+- Bảng áp dụng: `public.auth_audit_log`.
+- Thời gian lưu giữ: 90 ngày.
+- Cleanup: xóa cứng các dòng có `created_at < now() - interval '90 days'`.
+- Không archive trước khi xóa.
+- Không tạo meta-log table riêng cho cleanup. Kết quả cleanup được theo dõi qua response/log của Edge Function.
+
+## Cách cleanup chạy
+
+Cleanup gồm hai lớp:
+
+1. `public.auth_audit_log_cleanup_scheduled()` trong Postgres.
+   - Chỉ `service_role` được execute.
+   - `SECURITY DEFINER`.
+   - `SET search_path = public, pg_temp`.
+   - Xóa theo batch để tránh một lệnh DELETE quá lớn.
+   - Dùng advisory lock để tránh hai job chạy song song.
+
+2. Supabase Edge Function `auth-audit-cleanup`.
+   - Chỉ nhận `POST`.
+   - Yêu cầu header `Authorization: Bearer <CRON_SECRET>`.
+   - Dùng `SUPABASE_SERVICE_ROLE_KEY` để gọi RPC cleanup.
+   - Chỉ trả/log số liệu tổng hợp, không trả raw audit rows.
+
+## Lịch chạy đề xuất
+
+- Weekly Sunday 03:00 UTC.
+- Nếu tốc độ tăng log cao hơn dự kiến, chuyển sang daily 03:00 UTC mà không cần đổi schema.
+
+## Verification sau apply/deploy
+
+Chạy qua Supabase MCP, không dùng Supabase CLI cho DB operations:
+
+```sql
+select count(*)::bigint as row_count,
+       min(created_at) as oldest_created_at,
+       max(created_at) as newest_created_at,
+       pg_total_relation_size('public.auth_audit_log') as total_bytes
+from public.auth_audit_log;
+```
+
+Kiểm tra function/grants:
+
+```sql
+select p.proname,
+       p.prosecdef as security_definer,
+       p.proconfig as config
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+  and p.proname = 'auth_audit_log_cleanup_scheduled';
+```
+
+Chạy smoke:
+
+```text
+supabase/tests/auth_audit_log_smoke.sql
+supabase/tests/auth_audit_log_retention_smoke.sql
+```
+
+Sau đó chạy Supabase advisors:
+
+```text
+get_advisors(security)
+get_advisors(performance)
+```
+
+## Rollback
+
+Nếu cần tắt cleanup tự động, tắt schedule gọi Edge Function trước. Không drop RPC nếu đang cần điều tra.
+
+Nếu cần rollback schema:
+
+```sql
+revoke all on function public.auth_audit_log_cleanup_scheduled() from public;
+revoke all on function public.auth_audit_log_cleanup_scheduled() from anon;
+revoke all on function public.auth_audit_log_cleanup_scheduled() from authenticated;
+revoke all on function public.auth_audit_log_cleanup_scheduled() from service_role;
+drop function if exists public.auth_audit_log_cleanup_scheduled();
+```
+
+Không khôi phục được các dòng đã bị hard purge nếu không dùng bản backup DB.

--- a/docs/runbooks/auth-audit-log-retention.md
+++ b/docs/runbooks/auth-audit-log-retention.md
@@ -25,7 +25,7 @@ Cleanup gồm hai lớp:
    - Route dùng `SUPABASE_SERVICE_ROLE_KEY` để gọi RPC cleanup.
    - Chỉ trả/log số liệu tổng hợp, không trả raw audit rows.
 
-Supabase Edge Function `auth-audit-cleanup` vẫn có test handler và có thể dùng như fallback thủ công, nhưng schedule chuẩn của repo đi qua Vercel Cron để dùng được env quản lý bằng Vercel CLI.
+Supabase Edge Function `auth-audit-cleanup` vẫn có test handler và có thể dùng như fallback thủ công, nhưng schedule chuẩn của repo đi qua Vercel Cron để dùng được env quản lý bằng Vercel CLI. Nếu deploy fallback này, phải giữ `verify_jwt = false` trong `supabase/config.toml` vì handler tự xác thực bằng `Authorization: Bearer <CRON_SECRET>`.
 
 ## Lịch chạy đề xuất
 
@@ -107,7 +107,7 @@ Sau khi PR chứa `vercel.json` được merge và deploy production, Vercel Cro
 
 ## Rollback
 
-Nếu cần tắt cleanup tự động, xóa hoặc comment entry `/api/cron/auth-audit-cleanup` trong `vercel.json` rồi deploy lại production. Không drop RPC nếu đang cần điều tra.
+Nếu cần tắt cleanup tự động, xóa entry `/api/cron/auth-audit-cleanup` trong `vercel.json` rồi deploy lại production. Không drop RPC nếu đang cần điều tra.
 
 Nếu cần rollback schema:
 

--- a/docs/runbooks/auth-audit-log-retention.md
+++ b/docs/runbooks/auth-audit-log-retention.md
@@ -19,16 +19,45 @@ Cleanup gồm hai lớp:
    - Xóa theo batch để tránh một lệnh DELETE quá lớn.
    - Dùng advisory lock để tránh hai job chạy song song.
 
-2. Supabase Edge Function `auth-audit-cleanup`.
-   - Chỉ nhận `POST`.
-   - Yêu cầu header `Authorization: Bearer <CRON_SECRET>`.
-   - Dùng `SUPABASE_SERVICE_ROLE_KEY` để gọi RPC cleanup.
+2. Vercel Cron gọi `GET /api/cron/auth-audit-cleanup`.
+   - Lịch nằm trong `vercel.json`.
+   - Vercel tự gửi header `Authorization: Bearer <CRON_SECRET>` khi project có env `CRON_SECRET`.
+   - Route dùng `SUPABASE_SERVICE_ROLE_KEY` để gọi RPC cleanup.
    - Chỉ trả/log số liệu tổng hợp, không trả raw audit rows.
+
+Supabase Edge Function `auth-audit-cleanup` vẫn có test handler và có thể dùng như fallback thủ công, nhưng schedule chuẩn của repo đi qua Vercel Cron để dùng được env quản lý bằng Vercel CLI.
 
 ## Lịch chạy đề xuất
 
 - Weekly Sunday 03:00 UTC.
 - Nếu tốc độ tăng log cao hơn dự kiến, chuyển sang daily 03:00 UTC mà không cần đổi schema.
+
+`vercel.json`:
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/cron/auth-audit-cleanup",
+      "schedule": "0 3 * * 0"
+    }
+  ]
+}
+```
+
+## Env trên Vercel
+
+Production cần các env sau:
+
+- `CRON_SECRET`
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+`CRON_SECRET` đã được set bằng Vercel CLI trong phiên Issue #391. Khi rotate secret:
+
+```bash
+printf '%s\n' "$NEW_CRON_SECRET" | vercel env add CRON_SECRET production --force
+```
 
 ## Verification sau apply/deploy
 
@@ -68,9 +97,17 @@ get_advisors(security)
 get_advisors(performance)
 ```
 
+Kiểm tra Vercel env bằng CLI, chỉ xem tên biến, không in giá trị:
+
+```bash
+vercel env ls production | awk '{print $1}' | grep -E '^(CRON_SECRET|SUPABASE_URL|SUPABASE_SERVICE_ROLE_KEY)$'
+```
+
+Sau khi PR chứa `vercel.json` được merge và deploy production, Vercel Cron sẽ tự gọi route theo lịch.
+
 ## Rollback
 
-Nếu cần tắt cleanup tự động, tắt schedule gọi Edge Function trước. Không drop RPC nếu đang cần điều tra.
+Nếu cần tắt cleanup tự động, xóa hoặc comment entry `/api/cron/auth-audit-cleanup` trong `vercel.json` rồi deploy lại production. Không drop RPC nếu đang cần điều tra.
 
 Nếu cần rollback schema:
 

--- a/src/app/api/cron/auth-audit-cleanup/__tests__/route.test.ts
+++ b/src/app/api/cron/auth-audit-cleanup/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const supabaseMocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  rpc: vi.fn(),
+}))
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: supabaseMocks.createClient,
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+async function loadRoute() {
+  try {
+    const routeModulePath = ['..', 'route'].join('/')
+    return await import(/* @vite-ignore */ routeModulePath)
+  } catch {
+    return null
+  }
+}
+
+describe('/api/cron/auth-audit-cleanup', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    supabaseMocks.createClient.mockReset()
+    supabaseMocks.rpc.mockReset()
+    process.env = {
+      ...ORIGINAL_ENV,
+      CRON_SECRET: 'cron-secret',
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-secret',
+    }
+    supabaseMocks.createClient.mockReturnValue({ rpc: supabaseMocks.rpc })
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it('rejects requests without the Vercel cron bearer token', async () => {
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf('function')
+
+    const response = await mod!.GET(
+      new Request('https://example.test/api/cron/auth-audit-cleanup')
+    )
+
+    expect(response.status).toBe(401)
+    expect(supabaseMocks.createClient).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('calls auth_audit_log_cleanup_scheduled for an authorized cron request', async () => {
+    const cleanupResult = {
+      deleted_count: 3,
+      oldest_remaining: '2026-02-06T03:00:00.000Z',
+      batches_executed: 1,
+      cutoff_date: '2026-02-05T03:00:00.000Z',
+    }
+    supabaseMocks.rpc.mockResolvedValue({ data: [cleanupResult], error: null })
+
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf('function')
+
+    const response = await mod!.GET(
+      new Request('https://example.test/api/cron/auth-audit-cleanup', {
+        headers: { Authorization: 'Bearer cron-secret' },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(supabaseMocks.createClient).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'service-role-secret',
+      { auth: { persistSession: false } }
+    )
+    expect(supabaseMocks.rpc).toHaveBeenCalledWith('auth_audit_log_cleanup_scheduled')
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      result: [cleanupResult],
+    })
+  })
+
+  it('does not leak RPC errors in the response', async () => {
+    supabaseMocks.rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'database timeout with sensitive details' },
+    })
+
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf('function')
+
+    const response = await mod!.GET(
+      new Request('https://example.test/api/cron/auth-audit-cleanup', {
+        headers: { Authorization: 'Bearer cron-secret' },
+      })
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: 'Cleanup failed' })
+  })
+})

--- a/src/app/api/cron/auth-audit-cleanup/__tests__/vercel-config.test.ts
+++ b/src/app/api/cron/auth-audit-cleanup/__tests__/vercel-config.test.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('Vercel cron configuration for auth audit cleanup', () => {
+  it('schedules the auth audit cleanup route weekly', () => {
+    const configPath = path.resolve(process.cwd(), 'vercel.json')
+    expect(fs.existsSync(configPath)).toBe(true)
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8')) as {
+      crons?: Array<{ path?: string; schedule?: string }>
+    }
+
+    expect(config.crons).toContainEqual({
+      path: '/api/cron/auth-audit-cleanup',
+      schedule: '0 3 * * 0',
+    })
+  })
+})

--- a/src/app/api/cron/auth-audit-cleanup/route.ts
+++ b/src/app/api/cron/auth-audit-cleanup/route.ts
@@ -1,0 +1,59 @@
+import { createClient } from '@supabase/supabase-js'
+
+const AUTH_AUDIT_CLEANUP_RPC = 'auth_audit_log_cleanup_scheduled'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+function jsonResponse(body: unknown, status: number): Response {
+  return Response.json(body, { status })
+}
+
+function readRequiredEnv(): {
+  cronSecret: string
+  supabaseUrl: string
+  serviceRoleKey: string
+} | null {
+  const cronSecret = process.env.CRON_SECRET
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!cronSecret || !supabaseUrl || !serviceRoleKey) {
+    return null
+  }
+
+  return { cronSecret, supabaseUrl, serviceRoleKey }
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const env = readRequiredEnv()
+
+  if (!env) {
+    console.error('Missing auth audit cleanup cron environment variables')
+    return jsonResponse(
+      { error: 'Server configuration error: missing required environment variables' },
+      500
+    )
+  }
+
+  if (request.headers.get('Authorization') !== `Bearer ${env.cronSecret}`) {
+    console.error('Unauthorized auth audit cleanup cron attempt', {
+      userAgent: request.headers.get('user-agent'),
+    })
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  const supabase = createClient(env.supabaseUrl, env.serviceRoleKey, {
+    auth: { persistSession: false },
+  })
+  const { data, error } = await supabase.rpc(AUTH_AUDIT_CLEANUP_RPC)
+
+  if (error) {
+    console.error('Auth audit cleanup cron failed')
+    return jsonResponse({ error: 'Cleanup failed' }, 500)
+  }
+
+  console.log('Auth audit cleanup cron completed', { result: data })
+
+  return jsonResponse({ success: true, result: data }, 200)
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -318,6 +318,9 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+[functions.auth-audit-cleanup]
+verify_jwt = false
+
 [analytics]
 enabled = false
 port = 54327

--- a/supabase/functions/auth-audit-cleanup/__tests__/config.test.ts
+++ b/supabase/functions/auth-audit-cleanup/__tests__/config.test.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('auth-audit-cleanup Supabase function config', () => {
+  it('disables platform JWT verification for cron-secret auth fallback', () => {
+    const configPath = path.resolve(process.cwd(), 'supabase/config.toml')
+    const config = fs.readFileSync(configPath, 'utf8')
+
+    expect(config).toMatch(
+      /\[functions\.auth-audit-cleanup\][\s\S]*?verify_jwt\s*=\s*false/
+    )
+  })
+})

--- a/supabase/functions/auth-audit-cleanup/__tests__/handler.test.ts
+++ b/supabase/functions/auth-audit-cleanup/__tests__/handler.test.ts
@@ -110,7 +110,9 @@ describe('auth-audit-cleanup Edge Function handler', () => {
     )
 
     expect(response.status).toBe(500)
-    expect(logger.error).toHaveBeenCalledWith('Auth audit cleanup failed')
+    expect(logger.error).toHaveBeenCalledWith('Auth audit cleanup failed', {
+      rpcError: { message: 'database timeout with secret details' },
+    })
     await expect(response.json()).resolves.toEqual({ error: 'Cleanup failed' })
   })
 })

--- a/supabase/functions/auth-audit-cleanup/__tests__/handler.test.ts
+++ b/supabase/functions/auth-audit-cleanup/__tests__/handler.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+
+type CleanupResult = {
+  deleted_count: number
+  oldest_remaining: string | null
+  batches_executed: number
+  cutoff_date: string
+}
+
+async function loadHandler() {
+  try {
+    const handlerModulePath = ['..', 'handler'].join('/')
+    return await import(/* @vite-ignore */ handlerModulePath)
+  } catch {
+    return null
+  }
+}
+
+describe('auth-audit-cleanup Edge Function handler', () => {
+  it('rejects requests without the cron bearer token before calling the RPC', async () => {
+    const mod = await loadHandler()
+    expect(mod?.handleAuthAuditCleanupRequest).toBeTypeOf('function')
+
+    const rpc = vi.fn()
+    const logger = { error: vi.fn(), log: vi.fn() }
+    const response = await mod!.handleAuthAuditCleanupRequest(
+      new Request('https://example.test/auth-audit-cleanup', { method: 'POST' }),
+      {
+        env: {
+          cronSecret: 'cron-secret',
+          supabaseUrl: 'https://example.supabase.co',
+          serviceRoleKey: 'service-role-secret',
+        },
+        createRpcClient: () => ({ rpc }),
+        logger,
+      }
+    )
+
+    expect(response.status).toBe(401)
+    expect(rpc).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenCalledWith(
+      'Unauthorized auth audit cleanup attempt',
+      { ip: null, userAgent: null }
+    )
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('calls auth_audit_log_cleanup_scheduled for an authorized cron request', async () => {
+    const mod = await loadHandler()
+    expect(mod?.handleAuthAuditCleanupRequest).toBeTypeOf('function')
+
+    const cleanupResult: CleanupResult = {
+      deleted_count: 7,
+      oldest_remaining: '2026-02-06T03:00:00.000Z',
+      batches_executed: 1,
+      cutoff_date: '2026-02-05T03:00:00.000Z',
+    }
+    const rpc = vi.fn().mockResolvedValue({ data: [cleanupResult], error: null })
+    const logger = { error: vi.fn(), log: vi.fn() }
+    const response = await mod!.handleAuthAuditCleanupRequest(
+      new Request('https://example.test/auth-audit-cleanup', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer cron-secret' },
+      }),
+      {
+        env: {
+          cronSecret: 'cron-secret',
+          supabaseUrl: 'https://example.supabase.co',
+          serviceRoleKey: 'service-role-secret',
+        },
+        createRpcClient: () => ({ rpc }),
+        logger,
+      }
+    )
+
+    expect(response.status).toBe(200)
+    expect(rpc).toHaveBeenCalledWith('auth_audit_log_cleanup_scheduled')
+    expect(logger.log).toHaveBeenCalledWith('Auth audit cleanup completed', {
+      result: [cleanupResult],
+    })
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      result: [cleanupResult],
+    })
+  })
+
+  it('returns a generic failure when the cleanup RPC fails', async () => {
+    const mod = await loadHandler()
+    expect(mod?.handleAuthAuditCleanupRequest).toBeTypeOf('function')
+
+    const rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'database timeout with secret details' },
+    })
+    const logger = { error: vi.fn(), log: vi.fn() }
+    const response = await mod!.handleAuthAuditCleanupRequest(
+      new Request('https://example.test/auth-audit-cleanup', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer cron-secret' },
+      }),
+      {
+        env: {
+          cronSecret: 'cron-secret',
+          supabaseUrl: 'https://example.supabase.co',
+          serviceRoleKey: 'service-role-secret',
+        },
+        createRpcClient: () => ({ rpc }),
+        logger,
+      }
+    )
+
+    expect(response.status).toBe(500)
+    expect(logger.error).toHaveBeenCalledWith('Auth audit cleanup failed')
+    await expect(response.json()).resolves.toEqual({ error: 'Cleanup failed' })
+  })
+})

--- a/supabase/functions/auth-audit-cleanup/handler.ts
+++ b/supabase/functions/auth-audit-cleanup/handler.ts
@@ -77,7 +77,7 @@ export async function handleAuthAuditCleanupRequest(
   const { data, error } = await supabase.rpc(AUTH_AUDIT_CLEANUP_RPC)
 
   if (error) {
-    logger.error('Auth audit cleanup failed')
+    logger.error('Auth audit cleanup failed', { rpcError: error })
     return jsonResponse({ error: 'Cleanup failed' }, 500)
   }
 

--- a/supabase/functions/auth-audit-cleanup/handler.ts
+++ b/supabase/functions/auth-audit-cleanup/handler.ts
@@ -1,0 +1,87 @@
+export const AUTH_AUDIT_CLEANUP_RPC = 'auth_audit_log_cleanup_scheduled'
+
+export interface AuthAuditCleanupEnv {
+  cronSecret: string
+  supabaseUrl: string
+  serviceRoleKey: string
+}
+
+export interface CleanupResult {
+  deleted_count: number
+  oldest_remaining: string | null
+  batches_executed: number
+  cutoff_date: string
+}
+
+export interface RpcError {
+  message: string
+}
+
+export interface RpcClient {
+  rpc: (
+    functionName: typeof AUTH_AUDIT_CLEANUP_RPC
+  ) => Promise<{ data: CleanupResult[] | null; error: RpcError | null }>
+}
+
+export interface AuthAuditCleanupDeps {
+  env: AuthAuditCleanupEnv
+  createRpcClient: (env: AuthAuditCleanupEnv) => RpcClient
+  logger?: Pick<Console, 'error' | 'log'>
+}
+
+function jsonResponse(body: unknown, status: number, headers?: HeadersInit): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+  })
+}
+
+function hasRequiredEnv(env: AuthAuditCleanupEnv): boolean {
+  return Boolean(env.cronSecret && env.supabaseUrl && env.serviceRoleKey)
+}
+
+export async function handleAuthAuditCleanupRequest(
+  req: Request,
+  deps: AuthAuditCleanupDeps
+): Promise<Response> {
+  const logger = deps.logger ?? console
+
+  if (!hasRequiredEnv(deps.env)) {
+    logger.error('Missing auth audit cleanup environment variables', {
+      hasCronSecret: Boolean(deps.env.cronSecret),
+      hasSupabaseUrl: Boolean(deps.env.supabaseUrl),
+      hasServiceRoleKey: Boolean(deps.env.serviceRoleKey),
+    })
+    return jsonResponse(
+      { error: 'Server configuration error: missing required environment variables' },
+      500
+    )
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405, { Allow: 'POST' })
+  }
+
+  if (req.headers.get('Authorization') !== `Bearer ${deps.env.cronSecret}`) {
+    logger.error('Unauthorized auth audit cleanup attempt', {
+      ip: req.headers.get('x-forwarded-for'),
+      userAgent: req.headers.get('user-agent'),
+    })
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  const supabase = deps.createRpcClient(deps.env)
+  const { data, error } = await supabase.rpc(AUTH_AUDIT_CLEANUP_RPC)
+
+  if (error) {
+    logger.error('Auth audit cleanup failed')
+    return jsonResponse({ error: 'Cleanup failed' }, 500)
+  }
+
+  logger.log('Auth audit cleanup completed', { result: data })
+
+  return jsonResponse({ success: true, result: data }, 200)
+}

--- a/supabase/functions/auth-audit-cleanup/index.ts
+++ b/supabase/functions/auth-audit-cleanup/index.ts
@@ -1,0 +1,23 @@
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+import {
+  handleAuthAuditCleanupRequest,
+  type AuthAuditCleanupEnv,
+} from './handler.ts'
+
+function readEnv(): AuthAuditCleanupEnv {
+  return {
+    cronSecret: Deno.env.get('CRON_SECRET') ?? '',
+    supabaseUrl: Deno.env.get('SUPABASE_URL') ?? '',
+    serviceRoleKey: Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+  }
+}
+
+Deno.serve((req: Request) =>
+  handleAuthAuditCleanupRequest(req, {
+    env: readEnv(),
+    createRpcClient: (env) =>
+      createClient(env.supabaseUrl, env.serviceRoleKey, {
+        auth: { persistSession: false },
+      }),
+  })
+)

--- a/supabase/migrations/20260506022711_add_auth_audit_log_retention_cleanup.sql
+++ b/supabase/migrations/20260506022711_add_auth_audit_log_retention_cleanup.sql
@@ -1,0 +1,76 @@
+-- Issue #391: auth_audit_log retention and scheduled purge policy.
+--
+-- Policy:
+--   - retain auth_audit_log rows for 90 days
+--   - hard purge rows older than the retention window
+--   - no archive table and no persistent cleanup meta-log
+
+CREATE OR REPLACE FUNCTION public.auth_audit_log_cleanup_scheduled()
+RETURNS TABLE (
+  deleted_count bigint,
+  oldest_remaining timestamptz,
+  batches_executed integer,
+  cutoff_date timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  c_retention_days CONSTANT integer := 90;
+  c_batch_size CONSTANT integer := 1000;
+  c_max_batches CONSTANT integer := 100;
+  v_cutoff_date timestamptz := now() - (c_retention_days || ' days')::interval;
+  v_deleted_count bigint := 0;
+  v_batch_deleted bigint := 0;
+  v_batches_executed integer := 0;
+  v_oldest_remaining timestamptz;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('auth_audit_log_cleanup_scheduled'));
+
+  IF v_cutoff_date > now() - interval '24 hours' THEN
+    RAISE EXCEPTION 'Cannot delete auth audit logs from the last 24 hours';
+  END IF;
+
+  LOOP
+    WITH to_delete AS (
+      SELECT ctid
+      FROM public.auth_audit_log
+      WHERE created_at < v_cutoff_date
+      ORDER BY created_at
+      LIMIT c_batch_size
+      FOR UPDATE SKIP LOCKED
+    )
+    DELETE FROM public.auth_audit_log
+    WHERE ctid IN (SELECT ctid FROM to_delete);
+
+    GET DIAGNOSTICS v_batch_deleted = ROW_COUNT;
+
+    EXIT WHEN v_batch_deleted = 0;
+
+    v_deleted_count := v_deleted_count + v_batch_deleted;
+    v_batches_executed := v_batches_executed + 1;
+
+    EXIT WHEN v_batches_executed >= c_max_batches;
+  END LOOP;
+
+  SELECT MIN(created_at)
+  INTO v_oldest_remaining
+  FROM public.auth_audit_log;
+
+  RETURN QUERY
+  SELECT
+    v_deleted_count,
+    v_oldest_remaining,
+    v_batches_executed,
+    v_cutoff_date;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.auth_audit_log_cleanup_scheduled() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.auth_audit_log_cleanup_scheduled() FROM anon;
+REVOKE ALL ON FUNCTION public.auth_audit_log_cleanup_scheduled() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.auth_audit_log_cleanup_scheduled() TO service_role;
+
+COMMENT ON FUNCTION public.auth_audit_log_cleanup_scheduled() IS
+  'Scheduled service-role cleanup for auth_audit_log. Hard-purges rows older than 90 days in bounded batches.';

--- a/supabase/tests/auth_audit_log_retention_smoke.sql
+++ b/supabase/tests/auth_audit_log_retention_smoke.sql
@@ -1,0 +1,131 @@
+-- Local/DB-admin verification artifact for Issue #391.
+-- Run only after applying the auth_audit_log retention migration.
+-- Example:
+--   psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/auth_audit_log_retention_smoke.sql
+--
+-- This script is intentionally local-only and should not be wired into CI.
+
+DO $$
+DECLARE
+  v_has_search_path boolean;
+  v_is_security_definer boolean;
+  v_service_role_can_execute boolean;
+  v_public_can_execute boolean;
+  v_authenticated_can_execute boolean;
+  v_anon_can_execute boolean;
+BEGIN
+  SELECT p.prosecdef
+  INTO v_is_security_definer
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'auth_audit_log_cleanup_scheduled'
+    AND pg_get_function_identity_arguments(p.oid) = '';
+
+  IF v_is_security_definer IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Expected auth_audit_log_cleanup_scheduled to be SECURITY DEFINER';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    CROSS JOIN LATERAL unnest(p.proconfig) AS config(value)
+    WHERE n.nspname = 'public'
+      AND p.proname = 'auth_audit_log_cleanup_scheduled'
+      AND pg_get_function_identity_arguments(p.oid) = ''
+      AND config.value = 'search_path=public, pg_temp'
+  )
+  INTO v_has_search_path;
+
+  IF v_has_search_path IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Expected auth_audit_log_cleanup_scheduled search_path to be public, pg_temp';
+  END IF;
+
+  SELECT has_function_privilege('service_role', 'public.auth_audit_log_cleanup_scheduled()', 'EXECUTE')
+  INTO v_service_role_can_execute;
+  SELECT has_function_privilege('public', 'public.auth_audit_log_cleanup_scheduled()', 'EXECUTE')
+  INTO v_public_can_execute;
+  SELECT has_function_privilege('authenticated', 'public.auth_audit_log_cleanup_scheduled()', 'EXECUTE')
+  INTO v_authenticated_can_execute;
+  SELECT has_function_privilege('anon', 'public.auth_audit_log_cleanup_scheduled()', 'EXECUTE')
+  INTO v_anon_can_execute;
+
+  IF v_service_role_can_execute IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Expected service_role EXECUTE grant on auth_audit_log_cleanup_scheduled';
+  END IF;
+
+  IF v_public_can_execute OR v_authenticated_can_execute OR v_anon_can_execute THEN
+    RAISE EXCEPTION 'Expected auth_audit_log_cleanup_scheduled execute grants to exclude PUBLIC/anon/authenticated';
+  END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+  v_old_request_id text := 'smoke-auth-audit-retention-old';
+  v_new_request_id text := 'smoke-auth-audit-retention-new';
+  v_old_created_at timestamptz := now() - interval '91 days';
+  v_new_created_at timestamptz := now() - interval '89 days';
+  v_result record;
+  v_old_remaining integer;
+  v_new_remaining integer;
+BEGIN
+  DELETE FROM public.auth_audit_log
+  WHERE request_id IN (v_old_request_id, v_new_request_id);
+
+  PERFORM public.auth_audit_log_insert(
+    p_created_at := v_old_created_at,
+    p_event := 'login_success',
+    p_source := 'events_signin',
+    p_user_id := '391',
+    p_username := 'retention-old',
+    p_request_id := v_old_request_id,
+    p_user_agent := 'SmokeAuthAuditRetention/1.0'
+  );
+
+  PERFORM public.auth_audit_log_insert(
+    p_created_at := v_new_created_at,
+    p_event := 'login_success',
+    p_source := 'events_signin',
+    p_user_id := '391',
+    p_username := 'retention-new',
+    p_request_id := v_new_request_id,
+    p_user_agent := 'SmokeAuthAuditRetention/1.0'
+  );
+
+  SELECT *
+  INTO v_result
+  FROM public.auth_audit_log_cleanup_scheduled();
+
+  IF v_result.cutoff_date < now() - interval '91 days'
+     OR v_result.cutoff_date > now() - interval '89 days' THEN
+    RAISE EXCEPTION 'Expected auth audit cleanup cutoff to be about 90 days, got %', v_result.cutoff_date;
+  END IF;
+
+  IF v_result.deleted_count < 1 THEN
+    RAISE EXCEPTION 'Expected auth audit cleanup to delete at least one old row';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_old_remaining
+  FROM public.auth_audit_log
+  WHERE request_id = v_old_request_id;
+
+  SELECT COUNT(*)
+  INTO v_new_remaining
+  FROM public.auth_audit_log
+  WHERE request_id = v_new_request_id;
+
+  IF v_old_remaining <> 0 THEN
+    RAISE EXCEPTION 'Expected 91-day auth audit row to be purged';
+  END IF;
+
+  IF v_new_remaining <> 1 THEN
+    RAISE EXCEPTION 'Expected 89-day auth audit row to remain';
+  END IF;
+
+  DELETE FROM public.auth_audit_log
+  WHERE request_id IN (v_old_request_id, v_new_request_id);
+END;
+$$;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/auth-audit-cleanup",
+      "schedule": "0 3 * * 0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary\n- Define  retention as 90 days with hard purge and no archive/meta-log table.\n- Add  as a service-role-only SECURITY DEFINER RPC with pinned  and bounded batch deletes.\n- Add a testable  Edge Function handler plus runbook and SQL smoke coverage.\n\n## Live DB / Edge Function\n- Applied migration through Supabase MCP as version  ().\n- Live DB smoke passed for cleanup function grants/search_path and 91-day purge vs 89-day retention boundary.\n- Existing  smoke path still passed.\n- Deployed Edge Function  version 1 with  because it uses  custom auth.\n- Live unauthenticated/wrong-secret smoke currently returns 500 because required Edge Function runtime secrets are not configured in this session. Follow-up: #407.\n\n## Verification\n- RED DB:  missing before migration.\n- RED Edge: Vitest failed because  did not exist.\n- GREEN Edge: 
 RUN  v4.0.17 /root/qltbyt-nam-phong

 ✓ supabase/functions/auth-audit-cleanup/__tests__/handler.test.ts (3 tests) 24ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  02:31:10
   Duration  857ms (transform 68ms, setup 77ms, import 41ms, tests 24ms, environment 539ms) passed and proves valid cron request calls .\n- 
> nextn@0.1.0 verify:no-explicit-any
> node scripts/check-no-explicit-any-in-diff.js

No explicit any found in changed TypeScript files.\n- 
> nextn@0.1.0 typecheck
> tsc --noEmit\n- react-doctor v0.0.47

✔ Select projects to scan › nextn
Scanning changes: issue-391-auth-audit-retention → main

Scanning /root/qltbyt-nam-phong...


No issues found!

  ┌─────┐
  │ ◠ ◠ │
  │  ▽  │
  └─────┘
  React Doctor (www.react.doctor)

  100 / 100  Great

  ██████████████████████████████████████████████████ (no changed source files)\n- \n- Supabase MCP  and  run; only baseline/noise findings observed, including expected low-traffic unused-index notes.\n\nRefs #391\nRefs #407

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a 90-day retention policy for `public.auth_audit_log` with a secure, batched hard purge. Adds a `service_role` RPC and a Vercel Cron–driven Next.js route to run cleanup on schedule; Supabase Edge Function remains as a fallback. Satisfies #391.

- **New Features**
  - Postgres RPC `public.auth_audit_log_cleanup_scheduled()`:
    - Hard-deletes rows older than 90 days in bounded batches with an advisory lock; skips last 24 hours.
    - `SECURITY DEFINER`, `SET search_path = public, pg_temp`; returns deleted count, oldest remaining, batches, cutoff.
    - EXECUTE granted only to `service_role`.
  - Next.js route `/api/cron/auth-audit-cleanup`:
    - GET-only with `Authorization: Bearer <CRON_SECRET>`, uses `@supabase/supabase-js` and `SUPABASE_SERVICE_ROLE_KEY` to call the RPC.
    - Hides RPC errors behind generic failures; `vercel.json` schedules weekly Sun 03:00 UTC.
  - Supabase Edge Function `auth-audit-cleanup` (fallback):
    - POST-only with the same bearer scheme, uses `jsr:@supabase/supabase-js@2`; `verify_jwt = false` to allow cron-secret auth.
  - Tests and docs:
    - Vitest covers the Next.js route, Vercel cron config, and Edge handler; adds a runbook guard test.
    - SQL smoke validates grants and the 91-day purge vs 89-day retain boundary.
    - Runbook: `docs/runbooks/auth-audit-log-retention.md`.

- **Migration**
  - Apply migration to create `auth_audit_log_cleanup_scheduled` and grants (no archive; deletions are permanent).
  - Deploy with Vercel Cron and set env: `CRON_SECRET`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`.
  - Schedule is weekly at 03:00 UTC; switch to daily if needed. Follow-up to wire runtime secrets in the target env: #407.

<sup>Written for commit c021c5bd1165f5d47fdc27601a0a85213ccde3f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated cleanup for authentication audit logs with 90-day retention policy, including batch processing and safety checks.

* **Documentation**
  * Added comprehensive runbook documenting audit log retention policy, cleanup workflow, verification steps, and rollback procedures.

* **Tests**
  * Added handler tests and smoke tests to validate audit log cleanup functionality and privilege configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->