### PR TITLE
Fix #433: Migrate Device Quota filters to shared layout

### DIFF
--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryToolbar.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryToolbar.test.tsx
@@ -5,12 +5,43 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { DeviceQuotaCategoryToolbar } from '../_components/DeviceQuotaCategoryToolbar'
 import { useDeviceQuotaCategoryContext } from '../_hooks/useDeviceQuotaCategoryContext'
+import type { ListFilterSearchCardProps } from '@/components/shared/ListFilterSearchCard'
 
 vi.mock('../_hooks/useDeviceQuotaCategoryContext', () => ({
   useDeviceQuotaCategoryContext: vi.fn(),
 }))
 
+vi.mock('@/components/shared/ListFilterSearchCard', () => ({
+  ListFilterSearchCard: ({
+    searchValue,
+    onSearchChange,
+    searchPlaceholder,
+    actions,
+  }: ListFilterSearchCardProps) => (
+    <section data-testid="shared-category-toolbar">
+      {typeof searchPlaceholder === 'string' && typeof onSearchChange === 'function' ? (
+        <input
+          aria-label={searchPlaceholder}
+          placeholder={searchPlaceholder}
+          value={searchValue}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      ) : null}
+      {actions}
+    </section>
+  ),
+}))
+
 const mockUseContext = vi.mocked(useDeviceQuotaCategoryContext)
