### PR TITLE
Reports: visualize repair completion time

### DIFF
--- a/src/app/(app)/reports/components/__tests__/maintenance-report-completion-time.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-completion-time.test.tsx
@@ -73,7 +73,7 @@ describe("MaintenanceReportCompletionTime", () => {
     expect(screen.getByText("7,5 ngày")).toBeInTheDocument()
     expect(screen.getByText("Thời gian trung bình")).toBeInTheDocument()
     expect(screen.getByText("12,9 ngày")).toBeInTheDocument()
-    expect(screen.getByText("Tỉ lệ đúng hạn")).toBeInTheDocument()
+    expect(screen.getByText("Tỉ lệ đúng hạn (≤14 ngày)")).toBeInTheDocument()
     expect(screen.getByText("66,7%")).toBeInTheDocument()
     expect(screen.getByText("4/6 yêu cầu trong ngưỡng 14 ngày")).toBeInTheDocument()
     expect(screen.getByText("Xu hướng thời gian hoàn thành theo tháng")).toBeInTheDocument()
@@ -84,6 +84,9 @@ describe("MaintenanceReportCompletionTime", () => {
       expect.objectContaining({
         data: expect.arrayContaining([
           expect.objectContaining({ bucketKey: "30d+", count: 1, fill: "hsl(var(--destructive))" }),
+        ]),
+        bars: expect.arrayContaining([
+          expect.objectContaining({ key: "count", cellColorKey: "fill" }),
         ]),
       })
     )

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-completion-time.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-completion-time.test.tsx
@@ -1,0 +1,125 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockDynamicBarChart = vi.fn(() => <div data-testid="completion-histogram" />)
+const mockDynamicLineChart = vi.fn(() => <div data-testid="completion-trend" />)
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/progress", () => ({
+  Progress: ({ value }: { value?: number }) => <div data-testid="on-time-progress">{value}</div>,
+}))
+
+vi.mock("@/components/dynamic-chart", () => ({
+  DynamicBarChart: (props: unknown) => mockDynamicBarChart(props),
+  DynamicLineChart: (props: unknown) => mockDynamicLineChart(props),
+}))
+
+import { MaintenanceReportCompletionTime } from "../maintenance-report-completion-time"
+
+describe("MaintenanceReportCompletionTime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const completionTime = {
+    stats: {
+      totalCompleted: 6,
+      medianMinutes: 10800,
+      averageMinutes: 18600,
+      p90Minutes: 43200,
+      onTimeCount: 4,
+      onTimePercent: 66.7,
+      thresholdDays: 14,
+    },
+    distribution: [
+      { bucketKey: "0-1d", label: "0-1 ngày", count: 1, isOverThreshold: false },
+      { bucketKey: "1-3d", label: "1-3 ngày", count: 1, isOverThreshold: false },
+      { bucketKey: "3-7d", label: "3-7 ngày", count: 1, isOverThreshold: false },
+      { bucketKey: "7-14d", label: "7-14 ngày", count: 1, isOverThreshold: false },
+      { bucketKey: "14-30d", label: "14-30 ngày", count: 1, isOverThreshold: true },
+      { bucketKey: "30d+", label: ">30 ngày", count: 1, isOverThreshold: true },
+    ],
+  }
+
+  const completionTimeByMonth = [
+    {
+      period: "2026-03",
+      medianMinutes: 10800,
+      p90Minutes: 43200,
+      averageMinutes: 18600,
+      completedCount: 6,
+    },
+  ]
+
+  it("renders KPI, histogram, and trend cards for completion-time data", () => {
+    render(
+      <MaintenanceReportCompletionTime
+        isLoading={false}
+        repairCompletionTime={completionTime}
+        repairCompletionTimeByMonth={completionTimeByMonth}
+      />
+    )
+
+    expect(screen.getByText("Thời gian hoàn thành yêu cầu sửa chữa")).toBeInTheDocument()
+    expect(screen.getByText("Trung vị")).toBeInTheDocument()
+    expect(screen.getByText("7,5 ngày")).toBeInTheDocument()
+    expect(screen.getByText("Thời gian trung bình")).toBeInTheDocument()
+    expect(screen.getByText("12,9 ngày")).toBeInTheDocument()
+    expect(screen.getByText("Tỉ lệ đúng hạn")).toBeInTheDocument()
+    expect(screen.getByText("66,7%")).toBeInTheDocument()
+    expect(screen.getByText("4/6 yêu cầu trong ngưỡng 14 ngày")).toBeInTheDocument()
+    expect(screen.getByText("Xu hướng thời gian hoàn thành theo tháng")).toBeInTheDocument()
+    expect(screen.getByTestId("completion-histogram")).toBeInTheDocument()
+    expect(screen.getByTestId("completion-trend")).toBeInTheDocument()
+
+    expect(mockDynamicBarChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ bucketKey: "30d+", count: 1, fill: "hsl(var(--destructive))" }),
+        ]),
+      })
+    )
+    expect(mockDynamicLineChart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lines: expect.arrayContaining([
+          expect.objectContaining({ key: "medianMinutes", name: "Trung vị" }),
+          expect.objectContaining({ key: "p90Minutes", name: "90% hoàn thành trong" }),
+          expect.objectContaining({ key: "averageMinutes", name: "Trung bình" }),
+        ]),
+      })
+    )
+  })
+
+  it("renders an empty state when the date range has no completed repair requests", () => {
+    render(
+      <MaintenanceReportCompletionTime
+        isLoading={false}
+        repairCompletionTime={{
+          stats: {
+            totalCompleted: 0,
+            medianMinutes: 0,
+            averageMinutes: 0,
+            p90Minutes: 0,
+            onTimeCount: 0,
+            onTimePercent: 0,
+            thresholdDays: 14,
+          },
+          distribution: [],
+        }}
+        repairCompletionTimeByMonth={[]}
+      />
+    )
+
+    expect(screen.getByText("Chưa có yêu cầu hoàn thành trong khoảng thời gian đã chọn.")).toBeInTheDocument()
+    expect(mockDynamicBarChart).not.toHaveBeenCalled()
+    expect(mockDynamicLineChart).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mockDynamicBarChart = vi.fn(() => <div data-testid="bar-chart" />)
 const mockDynamicLineChart = vi.fn(() => <div data-testid="line-chart" />)
 const mockDynamicPieChart = vi.fn(() => <div data-testid="pie-chart" />)
+const SELECTED_START_DATE = new Date("2026-04-14T00:00:00.000Z")
+const VI_NUMBER_FORMATTER = new Intl.NumberFormat("vi-VN")
 
 vi.mock("@/components/ui/button", () => ({
   Button: ({
@@ -22,10 +24,10 @@ vi.mock("@/components/ui/button", () => ({
 
 vi.mock("@/components/ui/calendar", () => ({
   Calendar: ({ onSelect }: { onSelect?: (range?: { from?: Date; to?: Date }) => void }) => (
-    <button
-      type="button"
-      onClick={() => onSelect?.({ from: new Date("2026-04-14T00:00:00.000Z") })}
-    >
+      <button
+        type="button"
+        onClick={() => onSelect?.({ from: SELECTED_START_DATE })}
+      >
       Select start date
     </button>
   ),
@@ -41,6 +43,10 @@ vi.mock("@/components/ui/card", () => ({
 
 vi.mock("@/components/ui/skeleton", () => ({
   Skeleton: () => <div data-testid="skeleton" />,
+}))
+
+vi.mock("@/components/ui/progress", () => ({
+  Progress: ({ value }: { value?: number }) => <div data-testid="progress">{value}</div>,
 }))
 
 vi.mock("@/components/ui/popover", () => ({
@@ -69,6 +75,7 @@ vi.mock("@/components/dynamic-chart", () => ({
 }))
 
 import { MaintenanceReportDateFilter } from "../maintenance-report-date-filter"
+import { MaintenanceReportCompletionTime } from "../maintenance-report-completion-time"
 import { MaintenanceReportPlanChart } from "../maintenance-report-plan-chart"
 import { MaintenanceReportRepairCharts } from "../maintenance-report-repair-charts"
 import { MaintenanceReportRepairTables } from "../maintenance-report-repair-tables"
@@ -133,8 +140,7 @@ describe("maintenance report sections", () => {
     expect(mockDynamicBarChart).not.toHaveBeenCalled()
   })
 
-  it("renders repair tables with formatted counts and dates", () => {
-    const numberFormatter = new Intl.NumberFormat("vi-VN")
+  it("renders the top repaired equipment table without recent repair history", () => {
     const formatDateDisplay = (value?: string | null) => (value ? "12/04/2026" : "—")
 
     render(
@@ -150,17 +156,7 @@ describe("maintenance report sections", () => {
             latestCompletedDate: "2026-04-12",
           },
         ]}
-        recentRepairHistory={[
-          {
-            id: 99,
-            equipmentName: "Monitor",
-            issue: "Không lên nguồn",
-            requestedDate: "2026-04-12",
-            status: "Đang xử lý",
-            completedDate: null,
-          },
-        ]}
-        numberFormatter={numberFormatter}
+        numberFormatter={VI_NUMBER_FORMATTER}
         formatDateDisplay={formatDateDisplay}
       />
     )
@@ -168,8 +164,43 @@ describe("maintenance report sections", () => {
     expect(screen.getByText("Thiết bị sửa chữa nhiều nhất")).toBeInTheDocument()
     expect(screen.getByText("Máy thở")).toBeInTheDocument()
     expect(screen.getByText("5")).toBeInTheDocument()
-    expect(screen.getByText("Lịch sử sửa chữa gần đây")).toBeInTheDocument()
-    expect(screen.getByText("Monitor")).toBeInTheDocument()
-    expect(screen.getAllByText("12/04/2026")).toHaveLength(2)
+    expect(screen.queryByText("Lịch sử sửa chữa gần đây")).not.toBeInTheDocument()
+    expect(screen.getAllByText("12/04/2026")).toHaveLength(1)
+  })
+
+  it("renders repair completion KPI, histogram, and trend sections", () => {
+    render(
+      <MaintenanceReportCompletionTime
+        isLoading={false}
+        repairCompletionTime={{
+          stats: {
+            totalCompleted: 6,
+            medianMinutes: 10800,
+            averageMinutes: 18600,
+            p90Minutes: 43200,
+            onTimeCount: 4,
+            onTimePercent: 66.7,
+            thresholdDays: 14,
+          },
+          distribution: [
+            { bucketKey: "0-1d", label: "0-1 ngày", count: 1, isOverThreshold: false },
+          ],
+        }}
+        repairCompletionTimeByMonth={[
+          {
+            period: "2026-03",
+            medianMinutes: 10800,
+            p90Minutes: 43200,
+            averageMinutes: 18600,
+            completedCount: 6,
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText("Thời gian hoàn thành yêu cầu sửa chữa")).toBeInTheDocument()
+    expect(screen.getByText("Xu hướng thời gian hoàn thành theo tháng")).toBeInTheDocument()
+    expect(mockDynamicBarChart).toHaveBeenCalled()
+    expect(mockDynamicLineChart).toHaveBeenCalled()
   })
 })

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-tab.test.tsx
@@ -36,6 +36,10 @@ vi.mock("@/components/ui/skeleton", () => ({
   Skeleton: () => <div data-testid="skeleton" />,
 }))
 
+vi.mock("@/components/ui/progress", () => ({
+  Progress: ({ value }: { value?: number }) => <div data-testid="progress">{value}</div>,
+}))
+
 vi.mock("@/components/ui/table", () => ({
   Table: ({ children }: { children: React.ReactNode }) => <table>{children}</table>,
   TableBody: ({ children }: { children: React.ReactNode }) => <tbody>{children}</tbody>,
@@ -77,6 +81,31 @@ describe("MaintenanceReportTab", () => {
           repairStatusDistribution: [],
           maintenancePlanVsActual: [],
           repairFrequencyByMonth: [],
+          repairCostByMonth: [],
+          repairCostByFacility: [],
+          repairCompletionTime: {
+            stats: {
+              totalCompleted: 6,
+              medianMinutes: 10800,
+              averageMinutes: 18600,
+              p90Minutes: 43200,
+              onTimeCount: 4,
+              onTimePercent: 66.7,
+              thresholdDays: 14,
+            },
+            distribution: [
+              { bucketKey: "0-1d", label: "0-1 ngày", count: 1, isOverThreshold: false },
+            ],
+          },
+          repairCompletionTimeByMonth: [
+            {
+              period: "2026-03",
+              medianMinutes: 10800,
+              p90Minutes: 43200,
+              averageMinutes: 18600,
+              completedCount: 6,
+            },
+          ],
           repairUsageCostCorrelation: {
             period: {
               points: [],
@@ -98,7 +127,6 @@ describe("MaintenanceReportTab", () => {
         },
         topEquipmentRepairs: [],
         topEquipmentRepairCosts: [],
-        recentRepairHistory: [],
       },
       isLoading: false,
     })
@@ -115,5 +143,7 @@ describe("MaintenanceReportTab", () => {
     expect(screen.getByText("Thiếu chi phí")).toBeInTheDocument()
     expect(screen.getByText("2 ca hoàn thành đã ghi nhận")).toBeInTheDocument()
     expect(screen.getByText("1 ca hoàn thành chưa ghi nhận")).toBeInTheDocument()
+    expect(screen.getByText("Thời gian hoàn thành yêu cầu sửa chữa")).toBeInTheDocument()
+    expect(screen.queryByText("Lịch sử sửa chữa gần đây")).not.toBeInTheDocument()
   })
 })

--- a/src/app/(app)/reports/components/__tests__/maintenance-report-utils.test.ts
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-utils.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  buildCompletionTimeChartData,
+  buildCompletionTimeTrendData,
   buildMaintenancePlanChartData,
   buildRepairTrendChartData,
   buildTopEquipmentRepairRows,
   createMaintenanceReportDateFormatter,
+  formatDurationAuto,
   normalizeMaintenanceReportSummary,
   parseMaintenanceReportNumber,
 } from "../maintenance-report-utils"
@@ -86,5 +89,45 @@ describe("maintenance-report-utils", () => {
     expect(formatDateDisplay("2026-04-12")).toBe("12/04/2026")
     expect(formatDateDisplay("not-a-date")).toBe("—")
     expect(formatDateDisplay(null)).toBe("—")
+  })
+
+  it("formats completion durations using hours below one day and days at or above one day", () => {
+    expect(formatDurationAuto(90)).toBe("1,5 giờ")
+    expect(formatDurationAuto(1080)).toBe("18 giờ")
+    expect(formatDurationAuto(1440)).toBe("1 ngày")
+    expect(formatDurationAuto(10368)).toBe("7,2 ngày")
+    expect(formatDurationAuto(null)).toBe("—")
+  })
+
+  it("builds completion histogram and trend data from the RPC payload", () => {
+    expect(
+      buildCompletionTimeChartData([
+        { bucketKey: "0-1d", label: "0-1 ngày", count: "7", isOverThreshold: false },
+        { bucketKey: "30d+", label: ">30 ngày", count: 3, isOverThreshold: true },
+      ])
+    ).toEqual([
+      { bucketKey: "0-1d", label: "0-1 ngày", count: 7, fill: "hsl(var(--chart-1))" },
+      { bucketKey: "30d+", label: ">30 ngày", count: 3, fill: "hsl(var(--destructive))" },
+    ])
+
+    expect(
+      buildCompletionTimeTrendData([
+        {
+          period: "2026-03",
+          medianMinutes: "10800",
+          p90Minutes: 43200,
+          averageMinutes: 18600,
+          completedCount: "6",
+        },
+      ])
+    ).toEqual([
+      {
+        period: "thg 3 2026",
+        medianMinutes: 10800,
+        p90Minutes: 43200,
+        averageMinutes: 18600,
+        completedCount: 6,
+      },
+    ])
   })
 })

--- a/src/app/(app)/reports/components/maintenance-report-completion-time.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-completion-time.tsx
@@ -17,6 +17,8 @@ import {
   formatDurationAuto,
 } from "./maintenance-report-utils"
 
+const PERCENT_FORMATTER = new Intl.NumberFormat("vi-VN", { maximumFractionDigits: 1 })
+
 interface MaintenanceReportCompletionTimeProps {
   isLoading: boolean
   repairCompletionTime: RepairCompletionTimeChart
@@ -39,10 +41,6 @@ export function MaintenanceReportCompletionTime({
 
   const { stats } = repairCompletionTime
   const hasCompletionData = stats.totalCompleted > 0
-  const percentFormatter = React.useMemo(
-    () => new Intl.NumberFormat("vi-VN", { maximumFractionDigits: 1 }),
-    []
-  )
 
   if (isLoading) {
     return (
@@ -62,7 +60,7 @@ export function MaintenanceReportCompletionTime({
         </CardHeader>
         <CardContent>
           <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
-            <Inbox className="h-8 w-8 text-muted-foreground/60" />
+            <Inbox className="size-8 text-muted-foreground/60" />
             <span>Chưa có yêu cầu hoàn thành trong khoảng thời gian đã chọn.</span>
           </div>
         </CardContent>
@@ -82,9 +80,11 @@ export function MaintenanceReportCompletionTime({
             <CompletionStat label="Trung vị" value={formatDurationAuto(stats.medianMinutes)} />
             <CompletionStat label="Thời gian trung bình" value={formatDurationAuto(stats.averageMinutes)} />
             <div className="rounded-md border p-3">
-              <div className="text-xs text-muted-foreground">Tỉ lệ đúng hạn</div>
+              <div className="text-xs text-muted-foreground">
+                Tỉ lệ đúng hạn (≤{stats.thresholdDays} ngày)
+              </div>
               <div className="mt-1 text-xl font-semibold">
-                {percentFormatter.format(stats.onTimePercent)}%
+                {PERCENT_FORMATTER.format(stats.onTimePercent)}%
               </div>
               <Progress className="mt-3 h-2" value={stats.onTimePercent} />
               <div className="mt-2 text-xs text-muted-foreground">
@@ -97,7 +97,12 @@ export function MaintenanceReportCompletionTime({
             data={histogramData}
             height={300}
             xAxisKey="label"
-            bars={[{ key: "count", color: "hsl(var(--chart-1))", name: "Số yêu cầu" }]}
+            bars={[{
+              key: "count",
+              color: "hsl(var(--chart-1))",
+              name: "Số yêu cầu",
+              cellColorKey: "fill",
+            }]}
             margin={{ top: 16, right: 24, left: 16, bottom: 36 }}
           />
         </CardContent>
@@ -111,7 +116,7 @@ export function MaintenanceReportCompletionTime({
         <CardContent>
           {trendData.length === 0 ? (
             <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <Inbox className="size-8 text-muted-foreground/60" />
               <span>Chưa có dữ liệu theo tháng trong khoảng thời gian đã chọn.</span>
             </div>
           ) : (

--- a/src/app/(app)/reports/components/maintenance-report-completion-time.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-completion-time.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { Inbox } from "lucide-react"
+
+import { DynamicBarChart, DynamicLineChart } from "@/components/dynamic-chart"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { Skeleton } from "@/components/ui/skeleton"
+import type {
+  RepairCompletionTimeByMonthPoint,
+  RepairCompletionTimeChart,
+} from "../hooks/use-maintenance-data.types"
+import {
+  buildCompletionTimeChartData,
+  buildCompletionTimeTrendData,
+  formatDurationAuto,
+} from "./maintenance-report-utils"
+
+interface MaintenanceReportCompletionTimeProps {
+  isLoading: boolean
+  repairCompletionTime: RepairCompletionTimeChart
+  repairCompletionTimeByMonth: RepairCompletionTimeByMonthPoint[]
+}
+
+export function MaintenanceReportCompletionTime({
+  isLoading,
+  repairCompletionTime,
+  repairCompletionTimeByMonth,
+}: MaintenanceReportCompletionTimeProps) {
+  const histogramData = React.useMemo(
+    () => buildCompletionTimeChartData(repairCompletionTime.distribution),
+    [repairCompletionTime.distribution]
+  )
+  const trendData = React.useMemo(
+    () => buildCompletionTimeTrendData(repairCompletionTimeByMonth),
+    [repairCompletionTimeByMonth]
+  )
+
+  const { stats } = repairCompletionTime
+  const hasCompletionData = stats.totalCompleted > 0
+  const percentFormatter = React.useMemo(
+    () => new Intl.NumberFormat("vi-VN", { maximumFractionDigits: 1 }),
+    []
+  )
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Skeleton className="h-[460px] w-full" />
+        <Skeleton className="h-[460px] w-full" />
+      </div>
+    )
+  }
+
+  if (!hasCompletionData) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Thời gian hoàn thành yêu cầu sửa chữa</CardTitle>
+          <CardDescription>Thống kê các yêu cầu đã hoàn thành trong khoảng thời gian đã chọn.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Inbox className="h-8 w-8 text-muted-foreground/60" />
+            <span>Chưa có yêu cầu hoàn thành trong khoảng thời gian đã chọn.</span>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Thời gian hoàn thành yêu cầu sửa chữa</CardTitle>
+          <CardDescription>Phân bố thời gian từ lúc yêu cầu đến khi hoàn thành.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-3 md:grid-cols-3">
+            <CompletionStat label="Trung vị" value={formatDurationAuto(stats.medianMinutes)} />
+            <CompletionStat label="Thời gian trung bình" value={formatDurationAuto(stats.averageMinutes)} />
+            <div className="rounded-md border p-3">
+              <div className="text-xs text-muted-foreground">Tỉ lệ đúng hạn</div>
+              <div className="mt-1 text-xl font-semibold">
+                {percentFormatter.format(stats.onTimePercent)}%
+              </div>
+              <Progress className="mt-3 h-2" value={stats.onTimePercent} />
+              <div className="mt-2 text-xs text-muted-foreground">
+                {stats.onTimeCount}/{stats.totalCompleted} yêu cầu trong ngưỡng {stats.thresholdDays} ngày
+              </div>
+            </div>
+          </div>
+
+          <DynamicBarChart
+            data={histogramData}
+            height={300}
+            xAxisKey="label"
+            bars={[{ key: "count", color: "hsl(var(--chart-1))", name: "Số yêu cầu" }]}
+            margin={{ top: 16, right: 24, left: 16, bottom: 36 }}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Xu hướng thời gian hoàn thành theo tháng</CardTitle>
+          <CardDescription>Trung vị, mốc 90% và trung bình theo tháng hoàn thành.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {trendData.length === 0 ? (
+            <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <span>Chưa có dữ liệu theo tháng trong khoảng thời gian đã chọn.</span>
+            </div>
+          ) : (
+            <DynamicLineChart
+              data={trendData}
+              height={360}
+              xAxisKey="period"
+              lines={[
+                { key: "medianMinutes", color: "hsl(var(--chart-1))", name: "Trung vị" },
+                { key: "p90Minutes", color: "hsl(var(--chart-5))", name: "90% hoàn thành trong" },
+                { key: "averageMinutes", color: "hsl(var(--chart-2))", name: "Trung bình" },
+              ]}
+              margin={{ top: 16, right: 24, left: 16, bottom: 12 }}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function CompletionStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="mt-1 text-xl font-semibold">{value}</div>
+    </div>
+  )
+}

--- a/src/app/(app)/reports/components/maintenance-report-repair-tables.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-repair-tables.tsx
@@ -5,12 +5,11 @@ import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import type { RecentRepairHistoryRow, TopEquipmentRepairRow } from "./maintenance-report-utils"
+import type { TopEquipmentRepairRow } from "./maintenance-report-utils"
 
 interface MaintenanceReportRepairTablesProps {
   isLoading: boolean
   topEquipmentRows: TopEquipmentRepairRow[]
-  recentRepairHistory: RecentRepairHistoryRow[]
   numberFormatter: Intl.NumberFormat
   formatDateDisplay: (value?: string | null) => string
 }
@@ -18,99 +17,55 @@ interface MaintenanceReportRepairTablesProps {
 export function MaintenanceReportRepairTables({
   isLoading,
   topEquipmentRows,
-  recentRepairHistory,
   numberFormatter,
   formatDateDisplay,
 }: MaintenanceReportRepairTablesProps) {
   return (
-    <>
-      <Card className="border border-border/60 shadow-sm">
-        <CardHeader>
-          <CardTitle>Thiết bị sửa chữa nhiều nhất</CardTitle>
-          <CardDescription>Top thiết bị có số lượng yêu cầu sửa chữa cao trong khoảng thời gian đã chọn.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <Skeleton className="h-[220px] w-full" />
-          ) : topEquipmentRows.length === 0 ? (
-            <div className="text-sm text-muted-foreground">Không có dữ liệu sửa chữa trong khoảng thời gian đã chọn.</div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-[60px] text-center">#</TableHead>
-                    <TableHead>Thiết bị</TableHead>
-                    <TableHead>Số yêu cầu</TableHead>
-                    <TableHead>Trạng thái gần nhất</TableHead>
-                    <TableHead>Ngày sửa chữa gần nhất</TableHead>
+    <Card className="border border-border/60 shadow-sm">
+      <CardHeader>
+        <CardTitle>Thiết bị sửa chữa nhiều nhất</CardTitle>
+        <CardDescription>Top thiết bị có số lượng yêu cầu sửa chữa cao trong khoảng thời gian đã chọn.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-[220px] w-full" />
+        ) : topEquipmentRows.length === 0 ? (
+          <div className="text-sm text-muted-foreground">Không có dữ liệu sửa chữa trong khoảng thời gian đã chọn.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[60px] text-center">#</TableHead>
+                  <TableHead>Thiết bị</TableHead>
+                  <TableHead>Số yêu cầu</TableHead>
+                  <TableHead>Trạng thái gần nhất</TableHead>
+                  <TableHead>Ngày sửa chữa gần nhất</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {topEquipmentRows.map((item) => (
+                  <TableRow key={`${item.equipmentId}-${item.rank}`} className="group">
+                    <TableCell className="text-center">
+                        <span className="inline-flex size-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary group-hover:bg-primary/20">
+                        {item.rank}
+                      </span>
+                    </TableCell>
+                    <TableCell className="font-medium">{item.name}</TableCell>
+                    <TableCell>{numberFormatter.format(item.totalRequests)}</TableCell>
+                    <TableCell>
+                      <Badge variant={item.latestStatus === "Hoàn thành" ? "default" : "secondary"}>
+                        {item.latestStatus}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{formatDateDisplay(item.latestCompletedDate)}</TableCell>
                   </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {topEquipmentRows.map((item) => (
-                    <TableRow key={`${item.equipmentId}-${item.rank}`} className="group">
-                      <TableCell className="text-center">
-                        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary group-hover:bg-primary/20">
-                          {item.rank}
-                        </span>
-                      </TableCell>
-                      <TableCell className="font-medium">{item.name}</TableCell>
-                      <TableCell>{numberFormatter.format(item.totalRequests)}</TableCell>
-                      <TableCell>
-                        <Badge variant={item.latestStatus === "Hoàn thành" ? "default" : "secondary"}>
-                          {item.latestStatus}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>{formatDateDisplay(item.latestCompletedDate)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card className="border border-border/60 shadow-sm">
-        <CardHeader>
-          <CardTitle>Lịch sử sửa chữa gần đây</CardTitle>
-          <CardDescription>Các yêu cầu sửa chữa mới nhất nằm trong khoảng thời gian đã chọn.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <Skeleton className="h-[220px] w-full" />
-          ) : recentRepairHistory.length === 0 ? (
-            <div className="text-sm text-muted-foreground">Không có lịch sử sửa chữa trong khoảng thời gian đã chọn.</div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Thiết bị</TableHead>
-                    <TableHead>Sự cố</TableHead>
-                    <TableHead>Ngày yêu cầu</TableHead>
-                    <TableHead>Trạng thái</TableHead>
-                    <TableHead>Ngày hoàn thành</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {recentRepairHistory.map((item) => (
-                    <TableRow key={item.id}>
-                      <TableCell className="font-medium">{item.equipmentName}</TableCell>
-                      <TableCell className="max-w-[320px] truncate" title={item.issue}>{item.issue}</TableCell>
-                      <TableCell>{formatDateDisplay(item.requestedDate)}</TableCell>
-                      <TableCell>
-                        <Badge variant={item.status === "Hoàn thành" ? "default" : "secondary"}>{item.status}</Badge>
-                      </TableCell>
-                      <TableCell>{formatDateDisplay(item.completedDate)}</TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }

--- a/src/app/(app)/reports/components/maintenance-report-tab.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-tab.tsx
@@ -4,9 +4,10 @@ import * as React from "react"
 import { endOfYear, startOfYear } from "date-fns"
 
 import { useMaintenanceReportData } from "../hooks/use-maintenance-data"
-import type { DateRange } from "../hooks/use-maintenance-data.types"
+import { defaultMaintenanceReportData, type DateRange } from "../hooks/use-maintenance-data.types"
 import { MaintenanceRepairCostVisualizations } from "./maintenance-repair-cost-visualizations"
 import { MaintenanceReportDateFilter } from "./maintenance-report-date-filter"
+import { MaintenanceReportCompletionTime } from "./maintenance-report-completion-time"
 import { MaintenanceReportPlanChart } from "./maintenance-report-plan-chart"
 import { MaintenanceReportRepairCharts } from "./maintenance-report-repair-charts"
 import { MaintenanceReportRepairTables } from "./maintenance-report-repair-tables"
@@ -18,6 +19,8 @@ import {
   createMaintenanceReportDateFormatter,
   normalizeMaintenanceReportSummary,
 } from "./maintenance-report-utils"
+
+const VI_NUMBER_FORMATTER = new Intl.NumberFormat("vi-VN")
 
 interface MaintenanceReportTabProps {
   tenantFilter?: string
@@ -47,7 +50,6 @@ export function MaintenanceReportTab({
   const topEquipmentRepairs = reportData?.topEquipmentRepairs ?? []
   const topEquipmentRepairCosts = reportData?.topEquipmentRepairCosts ?? []
   const repairUsageCostCorrelation = charts?.repairUsageCostCorrelation
-  const recentRepairHistory = reportData?.recentRepairHistory ?? []
 
   const normalizedSummary = React.useMemo(
     () => normalizeMaintenanceReportSummary(summary),
@@ -69,7 +71,7 @@ export function MaintenanceReportTab({
     [topEquipmentRepairs]
   )
 
-  const numberFormatter = React.useMemo(() => new Intl.NumberFormat("vi-VN"), [])
+  const numberFormatter = VI_NUMBER_FORMATTER
   const formatDateDisplay = React.useMemo(() => createMaintenanceReportDateFormatter(), [])
 
   return (
@@ -91,6 +93,17 @@ export function MaintenanceReportTab({
         repairStatusData={repairStatusData}
       />
 
+      <MaintenanceReportCompletionTime
+        isLoading={isLoading}
+        repairCompletionTime={
+          charts?.repairCompletionTime ?? defaultMaintenanceReportData.charts.repairCompletionTime
+        }
+        repairCompletionTimeByMonth={
+          charts?.repairCompletionTimeByMonth ??
+          defaultMaintenanceReportData.charts.repairCompletionTimeByMonth
+        }
+      />
+
       <MaintenanceReportPlanChart
         isLoading={isLoading}
         maintenancePlanData={maintenancePlanData}
@@ -106,7 +119,6 @@ export function MaintenanceReportTab({
       <MaintenanceReportRepairTables
         isLoading={isLoading}
         topEquipmentRows={topEquipmentRows}
-        recentRepairHistory={recentRepairHistory}
         numberFormatter={numberFormatter}
         formatDateDisplay={formatDateDisplay}
       />

--- a/src/app/(app)/reports/components/maintenance-report-utils.ts
+++ b/src/app/(app)/reports/components/maintenance-report-utils.ts
@@ -4,7 +4,8 @@ import { vi } from "date-fns/locale"
 import type { ChartData } from "@/lib/chart-utils"
 import type {
   MaintenanceReportData,
-  RecentRepairHistoryEntry,
+  RepairCompletionBucket,
+  RepairCompletionTimeByMonthPoint,
   RepairFrequencyPoint,
   TopEquipmentRepairEntry,
 } from "../hooks/use-maintenance-data.types"
@@ -25,6 +26,21 @@ export interface MaintenancePlanChartPoint extends ChartData {
   actual: number
 }
 
+export interface CompletionTimeChartPoint extends ChartData {
+  bucketKey: string
+  label: string
+  count: number
+  fill: string
+}
+
+export interface CompletionTimeTrendPoint extends ChartData {
+  period: string
+  medianMinutes: number
+  p90Minutes: number
+  averageMinutes: number
+  completedCount: number
+}
+
 export interface TopEquipmentRepairRow {
   equipmentId: number
   name: string
@@ -33,8 +49,6 @@ export interface TopEquipmentRepairRow {
   latestCompletedDate?: string | null
   latestStatus: string
 }
-
-export type RecentRepairHistoryRow = RecentRepairHistoryEntry
 
 export function parseMaintenanceReportNumber(value: unknown): number {
   if (typeof value === "number") {
@@ -85,6 +99,58 @@ export function buildRepairTrendChartData(
       completedRequests: parseMaintenanceReportNumber(completed),
     }
   })
+}
+
+export function buildCompletionTimeChartData(
+  distribution: Array<Omit<RepairCompletionBucket, "count"> & { count: unknown }> = []
+): CompletionTimeChartPoint[] {
+  return distribution.map((bucket) => ({
+    bucketKey: bucket.bucketKey,
+    label: bucket.label,
+    count: parseMaintenanceReportNumber(bucket.count),
+    fill: getCompletionBucketColor(bucket),
+  }))
+}
+
+export function buildCompletionTimeTrendData(
+  points: Array<
+    Omit<RepairCompletionTimeByMonthPoint, "medianMinutes" | "p90Minutes" | "averageMinutes" | "completedCount"> & {
+      medianMinutes: unknown
+      p90Minutes: unknown
+      averageMinutes: unknown
+      completedCount: unknown
+    }
+  > = []
+): CompletionTimeTrendPoint[] {
+  return points.map((point) => ({
+    period: formatRepairFrequencyPeriod(point.period),
+    medianMinutes: parseMaintenanceReportNumber(point.medianMinutes),
+    p90Minutes: parseMaintenanceReportNumber(point.p90Minutes),
+    averageMinutes: parseMaintenanceReportNumber(point.averageMinutes),
+    completedCount: parseMaintenanceReportNumber(point.completedCount),
+  }))
+}
+
+export function formatDurationAuto(minutes?: number | null): string {
+  if (minutes == null || !Number.isFinite(minutes) || minutes <= 0) {
+    return "—"
+  }
+
+  const value = minutes < 24 * 60 ? minutes / 60 : minutes / (24 * 60)
+  const unit = minutes < 24 * 60 ? "giờ" : "ngày"
+  const formatted = new Intl.NumberFormat("vi-VN", {
+    maximumFractionDigits: 1,
+  }).format(value)
+
+  return `${formatted} ${unit}`
+}
+
+function getCompletionBucketColor(bucket: Pick<RepairCompletionBucket, "bucketKey" | "isOverThreshold">): string {
+  if (!bucket.isOverThreshold) {
+    return "hsl(var(--chart-1))"
+  }
+
+  return bucket.bucketKey === "30d+" ? "hsl(var(--destructive))" : "hsl(var(--chart-5))"
 }
 
 function formatRepairFrequencyPeriod(period: string): string {

--- a/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
@@ -44,16 +44,6 @@ export interface TopEquipmentRepairCostEntry {
   costRecordedCount: number
 }
 
-export interface RecentRepairHistoryEntry {
-  id: number
-  equipmentName: string
-  issue: string
-  status: string
-  requestedDate: string
-  completedDate?: string | null
-  repairCost?: number | null
-}
-
 export interface RepairUsageCostCorrelationPoint {
   equipmentId: number
   equipmentName: string
@@ -78,6 +68,36 @@ export interface RepairUsageCostCorrelationScope {
 export interface RepairUsageCostCorrelation {
   period: RepairUsageCostCorrelationScope
   cumulative: RepairUsageCostCorrelationScope
+}
+
+export interface RepairCompletionTimeStats {
+  totalCompleted: number
+  medianMinutes: number
+  averageMinutes: number
+  p90Minutes: number
+  onTimeCount: number
+  onTimePercent: number
+  thresholdDays: number
+}
+
+export interface RepairCompletionBucket {
+  bucketKey: string
+  label: string
+  count: number
+  isOverThreshold: boolean
+}
+
+export interface RepairCompletionTimeChart {
+  stats: RepairCompletionTimeStats
+  distribution: RepairCompletionBucket[]
+}
+
+export interface RepairCompletionTimeByMonthPoint {
+  period: string
+  medianMinutes: number
+  p90Minutes: number
+  averageMinutes: number
+  completedCount: number
 }
 
 export interface MaintenanceReportData {
@@ -105,11 +125,12 @@ export interface MaintenanceReportData {
     repairFrequencyByMonth: RepairFrequencyPoint[]
     repairCostByMonth: RepairCostByMonthPoint[]
     repairCostByFacility: RepairCostByFacilityPoint[]
+    repairCompletionTime: RepairCompletionTimeChart
+    repairCompletionTimeByMonth: RepairCompletionTimeByMonthPoint[]
     repairUsageCostCorrelation: RepairUsageCostCorrelation
   }
   topEquipmentRepairs: TopEquipmentRepairEntry[]
   topEquipmentRepairCosts: TopEquipmentRepairCostEntry[]
-  recentRepairHistory: RecentRepairHistoryEntry[]
 }
 
 function createDefaultRepairUsageCostCorrelationScope(): RepairUsageCostCorrelationScope {
@@ -120,6 +141,21 @@ function createDefaultRepairUsageCostCorrelationScope(): RepairUsageCostCorrelat
       equipmentWithRepairCost: 0,
       equipmentWithBoth: 0,
     },
+  }
+}
+
+function createDefaultRepairCompletionTimeChart(): RepairCompletionTimeChart {
+  return {
+    stats: {
+      totalCompleted: 0,
+      medianMinutes: 0,
+      averageMinutes: 0,
+      p90Minutes: 0,
+      onTimeCount: 0,
+      onTimePercent: 0,
+      thresholdDays: 14,
+    },
+    distribution: [],
   }
 }
 
@@ -140,6 +176,8 @@ export const defaultMaintenanceReportData: MaintenanceReportData = {
     repairFrequencyByMonth: [],
     repairCostByMonth: [],
     repairCostByFacility: [],
+    repairCompletionTime: createDefaultRepairCompletionTimeChart(),
+    repairCompletionTimeByMonth: [],
     repairUsageCostCorrelation: {
       period: createDefaultRepairUsageCostCorrelationScope(),
       cumulative: createDefaultRepairUsageCostCorrelationScope(),
@@ -147,7 +185,6 @@ export const defaultMaintenanceReportData: MaintenanceReportData = {
   },
   topEquipmentRepairs: [],
   topEquipmentRepairCosts: [],
-  recentRepairHistory: [],
 }
 
 type DeepPartial<T> = T extends readonly unknown[]
@@ -182,6 +219,18 @@ export function mergeMaintenanceReportData(
         nextCharts?.repairCostByMonth ?? defaultMaintenanceReportData.charts.repairCostByMonth,
       repairCostByFacility:
         nextCharts?.repairCostByFacility ?? defaultMaintenanceReportData.charts.repairCostByFacility,
+      repairCompletionTime: {
+        stats: {
+          ...defaultMaintenanceReportData.charts.repairCompletionTime.stats,
+          ...nextCharts?.repairCompletionTime?.stats,
+        },
+        distribution:
+          nextCharts?.repairCompletionTime?.distribution ??
+          defaultMaintenanceReportData.charts.repairCompletionTime.distribution,
+      },
+      repairCompletionTimeByMonth:
+        nextCharts?.repairCompletionTimeByMonth ??
+        defaultMaintenanceReportData.charts.repairCompletionTimeByMonth,
       repairUsageCostCorrelation: {
         period: {
           ...defaultMaintenanceReportData.charts.repairUsageCostCorrelation.period,
@@ -210,6 +259,5 @@ export function mergeMaintenanceReportData(
     topEquipmentRepairs: report?.topEquipmentRepairs ?? defaultMaintenanceReportData.topEquipmentRepairs,
     topEquipmentRepairCosts:
       report?.topEquipmentRepairCosts ?? defaultMaintenanceReportData.topEquipmentRepairCosts,
-    recentRepairHistory: report?.recentRepairHistory ?? defaultMaintenanceReportData.recentRepairHistory,
   }
 }

--- a/src/components/dynamic-chart.tsx
+++ b/src/components/dynamic-chart.tsx
@@ -148,6 +148,7 @@ interface BarChartBaseProps {
     color: string
     name?: string
     stackId?: string
+    cellColorKey?: string
   }>
   showGrid?: boolean
   showTooltip?: boolean
@@ -190,7 +191,7 @@ export function DynamicBarChart({
 
   return (
     <DynamicChart height={height}>
-      {({ BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer }) => (
+      {({ BarChart, Bar, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer }) => (
         <ResponsiveContainer width="100%" height={height}>
           <BarChart
             layout={isVertical ? 'vertical' : undefined}
@@ -231,7 +232,22 @@ export function DynamicBarChart({
                 fill={bar.color}
                 name={bar.name || bar.key}
                 stackId={bar.stackId}
-              />
+              >
+                {bar.cellColorKey
+                  ? (() => {
+                      const cellColorKey = bar.cellColorKey
+
+                      return data.map((entry) => {
+                        const fill = entry[cellColorKey]
+                        const rawCellKey = entry[xAxisKey] ?? (verticalYAxisKey ? entry[verticalYAxisKey] : null) ?? fill
+
+                        return typeof fill === "string" ? (
+                          <Cell key={`${bar.key}-${String(rawCellKey)}`} fill={fill} />
+                        ) : null
+                      })
+                    })()
+                  : null}
+              </Bar>
             ))}
           </BarChart>
         </ResponsiveContainer>

--- a/supabase/migrations/20260510160000_add_repair_completion_time_charts.sql
+++ b/supabase/migrations/20260510160000_add_repair_completion_time_charts.sql
@@ -1,0 +1,866 @@
+-- Issue #441: replace recent repair history with repair completion-time visualizations.
+-- Apply with Supabase MCP apply_migration only.
+--
+-- Rollback: restore the previous get_maintenance_report_data definition from
+-- supabase/migrations/20260413152000_add_repair_cost_usage_visualizations.sql
+-- if the new visualization payload needs to be removed.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_maintenance_report_data(
+  p_date_from date,
+  p_date_to date,
+  p_don_vi bigint DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_is_global boolean := false;
+  v_allowed bigint[];
+  v_effective bigint[];
+  v_result jsonb;
+  v_from_year integer := extract(year from p_date_from)::integer;
+  v_to_year integer := extract(year from p_date_to)::integer;
+BEGIN
+  v_role := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global := v_role IN ('global', 'admin');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_is_global THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    v_allowed := public.allowed_don_vi_for_session_safe();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object(
+        'summary', jsonb_build_object(
+          'totalRepairs', 0,
+          'repairCompletionRate', 0,
+          'totalMaintenancePlanned', 0,
+          'maintenanceCompletionRate', 0,
+          'totalRepairCost', 0,
+          'averageCompletedRepairCost', 0,
+          'costRecordedCount', 0,
+          'costMissingCount', 0
+        ),
+        'charts', jsonb_build_object(
+          'repairStatusDistribution', '[]'::jsonb,
+          'maintenancePlanVsActual', '[]'::jsonb,
+          'repairFrequencyByMonth', '[]'::jsonb,
+          'repairCostByMonth', '[]'::jsonb,
+          'repairCostByFacility', '[]'::jsonb,
+          'repairCompletionTime', jsonb_build_object(
+            'stats', jsonb_build_object(
+              'totalCompleted', 0,
+              'medianMinutes', 0,
+              'averageMinutes', 0,
+              'p90Minutes', 0,
+              'onTimeCount', 0,
+              'onTimePercent', 0,
+              'thresholdDays', 14
+            ),
+            'distribution', jsonb_build_array(
+              jsonb_build_object('bucketKey', '0-1d', 'label', '0-1 ngày', 'count', 0, 'isOverThreshold', false),
+              jsonb_build_object('bucketKey', '1-3d', 'label', '1-3 ngày', 'count', 0, 'isOverThreshold', false),
+              jsonb_build_object('bucketKey', '3-7d', 'label', '3-7 ngày', 'count', 0, 'isOverThreshold', false),
+              jsonb_build_object('bucketKey', '7-14d', 'label', '7-14 ngày', 'count', 0, 'isOverThreshold', false),
+              jsonb_build_object('bucketKey', '14-30d', 'label', '14-30 ngày', 'count', 0, 'isOverThreshold', true),
+              jsonb_build_object('bucketKey', '30d+', 'label', '>30 ngày', 'count', 0, 'isOverThreshold', true)
+            )
+          ),
+          'repairCompletionTimeByMonth', '[]'::jsonb,
+          'repairUsageCostCorrelation', jsonb_build_object(
+            'period', jsonb_build_object(
+              'points', '[]'::jsonb,
+              'dataQuality', jsonb_build_object(
+                'equipmentWithUsage', 0,
+                'equipmentWithRepairCost', 0,
+                'equipmentWithBoth', 0
+              )
+            ),
+            'cumulative', jsonb_build_object(
+              'points', '[]'::jsonb,
+              'dataQuality', jsonb_build_object(
+                'equipmentWithUsage', 0,
+                'equipmentWithRepairCost', 0,
+                'equipmentWithBoth', 0
+              )
+            )
+          )
+        ),
+        'topEquipmentRepairs', '[]'::jsonb,
+        'topEquipmentRepairCosts', '[]'::jsonb
+      );
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective := ARRAY[p_don_vi];
+      ELSE
+        RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING errcode = '42501';
+      END IF;
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  WITH scoped_equipment AS (
+    SELECT
+      tb.id AS equipment_id,
+      coalesce(nullif(trim(tb.ten_thiet_bi), ''), tb.ma_thiet_bi, 'Không xác định') AS equipment_name,
+      tb.ma_thiet_bi AS equipment_code,
+      tb.don_vi AS facility_id
+    FROM public.thiet_bi tb
+    WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+  ),
+  repair_data_raw AS (
+    SELECT
+      yc.id,
+      yc.trang_thai,
+      yc.mo_ta_su_co,
+      yc.ngay_yeu_cau,
+      yc.ngay_duyet,
+      yc.ngay_hoan_thanh,
+      yc.chi_phi_sua_chua,
+      se.equipment_id,
+      se.equipment_name,
+      se.equipment_code,
+      se.facility_id,
+      coalesce(dv.name, 'Không xác định') AS facility_name,
+      coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh) AS reference_timestamp,
+      (
+        lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%'
+        OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%'
+      ) AS is_completed
+    FROM public.yeu_cau_sua_chua yc
+    INNER JOIN scoped_equipment se ON yc.thiet_bi_id = se.equipment_id
+    LEFT JOIN public.don_vi dv ON dv.id = se.facility_id
+  ),
+  repair_data AS (
+    SELECT
+      id,
+      trang_thai,
+      mo_ta_su_co,
+      ngay_yeu_cau,
+      ngay_duyet,
+      ngay_hoan_thanh,
+      chi_phi_sua_chua,
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      facility_id,
+      facility_name,
+      reference_timestamp,
+      is_completed
+    FROM repair_data_raw
+    WHERE reference_timestamp IS NOT NULL
+      AND (reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN p_date_from AND p_date_to
+  ),
+  cumulative_repair_data AS (
+    SELECT
+      id,
+      trang_thai,
+      mo_ta_su_co,
+      ngay_yeu_cau,
+      ngay_duyet,
+      ngay_hoan_thanh,
+      chi_phi_sua_chua,
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      facility_id,
+      facility_name,
+      reference_timestamp,
+      is_completed
+    FROM repair_data_raw
+    WHERE reference_timestamp IS NOT NULL
+      AND (reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+  ),
+  repair_summary AS (
+    SELECT
+      count(*) AS total_repairs,
+      count(*) FILTER (WHERE is_completed) AS completed,
+      count(*) FILTER (WHERE lower(coalesce(trang_thai, '')) LIKE '%không ht%') AS not_completed,
+      count(*) FILTER (
+        WHERE lower(coalesce(trang_thai, '')) LIKE '%đã duyệt%'
+           OR lower(coalesce(trang_thai, '')) LIKE '%da duyet%'
+      ) AS approved,
+      count(*) FILTER (
+        WHERE lower(coalesce(trang_thai, '')) LIKE '%chờ%'
+           OR lower(coalesce(trang_thai, '')) LIKE '%cho%'
+      ) AS pending,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL) AS cost_missing_count
+    FROM repair_data
+  ),
+  maintenance_data AS (
+    SELECT
+      kh.id AS plan_id,
+      kh.nam,
+      kh.trang_thai,
+      kh.don_vi,
+      cv.id AS task_id,
+      cv.loai_cong_viec,
+      cv.thang_1,
+      cv.thang_1_hoan_thanh,
+      cv.thang_2,
+      cv.thang_2_hoan_thanh,
+      cv.thang_3,
+      cv.thang_3_hoan_thanh,
+      cv.thang_4,
+      cv.thang_4_hoan_thanh,
+      cv.thang_5,
+      cv.thang_5_hoan_thanh,
+      cv.thang_6,
+      cv.thang_6_hoan_thanh,
+      cv.thang_7,
+      cv.thang_7_hoan_thanh,
+      cv.thang_8,
+      cv.thang_8_hoan_thanh,
+      cv.thang_9,
+      cv.thang_9_hoan_thanh,
+      cv.thang_10,
+      cv.thang_10_hoan_thanh,
+      cv.thang_11,
+      cv.thang_11_hoan_thanh,
+      cv.thang_12,
+      cv.thang_12_hoan_thanh
+    FROM public.ke_hoach_bao_tri kh
+    LEFT JOIN public.cong_viec_bao_tri cv ON kh.id = cv.ke_hoach_id
+    WHERE (v_effective IS NULL OR kh.don_vi = ANY(v_effective))
+      AND kh.nam BETWEEN v_from_year AND v_to_year
+      AND kh.trang_thai = 'Đã duyệt'
+  ),
+  maintenance_summary AS (
+    SELECT
+      loai_cong_viec,
+      (
+        CASE WHEN thang_1 THEN 1 ELSE 0 END + CASE WHEN thang_2 THEN 1 ELSE 0 END +
+        CASE WHEN thang_3 THEN 1 ELSE 0 END + CASE WHEN thang_4 THEN 1 ELSE 0 END +
+        CASE WHEN thang_5 THEN 1 ELSE 0 END + CASE WHEN thang_6 THEN 1 ELSE 0 END +
+        CASE WHEN thang_7 THEN 1 ELSE 0 END + CASE WHEN thang_8 THEN 1 ELSE 0 END +
+        CASE WHEN thang_9 THEN 1 ELSE 0 END + CASE WHEN thang_10 THEN 1 ELSE 0 END +
+        CASE WHEN thang_11 THEN 1 ELSE 0 END + CASE WHEN thang_12 THEN 1 ELSE 0 END
+      ) AS planned,
+      (
+        CASE WHEN thang_1_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_2_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_3_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_4_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_5_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_6_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_7_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_8_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_9_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_10_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_11_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_12_hoan_thanh THEN 1 ELSE 0 END
+      ) AS actual
+    FROM maintenance_data
+    WHERE loai_cong_viec IN ('Bảo trì', 'Hiệu chuẩn', 'Kiểm định')
+  ),
+  maintenance_aggregated AS (
+    SELECT
+      loai_cong_viec,
+      sum(planned) AS total_planned,
+      sum(actual) AS total_actual
+    FROM maintenance_summary
+    GROUP BY loai_cong_viec
+  ),
+  repair_frequency AS (
+    SELECT
+      to_char(date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
+      count(*)::integer AS total,
+      count(*) FILTER (WHERE is_completed)::integer AS completed
+    FROM repair_data
+    GROUP BY date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  ),
+  repair_cost_by_month AS (
+    SELECT
+      to_char(date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  ),
+  repair_cost_by_facility AS (
+    SELECT
+      facility_id,
+      facility_name,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY facility_id, facility_name
+  ),
+  repair_completion_rows AS (
+    SELECT
+      id,
+      ngay_hoan_thanh,
+      extract(epoch from (ngay_hoan_thanh - ngay_yeu_cau)) / 60.0 AS completion_minutes
+    FROM repair_data
+    WHERE is_completed
+      AND ngay_hoan_thanh IS NOT NULL
+      AND ngay_yeu_cau IS NOT NULL
+      AND ngay_hoan_thanh >= ngay_yeu_cau
+  ),
+  repair_completion_stats AS (
+    SELECT
+      count(*)::integer AS total_completed,
+      round(coalesce(percentile_cont(0.5) WITHIN GROUP (ORDER BY completion_minutes), 0)::numeric, 1) AS median_minutes,
+      round(coalesce(avg(completion_minutes), 0)::numeric, 1) AS average_minutes,
+      round(coalesce(percentile_cont(0.9) WITHIN GROUP (ORDER BY completion_minutes), 0)::numeric, 1) AS p90_minutes,
+      count(*) FILTER (WHERE completion_minutes <= 14 * 24 * 60)::integer AS on_time_count,
+      CASE
+        WHEN count(*) > 0 THEN round((count(*) FILTER (WHERE completion_minutes <= 14 * 24 * 60)::numeric / count(*)::numeric) * 100, 1)
+        ELSE 0
+      END AS on_time_percent
+    FROM repair_completion_rows
+  ),
+  repair_completion_bucket_template AS (
+    SELECT *
+    FROM (
+      VALUES
+        (1, '0-1d', '0-1 ngày', 0::numeric, 1::numeric * 24 * 60, false),
+        (2, '1-3d', '1-3 ngày', 1::numeric * 24 * 60, 3::numeric * 24 * 60, false),
+        (3, '3-7d', '3-7 ngày', 3::numeric * 24 * 60, 7::numeric * 24 * 60, false),
+        (4, '7-14d', '7-14 ngày', 7::numeric * 24 * 60, 14::numeric * 24 * 60, false),
+        (5, '14-30d', '14-30 ngày', 14::numeric * 24 * 60, 30::numeric * 24 * 60, true),
+        (6, '30d+', '>30 ngày', 30::numeric * 24 * 60, NULL::numeric, true)
+    ) AS bucket(sort_order, bucket_key, bucket_label, min_minutes, max_minutes, is_over_threshold)
+  ),
+  repair_completion_distribution AS (
+    SELECT
+      bt.sort_order,
+      bt.bucket_key,
+      bt.bucket_label,
+      bt.is_over_threshold,
+      count(rcr.id)::integer AS bucket_count
+    FROM repair_completion_bucket_template bt
+    LEFT JOIN repair_completion_rows rcr
+      ON (
+        (bt.max_minutes IS NULL AND rcr.completion_minutes > bt.min_minutes)
+        OR (bt.sort_order = 1 AND rcr.completion_minutes >= bt.min_minutes AND rcr.completion_minutes < bt.max_minutes)
+        OR (bt.sort_order BETWEEN 2 AND 4 AND rcr.completion_minutes >= bt.min_minutes AND rcr.completion_minutes < bt.max_minutes)
+        OR (bt.sort_order = 5 AND rcr.completion_minutes > bt.min_minutes AND rcr.completion_minutes <= bt.max_minutes)
+      )
+    GROUP BY bt.sort_order, bt.bucket_key, bt.bucket_label, bt.is_over_threshold
+  ),
+  repair_completion_by_month AS (
+    SELECT
+      to_char(date_trunc('month', ngay_hoan_thanh AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
+      round((percentile_cont(0.5) WITHIN GROUP (ORDER BY completion_minutes))::numeric, 1) AS median_minutes,
+      round((percentile_cont(0.9) WITHIN GROUP (ORDER BY completion_minutes))::numeric, 1) AS p90_minutes,
+      round(avg(completion_minutes)::numeric, 1) AS average_minutes,
+      count(*)::integer AS completed_count
+    FROM repair_completion_rows
+    GROUP BY date_trunc('month', ngay_hoan_thanh AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  ),
+  equipment_repairs AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      count(*)::integer AS total_requests,
+      max(reference_timestamp) AS latest_event_at,
+      max(ngay_hoan_thanh) AS latest_completed_at,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  equipment_latest_status AS (
+    SELECT DISTINCT ON (equipment_id)
+      equipment_id,
+      coalesce(trang_thai, 'Không xác định') AS latest_status,
+      coalesce(ngay_hoan_thanh, ngay_duyet, ngay_yeu_cau, reference_timestamp) AS status_timestamp
+    FROM repair_data
+    ORDER BY equipment_id, coalesce(ngay_hoan_thanh, ngay_duyet, ngay_yeu_cau, reference_timestamp) DESC
+  ),
+  top_equipment AS (
+    SELECT
+      er.equipment_id,
+      er.equipment_name,
+      er.equipment_code,
+      er.total_requests,
+      er.total_repair_cost,
+      er.average_completed_repair_cost,
+      er.cost_recorded_count,
+      er.cost_missing_count,
+      els.latest_status,
+      CASE
+        WHEN er.latest_completed_at IS NOT NULL THEN to_char(er.latest_completed_at, 'YYYY-MM-DD"T"HH24:MI:SS')
+        ELSE NULL
+      END AS latest_completed_date
+    FROM equipment_repairs er
+    LEFT JOIN equipment_latest_status els ON els.equipment_id = er.equipment_id
+    ORDER BY er.total_requests DESC, er.equipment_name
+    LIMIT 10
+  ),
+  usage_data_raw AS (
+    SELECT
+      se.equipment_id,
+      se.equipment_name,
+      se.equipment_code,
+      nk.thoi_gian_bat_dau,
+      nk.thoi_gian_ket_thuc,
+      extract(epoch from (nk.thoi_gian_ket_thuc - nk.thoi_gian_bat_dau)) / 3600.0 AS usage_hours
+    FROM scoped_equipment se
+    INNER JOIN public.nhat_ky_su_dung nk
+      ON nk.thiet_bi_id = se.equipment_id
+    WHERE nk.thoi_gian_ket_thuc IS NOT NULL
+      AND nk.thoi_gian_ket_thuc > nk.thoi_gian_bat_dau
+  ),
+  period_usage_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      sum(usage_hours) AS total_usage_hours
+    FROM usage_data_raw
+    WHERE (thoi_gian_bat_dau AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN p_date_from AND p_date_to
+      AND (thoi_gian_ket_thuc AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  cumulative_usage_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      sum(usage_hours) AS total_usage_hours
+    FROM usage_data_raw
+    WHERE (thoi_gian_bat_dau AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+      AND (thoi_gian_ket_thuc AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  period_repair_costs_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed)::integer AS completed_repair_requests,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count
+    FROM repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  cumulative_repair_costs_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed)::integer AS completed_repair_requests,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count
+    FROM cumulative_repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  top_equipment_repair_costs AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      total_repair_cost,
+      average_completed_repair_cost,
+      completed_repair_requests,
+      cost_recorded_count
+    FROM period_repair_costs_by_equipment
+    WHERE cost_recorded_count > 0
+    ORDER BY total_repair_cost DESC, equipment_name
+    LIMIT 10
+  ),
+  period_correlation_points AS (
+    SELECT
+      pu.equipment_id,
+      pu.equipment_name,
+      pu.equipment_code,
+      pu.total_usage_hours,
+      pr.total_repair_cost,
+      pr.completed_repair_requests,
+      pr.cost_recorded_count
+    FROM period_usage_by_equipment pu
+    INNER JOIN period_repair_costs_by_equipment pr ON pr.equipment_id = pu.equipment_id
+    WHERE pu.total_usage_hours > 0
+      AND pr.cost_recorded_count > 0
+  ),
+  cumulative_correlation_points AS (
+    SELECT
+      cu.equipment_id,
+      cu.equipment_name,
+      cu.equipment_code,
+      cu.total_usage_hours,
+      cr.total_repair_cost,
+      cr.completed_repair_requests,
+      cr.cost_recorded_count
+    FROM cumulative_usage_by_equipment cu
+    INNER JOIN cumulative_repair_costs_by_equipment cr ON cr.equipment_id = cu.equipment_id
+    WHERE cu.total_usage_hours > 0
+      AND cr.cost_recorded_count > 0
+  ),
+  period_correlation_data_quality AS (
+    SELECT
+      (SELECT count(*)::integer FROM period_usage_by_equipment WHERE total_usage_hours > 0) AS equipment_with_usage,
+      (SELECT count(*)::integer FROM period_repair_costs_by_equipment WHERE cost_recorded_count > 0) AS equipment_with_repair_cost,
+      (SELECT count(*)::integer FROM period_correlation_points) AS equipment_with_both
+  ),
+  cumulative_correlation_data_quality AS (
+    SELECT
+      (SELECT count(*)::integer FROM cumulative_usage_by_equipment WHERE total_usage_hours > 0) AS equipment_with_usage,
+      (SELECT count(*)::integer FROM cumulative_repair_costs_by_equipment WHERE cost_recorded_count > 0) AS equipment_with_repair_cost,
+      (SELECT count(*)::integer FROM cumulative_correlation_points) AS equipment_with_both
+  )
+  SELECT jsonb_build_object(
+    'summary', (
+      SELECT jsonb_build_object(
+        'totalRepairs', coalesce(rs.total_repairs, 0),
+        'repairCompletionRate',
+          CASE
+            WHEN coalesce(rs.total_repairs, 0) > 0
+              THEN (coalesce(rs.completed, 0)::numeric / rs.total_repairs * 100)
+            ELSE 0
+          END,
+        'totalMaintenancePlanned', coalesce((SELECT sum(ma.total_planned) FROM maintenance_aggregated ma), 0),
+        'maintenanceCompletionRate',
+          CASE
+            WHEN coalesce((SELECT sum(ma.total_planned) FROM maintenance_aggregated ma), 0) > 0 THEN
+              (
+                coalesce((SELECT sum(ma.total_actual) FROM maintenance_aggregated ma), 0)::numeric /
+                (SELECT sum(ma.total_planned) FROM maintenance_aggregated ma) * 100
+              )
+            ELSE 0
+          END,
+        'totalRepairCost', coalesce(rs.total_repair_cost, 0),
+        'averageCompletedRepairCost', coalesce(rs.average_completed_repair_cost, 0),
+        'costRecordedCount', coalesce(rs.cost_recorded_count, 0),
+        'costMissingCount', coalesce(rs.cost_missing_count, 0)
+      )
+      FROM repair_summary rs
+    ),
+    'charts', jsonb_build_object(
+      'repairStatusDistribution', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'name', status_name,
+              'value', status_count,
+              'color', status_color
+            )
+          ),
+          '[]'::jsonb
+        )
+        FROM (
+          SELECT 'Hoàn thành' AS status_name, completed AS status_count, 'hsl(var(--chart-1))' AS status_color
+          FROM repair_summary
+          WHERE completed > 0
+          UNION ALL
+          SELECT 'Không HT', not_completed, 'hsl(var(--chart-5))'
+          FROM repair_summary
+          WHERE not_completed > 0
+          UNION ALL
+          SELECT 'Đã duyệt', approved, 'hsl(var(--chart-2))'
+          FROM repair_summary
+          WHERE approved > 0
+          UNION ALL
+          SELECT 'Chờ xử lý', pending, 'hsl(var(--chart-3))'
+          FROM repair_summary
+          WHERE pending > 0
+        ) statuses
+      ),
+      'maintenancePlanVsActual', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'name', loai_cong_viec,
+              'planned', total_planned,
+              'actual', total_actual
+            )
+            ORDER BY loai_cong_viec
+          ),
+          '[]'::jsonb
+        )
+        FROM maintenance_aggregated
+      ),
+      'repairFrequencyByMonth', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'period', period,
+              'total', total,
+              'completed', completed
+            )
+            ORDER BY period
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_frequency
+      ),
+      'repairCostByMonth', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'period', period,
+              'totalCost', total_cost,
+              'averageCost', coalesce(average_cost, 0),
+              'costRecordedCount', cost_recorded_count,
+              'costMissingCount', cost_missing_count
+            )
+            ORDER BY period
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_cost_by_month
+      ),
+      'repairCostByFacility', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'facilityId', facility_id,
+              'facilityName', facility_name,
+              'totalCost', total_cost,
+              'averageCost', coalesce(average_cost, 0),
+              'costRecordedCount', cost_recorded_count,
+              'costMissingCount', cost_missing_count
+            )
+            ORDER BY facility_name
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_cost_by_facility
+      ),
+      'repairCompletionTime', jsonb_build_object(
+        'stats', (
+          SELECT jsonb_build_object(
+            'totalCompleted', coalesce(rcs.total_completed, 0),
+            'medianMinutes', coalesce(rcs.median_minutes, 0),
+            'averageMinutes', coalesce(rcs.average_minutes, 0),
+            'p90Minutes', coalesce(rcs.p90_minutes, 0),
+            'onTimeCount', coalesce(rcs.on_time_count, 0),
+            'onTimePercent', coalesce(rcs.on_time_percent, 0),
+            'thresholdDays', 14
+          )
+          FROM repair_completion_stats rcs
+        ),
+        'distribution', (
+          SELECT coalesce(
+            jsonb_agg(
+              jsonb_build_object(
+                'bucketKey', rcd.bucket_key,
+                'label', rcd.bucket_label,
+                'count', rcd.bucket_count,
+                'isOverThreshold', rcd.is_over_threshold
+              )
+              ORDER BY rcd.sort_order
+            ),
+            '[]'::jsonb
+          )
+          FROM repair_completion_distribution rcd
+        )
+      ),
+      'repairCompletionTimeByMonth', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'period', rcbm.period,
+              'medianMinutes', rcbm.median_minutes,
+              'p90Minutes', rcbm.p90_minutes,
+              'averageMinutes', rcbm.average_minutes,
+              'completedCount', rcbm.completed_count
+            )
+            ORDER BY rcbm.period
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_completion_by_month rcbm
+      ),
+      'repairUsageCostCorrelation', jsonb_build_object(
+        'period', jsonb_build_object(
+          'points', (
+            SELECT coalesce(
+              jsonb_agg(
+                jsonb_build_object(
+                  'equipmentId', pcp.equipment_id,
+                  'equipmentName', pcp.equipment_name,
+                  'equipmentCode', pcp.equipment_code,
+                  'totalUsageHours', pcp.total_usage_hours,
+                  'totalRepairCost', pcp.total_repair_cost,
+                  'completedRepairRequests', pcp.completed_repair_requests,
+                  'costRecordedCount', pcp.cost_recorded_count
+                )
+                ORDER BY pcp.total_repair_cost DESC, pcp.equipment_name
+              ),
+              '[]'::jsonb
+            )
+            FROM period_correlation_points pcp
+          ),
+          'dataQuality', (
+            SELECT jsonb_build_object(
+              'equipmentWithUsage', coalesce(pcq.equipment_with_usage, 0),
+              'equipmentWithRepairCost', coalesce(pcq.equipment_with_repair_cost, 0),
+              'equipmentWithBoth', coalesce(pcq.equipment_with_both, 0)
+            )
+            FROM period_correlation_data_quality pcq
+          )
+        ),
+        'cumulative', jsonb_build_object(
+          'points', (
+            SELECT coalesce(
+              jsonb_agg(
+                jsonb_build_object(
+                  'equipmentId', ccp.equipment_id,
+                  'equipmentName', ccp.equipment_name,
+                  'equipmentCode', ccp.equipment_code,
+                  'totalUsageHours', ccp.total_usage_hours,
+                  'totalRepairCost', ccp.total_repair_cost,
+                  'completedRepairRequests', ccp.completed_repair_requests,
+                  'costRecordedCount', ccp.cost_recorded_count
+                )
+                ORDER BY ccp.total_repair_cost DESC, ccp.equipment_name
+              ),
+              '[]'::jsonb
+            )
+            FROM cumulative_correlation_points ccp
+          ),
+          'dataQuality', (
+            SELECT jsonb_build_object(
+              'equipmentWithUsage', coalesce(ccq.equipment_with_usage, 0),
+              'equipmentWithRepairCost', coalesce(ccq.equipment_with_repair_cost, 0),
+              'equipmentWithBoth', coalesce(ccq.equipment_with_both, 0)
+            )
+            FROM cumulative_correlation_data_quality ccq
+          )
+        )
+      )
+    ),
+    'topEquipmentRepairs', (
+      SELECT coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'equipmentId', te.equipment_id,
+            'equipmentName', te.equipment_name,
+            'totalRequests', te.total_requests,
+            'latestStatus', coalesce(te.latest_status, 'Không xác định'),
+            'latestCompletedDate', te.latest_completed_date,
+            'totalRepairCost', te.total_repair_cost,
+            'averageCompletedRepairCost', coalesce(te.average_completed_repair_cost, 0),
+            'costRecordedCount', te.cost_recorded_count,
+            'costMissingCount', te.cost_missing_count
+          )
+          ORDER BY te.total_requests DESC, te.equipment_name
+        ),
+        '[]'::jsonb
+      )
+      FROM top_equipment te
+    ),
+    'topEquipmentRepairCosts', (
+      SELECT coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'equipmentId', terc.equipment_id,
+            'equipmentName', terc.equipment_name,
+            'equipmentCode', terc.equipment_code,
+            'totalRepairCost', terc.total_repair_cost,
+            'averageCompletedRepairCost', coalesce(terc.average_completed_repair_cost, 0),
+            'completedRepairRequests', terc.completed_repair_requests,
+            'costRecordedCount', terc.cost_recorded_count
+          )
+          ORDER BY terc.total_repair_cost DESC, terc.equipment_name
+        ),
+        '[]'::jsonb
+      )
+      FROM top_equipment_repair_costs terc
+    )
+  ) INTO v_result;
+
+  RETURN coalesce(
+    v_result,
+    jsonb_build_object(
+      'summary', jsonb_build_object(
+        'totalRepairs', 0,
+        'repairCompletionRate', 0,
+        'totalMaintenancePlanned', 0,
+        'maintenanceCompletionRate', 0,
+        'totalRepairCost', 0,
+        'averageCompletedRepairCost', 0,
+        'costRecordedCount', 0,
+        'costMissingCount', 0
+      ),
+      'charts', jsonb_build_object(
+        'repairStatusDistribution', '[]'::jsonb,
+        'maintenancePlanVsActual', '[]'::jsonb,
+        'repairFrequencyByMonth', '[]'::jsonb,
+        'repairCostByMonth', '[]'::jsonb,
+        'repairCostByFacility', '[]'::jsonb,
+        'repairCompletionTime', jsonb_build_object(
+          'stats', jsonb_build_object(
+            'totalCompleted', 0,
+            'medianMinutes', 0,
+            'averageMinutes', 0,
+            'p90Minutes', 0,
+            'onTimeCount', 0,
+            'onTimePercent', 0,
+            'thresholdDays', 14
+          ),
+          'distribution', jsonb_build_array(
+            jsonb_build_object('bucketKey', '0-1d', 'label', '0-1 ngày', 'count', 0, 'isOverThreshold', false),
+            jsonb_build_object('bucketKey', '1-3d', 'label', '1-3 ngày', 'count', 0, 'isOverThreshold', false),
+            jsonb_build_object('bucketKey', '3-7d', 'label', '3-7 ngày', 'count', 0, 'isOverThreshold', false),
+            jsonb_build_object('bucketKey', '7-14d', 'label', '7-14 ngày', 'count', 0, 'isOverThreshold', false),
+            jsonb_build_object('bucketKey', '14-30d', 'label', '14-30 ngày', 'count', 0, 'isOverThreshold', true),
+            jsonb_build_object('bucketKey', '30d+', 'label', '>30 ngày', 'count', 0, 'isOverThreshold', true)
+          )
+        ),
+        'repairCompletionTimeByMonth', '[]'::jsonb,
+        'repairUsageCostCorrelation', jsonb_build_object(
+          'period', jsonb_build_object(
+            'points', '[]'::jsonb,
+            'dataQuality', jsonb_build_object(
+              'equipmentWithUsage', 0,
+              'equipmentWithRepairCost', 0,
+              'equipmentWithBoth', 0
+            )
+          ),
+          'cumulative', jsonb_build_object(
+            'points', '[]'::jsonb,
+            'dataQuality', jsonb_build_object(
+              'equipmentWithUsage', 0,
+              'equipmentWithRepairCost', 0,
+              'equipmentWithBoth', 0
+            )
+          )
+        )
+      ),
+      'topEquipmentRepairs', '[]'::jsonb,
+      'topEquipmentRepairCosts', '[]'::jsonb
+    )
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO anon;
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) FROM PUBLIC;
+
+COMMENT ON FUNCTION public.get_maintenance_report_data(date, date, bigint)
+IS 'Returns maintenance report data with tenant-aware aggregation, repair cost visualizations, repair completion-time distribution, top equipment rankings, and usage-cost correlation datasets.';
+
+COMMIT;

--- a/supabase/migrations/20260511011500_fix_repair_completion_time_boundaries.sql
+++ b/supabase/migrations/20260511011500_fix_repair_completion_time_boundaries.sql
@@ -1,0 +1,868 @@
+-- Issue #441 follow-up: fix repair completion-time completion-date scoping and exact-boundary buckets.
+-- Apply with Supabase MCP apply_migration only.
+--
+-- Forward-only follow-up to 20260510160000_add_repair_completion_time_charts.sql.
+-- Do not edit the already-applied migration; this redefines the RPC with the
+-- corrected completion-time CTEs.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_maintenance_report_data(
+  p_date_from date,
+  p_date_to date,
+  p_don_vi bigint DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_is_global boolean := false;
+  v_allowed bigint[];
+  v_effective bigint[];
+  v_result jsonb;
+  v_from_year integer := extract(year from p_date_from)::integer;
+  v_to_year integer := extract(year from p_date_to)::integer;
+BEGIN
+  v_role := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id := nullif(public._get_jwt_claim('user_id'), '');
+  v_is_global := v_role IN ('global', 'admin');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_is_global THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    v_allowed := public.allowed_don_vi_for_session_safe();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object(
+        'summary', jsonb_build_object(
+          'totalRepairs', 0,
+          'repairCompletionRate', 0,
+          'totalMaintenancePlanned', 0,
+          'maintenanceCompletionRate', 0,
+          'totalRepairCost', 0,
+          'averageCompletedRepairCost', 0,
+          'costRecordedCount', 0,
+          'costMissingCount', 0
+        ),
+        'charts', jsonb_build_object(
+          'repairStatusDistribution', '[]'::jsonb,
+          'maintenancePlanVsActual', '[]'::jsonb,
+          'repairFrequencyByMonth', '[]'::jsonb,
+          'repairCostByMonth', '[]'::jsonb,
+          'repairCostByFacility', '[]'::jsonb,
+          'repairCompletionTime', jsonb_build_object(
+            'stats', jsonb_build_object(
+              'totalCompleted', 0,
+              'medianMinutes', 0,
+              'averageMinutes', 0,
+              'p90Minutes', 0,
+              'onTimeCount', 0,
+              'onTimePercent', 0,
+              'thresholdDays', 14
+            ),
+            'distribution', jsonb_build_array(
+              jsonb_build_object('bucketKey', '0-1d', 'label', '0-1 ngày', 'count', 0, 'isOverThreshold', false),
+              jsonb_build_object('bucketKey', '1-3d', 'label', '1-3 ngày', 'count', 0, 'isOverThreshold', false),
+              jsonb_build_object('bucketKey', '3-7d', 'label', '3-7 ngày', 'count', 0, 'isOverThreshold', false),
+              jsonb_build_object('bucketKey', '7-14d', 'label', '7-14 ngày', 'count', 0, 'isOverThreshold', false),
+              jsonb_build_object('bucketKey', '14-30d', 'label', '14-30 ngày', 'count', 0, 'isOverThreshold', true),
+              jsonb_build_object('bucketKey', '30d+', 'label', '>30 ngày', 'count', 0, 'isOverThreshold', true)
+            )
+          ),
+          'repairCompletionTimeByMonth', '[]'::jsonb,
+          'repairUsageCostCorrelation', jsonb_build_object(
+            'period', jsonb_build_object(
+              'points', '[]'::jsonb,
+              'dataQuality', jsonb_build_object(
+                'equipmentWithUsage', 0,
+                'equipmentWithRepairCost', 0,
+                'equipmentWithBoth', 0
+              )
+            ),
+            'cumulative', jsonb_build_object(
+              'points', '[]'::jsonb,
+              'dataQuality', jsonb_build_object(
+                'equipmentWithUsage', 0,
+                'equipmentWithRepairCost', 0,
+                'equipmentWithBoth', 0
+              )
+            )
+          )
+        ),
+        'topEquipmentRepairs', '[]'::jsonb,
+        'topEquipmentRepairCosts', '[]'::jsonb
+      );
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF p_don_vi = ANY(v_allowed) THEN
+        v_effective := ARRAY[p_don_vi];
+      ELSE
+        RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING errcode = '42501';
+      END IF;
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  WITH scoped_equipment AS (
+    SELECT
+      tb.id AS equipment_id,
+      coalesce(nullif(trim(tb.ten_thiet_bi), ''), tb.ma_thiet_bi, 'Không xác định') AS equipment_name,
+      tb.ma_thiet_bi AS equipment_code,
+      tb.don_vi AS facility_id
+    FROM public.thiet_bi tb
+    WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+  ),
+  repair_data_raw AS (
+    SELECT
+      yc.id,
+      yc.trang_thai,
+      yc.mo_ta_su_co,
+      yc.ngay_yeu_cau,
+      yc.ngay_duyet,
+      yc.ngay_hoan_thanh,
+      yc.chi_phi_sua_chua,
+      se.equipment_id,
+      se.equipment_name,
+      se.equipment_code,
+      se.facility_id,
+      coalesce(dv.name, 'Không xác định') AS facility_name,
+      coalesce(yc.ngay_yeu_cau, yc.ngay_duyet, yc.ngay_hoan_thanh) AS reference_timestamp,
+      (
+        lower(coalesce(yc.trang_thai, '')) LIKE '%hoàn thành%'
+        OR lower(coalesce(yc.trang_thai, '')) LIKE '%hoan thanh%'
+      ) AS is_completed
+    FROM public.yeu_cau_sua_chua yc
+    INNER JOIN scoped_equipment se ON yc.thiet_bi_id = se.equipment_id
+    LEFT JOIN public.don_vi dv ON dv.id = se.facility_id
+  ),
+  repair_data AS (
+    SELECT
+      id,
+      trang_thai,
+      mo_ta_su_co,
+      ngay_yeu_cau,
+      ngay_duyet,
+      ngay_hoan_thanh,
+      chi_phi_sua_chua,
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      facility_id,
+      facility_name,
+      reference_timestamp,
+      is_completed
+    FROM repair_data_raw
+    WHERE reference_timestamp IS NOT NULL
+      AND (reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN p_date_from AND p_date_to
+  ),
+  cumulative_repair_data AS (
+    SELECT
+      id,
+      trang_thai,
+      mo_ta_su_co,
+      ngay_yeu_cau,
+      ngay_duyet,
+      ngay_hoan_thanh,
+      chi_phi_sua_chua,
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      facility_id,
+      facility_name,
+      reference_timestamp,
+      is_completed
+    FROM repair_data_raw
+    WHERE reference_timestamp IS NOT NULL
+      AND (reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+  ),
+  repair_summary AS (
+    SELECT
+      count(*) AS total_repairs,
+      count(*) FILTER (WHERE is_completed) AS completed,
+      count(*) FILTER (WHERE lower(coalesce(trang_thai, '')) LIKE '%không ht%') AS not_completed,
+      count(*) FILTER (
+        WHERE lower(coalesce(trang_thai, '')) LIKE '%đã duyệt%'
+           OR lower(coalesce(trang_thai, '')) LIKE '%da duyet%'
+      ) AS approved,
+      count(*) FILTER (
+        WHERE lower(coalesce(trang_thai, '')) LIKE '%chờ%'
+           OR lower(coalesce(trang_thai, '')) LIKE '%cho%'
+      ) AS pending,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL) AS cost_missing_count
+    FROM repair_data
+  ),
+  maintenance_data AS (
+    SELECT
+      kh.id AS plan_id,
+      kh.nam,
+      kh.trang_thai,
+      kh.don_vi,
+      cv.id AS task_id,
+      cv.loai_cong_viec,
+      cv.thang_1,
+      cv.thang_1_hoan_thanh,
+      cv.thang_2,
+      cv.thang_2_hoan_thanh,
+      cv.thang_3,
+      cv.thang_3_hoan_thanh,
+      cv.thang_4,
+      cv.thang_4_hoan_thanh,
+      cv.thang_5,
+      cv.thang_5_hoan_thanh,
+      cv.thang_6,
+      cv.thang_6_hoan_thanh,
+      cv.thang_7,
+      cv.thang_7_hoan_thanh,
+      cv.thang_8,
+      cv.thang_8_hoan_thanh,
+      cv.thang_9,
+      cv.thang_9_hoan_thanh,
+      cv.thang_10,
+      cv.thang_10_hoan_thanh,
+      cv.thang_11,
+      cv.thang_11_hoan_thanh,
+      cv.thang_12,
+      cv.thang_12_hoan_thanh
+    FROM public.ke_hoach_bao_tri kh
+    LEFT JOIN public.cong_viec_bao_tri cv ON kh.id = cv.ke_hoach_id
+    WHERE (v_effective IS NULL OR kh.don_vi = ANY(v_effective))
+      AND kh.nam BETWEEN v_from_year AND v_to_year
+      AND kh.trang_thai = 'Đã duyệt'
+  ),
+  maintenance_summary AS (
+    SELECT
+      loai_cong_viec,
+      (
+        CASE WHEN thang_1 THEN 1 ELSE 0 END + CASE WHEN thang_2 THEN 1 ELSE 0 END +
+        CASE WHEN thang_3 THEN 1 ELSE 0 END + CASE WHEN thang_4 THEN 1 ELSE 0 END +
+        CASE WHEN thang_5 THEN 1 ELSE 0 END + CASE WHEN thang_6 THEN 1 ELSE 0 END +
+        CASE WHEN thang_7 THEN 1 ELSE 0 END + CASE WHEN thang_8 THEN 1 ELSE 0 END +
+        CASE WHEN thang_9 THEN 1 ELSE 0 END + CASE WHEN thang_10 THEN 1 ELSE 0 END +
+        CASE WHEN thang_11 THEN 1 ELSE 0 END + CASE WHEN thang_12 THEN 1 ELSE 0 END
+      ) AS planned,
+      (
+        CASE WHEN thang_1_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_2_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_3_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_4_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_5_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_6_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_7_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_8_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_9_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_10_hoan_thanh THEN 1 ELSE 0 END +
+        CASE WHEN thang_11_hoan_thanh THEN 1 ELSE 0 END + CASE WHEN thang_12_hoan_thanh THEN 1 ELSE 0 END
+      ) AS actual
+    FROM maintenance_data
+    WHERE loai_cong_viec IN ('Bảo trì', 'Hiệu chuẩn', 'Kiểm định')
+  ),
+  maintenance_aggregated AS (
+    SELECT
+      loai_cong_viec,
+      sum(planned) AS total_planned,
+      sum(actual) AS total_actual
+    FROM maintenance_summary
+    GROUP BY loai_cong_viec
+  ),
+  repair_frequency AS (
+    SELECT
+      to_char(date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
+      count(*)::integer AS total,
+      count(*) FILTER (WHERE is_completed)::integer AS completed
+    FROM repair_data
+    GROUP BY date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  ),
+  repair_cost_by_month AS (
+    SELECT
+      to_char(date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY date_trunc('month', reference_timestamp AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  ),
+  repair_cost_by_facility AS (
+    SELECT
+      facility_id,
+      facility_name,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY facility_id, facility_name
+  ),
+  repair_completion_rows AS (
+    SELECT
+      id,
+      ngay_hoan_thanh,
+      extract(epoch from (ngay_hoan_thanh - ngay_yeu_cau)) / 60.0 AS completion_minutes
+    FROM repair_data_raw
+    WHERE is_completed
+      AND ngay_hoan_thanh IS NOT NULL
+      AND ngay_yeu_cau IS NOT NULL
+      AND ngay_hoan_thanh >= ngay_yeu_cau
+      AND (ngay_hoan_thanh AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN p_date_from AND p_date_to
+  ),
+  repair_completion_stats AS (
+    SELECT
+      count(*)::integer AS total_completed,
+      round(coalesce(percentile_cont(0.5) WITHIN GROUP (ORDER BY completion_minutes), 0)::numeric, 1) AS median_minutes,
+      round(coalesce(avg(completion_minutes), 0)::numeric, 1) AS average_minutes,
+      round(coalesce(percentile_cont(0.9) WITHIN GROUP (ORDER BY completion_minutes), 0)::numeric, 1) AS p90_minutes,
+      count(*) FILTER (WHERE completion_minutes <= 14 * 24 * 60)::integer AS on_time_count,
+      CASE
+        WHEN count(*) > 0 THEN round((count(*) FILTER (WHERE completion_minutes <= 14 * 24 * 60)::numeric / count(*)::numeric) * 100, 1)
+        ELSE 0
+      END AS on_time_percent
+    FROM repair_completion_rows
+  ),
+  repair_completion_bucket_template AS (
+    SELECT *
+    FROM (
+      VALUES
+        (1, '0-1d', '0-1 ngày', 0::numeric, 1::numeric * 24 * 60, false),
+        (2, '1-3d', '1-3 ngày', 1::numeric * 24 * 60, 3::numeric * 24 * 60, false),
+        (3, '3-7d', '3-7 ngày', 3::numeric * 24 * 60, 7::numeric * 24 * 60, false),
+        (4, '7-14d', '7-14 ngày', 7::numeric * 24 * 60, 14::numeric * 24 * 60, false),
+        (5, '14-30d', '14-30 ngày', 14::numeric * 24 * 60, 30::numeric * 24 * 60, true),
+        (6, '30d+', '>30 ngày', 30::numeric * 24 * 60, NULL::numeric, true)
+    ) AS bucket(sort_order, bucket_key, bucket_label, min_minutes, max_minutes, is_over_threshold)
+  ),
+  repair_completion_distribution AS (
+    SELECT
+      bt.sort_order,
+      bt.bucket_key,
+      bt.bucket_label,
+      bt.is_over_threshold,
+      count(rcr.id)::integer AS bucket_count
+    FROM repair_completion_bucket_template bt
+    LEFT JOIN repair_completion_rows rcr
+      ON (
+        (bt.max_minutes IS NULL AND rcr.completion_minutes > bt.min_minutes)
+        OR (bt.sort_order = 1 AND rcr.completion_minutes >= bt.min_minutes AND rcr.completion_minutes < bt.max_minutes)
+        OR (bt.sort_order BETWEEN 2 AND 3 AND rcr.completion_minutes >= bt.min_minutes AND rcr.completion_minutes < bt.max_minutes)
+        OR (bt.sort_order = 4 AND rcr.completion_minutes >= bt.min_minutes AND rcr.completion_minutes <= bt.max_minutes)
+        OR (bt.sort_order = 5 AND rcr.completion_minutes > bt.min_minutes AND rcr.completion_minutes <= bt.max_minutes)
+      )
+    GROUP BY bt.sort_order, bt.bucket_key, bt.bucket_label, bt.is_over_threshold
+  ),
+  repair_completion_by_month AS (
+    SELECT
+      to_char(date_trunc('month', ngay_hoan_thanh AT TIME ZONE 'Asia/Ho_Chi_Minh'), 'YYYY-MM') AS period,
+      round((percentile_cont(0.5) WITHIN GROUP (ORDER BY completion_minutes))::numeric, 1) AS median_minutes,
+      round((percentile_cont(0.9) WITHIN GROUP (ORDER BY completion_minutes))::numeric, 1) AS p90_minutes,
+      round(avg(completion_minutes)::numeric, 1) AS average_minutes,
+      count(*)::integer AS completed_count
+    FROM repair_completion_rows
+    GROUP BY date_trunc('month', ngay_hoan_thanh AT TIME ZONE 'Asia/Ho_Chi_Minh')
+  ),
+  equipment_repairs AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      count(*)::integer AS total_requests,
+      max(reference_timestamp) AS latest_event_at,
+      max(ngay_hoan_thanh) AS latest_completed_at,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NULL)::integer AS cost_missing_count
+    FROM repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  equipment_latest_status AS (
+    SELECT DISTINCT ON (equipment_id)
+      equipment_id,
+      coalesce(trang_thai, 'Không xác định') AS latest_status,
+      coalesce(ngay_hoan_thanh, ngay_duyet, ngay_yeu_cau, reference_timestamp) AS status_timestamp
+    FROM repair_data
+    ORDER BY equipment_id, coalesce(ngay_hoan_thanh, ngay_duyet, ngay_yeu_cau, reference_timestamp) DESC
+  ),
+  top_equipment AS (
+    SELECT
+      er.equipment_id,
+      er.equipment_name,
+      er.equipment_code,
+      er.total_requests,
+      er.total_repair_cost,
+      er.average_completed_repair_cost,
+      er.cost_recorded_count,
+      er.cost_missing_count,
+      els.latest_status,
+      CASE
+        WHEN er.latest_completed_at IS NOT NULL THEN to_char(er.latest_completed_at, 'YYYY-MM-DD"T"HH24:MI:SS')
+        ELSE NULL
+      END AS latest_completed_date
+    FROM equipment_repairs er
+    LEFT JOIN equipment_latest_status els ON els.equipment_id = er.equipment_id
+    ORDER BY er.total_requests DESC, er.equipment_name
+    LIMIT 10
+  ),
+  usage_data_raw AS (
+    SELECT
+      se.equipment_id,
+      se.equipment_name,
+      se.equipment_code,
+      nk.thoi_gian_bat_dau,
+      nk.thoi_gian_ket_thuc,
+      extract(epoch from (nk.thoi_gian_ket_thuc - nk.thoi_gian_bat_dau)) / 3600.0 AS usage_hours
+    FROM scoped_equipment se
+    INNER JOIN public.nhat_ky_su_dung nk
+      ON nk.thiet_bi_id = se.equipment_id
+    WHERE nk.thoi_gian_ket_thuc IS NOT NULL
+      AND nk.thoi_gian_ket_thuc > nk.thoi_gian_bat_dau
+  ),
+  period_usage_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      sum(usage_hours) AS total_usage_hours
+    FROM usage_data_raw
+    WHERE (thoi_gian_bat_dau AT TIME ZONE 'Asia/Ho_Chi_Minh')::date BETWEEN p_date_from AND p_date_to
+      AND (thoi_gian_ket_thuc AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  cumulative_usage_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      sum(usage_hours) AS total_usage_hours
+    FROM usage_data_raw
+    WHERE (thoi_gian_bat_dau AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+      AND (thoi_gian_ket_thuc AT TIME ZONE 'Asia/Ho_Chi_Minh')::date <= p_date_to
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  period_repair_costs_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed)::integer AS completed_repair_requests,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count
+    FROM repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  cumulative_repair_costs_by_equipment AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      coalesce(sum(chi_phi_sua_chua) FILTER (WHERE is_completed), 0) AS total_repair_cost,
+      avg(chi_phi_sua_chua) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL) AS average_completed_repair_cost,
+      count(*) FILTER (WHERE is_completed)::integer AS completed_repair_requests,
+      count(*) FILTER (WHERE is_completed AND chi_phi_sua_chua IS NOT NULL)::integer AS cost_recorded_count
+    FROM cumulative_repair_data
+    GROUP BY equipment_id, equipment_name, equipment_code
+  ),
+  top_equipment_repair_costs AS (
+    SELECT
+      equipment_id,
+      equipment_name,
+      equipment_code,
+      total_repair_cost,
+      average_completed_repair_cost,
+      completed_repair_requests,
+      cost_recorded_count
+    FROM period_repair_costs_by_equipment
+    WHERE cost_recorded_count > 0
+    ORDER BY total_repair_cost DESC, equipment_name
+    LIMIT 10
+  ),
+  period_correlation_points AS (
+    SELECT
+      pu.equipment_id,
+      pu.equipment_name,
+      pu.equipment_code,
+      pu.total_usage_hours,
+      pr.total_repair_cost,
+      pr.completed_repair_requests,
+      pr.cost_recorded_count
+    FROM period_usage_by_equipment pu
+    INNER JOIN period_repair_costs_by_equipment pr ON pr.equipment_id = pu.equipment_id
+    WHERE pu.total_usage_hours > 0
+      AND pr.cost_recorded_count > 0
+  ),
+  cumulative_correlation_points AS (
+    SELECT
+      cu.equipment_id,
+      cu.equipment_name,
+      cu.equipment_code,
+      cu.total_usage_hours,
+      cr.total_repair_cost,
+      cr.completed_repair_requests,
+      cr.cost_recorded_count
+    FROM cumulative_usage_by_equipment cu
+    INNER JOIN cumulative_repair_costs_by_equipment cr ON cr.equipment_id = cu.equipment_id
+    WHERE cu.total_usage_hours > 0
+      AND cr.cost_recorded_count > 0
+  ),
+  period_correlation_data_quality AS (
+    SELECT
+      (SELECT count(*)::integer FROM period_usage_by_equipment WHERE total_usage_hours > 0) AS equipment_with_usage,
+      (SELECT count(*)::integer FROM period_repair_costs_by_equipment WHERE cost_recorded_count > 0) AS equipment_with_repair_cost,
+      (SELECT count(*)::integer FROM period_correlation_points) AS equipment_with_both
+  ),
+  cumulative_correlation_data_quality AS (
+    SELECT
+      (SELECT count(*)::integer FROM cumulative_usage_by_equipment WHERE total_usage_hours > 0) AS equipment_with_usage,
+      (SELECT count(*)::integer FROM cumulative_repair_costs_by_equipment WHERE cost_recorded_count > 0) AS equipment_with_repair_cost,
+      (SELECT count(*)::integer FROM cumulative_correlation_points) AS equipment_with_both
+  )
+  SELECT jsonb_build_object(
+    'summary', (
+      SELECT jsonb_build_object(
+        'totalRepairs', coalesce(rs.total_repairs, 0),
+        'repairCompletionRate',
+          CASE
+            WHEN coalesce(rs.total_repairs, 0) > 0
+              THEN (coalesce(rs.completed, 0)::numeric / rs.total_repairs * 100)
+            ELSE 0
+          END,
+        'totalMaintenancePlanned', coalesce((SELECT sum(ma.total_planned) FROM maintenance_aggregated ma), 0),
+        'maintenanceCompletionRate',
+          CASE
+            WHEN coalesce((SELECT sum(ma.total_planned) FROM maintenance_aggregated ma), 0) > 0 THEN
+              (
+                coalesce((SELECT sum(ma.total_actual) FROM maintenance_aggregated ma), 0)::numeric /
+                (SELECT sum(ma.total_planned) FROM maintenance_aggregated ma) * 100
+              )
+            ELSE 0
+          END,
+        'totalRepairCost', coalesce(rs.total_repair_cost, 0),
+        'averageCompletedRepairCost', coalesce(rs.average_completed_repair_cost, 0),
+        'costRecordedCount', coalesce(rs.cost_recorded_count, 0),
+        'costMissingCount', coalesce(rs.cost_missing_count, 0)
+      )
+      FROM repair_summary rs
+    ),
+    'charts', jsonb_build_object(
+      'repairStatusDistribution', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'name', status_name,
+              'value', status_count,
+              'color', status_color
+            )
+          ),
+          '[]'::jsonb
+        )
+        FROM (
+          SELECT 'Hoàn thành' AS status_name, completed AS status_count, 'hsl(var(--chart-1))' AS status_color
+          FROM repair_summary
+          WHERE completed > 0
+          UNION ALL
+          SELECT 'Không HT', not_completed, 'hsl(var(--chart-5))'
+          FROM repair_summary
+          WHERE not_completed > 0
+          UNION ALL
+          SELECT 'Đã duyệt', approved, 'hsl(var(--chart-2))'
+          FROM repair_summary
+          WHERE approved > 0
+          UNION ALL
+          SELECT 'Chờ xử lý', pending, 'hsl(var(--chart-3))'
+          FROM repair_summary
+          WHERE pending > 0
+        ) statuses
+      ),
+      'maintenancePlanVsActual', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'name', loai_cong_viec,
+              'planned', total_planned,
+              'actual', total_actual
+            )
+            ORDER BY loai_cong_viec
+          ),
+          '[]'::jsonb
+        )
+        FROM maintenance_aggregated
+      ),
+      'repairFrequencyByMonth', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'period', period,
+              'total', total,
+              'completed', completed
+            )
+            ORDER BY period
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_frequency
+      ),
+      'repairCostByMonth', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'period', period,
+              'totalCost', total_cost,
+              'averageCost', coalesce(average_cost, 0),
+              'costRecordedCount', cost_recorded_count,
+              'costMissingCount', cost_missing_count
+            )
+            ORDER BY period
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_cost_by_month
+      ),
+      'repairCostByFacility', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'facilityId', facility_id,
+              'facilityName', facility_name,
+              'totalCost', total_cost,
+              'averageCost', coalesce(average_cost, 0),
+              'costRecordedCount', cost_recorded_count,
+              'costMissingCount', cost_missing_count
+            )
+            ORDER BY facility_name
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_cost_by_facility
+      ),
+      'repairCompletionTime', jsonb_build_object(
+        'stats', (
+          SELECT jsonb_build_object(
+            'totalCompleted', coalesce(rcs.total_completed, 0),
+            'medianMinutes', coalesce(rcs.median_minutes, 0),
+            'averageMinutes', coalesce(rcs.average_minutes, 0),
+            'p90Minutes', coalesce(rcs.p90_minutes, 0),
+            'onTimeCount', coalesce(rcs.on_time_count, 0),
+            'onTimePercent', coalesce(rcs.on_time_percent, 0),
+            'thresholdDays', 14
+          )
+          FROM repair_completion_stats rcs
+        ),
+        'distribution', (
+          SELECT coalesce(
+            jsonb_agg(
+              jsonb_build_object(
+                'bucketKey', rcd.bucket_key,
+                'label', rcd.bucket_label,
+                'count', rcd.bucket_count,
+                'isOverThreshold', rcd.is_over_threshold
+              )
+              ORDER BY rcd.sort_order
+            ),
+            '[]'::jsonb
+          )
+          FROM repair_completion_distribution rcd
+        )
+      ),
+      'repairCompletionTimeByMonth', (
+        SELECT coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'period', rcbm.period,
+              'medianMinutes', rcbm.median_minutes,
+              'p90Minutes', rcbm.p90_minutes,
+              'averageMinutes', rcbm.average_minutes,
+              'completedCount', rcbm.completed_count
+            )
+            ORDER BY rcbm.period
+          ),
+          '[]'::jsonb
+        )
+        FROM repair_completion_by_month rcbm
+      ),
+      'repairUsageCostCorrelation', jsonb_build_object(
+        'period', jsonb_build_object(
+          'points', (
+            SELECT coalesce(
+              jsonb_agg(
+                jsonb_build_object(
+                  'equipmentId', pcp.equipment_id,
+                  'equipmentName', pcp.equipment_name,
+                  'equipmentCode', pcp.equipment_code,
+                  'totalUsageHours', pcp.total_usage_hours,
+                  'totalRepairCost', pcp.total_repair_cost,
+                  'completedRepairRequests', pcp.completed_repair_requests,
+                  'costRecordedCount', pcp.cost_recorded_count
+                )
+                ORDER BY pcp.total_repair_cost DESC, pcp.equipment_name
+              ),
+              '[]'::jsonb
+            )
+            FROM period_correlation_points pcp
+          ),
+          'dataQuality', (
+            SELECT jsonb_build_object(
+              'equipmentWithUsage', coalesce(pcq.equipment_with_usage, 0),
+              'equipmentWithRepairCost', coalesce(pcq.equipment_with_repair_cost, 0),
+              'equipmentWithBoth', coalesce(pcq.equipment_with_both, 0)
+            )
+            FROM period_correlation_data_quality pcq
+          )
+        ),
+        'cumulative', jsonb_build_object(
+          'points', (
+            SELECT coalesce(
+              jsonb_agg(
+                jsonb_build_object(
+                  'equipmentId', ccp.equipment_id,
+                  'equipmentName', ccp.equipment_name,
+                  'equipmentCode', ccp.equipment_code,
+                  'totalUsageHours', ccp.total_usage_hours,
+                  'totalRepairCost', ccp.total_repair_cost,
+                  'completedRepairRequests', ccp.completed_repair_requests,
+                  'costRecordedCount', ccp.cost_recorded_count
+                )
+                ORDER BY ccp.total_repair_cost DESC, ccp.equipment_name
+              ),
+              '[]'::jsonb
+            )
+            FROM cumulative_correlation_points ccp
+          ),
+          'dataQuality', (
+            SELECT jsonb_build_object(
+              'equipmentWithUsage', coalesce(ccq.equipment_with_usage, 0),
+              'equipmentWithRepairCost', coalesce(ccq.equipment_with_repair_cost, 0),
+              'equipmentWithBoth', coalesce(ccq.equipment_with_both, 0)
+            )
+            FROM cumulative_correlation_data_quality ccq
+          )
+        )
+      )
+    ),
+    'topEquipmentRepairs', (
+      SELECT coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'equipmentId', te.equipment_id,
+            'equipmentName', te.equipment_name,
+            'totalRequests', te.total_requests,
+            'latestStatus', coalesce(te.latest_status, 'Không xác định'),
+            'latestCompletedDate', te.latest_completed_date,
+            'totalRepairCost', te.total_repair_cost,
+            'averageCompletedRepairCost', coalesce(te.average_completed_repair_cost, 0),
+            'costRecordedCount', te.cost_recorded_count,
+            'costMissingCount', te.cost_missing_count
+          )
+          ORDER BY te.total_requests DESC, te.equipment_name
+        ),
+        '[]'::jsonb
+      )
+      FROM top_equipment te
+    ),
+    'topEquipmentRepairCosts', (
+      SELECT coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'equipmentId', terc.equipment_id,
+            'equipmentName', terc.equipment_name,
+            'equipmentCode', terc.equipment_code,
+            'totalRepairCost', terc.total_repair_cost,
+            'averageCompletedRepairCost', coalesce(terc.average_completed_repair_cost, 0),
+            'completedRepairRequests', terc.completed_repair_requests,
+            'costRecordedCount', terc.cost_recorded_count
+          )
+          ORDER BY terc.total_repair_cost DESC, terc.equipment_name
+        ),
+        '[]'::jsonb
+      )
+      FROM top_equipment_repair_costs terc
+    )
+  ) INTO v_result;
+
+  RETURN coalesce(
+    v_result,
+    jsonb_build_object(
+      'summary', jsonb_build_object(
+        'totalRepairs', 0,
+        'repairCompletionRate', 0,
+        'totalMaintenancePlanned', 0,
+        'maintenanceCompletionRate', 0,
+        'totalRepairCost', 0,
+        'averageCompletedRepairCost', 0,
+        'costRecordedCount', 0,
+        'costMissingCount', 0
+      ),
+      'charts', jsonb_build_object(
+        'repairStatusDistribution', '[]'::jsonb,
+        'maintenancePlanVsActual', '[]'::jsonb,
+        'repairFrequencyByMonth', '[]'::jsonb,
+        'repairCostByMonth', '[]'::jsonb,
+        'repairCostByFacility', '[]'::jsonb,
+        'repairCompletionTime', jsonb_build_object(
+          'stats', jsonb_build_object(
+            'totalCompleted', 0,
+            'medianMinutes', 0,
+            'averageMinutes', 0,
+            'p90Minutes', 0,
+            'onTimeCount', 0,
+            'onTimePercent', 0,
+            'thresholdDays', 14
+          ),
+          'distribution', jsonb_build_array(
+            jsonb_build_object('bucketKey', '0-1d', 'label', '0-1 ngày', 'count', 0, 'isOverThreshold', false),
+            jsonb_build_object('bucketKey', '1-3d', 'label', '1-3 ngày', 'count', 0, 'isOverThreshold', false),
+            jsonb_build_object('bucketKey', '3-7d', 'label', '3-7 ngày', 'count', 0, 'isOverThreshold', false),
+            jsonb_build_object('bucketKey', '7-14d', 'label', '7-14 ngày', 'count', 0, 'isOverThreshold', false),
+            jsonb_build_object('bucketKey', '14-30d', 'label', '14-30 ngày', 'count', 0, 'isOverThreshold', true),
+            jsonb_build_object('bucketKey', '30d+', 'label', '>30 ngày', 'count', 0, 'isOverThreshold', true)
+          )
+        ),
+        'repairCompletionTimeByMonth', '[]'::jsonb,
+        'repairUsageCostCorrelation', jsonb_build_object(
+          'period', jsonb_build_object(
+            'points', '[]'::jsonb,
+            'dataQuality', jsonb_build_object(
+              'equipmentWithUsage', 0,
+              'equipmentWithRepairCost', 0,
+              'equipmentWithBoth', 0
+            )
+          ),
+          'cumulative', jsonb_build_object(
+            'points', '[]'::jsonb,
+            'dataQuality', jsonb_build_object(
+              'equipmentWithUsage', 0,
+              'equipmentWithRepairCost', 0,
+              'equipmentWithBoth', 0
+            )
+          )
+        )
+      ),
+      'topEquipmentRepairs', '[]'::jsonb,
+      'topEquipmentRepairCosts', '[]'::jsonb
+    )
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO anon;
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.get_maintenance_report_data(date, date, bigint) FROM PUBLIC;
+
+COMMENT ON FUNCTION public.get_maintenance_report_data(date, date, bigint)
+IS 'Returns maintenance report data with tenant-aware aggregation, repair cost visualizations, repair completion-time distribution, top equipment rankings, and usage-cost correlation datasets.';
+
+COMMIT;

--- a/supabase/tests/repair_completion_time_smoke.sql
+++ b/supabase/tests/repair_completion_time_smoke.sql
@@ -1,0 +1,319 @@
+-- supabase/tests/repair_completion_time_smoke.sql
+-- Purpose: smoke-test repair completion-time visualization payload contract after the migration is applied.
+-- How to run (MCP): execute this whole file through Supabase MCP execute_sql.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp._rct_set_claims(
+  p_role text,
+  p_user_id bigint,
+  p_don_vi bigint DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', p_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::text,
+      'sub', p_user_id::text,
+      'don_vi', p_don_vi::text
+    )::text,
+    true
+  );
+END;
+$$;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_date_from date := (date_trunc('month', current_date)::date - interval '2 months')::date;
+  v_date_to date := (date_trunc('month', current_date)::date + interval '1 month' - interval '1 day')::date;
+  v_base timestamp := (date_trunc('month', current_date)::date - interval '2 months')::timestamp + interval '9 hours';
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_user_id bigint;
+  v_equipment_a bigint;
+  v_equipment_b bigint;
+  v_equipment_other bigint;
+  v_report jsonb;
+  v_admin_scoped_report jsonb;
+  v_completion jsonb;
+  v_distribution jsonb;
+  v_by_month jsonb;
+  v_bucket_count integer;
+  v_other_count integer;
+  v_month_total integer;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair completion smoke tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Repair completion smoke other tenant ' || v_suffix, true)
+  RETURNING id INTO v_other_tenant;
+
+  INSERT INTO public.nhan_vien(username, password, full_name, role, don_vi, current_don_vi)
+  VALUES (
+    'repair_completion_smoke_' || v_suffix,
+    'smoke-password',
+    'Repair Completion Smoke',
+    'to_qltb',
+    v_tenant,
+    v_tenant
+  )
+  RETURNING id INTO v_user_id;
+
+  INSERT INTO public.thiet_bi(ma_thiet_bi, ten_thiet_bi, don_vi, tinh_trang_hien_tai, is_deleted)
+  VALUES
+    ('RCT-A-' || v_suffix, 'Thiết bị completion A ' || v_suffix, v_tenant, 'Hoạt động', false),
+    ('RCT-B-' || v_suffix, 'Thiết bị completion B ' || v_suffix, v_tenant, 'Hoạt động', false),
+    ('RCT-X-' || v_suffix, 'Thiết bị completion other ' || v_suffix, v_other_tenant, 'Hoạt động', false);
+
+  SELECT id INTO v_equipment_a
+  FROM public.thiet_bi
+  WHERE ma_thiet_bi = 'RCT-A-' || v_suffix;
+
+  SELECT id INTO v_equipment_b
+  FROM public.thiet_bi
+  WHERE ma_thiet_bi = 'RCT-B-' || v_suffix;
+
+  SELECT id INTO v_equipment_other
+  FROM public.thiet_bi
+  WHERE ma_thiet_bi = 'RCT-X-' || v_suffix;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    trang_thai,
+    ngay_yeu_cau,
+    ngay_duyet,
+    ngay_hoan_thanh,
+    nguoi_yeu_cau,
+    don_vi_thuc_hien,
+    chi_phi_sua_chua
+  )
+  VALUES
+    (
+      v_equipment_a,
+      'Completion smoke 0-1d',
+      'Completion item 0-1d',
+      'Hoàn thành',
+      v_base,
+      v_base + interval '8 hours',
+      v_base + interval '12 hours',
+      'Smoke requester',
+      'noi_bo',
+      100000
+    ),
+    (
+      v_equipment_a,
+      'Completion smoke 1-3d approved late',
+      'Completion item 1-3d',
+      'Hoàn thành',
+      v_base + interval '3 days',
+      v_base + interval '11 days',
+      v_base + interval '5 days',
+      'Smoke requester',
+      'noi_bo',
+      200000
+    ),
+    (
+      v_equipment_a,
+      'Completion smoke 3-7d',
+      'Completion item 3-7d',
+      'Hoàn thành',
+      v_base + interval '8 days',
+      v_base + interval '9 days',
+      v_base + interval '13 days',
+      'Smoke requester',
+      'noi_bo',
+      300000
+    ),
+    (
+      v_equipment_b,
+      'Completion smoke 7-14d',
+      'Completion item 7-14d',
+      'Hoàn thành',
+      v_base + interval '15 days',
+      v_base + interval '16 days',
+      v_base + interval '25 days',
+      'Smoke requester',
+      'noi_bo',
+      400000
+    ),
+    (
+      v_equipment_b,
+      'Completion smoke 14-30d',
+      'Completion item 14-30d',
+      'Hoàn thành',
+      v_base + interval '35 days',
+      v_base + interval '36 days',
+      v_base + interval '55 days',
+      'Smoke requester',
+      'noi_bo',
+      500000
+    ),
+    (
+      v_equipment_b,
+      'Completion smoke 30d+',
+      'Completion item 30d+',
+      'Hoàn thành',
+      v_base + interval '38 days',
+      v_base + interval '39 days',
+      v_base + interval '78 days',
+      'Smoke requester',
+      'noi_bo',
+      600000
+    ),
+    (
+      v_equipment_a,
+      'Completion smoke unfinished ignored',
+      'Completion item unfinished',
+      'Đã duyệt',
+      v_base + interval '40 days',
+      v_base + interval '41 days',
+      NULL,
+      'Smoke requester',
+      'noi_bo',
+      NULL
+    ),
+    (
+      v_equipment_other,
+      'Completion smoke other tenant ignored',
+      'Completion item other tenant',
+      'Hoàn thành',
+      v_base + interval '1 day',
+      v_base + interval '2 days',
+      v_base + interval '41 days',
+      'Smoke requester',
+      'noi_bo',
+      700000
+    );
+
+  PERFORM pg_temp._rct_set_claims('to_qltb', v_user_id, v_tenant);
+
+  v_report := public.get_maintenance_report_data(v_date_from, v_date_to, v_tenant);
+  v_completion := v_report #> '{charts,repairCompletionTime}';
+  v_distribution := v_completion->'distribution';
+  v_by_month := v_report #> '{charts,repairCompletionTimeByMonth}';
+
+  IF v_completion IS NULL THEN
+    RAISE EXCEPTION 'Expected charts.repairCompletionTime payload key, got %', v_report;
+  END IF;
+
+  IF v_by_month IS NULL THEN
+    RAISE EXCEPTION 'Expected charts.repairCompletionTimeByMonth payload key, got %', v_report;
+  END IF;
+
+  IF v_report ? 'recentRepairHistory' THEN
+    RAISE EXCEPTION 'Expected recentRepairHistory to be removed from payload, got %', v_report;
+  END IF;
+
+  IF (v_completion #>> '{stats,totalCompleted}')::integer IS DISTINCT FROM 6 THEN
+    RAISE EXCEPTION 'Expected totalCompleted=6, got %', v_completion #> '{stats,totalCompleted}';
+  END IF;
+
+  IF (v_completion #>> '{stats,medianMinutes}')::numeric IS DISTINCT FROM 10800 THEN
+    RAISE EXCEPTION 'Expected medianMinutes=10800 from ngay_yeu_cau durations, got %', v_completion #> '{stats,medianMinutes}';
+  END IF;
+
+  IF (v_completion #>> '{stats,p90Minutes}')::numeric IS DISTINCT FROM 43200 THEN
+    RAISE EXCEPTION 'Expected p90Minutes=43200 from ngay_yeu_cau durations, got %', v_completion #> '{stats,p90Minutes}';
+  END IF;
+
+  IF (v_completion #>> '{stats,averageMinutes}')::numeric IS DISTINCT FROM 18600 THEN
+    RAISE EXCEPTION 'Expected averageMinutes=18600 from ngay_yeu_cau durations, got %', v_completion #> '{stats,averageMinutes}';
+  END IF;
+
+  IF (v_completion #>> '{stats,onTimeCount}')::integer IS DISTINCT FROM 4 THEN
+    RAISE EXCEPTION 'Expected onTimeCount=4, got %', v_completion #> '{stats,onTimeCount}';
+  END IF;
+
+  IF abs((v_completion #>> '{stats,onTimePercent}')::numeric - 66.7) > 0.1 THEN
+    RAISE EXCEPTION 'Expected onTimePercent about 66.7, got %', v_completion #> '{stats,onTimePercent}';
+  END IF;
+
+  IF (v_completion #>> '{stats,thresholdDays}')::integer IS DISTINCT FROM 14 THEN
+    RAISE EXCEPTION 'Expected thresholdDays=14, got %', v_completion #> '{stats,thresholdDays}';
+  END IF;
+
+  IF jsonb_array_length(v_distribution) <> 6 THEN
+    RAISE EXCEPTION 'Expected 6 completion buckets, got %', v_distribution;
+  END IF;
+
+  SELECT count(*)
+  INTO v_bucket_count
+  FROM jsonb_array_elements(v_distribution) AS bucket(row_data)
+  WHERE (row_data->>'bucketKey', (row_data->>'count')::integer, (row_data->>'isOverThreshold')::boolean)
+    IN (
+      ('0-1d', 1, false),
+      ('1-3d', 1, false),
+      ('3-7d', 1, false),
+      ('7-14d', 1, false),
+      ('14-30d', 1, true),
+      ('30d+', 1, true)
+    );
+
+  IF v_bucket_count <> 6 THEN
+    RAISE EXCEPTION 'Expected exact completion bucket counts and threshold flags, got %', v_distribution;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_each(v_completion->'stats') AS pair(key_name, value_data)
+    WHERE key_name ~ '_'
+  )
+  OR EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_distribution) AS bucket(row_data)
+    JOIN LATERAL jsonb_each(bucket.row_data) AS pair(key_name, value_data) ON true
+    WHERE key_name ~ '_'
+  ) THEN
+    RAISE EXCEPTION 'Expected camelCase completion payload keys, got %', v_completion;
+  END IF;
+
+  SELECT coalesce(sum((row_data->>'completedCount')::integer), 0)
+  INTO v_month_total
+  FROM jsonb_array_elements(v_by_month) AS month_point(row_data);
+
+  IF v_month_total <> 6 THEN
+    RAISE EXCEPTION 'Expected monthly completion total=6, got % from %', v_month_total, v_by_month;
+  END IF;
+
+  IF NOT (
+    v_report ? 'summary'
+    AND v_report #> '{charts,repairStatusDistribution}' IS NOT NULL
+    AND v_report #> '{charts,maintenancePlanVsActual}' IS NOT NULL
+    AND v_report #> '{charts,repairFrequencyByMonth}' IS NOT NULL
+    AND v_report #> '{charts,repairCostByMonth}' IS NOT NULL
+    AND v_report #> '{charts,repairCostByFacility}' IS NOT NULL
+    AND v_report #> '{charts,repairUsageCostCorrelation}' IS NOT NULL
+    AND v_report ? 'topEquipmentRepairs'
+    AND v_report ? 'topEquipmentRepairCosts'
+  ) THEN
+    RAISE EXCEPTION 'Expected existing maintenance report payload keys to remain present, got %', v_report;
+  END IF;
+
+  PERFORM pg_temp._rct_set_claims('admin', v_user_id, NULL);
+
+  v_admin_scoped_report := public.get_maintenance_report_data(v_date_from, v_date_to, v_tenant);
+
+  SELECT count(*)
+  INTO v_other_count
+  FROM jsonb_array_elements(v_admin_scoped_report #> '{charts,repairCompletionTime,distribution}') AS bucket(row_data)
+  WHERE (row_data->>'count')::integer > 1;
+
+  IF v_other_count > 0 THEN
+    RAISE EXCEPTION 'Expected admin/global payload with p_don_vi to stay facility-scoped, got %', v_admin_scoped_report;
+  END IF;
+
+  RAISE NOTICE 'OK: repair completion time visualization payload contract passed';
+END $$;
+
+ROLLBACK;

--- a/supabase/tests/repair_completion_time_smoke.sql
+++ b/supabase/tests/repair_completion_time_smoke.sql
@@ -172,6 +172,42 @@ BEGIN
       600000
     ),
     (
+      v_equipment_b,
+      'Completion smoke exact 14d boundary',
+      'Completion item exact 14d',
+      'Hoàn thành',
+      v_base + interval '22 days',
+      v_base + interval '23 days',
+      v_base + interval '36 days',
+      'Smoke requester',
+      'noi_bo',
+      650000
+    ),
+    (
+      v_equipment_a,
+      'Completion smoke opened before range included by completion date',
+      'Completion item completion-date included',
+      'Hoàn thành',
+      v_date_from::timestamp - interval '1 day' + interval '9 hours',
+      v_date_from::timestamp + interval '10 hours',
+      v_date_from::timestamp + interval '1 day' + interval '9 hours',
+      'Smoke requester',
+      'noi_bo',
+      660000
+    ),
+    (
+      v_equipment_a,
+      'Completion smoke completed after range ignored',
+      'Completion item completion-date excluded',
+      'Hoàn thành',
+      v_date_to::timestamp - interval '1 day' + interval '9 hours',
+      v_date_to::timestamp,
+      v_date_to::timestamp + interval '3 days' + interval '9 hours',
+      'Smoke requester',
+      'noi_bo',
+      670000
+    ),
+    (
       v_equipment_a,
       'Completion smoke unfinished ignored',
       'Completion item unfinished',
@@ -215,28 +251,28 @@ BEGIN
     RAISE EXCEPTION 'Expected recentRepairHistory to be removed from payload, got %', v_report;
   END IF;
 
-  IF (v_completion #>> '{stats,totalCompleted}')::integer IS DISTINCT FROM 6 THEN
-    RAISE EXCEPTION 'Expected totalCompleted=6, got %', v_completion #> '{stats,totalCompleted}';
+  IF (v_completion #>> '{stats,totalCompleted}')::integer IS DISTINCT FROM 8 THEN
+    RAISE EXCEPTION 'Expected totalCompleted=8, got %', v_completion #> '{stats,totalCompleted}';
   END IF;
 
   IF (v_completion #>> '{stats,medianMinutes}')::numeric IS DISTINCT FROM 10800 THEN
     RAISE EXCEPTION 'Expected medianMinutes=10800 from ngay_yeu_cau durations, got %', v_completion #> '{stats,medianMinutes}';
   END IF;
 
-  IF (v_completion #>> '{stats,p90Minutes}')::numeric IS DISTINCT FROM 43200 THEN
-    RAISE EXCEPTION 'Expected p90Minutes=43200 from ngay_yeu_cau durations, got %', v_completion #> '{stats,p90Minutes}';
+  IF (v_completion #>> '{stats,p90Minutes}')::numeric IS DISTINCT FROM 37440 THEN
+    RAISE EXCEPTION 'Expected p90Minutes=37440 from ngay_yeu_cau durations, got %', v_completion #> '{stats,p90Minutes}';
   END IF;
 
-  IF (v_completion #>> '{stats,averageMinutes}')::numeric IS DISTINCT FROM 18600 THEN
-    RAISE EXCEPTION 'Expected averageMinutes=18600 from ngay_yeu_cau durations, got %', v_completion #> '{stats,averageMinutes}';
+  IF (v_completion #>> '{stats,averageMinutes}')::numeric IS DISTINCT FROM 16830 THEN
+    RAISE EXCEPTION 'Expected averageMinutes=16830 from ngay_yeu_cau durations, got %', v_completion #> '{stats,averageMinutes}';
   END IF;
 
-  IF (v_completion #>> '{stats,onTimeCount}')::integer IS DISTINCT FROM 4 THEN
-    RAISE EXCEPTION 'Expected onTimeCount=4, got %', v_completion #> '{stats,onTimeCount}';
+  IF (v_completion #>> '{stats,onTimeCount}')::integer IS DISTINCT FROM 6 THEN
+    RAISE EXCEPTION 'Expected onTimeCount=6, got %', v_completion #> '{stats,onTimeCount}';
   END IF;
 
-  IF abs((v_completion #>> '{stats,onTimePercent}')::numeric - 66.7) > 0.1 THEN
-    RAISE EXCEPTION 'Expected onTimePercent about 66.7, got %', v_completion #> '{stats,onTimePercent}';
+  IF abs((v_completion #>> '{stats,onTimePercent}')::numeric - 75.0) > 0.1 THEN
+    RAISE EXCEPTION 'Expected onTimePercent about 75.0, got %', v_completion #> '{stats,onTimePercent}';
   END IF;
 
   IF (v_completion #>> '{stats,thresholdDays}')::integer IS DISTINCT FROM 14 THEN
@@ -253,9 +289,9 @@ BEGIN
   WHERE (row_data->>'bucketKey', (row_data->>'count')::integer, (row_data->>'isOverThreshold')::boolean)
     IN (
       ('0-1d', 1, false),
-      ('1-3d', 1, false),
+      ('1-3d', 2, false),
       ('3-7d', 1, false),
-      ('7-14d', 1, false),
+      ('7-14d', 2, false),
       ('14-30d', 1, true),
       ('30d+', 1, true)
     );
@@ -282,8 +318,17 @@ BEGIN
   INTO v_month_total
   FROM jsonb_array_elements(v_by_month) AS month_point(row_data);
 
-  IF v_month_total <> 6 THEN
-    RAISE EXCEPTION 'Expected monthly completion total=6, got % from %', v_month_total, v_by_month;
+  IF v_month_total <> 8 THEN
+    RAISE EXCEPTION 'Expected monthly completion total=8, got % from %', v_month_total, v_by_month;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_by_month) AS month_point(row_data)
+    WHERE to_date(row_data->>'period', 'YYYY-MM') < date_trunc('month', v_date_from)::date
+       OR to_date(row_data->>'period', 'YYYY-MM') > date_trunc('month', v_date_to)::date
+  ) THEN
+    RAISE EXCEPTION 'Expected monthly completion periods to stay within completion-date range %, got %', v_date_from, v_by_month;
   END IF;
 
   IF NOT (
@@ -304,13 +349,11 @@ BEGIN
 
   v_admin_scoped_report := public.get_maintenance_report_data(v_date_from, v_date_to, v_tenant);
 
-  SELECT count(*)
+  SELECT (v_admin_scoped_report #>> '{charts,repairCompletionTime,stats,totalCompleted}')::integer
   INTO v_other_count
-  FROM jsonb_array_elements(v_admin_scoped_report #> '{charts,repairCompletionTime,distribution}') AS bucket(row_data)
-  WHERE (row_data->>'count')::integer > 1;
 
-  IF v_other_count > 0 THEN
-    RAISE EXCEPTION 'Expected admin/global payload with p_don_vi to stay facility-scoped, got %', v_admin_scoped_report;
+  IF v_other_count IS DISTINCT FROM 8 THEN
+    RAISE EXCEPTION 'Expected admin/global payload with p_don_vi to stay facility-scoped totalCompleted=8, got %', v_admin_scoped_report;
   END IF;
 
   RAISE NOTICE 'OK: repair completion time visualization payload contract passed';

--- a/supabase/tests/repair_completion_time_smoke.sql
+++ b/supabase/tests/repair_completion_time_smoke.sql
@@ -350,7 +350,7 @@ BEGIN
   v_admin_scoped_report := public.get_maintenance_report_data(v_date_from, v_date_to, v_tenant);
 
   SELECT (v_admin_scoped_report #>> '{charts,repairCompletionTime,stats,totalCompleted}')::integer
-  INTO v_other_count
+  INTO v_other_count;
 
   IF v_other_count IS DISTINCT FROM 8 THEN
     RAISE EXCEPTION 'Expected admin/global payload with p_don_vi to stay facility-scoped totalCompleted=8, got %', v_admin_scoped_report;


### PR DESCRIPTION
## Summary
- Replace recent repair history payload/UI with repair completion-time distribution and monthly trend data.
- Add `get_maintenance_report_data` migration with median, average, p90, on-time rate, bucket distribution, and monthly completion metrics based on `ngay_hoan_thanh - ngay_yeu_cau`.
- Add report tab visualization, utility mappers, default payload compatibility, and TDD coverage.

Fixes #441

## Verification
- RED SQL smoke failed before migration because `charts.repairCompletionTime` was missing and `recentRepairHistory` still existed.
- Supabase MCP `apply_migration`: `add_repair_completion_time_charts` applied to live project.
- Supabase MCP smoke: `supabase/tests/repair_completion_time_smoke.sql` passed after migration.
- Supabase MCP metadata check: `get_maintenance_report_data(date,date,bigint)` is `SECURITY DEFINER` with `search_path=public, pg_temp`.
- `git diff --check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- "src/app/(app)/reports/components/__tests__/maintenance-report-utils.test.ts" "src/app/(app)/reports/components/__tests__/maintenance-report-completion-time.test.tsx" "src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx" "src/app/(app)/reports/components/__tests__/maintenance-report-tab.test.tsx"`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` → 100/100, no issues found

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repair completion-time visualizations to the maintenance report, replacing “recent repair history.” Includes KPIs, a bucketed histogram with per-cell coloring, and a monthly trend; follow-up fixes correct completion-date scoping and exact bucket boundaries. Fixes #441.

- New Features
  - New “Repair Completion Time” section with KPIs (median, average, p90, on‑time rate) and a progress bar.
  - Histogram by completion buckets and a monthly line trend.
  - Added `MaintenanceReportCompletionTime` and utilities (`buildCompletionTimeChartData`, `buildCompletionTimeTrendData`, `formatDurationAuto`); wired into `MaintenanceReportTab` with default data.
  - `DynamicBarChart` now supports per-cell colors to highlight over-threshold buckets.
  - Removed “Recent repair history”; kept “Top repaired equipment” intact; updated types and tests.

- Migration
  - Updates `public.get_maintenance_report_data(date,date,bigint)` to return `repairCompletionTime` and `repairCompletionTimeByMonth`; removes `recentRepairHistory`.
  - Follow-up migration fixes completion-date scoping and exact-boundary buckets.
  - Adds a smoke test (`supabase/tests/repair_completion_time_smoke.sql`) to validate payload shape, stats, bucket counts, monthly totals, and tenant scoping; fixes its SQL syntax for MCP execution.

<sup>Written for commit fcd1fb20d8505911b76c8ca3f3baae00aef1dcb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repair completion-time analytics: stats (median/avg/p90, on-time %) with distribution and monthly trend charts; formatted duration KPIs and progress visualization.

* **Bug Fixes**
  * Improved completion-time calculations and bucket boundary behavior for more accurate reporting.

* **Changes**
  * Top-equipment table only (recent repair history removed); per-bar cell coloring in charts; clearer empty-state messaging when no completions.

* **Tests**
  * Expanded unit and integration smoke tests for completion-time reporting and charts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/443)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->