### PR TITLE
Refactor handover preview dialog for React Doctor P6

### DIFF
--- a/src/__tests__/react-doctor-p6-handover-preview-size.source.test.ts
+++ b/src/__tests__/react-doctor-p6-handover-preview-size.source.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const HANDOVER_PREVIEW_PATH = "src/components/handover-preview-dialog.tsx"
+
+function readSource(relativePath: string) {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8")
+}
+
+describe("React Doctor P6 handover preview size guard", () => {
+  it("keeps the dialog shell under the repo extraction threshold", () => {
+    const source = readSource(HANDOVER_PREVIEW_PATH)
+    const lineCount = source.split(/\r?\n/).length
+
+    expect(lineCount).toBeLessThanOrEqual(350)
+  })
+
+  it("keeps generated document markup outside the dialog shell", () => {
+    const source = readSource(HANDOVER_PREVIEW_PATH)
+
+    expect(source).not.toContain("<!DOCTYPE html>")
+    expect(source).not.toContain("<style>")
+    expect(source).toContain("generateHandoverHTML")
+  })
+})

--- a/src/__tests__/react-doctor-p6-handover-preview-size.source.test.ts
+++ b/src/__tests__/react-doctor-p6-handover-preview-size.source.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest"
 
 const HANDOVER_PREVIEW_PATH = "src/components/handover-preview-dialog.tsx"
 
-function readSource(relativePath: string) {
+function readSource(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8")
 }
 

--- a/src/components/__tests__/handover-preview-dialog.component.test.tsx
+++ b/src/components/__tests__/handover-preview-dialog.component.test.tsx
@@ -15,6 +15,12 @@ vi.mock("@/hooks/use-toast", () => ({
 
 import { HandoverPreviewDialog } from "@/components/handover-preview-dialog"
 
+type WindowOpenMock = Readonly<{
+  fakeDocument: Document
+  fakeWindow: Window
+  openSpy: ReturnType<typeof vi.spyOn>
+}>
+
 function makeTransfer(overrides: Partial<TransferRequest> = {}): TransferRequest {
   return {
     id: 1,
@@ -39,7 +45,7 @@ function makeTransfer(overrides: Partial<TransferRequest> = {}): TransferRequest
   }
 }
 
-function createWindowOpenMock() {
+function createWindowOpenMock(): WindowOpenMock {
   const fakeDocument = {
     open: vi.fn(),
     write: vi.fn(),
@@ -110,5 +116,50 @@ describe("HandoverPreviewDialog", () => {
       )
     })
     expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it("blocks preview when required fields are blank", async () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null)
+
+    render(
+      <HandoverPreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        transfer={makeTransfer()}
+      />,
+    )
+
+    await screen.findByText("Xem trước phiếu bàn giao - LC-0001")
+    fireEvent.click(screen.getByRole("button", { name: "Sửa" }))
+    fireEvent.change(screen.getByLabelText("Lý do bàn giao"), { target: { value: " " } })
+    fireEvent.click(screen.getByRole("button", { name: /Xem trước/ }))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: "⚠️ Thiếu thông tin bắt buộc",
+        }),
+      )
+    })
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it("preserves user edits when toggling between edit and preview modes", async () => {
+    render(
+      <HandoverPreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        transfer={makeTransfer()}
+      />,
+    )
+
+    await screen.findByText("Xem trước phiếu bàn giao - LC-0001")
+    fireEvent.click(screen.getByRole("button", { name: "Sửa" }))
+    fireEvent.change(screen.getByLabelText("Ghi chú"), { target: { value: "Giữ nguyên ghi chú" } })
+    fireEvent.click(screen.getByRole("button", { name: "Xem" }))
+    fireEvent.click(screen.getByRole("button", { name: "Sửa" }))
+
+    expect(screen.getByLabelText("Ghi chú")).toHaveValue("Giữ nguyên ghi chú")
   })
 })

--- a/src/components/__tests__/handover-preview-dialog.component.test.tsx
+++ b/src/components/__tests__/handover-preview-dialog.component.test.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { TransferRequest } from "@/types/database"
+
+const mocks = vi.hoisted(() => ({
+  toast: vi.fn(),
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}))
+
+import { HandoverPreviewDialog } from "@/components/handover-preview-dialog"
+
+function makeTransfer(overrides: Partial<TransferRequest> = {}): TransferRequest {
+  return {
+    id: 1,
+    ma_yeu_cau: "LC-0001",
+    thiet_bi_id: 10,
+    loai_hinh: "noi_bo",
+    trang_thai: "da_duyet",
+    ly_do_luan_chuyen: "Bàn giao phục vụ khám bệnh",
+    khoa_phong_hien_tai: "Khoa Cấp cứu",
+    khoa_phong_nhan: "Khoa Nội",
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    thiet_bi: {
+      id: 10,
+      ma_thiet_bi: "TB-001",
+      ten_thiet_bi: "Máy thở",
+      model: "M-100",
+      serial_number: "SN-001",
+      tinh_trang: "Hoạt động",
+    },
+    ...overrides,
+  }
+}
+
+function createWindowOpenMock() {
+  const fakeDocument = {
+    open: vi.fn(),
+    write: vi.fn(),
+    close: vi.fn(),
+  } as unknown as Document
+  const fakeWindow = {
+    document: fakeDocument,
+    print: vi.fn(),
+    onload: null,
+  } as unknown as Window
+
+  return {
+    fakeDocument,
+    fakeWindow,
+    openSpy: vi.spyOn(window, "open").mockReturnValue(fakeWindow),
+  }
+}
+
+describe("HandoverPreviewDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  it("opens a preview window with generated handover content", async () => {
+    const { fakeDocument, openSpy } = createWindowOpenMock()
+
+    render(
+      <HandoverPreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        transfer={makeTransfer()}
+      />,
+    )
+
+    await screen.findByText("Xem trước phiếu bàn giao - LC-0001")
+    fireEvent.click(screen.getByRole("button", { name: /Xem trước/ }))
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith("", "_blank")
+    })
+    expect(fakeDocument.write).toHaveBeenCalledWith(expect.stringContaining("LC-0001"))
+    expect(fakeDocument.write).toHaveBeenCalledWith(expect.stringContaining("Máy thở"))
+  })
+
+  it("blocks printing and switches to editing when required fields are blank", async () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null)
+
+    render(
+      <HandoverPreviewDialog
+        open
+        onOpenChange={vi.fn()}
+        transfer={makeTransfer()}
+      />,
+    )
+
+    await screen.findByText("Xem trước phiếu bàn giao - LC-0001")
+    fireEvent.click(screen.getByRole("button", { name: "Sửa" }))
+    fireEvent.change(screen.getByLabelText("Lý do bàn giao"), { target: { value: " " } })
+    fireEvent.click(screen.getByRole("button", { name: /In phiếu/ }))
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: "⚠️ Thiếu thông tin bắt buộc",
+        }),
+      )
+    })
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/__tests__/handover-preview-dialog.component.test.tsx
+++ b/src/components/__tests__/handover-preview-dialog.component.test.tsx
@@ -118,8 +118,8 @@ describe("HandoverPreviewDialog", () => {
     expect(openSpy).not.toHaveBeenCalled()
   })
 
-  it("blocks preview when required fields are blank", async () => {
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(null)
+  it("allows preview when required fields are blank", async () => {
+    const { fakeDocument, openSpy } = createWindowOpenMock()
 
     render(
       <HandoverPreviewDialog
@@ -131,18 +131,28 @@ describe("HandoverPreviewDialog", () => {
 
     await screen.findByText("Xem trước phiếu bàn giao - LC-0001")
     fireEvent.click(screen.getByRole("button", { name: "Sửa" }))
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "💡 Mẹo sử dụng",
+        }),
+      )
+    })
+    mocks.toast.mockClear()
+
     fireEvent.change(screen.getByLabelText("Lý do bàn giao"), { target: { value: " " } })
     fireEvent.click(screen.getByRole("button", { name: /Xem trước/ }))
 
     await waitFor(() => {
-      expect(mocks.toast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          variant: "destructive",
-          title: "⚠️ Thiếu thông tin bắt buộc",
-        }),
-      )
+      expect(openSpy).toHaveBeenCalledWith("", "_blank")
     })
