### PR TITLE
feat: add server-side device quota suggestion route

### DIFF
--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
@@ -183,7 +183,7 @@ describe("useSuggestMapping", () => {
     expect(res.matchedDevices).toBe(5)
   })
 
-  test("sets error status on RPC failure", async () => {
+  test("sets error status on network error", async () => {
     fetchMock.mockRejectedValue(new Error("Network error"))
 
     const { result } = renderHook(() =>

--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
@@ -1,20 +1,7 @@
-/**
- * Tests for useSuggestMapping orchestration hook.
- *
- * Verifies the 3-stage pipeline:
- * 1. Fetch unassigned names via RPC
- * 2. Generate embeddings via /api/embeddings/generate
- * 3. Hybrid search categories via RPC
- * Then merge results into grouped suggestions.
- */
 import { describe, test, expect, vi, beforeEach } from "vitest"
 import { renderHook, waitFor, act } from "@testing-library/react"
 import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-
-// ============================================
-// Mocks
-// ============================================
 
 const callRpcMock = vi.fn()
 vi.mock("@/lib/rpc-client", () => ({
@@ -26,7 +13,6 @@ vi.stubGlobal("fetch", fetchMock)
 
 import { useSuggestMapping } from "../_hooks/useSuggestMapping"
 
-// Wrapper with fresh QueryClient per test
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { mutations: { retry: false } },
@@ -36,57 +22,50 @@ function createWrapper() {
   }
 }
 
-// ============================================
-// Fixtures
-// ============================================
-
-const UNASSIGNED_NAMES = [
-  { ten_thiet_bi: "Máy thở", device_count: 3, device_ids: [1, 2, 3] },
-  { ten_thiet_bi: "Bơm tiêm điện", device_count: 2, device_ids: [4, 5] },
-  { ten_thiet_bi: "Máy X-quang", device_count: 1, device_ids: [6] },
-]
-
-const EMBEDDINGS = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
-
-const SEARCH_RESULTS = [
-  {
-    query_text: "Máy thở",
-    results: [{ id: 10, ten_nhom: "Máy thở chức năng cao", ma_nhom: "A.01", phan_loai: "Loại B", rrf_score: 0.95 }],
-  },
-  {
-    query_text: "Bơm tiêm điện",
-    results: [{ id: 20, ten_nhom: "Bơm tiêm điện tự động", ma_nhom: "B.02", phan_loai: "Loại C", rrf_score: 0.88 }],
-  },
-  {
-    query_text: "Máy X-quang",
-    results: [],  // unmatched
-  },
-]
+const PREVIEW_RESULT = {
+  groups: [
+    {
+      nhom_id: 10,
+      nhom_label: "Máy thở chức năng cao",
+      nhom_code: "A.01",
+      phan_loai: "Loại B",
+      rrf_score: 0.95,
+      device_names: ["Máy thở"],
+      device_ids: [1, 2, 3],
+      device_name_to_ids: { "Máy thở": [1, 2, 3] },
+    },
+    {
+      nhom_id: 20,
+      nhom_label: "Bơm tiêm điện tự động",
+      nhom_code: "B.02",
+      phan_loai: "Loại C",
+      rrf_score: 0.88,
+      device_names: ["Bơm tiêm điện"],
+      device_ids: [4, 5],
+      device_name_to_ids: { "Bơm tiêm điện": [4, 5] },
+    },
+  ],
+  unmatched: [{ device_name: "Máy X-quang", device_ids: [6] }],
+  totalDevices: 6,
+  matchedDevices: 5,
+}
 
 function setupSuccessfulPipeline() {
-  // Stage 1: unassigned names
-  callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
-    if (fn === "dinh_muc_thiet_bi_unassigned_names") {
-      return Promise.resolve(UNASSIGNED_NAMES)
-    }
-    if (fn === "hybrid_search_category_batch") {
-      return Promise.resolve(SEARCH_RESULTS)
-    }
-    return Promise.reject(new Error(`Unknown RPC: ${fn}`))
-  })
-
-  // Stage 2: embeddings
   fetchMock.mockResolvedValue(
     new Response(
-      JSON.stringify({ embeddings: EMBEDDINGS }),
+      JSON.stringify({
+        result: PREVIEW_RESULT,
+        meta: {
+          requestId: "req-1",
+          provider: "supabase",
+          itemCounts: { unassignedNames: 3, unassignedDevices: 6, categories: 2 },
+          catalogSignature: "v1-test",
+        },
+      }),
       { status: 200, headers: { "Content-Type": "application/json" } }
     )
   )
 }
-
-// ============================================
-// Tests
-// ============================================
 
 describe("useSuggestMapping", () => {
   beforeEach(() => {
@@ -102,6 +81,7 @@ describe("useSuggestMapping", () => {
     expect(result.current.status).toBe("idle")
     expect(result.current.result).toBeNull()
     expect(callRpcMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   test("stays idle when donViId is null", () => {
@@ -112,9 +92,10 @@ describe("useSuggestMapping", () => {
 
     expect(result.current.status).toBe("idle")
     expect(callRpcMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  test("runs full pipeline when enabled with valid donViId", async () => {
+  test("requests server-side suggested mapping once when enabled with valid donViId", async () => {
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -126,21 +107,18 @@ describe("useSuggestMapping", () => {
       expect(result.current.status).toBe("done")
     })
 
-    // Step 1: called unassigned names RPC
-    expect(callRpcMock).toHaveBeenCalledWith(
-      expect.objectContaining({ fn: "dinh_muc_thiet_bi_unassigned_names" })
-    )
-
-    // Step 2: called embedding proxy
+    expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(
-      "/api/embeddings/generate",
+      "/api/device-quota/mapping/suggest",
       expect.objectContaining({
         method: "POST",
+        body: JSON.stringify({ donViId: 1 }),
       })
     )
-
-    // Step 3: called hybrid search
-    expect(callRpcMock).toHaveBeenCalledWith(
+    expect(callRpcMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fn: "dinh_muc_thiet_bi_unassigned_names" })
+    )
+    expect(callRpcMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ fn: "hybrid_search_category_batch" })
     )
   })
@@ -160,13 +138,11 @@ describe("useSuggestMapping", () => {
     const res = result.current.result!
     expect(res.groups).toHaveLength(2)
 
-    // First group: "Máy thở" → nhom_id=10
     const group1 = res.groups.find(g => g.nhom_id === 10)!
     expect(group1.nhom_label).toBe("Máy thở chức năng cao")
     expect(group1.nhom_code).toBe("A.01")
     expect(group1.device_ids).toEqual([1, 2, 3])
 
-    // Second group: "Bơm tiêm điện" → nhom_id=20
     const group2 = res.groups.find(g => g.nhom_id === 20)!
     expect(group2.nhom_label).toBe("Bơm tiêm điện tự động")
     expect(group2.device_ids).toEqual([4, 5])
@@ -208,7 +184,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("sets error status on RPC failure", async () => {
-    callRpcMock.mockRejectedValue(new Error("Network error"))
+    fetchMock.mockRejectedValue(new Error("Network error"))
 
     const { result } = renderHook(() =>
       useSuggestMapping({ donViId: 1, enabled: true }),
@@ -222,16 +198,12 @@ describe("useSuggestMapping", () => {
     expect(result.current.error).toBe("Network error")
   })
 
-  test("sets error status on embedding proxy failure", async () => {
-    callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
-      if (fn === "dinh_muc_thiet_bi_unassigned_names") {
-        return Promise.resolve(UNASSIGNED_NAMES)
-      }
-      return Promise.reject(new Error("Unknown RPC"))
-    })
-
+  test("sets error status on server-side preview failure", async () => {
     fetchMock.mockResolvedValue(
-      new Response("Internal Server Error", { status: 500 })
+      new Response(JSON.stringify({ error: "Preview failed", requestId: "req-err" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      })
     )
 
     const { result } = renderHook(() =>
@@ -243,7 +215,7 @@ describe("useSuggestMapping", () => {
       expect(result.current.status).toBe("error")
     })
 
-    expect(result.current.error).toBeTruthy()
+    expect(result.current.error).toBe("Preview failed")
   })
 
   test("reset clears result and returns to idle", async () => {
@@ -267,36 +239,30 @@ describe("useSuggestMapping", () => {
     expect(result.current.error).toBeNull()
   })
 
-  test("groups devices with same nhom_id from different queries", async () => {
-    // Two different device names map to the same category
-    const duplicateCategoryResults = [
-      {
-        query_text: "Máy thở",
-        results: [{ id: 10, ten_nhom: "Máy thở chức năng cao", ma_nhom: "A.01", phan_loai: null, rrf_score: 0.95 }],
-      },
-      {
-        query_text: "Bơm tiêm điện",
-        results: [{ id: 10, ten_nhom: "Máy thở chức năng cao", ma_nhom: "A.01", phan_loai: null, rrf_score: 0.88 }],
-      },
-      {
-        query_text: "Máy X-quang",
-        results: [],
-      },
-    ]
-
-    callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
-      if (fn === "dinh_muc_thiet_bi_unassigned_names") {
-        return Promise.resolve(UNASSIGNED_NAMES)
-      }
-      if (fn === "hybrid_search_category_batch") {
-        return Promise.resolve(duplicateCategoryResults)
-      }
-      return Promise.reject(new Error(`Unknown RPC: ${fn}`))
-    })
-
+  test("passes the server-side preview result through unchanged", async () => {
+    const serverResult = {
+      groups: [
+        {
+          nhom_id: 10,
+          nhom_label: "Máy thở chức năng cao",
+          nhom_code: "A.01",
+          phan_loai: null,
+          rrf_score: 0.95,
+          device_names: ["Máy thở", "Bơm tiêm điện"],
+          device_ids: [1, 2, 3, 4, 5],
+          device_name_to_ids: {
+            "Máy thở": [1, 2, 3],
+            "Bơm tiêm điện": [4, 5],
+          },
+        },
+      ],
+      unmatched: [{ device_name: "Máy X-quang", device_ids: [6] }],
+      totalDevices: 6,
+      matchedDevices: 5,
+    }
     fetchMock.mockResolvedValue(
       new Response(
-        JSON.stringify({ embeddings: EMBEDDINGS }),
+        JSON.stringify({ result: serverResult }),
         { status: 200, headers: { "Content-Type": "application/json" } }
       )
     )
@@ -311,11 +277,7 @@ describe("useSuggestMapping", () => {
     })
 
     const res = result.current.result!
-    // Should merge into a single group with combined device_ids
-    expect(res.groups).toHaveLength(1)
-    expect(res.groups[0].device_ids).toEqual([1, 2, 3, 4, 5])
-    expect(res.groups[0].device_names).toContain("Máy thở")
-    expect(res.groups[0].device_names).toContain("Bơm tiêm điện")
+    expect(res).toEqual(serverResult)
   })
 
   test("auto-resets to idle when enabled becomes false after pipeline started", async () => {
@@ -328,13 +290,11 @@ describe("useSuggestMapping", () => {
       { initialProps: { enabled: true }, wrapper }
     )
 
-    // Wait for pipeline to complete
     await waitFor(() => {
       expect(result.current.status).toBe("done")
     })
     expect(result.current.result).not.toBeNull()
 
-    // Disable the hook — should auto-reset all state
     rerender({ enabled: false })
 
     expect(result.current.status).toBe("idle")
@@ -342,10 +302,6 @@ describe("useSuggestMapping", () => {
     expect(result.current.error).toBeNull()
     expect(result.current.progress).toBe(0)
   })
-
-  // ============================================
-  // Save Batch Mutation (Phase 4)
-  // ============================================
 
   describe("saveBatch", () => {
     const SAVE_RESULT = {
@@ -361,8 +317,6 @@ describe("useSuggestMapping", () => {
     test("calls dinh_muc_thiet_bi_link_batch RPC with correct payload", async () => {
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === "dinh_muc_thiet_bi_unassigned_names") return Promise.resolve(UNASSIGNED_NAMES)
-        if (fn === "hybrid_search_category_batch") return Promise.resolve(SEARCH_RESULTS)
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.resolve(SAVE_RESULT)
         return Promise.reject(new Error(`Unknown RPC: ${fn}`))
       })
@@ -399,11 +353,8 @@ describe("useSuggestMapping", () => {
     test("transitions through saving → saved status lifecycle", async () => {
       setupSuccessfulPipeline()
 
-      // Delay save RPC to observe saving state
       let resolveSave: (value: unknown) => void
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === "dinh_muc_thiet_bi_unassigned_names") return Promise.resolve(UNASSIGNED_NAMES)
-        if (fn === "hybrid_search_category_batch") return Promise.resolve(SEARCH_RESULTS)
         if (fn === "dinh_muc_thiet_bi_link_batch") {
           return new Promise((resolve) => { resolveSave = resolve })
         }
@@ -438,8 +389,6 @@ describe("useSuggestMapping", () => {
     test("exposes save result with affected and skipped counts", async () => {
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === "dinh_muc_thiet_bi_unassigned_names") return Promise.resolve(UNASSIGNED_NAMES)
-        if (fn === "hybrid_search_category_batch") return Promise.resolve(SEARCH_RESULTS)
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.resolve(SAVE_RESULT)
         return Promise.reject(new Error(`Unknown RPC: ${fn}`))
       })
@@ -465,8 +414,6 @@ describe("useSuggestMapping", () => {
     test("sets saveError on RPC failure", async () => {
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === "dinh_muc_thiet_bi_unassigned_names") return Promise.resolve(UNASSIGNED_NAMES)
-        if (fn === "hybrid_search_category_batch") return Promise.resolve(SEARCH_RESULTS)
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.reject(new Error("Permission denied"))
         return Promise.reject(new Error(`Unknown RPC: ${fn}`))
       })
@@ -490,4 +437,3 @@ describe("useSuggestMapping", () => {
     })
   })
 })
-

--- a/src/app/(app)/device-quota/mapping/_hooks/useSuggestMapping.ts
+++ b/src/app/(app)/device-quota/mapping/_hooks/useSuggestMapping.ts
@@ -1,7 +1,6 @@
-// Orchestration hook for suggested mapping pipeline.
-// Uses useMutation from TanStack Query for the 3-stage pipeline:
-// fetch unassigned names → embed → hybrid search.
-// Returns grouped suggestions ready for preview display.
+// Orchestration hook for suggested mapping preview.
+// Browser calls one server-side route; the route owns payload bundling,
+// embedding/search provider orchestration, auth, and facility-scope checks.
 
 import { useState, useEffect, useCallback, useRef } from "react"
 import { useMutation } from "@tanstack/react-query"
@@ -56,161 +55,45 @@ interface UseSuggestMappingOptions {
   enabled: boolean
 }
 
-interface UnassignedName {
-  ten_thiet_bi: string
-  device_count: number
-  device_ids: number[]
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-interface SearchResult {
-  query_text: string
-  results: {
-    id: number
-    ten_nhom: string
-    ma_nhom: string
-    phan_loai: string | null
-    rrf_score: number
-  }[]
-}
-
-const CHUNK_SIZE = 10
-
-// ============================================
-// Chunking helpers
-// ============================================
-
-function chunkArray<T>(arr: T[], size: number): T[][] {
-  const chunks: T[][] = []
-  for (let i = 0; i < arr.length; i += size) {
-    chunks.push(arr.slice(i, i + size))
+function getRouteErrorMessage(status: number, payload: unknown): string {
+  if (isRecord(payload) && typeof payload.error === "string" && payload.error) {
+    return payload.error
   }
-  return chunks
+  return `Suggestion preview failed (${status})`
 }
 
-// ============================================
-// Pipeline logic (pure async, no React state)
-// ============================================
-
-async function fetchEmbeddings(
-  texts: string[],
-  signal: AbortSignal,
-  onProgress?: (completedChunks: number, totalChunks: number) => void,
-): Promise<number[][]> {
-  const chunks = chunkArray(texts, CHUNK_SIZE)
-  const allEmbeddings: number[][] = []
-
-  for (let i = 0; i < chunks.length; i++) {
-    const res = await fetch("/api/embeddings/generate", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ texts: chunks[i] }),
-      signal,
-    })
-
-    if (!res.ok) {
-      throw new Error(`Embedding generation failed (${res.status})`)
-    }
-
-    const { embeddings } = await res.json()
-    if (!Array.isArray(embeddings)) {
-      throw new Error(`Invalid embedding response for chunk ${i + 1}`)
-    }
-    allEmbeddings.push(...embeddings)
-    if (!signal.aborted) onProgress?.(i + 1, chunks.length)
+function getRouteResult(payload: unknown): SuggestMappingResult {
+  if (isRecord(payload) && isRecord(payload.result)) {
+    return payload.result as unknown as SuggestMappingResult
   }
-
-  return allEmbeddings
+  throw new Error("Invalid suggestion preview response")
 }
 
-async function searchCategories(
-  queries: { text: string; embedding: number[] }[],
+async function fetchSuggestedMapping(
   donViId: number,
   signal: AbortSignal,
-  onProgress?: (completedChunks: number, totalChunks: number) => void,
-): Promise<SearchResult[]> {
-  const chunks = chunkArray(queries, CHUNK_SIZE)
-  const allResults: SearchResult[] = []
+): Promise<SuggestMappingResult> {
+  const response = await fetch("/api/device-quota/mapping/suggest", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ donViId }),
+    signal,
+  })
 
-  for (let i = 0; i < chunks.length; i++) {
-    if (signal.aborted) throw new DOMException("Aborted", "AbortError")
+  let payload: unknown = null
+  try {
+    payload = await response.json()
+  } catch {}
 
-    const chunk = chunks[i]
-    const p_queries = chunk.map((q) => ({
-      text: q.text,
-      embedding: q.embedding,
-    }))
-
-    const results = await callRpc<SearchResult[]>({
-      fn: "hybrid_search_category_batch",
-      args: { p_queries, p_don_vi: donViId },
-    })
-
-    allResults.push(...(results ?? []))
-    if (!signal.aborted) onProgress?.(i + 1, chunks.length)
+  if (!response.ok) {
+    throw new Error(getRouteErrorMessage(response.status, payload))
   }
 
-  return allResults
-}
-
-function mergeResults(
-  names: UnassignedName[],
-  searchResults: SearchResult[],
-): SuggestMappingResult {
-  const nameToDeviceInfo = new Map<string, UnassignedName>()
-  for (const n of names) {
-    nameToDeviceInfo.set(n.ten_thiet_bi, n)
-  }
-
-  const groupMap = new Map<number, SuggestedGroup>()
-  const unmatched: { device_name: string; device_ids: number[] }[] = []
-
-  for (const sr of searchResults) {
-    const nameInfo = nameToDeviceInfo.get(sr.query_text)
-    if (!nameInfo) continue
-
-    if (!sr.results || sr.results.length === 0) {
-      unmatched.push({
-        device_name: sr.query_text,
-        device_ids: nameInfo.device_ids,
-      })
-      continue
-    }
-
-    const best = sr.results[0]
-    const existing = groupMap.get(best.id)
-
-    if (existing) {
-      existing.device_ids.push(...nameInfo.device_ids)
-      if (!existing.device_names.includes(sr.query_text)) {
-        existing.device_names.push(sr.query_text)
-      }
-      existing.device_name_to_ids[sr.query_text] = [
-        ...(existing.device_name_to_ids[sr.query_text] ?? []),
-        ...nameInfo.device_ids,
-      ]
-      existing.rrf_score = Math.max(existing.rrf_score, best.rrf_score)
-    } else {
-      groupMap.set(best.id, {
-        nhom_id: best.id,
-        nhom_label: best.ten_nhom,
-        nhom_code: best.ma_nhom,
-        phan_loai: best.phan_loai,
-        rrf_score: best.rrf_score,
-        device_names: [sr.query_text],
-        device_ids: [...nameInfo.device_ids],
-        device_name_to_ids: { [sr.query_text]: [...nameInfo.device_ids] },
-      })
-    }
-  }
-
-  const groups = Array.from(groupMap.values()).sort(
-    (a, b) => b.device_ids.length - a.device_ids.length
-  )
-
-  const matchedDevices = groups.reduce((sum, g) => sum + g.device_ids.length, 0)
-  const totalDevices = names.reduce((sum, n) => sum + n.device_count, 0)
-
-  return { groups, unmatched, totalDevices, matchedDevices }
+  return getRouteResult(payload)
 }
 
 // ============================================
@@ -226,44 +109,12 @@ export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions
     mutationFn: async (dvId: number): Promise<SuggestMappingResult> => {
       const signal = abortRef.current!.signal
 
-      // Stage 1: Fetch unassigned names
       if (!signal.aborted) setPipelineStatus("fetching-names")
       if (!signal.aborted) setProgress(0)
 
-      const names = await callRpc<UnassignedName[]>({
-        fn: "dinh_muc_thiet_bi_unassigned_names",
-        args: { p_don_vi: dvId },
-      })
-
+      const result = await fetchSuggestedMapping(dvId, signal)
       if (signal.aborted) throw new DOMException("Aborted", "AbortError")
-
-      if (!names || names.length === 0) {
-        return { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 }
-      }
-
-      // Stage 2: Generate embeddings
-      if (!signal.aborted) setPipelineStatus("embedding")
-      const texts = names.map((n) => n.ten_thiet_bi)
-      const totalStages = 3
-      const embeddings = await fetchEmbeddings(texts, signal, (done, total) => {
-        if (!signal.aborted) setProgress(Math.round((done / total) * (100 / totalStages)))
-      })
-
-      if (signal.aborted) throw new DOMException("Aborted", "AbortError")
-
-      // Stage 3: Hybrid search
-      if (!signal.aborted) setPipelineStatus("searching")
-      const queries = texts.map((text, i) => ({
-        text,
-        embedding: embeddings[i],
-      }))
-      const searchResults = await searchCategories(queries, dvId, signal, (done, total) => {
-        if (!signal.aborted) setProgress(Math.round(((2 + done / total) / totalStages) * 100))
-      })
-
-      if (signal.aborted) throw new DOMException("Aborted", "AbortError")
-
-      return mergeResults(names, searchResults)
+      return result
     },
     onSuccess: (_data, _vars, _ctx) => {
       if (!abortRef.current?.signal.aborted) {

--- a/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
@@ -37,6 +37,14 @@ function createRequest(body: unknown): NextRequest {
   })
 }
 
+function createRawRequest(body: string): NextRequest {
+  return new NextRequest("http://localhost/api/device-quota/mapping/suggest", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
 const SESSION = {
   user: {
     id: "42",
@@ -108,6 +116,36 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).not.toHaveBeenCalled()
   })
 
+  test("returns 400 before preview work when donViId is missing", async () => {
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({}))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        error: "donViId must be a positive integer",
+        requestId: expect.any(String),
+      })
+    )
+    expect(assertSuggestionAccessMock).not.toHaveBeenCalled()
+    expect(runSuggestMappingMock).not.toHaveBeenCalled()
+  })
+
+  test("returns 400 before preview work when JSON is malformed", async () => {
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRawRequest("{bad"))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        error: "Invalid JSON body",
+        requestId: expect.any(String),
+      })
+    )
+    expect(assertSuggestionAccessMock).not.toHaveBeenCalled()
+    expect(runSuggestMappingMock).not.toHaveBeenCalled()
+  })
+
   test("invokes the Supabase provider once and preserves preview semantics", async () => {
     const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
     const response = await POST(createRequest({ donViId: 17 }))
@@ -152,6 +190,12 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     runSuggestMappingMock.mockRejectedValueOnce(new Error("provider failed"))
     const failedResponse = await POST(createRequest({ donViId: 17 }))
     expect(failedResponse.status).toBe(500)
+    expect(await failedResponse.json()).toEqual(
+      expect.objectContaining({
+        error: "Internal server error",
+        requestId: expect.any(String),
+      })
+    )
     expect(consoleErrorMock).toHaveBeenCalledWith(
       "[device-quota-suggest]",
       expect.objectContaining({
@@ -162,6 +206,27 @@ describe("POST /api/device-quota/mapping/suggest", () => {
         status: "error",
         failureReason: "provider failed",
         durationMs: expect.any(Number),
+      })
+    )
+  })
+
+  test("preserves structured details for safe client errors", async () => {
+    assertSuggestionAccessMock.mockRejectedValueOnce(
+      Object.assign(new Error("Forbidden: facility scope denied"), {
+        status: 403,
+        details: { reason: "region_mismatch" },
+      })
+    )
+
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 18 }))
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        error: "Forbidden: facility scope denied",
+        details: { reason: "region_mismatch" },
+        requestId: expect.any(String),
       })
     )
   })

--- a/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import { NextRequest } from "next/server"
+
+const getServerSessionMock = vi.fn()
+vi.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
+}))
+
+vi.mock("@/auth/config", () => ({
+  authOptions: {},
+}))
+
+const assertSuggestionAccessMock = vi.fn()
+const runSuggestMappingMock = vi.fn()
+
+vi.mock("@/app/api/device-quota/mapping/suggest/suggestion-service", () => ({
+  assertSuggestionAccess: (...args: unknown[]) => assertSuggestionAccessMock(...args),
+  runSuggestMapping: (...args: unknown[]) => runSuggestMappingMock(...args),
+  SuggestionRouteError: class SuggestionRouteError extends Error {
+    status: number
+
+    constructor(message: string, status: number) {
+      super(message)
+      this.status = status
+    }
+  },
+}))
+
+const consoleInfoMock = vi.spyOn(console, "info").mockImplementation(() => {})
+const consoleErrorMock = vi.spyOn(console, "error").mockImplementation(() => {})
+
+function createRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/device-quota/mapping/suggest", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const SESSION = {
+  user: {
+    id: "42",
+    role: "to_qltb",
+    don_vi: "17",
+    dia_ban_id: null,
+  },
+}
+
+const PREVIEW_RESULT = {
+  groups: [
+    {
+      nhom_id: 10,
+      nhom_label: "May tho",
+      nhom_code: "A.01",
+      phan_loai: "Loai B",
+      rrf_score: 0.95,
+      device_names: ["May tho"],
+      device_ids: [1, 2],
+      device_name_to_ids: { "May tho": [1, 2] },
+    },
+  ],
+  unmatched: [],
+  totalDevices: 2,
+  matchedDevices: 2,
+}
+
+describe("POST /api/device-quota/mapping/suggest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSessionMock.mockResolvedValue(SESSION)
+    assertSuggestionAccessMock.mockResolvedValue(undefined)
+    runSuggestMappingMock.mockResolvedValue({
+      result: PREVIEW_RESULT,
+      itemCounts: { unassignedNames: 1, unassignedDevices: 2, categories: 3 },
+      catalogSignature: "catalog-123",
+    })
+  })
+
+  test("returns 401 before preview work when unauthenticated", async () => {
+    getServerSessionMock.mockResolvedValue(null)
+
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 17 }))
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ error: "Unauthorized", requestId: expect.any(String) })
+    )
+    expect(assertSuggestionAccessMock).not.toHaveBeenCalled()
+    expect(runSuggestMappingMock).not.toHaveBeenCalled()
+  })
+
+  test("returns 403 before preview provider work when facility scope is denied", async () => {
+    assertSuggestionAccessMock.mockRejectedValue(
+      Object.assign(new Error("Forbidden: facility scope denied"), { status: 403 })
+    )
+
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 18 }))
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        error: "Forbidden: facility scope denied",
+        requestId: expect.any(String),
+      })
+    )
+    expect(runSuggestMappingMock).not.toHaveBeenCalled()
+  })
+
+  test("invokes the Supabase provider once and preserves preview semantics", async () => {
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 17 }))
+
+    expect(response.status).toBe(200)
+    expect(runSuggestMappingMock).toHaveBeenCalledTimes(1)
+    expect(runSuggestMappingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        donViId: 17,
+        provider: "supabase",
+      })
+    )
+
+    const body = await response.json()
+    expect(body.result).toEqual(PREVIEW_RESULT)
+    expect(body.meta).toEqual(
+      expect.objectContaining({
+        provider: "supabase",
+        requestId: expect.any(String),
+        catalogSignature: "catalog-123",
+        itemCounts: { unassignedNames: 1, unassignedDevices: 2, categories: 3 },
+      })
+    )
+  })
+
+  test("logs request metadata without secrets on success and failure", async () => {
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    await POST(createRequest({ donViId: 17 }))
+
+    expect(consoleInfoMock).toHaveBeenCalledWith(
+      "[device-quota-suggest]",
+      expect.objectContaining({
+        requestId: expect.any(String),
+        donViId: 17,
+        role: "to_qltb",
+        provider: "supabase",
+        status: "success",
+        durationMs: expect.any(Number),
+      })
+    )
+
+    runSuggestMappingMock.mockRejectedValueOnce(new Error("provider failed"))
+    const failedResponse = await POST(createRequest({ donViId: 17 }))
+    expect(failedResponse.status).toBe(500)
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      "[device-quota-suggest]",
+      expect.objectContaining({
+        requestId: expect.any(String),
+        donViId: 17,
+        role: "to_qltb",
+        provider: "supabase",
+        status: "error",
+        failureReason: "provider failed",
+        durationMs: expect.any(Number),
+      })
+    )
+  })
+})

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
@@ -1,18 +1,46 @@
-import { describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, test, vi } from "vitest"
 
 import {
   assertSuggestionAccess,
   createCatalogSignature,
+  lookupAccessibleFacilityIds,
   mergeSuggestionResults,
+  runSuggestMapping,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-service"
 
+const fetchMock = vi.fn()
+vi.stubGlobal("fetch", fetchMock)
+
+const USER = {
+  id: "1",
+  role: "to_qltb",
+  don_vi: "17",
+  dia_ban_id: null,
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
 describe("device quota suggestion service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchMock.mockReset()
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.test")
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-key")
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key")
+    vi.stubEnv("SUPABASE_JWT_SECRET", "test-secret")
+  })
+
   test("denies restricted roles before provider work", async () => {
     await expect(
       assertSuggestionAccess(
         { id: "1", role: "technician", don_vi: "17", dia_ban_id: null },
         17,
-        { lookupFacilityRegionId: vi.fn() }
+        { lookupAccessibleFacilityIds: vi.fn() }
       )
     ).rejects.toMatchObject({ message: "Forbidden: insufficient role", status: 403 })
   })
@@ -22,37 +50,56 @@ describe("device quota suggestion service", () => {
       assertSuggestionAccess(
         { id: "1", role: "to_qltb", don_vi: "17", dia_ban_id: null },
         18,
-        { lookupFacilityRegionId: vi.fn() }
+        { lookupAccessibleFacilityIds: vi.fn() }
       )
     ).rejects.toMatchObject({ message: "Forbidden: facility scope denied", status: 403 })
   })
 
   test("allows admin through global role normalization", async () => {
-    const lookupFacilityRegionId = vi.fn()
+    const lookupAccessibleFacilityIds = vi.fn()
 
     await expect(
       assertSuggestionAccess(
         { id: "1", role: "admin", don_vi: null, dia_ban_id: null },
         18,
-        { lookupFacilityRegionId }
+        { lookupAccessibleFacilityIds }
       )
     ).resolves.toBeUndefined()
 
-    expect(lookupFacilityRegionId).not.toHaveBeenCalled()
+    expect(lookupAccessibleFacilityIds).not.toHaveBeenCalled()
   })
 
   test("checks regional leader facility scope by region", async () => {
-    const lookupFacilityRegionId = vi.fn().mockResolvedValue(7)
+    const lookupAccessibleFacilityIds = vi.fn().mockResolvedValue([7])
+    const user = { id: "1", role: "regional_leader", don_vi: null, dia_ban_id: "8" }
 
     await expect(
       assertSuggestionAccess(
-        { id: "1", role: "regional_leader", don_vi: null, dia_ban_id: "8" },
+        user,
         18,
-        { lookupFacilityRegionId }
+        { lookupAccessibleFacilityIds }
       )
     ).rejects.toMatchObject({ message: "Forbidden: facility scope denied", status: 403 })
 
-    expect(lookupFacilityRegionId).toHaveBeenCalledWith(18)
+    expect(lookupAccessibleFacilityIds).toHaveBeenCalledWith(user)
+  })
+
+  test("looks up accessible facilities through a signed RPC", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ id: 17, name: "Benh vien A" }]))
+
+    await expect(lookupAccessibleFacilityIds(USER)).resolves.toEqual([17])
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://supabase.test/rest/v1/rpc/get_accessible_facilities",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          apikey: "anon-key",
+          Authorization: expect.stringMatching(/^Bearer /),
+        }),
+        body: "{}",
+      })
+    )
   })
 
   test("merges provider search results into the existing preview shape", () => {
@@ -109,5 +156,39 @@ describe("device quota suggestion service", () => {
 
     expect(first).toBe(second)
     expect(first).toMatch(/^v1-/)
+  })
+
+  test("preserves structured RPC error details", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ message: "RPC policy denied", details: "{\"code\":\"42501\"}" }, 403)
+      )
+      .mockResolvedValueOnce(jsonResponse([]))
+
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "supabase", user: USER })
+    ).rejects.toMatchObject({
+      message: "RPC policy denied",
+      details: { code: "42501" },
+    })
+  })
+
+  test("fails before search when embedding response count is incomplete", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([
+          { ten_thiet_bi: "May tho", device_count: 1, device_ids: [1] },
+          { ten_thiet_bi: "Bom tiem", device_count: 1, device_ids: [2] },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ embeddings: [[0.1, 0.2]] }))
+      .mockResolvedValueOnce(jsonResponse([]))
+
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "supabase", user: USER })
+    ).rejects.toThrow("Embedding response count mismatch")
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test, vi } from "vitest"
+
+import {
+  assertSuggestionAccess,
+  createCatalogSignature,
+  mergeSuggestionResults,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-service"
+
+describe("device quota suggestion service", () => {
+  test("denies restricted roles before provider work", async () => {
+    await expect(
+      assertSuggestionAccess(
+        { id: "1", role: "technician", don_vi: "17", dia_ban_id: null },
+        17,
+        { lookupFacilityRegionId: vi.fn() }
+      )
+    ).rejects.toMatchObject({ message: "Forbidden: insufficient role", status: 403 })
+  })
+
+  test("denies tenant-scoped users requesting another facility", async () => {
+    await expect(
+      assertSuggestionAccess(
+        { id: "1", role: "to_qltb", don_vi: "17", dia_ban_id: null },
+        18,
+        { lookupFacilityRegionId: vi.fn() }
+      )
+    ).rejects.toMatchObject({ message: "Forbidden: facility scope denied", status: 403 })
+  })
+
+  test("allows admin through global role normalization", async () => {
+    const lookupFacilityRegionId = vi.fn()
+
+    await expect(
+      assertSuggestionAccess(
+        { id: "1", role: "admin", don_vi: null, dia_ban_id: null },
+        18,
+        { lookupFacilityRegionId }
+      )
+    ).resolves.toBeUndefined()
+
+    expect(lookupFacilityRegionId).not.toHaveBeenCalled()
+  })
+
+  test("checks regional leader facility scope by region", async () => {
+    const lookupFacilityRegionId = vi.fn().mockResolvedValue(7)
+
+    await expect(
+      assertSuggestionAccess(
+        { id: "1", role: "regional_leader", don_vi: null, dia_ban_id: "8" },
+        18,
+        { lookupFacilityRegionId }
+      )
+    ).rejects.toMatchObject({ message: "Forbidden: facility scope denied", status: 403 })
+
+    expect(lookupFacilityRegionId).toHaveBeenCalledWith(18)
+  })
+
+  test("merges provider search results into the existing preview shape", () => {
+    const result = mergeSuggestionResults(
+      [
+        { ten_thiet_bi: "May tho", device_count: 2, device_ids: [1, 2] },
+        { ten_thiet_bi: "Bom tiem", device_count: 1, device_ids: [3] },
+      ],
+      [
+        {
+          query_text: "May tho",
+          results: [
+            {
+              id: 10,
+              ten_nhom: "May tho chuc nang cao",
+              ma_nhom: "A.01",
+              phan_loai: "Loai B",
+              rrf_score: 0.95,
+            },
+          ],
+        },
+        { query_text: "Bom tiem", results: [] },
+      ]
+    )
+
+    expect(result).toEqual({
+      groups: [
+        {
+          nhom_id: 10,
+          nhom_label: "May tho chuc nang cao",
+          nhom_code: "A.01",
+          phan_loai: "Loai B",
+          rrf_score: 0.95,
+          device_names: ["May tho"],
+          device_ids: [1, 2],
+          device_name_to_ids: { "May tho": [1, 2] },
+        },
+      ],
+      unmatched: [{ device_name: "Bom tiem", device_ids: [3] }],
+      totalDevices: 3,
+      matchedDevices: 2,
+    })
+  })
+
+  test("creates deterministic catalog signatures", () => {
+    const first = createCatalogSignature([
+      { id: 2, ma_nhom: "B", ten_nhom: "Beta", phan_loai: null, tu_khoa: ["b"] },
+      { id: 1, ma_nhom: "A", ten_nhom: "Alpha", phan_loai: "Loai A", tu_khoa: ["a"] },
+    ])
+    const second = createCatalogSignature([
+      { id: 1, ma_nhom: "A", ten_nhom: "Alpha", phan_loai: "Loai A", tu_khoa: ["a"] },
+      { id: 2, ma_nhom: "B", ten_nhom: "Beta", phan_loai: null, tu_khoa: ["b"] },
+    ])
+
+    expect(first).toBe(second)
+    expect(first).toMatch(/^v1-/)
+  })
+})

--- a/src/app/api/device-quota/mapping/suggest/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/auth/config"
+import {
+  assertSuggestionAccess,
+  runSuggestMapping,
+  SuggestionRouteError,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-service"
+import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+export const runtime = "nodejs"
+
+const PROVIDER = "supabase"
+
+function createRequestId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `req-${Date.now().toString(36)}`
+}
+
+function parseDonViId(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return null
+  }
+  return value
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function getErrorStatus(error: unknown): number {
+  if (error instanceof SuggestionRouteError) return error.status
+  if (isRecord(error) && typeof error.status === "number") return error.status
+  return 500
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  if (isRecord(error) && typeof error.message === "string") return error.message
+  return "Internal server error"
+}
+
+function getUserRole(user: SuggestionAccessUser | null): string | null {
+  return typeof user?.role === "string" ? user.role.toLowerCase() : null
+}
+
+export async function POST(request: NextRequest) {
+  const requestId = createRequestId()
+  const startedAt = Date.now()
+  let donViId: number | null = null
+  let role: string | null = null
+
+  try {
+    const session = await getServerSession(authOptions)
+    const user = session?.user as SuggestionAccessUser | undefined
+    role = getUserRole(user ?? null)
+
+    if (!user?.id) {
+      return NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 })
+    }
+
+    const body = (await request.json()) as { donViId?: unknown }
+    donViId = parseDonViId(body.donViId)
+    if (donViId === null) {
+      return NextResponse.json(
+        { error: "donViId must be a positive integer", requestId },
+        { status: 400 },
+      )
+    }
+
+    await assertSuggestionAccess(user, donViId)
+    const providerResult = await runSuggestMapping({ donViId, provider: PROVIDER, user })
+    const durationMs = Date.now() - startedAt
+
+    console.info("[device-quota-suggest]", {
+      requestId,
+      donViId,
+      role,
+      provider: PROVIDER,
+      status: "success",
+      itemCounts: providerResult.itemCounts,
+      durationMs,
+    })
+
+    return NextResponse.json({
+      result: providerResult.result,
+      meta: {
+        requestId,
+        provider: PROVIDER,
+        itemCounts: providerResult.itemCounts,
+        catalogSignature: providerResult.catalogSignature,
+      },
+    })
+  } catch (error) {
+    const status = getErrorStatus(error)
+    const message = getErrorMessage(error)
+    const durationMs = Date.now() - startedAt
+
+    console.error("[device-quota-suggest]", {
+      requestId,
+      donViId,
+      role,
+      provider: PROVIDER,
+      status: "error",
+      failureReason: message,
+      durationMs,
+    })
+
+    return NextResponse.json({ error: message, requestId }, { status })
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/route.ts
@@ -42,6 +42,13 @@ function getErrorMessage(error: unknown): string {
   return "Internal server error"
 }
 
+function getErrorDetails(error: unknown): unknown {
+  if (isRecord(error) && Object.prototype.hasOwnProperty.call(error, "details")) {
+    return error.details
+  }
+  return undefined
+}
+
 function getUserRole(user: SuggestionAccessUser | null): string | null {
   return typeof user?.role === "string" ? user.role.toLowerCase() : null
 }
@@ -61,7 +68,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 })
     }
 
