### PR TITLE
feat: add VM device quota suggestion provider

### DIFF
--- a/services/device-quota-suggestion-service/app/ranking.py
+++ b/services/device-quota-suggestion-service/app/ranking.py
@@ -24,6 +24,16 @@ def cosine_similarity(left: List[float], right: List[float]) -> float:
         return 0.0
     return max(0.0, min(1.0, dot / (left_norm * right_norm)))
 
+def normalize_vector(vector: List[float]) -> List[float]:
+    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
+    return [value / norm for value in vector]
+
+def normalized_dot_similarity(left: List[float], right: List[float]) -> float:
+    if not left or not right or len(left) != len(right):
+        return 0.0
+    dot = sum(a * b for a, b in zip(left, right))
+    return max(0.0, min(1.0, dot))
+
 
 def lexical_similarity(left: str, right: str) -> float:
     return lexical_similarity_normalized(
@@ -70,7 +80,7 @@ def rank_categories(
             device_normalized,
             category_vector.normalized_name,
         )
-        semantic = cosine_similarity(device_embedding, category_vector.embedding)
+        semantic = normalized_dot_similarity(device_embedding, category_vector.embedding)
         score = fused_score(lexical, semantic, options)
         ranked.append(
             {

--- a/services/device-quota-suggestion-service/app/service.py
+++ b/services/device-quota-suggestion-service/app/service.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple
 
 from app.embeddings import EmbeddingBackend
 from app.normalization import normalize_text
-from app.ranking import CategoryVector, needs_review, rank_categories
+from app.ranking import CategoryVector, needs_review, normalize_vector, rank_categories
 from app.schemas import CategoryItem, ResponseDict, SuggestRequest
 from app.settings import Settings
 
@@ -87,10 +87,11 @@ class SuggestionService:
         categories, category_hit = self._category_vectors(request)
         suggestions = []
         device_hits = 0
+        normalized_names = [normalize_text(item.name) for item in request.deviceNames]
+        device_embeddings = self._device_embeddings(normalized_names)
 
-        for item in request.deviceNames:
-            normalized_name = normalize_text(item.name)
-            embedding, hit = self._device_embedding(normalized_name)
+        for item, normalized_name in zip(request.deviceNames, normalized_names):
+            embedding, hit = device_embeddings[normalized_name]
             if hit:
                 device_hits += 1
             candidates = rank_categories(
@@ -152,7 +153,7 @@ class SuggestionService:
             CategoryVector(
                 category=category,
                 normalized_name=normalized_name,
-                embedding=embedding,
+                embedding=normalize_vector(embedding),
             )
             for category, normalized_name, embedding in zip(
                 request.categories,
@@ -164,23 +165,39 @@ class SuggestionService:
             self._category_embedding_cache[key] = vectors
         return vectors, False
 
-    def _device_embedding(self, normalized_name: str) -> Tuple[List[float], bool]:
-        key = self._device_key(normalized_name)
-        with self._lock:
-            cached = self._device_embedding_cache.get(key)
-            if cached is not None:
-                return cached, True
+    def _device_embeddings(
+        self,
+        normalized_names: List[str],
+    ) -> Dict[str, Tuple[List[float], bool]]:
+        unique_names = list(dict.fromkeys(normalized_names))
+        results: Dict[str, Tuple[List[float], bool]] = {}
+        missing_names: List[str] = []
 
-        embeddings = self.embedding_backend.embed([normalized_name])
-        if len(embeddings) != 1:
-            raise ValueError(
-                "Embedding response count mismatch: expected 1 device vector, received %d"
-                % len(embeddings)
-            )
-        embedding = embeddings[0]
         with self._lock:
-            self._device_embedding_cache[key] = embedding
-        return embedding, False
+            for normalized_name in unique_names:
+                key = self._device_key(normalized_name)
+                cached = self._device_embedding_cache.get(key)
+                if cached is not None:
+                    results[normalized_name] = (cached, True)
+                else:
+                    missing_names.append(normalized_name)
+
+        if not missing_names:
+            return results
+
+        embeddings = self.embedding_backend.embed(missing_names)
+        if len(embeddings) != len(missing_names):
+            raise ValueError(
+                "Embedding response count mismatch: expected %d device vectors, received %d"
+                % (len(missing_names), len(embeddings))
+            )
+
+        normalized_embeddings = [normalize_vector(embedding) for embedding in embeddings]
+        with self._lock:
+            for normalized_name, embedding in zip(missing_names, normalized_embeddings):
+                self._device_embedding_cache[self._device_key(normalized_name)] = embedding
+                results[normalized_name] = (embedding, False)
+        return results
 
     def _engine_signature(self) -> str:
         return "%s:%s:%s" % (

--- a/services/device-quota-suggestion-service/tests/test_smoke_load.py
+++ b/services/device-quota-suggestion-service/tests/test_smoke_load.py
@@ -1,3 +1,4 @@
+from app.embeddings import CountingEmbeddingBackend
 from app.embeddings import DeterministicEmbeddingBackend
 from app.service import SuggestionService
 
@@ -36,3 +37,37 @@ def test_service_handles_600_distinct_names_against_300_categories_without_oom()
     assert result["metrics"]["deviceNameCount"] == 600
     assert result["metrics"]["categoryCount"] == 300
     assert result["timings"]["totalMs"] >= 0
+
+def test_facility_sized_request_batches_device_embeddings():
+    categories = [
+        {
+            "id": index + 1,
+            "code": "CAT-%03d" % (index + 1),
+            "name": "Nhom thiet bi %03d" % (index + 1),
+            "classification": None,
+        }
+        for index in range(291)
+    ]
+    device_names = [
+        {
+            "name": "Thiet bi can phan loai %03d" % index,
+            "deviceIds": [index + 1],
+        }
+        for index in range(504)
+    ]
+    payload = {
+        "requestId": "req-facility-17-shape",
+        "facilityId": 17,
+        "catalogSignature": "catalog-facility-17",
+        "unassignedSignature": "unassigned-facility-17",
+        "deviceNames": device_names,
+        "categories": categories,
+        "options": {"topK": 3, "minConfidence": 0.10, "minMargin": 0.0},
+    }
+    backend = CountingEmbeddingBackend()
+    service = SuggestionService(embedding_backend=backend)
+
+    result = service.suggest(payload)
+
+    assert len(result["suggestions"]) == 504
+    assert backend.call_count == 2

--- a/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
@@ -75,6 +75,7 @@ const PREVIEW_RESULT = {
 describe("POST /api/device-quota/mapping/suggest", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
     getServerSessionMock.mockResolvedValue(SESSION)
     assertSuggestionAccessMock.mockResolvedValue(undefined)
     runSuggestMappingMock.mockResolvedValue({
@@ -171,6 +172,74 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     )
   })
 
+  test("selects the VM provider when explicitly configured", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_PROVIDER", "vm")
+
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 17 }))
+
+    expect(response.status).toBe(200)
+    expect(runSuggestMappingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        donViId: 17,
+        provider: "vm",
+      })
+    )
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          provider: "vm",
+        }),
+      })
+    )
+  })
+
+  test("uses VM only for canary allow-listed facilities", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_PROVIDER", "canary")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_CANARY_DON_VI_IDS", "17,21")
+
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 17 }))
+
+    expect(response.status).toBe(200)
+    expect(runSuggestMappingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        donViId: 17,
+        provider: "vm",
+      })
+    )
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          provider: "vm",
+        }),
+      })
+    )
+  })
+
+  test("keeps Supabase for canary facilities outside the allow-list", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_PROVIDER", "canary")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_CANARY_DON_VI_IDS", "17,21")
+
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 18 }))
+
+    expect(response.status).toBe(200)
+    expect(runSuggestMappingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        donViId: 18,
+        provider: "supabase",
+      })
+    )
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          provider: "supabase",
+        }),
+      })
+    )
+  })
+
   test("logs request metadata without secrets on success and failure", async () => {
     const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
     await POST(createRequest({ donViId: 17 }))
@@ -227,6 +296,31 @@ describe("POST /api/device-quota/mapping/suggest", () => {
         error: "Forbidden: facility scope denied",
         details: { reason: "region_mismatch" },
         requestId: expect.any(String),
+      })
+    )
+  })
+
+  test.each([
+    [429, "Suggestion request cooldown is active"],
+    [503, "VM suggestion provider circuit is open"],
+    [413, "VM suggestion payload is too large"],
+  ])("surfaces controlled %s suggestion errors to the client", async (status, message) => {
+    runSuggestMappingMock.mockRejectedValueOnce(
+      Object.assign(new Error(message), {
+        status,
+        details: { requestScope: "device-quota-suggest" },
+      })
+    )
+
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 17 }))
+
+    expect(response.status).toBe(status)
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        error: message,
+        requestId: expect.any(String),
+        details: { requestScope: "device-quota-suggest" },
       })
     )
   })

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
@@ -1,11 +1,19 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+const callVmSuggestMock = vi.hoisted(() => vi.fn())
+vi.mock("@/app/api/device-quota/mapping/suggest/suggestion-vm-client", () => ({
+  callVmSuggest: (...args: unknown[]) => callVmSuggestMock(...args),
+}))
 
 import {
   assertSuggestionAccess,
   createCatalogSignature,
+  getSuggestionRuntimeStateSizeForTests,
   lookupAccessibleFacilityIds,
   mergeSuggestionResults,
+  resetSuggestionRuntimeStateForTests,
   runSuggestMapping,
+  SuggestionRouteError,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-service"
 
 const fetchMock = vi.fn()
@@ -25,6 +33,49 @@ function jsonResponse(body: unknown, status = 200): Response {
   })
 }
 
