### PR TITLE
Fix #413: align Maintenance filters with shared layout

### DIFF
--- a/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
@@ -19,6 +19,7 @@ type MaintenancePlanRequest = {
 
 const mocks = vi.hoisted(() => ({
   useMaintenanceContext: vi.fn(),
+  useTenantSelection: vi.fn(),
   useIsMobile: vi.fn(),
   useFeatureFlag: vi.fn(),
   useSearchDebounce: vi.fn(),
@@ -49,6 +50,10 @@ vi.mock("@tanstack/react-table", () => ({
 
 vi.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => mocks.useIsMobile(),
+}))
+
+vi.mock("@/contexts/TenantSelectionContext", () => ({
+  useTenantSelection: () => mocks.useTenantSelection(),
 }))
 
 vi.mock("@/lib/feature-flags", () => ({
@@ -94,33 +99,32 @@ vi.mock("../_components/maintenance-page-legacy-mobile-cards", () => ({
 
 vi.mock("../_components/maintenance-page-desktop-content", () => ({
   MaintenancePageDesktopContent: ({
-    statusCounts,
-    isCountsLoading,
-    isCountsError,
-    onFacilityChange,
-    onPlanSearchChange,
-    onPageChange,
+    countsState,
+    filterState,
+    planListState,
   }: {
-    statusCounts?: Record<string, number>
-    isCountsLoading?: boolean
-    isCountsError?: boolean
-    onFacilityChange: (facilityId: number | null) => void
-    onPlanSearchChange: (value: string) => void
-    onPageChange: (page: number) => void
+    countsState: {
+      statusCounts?: Record<string, number>
+      isCountsLoading?: boolean
+      isCountsError?: boolean
+    }
+    filterState: {
+      onPlanSearchChange: (value: string) => void
+    }
+    planListState: {
+      onPageChange: (page: number) => void
+    }
   }) => (
     <div
       data-testid="desktop-layout"
-      data-counts={JSON.stringify(statusCounts ?? null)}
-      data-loading={String(Boolean(isCountsLoading))}
-      data-error={String(Boolean(isCountsError))}
+      data-counts={JSON.stringify(countsState.statusCounts ?? null)}
+      data-loading={String(Boolean(countsState.isCountsLoading))}
+      data-error={String(Boolean(countsState.isCountsError))}
     >
-      <button type="button" onClick={() => onFacilityChange(7)}>
-        set-facility
-      </button>
-      <button type="button" onClick={() => onPlanSearchChange("ngoai tim")}>
+      <button type="button" onClick={() => filterState.onPlanSearchChange("ngoai tim")}>
         set-search
       </button>
-      <button type="button" onClick={() => onPageChange(3)}>
+      <button type="button" onClick={() => planListState.onPageChange(3)}>
         set-page-3
       </button>
     </div>
@@ -129,19 +133,19 @@ vi.mock("../_components/maintenance-page-desktop-content", () => ({
 
 vi.mock("../_components/mobile-maintenance-layout", () => ({
   MobileMaintenanceLayout: ({
-    statusCounts,
-    isCountsLoading,
-    isCountsError,
+    countsState,
   }: {
-    statusCounts?: Record<string, number>
-    isCountsLoading?: boolean
-    isCountsError?: boolean
+    countsState: {
+      statusCounts?: Record<string, number>
+      isCountsLoading?: boolean
+      isCountsError?: boolean
+    }
   }) => (
     <div
       data-testid="mobile-layout"
-      data-counts={JSON.stringify(statusCounts ?? null)}
-      data-loading={String(Boolean(isCountsLoading))}
-      data-error={String(Boolean(isCountsError))}
+      data-counts={JSON.stringify(countsState.statusCounts ?? null)}
+      data-loading={String(Boolean(countsState.isCountsLoading))}
+      data-error={String(Boolean(countsState.isCountsError))}
     />
   ),
 }))
@@ -188,11 +192,25 @@ function createMaintenanceContext() {
 }
 
 function expectLastPlanRequest(request: MaintenancePlanRequest): Promise<void> {
-  return waitFor(() => expect(mocks.useMaintenancePlans).toHaveBeenLastCalledWith(request))
+  return waitFor(() => {
+    const lastCall = mocks.useMaintenancePlans.mock.calls.at(-1)
+    expect(lastCall?.[0]).toEqual(request)
+  })
 }
 
 function expectPlanRequestMissing(request: MaintenancePlanRequest): void {
-  expect(mocks.useMaintenancePlans).not.toHaveBeenCalledWith(request)
+  expect(mocks.useMaintenancePlans.mock.calls.map((call) => call[0])).not.toContainEqual(request)
+}
+
+function setTenantSelection(selectedFacilityId: number | null | undefined): void {
+  mocks.useTenantSelection.mockReturnValue({
+    selectedFacilityId,
+    setSelectedFacilityId: vi.fn(),
+    facilities: [],
+    showSelector: true,
+    isLoading: false,
+    shouldFetchData: selectedFacilityId !== undefined,
+  })
 }
 
 describe("Maintenance KPI integration", () => {
@@ -200,6 +218,7 @@ describe("Maintenance KPI integration", () => {
     vi.clearAllMocks()
 
     mocks.useMaintenanceContext.mockReturnValue(createMaintenanceContext())
+    setTenantSelection(null)
     mocks.useIsMobile.mockReturnValue(false)
     mocks.useFeatureFlag.mockReturnValue(false)
     mocks.useSearchDebounce.mockImplementation((value: string) => value)
@@ -224,15 +243,16 @@ describe("Maintenance KPI integration", () => {
     mocks.useTaskColumns.mockReturnValue([])
   })
 
-  it("calls useMaintenancePlanCounts with selectedFacilityId from local state", async () => {
-    render(<MaintenancePageClient />)
+  it("calls useMaintenancePlanCounts with selectedFacilityId from tenant selection context", async () => {
+    setTenantSelection(7)
 
-    fireEvent.click(screen.getByRole("button", { name: "set-facility" }))
+    render(<MaintenancePageClient />)
 
     await waitFor(() =>
       expect(mocks.useMaintenancePlanCounts).toHaveBeenLastCalledWith({
         facilityId: 7,
         search: undefined,
+        enabled: true,
       })
     )
   })
@@ -246,18 +266,20 @@ describe("Maintenance KPI integration", () => {
       expect(mocks.useMaintenancePlanCounts).toHaveBeenLastCalledWith({
         facilityId: null,
         search: "ngoai tim",
+        enabled: true,
       })
     )
   })
 
-  it("resets plan pagination before applying a facility filter", async () => {
+  it("resets plan pagination when tenant selection context changes", async () => {
     const user = userEvent.setup()
-    render(<MaintenancePageClient />)
+    const { rerender } = render(<MaintenancePageClient />)
 
     await user.click(screen.getByRole("button", { name: "set-page-3" }))
     await expectLastPlanRequest({ search: undefined, facilityId: null, page: 3, pageSize: 50 })
 
-    await user.click(screen.getByRole("button", { name: "set-facility" }))
+    setTenantSelection(7)
+    rerender(<MaintenancePageClient />)
 
     expectPlanRequestMissing({ search: undefined, facilityId: 7, page: 3, pageSize: 50 })
     await expectLastPlanRequest({ search: undefined, facilityId: 7, page: 1, pageSize: 50 })

--- a/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx
@@ -109,9 +109,11 @@ vi.mock("../_components/maintenance-page-desktop-content", () => ({
       isCountsError?: boolean
     }
     filterState: {
+      totalCount: number
       onPlanSearchChange: (value: string) => void
     }
     planListState: {
+      plans: unknown[]
       onPageChange: (page: number) => void
     }
   }) => (
@@ -120,6 +122,8 @@ vi.mock("../_components/maintenance-page-desktop-content", () => ({
       data-counts={JSON.stringify(countsState.statusCounts ?? null)}
       data-loading={String(Boolean(countsState.isCountsLoading))}
       data-error={String(Boolean(countsState.isCountsError))}
+      data-plan-count={String(planListState.plans.length)}
+      data-total-count={String(filterState.totalCount)}
     >
       <button type="button" onClick={() => filterState.onPlanSearchChange("ngoai tim")}>
         set-search
@@ -161,6 +165,7 @@ function createMaintenanceContext() {
     setSelectedPlan: vi.fn(),
     setActiveTab: vi.fn(),
     selectedPlan: null,
+    setDraftTasks: vi.fn(),
     fetchPlanDetails: vi.fn(),
     handleSelectPlan: vi.fn(),
     operations: {
@@ -283,6 +288,45 @@ describe("Maintenance KPI integration", () => {
 
     expectPlanRequestMissing({ search: undefined, facilityId: 7, page: 3, pageSize: 50 })
     await expectLastPlanRequest({ search: undefined, facilityId: 7, page: 1, pageSize: 50 })
+  })
+
+  it("suppresses cached maintenance plans while privileged tenant selection is unresolved", () => {
+    setTenantSelection(undefined)
+    mocks.useMaintenancePlans.mockReturnValueOnce({
+      data: {
+        data: [{ id: 42 }],
+        total: 1,
+      },
+      isLoading: false,
+    })
+
+    render(<MaintenancePageClient />)
+
+    expect(screen.getByTestId("desktop-layout")).toHaveAttribute("data-plan-count", "0")
+    expect(screen.getByTestId("desktop-layout")).toHaveAttribute("data-total-count", "0")
+    expect(mocks.useMaintenancePlans).toHaveBeenLastCalledWith(
+      expect.objectContaining({ facilityId: null }),
+      expect.objectContaining({ enabled: false }),
+    )
+  })
+
+  it("clears the selected plan and drafts when tenant selection changes", () => {
+    const context = {
+      ...createMaintenanceContext(),
+      selectedPlan: { id: 42, ten_ke_hoach: "Kế hoạch cũ" },
+      activeTab: "tasks",
+      draftTasks: [{ id: 101 }],
+    }
+    mocks.useMaintenanceContext.mockReturnValue(context)
+    const { rerender } = render(<MaintenancePageClient />)
+
+    setTenantSelection(7)
+    rerender(<MaintenancePageClient />)
+
+    expect(context.setSelectedPlan).toHaveBeenCalledWith(null)
+    expect(context.setActiveTab).toHaveBeenCalledWith("plans")
+    expect(context.setDraftTasks).toHaveBeenCalledWith([])
+    expect(context.setTaskRowSelection).toHaveBeenCalled()
   })
 
   it("resets plan pagination before applying debounced search", async () => {

--- a/src/app/(app)/maintenance/__tests__/MaintenancePageDesktopContent.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/MaintenancePageDesktopContent.test.tsx
@@ -63,31 +63,37 @@ import { MaintenancePageDesktopContent } from "../_components/maintenance-page-d
 function renderDesktopContent() {
   return render(
     <MaintenancePageDesktopContent
-      statusCounts={{ "Bản nháp": 1 }}
-      isCountsLoading={false}
-      isCountsError={false}
-      showFacilityFilter={false}
-      facilities={[]}
-      selectedFacilityId={null}
-      onFacilityChange={vi.fn()}
-      isLoadingFacilities={false}
-      totalCount={0}
-      planSearchTerm=""
-      onPlanSearchChange={vi.fn()}
-      isMobile={false}
-      mobilePlanCards={null}
-      planTable={{} as never}
-      planColumns={[]}
-      currentPage={1}
-      totalPages={1}
-      pageSize={10}
-      plans={[]}
-      isLoadingPlans={false}
-      onPageChange={vi.fn()}
-      onPageSizeChange={vi.fn()}
-      isFiltered={false}
-      taskTable={{} as never}
-      taskColumns={[]}
+      countsState={{
+        statusCounts: { "Bản nháp": 1 },
+        isCountsLoading: false,
+        isCountsError: false,
+      }}
+      filterState={{
+        showFacilityFilter: false,
+        totalCount: 0,
+        planSearchTerm: "",
+        onPlanSearchChange: vi.fn(),
+      }}
+      viewportState={{
+        isMobile: false,
+        mobilePlanCards: null,
+      }}
+      planListState={{
+        planTable: {} as never,
+        planColumns: [],
+        currentPage: 1,
+        totalPages: 1,
+        pageSize: 10,
+        plans: [],
+        isLoadingPlans: false,
+        onPageChange: vi.fn(),
+        onPageSizeChange: vi.fn(),
+        isFiltered: false,
+      }}
+      taskListState={{
+        taskTable: {} as never,
+        taskColumns: [],
+      }}
     />,
   )
 }

--- a/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
@@ -45,7 +45,17 @@ vi.mock("../_components/maintenance-mobile-tasks-panel", () => ({
 
 import { MobileMaintenanceLayout } from "../_components/mobile-maintenance-layout"
 
-function renderMobileLayout() {
+function renderMobileLayout({
+  planSearchTerm = "",
+  totalPages = 1,
+  totalCount = 0,
+  currentPage = 1,
+}: {
+  planSearchTerm?: string
+  totalPages?: number
+  totalCount?: number
+  currentPage?: number
+} = {}) {
   return render(
     <MobileMaintenanceLayout
       countsState={{
@@ -56,14 +66,14 @@ function renderMobileLayout() {
       plansState={{
         plans: [],
         isLoadingPlans: false,
-        planSearchTerm: "",
+        planSearchTerm,
         setPlanSearchTerm: vi.fn(),
         onClearSearch: vi.fn(),
       }}
       paginationState={{
-        totalPages: 1,
-        totalCount: 0,
-        currentPage: 1,
+        totalPages,
+        totalCount,
+        currentPage,
         setCurrentPage: vi.fn(),
       }}
       filterState={{ showFacilityFilter: false }}
@@ -100,5 +110,15 @@ describe("MobileMaintenanceLayout create-plan entry points", () => {
 
     expect(screen.getByRole("button", { name: "Tạo kế hoạch mới" })).toBeInTheDocument()
     expect(mocks.lastPlanCardsProps?.canCreatePlans).toBe(true)
+  })
+
+  it("labels icon-only search and pagination controls", () => {
+    renderMobileLayout({ planSearchTerm: "máy thở", totalPages: 3, totalCount: 12, currentPage: 2 })
+
+    expect(screen.getByRole("button", { name: "Xóa tìm kiếm" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Trang đầu" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Trang trước" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Trang sau" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Trang cuối" })).toBeInTheDocument()
   })
 })

--- a/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
@@ -48,29 +48,25 @@ import { MobileMaintenanceLayout } from "../_components/mobile-maintenance-layou
 function renderMobileLayout() {
   return render(
     <MobileMaintenanceLayout
-      statusCounts={{ "Bản nháp": 1 }}
-      isCountsLoading={false}
-      isCountsError={false}
-      plans={[]}
-      isLoadingPlans={false}
-      planSearchTerm=""
-      setPlanSearchTerm={vi.fn()}
-      onClearSearch={vi.fn()}
-      totalPages={1}
-      totalCount={0}
-      currentPage={1}
-      setCurrentPage={vi.fn()}
-      showFacilityFilter={false}
-      facilities={[]}
-      selectedFacilityId={null}
-      isLoadingFacilities={false}
-      isMobileFilterSheetOpen={false}
-      setIsMobileFilterSheetOpen={vi.fn()}
-      pendingFacilityFilter={null}
-      setPendingFacilityFilter={vi.fn()}
-      handleMobileFilterApply={vi.fn()}
-      handleMobileFilterClear={vi.fn()}
-      activeMobileFilterCount={0}
+      countsState={{
+        statusCounts: { "Bản nháp": 1 },
+        isCountsLoading: false,
+        isCountsError: false,
+      }}
+      plansState={{
+        plans: [],
+        isLoadingPlans: false,
+        planSearchTerm: "",
+        setPlanSearchTerm: vi.fn(),
+        onClearSearch: vi.fn(),
+      }}
+      paginationState={{
+        totalPages: 1,
+        totalCount: 0,
+        currentPage: 1,
+        setCurrentPage: vi.fn(),
+      }}
+      filterState={{ showFacilityFilter: false }}
       expandedTaskIds={{}}
       toggleTaskExpansion={vi.fn()}
     />,

--- a/src/app/(app)/maintenance/__tests__/plan-filters-bar.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/plan-filters-bar.test.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { PlanFiltersBar } from "../_components/plan-filters-bar"
+
+vi.mock("@/components/shared/TenantSelector", () => ({
+  TenantSelector: () => (
+    <button type="button" aria-label="Chọn cơ sở y tế" data-testid="tenant-selector-trigger">
+      Chọn cơ sở y tế
+    </button>
+  ),
+}))
+
+describe("PlanFiltersBar", () => {
+  it("uses the shared Equipment-style tenant slot before the search input on desktop", () => {
+    render(
+      <PlanFiltersBar
+        showFacilityFilter={true}
+        totalCount={3}
+        searchTerm=""
+        onSearchChange={vi.fn()}
+        isRegionalLeader={false}
+      />
+    )
+
+    const tenantTrigger = screen.getByTestId("tenant-selector-trigger")
+    const searchInput = screen.getByRole("searchbox", {
+      name: "Tìm kiếm theo tên kế hoạch, khoa/phòng, người lập...",
+    })
+
+    expect(tenantTrigger.compareDocumentPosition(searchInput)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+  })
+
+  it("does not render a tenant trigger for non-privileged filter contexts", () => {
+    render(
+      <PlanFiltersBar
+        showFacilityFilter={false}
+        totalCount={3}
+        searchTerm=""
+        onSearchChange={vi.fn()}
+        isRegionalLeader={false}
+      />
+    )
+
+    expect(screen.queryByTestId("tenant-selector-trigger")).not.toBeInTheDocument()
+    expect(screen.getByRole("searchbox", {
+      name: "Tìm kiếm theo tên kế hoạch, khoa/phòng, người lập...",
+    })).toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/maintenance/__tests__/use-maintenance-plan-list-controls.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/use-maintenance-plan-list-controls.test.tsx
@@ -1,0 +1,52 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useMaintenancePlanListControls } from "../_hooks/use-maintenance-plan-list-controls"
+
+describe("useMaintenancePlanListControls", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("resets the effective page when the pagination reset key changes", () => {
+    const { result, rerender } = renderHook(
+      ({ resetKey }: { resetKey?: number | null }) => useMaintenancePlanListControls(resetKey),
+      { initialProps: { resetKey: null } },
+    )
+
+    act(() => {
+      result.current.setCurrentPage(3)
+    })
+    expect(result.current.currentPage).toBe(3)
+
+    rerender({ resetKey: 7 })
+
+    expect(result.current.currentPage).toBe(1)
+  })
+
+  it("resets the effective page when debounced search changes", () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useMaintenancePlanListControls(null))
+
+    act(() => {
+      result.current.setCurrentPage(3)
+    })
+    expect(result.current.currentPage).toBe(3)
+
+    act(() => {
+      result.current.handlePlanSearchChange("máy thở")
+    })
+    expect(result.current.currentPage).toBe(1)
+
+    act(() => {
+      result.current.setCurrentPage(3)
+    })
+    expect(result.current.currentPage).toBe(3)
+
+    act(() => {
+      vi.advanceTimersByTime(250)
+    })
+
+    expect(result.current.currentPage).toBe(1)
+  })
+})

--- a/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react"
 import type { PaginationState, SortingState } from "@tanstack/react-table"
-import { useQuery } from "@tanstack/react-query"
 import {
   getCoreRowModel,
   getFilteredRowModel,
@@ -12,11 +11,9 @@ import {
 } from "@tanstack/react-table"
 
 import { useIsMobile } from "@/hooks/use-mobile"
-import { callRpc } from "@/lib/rpc-client"
-import { isGlobalRole, isRegionalLeaderRole } from "@/lib/rbac"
+import { useTenantSelection } from "@/contexts/TenantSelectionContext"
 import { useMaintenancePlans } from "@/hooks/use-cached-maintenance"
 import { useMaintenancePlanCounts } from "@/hooks/useMaintenancePlanCounts"
-import type { FacilityOption } from "@/types/tenant"
 import { useFeatureFlag } from "@/lib/feature-flags"
 
 import { useMaintenanceContext } from "../_hooks/useMaintenanceContext"
@@ -35,25 +32,23 @@ export function MaintenancePageClient() {
   const isMobile = useIsMobile()
   const mobileMaintenanceEnabled = useFeatureFlag("mobile-maintenance-redesign")
   const shouldUseMobileMaintenance = isMobile && mobileMaintenanceEnabled
+  const {
+    selectedFacilityId: tenantSelectedFacilityId,
+    showSelector: showFacilityFilter,
+    shouldFetchData,
+  } = useTenantSelection()
+  const selectedFacilityId = tenantSelectedFacilityId ?? null
 
   const {
     planSearchTerm,
     debouncedPlanSearch,
     handlePlanSearchChange,
     handleClearSearch,
-    selectedFacilityId,
-    handleFacilityChange,
     currentPage,
     setCurrentPage,
     pageSize,
     handlePageSizeChange,
-    isMobileFilterSheetOpen,
-    handleMobileFilterSheetOpenChange,
-    pendingFacilityFilter,
-    setPendingFacilityFilter,
-    handleMobileFilterApply,
-    handleMobileFilterClear,
-  } = useMaintenancePlanListControls()
+  } = useMaintenancePlanListControls(tenantSelectedFacilityId)
   const [expandedTaskIds, setExpandedTaskIds] = React.useState<Record<number, boolean>>({})
 
   const [planSorting, setPlanSorting] = React.useState<SortingState>([])
@@ -70,46 +65,19 @@ export function MaintenancePageClient() {
     facilityId: selectedFacilityId,
     page: currentPage,
     pageSize,
+  }, {
+    enabled: shouldFetchData,
   })
   const { counts: statusCounts, isLoading: isCountsLoading, isError: isCountsError } =
     useMaintenancePlanCounts({
       facilityId: selectedFacilityId,
       search: debouncedPlanSearch || undefined,
+      enabled: shouldFetchData,
     })
 
   const plans = React.useMemo(() => paginatedResponse?.data ?? [], [paginatedResponse?.data])
   const totalCount = paginatedResponse?.total ?? 0
   const totalPages = Math.ceil(totalCount / pageSize)
-  const showFacilityFilter = isGlobalRole(ctx.user?.role) || isRegionalLeaderRole(ctx.user?.role)
-
-  const {
-    data: facilities = [],
-    isLoading: isLoadingFacilities,
-  } = useQuery<Array<{ id: number; name: string }>>({
-    queryKey: ["maintenance", "facilities", ctx.user?.role ?? null],
-    queryFn: async () => {
-      const result = await callRpc<FacilityOption[]>({
-        fn: "get_facilities_with_equipment_count",
-        args: {},
-      })
-
-      return (result || []).map((facility) => ({
-        id: Number(facility.id),
-        name: String(facility.name || `Cơ sở ${facility.id}`),
-      }))
-    },
-    enabled: showFacilityFilter,
-    staleTime: 5 * 60 * 1000,
-    gcTime: 15 * 60 * 1000,
-  })
-
-  const activeMobileFilterCount = React.useMemo(() => {
-    let count = 0
-    if (selectedFacilityId) {
-      count += 1
-    }
-    return count
-  }, [selectedFacilityId])
 
   const clearTaskRowSelection = React.useCallback(() => {
     setTaskRowSelection((previousSelection) =>
@@ -257,29 +225,21 @@ export function MaintenancePageClient() {
       <>
         <MaintenanceDialogs />
         <MobileMaintenanceLayout
-          statusCounts={statusCounts}
-          isCountsLoading={isCountsLoading}
-          isCountsError={isCountsError}
-          plans={plans}
-          isLoadingPlans={isLoadingPlans}
-          planSearchTerm={planSearchTerm}
-          setPlanSearchTerm={handlePlanSearchChange}
-          onClearSearch={handleClearSearch}
-          totalPages={totalPages}
-          totalCount={totalCount}
-          currentPage={currentPage}
-          setCurrentPage={setCurrentPage}
-          showFacilityFilter={showFacilityFilter}
-          facilities={facilities}
-          selectedFacilityId={selectedFacilityId}
-          isLoadingFacilities={isLoadingFacilities}
-          isMobileFilterSheetOpen={isMobileFilterSheetOpen}
-          setIsMobileFilterSheetOpen={handleMobileFilterSheetOpenChange}
-          pendingFacilityFilter={pendingFacilityFilter}
-          setPendingFacilityFilter={setPendingFacilityFilter}
-          handleMobileFilterApply={handleMobileFilterApply}
-          handleMobileFilterClear={handleMobileFilterClear}
-          activeMobileFilterCount={activeMobileFilterCount}
+          countsState={{ statusCounts, isCountsLoading, isCountsError }}
+          plansState={{
+            plans,
+            isLoadingPlans,
+            planSearchTerm,
+            setPlanSearchTerm: handlePlanSearchChange,
+            onClearSearch: handleClearSearch,
+          }}
+          paginationState={{
+            totalPages,
+            totalCount,
+            currentPage,
+            setCurrentPage,
+          }}
+          filterState={{ showFacilityFilter }}
           expandedTaskIds={expandedTaskIds}
           toggleTaskExpansion={toggleTaskExpansion}
         />
@@ -291,31 +251,30 @@ export function MaintenancePageClient() {
     <>
       <MaintenanceDialogs />
       <MaintenancePageDesktopContent
-        statusCounts={statusCounts}
-        isCountsLoading={isCountsLoading}
-        isCountsError={isCountsError}
-        showFacilityFilter={showFacilityFilter}
-        facilities={facilities}
-        selectedFacilityId={selectedFacilityId}
-        onFacilityChange={handleFacilityChange}
-        isLoadingFacilities={isLoadingFacilities}
-        totalCount={totalCount}
-        planSearchTerm={planSearchTerm}
-        onPlanSearchChange={handlePlanSearchChange}
-        isMobile={isMobile}
-        mobilePlanCards={legacyMobileCards}
-        planTable={planTable}
-        planColumns={planColumns}
-        currentPage={currentPage}
-        totalPages={totalPages}
-        pageSize={pageSize}
-        plans={plans}
-        isLoadingPlans={isLoadingPlans}
-        onPageChange={setCurrentPage}
-        onPageSizeChange={handlePageSizeChange}
-        isFiltered={Boolean(debouncedPlanSearch || selectedFacilityId)}
-        taskTable={taskTable}
-        taskColumns={taskColumns}
+        countsState={{ statusCounts, isCountsLoading, isCountsError }}
+        filterState={{
+          showFacilityFilter,
+          totalCount,
+          planSearchTerm,
+          onPlanSearchChange: handlePlanSearchChange,
+        }}
+        viewportState={{
+          isMobile,
+          mobilePlanCards: legacyMobileCards,
+        }}
+        planListState={{
+          planTable,
+          planColumns,
+          currentPage,
+          totalPages,
+          pageSize,
+          plans,
+          isLoadingPlans,
+          onPageChange: setCurrentPage,
+          onPageSizeChange: handlePageSizeChange,
+          isFiltered: Boolean(debouncedPlanSearch || selectedFacilityId),
+        }}
+        taskListState={{ taskTable, taskColumns }}
       />
     </>
   )

--- a/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenancePageClient.tsx
@@ -76,8 +76,10 @@ export function MaintenancePageClient() {
     })
 
   const plans = React.useMemo(() => paginatedResponse?.data ?? [], [paginatedResponse?.data])
-  const totalCount = paginatedResponse?.total ?? 0
+  const visiblePlans = React.useMemo(() => shouldFetchData ? plans : [], [plans, shouldFetchData])
+  const totalCount = shouldFetchData ? paginatedResponse?.total ?? 0 : 0
   const totalPages = Math.ceil(totalCount / pageSize)
+  const visibleStatusCounts = shouldFetchData ? statusCounts : undefined
 
   const clearTaskRowSelection = React.useCallback(() => {
     setTaskRowSelection((previousSelection) =>
@@ -85,9 +87,28 @@ export function MaintenancePageClient() {
     )
   }, [setTaskRowSelection])
 
+  const previousTenantSelection = React.useRef(tenantSelectedFacilityId)
+  React.useEffect(() => {
+    if (previousTenantSelection.current === tenantSelectedFacilityId) {
+      return
+    }
+
+    previousTenantSelection.current = tenantSelectedFacilityId
+    setSelectedPlan(null)
+    setActiveTab("plans")
+    ctx.setDraftTasks([])
+    clearTaskRowSelection()
+  }, [
+    tenantSelectedFacilityId,
+    setSelectedPlan,
+    setActiveTab,
+    ctx.setDraftTasks,
+    clearTaskRowSelection,
+  ])
+
   // Deep-link resolution (URL → select plan / open dialog)
   useMaintenanceDeepLink({
-    plans,
+    plans: visiblePlans,
     isLoadingPlans,
     setIsAddPlanDialogOpen,
     canCreatePlans: ctx.canCreatePlans,
@@ -129,7 +150,7 @@ export function MaintenancePageClient() {
   })
 
   const planTable = useReactTable({
-    data: plans,
+    data: visiblePlans,
     columns: planColumns,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -225,9 +246,9 @@ export function MaintenancePageClient() {
       <>
         <MaintenanceDialogs />
         <MobileMaintenanceLayout
-          countsState={{ statusCounts, isCountsLoading, isCountsError }}
+          countsState={{ statusCounts: visibleStatusCounts, isCountsLoading, isCountsError }}
           plansState={{
-            plans,
+            plans: visiblePlans,
             isLoadingPlans,
             planSearchTerm,
             setPlanSearchTerm: handlePlanSearchChange,
@@ -251,7 +272,7 @@ export function MaintenancePageClient() {
     <>
       <MaintenanceDialogs />
       <MaintenancePageDesktopContent
-        countsState={{ statusCounts, isCountsLoading, isCountsError }}
+        countsState={{ statusCounts: visibleStatusCounts, isCountsLoading, isCountsError }}
         filterState={{
           showFacilityFilter,
           totalCount,
@@ -268,7 +289,7 @@ export function MaintenancePageClient() {
           currentPage,
           totalPages,
           pageSize,
-          plans,
+          plans: visiblePlans,
           isLoadingPlans,
           onPageChange: setCurrentPage,
           onPageSizeChange: handlePageSizeChange,

--- a/src/app/(app)/maintenance/_components/maintenance-page-desktop-content.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-page-desktop-content.tsx
@@ -26,22 +26,25 @@ import type { MaintenancePlan } from "@/hooks/use-cached-maintenance"
 import type { MaintenancePlanStatusCounts } from "@/hooks/useMaintenancePlanCounts"
 import type { MaintenanceTask } from "@/lib/data"
 
-interface MaintenancePageDesktopContentProps {
+interface MaintenanceCountsState {
   statusCounts?: MaintenancePlanStatusCounts
   isCountsLoading?: boolean
   isCountsError?: boolean
+}
+
+interface MaintenanceFilterState {
   showFacilityFilter: boolean
-  facilities: Array<{ id: number; name: string }>
-  selectedFacilityId: number | null
-  onFacilityChange: (facilityId: number | null) => void
-  isLoadingFacilities: boolean
   totalCount: number
   planSearchTerm: string
   onPlanSearchChange: (value: string) => void
+}
 
+interface MaintenanceViewportState {
   isMobile: boolean
   mobilePlanCards: React.ReactNode
+}
 
+interface MaintenancePlanListState {
   planTable: Table<MaintenancePlan>
   planColumns: ColumnDef<MaintenancePlan, unknown>[]
   currentPage: number
@@ -52,40 +55,46 @@ interface MaintenancePageDesktopContentProps {
   onPageChange: (page: number) => void
   onPageSizeChange: (size: number) => void
   isFiltered: boolean
+}
 
+interface MaintenanceTaskListState {
   taskTable: Table<MaintenanceTask>
   taskColumns: ColumnDef<MaintenanceTask, unknown>[]
 }
 
+interface MaintenancePageDesktopContentProps {
+  countsState: MaintenanceCountsState
+  filterState: MaintenanceFilterState
+  viewportState: MaintenanceViewportState
+  planListState: MaintenancePlanListState
+  taskListState: MaintenanceTaskListState
+}
+
 export function MaintenancePageDesktopContent({
-  statusCounts,
-  isCountsLoading,
-  isCountsError,
-  showFacilityFilter,
-  facilities,
-  selectedFacilityId,
-  onFacilityChange,
-  isLoadingFacilities,
-  totalCount,
-  planSearchTerm,
-  onPlanSearchChange,
-  isMobile,
-  mobilePlanCards,
-  planTable,
-  planColumns,
-  currentPage,
-  totalPages,
-  pageSize,
-  plans,
-  isLoadingPlans,
-  onPageChange,
-  onPageSizeChange,
-  isFiltered,
-  taskTable,
-  taskColumns,
+  countsState,
+  filterState,
+  viewportState,
+  planListState,
+  taskListState,
 }: MaintenancePageDesktopContentProps) {
   const ctx = useMaintenanceContext()
   const editingTaskId = ctx.taskEditing.editingTaskId
+  const { statusCounts, isCountsLoading, isCountsError } = countsState
+  const { showFacilityFilter, totalCount, planSearchTerm, onPlanSearchChange } = filterState
+  const { isMobile, mobilePlanCards } = viewportState
+  const {
+    planTable,
+    planColumns,
+    currentPage,
+    totalPages,
+    pageSize,
+    plans,
+    isLoadingPlans,
+    onPageChange,
+    onPageSizeChange,
+    isFiltered,
+  } = planListState
+  const { taskTable, taskColumns } = taskListState
 
   return (
     <div className="space-y-6">
@@ -117,7 +126,7 @@ export function MaintenancePageDesktopContent({
               </div>
               {ctx.canCreatePlans && (
                 <Button size="sm" className="h-8 gap-1 ml-auto" onClick={() => ctx.setIsAddPlanDialogOpen(true)}>
-                  <PlusCircle className="h-3.5 w-3.5" />
+                  <PlusCircle className="size-3.5" />
                   <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">Tạo kế hoạch mới</span>
                 </Button>
               )}
@@ -125,10 +134,6 @@ export function MaintenancePageDesktopContent({
             <CardContent>
               <PlanFiltersBar
                 showFacilityFilter={showFacilityFilter}
-                facilities={facilities}
-                selectedFacilityId={selectedFacilityId}
-                onFacilityChange={onFacilityChange}
-                isLoadingFacilities={isLoadingFacilities}
                 totalCount={totalCount}
                 searchTerm={planSearchTerm}
                 onSearchChange={onPlanSearchChange}
@@ -172,24 +177,24 @@ export function MaintenancePageDesktopContent({
                   {ctx.hasChanges && !ctx.isPlanApproved && ctx.canManagePlans && (
                     <>
                       <Button variant="outline" onClick={() => ctx.setIsConfirmingCancel(true)} disabled={ctx.isSavingAll}>
-                        <Undo2 className="mr-2 h-4 w-4" />
+                        <Undo2 className="mr-2 size-4" />
                         Hủy bỏ
                       </Button>
                       <Button onClick={() => void ctx.handleSaveAllChanges()} disabled={ctx.isSavingAll || !ctx.canManagePlans}>
-                        {ctx.isSavingAll ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+                        {ctx.isSavingAll ? <Loader2 className="mr-2 size-4 animate-spin" /> : <Save className="mr-2 size-4" />}
                         Lưu thay đổi
                       </Button>
                     </>
                   )}
                   {ctx.tasks.length > 0 && !ctx.isRegionalLeader && (
                     <Button variant="secondary" onClick={ctx.generatePlanForm} disabled={editingTaskId !== null || ctx.isSavingAll}>
-                      <FileText className="mr-2 h-4 w-4" />
+                      <FileText className="mr-2 size-4" />
                       Xuất phiếu KH
                     </Button>
                   )}
                   {!ctx.isPlanApproved && ctx.canManagePlans && (
                     <Button onClick={() => ctx.setIsAddTasksDialogOpen(true)} disabled={editingTaskId !== null || ctx.isSavingAll}>
-                      <PlusCircle className="mr-2 h-4 w-4" />
+                      <PlusCircle className="mr-2 size-4" />
                       Thêm thiết bị
                     </Button>
                   )}
@@ -199,7 +204,7 @@ export function MaintenancePageDesktopContent({
             <CardContent>
               {ctx.isLoadingTasks ? (
                 <div className="flex items-center justify-center py-10">
-                  <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                  <Loader2 className="size-8 animate-spin text-muted-foreground" />
                 </div>
               ) : (
                 <TasksTable

--- a/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
+++ b/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
@@ -105,6 +105,7 @@ export function MobileMaintenanceLayout({
               {planSearchTerm && (
                 <button
                   type="button"
+                  aria-label="Xóa tìm kiếm"
                   className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full bg-muted p-1"
                   onClick={onClearSearch}
                 >
@@ -207,7 +208,13 @@ export function MobileMaintenanceLayout({
               <span>{totalCount} kế hoạch</span>
             </div>
             <div className="grid grid-cols-4 gap-2 pb-2">
-              <Button variant="outline" className="h-10 rounded-xl" onClick={() => setCurrentPage(1)} disabled={currentPage === 1}>
+              <Button
+                variant="outline"
+                className="h-10 rounded-xl"
+                onClick={() => setCurrentPage(1)}
+                disabled={currentPage === 1}
+                aria-label="Trang đầu"
+              >
                 <ChevronsLeft className="size-4" />
               </Button>
               <Button
@@ -215,6 +222,7 @@ export function MobileMaintenanceLayout({
                 className="h-10 rounded-xl"
                 onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
                 disabled={currentPage === 1}
+                aria-label="Trang trước"
               >
                 <ChevronLeft className="size-4" />
               </Button>
@@ -223,6 +231,7 @@ export function MobileMaintenanceLayout({
                 className="h-10 rounded-xl"
                 onClick={() => setCurrentPage(Math.min(totalPages || 1, currentPage + 1))}
                 disabled={currentPage === (totalPages || 1)}
+                aria-label="Trang sau"
               >
                 <ChevronRight className="size-4" />
               </Button>
@@ -231,6 +240,7 @@ export function MobileMaintenanceLayout({
                 className="h-10 rounded-xl"
                 onClick={() => setCurrentPage(totalPages || 1)}
                 disabled={currentPage === (totalPages || 1)}
+                aria-label="Trang cuối"
               >
                 <ChevronsRight className="size-4" />
               </Button>

--- a/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
+++ b/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
@@ -6,8 +6,6 @@ import {
   ChevronRight,
   ChevronsLeft,
   ChevronsRight,
-  Filter,
-  Loader2,
   PlusCircle,
   Search,
   X,
@@ -15,107 +13,68 @@ import {
 import { KpiStatusBar } from "@/components/kpi"
 import { MAINTENANCE_STATUS_CONFIGS } from "@/components/kpi/configs/maintenance"
 import { FloatingActionButton } from "@/components/shared/FloatingActionButton"
+import { TenantSelector } from "@/components/shared/TenantSelector"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
-import {
-  Sheet,
-  SheetClose,
-  SheetContent,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet"
-import { Skeleton } from "@/components/ui/skeleton"
 import type { MaintenancePlan } from "@/hooks/use-cached-maintenance"
 import type { MaintenancePlanStatusCounts } from "@/hooks/useMaintenancePlanCounts"
 import { useMaintenanceContext } from "../_hooks/useMaintenanceContext"
 import { MaintenanceMobilePlanCards } from "./maintenance-mobile-plan-cards"
 import { MaintenanceMobileTasksPanel } from "./maintenance-mobile-tasks-panel"
 
-export interface MobileMaintenanceLayoutProps {
+interface MobileMaintenanceCountsState {
   statusCounts?: MaintenancePlanStatusCounts
   isCountsLoading?: boolean
   isCountsError?: boolean
+}
+
+interface MobileMaintenancePlansState {
   plans: MaintenancePlan[]
   isLoadingPlans: boolean
   planSearchTerm: string
   setPlanSearchTerm: (value: string) => void
   onClearSearch: () => void
+}
+
+interface MobileMaintenancePaginationState {
   totalPages: number
   totalCount: number
   currentPage: number
   setCurrentPage: (page: number) => void
+}
+
+interface MobileMaintenanceFilterState {
   showFacilityFilter: boolean
-  facilities: Array<{ id: number; name: string }>
-  selectedFacilityId: number | null
-  isLoadingFacilities: boolean
-  isMobileFilterSheetOpen: boolean
-  setIsMobileFilterSheetOpen: (open: boolean) => void
-  pendingFacilityFilter: number | null
-  setPendingFacilityFilter: (value: number | null) => void
-  handleMobileFilterApply: () => void
-  handleMobileFilterClear: () => void
-  activeMobileFilterCount: number
+}
+
+export interface MobileMaintenanceLayoutProps {
+  countsState: MobileMaintenanceCountsState
+  plansState: MobileMaintenancePlansState
+  paginationState: MobileMaintenancePaginationState
+  filterState: MobileMaintenanceFilterState
   expandedTaskIds: Record<number, boolean>
   toggleTaskExpansion: (taskId: number) => void
 }
 
 export function MobileMaintenanceLayout({
-  statusCounts,
-  isCountsLoading,
-  isCountsError,
-  plans,
-  isLoadingPlans,
-  planSearchTerm,
-  setPlanSearchTerm,
-  onClearSearch,
-  totalPages,
-  totalCount,
-  currentPage,
-  setCurrentPage,
-  showFacilityFilter,
-  facilities,
-  selectedFacilityId,
-  isLoadingFacilities,
-  isMobileFilterSheetOpen,
-  setIsMobileFilterSheetOpen,
-  pendingFacilityFilter,
-  setPendingFacilityFilter,
-  handleMobileFilterApply,
-  handleMobileFilterClear,
-  activeMobileFilterCount,
+  countsState,
+  plansState,
+  paginationState,
+  filterState,
   expandedTaskIds,
   toggleTaskExpansion,
 }: MobileMaintenanceLayoutProps) {
   const ctx = useMaintenanceContext()
+  const { statusCounts, isCountsLoading, isCountsError } = countsState
+  const { plans, isLoadingPlans, planSearchTerm, setPlanSearchTerm, onClearSearch } = plansState
+  const { totalPages, totalCount, currentPage, setCurrentPage } = paginationState
+  const { showFacilityFilter } = filterState
 
   const months = React.useMemo(() => Array.from({ length: 12 }, (_, index) => index + 1), [])
   const planTabActive = ctx.activeTab === "plans"
   const safeAreaFooterStyle = React.useMemo(
     () => ({ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 16px)" }),
     []
-  )
-  const facilityOptions = React.useMemo(() => {
-    if (!showFacilityFilter) {
-      return [] as Array<{ id: number; name: string }>
-    }
-    return facilities
-  }, [showFacilityFilter, facilities])
-
-  const activeFacilityLabel = React.useMemo(() => {
-    if (selectedFacilityId == null) {
-      return null
-    }
-    const match = facilities.find((facility) => facility.id === selectedFacilityId)
-    return match?.name || "Cơ sở đã chọn"
-  }, [facilities, selectedFacilityId])
-
-  const handleFacilityOptionSelect = React.useCallback(
-    (value: number | null) => {
-      setPendingFacilityFilter(value)
-    },
-    [setPendingFacilityFilter]
   )
 
   return (
@@ -132,8 +91,11 @@ export function MobileMaintenanceLayout({
           </div>
 
           <div className="space-y-2">
+            {showFacilityFilter ? (
+              <TenantSelector className="h-11 w-full rounded-xl border border-border/70" />
+            ) : null}
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={planSearchTerm}
                 onChange={(event) => setPlanSearchTerm(event.target.value)}
@@ -146,49 +108,10 @@ export function MobileMaintenanceLayout({
                   className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full bg-muted p-1"
                   onClick={onClearSearch}
                 >
-                  <X className="h-3.5 w-3.5" />
+                  <X className="size-3.5" />
                 </button>
               )}
             </div>
-
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                className="flex-1 h-11 rounded-xl border border-border/70"
-                onClick={() => setIsMobileFilterSheetOpen(true)}
-                disabled={isLoadingFacilities}
-              >
-                {isLoadingFacilities ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <Filter className="mr-2 h-4 w-4" />
-                )}
-                {isLoadingFacilities ? "Đang tải" : "Bộ lọc"}
-                {activeMobileFilterCount > 0 && (
-                  <Badge variant="secondary" className="ml-auto rounded-full bg-primary text-primary-foreground">
-                    {activeMobileFilterCount}
-                  </Badge>
-                )}
-              </Button>
-            </div>
-
-            {activeFacilityLabel && (
-              <div className="flex items-center gap-2">
-                <Badge
-                  variant="outline"
-                  className="flex items-center gap-2 rounded-full border-primary/40 bg-primary/5 px-3 py-1 text-xs text-primary"
-                >
-                  {activeFacilityLabel}
-                  <button
-                    type="button"
-                    onClick={handleMobileFilterClear}
-                    className="rounded-full bg-primary/10 p-0.5 text-primary hover:bg-primary/20"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                </Badge>
-              </div>
-            )}
           </div>
 
           <KpiStatusBar
@@ -285,7 +208,7 @@ export function MobileMaintenanceLayout({
             </div>
             <div className="grid grid-cols-4 gap-2 pb-2">
               <Button variant="outline" className="h-10 rounded-xl" onClick={() => setCurrentPage(1)} disabled={currentPage === 1}>
-                <ChevronsLeft className="h-4 w-4" />
+                <ChevronsLeft className="size-4" />
               </Button>
               <Button
                 variant="outline"
@@ -293,7 +216,7 @@ export function MobileMaintenanceLayout({
                 onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
                 disabled={currentPage === 1}
               >
-                <ChevronLeft className="h-4 w-4" />
+                <ChevronLeft className="size-4" />
               </Button>
               <Button
                 variant="outline"
@@ -301,7 +224,7 @@ export function MobileMaintenanceLayout({
                 onClick={() => setCurrentPage(Math.min(totalPages || 1, currentPage + 1))}
                 disabled={currentPage === (totalPages || 1)}
               >
-                <ChevronRight className="h-4 w-4" />
+                <ChevronRight className="size-4" />
               </Button>
               <Button
                 variant="outline"
@@ -309,79 +232,13 @@ export function MobileMaintenanceLayout({
                 onClick={() => setCurrentPage(totalPages || 1)}
                 disabled={currentPage === (totalPages || 1)}
               >
-                <ChevronsRight className="h-4 w-4" />
+                <ChevronsRight className="size-4" />
               </Button>
             </div>
           </div>
         </div>
       )}
 
-      <Sheet open={isMobileFilterSheetOpen} onOpenChange={setIsMobileFilterSheetOpen}>
-        <SheetContent side="bottom" className="flex h-[65vh] flex-col rounded-t-3xl border-border/60 bg-background px-6 pb-6 pt-4">
-          <SheetHeader>
-            <SheetTitle>Bộ lọc kế hoạch</SheetTitle>
-            <p className="text-sm text-muted-foreground">
-              Chọn cơ sở hoặc điều kiện phù hợp để thu hẹp danh sách kế hoạch hiển thị.
-            </p>
-          </SheetHeader>
-          <div className="mt-4 flex-1 overflow-y-auto">
-            {showFacilityFilter ? (
-              <div className="space-y-3">
-                <h3 className="text-sm font-semibold">Cơ sở</h3>
-                {isLoadingFacilities ? (
-                  <div className="space-y-2">
-                    {Array.from({ length: 4 }).map((_, index) => (
-                      <Skeleton key={index} className="h-11 w-full rounded-2xl" />
-                    ))}
-                  </div>
-                ) : (
-                  <div className="space-y-2">
-                    <button
-                      type="button"
-                      onClick={() => handleFacilityOptionSelect(null)}
-                      className={`w-full rounded-2xl border px-4 py-3 text-left text-sm transition ${pendingFacilityFilter === null ? "border-primary bg-primary/10 text-primary" : "border-border/70 bg-background"}`}
-                    >
-                      Tất cả cơ sở
-                    </button>
-                    {facilityOptions.map((facility) => (
-                      <button
-                        key={facility.id}
-                        type="button"
-                        onClick={() => handleFacilityOptionSelect(facility.id)}
-                        className={`w-full rounded-2xl border px-4 py-3 text-left text-sm transition ${pendingFacilityFilter === facility.id ? "border-primary bg-primary/10 text-primary" : "border-border/70 bg-background"}`}
-                      >
-                        {facility.name}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="rounded-2xl border border-dashed border-border/70 bg-muted/40 px-4 py-6 text-center text-sm text-muted-foreground">
-                Không có bộ lọc bổ sung cho vai trò của bạn.
-              </div>
-            )}
-          </div>
-          <SheetFooter className="mt-4 grid grid-cols-2 gap-3 shrink-0">
-            <Button variant="outline" onClick={() => setIsMobileFilterSheetOpen(false)}>
-              Hủy
-            </Button>
-            <div className="grid grid-cols-2 gap-2">
-              <Button
-                variant="ghost"
-                className="border border-border/60"
-                onClick={handleMobileFilterClear}
-                disabled={selectedFacilityId === null && pendingFacilityFilter === null}
-              >
-                Xóa
-              </Button>
-              <SheetClose asChild>
-                <Button onClick={handleMobileFilterApply}>Áp dụng</Button>
-              </SheetClose>
-            </div>
-          </SheetFooter>
-        </SheetContent>
-      </Sheet>
     </div>
   )
 }

--- a/src/app/(app)/maintenance/_components/plan-filters-bar.tsx
+++ b/src/app/(app)/maintenance/_components/plan-filters-bar.tsx
@@ -1,39 +1,23 @@
 "use client"
 
-import { AlertTriangle, Building2 } from "lucide-react"
+import * as React from "react"
+import { AlertTriangle } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { SearchInput } from "@/components/shared/SearchInput"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
+import { TenantSelector } from "@/components/shared/TenantSelector"
 
 export type PlanFiltersBarProps = {
-  // Facility filter
   showFacilityFilter: boolean
-  facilities: Array<{ id: number; name: string }>
-  selectedFacilityId: number | null
-  onFacilityChange: (id: number | null) => void
-  isLoadingFacilities: boolean
   totalCount: number
 
-  // Search
   searchTerm: string
   onSearchChange: (value: string) => void
 
-  // Regional leader banner
   isRegionalLeader: boolean
 }
 
 export function PlanFiltersBar({
   showFacilityFilter,
-  facilities,
-  selectedFacilityId,
-  onFacilityChange,
-  isLoadingFacilities,
   totalCount,
   searchTerm,
   onSearchChange,
@@ -45,7 +29,7 @@ export function PlanFiltersBar({
       {isRegionalLeader && (
         <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 p-4">
           <div className="flex items-start gap-3">
-            <AlertTriangle className="h-5 w-5 text-blue-600 mt-0.5" />
+            <AlertTriangle className="size-5 text-blue-600 mt-0.5" />
             <div className="flex-1">
               <h4 className="text-sm font-medium text-blue-900">Chế độ xem của Sở Y tế</h4>
               <p className="text-sm text-blue-700 mt-1">
@@ -57,65 +41,21 @@ export function PlanFiltersBar({
         </div>
       )}
 
-      {/* Facility Filter */}
-      {showFacilityFilter && (
-        <div className="flex items-center gap-2 mb-4 flex-wrap">
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
-            <Select
-              value={selectedFacilityId?.toString() || "all"}
-              onValueChange={(value) => onFacilityChange(value === "all" ? null : parseInt(value, 10))}
-              disabled={isLoadingFacilities || facilities.length === 0}
-            >
-              <SelectTrigger className="h-9 border-dashed">
-                <SelectValue placeholder={isLoadingFacilities ? "Đang tải..." : "Chọn cơ sở..."} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">
-                  <div className="flex items-center gap-2">
-                    <Building2 className="h-4 w-4 text-muted-foreground" />
-                    <span>Tất cả cơ sở</span>
-                  </div>
-                </SelectItem>
-                {facilities.length === 0 ? (
-                  <SelectItem value="empty" disabled>
-                    <span className="text-muted-foreground italic">Không có cơ sở</span>
-                  </SelectItem>
-                ) : (
-                  facilities.map((facility) => (
-                    <SelectItem key={facility.id} value={facility.id.toString()}>
-                      <span className="truncate">{facility.name}</span>
-                    </SelectItem>
-                  ))
-                )}
-              </SelectContent>
-            </Select>
-          </div>
-          {selectedFacilityId && (
-            <Badge variant="secondary" className="shrink-0">
-              {totalCount} kế hoạch
-            </Badge>
-          )}
-          {!selectedFacilityId && (
-            <Badge variant="outline" className="shrink-0">
-              {facilities.length} cơ sở • {totalCount} kế hoạch
-            </Badge>
-          )}
-        </div>
-      )}
-
-      {/* Search Section */}
-      <div className="flex flex-col sm:flex-row gap-4 mb-4">
-        <div className="flex-1">
-          <SearchInput
-            placeholder="Tìm kiếm theo tên kế hoạch, khoa/phòng, người lập..."
-            value={searchTerm}
-            onChange={onSearchChange}
-            showSearchIcon={false}
-            className="max-w-sm"
-          />
-        </div>
-      </div>
+      <ListFilterSearchCard
+        tenantControl={showFacilityFilter ? <TenantSelector className="w-full" /> : undefined}
+        surface="plain"
+        searchValue={searchTerm}
+        onSearchChange={onSearchChange}
+        searchPlaceholder="Tìm kiếm theo tên kế hoạch, khoa/phòng, người lập..."
+        showSearchIcon={false}
+        searchClassName="md:min-w-[280px] md:max-w-[420px]"
+        actions={(
+          <Badge variant="outline" className="shrink-0">
+            {totalCount} kế hoạch
+          </Badge>
+        )}
+        className="mb-4"
+      />
     </>
   )
 }

--- a/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
+++ b/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
@@ -7,35 +7,31 @@ export interface MaintenancePlanListControls {
   debouncedPlanSearch: string
   handlePlanSearchChange: (value: string) => void
   handleClearSearch: () => void
-  selectedFacilityId: number | null
-  handleFacilityChange: (facilityId: number | null) => void
   currentPage: number
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>
   pageSize: number
   handlePageSizeChange: (size: number) => void
-  isMobileFilterSheetOpen: boolean
-  handleMobileFilterSheetOpenChange: (open: boolean) => void
-  pendingFacilityFilter: number | null
-  setPendingFacilityFilter: React.Dispatch<React.SetStateAction<number | null>>
-  handleMobileFilterApply: () => void
-  handleMobileFilterClear: () => void
 }
 
-export function useMaintenancePlanListControls(): MaintenancePlanListControls {
+export function useMaintenancePlanListControls(
+  paginationResetKey?: number | null,
+): MaintenancePlanListControls {
   const [planSearchTerm, setPlanSearchTerm] = React.useState("")
-  const [selectedFacilityId, setSelectedFacilityId] = React.useState<number | null>(null)
   const [currentPage, setCurrentPage] = React.useState(1)
   const [pageSize, setPageSize] = React.useState(50)
-  const [isMobileFilterSheetOpen, setIsMobileFilterSheetOpen] = React.useState(false)
-  const [pendingFacilityFilter, setPendingFacilityFilter] = React.useState<number | null>(null)
   const debouncedPlanSearch = useSearchDebounce(planSearchTerm)
 
-  // Keep the query page reset in the same render where debounced search changes.
-  // This prevents one stale fetch with the new search and the old page number.
+  // Keep query page resets in the same render where debounced search or tenant changes.
+  // This prevents one stale fetch with the new filter and the old page number.
   let effectiveCurrentPage = currentPage
   const previousDebouncedPlanSearch = React.useRef(debouncedPlanSearch)
-  if (debouncedPlanSearch !== previousDebouncedPlanSearch.current) {
+  const previousPaginationResetKey = React.useRef(paginationResetKey)
+  if (
+    debouncedPlanSearch !== previousDebouncedPlanSearch.current
+    || paginationResetKey !== previousPaginationResetKey.current
+  ) {
     previousDebouncedPlanSearch.current = debouncedPlanSearch
+    previousPaginationResetKey.current = paginationResetKey
     effectiveCurrentPage = 1
     if (currentPage !== 1) {
       setCurrentPage(1)
@@ -52,37 +48,9 @@ export function useMaintenancePlanListControls(): MaintenancePlanListControls {
     setCurrentPage(1)
   }, [])
 
-  const handleFacilityChange = React.useCallback((facilityId: number | null) => {
-    setSelectedFacilityId(facilityId)
-    setCurrentPage(1)
-  }, [])
-
   const handlePageSizeChange = React.useCallback((size: number) => {
     setPageSize(size)
     setCurrentPage(1)
-  }, [])
-
-  const handleMobileFilterSheetOpenChange = React.useCallback(
-    (open: boolean) => {
-      setIsMobileFilterSheetOpen(open)
-      if (open) {
-        setPendingFacilityFilter(selectedFacilityId ?? null)
-      }
-    },
-    [selectedFacilityId]
-  )
-
-  const handleMobileFilterApply = React.useCallback(() => {
-    setSelectedFacilityId(pendingFacilityFilter ?? null)
-    setCurrentPage(1)
-    setIsMobileFilterSheetOpen(false)
-  }, [pendingFacilityFilter])
-
-  const handleMobileFilterClear = React.useCallback(() => {
-    setPendingFacilityFilter(null)
-    setSelectedFacilityId(null)
-    setCurrentPage(1)
-    setIsMobileFilterSheetOpen(false)
   }, [])
 
   return {
@@ -90,17 +58,9 @@ export function useMaintenancePlanListControls(): MaintenancePlanListControls {
     debouncedPlanSearch,
     handlePlanSearchChange,
     handleClearSearch,
-    selectedFacilityId,
-    handleFacilityChange,
     currentPage: effectiveCurrentPage,
     setCurrentPage,
     pageSize,
     handlePageSizeChange,
-    isMobileFilterSheetOpen,
-    handleMobileFilterSheetOpenChange,
-    pendingFacilityFilter,
-    setPendingFacilityFilter,
-    handleMobileFilterApply,
-    handleMobileFilterClear,
   }
 }

--- a/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
+++ b/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
@@ -21,22 +21,27 @@ export function useMaintenancePlanListControls(
   const [pageSize, setPageSize] = React.useState(50)
   const debouncedPlanSearch = useSearchDebounce(planSearchTerm)
 
-  // Keep query page resets in the same render where debounced search or tenant changes.
-  // This prevents one stale fetch with the new filter and the old page number.
-  let effectiveCurrentPage = currentPage
   const previousDebouncedPlanSearch = React.useRef(debouncedPlanSearch)
   const previousPaginationResetKey = React.useRef(paginationResetKey)
-  if (
+  const shouldResetPage =
     debouncedPlanSearch !== previousDebouncedPlanSearch.current
     || paginationResetKey !== previousPaginationResetKey.current
-  ) {
+
+  // Keep query page resets in the same render where debounced search or tenant changes.
+  // This prevents one stale fetch with the new filter and the old page number.
+  const effectiveCurrentPage = shouldResetPage ? 1 : currentPage
+
+  React.useEffect(() => {
+    if (!shouldResetPage) {
+      return
+    }
+
     previousDebouncedPlanSearch.current = debouncedPlanSearch
     previousPaginationResetKey.current = paginationResetKey
-    effectiveCurrentPage = 1
     if (currentPage !== 1) {
       setCurrentPage(1)
     }
-  }
+  }, [currentPage, debouncedPlanSearch, paginationResetKey, shouldResetPage])
 
   const handlePlanSearchChange = React.useCallback((value: string) => {
     setPlanSearchTerm(value)


### PR DESCRIPTION
## Summary
- migrate Maintenance plan filters to the Equipment-style `ListFilterSearchCard` section
- use the shared `TenantSelector` / `TenantSelectorSheet` path for tenant filtering on desktop and mobile
- remove Maintenance-owned facility dropdown/sheet state and gate Maintenance queries from `TenantSelectionContext`
- add focused tests for tenant-before-search layout and tenant-context pagination reset

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/maintenance/__tests__/plan-filters-bar.test.tsx' 'src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx' 'src/app/(app)/maintenance/__tests__/MaintenancePageDesktopContent.test.tsx' 'src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `git diff --check`

Fixes #413
Refs #410
Refs #428

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned Maintenance plan filters with the shared layout using `TenantSelector` and `ListFilterSearchCard`. Integrated `TenantSelectionContext` to gate fetches, hide data until a tenant is resolved, reset pagination and tenant-scoped state on tenant change, and added accessible labels for mobile controls. Fixes #413.

- **Refactors**
  - Unified desktop and mobile filtering with shared `TenantSelector`; removed local facility dropdown/sheet and facility fetching.
  - Switched to `ListFilterSearchCard` with the tenant slot before the search input.
  - Grouped props into `countsState`, `filterState`, `planListState`, `viewportState`, and `taskListState`; gated plan list/count queries with `enabled` and suppressed data until tenant resolution; reset page via `useMaintenancePlanListControls(tenantId)`.

- **Bug Fixes**
  - Cleared selected plan, drafts, active tab, and task row selection when the tenant changes.
  - Labeled icon-only search clear and pagination buttons on mobile for accessibility.
  - Added tests for tenant-before-search layout, pagination reset on tenant change, data suppression while tenant selection is unresolved, and mobile control labels.

<sup>Written for commit 70fd8c765fee02988a049886f3c8364b57cd3d22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated icon sizing and spacing for improved visual consistency across maintenance pages.

* **Tests**
  * Added new test coverage for plan filter UI and conditional rendering behavior.
  * Enhanced test fixtures to improve maintenance page coverage accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->