### PR TITLE
Refactor InteractiveEquipmentChart below file-size threshold

### DIFF
--- a/src/components/__tests__/interactive-equipment-chart.file-size.test.ts
+++ b/src/components/__tests__/interactive-equipment-chart.file-size.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+describe("InteractiveEquipmentChart file size", () => {
+  it("stays below the repo extraction threshold", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/components/interactive-equipment-chart.tsx"),
+      "utf8",
+    )
+    const lineCount = source.split(/\r?\n/).length
+
+    expect(lineCount).toBeLessThan(350)
+  })
+})

--- a/src/components/interactive-equipment-chart-controls.tsx
+++ b/src/components/interactive-equipment-chart-controls.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+import { Filter } from "lucide-react"
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+interface EquipmentChartFiltersProps {
+  viewType: "department" | "location"
+  selectedFilter: string
+  onFilterChange: (value: string) => void
+  departments: string[]
+  locations: string[]
+  isLoading: boolean
+}
+
+export function EquipmentChartFilters({
+  viewType,
+  selectedFilter,
+  onFilterChange,
+  departments,
+  locations,
+  isLoading,
+}: EquipmentChartFiltersProps) {
+  const options = viewType === "department" ? departments : locations
+  const placeholder = viewType === "department" ? "Tất cả khoa/phòng" : "Tất cả vị trí"
+
+  return (
+    <div className="flex items-center gap-2">
+      <Filter className="size-4 text-muted-foreground" />
+      <Select value={selectedFilter} onValueChange={onFilterChange} disabled={isLoading}>
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">{placeholder}</SelectItem>
+          {options.map((option) => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/src/components/interactive-equipment-chart-distribution-tab.tsx
+++ b/src/components/interactive-equipment-chart-distribution-tab.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { DynamicBarChart } from "@/components/dynamic-chart"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { TabsContent } from "@/components/ui/tabs"
+import {
+  STATUS_COLORS,
+  STATUS_LABELS,
+  type EquipmentDistributionItem,
+} from "@/hooks/use-equipment-distribution"
+import { cn } from "@/lib/utils"
+import { EquipmentChartTooltip } from "@/components/interactive-equipment-chart-tooltip"
+
+const DISTRIBUTION_CHART_HEIGHT = 400
+const DENSE_CATEGORY_THRESHOLD = 20
+const DENSE_CATEGORY_WIDTH = 56
+const STATUS_BARS = Object.entries(STATUS_COLORS).map(([key, color]) => ({
+  key,
+  color,
+  name: STATUS_LABELS[key as keyof typeof STATUS_LABELS],
+  stackId: "status",
+}))
+
+interface EquipmentChartDistributionTabProps {
+  value: "department" | "location"
+  chartData: EquipmentDistributionItem[]
+  isLoading: boolean
+  hasActiveFilters: boolean
+  onResetFilters: () => void
+}
+
+export function EquipmentChartDistributionTab({
+  value,
+  chartData,
+  isLoading,
+  hasActiveFilters,
+  onResetFilters,
+}: EquipmentChartDistributionTabProps) {
+  const isDenseChart = chartData.length > DENSE_CATEGORY_THRESHOLD
+  const chartContainerClassName = cn(
+    "min-w-0 max-w-full",
+    isDenseChart && "w-0 min-w-full overflow-x-auto pb-2",
+  )
+  const chartWidth = isDenseChart ? `${chartData.length * DENSE_CATEGORY_WIDTH}px` : undefined
+
+  return (
+    <TabsContent value={value} className="min-w-0 space-y-4">
+      {isLoading ? (
+        <Skeleton className="h-[400px] w-full" />
+      ) : chartData.length === 0 ? (
+        <div className="h-[400px] flex items-center justify-center">
+          <Alert>
+            <AlertDescription>
+              Không có dữ liệu để hiển thị với bộ lọc hiện tại.
+              {hasActiveFilters && (
+                <>
+                  {" "}
+                  <Button variant="link" className="p-0 h-auto" onClick={onResetFilters}>
+                    Xóa bộ lọc
+                  </Button>
+                  {" "}để xem tất cả dữ liệu.
+                </>
+              )}
+            </AlertDescription>
+          </Alert>
+        </div>
+      ) : (
+        <div className="min-w-0 space-y-4">
+          <div data-testid="equipment-chart-scroll-frame" className={chartContainerClassName}>
+            <div data-testid="equipment-chart-scroll-inner" style={{ width: chartWidth }}>
+              <DynamicBarChart
+                data={chartData}
+                height={DISTRIBUTION_CHART_HEIGHT}
+                xAxisKey="name"
+                bars={STATUS_BARS}
+                showGrid={true}
+                showTooltip={true}
+                showLegend={false}
+                xAxisAngle={-45}
+                customTooltip={EquipmentChartTooltip}
+                margin={{ top: 20, right: 30, left: 20, bottom: 100 }}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-4 justify-center pt-4 border-t">
+            {Object.entries(STATUS_LABELS).map(([key, label]) => (
+              <div key={key} className="flex items-center gap-2">
+                <div
+                  className="size-3 rounded"
+                  style={{ backgroundColor: STATUS_COLORS[key as keyof typeof STATUS_COLORS] }}
+                />
+                <span className="text-sm">{label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </TabsContent>
+  )
+}

--- a/src/components/interactive-equipment-chart-tooltip.tsx
+++ b/src/components/interactive-equipment-chart-tooltip.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+
+import type { ChartTooltipProps } from "@/lib/chart-utils"
+import { buildKeyedTooltipEntries } from "@/lib/runtime-list-keys"
+import { STATUS_LABELS } from "@/hooks/use-equipment-distribution"
+
+type TooltipPayloadEntry = NonNullable<ChartTooltipProps<number, string>["payload"]>[number]
+
+function getTooltipCategoryName(entry: TooltipPayloadEntry): string | null {
+  const row = entry.payload
+  if (!row || typeof row !== "object" || !("name" in row)) return null
+
+  const name = (row as Record<string, unknown>).name
+  return typeof name === "string" && name.trim() ? name : null
+}
+
+export const EquipmentChartTooltip = React.memo(function EquipmentChartTooltip({
+  active,
+  payload,
+  label,
+}: ChartTooltipProps<number, string>) {
+  const tooltipEntries = payload ?? []
+
+  if (!active || tooltipEntries.length === 0) return null
+
+  const total = tooltipEntries.reduce(
+    (sum, entry) => sum + (typeof entry.value === "number" ? entry.value : 0),
+    0,
+  )
+  const keyedPayload = buildKeyedTooltipEntries<TooltipPayloadEntry>(tooltipEntries)
+  const categoryName = tooltipEntries.map(getTooltipCategoryName).find(Boolean) ?? label
+
+  return (
+    <div className="bg-background border rounded-lg shadow-lg p-3 min-w-[200px]">
+      <p className="font-medium mb-2">{categoryName}</p>
+      <div className="space-y-1">
+        {keyedPayload.map(({ key, entry }) => (
+          <div key={key} className="flex items-center justify-between gap-2 text-sm">
+            <div className="flex items-center gap-2">
+              <div className="size-3 rounded" style={{ backgroundColor: entry.color }} />
+              <span>{STATUS_LABELS[entry.dataKey as keyof typeof STATUS_LABELS]}</span>
+            </div>
+            <span className="font-medium">{entry.value}</span>
+          </div>
+        ))}
+        <div className="border-t pt-1 mt-2">
+          <div className="flex items-center justify-between font-medium">
+            <span>Tổng:</span>
+            <span>{total}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+})

--- a/src/components/interactive-equipment-chart.tsx
+++ b/src/components/interactive-equipment-chart.tsx
@@ -1,23 +1,18 @@
 "use client"
 
 import * as React from "react"
-import { Filter, BarChart3, MapPin, Building2, X } from "lucide-react"
-import { DynamicBarChart } from "@/components/dynamic-chart"
-import type { ChartTooltipProps } from "@/lib/chart-utils"
+import { BarChart3, MapPin, Building2, X } from "lucide-react"
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { 
-  useEquipmentDistribution, 
-  STATUS_COLORS,
-  STATUS_LABELS
+  useEquipmentDistribution
 } from "@/hooks/use-equipment-distribution"
-import { buildKeyedTooltipEntries } from "@/lib/runtime-list-keys"
+import { EquipmentChartFilters } from "@/components/interactive-equipment-chart-controls"
+import { EquipmentChartDistributionTab } from "@/components/interactive-equipment-chart-distribution-tab"
 import { cn } from "@/lib/utils"
 
 interface InteractiveEquipmentChartProps {
@@ -25,108 +20,6 @@ interface InteractiveEquipmentChartProps {
   tenantFilter?: string
   selectedDonVi?: number | null
   effectiveTenantKey?: string
-}
-
-const DEFAULT_DISTRIBUTION_CHART_HEIGHT = 400
-const DENSE_DISTRIBUTION_CATEGORY_THRESHOLD = 20
-const DENSE_DISTRIBUTION_CATEGORY_WIDTH = 56
-
-type TooltipPayloadEntry = NonNullable<ChartTooltipProps<number, string>['payload']>[number]
-
-function getTooltipCategoryName(entry: TooltipPayloadEntry): string | null {
-  const row = entry.payload
-  if (!row || typeof row !== "object" || !("name" in row)) return null
-
-  const name = (row as Record<string, unknown>).name
-  return typeof name === "string" && name.trim() ? name : null
-}
-
-// Custom tooltip component — memoized to avoid re-computing keyed entries on unchanged payload
-const CustomTooltip = React.memo(function CustomTooltip({
-  active,
-  payload,
-  label,
-}: ChartTooltipProps<number, string>) {
-  const tooltipEntries = payload ?? []
-
-  if (active && tooltipEntries.length > 0) {
-    const total = tooltipEntries.reduce(
-      (sum, entry) => sum + (typeof entry.value === 'number' ? entry.value : 0),
-      0,
-    )
-    const keyedPayload = buildKeyedTooltipEntries<TooltipPayloadEntry>(tooltipEntries)
-    const categoryName = tooltipEntries.map(getTooltipCategoryName).find(Boolean) ?? label
-    
-    return (
-      <div className="bg-background border rounded-lg shadow-lg p-3 min-w-[200px]">
-        <p className="font-medium mb-2">{categoryName}</p>
-        <div className="space-y-1">
-          {keyedPayload.map(({ key, entry }) => (
-            <div key={key} className="flex items-center justify-between gap-2 text-sm">
-              <div className="flex items-center gap-2">
-                <div 
-                  className="size-3 rounded"
-                  style={{ backgroundColor: entry.color }}
-                />
-                <span>{STATUS_LABELS[entry.dataKey as keyof typeof STATUS_LABELS]}</span>
-              </div>
-              <span className="font-medium">{entry.value}</span>
-            </div>
-          ))}
-          <div className="border-t pt-1 mt-2">
-            <div className="flex items-center justify-between font-medium">
-              <span>Tổng:</span>
-              <span>{total}</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    )
-  }
-  return null
-})
-
-// Filter component for departments and locations
-function DataFilters({ 
-  viewType, 
-  selectedFilter, 
-  onFilterChange, 
-  departments, 
-  locations, 
-  isLoading 
-}: {
-  viewType: 'department' | 'location'
-  selectedFilter: string
-  onFilterChange: (value: string) => void
-  departments: string[]
-  locations: string[]
-  isLoading: boolean
-}) {
-  const options = viewType === 'department' ? departments : locations
-  const placeholder = viewType === 'department' ? 'Tất cả khoa/phòng' : 'Tất cả vị trí'
-  
-  return (
-    <div className="flex items-center gap-2">
-      <Filter className="size-4 text-muted-foreground" />
-      <Select 
-        value={selectedFilter} 
-        onValueChange={onFilterChange}
-        disabled={isLoading}
-      >
-        <SelectTrigger className="w-[200px]">
-          <SelectValue placeholder={placeholder} />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">{placeholder}</SelectItem>
-          {options.map(option => (
-            <SelectItem key={option} value={option}>
-              {option}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  )
 }
 
 export function InteractiveEquipmentChart({ className, tenantFilter, selectedDonVi, effectiveTenantKey }: InteractiveEquipmentChartProps) {
@@ -161,13 +54,6 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
 
     return viewType === 'department' ? data.byDepartment : data.byLocation
   }, [data, viewType])
-
-  const isDenseChart = chartData.length > DENSE_DISTRIBUTION_CATEGORY_THRESHOLD
-  const chartContainerClassName = cn(
-    "min-w-0 max-w-full",
-    isDenseChart && "w-0 min-w-full overflow-x-auto pb-2"
-  )
-  const chartWidth = isDenseChart ? `${chartData.length * DENSE_DISTRIBUTION_CATEGORY_WIDTH}px` : undefined
 
   // Statistics
   const stats = React.useMemo(() => {
@@ -277,7 +163,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
             <div className="flex w-full flex-wrap items-center gap-2 xl:w-auto xl:justify-end">
               {/* When viewing by department, allow filtering by location */}
               {viewType === 'department' && data?.locations && (
-                <DataFilters
+                <EquipmentChartFilters
                   viewType="location"
                   selectedFilter={selectedLocation}
                   onFilterChange={setSelectedLocation}
@@ -289,7 +175,7 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
               
               {/* When viewing by location, allow filtering by department */}
               {viewType === 'location' && data?.departments && (
-                <DataFilters
+                <EquipmentChartFilters
                   viewType="department"
                   selectedFilter={selectedDepartment}
                   onFilterChange={setSelectedDepartment}
@@ -314,127 +200,21 @@ export function InteractiveEquipmentChart({ className, tenantFilter, selectedDon
             </div>
           </div>
 
-          <TabsContent value="department" className="min-w-0 space-y-4">
-            {isLoading ? (
-              <Skeleton className="h-[400px] w-full" />
-            ) : chartData.length === 0 ? (
-              <div className="h-[400px] flex items-center justify-center">
-                <Alert>
-                  <AlertDescription>
-                    Không có dữ liệu để hiển thị với bộ lọc hiện tại.
-                    {hasActiveFilters && (
-                      <>
-                        {" "}
-                        <Button variant="link" className="p-0 h-auto" onClick={resetFilters}>
-                          Xóa bộ lọc
-                        </Button>
-                        {" "}để xem tất cả dữ liệu.
-                      </>
-                    )}
-                  </AlertDescription>
-                </Alert>
-              </div>
-            ) : (
-              <div className="min-w-0 space-y-4">
-                {/* Chart */}
-                <div data-testid="equipment-chart-scroll-frame" className={chartContainerClassName}>
-                  <div data-testid="equipment-chart-scroll-inner" style={{ width: chartWidth }}>
-                    <DynamicBarChart
-                      data={chartData}
-                      height={DEFAULT_DISTRIBUTION_CHART_HEIGHT}
-                      xAxisKey="name"
-                      bars={Object.entries(STATUS_COLORS).map(([key, color]) => ({
-                        key,
-                        color,
-                        name: STATUS_LABELS[key as keyof typeof STATUS_LABELS],
-                        stackId: "status"
-                      }))}
-                      showGrid={true}
-                      showTooltip={true}
-                      showLegend={false}
-                      xAxisAngle={-45}
-                      customTooltip={CustomTooltip}
-                      margin={{ top: 20, right: 30, left: 20, bottom: 100 }}
-                    />
-                  </div>
-                </div>
+          <EquipmentChartDistributionTab
+            value="department"
+            chartData={chartData}
+            isLoading={isLoading}
+            hasActiveFilters={hasActiveFilters}
+            onResetFilters={resetFilters}
+          />
 
-                {/* Legend */}
-                <div className="flex flex-wrap gap-4 justify-center pt-4 border-t">
-                  {Object.entries(STATUS_LABELS).map(([key, label]) => (
-                    <div key={key} className="flex items-center gap-2">
-                      <div
-                        className="size-3 rounded"
-                        style={{ backgroundColor: STATUS_COLORS[key as keyof typeof STATUS_COLORS] }}
-                      />
-                      <span className="text-sm">{label}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </TabsContent>
-
-          <TabsContent value="location" className="min-w-0 space-y-4">
-            {isLoading ? (
-              <Skeleton className="h-[400px] w-full" />
-            ) : chartData.length === 0 ? (
-              <div className="h-[400px] flex items-center justify-center">
-                <Alert>
-                  <AlertDescription>
-                    Không có dữ liệu để hiển thị với bộ lọc hiện tại.
-                    {hasActiveFilters && (
-                      <>
-                        {" "}
-                        <Button variant="link" className="p-0 h-auto" onClick={resetFilters}>
-                          Xóa bộ lọc
-                        </Button>
-                        {" "}để xem tất cả dữ liệu.
-                      </>
-                    )}
-                  </AlertDescription>
-                </Alert>
-              </div>
-            ) : (
-              <div className="min-w-0 space-y-4">
-                {/* Chart */}
-                <div data-testid="equipment-chart-scroll-frame" className={chartContainerClassName}>
-                  <div data-testid="equipment-chart-scroll-inner" style={{ width: chartWidth }}>
-                    <DynamicBarChart
-                      data={chartData}
-                      height={DEFAULT_DISTRIBUTION_CHART_HEIGHT}
-                      xAxisKey="name"
-                      bars={Object.entries(STATUS_COLORS).map(([key, color]) => ({
-                        key,
-                        color,
-                        name: STATUS_LABELS[key as keyof typeof STATUS_LABELS],
-                        stackId: "status"
-                      }))}
-                      showGrid={true}
-                      showTooltip={true}
-                      showLegend={false}
-                      xAxisAngle={-45}
-                      customTooltip={CustomTooltip}
-                      margin={{ top: 20, right: 30, left: 20, bottom: 100 }}
-                    />
-                  </div>
-                </div>
-
-                {/* Legend */}
-                <div className="flex flex-wrap gap-4 justify-center pt-4 border-t">
-                  {Object.entries(STATUS_LABELS).map(([key, label]) => (
-                    <div key={key} className="flex items-center gap-2">
-                      <div
-                        className="size-3 rounded"
-                        style={{ backgroundColor: STATUS_COLORS[key as keyof typeof STATUS_COLORS] }}
-                      />
-                      <span className="text-sm">{label}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </TabsContent>
+          <EquipmentChartDistributionTab
+            value="location"
+            chartData={chartData}
+            isLoading={isLoading}
+            hasActiveFilters={hasActiveFilters}
+            onResetFilters={resetFilters}
+          />
         </Tabs>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- Split `InteractiveEquipmentChart` internals into focused tooltip, filter, and distribution-tab components.
- Added a file-size regression test so the container stays below the repo extraction threshold.
- Preserved the public component API, dense chart horizontal scroll frame, and existing tooltip behavior.

Fixes #440

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/interactive-equipment-chart.file-size.test.ts src/components/__tests__/interactive-equipment-chart.tooltip.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `git diff --cached --check`
EOF 2>&1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the interactive equipment chart into smaller components to stay under the file-size threshold and make the code easier to maintain. UI and public API are unchanged, including dense-chart scrolling and tooltip behavior (fixes #440).

- **Refactors**
  - Extracted `EquipmentChartTooltip`, `EquipmentChartFilters`, and `EquipmentChartDistributionTab`.
  - Consolidated duplicate department/location tab logic into `EquipmentChartDistributionTab`.
  - Added a regression test to keep `interactive-equipment-chart.tsx` under 350 lines.

<sup>Written for commit 86b18b82aec21c59dc6241f345db36ae6622aaeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added file-size validation test to maintain code quality standards.

* **Refactor**
  * Reorganized equipment chart component into modular, reusable sub-components for improved code maintainability and structure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/446)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->