### PR TITLE
fix(transfers): use inline shared filters

### DIFF
--- a/src/app/(app)/transfers/_components/TransfersDateFilterButton.tsx
+++ b/src/app/(app)/transfers/_components/TransfersDateFilterButton.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import { Calendar as CalendarIcon } from "lucide-react"
+
+import { Calendar } from "@/components/ui/calendar"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+
+type TransfersDateFilterButtonProps = Readonly<{
+  label: string
+  value: Date | null
+  onChange: (date: Date | null) => void
+}>
+
+export function TransfersDateFilterButton({
+  label,
+  value,
+  onChange,
+}: TransfersDateFilterButtonProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className={cn(
+            "h-9 min-w-[116px] justify-start",
+            !value && "text-muted-foreground",
+          )}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {value ? value.toLocaleDateString("vi-VN") : label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0 z-[1100]" align="start">
+        <Calendar
+          mode="single"
+          selected={value ?? undefined}
+          onSelect={(date) => onChange(date ?? null)}
+          initialFocus
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/app/(app)/transfers/_components/TransfersPageContent.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPageContent.tsx
@@ -112,11 +112,13 @@ export function TransfersPageContent({ user }: TransfersPageContentProps) {
           onOpenAddDialog={() => controller.setIsAddDialogOpen(true)}
           filterChipsValue={controller.filterChipsValue}
           onRemoveFilter={controller.filtersState.handleRemoveFilter}
-            onClearAllFilters={controller.filtersState.handleClearAllFilters}
-            searchTerm={controller.filtersState.searchTerm}
-            onSearchTermChange={controller.filtersState.setSearchTerm}
-            filterVariant={controller.filterVariant}
-            viewMode={controller.viewMode}
+          onClearAllFilters={controller.filtersState.handleClearAllFilters}
+          searchTerm={controller.filtersState.searchTerm}
+          onSearchTermChange={controller.filtersState.setSearchTerm}
+          filterValue={controller.filterModalValue}
+          onFilterChange={controller.setFilterModalValue}
+          filterVariant={controller.filterVariant}
+          viewMode={controller.viewMode}
           dataState={{
             shouldFetch: controller.shouldFetchData,
             isLoading: controller.isListLoading,

--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -11,8 +11,10 @@ import { Filter, Loader2, PlusCircle } from "lucide-react"
 import { DataTablePagination } from "@/components/shared/DataTablePagination"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { TenantSelector } from "@/components/shared/TenantSelector"
+import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { TransferCard } from "@/components/transfers/TransferCard"
 import { FilterChips, type FilterChipsValue } from "@/components/transfers/FilterChips"
+import type { FilterModalValue } from "@/components/transfers/FilterModal"
 import { TransferTypeTabs } from "@/components/transfers/TransferTypeTabs"
 import { TransfersKanbanView } from "@/components/transfers/TransfersKanbanView"
 import { TransfersSearchParamsBoundary } from "@/components/transfers/TransfersSearchParamsBoundary"
@@ -28,9 +30,12 @@ import type {
   TransferKanbanResponse,
   TransferListFilters,
   TransferListItem,
+  TransferStatus,
   TransferType,
 } from "@/types/transfers-data-grid"
+import { TRANSFER_STATUS_LABELS } from "@/types/transfers-data-grid"
 
+import { TransfersDateFilterButton } from "./TransfersDateFilterButton"
 import type { TransferUserRole } from "./TransfersTypes"
 
 export type TransfersPagePanelPermissions = Readonly<{
@@ -58,6 +63,8 @@ type TransfersPagePanelProps = Readonly<{
   onClearAllFilters: () => void
   searchTerm: string
   onSearchTermChange: (value: string) => void
+  filterValue: FilterModalValue
+  onFilterChange: (value: FilterModalValue) => void
   filterVariant: "dialog" | "sheet"
   viewMode: "table" | "kanban"
   dataState: TransfersPagePanelDataState
@@ -106,6 +113,8 @@ export function TransfersPagePanel({
   onClearAllFilters,
   searchTerm,
   onSearchTermChange,
+  filterValue,
+  onFilterChange,
   filterVariant,
   viewMode,
   dataState,
@@ -129,6 +138,26 @@ export function TransfersPagePanel({
   const { shouldFetch, isLoading: isListLoading, isFetching: isListFetching } = dataState
   const transferTypeCounts = getTransferTypeCounts(activeTab, transferCounts, totalCount)
   const compactFilters = filterVariant === "sheet"
+  const statusOptions = React.useMemo(
+    () =>
+      (Object.entries(TRANSFER_STATUS_LABELS) as [TransferStatus, string][]).map(
+        ([value, label]) => ({ value, label }),
+      ),
+    [],
+  )
+
+  const setDateRangePart = React.useCallback(
+    (key: "from" | "to", date: Date | null) => {
+      onFilterChange({
+        ...filterValue,
+        dateRange: {
+          from: key === "from" ? date : filterValue.dateRange?.from ?? null,
+          to: key === "to" ? date : filterValue.dateRange?.to ?? null,
+        },
+      })
+    },
+    [filterValue, onFilterChange],
+  )
 
   const filterButton = (
     <Button
@@ -146,6 +175,29 @@ export function TransfersPagePanel({
     </Button>
   )
 
+  const filterControls = (
+    <>
+      <FacetedMultiSelectFilter
+        title="Trạng thái"
+        options={statusOptions}
+        value={filterValue.statuses}
+        onChange={(statuses) =>
+          onFilterChange({ ...filterValue, statuses: statuses as TransferStatus[] })
+        }
+      />
+      <TransfersDateFilterButton
+        label="Từ ngày"
+        value={filterValue.dateRange?.from ?? null}
+        onChange={(date) => setDateRangePart("from", date)}
+      />
+      <TransfersDateFilterButton
+        label="Đến ngày"
+        value={filterValue.dateRange?.to ?? null}
+        onChange={(date) => setDateRangePart("to", date)}
+      />
+    </>
+  )
+
   return (
     <Card>
       <CardContent className="space-y-4">
@@ -157,7 +209,7 @@ export function TransfersPagePanel({
           onSearchChange={onSearchTermChange}
           searchPlaceholder="Tìm kiếm mã yêu cầu, thiết bị, lý do..."
           showSearchIcon={true}
-          filterControls={filterButton}
+          filterControls={filterControls}
           mobileFilterControl={filterButton}
           compactFilters={compactFilters}
           actions={(
@@ -166,7 +218,10 @@ export function TransfersPagePanel({
                 <TransfersViewToggle />
               </div>
               {!isRegionalLeader && (
-                <Button onClick={onOpenAddDialog} className="h-11 gap-2 font-medium sm:h-9">
+                <Button
+                  onClick={onOpenAddDialog}
+                  className="h-11 gap-2 font-medium sm:h-9"
+                >
                   <PlusCircle className="h-5 w-5 sm:h-4 sm:w-4" />
                   Tạo yêu cầu mới
                 </Button>

--- a/src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx
+++ b/src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx
@@ -9,26 +9,14 @@ import { makeTransferItem } from "@/test-utils/transfers-fixtures"
 import type {
   TransferListFilters,
   TransferListItem,
+  TransferStatus,
   TransferType,
 } from "@/types/transfers-data-grid"
-// --- Heavy children: replaced with simple sentinels ---------------------
-
 vi.mock("@/components/shared/TenantSelector", () => ({
   TenantSelector: () => <div data-testid="tenant-selector" />,
 }))
 vi.mock("@/components/shared/ListFilterSearchCard", () => ({
-  ListFilterSearchCard: ({
-    surface,
-    tenantControl,
-    searchValue,
-    onSearchChange,
-    searchPlaceholder,
-    filterControls,
-    mobileFilterControl,
-    compactFilters,
-    actions,
-    chips,
-  }: {
+  ListFilterSearchCard: (props: {
     surface?: "card" | "plain"
     tenantControl?: React.ReactNode
     searchValue: string
@@ -39,86 +27,85 @@ vi.mock("@/components/shared/ListFilterSearchCard", () => ({
     compactFilters?: boolean
     actions?: React.ReactNode
     chips?: React.ReactNode
-  }) => (
-    <div
-      data-testid="list-filter-search-card"
-      data-surface={surface ?? "card"}
-      data-compact-filters={compactFilters ? "true" : "false"}
-      data-placeholder={searchPlaceholder}
-      data-has-mobile-filter={mobileFilterControl ? "true" : "false"}
-    >
-      <div data-testid="tenant-control-slot">{tenantControl}</div>
+  }) => {
+    const visibleFilters = props.compactFilters ? props.mobileFilterControl : props.filterControls
+    return (
+      <div
+        data-testid="list-filter-search-card"
+        data-surface={props.surface ?? "card"}
+        data-compact-filters={props.compactFilters ? "true" : "false"}
+        data-placeholder={props.searchPlaceholder}
+        data-has-mobile-filter={props.mobileFilterControl ? "true" : "false"}
+      >
+      <div data-testid="tenant-control-slot">{props.tenantControl}</div>
       <input
         aria-label="shared-transfer-search"
-        value={searchValue}
-        onChange={(event) => onSearchChange(event.target.value)}
+        value={props.searchValue}
+        onChange={(event) => props.onSearchChange(event.target.value)}
       />
-      <button type="button" onClick={() => onSearchChange("")}>
+      <button type="button" onClick={() => props.onSearchChange("")}>
         shared-clear-search
       </button>
-      <div data-testid="visible-filter-slot">
-        {compactFilters ? mobileFilterControl : filterControls}
-      </div>
-      <div data-testid="actions-slot">{actions}</div>
-      <div data-testid="chips-slot">{chips}</div>
+      <div data-testid="visible-filter-slot">{visibleFilters}</div>
+      <div data-testid="actions-slot">{props.actions}</div>
+      <div data-testid="chips-slot">{props.chips}</div>
     </div>
+  )},
+}))
+vi.mock("@/components/shared/table-filters/FacetedMultiSelectFilter", () => ({
+  FacetedMultiSelectFilter: (props: {
+    title?: string
+    value?: string[]
+    onChange?: (values: string[]) => void
+  }) => (
+    <button
+      type="button"
+      data-testid="transfer-status-filter"
+      data-value={(props.value ?? []).join(",")}
+      onClick={() => props.onChange?.(["da_duyet"])}
+    >
+      {props.title}
+    </button>
   ),
 }))
-
 vi.mock("@/components/shared/DataTablePagination", () => ({
   DataTablePagination: () => <div data-testid="data-table-pagination" />,
 }))
-
 vi.mock("@/components/transfers/TransferCard", () => ({
   TransferCard: ({ transfer }: { transfer: TransferListItem }) => (
     <div data-testid={`transfer-card-${transfer.id}`}>{transfer.ma_yeu_cau}</div>
   ),
 }))
-
 vi.mock("@/components/transfers/FilterChips", () => ({
   FilterChips: () => <div data-testid="filter-chips" />,
 }))
-
 vi.mock("@/components/transfers/TransferTypeTabs", () => ({
   TransferTypeTabs: ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="transfer-type-tabs">{children}</div>
   ),
 }))
-
 vi.mock("@/components/transfers/TransfersKanbanView", () => ({
-  TransfersKanbanView: ({
-    initialData,
-  }: {
-    initialData: unknown
-  }) => (
+  TransfersKanbanView: ({ initialData }: { initialData: unknown }) => (
     <div
       data-testid="transfers-kanban-view"
       data-initial={initialData === null ? "null" : "data"}
     />
   ),
 }))
-
 vi.mock("@/components/transfers/TransfersSearchParamsBoundary", () => ({
   TransfersSearchParamsBoundary: ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="search-params-boundary">{children}</div>
   ),
 }))
-
 vi.mock("@/components/transfers/TransfersTableView", () => ({
   TransfersTableView: () => <div data-testid="transfers-table-view" />,
 }))
-
 vi.mock("@/components/transfers/TransfersTenantSelectionPlaceholder", () => ({
-  TransfersTenantSelectionPlaceholder: () => (
-    <div data-testid="tenant-placeholder" />
-  ),
+  TransfersTenantSelectionPlaceholder: () => <div data-testid="tenant-placeholder" />,
 }))
-
 vi.mock("@/components/transfers/TransfersViewToggle", () => ({
   TransfersViewToggle: () => <div data-testid="view-toggle" />,
 }))
-
-// --- Helpers ------------------------------------------------------------
 
 type PanelProps = React.ComponentProps<typeof TransfersPagePanel>
 
@@ -149,6 +136,8 @@ function buildProps(overrides: Partial<PanelProps> = {}): PanelProps {
     onClearAllFilters: vi.fn(),
     searchTerm: "",
     onSearchTermChange: vi.fn(),
+    filterValue: { statuses: [], dateRange: null },
+    onFilterChange: vi.fn(),
     filterVariant: "dialog",
     viewMode: "table",
     tableData: [],
@@ -174,8 +163,6 @@ function buildProps(overrides: Partial<PanelProps> = {}): PanelProps {
 function renderPanel(overrides: Partial<PanelProps> = {}) {
   return render(<TransfersPagePanel {...buildProps(overrides)} />)
 }
-
-// --- Tests --------------------------------------------------------------
 
 describe("TransfersPagePanel grouped props", () => {
   it("renders TenantSelector when permissions.showFacilityFilter=true", () => {
@@ -273,15 +260,15 @@ describe("TransfersPagePanel grouped props", () => {
     expect(screen.getByText(/Đang đồng bộ dữ liệu/)).toBeInTheDocument()
   })
 
-  it("renders activeFilterCount badge when greater than zero", () => {
-    renderPanel({ viewMode: "table", activeFilterCount: 3 })
-    const filterButton = screen.getByRole("button", { name: /Bộ lọc/ })
-    expect(within(filterButton).getByText("3")).toBeInTheDocument()
-  })
-
   it("renders Transfers filters through the shared Equipment-aligned filter card", () => {
+    const onFilterChange = vi.fn()
     renderPanel({
       activeFilterCount: 2,
+      filterValue: {
+        statuses: ["cho_duyet" as TransferStatus],
+        dateRange: null,
+      },
+      onFilterChange,
       permissions: { showFacilityFilter: true, isRegionalLeader: false },
       searchTerm: "YC-001",
     })
@@ -295,9 +282,23 @@ describe("TransfersPagePanel grouped props", () => {
     expect(screen.getByTestId("tenant-control-slot")).toContainElement(
       screen.getByTestId("tenant-selector"),
     )
-    expect(screen.getByTestId("visible-filter-slot")).toContainElement(
-      screen.getByRole("button", { name: /Bộ lọc/ }),
+    const statusFilter = within(screen.getByTestId("visible-filter-slot")).getByTestId(
+      "transfer-status-filter",
     )
+    expect(statusFilter).toHaveAttribute("data-value", "cho_duyet")
+    fireEvent.click(statusFilter)
+    expect(onFilterChange).toHaveBeenCalledWith({
+      statuses: ["da_duyet"],
+      dateRange: null,
+    })
+    expect(within(screen.getByTestId("visible-filter-slot")).getByRole(
+      "button",
+      { name: /Từ ngày/ },
+    )).toBeInTheDocument()
+    expect(within(screen.getByTestId("visible-filter-slot")).queryByRole(
+      "button",
+      { name: /Bộ lọc/ },
+    )).toBeNull()
     expect(screen.getByTestId("actions-slot")).toContainElement(
       screen.getByRole("button", { name: /Tạo yêu cầu mới/ }),
     )
@@ -306,10 +307,12 @@ describe("TransfersPagePanel grouped props", () => {
     )
   })
 
-  it("uses the shared card mobile filter slot when Transfers filters render as a sheet", () => {
+  it("uses the shared card mobile filter slot when Transfers filters render as a sheet", async () => {
+    const onOpenFilterModal = vi.fn()
     renderPanel({
-      activeFilterCount: 1,
+      activeFilterCount: 3,
       filterVariant: "sheet",
+      onOpenFilterModal,
     })
 
     const card = screen.getByTestId("list-filter-search-card")
@@ -318,6 +321,10 @@ describe("TransfersPagePanel grouped props", () => {
     expect(screen.getByTestId("visible-filter-slot")).toContainElement(
       screen.getByRole("button", { name: /Bộ lọc/ }),
     )
+    const filterButton = screen.getByRole("button", { name: /Bộ lọc/ })
+    expect(within(filterButton).getByText("3")).toBeInTheDocument()
+    await userEvent.setup().click(filterButton)
+    expect(onOpenFilterModal).toHaveBeenCalledTimes(1)
   })
 
   it("keeps shared card search interactions wired to Transfers search state", async () => {
@@ -338,12 +345,4 @@ describe("TransfersPagePanel grouped props", () => {
     expect(onSearchTermChange).toHaveBeenLastCalledWith("")
   })
 
-  it("invokes onOpenFilterModal when filter button is clicked", async () => {
-    const onOpenFilterModal = vi.fn()
-    renderPanel({ onOpenFilterModal })
-    await userEvent.setup().click(
-      screen.getByRole("button", { name: /Bộ lọc/ }),
-    )
-    expect(onOpenFilterModal).toHaveBeenCalledTimes(1)
-  })
 })


### PR DESCRIPTION
## Summary
- Replace the Transfers desktop filter dialog trigger with inline shared filter controls.
- Use controlled FacetedMultiSelectFilter for transfer status and Popover date buttons, matching Repair Requests and Equipment desktop behavior.
- Keep the existing FilterModal/Sheet path for compact/mobile mode only.

## Root Cause
PR #423 aligned the Transfers filter/search layout shell with ListFilterSearchCard, but its desktop filterControls slot still contained the old `Bộ lọc` button that opened FilterModal. That left Transfers visually aligned but behaviorally inconsistent with Repair Requests and Equipment.

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx src/components/shared/__tests__/ListFilterSearchCard.test.tsx src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
- git diff --check

Refs #413
Refs #410

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Transfers desktop filter dialog with inline shared filters for status and date to match Repair Requests and Equipment. Keeps the modal/sheet flow for compact/mobile. Aligns with Linear #413.

- New Features
  - Inline desktop filters: `FacetedMultiSelectFilter` for status and popover date pickers via `TransfersDateFilterButton`.
  - Compact/mobile still uses the `Bộ lọc` button to open the modal/sheet.

- Refactors
  - `TransfersPagePanel` now accepts controlled `filterValue` and `onFilterChange`.
  - `ListFilterSearchCard` on desktop renders the inline filters instead of a single filter button.

<sup>Written for commit 2eb4d7610301b2f3f402c2505233ed1b77a22c18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

