### PR TITLE
Fix Issue #473: React Doctor knip exports cleanup

### DIFF
--- a/src/__tests__/react-doctor-p4-knip-exports.source.test.ts
+++ b/src/__tests__/react-doctor-p4-knip-exports.source.test.ts
@@ -148,10 +148,6 @@ const unusedExportSurface = [
     exports: ["useCreateEquipment","useEquipmentDetail"],
   },
   {
-    file: "src/hooks/use-cached-maintenance.ts",
-    exports: ["useUpdateMaintenancePlan"],
-  },
-  {
     file: "src/hooks/use-dashboard-stats.ts",
     exports: ["useDashboardKpiSummary"],
   },
@@ -253,6 +249,14 @@ const unusedExportSurface = [
   },
 ] as const
 
+const intentionalPublicExports = [
+  {
+    file: "src/hooks/use-cached-maintenance.ts",
+    exports: ["useUpdateMaintenancePlan"],
+    reason: "covered by src/hooks/__tests__/use-cached-maintenance-barrel.test.ts",
+  },
+] as const
+
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 
@@ -275,6 +279,19 @@ describe("React Doctor P4 knip/exports cleanup", () => {
         )
         expect(source, `${entry.file} still re-exports ${exportName}`).not.toMatch(
           namedExportPattern(exportName),
+        )
+      }
+    }
+  })
+
+  it("documents intentional public exports that remain despite knip reports", () => {
+    for (const entry of intentionalPublicExports) {
+      const source = readFileSync(join(process.cwd(), entry.file), "utf8")
+
+      for (const exportName of entry.exports) {
+        expect(entry.reason).toContain("use-cached-maintenance-barrel.test.ts")
+        expect(source, entry.file + " must keep public export " + exportName).toMatch(
+          exportDeclarationPattern(exportName),
         )
       }
     }

--- a/src/__tests__/react-doctor-p4-knip-exports.source.test.ts
+++ b/src/__tests__/react-doctor-p4-knip-exports.source.test.ts
@@ -37,7 +37,7 @@ const unusedExportSurface = [
   },
   {
     file: "src/app/(app)/reports/hooks/use-maintenance-data.ts",
-    exports: ["defaultMaintenanceReportData","maintenanceReportKeys"],
+    exports: ["maintenanceReportKeys"],
   },
   {
     file: "src/app/(app)/reports/hooks/use-unused-equipment-report.ts",
@@ -98,10 +98,6 @@ const unusedExportSurface = [
   {
     file: "src/components/ui/alert-dialog.tsx",
     exports: ["AlertDialogOverlay","AlertDialogPortal"],
-  },
-  {
-    file: "src/components/ui/avatar.tsx",
-    exports: ["AvatarImage"],
   },
   {
     file: "src/components/ui/badge.tsx",
@@ -226,10 +222,6 @@ const unusedExportSurface = [
   {
     file: "src/lib/excel-utils.ts",
     exports: ["exportArrayToExcel"],
-  },
-  {
-    file: "src/lib/feature-flags.ts",
-    exports: ["getFeatureFlag"],
   },
   {
     file: "src/lib/rbac.ts",

--- a/src/__tests__/react-doctor-p4-knip-exports.source.test.ts
+++ b/src/__tests__/react-doctor-p4-knip-exports.source.test.ts
@@ -1,0 +1,282 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const unusedExportSurface = [
+  {
+    file: "src/app/(app)/device-quota/categories/_components/category-tree-utils.ts",
+    exports: ["CATEGORY_ENTITY"],
+  },
+  {
+    file: "src/app/(app)/maintenance/_components/maintenance-task-row-id.ts",
+    exports: ["MAINTENANCE_TASK_ROW_ID_PREFIX"],
+  },
+  {
+    file: "src/app/(app)/maintenance/_components/MaintenanceContext.tsx",
+    exports: ["getNextMaintenanceTempTaskId"],
+  },
+  {
+    file: "src/app/(app)/maintenance/_hooks/maintenance-print-template.ts",
+    exports: ["formatValue"],
+  },
+  {
+    file: "src/app/(app)/repair-requests/_components/RepairRequestsApproveDialog.tsx",
+    exports: ["ApproveRequestDialog"],
+  },
+  {
+    file: "src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx",
+    exports: ["CreateRequestSheet"],
+  },
+  {
+    file: "src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts",
+    exports: ["buildRepairRequestViewCleanupPath","parseRepairRequestIdParam","resolveRepairRequestView"],
+  },
+  {
+    file: "src/app/(app)/reports/hooks/use-inventory-data.ts",
+    exports: ["reportsKeys"],
+  },
+  {
+    file: "src/app/(app)/reports/hooks/use-maintenance-data.ts",
+    exports: ["defaultMaintenanceReportData","maintenanceReportKeys"],
+  },
+  {
+    file: "src/app/(app)/reports/hooks/use-unused-equipment-report.ts",
+    exports: ["unusedEquipmentReportKeys"],
+  },
+  {
+    file: "src/app/(app)/users/_components/usersColumns.tsx",
+    exports: ["getRoleVariant"],
+  },
+  {
+    file: "src/app/api/transfers/legacy-adapter.ts",
+    exports: ["applyLegacyFilters","buildCountsFromItems","isMissingFunctionError","paginate","transformLegacyItem"],
+  },
+  {
+    file: "src/components/dashboard/kpi-cards.tsx",
+    exports: ["MaintenanceCountCard","MaintenancePlansCard","RepairRequestsCard","TotalEquipmentCard"],
+  },
+  {
+    file: "src/components/dynamic-chart.tsx",
+    exports: ["DynamicChart"],
+  },
+  {
+    file: "src/components/equipment-decommission-form.ts",
+    exports: ["DECOMMISSIONED_STATUS","getTodayDateForDecommissionField"],
+  },
+  {
+    file: "src/components/equipment-linked-request/index.ts",
+    exports: ["LinkedRequestSheetShell"],
+  },
+  {
+    file: "src/components/equipment/equipment-table-columns.tsx",
+    exports: ["filterableColumns"],
+  },
+  {
+    file: "src/components/error-boundary.tsx",
+    exports: ["withErrorBoundary"],
+  },
+  {
+    file: "src/components/onboarding/tour-configs.ts",
+    exports: ["dashboardWelcomeTour","sidebarNavigationTour"],
+  },
+  {
+    file: "src/components/realtime-status.tsx",
+    exports: ["useRealtimeStatus"],
+  },
+  {
+    file: "src/components/transfer-dialog.data.ts",
+    exports: ["transferDialogQueryKeys"],
+  },
+  {
+    file: "src/components/transfer-dialog.shared.ts",
+    exports: ["createTransferDialogFormDataFromTransfer","getSelectedEquipmentFromTransfer"],
+  },
+  {
+    file: "src/components/transfers/columnDefinitions.tsx",
+    exports: ["buildTransferColumns"],
+  },
+  {
+    file: "src/components/ui/alert-dialog.tsx",
+    exports: ["AlertDialogOverlay","AlertDialogPortal"],
+  },
+  {
+    file: "src/components/ui/avatar.tsx",
+    exports: ["AvatarImage"],
+  },
+  {
+    file: "src/components/ui/badge.tsx",
+    exports: ["badgeVariants"],
+  },
+  {
+    file: "src/components/ui/calendar-widget/CalendarWidgetShared.tsx",
+    exports: ["getEventTypeColor","getEventTypeIcon"],
+  },
+  {
+    file: "src/components/ui/dialog.tsx",
+    exports: ["DialogClose","DialogOverlay","DialogPortal"],
+  },
+  {
+    file: "src/components/ui/dropdown-menu.tsx",
+    exports: ["DropdownMenuGroup","DropdownMenuPortal","DropdownMenuRadioGroup","DropdownMenuRadioItem","DropdownMenuShortcut","DropdownMenuSub","DropdownMenuSubContent","DropdownMenuSubTrigger"],
+  },
+  {
+    file: "src/components/ui/form.tsx",
+    exports: ["useFormField"],
+  },
+  {
+    file: "src/components/ui/scroll-area.tsx",
+    exports: ["ScrollBar"],
+  },
+  {
+    file: "src/components/ui/select.tsx",
+    exports: ["SelectGroup","SelectLabel","SelectScrollDownButton","SelectScrollUpButton","SelectSeparator"],
+  },
+  {
+    file: "src/components/ui/sheet.tsx",
+    exports: ["SheetClose","SheetFooter","SheetOverlay","SheetPortal"],
+  },
+  {
+    file: "src/components/ui/table.tsx",
+    exports: ["TableCaption","TableFooter"],
+  },
+  {
+    file: "src/components/ui/toast.tsx",
+    exports: ["ToastAction"],
+  },
+  {
+    file: "src/hooks/use-cached-equipment.ts",
+    exports: ["useCreateEquipment","useEquipmentDetail"],
+  },
+  {
+    file: "src/hooks/use-cached-maintenance.ts",
+    exports: ["useUpdateMaintenancePlan"],
+  },
+  {
+    file: "src/hooks/use-dashboard-stats.ts",
+    exports: ["useDashboardKpiSummary"],
+  },
+  {
+    file: "src/hooks/use-equipment-distribution.ts",
+    exports: ["equipmentDistributionKeys"],
+  },
+  {
+    file: "src/hooks/use-page-transitions.ts",
+    exports: ["useManualTransition"],
+  },
+  {
+    file: "src/hooks/use-toast.ts",
+    exports: ["reducer"],
+  },
+  {
+    file: "src/hooks/use-usage-analytics.ts",
+    exports: ["usageAnalyticsKeys"],
+  },
+  {
+    file: "src/hooks/use-usage-logs.ts",
+    exports: ["usageLogKeys"],
+  },
+  {
+    file: "src/hooks/useTransferDataGrid.ts",
+    exports: ["getTransferListData","transferKanbanKeys","useInvalidateTransfersKanban","usePrefetchTransferCounts","usePrefetchTransferList","useTransferCounts","useTransferList"],
+  },
+  {
+    file: "src/hooks/useTransfersKanban.ts",
+    exports: ["useInvalidateTransfersKanban"],
+  },
+  {
+    file: "src/lib/advanced-cache-manager.ts",
+    exports: ["CachePerformanceMonitor","InvalidationPatterns","createAdvancedCacheManager"],
+  },
+  {
+    file: "src/lib/ai/draft/repair-request-draft-extraction.ts",
+    exports: ["repairRequestDraftExtractionSchema"],
+  },
+  {
+    file: "src/lib/ai/draft/repair-request-draft-session.ts",
+    exports: ["REPAIR_REQUEST_DRAFT_CANCEL_PHRASES","REPAIR_REQUEST_DRAFT_START_PHRASES","hasRepairRequestDraftCancelIntent"],
+  },
+  {
+    file: "src/lib/ai/errors.ts",
+    exports: ["MODEL_PROVIDER_QUOTA_MESSAGE","extractErrorMessage"],
+  },
+  {
+    file: "src/lib/ai/sql/audited-executor.ts",
+    exports: ["writeAssistantSqlAudit"],
+  },
+  {
+    file: "src/lib/ai/tools/registry.ts",
+    exports: ["hasWriteIntentToolName"],
+  },
+  {
+    file: "src/lib/ai/usage-metering.ts",
+    exports: ["__resetUsageMeteringForTests","getLatestUsage"],
+  },
+  {
+    file: "src/lib/category-import-validation.ts",
+    exports: ["HEADER_TO_DB_MAP","normalizeVietnamese"],
+  },
+  {
+    file: "src/lib/chart-utils.ts",
+    exports: ["CHART_COLORS","DEFAULT_CHART_CONFIG","RESPONSIVE_CONTAINER_PROPS","formatChartNumber","formatChartPercentage","processChartData"],
+  },
+  {
+    file: "src/lib/date-utils.ts",
+    exports: ["SUSPICIOUS_YEAR_THRESHOLD","parsePartialDateToISO"],
+  },
+  {
+    file: "src/lib/department-utils.ts",
+    exports: ["getUserEffectiveDepartments","normalizeDepartmentName","validateEquipmentAccess"],
+  },
+  {
+    file: "src/lib/excel-utils.ts",
+    exports: ["exportArrayToExcel"],
+  },
+  {
+    file: "src/lib/feature-flags.ts",
+    exports: ["getFeatureFlag"],
+  },
+  {
+    file: "src/lib/rbac.ts",
+    exports: ["DEPT_SCOPED_ROLES","EQUIPMENT_MANAGER_ROLES","GLOBAL_ROLES","PRIVILEGED_ROLES"],
+  },
+  {
+    file: "src/lib/rpc-normalize.ts",
+    exports: ["getDateOnly"],
+  },
+  {
+    file: "src/lib/supabase.ts",
+    exports: ["supabaseError"],
+  },
+  {
+    file: "src/types/transfers-data-grid.ts",
+    exports: ["TransferCountsResponseSchema","TransferEquipmentInfoSchema","TransferKanbanColumnDataSchema","TransferListItemSchema","TransferOverdueSummaryItemSchema","TransferOverdueSummarySchema"],
+  },
+] as const
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+const exportDeclarationPattern = (name: string) =>
+  new RegExp(
+    `\\bexport\\s+(?:declare\\s+)?(?:async\\s+)?(?:const|let|var|function|class|interface|type|enum)\\s+${escapeRegExp(name)}\\b`,
+  )
+
+const namedExportPattern = (name: string) =>
+  new RegExp(`\\bexport\\s*\\{[^}]*\\b${escapeRegExp(name)}\\b[^}]*\\}`, "s")
+
+describe("React Doctor P4 knip/exports cleanup", () => {
+  it("removes the current unused named export surface", () => {
+    for (const entry of unusedExportSurface) {
+      const source = readFileSync(join(process.cwd(), entry.file), "utf8")
+
+      for (const exportName of entry.exports) {
+        expect(source, `${entry.file} still exports ${exportName}`).not.toMatch(
+          exportDeclarationPattern(exportName),
+        )
+        expect(source, `${entry.file} still re-exports ${exportName}`).not.toMatch(
+          namedExportPattern(exportName),
+        )
+      }
+    }
+  })
+})

--- a/src/app/(app)/device-quota/categories/_components/category-tree-utils.ts
+++ b/src/app/(app)/device-quota/categories/_components/category-tree-utils.ts
@@ -4,8 +4,6 @@ import type { CategoryListItem } from "../_types/categories"
 // Constants
 // ============================================
 
-const CATEGORY_ENTITY = { singular: "nhóm gốc" } as const
-
 /** Shared grid template for column alignment across header, group rows, and child rows */
 export const CATEGORY_GRID_COLS = "grid grid-cols-[minmax(0,1fr)_5rem_12rem_2rem] gap-x-4 items-center"
 

--- a/src/app/(app)/device-quota/categories/_components/category-tree-utils.ts
+++ b/src/app/(app)/device-quota/categories/_components/category-tree-utils.ts
@@ -4,7 +4,7 @@ import type { CategoryListItem } from "../_types/categories"
 // Constants
 // ============================================
 
-export const CATEGORY_ENTITY = { singular: "nhóm gốc" } as const
+const CATEGORY_ENTITY = { singular: "nhóm gốc" } as const
 
 /** Shared grid template for column alignment across header, group rows, and child rows */
 export const CATEGORY_GRID_COLS = "grid grid-cols-[minmax(0,1fr)_5rem_12rem_2rem] gap-x-4 items-center"

--- a/src/app/(app)/maintenance/_components/MaintenanceContext.tsx
+++ b/src/app/(app)/maintenance/_components/MaintenanceContext.tsx
@@ -26,8 +26,6 @@ interface MaintenanceProviderProps {
   setTaskRowSelection: React.Dispatch<React.SetStateAction<RowSelectionState>>
 }
 
-export { getNextMaintenanceTempTaskId } from "./MaintenanceContextHelpers"
-
 export function MaintenanceProvider({
   children,
   taskRowSelection,

--- a/src/app/(app)/maintenance/_components/maintenance-task-row-id.ts
+++ b/src/app/(app)/maintenance/_components/maintenance-task-row-id.ts
@@ -1,6 +1,6 @@
 "use client"
 
-export const MAINTENANCE_TASK_ROW_ID_PREFIX = "task:"
+const MAINTENANCE_TASK_ROW_ID_PREFIX = "task:"
 
 export function toMaintenanceTaskRowId(taskId: number) {
   return `${MAINTENANCE_TASK_ROW_ID_PREFIX}${taskId}`

--- a/src/app/(app)/maintenance/_hooks/maintenance-print-template.ts
+++ b/src/app/(app)/maintenance/_hooks/maintenance-print-template.ts
@@ -10,7 +10,7 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;")
 }
 
-export function formatValue(value: unknown): string {
+function formatValue(value: unknown): string {
   if (value === null || value === undefined) {
     return ""
   }

--- a/src/app/(app)/repair-requests/_components/RepairRequestsApproveDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsApproveDialog.tsx
@@ -122,4 +122,4 @@ export function RepairRequestsApproveDialog() {
 }
 
 // Export alias for backwards compatibility
-export const ApproveRequestDialog = RepairRequestsApproveDialog
+const ApproveRequestDialog = RepairRequestsApproveDialog

--- a/src/app/(app)/repair-requests/_components/RepairRequestsApproveDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsApproveDialog.tsx
@@ -120,6 +120,3 @@ export function RepairRequestsApproveDialog() {
     </Dialog>
   )
 }
-
-// Export alias for backwards compatibility
-const ApproveRequestDialog = RepairRequestsApproveDialog

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx
@@ -341,6 +341,3 @@ export function RepairRequestsCreateSheet() {
     </Sheet>
   )
 }
-
-// Export alias for backwards compatibility
-const CreateRequestSheet = RepairRequestsCreateSheet

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheet.tsx
@@ -343,4 +343,4 @@ export function RepairRequestsCreateSheet() {
 }
 
 // Export alias for backwards compatibility
-export const CreateRequestSheet = RepairRequestsCreateSheet
+const CreateRequestSheet = RepairRequestsCreateSheet

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsDeepLinkView.ts
@@ -69,11 +69,11 @@ function mapEmbeddedEquipment(value: unknown): RepairRequestEquipment {
   }
 }
 
-export function parseRepairRequestIdParam(value: string | null) {
+function parseRepairRequestIdParam(value: string | null) {
   return toPositiveInt(value)
 }
 
-export function buildRepairRequestViewCleanupPath(
+function buildRepairRequestViewCleanupPath(
   pathname: string,
   searchParams: URLSearchParams,
 ) {
@@ -84,7 +84,7 @@ export function buildRepairRequestViewCleanupPath(
   return params.size ? `${pathname}?${params.toString()}` : pathname
 }
 
-export async function resolveRepairRequestView(
+async function resolveRepairRequestView(
   requestId: number,
 ): Promise<RepairRequestWithEquipment | null> {
   const request = await callRpc<RepairRequestRecord | null>({

--- a/src/app/(app)/reports/hooks/use-inventory-data.ts
+++ b/src/app/(app)/reports/hooks/use-inventory-data.ts
@@ -26,7 +26,7 @@ interface DateRange {
 }
 
 // Query keys for reports caching
-export const reportsKeys = {
+const reportsKeys = {
   all: ['reports'] as const,
   inventory: () => [...reportsKeys.all, 'inventory'] as const,
   inventoryData: (filters: InventoryDataFilters) => [...reportsKeys.inventory(), { filters }] as const,

--- a/src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts
+++ b/src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts
@@ -3,4 +3,11 @@ type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends
   (<T>() => T extends B ? 1 : 2) ? true : false
 
-type _inventoryDataFilterContractRemoved = Assert<Equal<true, true>>
+type _inventoryDataFilterContractRemoved = Assert<
+  Equal<
+    'reportsKeys' extends keyof typeof import('@/app/(app)/reports/hooks/use-inventory-data')
+      ? true
+      : false,
+    false
+  >
+>

--- a/src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts
+++ b/src/app/(app)/reports/hooks/use-inventory-data.types.assert.ts
@@ -1,11 +1,6 @@
-import { reportsKeys } from "@/app/(app)/reports/hooks/use-inventory-data"
-import type { InventoryDataFilters } from "@/app/(app)/reports/hooks/use-inventory-data.types"
-
 type Assert<T extends true> = T
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends
   (<T>() => T extends B ? 1 : 2) ? true : false
 
-type _inventoryDataFilters = Assert<
-  Equal<Parameters<typeof reportsKeys.inventoryData>[0], InventoryDataFilters>
->
+type _inventoryDataFilterContractRemoved = Assert<Equal<true, true>>

--- a/src/app/(app)/reports/hooks/use-maintenance-data.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.ts
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query'
 import { callRpc } from '@/lib/rpc-client'
 import { format, startOfYear, endOfYear } from 'date-fns'
 import {
-  defaultMaintenanceReportData,
   type DateRange,
   mergeMaintenanceReportData,
   type MaintenanceReportData,

--- a/src/app/(app)/reports/hooks/use-maintenance-data.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.ts
@@ -8,10 +8,8 @@ import {
   type MaintenanceReportData,
 } from './use-maintenance-data.types'
 
-export { defaultMaintenanceReportData } from './use-maintenance-data.types'
-
 // Query keys for maintenance reports caching
-export const maintenanceReportKeys = {
+const maintenanceReportKeys = {
   all: ['maintenance-reports'] as const,
   data: (filters: Record<string, unknown>) => [...maintenanceReportKeys.all, { filters }] as const,
 }

--- a/src/app/(app)/reports/hooks/use-maintenance-data.types.assert.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.types.assert.ts
@@ -1,9 +1,9 @@
-import { defaultMaintenanceReportData } from '@/app/(app)/reports/hooks/use-maintenance-data'
-import type {
-  MaintenanceReportData,
-  RepairUsageCostCorrelation,
-  RepairUsageCostCorrelationScope,
-  TopEquipmentRepairCostEntry,
+import {
+  defaultMaintenanceReportData,
+  type MaintenanceReportData,
+  type RepairUsageCostCorrelation,
+  type RepairUsageCostCorrelationScope,
+  type TopEquipmentRepairCostEntry,
 } from '@/app/(app)/reports/hooks/use-maintenance-data.types'
 
 type Assert<T extends true> = T

--- a/src/app/(app)/reports/hooks/use-unused-equipment-report.ts
+++ b/src/app/(app)/reports/hooks/use-unused-equipment-report.ts
@@ -56,7 +56,7 @@ export interface UseUnusedEquipmentReportParams {
   enabled: boolean
 }
 
-export const unusedEquipmentReportKeys = {
+const unusedEquipmentReportKeys = {
   data: (params: UseUnusedEquipmentReportParams) => [
     "reports",
     "unused-equipment",

--- a/src/app/(app)/users/_components/usersColumns.tsx
+++ b/src/app/(app)/users/_components/usersColumns.tsx
@@ -26,7 +26,7 @@ type UsersColumnsOptions = {
   onResetPassword: (user: UserSummary) => void
 }
 
-export function getRoleVariant(role: UserSummary["role"]) {
+function getRoleVariant(role: UserSummary["role"]) {
   if (isGlobalRole(role)) return "destructive"
 
   switch (role) {

--- a/src/app/api/transfers/legacy-adapter.ts
+++ b/src/app/api/transfers/legacy-adapter.ts
@@ -137,14 +137,14 @@ const matchesAssignee = (item: LegacyTransferItem, assigneeIds: number[] | null)
   return assigneeIds.includes(item.nguoi_yeu_cau_id)
 }
 
-export const isMissingFunctionError = (status: number, payload: unknown) => {
+const isMissingFunctionError = (status: number, payload: unknown) => {
   if (status !== 404) return false
   if (!payload || typeof payload !== "object") return false
   const maybe = payload as LegacyRpcError
   return maybe.error?.code === "PGRST202"
 }
 
-export const transformLegacyItem = (item: LegacyTransferItem) => ({
+const transformLegacyItem = (item: LegacyTransferItem) => ({
   ...item,
   ly_do_luan_chuyen: item.ly_do_luan_chuyen ?? "",
   thiet_bi: item.thiet_bi
@@ -156,7 +156,7 @@ export const transformLegacyItem = (item: LegacyTransferItem) => ({
     : null,
 })
 
-export const applyLegacyFilters = (data: LegacyTransferItem[], filters: LegacyFilterParams) => {
+const applyLegacyFilters = (data: LegacyTransferItem[], filters: LegacyFilterParams) => {
   return data.filter((item) => {
     if (!matchesStringArrayFilter(item.trang_thai, filters.statuses)) return false
     if (!matchesStringArrayFilter(item.loai_hinh, filters.types)) return false
@@ -168,7 +168,7 @@ export const applyLegacyFilters = (data: LegacyTransferItem[], filters: LegacyFi
   })
 }
 
-export const paginate = <T,>(items: T[], page: number, pageSize: number): PaginatedResult<T> => {
+const paginate = <T,>(items: T[], page: number, pageSize: number): PaginatedResult<T> => {
   const safePageSize = Math.max(1, pageSize)
   const safePage = Math.max(1, page)
   const offset = (safePage - 1) * safePageSize
@@ -181,7 +181,7 @@ export const paginate = <T,>(items: T[], page: number, pageSize: number): Pagina
   }
 }
 
-export const buildCountsFromItems = (items: LegacyTransferItem[]) => {
+const buildCountsFromItems = (items: LegacyTransferItem[]) => {
   const counts = {
     cho_duyet: 0,
     da_duyet: 0,

--- a/src/app/api/transfers/legacy-adapter.ts
+++ b/src/app/api/transfers/legacy-adapter.ts
@@ -52,6 +52,19 @@ export interface PaginatedResult<T> {
   pageSize: number
 }
 
+interface LegacyTransferCounts {
+  cho_duyet: number
+  da_duyet: number
+  dang_luan_chuyen: number
+  da_ban_giao: number
+  hoan_thanh: number
+}
+
+interface LegacyTransferCountsSummary {
+  counts: LegacyTransferCounts
+  totalCount: number
+}
+
 export const ALLOWED_STATUSES = [
   "cho_duyet",
   "da_duyet",
@@ -137,14 +150,14 @@ const matchesAssignee = (item: LegacyTransferItem, assigneeIds: number[] | null)
   return assigneeIds.includes(item.nguoi_yeu_cau_id)
 }
 
-const isMissingFunctionError = (status: number, payload: unknown) => {
+const isMissingFunctionError = (status: number, payload: unknown): boolean => {
   if (status !== 404) return false
   if (!payload || typeof payload !== "object") return false
   const maybe = payload as LegacyRpcError
   return maybe.error?.code === "PGRST202"
 }
 
-const transformLegacyItem = (item: LegacyTransferItem) => ({
+const transformLegacyItem = (item: LegacyTransferItem): LegacyTransferItem => ({
   ...item,
   ly_do_luan_chuyen: item.ly_do_luan_chuyen ?? "",
   thiet_bi: item.thiet_bi
@@ -156,7 +169,10 @@ const transformLegacyItem = (item: LegacyTransferItem) => ({
     : null,
 })
 
-const applyLegacyFilters = (data: LegacyTransferItem[], filters: LegacyFilterParams) => {
+const applyLegacyFilters = (
+  data: LegacyTransferItem[],
+  filters: LegacyFilterParams,
+): LegacyTransferItem[] => {
   return data.filter((item) => {
     if (!matchesStringArrayFilter(item.trang_thai, filters.statuses)) return false
     if (!matchesStringArrayFilter(item.loai_hinh, filters.types)) return false
@@ -181,8 +197,8 @@ const paginate = <T,>(items: T[], page: number, pageSize: number): PaginatedResu
   }
 }
 
-const buildCountsFromItems = (items: LegacyTransferItem[]) => {
-  const counts = {
+const buildCountsFromItems = (items: LegacyTransferItem[]): LegacyTransferCountsSummary => {
+  const counts: LegacyTransferCounts = {
     cho_duyet: 0,
     da_duyet: 0,
     dang_luan_chuyen: 0,
@@ -192,7 +208,7 @@ const buildCountsFromItems = (items: LegacyTransferItem[]) => {
 
   for (const item of items) {
     if (item.trang_thai in counts) {
-      counts[item.trang_thai as keyof typeof counts] += 1
+      counts[item.trang_thai as keyof LegacyTransferCounts] += 1
     }
   }
 

--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -38,7 +38,7 @@ const metricClass =
 const descriptionClass =
   "text-sm text-neutral-500 leading-snug md:text-xs md:text-muted-foreground md:leading-tight"
 
-export function TotalEquipmentCard() {
+function TotalEquipmentCard() {
   const { data: totalDevices, isLoading, error } = useTotalEquipment()
 
   return (
@@ -63,7 +63,7 @@ export function TotalEquipmentCard() {
   )
 }
 
-export function MaintenanceCountCard() {
+function MaintenanceCountCard() {
   const { data: maintenanceCount, isLoading, error } = useMaintenanceCount()
 
   return (
@@ -88,7 +88,7 @@ export function MaintenanceCountCard() {
   )
 }
 
-export function RepairRequestsCard() {
+function RepairRequestsCard() {
   const { data: repairStats, isLoading, error } = useRepairRequestStats()
 
   const pending = repairStats?.pending ?? 0
@@ -161,7 +161,7 @@ export function RepairRequestsCard() {
   )
 }
 
-export function MaintenancePlansCard() {
+function MaintenancePlansCard() {
   const { data: planStats, isLoading, error } = useMaintenancePlanStats()
   const total = planStats?.total ?? 0
   const draft = planStats?.draft ?? 0

--- a/src/components/dynamic-chart.tsx
+++ b/src/components/dynamic-chart.tsx
@@ -21,7 +21,7 @@ interface DynamicChartProps {
  * Dynamic Chart Component
  * Loads Recharts library only when needed and provides loading/error states
  */
-export function DynamicChart({
+function DynamicChart({
   children,
   height = 300,
   fallbackHeight,

--- a/src/components/equipment-decommission-form.ts
+++ b/src/components/equipment-decommission-form.ts
@@ -22,7 +22,7 @@ export {
   normalizeFullDateForForm,
 } from "@/lib/date-utils"
 
-export const DECOMMISSIONED_STATUS = "Ngưng sử dụng"
+const DECOMMISSIONED_STATUS = "Ngưng sử dụng"
 export const DECOMMISSION_DATE_STATUS_ERROR_MESSAGE =
   'Ngày ngừng sử dụng chỉ được phép khi tình trạng là "Ngưng sử dụng"'
 export const DECOMMISSION_DATE_CHRONOLOGICAL_ERROR_MESSAGE =
@@ -76,7 +76,7 @@ export function validateDecommissionDateRules(
   }
 }
 
-export function getTodayDateForDecommissionField(): string {
+function getTodayDateForDecommissionField(): string {
   const formatter = new Intl.DateTimeFormat("en-GB", {
     timeZone: "Asia/Ho_Chi_Minh",
     day: "2-digit",

--- a/src/components/equipment-linked-request/index.ts
+++ b/src/components/equipment-linked-request/index.ts
@@ -10,6 +10,5 @@
 export { LinkedRequestProvider, useLinkedRequest } from './LinkedRequestContext'
 export type { LinkedRequestContextValue } from './LinkedRequestContext'
 export { LinkedRequestRowIndicator } from './LinkedRequestRowIndicator'
-export { LinkedRequestSheetShell } from './LinkedRequestSheetShell'
 export { LinkedRequestSheetHost } from './LinkedRequestSheetHost'
 export type { LinkedRequestKind, LinkedRequestState, ActiveRepairResult } from './types'

--- a/src/components/equipment/equipment-table-columns.tsx
+++ b/src/components/equipment/equipment-table-columns.tsx
@@ -119,7 +119,7 @@ export const equipmentStatusOptions = [
 /**
  * Columns that support faceted filtering.
  */
-export const filterableColumns: (keyof Equipment)[] = [
+const filterableColumns: (keyof Equipment)[] = [
   'khoa_phong_quan_ly',
   'vi_tri_lap_dat',
   'nguoi_dang_truc_tiep_quan_ly',

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -123,7 +123,7 @@ export class ErrorBoundary extends Component<Props, State> {
 }
 
 // Hook for functional components to use ErrorBoundary (optional)
-export const withErrorBoundary = <P extends object>(
+const withErrorBoundary = <P extends object>(
   Component: React.ComponentType<P>,
   fallback?: ReactNode,
   onError?: (error: Error, errorInfo: ErrorInfo) => void

--- a/src/components/onboarding/tour-configs.ts
+++ b/src/components/onboarding/tour-configs.ts
@@ -13,7 +13,7 @@ export type TourId = (typeof TOUR_IDS)[keyof typeof TOUR_IDS]
 /**
  * Dashboard Welcome Tour - Introduces users to the main dashboard features
  */
-export const dashboardWelcomeTour: DriveStep[] = [
+const dashboardWelcomeTour: DriveStep[] = [
   {
     element: '[data-tour="welcome-banner"]',
     popover: {
@@ -86,7 +86,7 @@ export const dashboardWelcomeTour: DriveStep[] = [
 /**
  * Sidebar Navigation Tour - Introduces users to the sidebar navigation elements
  */
-export const sidebarNavigationTour: DriveStep[] = [
+const sidebarNavigationTour: DriveStep[] = [
   {
     element: '[data-tour="sidebar-logo"]',
     popover: {

--- a/src/components/realtime-status.tsx
+++ b/src/components/realtime-status.tsx
@@ -181,7 +181,7 @@ export function RealtimeStatus({
 }
 
 // Hook to get realtime status for use in other components
-export function useRealtimeStatus() {
+function useRealtimeStatus() {
   const { isConnected, connectionStatus, lastUpdate } = useRealtime()
   
   return {

--- a/src/components/transfer-dialog.data.ts
+++ b/src/components/transfer-dialog.data.ts
@@ -57,7 +57,7 @@ async function fetchTransferDepartments(): Promise<string[]> {
   return (list || []).map((item) => item.name).filter(Boolean)
 }
 
-export const transferDialogQueryKeys = {
+const transferDialogQueryKeys = {
   departments: ["departments_list"] as const,
   equipmentSearch: (searchTerm: string) =>
     ["equipment_list_enhanced", "transfer-dialog", { q: searchTerm }] as const,

--- a/src/components/transfer-dialog.shared.ts
+++ b/src/components/transfer-dialog.shared.ts
@@ -250,7 +250,7 @@ export function mapEquipmentSearchResults(rows: unknown[]): TransferEquipmentOpt
   }, [])
 }
 
-export function createTransferDialogFormDataFromTransfer(
+function createTransferDialogFormDataFromTransfer(
   transfer: TransferRequest,
 ): TransferDialogFormData {
   return {
@@ -268,7 +268,7 @@ export function createTransferDialogFormDataFromTransfer(
   }
 }
 
-export function getSelectedEquipmentFromTransfer(
+function getSelectedEquipmentFromTransfer(
   transfer: TransferRequest | null,
 ): TransferEquipmentOption | null {
   const equipment = transfer?.thiet_bi

--- a/src/components/transfers/columnDefinitions.tsx
+++ b/src/components/transfers/columnDefinitions.tsx
@@ -300,7 +300,7 @@ const createLiquidationColumns = (): ColumnDef<TransferListItem>[] => [
   },
 ]
 
-export const buildTransferColumns = (
+const buildTransferColumns = (
   options: TransferColumnOptions = {},
 ): TransferColumnGroups => {
   const referenceDate = options.referenceDate ?? new Date()

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -128,8 +128,6 @@ AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
 
 export {
   AlertDialog,
-  AlertDialogPortal,
-  AlertDialogOverlay,
   AlertDialogTrigger,
   AlertDialogContent,
   AlertDialogHeader,
@@ -137,5 +135,5 @@ export {
   AlertDialogTitle,
   AlertDialogDescription,
   AlertDialogAction,
-  AlertDialogCancel,
+  AlertDialogCancel
 }

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -47,4 +47,7 @@ const AvatarFallback = React.forwardRef<
 ))
 AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
 
-export { Avatar, AvatarImage, AvatarFallback }
+export {
+  Avatar,
+  AvatarFallback
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -20,18 +20,6 @@ const Avatar = React.forwardRef<
 ))
 Avatar.displayName = AvatarPrimitive.Root.displayName
 
-const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image
-    ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
-    {...props}
-  />
-))
-AvatarImage.displayName = AvatarPrimitive.Image.displayName
-
 const AvatarFallback = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Fallback>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -35,4 +35,6 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   )
 }
 
-export { Badge, badgeVariants }
+export {
+  Badge
+}

--- a/src/components/ui/calendar-widget/CalendarWidgetShared.tsx
+++ b/src/components/ui/calendar-widget/CalendarWidgetShared.tsx
@@ -48,7 +48,7 @@ const CALENDAR_SKELETON_COL_KEYS = [
   "calendar-skeleton-col-7",
 ] as const
 
-export function getEventTypeColor(type: TaskType, isCompleted: boolean) {
+function getEventTypeColor(type: TaskType, isCompleted: boolean) {
   if (isCompleted) {
     return "bg-green-100 text-green-800 border-green-200"
   }
@@ -65,7 +65,7 @@ export function getEventTypeColor(type: TaskType, isCompleted: boolean) {
   }
 }
 
-export function getEventTypeIcon(type: TaskType) {
+function getEventTypeIcon(type: TaskType) {
   switch (type) {
     case "Bảo trì":
       return "🔧"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -122,13 +122,10 @@ DialogDescription.displayName = DialogPrimitive.Description.displayName
 
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogClose,
   DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogFooter,
   DialogTitle,
-  DialogDescription,
+  DialogDescription
 }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -187,14 +187,6 @@ export {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuCheckboxItem,
-  DropdownMenuRadioItem,
   DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuShortcut,
-  DropdownMenuGroup,
-  DropdownMenuPortal,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuRadioGroup,
+  DropdownMenuSeparator
 }

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -167,12 +167,11 @@ const FormMessage = React.forwardRef<
 FormMessage.displayName = "FormMessage"
 
 export {
-  useFormField,
   Form,
   FormItem,
   FormLabel,
   FormControl,
   FormDescription,
   FormMessage,
-  FormField,
+  FormField
 }

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -45,4 +45,6 @@ const ScrollBar = React.forwardRef<
 ))
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
 
-export { ScrollArea, ScrollBar }
+export {
+  ScrollArea
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -148,13 +148,8 @@ SelectSeparator.displayName = SelectPrimitive.Separator.displayName
 
 export {
   Select,
-  SelectGroup,
   SelectValue,
   SelectTrigger,
   SelectContent,
-  SelectLabel,
-  SelectItem,
-  SelectSeparator,
-  SelectScrollUpButton,
-  SelectScrollDownButton,
+  SelectItem
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -128,13 +128,9 @@ SheetDescription.displayName = SheetPrimitive.Description.displayName
 
 export {
   Sheet,
-  SheetPortal,
-  SheetOverlay,
   SheetTrigger,
-  SheetClose,
   SheetContent,
   SheetHeader,
-  SheetFooter,
   SheetTitle,
-  SheetDescription,
+  SheetDescription
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -109,9 +109,7 @@ export {
   Table,
   TableHeader,
   TableBody,
-  TableFooter,
   TableHead,
   TableRow,
-  TableCell,
-  TableCaption,
+  TableCell
 }

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -124,6 +124,5 @@ export {
   Toast,
   ToastTitle,
   ToastDescription,
-  ToastClose,
-  ToastAction,
+  ToastClose
 }

--- a/src/hooks/use-cached-equipment.ts
+++ b/src/hooks/use-cached-equipment.ts
@@ -81,7 +81,7 @@ export function useEquipment(filters?: {
 }
 
 // Fetch single equipment details
-export function useEquipmentDetail(id: string | null) {
+function useEquipmentDetail(id: string | null) {
   return useQuery({
     queryKey: equipmentKeys.detail(id || ''),
     queryFn: async () => {
@@ -126,7 +126,7 @@ export function useUpdateEquipment() {
 }
 
 // Create equipment mutation
-export function useCreateEquipment() {
+function useCreateEquipment() {
   const queryClient = useQueryClient()
 
   return useMutation({

--- a/src/hooks/use-cached-equipment.types.assert.ts
+++ b/src/hooks/use-cached-equipment.types.assert.ts
@@ -1,8 +1,6 @@
 import type { Equipment } from '@/types/database'
 import {
-  useCreateEquipment,
   useEquipment,
-  useEquipmentDetail,
   useUpdateEquipment,
 } from '@/hooks/use-cached-equipment'
 
@@ -14,17 +12,9 @@ type IsEqual<A, B> =
     : false
 
 type UseEquipmentData = Exclude<ReturnType<typeof useEquipment>['data'], undefined>
-type UseEquipmentDetailData = ReturnType<typeof useEquipmentDetail>['data']
 type UseUpdateEquipmentData = ReturnType<typeof useUpdateEquipment>['data']
-type UseCreateEquipmentData = ReturnType<typeof useCreateEquipment>['data']
 
 type _UseEquipmentDataIsEquipmentArray = Assert<IsEqual<UseEquipmentData, Equipment[]>>
-type _UseEquipmentDetailDataMatchesEquipment = Assert<
-  IsEqual<UseEquipmentDetailData, Equipment | null | undefined>
->
 type _UseUpdateEquipmentDataMatchesVoid = Assert<
   IsEqual<UseUpdateEquipmentData, void | undefined>
->
-type _UseCreateEquipmentDataMatchesEquipment = Assert<
-  IsEqual<UseCreateEquipmentData, Equipment | undefined>
 >

--- a/src/hooks/use-cached-maintenance.ts
+++ b/src/hooks/use-cached-maintenance.ts
@@ -164,7 +164,7 @@ export function useCreateMaintenancePlan() {
   })
 }
 
-function useUpdateMaintenancePlan() {
+export function useUpdateMaintenancePlan() {
   const queryClient = useQueryClient()
 
   return useMutation({

--- a/src/hooks/use-cached-maintenance.ts
+++ b/src/hooks/use-cached-maintenance.ts
@@ -164,7 +164,7 @@ export function useCreateMaintenancePlan() {
   })
 }
 
-export function useUpdateMaintenancePlan() {
+function useUpdateMaintenancePlan() {
   const queryClient = useQueryClient()
 
   return useMutation({

--- a/src/hooks/use-dashboard-stats.ts
+++ b/src/hooks/use-dashboard-stats.ts
@@ -115,7 +115,7 @@ function normalizeDashboardKpiSummary(data: Partial<DashboardKpiSummary> | null 
   }
 }
 
-export function useDashboardKpiSummary() {
+function useDashboardKpiSummary() {
   const { data: session, status } = useSession()
   const user: DashboardSessionUser | undefined = session?.user
   const scope = getDashboardUserScope(user)

--- a/src/hooks/use-equipment-distribution.ts
+++ b/src/hooks/use-equipment-distribution.ts
@@ -34,7 +34,7 @@ interface EquipmentStatusDistributionRpc {
 }
 
 // Query keys for caching
-export const equipmentDistributionKeys = {
+const equipmentDistributionKeys = {
   all: ['equipment-distribution'] as const,
   data: (params: { filterDept?: string; filterLoc?: string; tenant?: string }) => (
     [...equipmentDistributionKeys.all, 'data', params.filterDept, params.filterLoc, params.tenant] as const

--- a/src/hooks/use-page-transitions.ts
+++ b/src/hooks/use-page-transitions.ts
@@ -65,7 +65,7 @@ export function usePageTransitions() {
 }
 
 // Hook for manual transitions (modals, dialogs, etc.)
-export function useManualTransition(type: 'modal' | 'loading' | 'page' = 'page') {
+function useManualTransition(type: 'modal' | 'loading' | 'page' = 'page') {
   const [isVisible, setIsVisible] = useState(false)
   const [transitionClass, setTransitionClass] = useState('')
 

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -74,7 +74,7 @@ const addToRemoveQueue = (toastId: string) => {
   toastTimeouts.set(toastId, timeout)
 }
 
-export const reducer = (state: State, action: Action): State => {
+const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case "ADD_TOAST":
       return {

--- a/src/hooks/use-usage-analytics.ts
+++ b/src/hooks/use-usage-analytics.ts
@@ -4,14 +4,14 @@ import { differenceInMinutes, startOfDay, endOfDay, subDays, format } from 'date
 import { type UsageLog } from '@/types/database'
 
 // Query keys for analytics
-export const usageAnalyticsKeys = {
+const usageAnalyticsKeys = {
   all: ['usage-analytics'] as const,
-  overview: (params?: Record<string, any>) => [...usageAnalyticsKeys.all, 'overview', params || {}] as const,
-  equipmentStats: (params?: Record<string, any>) => 
+  overview: (params?: Record<string, unknown>) => [...usageAnalyticsKeys.all, 'overview', params || {}] as const,
+  equipmentStats: (params?: Record<string, unknown>) =>
     [...usageAnalyticsKeys.all, 'equipment-stats', params || {}] as const,
-  userStats: (params?: Record<string, any>) => 
+  userStats: (params?: Record<string, unknown>) =>
     [...usageAnalyticsKeys.all, 'user-stats', params || {}] as const,
-  dailyUsage: (params?: Record<string, any>) => 
+  dailyUsage: (params?: Record<string, unknown>) =>
     [...usageAnalyticsKeys.all, 'daily-usage', params || {}] as const,
 }
 

--- a/src/hooks/use-usage-logs.ts
+++ b/src/hooks/use-usage-logs.ts
@@ -13,7 +13,7 @@ type UsageLogEquipmentKeyOptions = {
 }
 
 // Query keys for caching
-export const usageLogKeys = {
+const usageLogKeys = {
   all: ['usage-logs'] as const,
   lists: () => [...usageLogKeys.all, 'list'] as const,
   list: (filters: UsageLogListFilters) => [...usageLogKeys.lists(), { filters }] as const,

--- a/src/hooks/useTransferDataGrid.ts
+++ b/src/hooks/useTransferDataGrid.ts
@@ -199,13 +199,10 @@ export const transferDataGridKeys = {
 export {
   useTransfersKanban,
   useTransferColumnInfiniteScroll,
-  useMergedColumnData,
-  useInvalidateTransfersKanban,
-  transferKanbanKeys
+  useMergedColumnData
 } from './useTransfersKanban'
 
-
-export const useTransferList = (
+const useTransferList = (
   filters: TransferListFilters = {},
   options?: TransferListQueryOptions,
 ) => {
@@ -221,7 +218,7 @@ export const useTransferList = (
   })
 }
 
-export const useTransferCounts = (
+const useTransferCounts = (
   filters: TransferListFilters = {},
   options?: TransferCountsQueryOptions,
 ) => {
@@ -266,7 +263,7 @@ export const useTransferPageData = (
   })
 }
 
-export const usePrefetchTransferList = () => {
+const usePrefetchTransferList = () => {
   const queryClient = useQueryClient()
 
   return async (filters: TransferListFilters = {}) => {
@@ -277,7 +274,7 @@ export const usePrefetchTransferList = () => {
   }
 }
 
-export const usePrefetchTransferCounts = () => {
+const usePrefetchTransferCounts = () => {
   const queryClient = useQueryClient()
 
   return async (filters: TransferListFilters = {}) => {
@@ -288,6 +285,6 @@ export const usePrefetchTransferCounts = () => {
   }
 }
 
-export const getTransferListData = (
+const getTransferListData = (
   response: TransferListResponse | undefined,
 ): TransferListItem[] => response?.data ?? []

--- a/src/hooks/useTransfersKanban.ts
+++ b/src/hooks/useTransfersKanban.ts
@@ -174,7 +174,7 @@ export function useMergedColumnData(
   }
 }
 
-export function useInvalidateTransfersKanban() {
+function useInvalidateTransfersKanban() {
   const queryClient = useQueryClient()
 
   return () => {

--- a/src/lib/advanced-cache-manager.ts
+++ b/src/lib/advanced-cache-manager.ts
@@ -77,7 +77,7 @@ export const CacheKeys = {
 } as const
 
 // Cache invalidation patterns
-export const InvalidationPatterns = {
+const InvalidationPatterns = {
   // Invalidate all equipment-related caches
   equipment: (queryClient: QueryClient, userDepartment?: string) => {
     queryClient.invalidateQueries({ 
@@ -175,7 +175,7 @@ export class SmartPrefetcher {
 }
 
 // Performance monitoring utilities
-export class CachePerformanceMonitor {
+class CachePerformanceMonitor {
   private metrics: Map<string, {
     hits: number
     misses: number
@@ -282,7 +282,7 @@ export const DepartmentCacheUtils = {
 }
 
 // Export singleton instances
-export const createAdvancedCacheManager = (queryClient: QueryClient) => ({
+const createAdvancedCacheManager = (queryClient: QueryClient) => ({
   prefetcher: new SmartPrefetcher(queryClient),
   monitor: new CachePerformanceMonitor(),
   utils: DepartmentCacheUtils,

--- a/src/lib/ai/draft/repair-request-draft-extraction.ts
+++ b/src/lib/ai/draft/repair-request-draft-extraction.ts
@@ -13,7 +13,7 @@ const REQUIRED_REPAIR_REQUEST_DRAFT_FIELDS = [
 
 const requiredFieldSchema = z.enum(REQUIRED_REPAIR_REQUEST_DRAFT_FIELDS)
 
-export const repairRequestDraftExtractionSchema = z.object({
+const repairRequestDraftExtractionSchema = z.object({
   mo_ta_su_co: z.string().trim().min(1).nullable(),
   hang_muc_sua_chua: z.string().trim().min(1).nullable(),
   ngay_mong_muon_hoan_thanh: z.string().trim().min(1).nullable(),

--- a/src/lib/ai/draft/repair-request-draft-session.ts
+++ b/src/lib/ai/draft/repair-request-draft-session.ts
@@ -1,6 +1,6 @@
 import type { UIMessage } from 'ai'
 
-export const REPAIR_REQUEST_DRAFT_START_PHRASES = [
+const REPAIR_REQUEST_DRAFT_START_PHRASES = [
   'tạo phiếu sửa chữa',
   'tạo phiếu yêu cầu sửa chữa thiết bị',
   'lập yêu cầu sửa chữa',
@@ -8,7 +8,7 @@ export const REPAIR_REQUEST_DRAFT_START_PHRASES = [
   'điền trước form sửa chữa',
 ] as const
 
-export const REPAIR_REQUEST_DRAFT_CANCEL_PHRASES = [
+const REPAIR_REQUEST_DRAFT_CANCEL_PHRASES = [
   'thôi không tạo nữa',
   'hủy tạo phiếu',
   'không cần tạo phiếu',
@@ -103,7 +103,7 @@ export function hasRepairRequestDraftStartIntent(text: string): boolean {
   return getRepairRequestDraftIntent(text) === 'start'
 }
 
-export function hasRepairRequestDraftCancelIntent(text: string): boolean {
+function hasRepairRequestDraftCancelIntent(text: string): boolean {
   return getRepairRequestDraftIntent(text) === 'cancel'
 }
 

--- a/src/lib/ai/errors.ts
+++ b/src/lib/ai/errors.ts
@@ -5,7 +5,7 @@
  */
 
 export const GENERIC_CHAT_ERROR_MESSAGE = 'Đã xảy ra lỗi. Vui lòng thử lại.'
-export const MODEL_PROVIDER_QUOTA_MESSAGE =
+const MODEL_PROVIDER_QUOTA_MESSAGE =
   'Model AI đang vượt hạn mức sử dụng của nhà cung cấp.'
 
 const PROVIDER_QUOTA_PATTERNS = [
@@ -101,7 +101,7 @@ function extractSafeClientMessage(raw: string): string | null {
  * Extract a string message from an unknown error value.
  * Used server-side for logging — never expose the return value to clients.
  */
-export function extractErrorMessage(error: unknown): string {
+function extractErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
   if (typeof error === 'string') return error
   return String(error)

--- a/src/lib/ai/sql/audited-executor.ts
+++ b/src/lib/ai/sql/audited-executor.ts
@@ -104,7 +104,7 @@ function buildAuditRpcUrl(request: Request): string {
   return new URL('/api/rpc/assistant_query_database_audit_log', origin).toString()
 }
 
-export async function writeAssistantSqlAudit({
+async function writeAssistantSqlAudit({
   details,
   request,
 }: AssistantSqlAuditEvent): Promise<void> {

--- a/src/lib/ai/tools/registry.ts
+++ b/src/lib/ai/tools/registry.ts
@@ -117,7 +117,7 @@ function isQueryCatalogToolName(toolName: string): toolName is QueryCatalogToolN
   return QUERY_CATALOG_TOOL_NAME_SET.has(toolName)
 }
 
-export function hasWriteIntentToolName(toolName: string): boolean {
+function hasWriteIntentToolName(toolName: string): boolean {
   return /(create|update|delete)/i.test(toolName)
 }
 

--- a/src/lib/ai/usage-metering.ts
+++ b/src/lib/ai/usage-metering.ts
@@ -192,11 +192,11 @@ export function confirmUsage(
   })
 }
 
-export function getLatestUsage(userId: string) {
+function getLatestUsage(userId: string) {
   return latestUsageByUser.get(userId)
 }
 
-export function __resetUsageMeteringForTests() {
+function __resetUsageMeteringForTests() {
   recentRequestsByUser.clear()
   dailyUserRequests.clear()
   dailyTenantRequests.clear()

--- a/src/lib/category-import-validation.ts
+++ b/src/lib/category-import-validation.ts
@@ -49,7 +49,7 @@ export type ImportStatus = "idle" | "parsing" | "parsed" | "importing" | "succes
  * Normalize Vietnamese text by removing diacritics for header matching.
  * This allows Excel files with either diacritic or non-diacritic headers to work.
  */
-export function normalizeVietnamese(text: string): string {
+function normalizeVietnamese(text: string): string {
   return text
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "") // Remove diacritics
@@ -62,7 +62,7 @@ export function normalizeVietnamese(text: string): string {
  * Map normalized Vietnamese headers to database field names.
  * Supports both with and without diacritics.
  */
-export const HEADER_TO_DB_MAP: Record<string, string> = {
+const HEADER_TO_DB_MAP: Record<string, string> = {
   "stt": "_stt", // Ignored
   "ma nhom": "ma_nhom",
   "ten nhom": "ten_nhom",

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -100,7 +100,7 @@ export interface ChartErrorFallbackProps {
 /**
  * Common chart colors for consistent theming
  */
-export const CHART_COLORS = {
+const CHART_COLORS = {
   primary: '#447896',
   secondary: '#64748b',
   success: '#22c55e',
@@ -124,7 +124,7 @@ export const STATUS_COLORS = {
 /**
  * Common chart configuration
  */
-export const DEFAULT_CHART_CONFIG = {
+const DEFAULT_CHART_CONFIG = {
   margin: { top: 20, right: 30, left: 20, bottom: 5 },
   animationDuration: 300,
   grid: {
@@ -144,7 +144,7 @@ export const DEFAULT_CHART_CONFIG = {
 /**
  * Format number for chart display
  */
-export function formatChartNumber(value: number): string {
+function formatChartNumber(value: number): string {
   if (value >= 1000000) {
     return `${(value / 1000000).toFixed(1)}M`
   }
@@ -157,7 +157,7 @@ export function formatChartNumber(value: number): string {
 /**
  * Format percentage for chart display
  */
-export function formatChartPercentage(value: number, total: number): string {
+function formatChartPercentage(value: number, total: number): string {
   if (total === 0) return '0%'
   return `${((value / total) * 100).toFixed(1)}%`
 }
@@ -165,7 +165,7 @@ export function formatChartPercentage(value: number, total: number): string {
 /**
  * Generate chart data with proper formatting
  */
-export function processChartData<T extends Record<string, unknown>>(
+function processChartData<T extends Record<string, unknown>>(
   data: T[],
   keyField: keyof T,
   valueField: keyof T,
@@ -188,7 +188,7 @@ export function processChartData<T extends Record<string, unknown>>(
 /**
  * Common responsive container props
  */
-export const RESPONSIVE_CONTAINER_PROPS = {
+const RESPONSIVE_CONTAINER_PROPS = {
   width: '100%' as const,
   height: '100%' as const,
   debounce: 50,

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -4,7 +4,7 @@
  */
 
 /** Threshold year for suspicious dates (likely Excel import errors) */
-export const SUSPICIOUS_YEAR_THRESHOLD = 1970
+const SUSPICIOUS_YEAR_THRESHOLD = 1970
 
 /** Warning message for suspicious dates (Vietnamese) */
 export const SUSPICIOUS_DATE_WARNING =
@@ -313,7 +313,7 @@ export function formatPartialDateToDisplay(iso: string | null | undefined): stri
  * @param vn - Vietnamese format: "2020", "03/2020", or "15/03/2020"
  * @returns ISO format: "2020", "2020-03", or "2020-03-15" (or null if invalid)
  */
-export function parsePartialDateToISO(vn: string | null | undefined): string | null {
+function parsePartialDateToISO(vn: string | null | undefined): string | null {
   if (!vn) return null
   const s = String(vn).trim()
   if (s === "") return null

--- a/src/lib/department-utils.ts
+++ b/src/lib/department-utils.ts
@@ -13,7 +13,7 @@ import { isEquipmentManagerRole } from '@/lib/rbac'
  * - Converts to lowercase for case-insensitive comparison
  * - Handles null/undefined values
  */
-export function normalizeDepartmentName(department: string | null | undefined): string {
+function normalizeDepartmentName(department: string | null | undefined): string {
   if (!department) return ''
   return department.trim().toLowerCase()
 }
@@ -130,7 +130,7 @@ export function shouldBypassDepartmentFilter(userRole: string | null | undefined
  * Get user's effective departments for equipment access
  * Some users might have access to multiple departments
  */
-export function getUserEffectiveDepartments(
+function getUserEffectiveDepartments(
   userDepartment: string | null | undefined,
   userRole: string | null | undefined
 ): string[] {
@@ -164,7 +164,7 @@ function getSubDepartments(parentDepartment: string): string[] {
  * Validate department access for a specific equipment item
  * Used for additional security checks on individual equipment access
  */
-export function validateEquipmentAccess(
+function validateEquipmentAccess(
   userDepartment: string | null | undefined,
   userRole: string | null | undefined,
   equipmentDepartment: string | null | undefined

--- a/src/lib/excel-utils.ts
+++ b/src/lib/excel-utils.ts
@@ -286,7 +286,7 @@ export async function exportToExcel(
 /**
  * Export array of arrays to Excel file
  */
-export async function exportArrayToExcel(
+async function exportArrayToExcel(
   data: unknown[][],
   filename: string,
   sheetName: string = 'Sheet1',

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -6,7 +6,7 @@ const featureFlags = {
 
 export type FeatureFlagKey = keyof typeof featureFlags
 
-export function getFeatureFlag(flag: FeatureFlagKey): boolean {
+function getFeatureFlag(flag: FeatureFlagKey): boolean {
   return featureFlags[flag] ?? false
 }
 

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -6,10 +6,6 @@ const featureFlags = {
 
 export type FeatureFlagKey = keyof typeof featureFlags
 
-function getFeatureFlag(flag: FeatureFlagKey): boolean {
-  return featureFlags[flag] ?? false
-}
-
 export function useFeatureFlag(flag: FeatureFlagKey): boolean {
   // Static env-driven flag; memoized to avoid re-computation per render.
   return featureFlags[flag] ?? false

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -37,16 +37,16 @@ export const ROLES = {
 export type Role = (typeof ROLES)[keyof typeof ROLES]
 
 /** Roles with system-wide admin access */
-export const GLOBAL_ROLES = [ROLES.GLOBAL, ROLES.ADMIN] as const
+const GLOBAL_ROLES = [ROLES.GLOBAL, ROLES.ADMIN] as const
 
 /** Roles that can manage equipment (global + to_qltb) */
-export const EQUIPMENT_MANAGER_ROLES = [ROLES.GLOBAL, ROLES.ADMIN, ROLES.TO_QLTB] as const
+const EQUIPMENT_MANAGER_ROLES = [ROLES.GLOBAL, ROLES.ADMIN, ROLES.TO_QLTB] as const
 
 /** Roles restricted to their assigned department */
-export const DEPT_SCOPED_ROLES = [ROLES.TECHNICIAN, ROLES.QLTB_KHOA] as const
+const DEPT_SCOPED_ROLES = [ROLES.TECHNICIAN, ROLES.QLTB_KHOA] as const
 
 /** Roles with multi-tenant selection privileges */
-export const PRIVILEGED_ROLES = [ROLES.GLOBAL, ROLES.ADMIN, ROLES.REGIONAL_LEADER] as const
+const PRIVILEGED_ROLES = [ROLES.GLOBAL, ROLES.ADMIN, ROLES.REGIONAL_LEADER] as const
 
 // ============ Internal Helpers ============
 

--- a/src/lib/rpc-normalize.ts
+++ b/src/lib/rpc-normalize.ts
@@ -34,7 +34,7 @@ export function toStringValue(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
-export function getDateOnly(value: unknown): string | undefined {
+function getDateOnly(value: unknown): string | undefined {
   const raw = toStringValue(value)
   return raw ? raw.split('T')[0] : undefined
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -11,9 +11,11 @@ if (!supabaseUrl || !supabaseAnonKey) {
 } else {
     try {
         supabase = createClient(supabaseUrl, supabaseAnonKey)
-    } catch (e: any) {
-        supabaseError = "Lỗi khởi tạo Supabase client: " + e.message;
+    } catch (error: unknown) {
+        supabaseError = "Lỗi khởi tạo Supabase client: " + (error instanceof Error ? error.message : String(error));
     }
 }
 
-export { supabase, supabaseError };
+export {
+  supabase
+}

--- a/src/types/transfers-data-grid.ts
+++ b/src/types/transfers-data-grid.ts
@@ -118,7 +118,7 @@ export interface TransferPageDataResponse {
 }
 
 // Zod schema for equipment info validation
-export const TransferEquipmentInfoSchema = z.object({
+const TransferEquipmentInfoSchema = z.object({
   ten_thiet_bi: z.string().nullable(),
   ma_thiet_bi: z.string().nullable(),
   model: z.string().nullable(),
@@ -129,7 +129,7 @@ export const TransferEquipmentInfoSchema = z.object({
 })
 
 // Zod schema for runtime validation of individual transfer items
-export const TransferListItemSchema = z.object({
+const TransferListItemSchema = z.object({
   id: z.number(),
   ma_yeu_cau: z.string(),
   thiet_bi_id: z.number(),
@@ -166,7 +166,7 @@ export const TransferTableModeResponseSchema = z.object({
   pageSize: z.number().int().positive(),
 })
 
-export const TransferKanbanColumnDataSchema = z.object({
+const TransferKanbanColumnDataSchema = z.object({
   tasks: z.array(TransferListItemSchema),
   total: z.number().int().nonnegative(),
   hasMore: z.boolean(),
@@ -180,7 +180,7 @@ export const TransferKanbanResponseSchema = z.object({
   totalCount: z.number().int().nonnegative(),
 })
 
-export const TransferCountsResponseSchema = z.object({
+const TransferCountsResponseSchema = z.object({
   totalCount: z.number().int().nonnegative(),
   columnCounts: z.object({
     cho_duyet: z.number().int().nonnegative(),
@@ -195,13 +195,13 @@ const TransferOverdueEquipmentInfoSchema = TransferEquipmentInfoSchema.extend({
   is_deleted: z.boolean().nullable(),
 })
 
-export const TransferOverdueSummaryItemSchema = TransferListItemSchema.extend({
+const TransferOverdueSummaryItemSchema = TransferListItemSchema.extend({
   days_difference: z.number().int(),
   equipment_is_deleted: z.boolean().nullable(),
   thiet_bi: TransferOverdueEquipmentInfoSchema.nullable(),
 })
 
-export const TransferOverdueSummarySchema = z.object({
+const TransferOverdueSummarySchema = z.object({
   total: z.number().int().nonnegative(),
   overdue: z.number().int().nonnegative(),
   due_today: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary\n- Closes #473\n- Remove unused named export surface reported by knip/exports\n- Preserve one documented public export: useUpdateMaintenancePlan, covered by src/hooks/__tests__/use-cached-maintenance-barrel.test.ts\n- Add source audit test to lock the cleanup and document the intentional public-export exception\n- Update type assertion files to match the reduced public API surface\n\n## Cleanup Stats\n- knip/exports: 124 -> 1 intentional public export\n- knip/duplicates: 2 -> 0\n- Changed files: 65 source files plus 1 source audit test\n\n## Verification\n- node scripts/npm-run.js run verify:no-explicit-any\n- node scripts/npm-run.js run typecheck\n- node scripts/npm-run.js run test:run -- src/hooks/__tests__/use-cached-maintenance-barrel.test.ts src/__tests__/react-doctor-p4-knip-exports.source.test.ts src/__tests__/react-doctor-p4-knip-files-config.source.test.ts\n- node scripts/npm-run.js npx knip --reporter json\n- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main\n- git diff --check\n\n## Notes\nReact Doctor diff scores 97/100 and reports pre-existing non-target warnings on touched files: React 19 forwardRef readiness, design palette tokens, generic handler names, and one effect-event-handler warning.