### PR TITLE
chore: Phase 1 Tailwind size codemod

### DIFF
--- a/src/app/(app)/_components/AuthenticatedPageFallbacks.tsx
+++ b/src/app/(app)/_components/AuthenticatedPageFallbacks.tsx
@@ -25,7 +25,7 @@ export function AuthenticatedPageSpinnerFallback() {
       className="flex min-h-[50vh] items-center justify-center"
       data-testid="authenticated-page-spinner-fallback"
     >
-      <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      <Loader2 className="size-6 animate-spin text-muted-foreground" />
     </div>
   )
 }

--- a/src/app/(app)/activity-logs/page.tsx
+++ b/src/app/(app)/activity-logs/page.tsx
@@ -33,7 +33,7 @@ function ActivityLogsPageContent({ user }: ActivityLogsPageContentProps) {
             <div className="text-center space-y-4">
               <div className="flex justify-center">
                 <div className="p-3 bg-red-100 rounded-full">
-                  <Shield className="h-6 w-6 text-red-600" />
+                  <Shield className="size-6 text-red-600" />
                 </div>
               </div>
               <div>
@@ -46,7 +46,7 @@ function ActivityLogsPageContent({ user }: ActivityLogsPageContentProps) {
                 </p>
               </div>
               <div className="flex items-center justify-center text-xs text-gray-500 mt-4">
-                <AlertTriangle className="h-4 w-4 mr-1" />
+                <AlertTriangle className="size-4 mr-1" />
                 <span>Liên hệ quản trị viên nếu bạn cần hỗ trợ</span>
               </div>
             </div>
@@ -62,7 +62,7 @@ function ActivityLogsPageContent({ user }: ActivityLogsPageContentProps) {
       <div className="mb-8">
         <div className="flex items-center space-x-3 mb-2">
           <div className="p-2 bg-blue-100 rounded-lg">
-            <Activity className="h-6 w-6 text-blue-600" />
+            <Activity className="size-6 text-blue-600" />
           </div>
           <div>
             <h1 className="text-3xl font-bold text-gray-900">
@@ -77,7 +77,7 @@ function ActivityLogsPageContent({ user }: ActivityLogsPageContentProps) {
         {/* Security Badge */}
         <div className="flex items-center space-x-2 mt-4">
           <div className="flex items-center space-x-1 bg-green-50 text-green-700 px-3 py-1 rounded-full text-sm">
-            <Shield className="h-4 w-4" />
+            <Shield className="size-4" />
             <span>Chỉ dành cho quản trị viên hệ thống</span>
           </div>
           <div className="text-sm text-gray-500">

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -182,7 +182,7 @@ export default function Dashboard() {
           <div className="flex items-center justify-between">
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <Sparkles className="h-5 w-5 text-primary" />
+                <Sparkles className="size-5 text-primary" />
                 <h1 className="text-xl md:text-2xl font-bold text-slate-800">
                   {getGreeting()}, {user?.full_name || user?.username}!
                 </h1>
@@ -192,8 +192,8 @@ export default function Dashboard() {
               </p>
             </div>
             <div className="hidden md:block">
-              <div className="h-20 w-20 rounded-full bg-primary/5 flex items-center justify-center">
-                <Sparkles className="h-10 w-10 text-primary/40" />
+              <div className="size-20 rounded-full bg-primary/5 flex items-center justify-center">
+                <Sparkles className="size-10 text-primary/40" />
               </div>
             </div>
           </div>
@@ -221,9 +221,9 @@ export default function Dashboard() {
               {/* Báo sửa chữa (New) */}
               <Link href={buildRepairRequestCreateIntentHref()} className="group">
                 <div className="flex flex-col items-center gap-3">
-                  <div className="h-[72px] w-[72px] md:h-[88px] md:w-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
-                    <div className="h-11 w-11 md:h-14 md:w-14 rounded-xl bg-red-50 flex items-center justify-center">
-                      <Wrench className="h-[26px] w-[26px] md:h-8 md:w-8 text-red-600" />
+                  <div className="size-[72px] md:size-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
+                    <div className="size-11 md:size-14 rounded-xl bg-red-50 flex items-center justify-center">
+                      <Wrench className="size-[26px] md:size-8 text-red-600" />
                     </div>
                   </div>
                   <span className="text-xs md:text-sm font-medium text-slate-700 text-center">Báo sửa chữa</span>
@@ -233,9 +233,9 @@ export default function Dashboard() {
               {/* Add Equipment Card */}
               <Link href="/equipment?action=add" className="group">
                 <div className="flex flex-col items-center gap-3">
-                  <div className="h-[72px] w-[72px] md:h-[88px] md:w-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
-                    <div className="h-11 w-11 md:h-14 md:w-14 rounded-xl bg-blue-50 flex items-center justify-center">
-                      <Plus className="h-[26px] w-[26px] md:h-8 md:w-8 text-blue-600" />
+                  <div className="size-[72px] md:size-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
+                    <div className="size-11 md:size-14 rounded-xl bg-blue-50 flex items-center justify-center">
+                      <Plus className="size-[26px] md:size-8 text-blue-600" />
                     </div>
                   </div>
                   <span className="text-xs md:text-sm font-medium text-slate-700 text-center">Thêm thiết bị</span>
@@ -245,9 +245,9 @@ export default function Dashboard() {
               {/* Create Maintenance Plan Card */}
               <Link href="/maintenance?action=create" className="group">
                 <div className="flex flex-col items-center gap-3">
-                  <div className="h-[72px] w-[72px] md:h-[88px] md:w-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
-                    <div className="h-11 w-11 md:h-14 md:w-14 rounded-xl bg-emerald-50 flex items-center justify-center">
-                      <ClipboardList className="h-[26px] w-[26px] md:h-8 md:w-8 text-emerald-600" />
+                  <div className="size-[72px] md:size-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
+                    <div className="size-11 md:size-14 rounded-xl bg-emerald-50 flex items-center justify-center">
+                      <ClipboardList className="size-[26px] md:size-8 text-emerald-600" />
                     </div>
                   </div>
                   <span className="text-xs md:text-sm font-medium text-slate-700 text-center">Lập kế hoạch</span>
@@ -259,9 +259,9 @@ export default function Dashboard() {
           {/* QR Scanner Card: Always available - opens scanner directly */}
           <button data-tour="qr-scanner" onClick={handleStartScanning} className="group">
             <div className="flex flex-col items-center gap-3">
-              <div className="h-[72px] w-[72px] md:h-[88px] md:w-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
-                <div className="h-11 w-11 md:h-14 md:w-14 rounded-xl bg-sky-50 flex items-center justify-center">
-                  <QrCode className="h-[26px] w-[26px] md:h-8 md:w-8 text-sky-600" />
+              <div className="size-[72px] md:size-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
+                <div className="size-11 md:size-14 rounded-xl bg-sky-50 flex items-center justify-center">
+                  <QrCode className="size-[26px] md:size-8 text-sky-600" />
                 </div>
               </div>
               <span className="text-xs md:text-sm font-medium text-slate-700 text-center">Quét mã QR</span>

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -115,7 +115,7 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
                         aria-label={`Xem thiết bị ${category.ten_nhom}`}
                     >
                         <ChevronRight className={cn(
-                            "h-3 w-3 text-muted-foreground shrink-0 transition-transform duration-200",
+                            "size-3 text-muted-foreground shrink-0 transition-transform duration-200",
                             isExpanded && "rotate-90"
                         )} />
                         <QuotaProgressBar
@@ -136,22 +136,22 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
                         <Button
                             variant="ghost"
                             size="icon"
-                            className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                            className="size-7 opacity-0 group-hover:opacity-100 transition-opacity"
                             disabled={isMutating}
                         >
-                            <MoreHorizontal className="h-4 w-4" />
+                            <MoreHorizontal className="size-4" />
                         </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                         <DropdownMenuItem onSelect={() => onEdit(category)}>
-                            <Pencil className="mr-2 h-4 w-4" />
+                            <Pencil className="mr-2 size-4" />
                             Sửa
                         </DropdownMenuItem>
                         <DropdownMenuItem
                             onSelect={() => onDelete(category)}
                             className="text-destructive focus:text-destructive"
                         >
-                            <Trash2 className="mr-2 h-4 w-4" />
+                            <Trash2 className="mr-2 size-4" />
                             Xóa
                         </DropdownMenuItem>
                     </DropdownMenuContent>
@@ -235,9 +235,9 @@ const CategoryGroup = React.memo(function CategoryGroup({
                 <div className="min-w-0 flex items-center gap-3">
                     <span className="shrink-0 text-muted-foreground">
                         {isCollapsed ? (
-                            <ChevronRight className="h-4 w-4" />
+                            <ChevronRight className="size-4" />
                         ) : (
-                            <ChevronDown className="h-4 w-4" />
+                            <ChevronDown className="size-4" />
                         )}
                     </span>
                     <div className="min-w-0 flex-1">
@@ -277,7 +277,7 @@ const CategoryGroup = React.memo(function CategoryGroup({
                         aria-label={`Xem thiết bị ${root.ten_nhom}`}
                     >
                         <ChevronRight className={cn(
-                            "h-3 w-3 text-muted-foreground shrink-0 transition-transform duration-200",
+                            "size-3 text-muted-foreground shrink-0 transition-transform duration-200",
                             expandedCategoryId === root.id && "rotate-90"
                         )} />
                         <QuotaProgressBar
@@ -298,23 +298,23 @@ const CategoryGroup = React.memo(function CategoryGroup({
                         <Button
                             variant="ghost"
                             size="icon"
-                            className="h-7 w-7"
+                            className="size-7"
                             disabled={mutatingCategoryId === root.id}
                             onClick={(e) => e.stopPropagation()}
                         >
-                            <MoreHorizontal className="h-4 w-4" />
+                            <MoreHorizontal className="size-4" />
                         </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                         <DropdownMenuItem onSelect={() => onEdit(root)}>
-                            <Pencil className="mr-2 h-4 w-4" />
+                            <Pencil className="mr-2 size-4" />
                             Sửa
                         </DropdownMenuItem>
                         <DropdownMenuItem
                             onSelect={() => onDelete(root)}
                             className="text-destructive focus:text-destructive"
                         >
-                            <Trash2 className="mr-2 h-4 w-4" />
+                            <Trash2 className="mr-2 size-4" />
                             Xóa
                         </DropdownMenuItem>
                     </DropdownMenuContent>

--- a/src/app/(app)/device-quota/categories/_components/CategoryTreeStates.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryTreeStates.tsx
@@ -11,7 +11,7 @@ export function CategoryTreeSkeleton() {
             {SKELETON_KEYS.map((token) => (
                 <div key={token} className="rounded-lg border p-4 space-y-2">
                     <div className="flex items-center gap-3">
-                        <Skeleton className="h-4 w-4" />
+                        <Skeleton className="size-4" />
                         <Skeleton className="h-4 w-16" />
                         <Skeleton className="h-4 flex-1 max-w-[200px]" />
                         <Skeleton className="h-5 w-14 rounded-full" />
@@ -36,7 +36,7 @@ export function CategoryTreeEmpty({
     return (
         <div className="flex flex-col items-center justify-center py-12 text-center">
             <div className="rounded-full bg-muted p-3 mb-4">
-                <FolderTree className="h-6 w-6 text-muted-foreground" />
+                <FolderTree className="size-6 text-muted-foreground" />
             </div>
             <h3 className="font-semibold text-base mb-1">
                 {hasSearch ? "Không tìm thấy danh mục" : "Chưa có danh mục nào"}

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryAssignedEquipment.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryAssignedEquipment.tsx
@@ -103,7 +103,7 @@ export function DeviceQuotaCategoryAssignedEquipment({
                 </div>
             ) : !equipment || equipment.length === 0 ? (
                 <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
-                    <PackageOpen className="h-4 w-4" />
+                    <PackageOpen className="size-4" />
                     <span>Chưa có thiết bị nào được gán</span>
                 </div>
             ) : (

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDeleteDialog.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDeleteDialog.tsx
@@ -49,7 +49,7 @@ export function DeviceQuotaCategoryDeleteDialog() {
             disabled={isPending}
             className="bg-destructive hover:bg-destructive/90"
           >
-            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
             Xóa danh mục
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDialog.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDialog.tsx
@@ -281,7 +281,7 @@ export function DeviceQuotaCategoryDialog() {
                 Hủy
               </Button>
               <Button type="submit" disabled={isPending}>
-                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
                 Lưu
               </Button>
             </DialogFooter>

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog.tsx
@@ -246,7 +246,7 @@ export function DeviceQuotaCategoryImportDialog() {
       <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <FileSpreadsheet className="h-5 w-5" />
+            <FileSpreadsheet className="size-5" />
             Nhập danh mục từ Excel
           </DialogTitle>
           <DialogDescription>
@@ -271,7 +271,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* Parsing indicator */}
           {status === "parsing" && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Loader2 className="size-4 animate-spin" />
               Đang đọc file...
             </div>
           )}
@@ -279,7 +279,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* Parse error */}
           {parseError && (
             <Alert variant="destructive">
-              <AlertTriangle className="h-4 w-4" />
+              <AlertTriangle className="size-4" />
               <AlertTitle>Lỗi đọc file</AlertTitle>
               <AlertDescription>{parseError}</AlertDescription>
             </Alert>
@@ -288,7 +288,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* Validation errors (blocking - rows were skipped) */}
           {validationErrors.length > 0 && (
             <Alert variant="destructive">
-              <AlertTriangle className="h-4 w-4" />
+              <AlertTriangle className="size-4" />
               <AlertTitle>Lỗi dữ liệu - {validationErrors.length} dòng bị bỏ qua</AlertTitle>
               <AlertDescription>
                 <ScrollArea className="h-32 mt-2">
@@ -310,7 +310,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* Validation warnings (non-blocking) */}
           {validationWarnings.length > 0 && (
             <Alert className="border-yellow-200 bg-yellow-50">
-              <AlertCircle className="h-4 w-4 text-yellow-600" />
+              <AlertCircle className="size-4 text-yellow-600" />
               <AlertTitle className="text-yellow-800">Cảnh báo ({validationWarnings.length})</AlertTitle>
               <AlertDescription className="text-yellow-700">
                 <ScrollArea className="h-24 mt-2">
@@ -332,7 +332,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* Parsed successfully */}
           {status === "parsed" && parsedRows.length > 0 && (
             <Alert className={validationErrors.length > 0 ? "border-yellow-200 bg-yellow-50" : ""}>
-              <CheckCircle2 className={`h-4 w-4 ${validationErrors.length > 0 ? "text-yellow-600" : "text-green-600"}`} />
+              <CheckCircle2 className={`size-4 ${validationErrors.length > 0 ? "text-yellow-600" : "text-green-600"}`} />
               <AlertTitle className={validationErrors.length > 0 ? "text-yellow-800" : ""}>
                 {validationErrors.length > 0 ? "Sẵn sàng nhập (một phần)" : "Sẵn sàng nhập"}
               </AlertTitle>
@@ -348,7 +348,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* No valid rows */}
           {status === "parsed" && parsedRows.length === 0 && validationErrors.length > 0 && (
             <Alert variant="destructive">
-              <AlertTriangle className="h-4 w-4" />
+              <AlertTriangle className="size-4" />
               <AlertTitle>Không có dữ liệu hợp lệ</AlertTitle>
               <AlertDescription>
                 Tất cả các dòng trong file đều có lỗi. Vui lòng sửa file và thử lại.
@@ -359,7 +359,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* Import success */}
           {status === "success" && importResult && (
             <Alert className="border-green-200 bg-green-50">
-              <CheckCircle2 className="h-4 w-4 text-green-600" />
+              <CheckCircle2 className="size-4 text-green-600" />
               <AlertTitle className="text-green-800">Nhập thành công</AlertTitle>
               <AlertDescription className="text-green-700">
                 Đã thêm {importResult.inserted} danh mục vào hệ thống.
@@ -376,7 +376,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* Partial success – categories OK but quota import failed */}
           {status === "partial_success" && importResult && (
             <Alert className="border-yellow-200 bg-yellow-50">
-              <AlertTriangle className="h-4 w-4 text-yellow-600" />
+              <AlertTriangle className="size-4 text-yellow-600" />
               <AlertTitle className="text-yellow-800">Nhập thành công một phần</AlertTitle>
               <AlertDescription className="text-yellow-700">
                 Đã thêm {importResult.inserted} danh mục nhưng nhập định mức thất bại.
@@ -388,7 +388,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {/* Submitting indicator */}
           {isSubmitting && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Loader2 className="size-4 animate-spin" />
               Đang nhập dữ liệu...
             </div>
           )}
@@ -402,12 +402,12 @@ export function DeviceQuotaCategoryImportDialog() {
             <Button onClick={handleImport} disabled={!canImport || isSubmitting}>
               {isSubmitting ? (
                 <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  <Loader2 className="mr-2 size-4 animate-spin" />
                   Đang nhập...
                 </>
               ) : (
                 <>
-                  <Upload className="mr-2 h-4 w-4" />
+                  <Upload className="mr-2 size-4" />
                   Nhập {parsedRows.length > 0 ? `(${parsedRows.length})` : ""}
                 </>
               )}

--- a/src/app/(app)/device-quota/categories/page.tsx
+++ b/src/app/(app)/device-quota/categories/page.tsx
@@ -41,7 +41,7 @@ function DeviceQuotaCategoriesPageContent({
             <div className="text-center space-y-4">
               <div className="flex justify-center">
                 <div className="p-3 bg-red-100 rounded-full">
-                  <Shield className="h-6 w-6 text-red-600" />
+                  <Shield className="size-6 text-red-600" />
                 </div>
               </div>
               <div>
@@ -54,7 +54,7 @@ function DeviceQuotaCategoriesPageContent({
                 </p>
               </div>
               <div className="flex items-center justify-center text-xs text-gray-500 mt-4">
-                <AlertTriangle className="h-4 w-4 mr-1" />
+                <AlertTriangle className="size-4 mr-1" />
                 <span>Liên hệ quản trị viên nếu bạn cần hỗ trợ</span>
               </div>
             </div>

--- a/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaActiveDecision.tsx
+++ b/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaActiveDecision.tsx
@@ -79,7 +79,7 @@ export function DeviceQuotaActiveDecision() {
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
-          <FileText className="h-5 w-5 text-muted-foreground" />
+          <FileText className="size-5 text-muted-foreground" />
           Quyết định hiện hành
         </CardTitle>
       </CardHeader>
@@ -103,7 +103,7 @@ export function DeviceQuotaActiveDecision() {
                 {decisionData.so_quyet_dinh}
               </span>
               <Badge className="bg-green-100 text-green-800 hover:bg-green-100 border-green-200">
-                <CheckCircle className="h-3 w-3 mr-1" />
+                <CheckCircle className="size-3 mr-1" />
                 Đang hiệu lực
               </Badge>
             </div>
@@ -112,7 +112,7 @@ export function DeviceQuotaActiveDecision() {
             <div className="space-y-2 text-sm">
               {decisionData.ngay_ban_hanh ? (
                 <div className="flex items-center gap-2 text-muted-foreground">
-                  <Calendar className="h-4 w-4" />
+                  <Calendar className="size-4" />
                   <span className="font-medium">Ngày ban hành:</span>
                   <span>{formatVietnameseDate(decisionData.ngay_ban_hanh)}</span>
                 </div>
@@ -120,7 +120,7 @@ export function DeviceQuotaActiveDecision() {
 
               {decisionData.ngay_hieu_luc ? (
                 <div className="flex items-center gap-2 text-muted-foreground">
-                  <Calendar className="h-4 w-4" />
+                  <Calendar className="size-4" />
                   <span className="font-medium">Ngày hiệu lực:</span>
                   <span>{formatVietnameseDate(decisionData.ngay_hieu_luc)}</span>
                 </div>
@@ -128,7 +128,7 @@ export function DeviceQuotaActiveDecision() {
 
               {decisionData.ngay_het_hieu_luc ? (
                 <div className="flex items-center gap-2 text-muted-foreground">
-                  <Calendar className="h-4 w-4" />
+                  <Calendar className="size-4" />
                   <span className="font-medium">Ngày hết hiệu lực:</span>
                   <span>{formatVietnameseDate(decisionData.ngay_het_hieu_luc)}</span>
                 </div>
@@ -140,7 +140,7 @@ export function DeviceQuotaActiveDecision() {
               <Button variant="link" className="h-auto p-0" asChild>
                 <Link href="/device-quota/decisions">
                   Xem chi tiết
-                  <ArrowRight className="h-4 w-4 ml-1" />
+                  <ArrowRight className="size-4 ml-1" />
                 </Link>
               </Button>
             </div>

--- a/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaComplianceReport.tsx
+++ b/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaComplianceReport.tsx
@@ -115,7 +115,7 @@ export function DeviceQuotaComplianceReport({
       <Card className="border-destructive">
         <CardContent className="pt-6">
           <div className="flex items-center gap-2 text-destructive">
-            <AlertCircle className="h-5 w-5" />
+            <AlertCircle className="size-5" />
             <p className="text-sm">
               Không thể tải báo cáo: {getUnknownErrorMessage(error, "Lỗi không xác định")}
             </p>
@@ -149,12 +149,12 @@ export function DeviceQuotaComplianceReport({
         <Button onClick={handlePrint} disabled={isPrinting}>
           {isPrinting ? (
             <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <Loader2 className="mr-2 size-4 animate-spin" />
               Đang in...
             </>
           ) : (
             <>
-              <Printer className="mr-2 h-4 w-4" />
+              <Printer className="mr-2 size-4" />
               In báo cáo
             </>
           )}

--- a/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaReportDialog.tsx
+++ b/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaReportDialog.tsx
@@ -95,11 +95,11 @@ export function DeviceQuotaReportDialog({
         {/* Footer - Hidden during print */}
         <div className="print:hidden px-6 py-4 border-t flex-shrink-0 flex items-center justify-end gap-3">
           <Button variant="outline" onClick={handleClose}>
-            <X className="mr-2 h-4 w-4" />
+            <X className="mr-2 size-4" />
             Đóng
           </Button>
           <Button onClick={handlePrint} disabled={isPrinting}>
-            <Printer className="mr-2 h-4 w-4" />
+            <Printer className="mr-2 size-4" />
             {isPrinting ? "Đang in..." : "In báo cáo"}
           </Button>
         </div>

--- a/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaUnassignedAlert.tsx
+++ b/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaUnassignedAlert.tsx
@@ -37,7 +37,7 @@ export function DeviceQuotaUnassignedAlert() {
 
   return (
     <Alert className="relative border-amber-200 bg-amber-50/80 text-amber-900">
-      <AlertTriangle className="h-4 w-4 text-amber-600" />
+      <AlertTriangle className="size-4 text-amber-600" />
       <AlertTitle>Thiết bị chưa phân loại</AlertTitle>
       <AlertDescription className="mt-2 flex items-center justify-between gap-4">
         <span className="text-sm">
@@ -56,11 +56,11 @@ export function DeviceQuotaUnassignedAlert() {
           <Button
             variant="ghost"
             size="icon"
-            className="h-8 w-8 text-amber-700 hover:bg-amber-100"
+            className="size-8 text-amber-700 hover:bg-amber-100"
             onClick={handleDismiss}
             aria-label="Dismiss alert"
           >
-            <X className="h-4 w-4" />
+            <X className="size-4" />
           </Button>
         </div>
       </AlertDescription>

--- a/src/app/(app)/device-quota/dashboard/page.tsx
+++ b/src/app/(app)/device-quota/dashboard/page.tsx
@@ -73,7 +73,7 @@ function DeviceQuotaDashboardPageContent() {
             variant="outline"
             onClick={() => setReportDialogOpen(true)}
           >
-            <FileText className="mr-2 h-4 w-4" />
+            <FileText className="mr-2 size-4" />
             Xuất báo cáo
           </Button>
         )}

--- a/src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietTable.tsx
+++ b/src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietTable.tsx
@@ -36,7 +36,7 @@ function ComplianceStatus({ soLuongHienCo, soLuongDinhMuc, soLuongToiThieu }: Co
   if (isOverQuota) {
     return (
       <Badge variant="destructive" className="bg-orange-600 hover:bg-orange-700">
-        <AlertCircle className="h-3 w-3 mr-1" />
+        <AlertCircle className="size-3 mr-1" />
         Vượt định mức
       </Badge>
     )
@@ -45,7 +45,7 @@ function ComplianceStatus({ soLuongHienCo, soLuongDinhMuc, soLuongToiThieu }: Co
   if (isUnderMinimum) {
     return (
       <Badge variant="destructive">
-        <XCircle className="h-3 w-3 mr-1" />
+        <XCircle className="size-3 mr-1" />
         Chưa đạt
       </Badge>
     )
@@ -54,7 +54,7 @@ function ComplianceStatus({ soLuongHienCo, soLuongDinhMuc, soLuongToiThieu }: Co
   // Within range: meets minimum (or no minimum) AND doesn't exceed maximum
   return (
     <Badge variant="default" className="bg-green-600 hover:bg-green-700">
-      <CheckCircle className="h-3 w-3 mr-1" />
+      <CheckCircle className="size-3 mr-1" />
       Đạt định mức
     </Badge>
   )

--- a/src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietToolbar.tsx
+++ b/src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietToolbar.tsx
@@ -120,9 +120,9 @@ export function DeviceQuotaChiTietToolbar() {
             size="icon"
             onClick={() => router.push('/device-quota/decisions')}
             aria-label="Quay lại danh sách quyết định"
-            className="h-9 w-9"
+            className="size-9"
           >
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeft className="size-5" />
           </Button>
           <div>
             <h2 className="text-lg font-semibold">
@@ -149,7 +149,7 @@ export function DeviceQuotaChiTietToolbar() {
           {/* Alert when no categories available */}
           {!isCategoriesLoading && leafCategories.length === 0 && (
             <Alert className="bg-amber-50 border-amber-200">
-              <AlertCircle className="h-4 w-4 text-amber-600" aria-hidden="true" />
+              <AlertCircle className="size-4 text-amber-600" aria-hidden="true" />
               <AlertDescription className="text-amber-800">
                 Chưa có danh mục thiết bị. Vui lòng{" "}
                 <Link
@@ -172,7 +172,7 @@ export function DeviceQuotaChiTietToolbar() {
               className="h-9 w-full sm:w-auto"
               aria-label="Tải xuống file mẫu Excel định mức"
             >
-              <Download className="mr-2 h-4 w-4" />
+              <Download className="mr-2 size-4" />
               Tải mẫu Excel
             </Button>
 
@@ -184,7 +184,7 @@ export function DeviceQuotaChiTietToolbar() {
               className="h-9 w-full sm:w-auto"
               aria-label="Nhập định mức từ file Excel"
             >
-              <Upload className="mr-2 h-4 w-4" />
+              <Upload className="mr-2 size-4" />
               Nhập từ Excel
             </Button>
           </div>

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialog.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionDialog.tsx
@@ -205,7 +205,7 @@ export function DeviceQuotaDecisionDialog() {
                           )}
                           disabled={isPending}
                         >
-                          <CalendarIcon className="mr-2 h-4 w-4" />
+                          <CalendarIcon className="mr-2 size-4" />
                           {field.value ? (
                             format(field.value, "dd/MM/yyyy")
                           ) : (
@@ -247,7 +247,7 @@ export function DeviceQuotaDecisionDialog() {
                           )}
                           disabled={isPending}
                         >
-                          <CalendarIcon className="mr-2 h-4 w-4" />
+                          <CalendarIcon className="mr-2 size-4" />
                           {field.value ? (
                             format(field.value, "dd/MM/yyyy")
                           ) : (
@@ -295,7 +295,7 @@ export function DeviceQuotaDecisionDialog() {
                           )}
                           disabled={isPending}
                         >
-                          <CalendarIcon className="mr-2 h-4 w-4" />
+                          <CalendarIcon className="mr-2 size-4" />
                           {field.value ? (
                             format(field.value, "dd/MM/yyyy")
                           ) : (
@@ -401,7 +401,7 @@ export function DeviceQuotaDecisionDialog() {
                 disabled={isPending}
                 className="touch-target"
               >
-                {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
                 {isEditMode ? "Lưu thay đổi" : "Tạo quyết định"}
               </Button>
             </DialogFooter>

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx
@@ -81,7 +81,7 @@ function TableLoadingSkeleton() {
           <TableCell><Skeleton className="h-4 w-24" /></TableCell>
           <TableCell><Skeleton className="h-4 w-24" /></TableCell>
           <TableCell><Skeleton className="h-6 w-28" /></TableCell>
-          <TableCell><Skeleton className="h-8 w-8 rounded" /></TableCell>
+          <TableCell><Skeleton className="size-8 rounded" /></TableCell>
         </TableRow>
       ))}
     </>
@@ -135,21 +135,21 @@ function MobileDecisionCard({ decision, onView, onEdit, onActivate, onDelete }: 
 
       <div className="flex gap-2 flex-wrap pt-2">
         <Button variant="outline" size="sm" onClick={onView} className="flex-1">
-          <Eye className="mr-2 h-4 w-4" />
+          <Eye className="mr-2 size-4" />
           Xem
         </Button>
         {decision.trang_thai === "draft" && (
           <>
             <Button variant="outline" size="sm" onClick={onEdit} className="flex-1">
-              <Edit className="mr-2 h-4 w-4" />
+              <Edit className="mr-2 size-4" />
               Sửa
             </Button>
             <Button variant="outline" size="sm" onClick={onActivate}>
-              <CheckCircle className="mr-2 h-4 w-4" />
+              <CheckCircle className="mr-2 size-4" />
               Kích hoạt
             </Button>
             <Button variant="outline" size="sm" onClick={onDelete} className="text-destructive">
-              <Trash2 className="mr-2 h-4 w-4" />
+              <Trash2 className="mr-2 size-4" />
               Xóa
             </Button>
           </>
@@ -177,14 +177,14 @@ function ActionsDropdown({ decision, onView, onEdit, onActivate, onDelete }: Act
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-8 w-8">
-          <MoreHorizontal className="h-4 w-4" />
+        <Button variant="ghost" size="icon" className="size-8">
+          <MoreHorizontal className="size-4" />
           <span className="sr-only">Mở menu hành động</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={onView}>
-          <Eye className="mr-2 h-4 w-4" />
+          <Eye className="mr-2 size-4" />
           Xem chi tiết
         </DropdownMenuItem>
 
@@ -192,17 +192,17 @@ function ActionsDropdown({ decision, onView, onEdit, onActivate, onDelete }: Act
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={onEdit}>
-              <Edit className="mr-2 h-4 w-4" />
+              <Edit className="mr-2 size-4" />
               Chỉnh sửa
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={onActivate}>
-              <CheckCircle className="mr-2 h-4 w-4" />
+              <CheckCircle className="mr-2 size-4" />
               Kích hoạt
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={onDelete} className="text-destructive focus:text-destructive">
-              <Trash2 className="mr-2 h-4 w-4" />
+              <Trash2 className="mr-2 size-4" />
               Xóa
             </DropdownMenuItem>
           </>
@@ -347,7 +347,7 @@ export function DeviceQuotaDecisionsTable() {
               disabled={activateMutation.isPending}
             >
               {activateMutation.isPending && (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
               )}
               Kích hoạt
             </AlertDialogAction>
@@ -375,7 +375,7 @@ export function DeviceQuotaDecisionsTable() {
               className="bg-destructive hover:bg-destructive/90"
             >
               {deleteMutation.isPending && (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
               )}
               Xóa
             </AlertDialogAction>

--- a/src/app/(app)/device-quota/decisions/page.tsx
+++ b/src/app/(app)/device-quota/decisions/page.tsx
@@ -62,7 +62,7 @@ function DeviceQuotaDecisionsAuthFallback() {
       data-testid="device-quota-decisions-auth-fallback"
     >
       <div className="text-center space-y-2">
-        <Loader2 className="h-8 w-8 mx-auto animate-spin text-muted-foreground" />
+        <Loader2 className="size-8 mx-auto animate-spin text-muted-foreground" />
       </div>
     </div>
   )

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingActions.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingActions.tsx
@@ -89,7 +89,7 @@ export function DeviceQuotaMappingActions() {
                 onClick={() => setShowSuggested(true)}
                 title="Sử dụng AI để gợi ý — tốn tài nguyên server, chỉ dùng khi cần"
               >
-                <Sparkles className="h-4 w-4 text-amber-500 group-hover:animate-pulse" />
+                <Sparkles className="size-4 text-amber-500 group-hover:animate-pulse" />
                 Gợi ý phân loại
               </Button>
             )}
@@ -101,7 +101,7 @@ export function DeviceQuotaMappingActions() {
                 size="sm"
                 className="touch-target-sm"
               >
-                <Link className="h-4 w-4" />
+                <Link className="size-4" />
                 {isLinking ? "Đang xử lý..." : "Phân loại"}
               </Button>
             )}

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingGuide.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingGuide.tsx
@@ -71,7 +71,7 @@ export function DeviceQuotaMappingGuide() {
         >
             <div className="flex items-start gap-3">
                 <div className="rounded-full bg-blue-100 dark:bg-blue-900/50 p-1.5 mt-0.5 shrink-0">
-                    <Lightbulb className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    <Lightbulb className="size-4 text-blue-600 dark:text-blue-400" />
                 </div>
 
                 <div className="flex-1 min-w-0 space-y-2">

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingPreviewDialog.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingPreviewDialog.tsx
@@ -49,7 +49,7 @@ function CategoryCard({ category }: { category: Category }) {
             className="flex flex-col items-center justify-center gap-2 rounded-lg border bg-muted/50 p-4 text-center min-w-[160px] max-w-[200px]"
             data-testid="category-card"
         >
-            <Folder className="h-8 w-8 text-primary/70" />
+            <Folder className="size-8 text-primary/70" />
             <span className="text-xs text-muted-foreground">Gán vào danh mục:</span>
             <span className="text-sm font-bold">{category.ma_nhom}</span>
             <span className="text-sm">{category.ten_nhom}</span>
@@ -234,7 +234,7 @@ export function DeviceQuotaMappingPreviewDialog({
             <DialogContent className="max-w-2xl">
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2">
-                        <CheckCircle2 className="h-5 w-5 text-primary" />
+                        <CheckCircle2 className="size-5 text-primary" />
                         Xác nhận phân loại thiết bị
                     </DialogTitle>
                     <DialogDescription>
@@ -308,7 +308,7 @@ export function DeviceQuotaMappingPreviewDialog({
                         onClick={handleConfirm}
                         disabled={activeCount === 0 || isLinking}
                     >
-                        <CheckCircle2 className="h-4 w-4 mr-1" />
+                        <CheckCircle2 className="size-4 mr-1" />
                         {isLinking ? "Đang xử lý..." : "Xác nhận phân loại"}
                     </Button>
                 </DialogFooter>

--- a/src/app/(app)/device-quota/mapping/_components/MappingPreviewPrimitives.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/MappingPreviewPrimitives.tsx
@@ -56,7 +56,7 @@ export function MappingPreviewFooterNote({
             className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/50 rounded-md px-3 py-2"
             data-testid="footer-note"
         >
-            <Info className="h-3.5 w-3.5 shrink-0" />
+            <Info className="size-3.5 shrink-0" />
             <span>{message}</span>
         </div>
     )
@@ -134,14 +134,14 @@ export function MappingPreviewEquipmentItem({
             <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 shrink-0"
+                className="size-7 shrink-0"
                 onClick={onToggle}
                 aria-label={isExcluded ? "Khôi phục" : "Loại bỏ"}
             >
                 {isExcluded ? (
-                    <Undo2 className="h-4 w-4" />
+                    <Undo2 className="size-4" />
                 ) : (
-                    <X className="h-4 w-4 text-destructive" />
+                    <X className="size-4 text-destructive" />
                 )}
             </Button>
         </div>

--- a/src/app/(app)/device-quota/mapping/_components/SuggestedMappingGroupSection.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/SuggestedMappingGroupSection.tsx
@@ -47,14 +47,14 @@ function DeviceNameRow({
             <Button
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 shrink-0"
+                className="size-7 shrink-0"
                 onClick={onToggle}
                 aria-label={isExcluded ? "Khôi phục" : "Loại bỏ"}
             >
                 {isExcluded ? (
-                    <Undo2 className="h-4 w-4" />
+                    <Undo2 className="size-4" />
                 ) : (
-                    <X className="h-4 w-4 text-destructive" />
+                    <X className="size-4 text-destructive" />
                 )}
             </Button>
         </div>
@@ -89,7 +89,7 @@ export function SuggestedMappingGroupSection({
             {/* Group header */}
             <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2 min-w-0">
-                    <Folder className="h-5 w-5 text-primary/70 shrink-0" />
+                    <Folder className="size-5 text-primary/70 shrink-0" />
                     <div className="min-w-0">
                         <span className="text-sm font-semibold truncate block">
                             {group.nhom_label}
@@ -114,12 +114,12 @@ export function SuggestedMappingGroupSection({
                 >
                     {isGroupExcluded ? (
                         <>
-                            <Undo2 className="h-3.5 w-3.5 mr-1" />
+                            <Undo2 className="size-3.5 mr-1" />
                             Khôi phục nhóm
                         </>
                     ) : (
                         <>
-                            <X className="h-3.5 w-3.5 mr-1" />
+                            <X className="size-3.5 mr-1" />
                             Loại bỏ nhóm
                         </>
                     )}

--- a/src/app/(app)/device-quota/mapping/_components/SuggestedMappingPreviewDialog.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/SuggestedMappingPreviewDialog.tsx
@@ -209,7 +209,7 @@ export function SuggestedMappingPreviewDialog({
             <DialogContent className="max-w-2xl max-h-[85vh] flex flex-col">
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2">
-                        <Sparkles className="h-5 w-5 text-primary" />
+                        <Sparkles className="size-5 text-primary" />
                         Gợi ý phân loại thiết bị
                     </DialogTitle>
                     <DialogDescription>
@@ -237,7 +237,7 @@ export function SuggestedMappingPreviewDialog({
                 {/* Error state */}
                 {status === "error" && (
                     <div className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-                        <AlertTriangle className="h-4 w-4 shrink-0" />
+                        <AlertTriangle className="size-4 shrink-0" />
                         <span>{error}</span>
                     </div>
                 )}
@@ -245,7 +245,7 @@ export function SuggestedMappingPreviewDialog({
                 {/* Save error state */}
                 {saveStatus === "save-error" && (
                     <div className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-                        <AlertTriangle className="h-4 w-4 shrink-0" />
+                        <AlertTriangle className="size-4 shrink-0" />
                         <span>{saveError ?? "Không thể lưu phân loại. Vui lòng thử lại."}</span>
                     </div>
                 )}
@@ -302,12 +302,12 @@ export function SuggestedMappingPreviewDialog({
                         >
                             {saveStatus === "saving" ? (
                                 <>
-                                    <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                                    <Loader2 className="size-4 mr-1 animate-spin" />
                                     Đang lưu...
                                 </>
                             ) : (
                                 <>
-                                    <CheckCircle2 className="h-4 w-4 mr-1" />
+                                    <CheckCircle2 className="size-4 mr-1" />
                                     Áp dụng {activeGroupCount} gợi ý phân loại
                                 </>
                             )}

--- a/src/app/(app)/device-quota/mapping/_components/SuggestedMappingUnmatchedSection.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/SuggestedMappingUnmatchedSection.tsx
@@ -46,11 +46,11 @@ export function SuggestedMappingUnmatchedSection({
                 >
                     <ChevronRight
                         className={cn(
-                            "h-4 w-4 shrink-0 transition-transform",
+                            "size-4 shrink-0 transition-transform",
                             open && "rotate-90"
                         )}
                     />
-                    <AlertCircle className="h-4 w-4 shrink-0 text-amber-500" />
+                    <AlertCircle className="size-4 shrink-0 text-amber-500" />
                     <span>Chưa gợi ý được</span>
                     <span className="font-medium">({totalDevices} thiết bị)</span>
                 </button>

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailDetailsTab.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailDetailsTab.tsx
@@ -105,7 +105,7 @@ function FieldValue({
               <TooltipTrigger asChild>
                 <span className="inline-flex items-center">
                   <AlertTriangle
-                    className="h-4 w-4 text-amber-500 cursor-help"
+                    className="size-4 text-amber-500 cursor-help"
                     aria-hidden="true"
                   />
                   <span className="sr-only">{SUSPICIOUS_DATE_WARNING}</span>

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailFilesTab.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailFilesTab.tsx
@@ -128,7 +128,7 @@ export function EquipmentDetailFilesTab({
               />
             </div>
             <Alert>
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className="size-4" />
               <AlertTitle>Làm thế nào để lấy URL?</AlertTitle>
               <AlertDescription className="space-y-2">
                 <div>
@@ -143,7 +143,7 @@ export function EquipmentDetailFilesTab({
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-2"
                     >
-                      <ExternalLink className="h-4 w-4" />
+                      <ExternalLink className="size-4" />
                       Mở thư mục chung
                     </a>
                   </Button>
@@ -155,7 +155,7 @@ export function EquipmentDetailFilesTab({
               disabled={isAdding || !newFileName || !newFileUrl}
             >
               {isAdding && (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <Loader2 className="mr-2 size-4 animate-spin" />
               )}
               Lưu liên kết
             </Button>
@@ -188,20 +188,20 @@ export function EquipmentDetailFilesTab({
                     rel="noopener noreferrer"
                     className="flex items-center gap-2 text-primary hover:underline truncate"
                   >
-                    <LinkIcon className="h-4 w-4 shrink-0" />
+                    <LinkIcon className="size-4 shrink-0" />
                     <span className="truncate">{file.ten_file}</span>
                   </Link>
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-8 w-8 text-destructive hover:bg-destructive/10"
+                    className="size-8 text-destructive hover:bg-destructive/10"
                     onClick={() => handleDeleteAttachment(file.id)}
                     disabled={!!deletingAttachmentId || isDeleting}
                   >
                     {deletingAttachmentId === file.id ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="size-4 animate-spin" />
                     ) : (
-                      <Trash2 className="h-4 w-4" />
+                      <Trash2 className="size-4" />
                     )}
                   </Button>
                 </div>

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailFooter.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailFooter.tsx
@@ -47,7 +47,7 @@ export function EquipmentDetailFooter({
               <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
                   <Button variant="outline" size="icon" onClick={onStartEditing}>
-                    <Edit className="h-4 w-4" />
+                    <Edit className="size-4" />
                     <span className="sr-only">Sửa thông tin</span>
                   </Button>
                 </TooltipTrigger>
@@ -68,7 +68,7 @@ export function EquipmentDetailFooter({
                   form="equipment-inline-edit-form"
                   disabled={isUpdating}
                 >
-                  {isUpdating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  {isUpdating && <Loader2 className="mr-2 size-4 animate-spin" />}
                   Lưu thay đổi
                 </Button>
               </>
@@ -80,7 +80,7 @@ export function EquipmentDetailFooter({
               <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
                   <Button variant="outline" size="icon" onClick={onGenerateDeviceLabel}>
-                    <QrCode className="h-4 w-4" />
+                    <QrCode className="size-4" />
                     <span className="sr-only">Tạo nhãn thiết bị</span>
                   </Button>
                 </TooltipTrigger>
@@ -90,7 +90,7 @@ export function EquipmentDetailFooter({
               <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
                   <Button variant="outline" size="icon" onClick={onGenerateProfileSheet}>
-                    <Printer className="h-4 w-4" />
+                    <Printer className="size-4" />
                     <span className="sr-only">In lý lịch</span>
                   </Button>
                 </TooltipTrigger>
@@ -110,7 +110,7 @@ export function EquipmentDetailFooter({
                   className="text-destructive hover:bg-destructive hover:text-destructive-foreground border-destructive/30"
                   onClick={onDeleteEquipment}
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="size-4" />
                   <span className="sr-only">Xóa thiết bị</span>
                 </Button>
               </TooltipTrigger>

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailHistoryTab.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailHistoryTab.tsx
@@ -67,12 +67,12 @@ export function EquipmentDetailHistoryTab({
         {history.map((item) => (
           <div key={item.id} className="relative mb-8 last:mb-0">
             {/* Timeline dot */}
-            <div className="absolute left-0 top-1 w-3 h-3 rounded-full bg-primary ring-4 ring-background -translate-x-1/2 ml-3"></div>
+            <div className="absolute left-0 top-1 size-3 rounded-full bg-primary ring-4 ring-background -translate-x-1/2 ml-3"></div>
 
             <div className="pl-2">
               {/* Event header with icon */}
               <div className="flex items-center gap-4">
-                <div className="flex items-center justify-center h-8 w-8 rounded-full bg-muted">
+                <div className="flex items-center justify-center size-8 rounded-full bg-muted">
                   {getHistoryIcon(item.loai_su_kien)}
                 </div>
                 <div>

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailTypes.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailTypes.tsx
@@ -29,22 +29,22 @@ export {
 export function getHistoryIcon(eventType: string): React.ReactNode {
   switch (eventType) {
     case "Sửa chữa":
-      return <Wrench className="h-4 w-4 text-muted-foreground" />
+      return <Wrench className="size-4 text-muted-foreground" />
     case "Bảo trì":
     case "Bảo trì định kỳ":
     case "Bảo trì dự phòng":
-      return <Settings className="h-4 w-4 text-muted-foreground" />
+      return <Settings className="size-4 text-muted-foreground" />
     case "Luân chuyển":
     case "Luân chuyển nội bộ":
     case "Luân chuyển bên ngoài":
-      return <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
+      return <ArrowRightLeft className="size-4 text-muted-foreground" />
     case "Hiệu chuẩn":
     case "Kiểm định":
-      return <CheckCircle className="h-4 w-4 text-muted-foreground" />
+      return <CheckCircle className="size-4 text-muted-foreground" />
     case "Thanh lý":
-      return <Trash2 className="h-4 w-4 text-muted-foreground" />
+      return <Trash2 className="size-4 text-muted-foreground" />
     default:
-      return <Calendar className="h-4 w-4 text-muted-foreground" />
+      return <Calendar className="size-4 text-muted-foreground" />
   }
 }
 

--- a/src/app/(app)/equipment/equipment-content.tsx
+++ b/src/app/(app)/equipment/equipment-content.tsx
@@ -113,7 +113,7 @@ export function EquipmentContent({
       <div className="relative space-y-3">
         {isFetching && (
           <div className="absolute inset-0 bg-background/40 backdrop-blur-[1px] flex items-center justify-center z-10">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
           </div>
         )}
         {table.getRowModel().rows.map((row) => (
@@ -132,7 +132,7 @@ export function EquipmentContent({
     <div className="relative overflow-x-auto rounded-md border">
       {isFetching && (
         <div className="absolute inset-0 bg-background/40 backdrop-blur-[1px] flex items-center justify-center z-10">
-          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          <Loader2 className="size-5 animate-spin text-muted-foreground" />
         </div>
       )}
       <TooltipProvider>

--- a/src/app/(app)/maintenance/_components/maintenance-columns.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-columns.tsx
@@ -74,7 +74,7 @@ export function usePlanColumns(options: PlanColumnOptions): ColumnDef<Maintenanc
       header: ({ column }) => (
         <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
           Năm
-          <ArrowUpDown className="ml-2 h-4 w-4" />
+          <ArrowUpDown className="ml-2 size-4" />
         </Button>
       ),
       cell: ({ row }) => <div className="text-center">{row.getValue("nam")}</div>
@@ -138,11 +138,11 @@ export function usePlanColumns(options: PlanColumnOptions): ColumnDef<Maintenanc
             <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
-                className="h-8 w-8 p-0"
+                className="size-8 p-0"
                 onClick={(e) => e.stopPropagation()}
               >
                 <span className="sr-only">Mở menu</span>
-                <MoreHorizontal className="h-4 w-4" />
+                <MoreHorizontal className="size-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -156,11 +156,11 @@ export function usePlanColumns(options: PlanColumnOptions): ColumnDef<Maintenanc
                   {canManage && (
                     <>
                       <DropdownMenuItem onSelect={() => openApproveDialog(plan)}>
-                        <Check className="mr-2 h-4 w-4" />
+                        <Check className="mr-2 size-4" />
                         Duyệt
                       </DropdownMenuItem>
                       <DropdownMenuItem onSelect={() => openRejectDialog(plan)}>
-                        <X className="mr-2 h-4 w-4" />
+                        <X className="mr-2 size-4" />
                         Không duyệt
                       </DropdownMenuItem>
                     </>
@@ -168,12 +168,12 @@ export function usePlanColumns(options: PlanColumnOptions): ColumnDef<Maintenanc
                   {canManage && (
                     <>
                       <DropdownMenuItem onSelect={() => setEditingPlan(plan)}>
-                        <Edit className="mr-2 h-4 w-4" />
+                        <Edit className="mr-2 size-4" />
                         Sửa
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem onSelect={() => openDeleteDialog(plan)} className="text-destructive focus:text-destructive">
-                        <Trash2 className="mr-2 h-4 w-4" />
+                        <Trash2 className="mr-2 size-4" />
                         Xoá
                       </DropdownMenuItem>
                     </>
@@ -268,7 +268,7 @@ export function useTaskColumns(options: TaskColumnOptions): ColumnDef<Maintenanc
           const isScheduled = !!row.original[fieldName];
           if (!isScheduled) return null;
 
-          if (isLoadingCompletion) return <Skeleton className="h-4 w-4 mx-auto" />;
+          if (isLoadingCompletion) return <Skeleton className="size-4 mx-auto" />;
 
           // Check completion status from actual database field
           const completionFieldName = `thang_${month}_hoan_thanh` as keyof MaintenanceTask;
@@ -280,7 +280,7 @@ export function useTaskColumns(options: TaskColumnOptions): ColumnDef<Maintenanc
           if (isUpdating) {
             return (
               <div className="flex justify-center items-center h-full">
-                <Loader2 className="h-5 w-5 animate-spin text-primary" />
+                <Loader2 className="size-5 animate-spin text-primary" />
               </div>
             );
           }
@@ -293,7 +293,7 @@ export function useTaskColumns(options: TaskColumnOptions): ColumnDef<Maintenanc
             return (
               <div className="flex justify-center items-center h-full">
                 <div title={`Đã hoàn thành${formattedDate ? ` ngày ${formattedDate}` : ''}`}>
-                  <CheckCircle2 className="h-5 w-5 text-green-600" />
+                  <CheckCircle2 className="size-5 text-green-600" />
                 </div>
               </div>
             );
@@ -394,11 +394,11 @@ export function useTaskColumns(options: TaskColumnOptions): ColumnDef<Maintenanc
         if (isEditing) {
           return (
             <div className="flex items-center gap-1">
-              <Button variant="ghost" size="icon" className="h-8 w-8 text-green-600 hover:bg-green-100 hover:text-green-700" onClick={handleSaveTask}>
-                <Save className="h-4 w-4" />
+              <Button variant="ghost" size="icon" className="size-8 text-green-600 hover:bg-green-100 hover:text-green-700" onClick={handleSaveTask}>
+                <Save className="size-4" />
               </Button>
-              <Button variant="ghost" size="icon" className="h-8 w-8 text-gray-600 hover:bg-gray-100" onClick={handleCancelEdit}>
-                <X className="h-4 w-4" />
+              <Button variant="ghost" size="icon" className="size-8 text-gray-600 hover:bg-gray-100" onClick={handleCancelEdit}>
+                <X className="size-4" />
               </Button>
             </div>
           )
@@ -406,11 +406,11 @@ export function useTaskColumns(options: TaskColumnOptions): ColumnDef<Maintenanc
 
         return (
           <div className="flex items-center gap-1">
-            <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => handleStartEdit(task)} disabled={!!editingTaskId}>
-              <Edit className="h-4 w-4" />
+            <Button variant="ghost" size="icon" className="size-8" onClick={() => handleStartEdit(task)} disabled={!!editingTaskId}>
+              <Edit className="size-4" />
             </Button>
-            <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive hover:bg-destructive/10" onClick={() => setTaskToDelete(task)} disabled={!!editingTaskId}>
-              <Trash2 className="h-4 w-4" />
+            <Button variant="ghost" size="icon" className="size-8 text-destructive hover:bg-destructive/10" onClick={() => setTaskToDelete(task)} disabled={!!editingTaskId}>
+              <Trash2 className="size-4" />
             </Button>
           </div>
         )

--- a/src/app/(app)/maintenance/_components/maintenance-dialogs.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-dialogs.tsx
@@ -102,7 +102,7 @@ export function MaintenanceDialogs() {
           <AlertDialogFooter>
             <AlertDialogCancel disabled={operations.isApproving}>Hủy</AlertDialogCancel>
             <AlertDialogAction onClick={operations.handleApprovePlan} disabled={operations.isApproving}>
-              {operations.isApproving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {operations.isApproving && <Loader2 className="mr-2 size-4 animate-spin" />}
               Xác nhận duyệt
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -144,7 +144,7 @@ export function MaintenanceDialogs() {
               disabled={operations.isRejecting || !operations.confirmDialog.rejectionReason?.trim()}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              {operations.isRejecting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {operations.isRejecting && <Loader2 className="mr-2 size-4 animate-spin" />}
               Xác nhận không duyệt
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -169,7 +169,7 @@ export function MaintenanceDialogs() {
           <AlertDialogFooter>
             <AlertDialogCancel disabled={operations.isDeleting}>Hủy</AlertDialogCancel>
             <AlertDialogAction onClick={operations.handleDeletePlan} disabled={operations.isDeleting} className="bg-destructive hover:bg-destructive/90">
-              {operations.isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {operations.isDeleting && <Loader2 className="mr-2 size-4 animate-spin" />}
               Xóa
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/app/(app)/maintenance/_components/maintenance-mobile-task-card.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-mobile-task-card.tsx
@@ -76,7 +76,7 @@ export const MaintenanceMobileTaskCard = React.memo(function MaintenanceMobileTa
           onClick={onToggleExpansion}
           className="flex w-full items-center gap-3 px-4 py-3 text-left"
         >
-          <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+          <div className="flex size-10 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
             {index + 1}
           </div>
           <div className="flex-1 min-w-0">
@@ -97,7 +97,7 @@ export const MaintenanceMobileTaskCard = React.memo(function MaintenanceMobileTa
             )}
           </div>
           <ChevronDown
-            className={`h-5 w-5 flex-shrink-0 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
+            className={`size-5 flex-shrink-0 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
           />
         </button>
 
@@ -175,10 +175,10 @@ export const MaintenanceMobileTaskCard = React.memo(function MaintenanceMobileTa
                         }}
                       >
                         {isUpdating ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <Loader2 className="size-4 animate-spin" />
                         ) : isCompleted ? (
                           <div className="flex items-center gap-1">
-                            <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                            <CheckCircle2 className="size-4 text-emerald-600" />
                             <span>T{month}</span>
                           </div>
                         ) : (
@@ -223,7 +223,7 @@ export const MaintenanceMobileTaskCard = React.memo(function MaintenanceMobileTa
               {isPlanApproved ? null : isEditing ? (
                 <>
                   <Button type="button" size="sm" onClick={taskEditing.handleSaveTask}>
-                    <Save className="mr-2 h-4 w-4" />
+                    <Save className="mr-2 size-4" />
                     Lưu
                   </Button>
                   <Button type="button" size="sm" variant="outline" onClick={taskEditing.handleCancelEdit}>
@@ -233,11 +233,11 @@ export const MaintenanceMobileTaskCard = React.memo(function MaintenanceMobileTa
               ) : (
                 <>
                   <Button type="button" size="sm" variant="outline" onClick={() => taskEditing.handleStartEdit(task)} disabled={isPlanApproved}>
-                    <Edit className="mr-2 h-4 w-4" />
+                    <Edit className="mr-2 size-4" />
                     Sửa
                   </Button>
                   <Button type="button" size="sm" variant="outline" className="text-destructive" onClick={() => taskEditing.setTaskToDelete(task)}>
-                    <Trash2 className="mr-2 h-4 w-4" />
+                    <Trash2 className="mr-2 size-4" />
                     Xóa
                   </Button>
                 </>

--- a/src/app/(app)/maintenance/_components/maintenance-page-legacy-mobile-cards.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-page-legacy-mobile-cards.tsx
@@ -104,9 +104,9 @@ export function MaintenancePageLegacyMobileCards({
             </div>
             <DropdownMenu>
               <DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
-                <Button variant="ghost" className="h-8 w-8 p-0 touch-target-sm">
+                <Button variant="ghost" className="size-8 p-0 touch-target-sm">
                   <span className="sr-only">Mở menu</span>
-                  <MoreHorizontal className="h-4 w-4" />
+                  <MoreHorizontal className="size-4" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
@@ -118,15 +118,15 @@ export function MaintenancePageLegacyMobileCards({
                   <>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onSelect={() => onOpenApproveDialog(plan)}>
-                      <Check className="mr-2 h-4 w-4" />
+                      <Check className="mr-2 size-4" />
                       Duyệt
                     </DropdownMenuItem>
                     <DropdownMenuItem onSelect={() => onOpenRejectDialog(plan)}>
-                      <X className="mr-2 h-4 w-4" />
+                      <X className="mr-2 size-4" />
                       Không duyệt
                     </DropdownMenuItem>
                     <DropdownMenuItem onSelect={() => onEditPlan(plan)}>
-                      <Edit className="mr-2 h-4 w-4" />
+                      <Edit className="mr-2 size-4" />
                       Sửa
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
@@ -134,7 +134,7 @@ export function MaintenancePageLegacyMobileCards({
                       onSelect={() => onOpenDeleteDialog(plan)}
                       className="text-destructive"
                     >
-                      <Trash2 className="mr-2 h-4 w-4" />
+                      <Trash2 className="mr-2 size-4" />
                       Xóa
                     </DropdownMenuItem>
                   </>

--- a/src/app/(app)/maintenance/_components/tasks-table.tsx
+++ b/src/app/(app)/maintenance/_components/tasks-table.tsx
@@ -64,13 +64,13 @@ export function TasksTable({
             Đã chọn {selectedCount} mục:
           </span>
           <Button size="sm" variant="outline" onClick={onBulkSchedule}>
-            <CalendarDays className="mr-2 h-4 w-4" />
+            <CalendarDays className="mr-2 size-4" />
             Lên lịch hàng loạt
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button size="sm" variant="outline">
-                <Users className="mr-2 h-4 w-4" />
+                <Users className="mr-2 size-4" />
                 Gán ĐVTH
               </Button>
             </DropdownMenuTrigger>
@@ -82,7 +82,7 @@ export function TasksTable({
             </DropdownMenuContent>
           </DropdownMenu>
           <Button size="sm" variant="destructive" className="ml-auto" onClick={onBulkDelete}>
-            <Trash2 className="mr-2 h-4 w-4" />
+            <Trash2 className="mr-2 size-4" />
             Xóa ({selectedCount})
           </Button>
         </div>

--- a/src/app/(app)/qr-scanner/page.tsx
+++ b/src/app/(app)/qr-scanner/page.tsx
@@ -163,8 +163,8 @@ export default function QRScannerPage() {
         <div className="max-w-2xl mx-auto">
           <Card>
             <CardHeader className="text-center">
-              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-                <QrCode className="h-8 w-8 text-primary" />
+              <div className="mx-auto mb-4 flex size-16 items-center justify-center rounded-full bg-primary/10">
+                <QrCode className="size-8 text-primary" />
               </div>
               <CardTitle className="heading-responsive-h2">Quét mã QR thiết bị</CardTitle>
               <CardDescription className="body-responsive">
@@ -179,7 +179,7 @@ export default function QRScannerPage() {
                     onClick={handleStartScanning}
                     className="h-14 px-8 text-lg touch-target-lg"
                   >
-                    <Camera className="h-6 w-6 mr-3" />
+                    <Camera className="size-6 mr-3" />
                     <span className="button-text-responsive">Bắt đầu quét</span>
                   </Button>
                 </div>
@@ -188,7 +188,7 @@ export default function QRScannerPage() {
                   <h3 className="heading-responsive-h3 font-semibold mb-4">Chức năng có sẵn</h3>
                   <div className="grid gap-4 text-left">
                     <div className="flex items-start gap-3">
-                      <div className="h-2 w-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+                      <div className="size-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
                       <div>
                         <strong>Ghi nhật ký sử dụng thiết bị:</strong>
                         <p className="caption-responsive">
@@ -198,7 +198,7 @@ export default function QRScannerPage() {
                     </div>
 
                     <div className="flex items-start gap-3">
-                      <div className="h-2 w-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+                      <div className="size-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
                       <div>
                         <strong>Xem thông tin chi tiết:</strong>
                         <p className="caption-responsive">
@@ -208,7 +208,7 @@ export default function QRScannerPage() {
                     </div>
 
                     <div className="flex items-start gap-3">
-                      <div className="h-2 w-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+                      <div className="size-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
                       <div>
                         <strong>Lịch sử bảo trì & sửa chữa:</strong>
                         <p className="caption-responsive">
@@ -218,7 +218,7 @@ export default function QRScannerPage() {
                     </div>
 
                     <div className="flex items-start gap-3">
-                      <div className="h-2 w-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+                      <div className="size-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
                       <div>
                         <strong>Tạo yêu cầu sửa chữa:</strong>
                         <p className="text-sm text-muted-foreground">
@@ -228,7 +228,7 @@ export default function QRScannerPage() {
                     </div>
 
                     <div className="flex items-start gap-3">
-                      <div className="h-2 w-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
+                      <div className="size-2 rounded-full bg-primary mt-2 flex-shrink-0"></div>
                       <div>
                         <strong>Cập nhật trạng thái:</strong>
                         <p className="text-sm text-muted-foreground">
@@ -243,7 +243,7 @@ export default function QRScannerPage() {
               {/* Instructions */}
               <div className="bg-blue-50 dark:bg-blue-950/20 rounded-lg p-4">
                 <div className="flex items-start gap-3">
-                  <Smartphone className="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0" />
+                  <Smartphone className="size-5 text-blue-600 mt-0.5 flex-shrink-0" />
                   <div>
                     <h4 className="font-semibold text-blue-900 dark:text-blue-100">
                       Hướng dẫn sử dụng
@@ -261,7 +261,7 @@ export default function QRScannerPage() {
               <div className="text-center pt-4">
                 <Button asChild variant="outline" className="touch-target">
                   <Link href="/dashboard">
-                    <ArrowLeft className="h-4 w-4 mr-2" />
+                    <ArrowLeft className="size-4 mr-2" />
                     Về Dashboard
                   </Link>
                 </Button>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsApproveDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsApproveDialog.tsx
@@ -112,7 +112,7 @@ export function RepairRequestsApproveDialog() {
             Hủy
           </Button>
           <Button onClick={handleConfirm} disabled={approveMutation.isPending}>
-            {approveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {approveMutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
             Xác nhận duyệt
           </Button>
         </DialogFooter>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
@@ -64,9 +64,9 @@ export function renderActions(
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="h-8 w-8 p-0 touch-target-sm md:h-8 md:w-8">
+        <Button variant="ghost" className="size-8 p-0 touch-target-sm md:size-8">
           <span className="sr-only">Mở menu</span>
-          <MoreHorizontal className="h-4 w-4" />
+          <MoreHorizontal className="size-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
@@ -79,11 +79,11 @@ export function renderActions(
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem onSelect={() => setEditingRequest(request)}>
-              <Edit className="mr-2 h-4 w-4" />
+              <Edit className="mr-2 size-4" />
               Sửa
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => setRequestToDelete(request)} className="text-destructive focus:text-destructive">
-              <Trash2 className="mr-2 h-4 w-4" />
+              <Trash2 className="mr-2 size-4" />
               Xoá
             </DropdownMenuItem>
           </>
@@ -137,7 +137,7 @@ export function useRepairRequestColumns(options: RepairRequestColumnOptions): Co
       header: ({ column }) => (
         <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
           Thiết bị
-          <ArrowUpDown className="ml-2 h-4 w-4" />
+          <ArrowUpDown className="ml-2 size-4" />
         </Button>
       ),
       cell: ({ row }) => {
@@ -164,7 +164,7 @@ export function useRepairRequestColumns(options: RepairRequestColumnOptions): Co
       header: ({ column }) => (
         <Button variant="ghost" className="hover:bg-transparent px-0 font-semibold text-muted-foreground" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
           Người yêu cầu
-          <ArrowUpDown className="ml-2 h-3.5 w-3.5" />
+          <ArrowUpDown className="ml-2 size-3.5" />
         </Button>
       ),
       cell: ({ row }) => {
@@ -182,7 +182,7 @@ export function useRepairRequestColumns(options: RepairRequestColumnOptions): Co
       header: ({ column }) => (
         <Button variant="ghost" className="hover:bg-transparent px-0 font-semibold text-muted-foreground" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
           Ngày yêu cầu
-          <ArrowUpDown className="ml-2 h-3.5 w-3.5" />
+          <ArrowUpDown className="ml-2 size-3.5" />
         </Button>
       ),
       cell: ({ row }) => <div className="text-sm text-foreground/80">{format(parseISO(row.getValue("ngay_yeu_cau")), 'dd/MM/yyyy HH:mm', { locale: vi })}</div>,
@@ -193,7 +193,7 @@ export function useRepairRequestColumns(options: RepairRequestColumnOptions): Co
       header: ({ column }) => (
         <Button variant="ghost" className="hover:bg-transparent px-0 font-semibold text-muted-foreground" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
           Hạn hoàn thành
-          <ArrowUpDown className="ml-2 h-3.5 w-3.5" />
+          <ArrowUpDown className="ml-2 size-3.5" />
         </Button>
       ),
       cell: ({ row }) => {
@@ -249,7 +249,7 @@ export function useRepairRequestColumns(options: RepairRequestColumnOptions): Co
       header: ({ column }) => (
         <Button variant="ghost" className="hover:bg-transparent px-0 font-semibold text-muted-foreground" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
           Trạng thái
-          <ArrowUpDown className="ml-2 h-3.5 w-3.5" />
+          <ArrowUpDown className="ml-2 size-3.5" />
         </Button>
       ),
       cell: ({ row }) => {

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx
@@ -133,7 +133,7 @@ function CompleteDialogForm({
           Hủy
         </Button>
         <Button onClick={handleConfirm} disabled={isConfirmDisabled}>
-          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
           {completionType === "Hoàn thành" ? "Xác nhận hoàn thành" : "Xác nhận không hoàn thành"}
         </Button>
       </DialogFooter>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetActions.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetActions.tsx
@@ -24,7 +24,7 @@ export function RepairRequestsCreateSheetActions({
         Hủy
       </Button>
       <Button type="submit" className="flex-1 touch-target" disabled={isSubmitting}>
-        {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
         {isSubmitting ? "Đang gửi..." : "Gửi yêu cầu"}
       </Button>
     </div>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsDeleteDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsDeleteDialog.tsx
@@ -45,7 +45,7 @@ export function RepairRequestsDeleteDialog() {
             disabled={deleteMutation.isPending}
             className="bg-destructive hover:bg-destructive/90"
           >
-            {deleteMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {deleteMutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
             Xóa
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsEquipmentSearchField.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsEquipmentSearchField.tsx
@@ -67,7 +67,7 @@ export function RepairRequestsEquipmentSearchField({
       </div>
       {selectedEquipment && (
         <p className="flex items-center gap-1.5 pt-1 text-xs text-muted-foreground">
-          <Check className="h-3.5 w-3.5 text-green-600" />
+          <Check className="size-3.5 text-green-600" />
           <span>
             Đã chọn: {selectedEquipment.ten_thiet_bi} ({selectedEquipment.ma_thiet_bi})
           </span>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsFilterChips.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsFilterChips.tsx
@@ -48,11 +48,11 @@ export function RepairRequestsFilterChips({
           <Button
             variant="ghost"
             size="sm"
-            className="ml-1 h-5 w-5 p-0 rounded-full hover:bg-black/10 dark:hover:bg-white/10"
+            className="ml-1 size-5 p-0 rounded-full hover:bg-black/10 dark:hover:bg-white/10"
             onClick={() => onRemove("status", s)}
             aria-label={`Xóa trạng thái ${s}`}
           >
-            <X className="h-3 w-3" />
+            <X className="size-3" />
           </Button>
         </Badge>
       ))}
@@ -63,11 +63,11 @@ export function RepairRequestsFilterChips({
           <Button
             variant="ghost"
             size="sm"
-            className="ml-1 h-5 w-5 p-0 rounded-full hover:bg-muted-foreground/20"
+            className="ml-1 size-5 p-0 rounded-full hover:bg-muted-foreground/20"
             onClick={() => onRemove("facilityName")}
             aria-label="Xóa cơ sở"
           >
-            <X className="h-3 w-3" />
+            <X className="size-3" />
           </Button>
         </Badge>
       )}
@@ -82,11 +82,11 @@ export function RepairRequestsFilterChips({
           <Button
             variant="ghost"
             size="sm"
-            className="ml-1 h-5 w-5 p-0 rounded-full hover:bg-muted-foreground/20"
+            className="ml-1 size-5 p-0 rounded-full hover:bg-muted-foreground/20"
             onClick={() => onRemove("dateRange")}
             aria-label="Xóa khoảng ngày"
           >
-            <X className="h-3 w-3" />
+            <X className="size-3" />
           </Button>
         </Badge>
       )}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsFilterModal.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsFilterModal.tsx
@@ -97,7 +97,7 @@ export function RepairRequestsFilterModal({
                 variant="outline"
                 className={cn("justify-start text-left font-normal", !value.dateRange?.from && "text-muted-foreground")}
               >
-                <CalendarIcon className="mr-2 h-4 w-4" />
+                <CalendarIcon className="mr-2 size-4" />
                 {value.dateRange?.from ? value.dateRange.from.toLocaleDateString("vi-VN") : "Từ ngày"}
               </Button>
             </PopoverTrigger>
@@ -116,7 +116,7 @@ export function RepairRequestsFilterModal({
                 variant="outline"
                 className={cn("justify-start text-left font-normal", !value.dateRange?.to && "text-muted-foreground")}
               >
-                <CalendarIcon className="mr-2 h-4 w-4" />
+                <CalendarIcon className="mr-2 size-4" />
                 {value.dateRange?.to ? value.dateRange.to.toLocaleDateString("vi-VN") : "Đến ngày"}
               </Button>
             </PopoverTrigger>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
@@ -34,7 +34,7 @@ export function RepairRequestsMobileList({
   if (isLoading) {
     return (
       <div className="flex justify-center items-center gap-2 py-6">
-        <Loader2 className="h-4 w-4 animate-spin" />
+        <Loader2 className="size-4 animate-spin" />
         <span className="text-sm">Đang tải...</span>
       </div>
     )

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
@@ -181,7 +181,7 @@ export function RepairRequestsPageLayout({
                 {!isRegionalLeader ? (
                   <div className="flex items-center gap-2">
                     <Button onClick={() => openCreateSheet()} className="hidden md:flex touch-target">
-                      <PlusCircle className="mr-2 h-4 w-4" /> Tạo yêu cầu
+                      <PlusCircle className="mr-2 size-4" /> Tạo yêu cầu
                     </Button>
                   </div>
                 ) : null}
@@ -247,7 +247,7 @@ export function RepairRequestsPageLayout({
                 ) : (
                   <div className="flex items-center justify-center min-h-[400px]">
                     <div className="flex max-w-md flex-col items-center gap-4 text-center">
-                      <Building2 className="h-12 w-12 text-muted-foreground" />
+                      <Building2 className="size-12 text-muted-foreground" />
                       <div className="space-y-2">
                         <h3 className="text-lg font-medium">Chọn cơ sở y tế</h3>
                         <p className="text-sm text-muted-foreground">

--- a/src/app/(app)/repair-requests/_components/RepairRequestsProcessStepper.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsProcessStepper.tsx
@@ -119,12 +119,12 @@ export function RepairRequestsProcessStepper({ status, className }: RepairReques
                                 isFirst ? "pl-2" : "pl-8", // Adjust padding to account for the left cutout
                                 isLast ? "" : "pr-6" // Adjust padding to avoid text hitting arrow head
                             )}>
-                                <div className={cn("h-6 w-6 rounded-full flex items-center justify-center border-2 border-white/20 shadow-sm",
+                                <div className={cn("size-6 rounded-full flex items-center justify-center border-2 border-white/20 shadow-sm",
                                     (isActive || isCompleted) ? "bg-white/20" : "bg-transparent"
                                 )}>
-                                    {isCompleted ? <Check className="h-3.5 w-3.5" /> :
-                                        (isActive && isFailure) ? <X className="h-3.5 w-3.5" /> :
-                                            (isActive && idx !== 2) ? <Icon className="h-3.5 w-3.5 animate-pulse" /> :
+                                    {isCompleted ? <Check className="size-3.5" /> :
+                                        (isActive && isFailure) ? <X className="size-3.5" /> :
+                                            (isActive && idx !== 2) ? <Icon className="size-3.5 animate-pulse" /> :
                                                 <span className="text-xs font-bold">{idx + 1}</span>}
                                 </div>
                                 <span className="text-sm font-bold whitespace-nowrap hidden sm:inline-block">{step.title}</span>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsTable.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsTable.tsx
@@ -63,7 +63,7 @@ export function RepairRequestsTable({
                 className="h-24 text-center py-3"
               >
                 <div className="flex justify-center items-center gap-2 text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                   <span>Đang tải dữ liệu...</span>
                 </div>
               </TableCell>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
@@ -128,7 +128,7 @@ export function RepairRequestsToolbar({
       aria-label="Xóa bộ lọc"
     >
       <span className="hidden sm:inline">Xóa</span>
-      <FilterX className="h-4 w-4 sm:ml-2" />
+      <FilterX className="size-4 sm:ml-2" />
     </Button>
   ) : null
 
@@ -179,7 +179,7 @@ function DateFilterButton({ label, value, onChange }: DateFilterButtonProps) {
           size="sm"
           className={cn("h-9 min-w-[116px] justify-start", !value && "text-muted-foreground")}
         >
-          <CalendarIcon className="mr-2 h-4 w-4" />
+          <CalendarIcon className="mr-2 size-4" />
           {value ? value.toLocaleDateString("vi-VN") : label}
         </Button>
       </PopoverTrigger>

--- a/src/app/(app)/reports/components/export-report-dialog.tsx
+++ b/src/app/(app)/reports/components/export-report-dialog.tsx
@@ -122,7 +122,7 @@ function ExportReportDialogContent({
     <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <FileSpreadsheet className="h-5 w-5" />
+            <FileSpreadsheet className="size-5" />
             Xuất báo cáo Excel
           </DialogTitle>
           <DialogDescription>
@@ -181,8 +181,8 @@ function ExportReportDialogContent({
             Hủy
           </Button>
           <Button onClick={handleExport} disabled={isExporting || !hasFileName}>
-            {isExporting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            <Download className="mr-2 h-4 w-4" />
+            {isExporting && <Loader2 className="mr-2 size-4 animate-spin" />}
+            <Download className="mr-2 size-4" />
             {isExporting ? "Đang xuất..." : "Xuất Excel"}
           </Button>
         </DialogFooter>

--- a/src/app/(app)/reports/components/inventory-table.tsx
+++ b/src/app/(app)/reports/components/inventory-table.tsx
@@ -74,7 +74,7 @@ export function InventoryTable({ data, isLoading }: InventoryTableProps) {
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
             Ngày
-            <ArrowUpDown className="ml-2 h-4 w-4" />
+            <ArrowUpDown className="ml-2 size-4" />
           </Button>
         )
       },
@@ -92,7 +92,7 @@ export function InventoryTable({ data, isLoading }: InventoryTableProps) {
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
             Mã thiết bị
-            <ArrowUpDown className="ml-2 h-4 w-4" />
+            <ArrowUpDown className="ml-2 size-4" />
           </Button>
         )
       },
@@ -109,7 +109,7 @@ export function InventoryTable({ data, isLoading }: InventoryTableProps) {
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
             Tên thiết bị
-            <ArrowUpDown className="ml-2 h-4 w-4" />
+            <ArrowUpDown className="ml-2 size-4" />
           </Button>
         )
       },

--- a/src/app/(app)/reports/components/maintenance-repair-cost-visualizations.tsx
+++ b/src/app/(app)/reports/components/maintenance-repair-cost-visualizations.tsx
@@ -53,7 +53,7 @@ export function MaintenanceRepairCostVisualizations({
         <CardContent>
           {!hasRepairCostData ? (
             <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <Inbox className="size-8 text-muted-foreground/60" />
               <span>Không có dữ liệu chi phí sửa chữa trong khoảng thời gian đã chọn.</span>
             </div>
           ) : (
@@ -100,7 +100,7 @@ export function MaintenanceRepairCostVisualizations({
         <CardContent>
           {!hasCorrelationData ? (
             <div className="flex h-[360px] flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <Inbox className="size-8 text-muted-foreground/60" />
               <span>Chưa đủ dữ liệu để hiển thị tương quan.</span>
               <span>Thiết bị có giờ sử dụng: {activeCorrelationScope.dataQuality.equipmentWithUsage}</span>
               <span>Thiết bị có chi phí sửa chữa: {activeCorrelationScope.dataQuality.equipmentWithRepairCost}</span>

--- a/src/app/(app)/reports/components/maintenance-report-plan-chart.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-plan-chart.tsx
@@ -28,7 +28,7 @@ export function MaintenanceReportPlanChart({
           <Skeleton className="h-[360px] w-full" />
         ) : maintenancePlanData.length === 0 ? (
           <div className="text-sm text-muted-foreground h-[360px] flex flex-col items-center justify-center gap-2">
-            <Inbox className="h-8 w-8 text-muted-foreground/60" />
+            <Inbox className="size-8 text-muted-foreground/60" />
             <span>Không có dữ liệu kế hoạch bảo trì.</span>
           </div>
         ) : (

--- a/src/app/(app)/reports/components/maintenance-report-repair-charts.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-repair-charts.tsx
@@ -32,7 +32,7 @@ export function MaintenanceReportRepairCharts({
             <Skeleton className="h-[340px] w-full" />
           ) : repairTrendData.length === 0 ? (
             <div className="text-sm text-muted-foreground h-[340px] flex flex-col items-center justify-center gap-2">
-              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <Inbox className="size-8 text-muted-foreground/60" />
               <span>Không có dữ liệu xu hướng sửa chữa.</span>
             </div>
           ) : (
@@ -60,7 +60,7 @@ export function MaintenanceReportRepairCharts({
             <Skeleton className="h-[340px] w-full" />
           ) : repairStatusData.length === 0 ? (
             <div className="text-sm text-muted-foreground h-[340px] flex flex-col items-center justify-center gap-2">
-              <Inbox className="h-8 w-8 text-muted-foreground/60" />
+              <Inbox className="size-8 text-muted-foreground/60" />
               <span>Không có dữ liệu trạng thái sửa chữa.</span>
             </div>
           ) : (

--- a/src/app/(app)/reports/components/maintenance-report-summary-cards.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-summary-cards.tsx
@@ -23,7 +23,7 @@ export function MaintenanceReportSummaryCards({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Yêu cầu sửa chữa</CardTitle>
-            <Wrench className="h-4 w-4 text-muted-foreground" />
+            <Wrench className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{summary.totalRepairs}</div>}
@@ -33,7 +33,7 @@ export function MaintenanceReportSummaryCards({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tỷ lệ hoàn thành (Sửa chữa)</CardTitle>
-            <CheckCircle className="h-4 w-4 text-green-500" />
+            <CheckCircle className="size-4 text-green-500" />
           </CardHeader>
           <CardContent>
             {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{summary.repairCompletionRate.toFixed(1)}%</div>}
@@ -43,7 +43,7 @@ export function MaintenanceReportSummaryCards({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Công việc bảo trì (Kế hoạch)</CardTitle>
-            <Clock className="h-4 w-4 text-muted-foreground" />
+            <Clock className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{summary.totalMaintenancePlanned}</div>}
@@ -53,7 +53,7 @@ export function MaintenanceReportSummaryCards({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tỷ lệ hoàn thành (Bảo trì)</CardTitle>
-            <CheckCircle className="h-4 w-4 text-blue-500" />
+            <CheckCircle className="size-4 text-blue-500" />
           </CardHeader>
           <CardContent>
             {isLoading ? <Skeleton className="h-8 w-16" /> : <div className="text-2xl font-bold">{summary.maintenanceCompletionRate.toFixed(1)}%</div>}
@@ -66,7 +66,7 @@ export function MaintenanceReportSummaryCards({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tổng chi phí sửa chữa</CardTitle>
-            <Wrench className="h-4 w-4 text-muted-foreground" />
+            <Wrench className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             {isLoading ? (
@@ -80,7 +80,7 @@ export function MaintenanceReportSummaryCards({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Chi phí TB ca hoàn thành</CardTitle>
-            <CheckCircle className="h-4 w-4 text-green-500" />
+            <CheckCircle className="size-4 text-green-500" />
           </CardHeader>
           <CardContent>
             {isLoading ? (
@@ -94,7 +94,7 @@ export function MaintenanceReportSummaryCards({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Có ghi nhận chi phí</CardTitle>
-            <CheckCircle className="h-4 w-4 text-emerald-500" />
+            <CheckCircle className="size-4 text-emerald-500" />
           </CardHeader>
           <CardContent>
             {isLoading ? (
@@ -108,7 +108,7 @@ export function MaintenanceReportSummaryCards({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Thiếu chi phí</CardTitle>
-            <Clock className="h-4 w-4 text-amber-500" />
+            <Clock className="size-4 text-amber-500" />
           </CardHeader>
           <CardContent>
             {isLoading ? (

--- a/src/app/(app)/reports/components/tenant-selection-tip.tsx
+++ b/src/app/(app)/reports/components/tenant-selection-tip.tsx
@@ -8,7 +8,7 @@ export function TenantSelectionTip() {
     <Card>
       <CardContent className="flex items-center justify-center py-8">
         <div className="text-center space-y-2">
-          <FileText className="mx-auto h-8 w-8 text-muted-foreground" />
+          <FileText className="mx-auto size-8 text-muted-foreground" />
           <p className="text-muted-foreground">
             Vui lòng chọn đơn vị cụ thể ở bộ lọc để xem dữ liệu báo cáo
           </p>

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -37,7 +37,7 @@ function TabSkeleton() {
           <Card key={i}>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-4" />
+              <Skeleton className="size-4" />
             </CardHeader>
             <CardContent>
               <Skeleton className="h-8 w-16 mb-2" />

--- a/src/app/(app)/transfers/_components/TransfersDateFilterButton.tsx
+++ b/src/app/(app)/transfers/_components/TransfersDateFilterButton.tsx
@@ -31,7 +31,7 @@ export function TransfersDateFilterButton({
             !value && "text-muted-foreground",
           )}
         >
-          <CalendarIcon className="mr-2 h-4 w-4" />
+          <CalendarIcon className="mr-2 size-4" />
           {value ? value.toLocaleDateString("vi-VN") : label}
         </Button>
       </PopoverTrigger>

--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -165,7 +165,7 @@ export function TransfersPagePanel({
       onClick={onOpenFilterModal}
       className="h-11 gap-2 font-medium sm:h-9"
     >
-      <Filter className="h-5 w-5 sm:h-4 sm:w-4" />
+      <Filter className="size-5 sm:size-4" />
       <span className="hidden sm:inline">Bộ lọc</span>
       {activeFilterCount > 0 && (
         <Badge variant="secondary" className="h-5 px-1.5 text-xs sm:ml-1">
@@ -222,7 +222,7 @@ export function TransfersPagePanel({
                   onClick={onOpenAddDialog}
                   className="h-11 gap-2 font-medium sm:h-9"
                 >
-                  <PlusCircle className="h-5 w-5 sm:h-4 sm:w-4" />
+                  <PlusCircle className="size-5 sm:size-4" />
                   Tạo yêu cầu mới
                 </Button>
               )}
@@ -263,7 +263,7 @@ export function TransfersPagePanel({
                     {isListLoading ? (
                       <div className="flex min-h-[200px] items-center justify-center rounded-lg border border-dashed">
                         <div className="flex flex-col items-center gap-2 text-sm text-muted-foreground">
-                          <Loader2 className="h-6 w-6 animate-spin" />
+                          <Loader2 className="size-6 animate-spin" />
                           Đang tải dữ liệu...
                         </div>
                       </div>
@@ -302,7 +302,7 @@ export function TransfersPagePanel({
 
               {isListFetching && !isListLoading && (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" /> Đang đồng bộ dữ liệu...
+                  <Loader2 className="size-4 animate-spin" /> Đang đồng bộ dữ liệu...
                 </div>
               )}
             </div>

--- a/src/app/_components/LoginForm.tsx
+++ b/src/app/_components/LoginForm.tsx
@@ -128,7 +128,7 @@ export function LoginForm(): React.ReactElement {
       <section className="w-full lg:w-1/2 bg-background flex flex-col justify-center items-center px-6 md:px-16 py-12 relative">
         {/* Mobile Logo */}
         <div className="lg:hidden absolute top-8 left-8 flex items-center gap-2">
-          <Logo className="w-8 h-8" size={32} />
+          <Logo className="size-8" size={32} />
           <span className="font-bold text-xl text-primary">CVMEMS</span>
         </div>
 
@@ -137,7 +137,7 @@ export function LoginForm(): React.ReactElement {
           <div className="bg-white rounded-2xl shadow-lg shadow-black/5 p-8 md:p-10 space-y-8">
             {/* Logo + Brand */}
             <div className="flex items-center gap-3">
-              <Logo className="w-10 h-10" size={40} />
+              <Logo className="size-10" size={40} />
               <span className="font-bold text-xl text-foreground tracking-tight">CVMEMS</span>
             </div>
             {/* Header Text */}
@@ -170,7 +170,7 @@ export function LoginForm(): React.ReactElement {
                   render={({ field }) => (
                     <FormItem className="space-y-2">
                       <FormLabel className="flex items-center gap-2 text-sm font-semibold text-muted-foreground">
-                        <User className="h-3.5 w-3.5" />
+                        <User className="size-3.5" />
                         {t("login.username") || "Tên đăng nhập"}
                       </FormLabel>
                       <FormControl>
@@ -195,7 +195,7 @@ export function LoginForm(): React.ReactElement {
                   render={({ field }) => (
                     <FormItem className="space-y-2">
                       <FormLabel className="flex items-center gap-2 text-sm font-semibold text-muted-foreground">
-                        <Lock className="h-3.5 w-3.5" />
+                        <Lock className="size-3.5" />
                         {t("login.password") || "Mật khẩu"}
                       </FormLabel>
                       <FormControl>
@@ -221,7 +221,7 @@ export function LoginForm(): React.ReactElement {
                 >
                   {isSubmitting ? (
                     <>
-                      <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                      <div className="size-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
                       {t("login.signingIn") || "Đang xác thực..."}
                     </>
                   ) : (

--- a/src/app/_components/LoginIllustrationPanel.tsx
+++ b/src/app/_components/LoginIllustrationPanel.tsx
@@ -12,8 +12,8 @@ export function LoginIllustrationPanel() {
         <section className="hidden lg:flex w-1/2 bg-teal-split flex-col justify-between p-12 text-white relative">
             {/* Top Branding */}
             <div className="flex items-center gap-3">
-                <div className="w-10 h-10 bg-white/10 backdrop-blur-md rounded-xl flex items-center justify-center">
-                    <Logo className="w-7 h-7" size={28} />
+                <div className="size-10 bg-white/10 backdrop-blur-md rounded-xl flex items-center justify-center">
+                    <Logo className="size-7" size={28} />
                 </div>
                 <span className="font-bold text-2xl tracking-tight">CVMEMS</span>
             </div>
@@ -32,7 +32,7 @@ export function LoginIllustrationPanel() {
                     {/* Floating IoT Status Badge */}
                     <div className="absolute top-1/4 right-0 bg-white/10 backdrop-blur-md p-4 rounded-xl border border-white/5 animate-pulse">
                         <div className="flex items-center gap-2">
-                            <span className="w-2 h-2 rounded-full bg-green-400" />
+                            <span className="size-2 rounded-full bg-green-400" />
                             <span className="text-[10px] font-bold uppercase tracking-widest opacity-80">
                                 Device Active
                             </span>
@@ -54,9 +54,9 @@ export function LoginIllustrationPanel() {
             {/* Bottom Stats */}
             <div className="pt-8 border-t border-white/10 flex justify-between items-center text-xs uppercase tracking-widest text-white/50">
                 <span>99.9% Uptime</span>
-                <span className="w-1 h-1 bg-white/30 rounded-full" />
+                <span className="size-1 bg-white/30 rounded-full" />
                 <span>2.5s Response</span>
-                <span className="w-1 h-1 bg-white/30 rounded-full" />
+                <span className="size-1 bg-white/30 rounded-full" />
                 <span>24/7 Support</span>
             </div>
         </section>

--- a/src/components/activity-logs/activity-log-entry.tsx
+++ b/src/components/activity-logs/activity-log-entry.tsx
@@ -37,7 +37,7 @@ export function ActivityLogEntry({ log }: ActivityLogEntryProps) {
 
   return (
     <div className="flex items-start space-x-4 p-4 border rounded-lg hover:bg-gray-50 transition-colors">
-      <Avatar className="h-10 w-10">
+      <Avatar className="size-10">
         <AvatarFallback>{getInitials(log)}</AvatarFallback>
       </Avatar>
 
@@ -75,12 +75,12 @@ export function ActivityLogEntry({ log }: ActivityLogEntryProps) {
 
             <div className="flex items-center space-x-4 text-xs text-gray-500">
               <div className="flex items-center space-x-1">
-                <Clock className="h-3 w-3" />
+                <Clock className="size-3" />
                 <span>{formatVietnamDateTime(log.created_at)}</span>
               </div>
               {log.ip_address && (
                 <div className="flex items-center space-x-1">
-                  <MapPin className="h-3 w-3" />
+                  <MapPin className="size-3" />
                   <span>{log.ip_address}</span>
                 </div>
               )}

--- a/src/components/activity-logs/activity-logs-viewer.tsx
+++ b/src/components/activity-logs/activity-logs-viewer.tsx
@@ -141,7 +141,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center space-x-2">
-              <Activity className="h-4 w-4 text-blue-600" />
+              <Activity className="size-4 text-blue-600" />
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Hoạt động 24h</p>
                 <p className="text-2xl font-bold">
@@ -155,7 +155,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center space-x-2">
-              <User className="h-4 w-4 text-green-600" />
+              <User className="size-4 text-green-600" />
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Người dùng hoạt động</p>
                 <p className="text-2xl font-bold">
@@ -169,7 +169,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center space-x-2">
-              <TrendingUp className="h-4 w-4 text-orange-600" />
+              <TrendingUp className="size-4 text-orange-600" />
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Hoạt động phổ biến</p>
                 <p className="text-sm font-semibold truncate">
@@ -183,7 +183,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         <Card>
           <CardContent className="pt-6">
             <div className="flex items-center space-x-2">
-              <Clock className="h-4 w-4 text-purple-600" />
+              <Clock className="size-4 text-purple-600" />
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Hoạt động gần nhất</p>
                 <p className="text-sm font-semibold">
@@ -203,7 +203,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         <CardHeader className="pb-3">
           <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between space-y-3 lg:space-y-0">
             <CardTitle className="flex items-center space-x-2">
-              <Filter className="h-5 w-5" />
+              <Filter className="size-5" />
               <span>Bộ lọc và tìm kiếm</span>
             </CardTitle>
             <div className="flex items-center space-x-2">
@@ -213,7 +213,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
                 onClick={() => refetch()}
                 disabled={isLoading}
               >
-                <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
+                <RefreshCw className={`size-4 mr-2 ${isLoading ? 'animate-spin' : ''}`} />
                 Làm mới
               </Button>
             </div>
@@ -223,7 +223,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
             {/* Search Input */}
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 size-4" />
               <Input
                 placeholder="Tìm kiếm người dùng, hoạt động…"
                 value={searchTerm}
@@ -307,7 +307,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center justify-between">
             <div className="flex items-center space-x-2">
-              <Eye className="h-5 w-5" />
+              <Eye className="size-5" />
               <span>Nhật ký hoạt động</span>
               <Badge variant="secondary">
                 {filteredLogs.length > 0 ? filteredLogs[0].total_count : 0} mục
@@ -318,14 +318,14 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         <CardContent>
           {error ? (
             <div className="flex items-center justify-center py-8 text-red-600">
-              <AlertCircle className="h-5 w-5 mr-2" />
+              <AlertCircle className="size-5 mr-2" />
               <span>Lỗi tải dữ liệu: {error.message}</span>
             </div>
           ) : isLoading ? (
             <div className="space-y-4">
               {Array.from({ length: 5 }).map((_, i) => (
                 <div key={i} className="flex items-start space-x-4 p-4 border rounded-lg animate-pulse">
-                  <div className="w-10 h-10 bg-gray-200 rounded-full" />
+                  <div className="size-10 bg-gray-200 rounded-full" />
                   <div className="flex-1 space-y-2">
                     <div className="h-4 bg-gray-200 rounded w-1/4" />
                     <div className="h-3 bg-gray-200 rounded w-3/4" />
@@ -336,7 +336,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
             </div>
           ) : filteredLogs.length === 0 ? (
             <div className="text-center py-8 text-gray-500">
-              <Activity className="h-8 w-8 mx-auto mb-2 opacity-50" />
+              <Activity className="size-8 mx-auto mb-2 opacity-50" />
               <p>Không có hoạt động nào được tìm thấy</p>
             </div>
           ) : (

--- a/src/components/add-equipment-dialog.tsx
+++ b/src/components/add-equipment-dialog.tsx
@@ -183,7 +183,7 @@ export function AddEquipmentDialog({
                 type="submit"
                 disabled={createMutation.isPending || isRegionalLeader || isUserRole}
               >
-                {createMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {createMutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
                 Lưu
               </Button>
             </DialogFooter>

--- a/src/components/add-maintenance-plan-dialog.tsx
+++ b/src/components/add-maintenance-plan-dialog.tsx
@@ -241,7 +241,7 @@ export function AddMaintenancePlanDialog({ open, onOpenChange, onSuccess }: AddM
                 Hủy
               </Button>
               <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
                 Lưu kế hoạch
               </Button>
             </DialogFooter>

--- a/src/components/add-transfer-dialog.tsx
+++ b/src/components/add-transfer-dialog.tsx
@@ -259,7 +259,7 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
               Hủy
             </Button>
             <Button type="submit" disabled={isLoading || isRegionalLeader}>
-              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
               Tạo yêu cầu
             </Button>
           </DialogFooter>

--- a/src/components/app-sidebar-nav.tsx
+++ b/src/components/app-sidebar-nav.tsx
@@ -59,7 +59,7 @@ export function AppSidebarNav({
                 ? "bg-gradient-to-r from-primary to-primary/90 text-white font-semibold shadow-lg shadow-primary/25"
                 : "text-slate-600 hover:bg-slate-50 hover:text-primary",
               !isSheetVariant && isSidebarOpen ? "px-3 gap-3" : null,
-              !isSheetVariant && !isSidebarOpen ? "relative h-11 w-11 justify-center" : null
+              !isSheetVariant && !isSidebarOpen ? "relative size-11 justify-center" : null
             )}
             title={!isSheetVariant && !isSidebarOpen ? label : ""}
             aria-label={label}
@@ -69,7 +69,7 @@ export function AppSidebarNav({
           >
             <Icon
               className={cn(
-                "h-5 w-5 transition-colors",
+                "size-5 transition-colors",
                 isActive ? "text-white" : "text-slate-500"
               )}
             />

--- a/src/components/assistant/AssistantComposer.tsx
+++ b/src/components/assistant/AssistantComposer.tsx
@@ -75,20 +75,20 @@ export function AssistantComposer({
                         variant="destructive"
                         size="icon"
                         onClick={onStop}
-                        className="h-9 w-9 rounded-xl shrink-0"
+                        className="size-9 rounded-xl shrink-0"
                         aria-label="Dừng"
                     >
-                        <div className="h-3 w-3 rounded-sm bg-white" />
+                        <div className="size-3 rounded-sm bg-white" />
                     </Button>
                 ) : hasInput ? (
                     <Button
                         size="icon"
                         onClick={onSend}
                         disabled={isDisabled}
-                        className="h-9 w-9 rounded-xl shrink-0 bg-[hsl(var(--assistant-accent))] hover:bg-[hsl(var(--assistant-accent))]/90 text-white"
+                        className="size-9 rounded-xl shrink-0 bg-[hsl(var(--assistant-accent))] hover:bg-[hsl(var(--assistant-accent))]/90 text-white"
                         aria-label="Gửi"
                     >
-                        <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                             <path d="M12 19V5M5 12l7-7 7 7" />
                         </svg>
                     </Button>

--- a/src/components/assistant/AssistantDraftCard.tsx
+++ b/src/components/assistant/AssistantDraftCard.tsx
@@ -74,7 +74,7 @@ function RepairDraftCard({
         >
             {/* Header */}
             <div className="flex items-center gap-2">
-                <FileText className="h-4 w-4 text-orange-600" />
+                <FileText className="size-4 text-orange-600" />
                 <span className="text-xs font-semibold text-orange-800">
                     📝 Bản nháp yêu cầu sửa chữa
                 </span>
@@ -110,7 +110,7 @@ function RepairDraftCard({
             {/* Review notes */}
             {draft.reviewNotes && draft.reviewNotes.length > 0 && (
                 <div className="flex items-start gap-1.5 text-[11px] text-orange-700 bg-orange-100 rounded px-2 py-1.5">
-                    <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                    <AlertTriangle className="size-3.5 mt-0.5 shrink-0" />
                     <div>
                         {keyedReviewNotes.map(({ item: note, key }) => (
                             <p key={key}>{note}</p>
@@ -162,7 +162,7 @@ function TroubleshootingDraftCard({ draft }: { draft: TroubleshootingDraft }) {
         >
             {/* Header */}
             <div className="flex items-center gap-2">
-                <Stethoscope className="h-4 w-4 text-blue-600" />
+                <Stethoscope className="size-4 text-blue-600" />
                 <span className="text-xs font-semibold text-blue-800">
                     Khuyến nghị chẩn đoán
                 </span>

--- a/src/components/assistant/AssistantEmptyState.tsx
+++ b/src/components/assistant/AssistantEmptyState.tsx
@@ -21,9 +21,9 @@ export function AssistantEmptyState({
         <div className="flex flex-col items-center justify-center h-full px-6 text-center gap-4">
             <div
                 data-testid="assistant-empty-icon"
-                className="w-12 h-12 rounded-2xl bg-[hsl(var(--assistant-accent-muted))] flex items-center justify-center"
+                className="size-12 rounded-2xl bg-[hsl(var(--assistant-accent-muted))] flex items-center justify-center"
             >
-                <Sparkles className="h-6 w-6 text-[hsl(var(--assistant-accent))]" />
+                <Sparkles className="size-6 text-[hsl(var(--assistant-accent))]" />
             </div>
 
             <div className="space-y-1">

--- a/src/components/assistant/AssistantMessageList.tsx
+++ b/src/components/assistant/AssistantMessageList.tsx
@@ -114,8 +114,8 @@ function MessageBubble({
         >
             {/* AI avatar */}
             {!isUser && (
-                <div className="w-7 h-7 rounded-full bg-gradient-to-br from-primary/80 to-primary flex items-center justify-center shrink-0 mt-0.5">
-                    <Sparkles className="h-3.5 w-3.5 text-white" />
+                <div className="size-7 rounded-full bg-gradient-to-br from-primary/80 to-primary flex items-center justify-center shrink-0 mt-0.5">
+                    <Sparkles className="size-3.5 text-white" />
                 </div>
             )}
 

--- a/src/components/assistant/AssistantPanel.tsx
+++ b/src/components/assistant/AssistantPanel.tsx
@@ -149,7 +149,7 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
                         <div className="flex items-center gap-2">
                             <div
                                 data-testid="assistant-status-dot"
-                                className="w-1.5 h-1.5 rounded-full bg-[hsl(var(--assistant-status-online))] animate-pulse"
+                                className="size-1.5 rounded-full bg-[hsl(var(--assistant-status-online))] animate-pulse"
                             />
                             <div>
                                 <DialogTitle className="text-sm font-semibold text-foreground leading-snug">
@@ -166,19 +166,19 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
                                 variant="ghost"
                                 size="icon"
                                 onClick={handleReset}
-                                className="h-8 w-8"
+                                className="size-8"
                                 aria-label="Đặt lại cuộc trò chuyện"
                             >
-                                <RotateCcw className="h-4 w-4" />
+                                <RotateCcw className="size-4" />
                             </Button>
                             <Button
                                 variant="ghost"
                                 size="icon"
                                 onClick={onClose}
-                                className="h-8 w-8"
+                                className="size-8"
                                 aria-label="Đóng"
                             >
-                                <X className="h-4 w-4" />
+                                <X className="size-4" />
                             </Button>
                         </div>
                     </div>
@@ -204,7 +204,7 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
                         data-testid="assistant-error-banner"
                         className="mx-3 mb-2 px-3 py-2.5 rounded-lg bg-destructive/10 border border-destructive/20 flex items-start gap-2 shrink-0"
                     >
-                        <AlertTriangle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+                        <AlertTriangle className="size-4 text-destructive shrink-0 mt-0.5" />
                         <div className="flex-1 min-w-0">
                             <p className="text-sm text-destructive leading-snug">
                                 {parseErrorMessage(error.message)}
@@ -217,7 +217,7 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
                             className="shrink-0 h-7 px-2 text-xs text-destructive hover:text-destructive"
                             aria-label="Thử lại"
                         >
-                            <RefreshCw className="h-3 w-3 mr-1" />
+                            <RefreshCw className="size-3 mr-1" />
                             Thử lại
                         </Button>
                     </div>

--- a/src/components/assistant/AssistantSuggestedQuestions.tsx
+++ b/src/components/assistant/AssistantSuggestedQuestions.tsx
@@ -79,7 +79,7 @@ export function AssistantSuggestedQuestions({
                     )}
                     style={{ animationDelay: `${i * 80}ms` }}
                 >
-                    <Star className="h-3.5 w-3.5 shrink-0 text-[hsl(var(--assistant-accent))]" />
+                    <Star className="size-3.5 shrink-0 text-[hsl(var(--assistant-accent))]" />
                     <span>{text}</span>
                 </button>
             ))}
@@ -101,7 +101,7 @@ export function AssistantSuggestedQuestions({
                     )}
                     style={{ animationDelay: `${(PINNED_PROMPTS.length + i) * 80}ms` }}
                 >
-                    <Zap className="h-3.5 w-3.5 shrink-0 text-[hsl(var(--assistant-accent))]" />
+                    <Zap className="size-3.5 shrink-0 text-[hsl(var(--assistant-accent))]" />
                     <span>{text}</span>
                 </button>
             ))}

--- a/src/components/assistant/AssistantThinkingIndicator.tsx
+++ b/src/components/assistant/AssistantThinkingIndicator.tsx
@@ -17,7 +17,7 @@ export function AssistantThinkingIndicator() {
                 <div
                     key={dotId}
                     data-testid="assistant-thinking-dot"
-                    className="w-1.5 h-1.5 rounded-full bg-muted-foreground/50 assistant-dot"
+                    className="size-1.5 rounded-full bg-muted-foreground/50 assistant-dot"
                 />
             ))}
         </div>

--- a/src/components/assistant/AssistantToolExecutionCard.tsx
+++ b/src/components/assistant/AssistantToolExecutionCard.tsx
@@ -80,17 +80,17 @@ export function AssistantToolExecutionCard({
                 {isExecuting && (
                     <Loader2
                         data-testid="tool-executing-spinner"
-                        className="h-4 w-4 animate-spin text-[hsl(var(--assistant-tool-icon))]"
+                        className="size-4 animate-spin text-[hsl(var(--assistant-tool-icon))]"
                     />
                 )}
                 {isCompleted && (
                     <CheckCircle2
                         data-testid="tool-completed-check"
-                        className="h-4 w-4 text-[hsl(var(--assistant-status-online))]"
+                        className="size-4 text-[hsl(var(--assistant-status-online))]"
                     />
                 )}
                 {isError && (
-                    <AlertCircle className="h-4 w-4 text-destructive" />
+                    <AlertCircle className="size-4 text-destructive" />
                 )}
 
                 <span className="text-xs font-medium flex-1">
@@ -108,7 +108,7 @@ export function AssistantToolExecutionCard({
                     >
                         <ChevronDown
                             className={cn(
-                                "h-3.5 w-3.5 text-muted-foreground transition-transform duration-200",
+                                "size-3.5 text-muted-foreground transition-transform duration-200",
                                 isExpanded && "rotate-180",
                             )}
                         />

--- a/src/components/bulk-import/BulkImportDialogParts.tsx
+++ b/src/components/bulk-import/BulkImportDialogParts.tsx
@@ -54,7 +54,7 @@ export function BulkImportErrorAlert({ error }: BulkImportErrorAlertProps): JSX.
 
   return (
     <div className="flex items-center gap-2 text-sm text-destructive bg-destructive/10 p-3 rounded-md">
-      <AlertTriangle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+      <AlertTriangle className="size-4 flex-shrink-0" aria-hidden="true" />
       <span>{error}</span>
     </div>
   )
@@ -77,7 +77,7 @@ export function BulkImportValidationErrors({
   return (
     <div className="text-sm text-destructive bg-destructive/10 p-3 rounded-md">
       <div className="flex items-center gap-2 mb-2">
-        <AlertTriangle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+        <AlertTriangle className="size-4 flex-shrink-0" aria-hidden="true" />
         <span className="font-medium">Dữ liệu không hợp lệ:</span>
       </div>
       <ul
@@ -110,7 +110,7 @@ export function BulkImportSuccessMessage({
       role="status"
       aria-live="polite"
     >
-      <FileCheck className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+      <FileCheck className="size-4 flex-shrink-0" aria-hidden="true" />
       <span>
         Đã đọc file <strong>{fileName}</strong>. Tìm thấy <strong>{recordCount}</strong> bản ghi hợp lệ.
       </span>
@@ -146,7 +146,7 @@ export function BulkImportSubmitButton({
       onClick={onClick}
       disabled={disabled}
     >
-      {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
+      {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
       {isSubmitting ? 'Đang nhập...' : `Nhập ${recordCount} ${label}`}
     </Button>
   )

--- a/src/components/chart-fallbacks.tsx
+++ b/src/components/chart-fallbacks.tsx
@@ -13,7 +13,7 @@ export function ChartLoadingFallback({ height = 300 }: ChartLoadingFallbackProps
       style={{ height: `${height}px` }}
     >
       <div className="text-center space-y-2">
-        <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto"></div>
+        <div className="size-8 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto"></div>
         <p className="text-sm text-muted-foreground">Đang tải biểu đồ...</p>
       </div>
     </div>
@@ -34,7 +34,7 @@ export function ChartErrorFallback({
       style={{ height: `${height}px` }}
     >
       <div className="text-center space-y-3 p-4">
-        <div className="w-8 h-8 rounded-full bg-destructive/20 flex items-center justify-center mx-auto">
+        <div className="size-8 rounded-full bg-destructive/20 flex items-center justify-center mx-auto">
           <span className="text-destructive text-sm">!</span>
         </div>
         <div>

--- a/src/components/dashboard/RecentActivitiesCard.tsx
+++ b/src/components/dashboard/RecentActivitiesCard.tsx
@@ -206,7 +206,7 @@ export function RecentActivitiesCard({ className }: RecentActivitiesCardProps) {
       <CardHeader className="pb-4 md:p-8 md:pb-6">
         <div className="flex items-center gap-4">
           <div className="p-3 bg-gradient-to-br from-amber-500 to-orange-600 rounded-xl shadow-lg">
-            <Activity className="h-6 w-6 text-white" />
+            <Activity className="size-6 text-white" />
           </div>
           <div>
             <CardTitle className="text-2xl font-bold text-gray-900">

--- a/src/components/dashboard/dashboard-tabs.tsx
+++ b/src/components/dashboard/dashboard-tabs.tsx
@@ -120,7 +120,7 @@ export function DashboardTabs() {
                   value="equipment"
                   className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-600 data-[state=active]:text-white rounded-lg transition-all duration-200 gap-2"
                 >
-                  <Wrench className="h-4 w-4" />
+                  <Wrench className="size-4" />
                   <span className="hidden sm:inline">Thiết bị</span>
                   <span className="sm:hidden text-xs">TB</span>
                 </TabsTrigger>
@@ -128,7 +128,7 @@ export function DashboardTabs() {
                   value="plans"
                   className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-600 data-[state=active]:text-white rounded-lg transition-all duration-200 gap-2"
                 >
-                  <Calendar className="h-4 w-4" />
+                  <Calendar className="size-4" />
                   <span className="hidden sm:inline">Kế hoạch</span>
                   <span className="sm:hidden text-xs">KH</span>
                 </TabsTrigger>
@@ -136,7 +136,7 @@ export function DashboardTabs() {
                   value="monthly"
                   className="data-[state=active]:bg-gradient-to-r data-[state=active]:from-blue-500 data-[state=active]:to-purple-600 data-[state=active]:text-white rounded-lg transition-all duration-200 gap-2"
                 >
-                  <Clock className="h-4 w-4" />
+                  <Clock className="size-4" />
                   <span className="hidden sm:inline">Tháng này</span>
                   <span className="sm:hidden text-xs">T{month}</span>
                 </TabsTrigger>

--- a/src/components/dashboard/dashboard-tabs/DashboardEquipmentTab.tsx
+++ b/src/components/dashboard/dashboard-tabs/DashboardEquipmentTab.tsx
@@ -60,7 +60,7 @@ export function DashboardEquipmentTab({
         <Button asChild size="sm" variant="ghost" className="shrink-0 gap-1 self-start text-blue-600 hover:text-blue-700">
           <Link href={equipmentAttentionHref}>
             Xem tất cả
-            <ArrowUpRight className="h-4 w-4" />
+            <ArrowUpRight className="size-4" />
           </Link>
         </Button>
       </div>
@@ -127,8 +127,8 @@ export function DashboardEquipmentTab({
             ))
           ) : (
             <div className="text-center py-12 text-muted-foreground">
-              <div className="p-4 bg-gray-100/50 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-                <Wrench className="h-8 w-8 text-gray-400" />
+              <div className="p-4 bg-gray-100/50 rounded-full size-16 mx-auto mb-4 flex items-center justify-center">
+                <Wrench className="size-8 text-gray-400" />
               </div>
               <p>Không có thiết bị nào cần chú ý</p>
             </div>

--- a/src/components/dashboard/dashboard-tabs/DashboardMonthlyTab.tsx
+++ b/src/components/dashboard/dashboard-tabs/DashboardMonthlyTab.tsx
@@ -24,13 +24,13 @@ interface DashboardMonthlyTabProps {
 function getTaskIcon(type: CalendarEvent["type"]) {
   switch (type) {
     case "Bảo trì":
-      return <Wrench className="h-4 w-4" />
+      return <Wrench className="size-4" />
     case "Hiệu chuẩn":
-      return <Calendar className="h-4 w-4" />
+      return <Calendar className="size-4" />
     case "Kiểm định":
-      return <Clock className="h-4 w-4" />
+      return <Clock className="size-4" />
     default:
-      return <Calendar className="h-4 w-4" />
+      return <Calendar className="size-4" />
   }
 }
 
@@ -57,7 +57,7 @@ export function DashboardMonthlyTab({
         <Button asChild size="sm" variant="ghost" className="gap-1 text-blue-600 hover:text-blue-700">
           <Link href="/maintenance">
             Xem tất cả
-            <ArrowUpRight className="h-4 w-4" />
+            <ArrowUpRight className="size-4" />
           </Link>
         </Button>
       </div>
@@ -73,7 +73,7 @@ export function DashboardMonthlyTab({
               {Array.from({ length: 3 }).map((_, index) => (
                 <div key={index} className="p-4 rounded-xl border border-gray-200/50 bg-white/60 backdrop-blur-sm">
                   <div className="flex items-start gap-3">
-                    <Skeleton className="h-8 w-8 rounded" />
+                    <Skeleton className="size-8 rounded" />
                     <div className="space-y-2 flex-1">
                       <Skeleton className="h-4 w-3/4" />
                       <Skeleton className="h-3 w-1/2" />
@@ -84,8 +84,8 @@ export function DashboardMonthlyTab({
             </div>
           ) : events.length === 0 ? (
             <div className="text-center py-12 text-muted-foreground">
-              <div className="p-4 bg-gray-100/50 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-                <Calendar className="h-8 w-8 text-gray-400" />
+              <div className="p-4 bg-gray-100/50 rounded-full size-16 mx-auto mb-4 flex items-center justify-center">
+                <Calendar className="size-8 text-gray-400" />
               </div>
               <p>Không có công việc nào trong tháng này</p>
             </div>
@@ -109,7 +109,7 @@ export function DashboardMonthlyTab({
               {priorityTasks.length > 0 && (
                 <div className="p-3 bg-yellow-50/80 border border-yellow-200/50 rounded-xl backdrop-blur-sm">
                   <div className="flex items-center gap-2 text-yellow-700">
-                    <AlertTriangle className="h-4 w-4" />
+                    <AlertTriangle className="size-4" />
                     <span className="font-medium text-sm">{priorityTasks.length} công việc cần ưu tiên</span>
                   </div>
                 </div>

--- a/src/components/dashboard/dashboard-tabs/DashboardPlansTab.tsx
+++ b/src/components/dashboard/dashboard-tabs/DashboardPlansTab.tsx
@@ -55,7 +55,7 @@ export function DashboardPlansTab({
         <Button asChild size="sm" variant="ghost" className="gap-1 text-blue-600 hover:text-blue-700">
           <Link href="/maintenance">
             Xem tất cả
-            <ArrowUpRight className="h-4 w-4" />
+            <ArrowUpRight className="size-4" />
           </Link>
         </Button>
       </div>
@@ -109,15 +109,15 @@ export function DashboardPlansTab({
                         </span>
                       </div>
                     </div>
-                    <ArrowUpRight className="h-5 w-5 text-gray-400 shrink-0" />
+                    <ArrowUpRight className="size-5 text-gray-400 shrink-0" />
                   </div>
                 </div>
               </Link>
             ))
           ) : (
             <div className="text-center py-12 text-muted-foreground">
-              <div className="p-4 bg-gray-100/50 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-                <Calendar className="h-8 w-8 text-gray-400" />
+              <div className="p-4 bg-gray-100/50 rounded-full size-16 mx-auto mb-4 flex items-center justify-center">
+                <Calendar className="size-8 text-gray-400" />
               </div>
               <p>Chưa có kế hoạch nào</p>
             </div>

--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -28,10 +28,10 @@ const headerClass =
   "flex flex-row items-center justify-between space-y-0 p-4 pb-2 md:p-6 md:pb-2 gap-3 md:gap-2"
 const titleClass = "text-sm font-semibold truncate md:text-sm md:font-medium text-slate-600"
 // Icon colors matching card gradients - more vibrant
-const equipmentIconClass = "h-5 w-5 text-blue-600 md:h-4 md:w-4 flex-shrink-0"
-const maintenanceIconClass = "h-5 w-5 text-emerald-600 md:h-4 md:w-4 flex-shrink-0"
-const repairIconClass = "h-5 w-5 text-sky-600 md:h-4 md:w-4 flex-shrink-0"
-const planIconClass = "h-5 w-5 text-purple-600 md:h-4 md:w-4 flex-shrink-0"
+const equipmentIconClass = "size-5 text-blue-600 md:size-4 flex-shrink-0"
+const maintenanceIconClass = "size-5 text-emerald-600 md:size-4 flex-shrink-0"
+const repairIconClass = "size-5 text-sky-600 md:size-4 flex-shrink-0"
+const planIconClass = "size-5 text-purple-600 md:size-4 flex-shrink-0"
 const contentClass = "p-4 pt-0 space-y-2 md:p-6 md:pt-0"
 const metricClass =
   "text-4xl font-bold leading-tight tracking-tight md:text-2xl md:leading-snug md:tracking-normal text-slate-900"

--- a/src/components/edit-maintenance-plan-dialog.tsx
+++ b/src/components/edit-maintenance-plan-dialog.tsx
@@ -30,6 +30,7 @@ import { type MaintenancePlan, taskTypes } from "@/lib/data"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
 import { useSession } from "next-auth/react"
 import { isRegionalLeaderRole } from "@/lib/rbac"
+import { getUnknownErrorMessage } from "@/lib/error-utils"
 
 const planFormSchema = z.object({
   ten_ke_hoach: z.string().min(1, "Tên kế hoạch là bắt buộc."),
@@ -50,7 +51,7 @@ interface EditMaintenancePlanDialogProps {
 export function EditMaintenancePlanDialog({ open, onOpenChange, onSuccess, plan }: EditMaintenancePlanDialogProps) {
   const { toast } = useToast()
   const { data: session } = useSession()
-  const isRegionalLeader = isRegionalLeaderRole((session?.user as any)?.role)
+  const isRegionalLeader = isRegionalLeaderRole(session?.user?.role)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
 
   const form = useForm<PlanFormValues>({
@@ -105,11 +106,11 @@ export function EditMaintenancePlanDialog({ open, onOpenChange, onSuccess, plan 
       })
       onSuccess()
       onOpenChange(false)
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         variant: "destructive",
         title: "Lỗi",
-        description: "Không thể cập nhật kế hoạch. " + error.message,
+        description: "Không thể cập nhật kế hoạch. " + getUnknownErrorMessage(error),
       })
     } finally {
       setIsSubmitting(false)
@@ -193,7 +194,7 @@ export function EditMaintenancePlanDialog({ open, onOpenChange, onSuccess, plan 
                 Hủy
               </Button>
               <Button type="submit" disabled={isSubmitting || isRegionalLeader}>
-                {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
                 Lưu thay đổi
               </Button>
             </DialogFooter>

--- a/src/components/edit-transfer-dialog.tsx
+++ b/src/components/edit-transfer-dialog.tsx
@@ -290,7 +290,7 @@ export function EditTransferDialog({ open, onOpenChange, onSuccess, transfer }: 
               Hủy
             </Button>
             <Button type="submit" disabled={isLoading || !canEdit || isRegionalLeader}>
-              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
               Cập nhật
             </Button>
           </DialogFooter>

--- a/src/components/end-usage-dialog.tsx
+++ b/src/components/end-usage-dialog.tsx
@@ -154,7 +154,7 @@ export function EndUsageDialog({
               </div>
               <div className="col-span-1 sm:col-span-2">
                 <p className="text-sm font-medium text-muted-foreground flex items-center gap-1">
-                  <Clock className="h-4 w-4" />
+                  <Clock className="size-4" />
                   Thời gian sử dụng
                 </p>
                 <p className="text-sm font-medium text-primary">{formatDuration(usageDuration)}</p>
@@ -214,7 +214,7 @@ export function EndUsageDialog({
                 Hủy
               </Button>
               <Button type="submit" disabled={isLoading || isRegionalLeader}>
-                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
                 Kết thúc sử dụng
               </Button>
             </DialogFooter>

--- a/src/components/equipment-distribution-summary.tsx
+++ b/src/components/equipment-distribution-summary.tsx
@@ -93,7 +93,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
           <Card key={token}>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-4" />
+              <Skeleton className="size-4" />
             </CardHeader>
             <CardContent>
               <Skeleton className="h-8 w-16 mb-2" />
@@ -165,7 +165,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tình trạng tổng thể</CardTitle>
-            <Activity className="h-4 w-4 text-muted-foreground" />
+            <Activity className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <div className={`text-2xl font-bold ${getHealthScoreColor(overallStats.healthScore)}`}>
@@ -185,7 +185,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tổng thiết bị</CardTitle>
-            <CheckCircle className="h-4 w-4 text-green-600" />
+            <CheckCircle className="size-4 text-green-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-blue-600">

--- a/src/components/equipment-linked-request/LinkedRequestRowIndicator.tsx
+++ b/src/components/equipment-linked-request/LinkedRequestRowIndicator.tsx
@@ -41,14 +41,14 @@ export function LinkedRequestRowIndicator({ equipment }: LinkedRequestRowIndicat
             type="button"
             variant="ghost"
             size="icon"
-            className="ml-1 h-6 w-6 text-amber-500 hover:text-amber-600"
+            className="ml-1 size-6 text-amber-500 hover:text-amber-600"
             aria-label={STRINGS.rowIndicatorAriaLabel(equipment.ma_thiet_bi ?? '')}
             onClick={(event) => {
               event.stopPropagation()
               openRepair(equipment.id)
             }}
           >
-            <Wrench className="h-4 w-4" aria-hidden="true" />
+            <Wrench className="size-4" aria-hidden="true" />
           </Button>
         </TooltipTrigger>
         <TooltipContent side="top">{STRINGS.rowIndicatorTooltip}</TooltipContent>

--- a/src/components/equipment/equipment-actions-menu.tsx
+++ b/src/components/equipment/equipment-actions-menu.tsx
@@ -96,11 +96,11 @@ export function EquipmentActionsMenu({
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          className="h-8 w-8 p-0 touch-target-sm md:h-8 md:w-8"
+          className="size-8 p-0 touch-target-sm md:size-8"
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
         >
           <span className="sr-only">Open menu</span>
-          <MoreHorizontal className="h-4 w-4" />
+          <MoreHorizontal className="size-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>

--- a/src/components/equipment/equipment-table-columns.tsx
+++ b/src/components/equipment/equipment-table-columns.tsx
@@ -153,7 +153,7 @@ export function createEquipmentColumns(
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
             {columnLabels[key]}
-            <ArrowUpDown className="ml-2 h-4 w-4" />
+            <ArrowUpDown className="ml-2 size-4" />
           </Button>
         )
       },

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -109,11 +109,11 @@ export function EquipmentToolbar({
       variant="ghost"
       size="icon"
       onClick={qr.handleStartScanning}
-      className="h-8 w-8 hover:bg-primary/10"
+      className="size-8 hover:bg-primary/10"
       title="Quét mã QR"
       aria-label="Quét mã QR"
     >
-      <ScanLine className="h-4 w-4 text-muted-foreground hover:text-primary" />
+      <ScanLine className="size-4 text-muted-foreground hover:text-primary" />
     </Button>
   )
 
@@ -130,7 +130,7 @@ export function EquipmentToolbar({
             : "hover:border-primary/30"
         )}
       >
-        <Filter className="h-4 w-4 mr-2" />
+        <Filter className="size-4 mr-2" />
         <span className="font-medium">Lọc</span>
         {isFiltered && (
           <Badge
@@ -145,7 +145,7 @@ export function EquipmentToolbar({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" size="sm" className="h-9">
-            <Settings className="h-4 w-4 mr-2" />
+            <Settings className="size-4 mr-2" />
             Tùy chọn
           </Button>
         </DropdownMenuTrigger>
@@ -198,7 +198,7 @@ export function EquipmentToolbar({
           className="h-8 px-2 lg:px-3"
         >
           <span className="hidden sm:inline">Xóa tất cả</span>
-          <FilterX className="h-4 w-4 sm:ml-2" />
+          <FilterX className="size-4 sm:ml-2" />
         </Button>
       )}
       {hasFacilityFilter && (
@@ -208,7 +208,7 @@ export function EquipmentToolbar({
           className="h-8 px-2 lg:px-3"
         >
           <span className="hidden sm:inline">Xóa lọc cơ sở</span>
-          <FilterX className="h-4 w-4 sm:ml-2" />
+          <FilterX className="size-4 sm:ml-2" />
         </Button>
       )}
     </>
@@ -220,7 +220,7 @@ export function EquipmentToolbar({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button size="sm" className="hidden md:flex h-8 gap-1 touch-target-sm md:h-8">
-              <PlusCircle className="h-3.5 w-3.5" />
+              <PlusCircle className="size-3.5" />
               <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
                 Thêm thiết bị
               </span>
@@ -240,7 +240,7 @@ export function EquipmentToolbar({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" className="hidden lg:flex h-8 gap-1 touch-target-sm md:h-8">
-            <Settings className="h-3.5 w-3.5" />
+            <Settings className="size-3.5" />
             Tùy chọn
           </Button>
         </DropdownMenuTrigger>

--- a/src/components/equipment/filter-bottom-sheet.tsx
+++ b/src/components/equipment/filter-bottom-sheet.tsx
@@ -103,10 +103,10 @@ export function FilterBottomSheet({
           variant="ghost"
           size="icon"
           onClick={() => onOpenChange(false)}
-          className="h-10 w-10 rounded-full"
+          className="size-10 rounded-full"
           aria-label="Đóng bộ lọc"
         >
-          <X className="h-5 w-5" />
+          <X className="size-5" />
         </Button>
       </div>
 
@@ -139,14 +139,14 @@ export function FilterBottomSheet({
                       <div className="flex items-center gap-3">
                         <div
                           className={cn(
-                            "w-5 h-5 rounded-md border-2 flex items-center justify-center transition-all",
+                            "size-5 rounded-md border-2 flex items-center justify-center transition-all",
                             selected
                               ? "bg-[hsl(var(--primary))] border-[hsl(var(--primary))]"
                               : "border-muted-foreground/40"
                           )}
                         >
                           {selected && (
-                            <Check className="h-3.5 w-3.5 text-[hsl(var(--primary-foreground))]" strokeWidth={3} />
+                            <Check className="size-3.5 text-[hsl(var(--primary-foreground))]" strokeWidth={3} />
                           )}
                         </div>
                         <span

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -60,8 +60,8 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
           <Card className="w-full max-w-lg">
             <CardHeader className="text-center">
-              <div className="mx-auto w-12 h-12 bg-red-100 rounded-full flex items-center justify-center mb-4">
-                <AlertTriangle className="w-6 h-6 text-red-600" />
+              <div className="mx-auto size-12 bg-red-100 rounded-full flex items-center justify-center mb-4">
+                <AlertTriangle className="size-6 text-red-600" />
               </div>
               <CardTitle className="text-xl text-red-800">
                 Đã xảy ra lỗi
@@ -96,7 +96,7 @@ export class ErrorBoundary extends Component<Props, State> {
                   className="flex-1"
                   variant="default"
                 >
-                  <RefreshCw className="w-4 h-4 mr-2" />
+                  <RefreshCw className="size-4 mr-2" />
                   Thử lại
                 </Button>
                 <Button 
@@ -104,7 +104,7 @@ export class ErrorBoundary extends Component<Props, State> {
                   className="flex-1"
                   variant="outline"
                 >
-                  <Home className="w-4 h-4 mr-2" />
+                  <Home className="size-4 mr-2" />
                   Về trang chủ
                 </Button>
               </div>

--- a/src/components/handover-demo.tsx
+++ b/src/components/handover-demo.tsx
@@ -80,7 +80,7 @@ export function HandoverDemo() {
         
         <CardContent className="space-y-6">
           <Alert className="border-blue-200 bg-blue-50">
-            <Info className="h-4 w-4" />
+            <Info className="size-4" />
             <AlertDescription>
               <strong>📋 Dữ liệu mẫu:</strong> Thiết bị máy đo huyết áp Omron HEM-7120 với đầy đủ thông tin luân chuyển nội bộ từ Khoa Tim mạch đến Tổ QLTB.
             </AlertDescription>
@@ -89,7 +89,7 @@ export function HandoverDemo() {
           <Card className="bg-green-50">
             <CardHeader>
               <CardTitle className="text-green-700 flex items-center gap-2">
-                <CheckCircle className="h-5 w-5" />
+                <CheckCircle className="size-5" />
                 ✨ Tính năng Phase 3 - UX Enhancements:
               </CardTitle>
             </CardHeader>
@@ -137,13 +137,13 @@ export function HandoverDemo() {
               className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 text-lg"
               size="lg"
             >
-              <FileText className="mr-2 h-5 w-5" />
+              <FileText className="mr-2 size-5" />
               📄 Mở Phiếu Bàn Giao Mẫu
             </Button>
           </div>
 
           <Alert>
-            <Lightbulb className="h-4 w-4" />
+            <Lightbulb className="size-4" />
             <AlertDescription>
               <strong>💡 Cách test:</strong>
               <br />1. Nhấn nút trên để mở phiếu mẫu
@@ -155,7 +155,7 @@ export function HandoverDemo() {
           <Card className="bg-purple-50">
             <CardHeader>
               <CardTitle className="text-purple-700 flex items-center gap-2">
-                <Target className="h-5 w-5" />
+                <Target className="size-5" />
                 🎯 Roadmap tương lai (nếu cần):
               </CardTitle>
             </CardHeader>

--- a/src/components/handover-preview-dialog.tsx
+++ b/src/components/handover-preview-dialog.tsx
@@ -23,6 +23,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useToast } from "@/hooks/use-toast"
+import { getUnknownErrorMessage } from "@/lib/error-utils"
 import { type TransferRequest } from "@/types/database"
 
 interface HandoverPreviewDialogProps {
@@ -60,8 +61,8 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
   React.useEffect(() => {
     if (open && transfer?.thiet_bi) {
       // Auto-fill data from transfer request
-      const formatValue = (value: any) => value ?? ""
-      
+      const formatValue = (value: string | number | null | undefined) => String(value ?? "")
+
       const data: HandoverData = {
         department: formatValue(transfer.khoa_phong_hien_tai || "Tổ QLTB"),
         handoverDate: new Date().toLocaleDateString('vi-VN'),
@@ -84,9 +85,9 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
           note: "" // Default empty for manual entry
         }
       }
-      
+
       setHandoverData(data)
-      
+
       // Show tips for new users
       if (isEditing) {
         toast({
@@ -102,7 +103,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!open) return
-      
+
       // Ctrl+P for print
       if (event.ctrlKey && event.key === 'p') {
         event.preventDefault()
@@ -126,7 +127,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
   const handleInputChange = (field: string, value: string) => {
     if (!handoverData) return
-    
+
     if (field.startsWith('device.')) {
       const deviceField = field.replace('device.', '')
       setHandoverData({
@@ -146,13 +147,13 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
   const validateHandoverData = (data: HandoverData): { isValid: boolean; missingFields: string[] } => {
     const missingFields: string[] = []
-    
+
     if (!data.department?.trim()) missingFields.push('Khoa/Phòng lập')
     if (!data.reason?.trim()) missingFields.push('Lý do bàn giao')
     if (!data.giverName?.trim()) missingFields.push('Đại diện bên giao')
     if (!data.receiverName?.trim()) missingFields.push('Đại diện bên nhận')
     // Note: directorName is optional, not required for validation
-    
+
     return {
       isValid: missingFields.length === 0,
       missingFields
@@ -161,7 +162,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
   const handlePrint = async () => {
     if (!handoverData) return
-    
+
     // Validate required fields
     const validation = validateHandoverData(handoverData)
     if (!validation.isValid) {
@@ -173,29 +174,29 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
       setIsEditing(true) // Switch to edit mode to fill missing info
       return
     }
-    
+
     setIsPrinting(true)
     try {
       const htmlContent = generateHandoverHTML(handoverData)
       const newWindow = window.open("", "_blank")
-      
+
       if (newWindow) {
         newWindow.document.open()
         newWindow.document.write(htmlContent)
         newWindow.document.close()
-        
+
         // Auto print after loading
         newWindow.onload = () => {
           setTimeout(() => {
             newWindow.print()
-            
+
             // Close dialog after printing
             setTimeout(() => {
               onOpenChange(false)
             }, 1000)
           }, 500)
         }
-        
+
         toast({
           title: "✅ Thành công",
           description: "Đã mở cửa sổ in phiếu bàn giao. Dialog sẽ tự động đóng sau khi in.",
@@ -207,11 +208,11 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
           description: "Vui lòng cho phép popup để sử dụng tính năng in. Kiểm tra thanh địa chỉ trình duyệt.",
         })
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         variant: "destructive",
         title: "❌ Lỗi in phiếu",
-        description: error.message || "Có lỗi không xác định xảy ra khi in phiếu."
+        description: getUnknownErrorMessage(error, "Có lỗi không xác định xảy ra khi in phiếu.")
       })
     } finally {
       setIsPrinting(false)
@@ -220,17 +221,17 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
   const handlePreview = async () => {
     if (!handoverData) return
-    
+
     setIsPreviewing(true)
     try {
       const htmlContent = generateHandoverHTML(handoverData)
       const newWindow = window.open("", "_blank")
-      
+
       if (newWindow) {
         newWindow.document.open()
         newWindow.document.write(htmlContent)
         newWindow.document.close()
-        
+
         toast({
           title: "👁️ Xem trước",
           description: "Đã mở cửa sổ xem trước phiếu bàn giao.",
@@ -238,15 +239,15 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
       } else {
         toast({
           variant: "destructive",
-          title: "🚫 Bị chặn popup", 
+          title: "🚫 Bị chặn popup",
           description: "Vui lòng cho phép popup để xem trước. Kiểm tra cài đặt trình duyệt.",
         })
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         variant: "destructive",
         title: "❌ Lỗi xem trước",
-        description: error.message || "Có lỗi không xác định xảy ra khi xem trước phiếu."
+        description: getUnknownErrorMessage(error, "Có lỗi không xác định xảy ra khi xem trước phiếu.")
       })
     } finally {
       setIsPreviewing(false)
@@ -271,7 +272,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
             margin: 0;
             padding: 0;
         }
-        
+
         .a4-landscape-page {
             width: 29.7cm;
             min-height: 21cm;
@@ -283,11 +284,11 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
             display: flex;
             flex-direction: column;
         }
-        
+
         .content-body {
             flex-grow: 1;
         }
-        
+
         .form-input-line {
             font-family: inherit;
             font-size: inherit;
@@ -299,12 +300,12 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
             width: 100%;
             min-height: 1.1em;
         }
-        
+
         .form-input-readonly {
             border-bottom: 1px solid #000;
             font-weight: 500;
         }
-        
+
         .editable-cell {
             border-bottom: 1px solid #ccc !important;
             background-color: #f9f9f9;
@@ -312,19 +313,19 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
             min-height: 18px;
             padding: 3px 4px !important;
         }
-        
+
         .editable-cell:focus {
             background-color: #fff;
             border-bottom: 1px solid #007bff !important;
             outline: none;
         }
-        
+
         .editable-cell:empty:before {
             content: attr(data-placeholder);
             color: #999;
             font-style: italic;
         }
-        
+
         .font-bold { font-weight: 700; }
         .title-main { font-size: 20px; }
         .title-sub { font-size: 16px; }
@@ -332,7 +333,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
         .uppercase { text-transform: uppercase; }
         .italic { font-style: italic; }
         .whitespace-nowrap { white-space: nowrap; }
-        
+
         .flex { display: flex; }
         .items-center { align-items: center; }
         .items-baseline { align-items: baseline; }
@@ -340,17 +341,17 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
         .justify-between { justify-content: space-between; }
         .justify-around { justify-content: space-around; }
         .flex-grow { flex-grow: 1; }
-        
+
         .mt-3 { margin-top: 0.4rem; }
         .mt-4 { margin-top: 0.5rem; }
         .mt-8 { margin-top: 1rem; }
         .ml-2 { margin-left: 0.5rem; }
         .mb-1 { margin-bottom: 0.25rem; }
         .space-y-2 > * + * { margin-top: 0.3rem; }
-        
+
         .w-14 { width: 3.5rem; }
         .w-full { width: 100%; }
-        
+
         .data-table {
             width: 100%;
             border-collapse: collapse;
@@ -369,7 +370,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
             background-color: #f8f9fa;
             font-weight: bold;
         }
-        
+
         .data-table .col-stt { width: 2%; }
         .data-table .col-code { width: 7%; }
         .data-table .col-name { width: 16%; text-align: left; }
@@ -378,18 +379,18 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
         .data-table .col-accessories { width: 18%; text-align: center; }
         .data-table .col-condition { width: 15%; }
         .data-table .col-note { width: 12%; }
-        
+
         .signature-area {
             text-align: center;
             min-width: 180px;
         }
-        
+
         .signature-space {
             height: 50px;
             border-bottom: 1px solid #ddd;
             margin: 8px 0;
         }
-        
+
         @media print {
             body {
                 -webkit-print-color-adjust: exact !important;
@@ -397,7 +398,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                 background-color: #fff !important;
                 font-size: 11px;
             }
-            
+
             .a4-landscape-page {
                 width: 100% !important;
                 height: 100% !important;
@@ -407,11 +408,11 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                 border: none !important;
                 page-break-inside: avoid;
             }
-            
+
             body > *:not(.a4-landscape-page) {
                 display: none !important;
             }
-            
+
             .data-table {
                 font-size: 13px;
             }
@@ -419,15 +420,15 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
             .data-table th, .data-table td {
                 padding: 3px;
             }
-            
+
             .data-table thead {
                 display: table-header-group;
             }
-            
+
             .data-table tr, .signature-area {
                 page-break-inside: avoid;
             }
-            
+
             .print-footer {
                 position: fixed;
                 bottom: 0.4cm;
@@ -435,21 +436,21 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                 right: 0.6cm;
                 width: calc(100% - 1.2cm);
             }
-            
+
             .content-body {
                 padding-bottom: 35px;
             }
-            
+
             .editable-cell {
                 background-color: transparent !important;
                 border-bottom: 1px solid #000 !important;
             }
-            
+
             .title-main { font-size: 16px; }
             .title-sub { font-size: 13px; }
             .signature-space { height: 40px; }
         }
-        
+
         @media (max-width: 768px) {
             .a4-landscape-page {
                 width: 100%;
@@ -457,13 +458,13 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                 padding: 0.4cm;
                 box-shadow: none;
             }
-            
+
             .title-main { font-size: 16px; }
             .title-sub { font-size: 12px; }
             .data-table { font-size: 9px; }
             .data-table th, .data-table td { padding: 2px 1px; }
         }
-        
+
         .edit-instruction {
             font-size: 10px;
             color: #666;
@@ -479,9 +480,9 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
             <header class="text-center">
                 <div class="flex justify-between items-start">
                     <div class="text-center">
-                        <img src="https://i.postimg.cc/26dHxmnV/89307731ad9526cb7f84-1-Photoroom.png" 
-                             alt="Logo CDC" 
-                             class="w-14 mx-auto mb-1" 
+                        <img src="https://i.postimg.cc/26dHxmnV/89307731ad9526cb7f84-1-Photoroom.png"
+                             alt="Logo CDC"
+                             class="w-14 mx-auto mb-1"
                              onerror="this.style.display='none';">
                     </div>
                     <div class="flex-grow">
@@ -575,7 +576,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
       <DialogContent className="max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <FileText className="h-5 w-5" />
+            <FileText className="size-5" />
             Xem trước phiếu bàn giao - {transfer.ma_yeu_cau}
           </DialogTitle>
           <DialogDescription>
@@ -599,7 +600,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                       size="sm"
                       onClick={() => setIsEditing(!isEditing)}
                     >
-                      <Edit3 className="h-4 w-4 mr-1" />
+                      <Edit3 className="size-4 mr-1" />
                       {isEditing ? 'Xem' : 'Sửa'}
                     </Button>
                   </TooltipTrigger>
@@ -610,13 +611,13 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button 
-                      variant="outline" 
-                      size="sm" 
+                    <Button
+                      variant="outline"
+                      size="sm"
                       onClick={handlePreview}
                       disabled={isPreviewing || isPrinting}
                     >
-                      <Eye className="h-4 w-4 mr-1" />
+                      <Eye className="size-4 mr-1" />
                       {isPreviewing ? 'Đang xử lý...' : 'Xem trước'}
                     </Button>
                   </TooltipTrigger>
@@ -627,13 +628,13 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button 
-                      variant="default" 
-                      size="sm" 
+                    <Button
+                      variant="default"
+                      size="sm"
                       onClick={handlePrint}
                       disabled={isPrinting || isPreviewing}
                     >
-                      <Printer className="h-4 w-4 mr-1" />
+                      <Printer className="size-4 mr-1" />
                       {isPrinting ? 'Đang in...' : 'In phiếu'}
                     </Button>
                   </TooltipTrigger>
@@ -782,4 +783,4 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
       </DialogContent>
     </Dialog>
   )
-} 
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 
 export const Logo = ({
-  className = "w-16 h-16",
+  className = "size-16",
   size = 64,
 }: {
   className?: string;

--- a/src/components/import-equipment-dialog.tsx
+++ b/src/components/import-equipment-dialog.tsx
@@ -382,7 +382,7 @@ export function ImportEquipmentDialog({ open, onOpenChange, onSuccess }: ImportE
           {rejectedDatesCount > 0 && (
             <div className="text-sm text-amber-700 bg-amber-50 p-3 rounded-md border border-amber-200">
               <div className="flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4" />
+                <AlertTriangle className="size-4" />
                 <span>
                   <strong>{rejectedDatesCount}</strong> ngày có định dạng không hợp lệ (trước năm 1970) đã bị bỏ qua.
                   Các trường ngày này sẽ được để trống.

--- a/src/components/kpi/KpiStatusBar.tsx
+++ b/src/components/kpi/KpiStatusBar.tsx
@@ -64,7 +64,7 @@ export function KpiStatusBar<TStatus extends string>({
         <StatCard
           label={totalLabel}
           value={total}
-          icon={<Layers className="h-5 w-5" />}
+          icon={<Layers className="size-5" />}
           tone="default"
           loading={loading}
         />

--- a/src/components/kpi/configs/device-quota.tsx
+++ b/src/components/kpi/configs/device-quota.tsx
@@ -5,7 +5,7 @@ import type { StatusConfig } from "../types"
 export type DeviceQuotaComplianceStatus = "dat" | "thieu" | "vuot"
 
 export const DEVICE_QUOTA_CONFIGS: StatusConfig<DeviceQuotaComplianceStatus>[] = [
-  { key: "dat", label: "Đạt định mức", tone: "success", icon: <CheckCircle2 className="h-5 w-5" /> },
-  { key: "thieu", label: "Thiếu định mức", tone: "danger", icon: <XCircle className="h-5 w-5" /> },
-  { key: "vuot", label: "Vượt định mức", tone: "warning", icon: <AlertTriangle className="h-5 w-5" /> },
+  { key: "dat", label: "Đạt định mức", tone: "success", icon: <CheckCircle2 className="size-5" /> },
+  { key: "thieu", label: "Thiếu định mức", tone: "danger", icon: <XCircle className="size-5" /> },
+  { key: "vuot", label: "Vượt định mức", tone: "warning", icon: <AlertTriangle className="size-5" /> },
 ]

--- a/src/components/kpi/configs/maintenance.tsx
+++ b/src/components/kpi/configs/maintenance.tsx
@@ -5,7 +5,7 @@ import type { StatusConfig } from "../types"
 export type MaintenanceStatus = "Bản nháp" | "Đã duyệt" | "Không duyệt"
 
 export const MAINTENANCE_STATUS_CONFIGS: StatusConfig<MaintenanceStatus>[] = [
-  { key: "Bản nháp", label: "Bản nháp", tone: "warning", icon: <FileEdit className="h-5 w-5" /> },
-  { key: "Đã duyệt", label: "Đã duyệt", tone: "success", icon: <CheckCircle className="h-5 w-5" /> },
-  { key: "Không duyệt", label: "Không duyệt", tone: "danger", icon: <XCircle className="h-5 w-5" /> },
+  { key: "Bản nháp", label: "Bản nháp", tone: "warning", icon: <FileEdit className="size-5" /> },
+  { key: "Đã duyệt", label: "Đã duyệt", tone: "success", icon: <CheckCircle className="size-5" /> },
+  { key: "Không duyệt", label: "Không duyệt", tone: "danger", icon: <XCircle className="size-5" /> },
 ]

--- a/src/components/kpi/configs/repair-requests.tsx
+++ b/src/components/kpi/configs/repair-requests.tsx
@@ -5,8 +5,8 @@ import type { StatusConfig } from "../types"
 export type RepairStatus = "Chờ xử lý" | "Đã duyệt" | "Hoàn thành" | "Không HT"
 
 export const REPAIR_STATUS_CONFIGS: StatusConfig<RepairStatus>[] = [
-  { key: "Chờ xử lý", label: "Chờ xử lý", tone: "warning", icon: <Clock className="h-5 w-5" /> },
-  { key: "Đã duyệt", label: "Đã duyệt", tone: "muted", icon: <CheckCheck className="h-5 w-5" /> },
-  { key: "Hoàn thành", label: "Hoàn thành", tone: "success", icon: <CheckCircle className="h-5 w-5" /> },
-  { key: "Không HT", label: "Không HT", tone: "danger", icon: <XCircle className="h-5 w-5" /> },
+  { key: "Chờ xử lý", label: "Chờ xử lý", tone: "warning", icon: <Clock className="size-5" /> },
+  { key: "Đã duyệt", label: "Đã duyệt", tone: "muted", icon: <CheckCheck className="size-5" /> },
+  { key: "Hoàn thành", label: "Hoàn thành", tone: "success", icon: <CheckCircle className="size-5" /> },
+  { key: "Không HT", label: "Không HT", tone: "danger", icon: <XCircle className="size-5" /> },
 ]

--- a/src/components/kpi/configs/transfers.tsx
+++ b/src/components/kpi/configs/transfers.tsx
@@ -10,9 +10,9 @@ export type TransferStatus =
   | "hoan_thanh"
 
 export const TRANSFER_STATUS_CONFIGS: StatusConfig<TransferStatus>[] = [
-  { key: "cho_duyet", label: "Chờ duyệt", tone: "warning", icon: <Clock className="h-5 w-5" /> },
-  { key: "da_duyet", label: "Đã duyệt", tone: "muted", icon: <CheckCheck className="h-5 w-5" /> },
-  { key: "dang_luan_chuyen", label: "Đang luân chuyển", tone: "default", icon: <Truck className="h-5 w-5" /> },
-  { key: "da_ban_giao", label: "Đã bàn giao", tone: "muted", icon: <PackageCheck className="h-5 w-5" /> },
-  { key: "hoan_thanh", label: "Hoàn thành", tone: "success", icon: <CheckCircle className="h-5 w-5" /> },
+  { key: "cho_duyet", label: "Chờ duyệt", tone: "warning", icon: <Clock className="size-5" /> },
+  { key: "da_duyet", label: "Đã duyệt", tone: "muted", icon: <CheckCheck className="size-5" /> },
+  { key: "dang_luan_chuyen", label: "Đang luân chuyển", tone: "default", icon: <Truck className="size-5" /> },
+  { key: "da_ban_giao", label: "Đã bàn giao", tone: "muted", icon: <PackageCheck className="size-5" /> },
+  { key: "hoan_thanh", label: "Hoàn thành", tone: "success", icon: <CheckCircle className="size-5" /> },
 ]

--- a/src/components/login-template.tsx
+++ b/src/components/login-template.tsx
@@ -135,7 +135,7 @@ export function LoginTemplate() {
               
               <CardContent className="p-8">
                 <Alert className="mb-6 border-yellow-200 bg-yellow-50">
-                  <Info className="h-4 w-4" />
+                  <Info className="size-4" />
                   <AlertDescription>
                     <strong>Chú ý:</strong> Đây là template demo. Để đăng nhập thực tế, vui lòng sử dụng trang chính của ứng dụng.
                   </AlertDescription>
@@ -147,7 +147,7 @@ export function LoginTemplate() {
                       Tên đăng nhập
                     </Label>
                     <div className="relative mt-2">
-                      <User className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                      <User className="absolute left-3 top-1/2 transform -translate-y-1/2 size-4 text-gray-400" />
                       <Input
                         type="text"
                         id="username"
@@ -164,7 +164,7 @@ export function LoginTemplate() {
                       Mật khẩu
                     </Label>
                     <div className="relative mt-2">
-                      <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                      <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 size-4 text-gray-400" />
                       <Input
                         type="password"
                         id="password"

--- a/src/components/mobile-equipment-list-item.tsx
+++ b/src/components/mobile-equipment-list-item.tsx
@@ -109,7 +109,7 @@ export function MobileEquipmentListItem({
           {status && (
             <div className="flex items-center gap-1">
               <div className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full ${statusStyle.bg}`}>
-                <span className={`w-1.5 h-1.5 rounded-full ${statusStyle.dot}`} />
+                <span className={`size-1.5 rounded-full ${statusStyle.dot}`} />
                 <span className={`text-[10px] font-semibold uppercase tracking-tight ${statusStyle.text}`}>
                   {status}
                 </span>
@@ -126,7 +126,7 @@ export function MobileEquipmentListItem({
 
         {/* Row 3: Department + Location */}
         <div className="flex items-center text-xs text-muted-foreground gap-1.5">
-          <MapPin className="h-3.5 w-3.5 shrink-0" />
+          <MapPin className="size-3.5 shrink-0" />
           <span className="truncate">
             {equipment.khoa_phong_quan_ly || "N/A"}
             {equipment.vi_tri_lap_dat && ` • ${equipment.vi_tri_lap_dat}`}
@@ -195,7 +195,7 @@ function MobileEquipmentActionButtons({
           className={ghostBtn}
           onClick={() => onShowDetails(equipment)}
         >
-          <Eye className="h-3.5 w-3.5" />
+          <Eye className="size-3.5" />
           Xem chi tiết
         </button>
       </div>
@@ -217,7 +217,7 @@ function MobileEquipmentActionButtons({
           className={`${buttonBase} flex-[2] bg-destructive text-destructive-foreground hover:opacity-90`}
           onClick={handleViewRepairDetailsClick}
         >
-          <AlertTriangle className="h-3.5 w-3.5" />
+          <AlertTriangle className="size-3.5" />
           Chi tiết sự cố
         </button>
         <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
@@ -240,7 +240,7 @@ function MobileEquipmentActionButtons({
           className={ghostBtn}
           onClick={() => onShowDetails(equipment)}
         >
-          <Eye className="h-3.5 w-3.5" />
+          <Eye className="size-3.5" />
           Xem chi tiết
         </button>
         <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
@@ -262,7 +262,7 @@ function MobileEquipmentActionButtons({
         className={ghostBtn}
         onClick={handleCreateRepairRequestClick}
       >
-        <Wrench className="h-3.5 w-3.5" />
+        <Wrench className="size-3.5" />
         Báo sửa chữa
       </button>
       <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />

--- a/src/components/mobile-footer-nav.tsx
+++ b/src/components/mobile-footer-nav.tsx
@@ -79,7 +79,7 @@ export function MobileFooterNav({
               aria-current={isActive ? "page" : undefined}
             >
               <Icon className={cn(
-                "h-5 w-5 transition-colors",
+                "size-5 transition-colors",
                 isActive ? "text-white" : "text-slate-500"
               )} />
               <AppNotificationBadge count={badgeCount} active={isActive} mode="floating" />
@@ -104,7 +104,7 @@ export function MobileFooterNav({
               aria-label="Thêm tùy chọn"
             >
               <MoreHorizontal className={cn(
-                "h-5 w-5 transition-colors",
+                "size-5 transition-colors",
                 isMoreActive ? "text-white" : "text-slate-500"
               )} />
               <AppNotificationBadge count={moreBadgeCount} active={isMoreActive} mode="floating" />
@@ -135,7 +135,7 @@ export function MobileFooterNav({
                     aria-current={isActive ? "page" : undefined}
                   >
                     <Icon className={cn(
-                      "h-5 w-5 transition-colors",
+                      "size-5 transition-colors",
                       isActive ? "text-white" : "text-slate-500"
                     )} />
                     <span className="text-sm">{mobileLabel ?? label}</span>

--- a/src/components/mobile-usage-actions.tsx
+++ b/src/components/mobile-usage-actions.tsx
@@ -103,12 +103,12 @@ export function MobileUsageActions({ equipment, className = "" }: MobileUsageAct
           >
             {activeSession ? (
               <>
-                <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
+                <div className="size-2 bg-white rounded-full animate-pulse" />
                 Đang sử dụng
               </>
             ) : (
               <>
-                <Play className="h-4 w-4" />
+                <Play className="size-4" />
                 Sử dụng
               </>
             )}
@@ -131,27 +131,27 @@ export function MobileUsageActions({ equipment, className = "" }: MobileUsageAct
                 {/* Active Session Info */}
                 <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
                   <div className="flex items-center gap-2 mb-2">
-                    <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse" />
+                    <div className="size-3 bg-green-500 rounded-full animate-pulse" />
                     <span className="font-medium text-green-800">Đang được sử dụng</span>
                   </div>
                   
                   <div className="space-y-2 text-sm">
                     <div className="flex items-center gap-2">
-                      <User className="h-4 w-4 text-green-600" />
+                      <User className="size-4 text-green-600" />
                       <span className="text-green-700">
                         {activeSession.nguoi_su_dung?.full_name || 'Không xác định'}
                       </span>
                     </div>
                     
                     <div className="flex items-center gap-2">
-                      <Clock className="h-4 w-4 text-green-600" />
+                      <Clock className="size-4 text-green-600" />
                       <span className="text-green-700">
                         Bắt đầu: {formatVietnamDateTime(activeSession.thoi_gian_bat_dau)}
                       </span>
                     </div>
                     
                     <div className="flex items-center gap-2">
-                      <Clock className="h-4 w-4 text-green-600" />
+                      <Clock className="size-4 text-green-600" />
                       <span className="text-green-700 font-medium">
                         Thời gian: {formatDuration(usageDuration)}
                       </span>
@@ -168,7 +168,7 @@ export function MobileUsageActions({ equipment, className = "" }: MobileUsageAct
                       size="lg"
                       disabled={isRegionalLeader}
                     >
-                      <Square className="h-5 w-5" />
+                      <Square className="size-5" />
                       Kết thúc sử dụng
                     </Button>
                   ) : (
@@ -206,7 +206,7 @@ export function MobileUsageActions({ equipment, className = "" }: MobileUsageAct
                   size="lg"
                   disabled={isRegionalLeader}
                 >
-                  <Play className="h-5 w-5" />
+                  <Play className="size-5" />
                   Bắt đầu sử dụng thiết bị
                 </Button>
               </div>

--- a/src/components/notification-bell-dialog.tsx
+++ b/src/components/notification-bell-dialog.tsx
@@ -62,7 +62,7 @@ export function NotificationBellDialog({
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <Button variant="ghost" size="icon" className="relative rounded-full">
-          <Bell className="h-5 w-5" />
+          <Bell className="size-5" />
           <AppNotificationBadge
             count={totalAlertsCount}
             mode="floating"
@@ -80,7 +80,7 @@ export function NotificationBellDialog({
         <ScrollArea className="flex-grow pr-6 -mr-6">
           {totalAlertsCount === 0 ? (
             <div className="py-10 text-center text-muted-foreground">
-              <Bell className="mx-auto h-12 w-12 mb-4 opacity-50" />
+              <Bell className="mx-auto size-12 mb-4 opacity-50" />
               <p>Không có thông báo mới.</p>
             </div>
           ) : (
@@ -88,7 +88,7 @@ export function NotificationBellDialog({
               {repairCount > 0 && (
                 <section>
                   <h3 className="text-md font-semibold mb-2 flex items-center">
-                    <Wrench className="h-4 w-4 mr-2 text-orange-500" />
+                    <Wrench className="size-4 mr-2 text-orange-500" />
                     Yêu cầu Sửa chữa ({repairCount})
                   </h3>
                   <div className="p-3 border rounded-md">
@@ -105,7 +105,7 @@ export function NotificationBellDialog({
               {transferCount > 0 && (
                 <section>
                   <h3 className="text-md font-semibold mb-2 flex items-center">
-                    <ArrowLeftRight className="h-4 w-4 mr-2 text-blue-500" />
+                    <ArrowLeftRight className="size-4 mr-2 text-blue-500" />
                     Yêu cầu Luân chuyển ({transferCount})
                   </h3>
                   <div className="p-3 border rounded-md">
@@ -122,7 +122,7 @@ export function NotificationBellDialog({
               {maintenanceCount > 0 && (
                 <section>
                   <h3 className="text-md font-semibold mb-2 flex items-center">
-                    <HardHat className="h-4 w-4 mr-2 text-emerald-600" />
+                    <HardHat className="size-4 mr-2 text-emerald-600" />
                     Yêu cầu Bảo trì ({maintenanceCount})
                   </h3>
                   <div className="p-3 border rounded-md">

--- a/src/components/onboarding/HelpButton.tsx
+++ b/src/components/onboarding/HelpButton.tsx
@@ -104,13 +104,13 @@ export function HelpButton({ className }: HelpButtonProps) {
                 aria-label="Trợ giúp và hướng dẫn"
               >
                 <CircleHelp className={cn(
-                  "h-5 w-5 transition-colors",
+                  "size-5 transition-colors",
                   hasUncompletedTours && "text-primary"
                 )} />
                 {hasUncompletedTours && (
-                  <span className="absolute -top-0.5 -right-0.5 flex h-3 w-3">
+                  <span className="absolute -top-0.5 -right-0.5 flex size-3">
                     <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
-                    <span className="relative inline-flex h-3 w-3 rounded-full bg-primary" />
+                    <span className="relative inline-flex size-3 rounded-full bg-primary" />
                   </span>
                 )}
               </Button>
@@ -122,7 +122,7 @@ export function HelpButton({ className }: HelpButtonProps) {
         </Tooltip>
       <DropdownMenuContent align="end" className="w-64">
         <DropdownMenuLabel className="flex items-center gap-2">
-          <Sparkles className="h-4 w-4 text-primary" />
+          <Sparkles className="size-4 text-primary" />
           Trợ giúp & Hướng dẫn
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
@@ -131,7 +131,7 @@ export function HelpButton({ className }: HelpButtonProps) {
             onClick={handleResetAndStartTour}
             className="flex items-center gap-2 cursor-pointer group"
           >
-            <RotateCcw className="h-4 w-4 text-muted-foreground" />
+            <RotateCcw className="size-4 text-muted-foreground" />
             <div className="flex flex-col">
               <span>Xem lại hướng dẫn Dashboard</span>
               <span className="text-xs text-muted-foreground group-hover:text-accent-foreground">Khám phá lại tính năng Dashboard</span>
@@ -142,7 +142,7 @@ export function HelpButton({ className }: HelpButtonProps) {
             onClick={handleStartDashboardTour}
             className="flex items-center gap-2 cursor-pointer bg-primary/5 hover:bg-primary hover:text-primary-foreground group"
           >
-            <Sparkles className="h-4 w-4 text-primary group-hover:text-primary-foreground" />
+            <Sparkles className="size-4 text-primary group-hover:text-primary-foreground" />
             <div className="flex flex-col">
               <span className="font-medium text-primary group-hover:text-primary-foreground">Bắt đầu tour Dashboard</span>
               <span className="text-xs text-muted-foreground group-hover:text-primary-foreground/80">Khám phá các tính năng chính</span>
@@ -155,7 +155,7 @@ export function HelpButton({ className }: HelpButtonProps) {
             onClick={handleResetSidebarTour}
             className="flex items-center gap-2 cursor-pointer group"
           >
-            <RotateCcw className="h-4 w-4 text-muted-foreground" />
+            <RotateCcw className="size-4 text-muted-foreground" />
             <div className="flex flex-col">
               <span>Xem lại thanh điều hướng</span>
               <span className="text-xs text-muted-foreground group-hover:text-accent-foreground">Hướng dẫn sử dụng sidebar</span>
@@ -166,7 +166,7 @@ export function HelpButton({ className }: HelpButtonProps) {
             onClick={handleStartSidebarTour}
             className="flex items-center gap-2 cursor-pointer bg-primary/5 hover:bg-primary hover:text-primary-foreground group"
           >
-            <PanelLeft className="h-4 w-4 text-primary group-hover:text-primary-foreground" />
+            <PanelLeft className="size-4 text-primary group-hover:text-primary-foreground" />
             <div className="flex flex-col">
               <span className="font-medium text-primary group-hover:text-primary-foreground">Hướng dẫn thanh điều hướng</span>
               <span className="text-xs text-muted-foreground group-hover:text-primary-foreground/80">Khám phá menu bên trái</span>

--- a/src/components/overdue-transfers-alert.tsx
+++ b/src/components/overdue-transfers-alert.tsx
@@ -48,9 +48,9 @@ export function OverdueTransfersAlert({
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 {overdueSummary.overdue > 0 ? (
-                  <AlertTriangle className="h-5 w-5 text-destructive" />
+                  <AlertTriangle className="size-5 text-destructive" />
                 ) : (
-                  <Clock className="h-5 w-5 text-orange-500" />
+                  <Clock className="size-5 text-orange-500" />
                 )}
                 <div>
                   <CardTitle className="text-base">
@@ -84,7 +84,7 @@ export function OverdueTransfersAlert({
             {overdueTransfers.length > 0 && (
               <div>
                 <h4 className="font-medium text-destructive mb-2 flex items-center gap-2">
-                  <AlertTriangle className="h-4 w-4" />
+                  <AlertTriangle className="size-4" />
                   Thiết bị quá hạn hoàn trả ({overdueSummary.overdue})
                 </h4>
                 <div className="space-y-2">
@@ -106,7 +106,7 @@ export function OverdueTransfersAlert({
                             variant="outline"
                             onClick={() => onViewTransfer(transfer)}
                           >
-                            <Eye className="h-4 w-4 mr-1" />
+                            <Eye className="size-4 mr-1" />
                             Xem
                           </Button>
                         )}
@@ -121,7 +121,7 @@ export function OverdueTransfersAlert({
             {upcomingTransfers.length > 0 && (
               <div>
                 <h4 className="font-medium text-orange-600 mb-2 flex items-center gap-2">
-                  <Clock className="h-4 w-4" />
+                  <Clock className="size-4" />
                   Thiết bị sắp tới hạn hoàn trả ({upcomingCount})
                 </h4>
                 <div className="space-y-2">
@@ -143,7 +143,7 @@ export function OverdueTransfersAlert({
                             variant="outline"
                             onClick={() => onViewTransfer(transfer)}
                           >
-                            <Eye className="h-4 w-4 mr-1" />
+                            <Eye className="size-4 mr-1" />
                             Xem
                           </Button>
                         )}

--- a/src/components/page-transition-wrapper.tsx
+++ b/src/components/page-transition-wrapper.tsx
@@ -93,7 +93,7 @@ function LoadingTransition({
         <div className="loading-fade-enter loading-fade-enter-active">
           {fallback || (
             <div className="flex items-center justify-center p-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              <div className="animate-spin rounded-full size-8 border-b-2 border-primary"></div>
             </div>
           )}
         </div>

--- a/src/components/qr-action-sheet-actions.tsx
+++ b/src/components/qr-action-sheet-actions.tsx
@@ -25,8 +25,8 @@ export function QRActionSheetActions({ onAction }: QRActionSheetActionsProps) {
               onClick={() => onAction(item.action)}
             >
               <div className="flex items-center gap-3">
-                <div className={`flex h-10 w-10 items-center justify-center rounded-full ${item.iconContainerClassName}`}>
-                  <Icon className={`h-5 w-5 ${item.iconClassName}`} />
+                <div className={`flex size-10 items-center justify-center rounded-full ${item.iconContainerClassName}`}>
+                  <Icon className={`size-5 ${item.iconClassName}`} />
                 </div>
                 <div className="text-left">
                   <div className="font-semibold">{item.title}</div>

--- a/src/components/qr-action-sheet-error-state.tsx
+++ b/src/components/qr-action-sheet-error-state.tsx
@@ -59,11 +59,11 @@ export function QRActionSheetErrorState({
 
   return (
     <div className="text-center py-8">
-      <div className={`mx-auto flex h-16 w-16 items-center justify-center rounded-full ${palette.iconBg}`}>
+      <div className={`mx-auto flex size-16 items-center justify-center rounded-full ${palette.iconBg}`}>
         {errorType === "not_found" ? (
-          <Search className={`h-8 w-8 ${palette.iconText}`} />
+          <Search className={`size-8 ${palette.iconText}`} />
         ) : (
-          <AlertCircle className={`h-8 w-8 ${palette.iconText}`} />
+          <AlertCircle className={`size-8 ${palette.iconText}`} />
         )}
       </div>
 
@@ -128,7 +128,7 @@ export function QRActionSheetErrorState({
 
         <div className="flex justify-center gap-2 pt-2">
           <Button variant="outline" onClick={onRetry} className="gap-2">
-            <RotateCcw className="h-4 w-4" />
+            <RotateCcw className="size-4" />
             Thử lại
           </Button>
           <Button variant="ghost" onClick={onClose}>

--- a/src/components/qr-action-sheet.tsx
+++ b/src/components/qr-action-sheet.tsx
@@ -98,11 +98,11 @@ export function QRActionSheet({ qrCode, onClose, onAction }: QRActionSheetProps)
         <SheetHeader className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <Search className="h-5 w-5" />
+              <Search className="size-5" />
               <SheetTitle>Kết quả quét QR</SheetTitle>
             </div>
             <Button variant="ghost" size="icon" onClick={onClose} aria-label="Đóng bảng hành động QR">
-              <X className="h-4 w-4" />
+              <X className="size-4" />
             </Button>
           </div>
           
@@ -115,7 +115,7 @@ export function QRActionSheet({ qrCode, onClose, onAction }: QRActionSheetProps)
         <div className="mt-6 space-y-6">
           {loading && (
             <div className="flex flex-col items-center justify-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              <div className="animate-spin rounded-full size-8 border-b-2 border-primary"></div>
               <p className="mt-4 text-sm text-muted-foreground">Đang tìm kiếm thiết bị...</p>
             </div>
           )}

--- a/src/components/qr-scanner-camera.tsx
+++ b/src/components/qr-scanner-camera.tsx
@@ -306,7 +306,7 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
               onClick={onClose}
               className="text-white hover:bg-white/20"
             >
-              <ArrowLeft className="h-6 w-6" />
+              <ArrowLeft className="size-6" />
             </Button>
             <div>
               <h2 className="text-lg font-semibold text-white">Quét mã QR</h2>
@@ -319,7 +319,7 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
             onClick={() => setShowInstructions(true)}
             className="text-white hover:bg-white/20"
           >
-            <HelpCircle className="h-6 w-6" />
+            <HelpCircle className="size-6" />
           </Button>
         </div>
       </div>
@@ -341,12 +341,12 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
               {isScanning && (
                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                   <div className="relative">
-                    <div className="w-64 h-64 border-2 border-white rounded-lg relative">
+                    <div className="size-64 border-2 border-white rounded-lg relative">
                       {/* Corner indicators */}
-                      <div className="absolute top-0 left-0 w-8 h-8 border-t-4 border-l-4 border-primary rounded-tl-lg" />
-                      <div className="absolute top-0 right-0 w-8 h-8 border-t-4 border-r-4 border-primary rounded-tr-lg" />
-                      <div className="absolute bottom-0 left-0 w-8 h-8 border-b-4 border-l-4 border-primary rounded-bl-lg" />
-                      <div className="absolute bottom-0 right-0 w-8 h-8 border-b-4 border-r-4 border-primary rounded-br-lg" />
+                      <div className="absolute top-0 left-0 size-8 border-t-4 border-l-4 border-primary rounded-tl-lg" />
+                      <div className="absolute top-0 right-0 size-8 border-t-4 border-r-4 border-primary rounded-tr-lg" />
+                      <div className="absolute bottom-0 left-0 size-8 border-b-4 border-l-4 border-primary rounded-bl-lg" />
+                      <div className="absolute bottom-0 right-0 size-8 border-b-4 border-r-4 border-primary rounded-br-lg" />
                       
                       {/* Scanning line animation */}
                       <div className="absolute inset-0 overflow-hidden rounded-lg">
@@ -371,13 +371,13 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
                   <div className="text-center text-white max-w-sm">
                     {error ? (
                       <>
-                        <X className="h-12 w-12 mx-auto mb-4 text-red-400" />
+                        <X className="size-12 mx-auto mb-4 text-red-400" />
                         <h3 className="text-lg font-semibold mb-2">Không thể khởi động camera</h3>
                         <p className="text-sm text-gray-300 whitespace-pre-line">{error}</p>
                       </>
                     ) : (
                       <>
-                        <Camera className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                        <Camera className="size-12 mx-auto mb-4 opacity-50" />
                         <p>Đang khởi động camera...</p>
                       </>
                     )}
@@ -398,12 +398,12 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
               variant="ghost"
               size="icon"
               onClick={toggleFlash}
-              className="text-white hover:bg-white/20 h-14 w-14 rounded-full"
+              className="text-white hover:bg-white/20 size-14 rounded-full"
             >
               {isFlashOn ? (
-                <FlashlightOff className="h-6 w-6" />
+                <FlashlightOff className="size-6" />
               ) : (
-                <Flashlight className="h-6 w-6" />
+                <Flashlight className="size-6" />
               )}
             </Button>
           )}
@@ -414,9 +414,9 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
               variant="ghost"
               size="icon"
               onClick={switchCamera}
-              className="text-white hover:bg-white/20 h-14 w-14 rounded-full"
+              className="text-white hover:bg-white/20 size-14 rounded-full"
             >
-              <RotateCcw className="h-6 w-6" />
+              <RotateCcw className="size-6" />
             </Button>
           )}
         </div>

--- a/src/components/qr-scanner-error-boundary.tsx
+++ b/src/components/qr-scanner-error-boundary.tsx
@@ -44,8 +44,8 @@ export class QRScannerErrorBoundary extends React.Component<Props, State> {
           <Card className="max-w-md w-full">
             <CardContent className="pt-6">
               <div className="text-center space-y-4">
-                <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-red-100">
-                  <AlertTriangle className="h-8 w-8 text-red-600" />
+                <div className="mx-auto flex size-16 items-center justify-center rounded-full bg-red-100">
+                  <AlertTriangle className="size-8 text-red-600" />
                 </div>
                 <div>
                   <h3 className="text-lg font-semibold text-gray-900">
@@ -57,7 +57,7 @@ export class QRScannerErrorBoundary extends React.Component<Props, State> {
                 </div>
                 <div className="flex flex-col gap-2">
                   <Button onClick={this.handleReset} className="w-full">
-                    <RefreshCw className="h-4 w-4 mr-2" />
+                    <RefreshCw className="size-4 mr-2" />
                     Thử lại
                   </Button>
                   <Button

--- a/src/components/qr-scanner-instructions-dialog.tsx
+++ b/src/components/qr-scanner-instructions-dialog.tsx
@@ -32,7 +32,7 @@ export function QRScannerInstructionsDialog({
       <DialogContent className="max-w-sm">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Camera className="h-5 w-5" />
+            <Camera className="size-5" />
             Hướng dẫn quét mã QR
           </DialogTitle>
           <DialogDescription>
@@ -43,7 +43,7 @@ export function QRScannerInstructionsDialog({
           <div className="space-y-3">
             {INSTRUCTION_STEPS.map((step, index) => (
               <div key={step} className="flex items-start gap-3">
-                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
+                <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground">
                   {index + 1}
                 </div>
                 <p className="text-sm">{step}</p>

--- a/src/components/realtime-status.tsx
+++ b/src/components/realtime-status.tsx
@@ -93,12 +93,12 @@ export function RealtimeStatus({
               size="sm"
               onClick={handleClick}
               className={cn(
-                "h-8 w-8 p-0",
+                "size-8 p-0",
                 connectionStatus === 'connecting' && "animate-spin",
                 className
               )}
             >
-              <Icon className="h-4 w-4" />
+              <Icon className="size-4" />
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -130,7 +130,7 @@ export function RealtimeStatus({
         )}
       >
         <Icon className={cn(
-          "h-4 w-4",
+          "size-4",
           connectionStatus === 'connecting' && "animate-spin"
         )} />
         {showLabel && config.label}
@@ -152,9 +152,9 @@ export function RealtimeStatus({
             )}
             onClick={handleClick}
           >
-            <div className={cn("h-2 w-2 rounded-full", config.color)} />
+            <div className={cn("size-2 rounded-full", config.color)} />
             <Icon className={cn(
-              "h-3 w-3",
+              "size-3",
               connectionStatus === 'connecting' && "animate-spin"
             )} />
             {showLabel && <span className="text-xs">{config.label}</span>}

--- a/src/components/repair-request-alert.tsx
+++ b/src/components/repair-request-alert.tsx
@@ -50,7 +50,7 @@ export function RepairRequestAlert({ summary, isLoading }: RepairRequestAlertPro
       <AccordionItem value="repair-alert" className="border border-destructive/50 bg-destructive/5 shadow-lg rounded-lg">
         <AccordionTrigger className="px-4 py-3 text-destructive hover:no-underline">
           <div className="flex items-center">
-            <AlertTriangle className="h-5 w-5 mr-2" />
+            <AlertTriangle className="size-5 mr-2" />
             <span className="font-semibold">{alertTitle}</span>
           </div>
         </AccordionTrigger>

--- a/src/components/repair-result-form.tsx
+++ b/src/components/repair-result-form.tsx
@@ -55,7 +55,10 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
     nextMaintenanceDate: "2025-03-19"
   })
 
-  const handleInputChange = (field: keyof RepairResultFormData, value: any) => {
+  const handleInputChange = <Field extends keyof RepairResultFormData>(
+    field: Field,
+    value: RepairResultFormData[Field]
+  ) => {
     setFormData(prev => ({
       ...prev,
       [field]: value
@@ -93,7 +96,7 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
           />
           <CardTitle className="text-2xl font-bold text-blue-600 print:text-black">
             <div className="flex items-center justify-center gap-2">
-              <Wrench className="h-6 w-6" />
+              <Wrench className="size-6" />
               BIÊN BẢN KẾT QUẢ SỬA CHỮA THIẾT BỊ Y TẾ
             </div>
           </CardTitle>
@@ -322,11 +325,11 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
           {/* Action Buttons */}
           <div className="flex flex-col sm:flex-row gap-3 justify-center print:hidden">
             <Button onClick={handleSave} className="bg-green-600 hover:bg-green-700">
-              <Save className="mr-2 h-4 w-4" />
+              <Save className="mr-2 size-4" />
               Lưu biểu mẫu
             </Button>
             <Button onClick={handlePrint} variant="outline">
-              <Printer className="mr-2 h-4 w-4" />
+              <Printer className="mr-2 size-4" />
               In biểu mẫu
             </Button>
           </div>

--- a/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
+++ b/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
@@ -91,42 +91,42 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
         <Button
           type="button"
           variant="outline"
-          className={cn("hidden h-8 w-8 p-0", showFirstLastClass)}
+          className={cn("hidden size-8 p-0", showFirstLastClass)}
           onClick={onFirstPage}
           disabled={isDisabled || !canPreviousPage}
         >
           <span className="sr-only">{resolvedAriaLabels.firstPage}</span>
-          <ChevronsLeft className="h-4 w-4" />
+          <ChevronsLeft className="size-4" />
         </Button>
         <Button
           type="button"
           variant="outline"
-          className="h-11 w-11 p-0 rounded-xl sm:h-8 sm:w-8"
+          className="size-11 p-0 rounded-xl sm:size-8"
           onClick={onPreviousPage}
           disabled={isDisabled || !canPreviousPage}
         >
           <span className="sr-only">{resolvedAriaLabels.prevPage}</span>
-          <ChevronLeft className="h-5 w-5 sm:h-4 sm:w-4" />
+          <ChevronLeft className="size-5 sm:size-4" />
         </Button>
         <Button
           type="button"
           variant="outline"
-          className="h-11 w-11 p-0 rounded-xl sm:h-8 sm:w-8"
+          className="size-11 p-0 rounded-xl sm:size-8"
           onClick={onNextPage}
           disabled={isDisabled || !canNextPage}
         >
           <span className="sr-only">{resolvedAriaLabels.nextPage}</span>
-          <ChevronRight className="h-5 w-5 sm:h-4 sm:w-4" />
+          <ChevronRight className="size-5 sm:size-4" />
         </Button>
         <Button
           type="button"
           variant="outline"
-          className={cn("hidden h-8 w-8 p-0", showFirstLastClass)}
+          className={cn("hidden size-8 p-0", showFirstLastClass)}
           onClick={onLastPage}
           disabled={isDisabled || !canNextPage}
         >
           <span className="sr-only">{resolvedAriaLabels.lastPage}</span>
-          <ChevronsRight className="h-4 w-4" />
+          <ChevronsRight className="size-4" />
         </Button>
       </div>
     </div>

--- a/src/components/shared/FloatingActionButton.tsx
+++ b/src/components/shared/FloatingActionButton.tsx
@@ -29,7 +29,7 @@ export function floatingActionButtonClassName({
   placement = "page",
 }: Pick<FloatingActionButtonProps, "className" | "tone" | "placement"> = {}) {
   return cn(
-    "fixed inline-flex h-14 w-14 items-center justify-center rounded-full border p-0",
+    "fixed inline-flex size-14 items-center justify-center rounded-full border p-0",
     "shadow-[0_18px_34px_rgba(15,23,42,0.24)] transition-all duration-200 ease-out",
     "hover:-translate-y-0.5 hover:shadow-[0_22px_42px_rgba(15,23,42,0.28)]",
     "active:translate-y-0 active:scale-95 active:duration-100",

--- a/src/components/shared/SearchInput.tsx
+++ b/src/components/shared/SearchInput.tsx
@@ -91,7 +91,7 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
         {/* Search icon (left) */}
         {showSearchIcon ? (
           <Search
-            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
             aria-hidden="true"
           />
         ) : null}
@@ -117,7 +117,7 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
                 className="p-1 text-muted-foreground transition-all duration-150 hover:scale-110 hover:text-foreground active:scale-95"
                 aria-label="Xóa tìm kiếm"
               >
-                <X className="h-4 w-4" aria-hidden="true" />
+                <X className="size-4" aria-hidden="true" />
               </button>
             ) : null}
             {endAddon}

--- a/src/components/shared/TenantSelector.tsx
+++ b/src/components/shared/TenantSelector.tsx
@@ -61,9 +61,9 @@ export function TenantSelector({ className, hideAllOption = false }: TenantSelec
           className
         )}
       >
-        <Building2 className="h-4 w-4 shrink-0" />
+        <Building2 className="size-4 shrink-0" />
         <span className="truncate max-w-[200px]">{currentFacilityName}</span>
-        <ChevronDown className="h-4 w-4 shrink-0 opacity-50" />
+        <ChevronDown className="size-4 shrink-0 opacity-50" />
       </Button>
 
       <TenantSelectorSheet open={sheetOpen} onOpenChange={setSheetOpen} hideAllOption={hideAllOption} />

--- a/src/components/shared/TenantSelectorSheet.tsx
+++ b/src/components/shared/TenantSelectorSheet.tsx
@@ -89,7 +89,7 @@ export function TenantSelectorSheet({
         {/* Search input */}
         <div className="mt-4">
           <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
             <Input
               value={searchTerm}
               onChange={(event) => setSearchTerm(event.target.value)}
@@ -103,7 +103,7 @@ export function TenantSelectorSheet({
                 onClick={() => setSearchTerm("")}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition hover:text-foreground"
               >
-                <X className="h-4 w-4" />
+                <X className="size-4" />
               </button>
             ) : null}
           </div>
@@ -124,10 +124,10 @@ export function TenantSelectorSheet({
               )}
             >
               <div className="flex items-center gap-2">
-                <Building2 className="h-4 w-4" />
+                <Building2 className="size-4" />
                 <span className="font-medium">Tất cả cơ sở</span>
                 {selectedFacilityId === null ? (
-                  <Check className="h-4 w-4 text-primary" />
+                  <Check className="size-4 text-primary" />
                 ) : null}
               </div>
               <span className="text-xs text-muted-foreground">
@@ -161,7 +161,7 @@ export function TenantSelectorSheet({
                   <span className="flex items-center gap-2 truncate">
                     <span className="truncate">{facility.name}</span>
                     {isSelected ? (
-                      <Check className="h-4 w-4 text-primary" />
+                      <Check className="size-4 text-primary" />
                     ) : null}
                   </span>
                   <span className="text-xs text-muted-foreground">

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -175,7 +175,7 @@ export function FacetedMultiSelectFilter<TData, TValue>({
                 {/* Header */}
                 <div className="px-3 py-2.5 border-b border-slate-100 bg-slate-50/50">
                     <div className="flex items-center gap-2">
-                        <Filter className="h-4 w-4 text-primary" />
+                        <Filter className="size-4 text-primary" />
                         <span className="font-semibold text-sm text-slate-900">{title}</span>
                     </div>
                 </div>
@@ -184,7 +184,7 @@ export function FacetedMultiSelectFilter<TData, TValue>({
                     <div className="border-b border-slate-100 p-2">
                         <div className="relative">
                             <Search
-                                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
                                 aria-hidden="true"
                             />
                             <Input
@@ -224,12 +224,12 @@ export function FacetedMultiSelectFilter<TData, TValue>({
                                 )}
                             >
                                 <div className={cn(
-                                    "flex items-center justify-center h-5 w-5 rounded border-2 transition-all shrink-0",
+                                    "flex items-center justify-center size-5 rounded border-2 transition-all shrink-0",
                                     isSelected
                                         ? "bg-primary border-primary"
                                         : "border-slate-300 hover:border-primary/50"
                                 )}>
-                                    {isSelected && <Check className="h-3.5 w-3.5 text-white" strokeWidth={3} />}
+                                    {isSelected && <Check className="size-3.5 text-white" strokeWidth={3} />}
                                 </div>
                                 <span className={cn(
                                     "truncate text-left flex-1",

--- a/src/components/start-usage-dialog.tsx
+++ b/src/components/start-usage-dialog.tsx
@@ -211,7 +211,7 @@ export function StartUsageDialog({
                 Hủy
               </Button>
               <Button type="submit" disabled={isLoading || isRegionalLeader}>
-                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isLoading && <Loader2 className="mr-2 size-4 animate-spin" />}
                 Bắt đầu sử dụng
               </Button>
             </DialogFooter>

--- a/src/components/tenants-management-tenant-card.tsx
+++ b/src/components/tenants-management-tenant-card.tsx
@@ -115,7 +115,7 @@ export function TenantsManagementTenantCard({
                     )}
                   >
                     <div className="flex flex-1 items-center gap-3">
-                      <Avatar className="h-9 w-9">
+                      <Avatar className="size-9">
                         <AvatarFallback className="text-xs font-medium">
                           {getInitials(tenantUser.full_name || tenantUser.username)}
                         </AvatarFallback>
@@ -132,7 +132,7 @@ export function TenantsManagementTenantCard({
                     </div>
                     <ChevronDown
                       className={cn(
-                        "h-4 w-4 text-muted-foreground transition-transform",
+                        "size-4 text-muted-foreground transition-transform",
                         isExpanded && "-rotate-180",
                       )}
                     />
@@ -148,7 +148,7 @@ export function TenantsManagementTenantCard({
               className="flex w-full items-center justify-between rounded-lg border border-dashed border-border/60 px-4 py-3 text-left text-sm text-muted-foreground transition hover:border-border"
             >
               <span>Chưa có tài khoản Tổ QLTB</span>
-              <ChevronDown className={cn("h-4 w-4 transition-transform", isExpanded && "-rotate-180")} />
+              <ChevronDown className={cn("size-4 transition-transform", isExpanded && "-rotate-180")} />
             </button>
           )}
         </div>
@@ -202,7 +202,7 @@ function TenantLogo({
       width={48}
       height={48}
       unoptimized
-      className="h-12 w-12 rounded-lg border border-border/60 object-contain"
+      className="size-12 rounded-lg border border-border/60 object-contain"
       onError={() => setHasError(true)}
     />
   )
@@ -212,7 +212,7 @@ function HierarchyUserRow({ user, label }: { user: TenantHierarchyUser; label?: 
   return (
     <div className="flex items-center justify-between bg-background px-4 py-3">
       <div className="flex items-center gap-3">
-        <Avatar className="h-8 w-8">
+        <Avatar className="size-8">
           <AvatarFallback className="text-[11px] font-medium">
             {getInitials(user.full_name || user.username)}
           </AvatarFallback>

--- a/src/components/transfer-detail-dialog.tsx
+++ b/src/components/transfer-detail-dialog.tsx
@@ -119,7 +119,7 @@ export function TransferDetailDialog({
       <DialogContent className="h-[90vh] max-h-[90vh] max-w-4xl overflow-hidden flex flex-col">
         <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2">
-            <Package className="h-5 w-5" />
+            <Package className="size-5" />
             Chi tiết yêu cầu luân chuyển - {displayTransfer.ma_yeu_cau}
           </DialogTitle>
           <DialogDescription>

--- a/src/components/transfer-detail-overview.tsx
+++ b/src/components/transfer-detail-overview.tsx
@@ -54,7 +54,7 @@ export function TransferDetailOverview({
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <Package className="h-4 w-4 text-muted-foreground" />
+              <Package className="size-4 text-muted-foreground" />
               <span className="font-medium">Thiết bị:</span>
             </div>
             <div className="ml-6">
@@ -88,14 +88,14 @@ export function TransferDetailOverview({
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <MapPin className="h-4 w-4 text-muted-foreground" />
+                <MapPin className="size-4 text-muted-foreground" />
                 <span className="font-medium">Từ khoa/phòng:</span>
               </div>
               <p className="ml-6">{transfer.khoa_phong_hien_tai}</p>
             </div>
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <MapPin className="h-4 w-4 text-muted-foreground" />
+                <MapPin className="size-4 text-muted-foreground" />
                 <span className="font-medium">Đến khoa/phòng:</span>
               </div>
               <p className="ml-6">{transfer.khoa_phong_nhan}</p>
@@ -112,7 +112,7 @@ export function TransferDetailOverview({
               </div>
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <Building className="h-4 w-4 text-muted-foreground" />
+                  <Building className="size-4 text-muted-foreground" />
                   <span className="font-medium">Đơn vị nhận:</span>
                 </div>
                 <p className="ml-6">{transfer.don_vi_nhan}</p>
@@ -130,7 +130,7 @@ export function TransferDetailOverview({
               {transfer.nguoi_lien_he ? (
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <User className="h-4 w-4 text-muted-foreground" />
+                    <User className="size-4 text-muted-foreground" />
                     <span className="font-medium">Người liên hệ:</span>
                   </div>
                   <p className="ml-6">{transfer.nguoi_lien_he}</p>
@@ -139,7 +139,7 @@ export function TransferDetailOverview({
               {transfer.so_dien_thoai ? (
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <Phone className="h-4 w-4 text-muted-foreground" />
+                    <Phone className="size-4 text-muted-foreground" />
                     <span className="font-medium">Số điện thoại:</span>
                   </div>
                   <p className="ml-6">{transfer.so_dien_thoai}</p>
@@ -150,7 +150,7 @@ export function TransferDetailOverview({
             {transfer.ngay_du_kien_tra ? (
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <Calendar className="h-4 w-4 text-muted-foreground" />
+                  <Calendar className="size-4 text-muted-foreground" />
                   <span className="font-medium">Ngày dự kiến trả về:</span>
                 </div>
                 <p className="ml-6">
@@ -174,7 +174,7 @@ export function TransferDetailOverview({
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <Clock className="h-4 w-4 text-muted-foreground" />
+              <Clock className="size-4 text-muted-foreground" />
               <span className="font-medium">Ngày tạo:</span>
             </div>
             <p className="ml-6">{formatDateTime(transfer.created_at)}</p>
@@ -183,7 +183,7 @@ export function TransferDetailOverview({
           {transfer.ngay_duyet ? (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <Clock className="h-4 w-4 text-muted-foreground" />
+                <Clock className="size-4 text-muted-foreground" />
                 <span className="font-medium">Ngày duyệt:</span>
               </div>
               <p className="ml-6">{formatDateTime(transfer.ngay_duyet)}</p>
@@ -193,7 +193,7 @@ export function TransferDetailOverview({
           {transfer.ngay_ban_giao ? (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <Clock className="h-4 w-4 text-muted-foreground" />
+                <Clock className="size-4 text-muted-foreground" />
                 <span className="font-medium">Ngày bàn giao:</span>
               </div>
               <p className="ml-6">{formatDateTime(transfer.ngay_ban_giao)}</p>
@@ -203,7 +203,7 @@ export function TransferDetailOverview({
           {transfer.ngay_hoan_thanh ? (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <Clock className="h-4 w-4 text-muted-foreground" />
+                <Clock className="size-4 text-muted-foreground" />
                 <span className="font-medium">Ngày hoàn thành:</span>
               </div>
               <p className="ml-6">{formatDateTime(transfer.ngay_hoan_thanh)}</p>
@@ -220,7 +220,7 @@ export function TransferDetailOverview({
           {requesterName ? (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <User className="h-4 w-4 text-muted-foreground" />
+                <User className="size-4 text-muted-foreground" />
                 <span className="font-medium">Người yêu cầu:</span>
               </div>
               <p className="ml-6">{requesterName}</p>
@@ -230,7 +230,7 @@ export function TransferDetailOverview({
           {approverName ? (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <User className="h-4 w-4 text-muted-foreground" />
+                <User className="size-4 text-muted-foreground" />
                 <span className="font-medium">Người duyệt:</span>
               </div>
               <p className="ml-6">{approverName}</p>

--- a/src/components/transfer-dialog.equipment-search.tsx
+++ b/src/components/transfer-dialog.equipment-search.tsx
@@ -64,7 +64,7 @@ export function TransferDialogEquipmentSearch({
             {isEquipmentLoading && (
               <div className="absolute z-20 mt-1 w-full rounded-md border bg-popover p-3 shadow-lg">
                 <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                   <span>Đang tìm kiếm thiết bị...</span>
                 </div>
               </div>
@@ -106,7 +106,7 @@ export function TransferDialogEquipmentSearch({
       )}
       {selectedEquipment && (
         <p className="flex items-center gap-1.5 pt-1 text-xs text-muted-foreground">
-          <Check className="h-3.5 w-3.5 text-green-600" />
+          <Check className="size-3.5 text-green-600" />
           <span>
             Đã chọn: {selectedEquipment.ten_thiet_bi} ({selectedEquipment.ma_thiet_bi})
           </span>

--- a/src/components/transfers/FilterChips.tsx
+++ b/src/components/transfers/FilterChips.tsx
@@ -47,29 +47,29 @@ export function FilterChips({
           <Button
             variant="ghost"
             size="sm"
-            className="ml-1 h-5 w-5 p-0"
+            className="ml-1 size-5 p-0"
             onClick={() => onRemove("statuses", status)}
             aria-label={`Xóa trạng thái ${STATUS_LABELS[status]}`}
           >
-            <X className="h-3 w-3" />
+            <X className="size-3" />
           </Button>
         </Badge>
       ))}
 
       {hasDateRange && (
         <Badge variant="secondary" className="pr-1 gap-1">
-          <CalendarIcon className="h-3 w-3" />
+          <CalendarIcon className="size-3" />
           <span>
             {value.dateRange?.from ?? "…"} → {value.dateRange?.to ?? "…"}
           </span>
           <Button
             variant="ghost"
             size="sm"
-            className="ml-1 h-5 w-5 p-0"
+            className="ml-1 size-5 p-0"
             onClick={() => onRemove("dateRange")}
             aria-label="Xóa khoảng ngày"
           >
-            <X className="h-3 w-3" />
+            <X className="size-3" />
           </Button>
         </Badge>
       )}

--- a/src/components/transfers/FilterModal.tsx
+++ b/src/components/transfers/FilterModal.tsx
@@ -85,7 +85,7 @@ export function FilterModal({
                   !value.dateRange?.from && "text-muted-foreground"
                 )}
               >
-                <CalendarIcon className="mr-2 h-4 w-4" />
+                <CalendarIcon className="mr-2 size-4" />
                 {value.dateRange?.from
                   ? value.dateRange.from.toLocaleDateString("vi-VN")
                   : "Từ ngày"}
@@ -117,7 +117,7 @@ export function FilterModal({
                   !value.dateRange?.to && "text-muted-foreground"
                 )}
               >
-                <CalendarIcon className="mr-2 h-4 w-4" />
+                <CalendarIcon className="mr-2 size-4" />
                 {value.dateRange?.to
                   ? value.dateRange.to.toLocaleDateString("vi-VN")
                   : "Đến ngày"}

--- a/src/components/transfers/TransferRowActions.tsx
+++ b/src/components/transfers/TransferRowActions.tsx
@@ -61,13 +61,13 @@ export const TransferRowActions = React.memo(function TransferRowActions({
           <Button
             variant="ghost"
             size="icon"
-            className="h-10 w-10 sm:h-8 sm:w-8"
+            className="size-10 sm:size-8"
             onClick={(event) => {
               event.stopPropagation()
               onEdit(item)
             }}
           >
-            <Edit className="h-5 w-5 sm:h-4 sm:w-4" />
+            <Edit className="size-5 sm:size-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>
@@ -85,13 +85,13 @@ export const TransferRowActions = React.memo(function TransferRowActions({
             <TooltipTrigger asChild>
               <Button
                 size="icon"
-                className="h-10 w-10 sm:h-8 sm:w-8"
+                className="size-10 sm:size-8"
                 onClick={(event) => {
                   event.stopPropagation()
                   onApprove(item)
                 }}
               >
-                <Check className="h-5 w-5 sm:h-4 sm:w-4" />
+                <Check className="size-5 sm:size-4" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>
@@ -111,14 +111,14 @@ export const TransferRowActions = React.memo(function TransferRowActions({
             <TooltipTrigger asChild>
               <Button
                 size="icon"
-                className="h-10 w-10 sm:h-8 sm:w-8"
+                className="size-10 sm:size-8"
                 variant="secondary"
                 onClick={(event) => {
                   event.stopPropagation()
                   onStart(item)
                 }}
               >
-                <Play className="h-5 w-5 sm:h-4 sm:w-4" />
+                <Play className="size-5 sm:size-4" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>
@@ -141,13 +141,13 @@ export const TransferRowActions = React.memo(function TransferRowActions({
                 <Button
                   size="icon"
                   variant="outline"
-                  className="h-10 w-10 sm:h-8 sm:w-8"
+                  className="size-10 sm:size-8"
                   onClick={(event) => {
                     event.stopPropagation()
                     onGenerateHandoverSheet(item)
                   }}
                 >
-                  <FileText className="h-5 w-5 sm:h-4 sm:w-4" />
+                  <FileText className="size-5 sm:size-4" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
@@ -160,13 +160,13 @@ export const TransferRowActions = React.memo(function TransferRowActions({
               <TooltipTrigger asChild>
                 <Button
                   size="icon"
-                  className="h-10 w-10 sm:h-8 sm:w-8"
+                  className="size-10 sm:size-8"
                   onClick={(event) => {
                     event.stopPropagation()
                     onComplete(item)
                   }}
                 >
-                  <CheckCircle className="h-5 w-5 sm:h-4 sm:w-4" />
+                  <CheckCircle className="size-5 sm:size-4" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
@@ -180,14 +180,14 @@ export const TransferRowActions = React.memo(function TransferRowActions({
               <TooltipTrigger asChild>
                 <Button
                   size="icon"
-                  className="h-10 w-10 sm:h-8 sm:w-8"
+                  className="size-10 sm:size-8"
                   variant="secondary"
                   onClick={(event) => {
                     event.stopPropagation()
                     onHandover(item)
                   }}
                 >
-                  <Send className="h-5 w-5 sm:h-4 sm:w-4" />
+                  <Send className="size-5 sm:size-4" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
@@ -205,13 +205,13 @@ export const TransferRowActions = React.memo(function TransferRowActions({
             <TooltipTrigger asChild>
               <Button
                 size="icon"
-                className="h-10 w-10 sm:h-8 sm:w-8"
+                className="size-10 sm:size-8"
                 onClick={(event) => {
                   event.stopPropagation()
                   onReturn(item)
                 }}
               >
-                <Undo2 className="h-5 w-5 sm:h-4 sm:w-4" />
+                <Undo2 className="size-5 sm:size-4" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>
@@ -232,13 +232,13 @@ export const TransferRowActions = React.memo(function TransferRowActions({
           <Button
             variant="ghost"
             size="icon"
-            className="h-10 w-10 text-destructive hover:text-destructive sm:h-8 sm:w-8"
+            className="size-10 text-destructive hover:text-destructive sm:size-8"
             onClick={(event) => {
               event.stopPropagation()
               onDelete(item)
             }}
           >
-            <Trash2 className="h-5 w-5 sm:h-4 sm:w-4" />
+            <Trash2 className="size-5 sm:size-4" />
           </Button>
         </TooltipTrigger>
         <TooltipContent>

--- a/src/components/transfers/TransferStatusProgress.tsx
+++ b/src/components/transfers/TransferStatusProgress.tsx
@@ -62,14 +62,14 @@ export function TransferStatusProgress({
                 {/* Circle/Check indicator */}
                 <div
                   className={cn(
-                    "flex h-8 w-8 items-center justify-center rounded-full border-2 text-xs font-medium transition-colors",
+                    "flex size-8 items-center justify-center rounded-full border-2 text-xs font-medium transition-colors",
                     isCompleted && "border-primary bg-primary text-primary-foreground",
                     isCurrent && "border-primary bg-primary/10 text-primary",
                     !isCompleted && !isCurrent && "border-muted-foreground/30 bg-muted text-muted-foreground"
                   )}
                 >
                   {isCompleted ? (
-                    <Check className="h-4 w-4" />
+                    <Check className="size-4" />
                   ) : (
                     <span>{index + 1}</span>
                   )}

--- a/src/components/transfers/TransfersKanbanCard.tsx
+++ b/src/components/transfers/TransfersKanbanCard.tsx
@@ -92,7 +92,7 @@ function TransfersKanbanCardComponent({
 
         {/* Transfer direction */}
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <ArrowRight className="h-3 w-3 shrink-0" />
+          <ArrowRight className="size-3 shrink-0" />
           <span className="truncate" title={`${transfer.khoa_phong_hien_tai || 'N/A'} → ${transfer.khoa_phong_nhan || transfer.don_vi_nhan || 'N/A'}`}>
             {transfer.khoa_phong_hien_tai || 'N/A'} → {transfer.khoa_phong_nhan || transfer.don_vi_nhan || 'N/A'}
           </span>

--- a/src/components/transfers/TransfersKanbanColumn.tsx
+++ b/src/components/transfers/TransfersKanbanColumn.tsx
@@ -93,7 +93,7 @@ export function TransfersKanbanColumn({
       {/* Header */}
       <div className={cn("p-3 border-b shrink-0 transition-colors", STATUS_HEADER_STYLES[status])}>
         <div className="flex items-center gap-2">
-          {React.createElement(STATUS_ICONS[status], { className: "h-4 w-4" })}
+          {React.createElement(STATUS_ICONS[status], { className: "size-4" })}
           <h3 className="font-medium text-sm">
             {TRANSFER_STATUS_LABELS[status]}
           </h3>
@@ -153,7 +153,7 @@ export function TransfersKanbanColumn({
         {/* Loading more indicator */}
         {isLoadingMore && (
           <div className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
+            <Loader2 className="size-4 animate-spin" />
             <span>Đang tải thêm...</span>
           </div>
         )}

--- a/src/components/transfers/TransfersKanbanView.tsx
+++ b/src/components/transfers/TransfersKanbanView.tsx
@@ -173,7 +173,7 @@ function TransfersKanbanBoard({
     return (
       <div className="flex min-h-[400px] items-center justify-center">
         <div className="flex flex-col items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-6 w-6 animate-spin" />
+          <Loader2 className="size-6 animate-spin" />
           Đang tải dữ liệu...
         </div>
       </div>
@@ -231,13 +231,13 @@ function TransfersKanbanBoard({
             disabled={!canGoPrev}
             className={cn(
               "absolute left-0 top-1/2 -translate-y-1/2 z-10",
-              "w-8 h-8 rounded-full bg-background/80 backdrop-blur border shadow-sm",
+              "size-8 rounded-full bg-background/80 backdrop-blur border shadow-sm",
               "flex items-center justify-center transition-opacity",
               canGoPrev ? "opacity-100 hover:bg-muted" : "opacity-0 pointer-events-none"
             )}
             aria-label="Cột trước"
           >
-            <ChevronLeft className="h-4 w-4" />
+            <ChevronLeft className="size-4" />
           </button>
 
           <button
@@ -245,13 +245,13 @@ function TransfersKanbanBoard({
             disabled={!canGoNext}
             className={cn(
               "absolute right-0 top-1/2 -translate-y-1/2 z-10",
-              "w-8 h-8 rounded-full bg-background/80 backdrop-blur border shadow-sm",
+              "size-8 rounded-full bg-background/80 backdrop-blur border shadow-sm",
               "flex items-center justify-center transition-opacity",
               canGoNext ? "opacity-100 hover:bg-muted" : "opacity-0 pointer-events-none"
             )}
             aria-label="Cột sau"
           >
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="size-4" />
           </button>
 
           <div className="min-h-[calc(100vh-380px)]">
@@ -278,7 +278,7 @@ function TransfersKanbanBoard({
                 key={status}
                 onClick={() => setMobileSelectedStatus(status)}
                 className={cn(
-                  "w-2 h-2 rounded-full transition-all",
+                  "size-2 rounded-full transition-all",
                   index === currentMobileIndex
                     ? "bg-primary w-4"
                     : "bg-muted-foreground/30 hover:bg-muted-foreground/50"
@@ -315,7 +315,7 @@ function TransfersKanbanBoard({
 
       {isFetching && !isLoading && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
+          <Loader2 className="size-4 animate-spin" />
           Đang đồng bộ dữ liệu...
         </div>
       )}

--- a/src/components/transfers/TransfersSearchParamsBoundary.tsx
+++ b/src/components/transfers/TransfersSearchParamsBoundary.tsx
@@ -19,7 +19,7 @@ export function TransfersSearchParamsBoundary({
           aria-label="Đang tải bộ lọc điều chuyển"
           aria-live="polite"
         >
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
         </div>
       }
     >

--- a/src/components/transfers/TransfersTableView.tsx
+++ b/src/components/transfers/TransfersTableView.tsx
@@ -67,7 +67,7 @@ export function TransfersTableView({
           {isLoading ? (
             <TableRow>
               <TableCell colSpan={columns.length} className="h-40 text-center">
-                <Loader2 className="mx-auto h-6 w-6 animate-spin text-muted-foreground" />
+                <Loader2 className="mx-auto size-6 animate-spin text-muted-foreground" />
                 <p className="mt-2 text-sm text-muted-foreground">Đang tải dữ liệu...</p>
               </TableCell>
             </TableRow>

--- a/src/components/transfers/TransfersTenantSelectionPlaceholder.tsx
+++ b/src/components/transfers/TransfersTenantSelectionPlaceholder.tsx
@@ -15,7 +15,7 @@ export function TransfersTenantSelectionPlaceholder({
   return (
     <div className={`flex items-center justify-center ${className}`}>
       <div className="flex max-w-md flex-col items-center gap-4 text-center">
-        <Building2 className="h-12 w-12 text-muted-foreground" />
+        <Building2 className="size-12 text-muted-foreground" />
         <div className="space-y-2">
           <h3 className="text-lg font-medium">Chọn cơ sở y tế</h3>
           <p className="text-sm text-muted-foreground">

--- a/src/components/transfers/TransfersViewToggle.tsx
+++ b/src/components/transfers/TransfersViewToggle.tsx
@@ -20,7 +20,7 @@ export function TransfersViewToggle() {
         onClick={() => setView('table')}
         className="gap-2"
       >
-        <Table className="h-4 w-4" />
+        <Table className="size-4" />
         <span className="hidden sm:inline">Bảng</span>
       </Button>
       <Button
@@ -29,7 +29,7 @@ export function TransfersViewToggle() {
         onClick={() => setView('kanban')}
         className="gap-2"
       >
-        <LayoutGrid className="h-4 w-4" />
+        <LayoutGrid className="size-4" />
         <span className="hidden sm:inline">Kanban</span>
       </Button>
     </div>

--- a/src/components/transfers/columnDefinitions.tsx
+++ b/src/components/transfers/columnDefinitions.tsx
@@ -176,7 +176,7 @@ const createInternalColumns = (): ColumnDef<TransferListItem>[] => [
       return (
         <div className="flex items-center gap-2 text-sm">
           <span className="font-medium text-foreground">{from}</span>
-          <ArrowRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+          <ArrowRight className="size-4 flex-shrink-0 text-muted-foreground" />
           <span className="font-medium text-foreground">{to}</span>
         </div>
       )
@@ -196,7 +196,7 @@ const createExternalColumns = (referenceDate: Date): ColumnDef<TransferListItem>
       return (
         <div className="flex items-center gap-1.5 text-sm">
           <span className="truncate font-medium text-foreground">{from}</span>
-          <ArrowRight className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+          <ArrowRight className="size-3.5 flex-shrink-0 text-muted-foreground" />
           <span className="truncate font-medium text-foreground">{to}</span>
         </div>
       )
@@ -256,7 +256,7 @@ const createLiquidationColumns = (): ColumnDef<TransferListItem>[] => [
       return (
         <div className="flex items-center gap-2 text-sm">
           <span className="font-medium text-foreground">{from}</span>
-          <ArrowRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+          <ArrowRight className="size-4 flex-shrink-0 text-muted-foreground" />
           <span className="font-medium text-foreground">{to}</span>
         </div>
       )

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -34,7 +34,7 @@ const AccordionTrigger = React.forwardRef<
       {...props}
     >
       {children}
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+      <ChevronDown className="size-4 shrink-0 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ))

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -12,7 +12,7 @@ const Avatar = React.forwardRef<
   <AvatarPrimitive.Root
     ref={ref}
     className={cn(
-      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      "relative flex size-10 shrink-0 overflow-hidden rounded-full",
       className
     )}
     {...props}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -23,7 +23,7 @@ const buttonVariants = cva(
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        icon: "size-10",
       },
     },
     defaultVariants: {

--- a/src/components/ui/calendar-widget/CalendarWidgetGrid.tsx
+++ b/src/components/ui/calendar-widget/CalendarWidgetGrid.tsx
@@ -60,7 +60,7 @@ function CalendarWidgetDayCell({
               {dayEvents.slice(0, maxIndicators).map((event, index) => (
                 <div
                   key={event.id}
-                  className={`${compact ? "w-1.5 h-1.5" : "w-2 h-2"} rounded-full animate-pulse ${getEventIndicatorClassName(event)}`}
+                  className={`${compact ? "size-1.5" : "size-2"} rounded-full animate-pulse ${getEventIndicatorClassName(event)}`}
                   style={{ animationDelay: `${index * 50}ms` }}
                   title={compact ? undefined : `${event.type}: ${event.title}`}
                 />

--- a/src/components/ui/calendar-widget/CalendarWidgetHeader.tsx
+++ b/src/components/ui/calendar-widget/CalendarWidgetHeader.tsx
@@ -67,7 +67,7 @@ export function CalendarWidgetHeader({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl shadow-lg">
-              <CalendarIcon className="h-5 w-5 text-white" />
+              <CalendarIcon className="size-5 text-white" />
             </div>
             <div>
               <h2 className="text-lg font-bold text-gray-900">Lịch công việc</h2>
@@ -75,11 +75,11 @@ export function CalendarWidgetHeader({
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <Button size="sm" variant="ghost" className="h-9 w-9 rounded-lg" onClick={onPrevMonth}>
-              <ChevronLeft className="h-4 w-4" />
+            <Button size="sm" variant="ghost" className="size-9 rounded-lg" onClick={onPrevMonth}>
+              <ChevronLeft className="size-4" />
             </Button>
-            <Button size="sm" variant="ghost" className="h-9 w-9 rounded-lg" onClick={onNextMonth}>
-              <ChevronRight className="h-4 w-4" />
+            <Button size="sm" variant="ghost" className="size-9 rounded-lg" onClick={onNextMonth}>
+              <ChevronRight className="size-4" />
             </Button>
           </div>
         </div>
@@ -89,7 +89,7 @@ export function CalendarWidgetHeader({
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-4">
             <div className="p-3 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl shadow-lg">
-              <CalendarIcon className="h-6 w-6 text-white" />
+              <CalendarIcon className="size-6 text-white" />
             </div>
             <div>
               <CardTitle className="text-2xl font-bold text-gray-900">Lịch công việc</CardTitle>
@@ -132,13 +132,13 @@ export function CalendarWidgetMonthControls({
       <div className="hidden xl:flex items-center justify-between mb-6">
         <div className="flex items-center gap-2">
           <Button variant="outline" size="default" onClick={onPrevMonth} className="rounded-xl hover:bg-gray-100">
-            <ChevronLeft className="h-5 w-5" />
+            <ChevronLeft className="size-5" />
           </Button>
           <Button variant="outline" size="default" onClick={onToday} className="rounded-xl hover:bg-gray-100 font-medium">
             Hôm nay
           </Button>
           <Button variant="outline" size="default" onClick={onNextMonth} className="rounded-xl hover:bg-gray-100">
-            <ChevronRight className="h-5 w-5" />
+            <ChevronRight className="size-5" />
           </Button>
         </div>
         <h3 className="text-xl font-bold text-gray-700">

--- a/src/components/ui/calendar-widget/CalendarWidgetShared.tsx
+++ b/src/components/ui/calendar-widget/CalendarWidgetShared.tsx
@@ -129,7 +129,7 @@ export function CalendarWidgetErrorState(): React.JSX.Element {
       role="alert"
       className="flex flex-col items-center justify-center py-12 text-center text-destructive"
     >
-      <CalendarIcon className="mb-3 h-8 w-8" />
+      <CalendarIcon className="mb-3 size-8" />
       <p className="font-semibold">Không thể tải lịch bảo trì</p>
       <p className="mt-1 text-sm text-muted-foreground">Vui lòng thử lại sau.</p>
     </div>
@@ -141,7 +141,7 @@ export function CalendarSkeleton({ className }: CalendarWidgetProps) {
     <Card className={className}>
       <CardHeader className="pb-4 md:p-8 md:pb-6">
         <CardTitle className="flex items-center gap-2 text-responsive-lg md:text-2xl font-semibold leading-none tracking-tight">
-          <CalendarIcon className="h-4 w-4 md:h-5 md:w-5" />
+          <CalendarIcon className="size-4 md:size-5" />
           <span className="line-clamp-2 md:line-clamp-1">Lịch Bảo trì/Hiệu chuẩn/Kiểm định</span>
         </CardTitle>
       </CardHeader>
@@ -193,15 +193,15 @@ export function CalendarEventCard({
 export function CalendarEmptyDayState({ compact }: { compact: boolean }) {
   return compact ? (
     <div className="text-center py-8">
-      <div className="p-4 bg-gray-100/50 rounded-full w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-        <CalendarIcon className="h-8 w-8 text-gray-400" />
+      <div className="p-4 bg-gray-100/50 rounded-full size-16 mx-auto mb-4 flex items-center justify-center">
+        <CalendarIcon className="size-8 text-gray-400" />
       </div>
       <p className="text-gray-500 text-sm">Không có công việc nào trong ngày này</p>
     </div>
   ) : (
     <div className="text-center py-12">
-      <div className="p-4 bg-gray-100/50 rounded-full w-20 h-20 mx-auto mb-4 flex items-center justify-center">
-        <CalendarIcon className="h-10 w-10 text-gray-400" />
+      <div className="p-4 bg-gray-100/50 rounded-full size-20 mx-auto mb-4 flex items-center justify-center">
+        <CalendarIcon className="size-10 text-gray-400" />
       </div>
       <p className="text-gray-500">Không có công việc nào trong ngày này</p>
     </div>

--- a/src/components/ui/calendar-widget/CalendarWidgetStats.tsx
+++ b/src/components/ui/calendar-widget/CalendarWidgetStats.tsx
@@ -72,14 +72,14 @@ function SummaryStatCard({
 
   const iconClassName = compact
     ? {
-        blue: "h-4 w-4 text-blue-600",
-        green: "h-4 w-4 text-green-600",
-        orange: "h-4 w-4 text-orange-600",
+        blue: "size-4 text-blue-600",
+        green: "size-4 text-green-600",
+        orange: "size-4 text-orange-600",
       }[tone]
     : {
-        blue: "h-6 w-6 text-blue-600",
-        green: "h-6 w-6 text-green-600",
-        orange: "h-6 w-6 text-orange-600",
+        blue: "size-6 text-blue-600",
+        green: "size-6 text-green-600",
+        orange: "size-6 text-orange-600",
       }[tone]
 
   return (

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -27,7 +27,7 @@ function Calendar({
         nav: "space-x-1 flex items-center",
         nav_button: cn(
           buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100"
         ),
         nav_button_previous: "absolute left-1",
         nav_button_next: "absolute right-1",
@@ -36,10 +36,10 @@ function Calendar({
         head_cell:
           "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
         row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        cell: "size-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+          "size-9 p-0 font-normal aria-selected:opacity-100"
         ),
         day_range_end: "day-range-end",
         day_selected:
@@ -55,10 +55,10 @@ function Calendar({
       }}
       components={{
         IconLeft: ({ className, ...props }) => (
-          <ChevronLeft className={cn("h-4 w-4", className)} {...props} />
+          <ChevronLeft className={cn("size-4", className)} {...props} />
         ),
         IconRight: ({ className, ...props }) => (
-          <ChevronRight className={cn("h-4 w-4", className)} {...props} />
+          <ChevronRight className={cn("size-4", className)} {...props} />
         ),
       }}
       {...props}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "group/checkbox peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
+      "group/checkbox peer size-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
       className
     )}
     {...props}
@@ -22,8 +22,8 @@ const Checkbox = React.forwardRef<
       className={cn("flex items-center justify-center text-current")}
     >
       {/* Use data-state CSS selectors to show correct icon for both controlled and uncontrolled usage */}
-      <Check className="h-4 w-4 hidden group-data-[state=checked]/checkbox:block" />
-      <Minus className="h-4 w-4 hidden group-data-[state=indeterminate]/checkbox:block" />
+      <Check className="size-4 hidden group-data-[state=checked]/checkbox:block" />
+      <Minus className="size-4 hidden group-data-[state=indeterminate]/checkbox:block" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -40,7 +40,7 @@ export function DatePickerWithRange({
               !date.from && 'text-muted-foreground'
             )}
           >
-            <CalendarIcon className="mr-2 h-4 w-4" />
+            <CalendarIcon className="mr-2 size-4" />
             {date.from ? (
               date.to ? (
                 <>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ const DialogContent = React.forwardRef<
         {children}
         {showCloseButton ? (
           <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-            <X className="h-4 w-4" />
+            <X className="size-4" />
             <span className="sr-only">{closeLabel}</span>
           </DialogPrimitive.Close>
         ) : null}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -105,9 +105,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     checked={checked}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="size-4" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -128,9 +128,9 @@ const DropdownMenuRadioItem = React.forwardRef<
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Circle className="size-2 fill-current" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -26,7 +26,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="size-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -44,7 +44,7 @@ const SelectScrollUpButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronUp className="h-4 w-4" />
+    <ChevronUp className="size-4" />
   </SelectPrimitive.ScrollUpButton>
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
@@ -61,7 +61,7 @@ const SelectScrollDownButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronDown className="h-4 w-4" />
+    <ChevronDown className="size-4" />
   </SelectPrimitive.ScrollDownButton>
 ))
 SelectScrollDownButton.displayName =
@@ -123,9 +123,9 @@ const SelectItem = React.forwardRef<
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="size-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -66,7 +66,7 @@ const SheetContent = React.forwardRef<
     >
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
+        <X className="size-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>

--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -83,7 +83,7 @@ export function StatCard({ label, value, icon, tone = "default", loading, onClic
 
       <div className="p-4 flex items-center gap-4">
         {/* Icon with Circle Background */}
-        <div className={cn("h-12 w-12 rounded-full flex items-center justify-center shrink-0 transition-colors", styles.iconBg, styles.iconText)}>
+        <div className={cn("size-12 rounded-full flex items-center justify-center shrink-0 transition-colors", styles.iconBg, styles.iconText)}>
           {icon}
         </div>
 

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -83,7 +83,7 @@ const ToastClose = React.forwardRef<
     toast-close=""
     {...props}
   >
-    <X className="h-4 w-4" />
+    <X className="size-4" />
   </ToastPrimitives.Close>
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName

--- a/src/components/usage-analytics-dashboard.tsx
+++ b/src/components/usage-analytics-dashboard.tsx
@@ -107,7 +107,7 @@ export function UsageAnalyticsDashboard({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tổng phiên sử dụng</CardTitle>
-            <Activity className="h-4 w-4 text-muted-foreground" />
+            <Activity className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             {overviewLoading ? (
@@ -124,7 +124,7 @@ export function UsageAnalyticsDashboard({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tổng thời gian sử dụng</CardTitle>
-            <Clock className="h-4 w-4 text-muted-foreground" />
+            <Clock className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             {overviewLoading ? (
@@ -143,7 +143,7 @@ export function UsageAnalyticsDashboard({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Thiết bị được dùng nhiều nhất</CardTitle>
-            <TrendingUp className="h-4 w-4 text-muted-foreground" />
+            <TrendingUp className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             {overviewLoading ? (
@@ -166,7 +166,7 @@ export function UsageAnalyticsDashboard({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Người dùng tích cực nhất</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
+            <Users className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             {overviewLoading ? (
@@ -213,7 +213,7 @@ export function UsageAnalyticsDashboard({
                 )}
                 className="gap-2"
               >
-                <Download className="h-4 w-4" />
+                <Download className="size-4" />
                 Xuất CSV
               </Button>
             </CardHeader>
@@ -226,7 +226,7 @@ export function UsageAnalyticsDashboard({
                 </div>
               ) : !equipmentStats || equipmentStats.length === 0 ? (
                 <div className="text-center py-8 text-muted-foreground">
-                  <BarChart3 className="h-12 w-12 mx-auto mb-2 opacity-50" />
+                  <BarChart3 className="size-12 mx-auto mb-2 opacity-50" />
                   <p>Chưa có dữ liệu thống kê thiết bị</p>
                 </div>
               ) : isMobile ? (
@@ -242,7 +242,7 @@ export function UsageAnalyticsDashboard({
                             </div>
                             {equipment.currentlyInUse && (
                               <Badge variant="default" className="gap-1">
-                                <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
+                                <div className="size-2 bg-white rounded-full animate-pulse" />
                                 Đang dùng
                               </Badge>
                             )}
@@ -298,7 +298,7 @@ export function UsageAnalyticsDashboard({
                           <TableCell>
                             {equipment.currentlyInUse ? (
                               <Badge variant="default" className="gap-1">
-                                <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
+                                <div className="size-2 bg-white rounded-full animate-pulse" />
                                 Đang dùng
                               </Badge>
                             ) : (
@@ -334,7 +334,7 @@ export function UsageAnalyticsDashboard({
                 )}
                 className="gap-2"
               >
-                <Download className="h-4 w-4" />
+                <Download className="size-4" />
                 Xuất CSV
               </Button>
             </CardHeader>
@@ -347,7 +347,7 @@ export function UsageAnalyticsDashboard({
                 </div>
               ) : !userStats || userStats.length === 0 ? (
                 <div className="text-center py-8 text-muted-foreground">
-                  <Users className="h-12 w-12 mx-auto mb-2 opacity-50" />
+                  <Users className="size-12 mx-auto mb-2 opacity-50" />
                   <p>Chưa có dữ liệu thống kê người dùng</p>
                 </div>
               ) : isMobile ? (

--- a/src/components/usage-history-tab.tsx
+++ b/src/components/usage-history-tab.tsx
@@ -189,7 +189,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
             size="sm"
             className="gap-2"
           >
-            <Square className="h-4 w-4" />
+            <Square className="size-4" />
             Kết thúc sử dụng
           </Button>
         )}
@@ -233,7 +233,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                     <div className="flex items-start justify-between">
                       <div className="space-y-1">
                         <div className="flex items-center gap-2">
-                          <User className="h-4 w-4 text-muted-foreground" />
+                          <User className="size-4 text-muted-foreground" />
                           <span className="font-medium text-sm">
                             {log.nguoi_su_dung?.full_name || 'Không xác định'}
                           </span>
@@ -249,10 +249,10 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="h-8 w-8 p-0"
+                              className="size-8 p-0"
                               aria-label={`Xóa nhật ký sử dụng ${log.id}`}
                             >
-                              <Trash2 className="h-4 w-4" />
+                              <Trash2 className="size-4" />
                             </Button>
                           </AlertDialogTrigger>
                           <AlertDialogContent>
@@ -279,7 +279,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                   
                   <CardContent className="pt-0 space-y-2 text-sm">
                     <div className="flex items-center gap-2">
-                      <Clock className="h-4 w-4 text-muted-foreground" />
+                      <Clock className="size-4 text-muted-foreground" />
                       <span>
                         {formatVietnamDateTime(log.thoi_gian_bat_dau)}
                         {log.thoi_gian_ket_thuc && (
@@ -307,7 +307,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                     
                     {log.ghi_chu && (
                       <div className="flex gap-2">
-                        <FileText className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+                        <FileText className="size-4 text-muted-foreground mt-0.5 flex-shrink-0" />
                         <span className="text-muted-foreground">{log.ghi_chu}</span>
                       </div>
                     )}
@@ -369,10 +369,10 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                className="h-8 w-8 p-0"
+                                className="size-8 p-0"
                                 aria-label={`Xóa nhật ký sử dụng ${log.id}`}
                               >
-                                <Trash2 className="h-4 w-4" />
+                                <Trash2 className="size-4" />
                               </Button>
                             </AlertDialogTrigger>
                             <AlertDialogContent>
@@ -414,7 +414,7 @@ export function UsageHistoryTab({ equipment }: UsageHistoryTabProps) {
                 >
                   {isFetchingMore ? (
                     <>
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current" />
+                      <div className="animate-spin rounded-full size-4 border-b-2 border-current" />
                       Đang tải…
                     </>
                   ) : (

--- a/src/components/usage-history-tab.utils.tsx
+++ b/src/components/usage-history-tab.utils.tsx
@@ -51,7 +51,7 @@ export function UsageHistoryLoadingState(): ReactElement {
 export function UsageHistoryEmptyState(): ReactElement {
   return (
     <div className="text-center py-8 text-muted-foreground">
-      <Clock className="h-12 w-12 mx-auto mb-2 opacity-50" />
+      <Clock className="size-12 mx-auto mb-2 opacity-50" />
       <p>Chưa có lịch sử sử dụng</p>
     </div>
   )

--- a/src/components/usage-log-print.tsx
+++ b/src/components/usage-log-print.tsx
@@ -127,7 +127,7 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="gap-2">
-          <Printer className="h-4 w-4" />
+          <Printer className="size-4" />
           In báo cáo
         </Button>
       </DialogTrigger>
@@ -189,11 +189,11 @@ export function UsageLogPrint({ equipment }: UsageLogPrintProps) {
             Hủy
           </Button>
           <Button variant="outline" onClick={handleExport} className="gap-2">
-            <Download className="h-4 w-4" />
+            <Download className="size-4" />
             Xuất CSV
           </Button>
           <Button onClick={handlePrint} className="gap-2">
-            <Printer className="h-4 w-4" />
+            <Printer className="size-4" />
             In báo cáo
           </Button>
         </DialogFooter>

--- a/src/components/user-card.tsx
+++ b/src/components/user-card.tsx
@@ -60,17 +60,17 @@ export function UserCard({ user, onEdit, onDelete }: UserCardProps) {
               <Button
                 variant="ghost"
                 size="sm"
-                className="ml-auto h-8 w-8 p-0"
+                className="ml-auto size-8 p-0"
                 onClick={(e) => e.stopPropagation()}
               >
-                <MoreHorizontal className="h-4 w-4" />
+                <MoreHorizontal className="size-4" />
                 <span className="sr-only">Mở menu</span>
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuLabel>Hành động</DropdownMenuLabel>
               <DropdownMenuItem onSelect={() => onEdit(user)}>
-                <Edit className="mr-2 h-4 w-4" />
+                <Edit className="mr-2 size-4" />
                 Chỉnh sửa
               </DropdownMenuItem>
               {!isCurrentUserTheUserInCard && ( // Không cho xóa chính mình
@@ -80,7 +80,7 @@ export function UserCard({ user, onEdit, onDelete }: UserCardProps) {
                     onSelect={() => onDelete(user)}
                     className="text-destructive focus:text-destructive"
                   >
-                    <Trash2 className="mr-2 h-4 w-4" />
+                    <Trash2 className="mr-2 size-4" />
                     Xoá
                   </DropdownMenuItem>
                 </>


### PR DESCRIPTION
## Summary
- Part of #456 Phase 1: collapse identical Tailwind width/height pairs to `size-*`.
- Handles integer, decimal, arbitrary bracket, and matching responsive-variant pairs in TSX class literals.
- Keeps Issue #456 open for Phase 2 `space-*` and Phase 3 remaining cosmetic rules.

## TDD / Verification
- RED inventory before codemod: 613 same-axis candidates across 162 TSX files.
- Expanded REDs caught missed arbitrary and decimal sizes; final inventory: 0 remaining candidates.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `git diff --check`
- `node scripts/npm-run.js run build`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
  - Score: 81/100
  - `react-doctor/design-no-redundant-size-axes`: absent in final diff report

## Notes
- Code Review Graph reports high risk due to 166 changed files, but the diff is cosmetic class-token replacement plus minimal `unknown` typing needed for the repo's explicit-any gate.
- No React Doctor full scan rerun; this PR uses the saved full report and diff scan only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse identical Tailwind `h-*`/`w-*` pairs to `size-*` across the app to standardize sizing and reduce class noise. Implements Phase 1 of #456 with no functional or visual changes expected.

- **Refactors**
  - Replaced `h-*` + `w-*` with `size-*` in TSX class literals, including decimals, arbitrary `[value]`, and responsive variants (icons, skeletons, avatars, button icons, etc.).
  - Small type cleanups to satisfy strict checks (e.g., `session?.user?.role`, typed helpers, added `getUnknownErrorMessage` import).
  - Part of #456 Phase 1; Phase 2 will target `space-*`, and Phase 3 will cover remaining cosmetic rules.

<sup>Written for commit 8a07f97561f8eb9b1af76f7751974df9551680d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

