### PR TITLE
Fix password-change session invalidation lag

### DIFF
--- a/src/lib/__tests__/auth-signout.test.ts
+++ b/src/lib/__tests__/auth-signout.test.ts
@@ -126,10 +126,23 @@ describe("signOutWithReason", () => {
       sourceId: expect.any(String),
     })
     expect(mocks.broadcastClose).toHaveBeenCalled()
-    expect(window.localStorage.getItem("qltbyt:auth-signout")).toContain("forced_password_change")
+    expect(window.localStorage.getItem("qltbyt:auth-signout")).toBeNull()
     expect(mocks.broadcastPostMessage.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.signOut.mock.invocationCallOrder[0]
     )
+  })
+
+  it("uses localStorage as the sibling-tab fallback when BroadcastChannel is unavailable", async () => {
+    vi.stubGlobal("BroadcastChannel", undefined)
+
+    await signOutWithReason({
+      updateSession: mocks.updateSession,
+      reason: "forced_password_change",
+    })
+
+    expect(mocks.broadcastPostMessage).not.toHaveBeenCalled()
+    expect(window.localStorage.getItem("qltbyt:auth-signout")).toContain("forced_password_change")
+    expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
   })
 
   it("broadcasts sibling-tab signout before waiting the current-tab redirect delay", async () => {

--- a/src/lib/__tests__/auth-signout.test.ts
+++ b/src/lib/__tests__/auth-signout.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
   signOut: vi.fn(),
   updateSession: vi.fn(),
+  broadcastPostMessage: vi.fn(),
+  broadcastClose: vi.fn(),
 }))
 
 vi.mock("next-auth/react", () => ({
@@ -10,6 +12,22 @@ vi.mock("next-auth/react", () => ({
 }))
 
 import { signOutWithReason } from "../auth-signout"
+
+class FakeBroadcastChannel {
+  readonly name: string
+
+  constructor(name: string) {
+    this.name = name
+  }
+
+  postMessage(message: unknown): void {
+    mocks.broadcastPostMessage(message)
+  }
+
+  close(): void {
+    mocks.broadcastClose()
+  }
+}
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
@@ -26,7 +44,16 @@ describe("signOutWithReason", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-05-15T12:00:00.000Z"))
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel)
+    window.localStorage.clear()
     mocks.updateSession.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+    window.localStorage.clear()
   })
 
   it("awaits the session reason update before signing out", async () => {
@@ -82,6 +109,48 @@ describe("signOutWithReason", () => {
     })
 
     expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+  })
+
+  it("broadcasts signout intent to sibling tabs before redirecting the current tab", async () => {
+    await signOutWithReason({
+      updateSession: mocks.updateSession,
+      reason: "forced_password_change",
+      callbackUrl: "/",
+    })
+
+    expect(mocks.broadcastPostMessage).toHaveBeenCalledWith({
+      type: "auth:signout",
+      reason: "forced_password_change",
+      callbackUrl: "/",
+      issuedAt: Date.parse("2026-05-15T12:00:00.000Z"),
+      sourceId: expect.any(String),
+    })
+    expect(mocks.broadcastClose).toHaveBeenCalled()
+    expect(window.localStorage.getItem("qltbyt:auth-signout")).toContain("forced_password_change")
+    expect(mocks.broadcastPostMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.signOut.mock.invocationCallOrder[0]
+    )
+  })
+
+  it("broadcasts sibling-tab signout before waiting the current-tab redirect delay", async () => {
+    const signOutPromise = signOutWithReason({
+      updateSession: mocks.updateSession,
+      reason: "forced_password_change",
+      delayMs: 1_500,
+    })
+
+    await vi.waitFor(() => {
+      expect(mocks.broadcastPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "auth:signout",
+          reason: "forced_password_change",
+        })
+      )
+    })
+    expect(mocks.signOut).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1_500)
+    await signOutPromise
   })
 
   it("falls back to signOut when updateSession hangs", async () => {

--- a/src/lib/auth-signout-broadcast.ts
+++ b/src/lib/auth-signout-broadcast.ts
@@ -17,11 +17,28 @@ type AuthSignoutBroadcastInput = {
   issuedAt?: number
 }
 
+let fallbackSourceIdCounter = 0
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-const TAB_SOURCE_ID = Math.random().toString(36).slice(2)
+function createTabSourceId(): string {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID()
+  }
+
+  if (globalThis.crypto?.getRandomValues) {
+    const bytes = new Uint8Array(16)
+    globalThis.crypto.getRandomValues(bytes)
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")
+  }
+
+  fallbackSourceIdCounter += 1
+  return `tab-${Date.now().toString(36)}-${fallbackSourceIdCounter.toString(36)}`
+}
+
+const TAB_SOURCE_ID = createTabSourceId()
 
 export function isAuthSignoutBroadcastPayload(value: unknown): value is AuthSignoutBroadcastPayload {
   if (!isRecord(value)) {
@@ -63,29 +80,33 @@ export function broadcastAuthSignout({
     sourceId: TAB_SOURCE_ID,
   }
 
-  if (typeof window === "undefined") {
+  if (typeof globalThis.window === "undefined") {
     return payload
   }
 
+  let broadcastSucceeded = false
   try {
-    const channel = new BroadcastChannel(AUTH_SIGNOUT_CHANNEL)
+    const channel = new globalThis.BroadcastChannel(AUTH_SIGNOUT_CHANNEL)
     channel.postMessage(payload)
     channel.close()
+    broadcastSucceeded = true
   } catch {
     // Storage fallback below still fans out to other tabs.
   }
 
-  try {
-    window.localStorage.setItem(AUTH_SIGNOUT_STORAGE_KEY, JSON.stringify(payload))
-  } catch {
-    // Same-tab signOut still proceeds even if browser storage is unavailable.
+  if (!broadcastSucceeded) {
+    try {
+      globalThis.localStorage.setItem(AUTH_SIGNOUT_STORAGE_KEY, JSON.stringify(payload))
+    } catch {
+      // Same-tab signOut still proceeds even if browser storage is unavailable.
+    }
   }
 
   return payload
 }
 
 export function subscribeAuthSignout(listener: (payload: AuthSignoutBroadcastPayload) => void): () => void {
-  if (typeof window === "undefined") {
+  if (typeof globalThis.window === "undefined") {
     return () => {}
   }
 
@@ -116,10 +137,10 @@ export function subscribeAuthSignout(listener: (payload: AuthSignoutBroadcastPay
     }
   }
 
-  window.addEventListener("storage", handleStorage)
+  globalThis.addEventListener("storage", handleStorage)
 
   return () => {
     channel?.close()
-    window.removeEventListener("storage", handleStorage)
+    globalThis.removeEventListener("storage", handleStorage)
   }
 }

--- a/src/lib/auth-signout-broadcast.ts
+++ b/src/lib/auth-signout-broadcast.ts
@@ -1,0 +1,125 @@
+import type { AuthPendingSignoutReason } from "@/types/auth"
+
+export const AUTH_SIGNOUT_CHANNEL = "qltbyt:auth-signout"
+export const AUTH_SIGNOUT_STORAGE_KEY = "qltbyt:auth-signout"
+
+export type AuthSignoutBroadcastPayload = {
+  type: "auth:signout"
+  reason: AuthPendingSignoutReason
+  callbackUrl: string
+  issuedAt: number
+  sourceId: string
+}
+
+type AuthSignoutBroadcastInput = {
+  reason: AuthPendingSignoutReason
+  callbackUrl: string
+  issuedAt?: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+const TAB_SOURCE_ID = Math.random().toString(36).slice(2)
+
+export function isAuthSignoutBroadcastPayload(value: unknown): value is AuthSignoutBroadcastPayload {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return (
+    value.type === "auth:signout" &&
+    typeof value.reason === "string" &&
+    typeof value.callbackUrl === "string" &&
+    typeof value.issuedAt === "number" &&
+    typeof value.sourceId === "string"
+  )
+}
+
+function parseAuthSignoutPayload(value: string | null): AuthSignoutBroadcastPayload | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isAuthSignoutBroadcastPayload(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+export function broadcastAuthSignout({
+  reason,
+  callbackUrl,
+  issuedAt = Date.now(),
+}: AuthSignoutBroadcastInput): AuthSignoutBroadcastPayload {
+  const payload: AuthSignoutBroadcastPayload = {
+    type: "auth:signout",
+    reason,
+    callbackUrl,
+    issuedAt,
+    sourceId: TAB_SOURCE_ID,
+  }
+
+  if (typeof window === "undefined") {
+    return payload
+  }
+
+  try {
+    const channel = new BroadcastChannel(AUTH_SIGNOUT_CHANNEL)
+    channel.postMessage(payload)
+    channel.close()
+  } catch {
+    // Storage fallback below still fans out to other tabs.
+  }
+
+  try {
+    window.localStorage.setItem(AUTH_SIGNOUT_STORAGE_KEY, JSON.stringify(payload))
+  } catch {
+    // Same-tab signOut still proceeds even if browser storage is unavailable.
+  }
+
+  return payload
+}
+
+export function subscribeAuthSignout(listener: (payload: AuthSignoutBroadcastPayload) => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {}
+  }
+
+  const channel = (() => {
+    try {
+      return new BroadcastChannel(AUTH_SIGNOUT_CHANNEL)
+    } catch {
+      return null
+    }
+  })()
+
+  if (channel) {
+    channel.onmessage = (event: MessageEvent<unknown>) => {
+      if (isAuthSignoutBroadcastPayload(event.data) && event.data.sourceId !== TAB_SOURCE_ID) {
+        listener(event.data)
+      }
+    }
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key !== AUTH_SIGNOUT_STORAGE_KEY) {
+      return
+    }
+
+    const payload = parseAuthSignoutPayload(event.newValue)
+    if (payload && payload.sourceId !== TAB_SOURCE_ID) {
+      listener(payload)
+    }
+  }
+
+  window.addEventListener("storage", handleStorage)
+
+  return () => {
+    channel?.close()
+    window.removeEventListener("storage", handleStorage)
+  }
+}

--- a/src/lib/auth-signout.ts
+++ b/src/lib/auth-signout.ts
@@ -1,5 +1,6 @@
 import { signOut } from "next-auth/react"
 
+import { broadcastAuthSignout } from "@/lib/auth-signout-broadcast"
 import type { AuthPendingSignoutReason } from "@/types/auth"
 
 type SignOutReasonUpdate = {
@@ -46,6 +47,8 @@ export async function signOutWithReason({
   if (updateSession) {
     await persistReasonWithTimeout(updateSession, reason)
   }
+
+  broadcastAuthSignout({ reason, callbackUrl })
 
   if (delayMs > 0) {
     await wait(delayMs)

--- a/src/providers/__tests__/session-provider.test.tsx
+++ b/src/providers/__tests__/session-provider.test.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+import { render, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  SessionProvider: vi.fn(({ children }: { children: React.ReactNode }) => (
+    <div data-testid="session-provider">{children}</div>
+  )),
+  signOut: vi.fn(),
+}))
+
+vi.mock("next-auth/react", () => ({
+  SessionProvider: mocks.SessionProvider,
+  signOut: (...args: unknown[]) => mocks.signOut(...args),
+}))
+
+import { NextAuthSessionProvider } from "../session-provider"
+
+type BroadcastHandler = ((event: MessageEvent) => void) | null
+
+class FakeBroadcastChannel {
+  static instances: FakeBroadcastChannel[] = []
+
+  readonly name: string
+  onmessage: BroadcastHandler = null
+  closed = false
+
+  constructor(name: string) {
+    this.name = name
+    FakeBroadcastChannel.instances.push(this)
+  }
+
+  postMessage(): void {}
+
+  close(): void {
+    this.closed = true
+  }
+}
+
+describe("NextAuthSessionProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel)
+    window.localStorage.clear()
+    FakeBroadcastChannel.instances = []
+    mocks.signOut.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.localStorage.clear()
+  })
+
+  it("configures NextAuth to refresh sessions within the password-change invalidation SLA", () => {
+    render(
+      <NextAuthSessionProvider session={null}>
+        <div>child</div>
+      </NextAuthSessionProvider>
+    )
+
+    expect(mocks.SessionProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: null,
+        refetchInterval: 60,
+        refetchOnWindowFocus: true,
+      }),
+      expect.anything()
+    )
+  })
+
+  it("signs out the current tab when a sibling tab broadcasts a forced password-change signout", async () => {
+    render(
+      <NextAuthSessionProvider session={null}>
+        <div>child</div>
+      </NextAuthSessionProvider>
+    )
+
+    const channel = FakeBroadcastChannel.instances[0]
+    channel.onmessage?.({
+      data: {
+        type: "auth:signout",
+        reason: "forced_password_change",
+        callbackUrl: "/",
+        issuedAt: Date.now(),
+        sourceId: "other-tab",
+      },
+    } as MessageEvent)
+
+    await waitFor(() => {
+      expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+    })
+  })
+
+  it("uses the storage fallback when BroadcastChannel is unavailable", async () => {
+    vi.stubGlobal("BroadcastChannel", undefined)
+
+    render(
+      <NextAuthSessionProvider session={null}>
+        <div>child</div>
+      </NextAuthSessionProvider>
+    )
+
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "qltbyt:auth-signout",
+        newValue: JSON.stringify({
+          type: "auth:signout",
+          reason: "forced_password_change",
+          callbackUrl: "/",
+          issuedAt: Date.now(),
+          sourceId: "other-tab",
+        }),
+      })
+    )
+
+    await waitFor(() => {
+      expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
+    })
+  })
+})