+type CategoryContext = ReturnType<typeof useDeviceQuotaCategoryContext>
+
+const makeContext = (overrides: Partial<CategoryContext> = {}): CategoryContext => ({
+  openCreateDialog: vi.fn(),
+  openImportDialog: vi.fn(),
+  searchTerm: '',
+  setSearchTerm: vi.fn(),
+  ...overrides,
+} as unknown as CategoryContext)
 
 describe('DeviceQuotaCategoryToolbar', () => {
   beforeEach(() => {
@@ -20,12 +51,9 @@ describe('DeviceQuotaCategoryToolbar', () => {
   it('opens create dialog when clicking create button', () => {
     const openCreateDialog = vi.fn()
 
-    mockUseContext.mockReturnValue({
+    mockUseContext.mockReturnValue(makeContext({
       openCreateDialog,
-      openImportDialog: vi.fn(),
-      searchTerm: '',
-      setSearchTerm: vi.fn(),
-    } as any)
+    }))
 
     render(<DeviceQuotaCategoryToolbar />)
 
@@ -35,15 +63,32 @@ describe('DeviceQuotaCategoryToolbar', () => {
   })
 
   it('renders search input', () => {
-    mockUseContext.mockReturnValue({
-      openCreateDialog: vi.fn(),
-      openImportDialog: vi.fn(),
-      searchTerm: '',
-      setSearchTerm: vi.fn(),
-    } as any)
+    mockUseContext.mockReturnValue(makeContext())
 
     render(<DeviceQuotaCategoryToolbar />)
 
     expect(screen.getByPlaceholderText('Tìm theo mã, tên nhóm...')).toBeInTheDocument()
+  })
+
+  it('uses shared search layout and preserves toolbar callbacks', () => {
+    const openImportDialog = vi.fn()
+    const setSearchTerm = vi.fn()
+
+    mockUseContext.mockReturnValue(makeContext({
+      openImportDialog,
+      setSearchTerm,
+    }))
+
+    render(<DeviceQuotaCategoryToolbar />)
+
+    expect(screen.getByTestId('shared-category-toolbar')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Tìm theo mã, tên nhóm...' }), {
+      target: { value: 'x-quang' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Nhập từ Excel' }))
+
+    expect(setSearchTerm).toHaveBeenCalledWith('x-quang')
+    expect(openImportDialog).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryToolbar.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryToolbar.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { Download, PlusCircle, Upload } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
-import { SearchInput } from "@/components/shared/SearchInput"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { useToast } from "@/hooks/use-toast"
 import { downloadCategoryImportTemplate } from "@/lib/category-excel"
 import { useDeviceQuotaCategoryContext } from "../_hooks/useDeviceQuotaCategoryContext"
@@ -31,38 +31,41 @@ export function DeviceQuotaCategoryToolbar() {
     }
   }
 
+  const actions = (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleDownloadTemplate}
+        disabled={isDownloading}
+      >
+        <Download className="mr-2 size-4" />
+        {isDownloading ? "Đang tải..." : "Tải mẫu Excel"}
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={openImportDialog}
+      >
+        <Upload className="mr-2 size-4" />
+        Nhập từ Excel
+      </Button>
+      <Button onClick={openCreateDialog}>
+        <PlusCircle className="mr-2 size-4" />
+        Tạo danh mục
+      </Button>
+    </>
+  )
+
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="w-full sm:max-w-sm">
-        <SearchInput
-          value={searchTerm}
-          onChange={setSearchTerm}
-          placeholder="Tìm theo mã, tên nhóm..."
-        />
-      </div>
-      <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleDownloadTemplate}
-          disabled={isDownloading}
-        >
-          <Download className="mr-2 h-4 w-4" />
-          {isDownloading ? "Đang tải..." : "Tải mẫu Excel"}
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={openImportDialog}
-        >
-          <Upload className="mr-2 h-4 w-4" />
-          Nhập từ Excel
-        </Button>
-        <Button onClick={openCreateDialog}>
-          <PlusCircle className="mr-2 h-4 w-4" />
-          Tạo danh mục
-        </Button>
-      </div>
-    </div>
+    <ListFilterSearchCard
+      surface="plain"
+      searchValue={searchTerm}
+      onSearchChange={setSearchTerm}
+      searchPlaceholder="Tìm theo mã, tên nhóm..."
+      showSearchIcon={false}
+      searchClassName="md:min-w-[220px] md:max-w-[320px]"
+      actions={actions}
+    />
   )
 }

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsToolbar.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsToolbar.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { Plus, RefreshCw } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import {
   Select,
   SelectContent,
@@ -37,49 +38,56 @@ export function DeviceQuotaDecisionsToolbar() {
     isLoading,
   } = useDeviceQuotaDecisionsContext()
 
-  return (
-    <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
-      {/* Left: Filter controls */}
-      <div className="flex items-center gap-2 w-full sm:w-auto">
-        <Select
-          value={statusFilter}
-          onValueChange={(value) => setStatusFilter(value as StatusFilter)}
-        >
-          <SelectTrigger className="h-9 w-full sm:w-[180px]">
-            <SelectValue placeholder="Trạng thái" />
-          </SelectTrigger>
-          <SelectContent>
-            {STATUS_OPTIONS.map((option) => (
-              <SelectItem key={option.value} value={option.value}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+  const filterControls = (
+    <>
+      <Select
+        value={statusFilter}
+        onValueChange={(value) => setStatusFilter(value as StatusFilter)}
+      >
+        <SelectTrigger className="h-9 w-full sm:w-[180px]">
+          <SelectValue placeholder="Trạng thái" />
+        </SelectTrigger>
+        <SelectContent>
+          {STATUS_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </>
+  )
 
-        {/* Refresh button */}
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => refetch()}
-          disabled={isLoading}
-          className="h-9"
-          aria-label="Làm mới dữ liệu"
-        >
-          <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
-          <span className="ml-2 hidden sm:inline">Làm mới</span>
-        </Button>
-      </div>
+  const actions = (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => refetch()}
+        disabled={isLoading}
+        className="h-9"
+        aria-label="Làm mới dữ liệu"
+      >
+        <RefreshCw className={`size-4 ${isLoading ? 'animate-spin' : ''}`} />
+        <span className="ml-2 hidden sm:inline">Làm mới</span>
+      </Button>
 
-      {/* Right: Create button */}
       <Button
         onClick={openCreateDialog}
         size="sm"
         className="h-9 w-full sm:w-auto"
       >
-        <Plus className="mr-2 h-4 w-4" />
+        <Plus className="mr-2 size-4" />
         Tạo quyết định
       </Button>
-    </div>
+    </>
+  )
+
+  return (
+    <ListFilterSearchCard
+      surface="plain"
+      filterControls={filterControls}
+      actions={actions}
+    />
   )
 }

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsToolbar.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsToolbar.tsx
@@ -39,23 +39,21 @@ export function DeviceQuotaDecisionsToolbar() {
   } = useDeviceQuotaDecisionsContext()
 
   const filterControls = (
-    <>
-      <Select
-        value={statusFilter}
-        onValueChange={(value) => setStatusFilter(value as StatusFilter)}
-      >
-        <SelectTrigger className="h-9 w-full sm:w-[180px]">
-          <SelectValue placeholder="Trạng thái" />
-        </SelectTrigger>
-        <SelectContent>
-          {STATUS_OPTIONS.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </>
+    <Select
+      value={statusFilter}
+      onValueChange={(value) => setStatusFilter(value as StatusFilter)}
+    >
+      <SelectTrigger className="h-9 w-full sm:w-[180px]">
+        <SelectValue placeholder="Trạng thái" />
+      </SelectTrigger>
+      <SelectContent>
+        {STATUS_OPTIONS.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   )
 
   const actions = (

--- a/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionsToolbar.test.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionsToolbar.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import { DeviceQuotaDecisionsToolbar } from '../DeviceQuotaDecisionsToolbar'
+import { useDeviceQuotaDecisionsContext } from '../../_hooks/useDeviceQuotaDecisionsContext'
+import type { ListFilterSearchCardProps } from '@/components/shared/ListFilterSearchCard'
+import type { StatusFilter } from '../DeviceQuotaDecisionsContext'
+
+vi.mock('../../_hooks/useDeviceQuotaDecisionsContext', () => ({
+  useDeviceQuotaDecisionsContext: vi.fn(),
+}))
+
+vi.mock('@/components/shared/ListFilterSearchCard', () => ({
+  ListFilterSearchCard: ({
+    filterControls,
+    actions,
+  }: ListFilterSearchCardProps) => (
+    <section data-testid="shared-decisions-toolbar">
+      {filterControls}
+      {actions}
+    </section>
+  ),
+}))
+
+vi.mock('@/components/ui/select', async () => {
+  const React = await import('react')
+
+  interface SelectProps {
+    value: string
+    onValueChange: (value: string) => void
+    children: React.ReactNode
+  }
+
+  interface SelectItemProps {
+    value: string
+    children: React.ReactNode
+  }
+
+  return {
+    Select: ({ value, onValueChange, children }: SelectProps) => (
+      <select
+        aria-label="Trạng thái"
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+      >
+        {children}
+      </select>
+    ),
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectValue: () => null,
+    SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    SelectItem: ({ value, children }: SelectItemProps) => (
+      <option value={value}>{children}</option>
+    ),
+  }
+})
+
+const mockUseContext = vi.mocked(useDeviceQuotaDecisionsContext)
+type DecisionsContext = ReturnType<typeof useDeviceQuotaDecisionsContext>
+
+const makeContext = (overrides: Partial<DecisionsContext> = {}): DecisionsContext => ({
+  statusFilter: 'all',
+  setStatusFilter: vi.fn(),
+  openCreateDialog: vi.fn(),
+  refetch: vi.fn(),
+  isLoading: false,
+  ...overrides,
+} as unknown as DecisionsContext)
+
+describe('DeviceQuotaDecisionsToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses shared filter layout and preserves toolbar callbacks', () => {
+    const setStatusFilter = vi.fn()
+    const refetch = vi.fn()
+    const openCreateDialog = vi.fn()
+
+    mockUseContext.mockReturnValue(makeContext({
+      setStatusFilter,
+      refetch,
+      openCreateDialog,
+    }))
+
+    render(<DeviceQuotaDecisionsToolbar />)
+
+    expect(screen.getByTestId('shared-decisions-toolbar')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Trạng thái' }), {
+      target: { value: 'active' satisfies StatusFilter },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /làm mới/i }))
+    fireEvent.click(screen.getByRole('button', { name: /tạo quyết định/i }))
+
+    expect(setStatusFilter).toHaveBeenCalledWith('active')
+    expect(refetch).toHaveBeenCalledTimes(1)
+    expect(openCreateDialog).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaCategoryTree.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaCategoryTree.test.tsx
@@ -1,24 +1,69 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { DeviceQuotaCategoryTree } from '../_components/DeviceQuotaCategoryTree'
 import { useDeviceQuotaMappingContext } from '../_hooks/useDeviceQuotaMappingContext'
+import type { ListFilterSearchCardProps } from '@/components/shared/ListFilterSearchCard'
 
 vi.mock('../_hooks/useDeviceQuotaMappingContext', () => ({
   useDeviceQuotaMappingContext: vi.fn(),
 }))
 
-const mockUseContext = vi.mocked(useDeviceQuotaMappingContext)
+vi.mock('@/components/shared/ListFilterSearchCard', () => ({
+  ListFilterSearchCard: ({
+    title,
+    description,
+    searchValue,
+    onSearchChange,
+    searchPlaceholder,
+  }: ListFilterSearchCardProps) => (
+    <section data-testid="shared-category-filter-card">
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {typeof searchPlaceholder === 'string' && typeof onSearchChange === 'function' ? (
+        <input
+          aria-label={searchPlaceholder}
+          value={searchValue}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      ) : null}
+    </section>
+  ),
+}))
 
-const makeContext = (overrides: Record<string, unknown> = {}) => ({
+const mockUseContext = vi.mocked(useDeviceQuotaMappingContext)
+type MappingContext = ReturnType<typeof useDeviceQuotaMappingContext>
+
+const makeContext = (overrides: Partial<MappingContext> = {}): MappingContext => ({
+  user: null,
+  donViId: 1,
+  isFacilitySelected: true,
+  unassignedEquipment: [],
+  totalEquipmentCount: 0,
   categories: [],
   allCategories: [],
+  selectedEquipmentIds: new Set<number>(),
   selectedCategoryId: null,
+  toggleEquipmentSelection: vi.fn(),
+  selectAllEquipment: vi.fn(),
+  deselectPageEquipment: vi.fn(),
+  clearEquipmentSelection: vi.fn(),
   setSelectedCategory: vi.fn(),
+  filters: {} as unknown as MappingContext['filters'],
+  filterOptions: {
+    departments: [],
+    users: [],
+    locations: [],
+    fundingSources: [],
+  },
+  pagination: {} as unknown as MappingContext['pagination'],
   categorySearchTerm: '',
   setCategorySearchTerm: vi.fn(),
+  linkEquipment: {} as unknown as MappingContext['linkEquipment'],
   isLoading: false,
+  isLinking: false,
+  refetch: vi.fn(),
   ...overrides,
 })
 
@@ -28,7 +73,7 @@ describe('DeviceQuotaCategoryTree (mapping)', () => {
   })
 
   it('links empty state CTA to categories page', () => {
-    mockUseContext.mockReturnValue(makeContext() as any)
+    mockUseContext.mockReturnValue(makeContext())
 
     render(<DeviceQuotaCategoryTree />)
 
@@ -43,11 +88,28 @@ describe('DeviceQuotaCategoryTree (mapping)', () => {
       ],
       categories: [],
       categorySearchTerm: 'zzzzz',
-    }) as any)
+    }))
 
     render(<DeviceQuotaCategoryTree />)
 
     expect(screen.getByText('Không tìm thấy danh mục phù hợp')).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: 'Tạo danh mục' })).not.toBeInTheDocument()
+  })
+
+  it('uses shared search layout and preserves category search callback', () => {
+    const setCategorySearchTerm = vi.fn()
+    mockUseContext.mockReturnValue(makeContext({
+      setCategorySearchTerm,
+    }))
+
+    render(<DeviceQuotaCategoryTree />)
+
+    expect(screen.getByTestId('shared-category-filter-card')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Tìm danh mục...' }), {
+      target: { value: 'x-quang' },
+    })
+
+    expect(setCategorySearchTerm).toHaveBeenCalledWith('x-quang')
   })
 })

--- a/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaUnassignedList.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaUnassignedList.test.tsx
@@ -1,23 +1,71 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { DeviceQuotaUnassignedList } from '../_components/DeviceQuotaUnassignedList'
 import { useDeviceQuotaMappingContext } from '../_hooks/useDeviceQuotaMappingContext'
+import type { ListFilterSearchCardProps } from '@/components/shared/ListFilterSearchCard'
+import type { FacetedMultiSelectFilterProps } from '@/components/shared/table-filters/FacetedMultiSelectFilter'
 
 vi.mock('../_hooks/useDeviceQuotaMappingContext', () => ({
   useDeviceQuotaMappingContext: vi.fn(),
 }))
 
-const mockUseContext = vi.mocked(useDeviceQuotaMappingContext)
+vi.mock('@/components/shared/ListFilterSearchCard', () => ({
+  ListFilterSearchCard: ({
+    searchValue,
+    onSearchChange,
+    searchPlaceholder,
+    searchDisabled,
+    filterControls,
+  }: ListFilterSearchCardProps) => (
+    <section data-testid="shared-filter-search-card">
+      {typeof searchPlaceholder === 'string' && typeof onSearchChange === 'function' ? (
+        <input
+          aria-label={searchPlaceholder}
+          disabled={searchDisabled}
+          value={searchValue}
+          onChange={(event) => onSearchChange(event.target.value)}
+        />
+      ) : null}
+      {filterControls}
+    </section>
+  ),
+}))
 
-const makeContext = (overrides: Record<string, unknown> = {}) => ({
+vi.mock('@/components/shared/table-filters/FacetedMultiSelectFilter', () => ({
+  FacetedMultiSelectFilter: <TData, TValue,>({
+    title,
+    options,
+    value,
+    onChange,
+  }: FacetedMultiSelectFilterProps<TData, TValue>) => (
+    <button
+      type="button"
+      onClick={() => onChange([...(value ?? []), options[0]?.value as TValue].filter(Boolean))}
+    >
+      {title}
+    </button>
+  ),
+}))
+
+const mockUseContext = vi.mocked(useDeviceQuotaMappingContext)
+type MappingContext = ReturnType<typeof useDeviceQuotaMappingContext>
+
+const makeContext = (overrides: Partial<MappingContext> = {}): MappingContext => ({
+  user: null,
+  donViId: 1,
+  allCategories: [],
+  categories: [],
   unassignedEquipment: [],
   totalEquipmentCount: 0,
   selectedEquipmentIds: new Set<number>(),
   toggleEquipmentSelection: vi.fn(),
   selectAllEquipment: vi.fn(),
+  deselectPageEquipment: vi.fn(),
   clearEquipmentSelection: vi.fn(),
+  selectedCategoryId: null,
+  setSelectedCategory: vi.fn(),
   filters: {
     searchTerm: '',
     setSearchTerm: vi.fn(),
@@ -46,9 +94,14 @@ const makeContext = (overrides: Record<string, unknown> = {}) => ({
     canPreviousPage: false,
     canNextPage: false,
     setPagination: vi.fn(),
-  },
+  } as unknown as MappingContext['pagination'],
+  categorySearchTerm: '',
+  setCategorySearchTerm: vi.fn(),
+  linkEquipment: {} as unknown as MappingContext['linkEquipment'],
   isLoading: false,
+  isLinking: false,
   isFacilitySelected: true,
+  refetch: vi.fn(),
   ...overrides,
 })
 
@@ -60,10 +113,12 @@ describe('DeviceQuotaUnassignedList', () => {
   it('shows facility selection placeholder when no facility selected', () => {
     mockUseContext.mockReturnValue(makeContext({
       isFacilitySelected: false,
-    }) as any)
+    }))
 
     render(<DeviceQuotaUnassignedList />)
 
+    expect(screen.getByTestId('shared-filter-search-card')).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Chọn cơ sở để tìm kiếm...' })).toBeDisabled()
     expect(screen.getByText('Chọn cơ sở')).toBeInTheDocument()
     expect(
       screen.queryByText('Tất cả thiết bị đã được phân loại vào các nhóm định mức.')
@@ -76,7 +131,7 @@ describe('DeviceQuotaUnassignedList', () => {
         ...makeContext().filters,
         debouncedSearch: 'zzz',
       },
-    }) as any)
+    }))
 
     render(<DeviceQuotaUnassignedList />)
 
@@ -87,10 +142,42 @@ describe('DeviceQuotaUnassignedList', () => {
   })
 
   it('shows classified-empty state only when there is no active search/filter', () => {
-    mockUseContext.mockReturnValue(makeContext() as any)
+    mockUseContext.mockReturnValue(makeContext())
 
     render(<DeviceQuotaUnassignedList />)
 
     expect(screen.getByText('Hoàn thành phân loại')).toBeInTheDocument()
+  })
+
+  it('uses shared search and faceted filters without changing existing callbacks', () => {
+    const setSearchTerm = vi.fn()
+    const setSelectedDepartments = vi.fn()
+
+    mockUseContext.mockReturnValue(makeContext({
+      filters: {
+        ...makeContext().filters,
+        setSearchTerm,
+        selectedDepartments: [],
+        setSelectedDepartments,
+      },
+      filterOptions: {
+        departments: ['Khoa cấp cứu'],
+        users: [],
+        locations: [],
+        fundingSources: [],
+      },
+    }))
+
+    render(<DeviceQuotaUnassignedList />)
+
+    expect(screen.getByTestId('shared-filter-search-card')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Tìm kiếm thiết bị...' }), {
+      target: { value: 'máy thở' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Khoa/Phòng' }))
+
+    expect(setSearchTerm).toHaveBeenCalledWith('máy thở')
+    expect(setSelectedDepartments).toHaveBeenCalledWith(['Khoa cấp cứu'])
   })
 })

--- a/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaUnassignedList.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaUnassignedList.test.tsx
@@ -180,4 +180,36 @@ describe('DeviceQuotaUnassignedList', () => {
     expect(setSearchTerm).toHaveBeenCalledWith('máy thở')
     expect(setSelectedDepartments).toHaveBeenCalledWith(['Khoa cấp cứu'])
   })
+
+  it('exposes each equipment row as a single keyboard-toggle button', () => {
+    const toggleEquipmentSelection = vi.fn()
+
+    mockUseContext.mockReturnValue(makeContext({
+      unassignedEquipment: [
+        {
+          id: 10,
+          ma_thiet_bi: 'TB-010',
+          ten_thiet_bi: 'Máy thở',
+          model: 'MT-01',
+          serial: 'SER-01',
+          hang_san_xuat: null,
+          khoa_phong_quan_ly: 'Khoa hồi sức',
+          tinh_trang: null,
+        },
+      ],
+      totalEquipmentCount: 1,
+      toggleEquipmentSelection,
+    }))
+
+    render(<DeviceQuotaUnassignedList />)
+
+    const rowButton = screen.getByRole('button', { name: /Máy thở/i })
+    expect(rowButton).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getAllByRole('checkbox')).toHaveLength(1)
+
+    fireEvent.click(rowButton)
+
+    expect(toggleEquipmentSelection).toHaveBeenCalledTimes(1)
+    expect(toggleEquipmentSelection).toHaveBeenCalledWith(10)
+  })
 })

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaCategoryTree.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaCategoryTree.tsx
@@ -171,7 +171,7 @@ export function DeviceQuotaCategoryTree() {
 
   return (
     <Card className="h-full flex flex-col">
-      <CardHeader className="[&>*+*]:mt-0">
+      <CardHeader>
         <ListFilterSearchCard
           surface="plain"
           title="Danh mục định mức"

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaCategoryTree.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaCategoryTree.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import * as React from "react"
+import Link from "next/link"
 import { ChevronRight, FolderTree, Package } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
-import { SearchInput } from "@/components/shared/SearchInput"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { useDeviceQuotaMappingContext } from "../_hooks/useDeviceQuotaMappingContext"
 import type { Category } from "./DeviceQuotaMappingContext"
 
@@ -49,7 +50,7 @@ function CategoryTreeItem({ category, isSelected, onSelect }: CategoryTreeItemPr
           {/* Radio indicator */}
           <div
             className={cn(
-              "h-4 w-4 rounded-full border-2 flex-shrink-0 transition-colors",
+              "size-4 rounded-full border-2 flex-shrink-0 transition-colors",
               isSelected
                 ? "border-primary bg-primary"
                 : "border-muted-foreground/50"
@@ -61,7 +62,7 @@ function CategoryTreeItem({ category, isSelected, onSelect }: CategoryTreeItemPr
           </div>
 
           {category.level > 1 && (
-            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+            <ChevronRight className="size-3.5 text-muted-foreground flex-shrink-0" />
           )}
 
           <div className="min-w-0 flex-1">
@@ -80,7 +81,7 @@ function CategoryTreeItem({ category, isSelected, onSelect }: CategoryTreeItemPr
         </div>
 
         <Badge variant="secondary" className="flex-shrink-0 ml-2">
-          <Package className="h-3 w-3 mr-1" />
+          <Package className="mr-1 size-3" />
           {category.so_luong_hien_co}
         </Badge>
       </div>
@@ -93,7 +94,7 @@ function CategoryTreeSkeleton() {
     <div className="space-y-2">
       {MAPPING_TREE_SKELETON_KEYS.map((token) => (
         <div key={token} className="flex items-center gap-3 p-3">
-          <Skeleton className="h-4 w-4 rounded-full" />
+          <Skeleton className="size-4 rounded-full" />
           <Skeleton className="h-4 w-16" />
           <Skeleton className="h-4 flex-1" />
           <Skeleton className="h-5 w-12 rounded-full" />
@@ -107,7 +108,7 @@ function CategoryTreeEmpty() {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <div className="rounded-full bg-muted p-3 mb-4">
-        <FolderTree className="h-6 w-6 text-muted-foreground" />
+        <FolderTree className="size-6 text-muted-foreground" />
       </div>
       <h3 className="font-semibold text-base mb-1">
         Chưa có danh mục nào
@@ -117,9 +118,9 @@ function CategoryTreeEmpty() {
         Vui lòng tạo danh mục trước khi gán thiết bị.
       </p>
       <Button variant="outline" size="sm" asChild>
-        <a href="/device-quota/categories">
+        <Link href="/device-quota/categories">
           Tạo danh mục
-        </a>
+        </Link>
       </Button>
     </div>
   )
@@ -129,7 +130,7 @@ function CategoryTreeNoResults({ searchTerm }: { searchTerm: string }) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <div className="rounded-full bg-muted p-3 mb-4">
-        <FolderTree className="h-6 w-6 text-muted-foreground" />
+        <FolderTree className="size-6 text-muted-foreground" />
       </div>
       <h3 className="font-semibold text-base mb-1">
         Không tìm thấy danh mục phù hợp
@@ -170,20 +171,16 @@ export function DeviceQuotaCategoryTree() {
 
   return (
     <Card className="h-full flex flex-col">
-      <CardHeader>
-        <CardTitle className="text-lg">Danh mục định mức</CardTitle>
-        <CardDescription>
-          Chọn danh mục để gán thiết bị ({categories.length}/{allCategories.length} danh mục)
-        </CardDescription>
-
-        {/* Category Search */}
-        <div className="mt-3">
-          <SearchInput
-            value={categorySearchTerm}
-            onChange={setCategorySearchTerm}
-            placeholder="Tìm danh mục..."
-          />
-        </div>
+      <CardHeader className="[&>*+*]:mt-0">
+        <ListFilterSearchCard
+          surface="plain"
+          title="Danh mục định mức"
+          description={`Chọn danh mục để gán thiết bị (${categories.length}/${allCategories.length} danh mục)`}
+          searchValue={categorySearchTerm}
+          onSearchChange={setCategorySearchTerm}
+          searchPlaceholder="Tìm danh mục..."
+          searchClassName="md:min-w-[220px] md:max-w-[320px]"
+        />
       </CardHeader>
       <CardContent className="flex-1 overflow-auto">
         {isLoading ? (

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList.tsx
@@ -2,10 +2,10 @@
 
 import * as React from "react"
 import { CheckCircle2, Building2, SearchX } from "lucide-react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Skeleton } from "@/components/ui/skeleton"
-import { SearchInput } from "@/components/shared/SearchInput"
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { DataTablePaginationNavigation } from "@/components/shared/DataTablePagination/DataTablePaginationNavigation"
 import { DataTablePaginationSizeSelector } from "@/components/shared/DataTablePagination/DataTablePaginationSizeSelector"
@@ -69,51 +69,48 @@ export function DeviceQuotaUnassignedList() {
     [filterOptions.fundingSources]
   )
   const hasSearchOrFilters = filters.hasActiveFilters || filters.debouncedSearch.trim().length > 0
+  const filterControls = isFacilitySelected ? (
+    <>
+      <FacetedMultiSelectFilter
+        title="Khoa/Phòng"
+        options={departmentOptions}
+        value={filters.selectedDepartments}
+        onChange={filters.setSelectedDepartments}
+      />
+      <FacetedMultiSelectFilter
+        title="Người sử dụng"
+        options={userOptions}
+        value={filters.selectedUsers}
+        onChange={filters.setSelectedUsers}
+      />
+      <FacetedMultiSelectFilter
+        title="Vị trí"
+        options={locationOptions}
+        value={filters.selectedLocations}
+        onChange={filters.setSelectedLocations}
+      />
+      <FacetedMultiSelectFilter
+        title="Nguồn kinh phí"
+        options={fundingOptions}
+        value={filters.selectedFundingSources}
+        onChange={filters.setSelectedFundingSources}
+      />
+    </>
+  ) : undefined
 
   return (
     <Card className="flex flex-col h-full">
-      <CardHeader className="pb-4">
-        <CardTitle className="text-lg">Thiết bị chưa phân loại</CardTitle>
-
-        {/* Search */}
-        <div className="mt-4">
-          <SearchInput
-            value={filters.searchTerm}
-            onChange={filters.setSearchTerm}
-            placeholder={isFacilitySelected ? "Tìm kiếm thiết bị..." : "Chọn cơ sở để tìm kiếm..."}
-            disabled={!isFacilitySelected}
-          />
-        </div>
-
-        {/* Faceted Filters */}
-        {isFacilitySelected && (
-          <div className="flex flex-wrap gap-2 mt-3">
-            <FacetedMultiSelectFilter
-              title="Khoa/Phòng"
-              options={departmentOptions}
-              value={filters.selectedDepartments}
-              onChange={filters.setSelectedDepartments}
-            />
-            <FacetedMultiSelectFilter
-              title="Người sử dụng"
-              options={userOptions}
-              value={filters.selectedUsers}
-              onChange={filters.setSelectedUsers}
-            />
-            <FacetedMultiSelectFilter
-              title="Vị trí"
-              options={locationOptions}
-              value={filters.selectedLocations}
-              onChange={filters.setSelectedLocations}
-            />
-            <FacetedMultiSelectFilter
-              title="Nguồn kinh phí"
-              options={fundingOptions}
-              value={filters.selectedFundingSources}
-              onChange={filters.setSelectedFundingSources}
-            />
-          </div>
-        )}
+      <CardHeader className="pb-4 [&>*+*]:mt-0">
+        <ListFilterSearchCard
+          surface="plain"
+          title="Thiết bị chưa phân loại"
+          searchValue={filters.searchTerm}
+          onSearchChange={filters.setSearchTerm}
+          searchPlaceholder={isFacilitySelected ? "Tìm kiếm thiết bị..." : "Chọn cơ sở để tìm kiếm..."}
+          searchDisabled={!isFacilitySelected}
+          searchClassName="md:min-w-[220px] md:max-w-[320px]"
+          filterControls={filterControls}
+        />
       </CardHeader>
 
       <CardContent className="flex-1 overflow-y-auto">
@@ -203,13 +200,26 @@ interface EquipmentItemProps {
 }
 
 function EquipmentItem({ equipment, isSelected, onToggle }: EquipmentItemProps) {
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault()
+        onToggle()
+      }
+    },
+    [onToggle]
+  )
+
   return (
     <div
+      role="button"
+      tabIndex={0}
       className={cn(
         "flex items-start gap-3 p-3 rounded-lg border transition-colors cursor-pointer hover:bg-accent",
         isSelected && "bg-accent border-primary"
       )}
       onClick={onToggle}
+      onKeyDown={handleKeyDown}
     >
       <Checkbox
         checked={isSelected}
@@ -245,12 +255,12 @@ function LoadingSkeleton() {
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2 pb-3 border-b">
-        <Skeleton className="h-4 w-4" />
+        <Skeleton className="size-4" />
         <Skeleton className="h-4 w-32" />
       </div>
       {Array.from({ length: 5 }).map((_, i) => (
         <div key={i} className="flex items-start gap-3 p-3 rounded-lg border">
-          <Skeleton className="h-4 w-4 mt-1" />
+          <Skeleton className="size-4 mt-1" />
           <div className="flex-1 space-y-2">
             <Skeleton className="h-4 w-3/4" />
             <Skeleton className="h-3 w-1/2" />
@@ -270,7 +280,7 @@ function EmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <div className="rounded-full bg-green-100 dark:bg-green-900/20 p-3 mb-4">
-        <CheckCircle2 className="h-8 w-8 text-green-600 dark:text-green-500" />
+        <CheckCircle2 className="size-8 text-green-600 dark:text-green-500" />
       </div>
       <h3 className="font-semibold text-lg mb-1">Hoàn thành phân loại</h3>
       <p className="text-sm text-muted-foreground max-w-sm">
@@ -284,7 +294,7 @@ function NoResultsState() {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <div className="rounded-full bg-muted p-3 mb-4">
-        <SearchX className="h-8 w-8 text-muted-foreground" />
+        <SearchX className="size-8 text-muted-foreground" />
       </div>
       <h3 className="font-semibold text-lg mb-1">Không có kết quả phù hợp</h3>
       <p className="text-sm text-muted-foreground max-w-sm">
@@ -299,7 +309,7 @@ function FacilitySelectionEmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <div className="rounded-full bg-blue-100 dark:bg-blue-900/20 p-3 mb-4">
-        <Building2 className="h-8 w-8 text-blue-600 dark:text-blue-500" />
+        <Building2 className="size-8 text-blue-600 dark:text-blue-500" />
       </div>
       <h3 className="font-semibold text-lg mb-1">Chọn cơ sở</h3>
       <p className="text-sm text-muted-foreground max-w-sm">

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList.tsx
@@ -100,7 +100,7 @@ export function DeviceQuotaUnassignedList() {
 
   return (
     <Card className="flex flex-col h-full">
-      <CardHeader className="pb-4 [&>*+*]:mt-0">
+      <CardHeader className="pb-4">
         <ListFilterSearchCard
           surface="plain"
           title="Thiết bị chưa phân loại"

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { CheckCircle2, Building2, SearchX } from "lucide-react"
+import { Check, CheckCircle2, Building2, SearchX } from "lucide-react"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -200,33 +200,26 @@ interface EquipmentItemProps {
 }
 
 function EquipmentItem({ equipment, isSelected, onToggle }: EquipmentItemProps) {
-  const handleKeyDown = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault()
-        onToggle()
-      }
-    },
-    [onToggle]
-  )
-
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
+      aria-pressed={isSelected}
       className={cn(
-        "flex items-start gap-3 p-3 rounded-lg border transition-colors cursor-pointer hover:bg-accent",
+        "flex w-full items-start gap-3 p-3 text-left rounded-lg border transition-colors cursor-pointer hover:bg-accent",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isSelected && "bg-accent border-primary"
       )}
       onClick={onToggle}
-      onKeyDown={handleKeyDown}
     >
-      <Checkbox
-        checked={isSelected}
-        onCheckedChange={onToggle}
-        onClick={(e) => e.stopPropagation()}
-        className="mt-1"
-      />
+      <span
+        aria-hidden="true"
+        className={cn(
+          "mt-1 flex size-4 shrink-0 items-center justify-center rounded-sm border border-primary",
+          isSelected && "bg-primary text-primary-foreground"
+        )}
+      >
+        {isSelected ? <Check className="size-3" /> : null}
+      </span>
       <div className="flex-1 min-w-0 space-y-1">
         <div className="font-medium text-sm leading-tight">
           {equipment.ten_thiet_bi}
@@ -243,7 +236,7 @@ function EquipmentItem({ equipment, isSelected, onToggle }: EquipmentItemProps) 
           </div>
         )}
       </div>
-    </div>
+    </button>
   )
 }
 

--- a/src/components/shared/ListFilterSearchCard.tsx
+++ b/src/components/shared/ListFilterSearchCard.tsx
@@ -28,6 +28,7 @@ interface ListFilterSearchCardSearchProps {
   searchPlaceholder: string
   searchEndAddon?: React.ReactNode
   showSearchIcon?: boolean
+  searchDisabled?: boolean
 }
 
 interface ListFilterSearchCardFilterOnlyProps {
@@ -37,6 +38,7 @@ interface ListFilterSearchCardFilterOnlyProps {
   searchPlaceholder?: never
   searchEndAddon?: never
   showSearchIcon?: never
+  searchDisabled?: never
 }
 
 export type ListFilterSearchCardProps = ListFilterSearchCardBaseProps & (
@@ -55,6 +57,7 @@ export function ListFilterSearchCard({
   searchPlaceholder,
   searchEndAddon,
   showSearchIcon = true,
+  searchDisabled,
   filterControls,
   mobileFilterControl,
   compactFilters = false,
@@ -112,6 +115,7 @@ export function ListFilterSearchCard({
                 className="h-9 w-full"
                 endAddon={searchEndAddon}
                 aria-label={searchPlaceholder}
+                disabled={searchDisabled}
               />
             </div>
           ) : null}

--- a/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
+++ b/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
@@ -116,4 +116,17 @@ describe("ListFilterSearchCard", () => {
 
     expect(searchInputRef.current).toBe(screen.getByRole("searchbox", { name: "Tìm kiếm chung..." }))
   })
+
+  it("can disable the shared search input", () => {
+    render(
+      <ListFilterSearchCard
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Chọn cơ sở để tìm kiếm..."
+        searchDisabled
+      />
+    )
+
+    expect(screen.getByRole("searchbox", { name: "Chọn cơ sở để tìm kiếm..." })).toBeDisabled()
+  })
 })


### PR DESCRIPTION
## Summary
- Migrate Device Quota mapping filters/search to the shared `ListFilterSearchCard` layout.
- Migrate Device Quota categories toolbar search/actions to the shared layout.
- Migrate Device Quota decisions status filter/actions to the shared filter layout.
- Add `searchDisabled` support to `ListFilterSearchCard` so mapping search preserves the choose-facility-first behavior.
- Leave decision detail toolbar custom because it has navigation/status/import actions, not a page-level filter/search surface.

## TDD / Verification
- RED/GREEN slices were run for shared card, mapping unassigned list, mapping category tree, categories toolbar, and decisions toolbar.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/shared/__tests__/ListFilterSearchCard.test.tsx 'src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaUnassignedList.test.tsx' 'src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaCategoryTree.test.tsx' 'src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryToolbar.test.tsx' 'src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionsToolbar.test.tsx'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `git diff --check`

Fixes #433

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Device Quota mapping, categories, and decisions toolbars to the shared `ListFilterSearchCard` to unify filter/search UI and reduce duplicate code. Adds disabled search, better keyboard selection on rows, and small UI cleanups; fixes #433.

- **Refactors**
  - Mapping unassigned list: moved search and faceted filters to `ListFilterSearchCard`; uses `searchDisabled` until a facility is selected.
  - Equipment row: now a single focusable button with focus ring and aria-pressed; toggles on click/Enter/Space.
  - Category tree: moved header/search to the shared card and switched empty-state link to `next/link`.
  - Categories and decisions toolbars: moved actions/filters to the shared layout; kept decisions detail toolbar custom.

<sup>Written for commit 53de577de290b9b7181009f0dd84f681e33c1923. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to disable search inputs in toolbars.
  * Improved keyboard accessibility for equipment selection (Enter/Space).

* **Refactoring**
  * Unified toolbar layout across device quota screens into a shared filter/search card.
  * Updated icons, sizing and spacing for a more consistent UI.
  * List item selection rebuilt for better accessibility and focus handling.

* **Tests**
  * Expanded tests validating shared toolbar rendering and interactions (search, filters, refresh, import/create actions).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/436)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->