### PR TITLE
Fix device quota context React Doctor state warnings

### DIFF
--- a/src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
+++ b/src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
@@ -12,10 +12,25 @@ function extractFunctionSource(source: string, functionName: string): string {
   const start = source.indexOf(`function ${functionName}`)
   expect(start).toBeGreaterThanOrEqual(0)
 
-  const signatureEnd = source.indexOf(") {", start)
-  expect(signatureEnd).toBeGreaterThan(start)
-
-  const bodyStart = signatureEnd + 2
+  let parenDepth = 0
+  let sawOpenParen = false
+  let bodyStart = -1
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index]
+    if (char === "(") {
+      sawOpenParen = true
+      parenDepth += 1
+      continue
+    }
+    if (char === ")" && parenDepth > 0) {
+      parenDepth -= 1
+      continue
+    }
+    if (char === "{" && sawOpenParen && parenDepth === 0) {
+      bodyStart = index
+      break
+    }
+  }
   expect(bodyStart).toBeGreaterThan(start)
 
   let depth = 0
@@ -31,13 +46,16 @@ function extractFunctionSource(source: string, functionName: string): string {
 
 function extractEffectBodies(source: string): string[] {
   const bodies: string[] = []
-  let searchStart = 0
+  const effectPattern = /(?:React\.)?useEffect\s*\(/g
 
-  while (searchStart < source.length) {
-    const effectStart = source.indexOf("React.useEffect(() => {", searchStart)
-    if (effectStart === -1) return bodies
+  for (const match of source.matchAll(effectPattern)) {
+    const effectStart = match.index
+    expect(effectStart).toBeGreaterThanOrEqual(0)
 
-    const bodyStart = source.indexOf("{", effectStart)
+    const arrowStart = source.indexOf("=>", effectStart)
+    expect(arrowStart).toBeGreaterThan(effectStart)
+    const bodyStart = source.indexOf("{", arrowStart)
+    expect(bodyStart).toBeGreaterThan(arrowStart)
     let depth = 0
     for (let index = bodyStart; index < source.length; index += 1) {
       const char = source[index]
@@ -45,7 +63,6 @@ function extractEffectBodies(source: string): string[] {
       if (char === "}") depth -= 1
       if (depth === 0) {
         bodies.push(source.slice(bodyStart + 1, index))
-        searchStart = index + 1
         break
       }
     }

--- a/src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
+++ b/src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
@@ -78,8 +78,8 @@ describe("device quota context React Doctor state guards", () => {
     )
     const providerSource = extractFunctionSource(source, "DeviceQuotaCategoryProvider")
 
-    expect(providerSource).toContain("React.useReducer")
-    expect(providerSource.match(/React\.useState/g) ?? []).toHaveLength(0)
+    expect(providerSource).toMatch(/\b(?:React\.)?useReducer\s*\(/)
+    expect(providerSource.match(/\b(?:React\.)?useState\s*\(/g) ?? []).toHaveLength(0)
   })
 
   it("keeps mapping effects to at most one state mutation per effect", () => {

--- a/src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
+++ b/src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const repoRoot = process.cwd()
+
+function readSource(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function extractFunctionSource(source: string, functionName: string): string {
+  const start = source.indexOf(`function ${functionName}`)
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const signatureEnd = source.indexOf(") {", start)
+  expect(signatureEnd).toBeGreaterThan(start)
+
+  const bodyStart = signatureEnd + 2
+  expect(bodyStart).toBeGreaterThan(start)
+
+  let depth = 0
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const char = source[index]
+    if (char === "{") depth += 1
+    if (char === "}") depth -= 1
+    if (depth === 0) return source.slice(start, index + 1)
+  }
+
+  throw new Error(`Could not extract ${functionName}`)
+}
+
+function extractEffectBodies(source: string): string[] {
+  const bodies: string[] = []
+  let searchStart = 0
+
+  while (searchStart < source.length) {
+    const effectStart = source.indexOf("React.useEffect(() => {", searchStart)
+    if (effectStart === -1) return bodies
+
+    const bodyStart = source.indexOf("{", effectStart)
+    let depth = 0
+    for (let index = bodyStart; index < source.length; index += 1) {
+      const char = source[index]
+      if (char === "{") depth += 1
+      if (char === "}") depth -= 1
+      if (depth === 0) {
+        bodies.push(source.slice(bodyStart + 1, index))
+        searchStart = index + 1
+        break
+      }
+    }
+  }
+
+  return bodies
+}
+
+describe("device quota context React Doctor state guards", () => {
+  it("keeps category provider UI state in a reducer instead of scattered useState calls", () => {
+    const source = readSource(
+      "src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext.tsx"
+    )
+    const providerSource = extractFunctionSource(source, "DeviceQuotaCategoryProvider")
+
+    expect(providerSource).toContain("React.useReducer")
+    expect(providerSource.match(/React\.useState/g) ?? []).toHaveLength(0)
+  })
+
+  it("keeps mapping effects to at most one state mutation per effect", () => {
+    const source = readSource(
+      "src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx"
+    )
+    const effectBodies = extractEffectBodies(source)
+
+    expect(effectBodies.length).toBeGreaterThan(0)
+    for (const body of effectBodies) {
+      const stateMutationCount =
+        (body.match(/\bset[A-Z][A-Za-z0-9_]*\(/g) ?? []).length +
+        (body.match(/resetToFirstPage\(/g) ?? []).length
+
+      expect(stateMutationCount).toBeLessThanOrEqual(1)
+    }
+  })
+})

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
@@ -93,6 +93,28 @@ describe('DeviceQuotaCategoriesPage', () => {
     })
   })
 
+  it('opens and closes the create category dialog from the toolbar', async () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { role: 'admin', don_vi: '1' } },
+      status: 'authenticated',
+    })
+
+    mockCallRpc.mockResolvedValue([])
+
+    render(<DeviceQuotaCategoriesPage />, { wrapper: createWrapper() })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Tạo danh mục' }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Tạo danh mục mới')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hủy' }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
   it('includes descendants of matching categories on the categories page', async () => {
     mockUseSession.mockReturnValue({
       data: { user: { role: 'admin', don_vi: '1' } },

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
@@ -105,8 +105,8 @@ describe('DeviceQuotaCategoriesPage', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Tạo danh mục' }))
 
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(screen.getByText('Tạo danh mục mới')).toBeInTheDocument()
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(await screen.findByText('Tạo danh mục mới')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Hủy' }))
 

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext.tsx
@@ -80,6 +80,59 @@ interface DeviceQuotaCategoryProviderProps {
   children: React.ReactNode
 }
 
+type CategoryUiState = {
+  dialogState: CategoryDialogState
+  mutatingCategoryId: number | null
+  categoryToDelete: CategoryListItem | null
+  isImportDialogOpen: boolean
+  searchTerm: string
+}
+
+type CategoryUiAction =
+  | { type: "open-create-dialog" }
+  | { type: "open-edit-dialog"; category: CategoryListItem }
+  | { type: "close-dialog" }
+  | { type: "set-mutating-category"; id: number | null }
+  | { type: "open-delete-dialog"; category: CategoryListItem }
+  | { type: "close-delete-dialog" }
+  | { type: "open-import-dialog" }
+  | { type: "close-import-dialog" }
+  | { type: "set-search-term"; term: string }
+
+const initialCategoryUiState: CategoryUiState = {
+  dialogState: { mode: "closed" },
+  mutatingCategoryId: null,
+  categoryToDelete: null,
+  isImportDialogOpen: false,
+  searchTerm: "",
+}
+
+function categoryUiStateReducer(
+  state: CategoryUiState,
+  action: CategoryUiAction
+): CategoryUiState {
+  switch (action.type) {
+    case "open-create-dialog":
+      return { ...state, dialogState: { mode: "create" } }
+    case "open-edit-dialog":
+      return { ...state, dialogState: { mode: "edit", category: action.category } }
+    case "close-dialog":
+      return { ...state, dialogState: { mode: "closed" } }
+    case "set-mutating-category":
+      return { ...state, mutatingCategoryId: action.id }
+    case "open-delete-dialog":
+      return { ...state, categoryToDelete: action.category }
+    case "close-delete-dialog":
+      return { ...state, categoryToDelete: null }
+    case "open-import-dialog":
+      return { ...state, isImportDialogOpen: true }
+    case "close-import-dialog":
+      return { ...state, isImportDialogOpen: false }
+    case "set-search-term":
+      return { ...state, searchTerm: action.term }
+  }
+}
+
 export function DeviceQuotaCategoryProvider({ children }: DeviceQuotaCategoryProviderProps) {
   const { toast } = useToast()
   const queryClient = useQueryClient()
@@ -88,13 +141,17 @@ export function DeviceQuotaCategoryProvider({ children }: DeviceQuotaCategoryPro
 
   const donViId = user?.don_vi ? parseInt(user.don_vi, 10) : null
 
-  const [dialogState, setDialogState] = React.useState<CategoryDialogState>({ mode: "closed" })
-  const [mutatingCategoryId, setMutatingCategoryId] = React.useState<number | null>(null)
-  const [categoryToDelete, setCategoryToDelete] = React.useState<CategoryListItem | null>(null)
-  const [isImportDialogOpen, setIsImportDialogOpen] = React.useState(false)
-
-  // Search state (instant client-side filtering, no debounce needed for < 500 items)
-  const [searchTerm, setSearchTerm] = React.useState("")
+  const [uiState, dispatchUiState] = React.useReducer(
+    categoryUiStateReducer,
+    initialCategoryUiState
+  )
+  const {
+    dialogState,
+    mutatingCategoryId,
+    categoryToDelete,
+    isImportDialogOpen,
+    searchTerm,
+  } = uiState
 
   // Single query — fetch ALL categories once (< 500 items, no pagination needed)
   const {
@@ -138,31 +195,39 @@ export function DeviceQuotaCategoryProvider({ children }: DeviceQuotaCategoryPro
   }, [queryClient])
 
   const openCreateDialog = React.useCallback(() => {
-    setDialogState({ mode: "create" })
+    dispatchUiState({ type: "open-create-dialog" })
   }, [])
 
   const openEditDialog = React.useCallback((category: CategoryListItem) => {
-    setDialogState({ mode: "edit", category })
+    dispatchUiState({ type: "open-edit-dialog", category })
   }, [])
 
   const closeDialog = React.useCallback(() => {
-    setDialogState({ mode: "closed" })
+    dispatchUiState({ type: "close-dialog" })
   }, [])
 
   const openDeleteDialog = React.useCallback((category: CategoryListItem) => {
-    setCategoryToDelete(category)
+    dispatchUiState({ type: "open-delete-dialog", category })
   }, [])
 
   const closeDeleteDialog = React.useCallback(() => {
-    setCategoryToDelete(null)
+    dispatchUiState({ type: "close-delete-dialog" })
   }, [])
 
   const openImportDialog = React.useCallback(() => {
-    setIsImportDialogOpen(true)
+    dispatchUiState({ type: "open-import-dialog" })
   }, [])
 
   const closeImportDialog = React.useCallback(() => {
-    setIsImportDialogOpen(false)
+    dispatchUiState({ type: "close-import-dialog" })
+  }, [])
+
+  const setSearchTerm = React.useCallback((term: string) => {
+    dispatchUiState({ type: "set-search-term", term })
+  }, [])
+
+  const setMutatingCategoryId = React.useCallback((id: number | null) => {
+    dispatchUiState({ type: "set-mutating-category", id })
   }, [])
 
   const createMutation = useCreateMutation(

--- a/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaMappingContext.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaMappingContext.test.tsx
@@ -1,0 +1,186 @@
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { callRpc } from "@/lib/rpc-client"
+import {
+  DeviceQuotaMappingProvider,
+  type DeviceQuotaMappingContextValue,
+} from "../_components/DeviceQuotaMappingContext"
+import { useDeviceQuotaMappingContext } from "../_hooks/useDeviceQuotaMappingContext"
+
+const mockUseSession = vi.fn()
+vi.mock("next-auth/react", () => ({
+  useSession: () => mockUseSession(),
+}))
+
+vi.mock("@/contexts/TenantSelectionContext", () => ({
+  useTenantSelection: () => ({
+    selectedFacilityId: null,
+    showSelector: false,
+  }),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: vi.fn(),
+}))
+
+const mockCallRpc = vi.mocked(callRpc)
+
+type RpcCall = {
+  fn: string
+  args?: Record<string, unknown>
+}
+
+function Probe() {
+  const context: DeviceQuotaMappingContextValue = useDeviceQuotaMappingContext()
+  const selectedIds = Array.from(context.selectedEquipmentIds).join(",")
+
+  return (
+    <div>
+      <div data-testid="page">{context.pagination.page}</div>
+      <div data-testid="total">{context.totalEquipmentCount}</div>
+      <div data-testid="selected-equipment">{selectedIds}</div>
+      <div data-testid="selected-category">{context.selectedCategoryId ?? "none"}</div>
+      <button type="button" onClick={() => context.pagination.setPagination({ pageIndex: 1, pageSize: 20 })}>
+        Go page 2
+      </button>
+      <button type="button" onClick={context.selectAllEquipment}>
+        Select page
+      </button>
+      <button type="button" onClick={context.deselectPageEquipment}>
+        Deselect page
+      </button>
+      <button type="button" onClick={context.clearEquipmentSelection}>
+        Clear equipment
+      </button>
+      <button type="button" onClick={() => context.setSelectedCategory(5)}>
+        Select category
+      </button>
+    </div>
+  )
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function renderProvider() {
+  return render(
+    <DeviceQuotaMappingProvider>
+      <Probe />
+    </DeviceQuotaMappingProvider>,
+    { wrapper: createWrapper() }
+  )
+}
+
+describe("DeviceQuotaMappingProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "u1", role: "admin", don_vi: "1" } },
+      status: "authenticated",
+    })
+    mockCallRpc.mockImplementation(({ fn, args }: RpcCall) => {
+      if (fn === "dinh_muc_thiet_bi_unassigned_filter_options") {
+        return Promise.resolve({ departments: [], users: [], locations: [], fundingSources: [] })
+      }
+
+      if (fn === "dinh_muc_nhom_list") {
+        return Promise.resolve([
+          {
+            id: 5,
+            parent_id: null,
+            ma_nhom: "DM05",
+            ten_nhom: "Danh mục 5",
+            phan_loai: "B",
+            level: 1,
+            so_luong_hien_co: 0,
+          },
+        ])
+      }
+
+      if (fn === "dinh_muc_thiet_bi_unassigned") {
+        if (args?.p_offset === 20) return Promise.resolve([])
+
+        return Promise.resolve([
+          {
+            id: 101,
+            ma_thiet_bi: "TB101",
+            ten_thiet_bi: "Thiết bị 101",
+            model: null,
+            serial: null,
+            hang_san_xuat: null,
+            khoa_phong_quan_ly: null,
+            tinh_trang: null,
+            total_count: 21,
+          },
+          {
+            id: 102,
+            ma_thiet_bi: "TB102",
+            ten_thiet_bi: "Thiết bị 102",
+            model: null,
+            serial: null,
+            hang_san_xuat: null,
+            khoa_phong_quan_ly: null,
+            tinh_trang: null,
+            total_count: 21,
+          },
+        ])
+      }
+
+      return Promise.resolve([])
+    })
+  })
+
+  it("resets an empty out-of-range page back to the first page", async () => {
+    renderProvider()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("total")).toHaveTextContent("21")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Go page 2" }))
+
+    await waitFor(() => {
+      expect(mockCallRpc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fn: "dinh_muc_thiet_bi_unassigned",
+          args: expect.objectContaining({ p_offset: 20 }),
+        })
+      )
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("page")).toHaveTextContent("1")
+    })
+  })
+
+  it("keeps page selection actions and category selection independent", async () => {
+    renderProvider()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("total")).toHaveTextContent("21")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Select page" }))
+    fireEvent.click(screen.getByRole("button", { name: "Select category" }))
+
+    expect(screen.getByTestId("selected-equipment")).toHaveTextContent("101,102")
+    expect(screen.getByTestId("selected-category")).toHaveTextContent("5")
+
+    fireEvent.click(screen.getByRole("button", { name: "Deselect page" }))
+
+    expect(screen.getByTestId("selected-equipment")).toBeEmptyDOMElement()
+    expect(screen.getByTestId("selected-category")).toHaveTextContent("5")
+  })
+})

--- a/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaMappingContext.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaMappingContext.test.tsx
@@ -7,8 +7,8 @@ import { callRpc } from "@/lib/rpc-client"
 import {
   DeviceQuotaMappingProvider,
   type DeviceQuotaMappingContextValue,
-} from "../_components/DeviceQuotaMappingContext"
-import { useDeviceQuotaMappingContext } from "../_hooks/useDeviceQuotaMappingContext"
+} from "@/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext"
+import { useDeviceQuotaMappingContext } from "@/app/(app)/device-quota/mapping/_hooks/useDeviceQuotaMappingContext"
 
 const mockUseSession = vi.fn()
 vi.mock("next-auth/react", () => ({

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx
@@ -10,101 +10,16 @@ import { useServerPagination } from "@/hooks/useServerPagination"
 import { useUnassignedEquipmentFilters } from "../_hooks/useUnassignedEquipmentFilters"
 import { filterCategoriesWithAncestorsAndDescendants } from "../../categories/_utils/filterCategoriesWithAncestorsAndDescendants"
 import { useLinkEquipmentMutation } from "./DeviceQuotaMappingMutations"
-
-// ============================================
-// Types
-// ============================================
-
-interface UnassignedEquipmentRow {
-  id: number
-  ma_thiet_bi: string
-  ten_thiet_bi: string
-  model: string | null
-  serial: string | null
-  hang_san_xuat: string | null
-  khoa_phong_quan_ly: string | null
-  tinh_trang: string | null
-  total_count: number
-}
-
-export interface UnassignedEquipment {
-  id: number
-  ma_thiet_bi: string
-  ten_thiet_bi: string
-  model: string | null
-  serial: string | null
-  hang_san_xuat: string | null
-  khoa_phong_quan_ly: string | null
-  tinh_trang: string | null
-}
-
-export interface Category {
-  id: number
-  parent_id: number | null
-  ma_nhom: string
-  ten_nhom: string
-  phan_loai: string | null
-  level: number
-  so_luong_hien_co: number
-}
-
-interface AuthUser {
-  id: string
-  username: string
-  full_name?: string | null
-  role: string
-  don_vi?: string | null
-  dia_ban_id?: number | null
-}
-
-export interface FilterOptions {
-  departments: string[]
-  users: string[]
-  locations: string[]
-  fundingSources: string[]
-}
-
-export interface DeviceQuotaMappingContextValue {
-  user: AuthUser | null
-  donViId: number | null
-  isFacilitySelected: boolean
-
-  // Equipment data (current page)
-  unassignedEquipment: UnassignedEquipment[]
-  totalEquipmentCount: number
-
-  // Categories (all, and search-filtered)
-  allCategories: Category[]
-  categories: Category[]
-
-  // Selection
-  selectedEquipmentIds: Set<number>
-  selectedCategoryId: number | null
-  toggleEquipmentSelection: (id: number) => void
-  selectAllEquipment: () => void
-  deselectPageEquipment: () => void
-  clearEquipmentSelection: () => void
-  setSelectedCategory: (id: number | null) => void
-
-  // Equipment filters (from useUnassignedEquipmentFilters)
-  filters: ReturnType<typeof useUnassignedEquipmentFilters>
-  filterOptions: FilterOptions
-
-  // Equipment pagination (from useServerPagination)
-  pagination: ReturnType<typeof useServerPagination>
-
-  // Category search (client-side)
-  categorySearchTerm: string
-  setCategorySearchTerm: (term: string) => void
-
-  // Mutations
-  linkEquipment: ReturnType<typeof useLinkEquipmentMutation>
-
-  // Loading
-  isLoading: boolean
-  isLinking: boolean
-  refetch: () => void
-}
+import { getNextPaginationTotalCount } from "./DeviceQuotaMappingPagination"
+import type {
+  AuthUser,
+  Category,
+  DeviceQuotaMappingContextValue,
+  FilterOptions,
+  UnassignedEquipment,
+  UnassignedEquipmentRow,
+} from "./DeviceQuotaMappingTypes"
+export type { Category, DeviceQuotaMappingContextValue } from "./DeviceQuotaMappingTypes"
 
 // ============================================
 function useFilteredCategories(allCategories: Category[], searchTerm: string): Category[] {
@@ -209,29 +124,26 @@ export function DeviceQuotaMappingProvider({ children }: DeviceQuotaMappingProvi
     gcTime: 5 * 60 * 1000,
   })
 
-  // Keep total count synced to server while recovering from empty out-of-range pages:
-  // - If page has rows, read total_count from first row
-  // - If non-first page resolves empty, jump back to page 1 to refetch authoritative total
-  // - If page 1 resolves empty, total is truly 0
+  // Keep total count synced to server while recovering from empty out-of-range pages.
+  const nextPaginationTotalCount = React.useMemo(
+    () => getNextPaginationTotalCount({
+      donViId,
+      equipmentRawData,
+      page: paginationState.page,
+    }),
+    [donViId, equipmentRawData, paginationState.page]
+  )
+
   React.useEffect(() => {
-    if (!donViId) {
-      setPaginationTotalCount(0)
+    if (nextPaginationTotalCount === null) return
+    setPaginationTotalCount(nextPaginationTotalCount)
+  }, [nextPaginationTotalCount])
+
+  React.useEffect(() => {
+    if (!donViId || !equipmentRawData || equipmentRawData.length > 0 || paginationState.page === 1) {
       return
     }
-
-    if (!equipmentRawData) return
-
-    if (equipmentRawData.length > 0) {
-      setPaginationTotalCount(equipmentRawData[0]?.total_count ?? 0)
-      return
-    }
-
-    if (paginationState.page > 1) {
-      paginationState.resetToFirstPage()
-      return
-    }
-
-    setPaginationTotalCount(0)
+    paginationState.resetToFirstPage()
   }, [donViId, equipmentRawData, paginationState.page, paginationState.resetToFirstPage])
 
   const totalEquipmentCount = paginationTotalCount

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingPagination.ts
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingPagination.ts
@@ -1,18 +1,20 @@
 "use client"
 
-type CountedEquipmentRow = {
+export interface CountedEquipmentRow {
   total_count: number
+}
+
+export interface GetNextPaginationTotalCountParams {
+  donViId: number | null
+  equipmentRawData: CountedEquipmentRow[] | undefined
+  page: number
 }
 
 export function getNextPaginationTotalCount({
   donViId,
   equipmentRawData,
   page,
-}: {
-  donViId: number | null
-  equipmentRawData: CountedEquipmentRow[] | undefined
-  page: number
-}): number | null {
+}: GetNextPaginationTotalCountParams): number | null {
   if (!donViId) return 0
   if (!equipmentRawData) return null
   if (equipmentRawData.length > 0) return equipmentRawData[0]?.total_count ?? 0

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingPagination.ts
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingPagination.ts
@@ -1,0 +1,21 @@
+"use client"
+
+type CountedEquipmentRow = {
+  total_count: number
+}
+
+export function getNextPaginationTotalCount({
+  donViId,
+  equipmentRawData,
+  page,
+}: {
+  donViId: number | null
+  equipmentRawData: CountedEquipmentRow[] | undefined
+  page: number
+}): number | null {
+  if (!donViId) return 0
+  if (!equipmentRawData) return null
+  if (equipmentRawData.length > 0) return equipmentRawData[0]?.total_count ?? 0
+  if (page === 1) return 0
+  return null
+}

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingTypes.ts
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingTypes.ts
@@ -1,5 +1,5 @@
 import type { useServerPagination } from "@/hooks/useServerPagination"
-import type { useUnassignedEquipmentFilters } from "../_hooks/useUnassignedEquipmentFilters"
+import type { useUnassignedEquipmentFilters } from "@/app/(app)/device-quota/mapping/_hooks/useUnassignedEquipmentFilters"
 import type { useLinkEquipmentMutation } from "./DeviceQuotaMappingMutations"
 
 export interface UnassignedEquipmentRow {

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingTypes.ts
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingTypes.ts
@@ -1,0 +1,78 @@
+import type { useServerPagination } from "@/hooks/useServerPagination"
+import type { useUnassignedEquipmentFilters } from "../_hooks/useUnassignedEquipmentFilters"
+import type { useLinkEquipmentMutation } from "./DeviceQuotaMappingMutations"
+
+export interface UnassignedEquipmentRow {
+  id: number
+  ma_thiet_bi: string
+  ten_thiet_bi: string
+  model: string | null
+  serial: string | null
+  hang_san_xuat: string | null
+  khoa_phong_quan_ly: string | null
+  tinh_trang: string | null
+  total_count: number
+}
+
+export interface UnassignedEquipment {
+  id: number
+  ma_thiet_bi: string
+  ten_thiet_bi: string
+  model: string | null
+  serial: string | null
+  hang_san_xuat: string | null
+  khoa_phong_quan_ly: string | null
+  tinh_trang: string | null
+}
+
+export interface Category {
+  id: number
+  parent_id: number | null
+  ma_nhom: string
+  ten_nhom: string
+  phan_loai: string | null
+  level: number
+  so_luong_hien_co: number
+}
+
+export interface FilterOptions {
+  departments: string[]
+  users: string[]
+  locations: string[]
+  fundingSources: string[]
+}
+
+export interface AuthUser {
+  id: string
+  username: string
+  full_name?: string | null
+  role: string
+  don_vi?: string | null
+  dia_ban_id?: number | null
+}
+
+export interface DeviceQuotaMappingContextValue {
+  user: AuthUser | null
+  donViId: number | null
+  isFacilitySelected: boolean
+  unassignedEquipment: UnassignedEquipment[]
+  totalEquipmentCount: number
+  allCategories: Category[]
+  categories: Category[]
+  selectedEquipmentIds: Set<number>
+  selectedCategoryId: number | null
+  toggleEquipmentSelection: (id: number) => void
+  selectAllEquipment: () => void
+  deselectPageEquipment: () => void
+  clearEquipmentSelection: () => void
+  setSelectedCategory: (id: number | null) => void
+  filters: ReturnType<typeof useUnassignedEquipmentFilters>
+  filterOptions: FilterOptions
+  pagination: ReturnType<typeof useServerPagination>
+  categorySearchTerm: string
+  setCategorySearchTerm: (term: string) => void
+  linkEquipment: ReturnType<typeof useLinkEquipmentMutation>
+  isLoading: boolean
+  isLinking: boolean
+  refetch: () => void
+}


### PR DESCRIPTION
## Summary
- Move category provider UI state into a reducer to resolve `prefer-useReducer`.
- Split mapping pagination total sync/reset logic so each effect has a single state mutation.
- Add focused TDD coverage for React Doctor state guards, category dialog open/close, and mapping pagination/selection behavior.
- Extract mapping types/helper to keep touched context files under repo line-count thresholds.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts' 'src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx' 'src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaMappingContext.test.tsx'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` -> 100/100, no issues found

Closes #477

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes React Doctor state warnings in the device quota category and mapping contexts by moving UI state to a reducer and splitting pagination logic so each effect does a single state update. Adds tests, including a guard enforcing `useReducer` and one-mutation-per-effect. Addresses #477.

- **Bug Fixes**
  - Mapping: Sync total via `getNextPaginationTotalCount`; a separate effect resets to page 1 only when a non-first page is empty.
  - Selection: Page equipment selection and category selection are independent; out-of-range pages reset cleanly.

- **Refactors**
  - Category provider UI state moved to `useReducer` (dialog, delete/import, search, mutating id), resolving `react-doctor` warnings.
  - Extracted `DeviceQuotaMappingTypes.ts` and `DeviceQuotaMappingPagination.ts`; mapping effects now perform one state change each.

<sup>Written for commit a4047b8282cf58320a35d7133daa9cafac2aa372. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/488?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests for category create dialog, mapping pagination/selection, and state-management rules enforcement.

* **Bug Fixes**
  * Improved pagination recovery so empty pages reset to valid results.

* **Refactor**
  * Reorganized mapping code with shared types and refactored category UI state for more consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->