--- a/src/providers/__tests__/session-provider.test.tsx
+++ b/src/providers/__tests__/session-provider.test.tsx
@@ -117,4 +117,36 @@ describe("NextAuthSessionProvider", () => {
       expect(mocks.signOut).toHaveBeenCalledWith({ callbackUrl: "/" })
     })
   })
+
+  it("logs broadcast-triggered signout failures with callback context", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const error = new Error("signout failed")
+    mocks.signOut.mockRejectedValueOnce(error)
+
+    render(
+      <NextAuthSessionProvider session={null}>
+        <div>child</div>
+      </NextAuthSessionProvider>
+    )
+
+    const channel = FakeBroadcastChannel.instances[0]
+    channel.onmessage?.({
+      data: {
+        type: "auth:signout",
+        reason: "forced_password_change",
+        callbackUrl: "/",
+        issuedAt: Date.now(),
+        sourceId: "other-tab",
+      },
+    } as MessageEvent)
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith("subscribeAuthSignout failed to sign out", {
+        callbackUrl: "/",
+        error,
+      })
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
 })

--- a/src/providers/session-provider.tsx
+++ b/src/providers/session-provider.tsx
@@ -1,14 +1,31 @@
 "use client"
 
 import type { Session } from "next-auth"
-import { SessionProvider } from "next-auth/react"
+import { SessionProvider, signOut } from "next-auth/react"
 import React from "react"
