### PR TITLE
Fix auth transition stale screens

### DIFF
--- a/src/app/(app)/__tests__/AppLayoutShell.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.test.tsx
@@ -276,6 +276,28 @@ describe("AppLayoutShell", () => {
     })
   })
 
+  it("hides protected content immediately while user-menu signout redirect is pending", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <AppLayoutShell
+        user={{
+          role: "global",
+          full_name: "Test User",
+          username: "tester",
+          khoa_phong: "IT",
+        }}
+      >
+        <div>Child Content</div>
+      </AppLayoutShell>
+    )
+
+    await user.click(screen.getByRole("button", { name: /đăng xuất/i }))
+
+    expect(screen.queryByText("Child Content")).not.toBeInTheDocument()
+    expect(screen.getByTestId("authenticated-page-spinner-fallback")).toBeInTheDocument()
+  })
+
   it("redirects through signOut when the session becomes unauthenticated", () => {
     const sessionState = {
       data: { user: { id: "u1" } },

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -8,6 +8,7 @@ import dynamic from "next/dynamic"
 import { Copyright, KeyRound, LogOut, Menu, User } from "lucide-react"
 
 import { MainContentTransition } from "@/components/page-transition-wrapper"
+import { AuthenticatedPageSpinnerFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -78,6 +79,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
   const [isMobileSheetOpen, setIsMobileSheetOpen] = React.useState(false)
   const [isChangePasswordOpen, setIsChangePasswordOpen] = React.useState(false)
   const [isAssistantOpen, setIsAssistantOpen] = React.useState(false)
+  const [isSigningOut, setIsSigningOut] = React.useState(false)
   const branding = useTenantBranding()
   const { counts: notificationCounts } = useAppNotificationCounts({
     enabled: status === "authenticated" && shouldFetchData,
@@ -105,6 +107,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
     }
 
     hasHandledSessionExitRef.current = true
+    setIsSigningOut(true)
     clearAllEquipmentFilters()
     void signOut({ callbackUrl: "/" })
   }, [])
@@ -115,12 +118,14 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
     }
 
     hasHandledSessionExitRef.current = true
+    setIsSigningOut(true)
     clearAllEquipmentFilters()
     void signOutWithReason({
       updateSession: update,
       reason: "user_initiated",
     }).catch(() => {
       hasHandledSessionExitRef.current = false
+      setIsSigningOut(false)
     })
   }, [update])
 
@@ -132,8 +137,11 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
 
     if (status === "authenticated") {
       hasHandledSessionExitRef.current = false
+      setIsSigningOut(false)
     }
   }, [redirectToSignedOutHome, status])
