### PR TITLE
Fix #428: Migrate Reports filters to shared layout

### DIFF
--- a/src/app/(app)/reports/components/__tests__/inventory-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/inventory-report-tab.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { render, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { InventoryReportTab } from "../inventory-report-tab"
 
@@ -50,6 +50,40 @@ vi.mock("../export-report-dialog", () => ({
   ExportReportDialog: () => <div data-testid="export-report-dialog" />,
 }))
 
+vi.mock("@/components/shared/ListFilterSearchCard", () => ({
+  ListFilterSearchCard: ({
+    title,
+    description,
+    searchValue,
+    onSearchChange,
+    searchPlaceholder,
+    filterControls,
+    actions,
+  }: {
+    title?: React.ReactNode
+    description?: React.ReactNode
+    searchValue?: string
+    onSearchChange?: (value: string) => void
+    searchPlaceholder?: string
+    filterControls?: React.ReactNode
+    actions?: React.ReactNode
+  }) => (
+    <section data-testid="reports-shared-filter-section">
+      {title ? <h2>{title}</h2> : null}
+      {description ? <p>{description}</p> : null}
+      {searchPlaceholder ? (
+        <input
+          aria-label={searchPlaceholder}
+          value={searchValue ?? ""}
+          onChange={(event) => onSearchChange?.(event.target.value)}
+        />
+      ) : null}
+      {filterControls}
+      {actions}
+    </section>
+  ),
+}))
+
 vi.mock("@/components/interactive-equipment-chart", () => ({
   InteractiveEquipmentChart: () => <div data-testid="interactive-equipment-chart" />,
 }))
@@ -71,7 +105,9 @@ vi.mock("@/components/ui/card", () => ({
 }))
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>{children}</button>
+  ),
 }))
 
 vi.mock("@/components/ui/calendar", () => ({
@@ -105,6 +141,10 @@ vi.mock("@/components/ui/skeleton", () => ({
 }))
 
 describe("InventoryReportTab", () => {
+  const setSearchTerm = vi.fn()
+  const setSelectedDepartment = vi.fn()
+  const refetch = vi.fn()
+
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.useReportInventoryFilters.mockReturnValue({
@@ -117,14 +157,23 @@ describe("InventoryReportTab", () => {
         searchTerm: "",
       },
       setDateRange: vi.fn(),
-      setSelectedDepartment: vi.fn(),
-      setSearchTerm: vi.fn(),
+      setSelectedDepartment,
+      setSearchTerm,
     })
     mocks.useInventoryData.mockReturnValue({
-      data: undefined,
+      data: {
+        data: [],
+        summary: {
+          totalImported: 0,
+          totalExported: 0,
+          currentStock: 0,
+          netChange: 0,
+        },
+        departments: ["Khoa Nội"],
+      },
       isLoading: false,
-      error: { message: "Inventory unavailable" },
-      refetch: vi.fn(),
+      error: null,
+      refetch,
     })
     mocks.useEquipmentDistribution.mockReturnValue({ data: [] })
     mocks.useMaintenanceStats.mockReturnValue({ data: [] })
@@ -132,6 +181,13 @@ describe("InventoryReportTab", () => {
   })
 
   it("shows the plain-object error message in the destructive toast", async () => {
+    mocks.useInventoryData.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: { message: "Inventory unavailable" },
+      refetch,
+    })
+
     render(<InventoryReportTab tenantFilter="all" effectiveTenantKey="tenant-a" />)
 
     await waitFor(() => {
@@ -143,5 +199,34 @@ describe("InventoryReportTab", () => {
         })
       )
     })
+  })
+
+  it("renders inventory filters through the shared filter section and preserves search/action behavior", () => {
+    render(<InventoryReportTab tenantFilter="1" effectiveTenantKey="tenant-a" />)
+
+    expect(screen.getByTestId("reports-shared-filter-section")).toBeInTheDocument()
+    expect(screen.getByText("Báo cáo Xuất-Nhập-Tồn thiết bị")).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Tên hoặc mã thiết bị..." }), {
+      target: { value: "máy siêu âm" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Làm mới" }))
+
+    expect(setSearchTerm).toHaveBeenCalledWith("máy siêu âm")
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps department filtering hidden for global or regional report contexts", () => {
+    render(
+      <InventoryReportTab
+        tenantFilter="all"
+        effectiveTenantKey="tenant-a"
+        isGlobalOrRegionalLeader
+      />
+    )
+
+    expect(screen.getByTestId("reports-shared-filter-section")).toBeInTheDocument()
+    expect(screen.queryByText("Khoa/Phòng")).not.toBeInTheDocument()
+    expect(setSelectedDepartment).not.toHaveBeenCalled()
   })
 })

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-date-filter.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-date-filter.test.tsx
@@ -2,19 +2,37 @@ import * as React from "react"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
+const JANUARY_START = new Date("2026-01-01T00:00:00.000Z")
+const JANUARY_END = new Date("2026-01-31T00:00:00.000Z")
+const FEBRUARY_START = new Date("2026-02-01T00:00:00.000Z")
+const FEBRUARY_END = new Date("2026-02-28T00:00:00.000Z")
+
 vi.mock("@/components/shared/ListFilterSearchCard", () => ({
   ListFilterSearchCard: ({
     title,
     description,
+    searchValue,
+    onSearchChange,
+    searchPlaceholder,
     filterControls,
   }: {
     title?: React.ReactNode
     description?: React.ReactNode
+    searchValue?: string
+    onSearchChange?: (value: string) => void
+    searchPlaceholder?: string
     filterControls?: React.ReactNode
   }) => (
     <section data-testid="maintenance-report-shared-filter">
       {title ? <h2>{title}</h2> : null}
       {description ? <p>{description}</p> : null}
+      {searchPlaceholder ? (
+        <input
+          aria-label={searchPlaceholder}
+          value={searchValue ?? ""}
+          onChange={(event) => onSearchChange?.(event.target.value)}
+        />
+      ) : null}
       {filterControls}
     </section>
   ),
@@ -31,8 +49,8 @@ vi.mock("@/components/ui/calendar", () => ({
     <button
       type="button"
       onClick={() => onSelect?.({
-        from: new Date("2026-02-01T00:00:00.000Z"),
-        to: new Date("2026-02-28T00:00:00.000Z"),
+        from: FEBRUARY_START,
+        to: FEBRUARY_END,
       })}
     >
       Chọn tháng 2
@@ -53,8 +71,8 @@ describe("MaintenanceReportDateFilter", () => {
     render(
       <MaintenanceReportDateFilter
         dateRange={{
-          from: new Date("2026-01-01T00:00:00.000Z"),
-          to: new Date("2026-01-31T00:00:00.000Z"),
+          from: JANUARY_START,
+          to: JANUARY_END,
         }}
         onDateRangeChange={vi.fn()}
       />
@@ -71,8 +89,8 @@ describe("MaintenanceReportDateFilter", () => {
     render(
       <MaintenanceReportDateFilter
         dateRange={{
-          from: new Date("2026-01-01T00:00:00.000Z"),
-          to: new Date("2026-01-31T00:00:00.000Z"),
+          from: JANUARY_START,
+          to: JANUARY_END,
         }}
         onDateRangeChange={onDateRangeChange}
       />
@@ -81,8 +99,8 @@ describe("MaintenanceReportDateFilter", () => {
     fireEvent.click(screen.getByRole("button", { name: "Chọn tháng 2" }))
 
     expect(onDateRangeChange).toHaveBeenCalledWith({
-      from: new Date("2026-02-01T00:00:00.000Z"),
-      to: new Date("2026-02-28T00:00:00.000Z"),
+      from: FEBRUARY_START,
+      to: FEBRUARY_END,
     })
   })
 })

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-date-filter.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-date-filter.test.tsx
@@ -1,0 +1,88 @@
+import * as React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/components/shared/ListFilterSearchCard", () => ({
+  ListFilterSearchCard: ({
+    title,
+    description,
+    filterControls,
+  }: {
+    title?: React.ReactNode
+    description?: React.ReactNode
+    filterControls?: React.ReactNode
+  }) => (
+    <section data-testid="maintenance-report-shared-filter">
+      {title ? <h2>{title}</h2> : null}
+      {description ? <p>{description}</p> : null}
+      {filterControls}
+    </section>
+  ),
+}))
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>{children}</button>
+  ),
+}))
+
+vi.mock("@/components/ui/calendar", () => ({
+  Calendar: ({ onSelect }: { onSelect?: (range: { from?: Date; to?: Date }) => void }) => (
+    <button
+      type="button"
+      onClick={() => onSelect?.({
+        from: new Date("2026-02-01T00:00:00.000Z"),
+        to: new Date("2026-02-28T00:00:00.000Z"),
+      })}
+    >
+      Chọn tháng 2
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+import { MaintenanceReportDateFilter } from "../maintenance-report-date-filter"
+
+describe("MaintenanceReportDateFilter", () => {
+  it("renders through the shared filter section without a search box", () => {
+    render(
+      <MaintenanceReportDateFilter
+        dateRange={{
+          from: new Date("2026-01-01T00:00:00.000Z"),
+          to: new Date("2026-01-31T00:00:00.000Z"),
+        }}
+        onDateRangeChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId("maintenance-report-shared-filter")).toBeInTheDocument()
+    expect(screen.getByText("Bộ lọc báo cáo")).toBeInTheDocument()
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument()
+  })
+
+  it("keeps date range selection behavior", () => {
+    const onDateRangeChange = vi.fn()
+
+    render(
+      <MaintenanceReportDateFilter
+        dateRange={{
+          from: new Date("2026-01-01T00:00:00.000Z"),
+          to: new Date("2026-01-31T00:00:00.000Z"),
+        }}
+        onDateRangeChange={onDateRangeChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Chọn tháng 2" }))
+
+    expect(onDateRangeChange).toHaveBeenCalledWith({
+      from: new Date("2026-02-01T00:00:00.000Z"),
+      to: new Date("2026-02-28T00:00:00.000Z"),
+    })
+  })
+})

--- a/src/app/(app)/reports/components/inventory-report-filter-section.tsx
+++ b/src/app/(app)/reports/components/inventory-report-filter-section.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import * as React from "react"
+import { CalendarIcon, Download, FileText } from "lucide-react"
+import { format } from "date-fns"
+import { vi } from "date-fns/locale"
+
+import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
+import { cn } from "@/lib/utils"
+import type { DateRange } from "../hooks/use-report-filters"
+
+interface InventoryReportFilterSectionProps {
+  dateRange: DateRange
+  onDateRangeChange: (dateRange: DateRange) => void
+  selectedDepartment: string
+  onSelectedDepartmentChange: (department: string) => void
+  searchTerm: string
+  onSearchTermChange: (searchTerm: string) => void
+  departments: string[]
+  isGlobalOrRegionalLeader?: boolean
+  isLoading: boolean
+  onRefresh: () => void
+  onExport: () => void
+}
+
+export function InventoryReportFilterSection({
+  dateRange,
+  onDateRangeChange,
+  selectedDepartment,
+  onSelectedDepartmentChange,
+  searchTerm,
+  onSearchTermChange,
+  departments,
+  isGlobalOrRegionalLeader,
+  isLoading,
+  onRefresh,
+  onExport,
+}: InventoryReportFilterSectionProps) {
+  const filterControls = (
+    <>
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium">Khoảng thời gian</label>
+        <div className="flex flex-wrap gap-2">
+          <InventoryReportDateButton
+            label="Từ ngày"
+            value={dateRange.from}
+            onSelect={(date) => onDateRangeChange({ ...dateRange, from: date })}
+            isDateDisabled={(date) => date > new Date() || date < new Date("1900-01-01")}
+          />
+          <InventoryReportDateButton
+            label="Đến ngày"
+            value={dateRange.to}
+            onSelect={(date) => onDateRangeChange({ ...dateRange, to: date })}
+            isDateDisabled={(date) => date > new Date() || date < dateRange.from}
+          />
+        </div>
+      </div>
+
+      {!isGlobalOrRegionalLeader ? (
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium">Khoa/Phòng</label>
+          <Select value={selectedDepartment} onValueChange={onSelectedDepartmentChange}>
+            <SelectTrigger className="h-9 w-full min-w-[200px] md:w-[200px]">
+              <SelectValue placeholder="Chọn khoa/phòng" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Tất cả</SelectItem>
+              {departments.map((department) => (
+                <SelectItem key={department} value={department}>
+                  {department || "Chưa phân loại"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : null}
+    </>
+  )
+
+  const actions = (
+    <>
+      <Button variant="outline" onClick={onRefresh} disabled={isLoading}>
+        Làm mới
+      </Button>
+      <Button onClick={onExport}>
+        <Download className="mr-2 h-4 w-4" />
+        Xuất báo cáo
+      </Button>
+    </>
+  )
+
+  return (
+    <ListFilterSearchCard
+      title={(
+        <span className="flex items-center gap-2">
+          <FileText className="h-5 w-5" />
+          Báo cáo Xuất-Nhập-Tồn thiết bị
+        </span>
+      )}
+      description="Theo dõi tình hình xuất, nhập và tồn kho thiết bị theo thời gian"
+      searchValue={searchTerm}
+      onSearchChange={onSearchTermChange}
+      searchPlaceholder="Tên hoặc mã thiết bị..."
+      showSearchIcon={false}
+      searchClassName="md:min-w-[220px] md:max-w-[320px]"
+      filterControls={filterControls}
+      actions={actions}
+    />
+  )
+}
+
+interface InventoryReportDateButtonProps {
+  label: string
+  value: Date
+  onSelect: (date: Date) => void
+  isDateDisabled: (date: Date) => boolean
+}
+
+function InventoryReportDateButton({
+  label,
+  value,
+  onSelect,
+  isDateDisabled,
+}: InventoryReportDateButtonProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "h-9 w-[140px] justify-start text-left font-normal",
+            !value && "text-muted-foreground"
+          )}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {value ? format(value, "dd/MM/yyyy") : label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={value}
+          onSelect={(date) => date && onSelect(date)}
+          disabled={isDateDisabled}
+          initialFocus
+          locale={vi}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/app/(app)/reports/components/inventory-report-filter-section.tsx
+++ b/src/app/(app)/reports/components/inventory-report-filter-section.tsx
@@ -42,7 +42,27 @@ export function InventoryReportFilterSection({
   onRefresh,
   onExport,
 }: InventoryReportFilterSectionProps) {
-  const [maxReportDate] = React.useState(() => new Date())
+  const [maxReportDate, setMaxReportDate] = React.useState(() => new Date())
+
+  React.useEffect(() => {
+    let refreshTimer: ReturnType<typeof setTimeout>
+
+    const refreshMaxReportDate = () => {
+      const now = new Date()
+      const nextLocalMidnight = new Date(now)
+      nextLocalMidnight.setHours(24, 0, 0, 0)
+
+      setMaxReportDate(now)
+      refreshTimer = setTimeout(
+        refreshMaxReportDate,
+        Math.max(nextLocalMidnight.getTime() - now.getTime(), 1000)
+      )
+    }
+
+    refreshMaxReportDate()
+
+    return () => clearTimeout(refreshTimer)
+  }, [])
 
   const filterControls = (
     <>

--- a/src/app/(app)/reports/components/inventory-report-filter-section.tsx
+++ b/src/app/(app)/reports/components/inventory-report-filter-section.tsx
@@ -13,18 +13,20 @@ import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { cn } from "@/lib/utils"
 import type { DateRange } from "../hooks/use-report-filters"
 
+const MIN_REPORT_DATE = new Date("1900-01-01")
+
 interface InventoryReportFilterSectionProps {
-  dateRange: DateRange
-  onDateRangeChange: (dateRange: DateRange) => void
-  selectedDepartment: string
-  onSelectedDepartmentChange: (department: string) => void
-  searchTerm: string
-  onSearchTermChange: (searchTerm: string) => void
-  departments: string[]
-  isGlobalOrRegionalLeader?: boolean
-  isLoading: boolean
-  onRefresh: () => void
-  onExport: () => void
+  readonly dateRange: DateRange
+  readonly onDateRangeChange: (dateRange: DateRange) => void
+  readonly selectedDepartment: string
+  readonly onSelectedDepartmentChange: (department: string) => void
+  readonly searchTerm: string
+  readonly onSearchTermChange: (searchTerm: string) => void
+  readonly departments: string[]
+  readonly isGlobalOrRegionalLeader?: boolean
+  readonly isLoading: boolean
+  readonly onRefresh: () => void
+  readonly onExport: () => void
 }
 
 export function InventoryReportFilterSection({
@@ -40,29 +42,31 @@ export function InventoryReportFilterSection({
   onRefresh,
   onExport,
 }: InventoryReportFilterSectionProps) {
+  const [maxReportDate] = React.useState(() => new Date())
+
   const filterControls = (
     <>
-      <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium">Khoảng thời gian</label>
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-medium">Khoảng thời gian</legend>
         <div className="flex flex-wrap gap-2">
           <InventoryReportDateButton
             label="Từ ngày"
             value={dateRange.from}
             onSelect={(date) => onDateRangeChange({ ...dateRange, from: date })}
-            isDateDisabled={(date) => date > new Date() || date < new Date("1900-01-01")}
+            isDateDisabled={(date) => date > maxReportDate || date < MIN_REPORT_DATE}
           />
           <InventoryReportDateButton
             label="Đến ngày"
             value={dateRange.to}
             onSelect={(date) => onDateRangeChange({ ...dateRange, to: date })}
-            isDateDisabled={(date) => date > new Date() || date < dateRange.from}
+            isDateDisabled={(date) => date > maxReportDate || date < dateRange.from}
           />
         </div>
-      </div>
+      </fieldset>
 
       {!isGlobalOrRegionalLeader ? (
-        <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium">Khoa/Phòng</label>
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-sm font-medium">Khoa/Phòng</legend>
           <Select value={selectedDepartment} onValueChange={onSelectedDepartmentChange}>
             <SelectTrigger className="h-9 w-full min-w-[200px] md:w-[200px]">
               <SelectValue placeholder="Chọn khoa/phòng" />
@@ -76,7 +80,7 @@ export function InventoryReportFilterSection({
               ))}
             </SelectContent>
           </Select>
-        </div>
+        </fieldset>
       ) : null}
     </>
   )
@@ -87,7 +91,7 @@ export function InventoryReportFilterSection({
         Làm mới
       </Button>
       <Button onClick={onExport}>
-        <Download className="mr-2 h-4 w-4" />
+        <Download className="mr-2 size-4" />
         Xuất báo cáo
       </Button>
     </>
@@ -97,7 +101,7 @@ export function InventoryReportFilterSection({
     <ListFilterSearchCard
       title={(
         <span className="flex items-center gap-2">
-          <FileText className="h-5 w-5" />
+          <FileText className="size-5" />
           Báo cáo Xuất-Nhập-Tồn thiết bị
         </span>
       )}
@@ -114,10 +118,10 @@ export function InventoryReportFilterSection({
 }
 
 interface InventoryReportDateButtonProps {
-  label: string
-  value: Date
-  onSelect: (date: Date) => void
-  isDateDisabled: (date: Date) => boolean
+  readonly label: string
+  readonly value: Date
+  readonly onSelect: (date: Date) => void
+  readonly isDateDisabled: (date: Date) => boolean
 }
 
 function InventoryReportDateButton({
@@ -136,7 +140,7 @@ function InventoryReportDateButton({
             !value && "text-muted-foreground"
           )}
         >
-          <CalendarIcon className="mr-2 h-4 w-4" />
+          <CalendarIcon className="mr-2 size-4" />
           {value ? format(value, "dd/MM/yyyy") : label}
         </Button>
       </PopoverTrigger>

--- a/src/app/(app)/reports/components/inventory-report-tab.tsx
+++ b/src/app/(app)/reports/components/inventory-report-tab.tsx
@@ -147,7 +147,7 @@ export function InventoryReportTab({
         {/* Summary Cards */}
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between pb-2 [&>*+*]:mt-0">
               <CardTitle className="text-sm font-medium">Tổng nhập</CardTitle>
               <TrendingUp className="size-4 text-muted-foreground" />
             </CardHeader>
@@ -162,7 +162,7 @@ export function InventoryReportTab({
           </Card>
           
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between pb-2 [&>*+*]:mt-0">
               <CardTitle className="text-sm font-medium">Tổng xuất</CardTitle>
               <TrendingDown className="size-4 text-muted-foreground" />
             </CardHeader>
@@ -177,7 +177,7 @@ export function InventoryReportTab({
           </Card>
           
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between pb-2 [&>*+*]:mt-0">
               <CardTitle className="text-sm font-medium">Tồn kho</CardTitle>
               <Package className="size-4 text-muted-foreground" />
             </CardHeader>
@@ -192,7 +192,7 @@ export function InventoryReportTab({
           </Card>
           
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between pb-2 [&>*+*]:mt-0">
               <CardTitle className="text-sm font-medium">Biến động</CardTitle>
               <Badge variant={summary.netChange >= 0 ? "default" : "destructive"}>
                 {summary.netChange >= 0 ? "+" : ""}{summary.netChange}

--- a/src/app/(app)/reports/components/inventory-report-tab.tsx
+++ b/src/app/(app)/reports/components/inventory-report-tab.tsx
@@ -1,24 +1,17 @@
 "use client"
 
 import * as React from "react"
-import { CalendarIcon, Download, FileText, TrendingUp, TrendingDown, Package } from "lucide-react"
-import { format, subMonths, startOfMonth, endOfMonth } from "date-fns"
-import { vi } from "date-fns/locale"
+import { TrendingUp, TrendingDown, Package } from "lucide-react"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Calendar } from "@/components/ui/calendar"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Input } from "@/components/ui/input"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useToast } from "@/hooks/use-toast"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
-import { cn } from "@/lib/utils"
 import { InventoryCharts } from "./inventory-charts"
 import { InventoryTable } from "./inventory-table"
 import { ExportReportDialog } from "./export-report-dialog"
+import { InventoryReportFilterSection } from "./inventory-report-filter-section"
 import { useInventoryData } from "../hooks/use-inventory-data"
 import { InteractiveEquipmentChart } from "@/components/interactive-equipment-chart"
 import { EquipmentDistributionSummary } from "@/components/equipment-distribution-summary"
@@ -28,16 +21,28 @@ import { useEquipmentDistribution } from "@/hooks/use-equipment-distribution"
 import { useMaintenanceStats } from "../hooks/use-maintenance-stats"
 import { useUsageAnalytics } from "../hooks/use-usage-analytics"
 
-interface DateRange {
-  from: Date
-  to: Date
-}
-
 interface InventoryReportTabProps {
   tenantFilter?: string
   selectedDonVi?: number | null
   effectiveTenantKey?: string
   isGlobalOrRegionalLeader?: boolean
+}
+
+interface InventoryReportErrorToastProps {
+  error: unknown
+  toast: ReturnType<typeof useToast>["toast"]
+}
+
+function InventoryReportErrorToast({ error, toast }: InventoryReportErrorToastProps) {
+  React.useEffect(() => {
+    toast({
+      variant: "destructive",
+      title: "Lỗi tải dữ liệu",
+      description: getUnknownErrorMessage(error, "Không thể tải dữ liệu báo cáo")
+    })
+  }, [error, toast])
+
+  return null
 }
 
 export function InventoryReportTab({ 
@@ -121,151 +126,30 @@ export function InventoryReportTab({
     })
   }
 
-  // Show error if any
-  React.useEffect(() => {
-    if (error) {
-      toast({
-        variant: "destructive",
-        title: "Lỗi tải dữ liệu",
-        description: getUnknownErrorMessage(error, "Không thể tải dữ liệu báo cáo")
-      })
-    }
-  }, [error, toast])
-
   return (
     <>
+      {error ? <InventoryReportErrorToast error={error} toast={toast} /> : null}
       <div className="space-y-4">
-        {/* Filters Section */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <FileText className="h-5 w-5" />
-              Báo cáo Xuất-Nhập-Tồn thiết bị
-            </CardTitle>
-            <CardDescription>
-              Theo dõi tình hình xuất, nhập và tồn kho thiết bị theo thời gian
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-col sm:flex-row gap-4">
-              {/* Date Range Picker */}
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium">Khoảng thời gian</label>
-                <div className="flex gap-2">
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "w-[140px] justify-start text-left font-normal",
-                          !dateRange.from && "text-muted-foreground"
-                        )}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {dateRange.from ? (
-                          format(dateRange.from, "dd/MM/yyyy")
-                        ) : (
-                          "Từ ngày"
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={dateRange.from}
-                        onSelect={(date) => date && setDateRange({ ...dateRange, from: date })}
-                        disabled={(date) => date > new Date() || date < new Date("1900-01-01")}
-                        initialFocus
-                        locale={vi}
-                      />
-                    </PopoverContent>
-                  </Popover>
-                  
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "w-[140px] justify-start text-left font-normal",
-                          !dateRange.to && "text-muted-foreground"
-                        )}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {dateRange.to ? (
-                          format(dateRange.to, "dd/MM/yyyy")
-                        ) : (
-                          "Đến ngày"
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={dateRange.to}
-                        onSelect={(date) => date && setDateRange({ ...dateRange, to: date })}
-                        disabled={(date) => date > new Date() || date < dateRange.from}
-                        initialFocus
-                        locale={vi}
-                      />
-                    </PopoverContent>
-                  </Popover>
-                </div>
-              </div>
-
-              {/* Department Filter (hidden for RL/global users) */}
-              {!isGlobalOrRegionalLeader && (
-                <div className="flex flex-col gap-2">
-                  <label className="text-sm font-medium">Khoa/Phòng</label>
-                  <Select value={selectedDepartment} onValueChange={setSelectedDepartment}>
-                    <SelectTrigger className="w-[200px]">
-                      <SelectValue placeholder="Chọn khoa/phòng" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">Tất cả</SelectItem>
-                      {departments.map((dept: string) => (
-                        <SelectItem key={dept} value={dept}>
-                          {dept || "Chưa phân loại"}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
-
-              {/* Search */}
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium">Tìm kiếm</label>
-                <Input
-                  placeholder="Tên hoặc mã thiết bị..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-[200px]"
-                />
-              </div>
-
-              {/* Actions */}
-              <div className="flex flex-col gap-2 sm:ml-auto">
-                <label className="text-sm font-medium invisible">Actions</label>
-                <div className="flex gap-2">
-                  <Button variant="outline" onClick={handleRefresh} disabled={isLoading}>
-                    Làm mới
-                  </Button>
-                  <Button onClick={() => setShowExportDialog(true)}>
-                    <Download className="mr-2 h-4 w-4" />
-                    Xuất báo cáo
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <InventoryReportFilterSection
+          dateRange={dateRange}
+          onDateRangeChange={setDateRange}
+          selectedDepartment={selectedDepartment}
+          onSelectedDepartmentChange={setSelectedDepartment}
+          searchTerm={searchTerm}
+          onSearchTermChange={setSearchTerm}
+          departments={departments}
+          isGlobalOrRegionalLeader={isGlobalOrRegionalLeader}
+          isLoading={isLoading}
+          onRefresh={handleRefresh}
+          onExport={() => setShowExportDialog(true)}
+        />
 
         {/* Summary Cards */}
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Tổng nhập</CardTitle>
-              <TrendingUp className="h-4 w-4 text-muted-foreground" />
+              <TrendingUp className="size-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">
@@ -278,9 +162,9 @@ export function InventoryReportTab({
           </Card>
           
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Tổng xuất</CardTitle>
-              <TrendingDown className="h-4 w-4 text-muted-foreground" />
+              <TrendingDown className="size-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">
@@ -293,9 +177,9 @@ export function InventoryReportTab({
           </Card>
           
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Tồn kho</CardTitle>
-              <Package className="h-4 w-4 text-muted-foreground" />
+              <Package className="size-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">
@@ -308,7 +192,7 @@ export function InventoryReportTab({
           </Card>
           
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Biến động</CardTitle>
               <Badge variant={summary.netChange >= 0 ? "default" : "destructive"}>
                 {summary.netChange >= 0 ? "+" : ""}{summary.netChange}

--- a/src/app/(app)/reports/components/maintenance-report-date-filter.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-date-filter.tsx
@@ -7,8 +7,8 @@ import { Calendar as CalendarIcon } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import type { DateRange } from "../hooks/use-maintenance-data.types"
 
 interface MaintenanceReportDateFilterRange {
@@ -42,43 +42,43 @@ export function MaintenanceReportDateFilter({
   dateRange,
   onDateRangeChange,
 }: MaintenanceReportDateFilterProps) {
+  const filterControls = (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          id="date"
+          variant="outline"
+          className="h-9 w-full justify-start text-left font-normal sm:w-[300px]"
+        >
+          <CalendarIcon className="mr-2 size-4" />
+          {getDateRangeLabel(dateRange)}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          initialFocus
+          mode="range"
+          defaultMonth={dateRange.from}
+          selected={{ from: dateRange.from, to: dateRange.to }}
+          onSelect={(range) =>
+            range?.from &&
+            onDateRangeChange({
+              from: range.from,
+              to: range.to ?? range.from,
+            })
+          }
+          numberOfMonths={2}
+          locale={vi}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Bộ lọc báo cáo</CardTitle>
-        <CardDescription>Chọn khoảng thời gian để xem báo cáo.</CardDescription>
-      </CardHeader>
-      <CardContent className="flex items-center gap-4">
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button
-              id="date"
-              variant="outline"
-              className="w-[300px] justify-start text-left font-normal"
-            >
-              <CalendarIcon className="mr-2 h-4 w-4" />
-              {getDateRangeLabel(dateRange)}
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-0" align="start">
-            <Calendar
-              initialFocus
-              mode="range"
-              defaultMonth={dateRange.from}
-              selected={{ from: dateRange.from, to: dateRange.to }}
-              onSelect={(range) =>
-                range?.from &&
-                onDateRangeChange({
-                  from: range.from,
-                  to: range.to ?? range.from,
-                })
-              }
-              numberOfMonths={2}
-              locale={vi}
-            />
-          </PopoverContent>
-        </Popover>
-      </CardContent>
-    </Card>
+    <ListFilterSearchCard
+      title="Bộ lọc báo cáo"
+      description="Chọn khoảng thời gian để xem báo cáo."
+      filterControls={filterControls}
+    />
   )
 }

--- a/src/components/shared/ListFilterSearchCard.tsx
+++ b/src/components/shared/ListFilterSearchCard.tsx
@@ -6,17 +6,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { SearchInput } from "@/components/shared/SearchInput"
 import { cn } from "@/lib/utils"
 
-export interface ListFilterSearchCardProps {
+interface ListFilterSearchCardBaseProps {
   title?: React.ReactNode
   description?: React.ReactNode
   tenantControl?: React.ReactNode
   surface?: "card" | "plain"
-  searchValue: string
-  onSearchChange: (value: string) => void
-  searchInputRef?: React.Ref<HTMLInputElement>
-  searchPlaceholder: string
-  searchEndAddon?: React.ReactNode
-  showSearchIcon?: boolean
   filterControls?: React.ReactNode
   mobileFilterControl?: React.ReactNode
   compactFilters?: boolean
@@ -26,6 +20,29 @@ export interface ListFilterSearchCardProps {
   className?: string
   searchClassName?: string
 }
+
+interface ListFilterSearchCardSearchProps {
+  searchValue: string
+  onSearchChange: (value: string) => void
+  searchInputRef?: React.Ref<HTMLInputElement>
+  searchPlaceholder: string
+  searchEndAddon?: React.ReactNode
+  showSearchIcon?: boolean
+}
+
+interface ListFilterSearchCardFilterOnlyProps {
+  searchValue?: never
+  onSearchChange?: never
+  searchInputRef?: never
+  searchPlaceholder?: never
+  searchEndAddon?: never
+  showSearchIcon?: never
+}
+
+export type ListFilterSearchCardProps = ListFilterSearchCardBaseProps & (
+  | ListFilterSearchCardSearchProps
+  | ListFilterSearchCardFilterOnlyProps
+)
 
 export function ListFilterSearchCard({
   title,
@@ -48,6 +65,7 @@ export function ListFilterSearchCard({
   searchClassName,
 }: ListFilterSearchCardProps) {
   const visibleFilterControls = compactFilters ? mobileFilterControl : filterControls
+  const shouldRenderSearch = typeof searchPlaceholder === "string" && typeof onSearchChange === "function"
 
   const header = !title && !description
     ? null
@@ -83,18 +101,20 @@ export function ListFilterSearchCard({
             </div>
           ) : null}
 
-          <div className={cn("w-full md:min-w-[280px] md:max-w-[460px] md:flex-1", searchClassName)}>
-            <SearchInput
-              ref={searchInputRef}
-              placeholder={searchPlaceholder}
-              value={searchValue}
-              onChange={onSearchChange}
-              showSearchIcon={showSearchIcon}
-              className="h-9 w-full"
-              endAddon={searchEndAddon}
-              aria-label={searchPlaceholder}
-            />
-          </div>
+          {shouldRenderSearch ? (
+            <div className={cn("w-full md:min-w-[280px] md:max-w-[460px] md:flex-1", searchClassName)}>
+              <SearchInput
+                ref={searchInputRef}
+                placeholder={searchPlaceholder}
+                value={searchValue}
+                onChange={onSearchChange}
+                showSearchIcon={showSearchIcon}
+                className="h-9 w-full"
+                endAddon={searchEndAddon}
+                aria-label={searchPlaceholder}
+              />
+            </div>
+          ) : null}
 
           {visibleFilterControls ? (
             <div className="flex w-full flex-wrap items-center gap-2 md:w-auto">

--- a/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
+++ b/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
@@ -55,6 +55,20 @@ describe("ListFilterSearchCard", () => {
     expect(screen.getByRole("button", { name: "Tùy chọn" })).toBeInTheDocument()
   })
 
+  it("supports filter-only sections without rendering a search input", () => {
+    render(
+      <ListFilterSearchCard
+        title="Bộ lọc báo cáo"
+        filterControls={<button type="button">Khoảng thời gian</button>}
+        actions={<button type="button">Làm mới</button>}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Khoảng thời gian" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Làm mới" })).toBeInTheDocument()
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument()
+  })
+
   it("can render as a plain surface for embedding inside an existing card", () => {
     const { container } = render(
       <ListFilterSearchCard


### PR DESCRIPTION
## Summary
- Extend `ListFilterSearchCard` so Reports can use the shared filter section without forcing a search box.
- Extract the inventory report filter/search/actions into a shared-layout section while preserving date, department, search, refresh, export, and tenant visibility behavior.
- Move the maintenance report date filter onto the shared filter section in filter-only mode.
- Split Device Quota rollout to follow-up #433.

Fixes #428
Refs #413
Refs #433

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run src/components/shared/__tests__/ListFilterSearchCard.test.tsx src/app/'(app)'/reports/components/__tests__/inventory-report-tab.test.tsx src/app/'(app)'/reports/components/__tests__/maintenance-report-date-filter.test.tsx src/app/'(app)'/reports/components/__tests__/maintenance-report-tab.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated inventory and maintenance report filters to the shared `ListFilterSearchCard` layout, adding a filter-only mode and a dedicated inventory filter section. Fixes #428 and updates report date cutoff handling while preserving existing behavior.

- **New Features**
  - Extended `ListFilterSearchCard` with a filter-only mode and conditional search rendering.
  - Added `InventoryReportFilterSection` with date range, optional department, search, refresh, and export actions.
  - Moved maintenance report date filter to the shared section without a search box.

- **Refactors**
  - `InventoryReportTab` now uses `InventoryReportFilterSection`; department filter remains hidden for global/regional leaders.
  - Extracted error toast into `InventoryReportErrorToast`.
  - Fixed max selectable report date to refresh at local midnight to avoid stale cutoff.
  - Split Device Quota rollout to follow-up #433 (refs #413).

<sup>Written for commit f8de139ad74a56128e2d4f9d8f591a590d8d4104. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for inventory and maintenance report filters, including search interactions, department selection, and date range functionality.
  * Added test coverage for optional search functionality in shared filter components.

* **Refactor**
  * Reorganized report filter UI into dedicated filter sections for better maintainability and consistency.
  * Made search functionality optional in filter cards, allowing filters to be used without search capabilities.
  * Improved filter component styling and layout consistency across reports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/434)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->