### PR TITLE
chore: clean React Doctor knip types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "eslint": "9.36.0",
         "eslint-config-next": "15.5.3",
         "jsdom": "^27.4.0",
+        "knip": "^6.13.1",
         "patch-package": "^8.0.0",
         "postcss": "^8",
         "serwist": "^9.5.6",
@@ -429,19 +430,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -449,9 +452,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2649,6 +2652,727 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.130.0.tgz",
+      "integrity": "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.130.0.tgz",
+      "integrity": "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.130.0.tgz",
+      "integrity": "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.130.0.tgz",
+      "integrity": "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.130.0.tgz",
+      "integrity": "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.130.0.tgz",
+      "integrity": "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.130.0.tgz",
+      "integrity": "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.130.0.tgz",
+      "integrity": "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.130.0.tgz",
+      "integrity": "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.130.0.tgz",
+      "integrity": "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.130.0.tgz",
+      "integrity": "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.130.0.tgz",
+      "integrity": "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.130.0.tgz",
+      "integrity": "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.130.0.tgz",
+      "integrity": "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.130.0.tgz",
+      "integrity": "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.130.0.tgz",
+      "integrity": "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.130.0.tgz",
+      "integrity": "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.130.0.tgz",
+      "integrity": "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.130.0.tgz",
+      "integrity": "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.130.0.tgz",
+      "integrity": "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
+      "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
+      "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
+      "integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
+      "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
+      "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
+      "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
+      "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
+      "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
+      "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
+      "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
+      "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
+      "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
+      "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
+      "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
+      "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
+      "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
+      "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
+      "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
+      "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
+      "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
@@ -8670,6 +9394,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "dev": true,
@@ -8867,6 +9601,22 @@
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "license": "MIT"
     },
+    "node_modules/formatly": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
+      }
+    },
     "node_modules/formdata-node": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
