### PR TITLE
fix(transfers): scope overdue return alert to page data

### DIFF
--- a/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
@@ -11,6 +11,14 @@ const mockColumnCounts = {
   hoan_thanh: 6,
 }
 
+const mockOverdueSummary = {
+  total: 2,
+  overdue: 1,
+  due_today: 0,
+  due_soon: 1,
+  items: [],
+}
+
 const mocks = vi.hoisted(() => ({
   kpiConfigs: [
     { key: "cho_duyet", label: "Chờ duyệt", tone: "warning", icon: null },
@@ -249,6 +257,7 @@ describe("Transfers KPI", () => {
 
     mocks.useTransferPageData.mockReturnValue({
       data: {
+        viewMode: "table",
         list: {
           data: [],
           total: 20,
@@ -260,6 +269,7 @@ describe("Transfers KPI", () => {
           columnCounts: mockColumnCounts,
         },
         kanban: null,
+        overdue_summary: mockOverdueSummary,
       },
       isLoading: false,
       isFetching: false,
@@ -293,7 +303,7 @@ describe("Transfers KPI", () => {
       confirmDelete: vi.fn(),
       canEditTransfer: vi.fn(() => true),
       canDeleteTransfer: vi.fn(() => true),
-      mapToTransferRequest: vi.fn(),
+      mapToTransferRequest: vi.fn((item: Record<string, unknown>) => item),
       isRegionalLeader: false,
       isTransferCoreRole: true,
     })
@@ -479,6 +489,17 @@ describe("Transfers KPI", () => {
     expect(mocks.useTransferCounts).not.toHaveBeenCalled()
   })
 
+  it("passes the page-scoped overdue summary into the overdue alert", () => {
+    render(<TransfersPage />)
+
+    expect(mocks.OverdueTransfersAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overdueSummary: mockOverdueSummary,
+        isLoading: false,
+      }),
+    )
+  })
+
   it("skips page-invariant counts when only table pagination changes", () => {
     mocks.useServerPagination
       .mockReturnValueOnce({
@@ -521,6 +542,7 @@ describe("Transfers KPI", () => {
     mocks.rawViewMode = "kanban"
     mocks.useTransferPageData.mockReturnValue({
       data: {
+        viewMode: "kanban",
         list: null,
         counts: {
           totalCount: 20,
@@ -530,6 +552,7 @@ describe("Transfers KPI", () => {
           totalCount: 20,
           columns: {},
         },
+        overdue_summary: mockOverdueSummary,
       },
       isLoading: false,
       isFetching: false,
@@ -562,6 +585,7 @@ describe("Transfers KPI", () => {
     mocks.rawViewMode = "kanban"
     mocks.useTransferPageData.mockReturnValue({
       data: {
+        viewMode: "kanban",
         list: null,
         counts: {
           totalCount: 20,
@@ -571,6 +595,7 @@ describe("Transfers KPI", () => {
           totalCount: 20,
           columns: {},
         },
+        overdue_summary: mockOverdueSummary,
       },
       isLoading: false,
       isFetching: true,

--- a/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx
@@ -500,6 +500,38 @@ describe("Transfers KPI", () => {
     )
   })
 
+  it("hides stale overdue alert data while the page-data query refetches", () => {
+    mocks.useTransferPageData.mockReturnValue({
+      data: {
+        viewMode: "table",
+        list: {
+          data: [],
+          total: 20,
+          page: 1,
+          pageSize: 10,
+        },
+        counts: {
+          totalCount: 20,
+          columnCounts: mockColumnCounts,
+        },
+        kanban: null,
+        overdue_summary: mockOverdueSummary,
+      },
+      isLoading: false,
+      isFetching: true,
+      isError: false,
+    })
+
+    render(<TransfersPage />)
+
+    expect(mocks.OverdueTransfersAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overdueSummary: mockOverdueSummary,
+        isLoading: true,
+      }),
+    )
+  })
+
   it("skips page-invariant counts when only table pagination changes", () => {
     mocks.useServerPagination
       .mockReturnValueOnce({

--- a/src/app/(app)/transfers/_components/TransfersPageContent.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPageContent.tsx
@@ -82,7 +82,7 @@ export function TransfersPageContent({ user }: TransfersPageContentProps) {
 
       <OverdueTransfersAlert
         overdueSummary={controller.overdueSummary}
-        isLoading={controller.isListLoading}
+        isLoading={controller.isListLoading || controller.isListFetching}
         onViewTransfer={controller.openTransferFromAlert}
       />
 

--- a/src/app/(app)/transfers/_components/TransfersPageContent.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPageContent.tsx
@@ -80,7 +80,11 @@ export function TransfersPageContent({ user }: TransfersPageContentProps) {
         filterVariant={controller.filterVariant}
       />
 
-      <OverdueTransfersAlert onViewTransfer={controller.openTransferFromAlert} />
+      <OverdueTransfersAlert
+        overdueSummary={controller.overdueSummary}
+        isLoading={controller.isListLoading}
+        onViewTransfer={controller.openTransferFromAlert}
+      />
 
       <div className="space-y-6">
         <div className="flex items-center justify-between gap-3">

--- a/src/app/(app)/transfers/_components/useTransfersPageController.ts
+++ b/src/app/(app)/transfers/_components/useTransfersPageController.ts
@@ -25,12 +25,13 @@ import { getColumnsForType } from "@/components/transfers/columnDefinitions"
 import type { FilterModalValue } from "@/components/transfers/FilterModal"
 import type { FilterChipsValue } from "@/components/transfers/FilterChips"
 import { isGlobalRole } from "@/lib/rbac"
-import type { TransferRequest } from "@/types/database"
 import type {
   TransferListFilters,
   TransferListItem,
   TransferCountsResponse,
   TransferKanbanResponse,
+  TransferOverdueSummary,
+  TransferOverdueSummaryItem,
 } from "@/types/transfers-data-grid"
 
 import type { TransferUserRole } from "./TransfersTypes"
@@ -55,7 +56,8 @@ export interface TransfersPageControllerResult {
   setIsAddDialogOpen: React.Dispatch<React.SetStateAction<boolean>>
   invalidateTransferQueries: () => void
   rowActions: ReturnType<typeof useTransfersRowActions>
-  openTransferFromAlert: (transfer: TransferRequest) => void
+  openTransferFromAlert: (transfer: TransferOverdueSummaryItem) => void
+  overdueSummary: TransferOverdueSummary | null | undefined
   viewMode: "table" | "kanban"
   userRole: TransferUserRole | undefined
   isRegionalLeader: boolean
@@ -228,6 +230,7 @@ export function useTransfersPageController(
   const latestTransferCounts = transferPageData?.counts
   const transferCounts = latestTransferCounts ?? cachedTransferCounts
   const kanbanData = transferPageData?.kanban
+  const overdueSummary = transferPageData?.overdue_summary
 
   React.useEffect(() => {
     if (!latestTransferCounts) return
@@ -324,10 +327,10 @@ export function useTransfersPageController(
   )
 
   const openTransferFromAlert = React.useCallback(
-    (transfer: TransferRequest) => {
-      rowActions.openDetailTransfer(transfer)
+    (transfer: TransferOverdueSummaryItem) => {
+      rowActions.handleViewDetail(transfer)
     },
-    [rowActions.openDetailTransfer],
+    [rowActions.handleViewDetail],
   )
 
   return {
@@ -347,6 +350,7 @@ export function useTransfersPageController(
     invalidateTransferQueries,
     rowActions,
     openTransferFromAlert,
+    overdueSummary,
     viewMode,
     userRole,
     isRegionalLeader,

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -52,7 +52,6 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'transfer_request_delete',
   'transfer_request_complete',
   'transfer_change_history_list',
-  'transfer_request_external_pending_returns',
   'get_transfer_request_facilities',
   'get_equipment_location_suggestions',
   // Transfers - Data Grid

--- a/src/components/__tests__/overdue-transfers-alert.test.tsx
+++ b/src/components/__tests__/overdue-transfers-alert.test.tsx
@@ -1,0 +1,132 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: mocks.callRpc,
+}))
+
+import { OverdueTransfersAlert } from "../overdue-transfers-alert"
+
+const overdueSummary = {
+  total: 2,
+  overdue: 1,
+  due_today: 0,
+  due_soon: 1,
+  items: [
+    {
+      id: 88,
+      ma_yeu_cau: "LC-0088",
+      thiet_bi_id: 22,
+      loai_hinh: "ben_ngoai",
+      trang_thai: "da_ban_giao",
+      nguoi_yeu_cau_id: 1,
+      ly_do_luan_chuyen: "Cho mượn ngoài viện",
+      khoa_phong_hien_tai: null,
+      khoa_phong_nhan: null,
+      muc_dich: "cho_muon",
+      don_vi_nhan: "Bệnh viện B",
+      dia_chi_don_vi: null,
+      nguoi_lien_he: null,
+      so_dien_thoai: null,
+      ngay_du_kien_tra: "2026-05-01T00:00:00.000Z",
+      ngay_ban_giao: null,
+      ngay_hoan_tra: null,
+      ngay_hoan_thanh: null,
+      nguoi_duyet_id: null,
+      ngay_duyet: null,
+      ghi_chu_duyet: null,
+      created_at: "2026-04-01T00:00:00.000Z",
+      updated_at: "2026-04-01T00:00:00.000Z",
+      created_by: 1,
+      updated_by: 1,
+      thiet_bi: {
+        ten_thiet_bi: "Máy thở",
+        ma_thiet_bi: "MT-001",
+        model: null,
+        serial: null,
+        khoa_phong_quan_ly: null,
+        facility_name: "Cơ sở A",
+        facility_id: 7,
+        is_deleted: false,
+      },
+      days_difference: -5,
+    },
+    {
+      id: 89,
+      ma_yeu_cau: "LC-0089",
+      thiet_bi_id: 23,
+      loai_hinh: "ben_ngoai",
+      trang_thai: "dang_luan_chuyen",
+      nguoi_yeu_cau_id: 2,
+      ly_do_luan_chuyen: "Cho mượn ngoài viện",
+      khoa_phong_hien_tai: null,
+      khoa_phong_nhan: null,
+      muc_dich: "cho_muon",
+      don_vi_nhan: "Bệnh viện C",
+      dia_chi_don_vi: null,
+      nguoi_lien_he: null,
+      so_dien_thoai: null,
+      ngay_du_kien_tra: "2026-05-10T00:00:00.000Z",
+      ngay_ban_giao: null,
+      ngay_hoan_tra: null,
+      ngay_hoan_thanh: null,
+      nguoi_duyet_id: null,
+      ngay_duyet: null,
+      ghi_chu_duyet: null,
+      created_at: "2026-04-02T00:00:00.000Z",
+      updated_at: "2026-04-02T00:00:00.000Z",
+      created_by: 2,
+      updated_by: 2,
+      thiet_bi: {
+        ten_thiet_bi: "Bơm tiêm điện",
+        ma_thiet_bi: "BTD-001",
+        model: null,
+        serial: null,
+        khoa_phong_quan_ly: null,
+        facility_name: "Cơ sở A",
+        facility_id: 7,
+        is_deleted: false,
+      },
+      days_difference: 4,
+    },
+  ],
+}
+
+describe("OverdueTransfersAlert", () => {
+  beforeEach(() => {
+    mocks.callRpc.mockReset()
+    mocks.callRpc.mockResolvedValue([])
+  })
+
+  it("renders the page-scoped summary without calling the legacy pending-returns RPC", () => {
+    render(<OverdueTransfersAlert overdueSummary={overdueSummary} isLoading={false} />)
+
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+    expect(screen.getByText("1 thiết bị quá hạn")).toBeInTheDocument()
+    expect(screen.getByText("1 thiết bị sắp tới hạn")).toBeInTheDocument()
+  })
+
+  it("uses server-computed day differences when viewing summary items", () => {
+    const onViewTransfer = vi.fn()
+
+    render(
+      <OverdueTransfersAlert
+        overdueSummary={overdueSummary}
+        isLoading={false}
+        onViewTransfer={onViewTransfer}
+      />,
+    )
+
+    expect(screen.getByText(/Quá hạn 5 ngày/)).toBeInTheDocument()
+    expect(screen.getByText(/Còn 4 ngày/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Xem/i })[0])
+    expect(onViewTransfer).toHaveBeenCalledWith(overdueSummary.items[0])
+  })
+})

--- a/src/components/overdue-transfers-alert.tsx
+++ b/src/components/overdue-transfers-alert.tsx
@@ -8,86 +8,37 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
-import { callRpc } from "@/lib/rpc-client"
-import { TransferRequest } from "@/types/database"
+import type {
+  TransferOverdueSummary,
+  TransferOverdueSummaryItem,
+} from "@/types/transfers-data-grid"
 
 interface OverdueTransfersAlertProps {
-  onViewTransfer?: (transfer: TransferRequest) => void
+  overdueSummary?: TransferOverdueSummary | null
+  isLoading?: boolean
+  onViewTransfer?: (transfer: TransferOverdueSummaryItem) => void
 }
 
-export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertProps) {
-  const [overdueTransfers, setOverdueTransfers] = React.useState<TransferRequest[]>([])
-  const [upcomingTransfers, setUpcomingTransfers] = React.useState<TransferRequest[]>([])
-  const [isOpen, setIsOpen] = React.useState(false)
-  const [isLoading, setIsLoading] = React.useState(true)
-  const isMountedRef = React.useRef(true)
+export function OverdueTransfersAlert({
+  overdueSummary,
+  isLoading = false,
+  onViewTransfer,
+}: OverdueTransfersAlertProps) {
+  const [isOpen, setIsOpen] = React.useState(() => Boolean(overdueSummary?.overdue))
 
   React.useEffect(() => {
-    isMountedRef.current = true
-    fetchOverdueTransfers()
-    
-    return () => {
-      isMountedRef.current = false
+    if (overdueSummary?.overdue) {
+      setIsOpen(true)
     }
-  }, [])
+  }, [overdueSummary?.overdue])
 
-  const fetchOverdueTransfers = async () => {
-    try {
-      const today = new Date()
-      const nextWeek = new Date()
-      nextWeek.setDate(today.getDate() + 7)
-
-      const transfers = await callRpc<TransferRequest[]>({ fn: 'transfer_request_external_pending_returns' })
-      
-      // Prevent setState on unmounted component
-      if (!isMountedRef.current) return
-      
-      const overdue = transfers.filter(t => 
-        new Date(t.ngay_du_kien_tra!) < today
-      )
-      
-      const upcoming = transfers.filter(t => {
-        const dueDate = new Date(t.ngay_du_kien_tra!)
-        return dueDate >= today && dueDate <= nextWeek
-      })
-
-      setOverdueTransfers(overdue)
-      setUpcomingTransfers(upcoming)
-      
-      // Auto-open if there are overdue transfers
-      if (overdue.length > 0) {
-        setIsOpen(true)
-      }
-    } catch (error) {
-      console.error('Error fetching overdue transfers:', error)
-    } finally {
-      if (isMountedRef.current) {
-        setIsLoading(false)
-      }
-    }
-  }
-
-  const getDaysOverdue = (dueDate: string) => {
-    const today = new Date()
-    const due = new Date(dueDate)
-    const diffTime = today.getTime() - due.getTime()
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
-    return diffDays
-  }
-
-  const getDaysUntilDue = (dueDate: string) => {
-    const today = new Date()
-    const due = new Date(dueDate)
-    const diffTime = due.getTime() - today.getTime()
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
-    return diffDays
-  }
-
-  if (isLoading || (overdueTransfers.length === 0 && upcomingTransfers.length === 0)) {
+  if (isLoading || !overdueSummary || overdueSummary.total === 0) {
     return null
   }
 
-  const totalAlerts = overdueTransfers.length + upcomingTransfers.length
+  const overdueTransfers = overdueSummary.items.filter((transfer) => transfer.days_difference < 0)
+  const upcomingTransfers = overdueSummary.items.filter((transfer) => transfer.days_difference >= 0)
+  const upcomingCount = overdueSummary.due_today + overdueSummary.due_soon
 
   return (
     <Card className="mb-6">
@@ -96,7 +47,7 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
           <CardHeader className="cursor-pointer hover:bg-muted/50 transition-colors">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                {overdueTransfers.length > 0 ? (
+                {overdueSummary.overdue > 0 ? (
                   <AlertTriangle className="h-5 w-5 text-destructive" />
                 ) : (
                   <Clock className="h-5 w-5 text-orange-500" />
@@ -106,22 +57,22 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
                     Cảnh báo thiết bị cần hoàn trả
                   </CardTitle>
                   <p className="text-sm text-muted-foreground">
-                    {overdueTransfers.length > 0 && (
+                    {overdueSummary.overdue > 0 && (
                       <span className="text-destructive font-medium">
-                        {overdueTransfers.length} thiết bị quá hạn
+                        {overdueSummary.overdue} thiết bị quá hạn
                       </span>
                     )}
-                    {overdueTransfers.length > 0 && upcomingTransfers.length > 0 && " • "}
-                    {upcomingTransfers.length > 0 && (
+                    {overdueSummary.overdue > 0 && upcomingCount > 0 && " • "}
+                    {upcomingCount > 0 && (
                       <span className="text-orange-600 font-medium">
-                        {upcomingTransfers.length} thiết bị sắp tới hạn
+                        {upcomingCount} thiết bị sắp tới hạn
                       </span>
                     )}
                   </p>
                 </div>
               </div>
-              <Badge variant={overdueTransfers.length > 0 ? "destructive" : "secondary"}>
-                {totalAlerts}
+              <Badge variant={overdueSummary.overdue > 0 ? "destructive" : "secondary"}>
+                {overdueSummary.total}
               </Badge>
             </div>
           </CardHeader>
@@ -134,7 +85,7 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
               <div>
                 <h4 className="font-medium text-destructive mb-2 flex items-center gap-2">
                   <AlertTriangle className="h-4 w-4" />
-                  Thiết bị quá hạn hoàn trả ({overdueTransfers.length})
+                  Thiết bị quá hạn hoàn trả ({overdueSummary.overdue})
                 </h4>
                 <div className="space-y-2">
                   {overdueTransfers.map((transfer) => (
@@ -146,7 +97,7 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
                           </p>
                           <p className="text-sm">
                             Đơn vị: {transfer.don_vi_nhan} • 
-                            Quá hạn {getDaysOverdue(transfer.ngay_du_kien_tra!)} ngày
+                            Quá hạn {Math.abs(transfer.days_difference)} ngày
                           </p>
                         </div>
                         {onViewTransfer && (
@@ -171,7 +122,7 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
               <div>
                 <h4 className="font-medium text-orange-600 mb-2 flex items-center gap-2">
                   <Clock className="h-4 w-4" />
-                  Thiết bị sắp tới hạn hoàn trả ({upcomingTransfers.length})
+                  Thiết bị sắp tới hạn hoàn trả ({upcomingCount})
                 </h4>
                 <div className="space-y-2">
                   {upcomingTransfers.map((transfer) => (
@@ -183,7 +134,7 @@ export function OverdueTransfersAlert({ onViewTransfer }: OverdueTransfersAlertP
                           </p>
                           <p className="text-sm">
                             Đơn vị: {transfer.don_vi_nhan} • 
-                            Còn {getDaysUntilDue(transfer.ngay_du_kien_tra!)} ngày
+                            Còn {transfer.days_difference} ngày
                           </p>
                         </div>
                         {onViewTransfer && (

--- a/src/hooks/__tests__/useTransferPageData.test.tsx
+++ b/src/hooks/__tests__/useTransferPageData.test.tsx
@@ -7,6 +7,46 @@ const mocks = vi.hoisted(() => ({
   callRpc: vi.fn(),
 }))
 
+const mockOverdueItem = {
+  id: 88,
+  ma_yeu_cau: "LC-0088",
+  thiet_bi_id: 22,
+  loai_hinh: "ben_ngoai",
+  trang_thai: "da_ban_giao",
+  nguoi_yeu_cau_id: 1,
+  ly_do_luan_chuyen: "Smoke overdue",
+  khoa_phong_hien_tai: null,
+  khoa_phong_nhan: null,
+  muc_dich: "cho_muon",
+  don_vi_nhan: "External A",
+  dia_chi_don_vi: null,
+  nguoi_lien_he: null,
+  so_dien_thoai: null,
+  ngay_du_kien_tra: "2026-04-01T00:00:00.000Z",
+  ngay_ban_giao: null,
+  ngay_hoan_tra: null,
+  ngay_hoan_thanh: null,
+  nguoi_duyet_id: null,
+  ngay_duyet: null,
+  ghi_chu_duyet: null,
+  created_at: "2026-03-30T00:00:00.000Z",
+  updated_at: "2026-03-30T00:00:00.000Z",
+  created_by: 1,
+  updated_by: null,
+  equipment_is_deleted: true,
+  days_difference: -3,
+  thiet_bi: {
+    ten_thiet_bi: "Máy thở",
+    ma_thiet_bi: "MT-001",
+    model: null,
+    serial: null,
+    khoa_phong_quan_ly: "Khoa A",
+    facility_name: "Bệnh viện A",
+    facility_id: 7,
+    is_deleted: true,
+  },
+}
+
 vi.mock("@/lib/rpc-client", () => ({
   callRpc: mocks.callRpc,
 }))
@@ -49,7 +89,7 @@ describe("useTransferPageData", () => {
         overdue: 1,
         due_today: 0,
         due_soon: 1,
-        items: [],
+        items: [mockOverdueItem],
       },
     })
 
@@ -86,7 +126,7 @@ describe("useTransferPageData", () => {
       overdue: 1,
       due_today: 0,
       due_soon: 1,
-      items: [],
+      items: [mockOverdueItem],
     })
 
     expect(mocks.callRpc).toHaveBeenCalledWith({

--- a/src/hooks/__tests__/useTransferPageData.test.tsx
+++ b/src/hooks/__tests__/useTransferPageData.test.tsx
@@ -44,6 +44,13 @@ describe("useTransferPageData", () => {
         },
       },
       kanban: null,
+      overdue_summary: {
+        total: 2,
+        overdue: 1,
+        due_today: 0,
+        due_soon: 1,
+        items: [],
+      },
     })
 
     const queryClient = new QueryClient({
@@ -74,6 +81,13 @@ describe("useTransferPageData", () => {
     )
 
     await waitFor(() => expect(result.current.data?.viewMode).toBe("table"))
+    expect(result.current.data?.overdue_summary).toEqual({
+      total: 2,
+      overdue: 1,
+      due_today: 0,
+      due_soon: 1,
+      items: [],
+    })
 
     expect(mocks.callRpc).toHaveBeenCalledWith({
       fn: "transfer_request_page_data",
@@ -131,6 +145,13 @@ describe("useTransferPageData", () => {
     )
 
     await waitFor(() => expect(result.current.data?.counts).toBeNull())
+    expect(result.current.data?.overdue_summary).toEqual({
+      total: 0,
+      overdue: 0,
+      due_today: 0,
+      due_soon: 0,
+      items: [],
+    })
 
     expect(mocks.callRpc).toHaveBeenCalledWith({
       fn: "transfer_request_page_data",

--- a/src/types/transfers-data-grid.ts
+++ b/src/types/transfers-data-grid.ts
@@ -95,11 +95,24 @@ export interface TransferCountsResponse {
   columnCounts: TransferStatusCounts
 }
 
+export interface TransferOverdueSummaryItem extends TransferListItem {
+  days_difference: number
+}
+
+export interface TransferOverdueSummary {
+  total: number
+  overdue: number
+  due_today: number
+  due_soon: number
+  items: TransferOverdueSummaryItem[]
+}
+
 export interface TransferPageDataResponse {
   viewMode: ViewMode
   list: TransferListResponse | null
   counts: TransferCountsResponse | null
   kanban: TransferKanbanResponse | null
+  overdue_summary: TransferOverdueSummary
 }
 
 // Zod schema for equipment info validation
@@ -176,11 +189,32 @@ export const TransferCountsResponseSchema = z.object({
   }),
 })
 
+export const TransferOverdueSummaryItemSchema = TransferListItemSchema.extend({
+  days_difference: z.number().int(),
+})
+
+export const TransferOverdueSummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  overdue: z.number().int().nonnegative(),
+  due_today: z.number().int().nonnegative(),
+  due_soon: z.number().int().nonnegative(),
+  items: z.array(TransferOverdueSummaryItemSchema),
+})
+
+const EmptyTransferOverdueSummary = {
+  total: 0,
+  overdue: 0,
+  due_today: 0,
+  due_soon: 0,
+  items: [],
+}
+
 export const TransferPageDataResponseSchema = z.object({
   viewMode: z.enum(['table', 'kanban']),
   list: TransferTableModeResponseSchema.nullable(),
   counts: TransferCountsResponseSchema.nullable(),
   kanban: TransferKanbanResponseSchema.nullable(),
+  overdue_summary: TransferOverdueSummarySchema.optional().default(EmptyTransferOverdueSummary),
 })
 
 // TypeScript types inferred from Zod schemas

--- a/src/types/transfers-data-grid.ts
+++ b/src/types/transfers-data-grid.ts
@@ -97,6 +97,8 @@ export interface TransferCountsResponse {
 
 export interface TransferOverdueSummaryItem extends TransferListItem {
   days_difference: number
+  equipment_is_deleted: boolean | null
+  thiet_bi: (TransferEquipmentInfo & { is_deleted: boolean | null }) | null
 }
 
 export interface TransferOverdueSummary {
@@ -189,8 +191,14 @@ export const TransferCountsResponseSchema = z.object({
   }),
 })
 
+const TransferOverdueEquipmentInfoSchema = TransferEquipmentInfoSchema.extend({
+  is_deleted: z.boolean().nullable(),
+})
+
 export const TransferOverdueSummaryItemSchema = TransferListItemSchema.extend({
   days_difference: z.number().int(),
+  equipment_is_deleted: z.boolean().nullable(),
+  thiet_bi: TransferOverdueEquipmentInfoSchema.nullable(),
 })
 
 export const TransferOverdueSummarySchema = z.object({

--- a/supabase/migrations/20260506080000_enrich_transfer_page_data_with_overdue_summary.sql
+++ b/supabase/migrations/20260506080000_enrich_transfer_page_data_with_overdue_summary.sql
@@ -1,6 +1,12 @@
 -- Issue #386: keep the Transfers overdue-return alert on the same
 -- server-side filter/scope contract as transfer_request_page_data.
 -- Local-only until applied through Supabase MCP.
+-- Rollback pointer: restore the previous transfer_request_page_data body from
+-- supabase/migrations/20260502040000_add_transfer_request_page_data_rpc.sql.
+-- To restore the detached pending-returns RPC, use the body/grants from
+-- supabase/migrations/2025-09-29/20250927_regional_leader_phase4.sql
+-- or supabase/migrations/2025-09-15/20250915_transfers_rpcs_more.sql
+-- in a new forward-only superseding migration.
 
 CREATE OR REPLACE FUNCTION public.transfer_request_page_data(
   p_q text DEFAULT NULL::text,

--- a/supabase/migrations/20260506080000_enrich_transfer_page_data_with_overdue_summary.sql
+++ b/supabase/migrations/20260506080000_enrich_transfer_page_data_with_overdue_summary.sql
@@ -1,0 +1,325 @@
+-- Issue #386: keep the Transfers overdue-return alert on the same
+-- server-side filter/scope contract as transfer_request_page_data.
+-- Local-only until applied through Supabase MCP.
+
+CREATE OR REPLACE FUNCTION public.transfer_request_page_data(
+  p_q text DEFAULT NULL::text,
+  p_statuses text[] DEFAULT NULL::text[],
+  p_types text[] DEFAULT NULL::text[],
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_date_from date DEFAULT NULL::date,
+  p_date_to date DEFAULT NULL::date,
+  p_assignee_ids bigint[] DEFAULT NULL::bigint[],
+  p_view_mode text DEFAULT 'table'::text,
+  p_per_column_limit integer DEFAULT 30,
+  p_exclude_completed boolean DEFAULT false,
+  p_include_counts boolean DEFAULT true
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role text := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id text := NULLIF(COALESCE(public._get_jwt_claim('user_id'), public._get_jwt_claim('sub')), '');
+  v_view_mode text := COALESCE(p_view_mode, 'table');
+  v_is_global boolean := false;
+  v_effective_donvi bigint := NULL;
+  v_allowed bigint[] := NULL;
+  v_has_scope boolean := true;
+  v_sanitized_q text := NULL;
+  v_today date := (now() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date;
+  v_list jsonb := NULL;
+  v_kanban jsonb := NULL;
+  v_counts_raw jsonb := NULL;
+  v_counts jsonb := NULL;
+  v_total_count bigint := 0;
+  v_overdue_summary jsonb := jsonb_build_object(
+    'total', 0,
+    'overdue', 0,
+    'due_today', 0,
+    'due_soon', 0,
+    'items', '[]'::jsonb
+  );
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_view_mode NOT IN ('table', 'kanban') THEN
+    RAISE EXCEPTION 'Invalid view mode: %', v_view_mode USING ERRCODE = '22023';
+  END IF;
+
+  p_per_column_limit := LEAST(GREATEST(COALESCE(p_per_column_limit, 30), 1), 100);
+  v_is_global := v_role IN ('global', 'admin');
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_is_global THEN
+    v_effective_donvi := p_don_vi;
+  ELSE
+    v_allowed := public.allowed_don_vi_for_session();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      v_has_scope := false;
+    ELSIF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective_donvi := p_don_vi;
+      ELSE
+        v_has_scope := false;
+      END IF;
+    END IF;
+  END IF;
+
+  IF p_include_counts THEN
+    v_counts_raw := public.transfer_request_counts(
+      p_q,
+      p_don_vi,
+      p_date_from,
+      p_date_to,
+      p_types,
+      p_assignee_ids
+    );
+
+    v_total_count :=
+      COALESCE((v_counts_raw->>'cho_duyet')::bigint, 0) +
+      COALESCE((v_counts_raw->>'da_duyet')::bigint, 0) +
+      COALESCE((v_counts_raw->>'dang_luan_chuyen')::bigint, 0) +
+      COALESCE((v_counts_raw->>'da_ban_giao')::bigint, 0) +
+      COALESCE((v_counts_raw->>'hoan_thanh')::bigint, 0);
+
+    v_counts := jsonb_build_object(
+      'totalCount', v_total_count,
+      'columnCounts', jsonb_build_object(
+        'cho_duyet', COALESCE((v_counts_raw->>'cho_duyet')::integer, 0),
+        'da_duyet', COALESCE((v_counts_raw->>'da_duyet')::integer, 0),
+        'dang_luan_chuyen', COALESCE((v_counts_raw->>'dang_luan_chuyen')::integer, 0),
+        'da_ban_giao', COALESCE((v_counts_raw->>'da_ban_giao')::integer, 0),
+        'hoan_thanh', COALESCE((v_counts_raw->>'hoan_thanh')::integer, 0)
+      )
+    );
+  END IF;
+
+  IF v_has_scope THEN
+    WITH filtered AS (
+      SELECT
+        yclc.id,
+        yclc.ma_yeu_cau,
+        yclc.thiet_bi_id,
+        yclc.loai_hinh,
+        yclc.trang_thai,
+        yclc.nguoi_yeu_cau_id,
+        yclc.ly_do_luan_chuyen,
+        yclc.khoa_phong_hien_tai,
+        yclc.khoa_phong_nhan,
+        yclc.muc_dich,
+        yclc.don_vi_nhan,
+        yclc.dia_chi_don_vi,
+        yclc.nguoi_lien_he,
+        yclc.so_dien_thoai,
+        yclc.ngay_du_kien_tra,
+        yclc.ngay_ban_giao,
+        yclc.ngay_hoan_tra,
+        yclc.ngay_hoan_thanh,
+        yclc.nguoi_duyet_id,
+        yclc.ngay_duyet,
+        yclc.ghi_chu_duyet,
+        yclc.created_at,
+        yclc.updated_at,
+        yclc.created_by,
+        yclc.updated_by,
+        tb.ten_thiet_bi,
+        tb.ma_thiet_bi,
+        tb.model,
+        tb.serial,
+        tb.khoa_phong_quan_ly,
+        tb.is_deleted,
+        dv.name AS facility_name,
+        dv.id AS facility_id
+      FROM public.yeu_cau_luan_chuyen yclc
+      LEFT JOIN public.thiet_bi tb ON tb.id = yclc.thiet_bi_id
+      LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+      WHERE (
+        (v_is_global AND (v_effective_donvi IS NULL OR tb.don_vi = v_effective_donvi)) OR
+        (
+          NOT v_is_global
+          AND (
+            (v_effective_donvi IS NOT NULL AND tb.don_vi = v_effective_donvi) OR
+            (v_effective_donvi IS NULL AND tb.don_vi = ANY(v_allowed))
+          )
+        )
+      )
+      AND (p_statuses IS NULL OR yclc.trang_thai = ANY(p_statuses))
+      AND (p_types IS NULL OR yclc.loai_hinh = ANY(p_types))
+      AND (p_assignee_ids IS NULL OR yclc.nguoi_yeu_cau_id = ANY(p_assignee_ids))
+      AND (
+        v_sanitized_q IS NULL OR
+        yclc.ma_yeu_cau ILIKE '%' || v_sanitized_q || '%' OR
+        yclc.ly_do_luan_chuyen ILIKE '%' || v_sanitized_q || '%' OR
+        tb.ten_thiet_bi ILIKE '%' || v_sanitized_q || '%' OR
+        tb.ma_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+      )
+      AND (p_date_from IS NULL OR yclc.created_at >= (p_date_from::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'))
+      AND (p_date_to IS NULL OR yclc.created_at < ((p_date_to + interval '1 day')::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'))
+    ),
+    due_items AS (
+      SELECT
+        *,
+        ((ngay_du_kien_tra AT TIME ZONE 'Asia/Ho_Chi_Minh')::date - v_today) AS days_difference
+      FROM filtered
+      WHERE loai_hinh = 'ben_ngoai'
+        AND trang_thai IN ('da_ban_giao', 'dang_luan_chuyen')
+        AND ngay_du_kien_tra IS NOT NULL
+        AND (ngay_du_kien_tra AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= v_today + 7
+    ),
+    due_aggregated AS (
+      SELECT
+        count(*) AS total_count,
+        count(*) FILTER (WHERE days_difference < 0) AS overdue_count,
+        count(*) FILTER (WHERE days_difference = 0) AS due_today_count,
+        count(*) FILTER (WHERE days_difference BETWEEN 1 AND 7) AS due_soon_count
+      FROM due_items
+    ),
+    ranked_items AS (
+      SELECT *
+      FROM due_items
+      ORDER BY (ngay_du_kien_tra AT TIME ZONE 'Asia/Ho_Chi_Minh')::date ASC, id ASC
+      LIMIT 50
+    )
+    SELECT jsonb_build_object(
+      'total', COALESCE(due_aggregated.total_count, 0),
+      'overdue', COALESCE(due_aggregated.overdue_count, 0),
+      'due_today', COALESCE(due_aggregated.due_today_count, 0),
+      'due_soon', COALESCE(due_aggregated.due_soon_count, 0),
+      'items', COALESCE((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', id,
+            'ma_yeu_cau', ma_yeu_cau,
+            'thiet_bi_id', thiet_bi_id,
+            'loai_hinh', loai_hinh,
+            'trang_thai', trang_thai,
+            'nguoi_yeu_cau_id', nguoi_yeu_cau_id,
+            'ly_do_luan_chuyen', ly_do_luan_chuyen,
+            'khoa_phong_hien_tai', khoa_phong_hien_tai,
+            'khoa_phong_nhan', khoa_phong_nhan,
+            'muc_dich', muc_dich,
+            'don_vi_nhan', don_vi_nhan,
+            'dia_chi_don_vi', dia_chi_don_vi,
+            'nguoi_lien_he', nguoi_lien_he,
+            'so_dien_thoai', so_dien_thoai,
+            'ngay_du_kien_tra', ngay_du_kien_tra,
+            'ngay_ban_giao', ngay_ban_giao,
+            'ngay_hoan_tra', ngay_hoan_tra,
+            'ngay_hoan_thanh', ngay_hoan_thanh,
+            'nguoi_duyet_id', nguoi_duyet_id,
+            'ngay_duyet', ngay_duyet,
+            'ghi_chu_duyet', ghi_chu_duyet,
+            'created_at', created_at,
+            'updated_at', updated_at,
+            'created_by', created_by,
+            'updated_by', updated_by,
+            'equipment_is_deleted', is_deleted,
+            'days_difference', days_difference,
+            'thiet_bi', jsonb_build_object(
+              'ten_thiet_bi', ten_thiet_bi,
+              'ma_thiet_bi', ma_thiet_bi,
+              'model', model,
+              'serial', serial,
+              'khoa_phong_quan_ly', khoa_phong_quan_ly,
+              'facility_name', facility_name,
+              'facility_id', facility_id,
+              'is_deleted', is_deleted
+            )
+          )
+          ORDER BY (ngay_du_kien_tra AT TIME ZONE 'Asia/Ho_Chi_Minh')::date ASC, id ASC
+        )
+        FROM ranked_items
+      ), '[]'::jsonb)
+    )
+    INTO v_overdue_summary
+    FROM due_aggregated;
+  END IF;
+
+  IF v_view_mode = 'kanban' THEN
+    v_kanban := public.transfer_request_list(
+      p_q,
+      NULL,
+      p_types,
+      p_page,
+      p_page_size,
+      p_don_vi,
+      p_date_from,
+      p_date_to,
+      p_assignee_ids,
+      'kanban',
+      p_per_column_limit,
+      p_exclude_completed
+    );
+  ELSE
+    v_list := public.transfer_request_list(
+      p_q,
+      p_statuses,
+      p_types,
+      p_page,
+      p_page_size,
+      p_don_vi,
+      p_date_from,
+      p_date_to,
+      p_assignee_ids,
+      'table',
+      p_per_column_limit,
+      p_exclude_completed
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'viewMode', v_view_mode,
+    'list', v_list,
+    'counts', v_counts,
+    'kanban', v_kanban,
+    'overdue_summary', v_overdue_summary
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.transfer_request_page_data(
+  text,
+  text[],
+  text[],
+  integer,
+  integer,
+  bigint,
+  date,
+  date,
+  bigint[],
+  text,
+  integer,
+  boolean,
+  boolean
+) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.transfer_request_page_data(
+  text,
+  text[],
+  text[],
+  integer,
+  integer,
+  bigint,
+  date,
+  date,
+  bigint[],
+  text,
+  integer,
+  boolean,
+  boolean
+) FROM PUBLIC;
+
+REVOKE EXECUTE ON FUNCTION public.transfer_request_external_pending_returns() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.transfer_request_external_pending_returns() FROM anon;
+REVOKE EXECUTE ON FUNCTION public.transfer_request_external_pending_returns() FROM authenticated;

--- a/supabase/tests/transfer_request_page_data_overdue_summary_smoke.sql
+++ b/supabase/tests/transfer_request_page_data_overdue_summary_smoke.sql
@@ -158,6 +158,37 @@ BEGIN
     RAISE EXCEPTION 'Expected tenant B overdue summary total 1, got %', v_page->'overdue_summary'->>'total';
   END IF;
 
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'qltb_khoa',
+      'role', 'qltb_khoa',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant_a::text
+    )::text,
+    true
+  );
+
+  v_page := public.transfer_request_page_data(
+    NULL, NULL, ARRAY['ben_ngoai'], 1, 10, v_tenant_b, NULL, NULL, NULL, 'table', 30, false, true
+  );
+  IF (v_page->'overdue_summary'->>'total')::integer IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'Expected out-of-scope tenant overdue summary total 0, got %', v_page->'overdue_summary'->>'total';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'global',
+      'role', 'global',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant_a::text
+    )::text,
+    true
+  );
+
   v_page := public.transfer_request_page_data(
     NULL, NULL, ARRAY['ben_ngoai'], 1, 10, v_tenant_a, v_today - 2, NULL, NULL, 'table', 30, false, true
   );

--- a/supabase/tests/transfer_request_page_data_overdue_summary_smoke.sql
+++ b/supabase/tests/transfer_request_page_data_overdue_summary_smoke.sql
@@ -1,0 +1,199 @@
+-- Smoke tests for Issue #386 transfer_request_page_data.overdue_summary.
+-- Run only after applying 20260506080000_enrich_transfer_page_data_with_overdue_summary.sql.
+-- Non-destructive: wrapped in a transaction and rolled back.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_today date := (now() AT TIME ZONE 'Asia/Ho_Chi_Minh')::date;
+  v_user_id bigint;
+  v_tenant_a bigint;
+  v_tenant_b bigint;
+  v_equipment_a_overdue bigint;
+  v_equipment_a_upcoming bigint;
+  v_equipment_a_old bigint;
+  v_equipment_b_overdue bigint;
+  v_request_a_overdue bigint;
+  v_request_a_upcoming bigint;
+  v_request_a_old bigint;
+  v_request_b_overdue bigint;
+  v_page jsonb;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('transfer_request_page_data_overdue_summary_smoke'));
+
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active = true
+  ORDER BY nv.id
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Setup failed: no active nhan_vien row found';
+  END IF;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Transfer Overdue Smoke A ' || v_suffix, true)
+  RETURNING id INTO v_tenant_a;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Transfer Overdue Smoke B ' || v_suffix, true)
+  RETURNING id INTO v_tenant_b;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai, is_deleted)
+  VALUES ('SMK-TRF-OD-A-' || v_suffix, 'Transfer Overdue Smoke A ' || v_suffix, v_tenant_a, 'Khoa A', 'Hoat dong', false)
+  RETURNING id INTO v_equipment_a_overdue;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai, is_deleted)
+  VALUES ('SMK-TRF-UP-A-' || v_suffix, 'Transfer Upcoming Smoke A ' || v_suffix, v_tenant_a, 'Khoa A', 'Hoat dong', false)
+  RETURNING id INTO v_equipment_a_upcoming;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai, is_deleted)
+  VALUES ('SMK-TRF-OLD-A-' || v_suffix, 'Transfer Old Smoke A ' || v_suffix, v_tenant_a, 'Khoa A', 'Hoat dong', false)
+  RETURNING id INTO v_equipment_a_old;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai, is_deleted)
+  VALUES ('SMK-TRF-OD-B-' || v_suffix, 'Transfer Overdue Smoke B ' || v_suffix, v_tenant_b, 'Khoa B', 'Hoat dong', false)
+  RETURNING id INTO v_equipment_b_overdue;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'global',
+      'role', 'global',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant_a::text
+    )::text,
+    true
+  );
+
+  v_request_a_overdue := public.transfer_request_create(jsonb_build_object(
+    'thiet_bi_id', v_equipment_a_overdue,
+    'loai_hinh', 'ben_ngoai',
+    'ly_do_luan_chuyen', 'Smoke overdue ' || v_suffix,
+    'muc_dich', 'cho_muon',
+    'don_vi_nhan', 'External A'
+  ));
+
+  v_request_a_upcoming := public.transfer_request_create(jsonb_build_object(
+    'thiet_bi_id', v_equipment_a_upcoming,
+    'loai_hinh', 'ben_ngoai',
+    'ly_do_luan_chuyen', 'Smoke upcoming ' || v_suffix,
+    'muc_dich', 'cho_muon',
+    'don_vi_nhan', 'External A'
+  ));
+
+  v_request_a_old := public.transfer_request_create(jsonb_build_object(
+    'thiet_bi_id', v_equipment_a_old,
+    'loai_hinh', 'ben_ngoai',
+    'ly_do_luan_chuyen', 'Smoke old created ' || v_suffix,
+    'muc_dich', 'cho_muon',
+    'don_vi_nhan', 'External A'
+  ));
+
+  v_request_b_overdue := public.transfer_request_create(jsonb_build_object(
+    'thiet_bi_id', v_equipment_b_overdue,
+    'loai_hinh', 'ben_ngoai',
+    'ly_do_luan_chuyen', 'Smoke tenant B ' || v_suffix,
+    'muc_dich', 'cho_muon',
+    'don_vi_nhan', 'External B'
+  ));
+
+  UPDATE public.yeu_cau_luan_chuyen
+  SET
+    trang_thai = 'da_ban_giao',
+    ngay_du_kien_tra = ((v_today - 3)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'),
+    created_at = ((v_today - 1)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'),
+    updated_at = ((v_today - 1)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  WHERE id = v_request_a_overdue;
+
+  UPDATE public.yeu_cau_luan_chuyen
+  SET
+    trang_thai = 'dang_luan_chuyen',
+    ngay_du_kien_tra = ((v_today + 4)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'),
+    created_at = ((v_today - 1)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'),
+    updated_at = ((v_today - 1)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  WHERE id = v_request_a_upcoming;
+
+  UPDATE public.yeu_cau_luan_chuyen
+  SET
+    trang_thai = 'da_ban_giao',
+    ngay_du_kien_tra = ((v_today - 5)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'),
+    created_at = ((v_today - 30)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'),
+    updated_at = ((v_today - 30)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  WHERE id = v_request_a_old;
+
+  UPDATE public.yeu_cau_luan_chuyen
+  SET
+    trang_thai = 'da_ban_giao',
+    ngay_du_kien_tra = ((v_today - 2)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'),
+    created_at = ((v_today - 1)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'),
+    updated_at = ((v_today - 1)::timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  WHERE id = v_request_b_overdue;
+
+  v_page := public.transfer_request_page_data(
+    NULL, NULL, ARRAY['ben_ngoai'], 1, 10, v_tenant_a, NULL, NULL, NULL, 'table', 30, false, true
+  );
+
+  IF (v_page->'overdue_summary'->>'total')::integer IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'Expected tenant A overdue summary total 3, got %', v_page->'overdue_summary'->>'total';
+  END IF;
+  IF (v_page->'overdue_summary'->>'overdue')::integer IS DISTINCT FROM 2 THEN
+    RAISE EXCEPTION 'Expected tenant A overdue count 2, got %', v_page->'overdue_summary'->>'overdue';
+  END IF;
+  IF (v_page->'overdue_summary'->>'due_soon')::integer IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Expected tenant A due_soon count 1, got %', v_page->'overdue_summary'->>'due_soon';
+  END IF;
+  IF jsonb_array_length(v_page->'overdue_summary'->'items') IS DISTINCT FROM 3 THEN
+    RAISE EXCEPTION 'Expected tenant A overdue items length 3';
+  END IF;
+
+  v_page := public.transfer_request_page_data(
+    NULL, NULL, ARRAY['ben_ngoai'], 1, 10, v_tenant_b, NULL, NULL, NULL, 'table', 30, false, true
+  );
+  IF (v_page->'overdue_summary'->>'total')::integer IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Expected tenant B overdue summary total 1, got %', v_page->'overdue_summary'->>'total';
+  END IF;
+
+  v_page := public.transfer_request_page_data(
+    NULL, NULL, ARRAY['ben_ngoai'], 1, 10, v_tenant_a, v_today - 2, NULL, NULL, 'table', 30, false, true
+  );
+  IF (v_page->'overdue_summary'->>'total')::integer IS DISTINCT FROM 2 THEN
+    RAISE EXCEPTION 'Expected date-filtered tenant A total 2, got %', v_page->'overdue_summary'->>'total';
+  END IF;
+
+  v_page := public.transfer_request_page_data(
+    'UP-A-' || v_suffix, NULL, ARRAY['ben_ngoai'], 1, 10, v_tenant_a, NULL, NULL, NULL, 'table', 30, false, true
+  );
+  IF (v_page->'overdue_summary'->>'total')::integer IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Expected search-filtered summary total 1, got %', v_page->'overdue_summary'->>'total';
+  END IF;
+
+  v_page := public.transfer_request_page_data(
+    NULL, ARRAY['cho_duyet'], ARRAY['ben_ngoai'], 1, 10, v_tenant_a, NULL, NULL, NULL, 'table', 30, false, true
+  );
+  IF (v_page->'overdue_summary'->>'total')::integer IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'Expected status-filtered summary total 0, got %', v_page->'overdue_summary'->>'total';
+  END IF;
+
+  v_page := public.transfer_request_page_data(
+    NULL, NULL, ARRAY['ben_ngoai'], 1, 10, v_tenant_a, NULL, NULL, ARRAY[999999999::bigint], 'table', 30, false, true
+  );
+  IF (v_page->'overdue_summary'->>'total')::integer IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'Expected assignee-filtered summary total 0, got %', v_page->'overdue_summary'->>'total';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.transfer_request_external_pending_returns()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'anon should not execute legacy external pending returns RPC';
+  END IF;
+  IF has_function_privilege('authenticated', 'public.transfer_request_external_pending_returns()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'authenticated should not execute legacy external pending returns RPC';
+  END IF;
+
+  RAISE NOTICE 'OK: transfer_request_page_data overdue_summary smoke passed';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Move Transfers overdue-return alert to consume page-scoped `transfer_request_page_data.overdue_summary` instead of fetching `transfer_request_external_pending_returns` directly.
- Add local Supabase migration to compute overdue/upcoming transfer-return summary server-side with the same page filters/scope and revoke app access to the legacy detached RPC.
- Add RED/GREEN coverage for hook schema, Transfers page alert props, presentational alert behavior, and a local SQL smoke file for post-apply verification.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/hooks/__tests__/useTransferPageData.test.tsx src/app/'(app)'/transfers/__tests__/TransfersKpi.test.tsx src/components/__tests__/overdue-transfers-alert.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `git diff --check`



## Post-Apply Verification

Applied via Supabase MCP as live migration version `20260506115619_enrich_transfer_page_data_with_overdue_summary`.

- `transfer_request_page_data` now returns `overdue_summary` from the same server-side filter/scope contract as the Transfers page.
- SQL smoke `supabase/tests/transfer_request_page_data_overdue_summary_smoke.sql` passed after apply; it is rollback-only and left no smoke rows behind.
- Live checks confirmed `transfer_request_page_data` has `SECURITY DEFINER`, `search_path=public, pg_temp`, and `overdue_summary` in the function body.
- Live grants confirmed `transfer_request_external_pending_returns()` is no longer executable by `anon` or `authenticated`.
- Supabase advisors were run after apply; reported findings are existing baseline/global advisors, not a new Issue #386 blocker.

Refs #386

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the Transfers overdue-return alert to server-computed, page-scoped data and removes the legacy pending-returns RPC. Addresses Linear #386 by computing `overdue_summary` server-side and passing it (and loading state) through the page controller to avoid stale data.

- **Bug Fixes**
  - Alert now consumes `transfer_request_page_data.overdue_summary`, accepts `isLoading`, auto-opens when `overdue > 0`, and opens items via `rowActions.handleViewDetail`.
  - Controller exposes `overdueSummary` and wires `isListLoading || isListFetching` to hide stale alert data while refetching.
  - Removed calls to legacy `transfer_request_external_pending_returns` and its entry in `allowed-functions`.
  - Added `TransferOverdueSummary` types and schema default; UI uses server `days_difference` for messages; tests added/updated for component, hook schema, and KPI/controller.

- **Migration**
  - Apply `supabase/migrations/20260506080000_enrich_transfer_page_data_with_overdue_summary.sql` to add `overdue_summary` and revoke legacy RPC permissions.
  - Verify with `supabase/tests/transfer_request_page_data_overdue_summary_smoke.sql`.

<sup>Written for commit b0ad805763b91bce6791d93aada29faa0c5ed78c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an overdue transfers alert to the transfers page that displays overdue and upcoming transfer items with day-difference indicators.
  * Users can now quickly view and navigate to specific transfers directly from the alert.

* **Tests**
  * Added comprehensive test coverage for the overdue transfers alert and its page integration.

* **Chores**
  * Removed an outdated RPC endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
