### PR TITLE
Fix Device Quota assigned equipment panel

### DIFF
--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryAssignedEquipment.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryAssignedEquipment.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react'
 import "@testing-library/jest-dom"
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -111,6 +111,20 @@ describe('DeviceQuotaCategoryAssignedEquipment', () => {
         await waitFor(() => {
             expect(screen.getByText('Chưa có thiết bị nào được gán')).toBeInTheDocument()
         })
+    })
+
+    it('does not present a failed assigned-equipment RPC as an empty assignment', async () => {
+        mockCallRpc.mockRejectedValue(new Error('42702: column reference "id" is ambiguous'))
+
+        render(
+            <DeviceQuotaCategoryAssignedEquipment nhomId={24} donViId={17} />,
+            { wrapper: createWrapper() }
+        )
+
+        await waitForElementToBeRemoved(() => screen.queryAllByTestId('equipment-skeleton'))
+
+        expect(screen.queryByText('Chưa có thiết bị nào được gán')).not.toBeInTheDocument()
+        expect(screen.getByText('Không thể tải danh sách thiết bị được gán')).toBeInTheDocument()
     })
 
     it('does not render exclude or restore buttons (read-only)', async () => {

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryAssignedEquipment.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryAssignedEquipment.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { useQuery } from "@tanstack/react-query"
-import { PackageOpen } from "lucide-react"
+import { AlertCircle, PackageOpen } from "lucide-react"
 
 import { callRpc } from "@/lib/rpc-client"
 import { Badge } from "@/components/ui/badge"
@@ -85,7 +85,7 @@ export function DeviceQuotaCategoryAssignedEquipment({
     nhomId,
     donViId,
 }: DeviceQuotaCategoryAssignedEquipmentProps) {
-    const { data: equipment, isLoading } = useQuery({
+    const { data: equipment, isError, isLoading } = useQuery({
         queryKey: ["dinh_muc_thiet_bi_by_nhom", { nhomId, donViId }],
         queryFn: () =>
             callRpc<EquipmentPreviewItem[]>({
@@ -100,6 +100,11 @@ export function DeviceQuotaCategoryAssignedEquipment({
             {isLoading ? (
                 <div className="p-3">
                     <MappingPreviewLoadingState count={2} />
+                </div>
+            ) : isError ? (
+                <div className="flex items-center justify-center gap-2 py-6 text-sm text-destructive">
+                    <AlertCircle className="size-4" />
+                    <span>Không thể tải danh sách thiết bị được gán</span>
                 </div>
             ) : !equipment || equipment.length === 0 ? (
                 <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">

--- a/supabase/migrations/20260516143000_fix_dinh_muc_thiet_bi_by_nhom_ambiguous_id.sql
+++ b/supabase/migrations/20260516143000_fix_dinh_muc_thiet_bi_by_nhom_ambiguous_id.sql
@@ -1,0 +1,101 @@
+-- Fix assigned-equipment lookup for Device Quota categories.
+--
+-- Root cause:
+-- - dinh_muc_thiet_bi_by_nhom RETURNS TABLE exposes an output column named id.
+-- - The previous function used an unqualified WHERE id = p_nhom_id inside
+--   PL/pgSQL, making id ambiguous between the output column and nhom_thiet_bi.id.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.dinh_muc_thiet_bi_by_nhom(
+  p_nhom_id BIGINT,
+  p_don_vi BIGINT DEFAULT NULL
+)
+RETURNS TABLE (
+  id BIGINT,
+  ma_thiet_bi TEXT,
+  ten_thiet_bi TEXT,
+  model TEXT,
+  serial TEXT,
+  hang_san_xuat TEXT,
+  khoa_phong_quan_ly TEXT,
+  tinh_trang TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_role TEXT := current_setting('request.jwt.claims', true)::json->>'app_role';
+  v_user_id TEXT := NULLIF(current_setting('request.jwt.claims', true)::json->>'user_id', '');
+  v_don_vi TEXT := current_setting('request.jwt.claims', true)::json->>'don_vi';
+  v_category_don_vi BIGINT;
+  v_allowed_facilities BIGINT[];
+BEGIN
+  IF v_role IS NULL OR v_role = '' THEN
+    v_role := current_setting('request.jwt.claims', true)::json->>'role';
+  END IF;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING errcode = '42501';
+  END IF;
+
+  IF v_role IN ('global', 'admin') THEN
+    NULL;
+  ELSIF v_role = 'regional_leader' THEN
+    v_allowed_facilities := public.allowed_don_vi_for_session();
+    IF p_don_vi IS NULL OR NOT (p_don_vi = ANY(v_allowed_facilities)) THEN
+      RAISE EXCEPTION 'Access denied: facility % is not in your region', p_don_vi
+        USING errcode = '42501';
+    END IF;
+  ELSE
+    p_don_vi := NULLIF(v_don_vi, '')::BIGINT;
+    IF p_don_vi IS NULL THEN
+      RAISE EXCEPTION 'Missing facility claim' USING errcode = '42501';
+    END IF;
+  END IF;
+
+  IF p_nhom_id IS NULL THEN
+    RAISE EXCEPTION 'Category ID (p_nhom_id) is required.';
+  END IF;
+
+  SELECT ntb.don_vi_id
+  INTO v_category_don_vi
+  FROM public.nhom_thiet_bi ntb
+  WHERE ntb.id = p_nhom_id;
+
+  IF v_category_don_vi IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF p_don_vi IS NOT NULL AND v_category_don_vi != p_don_vi THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    tb.id,
+    tb.ma_thiet_bi,
+    tb.ten_thiet_bi,
+    tb.model,
+    tb.serial,
+    tb.hang_san_xuat,
+    tb.khoa_phong_quan_ly,
+    tb.tinh_trang_hien_tai AS tinh_trang
+  FROM public.thiet_bi tb
+  WHERE tb.nhom_thiet_bi_id = p_nhom_id
+    AND tb.don_vi = v_category_don_vi
+  ORDER BY tb.ten_thiet_bi, tb.ma_thiet_bi;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.dinh_muc_thiet_bi_by_nhom(BIGINT, BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.dinh_muc_thiet_bi_by_nhom IS
+  'List equipment assigned to a Device Quota category, scoped by tenant access.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- fix `dinh_muc_thiet_bi_by_nhom` ambiguous `id` lookup and keep tenant/JWT guards explicit
- show an error state when the assigned-equipment RPC fails instead of rendering the empty assignment message
- add regression coverage for the RPC rejection path

## Live DB verification
- Applied Supabase MCP migration: `fix_dinh_muc_thiet_bi_by_nhom_ambiguous_id`
- Verified tenant 17 mapped equipment now returns:
  - `DSA.2.92004.670647BU7` from group 24
  - `KHO-VTTBYT-64` from group 182
- Verified function metadata: `SECURITY DEFINER`, `search_path=public, pg_temp`, authenticated execute grant present
- Supabase security advisors still report existing project-wide warnings; none were introduced by this function metadata check

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryAssignedEquipment.test.tsx'`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` -> 99/100, one existing-style `no-side-tab-border` warning on the touched panel container
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Device Quota assigned equipment panel by repairing the `dinh_muc_thiet_bi_by_nhom` RPC and adding a clear error state when the RPC fails. Prevents false “no devices assigned” and restores correct tenant-scoped results.

- **Bug Fixes**
  - Qualified columns in `dinh_muc_thiet_bi_by_nhom` to resolve 42702 “id is ambiguous”; kept explicit tenant/JWT guards and `SECURITY DEFINER`/`search_path`.
  - Panel now shows an error message when the RPC fails instead of the empty state.
  - Added a regression test for the RPC rejection path.

- **Migration**
  - Apply `supabase/migrations/20260516143000_fix_dinh_muc_thiet_bi_by_nhom_ambiguous_id.sql`.

<sup>Written for commit f5f5ffa2b639ebf3c9888605ff152deaed51a834. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/499?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for device quota equipment assignments to display a clear error message when the equipment list fails to load, replacing the previous empty state display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->