### PR TITLE
Fix React Doctor P0 mutation invalidation findings

### DIFF
--- a/src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts
+++ b/src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts
@@ -14,17 +14,28 @@ const expectInvalidatesQueryKey = (source: string, queryKey: string) => {
 }
 
 const extractFunctionSource = (source: string, functionName: string) => {
-  const start = source.indexOf(`function ${functionName}`)
-  expect(start, `${functionName} should exist`).toBeGreaterThanOrEqual(0)
+  const functionPattern = new RegExp(
+    String.raw`(?:export\s+)?function\s+${functionName}\b`
+  )
+  const match = functionPattern.exec(source)
+  expect(match?.index, `${functionName} should exist`).toBeGreaterThanOrEqual(0)
 
-  const nextFunction = source.indexOf("\nfunction ", start + 1)
-  return source.slice(start, nextFunction === -1 ? undefined : nextFunction)
+  const start = match?.index ?? 0
+  const nextFunctionOffset = source
+    .slice(start + 1)
+    .search(/\n(?:export\s+)?function\s+/)
+
+  return source.slice(
+    start,
+    nextFunctionOffset === -1 ? undefined : start + 1 + nextFunctionOffset
+  )
 }
 
 const expectMutationOwnsInvalidation = (
   source: string,
   functionName: string,
-  queryKeys: string[]
+  queryKeys: string[],
+  extraAssertions: Array<(functionSource: string) => void> = []
 ) => {
   const functionSource = extractFunctionSource(source, functionName)
 
@@ -34,6 +45,16 @@ const expectMutationOwnsInvalidation = (
   for (const queryKey of queryKeys) {
     expectInvalidatesQueryKey(functionSource, queryKey)
   }
+
+  for (const assertion of extraAssertions) {
+    assertion(functionSource)
+  }
+}
+
+const expectInvalidatesRepairKeysAll = (functionSource: string) => {
+  expect(functionSource).toContain(
+    "queryClient.invalidateQueries({ queryKey: repairKeys.all })"
+  )
 }
 
 describe("React Doctor P0 mutation invalidation audit", () => {
@@ -57,7 +78,9 @@ describe("React Doctor P0 mutation invalidation audit", () => {
       "useApproveMutation",
       "useCompleteMutation",
     ]) {
-      expectMutationOwnsInvalidation(source, mutation, queryKeys)
+      expectMutationOwnsInvalidation(source, mutation, queryKeys, [
+        expectInvalidatesRepairKeysAll,
+      ])
     }
   })
 

--- a/src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts
+++ b/src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts
@@ -13,11 +13,42 @@ const expectInvalidatesQueryKey = (source: string, queryKey: string) => {
   )
 }
 