+
+import { subscribeAuthSignout } from "@/lib/auth-signout-broadcast"
 
 type Props = {
   children: React.ReactNode
   session?: Session | null
 }
 
+function AuthSignoutBroadcastListener() {
+  React.useEffect(() => {
+    return subscribeAuthSignout((payload) => {
+      void signOut({ callbackUrl: payload.callbackUrl })
+    })
+  }, [])
+
+  return null
+}
+
 export function NextAuthSessionProvider({ children, session }: Props) {
-  return <SessionProvider session={session}>{children}</SessionProvider>
+  return (
+    <SessionProvider session={session} refetchInterval={60} refetchOnWindowFocus>
+      <AuthSignoutBroadcastListener />
+      {children}
+    </SessionProvider>
+  )
 }

--- a/src/providers/session-provider.tsx
+++ b/src/providers/session-provider.tsx
@@ -1,8 +1,8 @@
 "use client"
 
+import React from "react"
 import type { Session } from "next-auth"
 import { SessionProvider, signOut } from "next-auth/react"
-import React from "react"
 
 import { subscribeAuthSignout } from "@/lib/auth-signout-broadcast"
 
@@ -11,10 +11,16 @@ type Props = {
   session?: Session | null
 }
 
-function AuthSignoutBroadcastListener() {
+function AuthSignoutBroadcastListener(): null {
   React.useEffect(() => {
     return subscribeAuthSignout((payload) => {
-      void signOut({ callbackUrl: payload.callbackUrl })
+      const signOutPromise = signOut({ callbackUrl: payload.callbackUrl })
+      signOutPromise.catch((error: unknown) => {
+        console.error("subscribeAuthSignout failed to sign out", {
+          callbackUrl: payload.callbackUrl,
+          error,
+        })
+      })
     })
   }, [])
 


### PR DESCRIPTION
## Summary
- configure NextAuth SessionProvider to refetch sessions every 60s and on window focus
- broadcast password-change signout intent across same-device tabs with BroadcastChannel plus localStorage fallback
- keep current-tab logout reason persistence and delay behavior while sibling tabs sign out immediately
- address review feedback by making localStorage a true fallback, replacing Math.random with Web Crypto source IDs, and handling broadcast-triggered signOut failures

Fixes #364

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/lib/__tests__/auth-signout.test.ts src/providers/__tests__/session-provider.test.tsx src/components/__tests__/change-password-dialog.signout.test.tsx src/auth/__tests__/auth-config.jwt-cooldown.test.ts
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
- node scripts/npm-run.js run build
- git diff --check
- rg -n "Math\.random\(" src/lib/auth-signout-broadcast.ts src/providers/session-provider.tsx || true

## Notes
- context-mode wrapper/server is healthy; the Codex MCP namespace was unavailable in this session, so later verification and review fetches used the context-mode wrapper directly.