### PR TITLE
fix: show department names in report chart tooltips

### DIFF
--- a/src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx
+++ b/src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx
@@ -1,0 +1,181 @@
+import * as React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ChartTooltipProps } from "@/lib/chart-utils"
+
+import { InteractiveEquipmentChart } from "@/components/interactive-equipment-chart"
+
+const mocks = vi.hoisted(() => ({
+  useEquipmentDistribution: vi.fn(),
+}))
+
+vi.mock("@/hooks/use-equipment-distribution", () => ({
+  useEquipmentDistribution: (...args: unknown[]) => mocks.useEquipmentDistribution(...args),
+  STATUS_COLORS: {
+    hoat_dong: "#22c55e",
+    cho_sua_chua: "#ef4444",
+    cho_bao_tri: "#f59e0b",
+    cho_hieu_chuan: "#8b5cf6",
+    ngung_su_dung: "#6b7280",
+    chua_co_nhu_cau: "#9ca3af",
+  },
+  STATUS_LABELS: {
+    hoat_dong: "Hoạt động",
+    cho_sua_chua: "Chờ sửa chữa",
+    cho_bao_tri: "Chờ bảo trì",
+    cho_hieu_chuan: "Chờ HC/KĐ",
+    ngung_su_dung: "Ngừng sử dụng",
+    chua_co_nhu_cau: "Chưa có nhu cầu",
+  },
+}))
+
+vi.mock("@/components/dynamic-chart", () => ({
+  DynamicBarChart: ({
+    data,
+    customTooltip: Tooltip,
+  }: {
+    data?: Array<Record<string, string | number | undefined>>
+    customTooltip?: React.FC<ChartTooltipProps<number, string>>
+  }) => {
+    const row = data?.[0] ?? {}
+    const activeCount = typeof row.hoat_dong === "number" ? row.hoat_dong : 0
+
+    return (
+      <div data-testid="bar-chart">
+        {Tooltip ? (
+          <div data-testid="rendered-tooltip">
+            <Tooltip
+              active
+              label={0}
+              payload={[
+                {
+                  dataKey: "hoat_dong",
+                  value: activeCount,
+                  color: "#22c55e",
+                  payload: row,
+                },
+              ]}
+            />
+          </div>
+        ) : null}
+      </div>
+    )
+  },
+}))
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+let latestTabValueChange: ((value: string) => void) | undefined
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({
+    children,
+    onValueChange,
+  }: {
+    children: React.ReactNode
+    value: string
+    onValueChange?: (value: string) => void
+  }) => {
+    latestTabValueChange = onValueChange
+    return <div>{children}</div>
+  },
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <button type="button" onClick={() => latestTabValueChange?.(value)}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: () => <div />,
+}))
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}))
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: () => <div data-testid="skeleton" />,
+}))
+
+vi.mock("@/components/ui/alert", () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+describe("InteractiveEquipmentChart tooltip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useEquipmentDistribution.mockReturnValue({
+      data: {
+        totalEquipment: 7,
+        byDepartment: [
+          {
+            name: "Khoa Nội",
+            total: 4,
+            hoat_dong: 4,
+            cho_sua_chua: 0,
+            cho_bao_tri: 0,
+            cho_hieu_chuan: 0,
+            ngung_su_dung: 0,
+            chua_co_nhu_cau: 0,
+          },
+        ],
+        byLocation: [
+          {
+            name: "Phòng Mổ",
+            total: 3,
+            hoat_dong: 3,
+            cho_sua_chua: 0,
+            cho_bao_tri: 0,
+            cho_hieu_chuan: 0,
+            ngung_su_dung: 0,
+            chua_co_nhu_cau: 0,
+          },
+        ],
+        departments: ["Khoa Nội"],
+        locations: ["Phòng Mổ"],
+      },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it("shows the department name in the custom bar tooltip when Recharts supplies a numeric category label", () => {
+    render(<InteractiveEquipmentChart tenantFilter="42" selectedDonVi={42} effectiveTenantKey="42" />)
+
+    const tooltip = screen.getAllByTestId("rendered-tooltip")[0]
+    expect(within(tooltip).getByText("Khoa Nội", { selector: "p" })).toBeInTheDocument()
+  })
+
+  it("shows the location name in the custom bar tooltip when Recharts supplies a numeric category label", () => {
+    render(<InteractiveEquipmentChart tenantFilter="42" selectedDonVi={42} effectiveTenantKey="42" />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Theo Vị trí/ }))
+
+    const tooltipHeadings = screen
+      .getAllByTestId("rendered-tooltip")
+      .map((tooltip) => within(tooltip).getByText("Phòng Mổ", { selector: "p" }))
+    expect(tooltipHeadings.length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/interactive-equipment-chart.tsx
+++ b/src/components/interactive-equipment-chart.tsx
@@ -28,6 +28,14 @@ interface InteractiveEquipmentChartProps {
 
 type TooltipPayloadEntry = NonNullable<ChartTooltipProps<number, string>['payload']>[number]
 
+function getTooltipCategoryName(entry: TooltipPayloadEntry): string | null {
+  const row = entry.payload
+  if (!row || typeof row !== "object" || !("name" in row)) return null
+
+  const name = (row as Record<string, unknown>).name
+  return typeof name === "string" && name.trim() ? name : null
+}
+
 // Custom tooltip component — memoized to avoid re-computing keyed entries on unchanged payload
 const CustomTooltip = React.memo(function CustomTooltip({
   active,
@@ -42,16 +50,17 @@ const CustomTooltip = React.memo(function CustomTooltip({
       0,
     )
     const keyedPayload = buildKeyedTooltipEntries<TooltipPayloadEntry>(tooltipEntries)
+    const categoryName = tooltipEntries.map(getTooltipCategoryName).find(Boolean) ?? label
     
     return (
       <div className="bg-background border rounded-lg shadow-lg p-3 min-w-[200px]">
-        <p className="font-medium mb-2">{label}</p>
+        <p className="font-medium mb-2">{categoryName}</p>
         <div className="space-y-1">
           {keyedPayload.map(({ key, entry }) => (
             <div key={key} className="flex items-center justify-between gap-2 text-sm">
               <div className="flex items-center gap-2">
                 <div 
-                  className="w-3 h-3 rounded"
+                  className="size-3 rounded"
                   style={{ backgroundColor: entry.color }}
                 />
                 <span>{STATUS_LABELS[entry.dataKey as keyof typeof STATUS_LABELS]}</span>
@@ -93,7 +102,7 @@ function DataFilters({
   
   return (
     <div className="flex items-center gap-2">
-      <Filter className="h-4 w-4 text-muted-foreground" />
+      <Filter className="size-4 text-muted-foreground" />
       <Select 
         value={selectedFilter} 
         onValueChange={onFilterChange}
@@ -172,7 +181,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
       <Card className={className}>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-red-600">
-            <BarChart3 className="h-5 w-5" />
+            <BarChart3 className="size-5" />
             Lỗi tải dữ liệu
           </CardTitle>
         </CardHeader>
@@ -193,7 +202,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
         <div className="flex items-center justify-between">
           <div>
             <CardTitle className="flex items-center gap-2">
-              <BarChart3 className="h-5 w-5" />
+              <BarChart3 className="size-5" />
               Phân bố Thiết bị theo {viewType === 'department' ? 'Khoa/Phòng' : 'Vị trí'}
             </CardTitle>
             <CardDescription className="flex items-center gap-2 flex-wrap">
@@ -235,11 +244,11 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
           <div className="flex items-center justify-between">
             <TabsList>
               <TabsTrigger value="department" className="flex items-center gap-2">
-                <Building2 className="h-4 w-4" />
+                <Building2 className="size-4" />
                 Theo Khoa/Phòng
               </TabsTrigger>
               <TabsTrigger value="location" className="flex items-center gap-2">
-                <MapPin className="h-4 w-4" />
+                <MapPin className="size-4" />
                 Theo Vị trí
               </TabsTrigger>
             </TabsList>
@@ -278,7 +287,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
                   onClick={resetFilters}
                   className="flex items-center gap-1"
                 >
-                  <X className="h-3 w-3" />
+                  <X className="size-3" />
                   Xóa bộ lọc
                 </Button>
               )}
@@ -331,7 +340,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
                   {Object.entries(STATUS_LABELS).map(([key, label]) => (
                     <div key={key} className="flex items-center gap-2">
                       <div
-                        className="w-3 h-3 rounded"
+                        className="size-3 rounded"
                         style={{ backgroundColor: STATUS_COLORS[key as keyof typeof STATUS_COLORS] }}
                       />
                       <span className="text-sm">{label}</span>
@@ -388,7 +397,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
                   {Object.entries(STATUS_LABELS).map(([key, label]) => (
                     <div key={key} className="flex items-center gap-2">
                       <div
-                        className="w-3 h-3 rounded"
+                        className="size-3 rounded"
                         style={{ backgroundColor: STATUS_COLORS[key as keyof typeof STATUS_COLORS] }}
                       />
                       <span className="text-sm">{label}</span>


### PR DESCRIPTION
## Root cause
- Reports > Xuất-Nhập-Tồn > Phân bố Thiết bị theo Khoa/Phòng and Theo Vị trí use `InteractiveEquipmentChart`.
- Its custom Recharts tooltip rendered the raw `label`; Recharts can provide the category index (`0`, `1`, `2`) there while the real department/location name remains on `payload[0].payload.name`.

## Fix
- Prefer the chart row `payload.name` for the tooltip heading, with the existing `label` as fallback.
- Added focused regression coverage for both Khoa/Phòng and Vị trí when Recharts supplies a numeric category label.
- Cleaned React Doctor Tailwind size-axis warnings in the touched chart file.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx` => 2 tests passed
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` => 100/100, no issues found