+const extractFunctionSource = (source: string, functionName: string) => {
+  const start = source.indexOf(`function ${functionName}`)
+  expect(start, `${functionName} should exist`).toBeGreaterThanOrEqual(0)
+
+  const nextFunction = source.indexOf("\nfunction ", start + 1)
+  return source.slice(start, nextFunction === -1 ? undefined : nextFunction)
+}
+
+const expectMutationOwnsInvalidation = (
+  source: string,
+  functionName: string,
+  queryKeys: string[]
+) => {
+  const functionSource = extractFunctionSource(source, functionName)
+
+  expect(functionSource).toContain("queryClient.invalidateQueries")
+  expect(functionSource).not.toContain("invalidate()")
+
+  for (const queryKey of queryKeys) {
+    expectInvalidatesQueryKey(functionSource, queryKey)
+  }
+}
+
 describe("React Doctor P0 mutation invalidation audit", () => {
-  it("keeps repair-request mutations wired to the shared invalidation callback", () => {
+  it("keeps repair-request mutations owning their affected query invalidation", () => {
     const source = readSource(
-      "src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx"
+      "src/app/(app)/repair-requests/_components/RepairRequestsMutations.ts"
     )
+
+    const queryKeys = [
+      "repair_request_list",
+      "repair_request_facilities",
+      "repair_request_status_counts",
+      "repair_request_change_history",
+      "dashboard-stats",
+    ]
 
     for (const mutation of [
       "useCreateMutation",
@@ -26,62 +57,59 @@ describe("React Doctor P0 mutation invalidation audit", () => {
       "useApproveMutation",
       "useCompleteMutation",
     ]) {
-      expect(source).toContain(`function ${mutation}`)
-    }
-
-    expect(source.match(/invalidate\(\)/g)).toHaveLength(5)
-    for (const queryKey of [
-      "repair_request_list",
-      "repair_request_facilities",
-      "repair_request_status_counts",
-      "repair_request_change_history",
-      "dashboard-stats",
-    ]) {
-      expectInvalidatesQueryKey(source, queryKey)
+      expectMutationOwnsInvalidation(source, mutation, queryKeys)
     }
   })
 
   it("keeps device-quota category mutations wired to quota query invalidation", () => {
     const source = readSource(
-      "src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext.tsx"
+      "src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryMutations.ts"
     )
 
-    expect(source.match(/invalidate\(\)/g)).toHaveLength(3)
-    for (const queryKey of [
+    const queryKeys = [
       "dinh_muc_nhom_list",
       "dinh_muc_compliance_summary",
+    ]
+
+    for (const mutation of [
+      "useCreateMutation",
+      "useUpdateMutation",
+      "useDeleteMutation",
     ]) {
-      expectInvalidatesQueryKey(source, queryKey)
+      expectMutationOwnsInvalidation(source, mutation, queryKeys)
     }
   })
 
   it("keeps device-quota decision mutations wired to decision query invalidation", () => {
     const source = readSource(
-      "src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsContext.tsx"
+      "src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionMutations.ts"
     )
 
-    expect(source.match(/invalidate\(\)/g)).toHaveLength(4)
-    for (const queryKey of [
+    const queryKeys = [
       "dinh_muc_quyet_dinh_list",
       "dinh_muc_compliance_summary",
+    ]
+
+    for (const mutation of [
+      "useCreateMutation",
+      "useUpdateMutation",
+      "useActivateMutation",
+      "useDeleteMutation",
     ]) {
-      expectInvalidatesQueryKey(source, queryKey)
+      expectMutationOwnsInvalidation(source, mutation, queryKeys)
     }
   })
 
   it("keeps device-quota mapping mutations wired to unassigned and compliance invalidation", () => {
     const source = readSource(
-      "src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx"
+      "src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingMutations.ts"
     )
 
-    expect(source.match(/invalidate\(\)/g)).toHaveLength(1)
-    for (const queryKey of [
+    expectMutationOwnsInvalidation(source, "useLinkEquipmentMutation", [
       "dinh_muc_thiet_bi_unassigned",
       "dinh_muc_thiet_bi_unassigned_filter_options",
       "dinh_muc_nhom_list",
       "dinh_muc_compliance_summary",
-    ]) {
-      expectInvalidatesQueryKey(source, queryKey)
-    }
+    ])
   })
 })

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext.tsx
@@ -1,20 +1,22 @@
 "use client"
 
 import * as React from "react"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
 
 import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
-import { translateRpcError } from "@/lib/error-translations"
-import { refreshCategoryEmbeddings } from "@/lib/refresh-category-embeddings"
 import { filterCategoriesWithAncestorsAndDescendants } from "../_utils/filterCategoriesWithAncestorsAndDescendants"
 import type {
   CategoryDeleteState,
   CategoryDialogState,
-  CategoryFormInput,
   CategoryListItem,
 } from "../_types/categories"
+import {
+  useCreateMutation,
+  useDeleteMutation,
+  useUpdateMutation,
+} from "./DeviceQuotaCategoryMutations"
 
 interface AuthUser {
   id: string
@@ -68,160 +70,6 @@ interface CategoryContextValue {
 }
 
 // ============================================
-// Mutation Hooks
-// ============================================
-
-function useCreateMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void,
-  closeDialog: () => void,
-  donViId: number | null
-) {
-  return useMutation({
-    mutationFn: async (data: CategoryFormInput) => {
-      if (!donViId) {
-        throw new Error("Thiếu thông tin đơn vị (don_vi)")
-      }
-      return callRpc({
-        fn: "dinh_muc_nhom_upsert",
-        args: {
-          p_id: null,
-          p_don_vi: donViId,
-          p_parent_id: data.parent_id,
-          p_ma_nhom: data.ma_nhom,
-          p_ten_nhom: data.ten_nhom,
-          p_phan_loai: data.phan_loai,
-          p_don_vi_tinh: data.don_vi_tinh,
-          p_thu_tu_hien_thi: data.thu_tu_hien_thi,
-          p_mo_ta: data.mo_ta,
-        },
-      })
-    },
-    onSuccess: (result: unknown) => {
-      toast({
-        title: "Thành công",
-        description: "Đã tạo danh mục thiết bị.",
-      })
-      closeDialog()
-      invalidate()
-      // Fire-and-forget: refresh embedding for newly created category
-      // dinh_muc_nhom_upsert returns scalar BIGINT (the category ID)
-      const categoryId = typeof result === 'number' ? result : null
-      if (categoryId) {
-        refreshCategoryEmbeddings([categoryId])
-      }
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Tạo danh mục thất bại",
-        description: translateRpcError(error.message),
-      })
-    },
-  })
-}
-
-function useUpdateMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void,
-  closeDialog: () => void,
-  setMutatingCategoryId: (id: number | null) => void,
-  donViId: number | null
-) {
-  return useMutation({
-    mutationFn: async (data: CategoryFormInput & { id: number }) => {
-      if (!donViId) {
-        throw new Error("Thiếu thông tin đơn vị (don_vi)")
-      }
-      return callRpc({
-        fn: "dinh_muc_nhom_upsert",
-        args: {
-          p_id: data.id,
-          p_don_vi: donViId,
-          p_parent_id: data.parent_id,
-          p_ma_nhom: data.ma_nhom,
-          p_ten_nhom: data.ten_nhom,
-          p_phan_loai: data.phan_loai,
-          p_don_vi_tinh: data.don_vi_tinh,
-          p_thu_tu_hien_thi: data.thu_tu_hien_thi,
-          p_mo_ta: data.mo_ta,
-        },
-      })
-    },
-    onMutate: (data) => {
-      setMutatingCategoryId(data.id)
-    },
-    onSuccess: (_result: unknown, variables) => {
-      toast({
-        title: "Thành công",
-        description: "Đã cập nhật danh mục.",
-      })
-      closeDialog()
-      invalidate()
-      // Fire-and-forget: refresh embedding for updated category
-      refreshCategoryEmbeddings([variables.id])
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi cập nhật",
-        description: translateRpcError(error.message),
-      })
-    },
-    onSettled: () => {
-      setMutatingCategoryId(null)
-    },
-  })
-}
-
-function useDeleteMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void,
-  closeDeleteDialog: () => void,
-  setMutatingCategoryId: (id: number | null) => void,
-  donViId: number | null
-) {
-  return useMutation({
-    mutationFn: async (id: number) => {
-      if (!donViId) {
-        throw new Error("Thiếu thông tin đơn vị (don_vi)")
-      }
-      return callRpc({
-        fn: "dinh_muc_nhom_delete",
-        args: {
-          p_id: id,
-          p_don_vi: donViId,
-        },
-      })
-    },
-    onMutate: (id) => {
-      setMutatingCategoryId(id)
-    },
-    onSuccess: () => {
-      toast({
-        title: "Đã xóa",
-        description: "Danh mục đã được xóa.",
-      })
-      closeDeleteDialog()
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Xóa danh mục thất bại",
-        description: translateRpcError(error.message),
-      })
-    },
-    onSettled: () => {
-      setMutatingCategoryId(null)
-    },
-  })
-}
-
-// ============================================
-// Context
-// ============================================
-
 const DeviceQuotaCategoryContext = React.createContext<CategoryContextValue | null>(null)
 
 // ============================================
