### PR TITLE
feat: redesign device quota categories split screen

### DIFF
--- a/src/app/(app)/device-quota/_components/DeviceQuotaSplitPane.tsx
+++ b/src/app/(app)/device-quota/_components/DeviceQuotaSplitPane.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+type DeviceQuotaSplitPaneRatio = "50-50" | "40-60"
+
+interface DeviceQuotaSplitPaneProps {
+  leftPanel: React.ReactNode
+  rightPanel: React.ReactNode
+  ratio?: DeviceQuotaSplitPaneRatio
+  className?: string
+  leftClassName?: string
+  rightClassName?: string
+}
+
+const RATIO_CLASSES: Record<DeviceQuotaSplitPaneRatio, string> = {
+  "50-50": "lg:grid-cols-2",
+  "40-60": "lg:grid-cols-[minmax(320px,40%)_minmax(0,60%)]",
+}
+
+export function DeviceQuotaSplitPane({
+  leftPanel,
+  rightPanel,
+  ratio = "50-50",
+  className,
+  leftClassName,
+  rightClassName,
+}: DeviceQuotaSplitPaneProps) {
+  return (
+    <div
+      data-testid="device-quota-split-pane"
+      className={cn(
+        "grid grid-cols-1 gap-6 min-h-[600px]",
+        RATIO_CLASSES[ratio],
+        className
+      )}
+    >
+      <div
+        className={cn(
+          "min-w-0 space-y-4 lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto",
+          leftClassName
+        )}
+      >
+        {leftPanel}
+      </div>
+      <div
+        className={cn(
+          "min-w-0 space-y-4 lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto",
+          rightClassName
+        )}
+      >
+        {rightPanel}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryAssignedEquipment.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryAssignedEquipment.test.tsx
@@ -100,6 +100,36 @@ describe('DeviceQuotaCategoryAssignedEquipment', () => {
         expect(screen.getByText('Bảo trì')).toBeInTheDocument()
     })
 
+    it('uses panel presentation with horizontal table scroll and long-text guards', async () => {
+        const longName = 'Máy siêu âm Doppler màu tim mạch cấu hình cao dùng cho phòng can thiệp với tên thiết bị rất dài'
+        mockCallRpc.mockResolvedValue([
+            {
+                ...sampleEquipment[0],
+                ten_thiet_bi: longName,
+                model: 'Model-name-with-a-very-long-value-that-must-not-overlap',
+                serial: 'Serial-number-with-a-very-long-value-that-must-not-overlap',
+                khoa_phong_quan_ly: 'Khoa phòng quản lý thiết bị có tên rất dài',
+            },
+        ])
+
+        render(
+            <DeviceQuotaCategoryAssignedEquipment nhomId={42} donViId={1} variant="panel" />,
+            { wrapper: createWrapper() }
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText(longName)).toBeInTheDocument()
+        })
+
+        expect(screen.getByTestId('assigned-equipment-table-scroll')).toHaveClass('overflow-x-auto')
+        expect(screen.getByRole('table')).toHaveClass('min-w-[760px]')
+        expect(screen.getByText(longName)).toHaveClass('line-clamp-2')
+        expect(screen.getByText(longName)).toHaveAttribute('title', longName)
+        expect(screen.getByText(/Model-name/)).toHaveClass('truncate')
+        expect(screen.getByText(/Serial-number/)).toHaveClass('truncate')
+        expect(screen.getByText(/Khoa phòng quản lý/)).toHaveClass('truncate')
+    })
+
     it('shows empty state when no equipment is assigned', async () => {
         mockCallRpc.mockResolvedValue([])
 

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
@@ -425,6 +425,17 @@ describe('DeviceQuotaCategoryTree', () => {
     expect(within(navPane).queryByTestId('assigned-equipment-panel-5')).not.toBeInTheDocument()
   })
 
+  it('does not select a row when keyboard interaction targets its action menu', () => {
+    renderWithThreeLevelTree()
+
+    const leafBRow = screen.getByRole('button', { name: /Chọn danh mục 01\.02: Leaf B/i })
+    const leafBMenu = within(leafBRow).getByRole('button', { name: /Mở menu danh mục Leaf B/i })
+
+    fireEvent.keyDown(leafBMenu, { key: 'Enter' })
+
+    expect(leafBRow).toHaveAttribute('aria-pressed', 'false')
+  })
+
   it('selects a focused category row with Enter or Space', () => {
     renderWithThreeLevelTree()
 
@@ -445,12 +456,15 @@ describe('DeviceQuotaCategoryTree', () => {
     renderWithThreeLevelTree()
 
     const navPane = screen.getByTestId('device-quota-category-nav-pane')
+    const detailPane = screen.getByTestId('device-quota-category-detail-pane')
     const intermediate = screen.getByRole('button', { name: /Chọn danh mục 01: Intermediate/i })
 
     fireEvent.click(intermediate)
 
     expect(intermediate).toHaveAttribute('aria-pressed', 'true')
     expect(within(navPane).queryByTestId(/assigned-equipment-panel-/)).not.toBeInTheDocument()
+    expect(within(detailPane).queryByTestId('assigned-equipment-panel-2')).not.toBeInTheDocument()
+    expect(within(detailPane).getByText('Chọn một danh mục con để xem danh sách thiết bị được gán')).toBeInTheDocument()
   })
 
   it('zero-count leaf is still selectable for scanning its empty assignment state', () => {

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import "@testing-library/jest-dom"
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -12,8 +12,16 @@ vi.mock('../_hooks/useDeviceQuotaCategoryContext', () => ({
 
 // Mock the assigned-equipment panel to isolate tree tests from RPC fetching
 vi.mock('../_components/DeviceQuotaCategoryAssignedEquipment', () => ({
-  DeviceQuotaCategoryAssignedEquipment: ({ nhomId }: { nhomId: number }) => (
-    <div data-testid={`assigned-equipment-panel-${nhomId}`}>Equipment panel</div>
+  DeviceQuotaCategoryAssignedEquipment: ({
+    nhomId,
+    variant,
+  }: {
+    nhomId: number
+    variant?: string
+  }) => (
+    <div data-testid={`assigned-equipment-panel-${nhomId}`} data-variant={variant}>
+      Equipment panel
+    </div>
   ),
 }))
 
@@ -104,9 +112,10 @@ describe('DeviceQuotaCategoryTree', () => {
 
     render(<DeviceQuotaCategoryTree />)
 
-    expect(screen.getByText('Nhóm gốc 1')).toBeInTheDocument()
-    expect(screen.getByText('Nhóm con 1.1')).toBeInTheDocument()
-    expect(screen.getByText('Nhóm con 1.2')).toBeInTheDocument()
+    const navPane = screen.getByTestId('device-quota-category-nav-pane')
+    expect(within(navPane).getByText('Nhóm gốc 1')).toBeInTheDocument()
+    expect(within(navPane).getByText('Nhóm con 1.1')).toBeInTheDocument()
+    expect(within(navPane).getByText('Nhóm con 1.2')).toBeInTheDocument()
     expect(screen.getAllByText('Loại A').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('Loại B')).toBeInTheDocument()
   })
@@ -156,6 +165,94 @@ describe('DeviceQuotaCategoryTree', () => {
 
     expect(screen.getByText('Phân loại')).toBeInTheDocument()
     expect(screen.getByText('Tình trạng sử dụng')).toBeInTheDocument()
+  })
+
+  it('renders split navigation and detail panes with a 40:60 layout', () => {
+    const categories = [
+      { id: 1, parent_id: null, ma_nhom: 'I', ten_nhom: 'Root', level: 1, so_luong_hien_co: 0, so_luong_toi_da: null },
+      { id: 2, parent_id: 1, ma_nhom: '01', ten_nhom: 'Leaf With Equipment', level: 2, so_luong_hien_co: 3, so_luong_toi_da: 9, phan_loai: 'A' },
+      { id: 3, parent_id: 1, ma_nhom: '02', ten_nhom: 'Empty Leaf', level: 2, so_luong_hien_co: 0, so_luong_toi_da: 4, phan_loai: 'B' },
+    ]
+    mockUseContext.mockReturnValue({
+      categories,
+      allCategories: categories,
+      donViId: 1,
+      isLoading: false,
+      totalRootCount: 1,
+      searchTerm: '',
+      pagination: basePagination,
+      openCreateDialog: vi.fn(),
+      openEditDialog: vi.fn(),
+      openDeleteDialog: vi.fn(),
+      mutatingCategoryId: null,
+    } as unknown as MockCategoryContextValue)
+
+    render(<DeviceQuotaCategoryTree />)
+
+    expect(screen.getByTestId('device-quota-split-pane')).toHaveClass(
+      'lg:grid-cols-[minmax(320px,40%)_minmax(0,60%)]'
+    )
+    expect(screen.getByTestId('device-quota-category-nav-pane')).toBeInTheDocument()
+    expect(screen.getByTestId('device-quota-category-detail-pane')).toBeInTheDocument()
+  })
+
+  it('selects the first visible leaf with assigned equipment by default', () => {
+    const categories = [
+      { id: 1, parent_id: null, ma_nhom: 'I', ten_nhom: 'Root', level: 1, so_luong_hien_co: 0, so_luong_toi_da: null },
+      { id: 2, parent_id: 1, ma_nhom: '01', ten_nhom: 'Empty Leaf', level: 2, so_luong_hien_co: 0, so_luong_toi_da: 4 },
+      { id: 3, parent_id: 1, ma_nhom: '02', ten_nhom: 'Leaf With Equipment', level: 2, so_luong_hien_co: 2, so_luong_toi_da: 5, phan_loai: 'A' },
+    ]
+    mockUseContext.mockReturnValue({
+      categories,
+      allCategories: categories,
+      donViId: 1,
+      isLoading: false,
+      totalRootCount: 1,
+      searchTerm: '',
+      pagination: basePagination,
+      openCreateDialog: vi.fn(),
+      openEditDialog: vi.fn(),
+      openDeleteDialog: vi.fn(),
+      mutatingCategoryId: null,
+    } as unknown as MockCategoryContextValue)
+
+    render(<DeviceQuotaCategoryTree />)
+
+    const detailPane = screen.getByTestId('device-quota-category-detail-pane')
+    expect(within(detailPane).getByText('Leaf With Equipment')).toBeInTheDocument()
+    expect(within(detailPane).getByTestId('assigned-equipment-panel-3')).toHaveAttribute(
+      'data-variant',
+      'panel'
+    )
+  })
+
+  it('clamps long category names while keeping the full name accessible', () => {
+    const longName = 'Máy cộng hưởng từ toàn thân cấu hình cao phục vụ chẩn đoán hình ảnh chuyên sâu tại nhiều khoa phòng'
+    const categories = [
+      { id: 1, parent_id: null, ma_nhom: 'MRI', ten_nhom: longName, level: 1, so_luong_hien_co: 1, so_luong_toi_da: null, mo_ta: 'Mô tả rất dài cần được giới hạn trong vùng đọc chi tiết để không đẩy bảng thiết bị xuống quá xa khỏi màn hình.' },
+    ]
+    mockUseContext.mockReturnValue({
+      categories,
+      allCategories: categories,
+      donViId: 1,
+      isLoading: false,
+      totalRootCount: 1,
+      searchTerm: '',
+      pagination: basePagination,
+      openCreateDialog: vi.fn(),
+      openEditDialog: vi.fn(),
+      openDeleteDialog: vi.fn(),
+      mutatingCategoryId: null,
+    } as unknown as MockCategoryContextValue)
+
+    render(<DeviceQuotaCategoryTree />)
+
+    const row = screen.getByRole('button', { name: new RegExp(`Chọn danh mục MRI: ${longName}`) })
+    expect(row).toHaveAttribute('title', longName)
+    expect(within(row).getByText(longName)).toHaveClass('line-clamp-2')
+
+    const detailPane = screen.getByTestId('device-quota-category-detail-pane')
+    expect(within(detailPane).getByRole('heading', { name: longName })).toHaveClass('line-clamp-3')
   })
 
   it('hides column header when no data', () => {
@@ -274,7 +371,7 @@ describe('DeviceQuotaCategoryTree', () => {
     renderWithThreeLevelTree()
 
     // Root (id:1): equipment = 5, known descendant quota = 10+5+5+4+4+3.
-    expect(screen.getByText('5/31')).toBeInTheDocument()
+    expect(screen.getAllByText('5/31').length).toBeGreaterThanOrEqual(1)
   })
 
   it('root header preserves unknown quota when direct root equipment has no direct quota', () => {
@@ -304,50 +401,62 @@ describe('DeviceQuotaCategoryTree', () => {
     expect(screen.getByText('2/–')).toBeInTheDocument()
   })
 
-  it('leaf with equipment shows expand button with aria-expanded', () => {
+  it('category rows are selectable and expose quota/classification context', () => {
     renderWithThreeLevelTree()
 
-    const expandButton = screen.getByRole('button', { name: /Leaf A/i })
-    expect(expandButton).toHaveAttribute('aria-expanded', 'false')
+    const row = screen.getByRole('button', { name: /Chọn danh mục 01\.01: Leaf A/i })
+    expect(row).toHaveAttribute('aria-pressed', 'true')
+    expect(row).toHaveAttribute('title', 'Leaf A')
+    expect(row).toHaveTextContent('2/5')
   })
 
-  it('clicking expand button opens assignment panel', () => {
+  it('clicking a category row updates the detail pane without rendering equipment inline', () => {
     renderWithThreeLevelTree()
 
-    const expandButton = screen.getByRole('button', { name: /Leaf A/i })
+    const navPane = screen.getByTestId('device-quota-category-nav-pane')
+    const detailPane = screen.getByTestId('device-quota-category-detail-pane')
+    const row = screen.getByRole('button', { name: /Chọn danh mục 01\.02: Leaf B/i })
 
-    fireEvent.click(expandButton)
+    fireEvent.click(row)
 
-    expect(expandButton).toHaveAttribute('aria-expanded', 'true')
-    expect(screen.getByTestId('assigned-equipment-panel-4')).toBeInTheDocument()
+    expect(row).toHaveAttribute('aria-pressed', 'true')
+    expect(within(detailPane).getByText('Leaf B')).toBeInTheDocument()
+    expect(within(detailPane).getByTestId('assigned-equipment-panel-5')).toBeInTheDocument()
+    expect(within(navPane).queryByTestId('assigned-equipment-panel-5')).not.toBeInTheDocument()
   })
 
-  it('clicking expand button again collapses the panel', () => {
+  it('selects a focused category row with Enter or Space', () => {
     renderWithThreeLevelTree()
 
-    const expandButton = screen.getByRole('button', { name: /Leaf A/i })
+    const detailPane = screen.getByTestId('device-quota-category-detail-pane')
+    const emptyLeaf = screen.getByRole('button', { name: /Chọn danh mục 02\.01: Empty Leaf A/i })
+    const emptyLeafB = screen.getByRole('button', { name: /Chọn danh mục 02\.02: Empty Leaf B/i })
 
-    // Open
-    fireEvent.click(expandButton)
-    expect(expandButton).toHaveAttribute('aria-expanded', 'true')
-    expect(screen.getByTestId('assigned-equipment-panel-4')).toBeInTheDocument()
+    fireEvent.keyDown(emptyLeaf, { key: 'Enter' })
+    expect(emptyLeaf).toHaveAttribute('aria-pressed', 'true')
+    expect(within(detailPane).getByText('Empty Leaf A')).toBeInTheDocument()
 
-    // Collapse
-    fireEvent.click(expandButton)
-    expect(expandButton).toHaveAttribute('aria-expanded', 'false')
-    expect(screen.queryByTestId('assigned-equipment-panel-4')).not.toBeInTheDocument()
+    fireEvent.keyDown(emptyLeafB, { key: ' ' })
+    expect(emptyLeafB).toHaveAttribute('aria-pressed', 'true')
+    expect(within(detailPane).getByText('Empty Leaf B')).toBeInTheDocument()
   })
 
-  it('intermediate node has no expand button', () => {
+  it('intermediate node is selectable but does not render inline equipment', () => {
     renderWithThreeLevelTree()
 
-    expect(screen.queryByRole('button', { name: /Intermediate/i })).not.toBeInTheDocument()
+    const navPane = screen.getByTestId('device-quota-category-nav-pane')
+    const intermediate = screen.getByRole('button', { name: /Chọn danh mục 01: Intermediate/i })
+
+    fireEvent.click(intermediate)
+
+    expect(intermediate).toHaveAttribute('aria-pressed', 'true')
+    expect(within(navPane).queryByTestId(/assigned-equipment-panel-/)).not.toBeInTheDocument()
   })
 
-  it('zero-count leaf has no expand button', () => {
+  it('zero-count leaf is still selectable for scanning its empty assignment state', () => {
     renderWithThreeLevelTree()
 
-    expect(screen.queryByRole('button', { name: /Empty Leaf A/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Chọn danh mục 02\.01: Empty Leaf A/i })).toBeInTheDocument()
   })
 
   it('displays full-tree aggregated totals even when categories is search-filtered', () => {
@@ -380,14 +489,14 @@ describe('DeviceQuotaCategoryTree', () => {
 
     // Root header quota denominator must also use full-tree scope:
     // Intermediate(10) + LeafA(5) + LeafB(5) + EmptyLeafA(4) + EmptyLeafB(4) + EmptyLeafC(3) = 31.
-    expect(screen.getByText('5/31')).toBeInTheDocument()
+    expect(screen.getAllByText('5/31').length).toBeGreaterThanOrEqual(1)
   })
 
   // ============================================
   // Root-level drill-down for single-level taxonomy
   // ============================================
 
-  it('root that is a leaf with equipment shows expand button and toggles panel', () => {
+  it('root that is a leaf with equipment is selected in the detail pane', () => {
     const singleLevel = [
       { id: 10, parent_id: null, ma_nhom: 'R', ten_nhom: 'Root Leaf', level: 1, so_luong_hien_co: 2, so_luong_toi_da: 5 },
     ]
@@ -408,20 +517,14 @@ describe('DeviceQuotaCategoryTree', () => {
 
     render(<DeviceQuotaCategoryTree />)
 
-    const rootExpandBtn = screen.getByRole('button', { name: /Xem thiết bị Root Leaf/i })
-    expect(rootExpandBtn).toHaveAttribute('aria-expanded', 'false')
-
-    fireEvent.click(rootExpandBtn)
-    expect(screen.getByTestId('assigned-equipment-panel-10')).toBeInTheDocument()
-    expect(rootExpandBtn).toHaveAttribute('aria-expanded', 'true')
-
-    // Collapse
-    fireEvent.click(rootExpandBtn)
-    expect(screen.queryByTestId('assigned-equipment-panel-10')).not.toBeInTheDocument()
-    expect(rootExpandBtn).toHaveAttribute('aria-expanded', 'false')
+    const detailPane = screen.getByTestId('device-quota-category-detail-pane')
+    const rootRow = screen.getByRole('button', { name: /Chọn danh mục R: Root Leaf/i })
+    expect(rootRow).toHaveAttribute('aria-pressed', 'true')
+    expect(within(detailPane).getByText('Root Leaf')).toBeInTheDocument()
+    expect(within(detailPane).getByTestId('assigned-equipment-panel-10')).toBeInTheDocument()
   })
 
-  it('root that is a leaf with zero equipment has no expand button', () => {
+  it('root that is a leaf with zero equipment is still selectable', () => {
     const singleLevelZero = [
       { id: 11, parent_id: null, ma_nhom: 'R', ten_nhom: 'Empty Root Leaf', level: 1, so_luong_hien_co: 0, so_luong_toi_da: 5 },
     ]
@@ -442,10 +545,13 @@ describe('DeviceQuotaCategoryTree', () => {
 
     render(<DeviceQuotaCategoryTree />)
 
-    expect(screen.queryByRole('button', { name: /Xem thiết bị Empty Root Leaf/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Chọn danh mục R: Empty Root Leaf/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
   })
 
-  it('root with children (not a leaf) has no expand button', () => {
+  it('root with children keeps a separate collapse control', () => {
     const rootWithChild = [
       { id: 12, parent_id: null, ma_nhom: 'R', ten_nhom: 'Root With Child', level: 1, so_luong_hien_co: 2, so_luong_toi_da: 5 },
       { id: 13, parent_id: 12, ma_nhom: '01', ten_nhom: 'Child', level: 2, so_luong_hien_co: 1, so_luong_toi_da: 5 },
@@ -467,11 +573,14 @@ describe('DeviceQuotaCategoryTree', () => {
 
     render(<DeviceQuotaCategoryTree />)
 
-    // Header remains a button for collapsing groups; ensure there is no root-level expand affordance
-    expect(screen.queryByRole('button', { name: /Xem thiết bị Root With Child/i })).not.toBeInTheDocument()
+    const collapseButton = screen.getByRole('button', { name: /Thu gọn nhóm R: Root With Child/i })
+    const rootRow = screen.getByRole('button', { name: /Chọn danh mục R: Root With Child/i })
+
+    expect(collapseButton).toHaveAttribute('aria-expanded', 'true')
+    expect(rootRow).toBeInTheDocument()
   })
 
-  it('clicking root expand button does not collapse the header (stopPropagation)', () => {
+  it('clicking the root row does not collapse the group', () => {
     const singleLevel = [
       { id: 20, parent_id: null, ma_nhom: 'R', ten_nhom: 'Root Leaf Stop', level: 1, so_luong_hien_co: 2, so_luong_toi_da: 5 },
     ]
@@ -492,18 +601,16 @@ describe('DeviceQuotaCategoryTree', () => {
 
     render(<DeviceQuotaCategoryTree />)
 
-    const header = screen.getByRole('button', { name: /Nhóm R: Root Leaf Stop/i })
-    const rootExpandBtn = screen.getByRole('button', { name: /Xem thiết bị Root Leaf Stop/i })
+    const collapseButton = screen.getByRole('button', { name: /Thu gọn nhóm R: Root Leaf Stop/i })
+    const rootRow = screen.getByRole('button', { name: /Chọn danh mục R: Root Leaf Stop/i })
 
     // Header should be expanded by default
-    expect(header).toHaveAttribute('aria-expanded', 'true')
+    expect(collapseButton).toHaveAttribute('aria-expanded', 'true')
 
-    // Click expand button: should not collapse header (aria-expanded stays true)
-    fireEvent.click(rootExpandBtn)
-    expect(header).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(rootRow)
+    expect(collapseButton).toHaveAttribute('aria-expanded', 'true')
 
-    // Click again to collapse the panel: header should still remain expanded
-    fireEvent.click(rootExpandBtn)
-    expect(header).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.keyDown(rootRow, { key: 'Enter' })
+    expect(collapseButton).toHaveAttribute('aria-expanded', 'true')
   })
 })

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
@@ -434,6 +434,8 @@ describe('DeviceQuotaCategoryTree', () => {
     fireEvent.keyDown(leafBMenu, { key: 'Enter' })
 
     expect(leafBRow).toHaveAttribute('aria-pressed', 'false')
+    expect(leafBMenu).toHaveAttribute('type', 'button')
+    expect(leafBMenu).not.toHaveClass('opacity-0')
   })
 
   it('selects a focused category row with Enter or Space', () => {

--- a/src/app/(app)/device-quota/categories/_components/CategoryActionMenu.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryActionMenu.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import * as React from "react"
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import type { CategoryListItem } from "../_types/categories"
+
+interface CategoryActionMenuProps {
+    category: CategoryListItem
+    disabled: boolean
+    onEdit: (category: CategoryListItem) => void
+    onDelete: (category: CategoryListItem) => void
+    className?: string
+}
+
+export function CategoryActionMenu({
+    category,
+    disabled,
+    onEdit,
+    onDelete,
+    className,
+}: CategoryActionMenuProps) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className={cn("size-7", className)}
+                    disabled={disabled}
+                    aria-label={`Mở menu danh mục ${category.ten_nhom}`}
+                    onClick={(event) => event.stopPropagation()}
+                >
+                    <MoreHorizontal className="size-4" />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={() => onEdit(category)}>
+                    <Pencil className="mr-2 size-4" />
+                    Sửa
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                    onSelect={() => onDelete(category)}
+                    className="text-destructive focus:text-destructive"
+                >
+                    <Trash2 className="mr-2 size-4" />
+                    Xóa
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}

--- a/src/app/(app)/device-quota/categories/_components/CategoryActionMenu.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryActionMenu.tsx
@@ -32,6 +32,7 @@ export function CategoryActionMenu({
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
                 <Button
+                    type="button"
                     variant="ghost"
                     size="icon"
                     className={cn("size-7", className)}

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -84,6 +84,9 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
             title={category.ten_nhom}
             onClick={selectCategory}
             onKeyDown={(event) => {
+                if (event.target !== event.currentTarget) {
+                    return
+                }
                 if (event.key === "Enter" || event.key === " ") {
                     event.preventDefault()
                     selectCategory()
@@ -143,8 +146,9 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
                     <Button
                         variant="ghost"
                         size="icon"
-                        className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
+                        className="size-7 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
                         disabled={isMutating}
+                        aria-label={`Mở menu danh mục ${category.ten_nhom}`}
                         onClick={(event) => event.stopPropagation()}
                     >
                         <MoreHorizontal className="size-4" />

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -20,8 +20,23 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { CATEGORY_GRID_COLS, CLASSIFICATION_STYLES, type AggregatedQuota } from "./category-tree-utils"
 import { QuotaProgressBar } from "./QuotaProgressBar"
-import { DeviceQuotaCategoryAssignedEquipment } from "./DeviceQuotaCategoryAssignedEquipment"
 import type { CategoryListItem } from "../_types/categories"
+
+function quotaLabel(current: number, max: number | null) {
+    return `${current}/${max ?? "–"}`
+}
+
+function categorySelectLabel(
+    category: CategoryListItem,
+    classLabel: string | null,
+    quotaText: string
+) {
+    return [
+        `Chọn danh mục ${category.ma_nhom}: ${category.ten_nhom}`,
+        classLabel,
+        `Tình trạng ${quotaText}`,
+    ].filter(Boolean).join(" · ")
+}
 
 // ============================================
 // Child Row
@@ -35,9 +50,8 @@ interface CategoryChildRowProps {
     aggregatedCount: number
     aggregatedQuota: AggregatedQuota | undefined
     isLeaf: boolean
-    isExpanded: boolean
-    onToggleExpand: (id: number) => void
-    donViId: number | null
+    isSelected: boolean
+    onSelectCategory: (category: CategoryListItem) => void
 }
 
 const CategoryChildRow = React.memo(function CategoryChildRow({
@@ -48,124 +62,109 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
     aggregatedCount,
     aggregatedQuota,
     isLeaf,
-    isExpanded,
-    onToggleExpand,
-    donViId,
+    isSelected,
+    onSelectCategory,
 }: CategoryChildRowProps) {
     const classStyle = CLASSIFICATION_STYLES[category.phan_loai || ""] ?? null
 
     const indentPx = Math.max(0, category.level - 2) * 20
 
-    const isExpandable = isLeaf && aggregatedCount > 0
     const quotaMax = aggregatedQuota?.hasUnknown ? null : (aggregatedQuota?.total ?? category.so_luong_toi_da)
+    const quotaText = quotaLabel(aggregatedCount, quotaMax)
+    const selectLabel = categorySelectLabel(category, classStyle?.label ?? null, quotaText)
+
+    const selectCategory = () => onSelectCategory(category)
 
     return (
-        <>
-            <div
-                className={cn(
-                    "group relative rounded-md border border-transparent px-4 py-2.5 transition-all duration-150",
-                    "hover:bg-accent/50 hover:border-border/50",
-                    isExpanded && "bg-accent/30 border-border/50",
-                    CATEGORY_GRID_COLS
-                )}
-            >
-                {/* Column 1: Category name */}
-                <div className="relative min-w-0" style={{ paddingLeft: `${indentPx}px` }}>
-                    {category.level > 2 && (
-                        <div
-                            className="absolute top-0 bottom-0 border-l-2 border-muted-foreground/15"
-                            style={{ left: `${Math.max(0, category.level - 3) * 20}px` }}
-                            aria-hidden="true"
-                        />
-                    )}
-                    <div className="flex items-baseline gap-2">
-                        <span className="text-sm font-semibold text-primary/80 shrink-0">
-                            {category.ma_nhom}
-                        </span>
-                        <span className="text-sm text-foreground/80 break-words">
-                            {category.ten_nhom}
-                        </span>
-                    </div>
-                    {category.mo_ta && (
-                        <p className="text-xs text-muted-foreground mt-1 italic">
-                            {category.mo_ta}
-                        </p>
-                    )}
-                </div>
-
-                {/* Column 2: Classification badge */}
-                <div>
-                    {classStyle && (
-                        <Badge variant="outline" className={cn("text-xs font-medium", classStyle.className)}>
-                            {classStyle.label}
-                        </Badge>
-                    )}
-                </div>
-
-                {/* Column 3: Quota progress bar — clickable for expandable leaves */}
-                {isExpandable ? (
-                    <button
-                        type="button"
-                        className="flex items-center gap-1.5 w-full text-left hover:opacity-80 transition-opacity cursor-pointer"
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            onToggleExpand(category.id)
-                        }}
-                        aria-expanded={isExpanded}
-                        aria-label={`Xem thiết bị ${category.ten_nhom}`}
-                    >
-                        <ChevronRight className={cn(
-                            "size-3 text-muted-foreground shrink-0 transition-transform duration-200",
-                            isExpanded && "rotate-90"
-                        )} />
-                        <QuotaProgressBar
-                            current={aggregatedCount}
-                            max={quotaMax}
-                        />
-                    </button>
-                ) : (
-                    <QuotaProgressBar
-                        current={aggregatedCount}
-                        max={quotaMax}
+        <div
+            role="button"
+            tabIndex={0}
+            aria-label={selectLabel}
+            aria-pressed={isSelected}
+            title={category.ten_nhom}
+            onClick={selectCategory}
+            onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault()
+                    selectCategory()
+                }
+            }}
+            className={cn(
+                "group relative cursor-pointer rounded-md border border-transparent px-4 py-2.5 transition-all duration-150",
+                "hover:bg-accent/50 hover:border-border/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                isSelected && "border-primary/30 bg-primary/5 ring-1 ring-primary/20",
+                CATEGORY_GRID_COLS
+            )}
+        >
+            {/* Column 1: Category name */}
+            <div className="relative min-w-0" style={{ paddingLeft: `${indentPx}px` }}>
+                {category.level > 2 && (
+                    <div
+                        className="absolute top-0 bottom-0 border-l-2 border-muted-foreground/15"
+                        style={{ left: `${Math.max(0, category.level - 3) * 20}px` }}
+                        aria-hidden="true"
                     />
                 )}
-
-                {/* Column 4: Actions */}
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            className="size-7 opacity-0 group-hover:opacity-100 transition-opacity"
-                            disabled={isMutating}
-                        >
-                            <MoreHorizontal className="size-4" />
-                        </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                        <DropdownMenuItem onSelect={() => onEdit(category)}>
-                            <Pencil className="mr-2 size-4" />
-                            Sửa
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                            onSelect={() => onDelete(category)}
-                            className="text-destructive focus:text-destructive"
-                        >
-                            <Trash2 className="mr-2 size-4" />
-                            Xóa
-                        </DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                <div className="flex items-baseline gap-2">
+                    <span className="shrink-0 text-sm font-semibold text-primary/80">
+                        {category.ma_nhom}
+                    </span>
+                    <span className="line-clamp-2 text-sm text-foreground/80">
+                        {category.ten_nhom}
+                    </span>
+                </div>
+                {category.mo_ta && (
+                    <p className="mt-1 line-clamp-2 text-xs italic text-muted-foreground">
+                        {category.mo_ta}
+                    </p>
+                )}
             </div>
 
-            {/* Expanded equipment panel */}
-            {isExpanded && isExpandable && (
-                <DeviceQuotaCategoryAssignedEquipment
-                    nhomId={category.id}
-                    donViId={donViId}
+            {/* Column 2: Classification badge */}
+            <div>
+                {classStyle && (
+                    <Badge variant="outline" className={cn("text-xs font-medium", classStyle.className)}>
+                        {classStyle.label}
+                    </Badge>
+                )}
+            </div>
+
+            {/* Column 3: Quota progress bar */}
+            <div aria-label={isLeaf ? "Danh mục lá" : "Danh mục cha"}>
+                <QuotaProgressBar
+                    current={aggregatedCount}
+                    max={quotaMax}
                 />
-            )}
-        </>
+            </div>
+
+            {/* Column 4: Actions */}
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 opacity-0 transition-opacity group-hover:opacity-100"
+                        disabled={isMutating}
+                        onClick={(event) => event.stopPropagation()}
+                    >
+                        <MoreHorizontal className="size-4" />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                    <DropdownMenuItem onSelect={() => onEdit(category)}>
+                        <Pencil className="mr-2 size-4" />
+                        Sửa
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                        onSelect={() => onDelete(category)}
+                        className="text-destructive focus:text-destructive"
+                    >
+                        <Trash2 className="mr-2 size-4" />
+                        Xóa
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
     )
 })
 
@@ -175,30 +174,28 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
 
 interface CategoryGroupProps {
     root: CategoryListItem
-    children: CategoryListItem[]
+    childCategories: CategoryListItem[]
     onEdit: (category: CategoryListItem) => void
     onDelete: (category: CategoryListItem) => void
     mutatingCategoryId: number | null
     aggregatedCounts: Map<number, number>
     aggregatedQuotas: Map<number, AggregatedQuota>
     leafIds: Set<number>
-    expandedCategoryId: number | null
-    onToggleExpand: (id: number) => void
-    donViId: number | null
+    selectedCategoryId: number | null
+    onSelectCategory: (category: CategoryListItem) => void
 }
 
 const CategoryGroup = React.memo(function CategoryGroup({
     root,
-    children,
+    childCategories,
     onEdit,
     onDelete,
     mutatingCategoryId,
     aggregatedCounts,
     aggregatedQuotas,
     leafIds,
-    expandedCategoryId,
-    onToggleExpand,
-    donViId,
+    selectedCategoryId,
+    onSelectCategory,
 }: CategoryGroupProps) {
     const [isCollapsed, setIsCollapsed] = React.useState(false)
     const classStyle = CLASSIFICATION_STYLES[root.phan_loai || ""] ?? null
@@ -208,48 +205,67 @@ const CategoryGroup = React.memo(function CategoryGroup({
     const rootQuota = aggregatedQuotas.get(root.id)
     const hasUnknownQuota = rootQuota?.hasUnknown ?? true
     const totalQuota = rootQuota?.total ?? 0
+    const quotaMax = hasUnknownQuota ? null : totalQuota
+    const rootQuotaText = quotaLabel(totalEquipment, quotaMax)
+    const rootSelectLabel = categorySelectLabel(root, classStyle?.label ?? null, rootQuotaText)
+    const rootSelected = selectedCategoryId === root.id
+    const toggleLabel = `${isCollapsed ? "Mở rộng" : "Thu gọn"} nhóm ${root.ma_nhom}: ${root.ten_nhom}`
+
+    const selectRoot = () => onSelectCategory(root)
 
     return (
         <div className="rounded-lg border bg-card overflow-hidden transition-shadow hover:shadow-sm">
             {/* Group Header */}
             <div
                 className={cn(
-                    "group cursor-pointer select-none px-4 py-3",
+                    "group select-none px-4 py-3",
                     "bg-muted/50 ring-1 ring-inset ring-primary/20",
                     "hover:bg-muted/80 transition-colors",
+                    rootSelected && "bg-primary/5 ring-primary/40",
                     CATEGORY_GRID_COLS
                 )}
-                onClick={() => setIsCollapsed(!isCollapsed)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault()
-                        setIsCollapsed(!isCollapsed)
-                    }
-                }}
-                aria-expanded={!isCollapsed}
-                aria-label={`Nhóm ${root.ma_nhom}: ${root.ten_nhom}`}
             >
                 {/* Column 1: Chevron + Root info */}
                 <div className="min-w-0 flex items-center gap-3">
-                    <span className="shrink-0 text-muted-foreground">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 shrink-0 text-muted-foreground"
+                        onClick={() => setIsCollapsed((current) => !current)}
+                        aria-expanded={!isCollapsed}
+                        aria-label={toggleLabel}
+                    >
                         {isCollapsed ? (
                             <ChevronRight className="size-4" />
                         ) : (
                             <ChevronDown className="size-4" />
                         )}
-                    </span>
-                    <div className="min-w-0 flex-1">
+                    </Button>
+                    <div
+                        role="button"
+                        tabIndex={0}
+                        aria-label={rootSelectLabel}
+                        aria-pressed={rootSelected}
+                        title={root.ten_nhom}
+                        onClick={selectRoot}
+                        onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                                event.preventDefault()
+                                selectRoot()
+                            }
+                        }}
+                        className="min-w-0 flex-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
                         <div className="flex items-baseline gap-2">
                             <span className="text-sm font-bold text-primary">
                                 {root.ma_nhom}
                             </span>
-                            <span className="text-sm font-semibold truncate">
+                            <span className="line-clamp-2 text-sm font-semibold">
                                 {root.ten_nhom}
                             </span>
                             <span className="text-xs text-muted-foreground whitespace-nowrap shrink-0">
-                                · {children.length} mục con
+                                · {childCategories.length} mục con
                             </span>
                         </div>
                     </div>
@@ -264,33 +280,13 @@ const CategoryGroup = React.memo(function CategoryGroup({
                     )}
                 </div>
 
-                {/* Column 3: Aggregated quota progress — clickable when root is a leaf with equipment */}
-                {leafIds.has(root.id) && totalEquipment > 0 ? (
-                    <button
-                        type="button"
-                        className="flex items-center gap-1.5 w-full text-left hover:opacity-80 transition-opacity cursor-pointer"
-                        onClick={(e) => {
-                            e.stopPropagation()
-                            onToggleExpand(root.id)
-                        }}
-                        aria-expanded={expandedCategoryId === root.id}
-                        aria-label={`Xem thiết bị ${root.ten_nhom}`}
-                    >
-                        <ChevronRight className={cn(
-                            "size-3 text-muted-foreground shrink-0 transition-transform duration-200",
-                            expandedCategoryId === root.id && "rotate-90"
-                        )} />
-                        <QuotaProgressBar
-                            current={totalEquipment}
-                            max={hasUnknownQuota ? null : totalQuota}
-                        />
-                    </button>
-                ) : (
+                {/* Column 3: Aggregated quota progress */}
+                <div aria-label={leafIds.has(root.id) ? "Danh mục lá" : "Danh mục cha"}>
                     <QuotaProgressBar
                         current={totalEquipment}
-                        max={hasUnknownQuota ? null : totalQuota}
+                        max={quotaMax}
                     />
-                )}
+                </div>
 
                 {/* Column 4: Actions */}
                 <DropdownMenu>
@@ -321,17 +317,10 @@ const CategoryGroup = React.memo(function CategoryGroup({
                 </DropdownMenu>
             </div>
 
-            {/* Root-level assigned equipment panel (single-level taxonomy support) */}
-            {!isCollapsed && children.length === 0 && expandedCategoryId === root.id && leafIds.has(root.id) && totalEquipment > 0 && (
-                <div className="border-t">
-                    <DeviceQuotaCategoryAssignedEquipment nhomId={root.id} donViId={donViId} />
-                </div>
-            )}
-
             {/* Children */}
-            {!isCollapsed && children.length > 0 && (
+            {!isCollapsed && childCategories.length > 0 && (
                 <div className="divide-y divide-border/50">
-                    {children.map((child) => (
+                    {childCategories.map((child) => (
                         <div key={child.id}>
                             <CategoryChildRow
                                 category={child}
@@ -341,9 +330,8 @@ const CategoryGroup = React.memo(function CategoryGroup({
                                 aggregatedCount={aggregatedCounts.get(child.id) ?? child.so_luong_hien_co}
                                 aggregatedQuota={aggregatedQuotas.get(child.id)}
                                 isLeaf={leafIds.has(child.id)}
-                                isExpanded={expandedCategoryId === child.id}
-                                onToggleExpand={onToggleExpand}
-                                donViId={donViId}
+                                isSelected={selectedCategoryId === child.id}
+                                onSelectCategory={onSelectCategory}
                             />
                         </div>
                     ))}

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -138,7 +138,7 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
                 disabled={isMutating}
                 onEdit={onEdit}
                 onDelete={onDelete}
-                className="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                className="opacity-100 transition-opacity focus-visible:opacity-100"
             />
         </div>
     )

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -4,20 +4,12 @@ import * as React from "react"
 import {
     ChevronDown,
     ChevronRight,
-    MoreHorizontal,
-    Pencil,
-    Trash2,
 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+import { CategoryActionMenu } from "./CategoryActionMenu"
 import { CATEGORY_GRID_COLS, CLASSIFICATION_STYLES, type AggregatedQuota } from "./category-tree-utils"
 import { QuotaProgressBar } from "./QuotaProgressBar"
 import type { CategoryListItem } from "../_types/categories"
@@ -141,33 +133,13 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
             </div>
 
             {/* Column 4: Actions */}
-            <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="size-7 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                        disabled={isMutating}
-                        aria-label={`Mở menu danh mục ${category.ten_nhom}`}
-                        onClick={(event) => event.stopPropagation()}
-                    >
-                        <MoreHorizontal className="size-4" />
-                    </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                    <DropdownMenuItem onSelect={() => onEdit(category)}>
-                        <Pencil className="mr-2 size-4" />
-                        Sửa
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                        onSelect={() => onDelete(category)}
-                        className="text-destructive focus:text-destructive"
-                    >
-                        <Trash2 className="mr-2 size-4" />
-                        Xóa
-                    </DropdownMenuItem>
-                </DropdownMenuContent>
-            </DropdownMenu>
+            <CategoryActionMenu
+                category={category}
+                disabled={isMutating}
+                onEdit={onEdit}
+                onDelete={onDelete}
+                className="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+            />
         </div>
     )
 })
@@ -293,32 +265,12 @@ const CategoryGroup = React.memo(function CategoryGroup({
                 </div>
 
                 {/* Column 4: Actions */}
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            className="size-7"
-                            disabled={mutatingCategoryId === root.id}
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            <MoreHorizontal className="size-4" />
-                        </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                        <DropdownMenuItem onSelect={() => onEdit(root)}>
-                            <Pencil className="mr-2 size-4" />
-                            Sửa
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                            onSelect={() => onDelete(root)}
-                            className="text-destructive focus:text-destructive"
-                        >
-                            <Trash2 className="mr-2 size-4" />
-                            Xóa
-                        </DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                <CategoryActionMenu
+                    category={root}
+                    disabled={mutatingCategoryId === root.id}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                />
             </div>
 
             {/* Children */}

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryAssignedEquipment.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryAssignedEquipment.tsx
@@ -6,6 +6,7 @@ import { AlertCircle, PackageOpen } from "lucide-react"
 
 import { callRpc } from "@/lib/rpc-client"
 import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
 import {
     MappingPreviewLoadingState,
     type EquipmentPreviewItem,
@@ -18,6 +19,7 @@ import {
 interface DeviceQuotaCategoryAssignedEquipmentProps {
     nhomId: number
     donViId: number | null
+    variant?: "inline" | "panel"
 }
 
 // ============================================
@@ -45,8 +47,10 @@ function EquipmentRow({ item }: { item: EquipmentPreviewItem }) {
             <td className="px-3 py-2 font-mono text-muted-foreground truncate max-w-[5rem]">
                 {item.ma_thiet_bi}
             </td>
-            <td className="px-3 py-2 font-medium truncate">
-                {item.ten_thiet_bi}
+            <td className="px-3 py-2 font-medium">
+                <span className="line-clamp-2" title={item.ten_thiet_bi}>
+                    {item.ten_thiet_bi}
+                </span>
             </td>
             <td className="px-3 py-2 text-muted-foreground truncate max-w-[6rem]">
                 {item.model ?? "–"}
@@ -84,6 +88,7 @@ function EquipmentRow({ item }: { item: EquipmentPreviewItem }) {
 export function DeviceQuotaCategoryAssignedEquipment({
     nhomId,
     donViId,
+    variant = "inline",
 }: DeviceQuotaCategoryAssignedEquipmentProps) {
     const { data: equipment, isError, isLoading } = useQuery({
         queryKey: ["dinh_muc_thiet_bi_by_nhom", { nhomId, donViId }],
@@ -94,9 +99,17 @@ export function DeviceQuotaCategoryAssignedEquipment({
             }),
         enabled: !!donViId,
     })
+    const isPanel = variant === "panel"
 
     return (
-        <div className="ml-6 mt-1 mb-2 rounded-md border border-border/50 bg-muted/30 border-l-2 border-l-primary/20 overflow-hidden">
+        <div
+            className={cn(
+                "rounded-md border border-border/50 bg-muted/30 overflow-hidden",
+                isPanel
+                    ? "border-l-0"
+                    : "ml-6 mt-1 mb-2 border-l-2 border-l-primary/20"
+            )}
+        >
             {isLoading ? (
                 <div className="p-3">
                     <MappingPreviewLoadingState count={2} />
@@ -112,23 +125,28 @@ export function DeviceQuotaCategoryAssignedEquipment({
                     <span>Chưa có thiết bị nào được gán</span>
                 </div>
             ) : (
-                <table className="w-full text-left">
-                    <thead>
-                        <tr className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide border-b">
-                            <th scope="col" className="px-3 py-1.5 font-medium">Mã TB</th>
-                            <th scope="col" className="px-3 py-1.5 font-medium">Tên thiết bị</th>
-                            <th scope="col" className="px-3 py-1.5 font-medium">Model</th>
-                            <th scope="col" className="px-3 py-1.5 font-medium">Serial</th>
-                            <th scope="col" className="px-3 py-1.5 font-medium">Khoa phòng</th>
-                            <th scope="col" className="px-3 py-1.5 font-medium">Tình trạng</th>
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-border/30">
-                        {equipment.map((item) => (
-                            <EquipmentRow key={item.id} item={item} />
-                        ))}
-                    </tbody>
-                </table>
+                <div
+                    data-testid="assigned-equipment-table-scroll"
+                    className={cn(isPanel && "overflow-x-auto")}
+                >
+                    <table className={cn("w-full text-left", isPanel && "min-w-[760px]")}>
+                        <thead>
+                            <tr className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide border-b">
+                                <th scope="col" className="px-3 py-1.5 font-medium">Mã TB</th>
+                                <th scope="col" className="px-3 py-1.5 font-medium">Tên thiết bị</th>
+                                <th scope="col" className="px-3 py-1.5 font-medium">Model</th>
+                                <th scope="col" className="px-3 py-1.5 font-medium">Serial</th>
+                                <th scope="col" className="px-3 py-1.5 font-medium">Khoa phòng</th>
+                                <th scope="col" className="px-3 py-1.5 font-medium">Tình trạng</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-border/30">
+                            {equipment.map((item) => (
+                                <EquipmentRow key={item.id} item={item} />
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
             )}
         </div>
     )

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDetailPane.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDetailPane.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import * as React from "react"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import type { CategoryListItem } from "../_types/categories"
+import {
+  CLASSIFICATION_STYLES,
+  type AggregatedQuota,
+} from "./category-tree-utils"
+import { DeviceQuotaCategoryAssignedEquipment } from "./DeviceQuotaCategoryAssignedEquipment"
+import { QuotaProgressBar } from "./QuotaProgressBar"
+
+interface DeviceQuotaCategoryDetailPaneProps {
+  category: CategoryListItem | null
+  allCategories: CategoryListItem[]
+  aggregatedCount: number
+  aggregatedQuota: AggregatedQuota | undefined
+  donViId: number | null
+}
+
+function buildCategoryPath(
+  category: CategoryListItem,
+  allCategories: CategoryListItem[]
+) {
+  const byId = new Map(allCategories.map((item) => [item.id, item]))
+  const path: CategoryListItem[] = []
+  let current: CategoryListItem | undefined = category
+
+  while (current) {
+    path.unshift(current)
+    current = current.parent_id === null ? undefined : byId.get(current.parent_id)
+  }
+
+  return path
+}
+
+export function DeviceQuotaCategoryDetailPane({
+  category,
+  allCategories,
+  aggregatedCount,
+  aggregatedQuota,
+  donViId,
+}: DeviceQuotaCategoryDetailPaneProps) {
+  if (!category) {
+    return (
+      <Card
+        data-testid="device-quota-category-detail-pane"
+        className="h-full"
+      >
+        <CardContent className="flex min-h-[18rem] items-center justify-center text-sm text-muted-foreground">
+          Chọn một danh mục để xem thiết bị được gán
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const classStyle = CLASSIFICATION_STYLES[category.phan_loai || ""] ?? null
+  const quotaMax = aggregatedQuota?.hasUnknown
+    ? null
+    : (aggregatedQuota?.total ?? category.so_luong_toi_da)
+  const categoryPath = buildCategoryPath(category, allCategories)
+  const parentPath = categoryPath.slice(0, -1)
+
+  return (
+    <Card
+      data-testid="device-quota-category-detail-pane"
+      className="h-full overflow-hidden"
+    >
+      <CardHeader className="space-y-3 pb-4">
+        <CardDescription className="line-clamp-1">
+          {parentPath.length > 0
+            ? parentPath.map((item) => item.ten_nhom).join(" / ")
+            : "Danh mục gốc"}
+        </CardDescription>
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary" className="font-mono">
+              {category.ma_nhom}
+            </Badge>
+            {classStyle && (
+              <Badge
+                variant="outline"
+                className={cn("text-xs font-medium", classStyle.className)}
+              >
+                {classStyle.label}
+              </Badge>
+            )}
+          </div>
+          <CardTitle
+            role="heading"
+            aria-level={2}
+            className="line-clamp-3 text-xl leading-snug"
+            title={category.ten_nhom}
+          >
+            {category.ten_nhom}
+          </CardTitle>
+          {category.mo_ta && (
+            <p
+              className="line-clamp-2 text-sm text-muted-foreground"
+              title={category.mo_ta}
+            >
+              {category.mo_ta}
+            </p>
+          )}
+        </div>
+        <div className="max-w-sm">
+          <QuotaProgressBar current={aggregatedCount} max={quotaMax} />
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <DeviceQuotaCategoryAssignedEquipment
+          nhomId={category.id}
+          donViId={donViId}
+          variant="panel"
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDetailPane.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDetailPane.tsx
@@ -2,6 +2,8 @@
 
 import * as React from "react"
 
+import { Layers } from "lucide-react"
+
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -24,6 +26,7 @@ interface DeviceQuotaCategoryDetailPaneProps {
   allCategories: CategoryListItem[]
   aggregatedCount: number
   aggregatedQuota: AggregatedQuota | undefined
+  isLeaf: boolean
   donViId: number | null
 }
 
@@ -48,6 +51,7 @@ export function DeviceQuotaCategoryDetailPane({
   allCategories,
   aggregatedCount,
   aggregatedQuota,
+  isLeaf,
   donViId,
 }: DeviceQuotaCategoryDetailPaneProps) {
   if (!category) {
@@ -117,11 +121,18 @@ export function DeviceQuotaCategoryDetailPane({
         </div>
       </CardHeader>
       <CardContent className="pt-0">
-        <DeviceQuotaCategoryAssignedEquipment
-          nhomId={category.id}
-          donViId={donViId}
-          variant="panel"
-        />
+        {isLeaf ? (
+          <DeviceQuotaCategoryAssignedEquipment
+            nhomId={category.id}
+            donViId={donViId}
+            variant="panel"
+          />
+        ) : (
+          <div className="flex min-h-[12rem] flex-col items-center justify-center gap-2 rounded-md border border-dashed bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+            <Layers className="size-5" aria-hidden="true" />
+            <span>Chọn một danh mục con để xem danh sách thiết bị được gán</span>
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryTree.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryTree.tsx
@@ -11,10 +11,29 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { DeviceQuotaSplitPane } from "../../_components/DeviceQuotaSplitPane"
+import type { CategoryListItem } from "../_types/categories"
 import { useDeviceQuotaCategoryContext } from "../_hooks/useDeviceQuotaCategoryContext"
 import { CATEGORY_GRID_COLS, groupByRoot, buildAggregatedCounts, buildAggregatedQuotas, getLeafIds } from "./category-tree-utils"
 import { CategoryGroup } from "./CategoryGroup"
+import { DeviceQuotaCategoryDetailPane } from "./DeviceQuotaCategoryDetailPane"
 import { CategoryTreeSkeleton, CategoryTreeEmpty } from "./CategoryTreeStates"
+
+function findDefaultCategory(
+  categories: CategoryListItem[],
+  aggregatedCounts: Map<number, number>,
+  leafIds: Set<number>
+) {
+  return (
+    categories.find(
+      (category) =>
+        leafIds.has(category.id) && (aggregatedCounts.get(category.id) ?? category.so_luong_hien_co) > 0
+    ) ??
+    categories.find((category) => leafIds.has(category.id)) ??
+    categories.find((category) => category.level === 1) ??
+    null
+  )
+}
 
 export function DeviceQuotaCategoryTree() {
   const {
@@ -49,16 +68,41 @@ export function DeviceQuotaCategoryTree() {
     [allCategories]
   )
 
-  const [expandedCategoryId, setExpandedCategoryId] = React.useState<number | null>(null)
+  const [selectedCategoryId, setSelectedCategoryId] = React.useState<number | null>(null)
 
-  const handleToggleExpand = React.useCallback((id: number) => {
-    setExpandedCategoryId((prev) => (prev === id ? null : id))
+  const defaultCategory = React.useMemo(
+    () => findDefaultCategory(categories, aggregatedCounts, leafIds),
+    [aggregatedCounts, categories, leafIds]
+  )
+
+  const visibleSelectedCategory = React.useMemo(
+    () => categories.find((category) => category.id === selectedCategoryId) ?? null,
+    [categories, selectedCategoryId]
+  )
+
+  const selectedCategory = visibleSelectedCategory ?? defaultCategory
+
+  React.useEffect(() => {
+    const nextSelectedId = selectedCategory?.id ?? null
+    if (selectedCategoryId !== nextSelectedId) {
+      setSelectedCategoryId(nextSelectedId)
+    }
+  }, [selectedCategory?.id, selectedCategoryId])
+
+  const handleSelectCategory = React.useCallback((category: CategoryListItem) => {
+    setSelectedCategoryId(category.id)
   }, [])
 
   const rootCount = roots.length
+  const selectedCount = selectedCategory
+    ? (aggregatedCounts.get(selectedCategory.id) ?? selectedCategory.so_luong_hien_co)
+    : 0
+  const selectedQuota = selectedCategory
+    ? aggregatedQuotas.get(selectedCategory.id)
+    : undefined
 
-  return (
-    <Card className="h-full flex flex-col">
+  const navigationPane = (
+    <Card className="h-full flex flex-col" data-testid="device-quota-category-nav-pane">
       <CardHeader className="pb-3">
         <CardTitle className="text-lg">
           Tiêu chuẩn, định mức thiết bị
@@ -105,16 +149,15 @@ export function DeviceQuotaCategoryTree() {
                 <div key={root.id} role="listitem">
                   <CategoryGroup
                     root={root}
-                    children={childrenMap.get(root.id) || []}
+                    childCategories={childrenMap.get(root.id) || []}
                     onEdit={openEditDialog}
                     onDelete={openDeleteDialog}
                     mutatingCategoryId={mutatingCategoryId}
                     aggregatedCounts={aggregatedCounts}
                     aggregatedQuotas={aggregatedQuotas}
                     leafIds={leafIds}
-                    expandedCategoryId={expandedCategoryId}
-                    onToggleExpand={handleToggleExpand}
-                    donViId={donViId}
+                    selectedCategoryId={selectedCategory?.id ?? null}
+                    onSelectCategory={handleSelectCategory}
                   />
                 </div>
               ))}
@@ -123,5 +166,22 @@ export function DeviceQuotaCategoryTree() {
         )}
       </CardContent>
     </Card>
+  )
+
+  return (
+    <DeviceQuotaSplitPane
+      ratio="40-60"
+      leftPanel={navigationPane}
+      rightPanel={
+        <DeviceQuotaCategoryDetailPane
+          category={selectedCategory}
+          allCategories={allCategories}
+          aggregatedCount={selectedCount}
+          aggregatedQuota={selectedQuota}
+          donViId={donViId}
+        />
+      }
+      leftClassName="lg:overflow-x-hidden"
+    />
   )
 }

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryTree.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryTree.tsx
@@ -178,6 +178,7 @@ export function DeviceQuotaCategoryTree() {
           allCategories={allCategories}
           aggregatedCount={selectedCount}
           aggregatedQuota={selectedQuota}
+          isLeaf={selectedCategory ? leafIds.has(selectedCategory.id) : false}
           donViId={donViId}
         />
       }

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingSplitView.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingSplitView.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { cn } from '@/lib/utils'
+import { DeviceQuotaSplitPane } from '../../_components/DeviceQuotaSplitPane'
 
 /**
  * Split-screen layout for device quota mapping interface
@@ -38,40 +39,12 @@ export function DeviceQuotaMappingSplitView({
   rightClassName,
 }: DeviceQuotaMappingSplitViewProps) {
   return (
-    <div
-      className={cn(
-        // Responsive grid: stacked on mobile, 50/50 on desktop
-        'grid grid-cols-1 lg:grid-cols-2',
-        // Gap between panels
-        'gap-6',
-        // Min height to prevent layout shift
-        'min-h-[600px]',
-        className
-      )}
-    >
-      {/* Left Panel */}
-      <div
-        className={cn(
-          'space-y-4',
-          // Optional: Add max height with scroll on desktop
-          'lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto',
-          leftClassName
-        )}
-      >
-        {leftPanel}
-      </div>
-
-      {/* Right Panel */}
-      <div
-        className={cn(
-          'space-y-4',
-          // Optional: Add max height with scroll on desktop
-          'lg:max-h-[calc(100vh-12rem)] lg:overflow-y-auto',
-          rightClassName
-        )}
-      >
-        {rightPanel}
-      </div>
-    </div>
+    <DeviceQuotaSplitPane
+      leftPanel={leftPanel}
+      rightPanel={rightPanel}
+      className={cn(className)}
+      leftClassName={leftClassName}
+      rightClassName={rightClassName}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- Redesign `/device-quota/categories` thành split-screen 40:60: danh mục bên trái, chi tiết thiết bị bên phải.
- Thêm selection state, detail pane, shared `DeviceQuotaSplitPane`, và chế độ panel cho bảng thiết bị được gán.
- Giữ scope UI-only: không đổi RPC/DB/RBAC/data contract/font; long text được clamp và bảng thiết bị có scroll ngang nội bộ.

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js npx vitest run src/app/\(app\)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx src/app/\(app\)/device-quota/categories/__tests__/DeviceQuotaCategoryAssignedEquipment.test.tsx`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- [x] `node scripts/npm-run.js run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned /device-quota/categories to a 40:60 split view with a selectable tree on the left and a detail pane on the right. Improves navigation, a11y, and long-text handling with no backend changes.

- New Features
  - Shared `DeviceQuotaSplitPane` with 40:60 layout.
  - `DeviceQuotaCategoryDetailPane` shows parent path, classification badge, quota bar, and assigned equipment; non-leaf shows a helpful empty state.
  - Selection-based navigation in the tree; default picks the first visible leaf with equipment.
  - `DeviceQuotaCategoryAssignedEquipment` adds `variant="panel"`, horizontal table scroll, min-width, and clamped long names with titles.

- Refactors
  - Removed inline equipment in the tree; selection updates the right pane instead. Separate collapse control for groups.
  - Better a11y: selectable rows (aria labels, keyboard support), clamped long names with titles, and stable selection when opening row menus.
  - Extracted reusable `CategoryActionMenu` for root and child rows; adds aria labels, uses `type="button"`, and stops propagation to prevent unintended selection.
  - Reused `DeviceQuotaSplitPane` in the mapping screen.
  - Updated tests for split layout, default selection, a11y, and panel table behaviors.

<sup>Written for commit 3a2be5fc5026cc579efedefdec64694665f15469. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/504?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split-pane device-quota layout with responsive ratio options
  * Dedicated category details panel showing breadcrumb, classification, quota progress, and assigned equipment in panel view
  * Inline action menu for categories with edit and delete actions

* **Refactor**
  * Navigation updated from expand/collapse to explicit category selection (keyboard & mouse accessible)

* **Tests**
  * Expanded coverage for split layouts, selection behavior, long-text handling, and accessibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->