### PR TITLE
Extract shared filter search card for Equipment

### DIFF
--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.attention-preset.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.attention-preset.test.tsx
@@ -58,7 +58,7 @@ vi.mock("../_components/EquipmentBulkDeleteBar", () => ({
 }))
 
 vi.mock("@/components/equipment/equipment-toolbar", () => ({
-  EquipmentToolbar: () => null,
+  EquipmentToolbar: ({ selectionActions }: { selectionActions?: React.ReactNode }) => <>{selectionActions}</>,
 }))
 
 vi.mock("@/components/equipment/filter-bottom-sheet", () => ({

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -7,10 +7,7 @@ import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
-  CardDescription,
   CardFooter,
-  CardHeader,
-  CardTitle,
 } from "@/components/ui/card"
 import {
   DropdownMenu,
@@ -218,63 +215,46 @@ function EquipmentPageContent({
         tenantBranding={tenantBranding}
       />
 
-      <Card>
-        <CardHeader>
-          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div>
-              <CardTitle className="heading-responsive-h2">Danh mục thiết bị</CardTitle>
-              <CardDescription className="body-responsive-sm">
-                Quản lý danh sách các trang thiết bị y tế.
-              </CardDescription>
-            </div>
+      <div className="space-y-4">
+        <EquipmentToolbar
+          table={table}
+          title="Danh mục thiết bị"
+          description="Quản lý danh sách các trang thiết bị y tế."
+          tenantControl={showFacilityFilter ? <TenantSelector className="w-full" /> : null}
+          searchTerm={searchTerm}
+          onSearchChange={setSearchTerm}
+          columnFilters={columnFilters}
+          isFiltered={isFiltered}
+          statuses={statuses}
+          departments={departments}
+          users={users}
+          classifications={classifications}
+          fundingSources={fundingSources}
+          isMobile={isMobile}
+          useTabletFilters={useTabletFilters}
+          canCreateEquipment={canCreateEquipment}
+          hasFacilityFilter={hasFacilityFilter}
+          isExporting={isExporting}
+          selectionActions={
+            <EquipmentBulkDeleteBar
+              table={table}
+              canBulkSelect={canBulkSelect}
+              isCardView={isCardView}
+            />
+          }
+          onOpenFilterSheet={() => setIsFilterSheetOpen(true)}
+          onOpenColumnsDialog={openColumnsDialog}
+          onDownloadTemplate={handleDownloadTemplate}
+          onExportData={handleExportData}
+          onAddEquipment={openAddDialog}
+          onImportEquipment={openImportDialog}
+          onClearFacilityFilter={handleFacilityClear}
+          onShowEquipmentDetails={(eq) => openDetailDialog(eq)}
+        />
 
-            {/* Facility selector using shared TenantSelector component */}
-            {showFacilityFilter ? (
-              <div className="flex w-full max-w-md items-center gap-2">
-                <TenantSelector className="flex-1" />
-              </div>
-            ) : null}
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-4 px-4 md:px-6">
-          {/* Unified toolbar */}
-          <EquipmentToolbar
-            table={table}
-            searchTerm={searchTerm}
-            onSearchChange={setSearchTerm}
-            columnFilters={columnFilters}
-            isFiltered={isFiltered}
-            statuses={statuses}
-            departments={departments}
-            users={users}
-            classifications={classifications}
-            fundingSources={fundingSources}
-            isMobile={isMobile}
-            useTabletFilters={useTabletFilters}
-            canCreateEquipment={canCreateEquipment}
-            hasFacilityFilter={hasFacilityFilter}
-            isExporting={isExporting}
-            selectionActions={
-              <EquipmentBulkDeleteBar
-                table={table}
-                canBulkSelect={canBulkSelect}
-                isCardView={isCardView}
-              />
-            }
-            onOpenFilterSheet={() => setIsFilterSheetOpen(true)}
-            onOpenColumnsDialog={openColumnsDialog}
-            onDownloadTemplate={handleDownloadTemplate}
-            onExportData={handleExportData}
-            onAddEquipment={openAddDialog}
-            onImportEquipment={openImportDialog}
-            onClearFacilityFilter={handleFacilityClear}
-            onShowEquipmentDetails={(eq) => openDetailDialog(eq)}
-          />
-
-          <EquipmentColumnsDialog table={table} />
-
-          <div className="mt-4">
+        <Card>
+          <CardContent className="space-y-4 px-4 pt-4 md:px-6">
+            <EquipmentColumnsDialog table={table} />
             <EquipmentContent
               isGlobal={isGlobal}
               isRegionalLeader={isRegionalLeader}
@@ -286,37 +266,37 @@ function EquipmentPageContent({
               columns={columns}
               onShowDetails={(eq) => openDetailDialog(eq)}
             />
-          </div>
-        </CardContent>
+          </CardContent>
 
-        <CardFooter className="flex flex-col gap-4 py-4 px-4 md:px-6 sm:flex-row sm:items-center sm:justify-between">
-          <DataTablePagination
-            table={table}
-            totalCount={total}
-            entity={EQUIPMENT_ENTITY}
-            paginationMode={{
-              mode: "controlled",
-              pagination,
-              onPaginationChange: setPagination,
-            }}
-            displayFormat={equipmentDisplayFormat}
-            responsive={{ showFirstLastAt: "sm", showSizeSelectorAt: "sm" }}
-            isLoading={isLoading}
-            enabled={shouldFetchEquipment}
-            slots={{
-              beforeNav: (
-                <button
-                  onClick={handleExportData}
-                  className="text-sm font-medium text-primary underline-offset-4 hover:underline disabled:text-muted-foreground disabled:no-underline disabled:cursor-not-allowed"
-                  disabled={table.getFilteredRowModel().rows.length === 0 || isLoading || isExporting}
-                >
-                  {isExporting ? "Đang tải..." : "Tải về file Excel"}
-                </button>
-              ),
-            }}
-          />
-        </CardFooter>
-      </Card>
+          <CardFooter className="flex flex-col gap-4 py-4 px-4 md:px-6 sm:flex-row sm:items-center sm:justify-between">
+            <DataTablePagination
+              table={table}
+              totalCount={total}
+              entity={EQUIPMENT_ENTITY}
+              paginationMode={{
+                mode: "controlled",
+                pagination,
+                onPaginationChange: setPagination,
+              }}
+              displayFormat={equipmentDisplayFormat}
+              responsive={{ showFirstLastAt: "sm", showSizeSelectorAt: "sm" }}
+              isLoading={isLoading}
+              enabled={shouldFetchEquipment}
+              slots={{
+                beforeNav: (
+                  <button
+                    onClick={handleExportData}
+                    className="text-sm font-medium text-primary underline-offset-4 hover:underline disabled:text-muted-foreground disabled:no-underline disabled:cursor-not-allowed"
+                    disabled={table.getFilteredRowModel().rows.length === 0 || isLoading || isExporting}
+                  >
+                    {isExporting ? "Đang tải..." : "Tải về file Excel"}
+                  </button>
+                ),
+              }}
+            />
+          </CardFooter>
+        </Card>
+      </div>
 
       {/* Floating Add Button - Mobile only */}
       {canCreateEquipment ? (

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -224,7 +224,6 @@ function EquipmentPageContent({
           searchTerm={searchTerm}
           onSearchChange={setSearchTerm}
           columnFilters={columnFilters}
-          isFiltered={isFiltered}
           statuses={statuses}
           departments={departments}
           users={users}

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -230,11 +230,9 @@ function EquipmentPageContent({
           users={users}
           classifications={classifications}
           fundingSources={fundingSources}
-          isMobile={isMobile}
-          useTabletFilters={useTabletFilters}
-          canCreateEquipment={canCreateEquipment}
-          hasFacilityFilter={hasFacilityFilter}
-          isExporting={isExporting}
+          filterMode={isMobile || useTabletFilters ? "sheet" : "faceted"}
+          filterState={{ isFiltered, hasFacilityFilter }}
+          actionState={{ canCreateEquipment, isExporting }}
           selectionActions={
             <EquipmentBulkDeleteBar
               table={table}

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -105,10 +105,15 @@ describe('EquipmentToolbar with shared filters', () => {
         users: ['User A'],
         classifications: ['Loại A'],
         fundingSources: ['Ngân sách'],
-        isMobile: false,
-        useTabletFilters: false,
-        canCreateEquipment: true,
-        hasFacilityFilter: false,
+        filterMode: 'faceted' as const,
+        filterState: {
+            isFiltered: false,
+            hasFacilityFilter: false,
+        },
+        actionState: {
+            canCreateEquipment: true,
+            isExporting: false,
+        },
         onOpenFilterSheet: vi.fn(),
         onOpenColumnsDialog: vi.fn(),
         onDownloadTemplate: vi.fn(),
@@ -129,7 +134,7 @@ describe('EquipmentToolbar with shared filters', () => {
     })
 
     it('renders mobile filter sheet trigger instead of faceted filters on mobile', () => {
-        render(<EquipmentToolbar {...baseProps} isMobile={true} />)
+        render(<EquipmentToolbar {...baseProps} filterMode="sheet" />)
 
         expect(screen.getByText('Lọc')).toBeInTheDocument()
         expect(screen.queryByText('Tình trạng')).not.toBeInTheDocument()
@@ -138,20 +143,30 @@ describe('EquipmentToolbar with shared filters', () => {
 
     it('calls onOpenFilterSheet when mobile filter button is clicked', () => {
         const onOpenFilterSheet = vi.fn()
-        render(<EquipmentToolbar {...baseProps} isMobile={true} onOpenFilterSheet={onOpenFilterSheet} />)
+        render(<EquipmentToolbar {...baseProps} filterMode="sheet" onOpenFilterSheet={onOpenFilterSheet} />)
 
         fireEvent.click(screen.getByText('Lọc'))
         expect(onOpenFilterSheet).toHaveBeenCalled()
     })
 
     it('shows clear all button when filters are active', () => {
-        render(<EquipmentToolbar {...baseProps} isFiltered={true} />)
+        render(
+            <EquipmentToolbar
+                {...baseProps}
+                filterState={{ ...baseProps.filterState, isFiltered: true }}
+            />
+        )
 
         expect(screen.getByText('Xóa tất cả')).toBeInTheDocument()
     })
 
     it('hides add actions when create permission is disabled', () => {
-        render(<EquipmentToolbar {...baseProps} canCreateEquipment={false} />)
+        render(
+            <EquipmentToolbar
+                {...baseProps}
+                actionState={{ ...baseProps.actionState, canCreateEquipment: false }}
+            />
+        )
 
         expect(screen.queryByText('Thêm thiết bị')).not.toBeInTheDocument()
     })

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -99,7 +99,6 @@ describe('EquipmentToolbar with shared filters', () => {
         searchTerm: '',
         onSearchChange: vi.fn(),
         columnFilters: [],
-        isFiltered: false,
         statuses: ['Hoạt động', 'Hỏng'],
         departments: ['ICU', 'Surgery'],
         users: ['User A'],

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -49,12 +49,15 @@ export interface EquipmentToolbarProps {
   users: string[]
   classifications: string[]
   fundingSources: string[]
-  isMobile: boolean
-  useTabletFilters: boolean
-  canCreateEquipment: boolean
-  hasFacilityFilter: boolean
-  /** Whether export is currently in progress */
-  isExporting?: boolean
+  filterMode: "faceted" | "sheet"
+  filterState: {
+    isFiltered: boolean
+    hasFacilityFilter: boolean
+  }
+  actionState: {
+    canCreateEquipment: boolean
+    isExporting?: boolean
+  }
   selectionActions?: React.ReactNode
   onOpenFilterSheet: () => void
   onOpenColumnsDialog: () => void
@@ -74,17 +77,14 @@ export function EquipmentToolbar({
   searchTerm,
   onSearchChange,
   columnFilters,
-  isFiltered,
   statuses,
   departments,
   users,
   classifications,
   fundingSources,
-  isMobile,
-  useTabletFilters,
-  canCreateEquipment,
-  hasFacilityFilter,
-  isExporting = false,
+  filterMode,
+  filterState,
+  actionState,
   selectionActions,
   onOpenFilterSheet,
   onOpenColumnsDialog,
@@ -96,7 +96,9 @@ export function EquipmentToolbar({
   onShowEquipmentDetails,
 }: EquipmentToolbarProps) {
   const qr = useQRScanner()
-  const compactFilters = isMobile || useTabletFilters
+  const compactFilters = filterMode === "sheet"
+  const { isFiltered, hasFacilityFilter } = filterState
+  const { canCreateEquipment, isExporting = false } = actionState
   const activeFilterCount = columnFilters.reduce((acc, filter) => {
     const vals = filter.value as string[] | undefined
     return acc + (vals?.length || 0)

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -20,7 +20,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { SearchInput } from "@/components/shared/SearchInput"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { useQRScanner } from "./useEquipmentQRScanner"
 import type { Equipment } from "@/types/database"
@@ -37,6 +37,9 @@ const QRActionSheet = dynamic(
 
 export interface EquipmentToolbarProps {
   table: Table<Equipment>
+  title?: React.ReactNode
+  description?: React.ReactNode
+  tenantControl?: React.ReactNode
   searchTerm: string
   onSearchChange: (value: string) => void
   columnFilters: ColumnFiltersState
@@ -65,6 +68,9 @@ export interface EquipmentToolbarProps {
 
 export function EquipmentToolbar({
   table,
+  title,
+  description,
+  tenantControl,
   searchTerm,
   onSearchChange,
   columnFilters,
@@ -90,6 +96,167 @@ export function EquipmentToolbar({
   onShowEquipmentDetails,
 }: EquipmentToolbarProps) {
   const qr = useQRScanner()
+  const compactFilters = isMobile || useTabletFilters
+  const activeFilterCount = columnFilters.reduce((acc, filter) => {
+    const vals = filter.value as string[] | undefined
+    return acc + (vals?.length || 0)
+  }, 0)
+
+  const searchEndAddon = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={qr.handleStartScanning}
+      className="h-8 w-8 hover:bg-primary/10"
+      title="Quét mã QR"
+      aria-label="Quét mã QR"
+    >
+      <ScanLine className="h-4 w-4 text-muted-foreground hover:text-primary" />
+    </Button>
+  )
+
+  const mobileFilterControl = (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onOpenFilterSheet}
+        className={cn(
+          "h-9 border-slate-200 shadow-sm transition-all",
+          isFiltered
+            ? "border-primary/50 bg-primary/5 hover:bg-primary/10"
+            : "hover:border-primary/30"
+        )}
+      >
+        <Filter className="h-4 w-4 mr-2" />
+        <span className="font-medium">Lọc</span>
+        {isFiltered && (
+          <Badge
+            variant="secondary"
+            className="ml-2 h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"
+          >
+            {activeFilterCount}
+          </Badge>
+        )}
+      </Button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="h-9">
+            <Settings className="h-4 w-4 mr-2" />
+            Tùy chọn
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuItem onSelect={onOpenColumnsDialog}>
+            Hiện/ẩn cột
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onDownloadTemplate}>
+            Tải Excel mẫu
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onExportData} disabled={isExporting}>
+            {isExporting ? "Đang tải..." : "Tải về dữ liệu"}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  )
+
+  const filterControls = (
+    <>
+      <FacetedMultiSelectFilter
+        column={table.getColumn("tinh_trang_hien_tai")}
+        title="Tình trạng"
+        options={statuses.map(s => ({ label: s, value: s }))}
+      />
+      <FacetedMultiSelectFilter
+        column={table.getColumn("khoa_phong_quan_ly")}
+        title="Khoa/Phòng"
+        options={departments.map(d => ({ label: d, value: d }))}
+      />
+      <FacetedMultiSelectFilter
+        column={table.getColumn("nguoi_dang_truc_tiep_quan_ly")}
+        title="Người sử dụng"
+        options={users.map(d => ({ label: d, value: d }))}
+      />
+      <FacetedMultiSelectFilter
+        column={table.getColumn("phan_loai_theo_nd98")}
+        title="Phân loại"
+        options={classifications.map(c => ({ label: c, value: c }))}
+      />
+      <FacetedMultiSelectFilter
+        column={table.getColumn("nguon_kinh_phi")}
+        title="Nguồn kinh phí"
+        options={fundingSources.map(f => ({ label: f, value: f }))}
+      />
+      {isFiltered && (
+        <Button
+          variant="ghost"
+          onClick={() => table.resetColumnFilters()}
+          className="h-8 px-2 lg:px-3"
+        >
+          <span className="hidden sm:inline">Xóa tất cả</span>
+          <FilterX className="h-4 w-4 sm:ml-2" />
+        </Button>
+      )}
+      {hasFacilityFilter && (
+        <Button
+          variant="ghost"
+          onClick={onClearFacilityFilter}
+          className="h-8 px-2 lg:px-3"
+        >
+          <span className="hidden sm:inline">Xóa lọc cơ sở</span>
+          <FilterX className="h-4 w-4 sm:ml-2" />
+        </Button>
+      )}
+    </>
+  )
+
+  const actions = (
+    <>
+      {canCreateEquipment && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button size="sm" className="hidden md:flex h-8 gap-1 touch-target-sm md:h-8">
+              <PlusCircle className="h-3.5 w-3.5" />
+              <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
+                Thêm thiết bị
+              </span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onAddEquipment}>
+              Thêm thủ công
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onImportEquipment}>
+              Nhập từ Excel
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" className="hidden lg:flex h-8 gap-1 touch-target-sm md:h-8">
+            <Settings className="h-3.5 w-3.5" />
+            Tùy chọn
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <DropdownMenuItem onSelect={onOpenColumnsDialog}>
+            Hiện/ẩn cột
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onDownloadTemplate}>
+            Tải Excel mẫu
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onExportData} disabled={isExporting}>
+            {isExporting ? "Đang tải..." : "Tải về dữ liệu"}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </>
+  )
 
   return (
     <>
@@ -113,184 +280,21 @@ export function EquipmentToolbar({
         />
       )}
 
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center md:justify-between">
-          {/* Left: search + filters */}
-          <div className="order-1 w-full flex flex-col gap-2 md:flex-row md:flex-1 md:flex-wrap md:items-center md:gap-2 md:min-w-0">
-            <div className="w-full md:w-auto md:min-w-[260px]">
-              <SearchInput
-                placeholder="Tìm kiếm chung..."
-                value={searchTerm}
-                onChange={onSearchChange}
-                showSearchIcon={false}
-                className="h-8 w-full"
-                endAddon={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={qr.handleStartScanning}
-                    className="h-8 w-8 hover:bg-primary/10"
-                    title="Quét mã QR"
-                  >
-                    <ScanLine className="h-4 w-4 text-muted-foreground hover:text-primary" />
-                  </Button>
-                }
-              />
-            </div>
-            <div className="flex flex-wrap items-center gap-2 w-full md:w-auto">
-              {(isMobile || useTabletFilters) ? (
-                <>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={onOpenFilterSheet}
-                    className={cn(
-                      "h-9 border-slate-200 shadow-sm transition-all",
-                      isFiltered
-                        ? "border-primary/50 bg-primary/5 hover:bg-primary/10"
-                        : "hover:border-primary/30"
-                    )}
-                  >
-                    <Filter className="h-4 w-4 mr-2" />
-                    <span className="font-medium">Lọc</span>
-                    {isFiltered && (
-                      <Badge
-                        variant="secondary"
-                        className="ml-2 h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"
-                      >
-                        {columnFilters.reduce((acc, filter) => {
-                          const vals = filter.value as string[] | undefined
-                          return acc + (vals?.length || 0)
-                        }, 0)}
-                      </Badge>
-                    )}
-                  </Button>
-
-                  {/* Mobile/Tablet Options button */}
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" size="sm" className="h-9">
-                        <Settings className="h-4 w-4 mr-2" />
-                        Tùy chọn
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" className="w-56">
-                      <DropdownMenuItem onSelect={onOpenColumnsDialog}>
-                        Hiện/ẩn cột
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onSelect={onDownloadTemplate}>
-                        Tải Excel mẫu
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onSelect={onExportData} disabled={isExporting}>
-                        {isExporting ? "Đang tải..." : "Tải về dữ liệu"}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </>
-              ) : (
-                <>
-                  <FacetedMultiSelectFilter
-                    column={table.getColumn("tinh_trang_hien_tai")}
-                    title="Tình trạng"
-                    options={statuses.map(s => ({ label: s, value: s }))}
-                  />
-                  <FacetedMultiSelectFilter
-                    column={table.getColumn("khoa_phong_quan_ly")}
-                    title="Khoa/Phòng"
-                    options={departments.map(d => ({ label: d, value: d }))}
-                  />
-                  <FacetedMultiSelectFilter
-                    column={table.getColumn("nguoi_dang_truc_tiep_quan_ly")}
-                    title="Người sử dụng"
-                    options={users.map(d => ({ label: d, value: d }))}
-                  />
-                  <FacetedMultiSelectFilter
-                    column={table.getColumn("phan_loai_theo_nd98")}
-                    title="Phân loại"
-                    options={classifications.map(c => ({ label: c, value: c }))}
-                  />
-                  <FacetedMultiSelectFilter
-                    column={table.getColumn("nguon_kinh_phi")}
-                    title="Nguồn kinh phí"
-                    options={fundingSources.map(f => ({ label: f, value: f }))}
-                  />
-                  {isFiltered && (
-                    <Button
-                      variant="ghost"
-                      onClick={() => table.resetColumnFilters()}
-                      className="h-8 px-2 lg:px-3"
-                    >
-                      <span className="hidden sm:inline">Xóa tất cả</span>
-                      <FilterX className="h-4 w-4 sm:ml-2" />
-                    </Button>
-                  )}
-                  {hasFacilityFilter && (
-                    <Button
-                      variant="ghost"
-                      onClick={onClearFacilityFilter}
-                      className="h-8 px-2 lg:px-3"
-                    >
-                      <span className="hidden sm:inline">Xóa lọc cơ sở</span>
-                      <FilterX className="h-4 w-4 sm:ml-2" />
-                    </Button>
-                  )}
-                </>
-              )}
-            </div>
-          </div>
-
-          {/* Right: actions */}
-          <div className="order-3 w-full md:order-2 md:w-auto flex items-center gap-2 justify-between md:justify-end">
-            {selectionActions ? (
-              <div className="flex min-w-0 shrink-0 justify-end">
-                {selectionActions}
-              </div>
-            ) : null}
-
-            {canCreateEquipment && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button size="sm" className="hidden md:flex h-8 gap-1 touch-target-sm md:h-8">
-                    <PlusCircle className="h-3.5 w-3.5" />
-                    <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
-                      Thêm thiết bị
-                    </span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onSelect={onAddEquipment}>
-                    Thêm thủ công
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={onImportEquipment}>
-                    Nhập từ Excel
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="hidden lg:flex h-8 gap-1 touch-target-sm md:h-8">
-                  <Settings className="h-3.5 w-3.5" />
-                  Tùy chọn
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuItem onSelect={onOpenColumnsDialog}>
-                  Hiện/ẩn cột
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={onDownloadTemplate}>
-                  Tải Excel mẫu
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={onExportData} disabled={isExporting}>
-                  {isExporting ? "Đang tải..." : "Tải về dữ liệu"}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-      </div>
+      <ListFilterSearchCard
+        title={title}
+        description={description}
+        tenantControl={tenantControl}
+        searchValue={searchTerm}
+        onSearchChange={onSearchChange}
+        searchPlaceholder="Tìm kiếm chung..."
+        searchEndAddon={searchEndAddon}
+        showSearchIcon={false}
+        filterControls={filterControls}
+        mobileFilterControl={mobileFilterControl}
+        compactFilters={compactFilters}
+        selectionActions={selectionActions}
+        actions={actions}
+      />
     </>
   )
 }

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -43,7 +43,6 @@ export interface EquipmentToolbarProps {
   searchTerm: string
   onSearchChange: (value: string) => void
   columnFilters: ColumnFiltersState
-  isFiltered: boolean
   statuses: string[]
   departments: string[]
   users: string[]

--- a/src/components/shared/ListFilterSearchCard.tsx
+++ b/src/components/shared/ListFilterSearchCard.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import * as React from "react"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { SearchInput } from "@/components/shared/SearchInput"
+import { cn } from "@/lib/utils"
+
+export interface ListFilterSearchCardProps {
+  title?: React.ReactNode
+  description?: React.ReactNode
+  tenantControl?: React.ReactNode
+  searchValue: string
+  onSearchChange: (value: string) => void
+  searchPlaceholder: string
+  searchEndAddon?: React.ReactNode
+  showSearchIcon?: boolean
+  filterControls?: React.ReactNode
+  mobileFilterControl?: React.ReactNode
+  compactFilters?: boolean
+  selectionActions?: React.ReactNode
+  actions?: React.ReactNode
+  chips?: React.ReactNode
+  className?: string
+  searchClassName?: string
+}
+
+export function ListFilterSearchCard({
+  title,
+  description,
+  tenantControl,
+  searchValue,
+  onSearchChange,
+  searchPlaceholder,
+  searchEndAddon,
+  showSearchIcon = true,
+  filterControls,
+  mobileFilterControl,
+  compactFilters = false,
+  selectionActions,
+  actions,
+  chips,
+  className,
+  searchClassName,
+}: ListFilterSearchCardProps) {
+  const visibleFilterControls = compactFilters ? mobileFilterControl : filterControls
+
+  return (
+    <Card className={className}>
+      {(title || description) ? (
+        <CardHeader className="space-y-1 pb-3">
+          {title ? (
+            <CardTitle className="heading-responsive-h2">{title}</CardTitle>
+          ) : null}
+          {description ? (
+            <CardDescription className="body-responsive-sm">{description}</CardDescription>
+          ) : null}
+        </CardHeader>
+      ) : null}
+
+      <CardContent className="space-y-3 px-4 pb-4 md:px-6">
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+          <div className="flex min-w-0 flex-1 flex-col gap-2 md:flex-row md:flex-wrap md:items-center">
+            {tenantControl ? (
+              <div className="w-full md:w-auto md:min-w-[220px] xl:min-w-[260px]">
+                {tenantControl}
+              </div>
+            ) : null}
+
+            <div className={cn("w-full md:min-w-[280px] md:max-w-[460px] md:flex-1", searchClassName)}>
+              <SearchInput
+                placeholder={searchPlaceholder}
+                value={searchValue}
+                onChange={onSearchChange}
+                showSearchIcon={showSearchIcon}
+                className="h-9 w-full"
+                endAddon={searchEndAddon}
+                aria-label={searchPlaceholder}
+              />
+            </div>
+
+            {visibleFilterControls ? (
+              <div className="flex w-full flex-wrap items-center gap-2 md:w-auto">
+                {visibleFilterControls}
+              </div>
+            ) : null}
+          </div>
+
+          {(selectionActions || actions) ? (
+            <div className="flex w-full flex-wrap items-center justify-between gap-2 xl:w-auto xl:justify-end">
+              {selectionActions ? (
+                <div className="min-w-0 shrink-0">{selectionActions}</div>
+              ) : null}
+              {actions ? (
+                <div className="flex items-center gap-2">{actions}</div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        {chips ? <div>{chips}</div> : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
+++ b/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ListFilterSearchCard } from "../ListFilterSearchCard"
+
+describe("ListFilterSearchCard", () => {
+  it("renders tenant control before search input", () => {
+    render(
+      <ListFilterSearchCard
+        title="Danh mục thiết bị"
+        description="Quản lý danh sách thiết bị."
+        tenantControl={<button type="button">Cơ sở</button>}
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Tìm kiếm chung..."
+      />
+    )
+
+    const tenant = screen.getByRole("button", { name: "Cơ sở" })
+    const search = screen.getByRole("searchbox", { name: "Tìm kiếm chung..." })
+
+    expect(tenant.compareDocumentPosition(search)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+
+  it("renders mobile filter control instead of desktop filter controls in compact mode", () => {
+    render(
+      <ListFilterSearchCard
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Tìm kiếm chung..."
+        compactFilters
+        filterControls={<button type="button">Tình trạng</button>}
+        mobileFilterControl={<button type="button">Bộ lọc</button>}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Bộ lọc" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Tình trạng" })).not.toBeInTheDocument()
+  })
+
+  it("supports action and selection slots without owning their behavior", () => {
+    render(
+      <ListFilterSearchCard
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Tìm kiếm chung..."
+        selectionActions={<div data-testid="selection-actions">Đã chọn 2</div>}
+        actions={<button type="button">Tùy chọn</button>}
+      />
+    )
+
+    expect(screen.getByTestId("selection-actions")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Tùy chọn" })).toBeInTheDocument()
+  })
+})

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -13,15 +13,30 @@
 
 import * as React from "react"
 import type { Column } from "@tanstack/react-table"
-import { Check, Filter } from "lucide-react"
+import { Check, Filter, Search } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+
+const DEFAULT_SEARCH_DEBOUNCE_MS = 300
+const DEFAULT_SEARCH_PLACEHOLDER = "Tìm lựa chọn..."
+const DEFAULT_EMPTY_SEARCH_MESSAGE = "Không tìm thấy lựa chọn phù hợp"
+
+function useDebouncedValue(value: string, delay: number): string {
+    const [debouncedValue, setDebouncedValue] = React.useState(value)
+
+    React.useEffect(() => {
+        const timer = window.setTimeout(() => {
+            setDebouncedValue(value)
+        }, delay)
+
+        return () => window.clearTimeout(timer)
+    }, [delay, value])
+
+    return debouncedValue
+}
 
 export interface FacetedMultiSelectFilterProps<TData, TValue> {
     column?: Column<TData, TValue>
@@ -34,6 +49,11 @@ export interface FacetedMultiSelectFilterProps<TData, TValue> {
     value?: string[]
     /** Controlled mode: callback when selection changes */
     onChange?: (values: string[]) => void
+    searchable?: boolean
+    searchPlaceholder?: string
+    searchDebounceMs?: number
+    emptySearchMessage?: string
+    contentClassName?: string
 }
 
 export function FacetedMultiSelectFilter<TData, TValue>({
@@ -42,7 +62,18 @@ export function FacetedMultiSelectFilter<TData, TValue>({
     options,
     value: controlledValue,
     onChange,
+    searchable = true,
+    searchPlaceholder = DEFAULT_SEARCH_PLACEHOLDER,
+    searchDebounceMs = DEFAULT_SEARCH_DEBOUNCE_MS,
+    emptySearchMessage = DEFAULT_EMPTY_SEARCH_MESSAGE,
+    contentClassName,
 }: FacetedMultiSelectFilterProps<TData, TValue>) {
+    const [open, setOpen] = React.useState(false)
+    const [optionSearch, setOptionSearch] = React.useState("")
+    const searchInputRef = React.useRef<HTMLInputElement>(null)
+    const firstOptionRef = React.useRef<HTMLButtonElement>(null)
+    const debouncedOptionSearch = useDebouncedValue(optionSearch, searchDebounceMs)
+
     // Resolve selected values from either column mode or controlled mode
     const isControlled = controlledValue !== undefined
     const selectedValues = new Set(
@@ -51,15 +82,70 @@ export function FacetedMultiSelectFilter<TData, TValue>({
             : (column?.getFilterValue() as string[]) || []
     )
 
+    const visibleOptions = React.useMemo(() => {
+        const normalizedSearch = debouncedOptionSearch.trim().toLocaleLowerCase()
+        if (!normalizedSearch) return options
+        return options.filter((option) =>
+            option.label.toLocaleLowerCase().includes(normalizedSearch) ||
+            option.value.toLocaleLowerCase().includes(normalizedSearch)
+        )
+    }, [debouncedOptionSearch, options])
+
+    React.useEffect(() => {
+        if (!open) {
+            setOptionSearch("")
+            return
+        }
+
+        if (!searchable) return
+
+        const timer = window.setTimeout(() => {
+            searchInputRef.current?.focus()
+        }, 0)
+
+        return () => window.clearTimeout(timer)
+    }, [open, searchable])
+
+    const updateSelectedValues = React.useCallback((filterValues: string[]) => {
+        if (isControlled) {
+            onChange?.(filterValues)
+            return
+        }
+
+        column?.setFilterValue(filterValues.length ? filterValues : undefined)
+    }, [column, isControlled, onChange])
+
+    const handleOptionToggle = React.useCallback((optionValue: string) => {
+        const nextValues = new Set(selectedValues)
+        if (nextValues.has(optionValue)) {
+            nextValues.delete(optionValue)
+        } else {
+            nextValues.add(optionValue)
+        }
+        updateSelectedValues(Array.from(nextValues))
+    }, [selectedValues, updateSelectedValues])
+
+    const handleClear = React.useCallback(() => {
+        updateSelectedValues([])
+    }, [updateSelectedValues])
+
+    const handleOptionSearchKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "ArrowDown") {
+            event.preventDefault()
+            firstOptionRef.current?.focus()
+        }
+    }, [])
+
     return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
                 <Button
                     type="button"
                     variant="outline"
                     size="sm"
+                    aria-haspopup="dialog"
                     className={cn(
-                        "h-9 border-slate-200 shadow-sm transition-all",
+                        "h-9 min-w-[132px] justify-start border-slate-200 shadow-sm transition-all",
                         selectedValues?.size > 0
                             ? "border-primary/50 bg-primary/5 hover:bg-primary/10"
                             : "hover:border-primary/30"
@@ -77,9 +163,12 @@ export function FacetedMultiSelectFilter<TData, TValue>({
                         )}
                     </div>
                 </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-                className="w-[240px] max-h-[400px] overflow-hidden rounded-xl border border-slate-200 shadow-lg p-0"
+            </PopoverTrigger>
+            <PopoverContent
+                className={cn(
+                    "w-[min(420px,calc(100vw-2rem))] max-h-[440px] overflow-hidden rounded-xl border border-slate-200 p-0 shadow-lg",
+                    contentClassName
+                )}
                 align="start"
             >
                 {/* Header */}
@@ -90,30 +179,43 @@ export function FacetedMultiSelectFilter<TData, TValue>({
                     </div>
                 </div>
 
+                {searchable ? (
+                    <div className="border-b border-slate-100 p-2">
+                        <div className="relative">
+                            <Search
+                                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                                aria-hidden="true"
+                            />
+                            <Input
+                                ref={searchInputRef}
+                                type="search"
+                                value={optionSearch}
+                                onChange={(event) => setOptionSearch(event.target.value)}
+                                onKeyDown={handleOptionSearchKeyDown}
+                                aria-label={`Tìm lựa chọn ${title ?? "bộ lọc"}`}
+                                placeholder={searchPlaceholder}
+                                className="h-9 pl-9"
+                            />
+                        </div>
+                    </div>
+                ) : null}
+
                 {/* Options List */}
                 <div className="max-h-[300px] overflow-y-auto py-1">
-                    {options.map((option) => {
+                    {visibleOptions.length === 0 ? (
+                        <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                            {emptySearchMessage}
+                        </div>
+                    ) : null}
+                    {visibleOptions.map((option, index) => {
                         const isSelected = selectedValues.has(option.value)
                         return (
                             <button
+                                ref={index === 0 ? firstOptionRef : undefined}
                                 type="button"
                                 key={option.value}
-                                onClick={(e) => {
-                                    e.preventDefault()
-                                    if (isSelected) {
-                                        selectedValues.delete(option.value)
-                                    } else {
-                                        selectedValues.add(option.value)
-                                    }
-                                    const filterValues = Array.from(selectedValues)
-                                    if (isControlled) {
-                                        onChange?.(filterValues)
-                                    } else {
-                                        column?.setFilterValue(
-                                            filterValues.length ? filterValues : undefined
-                                        )
-                                    }
-                                }}
+                                onClick={() => handleOptionToggle(option.value)}
+                                aria-pressed={isSelected}
                                 className={cn(
                                     "w-full flex items-center gap-3 px-3 py-2.5 text-sm transition-colors",
                                     "hover:bg-slate-50 active:bg-slate-100",
@@ -146,20 +248,14 @@ export function FacetedMultiSelectFilter<TData, TValue>({
                             type="button"
                             variant="ghost"
                             size="sm"
-                            onClick={() => {
-                                if (isControlled) {
-                                    onChange?.([])
-                                } else {
-                                    column?.setFilterValue(undefined)
-                                }
-                            }}
+                            onClick={handleClear}
                             className="w-full h-8 text-xs font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100"
                         >
                             Xóa bộ lọc
                         </Button>
                     </div>
                 )}
-            </DropdownMenuContent>
-        </DropdownMenu>
+            </PopoverContent>
+        </Popover>
     )
 }

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
@@ -1,55 +1,68 @@
 import * as React from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import "@testing-library/jest-dom"
-import { render, screen, fireEvent } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import {
     getCoreRowModel,
     getFacetedRowModel,
     getFacetedUniqueValues,
     getFilteredRowModel,
     useReactTable,
+    type ColumnFiltersState,
     type ColumnDef,
 } from '@tanstack/react-table'
 
+type PopoverStateProps = {
+    open?: boolean
+    setOpen?: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+type PopoverTriggerProps = PopoverStateProps & {
+    asChild?: boolean
+    children: React.ReactNode
+    onClick?: (...args: unknown[]) => void
+} & Record<string, unknown>
+
+type PopoverContentProps = PopoverStateProps & {
+    children: React.ReactNode
+} & React.HTMLAttributes<HTMLDivElement>
+
 /**
- * Mock radix DropdownMenu so content renders inline (no portal / no jsdom issues).
+ * Mock radix Popover so content renders inline (no portal / no jsdom issues).
  */
-vi.mock('@/components/ui/dropdown-menu', () => {
-    const Trigger = ({ children, asChild, ...rest }: any) => {
+vi.mock('@/components/ui/popover', () => {
+    const Trigger = ({ children, asChild, open, setOpen, ...rest }: PopoverTriggerProps) => {
+        const togglePopover = () => setOpen?.(!open)
         if (asChild && React.isValidElement(children)) {
-            return React.cloneElement(children as React.ReactElement<any>, rest)
+            const childElement = children as React.ReactElement<{ onClick?: (...args: unknown[]) => void }>
+            return React.cloneElement(childElement, {
+                ...rest,
+                onClick: (...args: unknown[]) => {
+                    togglePopover()
+                    childElement.props.onClick?.(...args)
+                },
+            })
         }
-        return <button {...rest}>{children}</button>
+        return <button {...rest} onClick={togglePopover}>{children}</button>
     }
+
     return {
-        DropdownMenu: ({ children }: any) => {
+        Popover: ({ children }: { children: React.ReactNode }) => {
             const [open, setOpen] = React.useState(false)
             return (
-                <div data-testid="dropdown-menu">
-                    {React.Children.map(children, (child: any) =>
+                <div data-testid="popover">
+                    {React.Children.map(children, (child) =>
                         React.isValidElement(child)
-                            ? React.cloneElement(child as React.ReactElement<any>, { open, setOpen })
+                            ? React.cloneElement(child as React.ReactElement<PopoverStateProps>, { open, setOpen })
                             : child
                     )}
                 </div>
             )
         },
-        DropdownMenuTrigger: ({ children, asChild, open, setOpen, ...rest }: any) => {
-            const handleClick = () => setOpen?.(!open)
-            if (asChild && React.isValidElement(children)) {
-                return React.cloneElement(children as React.ReactElement<any>, {
-                    ...rest,
-                    onClick: (...args: any[]) => {
-                        handleClick()
-                            ; (children as any).props?.onClick?.(...args)
-                    },
-                })
-            }
-            return <button {...rest} onClick={handleClick}>{children}</button>
-        },
-        DropdownMenuContent: ({ children, open, ...rest }: any) => {
+        PopoverTrigger: Trigger,
+        PopoverContent: ({ children, open, setOpen: _setOpen, ...rest }: PopoverContentProps) => {
             if (!open) return null
-            return <div data-testid="dropdown-content" {...rest}>{children}</div>
+            return <div data-testid="popover-content" role="dialog" {...rest}>{children}</div>
         },
     }
 })
@@ -81,11 +94,20 @@ const OPTIONS = [
     { label: 'Radiology', value: 'Radiology' },
 ]
 
+const EMPTY_CONTROLLED_VALUE: string[] = []
+
+afterEach(() => {
+    vi.useRealTimers()
+})
+
 /**
  * Test wrapper with real TanStack Table for integration testing.
  */
 function Wrapper({ onFilterChange }: { onFilterChange?: (values: string[] | undefined) => void }) {
-    const [columnFilters, setColumnFilters] = React.useState<any[]>([])
+    const [columnFilters, setColumnFilters] = React.useReducer(
+        (_state: ColumnFiltersState, next: ColumnFiltersState) => next,
+        [] as ColumnFiltersState
+    )
     const table = useReactTable({
         data: DATA,
         columns: COLUMNS,
@@ -93,7 +115,7 @@ function Wrapper({ onFilterChange }: { onFilterChange?: (values: string[] | unde
         onColumnFiltersChange: (updater) => {
             const next = typeof updater === 'function' ? updater(columnFilters) : updater
             setColumnFilters(next)
-            const deptFilter = next.find((f: any) => f.id === 'department')
+            const deptFilter = next.find((f) => f.id === 'department')
             onFilterChange?.(deptFilter?.value as string[] | undefined)
         },
         getCoreRowModel: getCoreRowModel(),
@@ -128,6 +150,79 @@ describe('FacetedMultiSelectFilter', () => {
         expect(screen.getByRole('button', { name: 'ICU' })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Surgery' })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Radiology' })).toBeInTheDocument()
+    })
+
+    it('debounces internal option search before filtering visible options', async () => {
+        vi.useFakeTimers()
+        render(<Wrapper />)
+
+        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
+        const optionSearch = screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' })
+
+        fireEvent.change(optionSearch, { target: { value: 'radio' } })
+
+        expect(screen.getByRole('button', { name: 'ICU' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Surgery' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Radiology' })).toBeInTheDocument()
+
+        act(() => {
+            vi.advanceTimersByTime(299)
+        })
+        expect(screen.getByRole('button', { name: 'ICU' })).toBeInTheDocument()
+
+        act(() => {
+            vi.advanceTimersByTime(1)
+        })
+
+        expect(screen.queryByRole('button', { name: 'ICU' })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Surgery' })).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Radiology' })).toBeInTheDocument()
+    })
+
+    it('does not change filter selection while typing internal option search', async () => {
+        vi.useFakeTimers()
+        const onFilterChange = vi.fn()
+        render(<Wrapper onFilterChange={onFilterChange} />)
+
+        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' }), {
+            target: { value: 'icu' },
+        })
+
+        act(() => {
+            vi.advanceTimersByTime(300)
+        })
+
+        expect(onFilterChange).not.toHaveBeenCalled()
+    })
+
+    it('shows empty state when internal option search has no match', async () => {
+        vi.useFakeTimers()
+        render(<Wrapper />)
+
+        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' }), {
+            target: { value: 'zzz' },
+        })
+
+        act(() => {
+            vi.advanceTimersByTime(300)
+        })
+
+        expect(screen.getByText('Không tìm thấy lựa chọn phù hợp')).toBeInTheDocument()
+    })
+
+    it('moves focus from option search to first visible option on ArrowDown', async () => {
+        vi.useFakeTimers()
+        render(<Wrapper />)
+
+        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
+        const optionSearch = screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' })
+        optionSearch.focus()
+
+        fireEvent.keyDown(optionSearch, { key: 'ArrowDown' })
+
+        expect(screen.getByRole('button', { name: 'ICU' })).toHaveFocus()
     })
 
     it('selects an option and calls column.setFilterValue', () => {
@@ -197,14 +292,17 @@ describe('FacetedMultiSelectFilter', () => {
 // ============================================
 
 function ControlledWrapper({
-    initialValue = [],
+    initialValue = EMPTY_CONTROLLED_VALUE,
     onChange,
 }: {
     initialValue?: string[]
     onChange?: (values: string[]) => void
 }) {
-    const [value, setValue] = React.useState(initialValue)
-    const handleChange = (newValues: string[]) => {
+    const [value, setValue] = React.useReducer(
+        (_state: string[], next: string[]) => next,
+        initialValue
+    )
+    const syncSelectedValues = (newValues: string[]) => {
         setValue(newValues)
         onChange?.(newValues)
     }
@@ -213,7 +311,7 @@ function ControlledWrapper({
             title="Khoa/Phòng"
             options={OPTIONS}
             value={value}
-            onChange={handleChange}
+            onChange={syncSelectedValues}
         />
     )
 }
@@ -272,5 +370,21 @@ describe('FacetedMultiSelectFilter — controlled mode', () => {
     it('shows badge count matching controlled value length', () => {
         render(<ControlledWrapper initialValue={['ICU', 'Surgery']} />)
         expect(screen.getByText('2')).toBeInTheDocument()
+    })
+
+    it('preserves selected value when option search hides that option', async () => {
+        vi.useFakeTimers()
+        render(<ControlledWrapper initialValue={['ICU']} />)
+
+        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' }), {
+            target: { value: 'surgery' },
+        })
+        act(() => {
+            vi.advanceTimersByTime(300)
+        })
+
+        expect(screen.queryByRole('button', { name: 'ICU' })).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Khoa\/Phòng/i })).toHaveTextContent('1')
     })
 })


### PR DESCRIPTION
## Summary
- replace `FacetedMultiSelectFilter` DropdownMenu with Popover and internal client-side option search debounced at 300ms
- add shared `ListFilterSearchCard` for tenant/search/filter/action layout
- migrate Equipment filter/search area to the shared card, including tenant selector placement for global/admin/regional leader scope
- keep existing `FacetedMultiSelectFilter` consumers call-site compatible
- group `EquipmentToolbar` state/action flags to resolve the React Doctor boolean-like props warning from #403

## Tests
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx src/components/shared/__tests__/ListFilterSearchCard.test.tsx src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx src/app/'(app)'/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx src/app/'(app)'/device-quota/mapping/__tests__/DeviceQuotaUnassignedList.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` (100/100, no issues found)
- `git diff --check`

## Follow-up
- Remaining page-level filter/search rollout tracked in #410.

Closes #403
