### PR TITLE
Fix tenant selector search normalization

### DIFF
--- a/src/components/shared/TenantSelectorSheet.tsx
+++ b/src/components/shared/TenantSelectorSheet.tsx
@@ -10,6 +10,7 @@
 
 import * as React from "react"
 import { Building2, Check, Search, X } from "lucide-react"
+import { includesNormalizedSearch, normalizeSearchText } from "@/lib/search-normalize"
 import { cn } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -51,10 +52,10 @@ export function TenantSelectorSheet({
 
   // Memoize filtered facilities (per rerender-memo)
   const filteredFacilities = React.useMemo(() => {
-    if (!searchTerm.trim()) return facilities
-    const query = searchTerm.trim().toLowerCase()
+    const query = normalizeSearchText(searchTerm)
+    if (!query) return facilities
     return facilities.filter((facility) =>
-      facility.name.toLowerCase().includes(query)
+      includesNormalizedSearch(facility.name, query)
     )
   }, [searchTerm, facilities])
 

--- a/src/components/shared/__tests__/TenantSelectorSheet.test.tsx
+++ b/src/components/shared/__tests__/TenantSelectorSheet.test.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import type { FacilityOption } from "@/types/tenant"
+import { useTenantSelection } from "@/contexts/TenantSelectionContext"
+import { TenantSelectorSheet } from "../TenantSelectorSheet"
+
+vi.mock("@/contexts/TenantSelectionContext", () => ({
+  useTenantSelection: vi.fn(),
+}))
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ open, children }: { open: boolean; children: React.ReactNode }) => (
+    open ? <div data-testid="tenant-selector-sheet">{children}</div> : null
+  ),
+  SheetContent: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+const mockUseTenantSelection = vi.mocked(useTenantSelection)
+
+const FACILITIES: FacilityOption[] = [
+  { id: 1, name: "Bệnh viện Đa khoa An Giang", count: 4 },
+  { id: 2, name: "Bệnh viện Đa khoa Cần Thơ", count: 7 },
+]
+
+function renderSheet() {
+  mockUseTenantSelection.mockReturnValue({
+    selectedFacilityId: undefined,
+    setSelectedFacilityId: vi.fn(),
+    facilities: FACILITIES,
+    showSelector: true,
+    isLoading: false,
+    shouldFetchData: false,
+  })
+
+  render(<TenantSelectorSheet open onOpenChange={vi.fn()} />)
+}
+
+describe("TenantSelectorSheet", () => {
+  it("matches facility search without accents or case sensitivity", async () => {
+    const user = userEvent.setup()
+    renderSheet()
+
+    await user.type(screen.getByPlaceholderText("Tìm kiếm cơ sở..."), "can tho")
+
+    expect(screen.getByRole("button", { name: /Bệnh viện Đa khoa Cần Thơ/ })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Bệnh viện Đa khoa An Giang/ })).not.toBeInTheDocument()
+  })
+
+  it("matches composed facility names with decomposed Unicode input", async () => {
+    const user = userEvent.setup()
+    renderSheet()
+
+    await user.type(screen.getByPlaceholderText("Tìm kiếm cơ sở..."), "Ca\u0302\u0300n tho")
+
+    expect(screen.getByRole("button", { name: /Bệnh viện Đa khoa Cần Thơ/ })).toBeInTheDocument()
+  })
+})

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -14,6 +14,7 @@
 import * as React from "react"
 import type { Column } from "@tanstack/react-table"
 import { Check, Filter, Search } from "lucide-react"
