### PR TITLE
fix: address React Doctor P0 correctness findings

### DIFF
--- a/src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts
+++ b/src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts
@@ -8,7 +8,7 @@ const readSource = (file: string) =>
 const expectInvalidatesQueryKey = (source: string, queryKey: string) => {
   expect(source).toMatch(
     new RegExp(
-      `invalidateQueries\\(\\{\\s*queryKey:\\s*\\[["']${queryKey}["']\\]`
+      String.raw`invalidateQueries\(\{\s*queryKey:\s*\[["']${queryKey}["']\]`
     )
   )
 }

--- a/src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts
+++ b/src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const readSource = (file: string) =>
+  readFileSync(join(process.cwd(), file), "utf8")
+
+const expectInvalidatesQueryKey = (source: string, queryKey: string) => {
+  expect(source).toMatch(
+    new RegExp(
+      `invalidateQueries\\(\\{\\s*queryKey:\\s*\\[["']${queryKey}["']\\]`
+    )
+  )
+}
+
+describe("React Doctor P0 mutation invalidation audit", () => {
+  it("keeps repair-request mutations wired to the shared invalidation callback", () => {
+    const source = readSource(
+      "src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx"
+    )
+
+    for (const mutation of [
+      "useCreateMutation",
+      "useUpdateMutation",
+      "useDeleteMutation",
+      "useApproveMutation",
+      "useCompleteMutation",
+    ]) {
+      expect(source).toContain(`function ${mutation}`)
+    }
+
+    expect(source.match(/invalidate\(\)/g)).toHaveLength(5)
+    for (const queryKey of [
+      "repair_request_list",
+      "repair_request_facilities",
+      "repair_request_status_counts",
+      "repair_request_change_history",
+      "dashboard-stats",
+    ]) {
+      expectInvalidatesQueryKey(source, queryKey)
+    }
+  })
+
+  it("keeps device-quota category mutations wired to quota query invalidation", () => {
+    const source = readSource(
+      "src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext.tsx"
+    )
+
+    expect(source.match(/invalidate\(\)/g)).toHaveLength(3)
+    for (const queryKey of [
+      "dinh_muc_nhom_list",
+      "dinh_muc_compliance_summary",
+    ]) {
+      expectInvalidatesQueryKey(source, queryKey)
+    }
+  })
+
+  it("keeps device-quota decision mutations wired to decision query invalidation", () => {
+    const source = readSource(
+      "src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsContext.tsx"
+    )
+
+    expect(source.match(/invalidate\(\)/g)).toHaveLength(4)
+    for (const queryKey of [
+      "dinh_muc_quyet_dinh_list",
+      "dinh_muc_compliance_summary",
+    ]) {
+      expectInvalidatesQueryKey(source, queryKey)
+    }
+  })
+
+  it("keeps device-quota mapping mutations wired to unassigned and compliance invalidation", () => {
+    const source = readSource(
+      "src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx"
+    )
+
+    expect(source.match(/invalidate\(\)/g)).toHaveLength(1)
+    for (const queryKey of [
+      "dinh_muc_thiet_bi_unassigned",
+      "dinh_muc_thiet_bi_unassigned_filter_options",
+      "dinh_muc_nhom_list",
+      "dinh_muc_compliance_summary",
+    ]) {
+      expectInvalidatesQueryKey(source, queryKey)
+    }
+  })
+})

--- a/src/__tests__/react-doctor-p0-style-jsx.source.test.ts
+++ b/src/__tests__/react-doctor-p0-style-jsx.source.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+describe("React Doctor P0 DOM correctness", () => {
+  it("does not render styled-jsx-only props on plain style tags", () => {
+    const files = [
+      "src/components/handover-template.tsx",
+      "src/components/maintenance-form.tsx",
+      "src/components/qr-scanner-camera.tsx",
+      "src/components/log-template.tsx",
+      "src/app/(app)/device-quota/dashboard/_components/DeviceQuotaComplianceReport.tsx",
+    ]
+
+    for (const file of files) {
+      const source = readFileSync(join(process.cwd(), file), "utf8")
+
+      expect(source).not.toContain("<style jsx>")
+    }
+  })
+})

