### PR TITLE
Fix password submit pending guard

### DIFF
--- a/src/components/__tests__/change-password-dialog.signout.test.tsx
+++ b/src/components/__tests__/change-password-dialog.signout.test.tsx
@@ -91,6 +91,17 @@ vi.mock("@/components/ui/label", () => ({
 
 import { ChangePasswordDialog } from "../change-password-dialog"
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, resolve, reject }
+}
+
 describe("ChangePasswordDialog forced signout", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -153,6 +164,56 @@ describe("ChangePasswordDialog forced signout", () => {
     })
   })
 
+  it("keeps the password form disabled while the password-change request is pending", async () => {
+    const pendingPasswordChange = createDeferred<{
+      success: boolean
+      message: string
+    }>()
+    mocks.rpc.mockReturnValueOnce(pendingPasswordChange.promise)
+
+    render(<ChangePasswordDialog open onOpenChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText("Mật khẩu hiện tại *"), {
+      target: { value: "old-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Xác nhận mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Thay đổi mật khẩu" }))
+
+    await waitFor(() => {
+      expect(mocks.rpc).toHaveBeenCalled()
+    })
+
+    const submitButton = screen.getByRole("button", { name: "Thay đổi mật khẩu" })
+
+    expect(screen.getByLabelText("Mật khẩu hiện tại *")).toBeDisabled()
+    expect(screen.getByLabelText("Mật khẩu mới *")).toBeDisabled()
+    expect(screen.getByLabelText("Xác nhận mật khẩu mới *")).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Hủy" })).toBeDisabled()
+    expect(submitButton).toBeDisabled()
+    expect(submitButton.querySelector(".animate-spin")).not.toBeNull()
+
+    await act(async () => {
+      pendingPasswordChange.resolve({
+        success: true,
+        message: "Đã thay đổi mật khẩu thành công với mã hóa bảo mật.",
+      })
+      await pendingPasswordChange.promise
+    })
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Thành công",
+        }),
+      )
+    })
+  })
+
   it("shows a logout-specific error if post-change signout fails after the password update succeeds", async () => {
     vi.useFakeTimers()
     mocks.signOut.mockRejectedValueOnce(new Error("redirect failed"))
@@ -168,10 +229,11 @@ describe("ChangePasswordDialog forced signout", () => {
     fireEvent.change(screen.getByLabelText("Xác nhận mật khẩu mới *"), {
       target: { value: "new-password" },
     })
-    fireEvent.click(screen.getByRole("button", { name: "Thay đổi mật khẩu" }))
-
-    await Promise.resolve()
-    await Promise.resolve()
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Thay đổi mật khẩu" }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500)

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -153,7 +153,6 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
           title: "Lỗi",
           description: "Không xác định được người dùng hiện tại."
         })
-        setIsSubmitting(false)
         return
       }
 
@@ -172,7 +171,6 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
           title: "Lỗi",
           description: data?.message || "Mật khẩu hiện tại không đúng."
         })
-        setIsSubmitting(false)
         return
       }
 

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -65,7 +65,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
     }
     return null
   }, [user?.id])
-  const [isLoading, setIsLoading] = React.useState(false)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
   const [showPasswords, setShowPasswords] = React.useState({
     current: false,
     new: false,
@@ -143,7 +143,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
       return
     }
 
-    setIsLoading(true)
+    setIsSubmitting(true)
     let passwordChanged = false
 
     try {
@@ -153,7 +153,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
           title: "Lỗi",
           description: "Không xác định được người dùng hiện tại."
         })
-        setIsLoading(false)
+        setIsSubmitting(false)
         return
       }
 
@@ -172,7 +172,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
           title: "Lỗi",
           description: data?.message || "Mật khẩu hiện tại không đúng."
         })
-        setIsLoading(false)
+        setIsSubmitting(false)
         return
       }
 
