### PR TITLE
fix: force dense report chart to scroll internally

### DIFF
--- a/src/app/(app)/reports/components/inventory-report-tab.tsx
+++ b/src/app/(app)/reports/components/inventory-report-tab.tsx
@@ -129,7 +129,7 @@ export function InventoryReportTab({
   return (
     <>
       {error ? <InventoryReportErrorToast error={error} toast={toast} /> : null}
-      <div className="space-y-4">
+      <div className="min-w-0 space-y-4">
         <InventoryReportFilterSection
           dateRange={dateRange}
           onDateRangeChange={setDateRange}

--- a/src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx
+++ b/src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx
@@ -261,11 +261,12 @@ describe("InteractiveEquipmentChart tooltip", () => {
     expect(screen.getByTestId("equipment-chart-tabs")).toHaveClass("min-w-0")
     expect(screen.getAllByTestId("equipment-chart-tab-content")[0]).toHaveClass("min-w-0")
     expect(screen.getAllByTestId("equipment-chart-scroll-frame")[0]).toHaveClass(
-      "min-w-0",
+      "w-0",
+      "min-w-full",
       "max-w-full",
       "overflow-x-auto",
     )
-    expect(screen.getAllByTestId("equipment-chart-scroll-inner")[0]).toHaveStyle({ minWidth: "1736px" })
+    expect(screen.getAllByTestId("equipment-chart-scroll-inner")[0]).toHaveStyle({ width: "1736px" })
     expect(mocks.dynamicBarChart).toHaveBeenCalledWith(
       expect.objectContaining({
         height: 400,

--- a/src/components/interactive-equipment-chart.tsx
+++ b/src/components/interactive-equipment-chart.tsx
@@ -163,8 +163,11 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
   }, [data, viewType])
 
   const isDenseChart = chartData.length > DENSE_DISTRIBUTION_CATEGORY_THRESHOLD
-  const chartContainerClassName = cn("min-w-0 max-w-full", isDenseChart && "overflow-x-auto pb-2")
-  const chartMinWidth = isDenseChart ? `${chartData.length * DENSE_DISTRIBUTION_CATEGORY_WIDTH}px` : undefined
+  const chartContainerClassName = cn(
+    "min-w-0 max-w-full",
+    isDenseChart && "w-0 min-w-full overflow-x-auto pb-2"
+  )
+  const chartWidth = isDenseChart ? `${chartData.length * DENSE_DISTRIBUTION_CATEGORY_WIDTH}px` : undefined
 
   // Statistics
   const stats = React.useMemo(() => {
@@ -335,7 +338,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
               <div className="min-w-0 space-y-4">
                 {/* Chart */}
                 <div data-testid="equipment-chart-scroll-frame" className={chartContainerClassName}>
-                  <div data-testid="equipment-chart-scroll-inner" style={{ minWidth: chartMinWidth }}>
+                  <div data-testid="equipment-chart-scroll-inner" style={{ width: chartWidth }}>
                     <DynamicBarChart
                       data={chartData}
                       height={DEFAULT_DISTRIBUTION_CHART_HEIGHT}
@@ -396,7 +399,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
               <div className="min-w-0 space-y-4">
                 {/* Chart */}
                 <div data-testid="equipment-chart-scroll-frame" className={chartContainerClassName}>
-                  <div data-testid="equipment-chart-scroll-inner" style={{ minWidth: chartMinWidth }}>
+                  <div data-testid="equipment-chart-scroll-inner" style={{ width: chartWidth }}>
                     <DynamicBarChart
                       data={chartData}
                       height={DEFAULT_DISTRIBUTION_CHART_HEIGHT}


### PR DESCRIPTION
## Summary
- Constrain the dense equipment chart scroll frame with  so it cannot expand the Reports layout.
- Use an explicit chart inner  based on category count instead of , so overflow is owned by the internal scroll frame.
- Add  to the inventory report tab wrapper as a shrink-safe parent guard.

## Verification
- 
> nextn@0.1.0 verify:no-explicit-any
> node scripts/check-no-explicit-any-in-diff.js

No explicit any found in changed TypeScript files.
- 
> nextn@0.1.0 typecheck
> tsc --noEmit
- 
> nextn@0.1.0 test:run
> vitest run src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx


 RUN  v4.0.17 /root/qltbyt-nam-phong

 ✓ src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx (4 tests) 313ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  02:03:43
   Duration  2.35s (transform 216ms, setup 99ms, import 933ms, tests 313ms, environment 666ms)
- 
> nextn@0.1.0 test:run
> vitest run src/app/(app)/reports/components/__tests__/inventory-report-tab.test.tsx


 RUN  v4.0.17 /root/qltbyt-nam-phong

 ✓ src/app/(app)/reports/components/__tests__/inventory-report-tab.test.tsx (3 tests) 345ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  02:03:47
   Duration  2.45s (transform 303ms, setup 79ms, import 1.21s, tests 345ms, environment 537ms)
- react-doctor v0.1.6

✔ Select projects to scan › nextn
Scanning changes: hotfix/reports-chart-scroll-width → main

Scanning /root/qltbyt-nam-phong...



  ⚠ react-doctor/no-giant-component
      Component "InteractiveEquipmentChart" is 311 lines — consider breaking it into smaller focused components
      → Extract logical sections into focused components: `<UserHeader />`, `<UserActions />`, etc.
      src/components/interactive-equipment-chart.tsx:132

  ┌─────┐  99 / 100 Great
  │ ◠ ◠ │  ██████████████████████████████████████████████████
  │  ▽  │  React Doctor (www.react.doctor)
  └─────┘

  1 issue across 1/3 files  in 276ms
  Full diagnostics written to /tmp/.ctx-mode-vWkLyK/react-doctor-7e64999b-0585-4a6d-9fc4-f81f918f659b
- 

## Notes
This keeps the existing DynamicBarChart rendering path. It does not reintroduce Recharts vertical layout for dense status-stacked charts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force dense equipment report charts to scroll inside the chart container so they don’t push the Reports layout wider. Fixes horizontal overflow when there are many categories.

- **Bug Fixes**
  - Enforced internal scrolling: scroll frame uses `w-0 min-w-full overflow-x-auto pb-2`; inner element now sets explicit `width` based on category count.
  - Added `min-w-0` to the Inventory Report tab wrapper to prevent layout expansion.
  - Updated tests to assert new classes and `width` behavior.

<sup>Written for commit 29989f1559c6287ee384016d22d7ef05efcd6c66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

