### PR TITLE
Fix equipment department prefilter normalization

### DIFF
--- a/supabase/migrations/20260515105905_fix_department_scope_unicode_aliases.sql
+++ b/supabase/migrations/20260515105905_fix_department_scope_unicode_aliases.sql
@@ -1,0 +1,48 @@
+-- Fix role=user department scope normalization for Vietnamese Unicode composition
+-- and known department abbreviations used by equipment read RPCs.
+--
+-- Scope:
+-- - Redefine only public._normalize_department_scope(text).
+-- - Preserve strict normalized equality; do not introduce fuzzy matching.
+-- - Keep the pinned search_path required for immutable helper safety.
+--
+-- Rollback:
+-- - Forward-only. Restore the previous helper body in a new timestamped
+--   migration if this comparison behavior must be reverted.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._normalize_department_scope(p_value text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_normalized text;
+BEGIN
+  IF p_value IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  v_normalized := normalize(p_value, NFC);
+  v_normalized := replace(v_normalized, chr(160), ' ');
+  v_normalized := replace(v_normalized, E'\r', ' ');
+  v_normalized := replace(v_normalized, E'\n', ' ');
+  v_normalized := replace(v_normalized, E'\t', ' ');
+  v_normalized := regexp_replace(v_normalized, '[-]+', ' ', 'g');
+  v_normalized := regexp_replace(v_normalized, '\s+', ' ', 'g');
+  v_normalized := lower(trim(v_normalized));
+  v_normalized := regexp_replace(v_normalized, '(^|\s)ct(\s|$)', '\1chấn thương\2', 'g');
+  v_normalized := regexp_replace(v_normalized, '\s+', ' ', 'g');
+  v_normalized := trim(v_normalized);
+
+  IF v_normalized = '' THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN v_normalized;
+END;
+$function$;
+
+COMMIT;

--- a/supabase/migrations/20260515113000_reassert_department_scope_unicode_aliases.sql
+++ b/supabase/migrations/20260515113000_reassert_department_scope_unicode_aliases.sql
@@ -1,14 +1,9 @@
--- Fix role=user department scope normalization for Vietnamese Unicode composition
--- and known department abbreviations used by equipment read RPCs.
+-- Reassert department scope normalization after Sonar-driven source cleanup.
 --
 -- Scope:
--- - Redefine only public._normalize_department_scope(text).
--- - Preserve strict normalized equality; do not introduce fuzzy matching.
--- - Keep the pinned search_path required for immutable helper safety.
---
--- Rollback:
--- - Forward-only. Restore the previous helper body in a new timestamped
---   migration if this comparison behavior must be reverted.
+-- - Keep behavior equivalent to 20260515105905.
+-- - Keep live DB aligned with the local migration source after avoiding a
+--   direct empty-string comparison flagged by static analysis.
 
 BEGIN;
 

--- a/supabase/tests/equipment_department_scope_reads_smoke.sql
+++ b/supabase/tests/equipment_department_scope_reads_smoke.sql
@@ -21,6 +21,7 @@ DECLARE
   v_sqlerrm text;
   v_names text[];
   v_proconfig text[];
+  v_dash_baseline text;
 BEGIN
   IF public._normalize_department_scope('Ngoại Lồng Ngực')
      IS DISTINCT FROM public._normalize_department_scope('Ngoại Lồng Ngực') THEN
@@ -32,12 +33,10 @@ BEGIN
     RAISE EXCEPTION '_normalize_department_scope should match scoped CT alias to Chấn Thương';
   END IF;
 
-  IF public._normalize_department_scope('aa-bb')
-     IS DISTINCT FROM public._normalize_department_scope('aa- bb')
-     OR public._normalize_department_scope('aa-bb')
-        IS DISTINCT FROM public._normalize_department_scope('aa -bb')
-     OR public._normalize_department_scope('aa-bb')
-        IS DISTINCT FROM public._normalize_department_scope('aa - bb') THEN
+  v_dash_baseline := public._normalize_department_scope('aa-bb');
+  IF v_dash_baseline IS DISTINCT FROM public._normalize_department_scope('aa- bb')
+     OR v_dash_baseline IS DISTINCT FROM public._normalize_department_scope('aa -bb')
+     OR v_dash_baseline IS DISTINCT FROM public._normalize_department_scope('aa - bb') THEN
     RAISE EXCEPTION '_normalize_department_scope should treat dash spacing variants equally';
   END IF;
 

--- a/supabase/tests/equipment_department_scope_reads_smoke.sql
+++ b/supabase/tests/equipment_department_scope_reads_smoke.sql
@@ -22,6 +22,39 @@ DECLARE
   v_names text[];
   v_proconfig text[];
 BEGIN
+  IF public._normalize_department_scope('Ngoại Lồng Ngực')
+     IS DISTINCT FROM public._normalize_department_scope('Ngoại Lồng Ngực') THEN
+    RAISE EXCEPTION '_normalize_department_scope should match decomposed and precomposed Vietnamese text';
+  END IF;
+
+  IF public._normalize_department_scope('Ngoại CT-Bỏng')
+     IS DISTINCT FROM public._normalize_department_scope('Ngoại Chấn Thương-Bỏng') THEN
+    RAISE EXCEPTION '_normalize_department_scope should match scoped CT alias to Chấn Thương';
+  END IF;
+
+  IF public._normalize_department_scope('aa-bb')
+     IS DISTINCT FROM public._normalize_department_scope('aa- bb')
+     OR public._normalize_department_scope('aa-bb')
+        IS DISTINCT FROM public._normalize_department_scope('aa -bb')
+     OR public._normalize_department_scope('aa-bb')
+        IS DISTINCT FROM public._normalize_department_scope('aa - bb') THEN
+    RAISE EXCEPTION '_normalize_department_scope should treat dash spacing variants equally';
+  END IF;
+
+  IF public._normalize_department_scope(NULL) IS NOT NULL THEN
+    RAISE EXCEPTION '_normalize_department_scope should preserve NULL input as NULL';
+  END IF;
+
+  IF public._normalize_department_scope(' ' || chr(160) || E'\n\t ')
+     IS NOT NULL THEN
+    RAISE EXCEPTION '_normalize_department_scope should preserve blank normalized input as NULL';
+  END IF;
+
+  IF public._normalize_department_scope('Khoa Nội')
+     = public._normalize_department_scope('Khoa Ngoại') THEN
+    RAISE EXCEPTION '_normalize_department_scope should not collapse distinct departments';
+  END IF;
+
   INSERT INTO public.don_vi(name, active)
   VALUES ('Smoke Department Scope Tenant ' || v_suffix, true)
   RETURNING id INTO v_tenant;


### PR DESCRIPTION
## Summary
- Add regression smoke coverage for department scope normalization: Vietnamese Unicode composition, `CT` alias, dash spacing variants, null/blank preservation, and non-fuzzy distinct department checks.
- Add a Supabase migration that redefines `public._normalize_department_scope(text)` with NFC normalization, token-boundary `ct` -> `chấn thương`, existing whitespace/dash normalization, and pinned `search_path`.
- Keep the fix server-side in the shared SQL helper used by role `user` equipment read filters.

## Verification
- RED: Supabase MCP smoke query failed before migration on decomposed/precomposed Vietnamese text: `_normalize_department_scope should match decomposed and precomposed Vietnamese text`.
- GREEN: Supabase MCP helper smoke assertions passed after applying migration.
- GREEN: Live unit 17 checks passed: user `92004-13` matches 5 `Ngoại CT-Bỏng` devices; user `92004-14` matches 10 `Ngoại Lồng Ngực` devices.
- Verified helper metadata: `IMMUTABLE`, not `SECURITY DEFINER`, `search_path=public, pg_temp`.
- Ran Supabase MCP `get_advisors(security)` after migration; findings are existing out-of-scope warnings/errors, not `_normalize_department_scope`.
- Ran `git diff --check`.

## Notes
- Migration was applied via Supabase MCP as live version `20260515105905_fix_department_scope_unicode_aliases`.
- TypeScript/React gates were not run because this change only touches SQL migration and SQL smoke coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes equipment department prefilter normalization so Vietnamese text and common abbreviations match correctly. Ensures user-scoped equipment reads return the right devices (e.g., “Ngoại Lồng Ngực”, “Ngoại CT-Bỏng”).

- **Bug Fixes**
  - Redefined `public._normalize_department_scope(text)` with NFC Unicode normalization, token-boundary `ct` → `chấn thương`, consistent whitespace/dash handling, and pinned `search_path`; added a follow-up migration to reassert behavior after source cleanup (no behavior change).
  - Preserves NULL/blank as NULL and keeps strict equality (no fuzzy matching); function remains `IMMUTABLE`.
  - Added smoke tests for decomposed vs precomposed Vietnamese, `CT` alias, dash-spacing variants, NULL/blank handling, and distinct department checks.

<sup>Written for commit 83be216a1c799b979f4dfefaf945384b22cbb657. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved department scope value normalization to correctly handle Vietnamese diacritics and special characters (spaces, hyphens, and whitespace variants).
  * Enhanced handling of null and empty inputs.

* **Tests**
  * Added validation tests for department scope normalization to ensure proper character handling and aliasing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/482)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->