### PR TITLE
Fix React Doctor flex spacing utilities

### DIFF
--- a/src/app/(app)/activity-logs/page.tsx
+++ b/src/app/(app)/activity-logs/page.tsx
@@ -60,7 +60,7 @@ function ActivityLogsPageContent({ user }: ActivityLogsPageContentProps) {
     <div className="container mx-auto px-4 py-8 max-w-7xl">
       {/* Page Header */}
       <div className="mb-8">
-        <div className="flex items-center space-x-3 mb-2">
+        <div className="flex items-center gap-x-3 mb-2">
           <div className="p-2 bg-blue-100 rounded-lg">
             <Activity className="size-6 text-blue-600" />
           </div>
@@ -75,8 +75,8 @@ function ActivityLogsPageContent({ user }: ActivityLogsPageContentProps) {
         </div>
         
         {/* Security Badge */}
-        <div className="flex items-center space-x-2 mt-4">
-          <div className="flex items-center space-x-1 bg-green-50 text-green-700 px-3 py-1 rounded-full text-sm">
+        <div className="flex items-center gap-x-2 mt-4">
+          <div className="flex items-center gap-x-1 bg-green-50 text-green-700 px-3 py-1 rounded-full text-sm">
             <Shield className="size-4" />
             <span>Chỉ dành cho quản trị viên hệ thống</span>
           </div>

--- a/src/app/(app)/maintenance/_components/maintenance-mobile-plan-cards.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-mobile-plan-cards.tsx
@@ -69,7 +69,7 @@ export function MaintenanceMobilePlanCards({
       <div className="space-y-3">
         {Array.from({ length: 4 }).map((_, index) => (
           <Card key={index} className="border-muted shadow-none">
-            <CardHeader className="space-y-2">
+            <CardHeader className="gap-y-2">
               <Skeleton className="h-6 w-2/3" />
               <Skeleton className="h-4 w-1/3" />
             </CardHeader>

--- a/src/app/(app)/maintenance/_components/maintenance-mobile-tasks-panel.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-mobile-tasks-panel.tsx
@@ -110,7 +110,7 @@ export function MaintenanceMobileTasksPanel({
   return (
     <div className="space-y-4">
       <Card className="rounded-2xl border border-border/80 bg-background">
-        <CardHeader className="space-y-2">
+        <CardHeader className="gap-y-2">
           <div className="flex items-start justify-between gap-3">
             <div>
               <h2 className="text-lg font-semibold leading-tight">{selectedPlan.ten_ke_hoach}</h2>

--- a/src/app/(app)/reports/components/maintenance-report-repair-charts.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-repair-charts.tsx
@@ -23,7 +23,7 @@ export function MaintenanceReportRepairCharts({
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <Card>
-        <CardHeader className="space-y-1">
+        <CardHeader className="gap-y-1">
           <CardTitle>Xu hướng sửa chữa theo thời gian</CardTitle>
           <CardDescription>Số lượng yêu cầu sửa chữa và hoàn thành theo tháng.</CardDescription>
         </CardHeader>

--- a/src/app/(app)/reports/components/maintenance-report-summary-cards.tsx
+++ b/src/app/(app)/reports/components/maintenance-report-summary-cards.tsx
@@ -21,7 +21,7 @@ export function MaintenanceReportSummaryCards({
     <>
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Yêu cầu sửa chữa</CardTitle>
             <Wrench className="size-4 text-muted-foreground" />
           </CardHeader>
@@ -31,7 +31,7 @@ export function MaintenanceReportSummaryCards({
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tỷ lệ hoàn thành (Sửa chữa)</CardTitle>
             <CheckCircle className="size-4 text-green-500" />
           </CardHeader>
@@ -41,7 +41,7 @@ export function MaintenanceReportSummaryCards({
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Công việc bảo trì (Kế hoạch)</CardTitle>
             <Clock className="size-4 text-muted-foreground" />
           </CardHeader>
@@ -51,7 +51,7 @@ export function MaintenanceReportSummaryCards({
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tỷ lệ hoàn thành (Bảo trì)</CardTitle>
             <CheckCircle className="size-4 text-blue-500" />
           </CardHeader>
@@ -64,7 +64,7 @@ export function MaintenanceReportSummaryCards({
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tổng chi phí sửa chữa</CardTitle>
             <Wrench className="size-4 text-muted-foreground" />
           </CardHeader>
@@ -78,7 +78,7 @@ export function MaintenanceReportSummaryCards({
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Chi phí TB ca hoàn thành</CardTitle>
             <CheckCircle className="size-4 text-green-500" />
           </CardHeader>
@@ -92,7 +92,7 @@ export function MaintenanceReportSummaryCards({
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Có ghi nhận chi phí</CardTitle>
             <CheckCircle className="size-4 text-emerald-500" />
           </CardHeader>
@@ -106,7 +106,7 @@ export function MaintenanceReportSummaryCards({
           </CardContent>
         </Card>
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Thiếu chi phí</CardTitle>
             <Clock className="size-4 text-amber-500" />
           </CardHeader>

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -35,7 +35,7 @@ function TabSkeleton() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
           <Card key={i}>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
               <Skeleton className="h-4 w-24" />
               <Skeleton className="size-4" />
             </CardHeader>

--- a/src/app/_components/LoginIllustrationPanel.tsx
+++ b/src/app/_components/LoginIllustrationPanel.tsx
@@ -19,7 +19,7 @@ export function LoginIllustrationPanel() {
             </div>
 
             {/* Central Illustration */}
-            <div className="flex-1 flex flex-col items-center justify-center text-center space-y-12">
+      <div className="flex-1 flex flex-col items-center justify-center text-center gap-y-12">
                 <div className="w-full max-w-lg aspect-square relative group">
                     <Image
                         src="/login-illustration.png"

--- a/src/components/activity-logs/activity-log-entry.tsx
+++ b/src/components/activity-logs/activity-log-entry.tsx
@@ -36,7 +36,7 @@ export function ActivityLogEntry({ log }: ActivityLogEntryProps) {
   const actionDetails = formatActionDetails(log.action_type, log.action_details)
 
   return (
-    <div className="flex items-start space-x-4 p-4 border rounded-lg hover:bg-gray-50 transition-colors">
+    <div className="flex items-start gap-x-4 p-4 border rounded-lg hover:bg-gray-50 transition-colors">
       <Avatar className="size-10">
         <AvatarFallback>{getInitials(log)}</AvatarFallback>
       </Avatar>
@@ -44,7 +44,7 @@ export function ActivityLogEntry({ log }: ActivityLogEntryProps) {
       <div className="flex-1 min-w-0">
         <div className="flex items-start justify-between">
           <div className="flex-1">
-            <div className="flex items-center space-x-2 mb-1">
+            <div className="flex items-center gap-x-2 mb-1">
               <p className="font-medium text-gray-900 truncate">
                 {log.admin_full_name || log.admin_username}
               </p>
@@ -73,13 +73,13 @@ export function ActivityLogEntry({ log }: ActivityLogEntryProps) {
               <p className="text-sm text-gray-600 mb-2">{actionDetails}</p>
             )}
 
-            <div className="flex items-center space-x-4 text-xs text-gray-500">
-              <div className="flex items-center space-x-1">
+            <div className="flex items-center gap-x-4 text-xs text-gray-500">
+              <div className="flex items-center gap-x-1">
                 <Clock className="size-3" />
                 <span>{formatVietnamDateTime(log.created_at)}</span>
               </div>
               {log.ip_address && (
-                <div className="flex items-center space-x-1">
+                <div className="flex items-center gap-x-1">
                   <MapPin className="size-3" />
                   <span>{log.ip_address}</span>
                 </div>

--- a/src/components/activity-logs/activity-logs-viewer.tsx
+++ b/src/components/activity-logs/activity-logs-viewer.tsx
@@ -140,7 +140,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card>
           <CardContent className="pt-6">
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center gap-x-2">
               <Activity className="size-4 text-blue-600" />
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Hoạt động 24h</p>
@@ -154,7 +154,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         
         <Card>
           <CardContent className="pt-6">
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center gap-x-2">
               <User className="size-4 text-green-600" />
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Người dùng hoạt động</p>
@@ -168,7 +168,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         
         <Card>
           <CardContent className="pt-6">
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center gap-x-2">
               <TrendingUp className="size-4 text-orange-600" />
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Hoạt động phổ biến</p>
@@ -182,7 +182,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
         
         <Card>
           <CardContent className="pt-6">
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center gap-x-2">
               <Clock className="size-4 text-purple-600" />
               <div className="space-y-1">
                 <p className="text-sm font-medium text-gray-600">Hoạt động gần nhất</p>
@@ -201,12 +201,12 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
       {/* Filters and Search */}
       <Card>
         <CardHeader className="pb-3">
-          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between space-y-3 lg:space-y-0">
-            <CardTitle className="flex items-center space-x-2">
+          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-y-3 lg:gap-y-0">
+            <CardTitle className="flex items-center gap-x-2">
               <Filter className="size-5" />
               <span>Bộ lọc và tìm kiếm</span>
             </CardTitle>
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center gap-x-2">
               <Button
                 variant="outline"
                 size="sm"
@@ -306,7 +306,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center justify-between">
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center gap-x-2">
               <Eye className="size-5" />
               <span>Nhật ký hoạt động</span>
               <Badge variant="secondary">
@@ -324,7 +324,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
           ) : isLoading ? (
             <div className="space-y-4">
               {Array.from({ length: 5 }).map((_, i) => (
-                <div key={i} className="flex items-start space-x-4 p-4 border rounded-lg animate-pulse">
+                <div key={i} className="flex items-start gap-x-4 p-4 border rounded-lg animate-pulse">
                   <div className="size-10 bg-gray-200 rounded-full" />
                   <div className="flex-1 space-y-2">
                     <div className="h-4 bg-gray-200 rounded w-1/4" />
@@ -355,7 +355,7 @@ export function ActivityLogsViewer({ className }: ActivityLogsViewerProps) {
               <p className="text-sm text-gray-600">
                 Hiển thị {(filters.offset || 0) + 1} - {Math.min((filters.offset || 0) + filteredLogs.length, filteredLogs[0]?.total_count || 0)} trong tổng số {filteredLogs[0]?.total_count || 0} mục
               </p>
-              <div className="flex space-x-2">
+              <div className="flex gap-x-2">
                 <Button
                   variant="outline"
                   size="sm"

--- a/src/components/bulk-schedule-dialog.tsx
+++ b/src/components/bulk-schedule-dialog.tsx
@@ -50,7 +50,7 @@ export function BulkScheduleDialog({ open, onOpenChange, onApply }: BulkSchedule
         </DialogHeader>
         <div className="py-4 grid grid-cols-4 gap-4">
           {Array.from({ length: 12 }, (_, i) => i + 1).map(month => (
-            <div key={month} className="flex items-center space-x-2">
+            <div key={month} className="flex items-center gap-x-2">
               <Checkbox
                 id={`month-${month}`}
                 checked={!!selectedMonths[`thang_${month}`]}

--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -25,7 +25,7 @@ const maintenanceCardClass = `${cardBaseClass}`
 const repairCardClass = `${cardBaseClass}`
 const planCardClass = `${cardBaseClass}`
 const headerClass =
-  "flex flex-row items-center justify-between space-y-0 p-4 pb-2 md:p-6 md:pb-2 gap-3 md:gap-2"
+  "flex flex-row items-center justify-between p-4 pb-2 md:p-6 md:pb-2 gap-3 md:gap-2"
 const titleClass = "text-sm font-semibold truncate md:text-sm md:font-medium text-slate-600"
 // Icon colors matching card gradients - more vibrant
 const equipmentIconClass = "size-5 text-blue-600 md:size-4 flex-shrink-0"

--- a/src/components/equipment-distribution-summary.tsx
+++ b/src/components/equipment-distribution-summary.tsx
@@ -91,7 +91,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         {EQUIPMENT_DISTRIBUTION_SKELETON_KEYS.map((token) => (
           <Card key={token}>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
               <Skeleton className="h-4 w-24" />
               <Skeleton className="size-4" />
             </CardHeader>
@@ -163,7 +163,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         {/* Equipment Health Score */}
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tình trạng tổng thể</CardTitle>
             <Activity className="size-4 text-muted-foreground" />
           </CardHeader>
@@ -183,7 +183,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
 
         {/* Total Equipment */}
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tổng thiết bị</CardTitle>
             <CheckCircle className="size-4 text-green-600" />
           </CardHeader>
@@ -199,7 +199,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
 
         {/* Departments */}
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Khoa/Phòng</CardTitle>
             <Badge variant="outline">{overallStats.departmentCount}</Badge>
           </CardHeader>
@@ -217,7 +217,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
 
         {/* Locations */}
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Vị trí</CardTitle>
             <Badge variant="outline">{overallStats.locationCount}</Badge>
           </CardHeader>

--- a/src/components/qr-action-sheet.tsx
+++ b/src/components/qr-action-sheet.tsx
@@ -95,7 +95,7 @@ export function QRActionSheet({ qrCode, onClose, onAction }: QRActionSheetProps)
   return (
     <Sheet open={true} onOpenChange={onClose}>
       <SheetContent side="bottom" className="h-[90vh] overflow-y-auto">
-        <SheetHeader className="space-y-4">
+        <SheetHeader className="gap-y-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Search className="size-5" />

--- a/src/components/repair-result-form.tsx
+++ b/src/components/repair-result-form.tsx
@@ -222,7 +222,7 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
                 "Vỏ thiết bị",
                 "Khác"
               ].map((part) => (
-                <div key={part} className="flex items-center space-x-2">
+                <div key={part} className="flex items-center gap-x-2">
                   <Checkbox
                     id={part}
                     checked={formData.partsReplaced.includes(part)}
@@ -275,7 +275,7 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
             </div>
           </div>
 
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center gap-x-2">
             <Checkbox
               id="warrantyCoverage"
               checked={formData.warrantyCoverage}

--- a/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
+++ b/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
@@ -87,7 +87,7 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
       >
         {resolvedLabels.pageIndicator} {currentPage} {resolvedLabels.pageSeparator} {totalPages}
       </div>
-      <div className="flex items-center space-x-2">
+      <div className="flex items-center gap-x-2">
         <Button
           type="button"
           variant="outline"

--- a/src/components/shared/DataTablePagination/DataTablePaginationSizeSelector.tsx
+++ b/src/components/shared/DataTablePagination/DataTablePaginationSizeSelector.tsx
@@ -29,7 +29,7 @@ export const DataTablePaginationSizeSelector = React.memo(function DataTablePagi
   const showAtClass = showAt ? `hidden ${showAt}:flex` : ""
 
   return (
-    <div className={cn("flex items-center space-x-2", showAtClass, className)}>
+    <div className={cn("flex items-center gap-x-2", showAtClass, className)}>
       <p className="text-sm font-medium">Số dòng</p>
       <Select
         value={`${pageSize}`}

--- a/src/components/shared/ListFilterSearchCard.tsx
+++ b/src/components/shared/ListFilterSearchCard.tsx
@@ -74,7 +74,7 @@ export function ListFilterSearchCard({
     ? null
     : surface === "card"
       ? (
-        <CardHeader className="space-y-1 pb-3">
+        <CardHeader className="gap-y-1 pb-3">
           {title ? (
             <CardTitle className="heading-responsive-h2">{title}</CardTitle>
           ) : null}

--- a/src/components/tenants-management.tsx
+++ b/src/components/tenants-management.tsx
@@ -184,7 +184,7 @@ export function TenantsManagement() {
   return (
     <div className="space-y-5">
       <Card>
-        <CardHeader className="space-y-2">
+        <CardHeader className="gap-y-2">
           <CardTitle className="heading-responsive-h2">Cấu hình đơn vị</CardTitle>
           <CardDescription>Quản lý đơn vị với phân cấp tài khoản.</CardDescription>
         </CardHeader>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -51,7 +51,7 @@ const AlertDialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
+      "flex flex-col gap-y-2 text-center sm:text-left",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-x-2",
       className
     )}
     {...props}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -20,11 +20,11 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        months: "flex flex-col sm:flex-row gap-y-4 sm:gap-x-4 sm:gap-y-0",
         month: "space-y-4",
         caption: "flex justify-center pt-1 relative items-center",
         caption_label: "text-sm font-medium",
-        nav: "space-x-1 flex items-center",
+        nav: "flex items-center gap-x-1",
         nav_button: cn(
           buttonVariants({ variant: "outline" }),
           "size-7 bg-transparent p-0 opacity-50 hover:opacity-100"

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col gap-y-1.5 p-6", className)}
     {...props}
   />
 ))

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -71,7 +71,7 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
+      "flex flex-col gap-y-1.5 text-center sm:text-left",
       className
     )}
     {...props}
@@ -85,7 +85,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-x-2",
       className
     )}
     {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -80,7 +80,7 @@ const SheetHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
+      "flex flex-col gap-y-2 text-center sm:text-left",
       className
     )}
     {...props}
@@ -94,7 +94,7 @@ const SheetFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-x-2",
       className
     )}
     {...props}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -25,7 +25,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative flex w-full items-center justify-between gap-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {

--- a/src/components/usage-analytics-dashboard.tsx
+++ b/src/components/usage-analytics-dashboard.tsx
@@ -105,7 +105,7 @@ export function UsageAnalyticsDashboard({
       {/* Overview Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tổng phiên sử dụng</CardTitle>
             <Activity className="size-4 text-muted-foreground" />
           </CardHeader>
@@ -122,7 +122,7 @@ export function UsageAnalyticsDashboard({
         </Card>
 
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Tổng thời gian sử dụng</CardTitle>
             <Clock className="size-4 text-muted-foreground" />
           </CardHeader>
@@ -141,7 +141,7 @@ export function UsageAnalyticsDashboard({
         </Card>
 
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Thiết bị được dùng nhiều nhất</CardTitle>
             <TrendingUp className="size-4 text-muted-foreground" />
           </CardHeader>
@@ -164,7 +164,7 @@ export function UsageAnalyticsDashboard({
         </Card>
 
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Người dùng tích cực nhất</CardTitle>
             <Users className="size-4 text-muted-foreground" />
           </CardHeader>


### PR DESCRIPTION
## Summary
- Replace flex/grid parent `space-x-*` / `space-y-*` utilities with `gap-x-*` / `gap-y-*` equivalents.
- Include object/string class maps in shared UI primitives, calendar, toast, KPI cards, reports, activity logs, repair form, and pagination.
- Keep this cosmetic-only; other React Doctor findings stay out of scope.

Fixes #467

## Verification
- RED inventory first failed with 49 candidates.
- Expanded source inventory after implementation: `expanded_parent_space_candidates=0`.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js test -- --run src/app/'\(app\)'/activity-logs/__tests__/ActivityLogsPage.auth.test.tsx src/components/__tests__/equipment-distribution-summary.donut.test.tsx src/components/__tests__/equipment-distribution-summary.utils.test.ts src/components/ui/__tests__/alert-dialog-z-index.test.tsx src/app/_components/__tests__/LoginForm.test.tsx src/app/'\(app\)'/dashboard/__tests__/dashboard-no-legacy-dialog.test.tsx`
- `git diff --check`
- `node scripts/npm-run.js run build`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` → 96/100, no `react-doctor/design-no-space-on-flex-children` finding.

## Notes
- Full React Doctor scan intentionally not rerun per #467 scope.
- Existing `inventory-report-tab.test.tsx` duplicate-text failure reproduces on clean `main`; filed follow-up #469 and excluded it from the final focused test batch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Tailwind `space-*` with `gap-*` on flex/grid parents across UI and app components to satisfy `react-doctor/design-no-space-on-flex-children`. Cosmetic-only; aligns with #467.

- **Refactors**
  - Replaced `space-x-*`/`space-y-*` with `gap-x-*`/`gap-y-*` across primitives and pages: calendar, toast, card headers, dialog/sheet/alert-dialog, pagination, KPI/usage dashboards, activity logs, equipment distribution, maintenance mobile views, repair form, reports, login, QR action sheet, and bulk schedule dialog.
  - Removed remaining `space-*` usage on flex/grid parents; the `react-doctor/design-no-space-on-flex-children` check no longer flags these areas.

<sup>Written for commit 1234508250b85a267c81080eabd295ef707ed8db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified layout spacing across the UI by switching spacing utilities to gap-based variants for more consistent spacing and alignment; purely cosmetic — no functional, behavioral, or API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/470)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->