@@ -319,14 +167,12 @@ export function DeviceQuotaCategoryProvider({ children }: DeviceQuotaCategoryPro
 
   const createMutation = useCreateMutation(
     toast,
-    invalidateAndRefetch,
     closeDialog,
     donViId
   )
 
   const updateMutation = useUpdateMutation(
     toast,
-    invalidateAndRefetch,
     closeDialog,
     setMutatingCategoryId,
     donViId
@@ -334,7 +180,6 @@ export function DeviceQuotaCategoryProvider({ children }: DeviceQuotaCategoryPro
 
   const deleteMutation = useDeleteMutation(
     toast,
-    invalidateAndRefetch,
     closeDeleteDialog,
     setMutatingCategoryId,
     donViId

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryMutations.ts
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryMutations.ts
@@ -1,0 +1,160 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { useToast } from "@/hooks/use-toast"
+import { translateRpcError } from "@/lib/error-translations"
+import { refreshCategoryEmbeddings } from "@/lib/refresh-category-embeddings"
+import { callRpc } from "@/lib/rpc-client"
+import type { CategoryFormInput } from "../_types/categories"
+
+export function useCreateMutation(
+  toast: ReturnType<typeof useToast>["toast"],
+  closeDialog: () => void,
+  donViId: number | null
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: CategoryFormInput) => {
+      if (!donViId) {
+        throw new Error("Thiếu thông tin đơn vị (don_vi)")
+      }
+      return callRpc({
+        fn: "dinh_muc_nhom_upsert",
+        args: {
+          p_id: null,
+          p_don_vi: donViId,
+          p_parent_id: data.parent_id,
+          p_ma_nhom: data.ma_nhom,
+          p_ten_nhom: data.ten_nhom,
+          p_phan_loai: data.phan_loai,
+          p_don_vi_tinh: data.don_vi_tinh,
+          p_thu_tu_hien_thi: data.thu_tu_hien_thi,
+          p_mo_ta: data.mo_ta,
+        },
+      })
+    },
+    onSuccess: (result: unknown) => {
+      toast({
+        title: "Thành công",
+        description: "Đã tạo danh mục thiết bị.",
+      })
+      closeDialog()
+      queryClient.invalidateQueries({ queryKey: ["dinh_muc_nhom_list"] })
+      queryClient.invalidateQueries({ queryKey: ["dinh_muc_compliance_summary"] })
+
+      const categoryId = typeof result === 'number' ? result : null
+      if (categoryId) {
+        refreshCategoryEmbeddings([categoryId])
+      }
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Tạo danh mục thất bại",
+        description: translateRpcError(error.message),
+      })
+    },
+  })
+}
+
+export function useUpdateMutation(
+  toast: ReturnType<typeof useToast>["toast"],
+  closeDialog: () => void,
+  setMutatingCategoryId: (id: number | null) => void,
+  donViId: number | null
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: CategoryFormInput & { id: number }) => {
+      if (!donViId) {
+        throw new Error("Thiếu thông tin đơn vị (don_vi)")
+      }
+      return callRpc({
+        fn: "dinh_muc_nhom_upsert",
+        args: {
+          p_id: data.id,
+          p_don_vi: donViId,
+          p_parent_id: data.parent_id,
+          p_ma_nhom: data.ma_nhom,
+          p_ten_nhom: data.ten_nhom,
+          p_phan_loai: data.phan_loai,
+          p_don_vi_tinh: data.don_vi_tinh,
+          p_thu_tu_hien_thi: data.thu_tu_hien_thi,
+          p_mo_ta: data.mo_ta,
+        },
+      })
+    },
+    onMutate: (data) => {
+      setMutatingCategoryId(data.id)
+    },
+    onSuccess: (_result: unknown, variables) => {
+      toast({
+        title: "Thành công",
+        description: "Đã cập nhật danh mục.",
+      })
+      closeDialog()
+      queryClient.invalidateQueries({ queryKey: ["dinh_muc_nhom_list"] })
+      queryClient.invalidateQueries({ queryKey: ["dinh_muc_compliance_summary"] })
+      refreshCategoryEmbeddings([variables.id])
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi cập nhật",
+        description: translateRpcError(error.message),
+      })
+    },
+    onSettled: () => {
+      setMutatingCategoryId(null)
+    },
+  })
+}
+
+export function useDeleteMutation(
+  toast: ReturnType<typeof useToast>["toast"],
+  closeDeleteDialog: () => void,
+  setMutatingCategoryId: (id: number | null) => void,
+  donViId: number | null
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      if (!donViId) {
+        throw new Error("Thiếu thông tin đơn vị (don_vi)")
+      }
+      return callRpc({
+        fn: "dinh_muc_nhom_delete",
+        args: {
+          p_id: id,
+          p_don_vi: donViId,
+        },
+      })
+    },
+    onMutate: (id) => {
+      setMutatingCategoryId(id)
+    },
+    onSuccess: () => {
+      toast({
+        title: "Đã xóa",
+        description: "Danh mục đã được xóa.",
+      })
+      closeDeleteDialog()
+      queryClient.invalidateQueries({ queryKey: ["dinh_muc_nhom_list"] })
+      queryClient.invalidateQueries({ queryKey: ["dinh_muc_compliance_summary"] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Xóa danh mục thất bại",
+        description: translateRpcError(error.message),
+      })
+    },
+    onSettled: () => {
+      setMutatingCategoryId(null)
+    },
+  })
+}

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionMutations.ts
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionMutations.ts
@@ -1,0 +1,155 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { useToast } from "@/hooks/use-toast"
+import { callRpc } from "@/lib/rpc-client"
+
+type DecisionInput = {
+  so_quyet_dinh: string
+  ngay_ban_hanh: string
+  ngay_hieu_luc: string
+  ngay_het_hieu_luc: string | null
+  nguoi_ky: string
+  chuc_vu_nguoi_ky: string
+  ghi_chu: string | null
+}
+
+
+export function useCreateMutation(
+  toast: ReturnType<typeof useToast>["toast"]
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: DecisionInput & { thay_the_cho_id: number | null }) => {
+      return callRpc({
+        fn: 'dinh_muc_quyet_dinh_create',
+        args: {
+          p_so_quyet_dinh: data.so_quyet_dinh,
+          p_ngay_ban_hanh: data.ngay_ban_hanh,
+          p_ngay_hieu_luc: data.ngay_hieu_luc,
+          p_ngay_het_hieu_luc: data.ngay_het_hieu_luc,
+          p_nguoi_ky: data.nguoi_ky,
+          p_chuc_vu_nguoi_ky: data.chuc_vu_nguoi_ky,
+          p_ghi_chu: data.ghi_chu,
+          p_thay_the_cho_id: data.thay_the_cho_id,
+        }
+      })
+    },
+    onSuccess: () => {
+      toast({
+        title: "Thành công",
+        description: "Quyết định đã được tạo."
+      })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_quyet_dinh_list'] })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_compliance_summary'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Tạo quyết định thất bại",
+        description: error.message
+      })
+    },
+  })
+}
+
+export function useUpdateMutation(
+  toast: ReturnType<typeof useToast>["toast"]
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: DecisionInput & { id: number }) => {
+      return callRpc({
+        fn: 'dinh_muc_quyet_dinh_update',
+        args: {
+          p_id: data.id,
+          p_so_quyet_dinh: data.so_quyet_dinh,
+          p_ngay_ban_hanh: data.ngay_ban_hanh,
+          p_ngay_hieu_luc: data.ngay_hieu_luc,
+          p_ngay_het_hieu_luc: data.ngay_het_hieu_luc,
+          p_nguoi_ky: data.nguoi_ky,
+          p_chuc_vu_nguoi_ky: data.chuc_vu_nguoi_ky,
+          p_ghi_chu: data.ghi_chu,
+        }
+      })
+    },
+    onSuccess: () => {
+      toast({
+        title: "Thành công",
+        description: "Đã cập nhật quyết định."
+      })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_quyet_dinh_list'] })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_compliance_summary'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi cập nhật",
+        description: error.message
+      })
+    },
+  })
+}
+
+export function useActivateMutation(
+  toast: ReturnType<typeof useToast>["toast"]
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      return callRpc({
+        fn: 'dinh_muc_quyet_dinh_activate',
+        args: { p_id: id }
+      })
+    },
+    onSuccess: () => {
+      toast({
+        title: "Thành công",
+        description: "Quyết định đã được kích hoạt."
+      })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_quyet_dinh_list'] })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_compliance_summary'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi kích hoạt quyết định",
+        description: error.message
+      })
+    },
+  })
+}
+
+export function useDeleteMutation(
+  toast: ReturnType<typeof useToast>["toast"]
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      return callRpc({
+        fn: 'dinh_muc_quyet_dinh_delete',
+        args: { p_id: id }
+      })
+    },
+    onSuccess: () => {
+      toast({
+        title: "Đã xóa",
+        description: "Quyết định đã được xóa thành công."
+      })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_quyet_dinh_list'] })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_compliance_summary'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi xóa quyết định",
+        description: error.message
+      })
+    },
+  })
+}

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsContext.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsContext.tsx
@@ -1,10 +1,16 @@
 "use client"
 
 import * as React from "react"
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
 import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
