### PR TITLE
fix: address React Doctor P1 hydration audit

### DIFF
--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialog.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialog.tsx
@@ -10,7 +10,6 @@
 import * as React from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import { z } from "zod"
 import { format } from "date-fns"
 import { Calendar as CalendarIcon, Loader2 } from "lucide-react"
 
@@ -36,66 +35,14 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
+import { useHydrationSafeNow } from "@/components/time/HydrationSafeRelativeTime"
 
 import { useDeviceQuotaDecisionsContext } from "../_hooks/useDeviceQuotaDecisionsContext"
-
-// ============================================
-// Helpers
-// ============================================
-
-/**
- * Parse a YYYY-MM-DD date string as a local date (not UTC).
- * Using new Date("2024-01-15") parses as UTC midnight, which can shift
- * the day in non-UTC timezones. This function creates a local date.
- */
-function parseLocalDate(dateString: string): Date {
-  const [year, month, day] = dateString.split("-").map(Number)
-  return new Date(year, month - 1, day)
-}
-
-// ============================================
-// Validation Schema
-// ============================================
-
-const decisionFormSchema = z.object({
-  so_quyet_dinh: z.string().min(1, "Số quyết định không được để trống"),
-  ngay_ban_hanh: z.date({
-    required_error: "Vui lòng chọn ngày ban hành",
-  }),
-  ngay_hieu_luc: z.date({
-    required_error: "Vui lòng chọn ngày hiệu lực",
-  }),
-  ngay_het_hieu_luc: z.date().optional().nullable(),
-  nguoi_ky: z.string().min(1, "Người ký không được để trống"),
-  chuc_vu_nguoi_ky: z.string().min(1, "Chức vụ người ký không được để trống"),
-  ghi_chu: z.string().optional().nullable(),
-}).refine(
-  (data) => {
-    // Validate ngay_hieu_luc >= ngay_ban_hanh
-    if (data.ngay_hieu_luc && data.ngay_ban_hanh) {
-      return data.ngay_hieu_luc >= data.ngay_ban_hanh
-    }
-    return true
-  },
-  {
-    message: "Ngày hiệu lực phải sau hoặc bằng ngày ban hành",
-    path: ["ngay_hieu_luc"],
-  }
-).refine(
-  (data) => {
-    // Validate ngay_het_hieu_luc > ngay_hieu_luc
-    if (data.ngay_het_hieu_luc && data.ngay_hieu_luc) {
-      return data.ngay_het_hieu_luc > data.ngay_hieu_luc
-    }
-    return true
-  },
-  {
-    message: "Ngày hết hiệu lực phải sau ngày hiệu lực",
-    path: ["ngay_het_hieu_luc"],
-  }
-)
-
-type DecisionFormValues = z.infer<typeof decisionFormSchema>
+import {
+  decisionFormSchema,
+  parseLocalDate,
+  type DecisionFormValues,
+} from "./DeviceQuotaDecisionDialogSchema"
 
 // ============================================
 // Component
