### PR TITLE
fix: throttle failed JWT profile refresh attempts

### DIFF
--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -136,6 +136,10 @@ async function runJwt(args: Partial<JwtArgs> & Pick<JwtArgs, "token">) {
   } as JwtArgs)
 }
 
+function profileRefreshRpcCalls() {
+  return supabaseState.rpcCalls.filter((call) => call.fn === "get_session_profile_for_jwt")
+}
+
 function authJwtTelemetryLogs(infoSpy: ReturnType<typeof vi.spyOn>): AuthJwtTelemetryLog[] {
   return infoSpy.mock.calls
     .map(([message]) => (typeof message === "string" ? message : ""))
@@ -415,23 +419,69 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
     expect(result).not.toHaveProperty("id")
   })
 
-  it("does not advance lastRefreshAt when the profile fetch fails", async () => {
+  it("throttles failed profile fetch retries without advancing lastRefreshAt", async () => {
     const now = Date.now()
     supabaseState.profileRpcRows = []
     supabaseState.profileRpcError = { message: "no row" }
+    const lastRefreshAt = now - 5 * 60_000
 
     const token = {
       ...baseToken,
       loginTime: now - 5 * 60_000,
-      lastRefreshAt: now - 5 * 60_000,
+      lastRefreshAt,
     }
 
     const result = await runJwt({ token })
 
-    expect(supabaseClient.rpc).toHaveBeenCalled()
+    expect(profileRefreshRpcCalls()).toHaveLength(1)
     expect(result).toMatchObject({
       id: "42",
-      lastRefreshAt: now - 5 * 60_000, // still the old value
+      lastRefreshAt,
+      lastRefreshAttemptAt: now,
+    })
+
+    supabaseState.rpcCalls = []
+
+    const retryResult = await runJwt({ token: result as JwtArgs["token"] })
+
+    expect(profileRefreshRpcCalls()).toHaveLength(0)
+    expect(retryResult).toMatchObject({
+      id: "42",
+      lastRefreshAt,
+      lastRefreshAttemptAt: now,
+    })
+  })
+
+  it("throttles no-profile refresh retries without advancing lastRefreshAt", async () => {
+    const now = Date.now()
+    supabaseState.profileRpcRows = []
+    supabaseState.profileRpcError = null
+    const lastRefreshAt = now - 5 * 60_000
+
+    const token = {
+      ...baseToken,
+      loginTime: now - 5 * 60_000,
+      lastRefreshAt,
+    }
+
+    const result = await runJwt({ token })
+
+    expect(profileRefreshRpcCalls()).toHaveLength(1)
+    expect(result).toMatchObject({
+      id: "42",
+      lastRefreshAt,
+      lastRefreshAttemptAt: now,
+    })
+
+    supabaseState.rpcCalls = []
+
+    const retryResult = await runJwt({ token: result as JwtArgs["token"] })
+
+    expect(profileRefreshRpcCalls()).toHaveLength(0)
+    expect(retryResult).toMatchObject({
+      id: "42",
+      lastRefreshAt,
+      lastRefreshAttemptAt: now,
     })
   })
 

--- a/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-cooldown.test.ts
@@ -136,7 +136,7 @@ async function runJwt(args: Partial<JwtArgs> & Pick<JwtArgs, "token">) {
   } as JwtArgs)
 }
 
-function profileRefreshRpcCalls() {
+function profileRefreshRpcCalls(): typeof supabaseState.rpcCalls {
   return supabaseState.rpcCalls.filter((call) => call.fn === "get_session_profile_for_jwt")
 }
 
@@ -450,6 +450,15 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
       lastRefreshAt,
       lastRefreshAttemptAt: now,
     })