+
+  const shouldHideProtectedContent = isSigningOut || status === "unauthenticated"
 
   return (
     <>
@@ -286,7 +294,9 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
                 </DropdownMenu>
               </header>
               <main className="flex flex-1 flex-col gap-4 bg-background p-4 pb-24 md:pb-4 lg:gap-8 lg:p-8">
-                <MainContentTransition>{children}</MainContentTransition>
+                <MainContentTransition>
+                  {shouldHideProtectedContent ? <AuthenticatedPageSpinnerFallback /> : children}
+                </MainContentTransition>
               </main>
 
               <MobileFooterNav notificationCounts={notificationCounts} />

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -268,7 +268,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-56">
                     <DropdownMenuLabel className="pb-2">
-                      <div className="flex flex-col space-y-1">
+                      <div className="flex flex-col gap-y-1">
                         <p className="text-sm font-medium leading-none">{user.full_name || user.username}</p>
                         <div className="flex items-center gap-2">
                           <Badge variant="outline" className="text-xs">

--- a/src/app/_components/LoginForm.tsx
+++ b/src/app/_components/LoginForm.tsx
@@ -142,7 +142,7 @@ export function LoginForm(): React.ReactElement {
             </div>
             {/* Header Text */}
             <div className="space-y-2">
-              <h2 className="text-3xl font-bold tracking-tight text-foreground">
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground">
                 {t("login.title") || "Đăng nhập"}
               </h2>
               <p className="text-muted-foreground">

--- a/src/app/_components/LoginForm.tsx
+++ b/src/app/_components/LoginForm.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useRouter } from "next/navigation"
 import { signIn } from "next-auth/react"
 import { useForm } from "react-hook-form"
 import { z } from "zod"
@@ -75,6 +76,8 @@ function getCredentialErrorMessage(
 
 export function LoginForm(): React.ReactElement {
   const { t } = useLanguage()
+  const { replace } = useRouter()
+  const [isRedirecting, setIsRedirecting] = React.useState(false)
   const loginFormSchema = React.useMemo(() => createLoginFormSchema(t), [t])
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginFormSchema),
@@ -102,7 +105,8 @@ export function LoginForm(): React.ReactElement {
       }
 
       // Success: NextAuth session established; no legacy bridge writes.
-      window.location.href = "/dashboard"
+      setIsRedirecting(true)
+      replace("/dashboard")
     } catch (err) {
       console.error("Unexpected login error", { error: err })
       form.setError("root", {
@@ -112,7 +116,7 @@ export function LoginForm(): React.ReactElement {
     }
   }
 
-  const isSubmitting = form.formState.isSubmitting
+  const isSubmitting = form.formState.isSubmitting || isRedirecting
   const rootError = form.formState.errors.root?.message
 
   return (

--- a/src/app/_components/__tests__/LoginForm.test.tsx
+++ b/src/app/_components/__tests__/LoginForm.test.tsx
@@ -7,7 +7,14 @@ import { LoginForm } from "@/app/_components/LoginForm"
 import { LanguageProvider } from "@/contexts/language-context"
 
 const mocks = vi.hoisted(() => ({
+  routerReplace: vi.fn(),
   signIn: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mocks.routerReplace,
+  }),
 }))
 
 vi.mock("next-auth/react", () => ({
@@ -32,6 +39,7 @@ function renderLoginForm(): ReturnType<typeof render> {
 
 describe("LoginForm", () => {
   beforeEach(() => {
+    mocks.routerReplace.mockReset()
     mocks.signIn.mockReset()
   })
 
@@ -120,6 +128,32 @@ describe("LoginForm", () => {
         redirect: false,
       })
     })
+    expect(mocks.routerReplace).toHaveBeenCalledWith("/dashboard")
     expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
+  it("keeps login controls unavailable after successful credentials while dashboard redirect is pending", async () => {
+    const user = userEvent.setup()
+    let resolveSignIn: (value: { ok: boolean; error: null }) => void = () => undefined
+    mocks.signIn.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSignIn = resolve
+      }),
+    )
+    renderLoginForm()
+
+    await user.type(screen.getByLabelText(/tên đăng nhập/i), "to-qltb")
+    await user.type(screen.getByLabelText(/mật khẩu/i), "secret")
+    await user.click(screen.getByRole("button", { name: /đăng nhập/i }))
+
+    expect(screen.getByRole("button", { name: /đang xác thực/i })).toBeDisabled()
+
+    resolveSignIn({ ok: true, error: null })
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /đang xác thực/i })).toBeDisabled()
+    })
+    expect(mocks.routerReplace).toHaveBeenCalledWith("/dashboard")
+    expect(screen.queryByRole("button", { name: /^đăng nhập/i })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Keep login controls in the pending state after successful credentials until Dashboard navigation starts.
- Hide protected app content immediately during explicit logout/session-exit redirects.
- Add RED regression coverage for login and logout stale-screen flashes, plus two small React Doctor UI cleanups.

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/app/_components/__tests__/LoginForm.test.tsx 'src/app/(app)/__tests__/AppLayoutShell.test.tsx'`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Notes
- React Doctor improved to 98/100 after the two small local cleanups.
- Remaining broader UI cleanup is tracked in #450.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale screens during auth transitions by keeping the login form pending until `replace('/dashboard')` starts and hiding protected content immediately when sign out begins. Adds focused tests and small UI cleanups.

- **Bug Fixes**
  - Login: keep controls disabled after successful credentials while redirect is pending (use `next/navigation` `replace('/dashboard')`).
  - Logout/session-exit: immediately hide protected content and show spinner fallback during `signOut` to prevent stale flashes.
  - Tests: added regression tests for login pending-redirect and signout content hiding; minor UI tweaks to address React Doctor warnings.

<sup>Written for commit 060ceb3261fdf72c6c45ae76e00d7013b0715b11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-out now displays a loading spinner to indicate that the sign-out process is in progress while redirecting

* **Refactor**
  * Enhanced login navigation and redirect handling for improved framework integration

* **Tests**
  * Added test coverage for sign-out behavior, including verification of loading states and redirect handling
  * Added tests for login flow with new navigation mechanism

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/451)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->