+import {
+  useActivateMutation,
+  useCreateMutation,
+  useDeleteMutation,
+  useUpdateMutation,
+} from "./DeviceQuotaDecisionMutations"
 
 // ============================================
 // Types
@@ -84,161 +90,6 @@ interface DeviceQuotaDecisionsContextValue {
 }
 
 // ============================================
-// Mutation Hooks
-// ============================================
-
-function useCreateMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void
-) {
-  return useMutation({
-    mutationFn: async (data: {
-      so_quyet_dinh: string
-      ngay_ban_hanh: string
-      ngay_hieu_luc: string
-      ngay_het_hieu_luc: string | null
-      nguoi_ky: string
-      chuc_vu_nguoi_ky: string
-      ghi_chu: string | null
-      thay_the_cho_id: number | null
-    }) => {
-      return callRpc({
-        fn: 'dinh_muc_quyet_dinh_create',
-        args: {
-          p_so_quyet_dinh: data.so_quyet_dinh,
-          p_ngay_ban_hanh: data.ngay_ban_hanh,
-          p_ngay_hieu_luc: data.ngay_hieu_luc,
-          p_ngay_het_hieu_luc: data.ngay_het_hieu_luc,
-          p_nguoi_ky: data.nguoi_ky,
-          p_chuc_vu_nguoi_ky: data.chuc_vu_nguoi_ky,
-          p_ghi_chu: data.ghi_chu,
-          p_thay_the_cho_id: data.thay_the_cho_id,
-        }
-      })
-    },
-    onSuccess: () => {
-      toast({
-        title: "Thành công",
-        description: "Quyết định đã được tạo."
-      })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Tạo quyết định thất bại",
-        description: error.message
-      })
-    },
-  })
-}
-
-function useUpdateMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void
-) {
-  return useMutation({
-    mutationFn: async (data: {
-      id: number
-      so_quyet_dinh: string
-      ngay_ban_hanh: string
-      ngay_hieu_luc: string
-      ngay_het_hieu_luc: string | null
-      nguoi_ky: string
-      chuc_vu_nguoi_ky: string
-      ghi_chu: string | null
-    }) => {
-      return callRpc({
-        fn: 'dinh_muc_quyet_dinh_update',
-        args: {
-          p_id: data.id,
-          p_so_quyet_dinh: data.so_quyet_dinh,
-          p_ngay_ban_hanh: data.ngay_ban_hanh,
-          p_ngay_hieu_luc: data.ngay_hieu_luc,
-          p_ngay_het_hieu_luc: data.ngay_het_hieu_luc,
-          p_nguoi_ky: data.nguoi_ky,
-          p_chuc_vu_nguoi_ky: data.chuc_vu_nguoi_ky,
-          p_ghi_chu: data.ghi_chu,
-        }
-      })
-    },
-    onSuccess: () => {
-      toast({
-        title: "Thành công",
-        description: "Đã cập nhật quyết định."
-      })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi cập nhật",
-        description: error.message
-      })
-    },
-  })
-}
-
-function useActivateMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void
-) {
-  return useMutation({
-    mutationFn: async (id: number) => {
-      return callRpc({
-        fn: 'dinh_muc_quyet_dinh_activate',
-        args: { p_id: id }
-      })
-    },
-    onSuccess: () => {
-      toast({
-        title: "Thành công",
-        description: "Quyết định đã được kích hoạt."
-      })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi kích hoạt quyết định",
-        description: error.message
-      })
-    },
-  })
-}
-
-function useDeleteMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void
-) {
-  return useMutation({
-    mutationFn: async (id: number) => {
-      return callRpc({
-        fn: 'dinh_muc_quyet_dinh_delete',
-        args: { p_id: id }
-      })
-    },
-    onSuccess: () => {
-      toast({
-        title: "Đã xóa",
-        description: "Quyết định đã được xóa thành công."
-      })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi xóa quyết định",
-        description: error.message
-      })
-    },
-  })
-}
-
-// ============================================
-// Context
-// ============================================
-
 const DeviceQuotaDecisionsContext = React.createContext<DeviceQuotaDecisionsContextValue | null>(null)
 
 // ============================================
