### PR TITLE
Perf: add nhan_vien lower(username) index migration

### DIFF
--- a/supabase/migrations/20260516041000_add_nhan_vien_lower_username_index.sql
+++ b/supabase/migrations/20260516041000_add_nhan_vien_lower_username_index.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- Match authenticate_user_dual_mode's case-insensitive username lookup:
+--   WHERE lower(nv.username) = v_username
+CREATE INDEX IF NOT EXISTS idx_nhan_vien_lower_username
+ON public.nhan_vien (lower(username));
+
+COMMIT;

--- a/supabase/migrations/20260516041000_add_nhan_vien_lower_username_index.sql
+++ b/supabase/migrations/20260516041000_add_nhan_vien_lower_username_index.sql
@@ -1,5 +1,6 @@
 BEGIN;
 
+-- Rollback: DROP INDEX IF EXISTS public.idx_nhan_vien_lower_username;
 -- Match authenticate_user_dual_mode's case-insensitive username lookup:
 --   WHERE lower(nv.username) = v_username
 CREATE INDEX IF NOT EXISTS idx_nhan_vien_lower_username


### PR DESCRIPTION
## Summary
- add migration for `idx_nhan_vien_lower_username` on `public.nhan_vien (lower(username))`
- keep auth behavior unchanged; this aligns the index with `authenticate_user_dual_mode` case-insensitive lookup
- use transactional `CREATE INDEX IF NOT EXISTS`, not `CONCURRENTLY`, to match repo migration patterns

## Verification
- static migration assertions passed: BEGIN/COMMIT, rollback note, index name, `public.nhan_vien`, `lower(username)`, no `CONCURRENTLY`
- source-order assertion passed: migration sorts after `20260515113000_reassert_department_scope_unicode_aliases.sql`
- `git diff --cached --check` passed before commit
- Code Review Graph change detection: 0 affected flows, risk score 0.00

## Live rollout smoke, 2026-05-16
- Applied via Supabase MCP as migration `20260516052422 add_nhan_vien_lower_username_index`
- Catalog check: index exists, `is_valid=true`, `is_ready=true`, expression `lower(username)`
- Default `EXPLAIN` for `lower(username) = ...`: `Index Scan` using `idx_nhan_vien_lower_username`
- Auth RPC smoke: nonexistent username returns `is_authenticated=false`, `authentication_mode='user_not_found'`
- Advisors ran after apply; findings are pre-existing/out-of-scope security and performance lint items, with no blocker specific to this index rollout

Fixes #485
