### PR TITLE
Fix React Doctor P3 remaining cosmetic rules

### DIFF
--- a/src/app/(app)/activity-logs/page.tsx
+++ b/src/app/(app)/activity-logs/page.tsx
@@ -65,7 +65,7 @@ function ActivityLogsPageContent({ user }: ActivityLogsPageContentProps) {
             <Activity className="size-6 text-blue-600" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold text-gray-900">
+            <h1 className="text-3xl font-semibold text-gray-900">
               Nhật ký hoạt động
             </h1>
             <p className="text-gray-600 mt-1">

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -32,7 +32,7 @@ const QRScannerCamera = dynamic(
   () => import("@/components/qr-scanner-camera").then(mod => ({ default: mod.QRScannerCamera })),
   {
     ssr: false,
-    loading: () => <div className="fixed inset-0 z-50 bg-black flex items-center justify-center text-white">Đang tải camera...</div>
+    loading: () => <div className="fixed inset-0 z-50 bg-gray-950 flex items-center justify-center text-white">Đang tải camera…</div>
   }
 )
 
@@ -183,7 +183,7 @@ export default function Dashboard() {
             <div className="space-y-2">
               <div className="flex items-center gap-2">
                 <Sparkles className="size-5 text-primary" />
-                <h1 className="text-xl md:text-2xl font-bold text-slate-800">
+                <h1 className="text-xl md:text-2xl font-semibold text-slate-800">
                   {getGreeting()}, {user?.full_name || user?.username}!
                 </h1>
               </div>
@@ -209,7 +209,7 @@ export default function Dashboard() {
       {/* Quick Actions Section - Native App Style */}
       <div data-tour="quick-actions" className="md:mt-6 md:space-y-5">
         <div className="mb-4 px-1">
-          <h2 className="text-lg font-bold text-slate-900 mb-1">Thao tác nhanh</h2>
+          <h2 className="text-lg font-semibold text-slate-900 mb-1">Thao tác nhanh</h2>
         </div>
         <div className={cn(
           "grid gap-4 md:gap-6",

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -215,7 +215,7 @@ const CategoryGroup = React.memo(function CategoryGroup({
             <div
                 className={cn(
                     "group cursor-pointer select-none px-4 py-3",
-                    "bg-muted/50 border-l-4 border-l-primary/60",
+                    "bg-muted/50 ring-1 ring-inset ring-primary/20",
                     "hover:bg-muted/80 transition-colors",
                     CATEGORY_GRID_COLS
                 )}

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog.tsx
@@ -272,7 +272,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {status === "parsing" && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="size-4 animate-spin" />
-              Đang đọc file...
+              Đang đọc file…
             </div>
           )}
 
@@ -298,7 +298,7 @@ export function DeviceQuotaCategoryImportDialog() {
                     ))}
                     {validationErrors.length > 20 && (
                       <li className="text-muted-foreground">
-                        ... và {validationErrors.length - 20} lỗi khác
+                        … và {validationErrors.length - 20} lỗi khác
                       </li>
                     )}
                   </ul>
@@ -320,7 +320,7 @@ export function DeviceQuotaCategoryImportDialog() {
                     ))}
                     {validationWarnings.length > 10 && (
                       <li className="text-yellow-600">
-                        ... và {validationWarnings.length - 10} cảnh báo khác
+                        … và {validationWarnings.length - 10} cảnh báo khác
                       </li>
                     )}
                   </ul>
@@ -389,7 +389,7 @@ export function DeviceQuotaCategoryImportDialog() {
           {isSubmitting && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="size-4 animate-spin" />
-              Đang nhập dữ liệu...
+              Đang nhập dữ liệu…
             </div>
           )}
         </div>
@@ -403,7 +403,7 @@ export function DeviceQuotaCategoryImportDialog() {
               {isSubmitting ? (
                 <>
                   <Loader2 className="mr-2 size-4 animate-spin" />
-                  Đang nhập...
+                  Đang nhập…
                 </>
               ) : (
                 <>

--- a/src/app/(app)/device-quota/categories/page.tsx
+++ b/src/app/(app)/device-quota/categories/page.tsx
@@ -69,7 +69,7 @@ function DeviceQuotaCategoriesPageContent({
       <div className="container mx-auto py-6 space-y-6">
         <div className="flex flex-col gap-4">
           <div>
-            <h1 className="text-2xl font-bold">Tiêu chuẩn, định mức sử dụng thiết bị y tế</h1>
+            <h1 className="text-2xl font-semibold">Tiêu chuẩn, định mức sử dụng thiết bị y tế</h1>
             <p className="text-sm text-muted-foreground">
               Quản lý tiêu chuẩn, định mức trang thiết bị y tế theo quy định
             </p>

--- a/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaComplianceReport.tsx
+++ b/src/app/(app)/device-quota/dashboard/_components/DeviceQuotaComplianceReport.tsx
@@ -150,7 +150,7 @@ export function DeviceQuotaComplianceReport({
           {isPrinting ? (
             <>
               <Loader2 className="mr-2 size-4 animate-spin" />
-              Đang in...
+              Đang in…
             </>
           ) : (
             <>
@@ -177,7 +177,7 @@ export function DeviceQuotaComplianceReport({
 
           {/* Report Title */}
           <div className="text-center mb-8 space-y-2">
-            <h1 className="text-xl font-bold uppercase">
+            <h1 className="text-xl font-semibold uppercase">
               BÁO CÁO TÌNH TRẠNG ĐỊNH MỨC THIẾT BỊ Y TẾ
             </h1>
             <p className="text-sm text-gray-600">(Theo Thông tư 08/2019/TT-BYT)</p>

--- a/src/app/(app)/device-quota/dashboard/page.tsx
+++ b/src/app/(app)/device-quota/dashboard/page.tsx
@@ -61,7 +61,7 @@ function DeviceQuotaDashboardPageContent() {
       {/* Page Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">Định mức thiết bị</h1>
+          <h1 className="text-2xl font-semibold">Định mức thiết bị</h1>
           <p className="text-muted-foreground">
             Tổng quan tình trạng định mức
           </p>

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingActions.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingActions.tsx
@@ -87,7 +87,7 @@ export function DeviceQuotaMappingActions() {
                 size="sm"
                 className="touch-target-sm group"
                 onClick={() => setShowSuggested(true)}
-                title="Sử dụng AI để gợi ý — tốn tài nguyên server, chỉ dùng khi cần"
+                title="Sử dụng AI để gợi ý - tốn tài nguyên server, chỉ dùng khi cần"
               >
                 <Sparkles className="size-4 text-amber-500 group-hover:animate-pulse" />
                 Gợi ý phân loại

--- a/src/app/(app)/device-quota/mapping/_components/SuggestedMappingPreviewDialog.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/SuggestedMappingPreviewDialog.tsx
@@ -303,7 +303,7 @@ export function SuggestedMappingPreviewDialog({
                             {saveStatus === "saving" ? (
                                 <>
                                     <Loader2 className="size-4 mr-1 animate-spin" />
-                                    Đang lưu...
+                                    Đang lưu…
                                 </>
                             ) : (
                                 <>
@@ -318,4 +318,3 @@ export function SuggestedMappingPreviewDialog({
         </Dialog>
     )
 }
-

--- a/src/app/(app)/device-quota/mapping/page.tsx
+++ b/src/app/(app)/device-quota/mapping/page.tsx
@@ -21,7 +21,7 @@ export default function DeviceQuotaMappingPage() {
             {/* Page header */}
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <h1 className="text-2xl font-bold">Phân loại thiết bị</h1>
+                <h1 className="text-2xl font-semibold">Phân loại thiết bị</h1>
                 <p className="text-muted-foreground">
                   Gán thiết bị vào các nhóm định mức
                 </p>

--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx
@@ -195,8 +195,7 @@ describe("EquipmentPageClient selection render boundary", () => {
 
     const button = screen.getByRole("button", { name: "Thêm thiết bị" })
     expect(button.className).toContain("bottom-[calc(env(safe-area-inset-bottom,0px)+5rem)]")
-    expect(button.className).toContain("h-14")
-    expect(button.className).toContain("w-14")
+    expect(button.className).toContain("size-14")
     expect(button.className).toContain("shadow-[0_18px_34px_rgba(15,23,42,0.24)]")
   })
 })

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailConfigTab.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailConfigTab.tsx
@@ -98,7 +98,7 @@ function ConfigEditForm(): React.ReactNode {
               <FormControl>
                 <Textarea
                   rows={8}
-                  placeholder="Nhập cấu hình thiết bị..."
+                  placeholder="Nhập cấu hình thiết bị…"
                   className="resize-y min-h-[120px]"
                   {...field}
                   value={field.value ?? ""}
@@ -119,7 +119,7 @@ function ConfigEditForm(): React.ReactNode {
               <FormControl>
                 <Textarea
                   rows={6}
-                  placeholder="Nhập phụ kiện kèm theo..."
+                  placeholder="Nhập phụ kiện kèm theo…"
                   className="resize-y min-h-[100px]"
                   {...field}
                   value={field.value ?? ""}

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailFilesTab.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailFilesTab.tsx
@@ -120,7 +120,7 @@ export function EquipmentDetailFilesTab({
               <Input
                 id="file-url"
                 type="url"
-                placeholder="https://..."
+                placeholder="https://…"
                 value={newFileUrl}
                 onChange={(e) => setNewFileUrl(e.target.value)}
                 required

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -274,7 +274,7 @@ function EquipmentPageContent({
             />
           </CardContent>
 
-          <CardFooter className="flex flex-col gap-4 py-4 px-4 md:px-6 sm:flex-row sm:items-center sm:justify-between">
+          <CardFooter className="flex flex-col gap-4 p-4 md:px-6 sm:flex-row sm:items-center sm:justify-between">
             <DataTablePagination
               table={table}
               totalCount={total}

--- a/src/app/(app)/forms/handover/page.tsx
+++ b/src/app/(app)/forms/handover/page.tsx
@@ -15,7 +15,7 @@ export default function HandoverFormPage() {
         {/* Handover Form Content */}
         <div className="content-body">
           <div className="text-center mb-6">
-            <h1 className="title-main font-bold uppercase">Biên Bản Bàn Giao Thiết Bị</h1>
+            <h1 className="title-main font-semibold uppercase">Biên Bản Bàn Giao Thiết Bị</h1>
             <p className="mt-2">Số: <span className="form-input-line" id="request-code"></span></p>
           </div>
           
@@ -46,9 +46,9 @@ export default function HandoverFormPage() {
                   <td><span className="form-input-line"></span></td>
                   <td><span className="form-input-line"></span></td>
                   <td><span className="form-input-line"></span></td>
-                  <td className="editable-cell" contentEditable data-placeholder="Nhập tài liệu/phụ kiện kèm theo..."></td>
-                  <td className="editable-cell" contentEditable data-placeholder="Nhập tình trạng thiết bị..."></td>
-                  <td className="editable-cell" contentEditable data-placeholder="Nhập ghi chú..."></td>
+                  <td className="editable-cell" contentEditable data-placeholder="Nhập tài liệu/phụ kiện kèm theo…"></td>
+                  <td className="editable-cell" contentEditable data-placeholder="Nhập tình trạng thiết bị…"></td>
+                  <td className="editable-cell" contentEditable data-placeholder="Nhập ghi chú…"></td>
                 </tr>
               </tbody>
             </table>

--- a/src/app/(app)/forms/maintenance/page.tsx
+++ b/src/app/(app)/forms/maintenance/page.tsx
@@ -21,7 +21,7 @@ export default function MaintenanceFormPage() {
                 {/* Logo will be handled by FormBrandingHeader */}
               </div>
               <div className="text-center w-1/2">
-                <h2 className="title-sub uppercase font-bold">TRUNG TÂM KIỂM SOÁT BỆNH TẬT THÀNH PHỐ CẦN THƠ</h2>
+                <h2 className="title-sub uppercase font-semibold">TRUNG TÂM KIỂM SOÁT BỆNH TẬT THÀNH PHỐ CẦN THƠ</h2>
                 <div className="flex items-baseline justify-center font-bold">
                   <label htmlFor="department-name">KHOA/PHÒNG:</label>
                   <input type="text" id="department-name" className="form-input-line flex-grow ml-2" />
@@ -30,7 +30,7 @@ export default function MaintenanceFormPage() {
               <div className="w-1/4"></div> {/* Spacer */}
             </div>
             <div className="text-center mt-4">
-              <h1 className="title-main uppercase font-bold flex justify-center items-baseline">
+              <h1 className="title-main uppercase font-semibold flex justify-center items-baseline">
                 KẾ HOẠCH BẢO TRÌ HIỆU CHUẨN/KIỂM ĐỊNH THIẾT BỊ NĂM
                 <input type="text" className="form-input-line w-24 ml-2" />
               </h1>

--- a/src/app/(app)/maintenance/_components/maintenance-dialogs.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-dialogs.tsx
@@ -131,7 +131,7 @@ export function MaintenanceDialogs() {
           <div className="py-4">
             <textarea
               className="w-full min-h-[100px] p-3 border border-input rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
-              placeholder="Nhập lý do không duyệt kế hoạch này..."
+              placeholder="Nhập lý do không duyệt kế hoạch này…"
               value={operations.confirmDialog.rejectionReason}
               onChange={(e) => operations.setRejectionReason(e.target.value)}
               disabled={operations.isRejecting}

--- a/src/app/(app)/maintenance/_components/maintenance-mobile-task-card.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-mobile-task-card.tsx
@@ -102,7 +102,7 @@ export const MaintenanceMobileTaskCard = React.memo(function MaintenanceMobileTa
         </button>
 
         {isExpanded && (
-          <div className="border-t border-border/70 px-4 py-4 space-y-4">
+          <div className="border-t border-border/70 p-4 space-y-4">
             <div className="flex flex-col gap-2 text-sm">
               <div className="flex items-start justify-between gap-3">
                 <span className="text-muted-foreground">Đơn vị thực hiện</span>

--- a/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
+++ b/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
@@ -99,7 +99,7 @@ export function MobileMaintenanceLayout({
               <Input
                 value={planSearchTerm}
                 onChange={(event) => setPlanSearchTerm(event.target.value)}
-                placeholder="Tìm kế hoạch, khoa/phòng, người lập..."
+                placeholder="Tìm kế hoạch, khoa/phòng, người lập…"
                 className="h-11 rounded-xl border-border/60 bg-white pl-10 pr-10 text-sm"
               />
               {planSearchTerm && (

--- a/src/app/(app)/qr-scanner/page.tsx
+++ b/src/app/(app)/qr-scanner/page.tsx
@@ -17,7 +17,7 @@ const QRScannerCamera = dynamic(
   () => import("@/components/qr-scanner-camera").then(mod => ({ default: mod.QRScannerCamera })),
   {
     ssr: false,
-    loading: () => <div className="flex items-center justify-center h-screen">Đang tải camera...</div>
+    loading: () => <div className="flex items-center justify-center h-screen">Đang tải camera…</div>
   }
 )
 
@@ -25,7 +25,7 @@ const QRActionSheet = dynamic(
   () => import("@/components/qr-action-sheet").then(mod => ({ default: mod.QRActionSheet })),
   {
     ssr: false,
-    loading: () => <div>Đang tải...</div>
+    loading: () => <div>Đang tải…</div>
   }
 )
 

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCompleteDialog.tsx
@@ -92,7 +92,7 @@ function CompleteDialogForm({
                 id="completion-result"
                 value={completionResult}
                 onChange={(e) => setCompletionResult(e.target.value)}
-                placeholder="Nhập kết quả và tình trạng thiết bị sau khi sửa chữa..."
+                placeholder="Nhập kết quả và tình trạng thiết bị sau khi sửa chữa…"
                 rows={4}
                 disabled={isPending}
               />
@@ -121,7 +121,7 @@ function CompleteDialogForm({
               id="non-completion-reason"
               value={nonCompletionReason}
               onChange={(e) => setNonCompletionReason(e.target.value)}
-              placeholder="Nhập lý do không thể hoàn thành sửa chữa..."
+              placeholder="Nhập lý do không thể hoàn thành sửa chữa…"
               rows={4}
               disabled={isPending}
             />

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx
@@ -95,7 +95,7 @@ export function RepairRequestsCreateSheetForm({
         <Label htmlFor="issue">Mô tả sự cố</Label>
         <Textarea
           id="issue"
-          placeholder="Mô tả chi tiết vấn đề gặp phải..."
+          placeholder="Mô tả chi tiết vấn đề gặp phải…"
           rows={4}
           value={issueDescription}
           onChange={(e) => onIssueDescriptionChange(e.target.value)}
@@ -106,7 +106,7 @@ export function RepairRequestsCreateSheetForm({
         <Label htmlFor="repair-items">Các hạng mục yêu cầu sửa chữa (nếu có)</Label>
         <Textarea
           id="repair-items"
-          placeholder="VD: Thay màn hình, sửa nguồn..."
+          placeholder="VD: Thay màn hình, sửa nguồn…"
           rows={3}
           value={repairItems}
           onChange={(e) => onRepairItemsChange(e.target.value)}
@@ -160,7 +160,7 @@ export function RepairRequestsCreateSheetForm({
           <Label htmlFor="external-company">Tên đơn vị được thuê</Label>
           <Input
             id="external-company"
-            placeholder="Nhập tên đơn vị được thuê sửa chữa..."
+            placeholder="Nhập tên đơn vị được thuê sửa chữa…"
             value={externalCompanyName}
             onChange={(e) => onExternalCompanyNameChange(e.target.value)}
             required

--- a/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
@@ -145,7 +145,7 @@ function RepairRequestsEditDialogContent({
             <Label htmlFor="edit-issue">Mô tả sự cố</Label>
             <Textarea
               id="edit-issue"
-              placeholder="Mô tả chi tiết vấn đề gặp phải..."
+              placeholder="Mô tả chi tiết vấn đề gặp phải…"
               rows={4}
               value={formState.issueDescription}
               onChange={(e) => dispatchForm({
@@ -159,7 +159,7 @@ function RepairRequestsEditDialogContent({
             <Label htmlFor="edit-repair-items">Các hạng mục yêu cầu sửa chữa</Label>
             <Textarea
               id="edit-repair-items"
-              placeholder="VD: Thay màn hình, sửa nguồn..."
+              placeholder="VD: Thay màn hình, sửa nguồn…"
               rows={3}
               value={formState.repairItems}
               onChange={(e) => dispatchForm({
@@ -230,7 +230,7 @@ function RepairRequestsEditDialogContent({
               <Label htmlFor="edit-external-company">Tên đơn vị được thuê</Label>
               <Input
                 id="edit-external-company"
-                placeholder="Nhập tên đơn vị được thuê sửa chữa..."
+                placeholder="Nhập tên đơn vị được thuê sửa chữa…"
                 value={formState.externalCompanyName}
                 onChange={(e) => dispatchForm({
                   type: "patch",

--- a/src/app/(app)/repair-requests/_components/RepairRequestsEquipmentSearchField.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsEquipmentSearchField.tsx
@@ -29,7 +29,7 @@ export function RepairRequestsEquipmentSearchField({
       <div className="relative">
         <Input
           id="search-equipment"
-          placeholder="Nhập tên hoặc mã để tìm kiếm..."
+          placeholder="Nhập tên hoặc mã để tìm kiếm…"
           value={searchQuery}
           onChange={onSearchChange}
           autoComplete="off"

--- a/src/app/(app)/repair-requests/_components/RepairRequestsFilterChips.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsFilterChips.tsx
@@ -48,7 +48,7 @@ export function RepairRequestsFilterChips({
           <Button
             variant="ghost"
             size="sm"
-            className="ml-1 size-5 p-0 rounded-full hover:bg-black/10 dark:hover:bg-white/10"
+            className="ml-1 size-5 p-0 rounded-full hover:bg-gray-950/10 dark:hover:bg-white/10"
             onClick={() => onRemove("status", s)}
             aria-label={`Xóa trạng thái ${s}`}
           >

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
@@ -55,7 +55,7 @@ export function RepairRequestsMobileList({
     return (
       <div className="flex justify-center items-center gap-2 py-6">
         <Loader2 className="size-4 animate-spin" />
-        <span className="text-sm">Đang tải...</span>
+        <span className="text-sm">Đang tải…</span>
       </div>
     )
   }

--- a/src/app/(app)/repair-requests/_components/RepairRequestsTable.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsTable.tsx
@@ -64,7 +64,7 @@ export function RepairRequestsTable({
               >
                 <div className="flex justify-center items-center gap-2 text-muted-foreground">
                   <Loader2 className="size-4 animate-spin" />
-                  <span>Đang tải dữ liệu...</span>
+                  <span>Đang tải dữ liệu…</span>
                 </div>
               </TableCell>
             </TableRow>

--- a/src/app/(app)/reports/components/export-report-dialog.tsx
+++ b/src/app/(app)/reports/components/export-report-dialog.tsx
@@ -170,7 +170,7 @@ function ExportReportDialogContent({
               ref={fileNameInputRef}
               defaultValue={defaultFileName}
               onChange={(e) => setHasFileName(e.target.value.trim().length > 0)}
-              placeholder="Nhập tên file..."
+              placeholder="Nhập tên file…"
             />
             <p className="text-xs text-muted-foreground">File sẽ được lưu với định dạng .xlsx</p>
           </div>

--- a/src/app/(app)/reports/components/inventory-table.tsx
+++ b/src/app/(app)/reports/components/inventory-table.tsx
@@ -250,7 +250,7 @@ export function InventoryTable({ data, isLoading }: InventoryTableProps) {
         {/* Table filters */}
         <div className="flex items-center gap-4 py-4">
           <Input
-            placeholder="Tìm kiếm thiết bị..."
+            placeholder="Tìm kiếm thiết bị…"
             value={globalFilter ?? ""}
             onChange={(event) => setGlobalFilter(String(event.target.value))}
             className="max-w-sm"

--- a/src/app/(app)/reports/components/unused-equipment-report-section.tsx
+++ b/src/app/(app)/reports/components/unused-equipment-report-section.tsx
@@ -108,7 +108,7 @@ export function UnusedEquipmentReportSection({
             </label>
             <Input
               id="unused-equipment-search"
-              placeholder="Tên, mã, model hoặc serial thiết bị..."
+              placeholder="Tên, mã, model hoặc serial thiết bị…"
               value={searchTerm}
               onChange={handleSearchChange}
             />

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -117,7 +117,7 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
   return (
     <div data-testid="reports-page-content" className="min-w-0 flex-1 space-y-4">
       <div className="flex flex-wrap items-center gap-4">
-        <h2 className="text-3xl font-bold tracking-tight">Báo cáo</h2>
+        <h2 className="text-3xl font-semibold tracking-tight">Báo cáo</h2>
 
         {/* Tenant selector for global/regional_leader users */}
         {showSelector && (

--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -264,7 +264,7 @@ export function TransfersPagePanel({
                       <div className="flex min-h-[200px] items-center justify-center rounded-lg border border-dashed">
                         <div className="flex flex-col items-center gap-2 text-sm text-muted-foreground">
                           <Loader2 className="size-6 animate-spin" />
-                          Đang tải dữ liệu...
+                          Đang tải dữ liệu…
                         </div>
                       </div>
                     ) : tableData.length > 0 ? (
@@ -302,7 +302,7 @@ export function TransfersPagePanel({
 
               {isListFetching && !isListLoading && (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 className="size-4 animate-spin" /> Đang đồng bộ dữ liệu...
+                  <Loader2 className="size-4 animate-spin" /> Đang đồng bộ dữ liệu…
                 </div>
               )}
             </div>

--- a/src/app/(app)/users/_components/UsersPageContent.tsx
+++ b/src/app/(app)/users/_components/UsersPageContent.tsx
@@ -141,7 +141,7 @@ export function UsersPageContent({ user }: UsersPageContentProps) {
                 </div>
                 <div className="flex items-center gap-2 md:ml-auto">
                   <Input
-                    placeholder="Tìm kiếm người dùng..."
+                    placeholder="Tìm kiếm người dùng…"
                     value={usersManagement.globalFilter}
                     onChange={(event) => usersManagement.setGlobalFilter(event.target.value)}
                     className="h-8 w-full md:w-64"

--- a/src/app/_components/LoginForm.tsx
+++ b/src/app/_components/LoginForm.tsx
@@ -132,7 +132,7 @@ export function LoginForm(): React.ReactElement {
           <span className="font-bold text-xl text-primary">CVMEMS</span>
         </div>
 
-        <div className="w-full max-w-md animate-in slide-in-from-right duration-700">
+        <div className="w-full max-w-md animate-in slide-in-from-right duration-500">
           {/* Login Card */}
           <div className="bg-white rounded-2xl shadow-lg shadow-black/5 p-8 md:p-10 space-y-8">
             {/* Logo + Brand */}

--- a/src/app/_components/LoginIllustrationPanel.tsx
+++ b/src/app/_components/LoginIllustrationPanel.tsx
@@ -42,7 +42,7 @@ export function LoginIllustrationPanel() {
 
                 {/* Hero Text */}
                 <div className="space-y-4 max-w-md">
-                    <h1 className="text-4xl font-bold leading-tight">
+                    <h1 className="text-4xl font-semibold leading-tight">
                         Quản Lý Thiết Bị Y Tế Thông Minh
                     </h1>
                     <p className="text-white/70 text-lg">

--- a/src/components/add-tasks-dialog.tsx
+++ b/src/components/add-tasks-dialog.tsx
@@ -284,7 +284,7 @@ export function AddTasksDialog({
         <div className="flex-grow flex flex-col overflow-hidden gap-4">
           <div className="flex items-center gap-2 flex-wrap">
             <SearchInput
-              placeholder="Tìm kiếm chung..."
+              placeholder="Tìm kiếm chung…"
               value={tableState.searchTerm}
               onChange={(value) => dispatchTable({ type: "set-search-term", value })}
               showSearchIcon={false}

--- a/src/components/add-tenant-dialog.tsx
+++ b/src/components/add-tenant-dialog.tsx
@@ -103,7 +103,7 @@ export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDial
             </div>
             <div className="grid gap-2">
               <Label htmlFor="logo">Logo URL</Label>
-              <Input id="logo" type="url" value={form.logo_url} onChange={(e) => setForm(s => ({ ...s, logo_url: e.target.value }))} placeholder="https://..." disabled={isPending} />
+              <Input id="logo" type="url" value={form.logo_url} onChange={(e) => setForm(s => ({ ...s, logo_url: e.target.value }))} placeholder="https://…" disabled={isPending} />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="quota">Hạn mức tài khoản thành viên</Label>
@@ -111,7 +111,7 @@ export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDial
             </div>
             <div className="grid gap-2">
               <Label htmlFor="google_drive_url">URL thư mục Google Drive chia sẻ</Label>
-              <Input id="google_drive_url" type="url" value={form.google_drive_folder_url} onChange={(e) => setForm(s => ({ ...s, google_drive_folder_url: e.target.value }))} placeholder="https://drive.google.com/drive/folders/..." disabled={isPending} />
+              <Input id="google_drive_url" type="url" value={form.google_drive_folder_url} onChange={(e) => setForm(s => ({ ...s, google_drive_folder_url: e.target.value }))} placeholder="https://drive.google.com/drive/folders/…" disabled={isPending} />
               <p className="text-xs text-muted-foreground">Thư mục Google Drive chia sẻ cho file đính kèm thiết bị của đơn vị này.</p>
             </div>
             <div className="flex items-center gap-2">

--- a/src/components/assistant/AssistantComposer.tsx
+++ b/src/components/assistant/AssistantComposer.tsx
@@ -58,7 +58,7 @@ export function AssistantComposer({
                     value={input}
                     onChange={(e) => onInputChange(e.target.value)}
                     onKeyDown={handleKeyDown}
-                    placeholder="Hỏi AI về thiết bị, bảo trì..."
+                    placeholder="Hỏi AI về thiết bị, bảo trì…"
                     rows={1}
                     disabled={isStreaming || isDisabled}
                     className={cn(

--- a/src/components/chart-fallbacks.tsx
+++ b/src/components/chart-fallbacks.tsx
@@ -14,7 +14,7 @@ export function ChartLoadingFallback({ height = 300 }: ChartLoadingFallbackProps
     >
       <div className="text-center space-y-2">
         <div className="size-8 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto"></div>
-        <p className="text-sm text-muted-foreground">Đang tải biểu đồ...</p>
+        <p className="text-sm text-muted-foreground">Đang tải biểu đồ…</p>
       </div>
     </div>
   )

--- a/src/components/dashboard/dashboard-tabs.tsx
+++ b/src/components/dashboard/dashboard-tabs.tsx
@@ -110,7 +110,7 @@ export function DashboardTabs() {
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <h3 className="text-lg md:text-xl font-bold text-gray-900">Thông tin chi tiết</h3>
+                  <h3 className="text-lg md:text-xl font-semibold text-gray-900">Thông tin chi tiết</h3>
                   <p className="text-sm text-gray-500 mt-1">Thiết bị và kế hoạch cần theo dõi</p>
                 </div>
               </div>

--- a/src/components/dashboard/dashboard-tabs/DashboardMonthlyTab.tsx
+++ b/src/components/dashboard/dashboard-tabs/DashboardMonthlyTab.tsx
@@ -130,13 +130,13 @@ export function DashboardMonthlyTab({
                   {pendingTasks.slice(0, 5).map((task) => (
                     <div
                       key={task.id}
-                      className={`p-3 rounded-xl border-l-4 backdrop-blur-sm transition-all duration-200 hover:scale-[1.01] hover:shadow-md ${priorityTasks.includes(task)
-                        ? "border-yellow-500 bg-yellow-50/80"
+                      className={`p-3 rounded-xl border backdrop-blur-sm transition-all duration-200 hover:scale-[1.01] hover:shadow-md ${priorityTasks.includes(task)
+                        ? "border-yellow-200 bg-yellow-50/80 ring-1 ring-inset ring-yellow-500/25"
                         : task.type === "Bảo trì"
-                          ? "border-blue-500 bg-blue-50/80"
+                          ? "border-blue-200 bg-blue-50/80 ring-1 ring-inset ring-blue-500/25"
                           : task.type === "Hiệu chuẩn"
-                            ? "border-orange-500 bg-orange-50/80"
-                            : "border-purple-500 bg-purple-50/80"
+                            ? "border-orange-200 bg-orange-50/80 ring-1 ring-inset ring-orange-500/25"
+                            : "border-purple-200 bg-purple-50/80 ring-1 ring-inset ring-purple-500/25"
                         }`}
                     >
                       <div className="flex items-start gap-2 mb-2">
@@ -179,7 +179,7 @@ export function DashboardMonthlyTab({
                     <div className="text-center py-2">
                       <Button asChild variant="link" size="sm" className="text-blue-600">
                         <Link href="/maintenance">
-                          Xem thêm {hiddenTaskCount} công việc khác...
+                          Xem thêm {hiddenTaskCount} công việc khác…
                         </Link>
                       </Button>
                     </div>

--- a/src/components/edit-tenant-dialog.tsx
+++ b/src/components/edit-tenant-dialog.tsx
@@ -133,7 +133,7 @@ export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: Edit
             </div>
             <div className="grid gap-2">
               <Label htmlFor="logo">Logo URL</Label>
-              <Input id="logo" type="url" value={form.logo_url} onChange={(e) => setForm(s => ({ ...s, logo_url: e.target.value }))} placeholder="https://..." disabled={isPending} />
+              <Input id="logo" type="url" value={form.logo_url} onChange={(e) => setForm(s => ({ ...s, logo_url: e.target.value }))} placeholder="https://…" disabled={isPending} />
               <p className="text-xs text-muted-foreground">Để trống để xóa logo.</p>
             </div>
             <div className="grid gap-2">
@@ -143,7 +143,7 @@ export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: Edit
             </div>
             <div className="grid gap-2">
               <Label htmlFor="google_drive_url">URL thư mục Google Drive chia sẻ</Label>
-              <Input id="google_drive_url" type="url" value={form.google_drive_folder_url} onChange={(e) => setForm(s => ({ ...s, google_drive_folder_url: e.target.value }))} placeholder="https://drive.google.com/drive/folders/..." disabled={isPending} />
+              <Input id="google_drive_url" type="url" value={form.google_drive_folder_url} onChange={(e) => setForm(s => ({ ...s, google_drive_folder_url: e.target.value }))} placeholder="https://drive.google.com/drive/folders/…" disabled={isPending} />
               <p className="text-xs text-muted-foreground">Thư mục Google Drive chia sẻ cho file đính kèm thiết bị của đơn vị này.</p>
             </div>
             <div className="flex items-center gap-2">

--- a/src/components/end-usage-dialog.tsx
+++ b/src/components/end-usage-dialog.tsx
@@ -194,7 +194,7 @@ export function EndUsageDialog({
                   <FormLabel>Ghi chú</FormLabel>
                   <FormControl>
                     <Textarea
-                      placeholder="Ghi chú về tình trạng thiết bị sau khi sử dụng..."
+                      placeholder="Ghi chú về tình trạng thiết bị sau khi sử dụng…"
                       className="min-h-[80px]"
                       {...field}
                     />

--- a/src/components/equipment/filter-bottom-sheet.tsx
+++ b/src/components/equipment/filter-bottom-sheet.tsx
@@ -96,7 +96,7 @@ export function FilterBottomSheet({
     <MobileBottomSheet open={open} onOpenChange={onOpenChange} ariaLabel="Bộ lọc thiết bị">
       {/* Header */}
       <div className="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
-        <h2 className="text-lg font-bold text-foreground">
+        <h2 className="text-lg font-semibold text-foreground">
           Bộ lọc thiết bị
         </h2>
         <Button
@@ -118,7 +118,7 @@ export function FilterBottomSheet({
         {filterSections.map((section) =>
           section.options.length > 0 ? (
             <div key={section.key}>
-              <h3 className="text-sm font-bold text-foreground mb-3">
+              <h3 className="text-sm font-semibold text-foreground mb-3">
                 {section.label}
               </h3>
               <div className="space-y-2">

--- a/src/components/handover-preview-dialog.tsx
+++ b/src/components/handover-preview-dialog.tsx
@@ -719,7 +719,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                       id="accessories"
                       value={handoverData.device.accessories}
                       onChange={(e) => handleInputChange('device.accessories', e.target.value)}
-                      placeholder="Nhập tài liệu, phụ kiện kèm theo..."
+                      placeholder="Nhập tài liệu, phụ kiện kèm theo…"
                       rows={3}
                     />
                   </div>
@@ -729,7 +729,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                       id="note"
                       value={handoverData.device.note}
                       onChange={(e) => handleInputChange('device.note', e.target.value)}
-                      placeholder="Nhập ghi chú..."
+                      placeholder="Nhập ghi chú…"
                       rows={3}
                     />
                   </div>

--- a/src/components/handover-template.tsx
+++ b/src/components/handover-template.tsx
@@ -119,7 +119,7 @@ export function HandoverTemplate({
                   className="mb-4"
                   tenantId={tenantId}
                 />
-                <h1 className="title-main uppercase font-bold">
+                <h1 className="title-main uppercase font-semibold">
                   BIÊN BẢN BÀN GIAO THIẾT BỊ
                 </h1>
               </div>
@@ -182,7 +182,7 @@ export function HandoverTemplate({
                       className="editable-cell text-left" 
                       contentEditable
                       suppressContentEditableWarning
-                      data-placeholder="Nhập tài liệu/phụ kiện kèm theo..."
+                      data-placeholder="Nhập tài liệu/phụ kiện kèm theo…"
                     >
                       {formatValue(device.accessories)}
                     </td>
@@ -190,7 +190,7 @@ export function HandoverTemplate({
                       className="editable-cell" 
                       contentEditable
                       suppressContentEditableWarning
-                      data-placeholder="Nhập tình trạng thiết bị..."
+                      data-placeholder="Nhập tình trạng thiết bị…"
                     >
                       {formatValue(device.condition)}
                     </td>
@@ -198,7 +198,7 @@ export function HandoverTemplate({
                       className="editable-cell" 
                       contentEditable
                       suppressContentEditableWarning
-                      data-placeholder="Nhập ghi chú..."
+                      data-placeholder="Nhập ghi chú…"
                     >
                       {formatValue(device.note)}
                     </td>

--- a/src/components/kpi/KpiStatusBar.tsx
+++ b/src/components/kpi/KpiStatusBar.tsx
@@ -12,7 +12,7 @@ import type { KpiStatusBarProps } from "./types"
  *
  * Renders a "Total" card (optional) followed by one card per status config.
  * Counts are mapped from a `Record<TStatus, number>`.
- * No onClick/active props — purely for display.
+ * No onClick/active props - purely for display.
  *
  * @example
  * ```tsx

--- a/src/components/log-template.tsx
+++ b/src/components/log-template.tsx
@@ -113,7 +113,7 @@ export function LogTemplate({
               </div>
               <div className="w-20"></div>
             </div>
-            <h1 className="title-main uppercase font-bold text-center my-4">
+            <h1 className="title-main uppercase font-semibold text-center my-4">
               NHẬT KÝ SỬ DỤNG THIẾT BỊ
             </h1>
           </header>

--- a/src/components/login-template.tsx
+++ b/src/components/login-template.tsx
@@ -36,7 +36,7 @@ export function LoginTemplate() {
               className="mb-6" 
             />
             
-            <h1 className="text-3xl md:text-4xl font-black text-[#004AAD] mb-4">
+            <h1 className="text-3xl md:text-4xl font-semibold text-[#004AAD] mb-4">
               Hệ Thống Quản Lý Thiết Bị Y Tế Toàn Diện
             </h1>
             <p className="text-gray-600 mb-8">
@@ -79,7 +79,7 @@ export function LoginTemplate() {
                 <Card key={feature.title} className="bg-blue-50 border-blue-100">
                   <CardContent className="p-4">
                     <div className="text-2xl mb-2">{feature.icon}</div>
-                    <h3 className="font-bold text-sm text-[#004AAD] mb-2">{feature.title}</h3>
+                    <h3 className="font-semibold text-sm text-[#004AAD] mb-2">{feature.title}</h3>
                     <p className="text-xs text-gray-500">{feature.description}</p>
                   </CardContent>
                 </Card>

--- a/src/components/maintenance-form.tsx
+++ b/src/components/maintenance-form.tsx
@@ -99,7 +99,7 @@ export function MaintenanceForm({
               <div className="w-1/4"></div>
             </div>
             <div className="text-center mt-4">
-              <h1 className="title-main uppercase font-bold flex justify-center items-baseline">
+              <h1 className="title-main uppercase font-semibold flex justify-center items-baseline">
                 KẾ HOẠCH BẢO TRÌ HIỆU CHUẨN/KIỂM ĐỊNH THIẾT BỊ NĂM
                 <input 
                   type="text" 

--- a/src/components/mobile-equipment-list-item.tsx
+++ b/src/components/mobile-equipment-list-item.tsx
@@ -120,7 +120,7 @@ export function MobileEquipmentListItem({
         </div>
 
         {/* Row 2: Equipment Name */}
-        <h3 className="text-[15px] font-bold text-foreground leading-tight">
+        <h3 className="text-[15px] font-semibold text-foreground leading-tight">
           {equipment.ten_thiet_bi}
         </h3>
 

--- a/src/components/pwa-install-prompt.tsx
+++ b/src/components/pwa-install-prompt.tsx
@@ -264,7 +264,7 @@ export function PWAStatus() {
   }
 
   return (
-    <div className="fixed top-4 right-4 bg-black/80 text-white text-xs p-2 rounded z-50">
+    <div className="fixed top-4 right-4 bg-gray-950/80 text-white text-xs p-2 rounded z-50">
       <div>SW: {state.swStatus}</div>
       <div>Online: {state.isOnline ? 'yes' : 'no'}</div>
       <div>Install: {state.installPromptAvailable ? 'available' : 'not available'}</div>

--- a/src/components/qr-action-sheet.tsx
+++ b/src/components/qr-action-sheet.tsx
@@ -116,7 +116,7 @@ export function QRActionSheet({ qrCode, onClose, onAction }: QRActionSheetProps)
           {loading && (
             <div className="flex flex-col items-center justify-center py-8">
               <div className="animate-spin rounded-full size-8 border-b-2 border-primary"></div>
-              <p className="mt-4 text-sm text-muted-foreground">Đang tìm kiếm thiết bị...</p>
+              <p className="mt-4 text-sm text-muted-foreground">Đang tìm kiếm thiết bị…</p>
             </div>
           )}
 

--- a/src/components/qr-scanner-camera.tsx
+++ b/src/components/qr-scanner-camera.tsx
@@ -295,9 +295,9 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
   }
 
   return (
-    <div className="fixed inset-0 z-50 bg-black">
+    <div className="fixed inset-0 z-50 bg-gray-950">
       {/* Header */}
-      <div className="absolute top-0 left-0 right-0 z-10 bg-black/50 backdrop-blur-sm">
+      <div className="absolute top-0 left-0 right-0 z-10 bg-gray-950/50 backdrop-blur-sm">
         <div className="flex items-center justify-between p-4">
           <div className="flex items-center gap-3">
             <Button
@@ -343,17 +343,17 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
                   <div className="relative">
                     <div className="size-64 border-2 border-white rounded-lg relative">
                       {/* Corner indicators */}
-                      <div className="absolute top-0 left-0 size-8 border-t-4 border-l-4 border-primary rounded-tl-lg" />
-                      <div className="absolute top-0 right-0 size-8 border-t-4 border-r-4 border-primary rounded-tr-lg" />
-                      <div className="absolute bottom-0 left-0 size-8 border-b-4 border-l-4 border-primary rounded-bl-lg" />
-                      <div className="absolute bottom-0 right-0 size-8 border-b-4 border-r-4 border-primary rounded-br-lg" />
+                      <div className="absolute top-0 left-0 size-8 border-t-4 border-l border-primary rounded-tl-lg" />
+                      <div className="absolute top-0 right-0 size-8 border-t-4 border-r border-primary rounded-tr-lg" />
+                      <div className="absolute bottom-0 left-0 size-8 border-b-4 border-l border-primary rounded-bl-lg" />
+                      <div className="absolute bottom-0 right-0 size-8 border-b-4 border-r border-primary rounded-br-lg" />
                       
                       {/* Scanning line animation */}
                       <div className="absolute inset-0 overflow-hidden rounded-lg">
                         <div 
                           className="absolute left-0 right-0 h-0.5 bg-primary"
                           style={{ 
-                            animation: "scan 2s linear infinite",
+                            animation: "scan 700ms linear infinite",
                           }} 
                         />
                       </div>
@@ -378,7 +378,7 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
                     ) : (
                       <>
                         <Camera className="size-12 mx-auto mb-4 opacity-50" />
-                        <p>Đang khởi động camera...</p>
+                        <p>Đang khởi động camera…</p>
                       </>
                     )}
                   </div>
@@ -390,7 +390,7 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
       </div>
 
       {/* Bottom Controls */}
-      <div className="absolute bottom-0 left-0 right-0 bg-black/50 backdrop-blur-sm">
+      <div className="absolute bottom-0 left-0 right-0 bg-gray-950/50 backdrop-blur-sm">
         <div className="flex items-center justify-center gap-8 p-6">
           {/* Flash Toggle */}
           {hasFlash && (

--- a/src/components/qr-scanner-error-boundary.tsx
+++ b/src/components/qr-scanner-error-boundary.tsx
@@ -40,7 +40,7 @@ export class QRScannerErrorBoundary extends React.Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="fixed inset-0 z-50 bg-black flex items-center justify-center p-4">
+        <div className="fixed inset-0 z-50 bg-gray-950 flex items-center justify-center p-4">
           <Card className="max-w-md w-full">
             <CardContent className="pt-6">
               <div className="text-center space-y-4">

--- a/src/components/repair-result-form.tsx
+++ b/src/components/repair-result-form.tsx
@@ -194,7 +194,7 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
               value={formData.issueDescription}
               onChange={(e) => handleInputChange('issueDescription', e.target.value)}
               className="mt-1 min-h-[80px]"
-              placeholder="Mô tả chi tiết sự cố hoặc vấn đề cần sửa chữa..."
+              placeholder="Mô tả chi tiết sự cố hoặc vấn đề cần sửa chữa…"
             />
           </div>
 
@@ -205,7 +205,7 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
               value={formData.actionTaken}
               onChange={(e) => handleInputChange('actionTaken', e.target.value)}
               className="mt-1 min-h-[80px]"
-              placeholder="Mô tả các biện pháp, quy trình sửa chữa đã thực hiện..."
+              placeholder="Mô tả các biện pháp, quy trình sửa chữa đã thực hiện…"
             />
           </div>
 
@@ -241,7 +241,7 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
               value={formData.testResults}
               onChange={(e) => handleInputChange('testResults', e.target.value)}
               className="mt-1 min-h-[80px]"
-              placeholder="Mô tả kết quả kiểm tra, thử nghiệm sau khi sửa chữa..."
+              placeholder="Mô tả kết quả kiểm tra, thử nghiệm sau khi sửa chữa…"
             />
           </div>
 
@@ -302,7 +302,7 @@ export function RepairResultForm({ tenantId = null }: RepairResultFormProps = {}
               value={formData.notes}
               onChange={(e) => handleInputChange('notes', e.target.value)}
               className="mt-1 min-h-[60px]"
-              placeholder="Ghi chú thêm về quá trình sửa chữa, khuyến nghị sử dụng..."
+              placeholder="Ghi chú thêm về quá trình sửa chữa, khuyến nghị sử dụng…"
             />
           </div>
 

--- a/src/components/shared/TenantSelectorSheet.tsx
+++ b/src/components/shared/TenantSelectorSheet.tsx
@@ -93,7 +93,7 @@ export function TenantSelectorSheet({
             <Input
               value={searchTerm}
               onChange={(event) => setSearchTerm(event.target.value)}
-              placeholder="Tìm kiếm cơ sở..."
+              placeholder="Tìm kiếm cơ sở…"
               className="h-11 rounded-xl border-border/70 pl-9 pr-9"
             />
             {/* Use explicit ternary for conditional (per rendering-conditional-render) */}

--- a/src/components/shared/mobile-bottom-sheet.tsx
+++ b/src/components/shared/mobile-bottom-sheet.tsx
@@ -100,7 +100,7 @@ export function MobileBottomSheet({
             {/* Backdrop */}
             <div
                 data-testid="mobile-bottom-sheet-backdrop"
-                className="absolute inset-0 bg-black/40 backdrop-blur-sm animate-in fade-in duration-300"
+                className="absolute inset-0 bg-gray-950/40 backdrop-blur-sm animate-in fade-in duration-300"
                 onClick={() => onOpenChange(false)}
                 aria-hidden="true"
             />

--- a/src/components/start-usage-dialog.tsx
+++ b/src/components/start-usage-dialog.tsx
@@ -191,7 +191,7 @@ export function StartUsageDialog({
                   <FormLabel>Ghi chú</FormLabel>
                   <FormControl>
                     <Textarea
-                      placeholder="Ghi chú về việc sử dụng thiết bị..."
+                      placeholder="Ghi chú về việc sử dụng thiết bị…"
                       className="min-h-[80px]"
                       {...field}
                     />

--- a/src/components/tenants-management-tenant-card.tsx
+++ b/src/components/tenants-management-tenant-card.tsx
@@ -50,7 +50,7 @@ export function TenantsManagementTenantCard({
           <TenantLogo logoUrl={tenant.logo_url} tenantName={tenant.name} />
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-3">
-              <h3 className="text-lg font-bold sm:text-xl">{tenant.name}</h3>
+              <h3 className="text-lg font-semibold sm:text-xl">{tenant.name}</h3>
               <Badge
                 className={cn(
                   "flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium uppercase tracking-wide",

--- a/src/components/tenants-management.tsx
+++ b/src/components/tenants-management.tsx
@@ -192,7 +192,7 @@ export function TenantsManagement() {
           <div className="flex flex-col gap-3 rounded-lg border border-dashed border-border/50 bg-muted/40 p-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex w-full flex-col gap-2 sm:max-w-xl sm:flex-row sm:items-center">
               <Input
-                placeholder="Tìm đơn vị, mã hoặc tài khoản..."
+                placeholder="Tìm đơn vị, mã hoặc tài khoản…"
                 value={q}
                 onChange={(event) => setQ(event.target.value)}
                 className="h-10"

--- a/src/components/transfer-dialog.equipment-search.tsx
+++ b/src/components/transfer-dialog.equipment-search.tsx
@@ -48,7 +48,7 @@ export function TransferDialogEquipmentSearch({
           id="equipment"
           value={searchTerm}
           onChange={onSearchChange}
-          placeholder="Tìm kiếm thiết bị..."
+          placeholder="Tìm kiếm thiết bị…"
           disabled={disabled}
           required={required}
         />
@@ -65,7 +65,7 @@ export function TransferDialogEquipmentSearch({
               <div className="absolute z-20 mt-1 w-full rounded-md border bg-popover p-3 shadow-lg">
                 <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
                   <Loader2 className="size-4 animate-spin" />
-                  <span>Đang tìm kiếm thiết bị...</span>
+                  <span>Đang tìm kiếm thiết bị…</span>
                 </div>
               </div>
             )}

--- a/src/components/transfers/ReturnLocationDialog.tsx
+++ b/src/components/transfers/ReturnLocationDialog.tsx
@@ -160,7 +160,7 @@ export function ReturnLocationDialog({
           <div className="space-y-2">
             <p className="text-sm font-medium">Vị trí gợi ý</p>
             {suggestionsQuery.isLoading ? (
-              <p className="text-sm text-muted-foreground">Đang tải vị trí gợi ý...</p>
+              <p className="text-sm text-muted-foreground">Đang tải vị trí gợi ý…</p>
             ) : suggestions.length > 0 ? (
               <div className="flex flex-wrap gap-2">
                 {suggestions.map((suggestion) => (

--- a/src/components/transfers/TransfersKanbanColumn.tsx
+++ b/src/components/transfers/TransfersKanbanColumn.tsx
@@ -154,7 +154,7 @@ export function TransfersKanbanColumn({
         {isLoadingMore && (
           <div className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground">
             <Loader2 className="size-4 animate-spin" />
-            <span>Đang tải thêm...</span>
+            <span>Đang tải thêm…</span>
           </div>
         )}
       </div>

--- a/src/components/transfers/TransfersKanbanView.tsx
+++ b/src/components/transfers/TransfersKanbanView.tsx
@@ -174,7 +174,7 @@ function TransfersKanbanBoard({
       <div className="flex min-h-[400px] items-center justify-center">
         <div className="flex flex-col items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="size-6 animate-spin" />
-          Đang tải dữ liệu...
+          Đang tải dữ liệu…
         </div>
       </div>
     )
@@ -316,7 +316,7 @@ function TransfersKanbanBoard({
       {isFetching && !isLoading && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="size-4 animate-spin" />
-          Đang đồng bộ dữ liệu...
+          Đang đồng bộ dữ liệu…
         </div>
       )}
     </div>

--- a/src/components/transfers/TransfersTableView.tsx
+++ b/src/components/transfers/TransfersTableView.tsx
@@ -68,7 +68,7 @@ export function TransfersTableView({
             <TableRow>
               <TableCell colSpan={columns.length} className="h-40 text-center">
                 <Loader2 className="mx-auto size-6 animate-spin text-muted-foreground" />
-                <p className="mt-2 text-sm text-muted-foreground">Đang tải dữ liệu...</p>
+                <p className="mt-2 text-sm text-muted-foreground">Đang tải dữ liệu…</p>
               </TableCell>
             </TableRow>
           ) : table.getRowModel().rows.length > 0 ? (

--- a/src/components/ui/calendar-widget/CalendarWidgetHeader.tsx
+++ b/src/components/ui/calendar-widget/CalendarWidgetHeader.tsx
@@ -70,7 +70,7 @@ export function CalendarWidgetHeader({
               <CalendarIcon className="size-5 text-white" />
             </div>
             <div>
-              <h2 className="text-lg font-bold text-gray-900">Lịch công việc</h2>
+              <h2 className="text-lg font-semibold text-gray-900">Lịch công việc</h2>
               <p className="text-sm text-gray-500">{format(currentDate, "MMMM yyyy", { locale: vi })}</p>
             </div>
           </div>
@@ -141,7 +141,7 @@ export function CalendarWidgetMonthControls({
             <ChevronRight className="size-5" />
           </Button>
         </div>
-        <h3 className="text-xl font-bold text-gray-700">
+        <h3 className="text-xl font-semibold text-gray-700">
           {format(currentDate, "MMMM yyyy", { locale: vi })}
         </h3>
       </div>

--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -92,7 +92,7 @@ export function StatCard({ label, value, icon, tone = "default", loading, onClic
             {label}
           </span>
           <span className={cn("text-2xl font-bold leading-none mt-1", styles.text)}>
-            {loading ? <span className="animate-pulse">...</span> : value}
+            {loading ? <span className="animate-pulse">…</span> : value}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Fixes #471
- Clears the remaining scoped Phase 3 cosmetic React Doctor rules from the branch diff: bold headings, JSX ellipses/em dash text, side-tab borders, pure black backgrounds, long transition duration, and redundant padding axes.
- Keeps the PR cosmetic-only; design-system palette/default Tailwind, dead code, giant component, and React 19 readiness work remain out of scope.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/_components/__tests__/LoginForm.test.tsx' 'src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryAssignedEquipment.test.tsx' 'src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx' 'src/app/(app)/equipment/__tests__/EquipmentPageClient.attention-preset.test.tsx' 'src/app/(app)/equipment/__tests__/EquipmentPageClient.auth.test.tsx' 'src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx'`\n- `git diff --check`\n- `node scripts/npm-run.js run build`\n- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` → 90/100, no #471 target rules in diff\n\n## Notes\n- React Doctor still reports out-of-scope/default-palette, maintainability, and code-smell findings on touched files; these remain tracked by the existing follow-up issues.\n- CRG scored the diff high-risk because 68 files changed, but edits are class/text-only with no logic/data-flow/API changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up remaining Phase 3 React Doctor cosmetic findings across the app: typography, ellipsis/dash usage, borders, colors, spacing, and minor animation tweaks. Visual-only changes; no logic, data flow, or API updates.

- **Refactors**
  - Headings use font-semibold instead of font-bold.
  - Replaced "..." with the typographic ellipsis (…) and normalized dash usage.
  - Swapped pure black backgrounds/overlays for gray-950 variants.
  - Replaced side/border-accent patterns with ring-1 ring-inset where appropriate.
  - Standardized spacing utilities (e.g., h-14+w-14 → size-14, px/py → p).
  - Unified loading and placeholder copy (e.g., “Đang tải…”), plus minor animation duration reductions.
  - Updated affected tests to match class name changes.

<sup>Written for commit 7408ca8c9bedf4d03bcdb308c6778c8eaf822399. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Style**
  * Updated typography across pages with adjusted font weights for improved visual hierarchy
  * Refined color schemes by updating dark overlay backgrounds for better consistency
  * Standardized spacing and padding in layout components
  * Improved scanning animation performance with faster animation loops
  * Unified ellipsis character formatting throughout the UI for consistent text punctuation

* **Tests**
  * Updated equipment page test assertions for button sizing classes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/472)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->