@@ -299,10 +150,10 @@ export function DeviceQuotaDecisionsProvider({ children }: DeviceQuotaDecisionsP
   }, [queryClient])
 
   // Mutations
-  const createMutation = useCreateMutation(toast, invalidateAndRefetch)
-  const updateMutation = useUpdateMutation(toast, invalidateAndRefetch)
-  const activateMutation = useActivateMutation(toast, invalidateAndRefetch)
-  const deleteMutation = useDeleteMutation(toast, invalidateAndRefetch)
+  const createMutation = useCreateMutation(toast)
+  const updateMutation = useUpdateMutation(toast)
+  const activateMutation = useActivateMutation(toast)
+  const deleteMutation = useDeleteMutation(toast)
 
   // Dialog actions
   const openCreateDialog = React.useCallback(() => {

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
 import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
@@ -9,6 +9,7 @@ import { useTenantSelection } from "@/contexts/TenantSelectionContext"
 import { useServerPagination } from "@/hooks/useServerPagination"
 import { useUnassignedEquipmentFilters } from "../_hooks/useUnassignedEquipmentFilters"
 import { filterCategoriesWithAncestorsAndDescendants } from "../../categories/_utils/filterCategoriesWithAncestorsAndDescendants"
+import { useLinkEquipmentMutation } from "./DeviceQuotaMappingMutations"
 
 // ============================================
 // Types
@@ -106,58 +107,12 @@ export interface DeviceQuotaMappingContextValue {
 }
 
 // ============================================
-// Mutation Hook
-// ============================================
-
-function useLinkEquipmentMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void,
-  clearSelection: () => void,
-  donViId: number | null
-) {
-  return useMutation({
-    mutationFn: async (data: { thiet_bi_ids: number[]; nhom_id: number }) => {
-      return callRpc({
-        fn: 'dinh_muc_thiet_bi_link',
-        args: {
-          p_thiet_bi_ids: data.thiet_bi_ids,
-          p_nhom_id: data.nhom_id,
-          p_don_vi: donViId,
-        }
-      })
-    },
-    onSuccess: (_, variables) => {
-      toast({
-        title: "Thành công",
-        description: `Đã gán ${variables.thiet_bi_ids.length} thiết bị vào nhóm định mức.`
-      })
-      clearSelection()
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi gán thiết bị",
-        description: error.message
-      })
-    },
-  })
-}
-
-// ============================================
-// Client-side Category Search with ancestor + descendant preservation
-// ============================================
-
 function useFilteredCategories(allCategories: Category[], searchTerm: string): Category[] {
   return React.useMemo(
     () => filterCategoriesWithAncestorsAndDescendants(allCategories, searchTerm),
     [allCategories, searchTerm]
   )
 }
-
-// ============================================
-// Context & Provider
-// ============================================
 
 const DeviceQuotaMappingContext = React.createContext<DeviceQuotaMappingContextValue | null>(null)
 
@@ -327,7 +282,7 @@ export function DeviceQuotaMappingProvider({ children }: DeviceQuotaMappingProvi
     setSelectedCategoryId(null)
   }, [])
 
