### PR TITLE
Fix React Doctor P2 rerender warnings

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsCreateSheet.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsCreateSheet.test.tsx
@@ -278,6 +278,45 @@ describe('RepairRequestsCreateSheet assistant draft hydration', () => {
     expect(screen.getByLabelText('Mô tả sự cố')).toHaveValue('Người dùng đã sửa mô tả')
   })
 
+  it('does not rerun draft equipment lookup after marking it complete', async () => {
+    mocks.callRpc.mockResolvedValue([])
+
+    setAssistantDraft({
+      equipment: {
+        thiet_bi_id: 999,
+        ma_thiet_bi: 'TB-001',
+        ten_thiet_bi: 'Máy siêu âm A',
+      },
+      formData: {
+        mo_ta_su_co: 'Lỗi cần chọn lại thiết bị',
+        hang_muc_sua_chua: 'Kiểm tra lại',
+      },
+      missingFields: [],
+      reviewNotes: [],
+    })
+
+    render(<RepairRequestsCreateSheet />)
+
+    await waitFor(() => {
+      expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+    })
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.objectContaining({ p_q: 'Máy siêu âm A (TB-001)' }),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('⚠️ Thiết bị trong bản nháp không tìm thấy ở cơ sở hiện tại. Vui lòng chọn thiết bị thủ công.')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 650))
+    })
+
+    expect(mocks.callRpc).toHaveBeenCalledTimes(1)
+  })
+
   it('does not overwrite manual equipment search input while draft lookup is pending', async () => {
     let releaseLookup: (() => void) | null = null
 

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx
@@ -201,13 +201,14 @@ export function RepairRequestsCreateSheet() {
       try {
         const eq = await fetchRepairRequestEquipmentList(q, 20, ctrl.signal)
         if (ctrl.signal.aborted) return
+        const completedDraftEquipmentLookup = Boolean(
+          assistantDraft?.equipment?.thiet_bi_id && q === draftEquipmentLabel,
+        )
         dispatchForm({
           type: "patch",
           updates: {
             allEquipment: eq || [],
-            hasDraftEquipmentLookupCompleted: assistantDraft?.equipment?.thiet_bi_id && q === draftEquipmentLabel
-              ? true
-              : formState.hasDraftEquipmentLookupCompleted,
+            ...(completedDraftEquipmentLookup ? { hasDraftEquipmentLookupCompleted: true } : {}),
             isSearchPending: false,
           },
         })
@@ -227,7 +228,6 @@ export function RepairRequestsCreateSheet() {
   }, [
     assistantDraft,
     draftEquipmentLabel,
-    formState.hasDraftEquipmentLookupCompleted,
     formState.searchQuery,
     formState.selectedEquipment,
   ])

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx
@@ -18,6 +18,52 @@ import { format } from "date-fns"
 
 const REPAIR_REQUEST_EQUIPMENT_SEARCH_DEBOUNCE_MS = 300
 
+interface RepairRequestsCreateFormState {
+  allEquipment: EquipmentSelectItem[]
+  desiredDate: Date | undefined
+  externalCompanyName: string
+  hasDraftEquipmentLookupCompleted: boolean
+  hasSeededDraftEquipmentLookup: boolean
+  isSearchPending: boolean
+  issueDescription: string
+  repairItems: string
+  repairUnit: RepairUnit
+  searchQuery: string
+  selectedEquipment: EquipmentSelectItem | null
+  unresolvedDraftEquipment: boolean
+}
+
+type RepairRequestsCreateFormAction =
+  | { type: "patch"; updates: Partial<RepairRequestsCreateFormState> }
+  | { type: "reset" }
+
+const initialCreateFormState: RepairRequestsCreateFormState = {
+  allEquipment: [],
+  desiredDate: undefined,
+  externalCompanyName: "",
+  hasDraftEquipmentLookupCompleted: false,
+  hasSeededDraftEquipmentLookup: false,
+  isSearchPending: false,
+  issueDescription: "",
+  repairItems: "",
+  repairUnit: "noi_bo",
+  searchQuery: "",
+  selectedEquipment: null,
+  unresolvedDraftEquipment: false,
+}
+
+function repairRequestsCreateFormReducer(
+  state: RepairRequestsCreateFormState,
+  action: RepairRequestsCreateFormAction,
+): RepairRequestsCreateFormState {
+  switch (action.type) {
+    case "patch":
+      return { ...state, ...action.updates }
+    case "reset":
+      return initialCreateFormState
+  }
+}
+
 export function RepairRequestsCreateSheet() {
   const {
     dialogState: { isCreateOpen, preSelectedEquipment },
@@ -33,19 +79,10 @@ export function RepairRequestsCreateSheet() {
   const hasHydratedFormFieldsRef = React.useRef(false)
   const hasUserEditedSearchRef = React.useRef(false)
 
-  // Local form state
-  const [selectedEquipment, setSelectedEquipment] = React.useState<EquipmentSelectItem | null>(null)
-  const [searchQuery, setSearchQuery] = React.useState("")
-  const [issueDescription, setIssueDescription] = React.useState("")
-  const [repairItems, setRepairItems] = React.useState("")
-  const [desiredDate, setDesiredDate] = React.useState<Date | undefined>()
-  const [repairUnit, setRepairUnit] = React.useState<RepairUnit>("noi_bo")
-  const [externalCompanyName, setExternalCompanyName] = React.useState("")
-  const [allEquipment, setAllEquipment] = React.useState<EquipmentSelectItem[]>([])
-  const [isSearchPending, setIsSearchPending] = React.useState(false)
-  const [unresolvedDraftEquipment, setUnresolvedDraftEquipment] = React.useState(false)
-  const [hasDraftEquipmentLookupCompleted, setHasDraftEquipmentLookupCompleted] = React.useState(false)
-  const [hasSeededDraftEquipmentLookup, setHasSeededDraftEquipmentLookup] = React.useState(false)
+  const [formState, dispatchForm] = React.useReducer(
+    repairRequestsCreateFormReducer,
+    initialCreateFormState,
+  )
 
   const draftEquipmentLabel = React.useMemo(() => {
     if (!assistantDraft?.equipment?.ten_thiet_bi || !assistantDraft.equipment.ma_thiet_bi) {
@@ -61,16 +98,7 @@ export function RepairRequestsCreateSheet() {
   // Reset form when sheet closes, or initialize from pre-selected equipment when sheet opens
   React.useEffect(() => {
     if (!isCreateOpen) {
-      setSelectedEquipment(null)
-      setSearchQuery("")
-      setIssueDescription("")
-      setRepairItems("")
-      setDesiredDate(undefined)
-      setRepairUnit("noi_bo")
-      setExternalCompanyName("")
-      setUnresolvedDraftEquipment(false)
-      setHasDraftEquipmentLookupCompleted(false)
-      setHasSeededDraftEquipmentLookup(false)
+      dispatchForm({ type: "reset" })
       hasPrefilledRef.current = false
       hasHydratedFormFieldsRef.current = false
       hasUserEditedSearchRef.current = false
@@ -78,43 +106,66 @@ export function RepairRequestsCreateSheet() {
       // Hydrate non-equipment fields exactly once.
       if (!hasHydratedFormFieldsRef.current) {
         const fd = assistantDraft.formData
-        if (fd.mo_ta_su_co) setIssueDescription(fd.mo_ta_su_co)
-        if (fd.hang_muc_sua_chua) setRepairItems(fd.hang_muc_sua_chua)
-        if (fd.ngay_mong_muon_hoan_thanh) {
-          setDesiredDate(parseDraftDate(fd.ngay_mong_muon_hoan_thanh))
-        }
-        if (fd.don_vi_thuc_hien) setRepairUnit(fd.don_vi_thuc_hien)
-        if (fd.ten_don_vi_thue) setExternalCompanyName(fd.ten_don_vi_thue)
+        dispatchForm({
+          type: "patch",
+          updates: {
+            desiredDate: fd.ngay_mong_muon_hoan_thanh
+              ? parseDraftDate(fd.ngay_mong_muon_hoan_thanh)
+              : formState.desiredDate,
+            externalCompanyName: fd.ten_don_vi_thue || formState.externalCompanyName,
+            issueDescription: fd.mo_ta_su_co || formState.issueDescription,
+            repairItems: fd.hang_muc_sua_chua || formState.repairItems,
+            repairUnit: fd.don_vi_thuc_hien || formState.repairUnit,
+          },
+        })
         hasHydratedFormFieldsRef.current = true
       }
 
       if (!hasPrefilledRef.current && assistantDraft.equipment?.thiet_bi_id) {
-        const resolved = allEquipment.find(
+        const resolved = formState.allEquipment.find(
           eq => eq.id === assistantDraft.equipment?.thiet_bi_id,
         )
         if (resolved) {
-          setSelectedEquipment(resolved)
-          setSearchQuery(formatEquipmentLabel(resolved))
-          setUnresolvedDraftEquipment(false)
+          dispatchForm({
+            type: "patch",
+            updates: {
+              searchQuery: formatEquipmentLabel(resolved),
+              selectedEquipment: resolved,
+              unresolvedDraftEquipment: false,
+            },
+          })
           hasPrefilledRef.current = true
-        } else if (hasDraftEquipmentLookupCompleted) {
+        } else if (formState.hasDraftEquipmentLookupCompleted) {
           // Equipment lookup finished but ID not found — cross-tenant or stale
-          setUnresolvedDraftEquipment(true)
+          dispatchForm({
+            type: "patch",
+            updates: { unresolvedDraftEquipment: true },
+          })
           hasPrefilledRef.current = true
         } else if (
           draftEquipmentLabel &&
-          !hasSeededDraftEquipmentLookup &&
+          !formState.hasSeededDraftEquipmentLookup &&
           !hasUserEditedSearchRef.current
         ) {
           // Seed the lookup once, but never clobber manual user input.
-          setSearchQuery(draftEquipmentLabel)
-          setHasSeededDraftEquipmentLookup(true)
+          dispatchForm({
+            type: "patch",
+            updates: {
+              hasSeededDraftEquipmentLookup: true,
+              searchQuery: draftEquipmentLabel,
+            },
+          })
         }
       }
     } else if (preSelectedEquipment && !hasPrefilledRef.current) {
       // Pre-fill only once when opened with equipment from context
-      setSelectedEquipment(preSelectedEquipment)
-      setSearchQuery(`${preSelectedEquipment.ten_thiet_bi} (${preSelectedEquipment.ma_thiet_bi})`)
+      dispatchForm({
+        type: "patch",
+        updates: {
+          searchQuery: formatEquipmentLabel(preSelectedEquipment),
+          selectedEquipment: preSelectedEquipment,
+        },
+      })
       hasPrefilledRef.current = true
       hasHydratedFormFieldsRef.current = true
     }
@@ -122,38 +173,50 @@ export function RepairRequestsCreateSheet() {
     isCreateOpen,
     preSelectedEquipment,
     assistantDraft,
-    allEquipment,
     draftEquipmentLabel,
-    hasDraftEquipmentLookupCompleted,
-    hasSeededDraftEquipmentLookup,
+    formState.allEquipment,
+    formState.desiredDate,
+    formState.externalCompanyName,
+    formState.hasDraftEquipmentLookupCompleted,
+    formState.hasSeededDraftEquipmentLookup,
+    formState.issueDescription,
+    formState.repairItems,
+    formState.repairUnit,
   ])
 
   // Fetch equipment options
   React.useEffect(() => {
-    const label = selectedEquipment
-      ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
+    const label = formState.selectedEquipment
+      ? formatEquipmentLabel(formState.selectedEquipment)
       : ""
-    const q = searchQuery?.trim()
+    const q = formState.searchQuery?.trim()
     if (!q || (label && q === label)) {
-      setIsSearchPending(false)
+      dispatchForm({ type: "patch", updates: { isSearchPending: false } })
       return
     }
 
     const ctrl = new AbortController()
-    setIsSearchPending(true)
+    dispatchForm({ type: "patch", updates: { isSearchPending: true } })
     const run = async () => {
       try {
         const eq = await fetchRepairRequestEquipmentList(q, 20, ctrl.signal)
         if (ctrl.signal.aborted) return
-        setAllEquipment(eq || [])
-        setIsSearchPending(false)
-        if (assistantDraft?.equipment?.thiet_bi_id && q === draftEquipmentLabel) {
-          setHasDraftEquipmentLookupCompleted(true)
-        }
+        dispatchForm({
+          type: "patch",
+          updates: {
+            allEquipment: eq || [],
+            hasDraftEquipmentLookupCompleted: assistantDraft?.equipment?.thiet_bi_id && q === draftEquipmentLabel
+              ? true
+              : formState.hasDraftEquipmentLookupCompleted,
+            isSearchPending: false,
+          },
+        })
       } catch (e) {
         if (ctrl.signal.aborted) return
-        setAllEquipment([])
-        setIsSearchPending(false)
+        dispatchForm({
+          type: "patch",
+          updates: { allEquipment: [], isSearchPending: false },
+        })
       }
     }
     const timeoutId = window.setTimeout(run, REPAIR_REQUEST_EQUIPMENT_SEARCH_DEBOUNCE_MS)
@@ -161,62 +224,76 @@ export function RepairRequestsCreateSheet() {
       ctrl.abort()
       window.clearTimeout(timeoutId)
     }
-  }, [assistantDraft, draftEquipmentLabel, searchQuery, selectedEquipment])
+  }, [
+    assistantDraft,
+    draftEquipmentLabel,
+    formState.hasDraftEquipmentLookupCompleted,
+    formState.searchQuery,
+    formState.selectedEquipment,
+  ])
 
   const filteredEquipment = React.useMemo(() => {
-    if (!searchQuery) return []
-    if (isSearchPending) return []
-    if (selectedEquipment && searchQuery === `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`) {
+    if (!formState.searchQuery) return []
+    if (formState.isSearchPending) return []
+    if (formState.selectedEquipment && formState.searchQuery === formatEquipmentLabel(formState.selectedEquipment)) {
       return []
     }
-    return allEquipment
-  }, [searchQuery, isSearchPending, allEquipment, selectedEquipment])
+    return formState.allEquipment
+  }, [formState.searchQuery, formState.isSearchPending, formState.allEquipment, formState.selectedEquipment])
 
   const shouldShowNoResults = React.useMemo(() => {
-    if (!searchQuery) return false
-    if (isSearchPending) return false
-    if (selectedEquipment && searchQuery === `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`) {
+    if (!formState.searchQuery) return false
+    if (formState.isSearchPending) return false
+    if (formState.selectedEquipment && formState.searchQuery === formatEquipmentLabel(formState.selectedEquipment)) {
       return false
     }
     return filteredEquipment.length === 0
-  }, [searchQuery, isSearchPending, selectedEquipment, filteredEquipment])
+  }, [formState.searchQuery, formState.isSearchPending, formState.selectedEquipment, filteredEquipment])
 
   const handleSelectEquipment = (equipment: EquipmentSelectItem) => {
-    setSelectedEquipment(equipment)
-    setSearchQuery(formatEquipmentLabel(equipment))
-    setUnresolvedDraftEquipment(false)
+    dispatchForm({
+      type: "patch",
+      updates: {
+        searchQuery: formatEquipmentLabel(equipment),
+        selectedEquipment: equipment,
+        unresolvedDraftEquipment: false,
+      },
+    })
     hasUserEditedSearchRef.current = true
   }
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const nextQuery = e.target.value
     const nextTrimmedQuery = nextQuery.trim()
-    const selectedLabel = selectedEquipment
-      ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`
+    const selectedLabel = formState.selectedEquipment
+      ? formatEquipmentLabel(formState.selectedEquipment)
       : ""
 
     hasUserEditedSearchRef.current = true
-    setSearchQuery(nextQuery)
-    setIsSearchPending(Boolean(nextTrimmedQuery) && nextTrimmedQuery !== selectedLabel)
-    if (selectedEquipment) {
-      setSelectedEquipment(null)
-    }
+    dispatchForm({
+      type: "patch",
+      updates: {
+        isSearchPending: Boolean(nextTrimmedQuery) && nextTrimmedQuery !== selectedLabel,
+        searchQuery: nextQuery,
+        selectedEquipment: formState.selectedEquipment ? null : formState.selectedEquipment,
+      },
+    })
   }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!selectedEquipment || !user) return
+    if (!formState.selectedEquipment || !user) return
 
     createMutation.mutate(
       {
-        thiet_bi_id: selectedEquipment.id,
-        mo_ta_su_co: issueDescription,
-        hang_muc_sua_chua: repairItems.trim() || null,
-        ngay_mong_muon_hoan_thanh: desiredDate ? format(desiredDate, "yyyy-MM-dd") : null,
+        thiet_bi_id: formState.selectedEquipment.id,
+        mo_ta_su_co: formState.issueDescription,
+        hang_muc_sua_chua: formState.repairItems.trim() || null,
+        ngay_mong_muon_hoan_thanh: formState.desiredDate ? format(formState.desiredDate, "yyyy-MM-dd") : null,
         nguoi_yeu_cau: user.full_name || user.username,
-        don_vi_thuc_hien: canSetRepairUnit ? repairUnit : null,
-        ten_don_vi_thue: canSetRepairUnit && repairUnit === "thue_ngoai"
-          ? externalCompanyName.trim()
+        don_vi_thuc_hien: canSetRepairUnit ? formState.repairUnit : null,
+        ten_don_vi_thue: canSetRepairUnit && formState.repairUnit === "thue_ngoai"
+          ? formState.externalCompanyName.trim()
           : null,
       },
       { onSuccess: closeAllDialogs }
@@ -234,28 +311,28 @@ export function RepairRequestsCreateSheet() {
           <div className="mt-4 flex-1 overflow-y-auto px-4 pb-4">
             <RepairRequestsCreateSheetAlerts
               hasAssistantDraft={Boolean(assistantDraft)}
-              showUnresolvedDraftEquipment={unresolvedDraftEquipment}
+              showUnresolvedDraftEquipment={formState.unresolvedDraftEquipment}
             />
             <RepairRequestsCreateSheetForm
               canSetRepairUnit={canSetRepairUnit}
-              desiredDate={desiredDate}
-              externalCompanyName={externalCompanyName}
+              desiredDate={formState.desiredDate}
+              externalCompanyName={formState.externalCompanyName}
               filteredEquipment={filteredEquipment}
               handleSearchChange={handleSearchChange}
               handleSelectEquipment={handleSelectEquipment}
               handleSubmit={handleSubmit}
               isSubmitting={createMutation.isPending}
-              issueDescription={issueDescription}
+              issueDescription={formState.issueDescription}
+              onDesiredDateChange={(desiredDate) => dispatchForm({ type: "patch", updates: { desiredDate } })}
+              onExternalCompanyNameChange={(externalCompanyName) => dispatchForm({ type: "patch", updates: { externalCompanyName } })}
+              onIssueDescriptionChange={(issueDescription) => dispatchForm({ type: "patch", updates: { issueDescription } })}
+              onRepairItemsChange={(repairItems) => dispatchForm({ type: "patch", updates: { repairItems } })}
+              onRepairUnitChange={(repairUnit) => dispatchForm({ type: "patch", updates: { repairUnit } })}
               onCancel={closeAllDialogs}
-              repairItems={repairItems}
-              repairUnit={repairUnit}
-              searchQuery={searchQuery}
-              selectedEquipment={selectedEquipment}
-              setDesiredDate={setDesiredDate}
-              setExternalCompanyName={setExternalCompanyName}
-              setIssueDescription={setIssueDescription}
-              setRepairItems={setRepairItems}
-              setRepairUnit={setRepairUnit}
+              repairItems={formState.repairItems}
+              repairUnit={formState.repairUnit}
+              searchQuery={formState.searchQuery}
+              selectedEquipment={formState.selectedEquipment}
               shouldShowNoResults={shouldShowNoResults}
             />
           </div>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx
@@ -38,11 +38,11 @@ interface RepairRequestsCreateSheetFormProps {
   repairUnit: RepairUnit
   searchQuery: string
   selectedEquipment: EquipmentSelectItem | null
-  setDesiredDate: React.Dispatch<React.SetStateAction<Date | undefined>>
-  setExternalCompanyName: React.Dispatch<React.SetStateAction<string>>
-  setIssueDescription: React.Dispatch<React.SetStateAction<string>>
-  setRepairItems: React.Dispatch<React.SetStateAction<string>>
-  setRepairUnit: React.Dispatch<React.SetStateAction<RepairUnit>>
+  onDesiredDateChange: (value: Date | undefined) => void
+  onExternalCompanyNameChange: (value: string) => void
+  onIssueDescriptionChange: (value: string) => void
+  onRepairItemsChange: (value: string) => void
+  onRepairUnitChange: (value: RepairUnit) => void
   shouldShowNoResults: boolean
 }
 
@@ -61,11 +61,11 @@ export function RepairRequestsCreateSheetForm({
   repairUnit,
   searchQuery,
   selectedEquipment,
-  setDesiredDate,
-  setExternalCompanyName,
-  setIssueDescription,
-  setRepairItems,
-  setRepairUnit,
+  onDesiredDateChange,
+  onExternalCompanyNameChange,
+  onIssueDescriptionChange,
+  onRepairItemsChange,
+  onRepairUnitChange,
   shouldShowNoResults,
 }: RepairRequestsCreateSheetFormProps) {
   const [minimumSelectableDate, setMinimumSelectableDate] = React.useState<Date | null>(null)
@@ -98,7 +98,7 @@ export function RepairRequestsCreateSheetForm({
           placeholder="Mô tả chi tiết vấn đề gặp phải..."
           rows={4}
           value={issueDescription}
-          onChange={(e) => setIssueDescription(e.target.value)}
+          onChange={(e) => onIssueDescriptionChange(e.target.value)}
           required
         />
       </div>
@@ -109,7 +109,7 @@ export function RepairRequestsCreateSheetForm({
           placeholder="VD: Thay màn hình, sửa nguồn..."
           rows={3}
           value={repairItems}
-          onChange={(e) => setRepairItems(e.target.value)}
+          onChange={(e) => onRepairItemsChange(e.target.value)}
         />
       </div>
       <div className="space-y-2">
@@ -129,13 +129,13 @@ export function RepairRequestsCreateSheetForm({
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-auto p-0">
-            <Calendar
-              mode="single"
-              selected={desiredDate}
-              onSelect={setDesiredDate}
-              initialFocus
-              disabled={isDateDisabled}
-            />
+                <Calendar
+                  mode="single"
+                  selected={desiredDate}
+                  onSelect={onDesiredDateChange}
+                  initialFocus
+                  disabled={isDateDisabled}
+                />
           </PopoverContent>
         </Popover>
       </div>
@@ -143,7 +143,7 @@ export function RepairRequestsCreateSheetForm({
       {canSetRepairUnit && (
         <div className="space-y-2">
           <Label htmlFor="repair-unit">Đơn vị thực hiện</Label>
-          <Select value={repairUnit} onValueChange={(value) => setRepairUnit(value as RepairUnit)}>
+          <Select value={repairUnit} onValueChange={(value) => onRepairUnitChange(value as RepairUnit)}>
             <SelectTrigger className="touch-target">
               <SelectValue placeholder="Chọn đơn vị thực hiện" />
             </SelectTrigger>
@@ -162,7 +162,7 @@ export function RepairRequestsCreateSheetForm({
             id="external-company"
             placeholder="Nhập tên đơn vị được thuê sửa chữa..."
             value={externalCompanyName}
-            onChange={(e) => setExternalCompanyName(e.target.value)}
+            onChange={(e) => onExternalCompanyNameChange(e.target.value)}
             required
             className="touch-target"
           />

--- a/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
@@ -28,6 +28,51 @@ import { Calendar as CalendarIcon, Loader2 } from "lucide-react"
 import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
 import type { RepairUnit } from "../types"
 
+interface RepairRequestsEditFormState {
+  desiredDate: Date | undefined
+  externalCompanyName: string
+  issueDescription: string
+  repairItems: string
+  repairUnit: RepairUnit
+}
+
+type RepairRequestsEditFormAction =
+  | { type: "patch"; updates: Partial<RepairRequestsEditFormState> }
+
+const initialEditFormState: RepairRequestsEditFormState = {
+  desiredDate: undefined,
+  externalCompanyName: "",
+  issueDescription: "",
+  repairItems: "",
+  repairUnit: "noi_bo",
+}
+
+function repairRequestsEditFormReducer(
+  state: RepairRequestsEditFormState,
+  action: RepairRequestsEditFormAction,
+): RepairRequestsEditFormState {
+  switch (action.type) {
+    case "patch":
+      return { ...state, ...action.updates }
+  }
+}
+
+type RepairRequestToEdit = NonNullable<
+  ReturnType<typeof useRepairRequestsContext>["dialogState"]["requestToEdit"]
+>
+
+function createEditFormState(requestToEdit: RepairRequestToEdit): RepairRequestsEditFormState {
+  return {
+    desiredDate: requestToEdit.ngay_mong_muon_hoan_thanh
+      ? parseISO(requestToEdit.ngay_mong_muon_hoan_thanh)
+      : undefined,
+    externalCompanyName: requestToEdit.ten_don_vi_thue || "",
+    issueDescription: requestToEdit.mo_ta_su_co,
+    repairItems: requestToEdit.hang_muc_sua_chua || "",
+    repairUnit: requestToEdit.don_vi_thuc_hien || "noi_bo",
+  }
+}
+
 export function RepairRequestsEditDialog() {
   const {
     dialogState: { requestToEdit },
@@ -36,27 +81,35 @@ export function RepairRequestsEditDialog() {
     canSetRepairUnit,
   } = useRepairRequestsContext()
 
-  // Local form state
-  const [issueDescription, setIssueDescription] = React.useState("")
-  const [repairItems, setRepairItems] = React.useState("")
-  const [desiredDate, setDesiredDate] = React.useState<Date | undefined>()
-  const [repairUnit, setRepairUnit] = React.useState<RepairUnit>("noi_bo")
-  const [externalCompanyName, setExternalCompanyName] = React.useState("")
+  if (!requestToEdit) return null
 
-  // Populate form when dialog opens
-  React.useEffect(() => {
-    if (requestToEdit) {
-      setIssueDescription(requestToEdit.mo_ta_su_co)
-      setRepairItems(requestToEdit.hang_muc_sua_chua || "")
-      setDesiredDate(
-        requestToEdit.ngay_mong_muon_hoan_thanh
-          ? parseISO(requestToEdit.ngay_mong_muon_hoan_thanh)
-          : undefined
-      )
-      setRepairUnit(requestToEdit.don_vi_thuc_hien || "noi_bo")
-      setExternalCompanyName(requestToEdit.ten_don_vi_thue || "")
-    }
-  }, [requestToEdit])
+  return (
+    <RepairRequestsEditDialogContent
+      key={requestToEdit.id}
+      canSetRepairUnit={canSetRepairUnit}
+      closeAllDialogs={closeAllDialogs}
+      requestToEdit={requestToEdit}
+      updateMutation={updateMutation}
+    />
+  )
+}
+
+function RepairRequestsEditDialogContent({
+  canSetRepairUnit,
+  closeAllDialogs,
+  requestToEdit,
+  updateMutation,
+}: {
+  canSetRepairUnit: boolean
+  closeAllDialogs: () => void
+  requestToEdit: RepairRequestToEdit
+  updateMutation: ReturnType<typeof useRepairRequestsContext>["updateMutation"]
+}) {
+  const [formState, dispatchForm] = React.useReducer(
+    repairRequestsEditFormReducer,
+    requestToEdit,
+    createEditFormState,
+  )
 
   const handleSubmit = () => {
     if (!requestToEdit) return
@@ -64,21 +117,19 @@ export function RepairRequestsEditDialog() {
     updateMutation.mutate(
       {
         id: requestToEdit.id,
-        mo_ta_su_co: issueDescription,
-        hang_muc_sua_chua: repairItems,
-        ngay_mong_muon_hoan_thanh: desiredDate
-          ? format(desiredDate, "yyyy-MM-dd")
+        mo_ta_su_co: formState.issueDescription,
+        hang_muc_sua_chua: formState.repairItems,
+        ngay_mong_muon_hoan_thanh: formState.desiredDate
+          ? format(formState.desiredDate, "yyyy-MM-dd")
           : null,
-        don_vi_thuc_hien: canSetRepairUnit ? repairUnit : undefined,
-        ten_don_vi_thue: canSetRepairUnit && repairUnit === "thue_ngoai"
-          ? externalCompanyName.trim()
+        don_vi_thuc_hien: canSetRepairUnit ? formState.repairUnit : undefined,
+        ten_don_vi_thue: canSetRepairUnit && formState.repairUnit === "thue_ngoai"
+          ? formState.externalCompanyName.trim()
           : null,
       },
       { onSuccess: closeAllDialogs }
     )
   }
-
-  if (!requestToEdit) return null
 
   return (
     <Dialog open={!!requestToEdit} onOpenChange={(open) => !open && closeAllDialogs()}>
@@ -96,8 +147,11 @@ export function RepairRequestsEditDialog() {
               id="edit-issue"
               placeholder="Mô tả chi tiết vấn đề gặp phải..."
               rows={4}
-              value={issueDescription}
-              onChange={(e) => setIssueDescription(e.target.value)}
+              value={formState.issueDescription}
+              onChange={(e) => dispatchForm({
+                type: "patch",
+                updates: { issueDescription: e.target.value },
+              })}
               required
             />
           </div>
@@ -107,8 +161,11 @@ export function RepairRequestsEditDialog() {
               id="edit-repair-items"
               placeholder="VD: Thay màn hình, sửa nguồn..."
               rows={3}
-              value={repairItems}
-              onChange={(e) => setRepairItems(e.target.value)}
+              value={formState.repairItems}
+              onChange={(e) => dispatchForm({
+                type: "patch",
+                updates: { repairItems: e.target.value },
+              })}
               required
             />
           </div>
@@ -120,18 +177,21 @@ export function RepairRequestsEditDialog() {
                   variant="outline"
                   className={cn(
                     "w-full justify-start text-left font-normal touch-target",
-                    !desiredDate && "text-muted-foreground"
+                    !formState.desiredDate && "text-muted-foreground"
                   )}
                 >
-                  <CalendarIcon className="mr-2 h-4 w-4" />
-                  {desiredDate ? format(desiredDate, "dd/MM/yyyy") : <span>Chọn ngày</span>}
+                  <CalendarIcon className="mr-2 size-4" />
+                  {formState.desiredDate ? format(formState.desiredDate, "dd/MM/yyyy") : <span>Chọn ngày</span>}
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="w-auto p-0">
                 <Calendar
                   mode="single"
-                  selected={desiredDate}
-                  onSelect={setDesiredDate}
+                  selected={formState.desiredDate}
+                  onSelect={(desiredDate) => dispatchForm({
+                    type: "patch",
+                    updates: { desiredDate },
+                  })}
                   initialFocus
                   disabled={(date) => {
                     const requestTimestamp = Date.parse(requestToEdit.ngay_yeu_cau)
@@ -148,8 +208,11 @@ export function RepairRequestsEditDialog() {
             <div className="space-y-2">
               <Label htmlFor="edit-repair-unit">Đơn vị thực hiện</Label>
               <Select
-                value={repairUnit}
-                onValueChange={(value) => setRepairUnit(value as RepairUnit)}
+                value={formState.repairUnit}
+                onValueChange={(value) => dispatchForm({
+                  type: "patch",
+                  updates: { repairUnit: value as RepairUnit },
+                })}
               >
                 <SelectTrigger className="touch-target">
                   <SelectValue placeholder="Chọn đơn vị thực hiện" />
@@ -162,14 +225,17 @@ export function RepairRequestsEditDialog() {
             </div>
           )}
 
-          {canSetRepairUnit && repairUnit === "thue_ngoai" && (
+          {canSetRepairUnit && formState.repairUnit === "thue_ngoai" && (
             <div className="space-y-2">
               <Label htmlFor="edit-external-company">Tên đơn vị được thuê</Label>
               <Input
                 id="edit-external-company"
                 placeholder="Nhập tên đơn vị được thuê sửa chữa..."
-                value={externalCompanyName}
-                onChange={(e) => setExternalCompanyName(e.target.value)}
+                value={formState.externalCompanyName}
+                onChange={(e) => dispatchForm({
+                  type: "patch",
+                  updates: { externalCompanyName: e.target.value },
+                })}
                 required
                 className="touch-target"
               />
@@ -190,7 +256,7 @@ export function RepairRequestsEditDialog() {
             disabled={updateMutation.isPending}
             className="touch-target"
           >
-            {updateMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {updateMutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
             Lưu thay đổi
           </Button>
         </DialogFooter>

--- a/src/components/__tests__/add-dialogs.error-handling.test.tsx
+++ b/src/components/__tests__/add-dialogs.error-handling.test.tsx
@@ -93,7 +93,9 @@ describe("dialog unknown-error handling", () => {
   it("surfaces plain-object tenant fetch errors in AddUserDialog", async () => {
     mocks.fetchTenantList.mockRejectedValueOnce({ message: "Permission denied" })
 
-    render(<AddUserDialog open onOpenChange={vi.fn()} onSuccess={vi.fn()} />)
+    render(<AddUserDialog open onOpenChange={vi.fn()} onSuccess={vi.fn()} />, {
+      wrapper: createWrapper(),
+    })
 
     await waitFor(() => {
       expect(mocks.toast).toHaveBeenCalledWith(

--- a/src/components/__tests__/react-doctor-p2-rerender-source.test.ts
+++ b/src/components/__tests__/react-doctor-p2-rerender-source.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8")
+}
+
+function extractFunction(source: string, functionName: string) {
+  const start = source.indexOf(`export function ${functionName}`)
+  const nextExport = source.indexOf("\nexport function", start + 1)
+  return source.slice(start, nextExport === -1 ? undefined : nextExport)
+}
+
+describe("React Doctor P2 rerender source guard", () => {
+  it("keeps the PWA install prompt state consolidated", () => {
+    const source = readSource("src/components/pwa-install-prompt.tsx")
+    const installPrompt = extractFunction(source, "PWAInstallPrompt")
+
+    expect(installPrompt).toContain("useReducer")
+    expect(installPrompt).toContain("useRef")
+    expect(installPrompt).not.toContain("useState")
+  })
+
+  it("keeps repair request create and edit form state reducer-based", () => {
+    const createSource = readSource(
+      "src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx",
+    )
+    const editSource = readSource(
+      "src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx",
+    )
+
+    expect(createSource).toContain("useReducer")
+    expect(createSource).not.toContain("setIssueDescription")
+    expect(editSource).toContain("useReducer")
+    expect(editSource).not.toContain("setIssueDescription")
+  })
+
+  it("keeps AddTasksDialog table state reducer-based and filter options single-pass", () => {
+    const source = readSource("src/components/add-tasks-dialog.tsx")
+
+    expect(source).toContain("useReducer")
+    expect(source).not.toContain(".filter(Boolean)")
+    expect(source).not.toContain("setRowSelection({})")
+  })
+
+  it("uses mutation or transition pending state in tenant and user submit dialogs", () => {
+    const files = [
+      "src/components/add-tenant-dialog.tsx",
+      "src/components/edit-tenant-dialog.tsx",
+      "src/components/add-user-dialog.tsx",
+      "src/components/edit-user-dialog.tsx",
+    ]
+
+    for (const file of files) {
+      const source = readSource(file)
+
+      expect(source).not.toContain("const [isLoading, setIsLoading]")
+      expect(source).not.toContain("setIsLoading(")
+    }
+  })
+})

--- a/src/components/__tests__/react-doctor-p2-rerender-source.test.ts
+++ b/src/components/__tests__/react-doctor-p2-rerender-source.test.ts
@@ -9,6 +9,9 @@ function readSource(relativePath: string) {
 
 function extractFunction(source: string, functionName: string) {
   const start = source.indexOf(`export function ${functionName}`)
+  if (start === -1) {
+    throw new Error(`Missing exported function: ${functionName}`)
+  }
   const nextExport = source.indexOf("\nexport function", start + 1)
   return source.slice(start, nextExport === -1 ? undefined : nextExport)
 }
@@ -21,6 +24,7 @@ describe("React Doctor P2 rerender source guard", () => {
     expect(installPrompt).toContain("useReducer")
     expect(installPrompt).toContain("useRef")
     expect(installPrompt).not.toContain("useState")
+    expect(installPrompt).not.toContain("console.log")
   })
 
   it("keeps repair request create and edit form state reducer-based", () => {
@@ -43,6 +47,7 @@ describe("React Doctor P2 rerender source guard", () => {
     expect(source).toContain("useReducer")
     expect(source).not.toContain(".filter(Boolean)")
     expect(source).not.toContain("setRowSelection({})")
+    expect(source).toContain("...initialAddTasksTableState")
   })
 
   it("uses mutation or transition pending state in tenant and user submit dialogs", () => {

--- a/src/components/add-tasks-dialog.tsx
+++ b/src/components/add-tasks-dialog.tsx
@@ -8,7 +8,15 @@
 "use client"
 
 import * as React from "react"
-import type { ColumnDef, ColumnFiltersState, SortingState, VisibilityState } from "@tanstack/react-table"
+import type {
+  ColumnDef,
+  ColumnFiltersState,
+  PaginationState,
+  RowSelectionState,
+  SortingState,
+  Updater,
+  VisibilityState,
+} from "@tanstack/react-table"
 import {
   flexRender,
   getCoreRowModel,
@@ -48,7 +56,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { useToast } from "@/hooks/use-toast"
 import { useAddTasksEquipment } from "@/hooks/useAddTasksEquipment"
 import type { Equipment, MaintenancePlan } from "@/lib/data"
 import { ScrollArea } from "./ui/scroll-area"
@@ -65,6 +72,83 @@ interface AddTasksDialogProps {
   onSuccess: (selectedEquipment: Equipment[]) => void
 }
 
+interface AddTasksTableState {
+  columnFilters: ColumnFiltersState
+  columnVisibility: VisibilityState
+  pagination: PaginationState
+  rowSelection: RowSelectionState
+  searchTerm: string
+  sorting: SortingState
+}
+
+type AddTasksTableAction =
+  | { type: "reset-dialog" }
+  | { type: "set-column-filters"; updater: Updater<ColumnFiltersState> }
+  | { type: "set-column-visibility"; updater: Updater<VisibilityState> }
+  | { type: "set-pagination"; updater: Updater<PaginationState> }
+  | { type: "set-row-selection"; updater: Updater<RowSelectionState> }
+  | { type: "set-search-term"; value: string }
+  | { type: "set-sorting"; updater: Updater<SortingState> }
+
+const initialAddTasksTableState: AddTasksTableState = {
+  columnFilters: [],
+  columnVisibility: {
+    "nguoi_dang_truc_tiep_quan_ly": false,
+    "vi_tri_lap_dat": false,
+  },
+  pagination: { pageIndex: 0, pageSize: 10 },
+  rowSelection: {},
+  searchTerm: "",
+  sorting: [],
+}
+
+function resolveUpdater<T>(updater: Updater<T>, current: T): T {
+  if (typeof updater !== "function") {
+    return updater
+  }
+
+  return (updater as (old: T) => T)(current)
+}
+
+function addTasksTableReducer(
+  state: AddTasksTableState,
+  action: AddTasksTableAction,
+): AddTasksTableState {
+  switch (action.type) {
+    case "reset-dialog":
+      return {
+        ...state,
+        columnFilters: [],
+        pagination: initialAddTasksTableState.pagination,
+        rowSelection: initialAddTasksTableState.rowSelection,
+        searchTerm: "",
+      }
+    case "set-column-filters":
+      return { ...state, columnFilters: resolveUpdater(action.updater, state.columnFilters) }
+    case "set-column-visibility":
+      return { ...state, columnVisibility: resolveUpdater(action.updater, state.columnVisibility) }
+    case "set-pagination":
+      return { ...state, pagination: resolveUpdater(action.updater, state.pagination) }
+    case "set-row-selection":
+      return { ...state, rowSelection: resolveUpdater(action.updater, state.rowSelection) }
+    case "set-search-term":
+      return { ...state, searchTerm: action.value }
+    case "set-sorting":
+      return { ...state, sorting: resolveUpdater(action.updater, state.sorting) }
+  }
+}
+
+function getUniqueTrimmedValues(equipment: Equipment[], key: keyof Equipment) {
+  return Array.from(new Set(
+    equipment.flatMap((item) => {
+      const value = item[key]
+      if (typeof value !== "string") return []
+      const trimmed = value.trim()
+      return trimmed ? [trimmed] : []
+    }),
+  ))
+}
+
 export function AddTasksDialog({
   open,
   onOpenChange,
@@ -72,39 +156,14 @@ export function AddTasksDialog({
   existingEquipmentIds,
   onSuccess,
 }: AddTasksDialogProps) {
-  const { toast } = useToast()
   const { data, isLoading, error } = useAddTasksEquipment(open)
   const equipment = data ?? []
-  const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const [tableState, dispatchTable] = React.useReducer(
+    addTasksTableReducer,
+    initialAddTasksTableState,
+  )
 
-  // Show toast on fetch error
-  React.useEffect(() => {
-    if (error) {
-      toast({ variant: "destructive", title: "Lỗi tải thiết bị", description: error.message })
-    }
-  }, [error, toast])
-
-  // Table state
-  const [sorting, setSorting] = React.useState<SortingState>([])
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
-  const [searchTerm, setSearchTerm] = React.useState("")
-  const debouncedSearch = useSearchDebounce(searchTerm)
-  const [rowSelection, setRowSelection] = React.useState({})
-  const [pagination, setPagination] = React.useState({ pageIndex: 0, pageSize: 10 })
-  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({
-    "nguoi_dang_truc_tiep_quan_ly": false,
-    "vi_tri_lap_dat": false,
-  })
-
-  // Reset table state when dialog closes
-  React.useEffect(() => {
-    if (!open) {
-      setRowSelection({})
-      setSearchTerm("")
-      setColumnFilters([])
-      setPagination({ pageIndex: 0, pageSize: 10 })
-    }
-  }, [open])
+  const debouncedSearch = useSearchDebounce(tableState.searchTerm)
 
   const columns: ColumnDef<Equipment>[] = React.useMemo(
     () => [
@@ -162,20 +221,20 @@ export function AddTasksDialog({
     data: equipment,
     columns,
     state: {
-      sorting,
-      columnFilters,
+      sorting: tableState.sorting,
+      columnFilters: tableState.columnFilters,
       globalFilter: debouncedSearch,
-      rowSelection,
-      columnVisibility,
-      pagination,
+      rowSelection: tableState.rowSelection,
+      columnVisibility: tableState.columnVisibility,
+      pagination: tableState.pagination,
     },
     enableRowSelection: (row) => !existingEquipmentIds.includes(row.original.id),
-    onRowSelectionChange: setRowSelection,
-    onSortingChange: setSorting,
-    onColumnFiltersChange: setColumnFilters,
-    onColumnVisibilityChange: setColumnVisibility,
-    onPaginationChange: setPagination,
-    onGlobalFilterChange: (value: string) => setSearchTerm(value),
+    onRowSelectionChange: (updater) => dispatchTable({ type: "set-row-selection", updater }),
+    onSortingChange: (updater) => dispatchTable({ type: "set-sorting", updater }),
+    onColumnFiltersChange: (updater) => dispatchTable({ type: "set-column-filters", updater }),
+    onColumnVisibilityChange: (updater) => dispatchTable({ type: "set-column-visibility", updater }),
+    onPaginationChange: (updater) => dispatchTable({ type: "set-pagination", updater }),
+    onGlobalFilterChange: (value: string) => dispatchTable({ type: "set-search-term", value }),
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
@@ -184,37 +243,36 @@ export function AddTasksDialog({
     getFacetedUniqueValues: getFacetedUniqueValues(),
   })
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      dispatchTable({ type: "reset-dialog" })
+    }
+    onOpenChange(nextOpen)
+  }
+
   const handleAdd = () => {
-    setIsSubmitting(true);
     const selectedEquipment = table.getFilteredSelectedRowModel().rows.map(row => row.original);
     if (selectedEquipment.length === 0) {
-      toast({
-        variant: "destructive",
-        title: "Chưa chọn thiết bị",
-        description: "Vui lòng chọn ít nhất một thiết bị để thêm.",
-      });
-      setIsSubmitting(false);
       return;
     }
     onSuccess(selectedEquipment);
-    onOpenChange(false);
-    setIsSubmitting(false);
+    handleOpenChange(false);
   }
 
-  const departments = React.useMemo(() => Array.from(new Set(equipment.map((item) => item.khoa_phong_quan_ly?.trim()).filter(Boolean))), [equipment])
-  const users = React.useMemo(() => Array.from(new Set(equipment.map((item) => item.nguoi_dang_truc_tiep_quan_ly?.trim()).filter(Boolean))), [equipment])
-  const locations = React.useMemo(() => Array.from(new Set(equipment.map((item) => item.vi_tri_lap_dat?.trim()).filter(Boolean))), [equipment])
+  const departments = React.useMemo(() => getUniqueTrimmedValues(equipment, "khoa_phong_quan_ly"), [equipment])
+  const users = React.useMemo(() => getUniqueTrimmedValues(equipment, "nguoi_dang_truc_tiep_quan_ly"), [equipment])
+  const locations = React.useMemo(() => getUniqueTrimmedValues(equipment, "vi_tri_lap_dat"), [equipment])
 
   const isFiltered = table.getState().columnFilters.length > 0 || (debouncedSearch?.length ?? 0) > 0;
 
   const totalSelectableRows = React.useMemo(
     () => table.getFilteredRowModel().rows.filter(row => row.getCanSelect()).length,
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [equipment, columnFilters, existingEquipmentIds, debouncedSearch]
+    [equipment, tableState.columnFilters, existingEquipmentIds, debouncedSearch]
   );
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-7xl h-[90vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>Thêm thiết bị vào kế hoạch: {plan?.ten_ke_hoach}</DialogTitle>
@@ -226,8 +284,8 @@ export function AddTasksDialog({
           <div className="flex items-center gap-2 flex-wrap">
             <SearchInput
               placeholder="Tìm kiếm chung..."
-              value={searchTerm}
-              onChange={setSearchTerm}
+              value={tableState.searchTerm}
+              onChange={(value) => dispatchTable({ type: "set-search-term", value })}
               showSearchIcon={false}
               className="h-8 w-[150px] lg:w-[250px]"
             />
@@ -251,12 +309,12 @@ export function AddTasksDialog({
                 variant="ghost"
                 onClick={() => {
                   table.resetColumnFilters();
-                  setSearchTerm("");
+                  dispatchTable({ type: "set-search-term", value: "" });
                 }}
                 className="h-8 px-2 lg:px-3"
               >
                 Xóa bộ lọc
-                <FilterX className="ml-2 h-4 w-4" />
+                <FilterX className="ml-2 size-4" />
               </Button>
             )}
             <div className="ml-auto">
@@ -264,7 +322,7 @@ export function AddTasksDialog({
                 <DropdownMenuTrigger asChild>
                   <Button variant="outline" className="h-8 gap-1">
                     Cột
-                    <ChevronDown className="h-3.5 w-3.5" />
+                    <ChevronDown className="size-3.5" />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-[180px]">
@@ -272,10 +330,10 @@ export function AddTasksDialog({
                   <DropdownMenuSeparator />
                   {table
                     .getAllColumns()
-                    .filter((column) => column.getCanHide())
-                    .map((column) => {
+                    .flatMap((column) => {
+                      if (!column.getCanHide()) return []
                       const header = (column.columnDef.header as string) || column.id;
-                      return (
+                      return [(
                         <DropdownMenuCheckboxItem
                           key={column.id}
                           className="capitalize"
@@ -287,7 +345,7 @@ export function AddTasksDialog({
                         >
                           {header}
                         </DropdownMenuCheckboxItem>
-                      )
+                      )]
                     })}
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -313,11 +371,17 @@ export function AddTasksDialog({
                   ))}
                 </TableHeader>
                 <TableBody>
-                  {isLoading ? (
+                  {error ? (
                     <TableRow>
-                      <TableCell colSpan={columns.length} className="h-24 text-center">
-                        <Loader2 className="mx-auto h-6 w-6 animate-spin" />
+                      <TableCell colSpan={columns.length} className="h-24 text-center text-destructive">
+                        Không thể tải thiết bị: {error.message}
                       </TableCell>
+                    </TableRow>
+                  ) : isLoading ? (
+		                    <TableRow>
+		                      <TableCell colSpan={columns.length} className="h-24 text-center">
+		                        <Loader2 className="mx-auto size-6 animate-spin" />
+		                      </TableCell>
                     </TableRow>
                   ) : table.getRowModel().rows?.length ? (
                     table.getRowModel().rows.map((row) => (
@@ -359,11 +423,10 @@ export function AddTasksDialog({
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Hủy
           </Button>
-          <Button onClick={handleAdd} disabled={isSubmitting || table.getFilteredSelectedRowModel().rows.length === 0}>
-            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          <Button onClick={handleAdd} disabled={table.getFilteredSelectedRowModel().rows.length === 0}>
             Thêm {table.getFilteredSelectedRowModel().rows.length > 0 ? `${table.getFilteredSelectedRowModel().rows.length} thiết bị` : ''}
           </Button>
         </DialogFooter>

--- a/src/components/add-tasks-dialog.tsx
+++ b/src/components/add-tasks-dialog.tsx
@@ -117,11 +117,12 @@ function addTasksTableReducer(
   switch (action.type) {
     case "reset-dialog":
       return {
-        ...state,
-        columnFilters: [],
-        pagination: initialAddTasksTableState.pagination,
-        rowSelection: initialAddTasksTableState.rowSelection,
-        searchTerm: "",
+        ...initialAddTasksTableState,
+        columnFilters: [...initialAddTasksTableState.columnFilters],
+        columnVisibility: { ...initialAddTasksTableState.columnVisibility },
+        pagination: { ...initialAddTasksTableState.pagination },
+        rowSelection: { ...initialAddTasksTableState.rowSelection },
+        sorting: [...initialAddTasksTableState.sorting],
       }
     case "set-column-filters":
       return { ...state, columnFilters: resolveUpdater(action.updater, state.columnFilters) }

--- a/src/components/add-tenant-dialog.tsx
+++ b/src/components/add-tenant-dialog.tsx
@@ -21,7 +21,6 @@ interface AddTenantDialogProps {
 export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDialogProps) {
   const { toast } = useToast()
   const qc = useQueryClient()
-  const [isLoading, setIsLoading] = React.useState(false)
   const [form, setForm] = React.useState({
     code: "",
     name: "",
@@ -57,32 +56,33 @@ export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDial
       const row = Array.isArray(res) ? res[0] as TenantRow : res as TenantRow
       return row
     },
-    onSuccess: (row) => {
-      const all = qc.getQueriesData<{ rows: TenantRow[] }>({ queryKey: ["don_vi"] })
-      all.forEach(([key, data]) => {
-        if (!data) return
-        const exists = data.rows.some(r => r.id === row.id)
-        const newRows = exists ? data.rows.map(r => r.id === row.id ? row : r) : [row, ...data.rows]
-        qc.setQueryData(key as any, { rows: newRows })
-      })
-      toast({ title: "Thành công", description: "Đã tạo đơn vị mới" })
-      onSuccess?.()
-      onOpenChange(false)
-    },
-    onError: (e: any) => {
-      toast({ variant: "destructive", title: "Lỗi", description: e?.message || "Không thể tạo đơn vị" })
-    }
-  })
+	    onSuccess: (row) => {
+	      const all = qc.getQueriesData<{ rows: TenantRow[] }>({ queryKey: ["don_vi"] })
+	      all.forEach(([key, data]) => {
+	        if (!data) return
+	        const exists = data.rows.some(r => r.id === row.id)
+	        const newRows = exists ? data.rows.map(r => r.id === row.id ? row : r) : [row, ...data.rows]
+	        qc.setQueryData(key, { rows: newRows })
+	      })
+	      toast({ title: "Thành công", description: "Đã tạo đơn vị mới" })
+	      onSuccess?.()
+	      onOpenChange(false)
+	    },
+	    onError: (error: unknown) => {
+	      const description = error instanceof Error ? error.message : "Không thể tạo đơn vị"
+	      toast({ variant: "destructive", title: "Lỗi", description })
+	    }
+	  })
+  const isPending = createMutation.isPending
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!form.name.trim()) {
       toast({ variant: "destructive", title: "Lỗi", description: "Tên đơn vị không được trống" })
-      return
-    }
-    setIsLoading(true)
-    createMutation.mutate(undefined, { onSettled: () => setIsLoading(false) })
-  }
+	      return
+	    }
+	    createMutation.mutate()
+	  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -95,33 +95,33 @@ export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDial
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
               <Label htmlFor="code">Mã đơn vị</Label>
-              <Input id="code" value={form.code} onChange={(e) => setForm(s => ({ ...s, code: e.target.value }))} placeholder="VD: CDCCT" disabled={isLoading} />
+              <Input id="code" value={form.code} onChange={(e) => setForm(s => ({ ...s, code: e.target.value }))} placeholder="VD: CDCCT" disabled={isPending} />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="name">Tên đơn vị *</Label>
-              <Input id="name" value={form.name} onChange={(e) => setForm(s => ({ ...s, name: e.target.value }))} placeholder="Nhập tên đơn vị" required disabled={isLoading} />
+              <Input id="name" value={form.name} onChange={(e) => setForm(s => ({ ...s, name: e.target.value }))} placeholder="Nhập tên đơn vị" required disabled={isPending} />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="logo">Logo URL</Label>
-              <Input id="logo" type="url" value={form.logo_url} onChange={(e) => setForm(s => ({ ...s, logo_url: e.target.value }))} placeholder="https://..." disabled={isLoading} />
+              <Input id="logo" type="url" value={form.logo_url} onChange={(e) => setForm(s => ({ ...s, logo_url: e.target.value }))} placeholder="https://..." disabled={isPending} />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="quota">Hạn mức tài khoản thành viên</Label>
-              <Input id="quota" inputMode="numeric" pattern="[0-9]*" value={form.membership_quota} onChange={(e) => setForm(s => ({ ...s, membership_quota: e.target.value }))} placeholder="Để trống nếu không giới hạn" disabled={isLoading} />
+              <Input id="quota" inputMode="numeric" pattern="[0-9]*" value={form.membership_quota} onChange={(e) => setForm(s => ({ ...s, membership_quota: e.target.value }))} placeholder="Để trống nếu không giới hạn" disabled={isPending} />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="google_drive_url">URL thư mục Google Drive chia sẻ</Label>
-              <Input id="google_drive_url" type="url" value={form.google_drive_folder_url} onChange={(e) => setForm(s => ({ ...s, google_drive_folder_url: e.target.value }))} placeholder="https://drive.google.com/drive/folders/..." disabled={isLoading} />
+              <Input id="google_drive_url" type="url" value={form.google_drive_folder_url} onChange={(e) => setForm(s => ({ ...s, google_drive_folder_url: e.target.value }))} placeholder="https://drive.google.com/drive/folders/..." disabled={isPending} />
               <p className="text-xs text-muted-foreground">Thư mục Google Drive chia sẻ cho file đính kèm thiết bị của đơn vị này.</p>
             </div>
             <div className="flex items-center gap-2">
-              <Checkbox id="active" checked={form.active} onCheckedChange={(v) => setForm(s => ({ ...s, active: !!v }))} disabled={isLoading} />
+              <Checkbox id="active" checked={form.active} onCheckedChange={(v) => setForm(s => ({ ...s, active: !!v }))} disabled={isPending} />
               <Label htmlFor="active">Đang hoạt động</Label>
             </div>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>Hủy</Button>
-            <Button type="submit" disabled={isLoading}>{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Tạo</Button>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>Hủy</Button>
+            <Button type="submit" disabled={isPending}>{isPending && <Loader2 className="mr-2 size-4 animate-spin" />}Tạo</Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/src/components/add-user-dialog.tsx
+++ b/src/components/add-user-dialog.tsx
@@ -22,6 +22,7 @@ import { USER_ROLES, type UserRole } from "@/types/database"
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { fetchTenantList, type AddEquipmentTenantOption } from "./add-equipment-dialog.queries"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 interface AddUserDialogProps {
   open: boolean
@@ -31,7 +32,7 @@ interface AddUserDialogProps {
 
 export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogProps) {
   const { toast } = useToast()
-  const [isLoading, setIsLoading] = React.useState(false)
+  const queryClient = useQueryClient()
   const [tenants, setTenants] = React.useState<AddEquipmentTenantOption[]>([])
   const [memberships, setMemberships] = React.useState<number[]>([])
   
@@ -70,22 +71,8 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
     run()
   }, [open, toast])
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    
-    if (!formData.username || !formData.password || !formData.full_name || !formData.role || !formData.current_don_vi) {
-      toast({
-        variant: "destructive",
-        title: "Lỗi",
-        description: "Vui lòng điền đầy đủ thông tin bắt buộc (bao gồm Đơn vị hiện tại)."
-      })
-      return
-    }
-
-    setIsLoading(true)
-
-    try {
-      // Create user via RPC with current don_vi + memberships
+  const createUserMutation = useMutation({
+    mutationFn: async () => {
       const id = await callRpc<number>({
         fn: 'user_create',
         args: {
@@ -102,20 +89,38 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
         throw new Error('Không nhận được ID người dùng sau khi tạo')
       }
 
+      return id
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["users-management"] })
       toast({ title: 'Thành công', description: 'Đã tạo tài khoản người dùng mới.' })
-
       onSuccess()
       onOpenChange(false)
-    } catch (error: unknown) {
+    },
+    onError: (error: unknown) => {
       console.error('Error creating user:', error)
       toast({
         variant: "destructive",
         title: "Lỗi",
         description: getUnknownErrorMessage(error, "Có lỗi xảy ra khi tạo tài khoản.")
       })
-    } finally {
-      setIsLoading(false)
+    },
+  })
+  const isPending = createUserMutation.isPending
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!formData.username || !formData.password || !formData.full_name || !formData.role || !formData.current_don_vi) {
+      toast({
+        variant: "destructive",
+        title: "Lỗi",
+        description: "Vui lòng điền đầy đủ thông tin bắt buộc (bao gồm Đơn vị hiện tại)."
+      })
+      return
     }
+
+    createUserMutation.mutate()
   }
 
   return (
@@ -136,7 +141,7 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
                 value={formData.username}
                 onChange={(e) => setFormData(prev => ({ ...prev, username: e.target.value }))}
                 placeholder="Nhập tên đăng nhập"
-                disabled={isLoading}
+                disabled={isPending}
                 required
               />
             </div>
@@ -148,7 +153,7 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
                 value={formData.password}
                 onChange={(e) => setFormData(prev => ({ ...prev, password: e.target.value }))}
                 placeholder="Nhập mật khẩu"
-                disabled={isLoading}
+                disabled={isPending}
                 required
               />
             </div>
@@ -159,7 +164,7 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
                 value={formData.full_name}
                 onChange={(e) => setFormData(prev => ({ ...prev, full_name: e.target.value }))}
                 placeholder="Nhập họ và tên đầy đủ"
-                disabled={isLoading}
+                disabled={isPending}
                 required
               />
             </div>
@@ -168,7 +173,7 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
               <Select
                 value={formData.role}
                 onValueChange={(value: UserRole) => setFormData(prev => ({ ...prev, role: value }))}
-                disabled={isLoading}
+                disabled={isPending}
                 required
               >
                 <SelectTrigger>
@@ -176,12 +181,11 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
                 </SelectTrigger>
                 <SelectContent>
                   {Object.entries(USER_ROLES)
-                    .filter(([key]) => key !== 'admin')
-                    .map(([key, label]) => (
+                    .flatMap(([key, label]) => key === 'admin' ? [] : [(
                       <SelectItem key={key} value={key}>
                         {label}
                       </SelectItem>
-                    ))}
+                    )])}
                 </SelectContent>
               </Select>
             </div>
@@ -190,7 +194,7 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
               <Select
                 value={formData.current_don_vi ? String(formData.current_don_vi) : ''}
                 onValueChange={(value) => setFormData(prev => ({ ...prev, current_don_vi: Number(value) }))}
-                disabled={isLoading}
+                disabled={isPending}
                 required
               >
                 <SelectTrigger>
@@ -242,12 +246,12 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={isLoading}
+              disabled={isPending}
             >
               Hủy
             </Button>
-            <Button type="submit" disabled={isLoading}>
-              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            <Button type="submit" disabled={isPending}>
+              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
               Tạo tài khoản
             </Button>
           </DialogFooter>

--- a/src/components/add-user-dialog.tsx
+++ b/src/components/add-user-dialog.tsx
@@ -91,8 +91,16 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
 
       return id
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["users-management"] })
+    onSuccess: async () => {
+      try {
+        await queryClient.invalidateQueries({ queryKey: ["users-management"] })
+      } catch (error: unknown) {
+        toast({
+          variant: "destructive",
+          title: "Không thể làm mới danh sách người dùng",
+          description: getUnknownErrorMessage(error, "Vui lòng tải lại trang để xem dữ liệu mới nhất."),
+        })
+      }
       toast({ title: 'Thành công', description: 'Đã tạo tài khoản người dùng mới.' })
       onSuccess()
       onOpenChange(false)

--- a/src/components/edit-tenant-dialog.tsx
+++ b/src/components/edit-tenant-dialog.tsx
@@ -32,7 +32,6 @@ interface EditTenantDialogProps {
 export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: EditTenantDialogProps) {
   const { toast } = useToast()
   const qc = useQueryClient()
-  const [isLoading, setIsLoading] = React.useState(false)
   const [form, setForm] = React.useState({
     code: "",
     name: "",
@@ -87,32 +86,33 @@ export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: Edit
       const row = Array.isArray(res) ? res[0] as TenantRow : res as TenantRow
       return row
     },
-    onSuccess: (row) => {
-      const all = qc.getQueriesData<{ rows: TenantRow[] }>({ queryKey: ["don_vi"] })
-      all.forEach(([key, data]) => {
-        if (!data) return
-        const newRows = data.rows.map(r => r.id === row.id ? { ...r, ...row } : r)
-        qc.setQueryData(key as any, { rows: newRows })
-      })
-      toast({ title: "Thành công", description: "Đã cập nhật đơn vị" })
-      onSuccess?.()
-      onOpenChange(false)
-    },
-    onError: (e: any) => {
-      toast({ variant: "destructive", title: "Lỗi", description: e?.message || "Không thể cập nhật đơn vị" })
-    }
-  })
+	    onSuccess: (row) => {
+	      const all = qc.getQueriesData<{ rows: TenantRow[] }>({ queryKey: ["don_vi"] })
+	      all.forEach(([key, data]) => {
+	        if (!data) return
+	        const newRows = data.rows.map(r => r.id === row.id ? { ...r, ...row } : r)
+	        qc.setQueryData(key, { rows: newRows })
+	      })
+	      toast({ title: "Thành công", description: "Đã cập nhật đơn vị" })
+	      onSuccess?.()
+	      onOpenChange(false)
+	    },
+	    onError: (error: unknown) => {
+	      const description = error instanceof Error ? error.message : "Không thể cập nhật đơn vị"
+	      toast({ variant: "destructive", title: "Lỗi", description })
+	    }
+	  })
+  const isPending = updateMutation.isPending
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!tenant) return
     if (!form.name.trim()) {
       toast({ variant: "destructive", title: "Lỗi", description: "Tên đơn vị không được trống" })
-      return
-    }
-    setIsLoading(true)
-    updateMutation.mutate(undefined, { onSettled: () => setIsLoading(false) })
-  }
+	      return
+	    }
+	    updateMutation.mutate()
+	  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -125,35 +125,35 @@ export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: Edit
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
               <Label htmlFor="code">Mã đơn vị</Label>
-              <Input id="code" value={form.code} onChange={(e) => setForm(s => ({ ...s, code: e.target.value }))} placeholder="VD: CDCCT" disabled={isLoading} />
+              <Input id="code" value={form.code} onChange={(e) => setForm(s => ({ ...s, code: e.target.value }))} placeholder="VD: CDCCT" disabled={isPending} />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="name">Tên đơn vị *</Label>
-              <Input id="name" value={form.name} onChange={(e) => setForm(s => ({ ...s, name: e.target.value }))} placeholder="Nhập tên đơn vị" required disabled={isLoading} />
+              <Input id="name" value={form.name} onChange={(e) => setForm(s => ({ ...s, name: e.target.value }))} placeholder="Nhập tên đơn vị" required disabled={isPending} />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="logo">Logo URL</Label>
-              <Input id="logo" type="url" value={form.logo_url} onChange={(e) => setForm(s => ({ ...s, logo_url: e.target.value }))} placeholder="https://..." disabled={isLoading} />
+              <Input id="logo" type="url" value={form.logo_url} onChange={(e) => setForm(s => ({ ...s, logo_url: e.target.value }))} placeholder="https://..." disabled={isPending} />
               <p className="text-xs text-muted-foreground">Để trống để xóa logo.</p>
             </div>
             <div className="grid gap-2">
               <Label htmlFor="quota">Hạn mức tài khoản thành viên</Label>
-              <Input id="quota" inputMode="numeric" pattern="[0-9]*" value={form.membership_quota} onChange={(e) => setForm(s => ({ ...s, membership_quota: e.target.value }))} placeholder="Để trống nếu không giới hạn" disabled={isLoading} />
+              <Input id="quota" inputMode="numeric" pattern="[0-9]*" value={form.membership_quota} onChange={(e) => setForm(s => ({ ...s, membership_quota: e.target.value }))} placeholder="Để trống nếu không giới hạn" disabled={isPending} />
               <p className="text-xs text-muted-foreground">Để trống để bỏ giới hạn.</p>
             </div>
             <div className="grid gap-2">
               <Label htmlFor="google_drive_url">URL thư mục Google Drive chia sẻ</Label>
-              <Input id="google_drive_url" type="url" value={form.google_drive_folder_url} onChange={(e) => setForm(s => ({ ...s, google_drive_folder_url: e.target.value }))} placeholder="https://drive.google.com/drive/folders/..." disabled={isLoading} />
+              <Input id="google_drive_url" type="url" value={form.google_drive_folder_url} onChange={(e) => setForm(s => ({ ...s, google_drive_folder_url: e.target.value }))} placeholder="https://drive.google.com/drive/folders/..." disabled={isPending} />
               <p className="text-xs text-muted-foreground">Thư mục Google Drive chia sẻ cho file đính kèm thiết bị của đơn vị này.</p>
             </div>
             <div className="flex items-center gap-2">
-              <Checkbox id="active" checked={form.active} onCheckedChange={(v) => setForm(s => ({ ...s, active: !!v }))} disabled={isLoading} />
+              <Checkbox id="active" checked={form.active} onCheckedChange={(v) => setForm(s => ({ ...s, active: !!v }))} disabled={isPending} />
               <Label htmlFor="active">Đang hoạt động</Label>
             </div>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>Hủy</Button>
-            <Button type="submit" disabled={isLoading}>{isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Lưu</Button>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>Hủy</Button>
+            <Button type="submit" disabled={isPending}>{isPending && <Loader2 className="mr-2 size-4 animate-spin" />}Lưu</Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/src/components/edit-user-dialog.tsx
+++ b/src/components/edit-user-dialog.tsx
@@ -19,6 +19,7 @@ import { useToast } from "@/hooks/use-toast"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
 import { callRpc } from "@/lib/rpc-client"
 import { USER_ROLES, type UserRole, type UserSummary } from "@/types/database"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 interface EditUserDialogProps {
   open: boolean
@@ -29,8 +30,7 @@ interface EditUserDialogProps {
 
 export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUserDialogProps) {
   const { toast } = useToast()
-  const [isLoading, setIsLoading] = React.useState(false)
-  
+  const queryClient = useQueryClient()
   const [formData, setFormData] = React.useState({
     username: "",
     full_name: "",
@@ -56,7 +56,43 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
     }
   }, [user, open])
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const updateUserMutation = useMutation({
+    mutationFn: async () => {
+      if (!user) {
+        throw new Error("Không có người dùng để cập nhật")
+      }
+
+      await callRpc<boolean>({
+        fn: "user_update_profile",
+        args: {
+          p_target_user_id: user.id,
+          p_username: formData.username.trim(),
+          p_full_name: formData.full_name.trim(),
+          p_role: formData.role,
+          p_khoa_phong: formData.khoa_phong.trim() || null,
+        },
+      })
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["users-management"] })
+      toast({
+        title: "Thành công",
+        description: "Đã cập nhật thông tin người dùng."
+      })
+      onSuccess()
+      onOpenChange(false)
+    },
+    onError: (error: unknown) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi",
+        description: getUnknownErrorMessage(error, "Có lỗi xảy ra khi cập nhật thông tin.")
+      })
+    },
+  })
+  const isPending = updateUserMutation.isPending
+
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
     if (!user || !formData.username || !formData.full_name || !formData.role) {
@@ -68,36 +104,7 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
       return
     }
 
-    setIsLoading(true)
-
-    try {
-      await callRpc<boolean>({
-        fn: "user_update_profile",
-        args: {
-          p_target_user_id: user.id,
-          p_username: formData.username.trim(),
-          p_full_name: formData.full_name.trim(),
-          p_role: formData.role,
-          p_khoa_phong: formData.khoa_phong.trim() || null,
-        },
-      })
-
-      toast({
-        title: "Thành công",
-        description: "Đã cập nhật thông tin người dùng."
-      })
-
-      onSuccess()
-      onOpenChange(false)
-    } catch (error: unknown) {
-      toast({
-        variant: "destructive",
-        title: "Lỗi",
-        description: getUnknownErrorMessage(error, "Có lỗi xảy ra khi cập nhật thông tin.")
-      })
-    } finally {
-      setIsLoading(false)
-    }
+    updateUserMutation.mutate()
   }
 
   return (
@@ -118,7 +125,7 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
                 value={formData.username}
                 onChange={(e) => setFormData(prev => ({ ...prev, username: e.target.value }))}
                 placeholder="Nhập tên đăng nhập"
-                disabled={isLoading}
+                disabled={isPending}
                 required
               />
             </div>
@@ -129,7 +136,7 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
                 value={formData.full_name}
                 onChange={(e) => setFormData(prev => ({ ...prev, full_name: e.target.value }))}
                 placeholder="Nhập họ và tên đầy đủ"
-                disabled={isLoading}
+                disabled={isPending}
                 required
               />
             </div>
@@ -138,7 +145,7 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
               <Select
                 value={formData.role}
                 onValueChange={(value: UserRole) => setFormData(prev => ({ ...prev, role: value }))}
-                disabled={isLoading}
+                disabled={isPending}
                 required
               >
                 <SelectTrigger>
@@ -146,12 +153,11 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
                 </SelectTrigger>
                 <SelectContent>
                   {Object.entries(USER_ROLES)
-                    .filter(([key]) => key !== 'admin')
-                    .map(([key, label]) => (
+                    .flatMap(([key, label]) => key === 'admin' ? [] : [(
                       <SelectItem key={key} value={key}>
                         {label}
                       </SelectItem>
-                    ))}
+                    )])}
                 </SelectContent>
               </Select>
             </div>
@@ -162,7 +168,7 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
                 value={formData.khoa_phong}
                 onChange={(e) => setFormData(prev => ({ ...prev, khoa_phong: e.target.value }))}
                 placeholder="Nhập khoa/phòng làm việc"
-                disabled={isLoading}
+                disabled={isPending}
               />
             </div>
           </div>
@@ -171,12 +177,12 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={isLoading}
+              disabled={isPending}
             >
               Hủy
             </Button>
-            <Button type="submit" disabled={isLoading}>
-              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            <Button type="submit" disabled={isPending}>
+              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
               Cập nhật
             </Button>
           </DialogFooter>
@@ -184,4 +190,4 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
       </DialogContent>
     </Dialog>
   )
-} 
+}

--- a/src/components/edit-user-dialog.tsx
+++ b/src/components/edit-user-dialog.tsx
@@ -73,8 +73,16 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
         },
       })
     },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["users-management"] })
+    onSuccess: async () => {
+      try {
+        await queryClient.invalidateQueries({ queryKey: ["users-management"] })
+      } catch (error: unknown) {
+        toast({
+          variant: "destructive",
+          title: "Không thể làm mới danh sách người dùng",
+          description: getUnknownErrorMessage(error, "Vui lòng tải lại trang để xem dữ liệu mới nhất."),
+        })
+      }
       toast({
         title: "Thành công",
         description: "Đã cập nhật thông tin người dùng."

--- a/src/components/pwa-install-prompt.tsx
+++ b/src/components/pwa-install-prompt.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useReducer, useRef, useState } from 'react';
+import { useEffect, useReducer, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Download, X } from 'lucide-react';
 
@@ -90,10 +90,11 @@ export function PWAInstallPrompt() {
       if (process.env.NODE_ENV === 'production') {
         try {
           const serwistWindow = window as SerwistWindow;
-          const registration = serwistWindow.serwist
-            ? await serwistWindow.serwist.register()
-            : await navigator.serviceWorker.register('/sw.js');
-          console.log('Service Worker registered:', registration);
+          if (serwistWindow.serwist) {
+            await serwistWindow.serwist.register();
+          } else {
+            await navigator.serviceWorker.register('/sw.js');
+          }
         } catch (error) {
           console.error('Service Worker registration failed:', error);
         }
@@ -108,7 +109,6 @@ export function PWAInstallPrompt() {
             ...regs.map(r => r.unregister()),
             ...cacheNames.map(name => caches.delete(name)),
           ]);
-          console.log('Service Worker unregistered and caches cleared for development');
         } catch (err) {
           console.warn('SW cleanup in development failed:', err);
         }
@@ -142,17 +142,15 @@ export function PWAInstallPrompt() {
   const handleInstallClick = async () => {
     if (!deferredPromptRef.current) return;
 
-    await deferredPromptRef.current.prompt();
-    const { outcome } = await deferredPromptRef.current.userChoice;
-    
-    if (outcome === 'accepted') {
-      console.log('User accepted the install prompt');
-    } else {
-      console.log('User dismissed the install prompt');
+    try {
+      await deferredPromptRef.current.prompt();
+      await deferredPromptRef.current.userChoice;
+    } catch (error) {
+      console.warn('PWA install prompt failed:', error);
+    } finally {
+      deferredPromptRef.current = null;
+      dispatch({ type: "prompt-consumed" });
     }
-    
-    deferredPromptRef.current = null;
-    dispatch({ type: "prompt-consumed" });
   };
 
   const handleDismiss = () => {

--- a/src/components/pwa-install-prompt.tsx
+++ b/src/components/pwa-install-prompt.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useReducer, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Download, X } from 'lucide-react';
 
@@ -15,30 +15,72 @@ interface SerwistWindow extends Window {
   };
 }
 
+interface StandaloneNavigator extends Navigator {
+  standalone?: boolean;
+}
+
+interface PWAInstallPromptState {
+  isDismissed: boolean;
+  isInstalled: boolean;
+  isMounted: boolean;
+  showInstallPrompt: boolean;
+}
+
+type PWAInstallPromptAction =
+  | { type: "app-installed" }
+  | { type: "dismiss" }
+  | { type: "mounted"; isDismissed: boolean; isInstalled: boolean }
+  | { type: "prompt-available" }
+  | { type: "prompt-consumed" }
+
+const initialInstallPromptState: PWAInstallPromptState = {
+  isDismissed: false,
+  isInstalled: false,
+  isMounted: false,
+  showInstallPrompt: false,
+}
+
+function pwaInstallPromptReducer(
+  state: PWAInstallPromptState,
+  action: PWAInstallPromptAction,
+): PWAInstallPromptState {
+  switch (action.type) {
+    case "app-installed":
+      return { ...state, isInstalled: true, showInstallPrompt: false }
+    case "dismiss":
+      return { ...state, isDismissed: true, showInstallPrompt: false }
+    case "mounted":
+      return {
+        ...state,
+        isDismissed: action.isDismissed,
+        isInstalled: action.isInstalled,
+        isMounted: true,
+      }
+    case "prompt-available":
+      return { ...state, showInstallPrompt: true }
+    case "prompt-consumed":
+      return { ...state, showInstallPrompt: false }
+  }
+}
+
+function isAppInstalled() {
+  if (window.matchMedia('(display-mode: standalone)').matches) {
+    return true;
+  }
+
+  return (window.navigator as StandaloneNavigator).standalone === true;
+}
+
 export function PWAInstallPrompt() {
-  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
-  const [showInstallPrompt, setShowInstallPrompt] = useState(false);
-  const [isInstalled, setIsInstalled] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
+  const deferredPromptRef = useRef<BeforeInstallPromptEvent | null>(null);
+  const [state, dispatch] = useReducer(pwaInstallPromptReducer, initialInstallPromptState);
 
   useEffect(() => {
-    setIsMounted(true);
-    
-    // Check if app is already installed
-    const checkIfInstalled = () => {
-      if (window.matchMedia('(display-mode: standalone)').matches) {
-        setIsInstalled(true);
-        return;
-      }
-      
-      // Check for iOS Safari standalone mode
-      if ((window.navigator as any).standalone === true) {
-        setIsInstalled(true);
-        return;
-      }
-    };
-
-    checkIfInstalled();
+    dispatch({
+      type: "mounted",
+      isDismissed: sessionStorage.getItem('pwa-install-dismissed') === 'true',
+      isInstalled: isAppInstalled(),
+    });
 
     // In production, register manually because Serwist auto-registration is disabled in config.
     // In development, unregister any stale SW and clear caches to avoid old precache behavior.
@@ -58,11 +100,14 @@ export function PWAInstallPrompt() {
       } else {
         // In development, unregister any existing SW to avoid precache 404s with Next dev assets
         try {
-          const regs = await navigator.serviceWorker.getRegistrations();
-          await Promise.all(regs.map(r => r.unregister()));
-          // Also clear outdated caches that may have been created by a prod SW
-          const cacheNames = await caches.keys();
-          await Promise.all(cacheNames.map(name => caches.delete(name)));
+          const [regs, cacheNames] = await Promise.all([
+            navigator.serviceWorker.getRegistrations(),
+            caches.keys(),
+          ]);
+          await Promise.all([
+            ...regs.map(r => r.unregister()),
+            ...cacheNames.map(name => caches.delete(name)),
+          ]);
           console.log('Service Worker unregistered and caches cleared for development');
         } catch (err) {
           console.warn('SW cleanup in development failed:', err);
@@ -75,15 +120,14 @@ export function PWAInstallPrompt() {
     // Listen for beforeinstallprompt event
     const handleBeforeInstallPrompt = (e: Event) => {
       e.preventDefault();
-      setDeferredPrompt(e as BeforeInstallPromptEvent);
-      setShowInstallPrompt(true);
+      deferredPromptRef.current = e as BeforeInstallPromptEvent;
+      dispatch({ type: "prompt-available" });
     };
 
     // Listen for appinstalled event
     const handleAppInstalled = () => {
-      setIsInstalled(true);
-      setShowInstallPrompt(false);
-      setDeferredPrompt(null);
+      deferredPromptRef.current = null;
+      dispatch({ type: "app-installed" });
     };
 
     window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
@@ -96,10 +140,10 @@ export function PWAInstallPrompt() {
   }, []);
 
   const handleInstallClick = async () => {
-    if (!deferredPrompt) return;
+    if (!deferredPromptRef.current) return;
 
-    await deferredPrompt.prompt();
-    const { outcome } = await deferredPrompt.userChoice;
+    await deferredPromptRef.current.prompt();
+    const { outcome } = await deferredPromptRef.current.userChoice;
     
     if (outcome === 'accepted') {
       console.log('User accepted the install prompt');
@@ -107,34 +151,34 @@ export function PWAInstallPrompt() {
       console.log('User dismissed the install prompt');
     }
     
-    setDeferredPrompt(null);
-    setShowInstallPrompt(false);
+    deferredPromptRef.current = null;
+    dispatch({ type: "prompt-consumed" });
   };
 
   const handleDismiss = () => {
-    setShowInstallPrompt(false);
     // Hide for this session
     if (typeof window !== 'undefined') {
       sessionStorage.setItem('pwa-install-dismissed', 'true');
     }
+    dispatch({ type: "dismiss" });
   };
 
   // Don't show if not mounted, already installed or dismissed
-  if (!isMounted || isInstalled || !showInstallPrompt || (typeof window !== 'undefined' && sessionStorage.getItem('pwa-install-dismissed'))) {
+  if (!state.isMounted || state.isInstalled || state.isDismissed || !state.showInstallPrompt) {
     return null;
   }
 
   return (
-    <div className="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:max-w-sm z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-4">
+    <div className="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:max-w-sm z-50 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg shadow-lg p-4">
       <div className="flex items-start gap-3">
         <div className="flex-1">
           <h3 className="font-medium text-sm mb-1">Cài đặt ứng dụng</h3>
-          <p className="text-xs text-gray-600 dark:text-gray-400 mb-3">
+          <p className="text-xs text-neutral-600 dark:text-neutral-400 mb-3">
             Cài đặt ứng dụng Quản lý TBYT để sử dụng offline và truy cập nhanh hơn.
           </p>
           <div className="flex gap-2">
             <Button size="sm" onClick={handleInstallClick} className="flex items-center gap-1">
-              <Download className="w-3 h-3" />
+              <Download className="size-3" />
               Cài đặt
             </Button>
             <Button size="sm" variant="outline" onClick={handleDismiss}>
@@ -148,7 +192,7 @@ export function PWAInstallPrompt() {
           onClick={handleDismiss}
           className="p-1 h-auto"
         >
-          <X className="w-4 h-4" />
+          <X className="size-4" />
         </Button>
       </div>
     </div>
@@ -157,36 +201,54 @@ export function PWAInstallPrompt() {
 
 // PWA Status component để debug
 export function PWAStatus() {
-  const [swStatus, setSWStatus] = useState<string>('checking...');
-  const [isOnline, setIsOnline] = useState(true);
-  const [installPromptAvailable, setInstallPromptAvailable] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
+  const [state, dispatch] = useReducer(
+    (
+      current: {
+        installPromptAvailable: boolean;
+        isMounted: boolean;
+        isOnline: boolean;
+        swStatus: string;
+      },
+      next: Partial<{
+        installPromptAvailable: boolean;
+        isMounted: boolean;
+        isOnline: boolean;
+        swStatus: string;
+      }>,
+    ) => ({ ...current, ...next }),
+    {
+      installPromptAvailable: false,
+      isMounted: false,
+      isOnline: true,
+      swStatus: 'checking...',
+    },
+  );
 
   useEffect(() => {
-    setIsMounted(true);
-    
+    dispatch({ isMounted: true });
+
     // Check service worker status
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.ready.then(() => {
-        setSWStatus('active');
+        dispatch({ swStatus: 'active' });
       }).catch(() => {
-        setSWStatus('failed');
+        dispatch({ swStatus: 'failed' });
       });
     } else {
-      setSWStatus('not supported');
+      dispatch({ swStatus: 'not supported' });
     }
 
     // Check online status
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
-    
-    setIsOnline(navigator.onLine);
+    const handleOnline = () => dispatch({ isOnline: true });
+    const handleOffline = () => dispatch({ isOnline: false });
+
+    dispatch({ isOnline: navigator.onLine });
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
 
     // Check install prompt
     const handleBeforeInstallPrompt = () => {
-      setInstallPromptAvailable(true);
+      dispatch({ installPromptAvailable: true });
     };
 
     window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
@@ -199,15 +261,15 @@ export function PWAStatus() {
   }, []);
 
   // Only show in development and after mounting
-  if (process.env.NODE_ENV !== 'development' || !isMounted) {
+  if (process.env.NODE_ENV !== 'development' || !state.isMounted) {
     return null;
   }
 
   return (
     <div className="fixed top-4 right-4 bg-black/80 text-white text-xs p-2 rounded z-50">
-      <div>SW: {swStatus}</div>
-      <div>Online: {isOnline ? 'yes' : 'no'}</div>
-      <div>Install: {installPromptAvailable ? 'available' : 'not available'}</div>
+      <div>SW: {state.swStatus}</div>
+      <div>Online: {state.isOnline ? 'yes' : 'no'}</div>
+      <div>Install: {state.installPromptAvailable ? 'available' : 'not available'}</div>
       <div>HTTPS: {typeof window !== 'undefined' ? (window.location.protocol === 'https:' ? 'yes' : 'no') : 'unknown'}</div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Refactor PWA, repair request, add-tasks, tenant, and user dialogs to remove React Doctor P2 re-render warnings.
- Consolidate related local state with reducers/refs and use mutation pending state for submit flows.
- Add a source guard test for the #455 React Doctor patterns.

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/components/__tests__/react-doctor-p2-rerender-source.test.ts src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx src/app/(app)/repair-requests/__tests__/RepairRequestsCreateSheet.test.tsx src/app/(app)/repair-requests/__tests__/RepairRequestsCreateSheet.submission.test.tsx src/app/(app)/repair-requests/__tests__/RepairRequestsCreateSheetShell.test.tsx src/app/(app)/users/__tests__/useUsersManagement.test.tsx src/app/(app)/users/__tests__/UsersPage.auth.test.tsx
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
- git diff --check

Fixes #455

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes React Doctor P2 re-render warnings by consolidating state with reducers and using mutation pending state across repair requests, tasks, tenants, users, and the PWA install prompt. Hardens equipment lookup (no re-runs after completion) and polishes a few UX edges. Fixes #455.

- **Refactors**
  - Repair requests create/edit: reducer-based form state; explicit onChange props; use mutation pending for submit; prevent duplicate draft equipment lookups; steadier draft hydration.
  - Add tasks dialog: reducer-backed table state (filters, sorting, visibility, selection, pagination, search); dedup filter options in one pass; reset on close; inline error row on fetch failure; removed local submitting state.
  - Tenant/user dialogs: switch to `@tanstack/react-query` mutations with pending state; invalidate relevant queries; remove `isLoading`; align icon sizes.
  - PWA install prompt: reducer + `useRef` for prompt event; streamlined install/dismiss; dev SW+cache cleanup in one pass; session-safe dismiss; neutral color/icon tweaks.

- **Tests**
  - Added source guard to verify reducer-based state, mutation/transition pending usage, and no `useState` in the PWA prompt.
  - New create-sheet test ensures draft equipment lookup doesn’t re-run once marked complete.

<sup>Written for commit e832c354952ad7614cfdcffbf8cad89aad5a47cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust equipment search, selection, and draft-hydration behavior in repair request flows.

* **Bug Fixes**
  * Ensure form state reliably resets and preserves user edits when dialogs/sheets open or close.
  * Fixes to loading/disabled UI so mutation-driven pending states are used consistently.

* **Tests**
  * Added tests enforcing reducer-based state patterns and draft hydration behavior.

* **Refactor**
  * Centralized form/table state management using reducer-driven patterns for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/465)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->