@@ -195,7 +195,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
         description: getPasswordChangeErrorMessage(error),
       })
     } finally {
-      setIsLoading(false)
+      setIsSubmitting(false)
     }
 
     if (passwordChanged) {
@@ -230,7 +230,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
                   value={formData.currentPassword}
                   onChange={(e) => setFormData(prev => ({ ...prev, currentPassword: e.target.value }))}
                   placeholder="Nhập mật khẩu hiện tại"
-                  disabled={isLoading}
+                  disabled={isSubmitting}
                   required
                   className="pr-10"
                 />
@@ -240,12 +240,12 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
                   size="sm"
                   className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
                   onClick={() => togglePasswordVisibility('current')}
-                  disabled={isLoading}
+                  disabled={isSubmitting}
                 >
                   {showPasswords.current ? (
-                    <EyeOff className="h-4 w-4" />
+                    <EyeOff className="size-4" />
                   ) : (
-                    <Eye className="h-4 w-4" />
+                    <Eye className="size-4" />
                   )}
                 </Button>
               </div>
@@ -259,7 +259,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
                   value={formData.newPassword}
                   onChange={(e) => setFormData(prev => ({ ...prev, newPassword: e.target.value }))}
                   placeholder="Nhập mật khẩu mới"
-                  disabled={isLoading}
+                  disabled={isSubmitting}
                   required
                   className="pr-10"
                 />
@@ -269,12 +269,12 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
                   size="sm"
                   className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
                   onClick={() => togglePasswordVisibility('new')}
-                  disabled={isLoading}
+                  disabled={isSubmitting}
                 >
                   {showPasswords.new ? (
-                    <EyeOff className="h-4 w-4" />
+                    <EyeOff className="size-4" />
                   ) : (
-                    <Eye className="h-4 w-4" />
+                    <Eye className="size-4" />
                   )}
                 </Button>
               </div>
@@ -288,7 +288,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
                   value={formData.confirmPassword}
                   onChange={(e) => setFormData(prev => ({ ...prev, confirmPassword: e.target.value }))}
                   placeholder="Nhập lại mật khẩu mới"
-                  disabled={isLoading}
+                  disabled={isSubmitting}
                   required
                   className="pr-10"
                 />
@@ -298,12 +298,12 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
                   size="sm"
                   className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
                   onClick={() => togglePasswordVisibility('confirm')}
-                  disabled={isLoading}
+                  disabled={isSubmitting}
                 >
                   {showPasswords.confirm ? (
-                    <EyeOff className="h-4 w-4" />
+                    <EyeOff className="size-4" />
                   ) : (
-                    <Eye className="h-4 w-4" />
+                    <Eye className="size-4" />
                   )}
                 </Button>
               </div>
@@ -314,12 +314,12 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={isLoading}
+              disabled={isSubmitting}
             >
               Hủy
             </Button>
-            <Button type="submit" disabled={isLoading}>
-              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
               Thay đổi mật khẩu
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## Summary
- Replace the generic ChangePasswordDialog `isLoading` state name with an explicit `isSubmitting` async submit guard.
- Add a regression test proving the password form stays disabled and shows the spinner while `change_password` is unresolved.
- Keep forced-signout sequencing unchanged; a useTransition-only spike was verified to drop pending disabled state on React 18.3.1.
- Clean up icon sizing in the changed file so React Doctor diff scan is clean.

Closes #390

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/change-password-dialog.signout.test.tsx src/components/__tests__/change-password-dialog.security-source.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## TDD Evidence
- Added pending-form regression test first.
- Applied a temporary useTransition-only spike; focused test failed with `expect(element).toBeDisabled()` because the password input was not disabled while the RPC was pending.
- Reverted the spike and kept the async submit guard; focused tests then passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the Change Password dialog disabled and show a spinner until the password update completes, preventing edits while the request is pending (closes #390). Switch to an explicit `isSubmitting` guard, consolidate state reset in `finally`, add a pending-state regression test, preserve forced signout sequencing, and tidy icon sizes.

<sup>Written for commit 1f9afe955f25940694d6e3404df2f2a9e4d4a434. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Change-password dialog now disables all password inputs, visibility toggles, and footer actions while a submission is in progress.
  * Submit button shows an updated loading spinner while submitting.
  * Internal submission state handling improved to ensure UI stays disabled during pending requests.

* **Tests**
  * Tests updated to more reliably verify UI remains disabled during pending requests and that success notification appears after completion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/449)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->