+    expect(authJwtTelemetryLogs(consoleInfoSpy)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "jwt_refresh_skipped_cooldown",
+          hasLastRefreshAt: true,
+          refreshReason: "cooldown",
+        }),
+      ])
+    )
   })
 
   it("throttles no-profile refresh retries without advancing lastRefreshAt", async () => {
@@ -483,6 +492,42 @@ describe("authOptions.jwt cooldown + trigger gate", () => {
       lastRefreshAt,
       lastRefreshAttemptAt: now,
     })
+    expect(authJwtTelemetryLogs(consoleInfoSpy)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "jwt_refresh_skipped_cooldown",
+          hasLastRefreshAt: true,
+          refreshReason: "cooldown",
+        }),
+      ])
+    )
+  })
+
+  it("reports cooldown skip telemetry accurately when only a failed attempt timestamp exists", async () => {
+    const now = Date.now()
+    const token = {
+      ...baseToken,
+      loginTime: now - 5 * 60_000,
+      lastRefreshAttemptAt: now - 10_000,
+    }
+
+    const result = await runJwt({ token })
+
+    expect(profileRefreshRpcCalls()).toHaveLength(0)
+    expect(result).toMatchObject({
+      id: "42",
+      lastRefreshAttemptAt: now - 10_000,
+    })
+    expect(result).not.toHaveProperty("lastRefreshAt")
+    expect(authJwtTelemetryLogs(consoleInfoSpy)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "jwt_refresh_skipped_cooldown",
+          hasLastRefreshAt: false,
+          refreshReason: "cooldown",
+        }),
+      ])
+    )
   })
 
   it("emits profile_refresh_failed lifecycle log when the profile RPC fails", async () => {

--- a/src/auth/next-auth-callbacks.ts
+++ b/src/auth/next-auth-callbacks.ts
@@ -91,7 +91,7 @@ export const authCallbacks: NonNullable<NextAuthOptions["callbacks"]> = {
       emitAuthJwtTelemetry("jwt_refresh_skipped_cooldown", {
         userId,
         trigger,
-        hasLastRefreshAt: true,
+        hasLastRefreshAt: lastRefreshAt !== null,
         refreshDue: false,
         refreshReason: "cooldown",
       })

--- a/src/auth/next-auth-callbacks.ts
+++ b/src/auth/next-auth-callbacks.ts
@@ -57,6 +57,14 @@ export const authCallbacks: NonNullable<NextAuthOptions["callbacks"]> = {
     // Force a refresh when NextAuth indicates an explicit update (e.g.
     // tenant switch via session.update()).
     const lastRefreshAt = typeof token.lastRefreshAt === "number" ? token.lastRefreshAt : null
+    const lastRefreshAttemptAt =
+      typeof token.lastRefreshAttemptAt === "number" ? token.lastRefreshAttemptAt : null
+    const lastProfileRefreshCheckAt =
+      lastRefreshAt === null
+        ? lastRefreshAttemptAt
+        : lastRefreshAttemptAt === null
+          ? lastRefreshAt
+          : Math.max(lastRefreshAt, lastRefreshAttemptAt)
     const isExplicitUpdate = trigger === "update"
     const refreshReason = user
       ? "sign_in"
@@ -68,11 +76,18 @@ export const authCallbacks: NonNullable<NextAuthOptions["callbacks"]> = {
       userId,
       trigger,
       hasLastRefreshAt: lastRefreshAt !== null,
-      refreshDue: isExplicitUpdate || lastRefreshAt === null || now - lastRefreshAt >= PROFILE_REFRESH_INTERVAL_MS,
+      refreshDue:
+        isExplicitUpdate ||
+        lastProfileRefreshCheckAt === null ||
+        now - lastProfileRefreshCheckAt >= PROFILE_REFRESH_INTERVAL_MS,
       refreshReason,
     })
 
-    if (!isExplicitUpdate && lastRefreshAt !== null && now - lastRefreshAt < PROFILE_REFRESH_INTERVAL_MS) {
+    if (
+      !isExplicitUpdate &&
+      lastProfileRefreshCheckAt !== null &&
+      now - lastProfileRefreshCheckAt < PROFILE_REFRESH_INTERVAL_MS
+    ) {
       emitAuthJwtTelemetry("jwt_refresh_skipped_cooldown", {
         userId,
         trigger,
@@ -103,6 +118,7 @@ export const authCallbacks: NonNullable<NextAuthOptions["callbacks"]> = {
       }
 
       const sessionProfileJwt = buildSessionProfileJwt(userId, appRole)
+      token.lastRefreshAttemptAt = now
       const supabase = createClient(supabaseUrl, anonKey, {
         global: {
           headers: {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -28,6 +28,7 @@ declare module "next-auth/jwt" {
   interface JWT extends DefaultJWT, Partial<NextAuthUserFields> {
     loginTime?: number
     lastRefreshAt?: number
+    lastRefreshAttemptAt?: number
     pending_signout_reason?: AuthPendingSignoutReason | null
   }
 }


### PR DESCRIPTION
## Summary
- Add `lastRefreshAttemptAt` to JWT tokens so failed/no-profile refresh attempts participate in cooldown.
- Keep `lastRefreshAt` reserved for successful profile refreshes.
- Cover failed RPC and no-profile retry throttling in focused JWT cooldown tests.

Fixes #431

## Verification
- RED: `node scripts/npm-run.js run test:run -- src/auth/__tests__/auth-config.jwt-cooldown.test.ts` failed 2 expected tests before implementation.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/auth/__tests__/auth-config.jwt-cooldown.test.ts src/auth/__tests__/auth-config.jwt-rpc.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle JWT profile refresh retries when the profile fetch fails or returns no profile by tracking a new `lastRefreshAttemptAt` timestamp; successful refreshes continue to use `lastRefreshAt`. Improves cooldown telemetry and fixes #431.

- **Bug Fixes**
  - Enforce `PROFILE_REFRESH_INTERVAL_MS` using the latest of `lastRefreshAt` and `lastRefreshAttemptAt`, unless `trigger === "update"`.
  - Set `lastRefreshAttemptAt` before calling `get_session_profile_for_jwt` to prevent rapid retry loops on RPC failure or no profile.
  - Emit accurate telemetry for cooldown skips (compute `hasLastRefreshAt` from `lastRefreshAt` only) and add tests for failed/no-profile retries and telemetry.

<sup>Written for commit 44d29985e5c4a17cd6d8319cdf77cd1861909fe7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT refresh-cooldown mechanism with enhanced retry throttling for profile refresh attempts.
  * Better handling of profile refresh failures and edge cases with separate attempt tracking.

* **Tests**
  * Added comprehensive test coverage verifying retry throttling behavior when profile refresh fails or returns no data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/481)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->