### PR TITLE
Fix repair completion tooltip labels

### DIFF
--- a/src/app/(app)/reports/components/__tests__/maintenance-report-completion-time.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/maintenance-report-completion-time.test.tsx
@@ -1,9 +1,14 @@
 import * as React from "react"
 import { render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ChartTooltipProps } from "@/lib/chart-utils"
 
 const mockDynamicBarChart = vi.fn(() => <div data-testid="completion-histogram" />)
 const mockDynamicLineChart = vi.fn(() => <div data-testid="completion-trend" />)
+
+interface CompletionBarChartProps {
+  customTooltip?: React.ElementType<ChartTooltipProps<number, string>>
+}
 
 vi.mock("@/components/ui/card", () => ({
   Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -99,6 +104,44 @@ describe("MaintenanceReportCompletionTime", () => {
         ]),
       })
     )
+  })
+
+  it("shows the duration bucket label in the histogram tooltip instead of the Recharts index", () => {
+    render(
+      <MaintenanceReportCompletionTime
+        isLoading={false}
+        repairCompletionTime={completionTime}
+        repairCompletionTimeByMonth={completionTimeByMonth}
+      />
+    )
+
+    const chartProps = mockDynamicBarChart.mock.calls[0]?.[0] as CompletionBarChartProps
+    expect(chartProps.customTooltip).toBeDefined()
+
+    const CompletionTooltip = chartProps.customTooltip
+    if (!CompletionTooltip) {
+      throw new Error("Expected completion histogram to provide a custom tooltip")
+    }
+
+    render(
+      <CompletionTooltip
+        active
+        label={0}
+        payload={[
+          {
+            dataKey: "count",
+            name: "Số yêu cầu",
+            value: 2,
+            color: "hsl(var(--chart-1))",
+            payload: { label: "7-14 ngày", count: 2 },
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText("7-14 ngày")).toBeInTheDocument()
+    expect(screen.getByText("Số yêu cầu: 2")).toBeInTheDocument()
+    expect(screen.queryByText("0")).not.toBeInTheDocument()
   })
 
   it("renders an empty state when the date range has no completed repair requests", () => {

--- a/src/app/(app)/reports/components/maintenance-report-completion-time.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-completion-time.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { Inbox } from "lucide-react"
 
+import type { ChartTooltipProps } from "@/lib/chart-utils"
 import { DynamicBarChart, DynamicLineChart } from "@/components/dynamic-chart"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
@@ -103,6 +104,7 @@ export function MaintenanceReportCompletionTime({
               name: "Số yêu cầu",
               cellColorKey: "fill",
             }]}
+            customTooltip={CompletionHistogramTooltip}
             margin={{ top: 16, right: 24, left: 16, bottom: 36 }}
           />
         </CardContent>
@@ -134,6 +136,26 @@ export function MaintenanceReportCompletionTime({
           )}
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+function CompletionHistogramTooltip({
+  active,
+  payload,
+}: ChartTooltipProps<number, string>) {
+  const entry = payload?.[0]
+  const bucketLabel = typeof entry?.payload?.label === "string" ? entry.payload.label : null
+  const count = typeof entry?.value === "number" ? entry.value : null
+
+  if (!active || !bucketLabel || count == null) {
+    return null
+  }
+
+  return (
+    <div className="rounded-md border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="font-medium text-foreground">{bucketLabel}</p>
+      <p className="text-muted-foreground">Số yêu cầu: {count}</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Show the repair completion duration bucket label in the histogram tooltip instead of Recharts' numeric category index.
- Add a regression test that renders the tooltip with `label={0}` and verifies it displays `7-14 ngày` plus the request count.

## Verification
- RED: focused Vitest failed on the new tooltip regression before the implementation.
- `git diff --check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/reports/components/__tests__/maintenance-report-completion-time.test.tsx'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` → 100/100, no issues

Follow-up to #441.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the repair completion histogram tooltip to show the human-readable duration bucket (e.g., "7-14 ngày") and request count, instead of the Recharts index. Improves clarity in the completion time report.

- **Bug Fixes**
  - Added `CompletionHistogramTooltip` and wired it via `customTooltip` on the histogram to display the bucket label and count.
  - Added a regression test that renders the tooltip with `label={0}` and asserts it shows `7-14 ngày` and the correct request count.

<sup>Written for commit 4f574e58b40d0b4e05aa0b04a5925a99cc13970b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced histogram tooltip display in maintenance reports with custom-formatted duration bucket labels and request counts.

* **Tests**
  * Added test coverage for custom tooltip rendering and data display validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/445)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->