### PR TITLE
Fix category quota roll-up for empty parent groups

### DIFF
--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
@@ -277,6 +277,33 @@ describe('DeviceQuotaCategoryTree', () => {
     expect(screen.getByText('5/31')).toBeInTheDocument()
   })
 
+  it('root header preserves unknown quota when direct root equipment has no direct quota', () => {
+    const categories = [
+      { id: 22, parent_id: null, ma_nhom: '02', ten_nhom: 'CT Scanner', level: 1, so_luong_hien_co: 2, so_luong_toi_da: null },
+      { id: 299, parent_id: 22, ma_nhom: '02.01', ten_nhom: 'CT < 64', level: 2, so_luong_hien_co: 0, so_luong_toi_da: 4 },
+      { id: 300, parent_id: 22, ma_nhom: '02.02', ten_nhom: 'CT 64-128', level: 2, so_luong_hien_co: 0, so_luong_toi_da: 4 },
+      { id: 301, parent_id: 22, ma_nhom: '02.03', ten_nhom: 'CT >= 256', level: 2, so_luong_hien_co: 0, so_luong_toi_da: 3 },
+    ]
+
+    mockUseContext.mockReturnValue({
+      categories,
+      allCategories: categories,
+      donViId: 1,
+      isLoading: false,
+      totalRootCount: 1,
+      searchTerm: '',
+      pagination: basePagination,
+      openCreateDialog: vi.fn(),
+      openEditDialog: vi.fn(),
+      openDeleteDialog: vi.fn(),
+      mutatingCategoryId: null,
+    } as unknown as MockCategoryContextValue)
+
+    render(<DeviceQuotaCategoryTree />)
+
+    expect(screen.getByText('2/–')).toBeInTheDocument()
+  })
+
   it('leaf with equipment shows expand button with aria-expanded', () => {
     renderWithThreeLevelTree()
 

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
@@ -200,7 +200,7 @@ describe('DeviceQuotaCategoryTree', () => {
 
     render(<DeviceQuotaCategoryTree />)
 
-    expect(screen.getByText('3/9')).toBeInTheDocument()
+    expect(screen.getAllByText('3/9').length).toBeGreaterThanOrEqual(1)
   })
 
   it('renders aggregated quota progress bar on group header', () => {
@@ -239,7 +239,9 @@ describe('DeviceQuotaCategoryTree', () => {
     { id: 4, parent_id: 2, ma_nhom: '01.01', ten_nhom: 'Leaf A', level: 3, so_luong_hien_co: 2, so_luong_toi_da: 5 },
     { id: 5, parent_id: 2, ma_nhom: '01.02', ten_nhom: 'Leaf B', level: 3, so_luong_hien_co: 3, so_luong_toi_da: 5 },
     { id: 3, parent_id: 1, ma_nhom: '02', ten_nhom: 'Empty Intermediate', level: 2, so_luong_hien_co: 0, so_luong_toi_da: null },
-    { id: 6, parent_id: 3, ma_nhom: '02.01', ten_nhom: 'Empty Leaf', level: 3, so_luong_hien_co: 0, so_luong_toi_da: null },
+    { id: 6, parent_id: 3, ma_nhom: '02.01', ten_nhom: 'Empty Leaf A', level: 3, so_luong_hien_co: 0, so_luong_toi_da: 4 },
+    { id: 7, parent_id: 3, ma_nhom: '02.02', ten_nhom: 'Empty Leaf B', level: 3, so_luong_hien_co: 0, so_luong_toi_da: 4 },
+    { id: 8, parent_id: 3, ma_nhom: '02.03', ten_nhom: 'Empty Leaf C', level: 3, so_luong_hien_co: 0, so_luong_toi_da: 3 },
   ]
 
   function renderWithThreeLevelTree() {
@@ -268,11 +270,11 @@ describe('DeviceQuotaCategoryTree', () => {
     expect(screen.getByText('5/20')).toBeInTheDocument()
   })
 
-  it('root header uses aggregated total without double-counting', () => {
+  it('root header rolls up known child quotas when the root has no direct quota', () => {
     renderWithThreeLevelTree()
 
-    // Root (id:1): aggregated = 5, so_luong_toi_da=null → "5/–"
-    expect(screen.getByText('5/–')).toBeInTheDocument()
+    // Root (id:1): equipment = 5, known descendant quota = 10+5+5+4+4+3.
+    expect(screen.getByText('5/31')).toBeInTheDocument()
   })
 
   it('leaf with equipment shows expand button with aria-expanded', () => {
@@ -318,7 +320,7 @@ describe('DeviceQuotaCategoryTree', () => {
   it('zero-count leaf has no expand button', () => {
     renderWithThreeLevelTree()
 
-    expect(screen.queryByRole('button', { name: /Empty Leaf/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Empty Leaf A/i })).not.toBeInTheDocument()
   })
 
   it('displays full-tree aggregated totals even when categories is search-filtered', () => {
@@ -350,9 +352,8 @@ describe('DeviceQuotaCategoryTree', () => {
     expect(screen.getByText('5/20')).toBeInTheDocument()
 
     // Root header quota denominator must also use full-tree scope:
-    // Root(null) + Intermediate(10) + LeafA(5) + LeafB(5) + EmptyInterm(null) + EmptyLeaf(null) = 20
-    // hasUnknown=true because Root/EmptyIntermediate/EmptyLeaf have null quota → shows "5/–"
-    expect(screen.getByText('5/–')).toBeInTheDocument()
+    // Intermediate(10) + LeafA(5) + LeafB(5) + EmptyLeafA(4) + EmptyLeafB(4) + EmptyLeafC(3) = 31.
+    expect(screen.getByText('5/31')).toBeInTheDocument()
   })
 
   // ============================================

--- a/src/app/(app)/device-quota/categories/__tests__/category-tree-utils.test.ts
+++ b/src/app/(app)/device-quota/categories/__tests__/category-tree-utils.test.ts
@@ -161,6 +161,19 @@ describe('buildAggregatedQuotas', () => {
     expect(quotas.get(22)).toEqual({ total: 11, hasUnknown: false })
   })
 
+  it('preserves unknown quota when an intermediate category has direct equipment but no direct quota', () => {
+    const categories: CategoryListItem[] = [
+      makeCat({ id: 22, level: 1, ma_nhom: '02', so_luong_hien_co: 2, so_luong_toi_da: null }),
+      makeCat({ id: 299, level: 2, parent_id: 22, ma_nhom: '02.01', so_luong_toi_da: 4 }),
+      makeCat({ id: 300, level: 2, parent_id: 22, ma_nhom: '02.02', so_luong_toi_da: 4 }),
+      makeCat({ id: 301, level: 2, parent_id: 22, ma_nhom: '02.03', so_luong_toi_da: 3 }),
+    ]
+
+    const quotas = buildAggregatedQuotas(categories)
+
+    expect(quotas.get(22)).toEqual({ total: 11, hasUnknown: true })
+  })
+
   it('propagates hasUnknown when any descendant has null quota', () => {
     const categories: CategoryListItem[] = [
       makeCat({ id: 1, level: 1, so_luong_toi_da: 5 }),

--- a/src/app/(app)/device-quota/categories/__tests__/category-tree-utils.test.ts
+++ b/src/app/(app)/device-quota/categories/__tests__/category-tree-utils.test.ts
@@ -148,6 +148,19 @@ describe('buildAggregatedQuotas', () => {
     expect(quotas.get(4)).toEqual({ total: 3, hasUnknown: false })
   })
 
+  it('uses descendant quotas when an intermediate category has no direct quota', () => {
+    const categories: CategoryListItem[] = [
+      makeCat({ id: 22, level: 1, ma_nhom: '02', so_luong_toi_da: null }),
+      makeCat({ id: 299, level: 2, parent_id: 22, ma_nhom: '02.01', so_luong_toi_da: 4 }),
+      makeCat({ id: 300, level: 2, parent_id: 22, ma_nhom: '02.02', so_luong_toi_da: 4 }),
+      makeCat({ id: 301, level: 2, parent_id: 22, ma_nhom: '02.03', so_luong_toi_da: 3 }),
+    ]
+
+    const quotas = buildAggregatedQuotas(categories)
+
+    expect(quotas.get(22)).toEqual({ total: 11, hasUnknown: false })
+  })
+
   it('propagates hasUnknown when any descendant has null quota', () => {
     const categories: CategoryListItem[] = [
       makeCat({ id: 1, level: 1, so_luong_toi_da: 5 }),

--- a/src/app/(app)/device-quota/categories/_components/category-tree-utils.ts
+++ b/src/app/(app)/device-quota/categories/_components/category-tree-utils.ts
@@ -138,12 +138,22 @@ export function buildAggregatedQuotas(
   categories: CategoryListItem[]
 ): Map<number, AggregatedQuota> {
   const quotas = new Map<number, AggregatedQuota>()
+  const parentIds = new Set<number>()
+
+  for (const cat of categories) {
+    if (cat.parent_id !== null) {
+      parentIds.add(cat.parent_id)
+    }
+  }
 
   // Seed each node with its own quota
   for (const cat of categories) {
+    const hasDirectQuota = cat.so_luong_toi_da != null
+    const hasChildren = parentIds.has(cat.id)
+
     quotas.set(cat.id, {
       total: cat.so_luong_toi_da ?? 0,
-      hasUnknown: cat.so_luong_toi_da == null,
+      hasUnknown: !hasDirectQuota && !hasChildren,
     })
   }
 

--- a/src/app/(app)/device-quota/categories/_components/category-tree-utils.ts
+++ b/src/app/(app)/device-quota/categories/_components/category-tree-utils.ts
@@ -129,7 +129,7 @@ export interface AggregatedQuota {
 /**
  * Build aggregated quota totals: each category's quota =
  * its own so_luong_toi_da + sum of all descendants' so_luong_toi_da.
- * Tracks whether any node in the subtree has null (unknown) quota.
+ * Tracks whether any counted equipment in the subtree has no matching quota.
  *
  * Must receive the FULL category list (allCategories) for same scope
  * as buildAggregatedCounts. Uses the same bottom-up reverse iteration.
@@ -150,10 +150,11 @@ export function buildAggregatedQuotas(
   for (const cat of categories) {
     const hasDirectQuota = cat.so_luong_toi_da != null
     const hasChildren = parentIds.has(cat.id)
+    const hasUnquotedDirectCount = !hasDirectQuota && cat.so_luong_hien_co > 0
 
     quotas.set(cat.id, {
       total: cat.so_luong_toi_da ?? 0,
-      hasUnknown: !hasDirectQuota && !hasChildren,
+      hasUnknown: (!hasDirectQuota && !hasChildren) || hasUnquotedDirectCount,
     })
   }
 


### PR DESCRIPTION
## Summary\n- fix category quota aggregation so parent/intermediate categories without direct max quota roll up known child max quotas\n- keep leaf categories without quota as unknown\n- add regression coverage for the live 02 -> 02.01/02.02/02.03 quota shape and search-filtered full-tree totals\n\nFixes #502\n\n## Verification\n- node scripts/npm-run.js run verify:no-explicit-any\n- node scripts/npm-run.js run typecheck\n- node scripts/npm-run.js run test:run -- 'src/app/(app)/device-quota/categories/__tests__/category-tree-utils.test.ts' 'src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx'\n- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix quota aggregation so parents without a direct max quota roll up known child quotas, while leaves without quotas remain unknown. Header totals now use full‑tree denominators (e.g., 5/31), and when a parent has direct equipment but no direct quota the denominator stays unknown (e.g., 2/–), with tests for the 02 → 02.01/02.02/02.03 shape and search‑filtered views.

<sup>Written for commit 8470a14b97f7f40fd9e66899f07a2c01bdf716df. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/503?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed device quota aggregation logic to correctly calculate and display totals when categories lack direct quota assignments, properly rolling up values from descendant categories.
* Enhanced quota roll-up calculations to ensure accurate aggregated totals across the category tree hierarchy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->