@@ -113,6 +60,7 @@ export function DeviceQuotaDecisionDialog() {
 
   const isOpen = isCreateDialogOpen || isEditDialogOpen
   const isEditMode = isEditDialogOpen && !!selectedDecision
+  const now = useHydrationSafeNow()
 
   // Form initialization
   const form = useForm<DecisionFormValues>({
@@ -271,7 +219,7 @@ export function DeviceQuotaDecisionDialog() {
                         mode="single"
                         selected={field.value}
                         onSelect={field.onChange}
-                        disabled={(date) => date > new Date()}
+                        disabled={(date) => now !== null && date.getTime() > now}
                         initialFocus
                       />
                     </PopoverContent>

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialogSchema.ts
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialogSchema.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+
+/**
+ * Parse a YYYY-MM-DD date string as a local date (not UTC).
+ * Using new Date("2024-01-15") parses as UTC midnight, which can shift
+ * the day in non-UTC timezones. This function creates a local date.
+ */
+export function parseLocalDate(dateString: string): Date {
+  const [year, month, day] = dateString.split("-").map(Number)
+  return new Date(year, month - 1, day)
+}
+
+export const decisionFormSchema = z.object({
+  so_quyet_dinh: z.string().min(1, "Số quyết định không được để trống"),
+  ngay_ban_hanh: z.date({
+    required_error: "Vui lòng chọn ngày ban hành",
+  }),
+  ngay_hieu_luc: z.date({
+    required_error: "Vui lòng chọn ngày hiệu lực",
+  }),
+  ngay_het_hieu_luc: z.date().optional().nullable(),
+  nguoi_ky: z.string().min(1, "Người ký không được để trống"),
+  chuc_vu_nguoi_ky: z.string().min(1, "Chức vụ người ký không được để trống"),
+  ghi_chu: z.string().optional().nullable(),
+}).refine(
+  (data) => {
+    if (data.ngay_hieu_luc && data.ngay_ban_hanh) {
+      return data.ngay_hieu_luc >= data.ngay_ban_hanh
+    }
+    return true
+  },
+  {
+    message: "Ngày hiệu lực phải sau hoặc bằng ngày ban hành",
+    path: ["ngay_hieu_luc"],
+  }
+).refine(
+  (data) => {
+    if (data.ngay_het_hieu_luc && data.ngay_hieu_luc) {
+      return data.ngay_het_hieu_luc > data.ngay_hieu_luc
+    }
+    return true
+  },
+  {
+    message: "Ngày hết hiệu lực phải sau ngày hiệu lực",
+    path: ["ngay_het_hieu_luc"],
+  }
+)
+
+export type DecisionFormValues = z.infer<typeof decisionFormSchema>

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialogSchema.ts
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialogSchema.ts
@@ -7,7 +7,28 @@ import { z } from "zod"
  */
 export function parseLocalDate(dateString: string): Date {
   const [year, month, day] = dateString.split("-").map(Number)
-  return new Date(year, month - 1, day)
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31
+  ) {
+    return new Date(Number.NaN)
+  }
+
+  const date = new Date(year, month - 1, day)
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() + 1 !== month ||
+    date.getDate() !== day
+  ) {
+    return new Date(Number.NaN)
+  }
+
+  return date
 }
 
 export const decisionFormSchema = z.object({

--- a/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionDialogSchema.test.ts
+++ b/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionDialogSchema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { parseLocalDate } from "../DeviceQuotaDecisionDialogSchema"
+import { parseLocalDate } from "@/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialogSchema"
 
 describe("parseLocalDate", () => {
   it("keeps valid local dates on the requested calendar day", () => {

--- a/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionDialogSchema.test.ts
+++ b/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionDialogSchema.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import { parseLocalDate } from "../DeviceQuotaDecisionDialogSchema"
+
+describe("parseLocalDate", () => {
+  it("keeps valid local dates on the requested calendar day", () => {
+    const date = parseLocalDate("2026-02-28")
+
+    expect(date.getFullYear()).toBe(2026)
+    expect(date.getMonth()).toBe(1)
+    expect(date.getDate()).toBe(28)
+  })
+
+  it("rejects invalid calendar dates instead of normalizing them", () => {
+    const date = parseLocalDate("2026-02-31")
+
+    expect(Number.isNaN(date.getTime())).toBe(true)
+  })
+})

--- a/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaMappingGuide.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaMappingGuide.test.tsx
@@ -11,7 +11,7 @@ import { DeviceQuotaMappingGuide } from '../_components/DeviceQuotaMappingGuide'
 
 const localStorageMock = (() => {
     let store: Record<string, string> = {}
-    return {
+    const api = {
         getItem: vi.fn((key: string) => store[key] ?? null),
         setItem: vi.fn((key: string, value: string) => {
             store[key] = value
@@ -19,7 +19,14 @@ const localStorageMock = (() => {
         clear: () => {
             store = {}
         },
+        resetMocks: () => {
+            api.getItem.mockImplementation((key: string) => store[key] ?? null)
+            api.setItem.mockImplementation((key: string, value: string) => {
+                store[key] = value
+            })
+        },
     }
+    return api
 })()
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock })
@@ -31,6 +38,7 @@ Object.defineProperty(window, 'localStorage', { value: localStorageMock })
 describe('DeviceQuotaMappingGuide', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        localStorageMock.resetMocks()
         localStorageMock.clear()
     })
 
@@ -80,5 +88,25 @@ describe('DeviceQuotaMappingGuide', () => {
         await waitFor(() => {
             expect(screen.queryByText(/Hướng dẫn phân loại thủ công/)).not.toBeInTheDocument()
         })
+    })
+
+    it('does not crash when localStorage reads are blocked', () => {
+        localStorageMock.getItem.mockImplementation(() => {
+            throw new Error('Storage disabled')
+        })
+
+        expect(() => render(<DeviceQuotaMappingGuide />)).not.toThrow()
+        expect(screen.queryByText(/Hướng dẫn phân loại thủ công/)).not.toBeInTheDocument()
+    })
+
+    it('does not crash when localStorage writes are blocked', async () => {
+        localStorageMock.setItem.mockImplementationOnce(() => {
+            throw new Error('Storage disabled')
+        })
+        render(<DeviceQuotaMappingGuide />)
+
+        const dismissButton = await screen.findByRole('button', { name: /đã hiểu/i })
+
+        expect(() => fireEvent.click(dismissButton)).not.toThrow()
     })
 })

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingGuide.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingGuide.tsx
@@ -5,29 +5,55 @@ import { Lightbulb, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
 const STORAGE_KEY = "mapping-guide-dismissed"
+const storageListeners = new Set<() => void>()
+
+function subscribeToDismissedState(onStoreChange: () => void) {
+    if (typeof window === "undefined") return () => {}
+
+    storageListeners.add(onStoreChange)
+    const handleStorage = (event: StorageEvent) => {
+        if (event.key === STORAGE_KEY) onStoreChange()
+    }
+    window.addEventListener("storage", handleStorage)
+
+    return () => {
+        storageListeners.delete(onStoreChange)
+        window.removeEventListener("storage", handleStorage)
+    }
+}
+
+function getDismissedSnapshot() {
+    if (typeof window === "undefined") return true
+    return localStorage.getItem(STORAGE_KEY) === "true"
+}
+
+function getServerDismissedSnapshot() {
+    return true
+}
+
+function notifyDismissedStateChange() {
+    storageListeners.forEach((listener) => listener())
+}
 
 /**
  * Dismissable 3-step guide teaching users how to map devices manually.
  * Persists dismissal via localStorage so it only appears once per user.
  *
- * Uses `null` as the initial state (not yet hydrated) to avoid both SSR
- * hydration mismatch and the first-paint flash for previously-dismissed users.
- * The component renders nothing until after mount, at which point it reads
- * localStorage and either shows or permanently hides the guide.
+ * Renders nothing on the server, then reads localStorage via useSyncExternalStore
+ * on the client so the first hydrated snapshot stays deterministic.
  */
 export function DeviceQuotaMappingGuide() {
-    // null = not yet hydrated; false = show guide; true = dismissed
-    const [dismissed, setDismissed] = React.useState<boolean | null>(null)
+    const dismissed = React.useSyncExternalStore(
+        subscribeToDismissedState,
+        getDismissedSnapshot,
+        getServerDismissedSnapshot
+    )
 
-    React.useEffect(() => {
-        setDismissed(localStorage.getItem(STORAGE_KEY) === "true")
-    }, [])
-
-    if (dismissed === null || dismissed) return null
+    if (dismissed) return null
 
     const handleDismiss = () => {
         localStorage.setItem(STORAGE_KEY, "true")
-        setDismissed(true)
+        notifyDismissedStateChange()
     }
 
     return (
@@ -61,7 +87,7 @@ export function DeviceQuotaMappingGuide() {
                     </ol>
 
                     <p className="text-xs text-blue-600 dark:text-blue-400 italic">
-                        Nút &quot;Gợi ý phân loại&quot; sử dụng AI và tốn nhiều tài nguyên server — chỉ dùng khi cần thiết.
+                        Nút &quot;Gợi ý phân loại&quot; sử dụng AI và tốn nhiều tài nguyên server, chỉ dùng khi cần thiết.
                     </p>
                 </div>
 

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingGuide.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingGuide.tsx
@@ -8,23 +8,27 @@ const STORAGE_KEY = "mapping-guide-dismissed"
 const storageListeners = new Set<() => void>()
 
 function subscribeToDismissedState(onStoreChange: () => void) {
-    if (typeof window === "undefined") return () => {}
+    if (typeof globalThis.window === "undefined") return () => {}
 
     storageListeners.add(onStoreChange)
     const handleStorage = (event: StorageEvent) => {
         if (event.key === STORAGE_KEY) onStoreChange()
     }
-    window.addEventListener("storage", handleStorage)
+    globalThis.window.addEventListener("storage", handleStorage)
 
     return () => {
         storageListeners.delete(onStoreChange)
-        window.removeEventListener("storage", handleStorage)
+        globalThis.window.removeEventListener("storage", handleStorage)
     }
 }
 
 function getDismissedSnapshot() {
-    if (typeof window === "undefined") return true
-    return localStorage.getItem(STORAGE_KEY) === "true"
+    if (typeof globalThis.window === "undefined") return true
+    try {
+        return globalThis.window.localStorage.getItem(STORAGE_KEY) === "true"
+    } catch {
+        return true
+    }
 }
 
 function getServerDismissedSnapshot() {
@@ -52,7 +56,11 @@ export function DeviceQuotaMappingGuide() {
     if (dismissed) return null
 
     const handleDismiss = () => {
-        localStorage.setItem(STORAGE_KEY, "true")
+        try {
+            globalThis.window.localStorage.setItem(STORAGE_KEY, "true")
+        } catch {
+            return
+        }
         notifyDismissedStateChange()
     }
 

--- a/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { parseISO, format } from "date-fns"
+import { parseISO, format, startOfDay } from "date-fns"
 import { Button } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
 import {
@@ -134,10 +134,10 @@ export function RepairRequestsEditDialog() {
                   onSelect={setDesiredDate}
                   initialFocus
                   disabled={(date) => {
-                    const requestDate = requestToEdit?.ngay_yeu_cau
-                      ? new Date(requestToEdit.ngay_yeu_cau)
-                      : new Date()
-                    return date < new Date(requestDate.setHours(0, 0, 0, 0))
+                    const requestTimestamp = Date.parse(requestToEdit.ngay_yeu_cau)
+                    return Number.isFinite(requestTimestamp)
+                      ? date.getTime() < startOfDay(requestTimestamp).getTime()
+                      : false
                   }}
                 />
               </PopoverContent>

--- a/src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/export-report-dialog.test.tsx
@@ -17,6 +17,13 @@ vi.mock('@/lib/excel-utils', () => ({
 
 import { ExportReportDialog } from '../export-report-dialog'
 
+function createJanuaryDateRange() {
+  return {
+    from: new Date('2026-01-01T00:00:00.000Z'),
+    to: new Date('2026-01-31T00:00:00.000Z'),
+  }
+}
+
 describe('ExportReportDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -64,10 +71,7 @@ describe('ExportReportDialog', () => {
           currentStock: 1,
           netChange: 1,
         }}
-        dateRange={{
-          from: new Date('2026-01-01T00:00:00.000Z'),
-          to: new Date('2026-01-31T00:00:00.000Z'),
-        }}
+        dateRange={createJanuaryDateRange()}
         department="all"
       />
     )
@@ -142,10 +146,7 @@ describe('ExportReportDialog', () => {
           currentStock: 1,
           netChange: 1,
         }}
-        dateRange={{
-          from: new Date('2026-01-01T00:00:00.000Z'),
-          to: new Date('2026-01-31T00:00:00.000Z'),
-        }}
+        dateRange={createJanuaryDateRange()}
         department="all"
       />
     )
@@ -180,10 +181,7 @@ describe('ExportReportDialog', () => {
           currentStock: 10,
           netChange: 0,
         }}
-        dateRange={{
-          from: new Date('2026-01-01T00:00:00.000Z'),
-          to: new Date('2026-01-31T00:00:00.000Z'),
-        }}
+        dateRange={createJanuaryDateRange()}
         department="all"
         distribution={{
           totalEquipment: 10,
@@ -263,10 +261,7 @@ describe('ExportReportDialog', () => {
           currentStock: 0,
           netChange: 0,
         }}
-        dateRange={{
-          from: new Date('2026-01-01T00:00:00.000Z'),
-          to: new Date('2026-01-31T00:00:00.000Z'),
-        }}
+        dateRange={createJanuaryDateRange()}
         department="all"
         maintenanceStats={{
           repair_summary: {

--- a/src/components/__tests__/usage-history-tab.utils.test.ts
+++ b/src/components/__tests__/usage-history-tab.utils.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   formatUsageDuration,
   getUsageLogPageSignature,
-} from "../usage-history-tab.utils"
+} from "@/components/usage-history-tab.utils"
 import type { UsageLog } from "@/types/database"
 
 function createUsageLog(overrides: Partial<UsageLog>): UsageLog {

--- a/src/components/__tests__/usage-history-tab.utils.test.ts
+++ b/src/components/__tests__/usage-history-tab.utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  formatUsageDuration,
+  getUsageLogPageSignature,
+} from "../usage-history-tab.utils"
+import type { UsageLog } from "@/types/database"
+
+function createUsageLog(overrides: Partial<UsageLog>): UsageLog {
+  return {
+    id: 1,
+    thiet_bi_id: 1,
+    thoi_gian_bat_dau: "2026-05-13T00:00:00Z",
+    trang_thai: "hoan_thanh",
+    created_at: "2026-05-13T00:00:00Z",
+    updated_at: "2026-05-13T00:00:00Z",
+    ...overrides,
+  }
+}
+
+describe("usage history utilities", () => {
+  it("keeps page signatures distinct when text fields contain delimiters", () => {
+    const first = getUsageLogPageSignature([
+      createUsageLog({
+        updated_at: "u",
+        ghi_chu: "note",
+      }),
+      createUsageLog({
+        id: 2,
+        updated_at: "u",
+      }),
+    ])
+    const second = getUsageLogPageSignature([
+      createUsageLog({
+        updated_at: "u",
+        ghi_chu: "note|2:u:hoan_thanh:::::",
+      }),
+    ])
+
+    expect(first).not.toBe(second)
+  })
+
+  it("returns a zero duration for invalid timestamps", () => {
+    expect(formatUsageDuration("not-a-date", undefined, Date.parse("2026-05-13T00:10:00Z"))).toBe("0m")
+  })
+})

--- a/src/components/activity-logs/activity-log-entry.tsx
+++ b/src/components/activity-logs/activity-log-entry.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { Clock, MapPin } from "lucide-react"
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Badge } from "@/components/ui/badge"
+import { HydrationSafeRelativeTime } from "@/components/time/HydrationSafeRelativeTime"
+import { formatVietnamDateTime } from "@/lib/date-utils"
+import {
+  type AuditLogEntry as AuditLogEntryData,
+  formatActionDetails,
+  getActionTypeLabel,
+} from "@/hooks/use-audit-logs"
+
+interface ActivityLogEntryProps {
+  log: AuditLogEntryData
+}
+
+function getActionTypeColor(actionType: string) {
+  if (actionType.includes("create")) return "bg-green-100 text-green-800"
+  if (actionType.includes("update")) return "bg-blue-100 text-blue-800"
+  if (actionType.includes("delete")) return "bg-red-100 text-red-800"
+  if (actionType.includes("approve")) return "bg-purple-100 text-purple-800"
+  if (actionType.includes("password")) return "bg-orange-100 text-orange-800"
+  return "bg-gray-100 text-gray-800"
+}
+
+function getInitials(log: AuditLogEntryData) {
+  return log.admin_full_name
+    ? log.admin_full_name.split(" ").map((name) => name[0]).join("").substring(0, 2)
+    : log.admin_username.substring(0, 2).toUpperCase()
+}
+
+export function ActivityLogEntry({ log }: ActivityLogEntryProps) {
+  const actionLabel = getActionTypeLabel(log.action_type)
+  const actionDetails = formatActionDetails(log.action_type, log.action_details)
+
+  return (
+    <div className="flex items-start space-x-4 p-4 border rounded-lg hover:bg-gray-50 transition-colors">
+      <Avatar className="h-10 w-10">
+        <AvatarFallback>{getInitials(log)}</AvatarFallback>
+      </Avatar>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between">
+          <div className="flex-1">
+            <div className="flex items-center space-x-2 mb-1">
+              <p className="font-medium text-gray-900 truncate">
+                {log.admin_full_name || log.admin_username}
+              </p>
+              <Badge
+                variant="secondary"
+                className={`text-xs ${getActionTypeColor(log.action_type)}`}
+              >
+                {actionLabel}
+              </Badge>
+            </div>
+
+            {log.target_user_id && log.target_user_id !== log.admin_user_id && (
+              <p className="text-sm text-gray-600 mb-1">
+                <span className="text-gray-500">Đối tượng:</span>{" "}
+                {log.target_full_name || log.target_username}
+              </p>
+            )}
+
+            {log.entity_label && (
+              <p className="text-sm text-gray-600 mb-1">
+                <span className="text-gray-500">Đối tượng:</span> {log.entity_label}
+              </p>
+            )}
+
+            {actionDetails && (
+              <p className="text-sm text-gray-600 mb-2">{actionDetails}</p>
+            )}
+
+            <div className="flex items-center space-x-4 text-xs text-gray-500">
+              <div className="flex items-center space-x-1">
+                <Clock className="h-3 w-3" />
+                <span>{formatVietnamDateTime(log.created_at)}</span>
+              </div>
+              {log.ip_address && (
+                <div className="flex items-center space-x-1">
+                  <MapPin className="h-3 w-3" />
+                  <span>{log.ip_address}</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="text-xs text-gray-500 text-right ml-4">
+            <HydrationSafeRelativeTime value={log.created_at} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/activity-logs/activity-logs-viewer.tsx
+++ b/src/components/activity-logs/activity-logs-viewer.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import React, { useState, useMemo } from 'react'
-import { format, formatDistanceToNow, startOfDay, endOfDay } from 'date-fns'
-import { vi } from 'date-fns/locale'
+import { startOfDay, endOfDay } from 'date-fns'
 import { 
   Activity, 
   Calendar, 
@@ -16,14 +15,12 @@ import {
   Eye,
   ChevronDown,
   Download,
-  MapPin
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import {
@@ -42,17 +39,17 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { DatePickerWithRange } from '@/components/ui/date-range-picker'
+import { HydrationSafeRelativeTime } from '@/components/time/HydrationSafeRelativeTime'
 
 import { 
   useAuditLogs, 
   useAuditLogsStats,
   useAuditLogsRecentSummary,
-  AuditLogEntry,
   AuditLogFilters,
   getActionTypeLabel,
-  formatActionDetails,
   ACTION_TYPE_LABELS
 } from '@/hooks/use-audit-logs'
+import { ActivityLogEntry } from './activity-log-entry'
 
 interface ActivityLogsViewerProps {
   className?: string
@@ -148,7 +145,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Hoạt động 24h</p>
                 <p className="text-2xl font-bold">
-                  {isSummaryLoading ? '...' : (summary?.total_activities || 0)}
+                  {isSummaryLoading ? '…' : (summary?.total_activities || 0)}
                 </p>
               </div>
             </div>
@@ -162,7 +159,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Người dùng hoạt động</p>
                 <p className="text-2xl font-bold">
-                  {isSummaryLoading ? '...' : (summary?.unique_users || 0)}
+                  {isSummaryLoading ? '…' : (summary?.unique_users || 0)}
                 </p>
               </div>
             </div>
@@ -176,7 +173,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Hoạt động phổ biến</p>
                 <p className="text-sm font-semibold truncate">
-                  {isSummaryLoading ? '...' : getActionTypeLabel(summary?.top_action_type || 'N/A')}
+                  {isSummaryLoading ? '…' : getActionTypeLabel(summary?.top_action_type || 'N/A')}
                 </p>
               </div>
             </div>
@@ -191,11 +188,8 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
                 <p className="text-sm font-medium text-gray-600">Hoạt động gần nhất</p>
                 <p className="text-sm font-semibold">
                   {isSummaryLoading || !summary?.latest_activity 
-                    ? '...' 
-                    : formatDistanceToNow(new Date(summary.latest_activity), { 
-                        addSuffix: true, 
-                        locale: vi 
-                      })
+                    ? '…'
+                    : <HydrationSafeRelativeTime value={summary.latest_activity} />
                   }
                 </p>
               </div>
@@ -231,7 +225,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
               <Input
-                placeholder="Tìm kiếm người dùng, hoạt động..."
+                placeholder="Tìm kiếm người dùng, hoạt động…"
                 value={searchTerm}
                 onChange={(e) => {
                   const v = e.target.value
@@ -246,7 +240,9 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
             <Select
               value={filters.entity_type || 'all'}
               onValueChange={(value) => updateFilters({ 
-                entity_type: (value === 'all' ? null : (value as any)) 
+                entity_type: value === 'all'
+                  ? null
+                  : value as NonNullable<AuditLogFilters['entity_type']>
               })}
             >
               <SelectTrigger>
@@ -346,7 +342,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
           ) : (
             <ScrollArea className="h-[600px]">
               <div className="space-y-1">
-                {filteredLogs.map((log, index) => (
+                {filteredLogs.map((log) => (
                   <ActivityLogEntry key={log.id} log={log} />
                 ))}
               </div>
@@ -381,105 +377,6 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
           )}
         </CardContent>
       </Card>
-    </div>
-  )
-}
-
-// Activity Log Entry Component
-interface ActivityLogEntryProps {
-  log: AuditLogEntry
-}
-
-function ActivityLogEntry({ log }: ActivityLogEntryProps) {
-  const actionLabel = getActionTypeLabel(log.action_type)
-  const actionDetails = formatActionDetails(log.action_type, log.action_details)
-  
-  // Get action type color
-  const getActionTypeColor = (actionType: string) => {
-    if (actionType.includes('create')) return 'bg-green-100 text-green-800'
-    if (actionType.includes('update')) return 'bg-blue-100 text-blue-800'
-    if (actionType.includes('delete')) return 'bg-red-100 text-red-800'
-    if (actionType.includes('approve')) return 'bg-purple-100 text-purple-800'
-    if (actionType.includes('password')) return 'bg-orange-100 text-orange-800'
-    return 'bg-gray-100 text-gray-800'
-  }
-
-  return (
-    <div className="flex items-start space-x-4 p-4 border rounded-lg hover:bg-gray-50 transition-colors">
-      {/* User Avatar */}
-      <Avatar className="h-10 w-10">
-        <AvatarFallback>
-          {log.admin_full_name
-            ? log.admin_full_name.split(' ').map(n => n[0]).join('').substring(0, 2)
-            : log.admin_username.substring(0, 2).toUpperCase()
-          }
-        </AvatarFallback>
-      </Avatar>
-
-      {/* Content */}
-      <div className="flex-1 min-w-0">
-        <div className="flex items-start justify-between">
-          <div className="flex-1">
-            {/* User and Action */}
-            <div className="flex items-center space-x-2 mb-1">
-              <p className="font-medium text-gray-900 truncate">
-                {log.admin_full_name || log.admin_username}
-              </p>
-              <Badge 
-                variant="secondary" 
-                className={`text-xs ${getActionTypeColor(log.action_type)}`}
-              >
-                {actionLabel}
-              </Badge>
-            </div>
-
-            {/* Target User (if applicable) */}
-            {log.target_user_id && log.target_user_id !== log.admin_user_id && (
-              <p className="text-sm text-gray-600 mb-1">
-                <span className="text-gray-500">Đối tượng:</span>{' '}
-                {log.target_full_name || log.target_username}
-              </p>
-            )}
-
-            {/* Entity Label */}
-            {log.entity_label && (
-              <p className="text-sm text-gray-600 mb-1">
-                <span className="text-gray-500">Đối tượng:</span>{' '}
-                {log.entity_label}
-              </p>
-            )}
-
-            {/* Action Details */}
-            {actionDetails && (
-              <p className="text-sm text-gray-600 mb-2">
-                {actionDetails}
-              </p>
-            )}
-
-            {/* Meta Information */}
-            <div className="flex items-center space-x-4 text-xs text-gray-500">
-              <div className="flex items-center space-x-1">
-                <Clock className="h-3 w-3" />
-                <span>{format(new Date(log.created_at), 'dd/MM/yyyy HH:mm', { locale: vi })}</span>
-              </div>
-              {log.ip_address && (
-                <div className="flex items-center space-x-1">
-                  <MapPin className="h-3 w-3" />
-                  <span>{log.ip_address}</span>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Timestamp (relative) */}
-          <div className="text-xs text-gray-500 text-right ml-4">
-            {formatDistanceToNow(new Date(log.created_at), { 
-              addSuffix: true, 
-              locale: vi 
-            })}
-          </div>
-        </div>
-      </div>
     </div>
   )
 }

--- a/src/components/end-usage-dialog.tsx
+++ b/src/components/end-usage-dialog.tsx
@@ -5,8 +5,6 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
 import { Loader2, Clock } from "lucide-react"
-import { format, differenceInMinutes } from "date-fns"
-import { vi } from "date-fns/locale"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -31,6 +29,8 @@ import { useEndUsageSession } from "@/hooks/use-usage-logs"
 import { useSession } from "next-auth/react"
 import { type SessionUser, type UsageLog } from "@/types/database"
 import { isRegionalLeaderRole } from "@/lib/rbac"
+import { formatVietnamDateTime } from "@/lib/date-utils"
+import { useHydrationSafeNow } from "@/components/time/HydrationSafeRelativeTime"
 
 const equipmentStatusOptions = [
   "Hoạt động",
@@ -63,6 +63,7 @@ export function EndUsageDialog({
   const user = session?.user as SessionUser | undefined
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
   const endUsageMutation = useEndUsageSession()
+  const now = useHydrationSafeNow()
 
   const form = useForm<EndUsageFormData>({
     resolver: zodResolver(endUsageSchema),
@@ -105,8 +106,8 @@ export function EndUsageDialog({
   const isLoading = endUsageMutation.isPending
 
   // Calculate usage duration
-  const usageDuration = usageLog 
-    ? differenceInMinutes(new Date(), new Date(usageLog.thoi_gian_bat_dau))
+  const usageDuration = usageLog && now !== null
+    ? Math.max(0, Math.floor((now - Date.parse(usageLog.thoi_gian_bat_dau)) / 60_000))
     : 0
 
   const formatDuration = (minutes: number) => {
@@ -143,12 +144,12 @@ export function EndUsageDialog({
               <div>
                 <p className="text-sm font-medium text-muted-foreground">Thời gian bắt đầu</p>
                 <p className="text-sm">
-                  {usageLog && format(new Date(usageLog.thoi_gian_bat_dau), "dd/MM/yyyy HH:mm", { locale: vi })}
+                  {usageLog && formatVietnamDateTime(usageLog.thoi_gian_bat_dau)}
                 </p>
               </div>
               <div>
                 <p className="text-sm font-medium text-muted-foreground">Thời gian kết thúc</p>
-                <p className="text-sm">{format(new Date(), "dd/MM/yyyy HH:mm", { locale: vi })}</p>
+                <p className="text-sm">{formatVietnamDateTime(now)}</p>
               </div>
               <div className="col-span-1 sm:col-span-2">
                 <p className="text-sm font-medium text-muted-foreground flex items-center gap-1">

--- a/src/components/end-usage-dialog.tsx
+++ b/src/components/end-usage-dialog.tsx
@@ -30,6 +30,7 @@ import { useSession } from "next-auth/react"
 import { type SessionUser, type UsageLog } from "@/types/database"
 import { isRegionalLeaderRole } from "@/lib/rbac"
 import { formatVietnamDateTime } from "@/lib/date-utils"
+import { calculateUsageDurationMinutes } from "@/lib/usage-duration"
 import { useHydrationSafeNow } from "@/components/time/HydrationSafeRelativeTime"
 
 const equipmentStatusOptions = [
@@ -107,7 +108,7 @@ export function EndUsageDialog({
 
   // Calculate usage duration
   const usageDuration = usageLog && now !== null
-    ? Math.max(0, Math.floor((now - Date.parse(usageLog.thoi_gian_bat_dau)) / 60_000))
+    ? calculateUsageDurationMinutes(usageLog.thoi_gian_bat_dau, now)
     : 0
 
   const formatDuration = (minutes: number) => {

--- a/src/components/mobile-usage-actions.tsx
+++ b/src/components/mobile-usage-actions.tsx
@@ -2,8 +2,6 @@
 
 import React from "react"
 import { Play, Square, Clock, User } from "lucide-react"
-import { format, differenceInMinutes } from "date-fns"
-import { vi } from "date-fns/locale"
 
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -18,6 +16,9 @@ import {
 import { useActiveUsageLogs } from "@/hooks/use-usage-logs"
 import { useSession } from "next-auth/react"
 import { isRegionalLeaderRole } from "@/lib/rbac"
+import { formatVietnamDateTime } from "@/lib/date-utils"
+import { useHydrationSafeNow } from "@/components/time/HydrationSafeRelativeTime"
+import type { SessionUser } from "@/types/database"
 import { StartUsageDialog } from "./start-usage-dialog"
 import { EndUsageDialog } from "./end-usage-dialog"
 
@@ -36,10 +37,10 @@ interface MobileUsageActionsProps {
 
 export function MobileUsageActions({ equipment, className = "" }: MobileUsageActionsProps) {
   const { data: session } = useSession()
-  const user = session?.user as any
+  const user = session?.user as SessionUser | undefined
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
   const userId = React.useMemo(() => {
-    const uid = (user?.id as any)
+    const uid = user?.id
     const n = typeof uid === 'string' ? Number(uid) : uid
     return Number.isFinite(n) ? (n as number) : null
   }, [user?.id])
@@ -47,6 +48,7 @@ export function MobileUsageActions({ equipment, className = "" }: MobileUsageAct
   const [isStartDialogOpen, setIsStartDialogOpen] = React.useState(false)
   const [isEndDialogOpen, setIsEndDialogOpen] = React.useState(false)
   const [isSheetOpen, setIsSheetOpen] = React.useState(false)
+  const now = useHydrationSafeNow()
 
   // Find active usage session for this equipment
   const activeSession = activeUsageLogs?.find(
@@ -68,8 +70,8 @@ export function MobileUsageActions({ equipment, className = "" }: MobileUsageAct
     return `${mins}m`
   }
 
-  const usageDuration = activeSession 
-    ? differenceInMinutes(new Date(), new Date(activeSession.thoi_gian_bat_dau))
+  const usageDuration = activeSession && now !== null
+    ? Math.max(0, Math.floor((now - Date.parse(activeSession.thoi_gian_bat_dau)) / 60_000))
     : 0
 
   const handleStartUsage = () => {
@@ -143,7 +145,7 @@ export function MobileUsageActions({ equipment, className = "" }: MobileUsageAct
                     <div className="flex items-center gap-2">
                       <Clock className="h-4 w-4 text-green-600" />
                       <span className="text-green-700">
-                        Bắt đầu: {format(new Date(activeSession.thoi_gian_bat_dau), "HH:mm dd/MM/yyyy", { locale: vi })}
+                        Bắt đầu: {formatVietnamDateTime(activeSession.thoi_gian_bat_dau)}
                       </span>
                     </div>
                     

--- a/src/components/mobile-usage-actions.tsx
+++ b/src/components/mobile-usage-actions.tsx
@@ -16,6 +16,7 @@ import {
 import { useActiveUsageLogs } from "@/hooks/use-usage-logs"
 import { useSession } from "next-auth/react"
 import { isRegionalLeaderRole } from "@/lib/rbac"
+import { calculateUsageDurationMinutes } from "@/lib/usage-duration"
 import { formatVietnamDateTime } from "@/lib/date-utils"
 import { useHydrationSafeNow } from "@/components/time/HydrationSafeRelativeTime"
 import type { SessionUser } from "@/types/database"
@@ -71,7 +72,7 @@ export function MobileUsageActions({ equipment, className = "" }: MobileUsageAct
   }
 
   const usageDuration = activeSession && now !== null
-    ? Math.max(0, Math.floor((now - Date.parse(activeSession.thoi_gian_bat_dau)) / 60_000))
+    ? calculateUsageDurationMinutes(activeSession.thoi_gian_bat_dau, now)
     : 0
 
   const handleStartUsage = () => {

--- a/src/components/start-usage-dialog.tsx
+++ b/src/components/start-usage-dialog.tsx
@@ -5,8 +5,6 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import * as z from "zod"
 import { Loader2 } from "lucide-react"
-import { format } from "date-fns"
-import { vi } from "date-fns/locale"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -32,6 +30,8 @@ import { useStartUsageSession } from "@/hooks/use-usage-logs"
 import { useToast } from "@/hooks/use-toast"
 import type { Equipment as DbEquipment, SessionUser } from "@/types/database"
 import { isRegionalLeaderRole } from "@/lib/rbac"
+import { formatVietnamDateTime } from "@/lib/date-utils"
+import { useHydrationSafeNow } from "@/components/time/HydrationSafeRelativeTime"
 
 const equipmentStatusOptions = [
   "Hoạt động",
@@ -66,6 +66,7 @@ export function StartUsageDialog({
   const user = session?.user as SessionUser | undefined
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
   const { toast } = useToast()
+  const now = useHydrationSafeNow()
   const currentUserId = React.useMemo(() => {
     const rawId = user?.id
     if (typeof rawId === "number" && Number.isFinite(rawId)) {
@@ -153,7 +154,7 @@ export function StartUsageDialog({
               </div>
               <div className="col-span-1 sm:col-span-2">
                 <p className="text-sm font-medium text-muted-foreground">Thời gian bắt đầu</p>
-                <p className="text-sm">{format(new Date(), "dd/MM/yyyy HH:mm", { locale: vi })}</p>
+                <p className="text-sm">{formatVietnamDateTime(now)}</p>
               </div>
             </div>
 

--- a/src/components/time/HydrationSafeRelativeTime.tsx
+++ b/src/components/time/HydrationSafeRelativeTime.tsx
@@ -18,33 +18,42 @@ interface HydrationSafeRelativeTimeProps {
 function subscribeToClientTime(onStoreChange: () => void): () => void {
   if (typeof window === "undefined") return () => {}
 
-  queueMicrotask(onStoreChange)
-  const intervalId = window.setInterval(onStoreChange, 60_000)
+  const tick = () => {
+    onStoreChange()
+  }
+
+  queueMicrotask(tick)
+  const intervalId = window.setInterval(tick, 60_000)
   return () => window.clearInterval(intervalId)
 }
 
-function getClientTimeSnapshot(): boolean {
-  return typeof window !== "undefined"
+function getClientTimeSnapshot(): number {
+  return Math.floor(Date.now() / 60_000)
 }
 
-function getServerTimeSnapshot(): boolean {
-  return false
+function getServerTimeSnapshot(): null {
+  return null
 }
 
 export function useHydrationSafeNow(): number | null {
-  const isClientReady = React.useSyncExternalStore(
+  const minuteSnapshot = React.useSyncExternalStore(
     subscribeToClientTime,
     getClientTimeSnapshot,
     getServerTimeSnapshot
   )
 
-  return isClientReady ? Date.now() : null
+  return minuteSnapshot === null ? null : minuteSnapshot * 60_000
 }
 
 function getTimestamp(value: RelativeTimeValue): number | null {
   if (value === null || value === undefined || value === "") return null
 
-  const timestamp = value instanceof Date ? value.getTime() : Date.parse(String(value))
+  const timestamp =
+    typeof value === "number"
+      ? value
+      : value instanceof Date
+        ? value.getTime()
+        : Date.parse(String(value))
   return Number.isNaN(timestamp) ? null : timestamp
 }
 

--- a/src/components/time/HydrationSafeRelativeTime.tsx
+++ b/src/components/time/HydrationSafeRelativeTime.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { formatDistanceToNow } from "date-fns"
+import { vi } from "date-fns/locale"
+
+import { formatVietnamDateTime } from "@/lib/date-utils"
+
+type RelativeTimeValue = string | number | Date | null | undefined
+
+interface HydrationSafeRelativeTimeProps {
+  value: RelativeTimeValue
+  fallback?: string
+  addSuffix?: boolean
+  className?: string
+}
+
+function subscribeToClientTime(onStoreChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {}
+
+  queueMicrotask(onStoreChange)
+  const intervalId = window.setInterval(onStoreChange, 60_000)
+  return () => window.clearInterval(intervalId)
+}
+
+function getClientTimeSnapshot(): boolean {
+  return typeof window !== "undefined"
+}
+
+function getServerTimeSnapshot(): boolean {
+  return false
+}
+
+export function useHydrationSafeNow(): number | null {
+  const isClientReady = React.useSyncExternalStore(
+    subscribeToClientTime,
+    getClientTimeSnapshot,
+    getServerTimeSnapshot
+  )
+
+  return isClientReady ? Date.now() : null
+}
+
+function getTimestamp(value: RelativeTimeValue): number | null {
+  if (value === null || value === undefined || value === "") return null
+
+  const timestamp = value instanceof Date ? value.getTime() : Date.parse(String(value))
+  return Number.isNaN(timestamp) ? null : timestamp
+}
+
+export function HydrationSafeRelativeTime({
+  value,
+  fallback = "-",
+  addSuffix = true,
+  className,
+}: HydrationSafeRelativeTimeProps) {
+  const now = useHydrationSafeNow()
+  const timestamp = getTimestamp(value)
+
+  const label =
+    now !== null && timestamp !== null
+      ? formatDistanceToNow(timestamp, { addSuffix, locale: vi })
+      : formatVietnamDateTime(value, fallback)
+
+  return <span className={className}>{label}</span>
+}

--- a/src/components/time/HydrationSafeRelativeTime.tsx
+++ b/src/components/time/HydrationSafeRelativeTime.tsx
@@ -54,7 +54,7 @@ function getTimestamp(value: RelativeTimeValue): number | null {
       : value instanceof Date
         ? value.getTime()
         : Date.parse(String(value))
-  return Number.isNaN(timestamp) ? null : timestamp
+  return Number.isFinite(timestamp) ? timestamp : null
 }
 
 export function HydrationSafeRelativeTime({

--- a/src/components/time/__tests__/HydrationSafeRelativeTime.test.tsx
+++ b/src/components/time/__tests__/HydrationSafeRelativeTime.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { HydrationSafeRelativeTime } from '../HydrationSafeRelativeTime'
+import { HydrationSafeRelativeTime } from '@/components/time/HydrationSafeRelativeTime'
 
 describe('HydrationSafeRelativeTime', () => {
   beforeEach(() => {
@@ -46,6 +46,12 @@ describe('HydrationSafeRelativeTime', () => {
     render(<HydrationSafeRelativeTime value={Date.parse('2025-01-15T14:58:00.000Z')} />)
 
     expect(screen.getByText(/2 phút trước/)).toBeInTheDocument()
+  })
+
+  it('uses the fallback placeholder for non-finite numeric values', () => {
+    render(<HydrationSafeRelativeTime value={Infinity} fallback="-" />)
+
+    expect(screen.getByText('-')).toBeInTheDocument()
   })
 
   it('uses the fallback placeholder for invalid values', () => {

--- a/src/components/time/__tests__/HydrationSafeRelativeTime.test.tsx
+++ b/src/components/time/__tests__/HydrationSafeRelativeTime.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -28,6 +28,24 @@ describe('HydrationSafeRelativeTime', () => {
     render(<HydrationSafeRelativeTime value="2025-01-15T14:30:00.000Z" />)
 
     expect(screen.getByText(/phút/)).toBeInTheDocument()
+  })
+
+  it('refreshes the relative label when the minute tick advances', async () => {
+    render(<HydrationSafeRelativeTime value="2025-01-15T14:58:00.000Z" />)
+
+    expect(screen.getByText(/2 phút trước/)).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(screen.getByText(/3 phút trước/)).toBeInTheDocument()
+  })
+
+  it('accepts numeric millisecond timestamps', () => {
+    render(<HydrationSafeRelativeTime value={Date.parse('2025-01-15T14:58:00.000Z')} />)
+
+    expect(screen.getByText(/2 phút trước/)).toBeInTheDocument()
   })
 
   it('uses the fallback placeholder for invalid values', () => {

--- a/src/components/time/__tests__/HydrationSafeRelativeTime.test.tsx
+++ b/src/components/time/__tests__/HydrationSafeRelativeTime.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HydrationSafeRelativeTime } from '../HydrationSafeRelativeTime'
+
+describe('HydrationSafeRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-15T15:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders a deterministic absolute timestamp on the server', () => {
+    const html = renderToStaticMarkup(
+      <HydrationSafeRelativeTime value="2025-01-15T14:30:00.000Z" />
+    )
+
+    expect(html).toContain('15/01/2025 21:30')
+    expect(html).not.toContain('phút')
+  })
+
+  it('upgrades to relative time after the client subscribes', async () => {
+    render(<HydrationSafeRelativeTime value="2025-01-15T14:30:00.000Z" />)
+
+    expect(screen.getByText(/phút/)).toBeInTheDocument()
+  })
+
+  it('uses the fallback placeholder for invalid values', () => {
+    render(<HydrationSafeRelativeTime value={null} fallback="-" />)
+
+    expect(screen.getByText('-')).toBeInTheDocument()
+  })
+})

--- a/src/components/transfer-detail-overview.tsx
+++ b/src/components/transfer-detail-overview.tsx
@@ -11,6 +11,7 @@ import {
   TRANSFER_TYPES,
   type TransferRequest,
 } from "@/types/database"
+import { formatVietnamDate, formatVietnamDateTime } from "@/lib/date-utils"
 
 interface TransferDetailOverviewProps {
   transfer: TransferRequest
@@ -36,8 +37,7 @@ function getStatusVariant(status: string) {
 }
 
 function formatDateTime(dateString: string | null | undefined) {
-  if (!dateString) return "Chưa có"
-  return new Date(dateString).toLocaleString("vi-VN")
+  return formatVietnamDateTime(dateString, "Chưa có")
 }
 
 export function TransferDetailOverview({
@@ -154,7 +154,7 @@ export function TransferDetailOverview({
                   <span className="font-medium">Ngày dự kiến trả về:</span>
                 </div>
                 <p className="ml-6">
-                  {new Date(transfer.ngay_du_kien_tra).toLocaleDateString("vi-VN")}
+                  {formatVietnamDate(transfer.ngay_du_kien_tra)}
                 </p>
               </div>
             ) : null}

--- a/src/components/transfers/TransfersKanbanCard.tsx
+++ b/src/components/transfers/TransfersKanbanCard.tsx
@@ -3,8 +3,7 @@ import { ArrowRight } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import type { TransferListItem } from '@/types/transfers-data-grid'
-import { formatDistanceToNow } from 'date-fns'
-import { vi } from 'date-fns/locale'
+import { HydrationSafeRelativeTime } from '@/components/time/HydrationSafeRelativeTime'
 
 interface TransfersKanbanCardProps {
   transfer: TransferListItem
@@ -42,8 +41,8 @@ function getTypeLabel(type: string): string {
 
 function isOverdue(dateStr: string | null, currentDate: Date): boolean {
   if (!dateStr) return false
-  const dueDate = new Date(dateStr)
-  return dueDate < currentDate && dueDate.getTime() !== 0
+  const dueTime = Date.parse(dateStr)
+  return Number.isFinite(dueTime) && dueTime < currentDate.getTime() && dueTime !== 0
 }
 
 function TransfersKanbanCardComponent({
@@ -52,7 +51,7 @@ function TransfersKanbanCardComponent({
   actions,
   referenceDate,
 }: TransfersKanbanCardProps) {
-  const handleClick = React.useCallback(
+  const openTransferFromCard = React.useCallback(
     (e: React.MouseEvent) => {
       // Allow clicks on actions menu to propagate
       if ((e.target as HTMLElement).closest('[data-actions-menu]')) {
@@ -66,7 +65,7 @@ function TransfersKanbanCardComponent({
   return (
     <Card
       className="mb-2 cursor-pointer hover:shadow-md transition-shadow"
-      onClick={handleClick}
+      onClick={openTransferFromCard}
       role="article"
       aria-label={`Transfer ${transfer.ma_yeu_cau}`}
     >
@@ -102,10 +101,7 @@ function TransfersKanbanCardComponent({
         {/* Footer: Date + overdue badge */}
         <div className="flex items-center justify-between pt-2 border-t">
           <span className="text-xs text-muted-foreground">
-            {formatDistanceToNow(new Date(transfer.created_at), {
-              addSuffix: true,
-              locale: vi,
-            })}
+            <HydrationSafeRelativeTime value={transfer.created_at} />
           </span>
           {transfer.ngay_du_kien_tra && isOverdue(transfer.ngay_du_kien_tra, referenceDate) && (
             <Badge variant="destructive" className="text-xs h-5">
@@ -115,7 +111,7 @@ function TransfersKanbanCardComponent({
         </div>
 
         {/* Actions menu */}
-        <div onClick={(e) => e.stopPropagation()} data-actions-menu>
+        <div onClick={(e) => e.stopPropagation()} data-actions-menu role="presentation">
           {actions}
         </div>
       </CardContent>

--- a/src/components/transfers/__tests__/FilterModal.test.tsx
+++ b/src/components/transfers/__tests__/FilterModal.test.tsx
@@ -23,6 +23,10 @@ describe("FilterModal", () => {
   it("clears status and date range filters from the modal controls", async () => {
     const onChange = vi.fn()
     const user = userEvent.setup()
+    const dateRange = {
+      from: new Date("2026-04-02T00:00:00.000Z"),
+      to: new Date("2026-04-05T00:00:00.000Z"),
+    }
 
     render(
       <FilterModal
@@ -31,10 +35,7 @@ describe("FilterModal", () => {
         onChange={onChange}
         value={{
           statuses: ["cho_duyet"],
-          dateRange: {
-            from: new Date("2026-04-02T00:00:00.000Z"),
-            to: new Date("2026-04-05T00:00:00.000Z"),
-          },
+          dateRange,
         }}
       />,
     )

--- a/src/components/usage-analytics-dashboard.tsx
+++ b/src/components/usage-analytics-dashboard.tsx
@@ -33,6 +33,7 @@ import {
   useUserUsageStats,
   useDailyUsageData
 } from "@/hooks/use-usage-analytics"
+import { buildCsvContent } from "@/lib/csv-utils"
 import { formatVietnamDate } from "@/lib/date-utils"
 
 interface UsageAnalyticsDashboardProps {
@@ -82,13 +83,7 @@ export function UsageAnalyticsDashboard({
   }
 
   const exportToCSV = <T extends object>(data: T[], filename: string, headers: string[]) => {
-    const csvContent = [
-      headers.join(','),
-      ...data.map(row => {
-        const rowRecord = row as Record<string, unknown>
-        return headers.map(header => `"${rowRecord[header] || ''}"`).join(',')
-      })
-    ].join('\n')
+    const csvContent = buildCsvContent(data, headers)
 
     const blob = new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8;' })
     const link = document.createElement('a')

--- a/src/components/usage-analytics-dashboard.tsx
+++ b/src/components/usage-analytics-dashboard.tsx
@@ -1,8 +1,6 @@
 "use client"
 
 import React from "react"
-import { format } from "date-fns"
-import { vi } from "date-fns/locale"
 import { 
   Clock, 
   Users, 
@@ -35,6 +33,7 @@ import {
   useUserUsageStats,
   useDailyUsageData
 } from "@/hooks/use-usage-analytics"
+import { formatVietnamDate } from "@/lib/date-utils"
 
 interface UsageAnalyticsDashboardProps {
   className?: string
@@ -42,6 +41,10 @@ interface UsageAnalyticsDashboardProps {
   selectedDonVi?: number | null
   effectiveTenantKey?: string
 }
+
+const fileDateFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "Asia/Ho_Chi_Minh",
+})
 
 export function UsageAnalyticsDashboard({ 
   className = "",
@@ -78,10 +81,13 @@ export function UsageAnalyticsDashboard({
     return `${hours}h ${remainingMins}m`
   }
 
-  const exportToCSV = (data: any[], filename: string, headers: string[]) => {
+  const exportToCSV = <T extends object>(data: T[], filename: string, headers: string[]) => {
     const csvContent = [
       headers.join(','),
-      ...data.map(row => headers.map(header => `"${row[header] || ''}"`).join(','))
+      ...data.map(row => {
+        const rowRecord = row as Record<string, unknown>
+        return headers.map(header => `"${rowRecord[header] || ''}"`).join(',')
+      })
     ].join('\n')
 
     const blob = new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8;' })
@@ -89,8 +95,9 @@ export function UsageAnalyticsDashboard({
     
     if (link.download !== undefined) {
       const url = URL.createObjectURL(blob)
+      const fileDate = fileDateFormatter.format()
       link.setAttribute('href', url)
-      link.setAttribute('download', `${filename}-${format(new Date(), 'yyyy-MM-dd')}.csv`)
+      link.setAttribute('download', `${filename}-${fileDate}.csv`)
       link.style.visibility = 'hidden'
       document.body.appendChild(link)
       link.click()
@@ -406,7 +413,7 @@ export function UsageAnalyticsDashboard({
                           <TableCell className="text-right">{user.equipmentUsed}</TableCell>
                           <TableCell>
                             {user.lastActivity 
-                              ? format(new Date(user.lastActivity), 'dd/MM/yyyy', { locale: vi })
+                              ? formatVietnamDate(user.lastActivity)
                               : '-'
                             }
                           </TableCell>

--- a/src/components/usage-history-tab.tsx
+++ b/src/components/usage-history-tab.tsx
@@ -1,8 +1,6 @@
 "use client"
 
 import React from "react"
-import { format, differenceInMinutes } from "date-fns"
-import { vi } from "date-fns/locale"
 import { Clock, User, FileText, Trash2, Square } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -28,31 +26,25 @@ import {
 } from "@/components/ui/alert-dialog"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Skeleton } from "@/components/ui/skeleton"
 import { useEquipmentUsageLogs, useEquipmentUsageLogsMore, useDeleteUsageLog } from "@/hooks/use-usage-logs"
 import { useSession } from "next-auth/react"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { getUsageLogFinalStatus, getUsageLogInitialStatus } from "@/lib/usage-log-status"
 import { type Equipment, type SessionUser, type UsageLog, USAGE_STATUS } from "@/types/database"
 import { isGlobalRole } from "@/lib/rbac"
+import { formatVietnamDateTime } from "@/lib/date-utils"
+import { useHydrationSafeNow } from "@/components/time/HydrationSafeRelativeTime"
 import { EndUsageDialog } from "./end-usage-dialog"
 import { UsageLogPrint } from "./usage-log-print"
+import {
+  formatUsageDuration,
+  getUsageLogPageSignature,
+  UsageHistoryEmptyState,
+  UsageHistoryLoadingState,
+} from "./usage-history-tab.utils"
 
 interface UsageHistoryTabProps {
   equipment: Pick<Equipment, 'id' | 'ten_thiet_bi' | 'ma_thiet_bi'> & Partial<Equipment>
-}
-
-function getUsageLogPageSignature(logs: UsageLog[]) {
-  return logs.map((log) => [
-    log.id,
-    log.updated_at,
-    log.trang_thai,
-    log.thoi_gian_ket_thuc ?? "",
-    log.tinh_trang_ban_dau ?? "",
-    log.tinh_trang_ket_thuc ?? "",
-    log.tinh_trang_thiet_bi ?? "",
-    log.ghi_chu ?? "",
-  ].join(":")).join("|")
 }
 
 export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
@@ -69,6 +61,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
   const [selectedUsageLog, setSelectedUsageLog] = React.useState<UsageLog | null>(null)
   const [loadMoreOffset, setLoadMoreOffset] = React.useState(0)
   const [loadedUsageLogPages, setLoadedUsageLogPages] = React.useState<Record<number, Record<number, UsageLog[]>>>({})
+  const now = useHydrationSafeNow()
 
   // Initial load - recent usage logs (last 3 months, 50 records)
   const { data: recentUsageLogs, isLoading } = useEquipmentUsageLogs(equipment.id.toString(), {
@@ -131,20 +124,6 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
     log => log.trang_thai === 'dang_su_dung' && (userId == null || log.nguoi_su_dung_id !== userId)
   )
 
-  const formatDuration = (startTime: string, endTime?: string) => {
-    const start = new Date(startTime)
-    const end = endTime ? new Date(endTime) : new Date()
-    const minutes = differenceInMinutes(end, start)
-    
-    const hours = Math.floor(minutes / 60)
-    const mins = minutes % 60
-    
-    if (hours > 0) {
-      return `${hours}h ${mins}m`
-    }
-    return `${mins}m`
-  }
-
   const handleEndUsage = (usageLog: UsageLog) => {
     setSelectedUsageLog(usageLog)
     setIsEndDialogOpen(true)
@@ -195,19 +174,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
   const showLoadMore = !isLoading && !isLoadingMore && usageLogs.length >= 50 && (loadMoreOffset === 0 || hasMoreData)
 
   if (isLoading) {
-    return (
-      <div className="space-y-4">
-        <div className="flex gap-2">
-          <Skeleton className="h-10 w-32" />
-          <Skeleton className="h-10 w-32" />
-        </div>
-        <div className="space-y-2">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <Skeleton key={i} className="h-16 w-full" />
-          ))}
-        </div>
-      </div>
-    )
+    return <UsageHistoryLoadingState />
   }
 
   return (
@@ -243,7 +210,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
         <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
           <p className="text-sm text-green-800">
             Bạn đang sử dụng thiết bị này từ{" "}
-            {format(new Date(activeSession.thoi_gian_bat_dau), "HH:mm dd/MM/yyyy", { locale: vi })}
+            {formatVietnamDateTime(activeSession.thoi_gian_bat_dau)}
           </p>
         </div>
       )}
@@ -253,10 +220,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
         <h4 className="font-medium mb-3">Lịch sử sử dụng</h4>
         
         {!usageLogs || usageLogs.length === 0 ? (
-          <div className="text-center py-8 text-muted-foreground">
-            <Clock className="h-12 w-12 mx-auto mb-2 opacity-50" />
-            <p>Chưa có lịch sử sử dụng</p>
-          </div>
+          <UsageHistoryEmptyState />
         ) : (
           <>
             {isMobile ? (
@@ -317,9 +281,9 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                     <div className="flex items-center gap-2">
                       <Clock className="h-4 w-4 text-muted-foreground" />
                       <span>
-                        {format(new Date(log.thoi_gian_bat_dau), "HH:mm dd/MM/yyyy", { locale: vi })}
+                        {formatVietnamDateTime(log.thoi_gian_bat_dau)}
                         {log.thoi_gian_ket_thuc && (
-                          <> - {format(new Date(log.thoi_gian_ket_thuc), "HH:mm dd/MM/yyyy", { locale: vi })}</>
+                          <> - {formatVietnamDateTime(log.thoi_gian_ket_thuc)}</>
                         )}
                       </span>
                     </div>
@@ -327,7 +291,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                     <div>
                       <span className="text-muted-foreground">Thời gian: </span>
                       <span className="font-medium">
-                        {formatDuration(log.thoi_gian_bat_dau, log.thoi_gian_ket_thuc)}
+                        {formatUsageDuration(log.thoi_gian_bat_dau, log.thoi_gian_ket_thuc, now)}
                       </span>
                     </div>
                     
@@ -376,16 +340,16 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                       {log.nguoi_su_dung?.full_name || 'Không xác định'}
                     </TableCell>
                     <TableCell>
-                      {format(new Date(log.thoi_gian_bat_dau), "HH:mm dd/MM/yyyy", { locale: vi })}
+                      {formatVietnamDateTime(log.thoi_gian_bat_dau)}
                     </TableCell>
                     <TableCell>
                       {log.thoi_gian_ket_thuc 
-                        ? format(new Date(log.thoi_gian_ket_thuc), "HH:mm dd/MM/yyyy", { locale: vi })
+                        ? formatVietnamDateTime(log.thoi_gian_ket_thuc)
                         : '-'
                       }
                     </TableCell>
                     <TableCell>
-                      {formatDuration(log.thoi_gian_bat_dau, log.thoi_gian_ket_thuc)}
+                      {formatUsageDuration(log.thoi_gian_bat_dau, log.thoi_gian_ket_thuc, now)}
                     </TableCell>
                     <TableCell>{getUsageLogInitialStatus(log) || '-'}</TableCell>
                     <TableCell>{getUsageLogFinalStatus(log) || '-'}</TableCell>
@@ -451,7 +415,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                   {isFetchingMore ? (
                     <>
                       <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current" />
-                      Đang tải...
+                      Đang tải…
                     </>
                   ) : (
                     'Tải thêm lịch sử'

--- a/src/components/usage-history-tab.utils.tsx
+++ b/src/components/usage-history-tab.utils.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { Clock } from "lucide-react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import type { UsageLog } from "@/types/database"
+
+export function getUsageLogPageSignature(logs: UsageLog[]) {
+  return logs.map((log) => [
+    log.id,
+    log.updated_at,
+    log.trang_thai,
+    log.thoi_gian_ket_thuc ?? "",
+    log.tinh_trang_ban_dau ?? "",
+    log.tinh_trang_ket_thuc ?? "",
+    log.tinh_trang_thiet_bi ?? "",
+    log.ghi_chu ?? "",
+  ].join(":")).join("|")
+}
+
+export function formatUsageDuration(startTime: string, endTime: string | undefined, now: number | null) {
+  const start = Date.parse(startTime)
+  const end = endTime ? Date.parse(endTime) : now
+  const minutes = Number.isFinite(start) && end !== null && Number.isFinite(end)
+    ? Math.max(0, Math.floor((end - start) / 60_000))
+    : 0
+
+  const hours = Math.floor(minutes / 60)
+  const mins = minutes % 60
+
+  if (hours > 0) {
+    return `${hours}h ${mins}m`
+  }
+  return `${mins}m`
+}
+
+export function UsageHistoryLoadingState() {
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <Skeleton className="h-10 w-32" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Skeleton key={index} className="h-16 w-full" />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function UsageHistoryEmptyState() {
+  return (
+    <div className="text-center py-8 text-muted-foreground">
+      <Clock className="h-12 w-12 mx-auto mb-2 opacity-50" />
+      <p>Chưa có lịch sử sử dụng</p>
+    </div>
+  )
+}

--- a/src/components/usage-history-tab.utils.tsx
+++ b/src/components/usage-history-tab.utils.tsx
@@ -1,12 +1,14 @@
 "use client"
 
+import type { ReactElement } from "react"
 import { Clock } from "lucide-react"
 
 import { Skeleton } from "@/components/ui/skeleton"
+import { calculateUsageDurationMinutes } from "@/lib/usage-duration"
 import type { UsageLog } from "@/types/database"
 
-export function getUsageLogPageSignature(logs: UsageLog[]) {
-  return logs.map((log) => [
+export function getUsageLogPageSignature(logs: UsageLog[]): string {
+  return JSON.stringify(logs.map((log) => [
     log.id,
     log.updated_at,
     log.trang_thai,
@@ -15,15 +17,11 @@ export function getUsageLogPageSignature(logs: UsageLog[]) {
     log.tinh_trang_ket_thuc ?? "",
     log.tinh_trang_thiet_bi ?? "",
     log.ghi_chu ?? "",
-  ].join(":")).join("|")
+  ]))
 }
 
-export function formatUsageDuration(startTime: string, endTime: string | undefined, now: number | null) {
-  const start = Date.parse(startTime)
-  const end = endTime ? Date.parse(endTime) : now
-  const minutes = Number.isFinite(start) && end !== null && Number.isFinite(end)
-    ? Math.max(0, Math.floor((end - start) / 60_000))
-    : 0
+export function formatUsageDuration(startTime: string, endTime: string | undefined, now: number | null): string {
+  const minutes = calculateUsageDurationMinutes(startTime, endTime ?? now)
 
   const hours = Math.floor(minutes / 60)
   const mins = minutes % 60
@@ -34,7 +32,7 @@ export function formatUsageDuration(startTime: string, endTime: string | undefin
   return `${mins}m`
 }
 
-export function UsageHistoryLoadingState() {
+export function UsageHistoryLoadingState(): ReactElement {
   return (
     <div className="space-y-4">
       <div className="flex gap-2">
@@ -50,7 +48,7 @@ export function UsageHistoryLoadingState() {
   )
 }
 
-export function UsageHistoryEmptyState() {
+export function UsageHistoryEmptyState(): ReactElement {
   return (
     <div className="text-center py-8 text-muted-foreground">
       <Clock className="h-12 w-12 mx-auto mb-2 opacity-50" />

--- a/src/components/usage-log-print-builder-utils.ts
+++ b/src/components/usage-log-print-builder-utils.ts
@@ -1,6 +1,7 @@
 import { differenceInMinutes } from "date-fns"
 
 import { getUsageLogFinalStatus, getUsageLogInitialStatus } from "@/lib/usage-log-status"
+import { escapeCsvCell as escapeSharedCsvCell } from "@/lib/csv-utils"
 import { type Equipment, type UsageLog } from "@/types/database"
 
 export type PrintableEquipment = Pick<Equipment, "ma_thiet_bi" | "ten_thiet_bi"> & Partial<Equipment>
@@ -48,9 +49,7 @@ export function escapeUrl(url: string | null | undefined): string {
 }
 
 export function escapeCsvCell(value: unknown): string {
-  const raw = value == null ? "" : String(value)
-  const sanitized = /^[=+\-@]/.test(raw) ? `'${raw}` : raw
-  return `"${sanitized.replace(/"/g, '""')}"`
+  return escapeSharedCsvCell(value)
 }
 
 export function parseDateInputAsLocalDate(dateString: string): Date {

--- a/src/lib/__tests__/csv-utils.test.ts
+++ b/src/lib/__tests__/csv-utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { buildCsvContent, escapeCsvCell } from "../csv-utils"
+
+describe("csv utils", () => {
+  it("escapes quotes and neutralizes spreadsheet formulas", () => {
+    expect(escapeCsvCell('=1+1 "quoted"')).toBe(`"'=1+1 ""quoted"""`)
+  })
+
+  it("preserves zero and false values", () => {
+    expect(escapeCsvCell(0)).toBe('"0"')
+    expect(escapeCsvCell(false)).toBe('"false"')
+  })
+
+  it("builds CSV rows from selected headers", () => {
+    const csv = buildCsvContent(
+      [{ name: '=cmd', count: 0, enabled: false }],
+      ["name", "count", "enabled"]
+    )
+
+    expect(csv).toBe(['"name","count","enabled"', `"'=cmd","0","false"`].join("\n"))
+  })
+})

--- a/src/lib/__tests__/csv-utils.test.ts
+++ b/src/lib/__tests__/csv-utils.test.ts
@@ -1,10 +1,23 @@
 import { describe, expect, it } from "vitest"
 
-import { buildCsvContent, escapeCsvCell } from "../csv-utils"
+import { buildCsvContent, escapeCsvCell } from "@/lib/csv-utils"
 
 describe("csv utils", () => {
   it("escapes quotes and neutralizes spreadsheet formulas", () => {
     expect(escapeCsvCell('=1+1 "quoted"')).toBe(`"'=1+1 ""quoted"""`)
+  })
+
+  it("neutralizes formulas with leading whitespace or control characters", () => {
+    expect(escapeCsvCell("\t=1+1")).toBe(`"'\t=1+1"`)
+    expect(escapeCsvCell(" =1+1")).toBe(`"' =1+1"`)
+  })
+
+  it("does not throw when object serialization fails", () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+
+    expect(() => escapeCsvCell(circular)).not.toThrow()
+    expect(escapeCsvCell(circular)).toBe('"[object Object]"')
   })
 
   it("preserves zero and false values", () => {

--- a/src/lib/__tests__/date-utils-full-date.test.ts
+++ b/src/lib/__tests__/date-utils-full-date.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   FULL_DATE_ERROR_MESSAGE,
+  formatVietnamDate,
+  formatVietnamDateTime,
   isValidFullDate,
   normalizeDateForImport,
   normalizeFullDateForForm,
@@ -98,5 +100,18 @@ describe('date-utils full-date helpers', () => {
 
   it('exports the strict validation error message', () => {
     expect(FULL_DATE_ERROR_MESSAGE).toBe('Định dạng ngày không hợp lệ. Sử dụng: DD/MM/YYYY')
+  })
+
+  describe('hydration-safe Vietnamese display formatters', () => {
+    it('formats instants with a fixed Vietnam timezone', () => {
+      expect(formatVietnamDateTime('2025-01-15T14:30:00.000Z')).toBe('15/01/2025 21:30')
+      expect(formatVietnamDate('2025-01-15T18:00:00.000Z')).toBe('16/01/2025')
+    })
+
+    it('returns a placeholder for missing or invalid values', () => {
+      expect(formatVietnamDateTime(null)).toBe('-')
+      expect(formatVietnamDateTime('not-a-date')).toBe('-')
+      expect(formatVietnamDate(undefined, 'Không có')).toBe('Không có')
+    })
   })
 })

--- a/src/lib/__tests__/usage-duration.test.ts
+++ b/src/lib/__tests__/usage-duration.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+
+import { calculateUsageDurationMinutes } from "../usage-duration"
+
+describe("calculateUsageDurationMinutes", () => {
+  it("returns zero when the start timestamp is invalid", () => {
+    expect(calculateUsageDurationMinutes("invalid-date", Date.parse("2026-05-13T00:10:00Z"))).toBe(0)
+  })
+
+  it("floors valid durations and clamps negative values", () => {
+    expect(calculateUsageDurationMinutes("2026-05-13T00:00:30Z", Date.parse("2026-05-13T00:10:59Z"))).toBe(10)
+    expect(calculateUsageDurationMinutes("2026-05-13T00:10:00Z", Date.parse("2026-05-13T00:00:00Z"))).toBe(0)
+  })
+})

--- a/src/lib/__tests__/usage-duration.test.ts
+++ b/src/lib/__tests__/usage-duration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { calculateUsageDurationMinutes } from "../usage-duration"
+import { calculateUsageDurationMinutes } from "@/lib/usage-duration"
 
 describe("calculateUsageDurationMinutes", () => {
   it("returns zero when the start timestamp is invalid", () => {

--- a/src/lib/csv-utils.ts
+++ b/src/lib/csv-utils.ts
@@ -1,0 +1,23 @@
+const FORMULA_PREFIX_PATTERN = /^[=+\-@]/
+
+export function escapeCsvCell(value: unknown): string {
+  const raw =
+    value == null
+      ? ""
+      : typeof value === "object"
+        ? JSON.stringify(value)
+        : String(value)
+  const hardened = FORMULA_PREFIX_PATTERN.test(raw) ? `'${raw}` : raw
+
+  return `"${hardened.replace(/"/g, '""')}"`
+}
+
+export function buildCsvContent<T extends object>(data: T[], headers: string[]): string {
+  return [
+    headers.map((header) => escapeCsvCell(header)).join(","),
+    ...data.map((row) => {
+      const rowRecord = row as Record<string, unknown>
+      return headers.map((header) => escapeCsvCell(rowRecord[header])).join(",")
+    }),
+  ].join("\n")
+}

--- a/src/lib/csv-utils.ts
+++ b/src/lib/csv-utils.ts
@@ -1,12 +1,18 @@
-const FORMULA_PREFIX_PATTERN = /^[=+\-@]/
+const FORMULA_PREFIX_PATTERN = /^[\s\u0000-\u001F]*[=+\-@]/
+
+function stringifyCsvValue(value: unknown): string {
+  if (value == null) return ""
+  if (typeof value !== "object") return String(value)
+
+  try {
+    return JSON.stringify(value) ?? ""
+  } catch {
+    return String(value)
+  }
+}
 
 export function escapeCsvCell(value: unknown): string {
-  const raw =
-    value == null
-      ? ""
-      : typeof value === "object"
-        ? JSON.stringify(value)
-        : String(value)
+  const raw = stringifyCsvValue(value)
   const hardened = FORMULA_PREFIX_PATTERN.test(raw) ? `'${raw}` : raw
 
   return `"${hardened.replace(/"/g, '""')}"`

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -12,6 +12,7 @@ export const SUSPICIOUS_DATE_WARNING =
 
 const FULL_DATE_VIETNAMESE_PATTERN = /^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})$/
 const FULL_DATE_ISO_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/
+export { formatVietnamDate, formatVietnamDateTime } from "./vietnam-date-format"
 
 function isValidCalendarDateParts(year: number, month: number, day: number): boolean {
   const date = new Date(Date.UTC(year, month - 1, day))

--- a/src/lib/usage-duration.ts
+++ b/src/lib/usage-duration.ts
@@ -1,0 +1,10 @@
+export function calculateUsageDurationMinutes(startTime: string, endTime: number | string | null): number {
+  const start = Date.parse(startTime)
+  const end = typeof endTime === "number" ? endTime : endTime ? Date.parse(endTime) : null
+
+  if (!Number.isFinite(start) || end === null || !Number.isFinite(end)) {
+    return 0
+  }
+
+  return Math.max(0, Math.floor((end - start) / 60_000))
+}

--- a/src/lib/vietnam-date-format.ts
+++ b/src/lib/vietnam-date-format.ts
@@ -1,0 +1,50 @@
+const VIETNAM_TIME_ZONE = "Asia/Ho_Chi_Minh"
+
+type DateInput = string | number | Date | null | undefined
+
+const vietnamDateTimeFormatter = new Intl.DateTimeFormat("vi-VN", {
+  timeZone: VIETNAM_TIME_ZONE,
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hourCycle: "h23",
+})
+
+const vietnamDateFormatter = new Intl.DateTimeFormat("vi-VN", {
+  timeZone: VIETNAM_TIME_ZONE,
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+})
+
+function parseDisplayDateInput(value: DateInput): Date | null {
+  if (value === null || value === undefined || value === "") return null
+
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function partsToRecord(parts: Intl.DateTimeFormatPart[]): Record<string, string> {
+  return parts.reduce<Record<string, string>>((acc, part) => {
+    if (part.type !== "literal") acc[part.type] = part.value
+    return acc
+  }, {})
+}
+
+export function formatVietnamDateTime(value: DateInput, fallback = "-"): string {
+  const date = parseDisplayDateInput(value)
+  if (!date) return fallback
+
+  const parts = partsToRecord(vietnamDateTimeFormatter.formatToParts(date))
+  return `${parts.day}/${parts.month}/${parts.year} ${parts.hour}:${parts.minute}`
+}
+
+export function formatVietnamDate(value: DateInput, fallback = "-"): string {
+  const date = parseDisplayDateInput(value)
+  if (!date) return fallback
+
+  const parts = partsToRecord(vietnamDateFormatter.formatToParts(date))
+  return `${parts.day}/${parts.month}/${parts.year}`
+}


### PR DESCRIPTION
## Summary
- Fixes #454.
- Adds hydration-safe Vietnamese date formatting and a relative-time component with deterministic SSR fallback.
- Replaces render-path date/relative-time formatting across the P1 affected surfaces.
- Migrates `DeviceQuotaMappingGuide` localStorage dismissal to `useSyncExternalStore`.
- Extracts touched over-limit files into smaller helpers/components while preserving behavior.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- Focused Vitest: 9 files, 34 tests passed
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
  - Result: 95/100; #454 hydration rules no longer reported.
  - Remaining warnings are non-P1 legacy/design/no-giant/useReducer findings on touched surfaces.
- `node scripts/npm-run.js run build`
- `git diff --check`
EOF 2>&1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hydration mismatches in #454 by making time and date UI deterministic on SSR and upgrading to relative time on the client. Adds Vietnamese time formatters, a hydration‑safe relative time component and “now” hook, and replaces affected usages across the app.

- **Bug Fixes**
  - Introduced `HydrationSafeRelativeTime` and `useHydrationSafeNow` to render absolute times on SSR and upgrade to relative on the client (minute updates).
  - Replaced ad‑hoc date/relative‑time code across P1 surfaces (activity logs with a new entry component, transfers Kanban, usage dialogs/history, analytics).
  - Made date pickers deterministic and safer: block future dates with a stable “now” and use `startOfDay` parsing (includes Repair Requests).
  - `DeviceQuotaMappingGuide` now uses `useSyncExternalStore` for SSR‑safe initial state, cross‑tab sync, and won’t crash if `localStorage` is blocked.
  - Hardened CSV export with `csv-utils`: timezone‑stable filenames and escaped cells; shared escaper used in usage‑log print builder.
  - Centralized usage duration math via `calculateUsageDurationMinutes` (clamps invalid/negative); used in mobile actions and end‑usage dialog.

- **Refactors**
  - Extracted decision dialog schema and robust local date parsing to `DeviceQuotaDecisionDialogSchema.ts` (invalid dates rejected) with tests.
  - Split `ActivityLogEntry` into its own component and simplified the viewer; centralized usage‑history utilities and stable page signatures.
  - Standardized Vietnamese time formats with `formatVietnamDate` and `formatVietnamDateTime` (fixed `Asia/Ho_Chi_Minh` timezone); added tests for relative time, VN formatters, CSV utils, usage duration, and page signatures.

<sup>Written for commit f937b3dbcba708874969877a94fb5a03f0ca1bd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity log entry UI with IP and dual timestamp displays
  * Hydration-safe relative-time component and stable "now" hook
  * Persistent dismissible guidance stored in browser storage

* **Bug Fixes**
  * Prevent selecting invalid/future dates and enforce correct date ordering
  * More robust duration and timestamp calculations across usage screens

* **Refactor**
  * Unified Vietnam timezone date/time formatting and safer CSV export

* **Tests**
  * Added unit tests for time, CSV, and duration utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/464)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->