-  const linkMutation = useLinkEquipmentMutation(toast, invalidateAndRefetch, clearSelection, donViId)
+  const linkMutation = useLinkEquipmentMutation(toast, clearSelection, donViId)
 
   // Selection actions — "select all" only selects current page
   const toggleEquipmentSelection = React.useCallback((id: number) => {

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingMutations.ts
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingMutations.ts
@@ -1,0 +1,45 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { useToast } from "@/hooks/use-toast"
+import { callRpc } from "@/lib/rpc-client"
+
+export function useLinkEquipmentMutation(
+  toast: ReturnType<typeof useToast>["toast"],
+  clearSelection: () => void,
+  donViId: number | null
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: { thiet_bi_ids: number[]; nhom_id: number }) => {
+      return callRpc({
+        fn: 'dinh_muc_thiet_bi_link',
+        args: {
+          p_thiet_bi_ids: data.thiet_bi_ids,
+          p_nhom_id: data.nhom_id,
+          p_don_vi: donViId,
+        }
+      })
+    },
+    onSuccess: (_, variables) => {
+      toast({
+        title: "Thành công",
+        description: `Đã gán ${variables.thiet_bi_ids.length} thiết bị vào nhóm định mức.`
+      })
+      clearSelection()
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_thiet_bi_unassigned'] })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_thiet_bi_unassigned_filter_options'] })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_nhom_list'] })
+      queryClient.invalidateQueries({ queryKey: ['dinh_muc_compliance_summary'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi gán thiết bị",
+        description: error.message
+      })
+    },
+  })
+}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx
@@ -1,19 +1,24 @@
 "use client"
 
 import * as React from "react"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 import { useSession } from "next-auth/react"
 import { useToast } from "@/hooks/use-toast"
-import { callRpc } from "@/lib/rpc-client"
 import { isEquipmentManagerRole, isRegionalLeaderRole } from "@/lib/rbac"
 import type {
   RepairRequestWithEquipment,
-  RepairUnit,
   AuthUser,
   EquipmentSelectItem
 } from "../types"
 import type { RepairRequestDraftPayload } from "@/lib/ai/draft/repair-request-draft-schema"
 import { useAssistantDraft } from "../_hooks/useAssistantDraft"
+import {
+  useApproveMutation,
+  useCompleteMutation,
+  useCreateMutation,
+  useDeleteMutation,
+  useUpdateMutation,
+} from "./RepairRequestsMutations"
 
 // ============================================
 // Context Types
@@ -65,192 +70,6 @@ interface RepairRequestsContextValue {
 }
 
 // ============================================
-// Mutation Hooks
-// ============================================
-
-function useCreateMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void
-) {
-  return useMutation({
-    mutationFn: async (data: {
-      thiet_bi_id: number
-      mo_ta_su_co: string
-      hang_muc_sua_chua: string | null
-      ngay_mong_muon_hoan_thanh: string | null
-      nguoi_yeu_cau: string
-      don_vi_thuc_hien: RepairUnit | null
-      ten_don_vi_thue: string | null
-    }) => {
-      return callRpc({
-        fn: 'repair_request_create',
-        args: {
-          p_thiet_bi_id: data.thiet_bi_id,
-          p_mo_ta_su_co: data.mo_ta_su_co,
-          p_hang_muc_sua_chua: data.hang_muc_sua_chua,
-          p_ngay_mong_muon_hoan_thanh: data.ngay_mong_muon_hoan_thanh,
-          p_nguoi_yeu_cau: data.nguoi_yeu_cau,
-          p_don_vi_thuc_hien: data.don_vi_thuc_hien,
-          p_ten_don_vi_thue: data.ten_don_vi_thue,
-        }
-      })
-    },
-    onSuccess: () => {
-      toast({ title: "Thành công", description: "Yêu cầu sửa chữa đã được gửi." })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Gửi yêu cầu thất bại",
-        description: error.message
-      })
-    },
-  })
-}
-
-function useUpdateMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void
-) {
-  return useMutation({
-    mutationFn: async (data: {
-      id: number
-      mo_ta_su_co: string
-      hang_muc_sua_chua: string
-      ngay_mong_muon_hoan_thanh: string | null
-      don_vi_thuc_hien?: RepairUnit
-      ten_don_vi_thue: string | null
-    }) => {
-      return callRpc({
-        fn: 'repair_request_update',
-        args: {
-          p_id: data.id,
-          p_mo_ta_su_co: data.mo_ta_su_co,
-          p_hang_muc_sua_chua: data.hang_muc_sua_chua,
-          p_ngay_mong_muon_hoan_thanh: data.ngay_mong_muon_hoan_thanh,
-          p_don_vi_thuc_hien: data.don_vi_thuc_hien,
-          p_ten_don_vi_thue: data.ten_don_vi_thue,
-        }
-      })
-    },
-    onSuccess: () => {
-      toast({ title: "Thành công", description: "Đã cập nhật yêu cầu." })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi cập nhật",
-        description: error.message
-      })
-    },
-  })
-}
-
-function useDeleteMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void
-) {
-  return useMutation({
-    mutationFn: async (id: number) => {
-      return callRpc({ fn: 'repair_request_delete', args: { p_id: id } })
-    },
-    onSuccess: () => {
-      toast({ title: "Đã xóa", description: "Yêu cầu đã được xóa thành công." })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi xóa yêu cầu",
-        description: error.message
-      })
-    },
-  })
-}
-
-function useApproveMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void,
-  user: AuthUser | null
-) {
-  return useMutation({
-    mutationFn: async (data: {
-      id: number
-      don_vi_thuc_hien: RepairUnit
-      ten_don_vi_thue: string | null
-    }) => {
-      return callRpc({
-        fn: 'repair_request_approve',
-        args: {
-          p_id: data.id,
-          p_nguoi_duyet: user?.full_name || user?.username || '',
-          p_don_vi_thuc_hien: data.don_vi_thuc_hien,
-          p_ten_don_vi_thue: data.ten_don_vi_thue,
-        }
-      })
-    },
-    onSuccess: () => {
-      toast({ title: "Thành công", description: "Đã duyệt yêu cầu." })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi duyệt yêu cầu",
-        description: error.message
-      })
-    },
-  })
-}
-
-function useCompleteMutation(
-  toast: ReturnType<typeof useToast>["toast"],
-  invalidate: () => void
-) {
-  return useMutation({
-    mutationFn: async (data: {
-      id: number
-      completion: string | null
-      reason: string | null
-      repairCost: number | null
-    }) => {
-      const completion = data.completion?.trim() ?? ""
-      const reason = data.reason?.trim() ?? ""
-
-      if (completion.length === 0 && reason.length === 0) {
-        throw new Error("Phải nhập kết quả sửa chữa hoặc lý do không hoàn thành")
-      }
-
-      return callRpc({
-        fn: 'repair_request_complete',
-        args: {
-          p_id: data.id,
-          p_completion: completion.length > 0 ? completion : null,
-          p_reason: reason.length > 0 ? reason : null,
-          p_chi_phi_sua_chua: data.repairCost,
-        }
-      })
-    },
-    onSuccess: () => {
-      toast({ title: "Thành công", description: "Đã cập nhật trạng thái yêu cầu." })
-      invalidate()
-    },
-    onError: (error: Error) => {
-      toast({
-        variant: "destructive",
-        title: "Lỗi cập nhật yêu cầu",
-        description: error.message
-      })
-    },
-  })
-}
-
-// ============================================
-// Context
-// ============================================
-
 const RepairRequestsContext = React.createContext<RepairRequestsContextValue | null>(null)
 
 // ============================================