+function queueVmCatalogResponses(times = 1): void {
+  for (let index = 0; index < times; index += 1) {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([{ ten_thiet_bi: "May tho", device_count: 2, device_ids: [1, 2] }])
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 10, ma_nhom: "A.01", ten_nhom: "May tho", phan_loai: null }])
+      )
+  }
+}
+
+function queueVmCatalogResponse({
+  names = [{ ten_thiet_bi: "May tho", device_count: 2, device_ids: [1, 2] }],
+  categories = [{ id: 10, ma_nhom: "A.01", ten_nhom: "May tho", phan_loai: null }],
+}: {
+  names?: unknown[]
+  categories?: unknown[]
+}): void {
+  fetchMock.mockResolvedValueOnce(jsonResponse(names)).mockResolvedValueOnce(jsonResponse(categories))
+}
+
+function successfulVmResponse() {
+  return {
+    requestId: "vm-req",
+    suggestions: [
+      {
+        deviceName: "May tho",
+        deviceIds: [1, 2],
+        candidates: [
+          {
+            categoryId: 10,
+            categoryCode: "A.01",
+            categoryName: "May tho",
+            classification: null,
+            score: 0.91,
+          },
+        ],
+      },
+    ],
+  }
+}
+
 describe("device quota suggestion service", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -33,6 +84,21 @@ describe("device quota suggestion service", () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-key")
     vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key")
     vi.stubEnv("SUPABASE_JWT_SECRET", "test-secret")
+    vi.stubEnv("DEVICE_QUOTA_VM_MAX_PAYLOAD_BYTES", "1000000")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_RESULT_CACHE_TTL_MS", "60000")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_RESULT_CACHE_MAX_ENTRIES", "200")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS", "10000")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_RATE_LIMIT_MAX", "3")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_RATE_LIMIT_WINDOW_MS", "60000")
+    vi.stubEnv("DEVICE_QUOTA_VM_CIRCUIT_THRESHOLD", "3")
+    vi.stubEnv("DEVICE_QUOTA_VM_CIRCUIT_WINDOW_MS", "60000")
+    vi.stubEnv("DEVICE_QUOTA_VM_CIRCUIT_OPEN_MS", "60000")
+    resetSuggestionRuntimeStateForTests()
+    callVmSuggestMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   test("denies restricted roles before provider work", async () => {
@@ -102,6 +168,28 @@ describe("device quota suggestion service", () => {
     )
   })
 
+  test("times out stalled Supabase RPC calls", async () => {
+    vi.useFakeTimers()
+    vi.stubEnv("SUPABASE_HTTP_TIMEOUT_MS", "5")
+    fetchMock.mockImplementationOnce((_url: string, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          const error = new Error("The operation was aborted")
+          error.name = "AbortError"
+          reject(error)
+        })
+      })
+    })
+
+    const pending = expect(lookupAccessibleFacilityIds(USER)).rejects.toMatchObject({
+      message: "Supabase RPC get_accessible_facilities timed out",
+      status: 503,
+    })
+    await vi.advanceTimersByTimeAsync(5)
+
+    await pending
+  })
+
   test("merges provider search results into the existing preview shape", () => {
     const result = mergeSuggestionResults(
       [
@@ -142,6 +230,29 @@ describe("device quota suggestion service", () => {
       totalDevices: 3,
       matchedDevices: 2,
     })
+  })
+
+  test("uses a null-prototype device-name map for dynamic device names", () => {
+    const result = mergeSuggestionResults(
+      [{ ten_thiet_bi: "__proto__", device_count: 1, device_ids: [99] }],
+      [
+        {
+          query_text: "__proto__",
+          results: [
+            {
+              id: 10,
+              ten_nhom: "Prototype literal",
+              ma_nhom: "A.01",
+              phan_loai: null,
+              rrf_score: 0.9,
+            },
+          ],
+        },
+      ]
+    )
+
+    expect(Object.getPrototypeOf(result.groups[0].device_name_to_ids)).toBeNull()
+    expect(result.groups[0].device_name_to_ids["__proto__"]).toEqual([99])
   })
 
   test("creates deterministic catalog signatures", () => {
@@ -190,5 +301,251 @@ describe("device quota suggestion service", () => {
     ).rejects.toThrow("Embedding response count mismatch")
 
     expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  test("bundles minimal VM payload and does not call Supabase embedding or hybrid search", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([{ ten_thiet_bi: "May tho", device_count: 2, device_ids: [1, 2] }])
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 10,
+            ma_nhom: "A.01",
+            ten_nhom: "May tho chuc nang cao",
+            phan_loai: "Loai B",
+            tu_khoa: ["icu"],
+            parent_id: null,
+          },
+        ])
+      )
+    callVmSuggestMock.mockResolvedValueOnce({
+      requestId: "vm-req",
+      suggestions: [
+        {
+          deviceName: "May tho",
+          deviceIds: [1, 2],
+          candidates: [
+            {
+              categoryId: 10,
+              categoryCode: "A.01",
+              categoryName: "May tho chuc nang cao",
+              classification: "Loai B",
+              score: 0.91,
+            },
+          ],
+        },
+      ],
+    })
+
+    const result = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+
+    expect(callVmSuggestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        facilityId: 17,
+        deviceNames: [{ name: "May tho", deviceIds: [1, 2] }],
+        categories: [
+          {
+            id: 10,
+            code: "A.01",
+            name: "May tho chuc nang cao",
+            classification: "Loai B",
+          },
+        ],
+        options: expect.objectContaining({ topK: 3 }),
+      })
+    )
+    const payload = callVmSuggestMock.mock.calls[0]?.[0] as Record<string, unknown>
+    expect(JSON.stringify(payload)).not.toContain("tu_khoa")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls.map((call) => String(call[0]))).not.toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("/functions/v1/embed-device-name"),
+        expect.stringContaining("hybrid_search_category_batch"),
+      ])
+    )
+    expect(result.result.groups).toEqual([
+      expect.objectContaining({
+        nhom_id: 10,
+        nhom_label: "May tho chuc nang cao",
+        device_ids: [1, 2],
+      }),
+    ])
+  })
+
+  test("rejects oversized VM payload before calling the VM service", async () => {
+    vi.stubEnv("DEVICE_QUOTA_VM_MAX_PAYLOAD_BYTES", "10")
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse([{ ten_thiet_bi: "May tho", device_count: 2, device_ids: [1, 2] }])
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 10, ma_nhom: "A.01", ten_nhom: "May tho", phan_loai: null }])
+      )
+
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({
+      message: "VM suggestion payload is too large",
+      status: 413,
+    })
+
+    expect(callVmSuggestMock).not.toHaveBeenCalled()
+  })
+
+  test("does not count local VM payload validation failures against the VM circuit", async () => {
+    vi.stubEnv("DEVICE_QUOTA_VM_MAX_PAYLOAD_BYTES", "10")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS", "0")
+    vi.stubEnv("DEVICE_QUOTA_VM_CIRCUIT_THRESHOLD", "1")
+    queueVmCatalogResponse({})
+    queueVmCatalogResponse({})
+
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({ status: 413 })
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({ status: 413 })
+
+    expect(callVmSuggestMock).not.toHaveBeenCalled()
+  })
+
+  test("opens the VM circuit after repeated failures without falling back to Supabase search", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS", "0")
+    vi.stubEnv("DEVICE_QUOTA_VM_CIRCUIT_THRESHOLD", "2")
+    queueVmCatalogResponses(3)
+    callVmSuggestMock.mockRejectedValue(
+      new SuggestionRouteError("VM suggestion provider request failed", 503)
+    )
+
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({ status: 503 })
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({ status: 503 })
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({
+      message: "VM suggestion provider circuit is open",
+      status: 503,
+    })
+
+    expect(callVmSuggestMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(6)
+    expect(fetchMock.mock.calls.map((call) => String(call[0]))).not.toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("/functions/v1/embed-device-name"),
+        expect.stringContaining("hybrid_search_category_batch"),
+      ])
+    )
+  })
+
+  test("serves VM result-cache hits before cooldown checks", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS", "60000")
+    queueVmCatalogResponses(2)
+    callVmSuggestMock.mockResolvedValue(successfulVmResponse())
+
+    const first = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    const second = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+
+    expect(second).toEqual(first)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(callVmSuggestMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not serve a VM result-cache hit when unassigned data changes", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS", "60000")
+    queueVmCatalogResponse({})
+    queueVmCatalogResponse({
+      names: [{ ten_thiet_bi: "May tho", device_count: 1, device_ids: [3] }],
+    })
+    callVmSuggestMock.mockResolvedValue(successfulVmResponse())
+
+    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(callVmSuggestMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("returns unmatched devices without calling VM when the category catalog is empty", async () => {
+    queueVmCatalogResponse({
+      categories: [],
+    })
+
+    const result = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+
+    expect(callVmSuggestMock).not.toHaveBeenCalled()
+    expect(result.result).toEqual({
+      groups: [],
+      unmatched: [{ device_name: "May tho", device_ids: [1, 2] }],
+      totalDevices: 2,
+      matchedDevices: 0,
+    })
+  })
+
+  test("returns cooldown 429 when a VM request is retried too quickly without a cache hit", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS", "60000")
+    queueVmCatalogResponses(2)
+    callVmSuggestMock.mockRejectedValueOnce(
+      new SuggestionRouteError("VM suggestion provider request failed", 503)
+    )
+
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({ status: 503 })
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({
+      message: "Suggestion request cooldown is active",
+      status: 429,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(callVmSuggestMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("returns burst rate-limit 429 for repeated uncached VM requests", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_RESULT_CACHE_TTL_MS", "0")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS", "0")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_RATE_LIMIT_MAX", "2")
+    queueVmCatalogResponses(3)
+    callVmSuggestMock.mockResolvedValue(successfulVmResponse())
+
+    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    await expect(
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    ).rejects.toMatchObject({
+      message: "Suggestion request rate limit exceeded",
+      status: 429,
+    })
+
+    expect(callVmSuggestMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("cleans expired throttle keys during later throttle checks", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-05-18T00:00:00Z"))
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_RESULT_CACHE_TTL_MS", "0")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS", "0")
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_RATE_LIMIT_WINDOW_MS", "1000")
+    queueVmCatalogResponse({})
+    queueVmCatalogResponse({})
+    callVmSuggestMock.mockResolvedValue(successfulVmResponse())
+
+    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    expect(getSuggestionRuntimeStateSizeForTests().throttleEntries).toBe(1)
+
+    vi.setSystemTime(new Date("2026-05-18T00:00:02Z"))
+    await runSuggestMapping({
+      donViId: 18,
+      provider: "vm",
+      user: { ...USER, id: "2", don_vi: "18" },
+    })
+
+    expect(getSuggestionRuntimeStateSizeForTests().throttleEntries).toBe(1)
   })
 })

--- a/src/app/api/device-quota/mapping/suggest/__tests__/vm-client.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/vm-client.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import {
+  callVmSuggest,
+  type VmSuggestRequest,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-vm-client"
+
+const fetchMock = vi.fn()
+vi.stubGlobal("fetch", fetchMock)
+
+const VM_REQUEST: VmSuggestRequest = {
+  requestId: "req-vm",
+  facilityId: 17,
+  catalogSignature: "catalog-1",
+  unassignedSignature: "unassigned-1",
+  deviceNames: [{ name: "May tho", deviceIds: [1, 2] }],
+  categories: [{ id: 10, code: "A.01", name: "May tho", classification: "Loai B" }],
+  options: { topK: 3 },
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("device quota VM suggestion client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    vi.stubEnv("DEVICE_QUOTA_VM_BASE_URL", "https://dqss.example.com/")
+    vi.stubEnv("DEVICE_QUOTA_VM_CF_ACCESS_CLIENT_ID", "cf-id")
+    vi.stubEnv("DEVICE_QUOTA_VM_CF_ACCESS_CLIENT_SECRET", "cf-secret")
+    vi.stubEnv("DQSS_INTERNAL_TOKEN", "internal-token")
+    vi.stubEnv("DEVICE_QUOTA_VM_TIMEOUT_MS", "8000")
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("posts to the VM suggest endpoint with Cloudflare Access and internal headers", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ requestId: "req-vm", suggestions: [] }))
+
+    await expect(callVmSuggest(VM_REQUEST)).resolves.toEqual({
+      requestId: "req-vm",
+      suggestions: [],
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://dqss.example.com/suggest",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "CF-Access-Client-Id": "cf-id",
+          "CF-Access-Client-Secret": "cf-secret",
+          "X-Internal-Token": "internal-token",
+          "X-Request-Id": "req-vm",
+        }),
+        body: JSON.stringify(VM_REQUEST),
+      }),
+    )
+  })
+
+  test("sanitizes structured VM 5xx errors before they reach clients", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "VM unavailable", details: { provider: "dqss" } }, 503),
+    )
+
+    await expect(callVmSuggest(VM_REQUEST)).rejects.toMatchObject({
+      message: "VM suggestion provider failed",
+      status: 503,
+      details: undefined,
+    })
+  })
+
+  test("preserves structured VM 4xx errors for controlled client handling", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "Payload rejected", details: { field: "deviceNames" } }, 422),
+    )
+
+    await expect(callVmSuggest(VM_REQUEST)).rejects.toMatchObject({
+      message: "Payload rejected",
+      status: 422,
+      details: { field: "deviceNames" },
+    })
+  })
+
+  test("maps network failures to a controlled 503", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("connect ECONNREFUSED"))
+
+    await expect(callVmSuggest(VM_REQUEST)).rejects.toMatchObject({
+      message: "VM suggestion provider request failed",
+      status: 503,
+    })
+  })
+
+  test("fails fast when required VM env is missing", async () => {
+    vi.stubEnv("DEVICE_QUOTA_VM_BASE_URL", "")
+
+    await expect(callVmSuggest(VM_REQUEST)).rejects.toThrow("Missing DEVICE_QUOTA_VM_BASE_URL")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("aborts slow VM requests with a controlled timeout", async () => {
+    vi.useFakeTimers()
+    vi.stubEnv("DEVICE_QUOTA_VM_TIMEOUT_MS", "5")
+    fetchMock.mockImplementationOnce((_url: string, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          const error = new Error("The operation was aborted")
+          error.name = "AbortError"
+          reject(error)
+        })
+      })
+    })
+
+    const pending = expect(callVmSuggest(VM_REQUEST)).rejects.toMatchObject({
+      message: "VM suggestion provider timed out",
+      status: 503,
+    })
+    await vi.advanceTimersByTimeAsync(5)
+
+    await pending
+  })
+})