-    expect(openSpy).not.toHaveBeenCalled()
+    expect(fakeDocument.write).toHaveBeenCalledWith(expect.stringContaining("LC-0001"))
+    expect(mocks.toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "destructive",
+        title: "⚠️ Thiếu thông tin bắt buộc",
+      }),
+    )
   })
 
   it("preserves user edits when toggling between edit and preview modes", async () => {

--- a/src/components/__tests__/handover-preview-dialog.component.test.tsx
+++ b/src/components/__tests__/handover-preview-dialog.component.test.tsx
@@ -105,6 +105,7 @@ describe("HandoverPreviewDialog", () => {
     await screen.findByText("Xem trước phiếu bàn giao - LC-0001")
     fireEvent.click(screen.getByRole("button", { name: "Sửa" }))
     fireEvent.change(screen.getByLabelText("Lý do bàn giao"), { target: { value: " " } })
+    fireEvent.click(screen.getByRole("button", { name: "Xem" }))
     fireEvent.click(screen.getByRole("button", { name: /In phiếu/ }))
 
     await waitFor(() => {
@@ -116,6 +117,7 @@ describe("HandoverPreviewDialog", () => {
       )
     })
     expect(openSpy).not.toHaveBeenCalled()
+    expect(screen.getByLabelText("Lý do bàn giao")).toBeInTheDocument()
   })
 
   it("allows preview when required fields are blank", async () => {

--- a/src/components/__tests__/handover-preview-dialog.data.test.ts
+++ b/src/components/__tests__/handover-preview-dialog.data.test.ts
@@ -91,6 +91,22 @@ describe("handover preview data helpers", () => {
     expect(data.receiverName).toBe("Đại diện Tổ QLTB")
   })
 
+  it("does not generate undefined representative labels for missing departments", () => {
+    const data = buildHandoverData(
+      makeTransfer({
+        khoa_phong_hien_tai: undefined,
+        khoa_phong_nhan: undefined,
+      }),
+      "16/05/2026",
+    )
+
+    expect(data.department).toBe("Tổ QLTB")
+    expect(data.giverName).toBe("Đại diện Tổ QLTB")
+    expect(data.receiverName).toBe("")
+    expect(validateHandoverData(data).missingFields).toContain("Đại diện bên nhận")
+  })
+
+
   it("requires department, reason, giver, and receiver but not director", () => {
     const validation = validateHandoverData(
       makeHandoverData({

--- a/src/components/__tests__/handover-preview-dialog.data.test.ts
+++ b/src/components/__tests__/handover-preview-dialog.data.test.ts
@@ -107,6 +107,20 @@ describe("handover preview data helpers", () => {
   })
 
 
+  it("falls back to QLTB when the current department is blank after trimming", () => {
+    const data = buildHandoverData(
+      makeTransfer({
+        khoa_phong_hien_tai: "   ",
+      }),
+      "16/05/2026",
+    )
+
+    expect(data.department).toBe("Tổ QLTB")
+    expect(data.giverName).toBe("Đại diện Tổ QLTB")
+    expect(validateHandoverData(data).missingFields).not.toContain("Khoa/Phòng lập")
+    expect(validateHandoverData(data).missingFields).not.toContain("Đại diện bên giao")
+  })
+
   it("requires department, reason, giver, and receiver but not director", () => {
     const validation = validateHandoverData(
       makeHandoverData({

--- a/src/components/__tests__/handover-preview-dialog.data.test.ts
+++ b/src/components/__tests__/handover-preview-dialog.data.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildHandoverData,
+  updateHandoverField,
+  validateHandoverData,
+  type HandoverData,
+} from "@/components/handover-preview-dialog.data"
+import type { TransferRequest } from "@/types/database"
+
+function makeTransfer(overrides: Partial<TransferRequest> = {}): TransferRequest {
+  return {
+    id: 1,
+    ma_yeu_cau: "LC-0001",
+    thiet_bi_id: 10,
+    loai_hinh: "noi_bo",
+    trang_thai: "da_duyet",
+    ly_do_luan_chuyen: "Bàn giao phục vụ khám bệnh",
+    khoa_phong_hien_tai: "Khoa Cấp cứu",
+    khoa_phong_nhan: "Khoa Nội",
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    thiet_bi: {
+      id: 10,
+      ma_thiet_bi: "TB-001",
+      ten_thiet_bi: "Máy thở",
+      model: "M-100",
+      serial_number: "SN-001",
+      tinh_trang: "Hoạt động",
+    },
+    ...overrides,
+  }
+}
+
+function makeHandoverData(overrides: Partial<HandoverData> = {}): HandoverData {
+  return {
+    department: "Khoa Cấp cứu",
+    handoverDate: "16/05/2026",
+    reason: "Bàn giao phục vụ khám bệnh",
+    requestCode: "LC-0001",
+    giverName: "Đại diện Khoa Cấp cứu",
+    directorName: "",
+    receiverName: "Đại diện Khoa Nội",
+    device: {
+      code: "TB-001",
+      name: "Máy thở",
+      model: "M-100",
+      serial: "SN-001",
+      condition: "Hoạt động",
+      accessories: "",
+      note: "",
+    },
+    ...overrides,
+  }
+}
+
+describe("handover preview data helpers", () => {
+  it("builds handover defaults from a transfer request", () => {
+    const data = buildHandoverData(makeTransfer(), "16/05/2026")
+
+    expect(data).toMatchObject({
+      department: "Khoa Cấp cứu",
+      handoverDate: "16/05/2026",
+      reason: "Bàn giao phục vụ khám bệnh",
+      requestCode: "LC-0001",
+      giverName: "Đại diện Khoa Cấp cứu",
+      directorName: "",
+      receiverName: "Đại diện Khoa Nội",
+      device: {
+        code: "TB-001",
+        name: "Máy thở",
+        model: "M-100",
+        serial: "SN-001",
+        condition: "Hoạt động",
+        accessories: "",
+        note: "",
+      },
+    })
+  })
+
+  it("keeps QLTB representative labels stable for QLTB transfers", () => {
+    const data = buildHandoverData(
+      makeTransfer({
+        khoa_phong_hien_tai: "Tổ QLTB",
+        khoa_phong_nhan: "Tổ QLTB",
+      }),
+      "16/05/2026",
+    )
+
+    expect(data.giverName).toBe("Đại diện Tổ QLTB")
+    expect(data.receiverName).toBe("Đại diện Tổ QLTB")
+  })
+
+  it("requires department, reason, giver, and receiver but not director", () => {
+    const validation = validateHandoverData(
+      makeHandoverData({
+        department: " ",
+        reason: "",
+        giverName: "",
+        directorName: "",
+        receiverName: "",
+      }),
+    )
+
+    expect(validation).toEqual({
+      isValid: false,
+      missingFields: [
+        "Khoa/Phòng lập",
+        "Lý do bàn giao",
+        "Đại diện bên giao",
+        "Đại diện bên nhận",
+      ],
+    })
+  })
+
+  it("updates top-level and nested device fields immutably", () => {
+    const data = makeHandoverData()
+
+    const updatedReason = updateHandoverField(data, "reason", "Lý do mới")
+    const updatedNote = updateHandoverField(data, "device.note", "Ghi chú mới")
+
+    expect(updatedReason.reason).toBe("Lý do mới")
+    expect(updatedReason.device).toBe(data.device)
+    expect(updatedNote.device.note).toBe("Ghi chú mới")
+    expect(updatedNote.device).not.toBe(data.device)
+    expect(data.reason).toBe("Bàn giao phục vụ khám bệnh")
+    expect(data.device.note).toBe("")
+  })
+})

--- a/src/components/__tests__/handover-preview-dialog.document.test.ts
+++ b/src/components/__tests__/handover-preview-dialog.document.test.ts
@@ -25,6 +25,22 @@ function makeHandoverData(): HandoverData {
 }
 
 describe("handover preview document generation", () => {
+  it("escapes HTML in user-editable fields", () => {
+    const html = generateHandoverHTML({
+      ...makeHandoverData(),
+      reason: '<script>alert("x")</script>',
+      device: {
+        ...makeHandoverData().device,
+        note: "<img src=x onerror=alert(1)>",
+      },
+    })
+
+    expect(html).toContain("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;")
+    expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;")
+    expect(html).not.toContain('<script>alert("x")</script>')
+    expect(html).not.toContain("<img src=x onerror=alert(1)>")
+  })
+
   it("renders the handover document with transfer, device, and signature details", () => {
     const html = generateHandoverHTML(makeHandoverData())
 

--- a/src/components/__tests__/handover-preview-dialog.document.test.ts
+++ b/src/components/__tests__/handover-preview-dialog.document.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+
+import { generateHandoverHTML } from "@/components/handover-preview-dialog.document"
+import type { HandoverData } from "@/components/handover-preview-dialog.data"
+
+function makeHandoverData(): HandoverData {
+  return {
+    department: "Khoa Cấp cứu",
+    handoverDate: "16/05/2026",
+    reason: "Bàn giao phục vụ khám bệnh",
+    requestCode: "LC-0001",
+    giverName: "Đại diện Khoa Cấp cứu",
+    directorName: "",
+    receiverName: "Đại diện Khoa Nội",
+    device: {
+      code: "TB-001",
+      name: "Máy thở",
+      model: "M-100",
+      serial: "SN-001",
+      condition: "Hoạt động",
+      accessories: "Dây nguồn",
+      note: "Không có",
+    },
+  }
+}
+
+describe("handover preview document generation", () => {
+  it("renders the handover document with transfer, device, and signature details", () => {
+    const html = generateHandoverHTML(makeHandoverData())
+
+    expect(html).toContain("<!DOCTYPE html>")
+    expect(html).toContain("BIÊN BẢN BÀN GIAO THIẾT BỊ")
+    expect(html).toContain("LC-0001")
+    expect(html).toContain("TB-001")
+    expect(html).toContain("Máy thở")
+    expect(html).toContain("Bàn giao phục vụ khám bệnh")
+    expect(html).toContain("Đại diện Khoa Cấp cứu")
+    expect(html).toContain("Đại diện Khoa Nội")
+    expect(html).toContain("Dây nguồn")
+  })
+
+  it("keeps the generated page printable as an A4 landscape document", () => {
+    const html = generateHandoverHTML(makeHandoverData())
+
+    expect(html).toContain(".a4-landscape-page")
+    expect(html).toContain("@media print")
+    expect(html).toContain("print-color-adjust")
+  })
+})

--- a/src/components/handover-preview-dialog.data.ts
+++ b/src/components/handover-preview-dialog.data.ts
@@ -20,7 +20,8 @@ export function buildHandoverData(
   transfer: TransferRequest,
   handoverDate = new Date().toLocaleDateString("vi-VN"),
 ): HandoverData {
-  const currentDepartment = formatValue(transfer.khoa_phong_hien_tai || "Tổ QLTB")
+  const normalizedCurrentDepartment = formatValue(transfer.khoa_phong_hien_tai).trim()
+  const currentDepartment = formatValue(normalizedCurrentDepartment || "Tổ QLTB")
   const receivingDepartment = formatValue(transfer.khoa_phong_nhan)
 
   return {

--- a/src/components/handover-preview-dialog.data.ts
+++ b/src/components/handover-preview-dialog.data.ts
@@ -9,21 +9,28 @@ function formatValue(value: string | number | null | undefined): string {
 }
 
 function resolveRepresentative(department: string | null | undefined): string {
-  return department === "Tổ QLTB" ? "Đại diện Tổ QLTB" : `Đại diện ${department}`
+  const normalizedDepartment = formatValue(department).trim()
+
+  if (!normalizedDepartment) return ""
+
+  return normalizedDepartment === "Tổ QLTB" ? "Đại diện Tổ QLTB" : `Đại diện ${normalizedDepartment}`
 }
 
 export function buildHandoverData(
   transfer: TransferRequest,
   handoverDate = new Date().toLocaleDateString("vi-VN"),
 ): HandoverData {
+  const currentDepartment = formatValue(transfer.khoa_phong_hien_tai || "Tổ QLTB")
+  const receivingDepartment = formatValue(transfer.khoa_phong_nhan)
+
   return {
-    department: formatValue(transfer.khoa_phong_hien_tai || "Tổ QLTB"),
+    department: currentDepartment,
     handoverDate,
     reason: formatValue(transfer.ly_do_luan_chuyen),
     requestCode: formatValue(transfer.ma_yeu_cau),
-    giverName: resolveRepresentative(transfer.khoa_phong_hien_tai),
+    giverName: resolveRepresentative(currentDepartment),
     directorName: "",
-    receiverName: resolveRepresentative(transfer.khoa_phong_nhan),
+    receiverName: resolveRepresentative(receivingDepartment),
     device: {
       code: formatValue(transfer.thiet_bi?.ma_thiet_bi),
       name: formatValue(transfer.thiet_bi?.ten_thiet_bi),

--- a/src/components/handover-preview-dialog.data.ts
+++ b/src/components/handover-preview-dialog.data.ts
@@ -1,0 +1,76 @@
+import type { TransferRequest } from "@/types/database"
+
+import type { HandoverData, HandoverField } from "./handover-preview-dialog.types"
+
+export type { HandoverData, HandoverField } from "./handover-preview-dialog.types"
+
+function formatValue(value: string | number | null | undefined): string {
+  return String(value ?? "")
+}
+
+function resolveRepresentative(department: string | null | undefined): string {
+  return department === "Tổ QLTB" ? "Đại diện Tổ QLTB" : `Đại diện ${department}`
+}
+
+export function buildHandoverData(
+  transfer: TransferRequest,
+  handoverDate = new Date().toLocaleDateString("vi-VN"),
+): HandoverData {
+  return {
+    department: formatValue(transfer.khoa_phong_hien_tai || "Tổ QLTB"),
+    handoverDate,
+    reason: formatValue(transfer.ly_do_luan_chuyen),
+    requestCode: formatValue(transfer.ma_yeu_cau),
+    giverName: resolveRepresentative(transfer.khoa_phong_hien_tai),
+    directorName: "",
+    receiverName: resolveRepresentative(transfer.khoa_phong_nhan),
+    device: {
+      code: formatValue(transfer.thiet_bi?.ma_thiet_bi),
+      name: formatValue(transfer.thiet_bi?.ten_thiet_bi),
+      model: formatValue(transfer.thiet_bi?.model),
+      serial: formatValue(transfer.thiet_bi?.serial_number),
+      condition: formatValue(transfer.thiet_bi?.tinh_trang),
+      accessories: "",
+      note: "",
+    },
+  }
+}
+
+export function updateHandoverField(
+  data: HandoverData,
+  field: HandoverField,
+  value: string,
+): HandoverData {
+  if (field.startsWith("device.")) {
+    const deviceField = field.replace("device.", "") as keyof HandoverData["device"]
+
+    return {
+      ...data,
+      device: {
+        ...data.device,
+        [deviceField]: value,
+      },
+    }
+  }
+
+  return {
+    ...data,
+    [field]: value,
+  }
+}
+
+export function validateHandoverData(
+  data: HandoverData,
+): { isValid: boolean; missingFields: string[] } {
+  const missingFields: string[] = []
+
+  if (!data.department.trim()) missingFields.push("Khoa/Phòng lập")
+  if (!data.reason.trim()) missingFields.push("Lý do bàn giao")
+  if (!data.giverName.trim()) missingFields.push("Đại diện bên giao")
+  if (!data.receiverName.trim()) missingFields.push("Đại diện bên nhận")
+
+  return {
+    isValid: missingFields.length === 0,
+    missingFields,
+  }
+}

--- a/src/components/handover-preview-dialog.document.ts
+++ b/src/components/handover-preview-dialog.document.ts
@@ -1,0 +1,107 @@
+import { HANDOVER_PRINT_STYLES } from "./handover-preview-dialog.print-styles"
+import type { HandoverData } from "./handover-preview-dialog.types"
+
+export function generateHandoverHTML(data: HandoverData): string {
+  return `
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Biên Bản Bàn Giao Thiết Bị</title>
+    <style>${HANDOVER_PRINT_STYLES}</style>
+</head>
+<body>
+    <div class="a4-landscape-page">
+        <div class="content-body">
+            <header class="text-center">
+                <div class="flex justify-between items-start">
+                    <div class="text-center">
+                        <img src="https://i.postimg.cc/26dHxmnV/89307731ad9526cb7f84-1-Photoroom.png"
+                             alt="Logo CDC"
+                             class="w-14 mx-auto mb-1"
+                             onerror="this.style.display='none';">
+                    </div>
+                    <div class="flex-grow">
+                        <h2 class="title-sub uppercase font-bold">TRUNG TÂM KIỂM SOÁT BỆNH TẬT THÀNH PHỐ CẦN THƠ</h2>
+                        <h1 class="title-main uppercase mt-3 font-bold">BIÊN BẢN BÀN GIAO THIẾT BỊ</h1>
+                    </div>
+                    <div class="w-14"></div>
+                </div>
+            </header>
+
+            <section class="mt-4 space-y-2">
+                <div class="flex items-baseline">
+                    <label class="whitespace-nowrap">Khoa/Phòng lập:</label>
+                    <div class="form-input-line form-input-readonly ml-2">${data.department}</div>
+                </div>
+                <div class="flex items-baseline">
+                    <label class="whitespace-nowrap">Ngày nhận/giao:</label>
+                    <div class="form-input-line form-input-readonly ml-2">${data.handoverDate}</div>
+                </div>
+                <div class="flex items-baseline">
+                    <label class="whitespace-nowrap">Lý do nhận bàn giao:</label>
+                    <div class="form-input-line form-input-readonly ml-2">${data.reason}</div>
+                </div>
+                <div class="flex items-baseline">
+                    <label class="whitespace-nowrap">Mã yêu cầu:</label>
+                    <div class="form-input-line form-input-readonly ml-2">${data.requestCode}</div>
+                </div>
+            </section>
+
+            <section class="mt-3">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th class="col-stt">STT</th>
+                            <th class="col-code">Mã thiết bị</th>
+                            <th class="col-name">Tên thiết bị</th>
+                            <th class="col-model">Model</th>
+                            <th class="col-serial">Serial</th>
+                            <th class="col-accessories">Tài liệu/phụ kiện kèm theo (nếu có)</th>
+                            <th class="col-condition">Tình trạng khi nhận/giao</th>
+                            <th class="col-note">Ghi chú</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="col-stt">1</td>
+                            <td class="col-code">${data.device.code}</td>
+                            <td class="col-name">${data.device.name}</td>
+                            <td class="col-model">${data.device.model}</td>
+                            <td class="col-serial">${data.device.serial}</td>
+                            <td class="col-accessories">${data.device.accessories}</td>
+                            <td class="col-condition">${data.device.condition}</td>
+                            <td class="col-note">${data.device.note}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+
+            <section class="mt-8">
+                <div class="flex justify-around">
+                    <div class="signature-area">
+                        <p class="font-bold">Đại diện bên giao</p>
+                        <p class="italic">(Ký, ghi rõ họ tên)</p>
+                        <div class="signature-space"></div>
+                        <div class="font-bold">${data.giverName}</div>
+                    </div>
+                    <div class="signature-area">
+                        <p class="font-bold">Ban Giám đốc</p>
+                        <p class="italic">(Ký, ghi rõ họ tên)</p>
+                        <div class="signature-space"></div>
+                        <div class="font-bold">${data.directorName}</div>
+                    </div>
+                    <div class="signature-area">
+                        <p class="font-bold">Đại diện bên nhận</p>
+                        <p class="italic">(Ký, ghi rõ họ tên)</p>
+                        <div class="signature-space"></div>
+                        <div class="font-bold">${data.receiverName}</div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+</body>
+</html>`
+}

--- a/src/components/handover-preview-dialog.document.ts
+++ b/src/components/handover-preview-dialog.document.ts
@@ -1,7 +1,35 @@
 import { HANDOVER_PRINT_STYLES } from "./handover-preview-dialog.print-styles"
 import type { HandoverData } from "./handover-preview-dialog.types"
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
 export function generateHandoverHTML(data: HandoverData): string {
+  const safe = {
+    department: escapeHtml(data.department),
+    handoverDate: escapeHtml(data.handoverDate),
+    reason: escapeHtml(data.reason),
+    requestCode: escapeHtml(data.requestCode),
+    giverName: escapeHtml(data.giverName),
+    directorName: escapeHtml(data.directorName),
+    receiverName: escapeHtml(data.receiverName),
+    device: {
+      code: escapeHtml(data.device.code),
+      name: escapeHtml(data.device.name),
+      model: escapeHtml(data.device.model),
+      serial: escapeHtml(data.device.serial),
+      condition: escapeHtml(data.device.condition),
+      accessories: escapeHtml(data.device.accessories),
+      note: escapeHtml(data.device.note),
+    },
+  }
+
   return `
 <!DOCTYPE html>
 <html lang="vi">
@@ -33,19 +61,19 @@ export function generateHandoverHTML(data: HandoverData): string {
             <section class="mt-4 space-y-2">
                 <div class="flex items-baseline">
                     <label class="whitespace-nowrap">Khoa/Phòng lập:</label>
-                    <div class="form-input-line form-input-readonly ml-2">${data.department}</div>
+                    <div class="form-input-line form-input-readonly ml-2">${safe.department}</div>
                 </div>
                 <div class="flex items-baseline">
                     <label class="whitespace-nowrap">Ngày nhận/giao:</label>
-                    <div class="form-input-line form-input-readonly ml-2">${data.handoverDate}</div>
+                    <div class="form-input-line form-input-readonly ml-2">${safe.handoverDate}</div>
                 </div>
                 <div class="flex items-baseline">
                     <label class="whitespace-nowrap">Lý do nhận bàn giao:</label>
-                    <div class="form-input-line form-input-readonly ml-2">${data.reason}</div>
+                    <div class="form-input-line form-input-readonly ml-2">${safe.reason}</div>
                 </div>
                 <div class="flex items-baseline">
                     <label class="whitespace-nowrap">Mã yêu cầu:</label>
-                    <div class="form-input-line form-input-readonly ml-2">${data.requestCode}</div>
+                    <div class="form-input-line form-input-readonly ml-2">${safe.requestCode}</div>
                 </div>
             </section>
 
@@ -66,13 +94,13 @@ export function generateHandoverHTML(data: HandoverData): string {
                     <tbody>
                         <tr>
                             <td class="col-stt">1</td>
-                            <td class="col-code">${data.device.code}</td>
-                            <td class="col-name">${data.device.name}</td>
-                            <td class="col-model">${data.device.model}</td>
-                            <td class="col-serial">${data.device.serial}</td>
-                            <td class="col-accessories">${data.device.accessories}</td>
-                            <td class="col-condition">${data.device.condition}</td>
-                            <td class="col-note">${data.device.note}</td>
+                            <td class="col-code">${safe.device.code}</td>
+                            <td class="col-name">${safe.device.name}</td>
+                            <td class="col-model">${safe.device.model}</td>
+                            <td class="col-serial">${safe.device.serial}</td>
+                            <td class="col-accessories">${safe.device.accessories}</td>
+                            <td class="col-condition">${safe.device.condition}</td>
+                            <td class="col-note">${safe.device.note}</td>
                         </tr>
                     </tbody>
                 </table>
@@ -84,19 +112,19 @@ export function generateHandoverHTML(data: HandoverData): string {
                         <p class="font-bold">Đại diện bên giao</p>
                         <p class="italic">(Ký, ghi rõ họ tên)</p>
                         <div class="signature-space"></div>
-                        <div class="font-bold">${data.giverName}</div>
+                        <div class="font-bold">${safe.giverName}</div>
                     </div>
                     <div class="signature-area">
                         <p class="font-bold">Ban Giám đốc</p>
                         <p class="italic">(Ký, ghi rõ họ tên)</p>
                         <div class="signature-space"></div>
-                        <div class="font-bold">${data.directorName}</div>
+                        <div class="font-bold">${safe.directorName}</div>
                     </div>
                     <div class="signature-area">
                         <p class="font-bold">Đại diện bên nhận</p>
                         <p class="italic">(Ký, ghi rõ họ tên)</p>
                         <div class="signature-space"></div>
-                        <div class="font-bold">${data.receiverName}</div>
+                        <div class="font-bold">${safe.receiverName}</div>
                     </div>
                 </div>
             </section>

--- a/src/components/handover-preview-dialog.form.tsx
+++ b/src/components/handover-preview-dialog.form.tsx
@@ -1,0 +1,104 @@
+import * as React from "react"
+
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+
+import type { HandoverData, HandoverField } from "./handover-preview-dialog.types"
+
+type HandoverPreviewFormProps = Readonly<{
+  data: HandoverData
+  onFieldChange: (field: HandoverField, value: string) => void
+}>
+
+export function HandoverPreviewForm({ data, onFieldChange }: HandoverPreviewFormProps) {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="department">Khoa/Phòng lập</Label>
+          <Input
+            id="department"
+            value={data.department}
+            onChange={(event) => onFieldChange("department", event.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="handoverDate">Ngày bàn giao</Label>
+          <Input
+            id="handoverDate"
+            value={data.handoverDate}
+            onChange={(event) => onFieldChange("handoverDate", event.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="reason">Lý do bàn giao</Label>
+        <Textarea
+          id="reason"
+          value={data.reason}
+          onChange={(event) => onFieldChange("reason", event.target.value)}
+          rows={2}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="giverName">Đại diện bên giao</Label>
+          <Input
+            id="giverName"
+            value={data.giverName}
+            onChange={(event) => onFieldChange("giverName", event.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="directorName">Ban Giám đốc</Label>
+          <Input
+            id="directorName"
+            value={data.directorName}
+            onChange={(event) => onFieldChange("directorName", event.target.value)}
+            placeholder="Tên Ban Giám đốc (tùy chọn)"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="receiverName">Đại diện bên nhận</Label>
+          <Input
+            id="receiverName"
+            value={data.receiverName}
+            onChange={(event) => onFieldChange("receiverName", event.target.value)}
+          />
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-4">
+        <h4 className="font-medium">Thông tin thiết bị</h4>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="accessories">Tài liệu/Phụ kiện kèm theo</Label>
+            <Textarea
+              id="accessories"
+              value={data.device.accessories}
+              onChange={(event) => onFieldChange("device.accessories", event.target.value)}
+              placeholder="Nhập tài liệu, phụ kiện kèm theo…"
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="note">Ghi chú</Label>
+            <Textarea
+              id="note"
+              value={data.device.note}
+              onChange={(event) => onFieldChange("device.note", event.target.value)}
+              placeholder="Nhập ghi chú…"
+              rows={3}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/handover-preview-dialog.print-styles.ts
+++ b/src/components/handover-preview-dialog.print-styles.ts
@@ -1,0 +1,166 @@
+export const HANDOVER_PRINT_STYLES = `
+body {
+    font-family: 'Times New Roman', Times, serif;
+    font-size: 13px;
+    color: #000;
+    background-color: #e5e7eb;
+    line-height: 1.4;
+    margin: 0;
+    padding: 0;
+}
+
+.a4-landscape-page {
+    width: 29.7cm;
+    min-height: 21cm;
+    padding: 1cm 2cm 1cm 1cm;
+    margin: 1cm auto;
+    background: white;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.content-body { flex-grow: 1; }
+.form-input-line {
+    font-family: inherit;
+    font-size: inherit;
+    border: none;
+    border-bottom: 1px dotted #000;
+    background-color: transparent;
+    padding: 2px 1px;
+    outline: none;
+    width: 100%;
+    min-height: 1.1em;
+}
+.form-input-readonly { border-bottom: 1px solid #000; font-weight: 500; }
+.editable-cell {
+    border-bottom: 1px solid #ccc !important;
+    background-color: #f9f9f9;
+    cursor: text;
+    min-height: 18px;
+    padding: 3px 4px !important;
+}
+.editable-cell:focus {
+    background-color: #fff;
+    border-bottom: 1px solid #007bff !important;
+    outline: none;
+}
+.editable-cell:empty:before {
+    content: attr(data-placeholder);
+    color: #999;
+    font-style: italic;
+}
+.font-bold { font-weight: 700; }
+.title-main { font-size: 20px; }
+.title-sub { font-size: 16px; }
+.text-center { text-align: center; }
+.uppercase { text-transform: uppercase; }
+.italic { font-style: italic; }
+.whitespace-nowrap { white-space: nowrap; }
+.flex { display: flex; }
+.items-center { align-items: center; }
+.items-baseline { align-items: baseline; }
+.items-start { align-items: flex-start; }
+.justify-between { justify-content: space-between; }
+.justify-around { justify-content: space-around; }
+.flex-grow { flex-grow: 1; }
+.mt-3 { margin-top: 0.4rem; }
+.mt-4 { margin-top: 0.5rem; }
+.mt-8 { margin-top: 1rem; }
+.ml-2 { margin-left: 0.5rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.space-y-2 > * + * { margin-top: 0.3rem; }
+.w-14 { width: 3.5rem; }
+.w-full { width: 100%; }
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+.data-table th, .data-table td {
+    border: 1px solid #000;
+    padding: 3px;
+    text-align: center;
+    vertical-align: middle;
+    word-wrap: break-word;
+}
+.data-table th {
+    background-color: #f8f9fa;
+    font-weight: bold;
+}
+.data-table .col-stt { width: 2%; }
+.data-table .col-code { width: 7%; }
+.data-table .col-name { width: 16%; text-align: left; }
+.data-table .col-model { width: 10%; }
+.data-table .col-serial { width: 10%; }
+.data-table .col-accessories { width: 18%; text-align: center; }
+.data-table .col-condition { width: 15%; }
+.data-table .col-note { width: 12%; }
+.signature-area { text-align: center; min-width: 180px; }
+.signature-space {
+    height: 50px;
+    border-bottom: 1px solid #ddd;
+    margin: 8px 0;
+}
+
+@media print {
+    body {
+        -webkit-print-color-adjust: exact !important;
+        print-color-adjust: exact !important;
+        background-color: #fff !important;
+        font-size: 11px;
+    }
+    .a4-landscape-page {
+        width: 100% !important;
+        height: 100% !important;
+        margin: 0 !important;
+        padding: 1cm 1.2cm 1cm 1cm !important;
+        box-shadow: none !important;
+        border: none !important;
+        page-break-inside: avoid;
+    }
+    body > *:not(.a4-landscape-page) { display: none !important; }
+    .data-table { font-size: 13px; }
+    .data-table th, .data-table td { padding: 3px; }
+    .data-table thead { display: table-header-group; }
+    .data-table tr, .signature-area { page-break-inside: avoid; }
+    .print-footer {
+        position: fixed;
+        bottom: 0.4cm;
+        left: 0.6cm;
+        right: 0.6cm;
+        width: calc(100% - 1.2cm);
+    }
+    .content-body { padding-bottom: 35px; }
+    .editable-cell {
+        background-color: transparent !important;
+        border-bottom: 1px solid #000 !important;
+    }
+    .title-main { font-size: 16px; }
+    .title-sub { font-size: 13px; }
+    .signature-space { height: 40px; }
+}
+
+@media (max-width: 768px) {
+    .a4-landscape-page {
+        width: 100%;
+        margin: 0;
+        padding: 0.4cm;
+        box-shadow: none;
+    }
+    .title-main { font-size: 16px; }
+    .title-sub { font-size: 12px; }
+    .data-table { font-size: 9px; }
+    .data-table th, .data-table td { padding: 2px 1px; }
+}
+
+.edit-instruction {
+    font-size: 10px;
+    color: #666;
+    font-style: italic;
+    margin-top: 6px;
+    text-align: center;
+}
+`

--- a/src/components/handover-preview-dialog.print-styles.ts
+++ b/src/components/handover-preview-dialog.print-styles.ts
@@ -72,6 +72,7 @@ body {
 .mb-1 { margin-bottom: 0.25rem; }
 .space-y-2 > * + * { margin-top: 0.3rem; }
 .w-14 { width: 3.5rem; }
+.mx-auto { display: block; margin-left: auto; margin-right: auto; }
 .w-full { width: 100%; }
 
 .data-table {

--- a/src/components/handover-preview-dialog.tsx
+++ b/src/components/handover-preview-dialog.tsx
@@ -1,8 +1,10 @@
 "use client"
 
 import * as React from "react"
-import { FileText, Printer, Download, Eye, Edit3 } from "lucide-react"
+import { Edit3, Eye, FileText, Printer } from "lucide-react"
 
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Dialog,
   DialogContent,
@@ -10,12 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
 import {
   Tooltip,
   TooltipContent,
@@ -24,34 +21,35 @@ import {
 } from "@/components/ui/tooltip"
 import { useToast } from "@/hooks/use-toast"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
-import { type TransferRequest } from "@/types/database"
 
-interface HandoverPreviewDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  transfer: TransferRequest | null
+import {
+  buildHandoverData,
+  updateHandoverField,
+  validateHandoverData,
+  type HandoverData,
+  type HandoverField,
+} from "./handover-preview-dialog.data"
+import { generateHandoverHTML } from "./handover-preview-dialog.document"
+import { HandoverPreviewForm } from "./handover-preview-dialog.form"
+import type { HandoverPreviewDialogProps } from "./handover-preview-dialog.types"
+
+function writeHandoverWindow(htmlContent: string): Window | null {
+  const newWindow = window.open("", "_blank")
+
+  if (!newWindow) return null
+
+  newWindow.document.open()
+  newWindow.document.write(htmlContent)
+  newWindow.document.close()
+
+  return newWindow
 }
 
-interface HandoverData {
-  department: string
-  handoverDate: string
-  reason: string
-  requestCode: string
-  giverName: string
-  directorName: string
-  receiverName: string
-  device: {
-    code: string
-    name: string
-    model: string
-    serial: string
-    condition: string
-    accessories: string
-    note: string
-  }
-}
-
-export function HandoverPreviewDialog({ open, onOpenChange, transfer }: HandoverPreviewDialogProps) {
+export function HandoverPreviewDialog({
+  open,
+  onOpenChange,
+  transfer,
+}: HandoverPreviewDialogProps) {
   const { toast } = useToast()
   const [isEditing, setIsEditing] = React.useState(false)
   const [handoverData, setHandoverData] = React.useState<HandoverData | null>(null)
@@ -60,35 +58,8 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
   React.useEffect(() => {
     if (open && transfer?.thiet_bi) {
-      // Auto-fill data from transfer request
-      const formatValue = (value: string | number | null | undefined) => String(value ?? "")
+      setHandoverData(buildHandoverData(transfer))
 
-      const data: HandoverData = {
-        department: formatValue(transfer.khoa_phong_hien_tai || "Tổ QLTB"),
-        handoverDate: new Date().toLocaleDateString('vi-VN'),
-        reason: formatValue(transfer.ly_do_luan_chuyen),
-        requestCode: formatValue(transfer.ma_yeu_cau),
-        giverName: transfer.khoa_phong_hien_tai === "Tổ QLTB"
-          ? "Đại diện Tổ QLTB"
-          : `Đại diện ${transfer.khoa_phong_hien_tai}`,
-        directorName: "", // Default empty for manual entry
-        receiverName: transfer.khoa_phong_nhan === "Tổ QLTB"
-          ? "Đại diện Tổ QLTB"
-          : `Đại diện ${transfer.khoa_phong_nhan}`,
-        device: {
-          code: formatValue(transfer.thiet_bi.ma_thiet_bi),
-          name: formatValue(transfer.thiet_bi.ten_thiet_bi),
-          model: formatValue(transfer.thiet_bi.model),
-          serial: formatValue(transfer.thiet_bi.serial_number),
-          condition: formatValue(transfer.thiet_bi.tinh_trang),
-          accessories: "", // Default empty for manual entry
-          note: "" // Default empty for manual entry
-        }
-      }
-
-      setHandoverData(data)
-
-      // Show tips for new users
       if (isEditing) {
         toast({
           title: "💡 Mẹo sử dụng",
@@ -99,98 +70,33 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
     }
   }, [open, transfer, isEditing, toast])
 
-  // Keyboard shortcuts
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (!open) return
-
-      // Ctrl+P for print
-      if (event.ctrlKey && event.key === 'p') {
-        event.preventDefault()
-        handlePrint()
-      }
-      // Ctrl+E for edit toggle
-      if (event.ctrlKey && event.key === 'e') {
-        event.preventDefault()
-        setIsEditing(!isEditing)
-      }
-      // Ctrl+Shift+P for preview
-      if (event.ctrlKey && event.shiftKey && event.key === 'P') {
-        event.preventDefault()
-        handlePreview()
-      }
-    }
-
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [open, isEditing])
-
-  const handleInputChange = (field: string, value: string) => {
-    if (!handoverData) return
-
-    if (field.startsWith('device.')) {
-      const deviceField = field.replace('device.', '')
-      setHandoverData({
-        ...handoverData,
-        device: {
-          ...handoverData.device,
-          [deviceField]: value
-        }
-      })
-    } else {
-      setHandoverData({
-        ...handoverData,
-        [field]: value
-      })
-    }
-  }
-
-  const validateHandoverData = (data: HandoverData): { isValid: boolean; missingFields: string[] } => {
-    const missingFields: string[] = []
-
-    if (!data.department?.trim()) missingFields.push('Khoa/Phòng lập')
-    if (!data.reason?.trim()) missingFields.push('Lý do bàn giao')
-    if (!data.giverName?.trim()) missingFields.push('Đại diện bên giao')
-    if (!data.receiverName?.trim()) missingFields.push('Đại diện bên nhận')
-    // Note: directorName is optional, not required for validation
-
-    return {
-      isValid: missingFields.length === 0,
-      missingFields
-    }
+  const handleInputChange = (field: HandoverField, value: string) => {
+    setHandoverData((current) => (current ? updateHandoverField(current, field, value) : current))
   }
 
   const handlePrint = async () => {
     if (!handoverData) return
 
-    // Validate required fields
     const validation = validateHandoverData(handoverData)
     if (!validation.isValid) {
       toast({
         variant: "destructive",
         title: "⚠️ Thiếu thông tin bắt buộc",
-        description: `Vui lòng điền đầy đủ: ${validation.missingFields.join(', ')}`,
+        description: `Vui lòng điền đầy đủ: ${validation.missingFields.join(", ")}`,
       })
-      setIsEditing(true) // Switch to edit mode to fill missing info
+      setIsEditing(true)
       return
     }
 
     setIsPrinting(true)
     try {
-      const htmlContent = generateHandoverHTML(handoverData)
-      const newWindow = window.open("", "_blank")
+      const newWindow = writeHandoverWindow(generateHandoverHTML(handoverData))
 
       if (newWindow) {
-        newWindow.document.open()
-        newWindow.document.write(htmlContent)
-        newWindow.document.close()
-
-        // Auto print after loading
         newWindow.onload = () => {
           setTimeout(() => {
             newWindow.print()
 
-            // Close dialog after printing
             setTimeout(() => {
               onOpenChange(false)
             }, 1000)
@@ -212,7 +118,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
       toast({
         variant: "destructive",
         title: "❌ Lỗi in phiếu",
-        description: getUnknownErrorMessage(error, "Có lỗi không xác định xảy ra khi in phiếu.")
+        description: getUnknownErrorMessage(error, "Có lỗi không xác định xảy ra khi in phiếu."),
       })
     } finally {
       setIsPrinting(false)
@@ -224,14 +130,9 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
     setIsPreviewing(true)
     try {
-      const htmlContent = generateHandoverHTML(handoverData)
-      const newWindow = window.open("", "_blank")
+      const newWindow = writeHandoverWindow(generateHandoverHTML(handoverData))
 
       if (newWindow) {
-        newWindow.document.open()
-        newWindow.document.write(htmlContent)
-        newWindow.document.close()
-
         toast({
           title: "👁️ Xem trước",
           description: "Đã mở cửa sổ xem trước phiếu bàn giao.",
@@ -247,327 +148,34 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
       toast({
         variant: "destructive",
         title: "❌ Lỗi xem trước",
-        description: getUnknownErrorMessage(error, "Có lỗi không xác định xảy ra khi xem trước phiếu.")
+        description: getUnknownErrorMessage(error, "Có lỗi không xác định xảy ra khi xem trước phiếu."),
       })
     } finally {
       setIsPreviewing(false)
     }
   }
 
-  const generateHandoverHTML = (data: HandoverData) => {
-    return `
-<!DOCTYPE html>
-<html lang="vi">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Biên Bản Bàn Giao Thiết Bị</title>
-    <style>
-        body {
-            font-family: 'Times New Roman', Times, serif;
-            font-size: 13px;
-            color: #000;
-            background-color: #e5e7eb;
-            line-height: 1.4;
-            margin: 0;
-            padding: 0;
-        }
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!open) return
 
-        .a4-landscape-page {
-            width: 29.7cm;
-            min-height: 21cm;
-            padding: 1cm 2cm 1cm 1cm;
-            margin: 1cm auto;
-            background: white;
-            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-            position: relative;
-            display: flex;
-            flex-direction: column;
-        }
+      if (event.ctrlKey && event.key === "p") {
+        event.preventDefault()
+        handlePrint()
+      }
+      if (event.ctrlKey && event.key === "e") {
+        event.preventDefault()
+        setIsEditing(!isEditing)
+      }
+      if (event.ctrlKey && event.shiftKey && event.key === "P") {
+        event.preventDefault()
+        handlePreview()
+      }
+    }
 
-        .content-body {
-            flex-grow: 1;
-        }
-
-        .form-input-line {
-            font-family: inherit;
-            font-size: inherit;
-            border: none;
-            border-bottom: 1px dotted #000;
-            background-color: transparent;
-            padding: 2px 1px;
-            outline: none;
-            width: 100%;
-            min-height: 1.1em;
-        }
-
-        .form-input-readonly {
-            border-bottom: 1px solid #000;
-            font-weight: 500;
-        }
-
-        .editable-cell {
-            border-bottom: 1px solid #ccc !important;
-            background-color: #f9f9f9;
-            cursor: text;
-            min-height: 18px;
-            padding: 3px 4px !important;
-        }
-
-        .editable-cell:focus {
-            background-color: #fff;
-            border-bottom: 1px solid #007bff !important;
-            outline: none;
-        }
-
-        .editable-cell:empty:before {
-            content: attr(data-placeholder);
-            color: #999;
-            font-style: italic;
-        }
-
-        .font-bold { font-weight: 700; }
-        .title-main { font-size: 20px; }
-        .title-sub { font-size: 16px; }
-        .text-center { text-align: center; }
-        .uppercase { text-transform: uppercase; }
-        .italic { font-style: italic; }
-        .whitespace-nowrap { white-space: nowrap; }
-
-        .flex { display: flex; }
-        .items-center { align-items: center; }
-        .items-baseline { align-items: baseline; }
-        .items-start { align-items: flex-start; }
-        .justify-between { justify-content: space-between; }
-        .justify-around { justify-content: space-around; }
-        .flex-grow { flex-grow: 1; }
-
-        .mt-3 { margin-top: 0.4rem; }
-        .mt-4 { margin-top: 0.5rem; }
-        .mt-8 { margin-top: 1rem; }
-        .ml-2 { margin-left: 0.5rem; }
-        .mb-1 { margin-bottom: 0.25rem; }
-        .space-y-2 > * + * { margin-top: 0.3rem; }
-
-        .w-14 { width: 3.5rem; }
-        .w-full { width: 100%; }
-
-        .data-table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 13px;
-        }
-
-        .data-table th, .data-table td {
-            border: 1px solid #000;
-            padding: 3px;
-            text-align: center;
-            vertical-align: middle;
-            word-wrap: break-word;
-        }
-
-        .data-table th {
-            background-color: #f8f9fa;
-            font-weight: bold;
-        }
-
-        .data-table .col-stt { width: 2%; }
-        .data-table .col-code { width: 7%; }
-        .data-table .col-name { width: 16%; text-align: left; }
-        .data-table .col-model { width: 10%; }
-        .data-table .col-serial { width: 10%; }
-        .data-table .col-accessories { width: 18%; text-align: center; }
-        .data-table .col-condition { width: 15%; }
-        .data-table .col-note { width: 12%; }
-
-        .signature-area {
-            text-align: center;
-            min-width: 180px;
-        }
-
-        .signature-space {
-            height: 50px;
-            border-bottom: 1px solid #ddd;
-            margin: 8px 0;
-        }
-
-        @media print {
-            body {
-                -webkit-print-color-adjust: exact !important;
-                print-color-adjust: exact !important;
-                background-color: #fff !important;
-                font-size: 11px;
-            }
-
-            .a4-landscape-page {
-                width: 100% !important;
-                height: 100% !important;
-                margin: 0 !important;
-                padding: 1cm 1.2cm 1cm 1cm !important;
-                box-shadow: none !important;
-                border: none !important;
-                page-break-inside: avoid;
-            }
-
-            body > *:not(.a4-landscape-page) {
-                display: none !important;
-            }
-
-            .data-table {
-                font-size: 13px;
-            }
-
-            .data-table th, .data-table td {
-                padding: 3px;
-            }
-
-            .data-table thead {
-                display: table-header-group;
-            }
-
-            .data-table tr, .signature-area {
-                page-break-inside: avoid;
-            }
-
-            .print-footer {
-                position: fixed;
-                bottom: 0.4cm;
-                left: 0.6cm;
-                right: 0.6cm;
-                width: calc(100% - 1.2cm);
-            }
-
-            .content-body {
-                padding-bottom: 35px;
-            }
-
-            .editable-cell {
-                background-color: transparent !important;
-                border-bottom: 1px solid #000 !important;
-            }
-
-            .title-main { font-size: 16px; }
-            .title-sub { font-size: 13px; }
-            .signature-space { height: 40px; }
-        }
-
-        @media (max-width: 768px) {
-            .a4-landscape-page {
-                width: 100%;
-                margin: 0;
-                padding: 0.4cm;
-                box-shadow: none;
-            }
-
-            .title-main { font-size: 16px; }
-            .title-sub { font-size: 12px; }
-            .data-table { font-size: 9px; }
-            .data-table th, .data-table td { padding: 2px 1px; }
-        }
-
-        .edit-instruction {
-            font-size: 10px;
-            color: #666;
-            font-style: italic;
-            margin-top: 6px;
-            text-align: center;
-        }
-    </style>
-</head>
-<body>
-    <div class="a4-landscape-page">
-        <div class="content-body">
-            <header class="text-center">
-                <div class="flex justify-between items-start">
-                    <div class="text-center">
-                        <img src="https://i.postimg.cc/26dHxmnV/89307731ad9526cb7f84-1-Photoroom.png"
-                             alt="Logo CDC"
-                             class="w-14 mx-auto mb-1"
-                             onerror="this.style.display='none';">
-                    </div>
-                    <div class="flex-grow">
-                        <h2 class="title-sub uppercase font-bold">TRUNG TÂM KIỂM SOÁT BỆNH TẬT THÀNH PHỐ CẦN THƠ</h2>
-                        <h1 class="title-main uppercase mt-3 font-bold">BIÊN BẢN BÀN GIAO THIẾT BỊ</h1>
-                    </div>
-                    <div class="w-14"></div>
-                </div>
-            </header>
-
-            <section class="mt-4 space-y-2">
-                <div class="flex items-baseline">
-                    <label class="whitespace-nowrap">Khoa/Phòng lập:</label>
-                    <div class="form-input-line form-input-readonly ml-2">${data.department}</div>
-                </div>
-                <div class="flex items-baseline">
-                    <label class="whitespace-nowrap">Ngày nhận/giao:</label>
-                    <div class="form-input-line form-input-readonly ml-2">${data.handoverDate}</div>
-                </div>
-                <div class="flex items-baseline">
-                    <label class="whitespace-nowrap">Lý do nhận bàn giao:</label>
-                    <div class="form-input-line form-input-readonly ml-2">${data.reason}</div>
-                </div>
-                <div class="flex items-baseline">
-                    <label class="whitespace-nowrap">Mã yêu cầu:</label>
-                    <div class="form-input-line form-input-readonly ml-2">${data.requestCode}</div>
-                </div>
-            </section>
-
-            <section class="mt-3">
-                <table class="data-table">
-                    <thead>
-                        <tr>
-                            <th class="col-stt">STT</th>
-                            <th class="col-code">Mã thiết bị</th>
-                            <th class="col-name">Tên thiết bị</th>
-                            <th class="col-model">Model</th>
-                            <th class="col-serial">Serial</th>
-                            <th class="col-accessories">Tài liệu/phụ kiện kèm theo (nếu có)</th>
-                            <th class="col-condition">Tình trạng khi nhận/giao</th>
-                            <th class="col-note">Ghi chú</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="col-stt">1</td>
-                            <td class="col-code">${data.device.code}</td>
-                            <td class="col-name">${data.device.name}</td>
-                            <td class="col-model">${data.device.model}</td>
-                            <td class="col-serial">${data.device.serial}</td>
-                            <td class="col-accessories">${data.device.accessories}</td>
-                            <td class="col-condition">${data.device.condition}</td>
-                            <td class="col-note">${data.device.note}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </section>
-
-            <section class="mt-8">
-                <div class="flex justify-around">
-                    <div class="signature-area">
-                        <p class="font-bold">Đại diện bên giao</p>
-                        <p class="italic">(Ký, ghi rõ họ tên)</p>
-                        <div class="signature-space"></div>
-                        <div class="font-bold">${data.giverName}</div>
-                    </div>
-                    <div class="signature-area">
-                        <p class="font-bold">Ban Giám đốc</p>
-                        <p class="italic">(Ký, ghi rõ họ tên)</p>
-                        <div class="signature-space"></div>
-                        <div class="font-bold">${data.directorName}</div>
-                    </div>
-                    <div class="signature-area">
-                        <p class="font-bold">Đại diện bên nhận</p>
-                        <p class="italic">(Ký, ghi rõ họ tên)</p>
-                        <div class="signature-space"></div>
-                        <div class="font-bold">${data.receiverName}</div>
-                    </div>
-                </div>
-            </section>
-        </div>
-    </div>
-</body>
-</html>`
-  }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [open, isEditing])
 
   if (!transfer || !handoverData) return null
 
@@ -585,23 +193,18 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
         </DialogHeader>
 
         <div className="flex-grow overflow-auto space-y-6">
-          {/* Action Buttons */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <Badge variant="outline">{transfer.loai_hinh === 'noi_bo' ? 'Nội bộ' : 'Bên ngoài'}</Badge>
+              <Badge variant="outline">{transfer.loai_hinh === "noi_bo" ? "Nội bộ" : "Bên ngoài"}</Badge>
               <Badge variant="secondary">{transfer.thiet_bi?.ma_thiet_bi}</Badge>
             </div>
             <TooltipProvider>
               <div className="flex items-center gap-2">
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setIsEditing(!isEditing)}
-                    >
+                    <Button variant="outline" size="sm" onClick={() => setIsEditing(!isEditing)}>
                       <Edit3 className="size-4 mr-1" />
-                      {isEditing ? 'Xem' : 'Sửa'}
+                      {isEditing ? "Xem" : "Sửa"}
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -618,7 +221,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                       disabled={isPreviewing || isPrinting}
                     >
                       <Eye className="size-4 mr-1" />
-                      {isPreviewing ? 'Đang xử lý...' : 'Xem trước'}
+                      {isPreviewing ? "Đang xử lý..." : "Xem trước"}
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -635,7 +238,7 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                       disabled={isPrinting || isPreviewing}
                     >
                       <Printer className="size-4 mr-1" />
-                      {isPrinting ? 'Đang in...' : 'In phiếu'}
+                      {isPrinting ? "Đang in..." : "In phiếu"}
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -648,105 +251,18 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
 
           <Separator />
 
-          {/* Editable Form */}
           {isEditing ? (
-            <div className="space-y-6">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="department">Khoa/Phòng lập</Label>
-                  <Input
-                    id="department"
-                    value={handoverData.department}
-                    onChange={(e) => handleInputChange('department', e.target.value)}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="handoverDate">Ngày bàn giao</Label>
-                  <Input
-                    id="handoverDate"
-                    value={handoverData.handoverDate}
-                    onChange={(e) => handleInputChange('handoverDate', e.target.value)}
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="reason">Lý do bàn giao</Label>
-                <Textarea
-                  id="reason"
-                  value={handoverData.reason}
-                  onChange={(e) => handleInputChange('reason', e.target.value)}
-                  rows={2}
-                />
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="giverName">Đại diện bên giao</Label>
-                  <Input
-                    id="giverName"
-                    value={handoverData.giverName}
-                    onChange={(e) => handleInputChange('giverName', e.target.value)}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="directorName">Ban Giám đốc</Label>
-                  <Input
-                    id="directorName"
-                    value={handoverData.directorName}
-                    onChange={(e) => handleInputChange('directorName', e.target.value)}
-                    placeholder="Tên Ban Giám đốc (tùy chọn)"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="receiverName">Đại diện bên nhận</Label>
-                  <Input
-                    id="receiverName"
-                    value={handoverData.receiverName}
-                    onChange={(e) => handleInputChange('receiverName', e.target.value)}
-                  />
-                </div>
-              </div>
-
-              <Separator />
-
-              <div className="space-y-4">
-                <h4 className="font-medium">Thông tin thiết bị</h4>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="accessories">Tài liệu/Phụ kiện kèm theo</Label>
-                    <Textarea
-                      id="accessories"
-                      value={handoverData.device.accessories}
-                      onChange={(e) => handleInputChange('device.accessories', e.target.value)}
-                      placeholder="Nhập tài liệu, phụ kiện kèm theo…"
-                      rows={3}
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="note">Ghi chú</Label>
-                    <Textarea
-                      id="note"
-                      value={handoverData.device.note}
-                      onChange={(e) => handleInputChange('device.note', e.target.value)}
-                      placeholder="Nhập ghi chú…"
-                      rows={3}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
+            <HandoverPreviewForm data={handoverData} onFieldChange={handleInputChange} />
           ) : (
-            /* Preview Mode */
             <div className="space-y-6">
-              <div className="bg-gray-50 p-4 rounded-lg">
+              <div className="bg-zinc-50 p-4 rounded-lg">
                 <h4 className="font-medium mb-3">Thông tin bàn giao</h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                   <div><span className="font-medium">Khoa/Phòng:</span> {handoverData.department}</div>
                   <div><span className="font-medium">Ngày:</span> {handoverData.handoverDate}</div>
                   <div className="md:col-span-2"><span className="font-medium">Lý do:</span> {handoverData.reason}</div>
                   <div><span className="font-medium">Bên giao:</span> {handoverData.giverName}</div>
-                  <div><span className="font-medium">Ban Giám đốc:</span> {handoverData.directorName || 'Chưa nhập'}</div>
+                  <div><span className="font-medium">Ban Giám đốc:</span> {handoverData.directorName || "Chưa nhập"}</div>
                   <div><span className="font-medium">Bên nhận:</span> {handoverData.receiverName}</div>
                 </div>
               </div>
@@ -760,10 +276,10 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
                   <div><span className="font-medium">Serial:</span> {handoverData.device.serial}</div>
                   <div><span className="font-medium">Tình trạng:</span> {handoverData.device.condition}</div>
                   <div className="md:col-span-2">
-                    <span className="font-medium">Phụ kiện:</span> {handoverData.device.accessories || 'Chưa nhập'}
+                    <span className="font-medium">Phụ kiện:</span> {handoverData.device.accessories || "Chưa nhập"}
                   </div>
                   <div className="md:col-span-2">
-                    <span className="font-medium">Ghi chú:</span> {handoverData.device.note || 'Chưa có'}
+                    <span className="font-medium">Ghi chú:</span> {handoverData.device.note || "Chưa có"}
                   </div>
                 </div>
               </div>
@@ -771,7 +287,6 @@ export function HandoverPreviewDialog({ open, onOpenChange, transfer }: Handover
           )}
         </div>
 
-        {/* Keyboard shortcuts info */}
         <div className="pt-4 border-t text-xs text-muted-foreground">
           <p className="flex items-center gap-4">
             <span><kbd className="px-1.5 py-0.5 bg-muted rounded">Ctrl+E</kbd> Chỉnh sửa</span>

--- a/src/components/handover-preview-dialog.tsx
+++ b/src/components/handover-preview-dialog.tsx
@@ -134,12 +134,6 @@ export function HandoverPreviewDialog({
   const handlePreview = React.useCallback(async () => {
     if (!handoverData) return
 
-    const validation = validateHandoverData(handoverData)
-    if (!validation.isValid) {
-      showMissingFieldsToast(validation.missingFields)
-      return
-    }
-
     setIsPreviewing(true)
     try {
       const newWindow = writeHandoverWindow(generateHandoverHTML(handoverData))
@@ -165,7 +159,7 @@ export function HandoverPreviewDialog({
     } finally {
       setIsPreviewing(false)
     }
-  }, [handoverData, showMissingFieldsToast, toast])
+  }, [handoverData, toast])
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/components/handover-preview-dialog.tsx
+++ b/src/components/handover-preview-dialog.tsx
@@ -59,32 +59,38 @@ export function HandoverPreviewDialog({
   React.useEffect(() => {
     if (open && transfer?.thiet_bi) {
       setHandoverData(buildHandoverData(transfer))
-
-      if (isEditing) {
-        toast({
-          title: "💡 Mẹo sử dụng",
-          description: "Sử dụng Ctrl+E để chuyển đổi chế độ, Ctrl+P để in nhanh",
-          duration: 3000,
-        })
-      }
     }
-  }, [open, transfer, isEditing, toast])
+  }, [open, transfer])
+
+  React.useEffect(() => {
+    if (!open || !isEditing) return
+
+    toast({
+      title: "💡 Mẹo sử dụng",
+      description: "Sử dụng Ctrl+E để chuyển đổi chế độ, Ctrl+P để in nhanh",
+      duration: 3000,
+    })
+  }, [open, isEditing, toast])
 
   const handleInputChange = (field: HandoverField, value: string) => {
     setHandoverData((current) => (current ? updateHandoverField(current, field, value) : current))
   }
 
-  const handlePrint = async () => {
+  const showMissingFieldsToast = React.useCallback((missingFields: string[]) => {
+    toast({
+      variant: "destructive",
+      title: "⚠️ Thiếu thông tin bắt buộc",
+      description: `Vui lòng điền đầy đủ: ${missingFields.join(", ")}`,
+    })
+    setIsEditing(true)
+  }, [toast])
+
+  const handlePrint = React.useCallback(async () => {
     if (!handoverData) return
 
     const validation = validateHandoverData(handoverData)
     if (!validation.isValid) {
-      toast({
-        variant: "destructive",
-        title: "⚠️ Thiếu thông tin bắt buộc",
-        description: `Vui lòng điền đầy đủ: ${validation.missingFields.join(", ")}`,
-      })
-      setIsEditing(true)
+      showMissingFieldsToast(validation.missingFields)
       return
     }
 
@@ -123,10 +129,16 @@ export function HandoverPreviewDialog({
     } finally {
       setIsPrinting(false)
     }
-  }
+  }, [handoverData, onOpenChange, showMissingFieldsToast, toast])
 
-  const handlePreview = async () => {
+  const handlePreview = React.useCallback(async () => {
     if (!handoverData) return
+
+    const validation = validateHandoverData(handoverData)
+    if (!validation.isValid) {
+      showMissingFieldsToast(validation.missingFields)
+      return
+    }
 
     setIsPreviewing(true)
     try {
@@ -153,29 +165,33 @@ export function HandoverPreviewDialog({
     } finally {
       setIsPreviewing(false)
     }
-  }
+  }, [handoverData, showMissingFieldsToast, toast])
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!open) return
 
-      if (event.ctrlKey && event.key === "p") {
-        event.preventDefault()
-        handlePrint()
-      }
-      if (event.ctrlKey && event.key === "e") {
-        event.preventDefault()
-        setIsEditing(!isEditing)
-      }
-      if (event.ctrlKey && event.shiftKey && event.key === "P") {
+      const key = event.key.toLowerCase()
+
+      if (event.ctrlKey && event.shiftKey && key === "p") {
         event.preventDefault()
         handlePreview()
+        return
+      }
+      if (event.ctrlKey && key === "p") {
+        event.preventDefault()
+        handlePrint()
+        return
+      }
+      if (event.ctrlKey && key === "e") {
+        event.preventDefault()
+        setIsEditing((current) => !current)
       }
     }
 
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [open, isEditing])
+  }, [open, handlePrint, handlePreview])
 
   if (!transfer || !handoverData) return null
 
@@ -202,7 +218,7 @@ export function HandoverPreviewDialog({
               <div className="flex items-center gap-2">
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button variant="outline" size="sm" onClick={() => setIsEditing(!isEditing)}>
+                    <Button variant="outline" size="sm" onClick={() => setIsEditing((current) => !current)}>
                       <Edit3 className="size-4 mr-1" />
                       {isEditing ? "Xem" : "Sửa"}
                     </Button>

--- a/src/components/handover-preview-dialog.types.ts
+++ b/src/components/handover-preview-dialog.types.ts
@@ -1,0 +1,30 @@
+import type { TransferRequest } from "@/types/database"
+
+export type HandoverPreviewDialogProps = Readonly<{
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  transfer: TransferRequest | null
+}>
+
+export type HandoverDeviceData = Readonly<{
+  code: string
+  name: string
+  model: string
+  serial: string
+  condition: string
+  accessories: string
+  note: string
+}>
+
+export type HandoverData = Readonly<{
+  department: string
+  handoverDate: string
+  reason: string
+  requestCode: string
+  giverName: string
+  directorName: string
+  receiverName: string
+  device: HandoverDeviceData
+}>
+
+export type HandoverField = Exclude<keyof HandoverData, "device"> | `device.${keyof HandoverDeviceData}`


### PR DESCRIPTION
## Summary
- Refs #459 Batch 1: split `HandoverPreviewDialog` below the 350-line extraction target.
- Move handover data building, validation, field updates, print document generation, styles, and form fields into focused helper modules.
- Add TDD/source guard and characterization coverage for data, document generation, and preview/print behavior.

## Verification
- RED confirmed before implementation: focused handover tests failed on 787 LOC, inline document markup, and missing helper modules.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/__tests__/react-doctor-p6-handover-preview-size.source.test.ts src/components/__tests__/handover-preview-dialog.data.test.ts src/components/__tests__/handover-preview-dialog.document.test.ts src/components/__tests__/handover-preview-dialog.component.test.tsx`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` -> 100/100 after staging all files
- `git diff --cached --check`
- `node scripts/npm-run.js run build`

## Notes
- Does not close #459 because the issue tracks 11 files and this PR only handles Batch 1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the handover preview dialog into focused modules with tests, hardened preview/print with input escaping, and kept the dialog shell ≤350 lines. Aligns with Linear #459 (Batch 1) for React Doctor P6 and preserves preview behavior and user edits.

- **Refactors**
  - Split `HandoverPreviewDialog` into `handover-preview-dialog.data`, `.document`, `.form`, `.print-styles`, and `.types` with helpers for data build/update/validate and HTML generation.
  - Simplified preview/print with an isolated window writer; normalized shortcuts (Ctrl+P, Ctrl+Shift+P, Ctrl+E).
  - Added a size guard and tests for data, document, and component preview/print flows, including the print-validation-to-edit switch.

- **Bug Fixes**
  - Escaped user input in generated HTML to prevent XSS in preview/print.
  - Validate required fields before print only; block with a destructive toast and switch to edit. Preview remains allowed.
  - Normalize department fallback to `Tổ QLTB` when blank/missing; avoid undefined representative labels.
  - Preserved user edits when toggling between edit and preview.

<sup>Written for commit 661482f1291c6ce19fc57a15344b21f865a5340a. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/492?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handover preview dialog with print and preview, editable form, validation, error toasts, loading states, and keyboard shortcuts (print/preview/edit).
  * Added printable A4 landscape styling and safer HTML generation for previews.

* **Tests**
  * New unit and document tests covering data builders, validation, immutable updates, HTML generation/escaping, preview/print behaviors, and source-size/markup guards.

* **Types**
  * Added reusable types for the handover preview data and fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->