@@ -9051,7 +9801,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.10.1",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10276,6 +11028,110 @@
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
+      }
+    },
+    "node_modules/knip": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.13.1.tgz",
+      "integrity": "sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "formatly": "^0.3.0",
+        "get-tsconfig": "4.14.0",
+        "jiti": "^2.7.0",
+        "minimist": "^1.2.8",
+        "oxc-parser": "^0.130.0",
+        "oxc-resolver": "^11.19.1",
+        "picomatch": "^4.0.4",
+        "smol-toml": "^1.6.1",
+        "strip-json-comments": "5.0.3",
+        "tinyglobby": "^0.2.16",
+        "unbash": "^3.0.0",
+        "yaml": "^2.9.0",
+        "zod": "^4.1.11"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/knip/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/knip/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/knip/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/knip/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/knip/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/kolorist": {
@@ -12025,6 +12881,76 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.130.0.tgz",
+      "integrity": "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.130.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.130.0",
+        "@oxc-parser/binding-android-arm64": "0.130.0",
+        "@oxc-parser/binding-darwin-arm64": "0.130.0",
+        "@oxc-parser/binding-darwin-x64": "0.130.0",
+        "@oxc-parser/binding-freebsd-x64": "0.130.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.130.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.130.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.130.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.130.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.130.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.130.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.130.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.130.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.130.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.130.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
+      "integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
+        "@oxc-resolver/binding-android-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-x64": "11.19.1",
+        "@oxc-resolver/binding-freebsd-x64": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
+        "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
+        "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
+      }
+    },
     "node_modules/p-defer": {
       "version": "4.0.1",
       "license": "MIT",
@@ -13559,6 +14485,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
@@ -14197,12 +15136,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -14521,6 +15462,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unbash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
+      "integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/unbox-primitive": {
@@ -15132,6 +16083,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "dev": true,
@@ -15441,9 +16402,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "eslint": "9.36.0",
     "eslint-config-next": "15.5.3",
     "jsdom": "^27.4.0",
+    "knip": "^6.13.1",
     "patch-package": "^8.0.0",
     "postcss": "^8",
     "serwist": "^9.5.6",

--- a/src/__tests__/react-doctor-p4-knip-types.source.test.ts
+++ b/src/__tests__/react-doctor-p4-knip-types.source.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 
 interface KnipTypeFinding {
@@ -24,7 +25,7 @@ const intentionalPublicTypes = [
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null
 
-const getTypeName = (value: unknown) => {
+const getTypeName = (value: unknown): string | null => {
   if (typeof value === "string") {
     return value
   }
@@ -37,9 +38,15 @@ const getTypeName = (value: unknown) => {
 }
 
 const getKnipTypeFindings = (): KnipTypeFinding[] => {
+  const knipBin = join(
+    process.cwd(),
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "knip.cmd" : "knip",
+  )
   const result = spawnSync(
-    "node",
-    ["scripts/npm-run.js", "npx", "-y", "knip", "--reporter", "json"],
+    knipBin,
+    ["--reporter", "json"],
     {
       cwd: process.cwd(),
       encoding: "utf8",
@@ -70,7 +77,7 @@ const getKnipTypeFindings = (): KnipTypeFinding[] => {
   })
 }
 
-const findingKey = (finding: Pick<KnipTypeFinding, "file" | "symbol">) =>
+const findingKey = (finding: Pick<KnipTypeFinding, "file" | "symbol">): string =>
   `${finding.file}#${finding.symbol}`
 
 describe("React Doctor P4 knip/types cleanup", () => {

--- a/src/__tests__/react-doctor-p4-knip-types.source.test.ts
+++ b/src/__tests__/react-doctor-p4-knip-types.source.test.ts
@@ -1,0 +1,91 @@
+import { spawnSync } from "node:child_process"
+import { describe, expect, it } from "vitest"
+
+interface KnipTypeFinding {
+  file: string
+  symbol: string
+}
+
+interface IntentionalPublicType {
+  file: string
+  symbol: string
+  reason: string
+}
+
+const intentionalPublicTypes = [
+  {
+    file: "src/app/(app)/reports/hooks/use-maintenance-data.types.ts",
+    symbol: "RepairUsageCostCorrelationScope",
+    reason:
+      "Imported by use-maintenance-data.types.assert.ts to lock the report chart contract.",
+  },
+] as const satisfies readonly IntentionalPublicType[]
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null
+
+const getTypeName = (value: unknown) => {
+  if (typeof value === "string") {
+    return value
+  }
+
+  if (isRecord(value) && typeof value.name === "string") {
+    return value.name
+  }
+
+  return null
+}
+
+const getKnipTypeFindings = (): KnipTypeFinding[] => {
+  const result = spawnSync(
+    "node",
+    ["scripts/npm-run.js", "npx", "-y", "knip", "--reporter", "json"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+      },
+      maxBuffer: 1024 * 1024 * 20,
+    },
+  )
+
+  if (!result.stdout) {
+    throw new Error(result.stderr || "knip did not emit JSON output")
+  }
+
+  const parsed: unknown = JSON.parse(result.stdout)
+  const issues = isRecord(parsed) && Array.isArray(parsed.issues) ? parsed.issues : []
+
+  return issues.flatMap((issue) => {
+    if (!isRecord(issue) || typeof issue.file !== "string" || !Array.isArray(issue.types)) {
+      return []
+    }
+
+    return issue.types.flatMap((typeIssue) => {
+      const symbol = getTypeName(typeIssue)
+      return symbol === null ? [] : [{ file: issue.file, symbol }]
+    })
+  })
+}
+
+const findingKey = (finding: Pick<KnipTypeFinding, "file" | "symbol">) =>
+  `${finding.file}#${finding.symbol}`
+
+describe("React Doctor P4 knip/types cleanup", () => {
+  it("has no actionable unused exported type findings", () => {
+    const intentionalTypeKeys = new Set(intentionalPublicTypes.map(findingKey))
+    const actionableFindings = getKnipTypeFindings().filter(
+      (finding) => !intentionalTypeKeys.has(findingKey(finding)),
+    )
+
+    expect(actionableFindings).toEqual([])
+  }, 30_000)
+
+  it("documents every intentionally retained public type", () => {
+    for (const finding of intentionalPublicTypes) {
+      expect(finding.reason.trim().length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -354,4 +354,3 @@ const CategoryGroup = React.memo(function CategoryGroup({
 })
 
 export { CategoryGroup }
-export type { CategoryGroupProps }

--- a/src/app/(app)/device-quota/categories/_components/QuotaProgressBar.tsx
+++ b/src/app/(app)/device-quota/categories/_components/QuotaProgressBar.tsx
@@ -46,4 +46,3 @@ const QuotaProgressBar = React.memo(function QuotaProgressBar({
 })
 
 export { QuotaProgressBar }
-export type { QuotaProgressBarProps }

--- a/src/app/(app)/device-quota/categories/_types/categories.ts
+++ b/src/app/(app)/device-quota/categories/_types/categories.ts
@@ -13,7 +13,7 @@ export interface CategoryListItem {
   mo_ta?: string | null
 }
 
-export interface CategoryFull extends CategoryListItem {
+interface CategoryFull extends CategoryListItem {
   created_at?: string
   updated_at?: string
 }

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailTypes.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailTypes.tsx
@@ -15,7 +15,6 @@ import {
 export {
   equipmentFormSchema,
   type EquipmentFormValues,
-  type EquipmentStatus,
 } from "@/components/equipment-edit/EquipmentEditTypes"
 
 // ============================================================================

--- a/src/app/(app)/equipment/types.ts
+++ b/src/app/(app)/equipment/types.ts
@@ -12,16 +12,20 @@ import type { RouteAction } from "./_hooks/useEquipmentRouteSync"
 import type { FacilityOption } from "@/types/tenant"
 
 // Re-export commonly used types
-export type { Equipment, UsageLog, SessionUser }
+export type {
+  Equipment,
+  UsageLog,
+  SessionUser }
 
-export type EquipmentDateField =
+type EquipmentDateField =
   | "ngay_nhap"
   | "ngay_dua_vao_su_dung"
   | "han_bao_hanh"
   | "ngay_ngung_su_dung"
 
 // Re-export FacilityOption from canonical location
-export type { FacilityOption } from "@/types/tenant"
+export type { FacilityOption
+} from "@/types/tenant"
 
 // ============================================================================
 // Equipment Detail Dialog Types

--- a/src/app/(app)/equipment/use-equipment-page.tsx
+++ b/src/app/(app)/equipment/use-equipment-page.tsx
@@ -15,14 +15,6 @@ import { useEquipmentTable } from "./_hooks/useEquipmentTable"
 import { useEquipmentExport } from "./_hooks/useEquipmentExport"
 import { useEquipmentRouteSync } from "./_hooks/useEquipmentRouteSync"
 
-// Re-export types from centralized types file
-export type {
-  Equipment,
-  SessionUser,
-  FilterBottomSheetData,
-  FacilityOption,
-} from "./types"
-
 // Re-export hook return type
 export type { UseEquipmentPageReturn } from "./types"
 

--- a/src/app/(app)/maintenance/_components/maintenance-columns.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-columns.tsx
@@ -23,7 +23,7 @@ import type { MaintenanceTask } from "@/lib/data"
 import { NotesInput } from "./notes-input"
 import type { PlanColumnOptions, TableMeta, TaskColumnOptions } from "./maintenance-columns.types"
 
-export type { PlanColumnOptions, TableMeta, TaskColumnOptions } from "./maintenance-columns.types"
+export type { PlanColumnOptions, TaskColumnOptions } from "./maintenance-columns.types"
 
 // Helper function for status badge variants
 const getStatusVariant = (status: MaintenancePlan["trang_thai"]) => {

--- a/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
@@ -11,9 +11,6 @@ import { calculateDaysRemaining, getStatusVariant } from "../utils"
 import { cn } from "@/lib/utils"
 import { isEquipmentManagerRole } from "@/lib/rbac"
 
-// Re-export for backward compatibility
-export type { AuthUser } from "../types"
-
 /**
  * Options for repair request table columns.
  * All action callbacks are passed from parent component.

--- a/src/app/(app)/repair-requests/types.ts
+++ b/src/app/(app)/repair-requests/types.ts
@@ -39,7 +39,7 @@ export type RepairRequestWithEquipment = {
   } | null
 }
 
-export type RepairRequestOverdueItem = RepairRequestWithEquipment & {
+type RepairRequestOverdueItem = RepairRequestWithEquipment & {
   days_difference: number
 }
 

--- a/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
+++ b/src/app/(app)/reports/hooks/use-maintenance-data.types.ts
@@ -9,7 +9,7 @@ export interface RepairFrequencyPoint {
   completed: number
 }
 
-export interface RepairCostByMonthPoint {
+interface RepairCostByMonthPoint {
   period: string
   totalCost: number
   averageCost: number
@@ -17,7 +17,7 @@ export interface RepairCostByMonthPoint {
   costMissingCount: number
 }
 
-export interface RepairCostByFacilityPoint {
+interface RepairCostByFacilityPoint {
   facilityId: number | null
   facilityName: string
   totalCost: number
@@ -44,7 +44,7 @@ export interface TopEquipmentRepairCostEntry {
   costRecordedCount: number
 }
 
-export interface RepairUsageCostCorrelationPoint {
+interface RepairUsageCostCorrelationPoint {
   equipmentId: number
   equipmentName: string
   equipmentCode: string
@@ -54,7 +54,7 @@ export interface RepairUsageCostCorrelationPoint {
   costRecordedCount: number
 }
 
-export interface RepairUsageCostCorrelationDataQuality {
+interface RepairUsageCostCorrelationDataQuality {
   equipmentWithUsage: number
   equipmentWithRepairCost: number
   equipmentWithBoth: number
@@ -70,7 +70,7 @@ export interface RepairUsageCostCorrelation {
   cumulative: RepairUsageCostCorrelationScope
 }
 
-export interface RepairCompletionTimeStats {
+interface RepairCompletionTimeStats {
   totalCompleted: number
   medianMinutes: number
   averageMinutes: number

--- a/src/app/(app)/reports/hooks/use-unused-equipment-report.ts
+++ b/src/app/(app)/reports/hooks/use-unused-equipment-report.ts
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { callRpc } from "@/lib/rpc-client"
 
-export interface UnusedEquipmentReportSummary {
+interface UnusedEquipmentReportSummary {
   totalCount: number
   deviceTypeCount: number
   departmentCount: number

--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -38,12 +38,12 @@ import { TRANSFER_STATUS_LABELS } from "@/types/transfers-data-grid"
 import { TransfersDateFilterButton } from "./TransfersDateFilterButton"
 import type { TransferUserRole } from "./TransfersTypes"
 
-export type TransfersPagePanelPermissions = Readonly<{
+type TransfersPagePanelPermissions = Readonly<{
   showFacilityFilter: boolean
   isRegionalLeader: boolean
 }>
 
-export type TransfersPagePanelDataState = Readonly<{
+type TransfersPagePanelDataState = Readonly<{
   shouldFetch: boolean
   isLoading: boolean
   isFetching: boolean

--- a/src/app/(app)/transfers/_components/useTransfersFilters.ts
+++ b/src/app/(app)/transfers/_components/useTransfersFilters.ts
@@ -5,12 +5,12 @@ import * as React from "react"
 import { useTransferSearch } from "@/hooks/useTransferSearch"
 import type { TransferStatus, TransferType } from "@/types/transfers-data-grid"
 
-export type TransferDateRange = {
+type TransferDateRange = {
   from: Date | null
   to: Date | null
 } | null
 
-export type FilterChipKey = "statuses" | "dateRange" | "searchText"
+type FilterChipKey = "statuses" | "dateRange" | "searchText"
 
 export interface UseTransfersFiltersOptions {
   activeTab: TransferType

--- a/src/app/api/transfers/legacy-adapter.ts
+++ b/src/app/api/transfers/legacy-adapter.ts
@@ -1,4 +1,4 @@
-export interface LegacyTransferItem {
+interface LegacyTransferItem {
   id: number
   ma_yeu_cau: string
   thiet_bi_id: number
@@ -35,7 +35,7 @@ export interface LegacyTransferItem {
   } | null
 }
 
-export interface LegacyFilterParams {
+interface LegacyFilterParams {
   q: string | null
   statuses: string[] | null
   types: string[] | null
@@ -45,7 +45,7 @@ export interface LegacyFilterParams {
   assigneeIds: number[] | null
 }
 
-export interface PaginatedResult<T> {
+interface PaginatedResult<T> {
   data: T[]
   total: number
   page: number

--- a/src/auth/logging.ts
+++ b/src/auth/logging.ts
@@ -1,7 +1,7 @@
 import { sanitizeForLog } from "@/lib/log-sanitizer"
 import type { AuthPendingSignoutReason } from "@/types/auth"
 
-export type AuthLifecycleEvent =
+type AuthLifecycleEvent =
   | "login_success"
   | "login_failure"
   | "tenant_inactive"
@@ -10,14 +10,14 @@ export type AuthLifecycleEvent =
   | "signout"
   | "forced_signout"
 
-export type AuthLifecycleReasonCode =
+type AuthLifecycleReasonCode =
   | "invalid_credentials"
   | "rpc_error"
   | "tenant_inactive"
   | "authorize_exception"
   | "config_error"
 
-export type AuthLogSource =
+type AuthLogSource =
   | "authorize"
   | "jwt_callback"
   | "events_signin"

--- a/src/components/bulk-import/index.ts
+++ b/src/components/bulk-import/index.ts
@@ -21,17 +21,11 @@
 // Types
 export type {
   BulkImportRpcResult,
-  BulkImportState,
   ValidationResult,
-  BulkImportDetailItem
 } from './bulk-import-types'
 
 // State management hook
 export { useBulkImportState } from './useBulkImportState'
-export type {
-  UseBulkImportStateOptions,
-  UseBulkImportStateReturn
-} from './useBulkImportState'
 
 // UI components
 export {
@@ -41,19 +35,8 @@ export {
   BulkImportSuccessMessage,
   BulkImportSubmitButton
 } from "./BulkImportDialogParts"
-export type {
-  BulkImportFileInputProps,
-  BulkImportErrorAlertProps,
-  BulkImportValidationErrorsProps,
-  BulkImportSuccessMessageProps,
-  BulkImportSubmitButtonProps
-} from './BulkImportDialogParts'
 
 // Error utilities
 export {
   buildImportToastMessage
 } from "./bulk-import-error-utils"
-export type {
-  BuildImportToastParams,
-  ImportToastMessage
-} from './bulk-import-error-utils'

--- a/src/components/change-history/ChangeHistoryTypes.ts
+++ b/src/components/change-history/ChangeHistoryTypes.ts
@@ -6,7 +6,7 @@
  */
 
 /** A single key-value detail row within a history entry */
-export interface ChangeHistoryDetail {
+interface ChangeHistoryDetail {
   label: string
   value: string
 }

--- a/src/components/equipment-linked-request/LinkedRequestContext.tsx
+++ b/src/components/equipment-linked-request/LinkedRequestContext.tsx
@@ -50,7 +50,3 @@ export function useLinkedRequest(): LinkedRequestContextValue {
   }
   return value
 }
-
-// Phase 2/3 may reuse these types/aliases without the kind union widening;
-// re-export so consumers don't import from ./types directly.
-export type { LinkedRequestKind, LinkedRequestState }

--- a/src/components/equipment-linked-request/index.ts
+++ b/src/components/equipment-linked-request/index.ts
@@ -8,7 +8,6 @@
  */
 
 export { LinkedRequestProvider, useLinkedRequest } from './LinkedRequestContext'
-export type { LinkedRequestContextValue } from './LinkedRequestContext'
+
 export { LinkedRequestRowIndicator } from './LinkedRequestRowIndicator'
 export { LinkedRequestSheetHost } from './LinkedRequestSheetHost'
-export type { LinkedRequestKind, LinkedRequestState, ActiveRepairResult } from './types'

--- a/src/components/kpi/types.ts
+++ b/src/components/kpi/types.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from "react"
 import type { StatCardProps } from "@/components/ui/stat-card"
 
 /** Tone values supported by StatCard */
-export type StatusTone = NonNullable<StatCardProps["tone"]>
+type StatusTone = NonNullable<StatCardProps["tone"]>
 
 /**
  * Configuration for a single KPI status.

--- a/src/components/shared/DataTablePagination/types.ts
+++ b/src/components/shared/DataTablePagination/types.ts
@@ -21,7 +21,7 @@ export interface DisplayContext {
   entity: EntityLabels
 }
 
-export interface EntityLabels {
+interface EntityLabels {
   singular: string // "thiet bi", "yeu cau", "ke hoach", "cong viec"
   plural?: string // Optional, defaults to singular
 }
@@ -52,13 +52,13 @@ interface ServerMode {
   onPageSizeChange: (size: number) => void
 }
 
-export type PaginationMode = TanStackManagedMode | ControlledMode | ServerMode
+type PaginationMode = TanStackManagedMode | ControlledMode | ServerMode
 
 // ============================================================================
 // Responsive Configuration
 // ============================================================================
 
-export interface ResponsiveConfig {
+interface ResponsiveConfig {
   /** Breakpoint to show first/last nav buttons (default: "sm") */
   showFirstLastAt?: "sm" | "md" | "lg"
   /** Breakpoint to show page size selector, null = always show (default: null) */

--- a/src/components/transfers/columnDefinitions.tsx
+++ b/src/components/transfers/columnDefinitions.tsx
@@ -116,7 +116,7 @@ export interface TransferColumnOptions {
   referenceDate?: Date
 }
 
-export interface TransferColumnGroups {
+interface TransferColumnGroups {
   common: ColumnDef<TransferListItem>[]
   noiBo: ColumnDef<TransferListItem>[]
   benNgoai: ColumnDef<TransferListItem>[]

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -25,7 +25,7 @@ const badgeVariants = cva(
   }
 )
 
-export interface BadgeProps
+interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -33,7 +33,7 @@ const buttonVariants = cva(
   }
 )
 
-export interface ButtonProps
+interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -7,7 +7,7 @@ import { DayPicker } from "react-day-picker"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
 
-export type CalendarProps = React.ComponentProps<typeof DayPicker>
+type CalendarProps = React.ComponentProps<typeof DayPicker>
 
 function Calendar({
   className,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -29,7 +29,7 @@ const DialogOverlay = React.forwardRef<
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
-export interface DialogContentProps
+interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   showCloseButton?: boolean
   closeLabel?: string

--- a/src/components/usage-log-print-builder-utils.ts
+++ b/src/components/usage-log-print-builder-utils.ts
@@ -4,7 +4,7 @@ import { getUsageLogFinalStatus, getUsageLogInitialStatus } from "@/lib/usage-lo
 import { escapeCsvCell as escapeSharedCsvCell } from "@/lib/csv-utils"
 import { type Equipment, type UsageLog } from "@/types/database"
 
-export type PrintableEquipment = Pick<Equipment, "ma_thiet_bi" | "ten_thiet_bi"> & Partial<Equipment>
+type PrintableEquipment = Pick<Equipment, "ma_thiet_bi" | "ten_thiet_bi"> & Partial<Equipment>
 
 export interface BuildUsageLogPrintHtmlArgs {
   equipment: PrintableEquipment

--- a/src/hooks/use-audit-logs.ts
+++ b/src/hooks/use-audit-logs.ts
@@ -11,7 +11,7 @@ type AuditActionDetailValue =
   | AuditActionDetailValue[]
   | { [key: string]: AuditActionDetailValue }
 
-export type AuditActionDetails = Record<string, AuditActionDetailValue>
+type AuditActionDetails = Record<string, AuditActionDetailValue>
 export type AuditActionDetailsInput = AuditActionDetails | string
 type AuditLogEntityType =
   | 'assistant_sql'

--- a/src/hooks/use-dashboard-stats.ts
+++ b/src/hooks/use-dashboard-stats.ts
@@ -49,7 +49,7 @@ export function useMaintenanceCount() {
 }
 
 // Interface for repair request statistics
-export interface RepairRequestStats {
+interface RepairRequestStats {
   total: number
   pending: number
   approved: number
@@ -63,7 +63,7 @@ export function useRepairRequestStats() {
 }
 
 // Interface for maintenance plan statistics
-export interface MaintenancePlanStats {
+interface MaintenancePlanStats {
   total: number
   draft: number
   approved: number
@@ -78,7 +78,7 @@ export interface MaintenancePlanStats {
   }>
 }
 
-export interface DashboardKpiSummary {
+interface DashboardKpiSummary {
   totalEquipment: number
   maintenanceCount: number
   repairRequests: RepairRequestStats

--- a/src/lib/ai/chat-request-schema.ts
+++ b/src/lib/ai/chat-request-schema.ts
@@ -28,4 +28,4 @@ export const chatRequestSchema = z.object({
   selectedFacilityName: z.string().trim().max(200).nullish(),
 })
 
-export type ChatRequest = z.infer<typeof chatRequestSchema>
+type ChatRequest = z.infer<typeof chatRequestSchema>

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -1,5 +1,5 @@
-export type AiChatCapability = 'default_chat'
-export type AiProviderTransport = 'gateway' | 'google' | 'openai-compatible'
+type AiChatCapability = 'default_chat'
+type AiProviderTransport = 'gateway' | 'google' | 'openai-compatible'
 
 export interface ResolvedDefaultChatConfig {
   capability: AiChatCapability

--- a/src/lib/ai/draft/troubleshooting-tool.ts
+++ b/src/lib/ai/draft/troubleshooting-tool.ts
@@ -108,6 +108,6 @@ export const generateTroubleshootingDraft = tool({
 })
 
 /** Typed invocation for Phase 4 UI rendering. */
-export type TroubleshootingDraftInvocation = UIToolInvocation<
+type TroubleshootingDraftInvocation = UIToolInvocation<
   typeof generateTroubleshootingDraft
 >

--- a/src/lib/ai/sql/audited-executor.ts
+++ b/src/lib/ai/sql/audited-executor.ts
@@ -8,9 +8,9 @@ import {
 } from './executor'
 import type { AssistantSqlScope } from './scope'
 
-export type AssistantSqlAuditStatus = 'failure' | 'success'
+type AssistantSqlAuditStatus = 'failure' | 'success'
 
-export interface AssistantSqlAuditDetails {
+interface AssistantSqlAuditDetails {
   effective_facility_id: number
   error_class: string | null
   facility_source: AssistantSqlScope['facilitySource']
@@ -26,7 +26,7 @@ export interface AssistantSqlAuditDetails {
   tool_path: typeof ASSISTANT_SQL_TOOL_NAME
 }
 
-export interface AssistantSqlAuditEvent {
+interface AssistantSqlAuditEvent {
   details: AssistantSqlAuditDetails
   request: Request
 }

--- a/src/lib/ai/sql/scope.ts
+++ b/src/lib/ai/sql/scope.ts
@@ -5,7 +5,7 @@ const DEFAULT_FACILITY_REQUIRED_MESSAGE =
 const DEFAULT_UNRESOLVED_FACILITY_MESSAGE =
   'Unable to resolve facility context for tool execution.'
 
-export type AssistantSqlFacilitySource = 'selected' | 'session'
+type AssistantSqlFacilitySource = 'selected' | 'session'
 
 export interface AssistantSqlScope {
   effectiveFacilityId: number

--- a/src/lib/ai/tools/query-catalog.ts
+++ b/src/lib/ai/tools/query-catalog.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export type MigrationStatus = 'migrated' | 'pending'
 
-export interface QueryCatalogModelBudget {
+interface QueryCatalogModelBudget {
   maxItems?: number
   maxBytes?: number
   modelVisibleFields?: string[]
@@ -10,13 +10,13 @@ export interface QueryCatalogModelBudget {
 
 export type QueryCatalogRoutingGroup = 'repair' | 'quota' | 'equipmentLookup'
 
-export type QueryCatalogRoutingRole =
+type QueryCatalogRoutingRole =
   | 'equipment-status'
   | 'workflow-summary'
   | 'specific-item'
   | 'facility-summary'
 
-export interface QueryCatalogRoutingIntent {
+interface QueryCatalogRoutingIntent {
   group: QueryCatalogRoutingGroup
   role: QueryCatalogRoutingRole
 }

--- a/src/lib/ai/tools/registry.ts
+++ b/src/lib/ai/tools/registry.ts
@@ -26,7 +26,7 @@ export type { MigrationStatus } from '@/lib/ai/tools/query-catalog'
 // Draft Tool Definitions (non-RPC, advisory-only)
 // ============================================
 
-export type DraftToolDefinition = {
+type DraftToolDefinition = {
   description: string
   draftKind: 'troubleshootingDraft' | 'repairRequestDraft'
   requiresEvidence: boolean

--- a/src/lib/ai/tools/tool-response-envelope.ts
+++ b/src/lib/ai/tools/tool-response-envelope.ts
@@ -11,14 +11,14 @@ import { isRecord } from './type-guards'
 // Types
 // ---------------------------------------------------------------------------
 
-export interface ModelSummary {
+interface ModelSummary {
   summaryText: string
   importantFields?: Record<string, unknown>
   itemCount?: number
   truncated?: boolean
 }
 
-export interface ToolResponseEnvelopeUiArtifact {
+interface ToolResponseEnvelopeUiArtifact {
   /** The original, uncompacted RPC payload — consumed by UI renderers. */
   rawPayload: unknown
 }
@@ -29,33 +29,33 @@ export interface ToolResponseEnvelope {
   uiArtifact?: ToolResponseEnvelopeUiArtifact
 }
 
-export type ReportChartType = 'bar' | 'line' | 'pie'
+type ReportChartType = 'bar' | 'line' | 'pie'
 
 interface ReportChartBase {
   type: ReportChartType
   data: Array<Record<string, unknown>>
 }
 
-export interface ReportChartBarConfig extends ReportChartBase {
+interface ReportChartBarConfig extends ReportChartBase {
   type: 'bar'
   xKey: string
   yKey: string
 }
 
-export interface ReportChartLineConfig extends ReportChartBase {
+interface ReportChartLineConfig extends ReportChartBase {
   type: 'line'
   xKey: string
   yKey: string
 }
 
-export interface ReportChartPieConfig extends ReportChartBase {
+interface ReportChartPieConfig extends ReportChartBase {
   type: 'pie'
   labelKey: string
   valueKey: string
   innerRadius?: number
 }
 
-export type ReportChartConfig =
+type ReportChartConfig =
   | ReportChartBarConfig
   | ReportChartLineConfig
   | ReportChartPieConfig
@@ -85,7 +85,6 @@ export const DRAFT_TOOL_NAMES_SET: ReadonlySet<string> = new Set([
 // ---------------------------------------------------------------------------
 // Guards
 // ---------------------------------------------------------------------------
-
 
 /**
  * Returns `true` when `output` looks like a `ToolResponseEnvelope`.

--- a/src/lib/ai/usage-metering.ts
+++ b/src/lib/ai/usage-metering.ts
@@ -5,7 +5,7 @@ import {
   AI_RATE_LIMIT_WINDOW_MS,
 } from '@/lib/ai/limits'
 
-export type UsageLimitReason = 'rate_limit' | 'user_quota' | 'tenant_quota'
+type UsageLimitReason = 'rate_limit' | 'user_quota' | 'tenant_quota'
 
 export interface UsageContext {
   userId: string

--- a/src/lib/category-import-validation.ts
+++ b/src/lib/category-import-validation.ts
@@ -24,7 +24,7 @@ export interface ParsedCategoryRow {
   toi_thieu: number | null
 }
 
-export interface ImportResultDetail {
+interface ImportResultDetail {
   ma_nhom: string
   success: boolean
   error?: string

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -13,7 +13,7 @@ export interface ChartData {
   [key: string]: unknown
 }
 
-export interface ChartProps {
+interface ChartProps {
   data: ChartData[]
   width?: string | number
   height?: string | number

--- a/src/lib/chart-utils.ts
+++ b/src/lib/chart-utils.ts
@@ -13,18 +13,6 @@ export interface ChartData {
   [key: string]: unknown
 }
 
-interface ChartProps {
-  data: ChartData[]
-  width?: string | number
-  height?: string | number
-  margin?: {
-    top?: number
-    right?: number
-    bottom?: number
-    left?: number
-  }
-}
-
 export type RechartsComponents = Pick<
   RechartsModule,
   | 'LineChart'

--- a/src/lib/rr-prefs.ts
+++ b/src/lib/rr-prefs.ts
@@ -4,7 +4,7 @@
 export type ViewDensity = 'compact' | 'standard' | 'spacious'
 export type TextWrap = 'truncate' | 'wrap'
 
-export type UiDateRange = { from: string | null; to: string | null }
+type UiDateRange = { from: string | null; to: string | null }
 export type UiFilters = {
   status: string[]
   dateRange?: UiDateRange | null
@@ -30,7 +30,7 @@ const safeGet = (key: string): string | null => {
   }
 }
 
-const safeSet = (key: string, value: any) => {
+const safeSet = (key: string, value: unknown) => {
   if (typeof window === 'undefined') return
   try {
     if (value === undefined || value === null) {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -111,7 +111,7 @@ export const USAGE_STATUS = {
   hoan_thanh: 'Hoàn thành'
 } as const;
 
-export type UsageStatus = keyof typeof USAGE_STATUS;
+type UsageStatus = keyof typeof USAGE_STATUS;
 
 // Transfer Request interfaces
 export interface TransferRequest {
@@ -207,10 +207,10 @@ export const TRANSFER_PURPOSES = {
 } as const;
 
 export type TransferType = keyof typeof TRANSFER_TYPES;
-export type TransferStatus = keyof typeof TRANSFER_STATUSES;
+type TransferStatus = keyof typeof TRANSFER_STATUSES;
 export type TransferPurpose = keyof typeof TRANSFER_PURPOSES;
 
-export interface MaintenanceTask {
+interface MaintenanceTask {
   id: number;
   ke_hoach_id: number;
   thiet_bi_id: number;

--- a/src/types/tenant.ts
+++ b/src/types/tenant.ts
@@ -10,8 +10,6 @@ export interface FacilityOption {
   code?: string   // Optional - facility code for display
 }
 
-type TenantRole = 'global' | 'admin' | 'regional_leader' | 'to_qltb' | 'technician' | 'qltb_khoa' | 'user'
-
 /**
  * Check if the given role has multi-tenant selection privileges.
  * Global, admin, and regional_leader users can select which facility to view.

--- a/src/types/tenant.ts
+++ b/src/types/tenant.ts
@@ -10,7 +10,7 @@ export interface FacilityOption {
   code?: string   // Optional - facility code for display
 }
 
-export type TenantRole = 'global' | 'admin' | 'regional_leader' | 'to_qltb' | 'technician' | 'qltb_khoa' | 'user'
+type TenantRole = 'global' | 'admin' | 'regional_leader' | 'to_qltb' | 'technician' | 'qltb_khoa' | 'user'
 
 /**
  * Check if the given role has multi-tenant selection privileges.

--- a/src/types/transfers-data-grid.ts
+++ b/src/types/transfers-data-grid.ts
@@ -36,7 +36,7 @@ export interface TransferListFilters {
   _tenantKey?: string | number
 }
 
-export interface TransferEquipmentInfo {
+interface TransferEquipmentInfo {
   ten_thiet_bi: string | null
   ma_thiet_bi: string | null
   model: string | null
@@ -226,7 +226,7 @@ export const TransferPageDataResponseSchema = z.object({
 })
 
 // TypeScript types inferred from Zod schemas
-export type TransferKanbanColumnData = z.infer<typeof TransferKanbanColumnDataSchema>
+type TransferKanbanColumnData = z.infer<typeof TransferKanbanColumnDataSchema>
 export type TransferKanbanResponse = z.infer<typeof TransferKanbanResponseSchema>
 
 export type ViewMode = 'table' | 'kanban'


### PR DESCRIPTION
## Summary
- add a TDD source guard for React Doctor P4 knip/types findings
- remove unused exported type surfaces and stale type re-exports across touched modules
- keep the report correlation scope as an intentional public type because the report type assertion imports it to lock the chart contract

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/__tests__/react-doctor-p4-knip-types.source.test.ts src/components/bulk-import/__tests__/bulk-import-index.test.ts src/components/bulk-import/__tests__/bulk-import-error-utils.test.ts src/components/__tests__/import-equipment-dialog.test.tsx src/lib/ai/tools/__tests__/tool-response-envelope.test.ts src/lib/ai/tools/__tests__/category-suggestion-envelope.test.ts src/lib/ai/tools/__tests__/department-list-envelope.test.ts src/lib/ai/draft/__tests__/repair-request-draft-evidence.test.ts src/hooks/__tests__/use-dashboard-stats.types.test.ts src/components/dashboard/__tests__/kpi-cards.test.tsx 'src/app/(app)/reports/components/__tests__/maintenance-report-sections.test.tsx' 'src/app/(app)/reports/components/__tests__/unused-equipment-report-section.test.tsx'
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main: 98/100; remaining warnings are non-knip/types rules and outside #474 scope
- node scripts/npm-run.js npx -y knip --reporter symbols: unused exported types reduced to 1 documented intentional type
- git diff --check

Fixes #474

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned unused exported types and stale re-exports to satisfy `knip` types for React Doctor P4. Added a test to enforce zero actionable unused exported types and document the one intentional public type. Fixes #474.

- **Refactors**
  - Made many exported interfaces/types internal and removed stale re-exports across device-quota, equipment, repair-requests, transfers, reports, bulk-import, linked-request, UI primitives, and AI modules; removed unused helpers like ChartProps and tightened local prop/type aliases.
  - Kept `RepairUsageCostCorrelationScope` public (used by the report type assertion to lock the chart contract).

- **Dependencies**
  - Added `knip` as a dev dependency for the test runner.

<sup>Written for commit 027fa19b3618ae2ddaa6eb6b23bdb35f1f78bc14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal type exports across the codebase by making numerous TypeScript type definitions non-exported, ensuring only intentional public APIs remain accessible.

* **Tests**
  * Added automated test to detect unintentional public type exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/480)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->