@@ -302,11 +121,11 @@ export function RepairRequestsProvider({ children }: RepairRequestsProviderProps
   }, [queryClient])
 
   // Mutations
-  const createMutation = useCreateMutation(toast, invalidateAndRefetch)
-  const updateMutation = useUpdateMutation(toast, invalidateAndRefetch)
-  const deleteMutation = useDeleteMutation(toast, invalidateAndRefetch)
-  const approveMutation = useApproveMutation(toast, invalidateAndRefetch, user)
-  const completeMutation = useCompleteMutation(toast, invalidateAndRefetch)
+  const createMutation = useCreateMutation(toast)
+  const updateMutation = useUpdateMutation(toast)
+  const deleteMutation = useDeleteMutation(toast)
+  const approveMutation = useApproveMutation(toast, user)
+  const completeMutation = useCompleteMutation(toast)
 
   // Dialog actions
   const openEditDialog = React.useCallback((request: RepairRequestWithEquipment) => {

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMutations.ts
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMutations.ts
@@ -1,0 +1,212 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { useToast } from "@/hooks/use-toast"
+import { callRpc } from "@/lib/rpc-client"
+import type { AuthUser, RepairUnit } from "../types"
+
+
+export function useCreateMutation(
+  toast: ReturnType<typeof useToast>["toast"]
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: {
+      thiet_bi_id: number
+      mo_ta_su_co: string
+      hang_muc_sua_chua: string | null
+      ngay_mong_muon_hoan_thanh: string | null
+      nguoi_yeu_cau: string
+      don_vi_thuc_hien: RepairUnit | null
+      ten_don_vi_thue: string | null
+    }) => {
+      return callRpc({
+        fn: 'repair_request_create',
+        args: {
+          p_thiet_bi_id: data.thiet_bi_id,
+          p_mo_ta_su_co: data.mo_ta_su_co,
+          p_hang_muc_sua_chua: data.hang_muc_sua_chua,
+          p_ngay_mong_muon_hoan_thanh: data.ngay_mong_muon_hoan_thanh,
+          p_nguoi_yeu_cau: data.nguoi_yeu_cau,
+          p_don_vi_thuc_hien: data.don_vi_thuc_hien,
+          p_ten_don_vi_thue: data.ten_don_vi_thue,
+        }
+      })
+    },
+    onSuccess: () => {
+      toast({ title: "Thành công", description: "Yêu cầu sửa chữa đã được gửi." })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_list'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_facilities'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Gửi yêu cầu thất bại",
+        description: error.message
+      })
+    },
+  })
+}
+
+export function useUpdateMutation(
+  toast: ReturnType<typeof useToast>["toast"]
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: {
+      id: number
+      mo_ta_su_co: string
+      hang_muc_sua_chua: string
+      ngay_mong_muon_hoan_thanh: string | null
+      don_vi_thuc_hien?: RepairUnit
+      ten_don_vi_thue: string | null
+    }) => {
+      return callRpc({
+        fn: 'repair_request_update',
+        args: {
+          p_id: data.id,
+          p_mo_ta_su_co: data.mo_ta_su_co,
+          p_hang_muc_sua_chua: data.hang_muc_sua_chua,
+          p_ngay_mong_muon_hoan_thanh: data.ngay_mong_muon_hoan_thanh,
+          p_don_vi_thuc_hien: data.don_vi_thuc_hien,
+          p_ten_don_vi_thue: data.ten_don_vi_thue,
+        }
+      })
+    },
+    onSuccess: () => {
+      toast({ title: "Thành công", description: "Đã cập nhật yêu cầu." })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_list'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_facilities'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi cập nhật",
+        description: error.message
+      })
+    },
+  })
+}
+
+export function useDeleteMutation(
+  toast: ReturnType<typeof useToast>["toast"]
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      return callRpc({ fn: 'repair_request_delete', args: { p_id: id } })
+    },
+    onSuccess: () => {
+      toast({ title: "Đã xóa", description: "Yêu cầu đã được xóa thành công." })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_list'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_facilities'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi xóa yêu cầu",
+        description: error.message
+      })
+    },
+  })
+}
+
+export function useApproveMutation(
+  toast: ReturnType<typeof useToast>["toast"],
+  user: AuthUser | null
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: {
+      id: number
+      don_vi_thuc_hien: RepairUnit
+      ten_don_vi_thue: string | null
+    }) => {
+      return callRpc({
+        fn: 'repair_request_approve',
+        args: {
+          p_id: data.id,
+          p_nguoi_duyet: user?.full_name || user?.username || '',
+          p_don_vi_thuc_hien: data.don_vi_thuc_hien,
+          p_ten_don_vi_thue: data.ten_don_vi_thue,
+        }
+      })
+    },
+    onSuccess: () => {
+      toast({ title: "Thành công", description: "Đã duyệt yêu cầu." })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_list'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_facilities'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi phê duyệt",
+        description: error.message
+      })
+    },
+  })
+}
+
+export function useCompleteMutation(
+  toast: ReturnType<typeof useToast>["toast"]
+) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (data: {
+      id: number
+      completion: string | null
+      reason: string | null
+      repairCost: number | null
+    }) => {
+      const completion = data.completion?.trim() ?? ""
+      const reason = data.reason?.trim() ?? ""
+
+      if (completion.length === 0 && reason.length === 0) {
+        throw new Error("Phải nhập kết quả sửa chữa hoặc lý do không hoàn thành")
+      }
+
+      return callRpc({
+        fn: 'repair_request_complete',
+        args: {
+          p_id: data.id,
+          p_completion: completion.length > 0 ? completion : null,
+          p_reason: reason.length > 0 ? reason : null,
+          p_chi_phi_sua_chua: data.repairCost,
+        }
+      })
+    },
+    onSuccess: () => {
+      toast({ title: "Thành công", description: "Đã cập nhật trạng thái yêu cầu." })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_list'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_facilities'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
+      queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Lỗi cập nhật yêu cầu",
+        description: error.message
+      })
+    },
+  })
+}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMutations.ts
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMutations.ts
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
+import { repairKeys } from "@/hooks/use-cached-repair"
 import type { AuthUser, RepairUnit } from "../types"
 
 
