### PR TITLE
Fix React Doctor warnings for maintenance mobile

### DIFF
--- a/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
@@ -20,8 +20,30 @@ const mocks = vi.hoisted(() => ({
       openDeleteDialog: vi.fn(),
     },
     setEditingPlan: vi.fn(),
+    tasks: [],
+    draftTasks: [],
+    hasChanges: false,
+    isSavingAll: false,
+    isLoadingTasks: false,
+    isPlanApproved: false,
+    canCompleteTask: true,
+    isCompletingTask: new Set<string>(),
+    taskEditing: {
+      editingTaskId: null,
+      editingTaskData: null,
+      handleTaskDataChange: vi.fn(),
+      handleSaveTask: vi.fn(),
+      handleCancelEdit: vi.fn(),
+      handleStartEdit: vi.fn(),
+      setTaskToDelete: vi.fn(),
+    },
+    generatePlanForm: vi.fn(),
+    setIsConfirmingCancel: vi.fn(),
+    handleSaveAllChanges: vi.fn(),
+    handleMarkAsCompleted: vi.fn(),
   },
-  lastPlanCardsProps: null as { canCreatePlans?: boolean } | null,
+  lastPlanCardsProps: null as { access?: { canCreatePlans?: boolean } } | null,
+  lastTasksPanelProps: null as { panelState?: { isLoadingTasks?: boolean } } | null,
 }))
 
 vi.mock("@/components/kpi", () => ({
@@ -33,14 +55,17 @@ vi.mock("../_hooks/useMaintenanceContext", () => ({
 }))
 
 vi.mock("../_components/maintenance-mobile-plan-cards", () => ({
-  MaintenanceMobilePlanCards: (props: { canCreatePlans?: boolean }) => {
+  MaintenanceMobilePlanCards: (props: { access?: { canCreatePlans?: boolean } }) => {
     mocks.lastPlanCardsProps = props
     return <div data-testid="mobile-plan-cards" />
   },
 }))
 
 vi.mock("../_components/maintenance-mobile-tasks-panel", () => ({
-  MaintenanceMobileTasksPanel: () => <div data-testid="mobile-tasks-panel" />,
+  MaintenanceMobileTasksPanel: (props: { panelState?: { isLoadingTasks?: boolean } }) => {
+    mocks.lastTasksPanelProps = props
+    return <div data-testid="mobile-tasks-panel" />
+  },
 }))
 
 import { MobileMaintenanceLayout } from "../_components/mobile-maintenance-layout"
@@ -90,7 +115,10 @@ describe("MobileMaintenanceLayout create-plan entry points", () => {
     mocks.context.canManagePlans = true
     mocks.context.canCreatePlans = false
     mocks.context.activeTab = "plans"
+    mocks.context.selectedPlan = null
+    mocks.context.isLoadingTasks = false
     mocks.lastPlanCardsProps = null
+    mocks.lastTasksPanelProps = null
   })
 
   it.each(["global", "admin"])("hides create-plan controls for %s users", (role) => {
@@ -99,7 +127,7 @@ describe("MobileMaintenanceLayout create-plan entry points", () => {
     renderMobileLayout()
 
     expect(screen.queryByRole("button", { name: "Tạo kế hoạch mới" })).not.toBeInTheDocument()
-    expect(mocks.lastPlanCardsProps?.canCreatePlans).toBe(false)
+    expect(mocks.lastPlanCardsProps?.access?.canCreatePlans).toBe(false)
   })
 
   it("keeps create-plan controls available for non-global maintenance managers", () => {
@@ -109,7 +137,24 @@ describe("MobileMaintenanceLayout create-plan entry points", () => {
     renderMobileLayout()
 
     expect(screen.getByRole("button", { name: "Tạo kế hoạch mới" })).toBeInTheDocument()
-    expect(mocks.lastPlanCardsProps?.canCreatePlans).toBe(true)
+    expect(mocks.lastPlanCardsProps?.access?.canCreatePlans).toBe(true)
+  })
+
+  it("passes grouped task state to the mobile tasks panel", () => {
+    mocks.context.activeTab = "tasks"
+    mocks.context.selectedPlan = {
+      id: 1,
+      ten_ke_hoach: "Kế hoạch tháng 5",
+      nam: 2026,
+      khoa_phong: "Khoa Nội",
+      trang_thai: "Bản nháp",
+    }
+    mocks.context.isLoadingTasks = true
+
+    renderMobileLayout()
+
+    expect(screen.getByTestId("mobile-tasks-panel")).toBeInTheDocument()
+    expect(mocks.lastTasksPanelProps?.panelState?.isLoadingTasks).toBe(true)
   })
 
   it("labels icon-only search and pagination controls", () => {

--- a/src/app/(app)/maintenance/_components/maintenance-mobile-plan-cards.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-mobile-plan-cards.tsx
@@ -19,12 +19,17 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { CalendarDays, MoreHorizontal, PlusCircle } from "lucide-react"
 import { getPlanStatusTone, resolveStatusBadgeVariant } from "./maintenance-mobile-status"
 
-interface MaintenanceMobilePlanCardsProps {
-  plans: MaintenancePlan[]
+interface MaintenanceMobilePlanCardsState {
   isLoadingPlans: boolean
   showFacilityFilter: boolean
+}
+
+interface MaintenanceMobilePlanCardsAccess {
   canManagePlans: boolean
   canCreatePlans: boolean
+}
+
+interface MaintenanceMobilePlanCardsActions {
   onOpenAddPlanDialog: () => void
   onSelectPlan: (plan: MaintenancePlan) => void
   onSetTasksTab: () => void
@@ -34,20 +39,31 @@ interface MaintenanceMobilePlanCardsProps {
   onOpenDeleteDialog: (plan: MaintenancePlan) => void
 }
 
+interface MaintenanceMobilePlanCardsProps {
+  plans: MaintenancePlan[]
+  planState: MaintenanceMobilePlanCardsState
+  access: MaintenanceMobilePlanCardsAccess
+  actions: MaintenanceMobilePlanCardsActions
+}
+
 export function MaintenanceMobilePlanCards({
   plans,
-  isLoadingPlans,
-  showFacilityFilter,
-  canManagePlans,
-  canCreatePlans,
-  onOpenAddPlanDialog,
-  onSelectPlan,
-  onSetTasksTab,
-  onEditPlan,
-  onOpenApproveDialog,
-  onOpenRejectDialog,
-  onOpenDeleteDialog,
+  planState,
+  access,
+  actions,
 }: MaintenanceMobilePlanCardsProps) {
+  const { isLoadingPlans, showFacilityFilter } = planState
+  const { canManagePlans, canCreatePlans } = access
+  const {
+    onOpenAddPlanDialog,
+    onSelectPlan,
+    onSetTasksTab,
+    onEditPlan,
+    onOpenApproveDialog,
+    onOpenRejectDialog,
+    onOpenDeleteDialog,
+  } = actions
+
   if (isLoadingPlans) {
     return (
       <div className="space-y-3">
@@ -71,9 +87,9 @@ export function MaintenanceMobilePlanCards({
   if (!plans.length) {
     return (
       <Card className="border-dashed bg-muted/40">
-        <CardContent className="flex flex-col items-center justify-center space-y-3 py-8 text-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-            <CalendarDays className="h-6 w-6 text-muted-foreground" />
+        <CardContent className="flex flex-col items-center justify-center gap-y-3 py-8 text-center">
+          <div className="flex size-12 items-center justify-center rounded-full bg-muted">
+            <CalendarDays className="size-6 text-muted-foreground" />
           </div>
           <div>
             <h3 className="text-base font-semibold">Chưa có kế hoạch</h3>
@@ -83,7 +99,7 @@ export function MaintenanceMobilePlanCards({
           </div>
           {canCreatePlans && (
             <Button onClick={onOpenAddPlanDialog} className="h-11 px-6">
-              <PlusCircle className="mr-2 h-4 w-4" />
+              <PlusCircle className="mr-2 size-4" />
               Tạo kế hoạch mới
             </Button>
           )}
@@ -155,8 +171,8 @@ export function MaintenanceMobilePlanCards({
                 </Button>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
-                    <Button variant="ghost" size="icon" className="h-9 w-9">
-                      <MoreHorizontal className="h-5 w-5" />
+                    <Button variant="ghost" size="icon" className="size-9">
+                      <MoreHorizontal className="size-5" />
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-48">

--- a/src/app/(app)/maintenance/_components/maintenance-mobile-tasks-panel.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-mobile-tasks-panel.tsx
@@ -19,27 +19,45 @@ import { MaintenanceMobileTaskCard } from "./maintenance-mobile-task-card"
 
 interface MaintenanceMobileTasksPanelProps {
   selectedPlan: MaintenancePlan | null
-  canManagePlans: boolean
   tasks: MaintenanceTask[]
   draftTasks: MaintenanceTask[]
+  panelState: MaintenanceMobileTasksPanelState
+  access: MaintenanceMobileTasksPanelAccess
+  taskEditing: MaintenanceMobileTaskEditing
+  months: number[]
+  expansion: MaintenanceMobileTasksExpansion
+  actions: MaintenanceMobileTasksActions
+}
+
+interface MaintenanceMobileTasksPanelState {
   hasChanges: boolean
   isSavingAll: boolean
   isLoadingTasks: boolean
   isPlanApproved: boolean
-  canCompleteTask: boolean
   isCompletingTask: Set<string>
-  taskEditing: {
-    editingTaskId: number | null
-    editingTaskData: Partial<MaintenanceTask> | null
-    handleTaskDataChange: (field: keyof MaintenanceTask, value: unknown) => void
-    handleSaveTask: () => void
-    handleCancelEdit: () => void
-    handleStartEdit: (task: MaintenanceTask) => void
-    setTaskToDelete: (task: MaintenanceTask | null) => void
-  }
-  months: number[]
+}
+
+interface MaintenanceMobileTasksPanelAccess {
+  canManagePlans: boolean
+  canCompleteTask: boolean
+}
+
+interface MaintenanceMobileTaskEditing {
+  editingTaskId: number | null
+  editingTaskData: Partial<MaintenanceTask> | null
+  handleTaskDataChange: (field: keyof MaintenanceTask, value: unknown) => void
+  handleSaveTask: () => void
+  handleCancelEdit: () => void
+  handleStartEdit: (task: MaintenanceTask) => void
+  setTaskToDelete: (task: MaintenanceTask | null) => void
+}
+
+interface MaintenanceMobileTasksExpansion {
   expandedTaskIds: Record<number, boolean>
   toggleTaskExpansion: (taskId: number) => void
+}
+
+interface MaintenanceMobileTasksActions {
   setIsAddTasksDialogOpen: (open: boolean) => void
   generatePlanForm: () => void
   setIsConfirmingCancel: (open: boolean) => void
@@ -49,31 +67,32 @@ interface MaintenanceMobileTasksPanelProps {
 
 export function MaintenanceMobileTasksPanel({
   selectedPlan,
-  canManagePlans,
   tasks,
   draftTasks,
-  hasChanges,
-  isSavingAll,
-  isLoadingTasks,
-  isPlanApproved,
-  canCompleteTask,
-  isCompletingTask,
+  panelState,
+  access,
   taskEditing,
   months,
-  expandedTaskIds,
-  toggleTaskExpansion,
-  setIsAddTasksDialogOpen,
-  generatePlanForm,
-  setIsConfirmingCancel,
-  handleSaveAllChanges,
-  handleMarkAsCompleted,
+  expansion,
+  actions,
 }: MaintenanceMobileTasksPanelProps) {
+  const { hasChanges, isSavingAll, isLoadingTasks, isPlanApproved, isCompletingTask } = panelState
+  const { canManagePlans, canCompleteTask } = access
+  const { expandedTaskIds, toggleTaskExpansion } = expansion
+  const {
+    setIsAddTasksDialogOpen,
+    generatePlanForm,
+    setIsConfirmingCancel,
+    handleSaveAllChanges,
+    handleMarkAsCompleted,
+  } = actions
+
   if (!selectedPlan) {
     return (
       <Card className="border-dashed bg-muted/30">
-        <CardContent className="flex flex-col items-center justify-center space-y-3 py-10 text-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-            <ClipboardList className="h-6 w-6 text-muted-foreground" />
+        <CardContent className="flex flex-col items-center justify-center gap-y-3 py-10 text-center">
+          <div className="flex size-12 items-center justify-center rounded-full bg-muted">
+            <ClipboardList className="size-6 text-muted-foreground" />
           </div>
           <div>
             <h3 className="text-base font-semibold">Chọn kế hoạch để xem công việc</h3>
@@ -111,7 +130,7 @@ export function MaintenanceMobileTasksPanel({
           <div className="flex flex-wrap items-center gap-2">
             {canManagePlans && isDraft && (
               <Button size="sm" onClick={() => setIsAddTasksDialogOpen(true)}>
-                <PlusCircle className="mr-2 h-4 w-4" />
+                <PlusCircle className="mr-2 size-4" />
                 Thêm thiết bị
               </Button>
             )}
@@ -123,7 +142,7 @@ export function MaintenanceMobileTasksPanel({
                 disabled={isSavingAll}
                 className="flex items-center"
               >
-                <FileText className="mr-2 h-4 w-4" />
+                <FileText className="mr-2 size-4" />
                 Xuất phiếu kế hoạch
               </Button>
             )}
@@ -134,7 +153,7 @@ export function MaintenanceMobileTasksPanel({
       {hasChanges && isDraft && (
         <div className="rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-3 shadow-sm">
           <div className="flex items-start gap-3">
-            <AlertTriangle className="mt-1 h-5 w-5 text-amber-600" />
+            <AlertTriangle className="mt-1 size-5 text-amber-600" />
             <div className="flex-1">
               <div className="text-sm font-medium text-amber-900">Có thay đổi chưa lưu</div>
               <p className="mt-1 text-xs text-amber-700">
@@ -150,7 +169,7 @@ export function MaintenanceMobileTasksPanel({
                   Hủy bỏ
                 </Button>
                 <Button onClick={() => void handleSaveAllChanges()} disabled={isSavingAll}>
-                  {isSavingAll && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {isSavingAll && <Loader2 className="mr-2 size-4 animate-spin" />}
                   Lưu thay đổi
                 </Button>
               </div>
@@ -164,7 +183,7 @@ export function MaintenanceMobileTasksPanel({
           {Array.from({ length: 3 }).map((_, index) => (
             <Card key={index} className="rounded-2xl border border-border/70 bg-background">
               <CardHeader className="flex flex-row items-center gap-3">
-                <Skeleton className="h-10 w-10 rounded-full" />
+                <Skeleton className="size-10 rounded-full" />
                 <div className="space-y-2">
                   <Skeleton className="h-4 w-40" />
                   <Skeleton className="h-3 w-24" />

--- a/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
+++ b/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
@@ -153,39 +153,47 @@ export function MobileMaintenanceLayout({
           {planTabActive ? (
             <MaintenanceMobilePlanCards
               plans={plans}
-              isLoadingPlans={isLoadingPlans}
-              showFacilityFilter={showFacilityFilter}
-              canManagePlans={ctx.canManagePlans}
-              canCreatePlans={ctx.canCreatePlans}
-              onOpenAddPlanDialog={() => ctx.setIsAddPlanDialogOpen(true)}
-              onSelectPlan={ctx.handleSelectPlan}
-              onSetTasksTab={() => ctx.setActiveTab("tasks")}
-              onEditPlan={ctx.setEditingPlan}
-              onOpenApproveDialog={ctx.operations.openApproveDialog}
-              onOpenRejectDialog={ctx.operations.openRejectDialog}
-              onOpenDeleteDialog={ctx.operations.openDeleteDialog}
+              planState={{ isLoadingPlans, showFacilityFilter }}
+              access={{
+                canManagePlans: ctx.canManagePlans,
+                canCreatePlans: ctx.canCreatePlans,
+              }}
+              actions={{
+                onOpenAddPlanDialog: () => ctx.setIsAddPlanDialogOpen(true),
+                onSelectPlan: ctx.handleSelectPlan,
+                onSetTasksTab: () => ctx.setActiveTab("tasks"),
+                onEditPlan: ctx.setEditingPlan,
+                onOpenApproveDialog: ctx.operations.openApproveDialog,
+                onOpenRejectDialog: ctx.operations.openRejectDialog,
+                onOpenDeleteDialog: ctx.operations.openDeleteDialog,
+              }}
             />
           ) : (
             <MaintenanceMobileTasksPanel
               selectedPlan={ctx.selectedPlan}
-              canManagePlans={ctx.canManagePlans}
               tasks={ctx.tasks}
               draftTasks={ctx.draftTasks}
-              hasChanges={ctx.hasChanges}
-              isSavingAll={ctx.isSavingAll}
-              isLoadingTasks={ctx.isLoadingTasks}
-              isPlanApproved={ctx.isPlanApproved}
-              canCompleteTask={ctx.canCompleteTask}
-              isCompletingTask={ctx.isCompletingTask}
+              panelState={{
+                hasChanges: ctx.hasChanges,
+                isSavingAll: ctx.isSavingAll,
+                isLoadingTasks: ctx.isLoadingTasks,
+                isPlanApproved: ctx.isPlanApproved,
+                isCompletingTask: ctx.isCompletingTask,
+              }}
+              access={{
+                canManagePlans: ctx.canManagePlans,
+                canCompleteTask: ctx.canCompleteTask,
+              }}
               taskEditing={ctx.taskEditing}
               months={months}
-              expandedTaskIds={expandedTaskIds}
-              toggleTaskExpansion={toggleTaskExpansion}
-              setIsAddTasksDialogOpen={ctx.setIsAddTasksDialogOpen}
-              generatePlanForm={ctx.generatePlanForm}
-              setIsConfirmingCancel={ctx.setIsConfirmingCancel}
-              handleSaveAllChanges={ctx.handleSaveAllChanges}
-              handleMarkAsCompleted={ctx.handleMarkAsCompleted}
+              expansion={{ expandedTaskIds, toggleTaskExpansion }}
+              actions={{
+                setIsAddTasksDialogOpen: ctx.setIsAddTasksDialogOpen,
+                generatePlanForm: ctx.generatePlanForm,
+                setIsConfirmingCancel: ctx.setIsConfirmingCancel,
+                handleSaveAllChanges: ctx.handleSaveAllChanges,
+                handleMarkAsCompleted: ctx.handleMarkAsCompleted,
+              }}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- Group maintenance mobile plan/task props to remove React Doctor boolean-prop warnings
- Preserve existing mobile maintenance behavior and add prop-wiring regression coverage
- Clean touched Tailwind utility warnings so React Doctor diff is clean

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- "src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx" "src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx" "src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx" "src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx"
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

Closes #404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `react-doctor` boolean-prop warnings in maintenance mobile by grouping component props into state/access/action objects and cleaning a few `Tailwind` utilities. Behavior is unchanged; adds tests for prop wiring and task panel state. Closes #404.

- **Refactors**
  - Grouped props in `MaintenanceMobilePlanCards`, `MaintenanceMobileTasksPanel`, and `MobileMaintenanceLayout` (`planState`, `panelState`, `access`, `actions`, `expansion`).
  - Normalized icon sizing and spacing (e.g., `size-*`) to clear utility warnings.
  - Updated tests to assert `access.canCreatePlans` and `panelState.isLoadingTasks` pass-throughs.

<sup>Written for commit d650d77fc4477c007ee637dcf078d8c3976e022a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for icon sizes and spacing in the maintenance mobile interface.

* **Refactor**
  * Reorganized internal code structure for improved maintainability.

* **Tests**
  * Updated test coverage to reflect code organization changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->