--- a/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaComplianceReport.tsx
+++ b/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaComplianceReport.tsx
@@ -314,7 +314,7 @@ export function DeviceQuotaComplianceReport({
       </div>
 
       {/* Print-specific styles */}
-      <style jsx>{`
+      <style>{`
         @media print {
           /* A4 Page Setup */
           @page {

--- a/src/app/(app)/equipment/__tests__/EquipmentPage.suspense.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPage.suspense.test.tsx
@@ -8,13 +8,14 @@ const mocks = vi.hoisted(() => ({
   renderEquipmentPageClient: vi.fn<() => React.ReactNode>(),
 }))
 
+interface MockAuthenticatedPageBoundaryProps {
+  children: () => React.ReactNode
+}
+
 vi.mock("@/app/(app)/_components/AuthenticatedPageBoundary", () => ({
   AuthenticatedPageBoundary: ({
     children,
-  }: {
-    children: () => React.ReactNode
-    fallback: React.ReactNode
-  }) => <>{children()}</>,
+  }: MockAuthenticatedPageBoundaryProps) => <>{children()}</>,
 }))
 
 vi.mock("@/app/(app)/_components/AuthenticatedPageFallbacks", () => ({

--- a/src/app/(app)/equipment/__tests__/EquipmentPage.suspense.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPage.suspense.test.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+const pendingEquipmentPage = new Promise<never>(() => {})
+
+const mocks = vi.hoisted(() => ({
+  renderEquipmentPageClient: vi.fn<() => React.ReactNode>(),
+}))
+
+vi.mock("@/app/(app)/_components/AuthenticatedPageBoundary", () => ({
+  AuthenticatedPageBoundary: ({
+    children,
+  }: {
+    children: () => React.ReactNode
+    fallback: React.ReactNode
+  }) => <>{children()}</>,
+}))
+
+vi.mock("@/app/(app)/_components/AuthenticatedPageFallbacks", () => ({
+  AuthenticatedPageSkeletonFallback: () => (
+    <div data-testid="equipment-page-suspense-fallback" />
+  ),
+}))
+
+vi.mock("../_components/EquipmentPageClient", () => ({
+  EquipmentPageClient: () => mocks.renderEquipmentPageClient(),
+}))
+
+import EquipmentPage from "../page"
+
+describe("EquipmentPage Suspense boundary", () => {
+  it("renders the page skeleton when the client route sync suspends", async () => {
+    mocks.renderEquipmentPageClient.mockImplementation(() => {
+      throw pendingEquipmentPage
+    })
+
+    render(<EquipmentPage />)
+
+    expect(
+      await screen.findByTestId("equipment-page-suspense-fallback")
+    ).toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/equipment/__tests__/EquipmentPage.suspense.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPage.suspense.test.tsx
@@ -23,11 +23,11 @@ vi.mock("@/app/(app)/_components/AuthenticatedPageFallbacks", () => ({
   ),
 }))
 
-vi.mock("../_components/EquipmentPageClient", () => ({
+vi.mock("@/app/(app)/equipment/_components/EquipmentPageClient", () => ({
   EquipmentPageClient: () => mocks.renderEquipmentPageClient(),
 }))
 
-import EquipmentPage from "../page"
+import EquipmentPage from "@/app/(app)/equipment/page"
 
 describe("EquipmentPage Suspense boundary", () => {
   it("renders the page skeleton when the client route sync suspends", async () => {

--- a/src/app/(app)/equipment/page.tsx
+++ b/src/app/(app)/equipment/page.tsx
@@ -10,7 +10,11 @@ import { EquipmentPageClient } from "./_components/EquipmentPageClient"
 export default function EquipmentPage() {
   return (
     <AuthenticatedPageBoundary fallback={<AuthenticatedPageSkeletonFallback />}>
-      {() => <EquipmentPageClient />}
+      {() => (
+        <React.Suspense fallback={<AuthenticatedPageSkeletonFallback />}>
+          <EquipmentPageClient />
+        </React.Suspense>
+      )}
     </AuthenticatedPageBoundary>
   )
 }

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsCompleteDialog.exports.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsCompleteDialog.exports.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+describe("RepairRequestsCompleteDialog exports", () => {
+  it("keeps RepairRequestsCompleteDialog as the single complete-dialog export", () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        "src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx"
+      ),
+      "utf8"
+    )
+
+    expect(source).toContain("export function RepairRequestsCompleteDialog")
+    expect(source).not.toContain("CompleteRequestDialog")
+  })
+})

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx
@@ -201,4 +201,3 @@ export function RepairRequestsCompleteDialog() {
 }
 
 // Export alias for backwards compatibility
-export const CompleteRequestDialog = RepairRequestsCompleteDialog

--- a/src/components/assistant/AssistantDraftCard.tsx
+++ b/src/components/assistant/AssistantDraftCard.tsx
@@ -15,6 +15,25 @@ interface AssistantDraftCardProps {
     onApplyDraft: (draft: DraftPayload) => void
 }
 
+function withOccurrenceKeys<T>(
+    items: T[],
+    prefix: string,
+    getParts: (item: T) => string[],
+) {
+    const counts = new Map<string, number>()
+
+    return items.map((item) => {
+        const baseKey = [prefix, ...getParts(item)].join("-")
+        const nextCount = (counts.get(baseKey) ?? 0) + 1
+        counts.set(baseKey, nextCount)
+
+        return {
+            item,
+            key: nextCount === 1 ? baseKey : `${baseKey}-${nextCount}`,
+        }
+    })
+}
+
 /**
  * Renders a structured draft card for AI-generated draft artifacts.
  *
@@ -40,6 +59,12 @@ function RepairDraftCard({
     draft: RepairRequestDraft
     onApplyDraft: (draft: RepairRequestDraft) => void
 }) {
+    const keyedReviewNotes = withOccurrenceKeys(
+        draft.reviewNotes ?? [],
+        "review-note",
+        (note) => [note],
+    )
+
     return (
         <div
             className={cn(
@@ -87,8 +112,8 @@ function RepairDraftCard({
                 <div className="flex items-start gap-1.5 text-[11px] text-orange-700 bg-orange-100 rounded px-2 py-1.5">
                     <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
                     <div>
-                        {draft.reviewNotes.map((note) => (
-                            <p key={`review-note-${note}`}>{note}</p>
+                        {keyedReviewNotes.map(({ item: note, key }) => (
+                            <p key={key}>{note}</p>
                         ))}
                     </div>
                 </div>
@@ -117,6 +142,17 @@ function RepairDraftCard({
 // ---------------------
 
 function TroubleshootingDraftCard({ draft }: { draft: TroubleshootingDraft }) {
+    const keyedCauses = withOccurrenceKeys(
+        draft.probable_causes,
+        "cause",
+        (cause) => [cause.label, cause.rationale],
+    )
+    const keyedSteps = withOccurrenceKeys(
+        draft.remediation_steps,
+        "step",
+        (step) => [step.type, step.step],
+    )
+
     return (
         <div
             className={cn(
@@ -137,9 +173,9 @@ function TroubleshootingDraftCard({ draft }: { draft: TroubleshootingDraft }) {
                 <p className="text-[11px] font-medium text-blue-700">
                     Nguyên nhân có thể:
                 </p>
-                {draft.probable_causes.map((cause) => (
+                {keyedCauses.map(({ item: cause, key }) => (
                     <div
-                        key={`cause-${cause.label}-${cause.rationale}`}
+                        key={key}
                         className="flex items-start gap-1.5 text-xs text-blue-900"
                     >
                         <span className="text-blue-500 mt-0.5">•</span>
@@ -158,9 +194,9 @@ function TroubleshootingDraftCard({ draft }: { draft: TroubleshootingDraft }) {
                 <p className="text-[11px] font-medium text-blue-700">
                     Bước xử lý đề xuất:
                 </p>
-                {draft.remediation_steps.map((step, i) => (
+                {keyedSteps.map(({ item: step, key }, i) => (
                     <div
-                        key={`step-${step.type}-${step.step}`}
+                        key={key}
                         className="flex items-start gap-1.5 text-xs text-blue-900"
                     >
                         <span className="text-blue-500 font-mono text-[10px] mt-0.5">

--- a/src/components/assistant/AssistantDraftCard.tsx
+++ b/src/components/assistant/AssistantDraftCard.tsx
@@ -87,8 +87,8 @@ function RepairDraftCard({
                 <div className="flex items-start gap-1.5 text-[11px] text-orange-700 bg-orange-100 rounded px-2 py-1.5">
                     <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
                     <div>
-                        {draft.reviewNotes.map((note, i) => (
-                            <p key={i}>{note}</p>
+                        {draft.reviewNotes.map((note) => (
+                            <p key={`review-note-${note}`}>{note}</p>
                         ))}
                     </div>
                 </div>
@@ -137,9 +137,9 @@ function TroubleshootingDraftCard({ draft }: { draft: TroubleshootingDraft }) {
                 <p className="text-[11px] font-medium text-blue-700">
                     Nguyên nhân có thể:
                 </p>
-                {draft.probable_causes.map((cause, i) => (
+                {draft.probable_causes.map((cause) => (
                     <div
-                        key={i}
+                        key={`cause-${cause.label}-${cause.rationale}`}
                         className="flex items-start gap-1.5 text-xs text-blue-900"
                     >
                         <span className="text-blue-500 mt-0.5">•</span>
@@ -160,7 +160,7 @@ function TroubleshootingDraftCard({ draft }: { draft: TroubleshootingDraft }) {
                 </p>
                 {draft.remediation_steps.map((step, i) => (
                     <div
-                        key={i}
+                        key={`step-${step.type}-${step.step}`}
                         className="flex items-start gap-1.5 text-xs text-blue-900"
                     >
                         <span className="text-blue-500 font-mono text-[10px] mt-0.5">

--- a/src/components/assistant/AssistantThinkingIndicator.tsx
+++ b/src/components/assistant/AssistantThinkingIndicator.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
 
+const THINKING_DOT_IDS = ["first", "second", "third"] as const
+
 /**
  * Thinking indicator: 3 bouncing dots in a pill-shaped AI bubble.
  * Uses assistant-dot animation class from assistant-styles.css.
@@ -11,9 +13,9 @@ export function AssistantThinkingIndicator() {
             data-testid="assistant-thinking-container"
             className="inline-flex items-center gap-1 px-4 py-3 rounded-2xl bg-[hsl(var(--assistant-ai-bubble))] assistant-message-enter"
         >
-            {[0, 1, 2].map((i) => (
+            {THINKING_DOT_IDS.map((dotId) => (
                 <div
-                    key={i}
+                    key={dotId}
                     data-testid="assistant-thinking-dot"
                     className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 assistant-dot"
                 />

--- a/src/components/assistant/__tests__/AssistantDraftCard.test.tsx
+++ b/src/components/assistant/__tests__/AssistantDraftCard.test.tsx
@@ -120,6 +120,31 @@ describe('AssistantDraftCard', () => {
                 screen.getByText(/Kiểm tra lại model trước khi gửi/),
             ).toBeInTheDocument()
         })
+
+        it('does not warn when AI-generated review notes repeat', () => {
+            const consoleError = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined)
+
+            render(
+                <AssistantDraftCard
+                    draft={{
+                        ...REPAIR_DRAFT,
+                        reviewNotes: [
+                            'Kiểm tra lại model trước khi gửi',
+                            'Kiểm tra lại model trước khi gửi',
+                        ],
+                    }}
+                    onApplyDraft={vi.fn()}
+                />,
+            )
+
+            expect(consoleError).not.toHaveBeenCalledWith(
+                expect.stringContaining('Encountered two children with the same key'),
+                expect.anything(),
+            )
+            consoleError.mockRestore()
+        })
     })
 
     describe('troubleshootingDraft', () => {
@@ -145,6 +170,31 @@ describe('AssistantDraftCard', () => {
             expect(
                 screen.getByText(/Kiểm tra cáp kết nối/),
             ).toBeInTheDocument()
+        })
+
+        it('does not warn when troubleshooting causes and steps repeat', () => {
+            const consoleError = vi
+                .spyOn(console, 'error')
+                .mockImplementation(() => undefined)
+            const repeatedCause = TROUBLESHOOTING_DRAFT.probable_causes[0]
+            const repeatedStep = TROUBLESHOOTING_DRAFT.remediation_steps[0]
+
+            render(
+                <AssistantDraftCard
+                    draft={{
+                        ...TROUBLESHOOTING_DRAFT,
+                        probable_causes: [repeatedCause, repeatedCause],
+                        remediation_steps: [repeatedStep, repeatedStep],
+                    }}
+                    onApplyDraft={vi.fn()}
+                />,
+            )
+
+            expect(consoleError).not.toHaveBeenCalledWith(
+                expect.stringContaining('Encountered two children with the same key'),
+                expect.anything(),
+            )
+            consoleError.mockRestore()
         })
 
         it('does NOT render repair CTA button', () => {

--- a/src/components/assistant/__tests__/assistant-stable-keys.source.test.ts
+++ b/src/components/assistant/__tests__/assistant-stable-keys.source.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+describe("assistant list keys", () => {
+  it("does not key assistant lists by array index", () => {
+    const files = [
+      "src/components/assistant/AssistantDraftCard.tsx",
+      "src/components/assistant/AssistantThinkingIndicator.tsx",
+    ]
+
+    for (const file of files) {
+      const source = readFileSync(join(process.cwd(), file), "utf8")
+
+      expect(source).not.toMatch(/key=\{i\}/)
+      expect(source).not.toMatch(/key=\{index\}/)
+    }
+  })
+})

--- a/src/components/handover-template.tsx
+++ b/src/components/handover-template.tsx
@@ -65,7 +65,7 @@ export function HandoverTemplate({
     }
   }
 
-  const formatValue = (value: any) => {
+  const formatValue = (value: unknown) => {
     if (value === null || value === undefined || value === '') {
       return ''
     }
@@ -237,7 +237,7 @@ export function HandoverTemplate({
         </div>
       </div>
 
-      <style jsx>{`
+      <style>{`
         .a4-landscape-page {
           width: 29.7cm;
           min-height: 21cm;

--- a/src/components/log-template.tsx
+++ b/src/components/log-template.tsx
@@ -197,7 +197,7 @@ export function LogTemplate({
         </div>
       </div>
 
-      <style jsx>{`
+      <style>{`
         .a4-page {
           width: 21cm;
           min-height: 29.7cm;

--- a/src/components/maintenance-form.tsx
+++ b/src/components/maintenance-form.tsx
@@ -32,7 +32,7 @@ export function MaintenanceForm({
   devices = EMPTY_DEVICES,
   tenantId = null
 }: MaintenanceFormProps) {
-  const formatValue = (value: any) => {
+  const formatValue = (value: unknown) => {
     if (value === null || value === undefined || value === '') {
       return ''
     }
@@ -201,7 +201,7 @@ export function MaintenanceForm({
         </div>
       </div>
 
-      <style jsx>{`
+      <style>{`
         .a4-landscape-page {
           width: 29.7cm;
           min-height: 21cm;

--- a/src/components/qr-scanner-camera.tsx
+++ b/src/components/qr-scanner-camera.tsx
@@ -5,20 +5,19 @@ import { X, Camera, Flashlight, FlashlightOff, RotateCcw, HelpCircle, ArrowLeft 
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
 import { useToast } from "@/hooks/use-toast"
 import jsQR from "jsqr"
+
+import { QRScannerInstructionsDialog } from "./qr-scanner-instructions-dialog"
 
 interface QRScannerCameraProps {
   onScanSuccess: (result: string) => void
   onClose: () => void
   isActive: boolean
+}
+
+type TorchMediaTrackConstraintSet = MediaTrackConstraintSet & {
+  torch: boolean
 }
 
 export function QRScannerCamera({ onScanSuccess, onClose, isActive }: QRScannerCameraProps) {
@@ -154,10 +153,11 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
       const capabilities = track.getCapabilities()
       setHasFlash('torch' in capabilities)
 
-    } catch (error: any) {
+    } catch (error) {
       let errorMessage = "Không thể truy cập camera"
+      const errorName = error instanceof Error ? error.name : ""
       
-      if (error.name === 'NotAllowedError') {
+      if (errorName === 'NotAllowedError') {
         errorMessage = `❌ Quyền truy cập camera bị từ chối
 
 🔧 Cách khắc phục:
@@ -168,15 +168,15 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
 📱 Trên mobile:
 • Vào Settings → Site Settings → Camera
 • Cho phép truy cập camera cho trang này`
-      } else if (error.name === 'NotFoundError') {
+      } else if (errorName === 'NotFoundError') {
         errorMessage = "❌ Không tìm thấy camera nào\n\n🔧 Vui lòng kiểm tra:\n• Camera có được kết nối không\n• Driver camera đã cài đặt chưa"
-      } else if (error.name === 'NotSupportedError') {
+      } else if (errorName === 'NotSupportedError') {
         errorMessage = "❌ Trình duyệt không hỗ trợ camera\n\n🔧 Vui lòng:\n• Sử dụng Chrome, Firefox, Safari hoặc Edge\n• Cập nhật trình duyệt lên phiên bản mới"
-      } else if (error.name === 'NotReadableError') {
+      } else if (errorName === 'NotReadableError') {
         errorMessage = "❌ Camera đang được sử dụng\n\n🔧 Vui lòng:\n• Đóng các ứng dụng khác đang dùng camera\n• Thử lại sau"
-      } else if (error.name === 'SecurityError') {
+      } else if (errorName === 'SecurityError') {
         errorMessage = "❌ Lỗi bảo mật\n\nCamera chỉ hoạt động trên:\n• HTTPS\n• localhost\n• 127.0.0.1"
-      } else if (error.name === 'OverconstrainedError') {
+      } else if (errorName === 'OverconstrainedError') {
         errorMessage = "❌ Thiết lập camera không phù hợp\n\nThử lại với camera khác"
       }
       
@@ -203,9 +203,13 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
     
     try {
       const track = streamRef.current.getVideoTracks()[0]
-      await track.applyConstraints({
-        advanced: [{ torch: !isFlashOn } as any]
-      })
+      const torchConstraints: MediaTrackConstraints & {
+        advanced: TorchMediaTrackConstraintSet[]
+      } = {
+        advanced: [{ torch: !isFlashOn }],
+      }
+
+      await track.applyConstraints(torchConstraints)
       setIsFlashOn(!isFlashOn)
       toast({
         title: isFlashOn ? "Đã tắt đèn flash" : "Đã bật đèn flash",
@@ -418,63 +422,13 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
         </div>
       </div>
 
-      {/* Instructions Dialog */}
-      <Dialog open={showInstructions} onOpenChange={setShowInstructions}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Camera className="h-5 w-5" />
-              Hướng dẫn quét mã QR
-            </DialogTitle>
-            <DialogDescription>
-              Làm theo các bước sau để quét mã QR thiết bị
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="space-y-3">
-              <div className="flex items-start gap-3">
-                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
-                  1
-                </div>
-                <p className="text-sm">Đưa mã QR vào khung quét trên màn hình</p>
-              </div>
-              <div className="flex items-start gap-3">
-                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
-                  2
-                </div>
-                <p className="text-sm">Giữ camera ổn định, cách mã QR khoảng 15-20cm</p>
-              </div>
-              <div className="flex items-start gap-3">
-                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
-                  3
-                </div>
-                <p className="text-sm">Chờ hệ thống tự động nhận diện mã</p>
-              </div>
-              <div className="flex items-start gap-3">
-                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
-                  4
-                </div>
-                <p className="text-sm">Chọn hành động muốn thực hiện với thiết bị</p>
-              </div>
-            </div>
-            <div className="rounded-lg bg-muted p-3">
-              <p className="text-xs text-muted-foreground">
-                <strong>Mẹo:</strong> Đảm bảo mã QR không bị nhăn, mờ hoặc che khuất.
-                Nếu quét không thành công, thử điều chỉnh khoảng cách hoặc góc quét.
-              </p>
-            </div>
-            <Button
-              onClick={() => setShowInstructions(false)}
-              className="w-full"
-            >
-              Đã hiểu
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <QRScannerInstructionsDialog
+        open={showInstructions}
+        onOpenChange={setShowInstructions}
+      />
 
       {/* CSS for scanning animation */}
-      <style jsx>{`
+      <style>{`
         @keyframes scan {
           0% { top: 0; }
           50% { top: 100%; }

--- a/src/components/qr-scanner-instructions-dialog.tsx
+++ b/src/components/qr-scanner-instructions-dialog.tsx
@@ -12,8 +12,8 @@ import {
 } from "@/components/ui/dialog"
 
 interface QRScannerInstructionsDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
 }
 
 const INSTRUCTION_STEPS = [

--- a/src/components/qr-scanner-instructions-dialog.tsx
+++ b/src/components/qr-scanner-instructions-dialog.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { Camera } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface QRScannerInstructionsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const INSTRUCTION_STEPS = [
+  "Đưa mã QR vào khung quét trên màn hình",
+  "Giữ camera ổn định, cách mã QR khoảng 15-20cm",
+  "Chờ hệ thống tự động nhận diện mã",
+  "Chọn hành động muốn thực hiện với thiết bị",
+] as const
+
+export function QRScannerInstructionsDialog({
+  open,
+  onOpenChange,
+}: QRScannerInstructionsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Camera className="h-5 w-5" />
+            Hướng dẫn quét mã QR
+          </DialogTitle>
+          <DialogDescription>
+            Làm theo các bước sau để quét mã QR thiết bị
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-3">
+            {INSTRUCTION_STEPS.map((step, index) => (
+              <div key={step} className="flex items-start gap-3">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
+                  {index + 1}
+                </div>
+                <p className="text-sm">{step}</p>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-lg bg-muted p-3">
+            <p className="text-xs text-muted-foreground">
+              <strong>Mẹo:</strong> Đảm bảo mã QR không bị nhăn, mờ hoặc che
+              khuất. Nếu quét không thành công, thử điều chỉnh khoảng cách hoặc
+              góc quét.
+            </p>
+          </div>
+          <Button onClick={() => onOpenChange(false)} className="w-full">
+            Đã hiểu
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- Add Equipment page Suspense boundary for `useSearchParams` bailout safety
- Remove duplicate repair-complete dialog export and lock assistant list keys to stable values
- Remove styled-jsx-only `jsx` props from plain style tags and extract QR scanner instructions to keep the touched file under the hard line ceiling
- Add source/characterization tests for the React Doctor P0 mutation invalidation audit

Fixes #453

## Verification
- `node scripts/npm-run.js run test:run -- src/app/(app)/equipment/__tests__/EquipmentPage.suspense.test.tsx src/app/(app)/repair-requests/__tests__/RepairRequestsCompleteDialog.exports.test.ts src/components/assistant/__tests__/assistant-stable-keys.source.test.ts src/__tests__/react-doctor-p0-style-jsx.source.test.ts src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts src/components/assistant/__tests__/AssistantDraftCard.test.tsx src/components/assistant/__tests__/AssistantThinkingIndicator.test.tsx src/app/(app)/repair-requests/__tests__/RepairRequestsCompleteDialog.test.tsx src/app/(app)/device-quota/dashboard/_components/__tests__/DeviceQuotaComplianceReport.test.tsx src/app/(app)/qr-scanner/__tests__/qr-scanner-no-legacy-dialog.test.tsx`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose --yes --project nextn --offline --diff main`

React Doctor diff summary: #453 P0 rules are not found (`query-mutation-missing-invalidation`, `nextjs-no-use-search-params-without-suspense`, `knip/duplicates`, `react/no-unknown-property`, `no-array-index-as-key`). Remaining diff warnings are out-of-scope P1/P2 design/a11y/giant-component cleanup already tracked by #462.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes React Doctor P0 correctness issues to satisfy #453 and clear all P0 findings. Adds an Equipment page Suspense boundary, duplicate-safe list keys, DOM prop cleanup, and an extracted QR scanner instructions dialog; expands tests to lock mutation invalidation and UI correctness.

- **Bug Fixes**
  - Equipment: wrap `EquipmentPageClient` in `React.Suspense` with a skeleton fallback; add test coverage for the Suspense fallback.
  - Assistant: replace index keys with stable, duplicate-safe keys in draft cards; use named IDs for thinking dots.
  - Repair Requests: remove the deprecated export alias; keep only `RepairRequestsCompleteDialog`.
  - DOM: replace `<style jsx>` with `<style>` in QR/print templates (`handover-template`, `maintenance-form`, `log-template`) and the device-quota report.
  - QR Scanner: extract instructions to `QRScannerInstructionsDialog`; tighten torch constraint typing and improve media error handling.
  - Types: change `formatValue` param types to `unknown` in `handover-template` and `maintenance-form`.
  - Tests: add source/behavior tests for mutation invalidation, DOM prop correctness, stable keys (dot and draft lists), single export, and Equipment Suspense; `react-doctor` reports no P0 issues (`query-mutation-missing-invalidation`, `nextjs-no-use-search-params-without-suspense`, `react/no-unknown-property`, `no-array-index-as-key`, `knip/duplicates`).

<sup>Written for commit 7ba150088e7533c8eeb90676da44af23ba011410. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a QR scanner instructions dialog.

* **Improvements**
  * Equipment page shows a skeleton while loading (Suspense).
  * More stable list rendering in assistant UI (content-derived keys).
  * Improved QR scanner error handling and user feedback.
  * Converted several components’ inline CSS to plain style tags and tightened some internal typings.

* **Code Cleanup**
  * Removed a deprecated export alias.

* **Tests**
  * Added tests for UI keys, DOM/style correctness, suspense fallback, exports, and mutation invalidation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/463)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->