+import { includesNormalizedSearch, normalizeSearchText } from "@/lib/search-normalize"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -83,11 +84,11 @@ export function FacetedMultiSelectFilter<TData, TValue>({
     )
 
     const visibleOptions = React.useMemo(() => {
-        const normalizedSearch = debouncedOptionSearch.trim().toLocaleLowerCase()
+        const normalizedSearch = normalizeSearchText(debouncedOptionSearch)
         if (!normalizedSearch) return options
         return options.filter((option) =>
-            option.label.toLocaleLowerCase().includes(normalizedSearch) ||
-            option.value.toLocaleLowerCase().includes(normalizedSearch)
+            includesNormalizedSearch(option.label, normalizedSearch) ||
+            includesNormalizedSearch(option.value, normalizedSearch)
         )
     }, [debouncedOptionSearch, options])
 

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
@@ -94,6 +94,11 @@ const OPTIONS = [
     { label: 'Radiology', value: 'Radiology' },
 ]
 
+const FACILITY_OPTIONS = [
+    { label: 'Bệnh viện Đa khoa Cần Thơ', value: 'can-tho' },
+    { label: 'Bệnh viện Đa khoa An Giang', value: 'an-giang' },
+]
+
 const EMPTY_CONTROLLED_VALUE: string[] = []
 
 afterEach(() => {
@@ -177,6 +182,23 @@ describe('FacetedMultiSelectFilter', () => {
         expect(screen.queryByRole('button', { name: 'ICU' })).not.toBeInTheDocument()
         expect(screen.queryByRole('button', { name: 'Surgery' })).not.toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Radiology' })).toBeInTheDocument()
+    })
+
+    it('matches option search without accents or case sensitivity', async () => {
+        vi.useFakeTimers()
+        render(<FacetedMultiSelectFilter title="Cơ sở" options={FACILITY_OPTIONS} />)
+        fireEvent.click(screen.getByText('Cơ sở'))
+
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Tìm lựa chọn Cơ sở' }), {
+            target: { value: 'can tho' },
+        })
+
+        act(() => {
+            vi.advanceTimersByTime(300)
+        })
+
+        expect(screen.getByRole('button', { name: 'Bệnh viện Đa khoa Cần Thơ' })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Bệnh viện Đa khoa An Giang' })).not.toBeInTheDocument()
     })
 
     it('does not change filter selection while typing internal option search', async () => {

--- a/src/lib/search-normalize.ts
+++ b/src/lib/search-normalize.ts
@@ -1,0 +1,17 @@
+const COMBINING_MARKS = /[\u0300-\u036f]/g
+const MULTIPLE_WHITESPACE = /\s+/g
+
+export function normalizeSearchText(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(COMBINING_MARKS, "")
+    .replace(/[đĐ]/g, "d")
+    .toLocaleLowerCase("vi-VN")
+    .trim()
+    .replace(MULTIPLE_WHITESPACE, " ")
+}
+
+export function includesNormalizedSearch(source: string, normalizedSearch: string): boolean {
+  if (!normalizedSearch) return true
+  return normalizeSearchText(source).includes(normalizedSearch)
+}


### PR DESCRIPTION
## Summary
- Add shared client-side search normalization for tenant/facility option matching.
- Make TenantSelectorSheet and FacetedMultiSelectFilter search case-insensitive, accent-insensitive, and Unicode-normalized.
- Add focused TDD coverage for  / decomposed Unicode matching against .

## Follow-up
- Server-side FTS / paginated search is tracked separately in #415 for larger future datasets.

## Verification
- RED first: focused tests failed on  / decomposed Unicode search before implementation.
- 
> nextn@0.1.0 verify:no-explicit-any
> node scripts/check-no-explicit-any-in-diff.js

No explicit any found in changed TypeScript files.
- 
> nextn@0.1.0 typecheck
> tsc --noEmit
- 
> nextn@0.1.0 test:run
> vitest run src/components/shared/__tests__/TenantSelectorSheet.test.tsx src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx


 RUN  v4.0.17 /root/qltbyt-nam-phong

 ✓ src/components/shared/__tests__/TenantSelectorSheet.test.tsx (2 tests) 531ms
     ✓ matches facility search without accents or case sensitivity  423ms
 ✓ src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx (20 tests) 1155ms

 Test Files  2 passed (2)
      Tests  22 passed (22)
   Start at  08:38:55
   Duration  3.09s (transform 323ms, setup 159ms, import 1.99s, tests 1.69s, environment 1.15s)
- react-doctor v0.0.47

✔ Select projects to scan › nextn
Scanning changes: fix-tenant-selector-search-normalization → main

Scanning /root/qltbyt-nam-phong...


No issues found!

  ┌─────┐
  │ ◠ ◠ │
  │  ▽  │
  └─────┘
  React Doctor (www.react.doctor)

  100 / 100  Great

  ██████████████████████████████████████████████████ (100/100)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tenant and option searches to be case-, accent-, and Unicode-insensitive for Vietnamese names. Users can now find facilities with or without accents or decomposed characters.

- **Bug Fixes**
  - Added `normalizeSearchText` and `includesNormalizedSearch` in `src/lib/search-normalize.ts` (NFD normalization, strip combining marks, map `đ/Đ`→`d`, lowercase, trim/collapse spaces).
  - Updated `TenantSelectorSheet` and `FacetedMultiSelectFilter` to use normalized matching.
  - Added tests covering accentless and decomposed Unicode queries.

<sup>Written for commit f9be829aa7d00c5d66a308d307bb11bb65d60e62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

