### PR TITLE
feat: roll out repair request shared filters

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
@@ -80,35 +80,43 @@ vi.mock('@/components/shared/TenantSelector', () => ({
 // ── Helpers ────────────────────────────────────────────────────────────
 const defaultProps = {
   selectedFacilityName: null,
-  isRegionalLeader: false,
+  accessState: {
+    isRegionalLeader: false,
+    showFacilityFilter: false,
+    shouldFetchData: true,
+  },
   statusCounts: { 'Chờ xử lý': 3, 'Đã duyệt': 2, 'Hoàn thành': 5, 'Không HT': 0 } as Record<RepairStatus, number> | undefined,
-  statusCountsLoading: false,
   overdueSummary: undefined,
-  overdueLoading: false,
+  summaryState: {
+    statusCountsLoading: false,
+    overdueLoading: false,
+  },
   requests: [],
   searchTerm: '',
   onSearchChange: vi.fn(),
   searchInputRef: { current: null },
-  isFiltered: false,
   onClearFilters: vi.fn(),
-  isFilterModalOpen: false,
   onFilterModalOpenChange: vi.fn(),
   uiFilters: { status: [] as string[], dateRange: null },
   onFilterChange: vi.fn(),
   selectedFacilityId: null as number | null,
-  showFacilityFilter: false,
   facilityOptions: [] as Array<{ id: number; name: string }>,
   onRemoveFilter: vi.fn(),
+  filterState: {
+    isFiltered: false,
+    isFilterModalOpen: false,
+  },
   table: {
     getRowModel: () => ({ rows: [] }),
     getState: () => ({ columnFilters: [] }),
     resetColumnFilters: vi.fn(),
   } as unknown as Table<RepairRequestWithEquipment>,
   tableKey: 'all_0',
-  isMobile: false,
-  shouldFetchData: true,
-  isLoading: false,
-  isFetching: false,
+  listState: {
+    isMobile: false,
+    isLoading: false,
+    isFetching: false,
+  },
   totalRequests: 0,
   repairPagination: {
     pagination: { pageIndex: 0, pageSize: 20 },
@@ -118,6 +126,14 @@ const defaultProps = {
   setRequestToView: vi.fn(),
   openCreateSheet: vi.fn(),
 }
+
+const withAccessState = (overrides: Partial<typeof defaultProps.accessState>) => ({
+  ...defaultProps,
+  accessState: {
+    ...defaultProps.accessState,
+    ...overrides,
+  },
+})
 
 // ── Tests ──────────────────────────────────────────────────────────────
 describe('RepairRequestsPageLayout', () => {
@@ -132,23 +148,28 @@ describe('RepairRequestsPageLayout', () => {
   })
 
   it('hides create button when isRegionalLeader=true', () => {
-    render(<RepairRequestsPageLayout {...defaultProps} isRegionalLeader={true} />)
+    render(<RepairRequestsPageLayout {...withAccessState({ isRegionalLeader: true })} />)
     expect(screen.queryByText('Tạo yêu cầu')).not.toBeInTheDocument()
   })
 
   it('shows create button when isRegionalLeader=false', () => {
-    render(<RepairRequestsPageLayout {...defaultProps} isRegionalLeader={false} isMobile={false} />)
+    render(
+      <RepairRequestsPageLayout
+        {...withAccessState({ isRegionalLeader: false })}
+        listState={{ ...defaultProps.listState, isMobile: false }}
+      />
+    )
     expect(screen.getByText('Tạo yêu cầu')).toBeInTheDocument()
   })
 
   it('shows tenant selection placeholder when shouldFetchData=false', () => {
-    render(<RepairRequestsPageLayout {...defaultProps} shouldFetchData={false} />)
+    render(<RepairRequestsPageLayout {...withAccessState({ shouldFetchData: false })} />)
     expect(screen.getByText('Chọn cơ sở y tế')).toBeInTheDocument()
     expect(screen.getByText(/Vui lòng chọn một cơ sở y tế/)).toBeInTheDocument()
   })
 
   it('shows table content when shouldFetchData=true', () => {
-    render(<RepairRequestsPageLayout {...defaultProps} shouldFetchData={true} />)
+    render(<RepairRequestsPageLayout {...withAccessState({ shouldFetchData: true })} />)
     expect(screen.queryByText('Chọn cơ sở y tế')).not.toBeInTheDocument()
     expect(screen.getByTestId('repair-table')).toBeInTheDocument()
     expect(screen.getByTestId('pagination')).toBeInTheDocument()

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
@@ -1,0 +1,96 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { RepairRequestsToolbar } from "../_components/RepairRequestsToolbar"
+
+const baseProps = {
+  searchTerm: "",
+  onSearchChange: vi.fn(),
+  searchInputRef: React.createRef<HTMLInputElement>(),
+  isFiltered: false,
+  onClearFilters: vi.fn(),
+  onOpenFilterModal: vi.fn(),
+  uiFilters: { status: [], dateRange: null },
+  selectedFacilityName: null,
+  selectedFacilityId: null,
+  showFacilityFilter: true,
+  facilities: [
+    { id: 1, name: "Bệnh viện A" },
+    { id: 2, name: "Bệnh viện B" },
+  ],
+  onFilterChange: vi.fn(),
+  onRemoveFilter: vi.fn(),
+  compactFilters: false,
+}
+
+describe("RepairRequestsToolbar", () => {
+  it("renders desktop filter controls inline instead of only a filter dialog trigger", () => {
+    render(<RepairRequestsToolbar {...baseProps} />)
+
+    expect(screen.getByRole("searchbox", { name: "Tìm thiết bị, mô tả..." })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Trạng thái" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Cơ sở" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Từ ngày" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Đến ngày" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Bộ lọc" })).not.toBeInTheDocument()
+  })
+
+  it("keeps the compact filter trigger for mobile layouts", () => {
+    render(<RepairRequestsToolbar {...baseProps} compactFilters />)
+
+    expect(screen.getByRole("button", { name: "Bộ lọc" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Trạng thái" })).not.toBeInTheDocument()
+  })
+
+  it("updates status filters from the inline status control", async () => {
+    const user = userEvent.setup()
+    const onFilterChange = vi.fn()
+
+    render(<RepairRequestsToolbar {...baseProps} onFilterChange={onFilterChange} />)
+
+    await user.click(screen.getByRole("button", { name: "Trạng thái" }))
+    await user.click(screen.getByRole("button", { name: "Chờ xử lý" }))
+
+    expect(onFilterChange).toHaveBeenCalledWith({
+      status: ["Chờ xử lý"],
+      facilityId: null,
+      dateRange: null,
+    })
+  })
+
+  it("preserves search, clear, and chip removal callbacks", async () => {
+    const user = userEvent.setup()
+    const onSearchChange = vi.fn()
+    const onClearFilters = vi.fn()
+    const onRemoveFilter = vi.fn()
+
+    render(
+      <RepairRequestsToolbar
+        {...baseProps}
+        searchTerm="máy thở"
+        onSearchChange={onSearchChange}
+        isFiltered
+        onClearFilters={onClearFilters}
+        uiFilters={{ status: ["Chờ xử lý"], dateRange: null }}
+        onRemoveFilter={onRemoveFilter}
+      />
+    )
+
+    await user.type(screen.getByRole("searchbox", { name: "Tìm thiết bị, mô tả..." }), " A")
+    await user.click(screen.getByRole("button", { name: "Xóa bộ lọc" }))
+    await user.click(screen.getByRole("button", { name: "Xóa trạng thái Chờ xử lý" }))
+
+    expect(onSearchChange).toHaveBeenCalled()
+    expect(onClearFilters).toHaveBeenCalledTimes(1)
+    expect(onRemoveFilter).toHaveBeenCalledWith("status", "Chờ xử lý")
+  })
+
+  it("hides the inline facility filter when facility scope is not visible", () => {
+    render(<RepairRequestsToolbar {...baseProps} showFacilityFilter={false} />)
+
+    expect(screen.queryByRole("button", { name: "Cơ sở" })).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/repair-requests/_components/RepairRequestsFilterModal.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsFilterModal.tsx
@@ -17,7 +17,7 @@ export type FilterModalValue = {
   dateRange?: { from: Date | null; to: Date | null } | null
 }
 
-const STATUS_OPTIONS = ['Chờ xử lý', 'Đã duyệt', 'Hoàn thành', 'Không HT'] as const
+export const REPAIR_REQUEST_STATUS_OPTIONS = ['Chờ xử lý', 'Đã duyệt', 'Hoàn thành', 'Không HT'] as const
 
 type Variant = "dialog" | "sheet"
 
@@ -51,7 +51,7 @@ export function RepairRequestsFilterModal({
       <div className="space-y-2">
         <Label>Trạng thái</Label>
         <div className="flex flex-wrap gap-2">
-          {STATUS_OPTIONS.map((s) => (
+          {REPAIR_REQUEST_STATUS_OPTIONS.map((s) => (
             <Button
               key={s}
               variant={value.status.includes(s) ? "default" : "outline"}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -294,31 +294,25 @@ function RepairRequestsPageClientInner() {
 
         <RepairRequestsPageLayout
           selectedFacilityName={selectedFacilityName}
-          isRegionalLeader={isRegionalLeader}
+          accessState={{ isRegionalLeader, showFacilityFilter, shouldFetchData }}
           statusCounts={statusCounts}
-          statusCountsLoading={statusCountsLoading}
           overdueSummary={overdueSummary}
-          overdueLoading={overdueLoading}
+          summaryState={{ statusCountsLoading, overdueLoading }}
           requests={requests}
           searchTerm={searchTerm}
           onSearchChange={setSearchTerm}
           searchInputRef={searchInputRef}
-          isFiltered={isFiltered as boolean}
           onClearFilters={handleClearFilters}
-          isFilterModalOpen={isFilterModalOpen}
           onFilterModalOpenChange={setIsFilterModalOpen}
           uiFilters={uiFilters}
           onFilterChange={handleFilterChange}
           selectedFacilityId={selectedFacilityId ?? null}
-          showFacilityFilter={showFacilityFilter}
           facilityOptions={facilityOptions.map(f => ({ id: f.id, name: f.name }))}
           onRemoveFilter={handleRemoveFilter}
+          filterState={{ isFiltered: isFiltered as boolean, isFilterModalOpen }}
           table={table}
           tableKey={tableKey}
-          isMobile={isMobile}
-          shouldFetchData={shouldFetchData}
-          isLoading={isLoading}
-          isFetching={isFetching}
+          listState={{ isMobile, isLoading, isFetching }}
           totalRequests={totalRequests}
           repairPagination={repairPagination}
           columnOptions={columnOptions}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -231,7 +231,11 @@ function RepairRequestsPageClientInner() {
     getFacetedUniqueValues: getFacetedUniqueValues(),
   });
 
-  const isFiltered = table.getState().columnFilters.length > 0 || debouncedSearch.length > 0 || (uiFilters.dateRange?.from || uiFilters.dateRange?.to);
+  const isFiltered = (
+    table.getState().columnFilters.length > 0 ||
+    debouncedSearch.length > 0 ||
+    Boolean(uiFilters.dateRange?.from || uiFilters.dateRange?.to)
+  );
 
   // Keyboard shortcuts: '/', 'n'
   useRepairRequestShortcuts({
@@ -309,7 +313,7 @@ function RepairRequestsPageClientInner() {
           selectedFacilityId={selectedFacilityId ?? null}
           facilityOptions={facilityOptions.map(f => ({ id: f.id, name: f.name }))}
           onRemoveFilter={handleRemoveFilter}
-          filterState={{ isFiltered: isFiltered as boolean, isFilterModalOpen }}
+          filterState={{ isFiltered, isFilterModalOpen }}
           table={table}
           tableKey={tableKey}
           listState={{ isMobile, isLoading, isFetching }}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
@@ -197,7 +197,7 @@ export function RepairRequestsPageLayout({
                   searchTerm={searchTerm}
                   onSearchChange={onSearchChange}
                   searchInputRef={searchInputRef}
-                  isFiltered={isFiltered as boolean}
+                  isFiltered={isFiltered}
                   onClearFilters={onClearFilters}
                   onOpenFilterModal={() => onFilterModalOpenChange(true)}
                   compactFilters={isMobile}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
@@ -36,13 +36,19 @@ const REPAIR_REQUEST_ENTITY = { singular: "yêu cầu" } as const
 interface RepairRequestsPageLayoutProps {
   // Header
   selectedFacilityName: string | null
-  isRegionalLeader: boolean
+  accessState: {
+    isRegionalLeader: boolean
+    showFacilityFilter: boolean
+    shouldFetchData: boolean
+  }
 
   // Summary
   statusCounts: Record<RepairStatus, number> | undefined
-  statusCountsLoading: boolean
   overdueSummary: RepairRequestOverdueSummary | undefined
-  overdueLoading: boolean
+  summaryState: {
+    statusCountsLoading: boolean
+    overdueLoading: boolean
+  }
 
   // Requests data
   requests: RepairRequestWithEquipment[]
@@ -51,24 +57,26 @@ interface RepairRequestsPageLayoutProps {
   searchTerm: string
   onSearchChange: (value: string) => void
   searchInputRef: React.RefObject<HTMLInputElement>
-  isFiltered: boolean
   onClearFilters: () => void
-  isFilterModalOpen: boolean
   onFilterModalOpenChange: (open: boolean) => void
   uiFilters: UiFiltersPrefs
   onFilterChange: (v: FilterModalValue) => void
   selectedFacilityId: number | null
-  showFacilityFilter: boolean
   facilityOptions: Array<{ id: number; name: string }>
   onRemoveFilter: (key: "status" | "facilityName" | "dateRange", sub?: string) => void
+  filterState: {
+    isFiltered: boolean
+    isFilterModalOpen: boolean
+  }
 
   // Table
   table: Table<RepairRequestWithEquipment>
   tableKey: string
-  isMobile: boolean
-  shouldFetchData: boolean
-  isLoading: boolean
-  isFetching: boolean
+  listState: {
+    isMobile: boolean
+    isLoading: boolean
+    isFetching: boolean
+  }
 
   // Pagination
   totalRequests: number
@@ -92,37 +100,36 @@ interface RepairRequestsPageLayoutProps {
  */
 export function RepairRequestsPageLayout({
   selectedFacilityName,
-  isRegionalLeader,
+  accessState,
   statusCounts,
-  statusCountsLoading,
   overdueSummary,
-  overdueLoading,
+  summaryState,
   requests,
   searchTerm,
   onSearchChange,
   searchInputRef,
-  isFiltered,
   onClearFilters,
-  isFilterModalOpen,
   onFilterModalOpenChange,
   uiFilters,
   onFilterChange,
   selectedFacilityId,
-  showFacilityFilter,
   facilityOptions,
   onRemoveFilter,
+  filterState,
   table,
   tableKey,
-  isMobile,
-  shouldFetchData,
-  isLoading,
-  isFetching,
+  listState,
   totalRequests,
   repairPagination,
   columnOptions,
   setRequestToView,
   openCreateSheet,
 }: RepairRequestsPageLayoutProps) {
+  const { isRegionalLeader, showFacilityFilter, shouldFetchData } = accessState
+  const { statusCountsLoading, overdueLoading } = summaryState
+  const { isFiltered, isFilterModalOpen } = filterState
+  const { isMobile, isLoading, isFetching } = listState
+
   return (
     <>
       {/* Repair Request Alert */}
@@ -193,9 +200,13 @@ export function RepairRequestsPageLayout({
                   isFiltered={isFiltered as boolean}
                   onClearFilters={onClearFilters}
                   onOpenFilterModal={() => onFilterModalOpenChange(true)}
+                  compactFilters={isMobile}
                   uiFilters={uiFilters}
+                  selectedFacilityId={selectedFacilityId}
                   selectedFacilityName={selectedFacilityName}
                   showFacilityFilter={showFacilityFilter}
+                  facilities={facilityOptions.map(f => ({ id: f.id, name: f.name }))}
+                  onFilterChange={onFilterChange}
                   onRemoveFilter={onRemoveFilter}
                 />
 

--- a/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
@@ -75,6 +75,8 @@ export function RepairRequestsToolbar({
   }, [filterValue, onFilterChange])
 
   const handleFacilityChange = React.useCallback((values: string[]) => {
+    // Facility stays single-select even though FacetedMultiSelectFilter emits string[]:
+    // keep the newly toggled value, clear on toggle-off, and revisit if true multi-select is needed.
     const currentValue = selectedFacilityId != null ? String(selectedFacilityId) : null
     const nextValue = values.find((value) => value !== currentValue) ?? values.at(-1) ?? null
 
@@ -182,15 +184,13 @@ export function RepairRequestsToolbar({
   )
 }
 
-function DateFilterButton({
-  label,
-  value,
-  onChange,
-}: {
-  label: string
-  value: Date | null
-  onChange: (date: Date | null) => void
-}) {
+interface DateFilterButtonProps {
+  readonly label: string
+  readonly value: Date | null
+  readonly onChange: (date: Date | null) => void
+}
+
+function DateFilterButton({ label, value, onChange }: DateFilterButtonProps) {
   return (
     <Popover>
       <PopoverTrigger asChild>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
@@ -1,10 +1,16 @@
 "use client"
 
 import * as React from "react"
+import { parseISO } from "date-fns"
 import { Button } from "@/components/ui/button"
-import { FilterX } from "lucide-react"
-import { SearchInput } from "@/components/shared/SearchInput"
+import { Calendar as CalendarIcon, FilterX } from "lucide-react"
+import { Calendar } from "@/components/ui/calendar"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
+import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
+import { cn } from "@/lib/utils"
 import { RepairRequestsFilterChips, type FilterChipsValue } from "./RepairRequestsFilterChips"
+import { REPAIR_REQUEST_STATUS_OPTIONS, type FilterModalValue } from "./RepairRequestsFilterModal"
 import type { UiFilters as UiFiltersPrefs } from "@/lib/rr-prefs"
 
 interface RepairRequestsToolbarProps {
@@ -14,11 +20,21 @@ interface RepairRequestsToolbarProps {
   isFiltered: boolean
   onClearFilters: () => void
   onOpenFilterModal: () => void
+  compactFilters?: boolean
   // Filter chips
   uiFilters: UiFiltersPrefs
+  selectedFacilityId: number | null
   selectedFacilityName: string | null
   showFacilityFilter: boolean
+  facilities: { id: number; name: string }[]
+  onFilterChange: (v: FilterModalValue) => void
   onRemoveFilter: (key: keyof FilterChipsValue, sub?: string) => void
+}
+
+const parseFilterDate = (value: string | null | undefined) => {
+  if (!value) return null
+  const date = parseISO(value)
+  return Number.isNaN(date.getTime()) ? null : date
 }
 
 export function RepairRequestsToolbar({
@@ -28,60 +44,174 @@ export function RepairRequestsToolbar({
   isFiltered,
   onClearFilters,
   onOpenFilterModal,
+  compactFilters = false,
   uiFilters,
+  selectedFacilityId,
   selectedFacilityName,
   showFacilityFilter,
+  facilities,
+  onFilterChange,
   onRemoveFilter,
 }: RepairRequestsToolbarProps) {
-  return (
+  const dateRange = uiFilters.dateRange && (uiFilters.dateRange.from || uiFilters.dateRange.to)
+    ? {
+      from: parseFilterDate(uiFilters.dateRange.from),
+      to: parseFilterDate(uiFilters.dateRange.to),
+    }
+    : null
+
+  const filterValue = React.useMemo<FilterModalValue>(() => ({
+    status: uiFilters.status,
+    facilityId: selectedFacilityId ?? null,
+    dateRange,
+  }), [dateRange, selectedFacilityId, uiFilters.status])
+
+  const applyFilterChange = React.useCallback((patch: Partial<FilterModalValue>) => {
+    onFilterChange({
+      status: patch.status ?? filterValue.status,
+      facilityId: patch.facilityId === undefined ? filterValue.facilityId ?? null : patch.facilityId,
+      dateRange: patch.dateRange === undefined ? filterValue.dateRange ?? null : patch.dateRange,
+    })
+  }, [filterValue, onFilterChange])
+
+  const handleFacilityChange = React.useCallback((values: string[]) => {
+    const currentValue = selectedFacilityId != null ? String(selectedFacilityId) : null
+    const nextValue = values.find((value) => value !== currentValue) ?? values.at(-1) ?? null
+
+    applyFilterChange({ facilityId: nextValue ? Number(nextValue) : null })
+  }, [applyFilterChange, selectedFacilityId])
+
+  const setDateRangePart = React.useCallback((key: "from" | "to", date: Date | null) => {
+    applyFilterChange({
+      dateRange: {
+        from: key === "from" ? date : filterValue.dateRange?.from ?? null,
+        to: key === "to" ? date : filterValue.dateRange?.to ?? null,
+      },
+    })
+  }, [applyFilterChange, filterValue.dateRange])
+
+  const statusOptions = React.useMemo(() => REPAIR_REQUEST_STATUS_OPTIONS.map((status) => ({
+    label: status,
+    value: status,
+  })), [])
+
+  const facilityOptions = React.useMemo(() => facilities.map((facility) => ({
+    label: facility.name,
+    value: String(facility.id),
+  })), [facilities])
+
+  const filterControls = (
     <>
-      <div className="flex items-center justify-between gap-2 flex-wrap mb-2 md:mb-3">
-        <div className="flex flex-1 items-center gap-2">
-          <SearchInput
-            ref={searchInputRef}
-            placeholder="Tìm thiết bị, mô tả..."
-            value={searchTerm}
-            onChange={onSearchChange}
-            showSearchIcon={false}
-            className="h-8 w-[120px] md:w-[200px] lg:w-[250px] touch-target-sm md:h-8"
-          />
-
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8 touch-target-sm"
-            onClick={onOpenFilterModal}
-          >
-            Bộ lọc
-          </Button>
-
-          {isFiltered && (
-            <Button
-              variant="ghost"
-              onClick={onClearFilters}
-              className="h-8 px-2 lg:px-3 touch-target-sm md:h-8"
-              aria-label="Xóa bộ lọc"
-            >
-              <span className="hidden sm:inline">Xóa</span>
-              <FilterX className="h-4 w-4 sm:ml-2" />
-            </Button>
-          )}
-        </div>
-
-        <div className="w-full pt-2">
-          <RepairRequestsFilterChips
-            value={{
-              status: uiFilters.status,
-              facilityName: selectedFacilityName,
-              dateRange: uiFilters.dateRange
-                ? { from: uiFilters.dateRange.from ?? null, to: uiFilters.dateRange.to ?? null }
-                : null,
-            }}
-            showFacility={showFacilityFilter}
-            onRemove={onRemoveFilter}
-          />
-        </div>
-      </div>
+      <FacetedMultiSelectFilter
+        title="Trạng thái"
+        options={statusOptions}
+        value={filterValue.status}
+        onChange={(values) => applyFilterChange({ status: values })}
+      />
+      {showFacilityFilter ? (
+        <FacetedMultiSelectFilter
+          title="Cơ sở"
+          options={facilityOptions}
+          value={selectedFacilityId != null ? [String(selectedFacilityId)] : []}
+          onChange={handleFacilityChange}
+        />
+      ) : null}
+      <DateFilterButton
+        label="Từ ngày"
+        value={filterValue.dateRange?.from ?? null}
+        onChange={(date) => setDateRangePart("from", date)}
+      />
+      <DateFilterButton
+        label="Đến ngày"
+        value={filterValue.dateRange?.to ?? null}
+        onChange={(date) => setDateRangePart("to", date)}
+      />
     </>
+  )
+
+  const mobileFilterControl = (
+    <Button
+      variant="outline"
+      size="sm"
+      className="h-9 touch-target-sm"
+      onClick={onOpenFilterModal}
+    >
+      Bộ lọc
+    </Button>
+  )
+
+  const clearAction = isFiltered ? (
+    <Button
+      variant="ghost"
+      onClick={onClearFilters}
+      className="h-9 px-2 lg:px-3 touch-target-sm"
+      aria-label="Xóa bộ lọc"
+    >
+      <span className="hidden sm:inline">Xóa</span>
+      <FilterX className="h-4 w-4 sm:ml-2" />
+    </Button>
+  ) : null
+
+  return (
+    <ListFilterSearchCard
+      surface="plain"
+      searchInputRef={searchInputRef}
+      searchValue={searchTerm}
+      onSearchChange={onSearchChange}
+      searchPlaceholder="Tìm thiết bị, mô tả..."
+      showSearchIcon={false}
+      searchClassName="md:min-w-[220px] md:max-w-[320px] xl:min-w-[260px]"
+      filterControls={filterControls}
+      mobileFilterControl={mobileFilterControl}
+      compactFilters={compactFilters}
+      actions={clearAction}
+      chips={
+        <RepairRequestsFilterChips
+          value={{
+            status: uiFilters.status,
+            facilityName: selectedFacilityName,
+            dateRange: uiFilters.dateRange
+              ? { from: uiFilters.dateRange.from ?? null, to: uiFilters.dateRange.to ?? null }
+              : null,
+          }}
+          showFacility={showFacilityFilter}
+          onRemove={onRemoveFilter}
+        />
+      }
+    />
+  )
+}
+
+function DateFilterButton({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: Date | null
+  onChange: (date: Date | null) => void
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className={cn("h-9 min-w-[116px] justify-start", !value && "text-muted-foreground")}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {value ? value.toLocaleDateString("vi-VN") : label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0 z-[1100]" align="start">
+        <Calendar
+          mode="single"
+          selected={value ?? undefined}
+          onSelect={(date) => onChange(date ?? null)}
+          initialFocus
+        />
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/src/components/shared/ListFilterSearchCard.tsx
+++ b/src/components/shared/ListFilterSearchCard.tsx
@@ -10,8 +10,10 @@ export interface ListFilterSearchCardProps {
   title?: React.ReactNode
   description?: React.ReactNode
   tenantControl?: React.ReactNode
+  surface?: "card" | "plain"
   searchValue: string
   onSearchChange: (value: string) => void
+  searchInputRef?: React.Ref<HTMLInputElement>
   searchPlaceholder: string
   searchEndAddon?: React.ReactNode
   showSearchIcon?: boolean
@@ -29,8 +31,10 @@ export function ListFilterSearchCard({
   title,
   description,
   tenantControl,
+  surface = "card",
   searchValue,
   onSearchChange,
+  searchInputRef,
   searchPlaceholder,
   searchEndAddon,
   showSearchIcon = true,
@@ -45,9 +49,10 @@ export function ListFilterSearchCard({
 }: ListFilterSearchCardProps) {
   const visibleFilterControls = compactFilters ? mobileFilterControl : filterControls
 
-  return (
-    <Card className={className}>
-      {(title || description) ? (
+  const header = !title && !description
+    ? null
+    : surface === "card"
+      ? (
         <CardHeader className="space-y-1 pb-3">
           {title ? (
             <CardTitle className="heading-responsive-h2">{title}</CardTitle>
@@ -56,49 +61,78 @@ export function ListFilterSearchCard({
             <CardDescription className="body-responsive-sm">{description}</CardDescription>
           ) : null}
         </CardHeader>
-      ) : null}
+      )
+      : (
+        <div className="space-y-1 pb-3">
+          {title ? (
+            <div className="heading-responsive-h2 font-semibold">{title}</div>
+          ) : null}
+          {description ? (
+            <div className="body-responsive-sm text-muted-foreground">{description}</div>
+          ) : null}
+        </div>
+      )
 
-      <CardContent className="space-y-3 px-4 pb-4 md:px-6">
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-          <div className="flex min-w-0 flex-1 flex-col gap-2 md:flex-row md:flex-wrap md:items-center">
-            {tenantControl ? (
-              <div className="w-full md:w-auto md:min-w-[220px] xl:min-w-[260px]">
-                {tenantControl}
-              </div>
-            ) : null}
-
-            <div className={cn("w-full md:min-w-[280px] md:max-w-[460px] md:flex-1", searchClassName)}>
-              <SearchInput
-                placeholder={searchPlaceholder}
-                value={searchValue}
-                onChange={onSearchChange}
-                showSearchIcon={showSearchIcon}
-                className="h-9 w-full"
-                endAddon={searchEndAddon}
-                aria-label={searchPlaceholder}
-              />
+  const content = (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex min-w-0 flex-1 flex-col gap-2 md:flex-row md:flex-wrap md:items-center">
+          {tenantControl ? (
+            <div className="w-full md:w-auto md:min-w-[220px] xl:min-w-[260px]">
+              {tenantControl}
             </div>
+          ) : null}
 
-            {visibleFilterControls ? (
-              <div className="flex w-full flex-wrap items-center gap-2 md:w-auto">
-                {visibleFilterControls}
-              </div>
-            ) : null}
+          <div className={cn("w-full md:min-w-[280px] md:max-w-[460px] md:flex-1", searchClassName)}>
+            <SearchInput
+              ref={searchInputRef}
+              placeholder={searchPlaceholder}
+              value={searchValue}
+              onChange={onSearchChange}
+              showSearchIcon={showSearchIcon}
+              className="h-9 w-full"
+              endAddon={searchEndAddon}
+              aria-label={searchPlaceholder}
+            />
           </div>
 
-          {(selectionActions || actions) ? (
-            <div className="flex w-full flex-wrap items-center justify-between gap-2 xl:w-auto xl:justify-end">
-              {selectionActions ? (
-                <div className="min-w-0 shrink-0">{selectionActions}</div>
-              ) : null}
-              {actions ? (
-                <div className="flex items-center gap-2">{actions}</div>
-              ) : null}
+          {visibleFilterControls ? (
+            <div className="flex w-full flex-wrap items-center gap-2 md:w-auto">
+              {visibleFilterControls}
             </div>
           ) : null}
         </div>
 
-        {chips ? <div>{chips}</div> : null}
+        {(selectionActions || actions) ? (
+          <div className="flex w-full flex-wrap items-center justify-between gap-2 xl:w-auto xl:justify-end">
+            {selectionActions ? (
+              <div className="min-w-0 shrink-0">{selectionActions}</div>
+            ) : null}
+            {actions ? (
+              <div className="flex items-center gap-2">{actions}</div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      {chips ? <div>{chips}</div> : null}
+    </div>
+  )
+
+  if (surface === "plain") {
+    return (
+      <div className={className}>
+        {header}
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <Card className={className}>
+      {header}
+      <CardContent className="px-4 pb-4 md:px-6">
+        {content}
       </CardContent>
     </Card>
   )

--- a/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
+++ b/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
@@ -54,4 +54,33 @@ describe("ListFilterSearchCard", () => {
     expect(screen.getByTestId("selection-actions")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Tùy chọn" })).toBeInTheDocument()
   })
+
+  it("can render as a plain surface for embedding inside an existing card", () => {
+    const { container } = render(
+      <ListFilterSearchCard
+        surface="plain"
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Tìm kiếm chung..."
+      />
+    )
+
+    expect(container.firstElementChild).not.toHaveClass("rounded-lg")
+    expect(container.firstElementChild).not.toHaveClass("border")
+  })
+
+  it("forwards searchInputRef to the search input", () => {
+    const searchInputRef = React.createRef<HTMLInputElement>()
+
+    render(
+      <ListFilterSearchCard
+        searchInputRef={searchInputRef}
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Tìm kiếm chung..."
+      />
+    )
+
+    expect(searchInputRef.current).toBe(screen.getByRole("searchbox", { name: "Tìm kiếm chung..." }))
+  })
 })


### PR DESCRIPTION
## Summary
- Roll out `ListFilterSearchCard` to the Repair Requests page.
- Split Repair Requests desktop filters inline like Equipment while keeping compact/mobile filter access via the existing modal/sheet trigger.
- Add `surface="plain"` and `searchInputRef` support to the shared card for embedded, keyboard-focusable surfaces.
- Group `RepairRequestsPageLayout` state props to keep React Doctor clean.

## Follow-up
- Opened #413 for the remaining non-repair filter/search pages.
- Refs #410; keeping #410 open as the umbrella issue.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js exec vitest run src/components/shared/__tests__/ListFilterSearchCard.test.tsx --reporter=dot`
- `node scripts/npm-run.js exec vitest run 'src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx' --reporter=dot`
- `node scripts/npm-run.js exec vitest run 'src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx' --reporter=dot`
- `node scripts/npm-run.js exec vitest run src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx --reporter=dot`
- `git diff --check`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` -> 100/100, no issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls out the shared filter/search UI to the Repair Requests page with inline desktop filters and a compact mobile trigger. Refactors the toolbar to use `ListFilterSearchCard` (plain surface + input ref) and groups layout props into state objects. Progress toward Linear #410.

- New Features
  - Inline filters on desktop: status, facility, and from/to date via calendar popovers; keep mobile modal/sheet via `compactFilters`.
  - `ListFilterSearchCard` adds `surface="plain"` and `searchInputRef`; toolbar integrates chips and a clear action.
  - Exported `REPAIR_REQUEST_STATUS_OPTIONS`; toolbar uses faceted filters and passes facility options; added tests for toolbar and card.
  - Grouped layout props into `accessState`, `summaryState`, `filterState`, and `listState`.

- Bug Fixes
  - Hide facility filter when out of scope; facility selection stays single-select.
  - Safer date parsing from prefs and stricter boolean checks; ensures search ref forwards to the input.

<sup>Written for commit b05902de338bb01776d068b7d0ec6b820c5a46c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized repair request filter toolbar and layout component structure for improved maintainability.
  * Consolidated filter, search, and mobile UI controls using a unified card-based layout component.

* **Tests**
  * Added comprehensive test coverage for repair request toolbar filter behavior.
  * Updated layout tests to verify reorganized component state structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->