### PR TITLE
fix: constrain dense report chart card

### DIFF
--- a/src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx
+++ b/src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx
@@ -80,8 +80,24 @@ vi.mock("@/components/dynamic-chart", () => ({
 }))
 
 vi.mock("@/components/ui/card", () => ({
-  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
-  CardContent: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
+  Card: ({
+    children,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode
+    className?: string
+    "data-testid"?: string
+  }) => <div className={className} {...props}>{children}</div>,
+  CardContent: ({
+    children,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode
+    className?: string
+    "data-testid"?: string
+  }) => <div className={className} {...props}>{children}</div>,
   CardDescription: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
   CardHeader: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
   CardTitle: ({ children, className }: { children: React.ReactNode; className?: string }) => <div className={className}>{children}</div>,
@@ -92,17 +108,19 @@ let latestTabValueChange: ((value: string) => void) | undefined
 vi.mock("@/components/ui/tabs", () => ({
   Tabs: ({
     children,
+    className,
     onValueChange,
   }: {
     children: React.ReactNode
+    className?: string
     value: string
     onValueChange?: (value: string) => void
   }) => {
     latestTabValueChange = onValueChange
-    return <div>{children}</div>
+    return <div data-testid="equipment-chart-tabs" className={className}>{children}</div>
   },
   TabsContent: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-    <div className={className}>{children}</div>
+    <div data-testid="equipment-chart-tab-content" className={className}>{children}</div>
   ),
   TabsList: ({ children, className }: { children: React.ReactNode; className?: string }) => (
     <div data-testid="equipment-chart-tabs-list" className={className}>{children}</div>
@@ -238,7 +256,15 @@ describe("InteractiveEquipmentChart tooltip", () => {
 
     render(<InteractiveEquipmentChart tenantFilter="42" selectedDonVi={42} effectiveTenantKey="42" />)
 
-    expect(screen.getAllByTestId("equipment-chart-scroll-frame")[0]).toHaveClass("overflow-x-auto")
+    expect(screen.getByTestId("equipment-chart-card")).toHaveClass("min-w-0", "overflow-hidden")
+    expect(screen.getByTestId("equipment-chart-content")).toHaveClass("min-w-0")
+    expect(screen.getByTestId("equipment-chart-tabs")).toHaveClass("min-w-0")
+    expect(screen.getAllByTestId("equipment-chart-tab-content")[0]).toHaveClass("min-w-0")
+    expect(screen.getAllByTestId("equipment-chart-scroll-frame")[0]).toHaveClass(
+      "min-w-0",
+      "max-w-full",
+      "overflow-x-auto",
+    )
     expect(screen.getAllByTestId("equipment-chart-scroll-inner")[0]).toHaveStyle({ minWidth: "1736px" })
     expect(mocks.dynamicBarChart).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/components/interactive-equipment-chart.tsx
+++ b/src/components/interactive-equipment-chart.tsx
@@ -18,6 +18,7 @@ import {
   STATUS_LABELS
 } from "@/hooks/use-equipment-distribution"
 import { buildKeyedTooltipEntries } from "@/lib/runtime-list-keys"
+import { cn } from "@/lib/utils"
 
 interface InteractiveEquipmentChartProps {
   className?: string
@@ -162,7 +163,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
   }, [data, viewType])
 
   const isDenseChart = chartData.length > DENSE_DISTRIBUTION_CATEGORY_THRESHOLD
-  const chartContainerClassName = isDenseChart ? "overflow-x-auto pb-2" : ""
+  const chartContainerClassName = cn("min-w-0 max-w-full", isDenseChart && "overflow-x-auto pb-2")
   const chartMinWidth = isDenseChart ? `${chartData.length * DENSE_DISTRIBUTION_CATEGORY_WIDTH}px` : undefined
 
   // Statistics
@@ -186,7 +187,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
 
   if (error) {
     return (
-      <Card className={className}>
+      <Card className={cn("min-w-0 overflow-hidden", className)}>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-red-600">
             <BarChart3 className="size-5" />
@@ -205,7 +206,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
   }
 
   return (
-    <Card className={className}>
+    <Card data-testid="equipment-chart-card" className={cn("min-w-0 overflow-hidden", className)}>
       <CardHeader>
         <div
           data-testid="equipment-chart-header"
@@ -250,8 +251,8 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
         </div>
       </CardHeader>
 
-      <CardContent>
-        <Tabs value={viewType} onValueChange={(value) => setViewType(value as 'department' | 'location')} className="space-y-4">
+      <CardContent data-testid="equipment-chart-content" className="min-w-0">
+        <Tabs value={viewType} onValueChange={(value) => setViewType(value as 'department' | 'location')} className="min-w-0 space-y-4">
           <div
             data-testid="equipment-chart-toolbar"
             className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between"
@@ -310,7 +311,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
             </div>
           </div>
 
-          <TabsContent value="department" className="space-y-4">
+          <TabsContent value="department" className="min-w-0 space-y-4">
             {isLoading ? (
               <Skeleton className="h-[400px] w-full" />
             ) : chartData.length === 0 ? (
@@ -331,7 +332,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
                 </Alert>
               </div>
             ) : (
-              <div className="space-y-4">
+              <div className="min-w-0 space-y-4">
                 {/* Chart */}
                 <div data-testid="equipment-chart-scroll-frame" className={chartContainerClassName}>
                   <div data-testid="equipment-chart-scroll-inner" style={{ minWidth: chartMinWidth }}>
@@ -371,7 +372,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
             )}
           </TabsContent>
 
-          <TabsContent value="location" className="space-y-4">
+          <TabsContent value="location" className="min-w-0 space-y-4">
             {isLoading ? (
               <Skeleton className="h-[400px] w-full" />
             ) : chartData.length === 0 ? (
@@ -392,7 +393,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
                 </Alert>
               </div>
             ) : (
-              <div className="space-y-4">
+              <div className="min-w-0 space-y-4">
                 {/* Chart */}
                 <div data-testid="equipment-chart-scroll-frame" className={chartContainerClassName}>
                   <div data-testid="equipment-chart-scroll-inner" style={{ minWidth: chartMinWidth }}>


### PR DESCRIPTION
## Summary
- Keep dense department charts on the existing working Recharts bar chart path.
- Add shrink-safe wrappers (, , ) so the card follows the viewport.
- Keep the wide chart inside an internal horizontal scroll frame when department count is dense.

## Verification
- 
> nextn@0.1.0 verify:no-explicit-any
> node scripts/check-no-explicit-any-in-diff.js

No explicit any found in changed TypeScript files.
- 
> nextn@0.1.0 typecheck
> tsc --noEmit
- 
> nextn@0.1.0 test:run
> vitest run src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx


 RUN  v4.0.17 /root/qltbyt-nam-phong

 ✓ src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx (4 tests) 302ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  14:48:41
   Duration  2.03s (transform 195ms, setup 86ms, import 859ms, tests 302ms, environment 536ms)
- react-doctor v0.1.6

✔ Select projects to scan › nextn
Scanning changes: hotfix/reports-dense-chart-scroll → origin/main

Scanning /root/qltbyt-nam-phong...



  ⚠ react-doctor/no-giant-component
      Component "InteractiveEquipmentChart" is 308 lines — consider breaking it into smaller focused components
      → Extract logical sections into focused components: `<UserHeader />`, `<UserActions />`, etc.
      src/components/interactive-equipment-chart.tsx:132

  ┌─────┐  99 / 100 Great
  │ ◠ ◠ │  ██████████████████████████████████████████████████
  │  ▽  │  React Doctor (www.react.doctor)
  └─────┘

  1 issue across 1/2 files  in 295ms
  Full diagnostics written to /tmp/.ctx-mode-FrkgIE/react-doctor-cb820043-f247-490a-bcfb-e7e634e191b8
- 

Note: local  has unrelated unpushed docs/plan commits, so this hotfix is isolated on a branch from .

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dense report charts overflowing by constraining the chart card and content to the viewport. Wide charts now stay inside a horizontal scroll frame without breaking layout.

- **Bug Fixes**
  - Constrain `InteractiveEquipmentChart` card and tab content with min-w-0 and overflow-hidden.
  - Keep dense department/location charts in an internal horizontal scroll (overflow-x-auto) with min width based on category count.
  - Add test IDs and update tests to assert new classes and scroll behavior; no changes for sparse charts.

<sup>Written for commit 344d3e0dd710f619c6cc3fa3ca8cfb9b42faff4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined component sizing and overflow handling to ensure consistent layout behavior across different content states and screen configurations.

* **Tests**
  * Updated test infrastructure to better verify styling application and enhanced assertions to validate layout behavior across component states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/442)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->