### PR TITLE
feat(reports): add unused equipment report RPC

### DIFF
--- a/src/app/(app)/reports/components/__tests__/inventory-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/inventory-report-tab.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   useEquipmentDistribution: vi.fn(),
   useMaintenanceStats: vi.fn(),
   useUsageAnalytics: vi.fn(),
+  useUnusedEquipmentReport: vi.fn(),
 }))
 
 vi.mock("@/hooks/use-toast", () => ({
@@ -36,6 +37,10 @@ vi.mock("../../hooks/use-maintenance-stats", () => ({
 
 vi.mock("../../hooks/use-usage-analytics", () => ({
   useUsageAnalytics: mocks.useUsageAnalytics,
+}))
+
+vi.mock("../../hooks/use-unused-equipment-report", () => ({
+  useUnusedEquipmentReport: mocks.useUnusedEquipmentReport,
 }))
 
 vi.mock("../inventory-charts", () => ({
@@ -178,6 +183,49 @@ describe("InventoryReportTab", () => {
     mocks.useEquipmentDistribution.mockReturnValue({ data: [] })
     mocks.useMaintenanceStats.mockReturnValue({ data: [] })
     mocks.useUsageAnalytics.mockReturnValue({ data: [] })
+    mocks.useUnusedEquipmentReport.mockReturnValue({
+      data: {
+        summary: {
+          totalCount: 2,
+          deviceTypeCount: 1,
+          departmentCount: 1,
+          totalOriginalValue: 3000000,
+        },
+        topDeviceGroups: [
+          {
+            deviceName: "Máy thở HFNC",
+            equipmentCount: 2,
+            totalOriginalValue: 3000000,
+          },
+        ],
+        departments: [
+          {
+            departmentName: "ICU",
+            equipmentCount: 2,
+            totalOriginalValue: 3000000,
+          },
+        ],
+        items: [
+          {
+            id: 1,
+            maThietBi: "TB001",
+            tenThietBi: "Máy thở HFNC",
+            model: "HFNC",
+            serial: "SER001",
+            khoaPhongQuanLy: "ICU",
+            ngayNhap: "2026-01-10",
+            createdAt: "2026-01-10T00:00:00.000Z",
+            giaGoc: 3000000,
+            donVi: 17,
+          },
+        ],
+        totalCount: 2,
+        page: 1,
+        pageSize: 10,
+      },
+      isLoading: false,
+      error: null,
+    })
   })
 
   it("shows the plain-object error message in the destructive toast", async () => {
@@ -228,5 +276,48 @@ describe("InventoryReportTab", () => {
     expect(screen.getByTestId("reports-shared-filter-section")).toBeInTheDocument()
     expect(screen.queryByText("Khoa/Phòng")).not.toBeInTheDocument()
     expect(setSelectedDepartment).not.toHaveBeenCalled()
+  })
+
+  it("renders the unused equipment section for a selected facility", () => {
+    render(
+      <InventoryReportTab
+        tenantFilter="17"
+        selectedDonVi={17}
+        effectiveTenantKey="17"
+      />
+    )
+
+    expect(screen.getAllByText("Thiết bị chưa có nhu cầu sử dụng").length).toBeGreaterThan(0)
+    expect(screen.getByText("Số thiết bị")).toBeInTheDocument()
+    expect(screen.getByText("Cơ cấu theo loại thiết bị")).toBeInTheDocument()
+    expect(screen.getByText("Danh sách thiết bị chưa có nhu cầu sử dụng")).toBeInTheDocument()
+    expect(screen.getByText("Máy thở HFNC")).toBeInTheDocument()
+    expect(mocks.useUnusedEquipmentReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedDonVi: 17,
+        enabled: true,
+      })
+    )
+  })
+
+  it("shows a facility-selection placeholder for privileged all-facility context", () => {
+    render(
+      <InventoryReportTab
+        tenantFilter="all"
+        selectedDonVi={null}
+        effectiveTenantKey="all"
+        isGlobalOrRegionalLeader
+      />
+    )
+
+    expect(
+      screen.getAllByText("Chọn đơn vị để xem danh sách thiết bị chưa có nhu cầu sử dụng").length
+    ).toBeGreaterThan(0)
+    expect(mocks.useUnusedEquipmentReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedDonVi: null,
+        enabled: false,
+      })
+    )
   })
 })

--- a/src/app/(app)/reports/components/__tests__/unused-equipment-report-section.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/unused-equipment-report-section.test.tsx
@@ -1,0 +1,81 @@
+import * as React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { UnusedEquipmentReportSection } from "../unused-equipment-report-section"
+
+const mocks = vi.hoisted(() => ({
+  useUnusedEquipmentReport: vi.fn(),
+}))
+
+vi.mock("../../hooks/use-unused-equipment-report", () => ({
+  useUnusedEquipmentReport: mocks.useUnusedEquipmentReport,
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    children,
+    value,
+    onValueChange,
+  }: {
+    children: React.ReactNode
+    value?: string
+    onValueChange?: (value: string) => void
+  }) => (
+    <select value={value} onChange={(event) => onValueChange?.(event.target.value)}>
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+}))
+
+describe("UnusedEquipmentReportSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.useUnusedEquipmentReport.mockReturnValue({
+      data: {
+        summary: {
+          totalCount: 30,
+          deviceTypeCount: 1,
+          departmentCount: 1,
+          totalOriginalValue: 1000000,
+        },
+        topDeviceGroups: [],
+        departments: [],
+        items: [],
+        totalCount: 30,
+        page: 1,
+        pageSize: 10,
+      },
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  it("resets to the first page when page size changes", () => {
+    render(<UnusedEquipmentReportSection selectedDonVi={17} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Sau" }))
+    expect(mocks.useUnusedEquipmentReport).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        page: 2,
+        pageSize: 10,
+      })
+    )
+
+    const pageSizeSelect = screen.getAllByRole("combobox").at(-1)
+    expect(pageSizeSelect).toBeDefined()
+    fireEvent.change(pageSizeSelect as HTMLElement, { target: { value: "20" } })
+
+    expect(mocks.useUnusedEquipmentReport).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        page: 1,
+        pageSize: 20,
+      })
+    )
+  })
+})