@@ -42,6 +43,7 @@ export function useCreateMutation(
       queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
       queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+      queryClient.invalidateQueries({ queryKey: repairKeys.all })
     },
     onError: (error: Error) => {
       toast({
@@ -86,6 +88,7 @@ export function useUpdateMutation(
       queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
       queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+      queryClient.invalidateQueries({ queryKey: repairKeys.all })
     },
     onError: (error: Error) => {
       toast({
@@ -113,6 +116,7 @@ export function useDeleteMutation(
       queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
       queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+      queryClient.invalidateQueries({ queryKey: repairKeys.all })
     },
     onError: (error: Error) => {
       toast({
@@ -153,6 +157,7 @@ export function useApproveMutation(
       queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
       queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+      queryClient.invalidateQueries({ queryKey: repairKeys.all })
     },
     onError: (error: Error) => {
       toast({
@@ -200,6 +205,7 @@ export function useCompleteMutation(
       queryClient.invalidateQueries({ queryKey: ['repair_request_status_counts'] })
       queryClient.invalidateQueries({ queryKey: ['repair_request_change_history'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
+      queryClient.invalidateQueries({ queryKey: repairKeys.all })
     },
     onError: (error: Error) => {
       toast({


### PR DESCRIPTION
## Summary
- Resolve the 13 remaining `react-doctor/query-mutation-missing-invalidation` P0 findings.
- Extract repair-request and device-quota mutation hooks into focused mutation files so each `useMutation` owns direct `queryClient.invalidateQueries(...)` calls.
- Tighten the React Doctor P0 source test to catch callback-only invalidation indirection.

## Verification
- RED confirmed: `node scripts/npm-run.js run test:run -- src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts` failed on callback-only invalidation before production changes.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/__tests__/react-doctor-p0-mutation-invalidation.source.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose --yes --project nextn --offline --diff main`
- `node scripts/npm-run.js npx react-doctor@latest . --full --verbose --project nextn --offline`

## React Doctor Notes
- Full scan improved from `79 / 100`, 560 issues to `80 / 100`, 547 issues.
- Current full scan has no `react-doctor/query-mutation-missing-invalidation` results.
- Diff scan still reports 2 non-P0 pre-existing warnings in touched context files: `prefer-useReducer` and `no-cascading-set-state`; these are intentionally outside this P0 PR scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all remaining P0 React Doctor invalidation findings by making each mutation own its `queryClient.invalidateQueries(...)` and moving mutation hooks into focused modules. This prevents stale UI after mutations and tightens the source test to forbid shared invalidation callbacks.

- **Bug Fixes**
  - Repair requests: invalidate `repair_request_list`, `repair_request_facilities`, `repair_request_status_counts`, `repair_request_change_history`, `dashboard-stats`, and `repairKeys.all`.
  - Device quota: categories invalidate `dinh_muc_nhom_list`, `dinh_muc_compliance_summary`; decisions invalidate `dinh_muc_quyet_dinh_list`, `dinh_muc_compliance_summary`; mapping invalidates `dinh_muc_thiet_bi_unassigned`, `dinh_muc_thiet_bi_unassigned_filter_options`, `dinh_muc_nhom_list`, `dinh_muc_compliance_summary`.

- **Refactors**
  - Extracted mutation hooks into `RepairRequestsMutations.ts`, `DeviceQuotaCategoryMutations.ts`, `DeviceQuotaDecisionMutations.ts`, and `DeviceQuotaMappingMutations.ts`.
  - Updated contexts to use the new hooks and removed shared invalidation callbacks; preserved category embedding refresh on create/update.

<sup>Written for commit 945de70dff4dbbdb4edd235110c1e74ae2ad03bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized mutation management by extracting mutation hooks into dedicated modules for repair-request, device-quota category, decision, and mapping operations, improving code separation, reducing duplication, and enhancing maintainability across context providers.

* **Tests**
  * Updated and enhanced test coverage to validate that mutation implementations correctly handle cache invalidation, data persistence, and error handling at the module level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/476)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->