--- a/src/app/api/device-quota/mapping/suggest/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/route.ts
@@ -7,11 +7,10 @@ import {
   runSuggestMapping,
   SuggestionRouteError,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-service"
+import { selectSuggestionProvider } from "@/app/api/device-quota/mapping/suggest/suggestion-config"
 import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 
 export const runtime = "nodejs"
-
-const PROVIDER = "supabase"
 
 function createRequestId(): string {
   return typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -49,6 +48,10 @@ function getErrorDetails(error: unknown): unknown {
   return undefined
 }
 
+function canExposeError(status: number): boolean {
+  return status < 500 || status === 503
+}
+
 function getUserRole(user: SuggestionAccessUser | null): string | null {
   return typeof user?.role === "string" ? user.role.toLowerCase() : null
 }
@@ -84,14 +87,21 @@ export async function POST(request: NextRequest) {
     }
 
     await assertSuggestionAccess(user, donViId)
-    const providerResult = await runSuggestMapping({ donViId, provider: PROVIDER, user })
+    const providerSelection = selectSuggestionProvider(donViId)
+    const providerResult = await runSuggestMapping({
+      donViId,
+      provider: providerSelection.provider,
+      requestId,
+      user,
+    })
     const durationMs = Date.now() - startedAt
 
     console.info("[device-quota-suggest]", {
       requestId,
       donViId,
       role,
-      provider: PROVIDER,
+      provider: providerSelection.provider,
+      providerPolicy: providerSelection.policy,
       status: "success",
       itemCounts: providerResult.itemCounts,
       durationMs,
@@ -101,7 +111,8 @@ export async function POST(request: NextRequest) {
       result: providerResult.result,
       meta: {
         requestId,
-        provider: PROVIDER,
+        provider: providerSelection.provider,
+        providerPolicy: providerSelection.policy,
         itemCounts: providerResult.itemCounts,
         catalogSignature: providerResult.catalogSignature,
       },
@@ -109,15 +120,16 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     const status = getErrorStatus(error)
     const failureReason = getErrorMessage(error)
-    const responseMessage = status >= 500 ? "Internal server error" : failureReason
-    const details = status >= 500 ? undefined : getErrorDetails(error)
+    const exposeError = canExposeError(status)
+    const responseMessage = exposeError ? failureReason : "Internal server error"
+    const details = exposeError ? getErrorDetails(error) : undefined
     const durationMs = Date.now() - startedAt
 
     console.error("[device-quota-suggest]", {
       requestId,
       donViId,
       role,
-      provider: PROVIDER,
+      provider: donViId === null ? "unknown" : selectSuggestionProvider(donViId).provider,
       status: "error",
       failureReason,
       durationMs,

--- a/src/app/api/device-quota/mapping/suggest/suggestion-config.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-config.ts
@@ -1,0 +1,53 @@
+import type {
+  SuggestionProvider,
+  SuggestionProviderMode,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+export type SuggestionProviderPolicy =
+  | "default"
+  | "explicit"
+  | "canary-allow-listed"
+  | "canary-supabase"
+
+export type SuggestionProviderSelection = {
+  configuredProvider: SuggestionProviderMode
+  provider: SuggestionProvider
+  policy: SuggestionProviderPolicy
+}
+
+function parseProviderMode(value: string | undefined): SuggestionProviderMode {
+  const normalized = (value ?? "supabase").trim().toLowerCase()
+  if (normalized === "vm" || normalized === "canary" || normalized === "supabase") {
+    return normalized
+  }
+  return "supabase"
+}
+
+function parseCanaryFacilityIds(value: string | undefined): Set<number> {
+  const ids = new Set<number>()
+  for (const raw of (value ?? "").split(",")) {
+    const parsed = Number(raw.trim())
+    if (Number.isInteger(parsed) && parsed > 0) ids.add(parsed)
+  }
+  return ids
+}
+
+export function selectSuggestionProvider(donViId: number): SuggestionProviderSelection {
+  const configuredProvider = parseProviderMode(process.env.DEVICE_QUOTA_SUGGESTION_PROVIDER)
+
+  if (configuredProvider === "vm") {
+    return { configuredProvider, provider: "vm", policy: "explicit" }
+  }
+
+  if (configuredProvider === "canary") {
+    const canaryFacilityIds = parseCanaryFacilityIds(
+      process.env.DEVICE_QUOTA_SUGGESTION_CANARY_DON_VI_IDS,
+    )
+    if (canaryFacilityIds.has(donViId)) {
+      return { configuredProvider, provider: "vm", policy: "canary-allow-listed" }
+    }
+    return { configuredProvider, provider: "supabase", policy: "canary-supabase" }
+  }
+
+  return { configuredProvider, provider: "supabase", policy: "default" }
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-errors.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-errors.ts
@@ -1,0 +1,35 @@
+export class SuggestionRouteError extends Error {
+  status: number
+  details?: unknown
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message)
+    this.status = status
+    this.details = details
+  }
+}
+
+export function parseStructuredDetails(details: unknown): unknown {
+  if (typeof details !== "string") return details
+  try {
+    return JSON.parse(details) as unknown
+  } catch {
+    return details
+  }
+}
+
+export function getPayloadMessage(payload: unknown, fallback: string): string {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return fallback
+  const record = payload as Record<string, unknown>
+  for (const key of ["message", "details", "hint"]) {
+    const value = record[key]
+    if (typeof value === "string" && value.trim() !== "") return value
+  }
+  return fallback
+}
+
+export function getPayloadDetails(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined
+  const record = payload as Record<string, unknown>
+  return parseStructuredDetails(record.details)
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-merge.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-merge.ts
@@ -1,0 +1,90 @@
+import type {
+  CategoryCatalogItem,
+  SearchResult,
+  SuggestMappingResult,
+  SuggestedGroup,
+  UnassignedName,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+export function mergeSuggestionResults(
+  names: UnassignedName[],
+  searchResults: SearchResult[],
+): SuggestMappingResult {
+  const nameToDeviceInfo = new Map<string, UnassignedName>()
+  for (const name of names) {
+    nameToDeviceInfo.set(name.ten_thiet_bi, name)
+  }
+
+  const groupMap = new Map<number, SuggestedGroup>()
+  const unmatched: { device_name: string; device_ids: number[] }[] = []
+
+  for (const searchResult of searchResults) {
+    const nameInfo = nameToDeviceInfo.get(searchResult.query_text)
+    if (!nameInfo) continue
+
+    if (!searchResult.results || searchResult.results.length === 0) {
+      unmatched.push({
+        device_name: searchResult.query_text,
+        device_ids: nameInfo.device_ids,
+      })
+      continue
+    }
+
+    const best = searchResult.results[0]
+    const existing = groupMap.get(best.id)
+    if (existing) {
+      existing.device_ids.push(...nameInfo.device_ids)
+      if (!existing.device_names.includes(searchResult.query_text)) {
+        existing.device_names.push(searchResult.query_text)
+      }
+      existing.device_name_to_ids[searchResult.query_text] = [
+        ...(existing.device_name_to_ids[searchResult.query_text] ?? []),
+        ...nameInfo.device_ids,
+      ]
+      existing.rrf_score = Math.max(existing.rrf_score, best.rrf_score)
+    } else {
+      const deviceNameToIds: Record<string, number[]> = Object.create(null) as Record<
+        string,
+        number[]
+      >
+      deviceNameToIds[searchResult.query_text] = [...nameInfo.device_ids]
+      groupMap.set(best.id, {
+        nhom_id: best.id,
+        nhom_label: best.ten_nhom,
+        nhom_code: best.ma_nhom,
+        phan_loai: best.phan_loai,
+        rrf_score: best.rrf_score,
+        device_names: [searchResult.query_text],
+        device_ids: [...nameInfo.device_ids],
+        device_name_to_ids: deviceNameToIds,
+      })
+    }
+  }
+
+  const groups = Array.from(groupMap.values()).sort(
+    (left, right) => right.device_ids.length - left.device_ids.length,
+  )
+  const matchedDevices = groups.reduce((sum, group) => sum + group.device_ids.length, 0)
+  const totalDevices = names.reduce((sum, name) => sum + name.device_ids.length, 0)
+
+  return { groups, unmatched, totalDevices, matchedDevices }
+}
+
+export function createCatalogSignature(categories: CategoryCatalogItem[]): string {
+  const normalized = categories
+    .map((category) => ({
+      id: category.id,
+      ma_nhom: category.ma_nhom ?? "",
+      ten_nhom: category.ten_nhom ?? "",
+      phan_loai: category.phan_loai ?? "",
+      tu_khoa: [...(category.tu_khoa ?? [])].sort((left, right) => left.localeCompare(right)),
+    }))
+    .sort((left, right) => left.id - right.id)
+
+  const input = JSON.stringify(normalized)
+  let hash = 5381
+  for (let i = 0; i < input.length; i += 1) {
+    hash = ((hash * 33) ^ input.charCodeAt(i)) >>> 0
+  }
+  return `v1-${normalized.length}-${hash.toString(36)}`
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
@@ -1,362 +1,44 @@
-import jwt from "jsonwebtoken"
-
-import { isGlobalRole, isRegionalLeaderRole } from "@/lib/rbac"
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { createCatalogSignature, mergeSuggestionResults } from "@/app/api/device-quota/mapping/suggest/suggestion-merge"
+import {
+  assertSuggestionAccess,
+  lookupAccessibleFacilityIds,
+  runSupabaseSuggestMapping,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-supabase-provider"
+import {
+  getSuggestionRuntimeStateSizeForTests,
+  resetSuggestionRuntimeStateForTests,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-traffic-control"
+import { runVmSuggestMapping } from "@/app/api/device-quota/mapping/suggest/suggestion-vm-provider"
 import type {
-  CategoryCatalogItem,
-  DinhMucNhomRow,
-  SearchResult,
-  SuggestMappingResult,
-  SuggestedGroup,
   SuggestionAccessUser,
   SuggestionProvider,
   SuggestionProviderResult,
-  UnassignedName,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 
-const CHUNK_SIZE = 10
-const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
-
-type AccessDeps = {
-  lookupAccessibleFacilityIds: (user: SuggestionAccessUser) => Promise<number[]>
-}
-
-export class SuggestionRouteError extends Error {
-  status: number
-  details?: unknown
-
-  constructor(message: string, status: number, details?: unknown) {
-    super(message)
-    this.status = status
-    this.details = details
-  }
-}
-
-function getEnv(name: string): string {
-  const value = process.env[name]
-  if (!value) throw new Error(`Missing ${name}`)
-  return value
-}
-
-function toNumber(value: string | number | null | undefined): number | null {
-  if (typeof value === "number") return Number.isFinite(value) ? value : null
-  if (typeof value !== "string" || value.trim() === "") return null
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : null
-}
-
-function toRole(value: string | null | undefined): string {
-  return (value ?? "").trim().toLowerCase()
-}
-
-function chunkArray<T>(items: T[], size: number): T[][] {
-  const chunks: T[][] = []
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size))
-  }
-  return chunks
-}
-
-function parseStructuredDetails(details: unknown): unknown {
-  if (typeof details !== "string") return details
-  try {
-    return JSON.parse(details) as unknown
-  } catch {
-    return details
-  }
-}
-
-function getPayloadMessage(payload: unknown, fallback: string): string {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return fallback
-  const record = payload as Record<string, unknown>
-  for (const key of ["message", "details", "hint"]) {
-    const value = record[key]
-    if (typeof value === "string" && value.trim() !== "") return value
-  }
-  return fallback
-}
-
-function getPayloadDetails(payload: unknown): unknown {
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined
-  const record = payload as Record<string, unknown>
-  return parseStructuredDetails(record.details)
-}
-
-export async function lookupAccessibleFacilityIds(user: SuggestionAccessUser): Promise<number[]> {
-  const rows = await callSupabaseRpc<unknown>("get_accessible_facilities", {}, user)
-  if (!Array.isArray(rows)) return []
-
-  const ids: number[] = []
-  for (const row of rows) {
-    if (!row || typeof row !== "object" || Array.isArray(row)) continue
-    const id = toNumber((row as Record<string, unknown>).id as string | number | null | undefined)
-    if (id !== null) ids.push(id)
-  }
-  return ids
-}
-
-export async function assertSuggestionAccess(
-  user: SuggestionAccessUser,
-  donViId: number,
-  deps: AccessDeps = { lookupAccessibleFacilityIds },
-): Promise<void> {
-  const role = toRole(user.role)
-
-  if (!["global", "admin", "to_qltb", "regional_leader"].includes(role)) {
-    throw new SuggestionRouteError("Forbidden: insufficient role", 403)
-  }
-
-  if (isGlobalRole(role)) {
-    return
-  }
-
-  if (isRegionalLeaderRole(role)) {
-    const userRegionId = toNumber(user.dia_ban_id)
-    if (userRegionId === null) {
-      throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
-    }
-
-    const accessibleFacilityIds = await deps.lookupAccessibleFacilityIds(user)
-    if (!accessibleFacilityIds.includes(donViId)) {
-      throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
-    }
-    return
-  }
-
-  if (toNumber(user.don_vi) !== donViId) {
-    throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
-  }
-}
-
-function createSupabaseJwt(user: SuggestionAccessUser): string {
-  const role = toRole(user.role)
-  const appRole = role === "admin" ? "global" : role
-  const userId = user.id ? String(user.id) : ""
-  const now = Math.floor(Date.now() / 1000)
-  const issuedAt = now - SUPABASE_JWT_CLOCK_SKEW_SECONDS
-  const expiresAt = now + 120
-  const claims: Record<string, string | number | null> = {
-    role: "authenticated",
-    iat: issuedAt,
-    exp: expiresAt,
-    sub: userId,
-    app_role: appRole,
-    don_vi: user.don_vi ? String(user.don_vi) : null,
-    user_id: userId,
-    dia_ban: user.dia_ban_id ? String(user.dia_ban_id) : null,
-    khoa_phong: user.khoa_phong ?? null,
-  }
-
-  return jwt.sign(claims, getEnv("SUPABASE_JWT_SECRET"), { algorithm: "HS256" })
-}
-
-async function callSupabaseRpc<TRes>(
-  fn: string,
-  args: Record<string, unknown>,
-  user: SuggestionAccessUser,
-): Promise<TRes> {
-  const token = createSupabaseJwt(user)
-  const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL")
-  const response = await fetch(`${supabaseUrl}/rest/v1/rpc/${encodeURIComponent(fn)}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-      apikey: getEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
-    },
-    body: JSON.stringify(args),
-  })
-
-  if (!response.ok) {
-    let message = `RPC ${fn} failed (${response.status})`
-    let details: unknown
-    try {
-      const payload = (await response.json()) as unknown
-      details = getPayloadDetails(payload)
-      message = getPayloadMessage(payload, message)
-    } catch {}
-    throw new SuggestionRouteError(message, response.status, details)
-  }
-
-  return (await response.json()) as TRes
-}
-
-async function fetchEmbeddings(texts: string[]): Promise<number[][]> {
-  const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL")
-  const serviceRoleKey = getEnv("SUPABASE_SERVICE_ROLE_KEY")
-  const embeddings: number[][] = []
-
-  for (const chunk of chunkArray(texts, CHUNK_SIZE)) {
-    const response = await fetch(`${supabaseUrl}/functions/v1/embed-device-name`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${serviceRoleKey}`,
-      },
-      body: JSON.stringify({ texts: chunk }),
-    })
-
-    if (!response.ok) {
-      throw new Error(`Embedding generation failed (${response.status})`)
-    }
-
-    const body = (await response.json()) as { embeddings?: number[][] }
-    if (!Array.isArray(body.embeddings)) {
-      throw new Error("Invalid embedding response")
-    }
-    embeddings.push(...body.embeddings)
-  }
-
-  return embeddings
-}
-
-async function searchCategories(
-  queries: { text: string; embedding: number[] }[],
-  donViId: number,
-  user: SuggestionAccessUser,
-): Promise<SearchResult[]> {
-  const allResults: SearchResult[] = []
-  for (const chunk of chunkArray(queries, CHUNK_SIZE)) {
-    const p_queries = chunk.map((query) => ({
-      text: query.text,
-      embedding: query.embedding,
-    }))
-    const results = await callSupabaseRpc<SearchResult[]>(
-      "hybrid_search_category_batch",
-      { p_queries, p_don_vi: donViId },
-      user,
-    )
-    allResults.push(...(results ?? []))
-  }
-  return allResults
-}
-
-export function mergeSuggestionResults(
-  names: UnassignedName[],
-  searchResults: SearchResult[],
-): SuggestMappingResult {
-  const nameToDeviceInfo = new Map<string, UnassignedName>()
-  for (const name of names) {
-    nameToDeviceInfo.set(name.ten_thiet_bi, name)
-  }
-
-  const groupMap = new Map<number, SuggestedGroup>()
-  const unmatched: { device_name: string; device_ids: number[] }[] = []
-
-  for (const searchResult of searchResults) {
-    const nameInfo = nameToDeviceInfo.get(searchResult.query_text)
-    if (!nameInfo) continue
-
-    if (!searchResult.results || searchResult.results.length === 0) {
-      unmatched.push({
-        device_name: searchResult.query_text,
-        device_ids: nameInfo.device_ids,
-      })
-      continue
-    }
-
-    const best = searchResult.results[0]
-    const existing = groupMap.get(best.id)
-    if (existing) {
-      existing.device_ids.push(...nameInfo.device_ids)
-      if (!existing.device_names.includes(searchResult.query_text)) {
-        existing.device_names.push(searchResult.query_text)
-      }
-      existing.device_name_to_ids[searchResult.query_text] = [
-        ...(existing.device_name_to_ids[searchResult.query_text] ?? []),
-        ...nameInfo.device_ids,
-      ]
-      existing.rrf_score = Math.max(existing.rrf_score, best.rrf_score)
-    } else {
-      groupMap.set(best.id, {
-        nhom_id: best.id,
-        nhom_label: best.ten_nhom,
-        nhom_code: best.ma_nhom,
-        phan_loai: best.phan_loai,
-        rrf_score: best.rrf_score,
-        device_names: [searchResult.query_text],
-        device_ids: [...nameInfo.device_ids],
-        device_name_to_ids: { [searchResult.query_text]: [...nameInfo.device_ids] },
-      })
-    }
-  }
-
-  const groups = Array.from(groupMap.values()).sort(
-    (left, right) => right.device_ids.length - left.device_ids.length,
-  )
-  const matchedDevices = groups.reduce((sum, group) => sum + group.device_ids.length, 0)
-  const totalDevices = names.reduce((sum, name) => sum + name.device_ids.length, 0)
-
-  return { groups, unmatched, totalDevices, matchedDevices }
-}
-
-export function createCatalogSignature(categories: CategoryCatalogItem[]): string {
-  const normalized = categories
-    .map((category) => ({
-      id: category.id,
-      ma_nhom: category.ma_nhom ?? "",
-      ten_nhom: category.ten_nhom ?? "",
-      phan_loai: category.phan_loai ?? "",
-      tu_khoa: [...(category.tu_khoa ?? [])].sort((left, right) => left.localeCompare(right)),
-    }))
-    .sort((left, right) => left.id - right.id)
-
-  const input = JSON.stringify(normalized)
-  let hash = 5381
-  for (let i = 0; i < input.length; i += 1) {
-    hash = ((hash * 33) ^ input.charCodeAt(i)) >>> 0
-  }
-  return `v1-${normalized.length}-${hash.toString(36)}`
-}
+export { SuggestionRouteError }
+export { createCatalogSignature, mergeSuggestionResults }
+export { assertSuggestionAccess, lookupAccessibleFacilityIds }
+export { getSuggestionRuntimeStateSizeForTests, resetSuggestionRuntimeStateForTests }
 
 export async function runSuggestMapping({
   donViId,
+  provider,
+  requestId,
   user,
 }: {
   donViId: number
   provider: SuggestionProvider
+  requestId?: string
   user: SuggestionAccessUser
 }): Promise<SuggestionProviderResult> {
-  const [names, categories] = await Promise.all([
-    callSupabaseRpc<UnassignedName[]>(
-      "dinh_muc_thiet_bi_unassigned_names",
-      { p_don_vi: donViId },
-      user,
-    ),
-    callSupabaseRpc<DinhMucNhomRow[]>("dinh_muc_nhom_list", { p_don_vi: donViId }, user),
-  ])
-
-  const catalogSignature = createCatalogSignature(categories)
-  const itemCounts = {
-    unassignedNames: names.length,
-    unassignedDevices: names.reduce((sum, name) => sum + name.device_ids.length, 0),
-    categories: categories.length,
+  if (provider === "supabase") {
+    return runSupabaseSuggestMapping({ donViId, user })
   }
 
-  if (names.length === 0) {
-    return {
-      result: { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 },
-      itemCounts,
-      catalogSignature,
-    }
-  }
-
-  const texts = names.map((name) => name.ten_thiet_bi)
-  const embeddings = await fetchEmbeddings(texts)
-  if (embeddings.length !== texts.length) {
-    throw new Error(
-      `Embedding response count mismatch: expected ${texts.length}, received ${embeddings.length}`,
-    )
-  }
-  const searchResults = await searchCategories(
-    texts.map((text, index) => ({ text, embedding: embeddings[index]! })),
+  return runVmSuggestMapping({
     donViId,
+    requestId: requestId ?? `dqss-${Date.now().toString(36)}`,
     user,
-  )
-
-  return {
-    result: mergeSuggestionResults(names, searchResults),
-    itemCounts,
-    catalogSignature,
-  }
+  })
 }

--- a/src/app/api/device-quota/mapping/suggest/suggestion-supabase-provider.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-supabase-provider.ts
@@ -1,0 +1,279 @@
+import jwt from "jsonwebtoken"
+
+import { isGlobalRole, isRegionalLeaderRole } from "@/lib/rbac"
+import {
+  getPayloadDetails,
+  getPayloadMessage,
+  SuggestionRouteError,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { createCatalogSignature, mergeSuggestionResults } from "@/app/api/device-quota/mapping/suggest/suggestion-merge"
+import type {
+  DinhMucNhomRow,
+  SearchResult,
+  SuggestionAccessUser,
+  SuggestionProviderResult,
+  UnassignedName,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+import {
+  chunkArray,
+  getRequiredEnv,
+  SUPABASE_SEARCH_CHUNK_SIZE,
+  toNumber,
+  toRole,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-utils"
+
+const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
+const DEFAULT_SUPABASE_HTTP_TIMEOUT_MS = 8000
+
+type AccessDeps = {
+  lookupAccessibleFacilityIds: (user: SuggestionAccessUser) => Promise<number[]>
+}
+
+function createSupabaseJwt(user: SuggestionAccessUser): string {
+  const role = toRole(user.role)
+  const appRole = role === "admin" ? "global" : role
+  const userId = user.id ? String(user.id) : ""
+  const now = Math.floor(Date.now() / 1000)
+  const issuedAt = now - SUPABASE_JWT_CLOCK_SKEW_SECONDS
+  const expiresAt = now + 120
+  const claims: Record<string, string | number | null> = {
+    role: "authenticated",
+    iat: issuedAt,
+    exp: expiresAt,
+    sub: userId,
+    app_role: appRole,
+    don_vi: user.don_vi ? String(user.don_vi) : null,
+    user_id: userId,
+    dia_ban: user.dia_ban_id ? String(user.dia_ban_id) : null,
+    khoa_phong: user.khoa_phong ?? null,
+  }
+
+  return jwt.sign(claims, getRequiredEnv("SUPABASE_JWT_SECRET"), { algorithm: "HS256" })
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function getSupabaseHttpTimeoutMs(): number {
+  return parsePositiveInteger(process.env.SUPABASE_HTTP_TIMEOUT_MS, DEFAULT_SUPABASE_HTTP_TIMEOUT_MS)
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError"
+}
+
+async function fetchWithTimeout(
+  input: string,
+  init: RequestInit,
+  timeoutMessage: string,
+): Promise<Response> {
+  const controller = new AbortController()
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, getSupabaseHttpTimeoutMs())
+
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: controller.signal,
+    })
+  } catch (error) {
+    if (timedOut || isAbortError(error)) {
+      throw new SuggestionRouteError(timeoutMessage, 503)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export async function callSupabaseRpc<TRes>(
+  fn: string,
+  args: Record<string, unknown>,
+  user: SuggestionAccessUser,
+): Promise<TRes> {
+  const token = createSupabaseJwt(user)
+  const supabaseUrl = getRequiredEnv("NEXT_PUBLIC_SUPABASE_URL")
+  const response = await fetchWithTimeout(
+    `${supabaseUrl}/rest/v1/rpc/${encodeURIComponent(fn)}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        apikey: getRequiredEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+      },
+      body: JSON.stringify(args),
+    },
+    `Supabase RPC ${fn} timed out`,
+  )
+
+  if (!response.ok) {
+    let message = `RPC ${fn} failed (${response.status})`
+    let details: unknown
+    try {
+      const payload = (await response.json()) as unknown
+      details = getPayloadDetails(payload)
+      message = getPayloadMessage(payload, message)
+    } catch {}
+    throw new SuggestionRouteError(message, response.status, details)
+  }
+
+  return (await response.json()) as TRes
+}
+
+export async function lookupAccessibleFacilityIds(user: SuggestionAccessUser): Promise<number[]> {
+  const rows = await callSupabaseRpc<unknown>("get_accessible_facilities", {}, user)
+  if (!Array.isArray(rows)) return []
+
+  const ids: number[] = []
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) continue
+    const id = toNumber((row as Record<string, unknown>).id as string | number | null | undefined)
+    if (id !== null) ids.push(id)
+  }
+  return ids
+}
+
+export async function assertSuggestionAccess(
+  user: SuggestionAccessUser,
+  donViId: number,
+  deps: AccessDeps = { lookupAccessibleFacilityIds },
+): Promise<void> {
+  const role = toRole(user.role)
+
+  if (!["global", "admin", "to_qltb", "regional_leader"].includes(role)) {
+    throw new SuggestionRouteError("Forbidden: insufficient role", 403)
+  }
+
+  if (isGlobalRole(role)) {
+    return
+  }
+
+  if (isRegionalLeaderRole(role)) {
+    const userRegionId = toNumber(user.dia_ban_id)
+    if (userRegionId === null) {
+      throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
+    }
+
+    const accessibleFacilityIds = await deps.lookupAccessibleFacilityIds(user)
+    if (!accessibleFacilityIds.includes(donViId)) {
+      throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
+    }
+    return
+  }
+
+  if (toNumber(user.don_vi) !== donViId) {
+    throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
+  }
+}
+
+async function fetchEmbeddings(texts: string[]): Promise<number[][]> {
+  const supabaseUrl = getRequiredEnv("NEXT_PUBLIC_SUPABASE_URL")
+  const serviceRoleKey = getRequiredEnv("SUPABASE_SERVICE_ROLE_KEY")
+  const embeddings: number[][] = []
+
+  for (const chunk of chunkArray(texts, SUPABASE_SEARCH_CHUNK_SIZE)) {
+    const response = await fetchWithTimeout(
+      `${supabaseUrl}/functions/v1/embed-device-name`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${serviceRoleKey}`,
+        },
+        body: JSON.stringify({ texts: chunk }),
+      },
+      "Supabase embedding generation timed out",
+    )
+
+    if (!response.ok) {
+      throw new Error(`Embedding generation failed (${response.status})`)
+    }
+
+    const body = (await response.json()) as { embeddings?: number[][] }
+    if (!Array.isArray(body.embeddings)) {
+      throw new Error("Invalid embedding response")
+    }
+    embeddings.push(...body.embeddings)
+  }
+
+  return embeddings
+}
+
+async function searchCategories(
+  queries: { text: string; embedding: number[] }[],
+  donViId: number,
+  user: SuggestionAccessUser,
+): Promise<SearchResult[]> {
+  const allResults: SearchResult[] = []
+  for (const chunk of chunkArray(queries, SUPABASE_SEARCH_CHUNK_SIZE)) {
+    const p_queries = chunk.map((query) => ({
+      text: query.text,
+      embedding: query.embedding,
+    }))
+    const results = await callSupabaseRpc<SearchResult[]>(
+      "hybrid_search_category_batch",
+      { p_queries, p_don_vi: donViId },
+      user,
+    )
+    allResults.push(...(results ?? []))
+  }
+  return allResults
+}
+
+export async function runSupabaseSuggestMapping({
+  donViId,
+  user,
+}: {
+  donViId: number
+  user: SuggestionAccessUser
+}): Promise<SuggestionProviderResult> {
+  const [names, categories] = await Promise.all([
+    callSupabaseRpc<UnassignedName[]>(
+      "dinh_muc_thiet_bi_unassigned_names",
+      { p_don_vi: donViId },
+      user,
+    ),
+    callSupabaseRpc<DinhMucNhomRow[]>("dinh_muc_nhom_list", { p_don_vi: donViId }, user),
+  ])
+
+  const catalogSignature = createCatalogSignature(categories)
+  const itemCounts = {
+    unassignedNames: names.length,
+    unassignedDevices: names.reduce((sum, name) => sum + name.device_ids.length, 0),
+    categories: categories.length,
+  }
+
+  if (names.length === 0) {
+    return {
+      result: { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 },
+      itemCounts,
+      catalogSignature,
+    }
+  }
+
+  const texts = names.map((name) => name.ten_thiet_bi)
+  const embeddings = await fetchEmbeddings(texts)
+  if (embeddings.length !== texts.length) {
+    throw new Error(
+      `Embedding response count mismatch: expected ${texts.length}, received ${embeddings.length}`,
+    )
+  }
+  const searchResults = await searchCategories(
+    texts.map((text, index) => ({ text, embedding: embeddings[index]! })),
+    donViId,
+    user,
+  )
+
+  return {
+    result: mergeSuggestionResults(names, searchResults),
+    itemCounts,
+    catalogSignature,
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-traffic-control.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-traffic-control.ts
@@ -1,0 +1,161 @@
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import type {
+  SuggestionAccessUser,
+  SuggestionProvider,
+  SuggestionProviderResult,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+type CacheEntry = {
+  expiresAt: number
+  value: SuggestionProviderResult
+}
+
+type ThrottleEntry = {
+  lastStartedAt: number
+  startedAt: number[]
+}
+
+const resultCache = new Map<string, CacheEntry>()
+const throttleEntries = new Map<string, ThrottleEntry>()
+let vmFailureTimestamps: number[] = []
+let vmCircuitOpenedUntil = 0
+
+function parseInteger(value: string | undefined, fallback: number, allowZero = false): number {
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed)) return fallback
+  if (allowZero ? parsed >= 0 : parsed > 0) return parsed
+  return fallback
+}
+
+function now(): number {
+  return Date.now()
+}
+
+function getUserKey(user: SuggestionAccessUser): string {
+  return user.id ? String(user.id) : "anonymous"
+}
+
+export function createSuggestionRuntimeKey({
+  dataSignature,
+  donViId,
+  provider,
+  user,
+}: {
+  dataSignature?: string
+  donViId: number
+  provider: SuggestionProvider
+  user: SuggestionAccessUser
+}): string {
+  return `${provider}:${getUserKey(user)}:${donViId}:${dataSignature ?? "none"}`
+}
+
+export function getCachedSuggestionResult(key: string): SuggestionProviderResult | null {
+  const entry = resultCache.get(key)
+  if (!entry) return null
+  if (entry.expiresAt <= now()) {
+    resultCache.delete(key)
+    return null
+  }
+  resultCache.delete(key)
+  resultCache.set(key, entry)
+  return entry.value
+}
+
+export function cacheSuggestionResult(key: string, value: SuggestionProviderResult): void {
+  const ttlMs = parseInteger(process.env.DEVICE_QUOTA_SUGGESTION_RESULT_CACHE_TTL_MS, 60000, true)
+  if (ttlMs <= 0) return
+  const maxEntries = parseInteger(process.env.DEVICE_QUOTA_SUGGESTION_RESULT_CACHE_MAX_ENTRIES, 200)
+  resultCache.delete(key)
+  while (resultCache.size >= maxEntries) {
+    const oldest = resultCache.keys().next().value
+    if (typeof oldest !== "string") break
+    resultCache.delete(oldest)
+  }
+  resultCache.set(key, {
+    expiresAt: now() + ttlMs,
+    value,
+  })
+}
+
+export function enforceSuggestionThrottle(key: string): void {
+  const current = now()
+  const cooldownMs = parseInteger(process.env.DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS, 10000, true)
+  const rateLimitMax = parseInteger(process.env.DEVICE_QUOTA_SUGGESTION_RATE_LIMIT_MAX, 3)
+  const rateLimitWindowMs = parseInteger(
+    process.env.DEVICE_QUOTA_SUGGESTION_RATE_LIMIT_WINDOW_MS,
+    60000,
+  )
+  const entry = throttleEntries.get(key) ?? { lastStartedAt: 0, startedAt: [] }
+  const windowStart = current - rateLimitWindowMs
+
+  for (const [entryKey, existing] of throttleEntries.entries()) {
+    const hasRecentStarts = existing.startedAt.some((timestamp) => timestamp > windowStart)
+    const hasRecentCooldown = cooldownMs > 0 && current - existing.lastStartedAt < cooldownMs
+    if (!hasRecentStarts && !hasRecentCooldown) {
+      throttleEntries.delete(entryKey)
+    }
+  }
+
+  if (cooldownMs > 0 && current - entry.lastStartedAt < cooldownMs) {
+    throw new SuggestionRouteError("Suggestion request cooldown is active", 429, {
+      retryAfterMs: cooldownMs - (current - entry.lastStartedAt),
+    })
+  }
+
+  entry.startedAt = entry.startedAt.filter((timestamp) => timestamp > windowStart)
+  if (entry.startedAt.length >= rateLimitMax) {
+    throw new SuggestionRouteError("Suggestion request rate limit exceeded", 429, {
+      windowMs: rateLimitWindowMs,
+      max: rateLimitMax,
+    })
+  }
+
+  entry.lastStartedAt = current
+  entry.startedAt.push(current)
+  throttleEntries.set(key, entry)
+}
+
+export function assertVmCircuitClosed(): void {
+  const current = now()
+  if (vmCircuitOpenedUntil > current) {
+    throw new SuggestionRouteError("VM suggestion provider circuit is open", 503, {
+      retryAfterMs: vmCircuitOpenedUntil - current,
+    })
+  }
+}
+
+export function recordVmSuccess(): void {
+  vmFailureTimestamps = []
+  vmCircuitOpenedUntil = 0
+}
+
+export function recordVmFailure(): void {
+  const current = now()
+  const threshold = parseInteger(process.env.DEVICE_QUOTA_VM_CIRCUIT_THRESHOLD, 3)
+  const windowMs = parseInteger(process.env.DEVICE_QUOTA_VM_CIRCUIT_WINDOW_MS, 60000)
+  const openMs = parseInteger(process.env.DEVICE_QUOTA_VM_CIRCUIT_OPEN_MS, 60000)
+  const windowStart = current - windowMs
+
+  vmFailureTimestamps = vmFailureTimestamps.filter((timestamp) => timestamp > windowStart)
+  vmFailureTimestamps.push(current)
+  if (vmFailureTimestamps.length >= threshold) {
+    vmCircuitOpenedUntil = current + openMs
+  }
+}
+
+export function resetSuggestionRuntimeStateForTests(): void {
+  resultCache.clear()
+  throttleEntries.clear()
+  vmFailureTimestamps = []
+  vmCircuitOpenedUntil = 0
+}
+
+export function getSuggestionRuntimeStateSizeForTests(): {
+  resultCacheEntries: number
+  throttleEntries: number
+} {
+  return {
+    resultCacheEntries: resultCache.size,
+    throttleEntries: throttleEntries.size,
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-types.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-types.ts
@@ -1,4 +1,5 @@
-export type SuggestionProvider = "supabase"
+export type SuggestionProvider = "supabase" | "vm"
+export type SuggestionProviderMode = SuggestionProvider | "canary"
 
 export type SuggestionAccessUser = {
   id?: string | number | null

--- a/src/app/api/device-quota/mapping/suggest/suggestion-utils.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-utils.ts
@@ -1,0 +1,29 @@
+export const SUPABASE_SEARCH_CHUNK_SIZE = 10
+
+export function getRequiredEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing ${name}`)
+  return value
+}
+
+export function toNumber(value: string | number | null | undefined): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null
+  if (typeof value !== "string" || value.trim() === "") return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function toRole(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase()
+}
+
+export function chunkArray<T>(items: T[], size: number): T[][] {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error("chunk size must be a positive integer")
+  }
+  const chunks: T[][] = []
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size))
+  }
+  return chunks
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-vm-client.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-vm-client.ts
@@ -1,0 +1,130 @@
+import {
+  getPayloadDetails,
+  getPayloadMessage,
+  SuggestionRouteError,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { getRequiredEnv } from "@/app/api/device-quota/mapping/suggest/suggestion-utils"
+
+export type VmSuggestRequest = {
+  requestId: string
+  facilityId: number
+  catalogSignature: string
+  unassignedSignature: string
+  deviceNames: { name: string; deviceIds: number[] }[]
+  categories: { id: number; code: string | null; name: string; classification: string | null }[]
+  options: {
+    topK: number
+    semanticWeight?: number
+    lexicalWeight?: number
+    minConfidence?: number
+    minMargin?: number
+  }
+}
+
+export type VmSuggestResponse = {
+  requestId: string
+  provider?: {
+    name?: string
+    version?: string
+    model?: string
+  }
+  timings?: Record<string, unknown>
+  metrics?: Record<string, unknown>
+  cache?: Record<string, unknown>
+  suggestions: {
+    deviceName: string
+    deviceIds: number[]
+    candidates: {
+      categoryId: number
+      categoryCode: string | null
+      categoryName: string
+      classification: string | null
+      score: number
+    }[]
+  }[]
+}
+
+type VmClientConfig = {
+  baseUrl: string
+  cfAccessClientId: string
+  cfAccessClientSecret: string
+  internalToken: string
+  timeoutMs: number
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1
+  }
+  return value.slice(0, end)
+}
+
+function getVmClientConfig(): VmClientConfig {
+  return {
+    baseUrl: stripTrailingSlashes(getRequiredEnv("DEVICE_QUOTA_VM_BASE_URL")),
+    cfAccessClientId: getRequiredEnv("DEVICE_QUOTA_VM_CF_ACCESS_CLIENT_ID"),
+    cfAccessClientSecret: getRequiredEnv("DEVICE_QUOTA_VM_CF_ACCESS_CLIENT_SECRET"),
+    internalToken: getRequiredEnv("DQSS_INTERNAL_TOKEN"),
+    timeoutMs: parsePositiveInteger(process.env.DEVICE_QUOTA_VM_TIMEOUT_MS, 8000),
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError"
+}
+
+export async function callVmSuggest(request: VmSuggestRequest): Promise<VmSuggestResponse> {
+  const config = getVmClientConfig()
+  const controller = new AbortController()
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, config.timeoutMs)
+
+  try {
+    const response = await fetch(`${config.baseUrl}/suggest`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "CF-Access-Client-Id": config.cfAccessClientId,
+        "CF-Access-Client-Secret": config.cfAccessClientSecret,
+        "X-Internal-Token": config.internalToken,
+        "X-Request-Id": request.requestId,
+      },
+      body: JSON.stringify(request),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      let message = `VM suggestion provider failed (${response.status})`
+      let details: unknown
+      try {
+        const payload = (await response.json()) as unknown
+        if (response.status < 500) {
+          message = getPayloadMessage(payload, message)
+          details = getPayloadDetails(payload)
+        } else {
+          message = "VM suggestion provider failed"
+        }
+      } catch {}
+      throw new SuggestionRouteError(message, response.status >= 500 ? 503 : response.status, details)
+    }
+
+    return (await response.json()) as VmSuggestResponse
+  } catch (error) {
+    if (error instanceof SuggestionRouteError) throw error
+    if (timedOut || isAbortError(error)) {
+      throw new SuggestionRouteError("VM suggestion provider timed out", 503)
+    }
+    throw new SuggestionRouteError("VM suggestion provider request failed", 503)
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-vm-provider.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-vm-provider.ts
@@ -1,0 +1,200 @@
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { createCatalogSignature, mergeSuggestionResults } from "@/app/api/device-quota/mapping/suggest/suggestion-merge"
+import {
+  assertVmCircuitClosed,
+  cacheSuggestionResult,
+  createSuggestionRuntimeKey,
+  enforceSuggestionThrottle,
+  getCachedSuggestionResult,
+  recordVmFailure,
+  recordVmSuccess,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-traffic-control"
+import { callVmSuggest, type VmSuggestRequest } from "@/app/api/device-quota/mapping/suggest/suggestion-vm-client"
+import { callSupabaseRpc } from "@/app/api/device-quota/mapping/suggest/suggestion-supabase-provider"
+import type {
+  DinhMucNhomRow,
+  SearchResult,
+  SuggestionAccessUser,
+  SuggestionProviderResult,
+  UnassignedName,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+const DEFAULT_VM_MAX_PAYLOAD_BYTES = 1_000_000
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function stableHash(value: unknown): string {
+  const input = JSON.stringify(value)
+  let hash = 5381
+  for (let i = 0; i < input.length; i += 1) {
+    hash = ((hash * 33) ^ input.charCodeAt(i)) >>> 0
+  }
+  return hash.toString(36)
+}
+
+function createUnassignedSignature(names: UnassignedName[]): string {
+  const normalized = names
+    .map((name) => ({
+      name: name.ten_thiet_bi,
+      deviceIds: [...name.device_ids].sort((left, right) => left - right),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+  return `v1-${normalized.length}-${stableHash(normalized)}`
+}
+
+function createEmptyCategoryResult(names: UnassignedName[]): SearchResult[] {
+  return names.map((name) => ({
+    query_text: name.ten_thiet_bi,
+    results: [],
+  }))
+}
+
+function toVmRequest({
+  requestId,
+  donViId,
+  names,
+  categories,
+  catalogSignature,
+}: {
+  requestId: string
+  donViId: number
+  names: UnassignedName[]
+  categories: DinhMucNhomRow[]
+  catalogSignature: string
+}): VmSuggestRequest {
+  return {
+    requestId,
+    facilityId: donViId,
+    catalogSignature,
+    unassignedSignature: createUnassignedSignature(names),
+    deviceNames: names.map((name) => ({
+      name: name.ten_thiet_bi,
+      deviceIds: name.device_ids,
+    })),
+    categories: categories.map((category) => ({
+      id: category.id,
+      code: category.ma_nhom,
+      name: category.ten_nhom ?? category.ma_nhom ?? String(category.id),
+      classification: category.phan_loai,
+    })),
+    options: {
+      topK: 3,
+      semanticWeight: 1,
+      lexicalWeight: 1,
+      minConfidence: 0.62,
+      minMargin: 0.04,
+    },
+  }
+}
+
+function assertPayloadSize(request: VmSuggestRequest): void {
+  const maxBytes = parsePositiveInteger(
+    process.env.DEVICE_QUOTA_VM_MAX_PAYLOAD_BYTES,
+    DEFAULT_VM_MAX_PAYLOAD_BYTES,
+  )
+  const payloadBytes = new TextEncoder().encode(JSON.stringify(request)).length
+  if (payloadBytes > maxBytes) {
+    throw new SuggestionRouteError("VM suggestion payload is too large", 413, {
+      payloadBytes,
+      maxBytes,
+    })
+  }
+}
+
+function toSearchResults(response: Awaited<ReturnType<typeof callVmSuggest>>): SearchResult[] {
+  return response.suggestions.map((suggestion) => ({
+    query_text: suggestion.deviceName,
+    results: suggestion.candidates.map((candidate) => ({
+      id: candidate.categoryId,
+      ten_nhom: candidate.categoryName,
+      ma_nhom: candidate.categoryCode ?? "",
+      phan_loai: candidate.classification,
+      rrf_score: candidate.score,
+    })),
+  }))
+}
+
+export async function runVmSuggestMapping({
+  donViId,
+  requestId,
+  user,
+}: {
+  donViId: number
+  requestId: string
+  user: SuggestionAccessUser
+}): Promise<SuggestionProviderResult> {
+  const [names, categories] = await Promise.all([
+    callSupabaseRpc<UnassignedName[]>(
+      "dinh_muc_thiet_bi_unassigned_names",
+      { p_don_vi: donViId },
+      user,
+    ),
+    callSupabaseRpc<DinhMucNhomRow[]>("dinh_muc_nhom_list", { p_don_vi: donViId }, user),
+  ])
+
+  const catalogSignature = createCatalogSignature(categories)
+  const unassignedSignature = createUnassignedSignature(names)
+  const itemCounts = {
+    unassignedNames: names.length,
+    unassignedDevices: names.reduce((sum, name) => sum + name.device_ids.length, 0),
+    categories: categories.length,
+  }
+
+  if (names.length === 0) {
+    return {
+      result: { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 },
+      itemCounts,
+      catalogSignature,
+    }
+  }
+
+  const runtimeKey = createSuggestionRuntimeKey({
+    dataSignature: `${catalogSignature}:${unassignedSignature}`,
+    donViId,
+    provider: "vm",
+    user,
+  })
+  const cached = getCachedSuggestionResult(runtimeKey)
+  if (cached) return cached
+
+  if (categories.length === 0) {
+    const result = {
+      result: mergeSuggestionResults(names, createEmptyCategoryResult(names)),
+      itemCounts,
+      catalogSignature,
+    }
+    cacheSuggestionResult(runtimeKey, result)
+    return result
+  }
+
+  const vmRequest = toVmRequest({
+    requestId,
+    donViId,
+    names,
+    categories,
+    catalogSignature,
+  })
+  assertPayloadSize(vmRequest)
+  enforceSuggestionThrottle(runtimeKey)
+  assertVmCircuitClosed()
+
+  try {
+    const vmResponse = await callVmSuggest(vmRequest)
+    const result = {
+      result: mergeSuggestionResults(names, toSearchResults(vmResponse)),
+      itemCounts,
+      catalogSignature,
+    }
+    recordVmSuccess()
+    cacheSuggestionResult(runtimeKey, result)
+    return result
+  } catch (error) {
+    if (error instanceof SuggestionRouteError && error.status >= 500) {
+      recordVmFailure()
+    }
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- add provider selection for supabase/vm/canary and Cloudflare Access VM client
- split Supabase suggestion provider from orchestration and add VM payload mapping with embedding-space separation
- add VM runtime guards: payload size, result cache, cooldown/rate limit, circuit breaker, and controlled 429/503/413 responses
- optimize the VM service by batching device-name embeddings and using normalized dot similarity

## Tests
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts src/app/api/device-quota/mapping/suggest/__tests__/vm-client.test.ts 'src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts'
- cd services/device-quota-suggestion-service && PYTHONPATH=. /tmp/dqss-venv/bin/python -m pytest tests -q
- git diff --check
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

Fixes #496

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a VM-based device quota suggestion provider with canary rollout and runtime safeguards, keeping `supabase` as the default. Improves accuracy and throughput by batching embeddings, normalizing vectors, and using normalized-dot similarity; fulfills #496.

- **New Features**
  - Provider selection: `supabase` (default), `vm`, or `canary` (allow-list); response meta includes `provider` and `providerPolicy`.
  - VM client: Cloudflare Access headers (`CF-Access-*`), `X-Internal-Token`/`X-Request-Id`, request timeout, and structured errors (preserves 4xx; sanitizes 5xx to 503).
  - Traffic control: result cache (keyed by catalog+unassigned signatures), per-user cooldown and rate limit, and a VM circuit breaker (no fallback to `supabase` on VM failure).
  - Providers/perf: Supabase provider split from orchestration with HTTP timeouts for RPC/functions; VM sends a minimal payload; ranking uses normalized vectors and normalized-dot similarity with batched device-name embeddings.

- **Migration**
  - Configure provider selection:
    - `DEVICE_QUOTA_SUGGESTION_PROVIDER` = `supabase` | `vm` | `canary` (default `supabase`)
    - `DEVICE_QUOTA_SUGGESTION_CANARY_DON_VI_IDS` = comma-separated IDs (for `canary`)
  - VM client (required for `vm`/canary facilities):
    - `DEVICE_QUOTA_VM_BASE_URL`, `DEVICE_QUOTA_VM_CF_ACCESS_CLIENT_ID`, `DEVICE_QUOTA_VM_CF_ACCESS_CLIENT_SECRET`, `DQSS_INTERNAL_TOKEN`
    - Optional: `DEVICE_QUOTA_VM_TIMEOUT_MS`, `DEVICE_QUOTA_VM_MAX_PAYLOAD_BYTES`
  - Supabase (timeouts):
    - Optional: `SUPABASE_HTTP_TIMEOUT_MS`
  - Traffic control (optional):
    - `DEVICE_QUOTA_SUGGESTION_RESULT_CACHE_TTL_MS`, `DEVICE_QUOTA_SUGGESTION_RESULT_CACHE_MAX_ENTRIES`
    - `DEVICE_QUOTA_SUGGESTION_COOLDOWN_MS`, `DEVICE_QUOTA_SUGGESTION_RATE_LIMIT_MAX`, `DEVICE_QUOTA_SUGGESTION_RATE_LIMIT_WINDOW_MS`
    - `DEVICE_QUOTA_VM_CIRCUIT_THRESHOLD`, `DEVICE_QUOTA_VM_CIRCUIT_WINDOW_MS`, `DEVICE_QUOTA_VM_CIRCUIT_OPEN_MS`

<sup>Written for commit a2af43d07a35eebb8a40ce2d39864d79291243b7. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/510?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added VM provider as an alternative backend for device quota suggestions, with canary mode for gradual facility rollout.
  * Dynamic provider selection based on facility configuration.
  * Implemented result caching and request throttling to improve performance and control usage.
  * Added circuit breaker for VM provider to prevent cascading failures.
  * Enhanced error responses with structured error details.

* **Tests**
  * Expanded test coverage for provider selection logic and failure scenarios.
  * Added smoke tests for batch processing efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->