--- a/src/app/(app)/reports/components/inventory-report-tab.tsx
+++ b/src/app/(app)/reports/components/inventory-report-tab.tsx
@@ -20,6 +20,7 @@ import { useReportInventoryFilters } from "../hooks/use-report-filters"
 import { useEquipmentDistribution } from "@/hooks/use-equipment-distribution"
 import { useMaintenanceStats } from "../hooks/use-maintenance-stats"
 import { useUsageAnalytics } from "../hooks/use-usage-analytics"
+import { UnusedEquipmentReportSection } from "./unused-equipment-report-section"
 
 interface InventoryReportTabProps {
   tenantFilter?: string
@@ -231,6 +232,12 @@ export function InventoryReportTab({
         {tenantFilter !== 'all' && (
           <InventoryCharts data={data} isLoading={isLoading} />
         )}
+
+        <UnusedEquipmentReportSection
+          key={selectedDonVi ?? "unselected"}
+          selectedDonVi={selectedDonVi}
+          isGlobalOrRegionalLeader={isGlobalOrRegionalLeader}
+        />
 
         {/* Detailed Table - Only show for single facility */}
         {tenantFilter === 'all' ? (

--- a/src/app/(app)/reports/components/unused-equipment-report-charts.tsx
+++ b/src/app/(app)/reports/components/unused-equipment-report-charts.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import * as React from "react"
+
+import { DynamicBarChart } from "@/components/dynamic-chart"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import type { ChartData } from "@/lib/chart-utils"
+import type {
+  UnusedEquipmentReportDepartment,
+  UnusedEquipmentReportGroup,
+} from "../hooks/use-unused-equipment-report"
+
+interface UnusedEquipmentChartsProps {
+  deviceGroups: UnusedEquipmentReportGroup[]
+  departments: UnusedEquipmentReportDepartment[]
+  isLoading: boolean
+}
+
+function toDeviceChartData(groups: UnusedEquipmentReportGroup[]): ChartData[] {
+  return groups.map((group) => ({
+    name: group.deviceName,
+    count: group.equipmentCount,
+  }))
+}
+
+function toDepartmentChartData(groups: UnusedEquipmentReportDepartment[]): ChartData[] {
+  return groups.map((group) => ({
+    name: group.departmentName,
+    count: group.equipmentCount,
+  }))
+}
+
+export function UnusedEquipmentCharts({
+  deviceGroups,
+  departments,
+  isLoading,
+}: UnusedEquipmentChartsProps) {
+  const deviceData = React.useMemo(() => toDeviceChartData(deviceGroups), [deviceGroups])
+  const departmentData = React.useMemo(() => toDepartmentChartData(departments), [departments])
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Cơ cấu theo loại thiết bị</CardTitle>
+          <CardDescription>Nhóm thiết bị chưa có nhu cầu sử dụng theo số lượng</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-[320px] w-full" />
+          ) : deviceData.length > 0 ? (
+            <DynamicBarChart
+              data={deviceData}
+              height={Math.max(260, deviceData.length * 36)}
+              layout="vertical"
+              xAxisKey="count"
+              yAxisKey="name"
+              bars={[{ key: "count", color: "#2563eb", name: "Số thiết bị" }]}
+              showLegend={false}
+              margin={{ top: 8, right: 24, bottom: 8, left: 24 }}
+            />
+          ) : (
+            <div className="flex h-[220px] items-center justify-center text-sm text-muted-foreground">
+              Không có dữ liệu.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Phân bố theo khoa/phòng</CardTitle>
+          <CardDescription>Khoa/phòng đang quản lý thiết bị</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <Skeleton className="h-[320px] w-full" />
+          ) : departmentData.length > 0 ? (
+            <DynamicBarChart
+              data={departmentData}
+              height={Math.max(260, departmentData.length * 36)}
+              layout="vertical"
+              xAxisKey="count"
+              yAxisKey="name"
+              bars={[{ key: "count", color: "#16a34a", name: "Số thiết bị" }]}
+              showLegend={false}
+              margin={{ top: 8, right: 24, bottom: 8, left: 24 }}
+            />
+          ) : (
+            <div className="flex h-[220px] items-center justify-center text-sm text-muted-foreground">
+              Không có dữ liệu.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(app)/reports/components/unused-equipment-report-format.ts
+++ b/src/app/(app)/reports/components/unused-equipment-report-format.ts
@@ -1,0 +1,10 @@
+const NUMBER_FORMATTER = new Intl.NumberFormat("vi-VN")
+
+export function formatReportNumber(value: number) {
+  return NUMBER_FORMATTER.format(value)
+}
+
+export function formatReportCurrency(value: number | null | undefined) {
+  if (value == null) return "-"
+  return `${NUMBER_FORMATTER.format(value)} đ`
+}

--- a/src/app/(app)/reports/components/unused-equipment-report-kpis.tsx
+++ b/src/app/(app)/reports/components/unused-equipment-report-kpis.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import * as React from "react"
+import { BarChart3, Building2, Layers3, PackageSearch } from "lucide-react"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { formatReportCurrency, formatReportNumber } from "./unused-equipment-report-format"
+
+interface UnusedEquipmentKpiCardsProps {
+  totalCount: number
+  deviceTypeCount: number
+  departmentCount: number
+  totalOriginalValue: number
+  isLoading: boolean
+}
+
+export function UnusedEquipmentKpiCards({
+  totalCount,
+  deviceTypeCount,
+  departmentCount,
+  totalOriginalValue,
+  isLoading,
+}: UnusedEquipmentKpiCardsProps) {
+  const cards = [
+    {
+      title: "Số thiết bị",
+      value: formatReportNumber(totalCount),
+      description: "Thiết bị chưa có nhu cầu sử dụng",
+      icon: PackageSearch,
+    },
+    {
+      title: "Số loại thiết bị",
+      value: formatReportNumber(deviceTypeCount),
+      description: "Theo tên thiết bị",
+      icon: Layers3,
+    },
+    {
+      title: "Số khoa/phòng quản lý",
+      value: formatReportNumber(departmentCount),
+      description: "Đang quản lý thiết bị",
+      icon: Building2,
+    },
+    {
+      title: "Tổng nguyên giá",
+      value: formatReportCurrency(totalOriginalValue),
+      description: "Theo dữ liệu ghi nhận",
+      icon: BarChart3,
+    },
+  ] as const
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {cards.map((card) => {
+        const Icon = card.icon
+
+        return (
+          <Card key={card.title}>
+            <CardHeader className="flex flex-row items-center justify-between pb-2 [&>*+*]:mt-0">
+              <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
+              <Icon className="size-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">
+                {isLoading ? <Skeleton className="h-8 w-20" /> : card.value}
+              </div>
+              <p className="text-xs text-muted-foreground">{card.description}</p>
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/(app)/reports/components/unused-equipment-report-section.tsx
+++ b/src/app/(app)/reports/components/unused-equipment-report-section.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import * as React from "react"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { UnusedEquipmentCharts } from "./unused-equipment-report-charts"
+import { UnusedEquipmentKpiCards } from "./unused-equipment-report-kpis"
+import { UnusedEquipmentTable } from "./unused-equipment-report-table"
+import { useUnusedEquipmentReport } from "../hooks/use-unused-equipment-report"
+
+interface UnusedEquipmentReportSectionProps {
+  selectedDonVi?: number | null
+  isGlobalOrRegionalLeader?: boolean
+}
+
+const EMPTY_SUMMARY = {
+  totalCount: 0,
+  deviceTypeCount: 0,
+  departmentCount: 0,
+  totalOriginalValue: 0,
+}
+
+export function UnusedEquipmentReportSection({
+  selectedDonVi,
+  isGlobalOrRegionalLeader,
+}: UnusedEquipmentReportSectionProps) {
+  const [searchTerm, setSearchTerm] = React.useState("")
+  const [selectedDepartment, setSelectedDepartment] = React.useState("all")
+  const [page, setPage] = React.useState(1)
+  const [pageSize, setPageSize] = React.useState(10)
+  const enabled = !isGlobalOrRegionalLeader || selectedDonVi != null
+
+  const report = useUnusedEquipmentReport({
+    selectedDonVi,
+    searchTerm,
+    selectedDepartment,
+    page,
+    pageSize,
+    sort: "ten_thiet_bi.asc",
+    enabled,
+  })
+
+  const data = report.data
+  const summary = data?.summary ?? EMPTY_SUMMARY
+  const departments = data?.departments ?? []
+  const items = data?.items ?? []
+  const topDeviceGroups = data?.topDeviceGroups ?? []
+  const totalCount = data?.totalCount ?? 0
+
+  const handleSearchChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value)
+    setPage(1)
+  }, [])
+
+  const handleDepartmentChange = React.useCallback((value: string) => {
+    setSelectedDepartment(value)
+    setPage(1)
+  }, [])
+
+  const handlePageSizeChange = React.useCallback((value: string) => {
+    setPageSize(Number(value))
+    setPage(1)
+  }, [])
+
+  if (!enabled) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Thiết bị chưa có nhu cầu sử dụng</CardTitle>
+          <CardDescription>Chọn đơn vị để xem danh sách thiết bị chưa có nhu cầu sử dụng</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+            Chọn đơn vị để xem danh sách thiết bị chưa có nhu cầu sử dụng
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <section className="space-y-4" aria-labelledby="unused-equipment-report-title">
+      <div>
+        <h3 id="unused-equipment-report-title" className="text-lg font-semibold">
+          Thiết bị chưa có nhu cầu sử dụng
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          Theo dõi thiết bị chưa có nhu cầu sử dụng trong phạm vi đơn vị đang xem.
+        </p>
+      </div>
+
+      <UnusedEquipmentKpiCards
+        totalCount={summary.totalCount}
+        deviceTypeCount={summary.deviceTypeCount}
+        departmentCount={summary.departmentCount}
+        totalOriginalValue={summary.totalOriginalValue}
+        isLoading={report.isLoading}
+      />
+
+      <Card>
+        <CardContent className="flex flex-col gap-3 pt-6 md:flex-row md:items-end">
+          <div className="flex flex-1 flex-col gap-2">
+            <label htmlFor="unused-equipment-search" className="text-sm font-medium">
+              Tìm kiếm
+            </label>
+            <Input
+              id="unused-equipment-search"
+              placeholder="Tên, mã, model hoặc serial thiết bị..."
+              value={searchTerm}
+              onChange={handleSearchChange}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="unused-equipment-department" className="text-sm font-medium">
+              Khoa/phòng quản lý
+            </label>
+            <Select value={selectedDepartment} onValueChange={handleDepartmentChange}>
+              <SelectTrigger id="unused-equipment-department" className="w-full md:w-[220px]">
+                <SelectValue placeholder="Khoa/phòng quản lý" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Tất cả</SelectItem>
+                {departments.map((department) => (
+                  <SelectItem key={department.departmentName} value={department.departmentName}>
+                    {department.departmentName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="unused-equipment-page-size" className="text-sm font-medium">
+              Số dòng/trang
+            </label>
+            <Select value={String(pageSize)} onValueChange={handlePageSizeChange}>
+              <SelectTrigger id="unused-equipment-page-size" className="w-full md:w-[140px]">
+                <SelectValue placeholder="Số dòng" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="10">10</SelectItem>
+                <SelectItem value="20">20</SelectItem>
+                <SelectItem value="50">50</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <UnusedEquipmentCharts
+        deviceGroups={topDeviceGroups}
+        departments={departments}
+        isLoading={report.isLoading}
+      />
+
+      <UnusedEquipmentTable
+        items={items}
+        totalCount={totalCount}
+        page={page}
+        pageSize={pageSize}
+        isLoading={report.isLoading}
+        onPageChange={setPage}
+      />
+    </section>
+  )
+}

--- a/src/app/(app)/reports/components/unused-equipment-report-table.tsx
+++ b/src/app/(app)/reports/components/unused-equipment-report-table.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import * as React from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import type { UnusedEquipmentReportItem } from "../hooks/use-unused-equipment-report"
+import { formatReportCurrency, formatReportNumber } from "./unused-equipment-report-format"
+
+const UNUSED_EQUIPMENT_TABLE_SKELETON_ROWS = [
+  "unused-equipment-loading-1",
+  "unused-equipment-loading-2",
+  "unused-equipment-loading-3",
+  "unused-equipment-loading-4",
+  "unused-equipment-loading-5",
+] as const
+
+interface UnusedEquipmentTableProps {
+  items: UnusedEquipmentReportItem[]
+  totalCount: number
+  page: number
+  pageSize: number
+  isLoading: boolean
+  onPageChange: (page: number) => void
+}
+
+export function UnusedEquipmentTable({
+  items,
+  totalCount,
+  page,
+  pageSize,
+  isLoading,
+  onPageChange,
+}: UnusedEquipmentTableProps) {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
+  const canPrevious = page > 1
+  const canNext = page < totalPages
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Danh sách thiết bị chưa có nhu cầu sử dụng</CardTitle>
+        <CardDescription>Danh sách chi tiết theo phạm vi đơn vị đang xem</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Mã thiết bị</TableHead>
+                <TableHead>Tên thiết bị</TableHead>
+                <TableHead>Model</TableHead>
+                <TableHead>Serial</TableHead>
+                <TableHead>Khoa/phòng quản lý</TableHead>
+                <TableHead>Ngày nhập</TableHead>
+                <TableHead className="text-right">Nguyên giá</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                UNUSED_EQUIPMENT_TABLE_SKELETON_ROWS.map((rowKey) => (
+                  <TableRow key={rowKey}>
+                    <TableCell colSpan={7}>
+                      <Skeleton className="h-8 w-full" />
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : items.length > 0 ? (
+                items.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell className="font-medium">{item.maThietBi || "-"}</TableCell>
+                    <TableCell>{item.tenThietBi || "Không xác định"}</TableCell>
+                    <TableCell>{item.model || "-"}</TableCell>
+                    <TableCell>{item.serial || "-"}</TableCell>
+                    <TableCell>{item.khoaPhongQuanLy || "Không xác định"}</TableCell>
+                    <TableCell>{item.ngayNhap || "-"}</TableCell>
+                    <TableCell className="text-right">{formatReportCurrency(item.giaGoc)}</TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={7} className="h-24 text-center">
+                    Không có dữ liệu.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <div className="flex flex-col gap-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+          <span>
+            Trang {formatReportNumber(totalCount === 0 ? 0 : page)} /{" "}
+            {formatReportNumber(totalCount === 0 ? 0 : totalPages)} -{" "}
+            {formatReportNumber(totalCount)} thiết bị
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!canPrevious || isLoading}
+              onClick={() => onPageChange(page - 1)}
+            >
+              Trước
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!canNext || isLoading}
+              onClick={() => onPageChange(page + 1)}
+            >
+              Sau
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(app)/reports/hooks/__tests__/use-unused-equipment-report.test.tsx
+++ b/src/app/(app)/reports/hooks/__tests__/use-unused-equipment-report.test.tsx
@@ -1,0 +1,107 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: mocks.callRpc,
+}))
+
+import { useUnusedEquipmentReport } from "../use-unused-equipment-report"
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+describe("useUnusedEquipmentReport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("calls the server-side report RPC with facility scope and table controls", async () => {
+    mocks.callRpc.mockResolvedValueOnce({
+      summary: {
+        totalCount: 1,
+        deviceTypeCount: 1,
+        departmentCount: 1,
+        totalOriginalValue: 1000000,
+      },
+      topDeviceGroups: [],
+      departments: [],
+      items: [],
+      totalCount: 1,
+      page: 2,
+      pageSize: 20,
+    })
+
+    const queryClient = createQueryClient()
+
+    renderHook(
+      () =>
+        useUnusedEquipmentReport({
+          selectedDonVi: 17,
+          searchTerm: "Máy thở",
+          selectedDepartment: "ICU",
+          page: 2,
+          pageSize: 20,
+          sort: "ten_thiet_bi.asc",
+          enabled: true,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await waitFor(() => expect(mocks.callRpc).toHaveBeenCalledTimes(1))
+
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fn: "unused_equipment_report_for_reports",
+        args: {
+          p_don_vi: 17,
+          p_q: "Máy thở",
+          p_khoa_phong: "ICU",
+          p_page: 2,
+          p_page_size: 20,
+          p_sort: "ten_thiet_bi.asc",
+        },
+        signal: expect.any(AbortSignal),
+      })
+    )
+  })
+
+  it("keeps the query disabled when facility scope is not ready", async () => {
+    const queryClient = createQueryClient()
+
+    const { result } = renderHook(
+      () =>
+        useUnusedEquipmentReport({
+          selectedDonVi: null,
+          searchTerm: "",
+          selectedDepartment: "all",
+          page: 1,
+          pageSize: 10,
+          sort: "ten_thiet_bi.asc",
+          enabled: false,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    expect(result.current.fetchStatus).toBe("idle")
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/reports/hooks/use-unused-equipment-report.ts
+++ b/src/app/(app)/reports/hooks/use-unused-equipment-report.ts
@@ -1,0 +1,110 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { callRpc } from "@/lib/rpc-client"
+
+export interface UnusedEquipmentReportSummary {
+  totalCount: number
+  deviceTypeCount: number
+  departmentCount: number
+  totalOriginalValue: number
+}
+
+export interface UnusedEquipmentReportGroup {
+  deviceName: string
+  equipmentCount: number
+  totalOriginalValue: number
+}
+
+export interface UnusedEquipmentReportDepartment {
+  departmentName: string
+  equipmentCount: number
+  totalOriginalValue: number
+}
+
+export interface UnusedEquipmentReportItem {
+  id: number
+  maThietBi: string | null
+  tenThietBi: string | null
+  model: string | null
+  serial: string | null
+  khoaPhongQuanLy: string | null
+  ngayNhap: string | null
+  createdAt: string
+  giaGoc: number | null
+  donVi: number
+}
+
+export interface UnusedEquipmentReportData {
+  summary: UnusedEquipmentReportSummary
+  topDeviceGroups: UnusedEquipmentReportGroup[]
+  departments: UnusedEquipmentReportDepartment[]
+  items: UnusedEquipmentReportItem[]
+  totalCount: number
+  page: number
+  pageSize: number
+}
+
+export interface UseUnusedEquipmentReportParams {
+  selectedDonVi?: number | null
+  searchTerm: string
+  selectedDepartment: string
+  page: number
+  pageSize: number
+  sort: string
+  enabled: boolean
+}
+
+export const unusedEquipmentReportKeys = {
+  data: (params: UseUnusedEquipmentReportParams) => [
+    "reports",
+    "unused-equipment",
+    {
+      selectedDonVi: params.selectedDonVi ?? null,
+      searchTerm: params.searchTerm,
+      selectedDepartment: params.selectedDepartment,
+      page: params.page,
+      pageSize: params.pageSize,
+      sort: params.sort,
+      enabled: params.enabled,
+    },
+  ] as const,
+}
+
+const EMPTY_UNUSED_EQUIPMENT_REPORT: UnusedEquipmentReportData = {
+  summary: {
+    totalCount: 0,
+    deviceTypeCount: 0,
+    departmentCount: 0,
+    totalOriginalValue: 0,
+  },
+  topDeviceGroups: [],
+  departments: [],
+  items: [],
+  totalCount: 0,
+  page: 1,
+  pageSize: 10,
+}
+
+export function useUnusedEquipmentReport(params: UseUnusedEquipmentReportParams) {
+  return useQuery({
+    queryKey: unusedEquipmentReportKeys.data(params),
+    queryFn: async ({ signal }) => {
+      return callRpc<UnusedEquipmentReportData>({
+        fn: "unused_equipment_report_for_reports",
+        args: {
+          p_don_vi: params.selectedDonVi ?? null,
+          p_q: params.searchTerm || null,
+          p_khoa_phong: params.selectedDepartment === "all" ? null : params.selectedDepartment,
+          p_page: params.page,
+          p_page_size: params.pageSize,
+          p_sort: params.sort,
+        },
+        signal,
+      })
+    },
+    enabled: params.enabled,
+    placeholderData: (previousData) => previousData ?? EMPTY_UNUSED_EQUIPMENT_REPORT,
+    staleTime: 60_000,
+  })
+}

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -117,6 +117,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'usage_log_delete',
   // Reports: status distribution
   'equipment_status_distribution',
+  'unused_equipment_report_for_reports',
   // Audit logs (global users only)
   'audit_logs_list',
   'audit_logs_list_v2',

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -43,6 +43,13 @@ describe('RPC proxy whitelist', () => {
     await expect(res.json()).resolves.toEqual({ error: 'Content-Length header required' })
   })
 
+  it('allows unused_equipment_report_for_reports through whitelist checks', async () => {
+    const res = await invokeRpcProxy('unused_equipment_report_for_reports')
+
+    expect(res.status).toBe(411)
+    await expect(res.json()).resolves.toEqual({ error: 'Content-Length header required' })
+  })
+
   it('allows change_password through whitelist checks', async () => {
     const res = await invokeRpcProxy('change_password')
 

--- a/supabase/migrations/20260511130000_add_unused_equipment_report_rpc.sql
+++ b/supabase/migrations/20260511130000_add_unused_equipment_report_rpc.sql
@@ -1,0 +1,274 @@
+-- Add server-side report data for equipment without current usage demand.
+-- Apply with Supabase MCP apply_migration only.
+
+CREATE INDEX IF NOT EXISTS idx_thiet_bi_unused_report
+  ON public.thiet_bi (don_vi, khoa_phong_quan_ly)
+  WHERE tinh_trang_hien_tai = 'Chưa có nhu cầu sử dụng'
+    AND coalesce(is_deleted, false) = false;
+
+CREATE OR REPLACE FUNCTION public.unused_equipment_report_for_reports(
+  p_don_vi bigint DEFAULT NULL,
+  p_q text DEFAULT NULL,
+  p_khoa_phong text DEFAULT NULL,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 20,
+  p_sort text DEFAULT 'ten_thiet_bi.asc'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_claim_don_vi bigint;
+  v_allowed bigint[];
+  v_effective_don_vi bigint;
+  v_sort_col text;
+  v_sort_dir text;
+  v_order_sql text;
+  v_limit integer;
+  v_offset integer;
+  v_sanitized_q text;
+  v_pattern text;
+  v_summary jsonb;
+  v_top_device_groups jsonb;
+  v_departments jsonb;
+  v_items jsonb;
+  v_total_count integer;
+BEGIN
+  v_role := lower(coalesce(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id := nullif(public._get_jwt_claim('user_id'), '');
+  v_claim_don_vi := nullif(public._get_jwt_claim('don_vi'), '')::bigint;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING errcode = '42501';
+  END IF;
+
+  IF v_role IN ('global', 'admin') THEN
+    IF p_don_vi IS NULL THEN
+      RAISE EXCEPTION 'Facility selection is required' USING errcode = '42501';
+    END IF;
+    v_effective_don_vi := p_don_vi;
+  ELSIF v_role = 'regional_leader' THEN
+    IF p_don_vi IS NULL THEN
+      RAISE EXCEPTION 'Facility selection is required' USING errcode = '42501';
+    END IF;
+
+    v_allowed := public.allowed_don_vi_for_session_safe();
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL OR NOT p_don_vi = ANY(v_allowed) THEN
+      RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING errcode = '42501';
+    END IF;
+
+    v_effective_don_vi := p_don_vi;
+  ELSE
+    IF v_claim_don_vi IS NULL THEN
+      RAISE EXCEPTION 'Missing don_vi claim for role %', v_role USING errcode = '42501';
+    END IF;
+
+    IF p_don_vi IS NOT NULL AND p_don_vi <> v_claim_don_vi THEN
+      RAISE EXCEPTION 'Access denied for facility %', p_don_vi USING errcode = '42501';
+    END IF;
+
+    v_effective_don_vi := v_claim_don_vi;
+  END IF;
+
+  v_sort_col := lower(split_part(coalesce(p_sort, 'ten_thiet_bi.asc'), '.', 1));
+  v_sort_dir := CASE lower(split_part(coalesce(p_sort, 'ten_thiet_bi.asc'), '.', 2))
+    WHEN 'desc' THEN 'DESC'
+    ELSE 'ASC'
+  END;
+
+  IF v_sort_col NOT IN ('id', 'ma_thiet_bi', 'ten_thiet_bi', 'khoa_phong_quan_ly', 'ngay_nhap', 'gia_goc', 'created_at') THEN
+    v_sort_col := 'ten_thiet_bi';
+  END IF;
+
+  v_order_sql := format('%I %s, id ASC', v_sort_col, v_sort_dir);
+  v_limit := LEAST(GREATEST(coalesce(p_page_size, 20), 1), 100);
+  v_offset := GREATEST(coalesce(p_page, 1) - 1, 0) * v_limit;
+  v_sanitized_q := public._sanitize_ilike_pattern(lower(trim(coalesce(p_q, ''))));
+  v_pattern := CASE WHEN v_sanitized_q IS NULL THEN NULL ELSE '%' || v_sanitized_q || '%' END;
+
+  WITH filtered AS MATERIALIZED (
+    SELECT
+      tb.id,
+      tb.ma_thiet_bi,
+      tb.ten_thiet_bi,
+      tb.model,
+      tb.serial,
+      tb.khoa_phong_quan_ly,
+      tb.ngay_nhap,
+      tb.created_at,
+      tb.gia_goc,
+      tb.don_vi
+    FROM public.thiet_bi tb
+    WHERE coalesce(tb.is_deleted, false) = false
+      AND tb.don_vi = v_effective_don_vi
+      AND tb.tinh_trang_hien_tai = 'Chưa có nhu cầu sử dụng'
+      AND (p_khoa_phong IS NULL OR p_khoa_phong = '' OR tb.khoa_phong_quan_ly = p_khoa_phong)
+      AND (
+        v_pattern IS NULL
+        OR lower(coalesce(tb.ten_thiet_bi, '')) ILIKE v_pattern ESCAPE '\'
+        OR lower(coalesce(tb.ma_thiet_bi, '')) ILIKE v_pattern ESCAPE '\'
+        OR lower(coalesce(tb.model, '')) ILIKE v_pattern ESCAPE '\'
+        OR lower(coalesce(tb.serial, '')) ILIKE v_pattern ESCAPE '\'
+      )
+  ),
+  summary_data AS (
+    SELECT
+      count(*)::int AS total_count,
+      count(DISTINCT nullif(trim(ten_thiet_bi), ''))::int AS device_type_count,
+      count(DISTINCT nullif(trim(khoa_phong_quan_ly), ''))::int AS department_count,
+      coalesce(sum(gia_goc), 0)::numeric AS total_original_value
+    FROM filtered
+  ),
+  top_device_groups AS (
+    SELECT
+      coalesce(nullif(trim(ten_thiet_bi), ''), 'Không xác định') AS device_name,
+      count(*)::int AS equipment_count,
+      coalesce(sum(gia_goc), 0)::numeric AS total_original_value
+    FROM filtered
+    GROUP BY coalesce(nullif(trim(ten_thiet_bi), ''), 'Không xác định')
+    ORDER BY equipment_count DESC, device_name ASC
+    LIMIT 10
+  ),
+  top_departments AS (
+    SELECT
+      coalesce(nullif(trim(khoa_phong_quan_ly), ''), 'Không xác định') AS department_name,
+      count(*)::int AS equipment_count,
+      coalesce(sum(gia_goc), 0)::numeric AS total_original_value
+    FROM filtered
+    GROUP BY coalesce(nullif(trim(khoa_phong_quan_ly), ''), 'Không xác định')
+    ORDER BY equipment_count DESC, department_name ASC
+    LIMIT 10
+  )
+  SELECT
+    jsonb_build_object(
+      'totalCount', s.total_count,
+      'deviceTypeCount', s.device_type_count,
+      'departmentCount', s.department_count,
+      'totalOriginalValue', s.total_original_value
+    ),
+    s.total_count,
+    coalesce(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'deviceName', device_name,
+            'equipmentCount', equipment_count,
+            'totalOriginalValue', total_original_value
+          )
+          ORDER BY equipment_count DESC, device_name ASC
+        )
+        FROM top_device_groups
+      ),
+      '[]'::jsonb
+    ),
+    coalesce(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'departmentName', department_name,
+            'equipmentCount', equipment_count,
+            'totalOriginalValue', total_original_value
+          )
+          ORDER BY equipment_count DESC, department_name ASC
+        )
+        FROM top_departments
+      ),
+      '[]'::jsonb
+    )
+  INTO v_summary, v_total_count, v_top_device_groups, v_departments
+  FROM summary_data s;
+
+  EXECUTE format(
+    $sql$
+      WITH filtered AS (
+        SELECT
+          tb.id,
+          tb.ma_thiet_bi,
+          tb.ten_thiet_bi,
+          tb.model,
+          tb.serial,
+          tb.khoa_phong_quan_ly,
+          tb.ngay_nhap,
+          tb.created_at,
+          tb.gia_goc,
+          tb.don_vi
+        FROM public.thiet_bi tb
+        WHERE coalesce(tb.is_deleted, false) = false
+          AND tb.don_vi = $1
+          AND tb.tinh_trang_hien_tai = 'Chưa có nhu cầu sử dụng'
+          AND ($2::text IS NULL OR $2 = '' OR tb.khoa_phong_quan_ly = $2)
+          AND (
+            $3::text IS NULL
+            OR lower(coalesce(tb.ten_thiet_bi, '')) ILIKE $3 ESCAPE '\'
+            OR lower(coalesce(tb.ma_thiet_bi, '')) ILIKE $3 ESCAPE '\'
+            OR lower(coalesce(tb.model, '')) ILIKE $3 ESCAPE '\'
+            OR lower(coalesce(tb.serial, '')) ILIKE $3 ESCAPE '\'
+          )
+      ),
+      paged AS (
+        SELECT *
+        FROM filtered
+        ORDER BY %s
+        OFFSET $4 LIMIT $5
+      )
+      SELECT coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'id', id,
+            'maThietBi', ma_thiet_bi,
+            'tenThietBi', ten_thiet_bi,
+            'model', model,
+            'serial', serial,
+            'khoaPhongQuanLy', khoa_phong_quan_ly,
+            'ngayNhap', ngay_nhap,
+            'createdAt', created_at,
+            'giaGoc', gia_goc,
+            'donVi', don_vi
+          )
+        ),
+        '[]'::jsonb
+      )
+      FROM paged
+    $sql$,
+    v_order_sql
+  )
+  INTO v_items
+  USING v_effective_don_vi, p_khoa_phong, v_pattern, v_offset, v_limit;
+
+  RETURN jsonb_build_object(
+    'summary', coalesce(v_summary, jsonb_build_object(
+      'totalCount', 0,
+      'deviceTypeCount', 0,
+      'departmentCount', 0,
+      'totalOriginalValue', 0
+    )),
+    'topDeviceGroups', coalesce(v_top_device_groups, '[]'::jsonb),
+    'departments', coalesce(v_departments, '[]'::jsonb),
+    'items', coalesce(v_items, '[]'::jsonb),
+    'totalCount', coalesce(v_total_count, 0),
+    'page', GREATEST(coalesce(p_page, 1), 1),
+    'pageSize', v_limit
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.unused_equipment_report_for_reports(
+  bigint,
+  text,
+  text,
+  integer,
+  integer,
+  text
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.unused_equipment_report_for_reports(
+  bigint,
+  text,
+  text,
+  integer,
+  integer,
+  text
+) TO authenticated;

--- a/supabase/tests/unused_equipment_report_smoke.sql
+++ b/supabase/tests/unused_equipment_report_smoke.sql
@@ -1,0 +1,299 @@
+-- supabase/tests/unused_equipment_report_smoke.sql
+-- Purpose: validate the server-side report for equipment with no current usage demand.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := replace(gen_random_uuid()::text, '-', '');
+  v_region_allowed bigint;
+  v_region_blocked bigint;
+  v_tenant_allowed bigint;
+  v_tenant_blocked bigint;
+  v_allowed_device_id bigint;
+  v_other_status_id bigint;
+  v_deleted_device_id bigint;
+  v_report jsonb;
+  v_items jsonb;
+  v_total_count int;
+  v_forbidden_ok boolean := false;
+BEGIN
+  INSERT INTO public.dia_ban(ma_dia_ban, ten_dia_ban, active)
+  VALUES ('SMOKE-IDLE-A-' || v_suffix, 'Smoke Idle Region A ' || v_suffix, true)
+  RETURNING id INTO v_region_allowed;
+
+  INSERT INTO public.dia_ban(ma_dia_ban, ten_dia_ban, active)
+  VALUES ('SMOKE-IDLE-B-' || v_suffix, 'Smoke Idle Region B ' || v_suffix, true)
+  RETURNING id INTO v_region_blocked;
+
+  INSERT INTO public.don_vi(name, active, dia_ban_id)
+  VALUES ('Smoke Idle Facility A ' || v_suffix, true, v_region_allowed)
+  RETURNING id INTO v_tenant_allowed;
+
+  INSERT INTO public.don_vi(name, active, dia_ban_id)
+  VALUES ('Smoke Idle Facility B ' || v_suffix, true, v_region_blocked)
+  RETURNING id INTO v_tenant_blocked;
+
+  INSERT INTO public.thiet_bi (
+    ma_thiet_bi,
+    ten_thiet_bi,
+    model,
+    serial,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    ngay_nhap,
+    gia_goc,
+    is_deleted
+  )
+  VALUES (
+    'SMOKE-IDLE-A-1-' || v_suffix,
+    'Smoke Idle Ventilator',
+    'HFNC',
+    'SER-A-1-' || v_suffix,
+    v_tenant_allowed,
+    'ICU',
+    'Chưa có nhu cầu sử dụng',
+    '2026-01-10',
+    1000000,
+    false
+  )
+  RETURNING id INTO v_allowed_device_id;
+
+  INSERT INTO public.thiet_bi (
+    ma_thiet_bi,
+    ten_thiet_bi,
+    model,
+    serial,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    ngay_nhap,
+    gia_goc,
+    is_deleted
+  )
+  VALUES (
+    'SMOKE-IDLE-A-2-' || v_suffix,
+    'Smoke Idle Ventilator',
+    'HFNC',
+    'SER-A-2-' || v_suffix,
+    v_tenant_allowed,
+    'ICU',
+    'Chưa có nhu cầu sử dụng',
+    '2026-01-11',
+    2000000,
+    false
+  );
+
+  INSERT INTO public.thiet_bi (
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    gia_goc,
+    is_deleted
+  )
+  VALUES (
+    'SMOKE-IDLE-A-OTHER-' || v_suffix,
+    'Smoke Active Equipment',
+    v_tenant_allowed,
+    'ICU',
+    'Hoạt động',
+    3000000,
+    false
+  )
+  RETURNING id INTO v_other_status_id;
+
+  INSERT INTO public.thiet_bi (
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    gia_goc,
+    is_deleted
+  )
+  VALUES (
+    'SMOKE-IDLE-A-DELETED-' || v_suffix,
+    'Smoke Deleted Idle Equipment',
+    v_tenant_allowed,
+    'ICU',
+    'Chưa có nhu cầu sử dụng',
+    4000000,
+    true
+  )
+  RETURNING id INTO v_deleted_device_id;
+
+  INSERT INTO public.thiet_bi (
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    gia_goc,
+    is_deleted
+  )
+  VALUES (
+    'SMOKE-IDLE-B-1-' || v_suffix,
+    'Smoke Blocked Idle Equipment',
+    v_tenant_blocked,
+    'ER',
+    'Chưa có nhu cầu sử dụng',
+    5000000,
+    false
+  );
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'global',
+      'role', 'authenticated',
+      'user_id', 'smoke-global-' || v_suffix
+    )::text,
+    true
+  );
+
+  BEGIN
+    PERFORM public.unused_equipment_report_for_reports(
+      p_don_vi => NULL,
+      p_q => NULL,
+      p_khoa_phong => NULL,
+      p_page => 1,
+      p_page_size => 10,
+      p_sort => 'id.asc'
+    );
+  EXCEPTION WHEN insufficient_privilege THEN
+    v_forbidden_ok := true;
+  END;
+
+  IF NOT v_forbidden_ok THEN
+    RAISE EXCEPTION 'global scope without p_don_vi must fail closed';
+  END IF;
+
+  v_report := public.unused_equipment_report_for_reports(
+    p_don_vi => v_tenant_allowed,
+    p_q => 'Smoke Idle',
+    p_khoa_phong => 'ICU',
+    p_page => 1,
+    p_page_size => 10,
+    p_sort => 'id.asc'
+  );
+
+  v_total_count := (v_report -> 'summary' ->> 'totalCount')::int;
+  IF v_total_count <> 2 THEN
+    RAISE EXCEPTION 'unused equipment summary expected 2 active rows, got %', v_total_count;
+  END IF;
+
+  v_items := v_report -> 'items';
+  IF jsonb_array_length(v_items) <> 2 THEN
+    RAISE EXCEPTION 'unused equipment items expected 2 active rows, got %', jsonb_array_length(v_items);
+  END IF;
+
+  IF v_items @> jsonb_build_array(jsonb_build_object('id', v_other_status_id)) THEN
+    RAISE EXCEPTION 'unused equipment report included non-target status row';
+  END IF;
+
+  IF v_items @> jsonb_build_array(jsonb_build_object('id', v_deleted_device_id)) THEN
+    RAISE EXCEPTION 'unused equipment report included deleted row';
+  END IF;
+
+  IF NOT (v_items @> jsonb_build_array(jsonb_build_object('id', v_allowed_device_id))) THEN
+    RAISE EXCEPTION 'unused equipment report missed expected allowed row';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', 'smoke-toqltb-' || v_suffix,
+      'don_vi', v_tenant_allowed
+    )::text,
+    true
+  );
+
+  v_report := public.unused_equipment_report_for_reports(
+    p_don_vi => NULL,
+    p_q => 'Smoke Idle',
+    p_khoa_phong => NULL,
+    p_page => 1,
+    p_page_size => 10,
+    p_sort => 'id.asc'
+  );
+
+  IF (v_report -> 'summary' ->> 'totalCount')::int <> 2 THEN
+    RAISE EXCEPTION 'to_qltb session scope expected 2 rows, got %', v_report -> 'summary' ->> 'totalCount';
+  END IF;
+
+  v_forbidden_ok := false;
+  BEGIN
+    PERFORM public.unused_equipment_report_for_reports(
+      p_don_vi => v_tenant_blocked,
+      p_q => NULL,
+      p_khoa_phong => NULL,
+      p_page => 1,
+      p_page_size => 10,
+      p_sort => 'id.asc'
+    );
+  EXCEPTION WHEN insufficient_privilege THEN
+    v_forbidden_ok := true;
+  END;
+
+  IF NOT v_forbidden_ok THEN
+    RAISE EXCEPTION 'to_qltb must not read another facility';
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'regional_leader',
+      'role', 'authenticated',
+      'user_id', 'smoke-rl-' || v_suffix,
+      'dia_ban', v_region_allowed
+    )::text,
+    true
+  );
+
+  v_report := public.unused_equipment_report_for_reports(
+    p_don_vi => v_tenant_allowed,
+    p_q => 'Smoke Idle',
+    p_khoa_phong => NULL,
+    p_page => 1,
+    p_page_size => 10,
+    p_sort => 'id.asc'
+  );
+
+  IF (v_report -> 'summary' ->> 'totalCount')::int <> 2 THEN
+    RAISE EXCEPTION 'regional_leader allowed scope expected 2 rows, got %', v_report -> 'summary' ->> 'totalCount';
+  END IF;
+
+  IF jsonb_array_length(v_report -> 'topDeviceGroups') <> 1 THEN
+    RAISE EXCEPTION 'regional_leader topDeviceGroups expected 1 group, got %', jsonb_array_length(v_report -> 'topDeviceGroups');
+  END IF;
+
+  IF jsonb_array_length(v_report -> 'departments') <> 1 THEN
+    RAISE EXCEPTION 'regional_leader departments expected 1 group, got %', jsonb_array_length(v_report -> 'departments');
+  END IF;
+
+  v_forbidden_ok := false;
+  BEGIN
+    PERFORM public.unused_equipment_report_for_reports(
+      p_don_vi => v_tenant_blocked,
+      p_q => NULL,
+      p_khoa_phong => NULL,
+      p_page => 1,
+      p_page_size => 10,
+      p_sort => 'id.asc'
+    );
+  EXCEPTION WHEN insufficient_privilege THEN
+    v_forbidden_ok := true;
+  END;
+
+  IF NOT v_forbidden_ok THEN
+    RAISE EXCEPTION 'regional_leader must not read a facility outside dia_ban';
+  END IF;
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Add a server-side RPC for the Reports > Xuất-Nhập-Tồn section listing thiết bị chưa có nhu cầu sử dụng
- Add a rollback-wrapped SQL smoke test covering status filtering, soft-delete exclusion, tenant scope, and regional_leader denial
- Keep this PR backend-only; frontend batch will be a separate commit/PR step after backend review/apply checkpoint

## Migration status
- Migration file is committed but not applied
- Per instruction, smoke SQL GREEN verification will run only after explicit approval to apply the migration via Supabase MCP

## Tests
- RED verified before migration: live DB reports public.unused_equipment_report_for_reports does not exist
- git diff --cached --check passed before commit

## Notes
- No frontend UI changes in this batch
- No Supabase CLI used

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end “Unused Equipment” report in Reports > Xuất-Nhập-Tồn with a secure RPC, KPIs, charts, and a paginated table. Works per facility with search and department filters; global/regional users must pick a facility first.

- **New Features**
  - Adds `public.unused_equipment_report_for_reports(p_don_vi, p_q, p_khoa_phong, p_page, p_page_size, p_sort)` returning JSON: `summary`, `topDeviceGroups`, `departments`, `items`, `totalCount`, `page`, `pageSize`; filters by facility/department/search; excludes soft-deleted; sortable by `id`, `ma_thiet_bi`, `ten_thiet_bi`, `khoa_phong_quan_ly`, `ngay_nhap`, `gia_goc`, `created_at` (ASC/DESC); page size capped at 100; enforces JWT claims (global/admin require facility, user-scoped facility only, `regional_leader` limited to allowed facilities).
  - Adds partial index `idx_thiet_bi_unused_report` to speed up report queries.
  - Whitelists `unused_equipment_report_for_reports` in the API RPC proxy.
  - UI: integrates `UnusedEquipmentReportSection` in the inventory tab with KPI cards, bar charts by device type and department, a searchable and paginated table, department filter, and page size options (10/20/50); shows a facility-selection prompt and keeps the query disabled for `global/regional_leader` until a facility is chosen.
  - Adds `useUnusedEquipmentReport` hook (React Query with 60s stale time and placeholder data) and tests for the hook, section behavior (page-size resets to page 1), tab rendering, RPC whitelist, plus a rollback-wrapped SQL smoke test.

- **Migration**
  - Apply `supabase/migrations/20260511130000_add_unused_equipment_report_rpc.sql` via Supabase MCP to create the RPC and index before deploying the frontend.

<sup>Written for commit cc74d11905a4e76bc12bd2c0187f75f460125998. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unused equipment reporting with support for filtering by facility, department, and search terms
  * Reports include summary statistics (total count, device types, departments, and total value) with pagination support
  * Integrated role-based access control to ensure users only see authorized equipment data

* **Tests**
  * Added comprehensive test coverage for report generation and access control validation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/448)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->