-    const body = (await request.json()) as { donViId?: unknown }
+    let body: { donViId?: unknown }
+    try {
+      body = (await request.json()) as { donViId?: unknown }
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body", requestId }, { status: 400 })
+    }
+
     donViId = parseDonViId(body.donViId)
     if (donViId === null) {
       return NextResponse.json(
@@ -95,7 +108,9 @@ export async function POST(request: NextRequest) {
     })
   } catch (error) {
     const status = getErrorStatus(error)
-    const message = getErrorMessage(error)
+    const failureReason = getErrorMessage(error)
+    const responseMessage = status >= 500 ? "Internal server error" : failureReason
+    const details = status >= 500 ? undefined : getErrorDetails(error)
     const durationMs = Date.now() - startedAt
 
     console.error("[device-quota-suggest]", {
@@ -104,10 +119,13 @@ export async function POST(request: NextRequest) {
       role,
       provider: PROVIDER,
       status: "error",
-      failureReason: message,
+      failureReason,
       durationMs,
     })
 
-    return NextResponse.json({ error: message, requestId }, { status })
+    return NextResponse.json(
+      { error: responseMessage, requestId, ...(details !== undefined ? { details } : {}) },
+      { status },
+    )
   }
 }

--- a/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
@@ -1,0 +1,335 @@
+import jwt from "jsonwebtoken"
+
+import { isGlobalRole, isRegionalLeaderRole } from "@/lib/rbac"
+import type {
+  CategoryCatalogItem,
+  DinhMucNhomRow,
+  SearchResult,
+  SuggestMappingResult,
+  SuggestedGroup,
+  SuggestionAccessUser,
+  SuggestionProvider,
+  SuggestionProviderResult,
+  UnassignedName,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+const CHUNK_SIZE = 10
+const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
+
+type AccessDeps = {
+  lookupFacilityRegionId: (donViId: number) => Promise<number | null>
+}
+
+export class SuggestionRouteError extends Error {
+  status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.status = status
+  }
+}
+
+function getEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing ${name}`)
+  return value
+}
+
+function toNumber(value: string | number | null | undefined): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null
+  if (typeof value !== "string" || value.trim() === "") return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function toRole(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase()
+}
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}
+
+export async function lookupFacilityRegionId(donViId: number): Promise<number | null> {
+  const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL")
+  const serviceRoleKey = getEnv("SUPABASE_SERVICE_ROLE_KEY")
+  const url = `${supabaseUrl}/rest/v1/don_vi?select=dia_ban_id&id=eq.${encodeURIComponent(String(donViId))}&limit=1`
+  const response = await fetch(url, {
+    headers: {
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+      Accept: "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Facility lookup failed (${response.status})`)
+  }
+
+  const rows = (await response.json()) as { dia_ban_id: number | null }[]
+  return rows[0]?.dia_ban_id ?? null
+}
+
+export async function assertSuggestionAccess(
+  user: SuggestionAccessUser,
+  donViId: number,
+  deps: AccessDeps = { lookupFacilityRegionId },
+): Promise<void> {
+  const role = toRole(user.role)
+
+  if (!["global", "admin", "to_qltb", "regional_leader"].includes(role)) {
+    throw new SuggestionRouteError("Forbidden: insufficient role", 403)
+  }
+
+  if (isGlobalRole(role)) {
+    return
+  }
+
+  if (isRegionalLeaderRole(role)) {
+    const userRegionId = toNumber(user.dia_ban_id)
+    if (userRegionId === null) {
+      throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
+    }
+
+    const facilityRegionId = await deps.lookupFacilityRegionId(donViId)
+    if (facilityRegionId !== userRegionId) {
+      throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
+    }
+    return
+  }
+
+  if (toNumber(user.don_vi) !== donViId) {
+    throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
+  }
+}
+
+function createSupabaseJwt(user: SuggestionAccessUser): string {
+  const role = toRole(user.role)
+  const appRole = role === "admin" ? "global" : role
+  const userId = user.id ? String(user.id) : ""
+  const now = Math.floor(Date.now() / 1000)
+  const issuedAt = now - SUPABASE_JWT_CLOCK_SKEW_SECONDS
+  const expiresAt = now + 120
+  const claims: Record<string, string | number | null> = {
+    role: "authenticated",
+    iat: issuedAt,
+    exp: expiresAt,
+    sub: userId,
+    app_role: appRole,
+    don_vi: user.don_vi ? String(user.don_vi) : null,
+    user_id: userId,
+    dia_ban: user.dia_ban_id ? String(user.dia_ban_id) : null,
+    khoa_phong: user.khoa_phong ?? null,
+  }
+
+  return jwt.sign(claims, getEnv("SUPABASE_JWT_SECRET"), { algorithm: "HS256" })
+}
+
+async function callSupabaseRpc<TRes>(
+  fn: string,
+  args: Record<string, unknown>,
+  user: SuggestionAccessUser,
+): Promise<TRes> {
+  const token = createSupabaseJwt(user)
+  const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL")
+  const response = await fetch(`${supabaseUrl}/rest/v1/rpc/${encodeURIComponent(fn)}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+      apikey: getEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    },
+    body: JSON.stringify(args),
+  })
+
+  if (!response.ok) {
+    let message = `RPC ${fn} failed (${response.status})`
+    try {
+      const payload = (await response.json()) as { message?: string; details?: string; hint?: string }
+      message = payload.message || payload.details || payload.hint || message
+    } catch {}
+    throw new Error(message)
+  }
+
+  return (await response.json()) as TRes
+}
+
+async function fetchEmbeddings(texts: string[]): Promise<number[][]> {
+  const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL")
+  const serviceRoleKey = getEnv("SUPABASE_SERVICE_ROLE_KEY")
+  const embeddings: number[][] = []
+
+  for (const chunk of chunkArray(texts, CHUNK_SIZE)) {
+    const response = await fetch(`${supabaseUrl}/functions/v1/embed-device-name`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${serviceRoleKey}`,
+      },
+      body: JSON.stringify({ texts: chunk }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Embedding generation failed (${response.status})`)
+    }
+
+    const body = (await response.json()) as { embeddings?: number[][] }
+    if (!Array.isArray(body.embeddings)) {
+      throw new Error("Invalid embedding response")
+    }
+    embeddings.push(...body.embeddings)
+  }
+
+  return embeddings
+}
+
+async function searchCategories(
+  queries: { text: string; embedding: number[] }[],
+  donViId: number,
+  user: SuggestionAccessUser,
+): Promise<SearchResult[]> {
+  const allResults: SearchResult[] = []
+  for (const chunk of chunkArray(queries, CHUNK_SIZE)) {
+    const p_queries = chunk.map((query) => ({
+      text: query.text,
+      embedding: query.embedding,
+    }))
+    const results = await callSupabaseRpc<SearchResult[]>(
+      "hybrid_search_category_batch",
+      { p_queries, p_don_vi: donViId },
+      user,
+    )
+    allResults.push(...(results ?? []))
+  }
+  return allResults
+}
+
+export function mergeSuggestionResults(
+  names: UnassignedName[],
+  searchResults: SearchResult[],
+): SuggestMappingResult {
+  const nameToDeviceInfo = new Map<string, UnassignedName>()
+  for (const name of names) {
+    nameToDeviceInfo.set(name.ten_thiet_bi, name)
+  }
+
+  const groupMap = new Map<number, SuggestedGroup>()
+  const unmatched: { device_name: string; device_ids: number[] }[] = []
+
+  for (const searchResult of searchResults) {
+    const nameInfo = nameToDeviceInfo.get(searchResult.query_text)
+    if (!nameInfo) continue
+
+    if (!searchResult.results || searchResult.results.length === 0) {
+      unmatched.push({
+        device_name: searchResult.query_text,
+        device_ids: nameInfo.device_ids,
+      })
+      continue
+    }
+
+    const best = searchResult.results[0]
+    const existing = groupMap.get(best.id)
+    if (existing) {
+      existing.device_ids.push(...nameInfo.device_ids)
+      if (!existing.device_names.includes(searchResult.query_text)) {
+        existing.device_names.push(searchResult.query_text)
+      }
+      existing.device_name_to_ids[searchResult.query_text] = [
+        ...(existing.device_name_to_ids[searchResult.query_text] ?? []),
+        ...nameInfo.device_ids,
+      ]
+      existing.rrf_score = Math.max(existing.rrf_score, best.rrf_score)
+    } else {
+      groupMap.set(best.id, {
+        nhom_id: best.id,
+        nhom_label: best.ten_nhom,
+        nhom_code: best.ma_nhom,
+        phan_loai: best.phan_loai,
+        rrf_score: best.rrf_score,
+        device_names: [searchResult.query_text],
+        device_ids: [...nameInfo.device_ids],
+        device_name_to_ids: { [searchResult.query_text]: [...nameInfo.device_ids] },
+      })
+    }
+  }
+
+  const groups = Array.from(groupMap.values()).sort(
+    (left, right) => right.device_ids.length - left.device_ids.length,
+  )
+  const matchedDevices = groups.reduce((sum, group) => sum + group.device_ids.length, 0)
+  const totalDevices = names.reduce((sum, name) => sum + name.device_ids.length, 0)
+
+  return { groups, unmatched, totalDevices, matchedDevices }
+}
+
+export function createCatalogSignature(categories: CategoryCatalogItem[]): string {
+  const normalized = categories
+    .map((category) => ({
+      id: category.id,
+      ma_nhom: category.ma_nhom ?? "",
+      ten_nhom: category.ten_nhom ?? "",
+      phan_loai: category.phan_loai ?? "",
+      tu_khoa: [...(category.tu_khoa ?? [])].sort((left, right) => left.localeCompare(right)),
+    }))
+    .sort((left, right) => left.id - right.id)
+
+  const input = JSON.stringify(normalized)
+  let hash = 5381
+  for (let i = 0; i < input.length; i += 1) {
+    hash = ((hash * 33) ^ input.charCodeAt(i)) >>> 0
+  }
+  return `v1-${normalized.length}-${hash.toString(36)}`
+}
+
+export async function runSuggestMapping({
+  donViId,
+  user,
+}: {
+  donViId: number
+  provider: SuggestionProvider
+  user: SuggestionAccessUser
+}): Promise<SuggestionProviderResult> {
+  const [names, categories] = await Promise.all([
+    callSupabaseRpc<UnassignedName[]>(
+      "dinh_muc_thiet_bi_unassigned_names",
+      { p_don_vi: donViId },
+      user,
+    ),
+    callSupabaseRpc<DinhMucNhomRow[]>("dinh_muc_nhom_list", { p_don_vi: donViId }, user),
+  ])
+
+  const catalogSignature = createCatalogSignature(categories)
+  const itemCounts = {
+    unassignedNames: names.length,
+    unassignedDevices: names.reduce((sum, name) => sum + name.device_ids.length, 0),
+    categories: categories.length,
+  }
+
+  if (names.length === 0) {
+    return {
+      result: { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 },
+      itemCounts,
+      catalogSignature,
+    }
+  }
+
+  const texts = names.map((name) => name.ten_thiet_bi)
+  const embeddings = await fetchEmbeddings(texts)
+  const searchResults = await searchCategories(
+    texts.map((text, index) => ({ text, embedding: embeddings[index] ?? [] })),
+    donViId,
+    user,
+  )
+
+  return {
+    result: mergeSuggestionResults(names, searchResults),
+    itemCounts,
+    catalogSignature,
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
@@ -17,15 +17,17 @@ const CHUNK_SIZE = 10
 const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
 
 type AccessDeps = {
-  lookupFacilityRegionId: (donViId: number) => Promise<number | null>
+  lookupAccessibleFacilityIds: (user: SuggestionAccessUser) => Promise<number[]>
 }
 
 export class SuggestionRouteError extends Error {
   status: number
+  details?: unknown
 
-  constructor(message: string, status: number) {
+  constructor(message: string, status: number, details?: unknown) {
     super(message)
     this.status = status
+    this.details = details
   }
 }
 
@@ -54,30 +56,48 @@ function chunkArray<T>(items: T[], size: number): T[][] {
   return chunks
 }
 
-export async function lookupFacilityRegionId(donViId: number): Promise<number | null> {
-  const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL")
-  const serviceRoleKey = getEnv("SUPABASE_SERVICE_ROLE_KEY")
-  const url = `${supabaseUrl}/rest/v1/don_vi?select=dia_ban_id&id=eq.${encodeURIComponent(String(donViId))}&limit=1`
-  const response = await fetch(url, {
-    headers: {
-      apikey: serviceRoleKey,
-      Authorization: `Bearer ${serviceRoleKey}`,
-      Accept: "application/json",
-    },
-  })
-
-  if (!response.ok) {
-    throw new Error(`Facility lookup failed (${response.status})`)
+function parseStructuredDetails(details: unknown): unknown {
+  if (typeof details !== "string") return details
+  try {
+    return JSON.parse(details) as unknown
+  } catch {
+    return details
   }
+}
 
-  const rows = (await response.json()) as { dia_ban_id: number | null }[]
-  return rows[0]?.dia_ban_id ?? null
+function getPayloadMessage(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return fallback
+  const record = payload as Record<string, unknown>
+  for (const key of ["message", "details", "hint"]) {
+    const value = record[key]
+    if (typeof value === "string" && value.trim() !== "") return value
+  }
+  return fallback
+}
+
+function getPayloadDetails(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined
+  const record = payload as Record<string, unknown>
+  return parseStructuredDetails(record.details)
+}
+
+export async function lookupAccessibleFacilityIds(user: SuggestionAccessUser): Promise<number[]> {
+  const rows = await callSupabaseRpc<unknown>("get_accessible_facilities", {}, user)
+  if (!Array.isArray(rows)) return []
+
+  const ids: number[] = []
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) continue
+    const id = toNumber((row as Record<string, unknown>).id as string | number | null | undefined)
+    if (id !== null) ids.push(id)
+  }
+  return ids
 }
 
 export async function assertSuggestionAccess(
   user: SuggestionAccessUser,
   donViId: number,
-  deps: AccessDeps = { lookupFacilityRegionId },
+  deps: AccessDeps = { lookupAccessibleFacilityIds },
 ): Promise<void> {
   const role = toRole(user.role)
 
@@ -95,8 +115,8 @@ export async function assertSuggestionAccess(
       throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
     }
 
-    const facilityRegionId = await deps.lookupFacilityRegionId(donViId)
-    if (facilityRegionId !== userRegionId) {
+    const accessibleFacilityIds = await deps.lookupAccessibleFacilityIds(user)
+    if (!accessibleFacilityIds.includes(donViId)) {
       throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
     }
     return
@@ -149,11 +169,13 @@ async function callSupabaseRpc<TRes>(
 
   if (!response.ok) {
     let message = `RPC ${fn} failed (${response.status})`
+    let details: unknown
     try {
-      const payload = (await response.json()) as { message?: string; details?: string; hint?: string }
-      message = payload.message || payload.details || payload.hint || message
+      const payload = (await response.json()) as unknown
+      details = getPayloadDetails(payload)
+      message = getPayloadMessage(payload, message)
     } catch {}
-    throw new Error(message)
+    throw new SuggestionRouteError(message, response.status, details)
   }
 
   return (await response.json()) as TRes
@@ -321,8 +343,13 @@ export async function runSuggestMapping({
 
   const texts = names.map((name) => name.ten_thiet_bi)
   const embeddings = await fetchEmbeddings(texts)
+  if (embeddings.length !== texts.length) {
+    throw new Error(
+      `Embedding response count mismatch: expected ${texts.length}, received ${embeddings.length}`,
+    )
+  }
   const searchResults = await searchCategories(
-    texts.map((text, index) => ({ text, embedding: embeddings[index] ?? [] })),
+    texts.map((text, index) => ({ text, embedding: embeddings[index]! })),
     donViId,
     user,
   )

--- a/src/app/api/device-quota/mapping/suggest/suggestion-types.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-types.ts
@@ -1,0 +1,70 @@
+export type SuggestionProvider = "supabase"
+
+export type SuggestionAccessUser = {
+  id?: string | number | null
+  role?: string | null
+  don_vi?: string | number | null
+  dia_ban_id?: string | number | null
+  khoa_phong?: string | null
+}
+
+export type SuggestedGroup = {
+  nhom_id: number
+  nhom_label: string
+  nhom_code: string
+  phan_loai: string | null
+  rrf_score: number
+  device_names: string[]
+  device_ids: number[]
+  device_name_to_ids: Record<string, number[]>
+}
+
+export type SuggestMappingResult = {
+  groups: SuggestedGroup[]
+  unmatched: { device_name: string; device_ids: number[] }[]
+  totalDevices: number
+  matchedDevices: number
+}
+
+export type SuggestionItemCounts = {
+  unassignedNames: number
+  unassignedDevices: number
+  categories: number
+}
+
+export type SuggestionProviderResult = {
+  result: SuggestMappingResult
+  itemCounts: SuggestionItemCounts
+  catalogSignature: string
+}
+
+export type UnassignedName = {
+  ten_thiet_bi: string
+  device_count: number
+  device_ids: number[]
+}
+
+export type SearchResult = {
+  query_text: string
+  results: {
+    id: number
+    ten_nhom: string
+    ma_nhom: string
+    phan_loai: string | null
+    rrf_score: number
+  }[]
+}
+
+export type CategoryCatalogItem = {
+  id: number
+  ma_nhom: string | null
+  ten_nhom: string | null
+  phan_loai: string | null
+  tu_khoa?: string[] | null
+}
+
+export type DinhMucNhomRow = CategoryCatalogItem & {
+  parent_id?: number | null
+  don_vi_tinh?: string | null
+  level?: number | null
+}


### PR DESCRIPTION
## Summary
- Add POST /api/device-quota/mapping/suggest as the server-side suggested-mapping integration point
- Move browser preview orchestration to one app-route request while preserving the preview result shape
- Keep the existing Supabase embedding/search provider as the Phase 1 compatibility baseline
- Add authorization/facility-scope/provider/error-shape coverage

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts 'src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts'
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

Closes #494
Refs #490

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a server-side suggestion route at POST `/api/device-quota/mapping/suggest` to generate device‑quota mapping previews. The browser now makes one request; the server handles auth, facility scope, Supabase orchestration, and returns the same preview shape plus request metadata and consistent errors (closes #494; refs #490).

- New Features
  - New route returns `{ result, meta }` with `requestId`, `provider`, `itemCounts`, and `catalogSignature`.
  - Strict auth and facility-scope checks (supports admin/regional leader) with 401/403 before provider work; 400s for invalid JSON or `donViId`, with safe structured `details` on 4xx.
  - Server orchestrates Supabase with a signed user JWT for RPCs and service-role embeddings, deterministic catalog signatures, and sanitized success/error logs with timings.

- Refactors
  - `useSuggestMapping` now calls the new route once; removes client RPC/embedding pipeline; preserves preview shape and statuses.
  - New service layer: `assertSuggestionAccess`, `mergeSuggestionResults`, `createCatalogSignature`; batched RPC/search via Supabase; added tests for auth, error details, logging, and embedding count mismatches.

<sup>Written for commit 5f42b5665dc47a272f3709bad441988547b30ab8. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/507?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side endpoint for device quota mapping suggestions, providing a streamlined experience.

* **Refactor**
  * Simplified suggestion workflow by consolidating multi-stage client-side operations into a single server call, improving performance and reliability.

* **Tests**
  * Added comprehensive test coverage for the new suggestion service, including authorization checks, error handling, and logging verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->