### PR TITLE
feat: add shared datatable page jump

### DIFF
--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingContext.tsx
@@ -84,6 +84,7 @@ export function DeviceQuotaMappingProvider({ children }: DeviceQuotaMappingProvi
   const paginationState = useServerPagination({
     totalCount: paginationTotalCount,
     initialPageSize: 20,
+    pageSizeStorageKey: "datatable:device-quota-unassigned:page-size",
     resetKey: paginationResetKey,
   })
 

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaUnassignedList.tsx
@@ -174,6 +174,7 @@ export function DeviceQuotaUnassignedList() {
                 onPreviousPage={() => pagination.setPagination(prev => ({ ...prev, pageIndex: prev.pageIndex - 1 }))}
                 onNextPage={() => pagination.setPagination(prev => ({ ...prev, pageIndex: prev.pageIndex + 1 }))}
                 onLastPage={() => pagination.setPagination(prev => ({ ...prev, pageIndex: pagination.pageCount - 1 }))}
+                onPageJump={(page) => pagination.setPagination(prev => ({ ...prev, pageIndex: page - 1 }))}
               />
             </div>
           </div>

--- a/src/app/(app)/maintenance/__tests__/use-maintenance-plan-list-controls.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/use-maintenance-plan-list-controls.test.tsx
@@ -73,4 +73,15 @@ describe("useMaintenancePlanListControls", () => {
     expect(nextHook.result.current.currentPage).toBe(1)
     expect(nextHook.result.current.pageSize).toBe(200)
   })
+
+  it("normalizes non-finite pageSize values before persisting", () => {
+    const { result } = renderHook(() => useMaintenancePlanListControls(null))
+
+    act(() => {
+      result.current.handlePageSizeChange(Number.NaN)
+    })
+
+    expect(result.current.pageSize).toBe(1)
+    expect(window.localStorage.getItem("datatable:maintenance-plans:page-size")).toBe("1")
+  })
 })

--- a/src/app/(app)/maintenance/__tests__/use-maintenance-plan-list-controls.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/use-maintenance-plan-list-controls.test.tsx
@@ -6,6 +6,7 @@ import { useMaintenancePlanListControls } from "../_hooks/use-maintenance-plan-l
 describe("useMaintenancePlanListControls", () => {
   afterEach(() => {
     vi.useRealTimers()
+    window.localStorage.clear()
   })
 
   it("resets the effective page when the pagination reset key changes", () => {
@@ -48,5 +49,28 @@ describe("useMaintenancePlanListControls", () => {
     })
 
     expect(result.current.currentPage).toBe(1)
+  })
+
+  it("persists pageSize without persisting the current page", () => {
+    window.localStorage.setItem("datatable:maintenance-plans:page-size", "100")
+
+    const { result, unmount } = renderHook(() => useMaintenancePlanListControls(null))
+
+    expect(result.current.pageSize).toBe(100)
+
+    act(() => {
+      result.current.setCurrentPage(3)
+      result.current.handlePageSizeChange(200)
+    })
+
+    expect(window.localStorage.getItem("datatable:maintenance-plans:page-size")).toBe("200")
+    expect(window.localStorage.getItem("datatable:maintenance-plans:page-index")).toBeNull()
+
+    unmount()
+
+    const nextHook = renderHook(() => useMaintenancePlanListControls(null))
+
+    expect(nextHook.result.current.currentPage).toBe(1)
+    expect(nextHook.result.current.pageSize).toBe(200)
   })
 })

--- a/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
+++ b/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
@@ -1,7 +1,7 @@
 import * as React from "react"
 
 import { useSearchDebounce } from "@/hooks/use-debounce"
-import { readPageSizeFromStorage, writePageSizeToStorage } from "@/lib/page-size-storage"
+import { normalizePageSize, readPageSizeFromStorage, writePageSizeToStorage } from "@/lib/page-size-storage"
 
 const MAINTENANCE_PLAN_PAGE_SIZE_STORAGE_KEY = "datatable:maintenance-plans:page-size"
 
@@ -59,7 +59,7 @@ export function useMaintenancePlanListControls(
   }, [])
 
   const handlePageSizeChange = React.useCallback((size: number) => {
-    const safeSize = Math.max(1, size)
+    const safeSize = normalizePageSize(size)
     setPageSize(safeSize)
     writePageSizeToStorage(MAINTENANCE_PLAN_PAGE_SIZE_STORAGE_KEY, safeSize)
     setCurrentPage(1)

--- a/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
+++ b/src/app/(app)/maintenance/_hooks/use-maintenance-plan-list-controls.ts
@@ -1,6 +1,9 @@
 import * as React from "react"
 
 import { useSearchDebounce } from "@/hooks/use-debounce"
+import { readPageSizeFromStorage, writePageSizeToStorage } from "@/lib/page-size-storage"
+
+const MAINTENANCE_PLAN_PAGE_SIZE_STORAGE_KEY = "datatable:maintenance-plans:page-size"
 
 export interface MaintenancePlanListControls {
   planSearchTerm: string
@@ -18,7 +21,9 @@ export function useMaintenancePlanListControls(
 ): MaintenancePlanListControls {
   const [planSearchTerm, setPlanSearchTerm] = React.useState("")
   const [currentPage, setCurrentPage] = React.useState(1)
-  const [pageSize, setPageSize] = React.useState(50)
+  const [pageSize, setPageSize] = React.useState(() =>
+    readPageSizeFromStorage(MAINTENANCE_PLAN_PAGE_SIZE_STORAGE_KEY, 50)
+  )
   const debouncedPlanSearch = useSearchDebounce(planSearchTerm)
 
   const previousDebouncedPlanSearch = React.useRef(debouncedPlanSearch)
@@ -54,7 +59,9 @@ export function useMaintenancePlanListControls(
   }, [])
 
   const handlePageSizeChange = React.useCallback((size: number) => {
-    setPageSize(size)
+    const safeSize = Math.max(1, size)
+    setPageSize(safeSize)
+    writePageSizeToStorage(MAINTENANCE_PLAN_PAGE_SIZE_STORAGE_KEY, safeSize)
     setCurrentPage(1)
   }, [])
 

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestsData.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestsData.ts
@@ -68,6 +68,7 @@ export function useRepairRequestsData(
   const [totalRequests, setTotalRequests] = React.useState(0)
   const repairPagination = useServerPagination({
     totalCount: totalRequests,
+    pageSizeStorageKey: "datatable:repair-requests:page-size",
     resetKey: paginationResetKey,
   })
 

--- a/src/app/(app)/transfers/_components/useTransfersPageController.ts
+++ b/src/app/(app)/transfers/_components/useTransfersPageController.ts
@@ -150,6 +150,7 @@ export function useTransfersPageController(
 
   const transferPagination = useServerPagination({
     totalCount,
+    pageSizeStorageKey: "datatable:transfers:page-size",
     resetKey: paginationResetKey,
   })
 

--- a/src/components/__tests__/data-table-pagination.test.tsx
+++ b/src/components/__tests__/data-table-pagination.test.tsx
@@ -48,8 +48,21 @@ function TanstackWrapper() {
   )
 }
 
-function ControlledWrapper() {
+function ControlledWrapper({
+  totalCount = DATA.length,
+  onPaginationChange,
+}: {
+  totalCount?: number
+  onPaginationChange?: (pagination: { pageIndex: number; pageSize: number }) => void
+}) {
   const [pagination, setPagination] = React.useState({ pageIndex: 0, pageSize: 5 })
+  const handlePaginationChange = React.useCallback(
+    (nextPagination: { pageIndex: number; pageSize: number }) => {
+      setPagination(nextPagination)
+      onPaginationChange?.(nextPagination)
+    },
+    [onPaginationChange]
+  )
   const table = useReactTable({
     data: DATA,
     columns: COLUMNS,
@@ -63,19 +76,29 @@ function ControlledWrapper() {
   return (
     <DataTablePagination
       table={table}
-      totalCount={DATA.length}
+      totalCount={totalCount}
       entity={{ singular: 'muc' }}
       paginationMode={{
         mode: 'controlled',
         pagination,
-        onPaginationChange: setPagination,
+        onPaginationChange: handlePaginationChange,
       }}
       pageSizeOptions={[]}
     />
   )
 }
 
-function ServerWrapper({ onPageChange }: { onPageChange: (page: number) => void }) {
+function ServerWrapper({
+  currentPage = 1,
+  totalPages = 12,
+  isLoading = false,
+  onPageChange,
+}: {
+  currentPage?: number
+  totalPages?: number
+  isLoading?: boolean
+  onPageChange: (page: number) => void
+}) {
   const table = useReactTable({
     data: DATA,
     columns: COLUMNS,
@@ -91,13 +114,14 @@ function ServerWrapper({ onPageChange }: { onPageChange: (page: number) => void 
       entity={{ singular: 'muc' }}
       paginationMode={{
         mode: 'server',
-        currentPage: 1,
-        totalPages: 3,
+        currentPage,
+        totalPages,
         pageSize: 5,
         onPageChange,
         onPageSizeChange: vi.fn(),
       }}
       pageSizeOptions={[]}
+      isLoading={isLoading}
     />
   )
 }
@@ -119,6 +143,61 @@ describe('DataTablePagination', () => {
     render(<ServerWrapper onPageChange={onPageChange} />)
     fireEvent.click(screen.getByRole('button', { name: /Trang ti/i }))
     expect(onPageChange).toHaveBeenCalledWith(2)
+  })
+
+  it('jumps to a submitted page in server mode once', () => {
+    const onPageChange = vi.fn()
+    render(<ServerWrapper onPageChange={onPageChange} />)
+
+    const input = screen.getByRole('spinbutton', { name: /đi tới trang/i })
+    fireEvent.change(input, { target: { value: '10' } })
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+
+    expect(onPageChange).toHaveBeenCalledTimes(1)
+    expect(onPageChange).toHaveBeenCalledWith(10)
+  })
+
+  it('does not jump while typing a page number', () => {
+    const onPageChange = vi.fn()
+    render(<ServerWrapper onPageChange={onPageChange} />)
+
+    fireEvent.change(screen.getByRole('spinbutton', { name: /đi tới trang/i }), {
+      target: { value: '10' },
+    })
+
+    expect(onPageChange).not.toHaveBeenCalled()
+  })
+
+  it('clamps submitted server page jumps to available pages', () => {
+    const onPageChange = vi.fn()
+    render(<ServerWrapper onPageChange={onPageChange} />)
+
+    const input = screen.getByRole('spinbutton', { name: /đi tới trang/i })
+    fireEvent.change(input, { target: { value: '999' } })
+    fireEvent.click(screen.getByRole('button', { name: /đi tới trang/i }))
+    fireEvent.change(input, { target: { value: '0' } })
+    fireEvent.click(screen.getByRole('button', { name: /đi tới trang/i }))
+
+    expect(onPageChange).toHaveBeenNthCalledWith(1, 12)
+    expect(onPageChange).toHaveBeenNthCalledWith(2, 1)
+  })
+
+  it('jumps through controlled pagination state', () => {
+    const onPaginationChange = vi.fn()
+    render(<ControlledWrapper totalCount={60} onPaginationChange={onPaginationChange} />)
+
+    const input = screen.getByRole('spinbutton', { name: /đi tới trang/i })
+    fireEvent.change(input, { target: { value: '10' } })
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+
+    expect(onPaginationChange).toHaveBeenCalledWith({ pageIndex: 9, pageSize: 5 })
+  })
+
+  it('disables page jump controls while loading', () => {
+    render(<ServerWrapper isLoading onPageChange={vi.fn()} />)
+
+    expect(screen.getByRole('spinbutton', { name: /đi tới trang/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /đi tới trang/i })).toBeDisabled()
   })
 
   it('renders custom display format', () => {

--- a/src/components/__tests__/data-table-pagination.test.tsx
+++ b/src/components/__tests__/data-table-pagination.test.tsx
@@ -193,6 +193,16 @@ describe('DataTablePagination', () => {
     expect(onPaginationChange).toHaveBeenCalledWith({ pageIndex: 9, pageSize: 5 })
   })
 
+  it('syncs page jump input after controlled navigation', () => {
+    render(<ControlledWrapper totalCount={60} />)
+
+    const input = screen.getByRole('spinbutton', { name: /đi tới trang/i })
+    fireEvent.change(input, { target: { value: '10' } })
+    fireEvent.click(screen.getByRole('button', { name: /Trang ti/i }))
+
+    expect(screen.getByRole('spinbutton', { name: /đi tới trang/i })).toHaveValue(2)
+  })
+
   it('disables page jump controls while loading', () => {
     render(<ServerWrapper isLoading onPageChange={vi.fn()} />)
 

--- a/src/components/shared/DataTablePagination/DataTablePagination.tsx
+++ b/src/components/shared/DataTablePagination/DataTablePagination.tsx
@@ -125,6 +125,14 @@ export function DataTablePaginationMain<TData extends RowData>({
     setPageIndex(lastPageIndex)
   }, [setPageIndex, lastPageIndex])
 
+  const handlePageJump = React.useCallback(
+    (page: number) => {
+      const safePage = totalPages > 0 ? Math.min(Math.max(page, 1), totalPages) : 1
+      setPageIndex(safePage - 1)
+    },
+    [setPageIndex, totalPages]
+  )
+
   // Early return AFTER all hooks
   if (!enabled) {
     return null
@@ -217,6 +225,7 @@ export function DataTablePaginationMain<TData extends RowData>({
             onPreviousPage={handlePreviousPage}
             onNextPage={handleNextPage}
             onLastPage={handleLastPage}
+            onPageJump={isServer || isControlled ? handlePageJump : undefined}
             showFirstLastAt={showFirstLastAt}
             stackAt={stackLayoutAt}
             disabled={disabled}

--- a/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
+++ b/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
@@ -1,9 +1,16 @@
 "use client"
 
 import * as React from "react"
-import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react"
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  CornerDownRight,
+} from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
 const DEFAULT_ARIA_LABELS = {
@@ -27,6 +34,7 @@ export interface DataTablePaginationNavigationProps {
   onPreviousPage: () => void
   onNextPage: () => void
   onLastPage: () => void
+  onPageJump?: (page: number) => void
   showFirstLastAt?: "sm" | "md" | "lg"
   stackAt?: "sm" | "md" | "lg"
   disabled?: boolean
@@ -53,6 +61,7 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
   onPreviousPage,
   onNextPage,
   onLastPage,
+  onPageJump,
   showFirstLastAt = "sm",
   stackAt = "sm",
   disabled,
@@ -61,9 +70,20 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
   labels,
   className,
 }: DataTablePaginationNavigationProps) {
+  const [pageJumpValue, setPageJumpValue] = React.useState(() =>
+    currentPage > 0 ? String(currentPage) : ""
+  )
+  const previousCurrentPage = React.useRef(currentPage)
+  const hasPageChanged = currentPage !== previousCurrentPage.current
+  const displayedPageJumpValue = hasPageChanged
+    ? (currentPage > 0 ? String(currentPage) : "")
+    : pageJumpValue
+  previousCurrentPage.current = currentPage
+
   const resolvedAriaLabels = { ...DEFAULT_ARIA_LABELS, ...ariaLabels }
   const resolvedLabels = { ...DEFAULT_LABELS, ...labels }
   const isDisabled = disabled || isLoading
+  const canJump = Boolean(onPageJump) && totalPages > 0
   const showFirstLastClass =
     showFirstLastAt === "md"
       ? "md:flex"
@@ -77,9 +97,34 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
         ? "lg:flex-row lg:gap-3"
         : "sm:flex-row sm:gap-3"
 
+  const commitPageJump = React.useCallback(() => {
+    if (!onPageJump || isDisabled || totalPages <= 0) {
+      return
+    }
+
+    const parsedPage = Number.parseInt(displayedPageJumpValue, 10)
+    if (Number.isNaN(parsedPage)) {
+      return
+    }
+
+    const nextPage = Math.min(Math.max(parsedPage, 1), totalPages)
+    onPageJump(nextPage)
+    setPageJumpValue(String(nextPage))
+  },
+    [displayedPageJumpValue, isDisabled, onPageJump, totalPages]
+  )
+
+  const handlePageJumpSubmit = React.useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      commitPageJump()
+    },
+    [commitPageJump]
+  )
+
   return (
     <div className={cn("flex flex-col items-center gap-2", stackClass, className)}>
-      <div 
+      <div
         className="text-sm font-medium"
         role="status"
         aria-live="polite"
@@ -87,6 +132,38 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
       >
         {resolvedLabels.pageIndicator} {currentPage} {resolvedLabels.pageSeparator} {totalPages}
       </div>
+      {onPageJump ? (
+        <form className="flex items-center gap-2" onSubmit={handlePageJumpSubmit}>
+          <Input
+            aria-label="Đi tới trang"
+            type="number"
+            inputMode="numeric"
+            min={1}
+            max={Math.max(1, totalPages)}
+            value={displayedPageJumpValue}
+            onChange={(event) => setPageJumpValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter") {
+                return
+              }
+              event.preventDefault()
+              commitPageJump()
+            }}
+            className="h-8 w-20"
+            disabled={isDisabled || !canJump}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            className="h-8 px-2"
+            disabled={isDisabled || !canJump}
+            aria-label="Đi tới trang"
+            onClick={commitPageJump}
+          >
+            <CornerDownRight className="size-4" />
+          </Button>
+        </form>
+      ) : null}
       <div className="flex items-center gap-x-2">
         <Button
           type="button"

--- a/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
+++ b/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
@@ -52,6 +52,81 @@ export interface DataTablePaginationNavigationProps {
   className?: string
 }
 
+interface DataTablePaginationPageJumpProps {
+  currentPage: number
+  totalPages: number
+  isDisabled: boolean | undefined
+  onPageJump: (page: number) => void
+}
+
+const DataTablePaginationPageJump = React.memo(function DataTablePaginationPageJump({
+  currentPage,
+  totalPages,
+  isDisabled,
+  onPageJump,
+}: DataTablePaginationPageJumpProps) {
+  const [pageJumpValue, setPageJumpValue] = React.useState(() =>
+    currentPage > 0 ? String(currentPage) : ""
+  )
+  const canJump = totalPages > 0
+
+  const commitPageJump = React.useCallback(() => {
+    if (isDisabled || totalPages <= 0) {
+      return
+    }
+
+    const parsedPage = Number.parseInt(pageJumpValue, 10)
+    if (Number.isNaN(parsedPage)) {
+      return
+    }
+
+    const nextPage = Math.min(Math.max(parsedPage, 1), totalPages)
+    onPageJump(nextPage)
+    setPageJumpValue(String(nextPage))
+  }, [isDisabled, onPageJump, pageJumpValue, totalPages])
+
+  const handlePageJumpSubmit = React.useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      commitPageJump()
+    },
+    [commitPageJump]
+  )
+
+  return (
+    <form className="flex items-center gap-2" onSubmit={handlePageJumpSubmit}>
+      <Input
+        aria-label="Đi tới trang"
+        type="number"
+        inputMode="numeric"
+        min={1}
+        max={Math.max(1, totalPages)}
+        value={pageJumpValue}
+        onChange={(event) => setPageJumpValue(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter") {
+            return
+          }
+          event.preventDefault()
+          commitPageJump()
+        }}
+        className="h-8 w-20"
+        disabled={isDisabled || !canJump}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        className="h-8 px-2"
+        disabled={isDisabled || !canJump}
+        aria-label="Đi tới trang"
+        onClick={commitPageJump}
+      >
+        <CornerDownRight className="size-4" />
+      </Button>
+    </form>
+  )
+})
+
 export const DataTablePaginationNavigation = React.memo(function DataTablePaginationNavigation({
   currentPage,
   totalPages,
@@ -70,20 +145,9 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
   labels,
   className,
 }: DataTablePaginationNavigationProps) {
-  const [pageJumpValue, setPageJumpValue] = React.useState(() =>
-    currentPage > 0 ? String(currentPage) : ""
-  )
-  const previousCurrentPage = React.useRef(currentPage)
-  const hasPageChanged = currentPage !== previousCurrentPage.current
-  const displayedPageJumpValue = hasPageChanged
-    ? (currentPage > 0 ? String(currentPage) : "")
-    : pageJumpValue
-  previousCurrentPage.current = currentPage
-
   const resolvedAriaLabels = { ...DEFAULT_ARIA_LABELS, ...ariaLabels }
   const resolvedLabels = { ...DEFAULT_LABELS, ...labels }
   const isDisabled = disabled || isLoading
-  const canJump = Boolean(onPageJump) && totalPages > 0
   const showFirstLastClass =
     showFirstLastAt === "md"
       ? "md:flex"
@@ -97,31 +161,6 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
         ? "lg:flex-row lg:gap-3"
         : "sm:flex-row sm:gap-3"
 
-  const commitPageJump = React.useCallback(() => {
-    if (!onPageJump || isDisabled || totalPages <= 0) {
-      return
-    }
-
-    const parsedPage = Number.parseInt(displayedPageJumpValue, 10)
-    if (Number.isNaN(parsedPage)) {
-      return
-    }
-
-    const nextPage = Math.min(Math.max(parsedPage, 1), totalPages)
-    onPageJump(nextPage)
-    setPageJumpValue(String(nextPage))
-  },
-    [displayedPageJumpValue, isDisabled, onPageJump, totalPages]
-  )
-
-  const handlePageJumpSubmit = React.useCallback(
-    (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault()
-      commitPageJump()
-    },
-    [commitPageJump]
-  )
-
   return (
     <div className={cn("flex flex-col items-center gap-2", stackClass, className)}>
       <div
@@ -133,36 +172,13 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
         {resolvedLabels.pageIndicator} {currentPage} {resolvedLabels.pageSeparator} {totalPages}
       </div>
       {onPageJump ? (
-        <form className="flex items-center gap-2" onSubmit={handlePageJumpSubmit}>
-          <Input
-            aria-label="Đi tới trang"
-            type="number"
-            inputMode="numeric"
-            min={1}
-            max={Math.max(1, totalPages)}
-            value={displayedPageJumpValue}
-            onChange={(event) => setPageJumpValue(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key !== "Enter") {
-                return
-              }
-              event.preventDefault()
-              commitPageJump()
-            }}
-            className="h-8 w-20"
-            disabled={isDisabled || !canJump}
-          />
-          <Button
-            type="button"
-            variant="outline"
-            className="h-8 px-2"
-            disabled={isDisabled || !canJump}
-            aria-label="Đi tới trang"
-            onClick={commitPageJump}
-          >
-            <CornerDownRight className="size-4" />
-          </Button>
-        </form>
+        <DataTablePaginationPageJump
+          key={currentPage}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          isDisabled={isDisabled}
+          onPageJump={onPageJump}
+        />
       ) : null}
       <div className="flex items-center gap-x-2">
         <Button

--- a/src/components/shared/DataTablePagination/types.ts
+++ b/src/components/shared/DataTablePagination/types.ts
@@ -123,6 +123,8 @@ export interface UsePaginationStateOptions {
   initialPageSize?: number
   initialPageIndex?: number
   totalCount: number
+  /** Optional localStorage key. Persists pageSize only, never current page. */
+  pageSizeStorageKey?: string
   /** Simple key for reset - changes trigger reset to page 0 */
   resetKey?: string | number
 }

--- a/src/hooks/__tests__/usePaginationState.test.ts
+++ b/src/hooks/__tests__/usePaginationState.test.ts
@@ -109,4 +109,20 @@ describe('usePaginationState', () => {
 
     expect(nextHook.result.current.pagination).toEqual({ pageIndex: 0, pageSize: 50 })
   })
+
+  it('normalizes non-finite page sizes before storing them', () => {
+    const { result } = renderHook(() =>
+      usePaginationState({
+        totalCount: 300,
+        pageSizeStorageKey: 'pagination:test-table:page-size',
+      })
+    )
+
+    act(() => {
+      result.current.setPageSize(Number.NaN)
+    })
+
+    expect(result.current.pagination.pageSize).toBe(1)
+    expect(window.localStorage.getItem('pagination:test-table:page-size')).toBe('1')
+  })
 })

--- a/src/hooks/__tests__/usePaginationState.test.ts
+++ b/src/hooks/__tests__/usePaginationState.test.ts
@@ -1,9 +1,13 @@
 import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { beforeEach, describe, it, expect } from 'vitest'
 
 import { usePaginationState } from '@/hooks/usePaginationState'
 
 describe('usePaginationState', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
   it('initializes with defaults', () => {
     const { result } = renderHook(() => usePaginationState({ totalCount: 100 }))
 
@@ -61,5 +65,48 @@ describe('usePaginationState', () => {
     })
 
     expect(result.current.pagination).toEqual({ pageIndex: 0, pageSize: 50 })
+  })
+
+  it('initializes pageSize from pageSizeStorageKey', () => {
+    window.localStorage.setItem('pagination:test-table:page-size', '75')
+
+    const { result } = renderHook(() =>
+      usePaginationState({
+        totalCount: 300,
+        initialPageIndex: 2,
+        initialPageSize: 20,
+        pageSizeStorageKey: 'pagination:test-table:page-size',
+      })
+    )
+
+    expect(result.current.pagination).toEqual({ pageIndex: 2, pageSize: 75 })
+  })
+
+  it('persists pageSize without persisting current page', () => {
+    const { result, unmount } = renderHook(() =>
+      usePaginationState({
+        totalCount: 300,
+        pageSizeStorageKey: 'pagination:test-table:page-size',
+      })
+    )
+
+    act(() => {
+      result.current.goToPage(4)
+      result.current.setPageSize(50)
+    })
+
+    expect(window.localStorage.getItem('pagination:test-table:page-size')).toBe('50')
+    expect(window.localStorage.getItem('pagination:test-table:page-index')).toBeNull()
+
+    unmount()
+
+    const nextHook = renderHook(() =>
+      usePaginationState({
+        totalCount: 300,
+        pageSizeStorageKey: 'pagination:test-table:page-size',
+      })
+    )
+
+    expect(nextHook.result.current.pagination).toEqual({ pageIndex: 0, pageSize: 50 })
   })
 })

--- a/src/hooks/__tests__/useServerPagination.test.ts
+++ b/src/hooks/__tests__/useServerPagination.test.ts
@@ -3,11 +3,15 @@
  * with server-side pagination conveniences (1-based page, resetKey, pageCount).
  */
 import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { beforeEach, describe, it, expect } from 'vitest'
 
 import { useServerPagination } from '@/hooks/useServerPagination'
 
 describe('useServerPagination', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
   it('provides 1-based page number for RPC calls', () => {
     const { result } = renderHook(() =>
       useServerPagination({ totalCount: 100 })
@@ -131,5 +135,19 @@ describe('useServerPagination', () => {
       result.current.resetToFirstPage()
     })
     expect(result.current.page).toBe(1)
+  })
+
+  it('uses a persisted pageSize when pageSizeStorageKey is provided', () => {
+    window.localStorage.setItem('pagination:server-table:page-size', '40')
+
+    const { result } = renderHook(() =>
+      useServerPagination({
+        totalCount: 100,
+        initialPageSize: 20,
+        pageSizeStorageKey: 'pagination:server-table:page-size',
+      })
+    )
+
+    expect(result.current.pageSize).toBe(40)
   })
 })

--- a/src/hooks/usePaginationState.ts
+++ b/src/hooks/usePaginationState.ts
@@ -1,15 +1,19 @@
 import * as React from "react"
 import type { UsePaginationStateOptions, UsePaginationStateReturn } from "@/components/shared/DataTablePagination/types"
+import { readPageSizeFromStorage, writePageSizeToStorage } from "@/lib/page-size-storage"
+
+type PaginationState = { pageIndex: number; pageSize: number }
 
 export function usePaginationState({
   initialPageSize = 20,
   initialPageIndex = 0,
   totalCount,
+  pageSizeStorageKey,
   resetKey,
 }: UsePaginationStateOptions): UsePaginationStateReturn {
   const [pagination, setPagination] = React.useState({
     pageIndex: Math.max(0, initialPageIndex),
-    pageSize: Math.max(1, initialPageSize),
+    pageSize: readPageSizeFromStorage(pageSizeStorageKey, initialPageSize),
   })
 
   const pageCount = Math.max(0, Math.ceil(totalCount / pagination.pageSize))
@@ -32,24 +36,42 @@ export function usePaginationState({
     }
   }, [pagination.pageIndex, pageCount])
 
+  const setPersistedPagination = React.useCallback<React.Dispatch<React.SetStateAction<PaginationState>>>((nextPagination) => {
+    setPagination(prev => {
+      const resolvedPagination = typeof nextPagination === "function"
+        ? nextPagination(prev)
+        : nextPagination
+      const safePagination = {
+        pageIndex: Math.max(0, resolvedPagination.pageIndex),
+        pageSize: Math.max(1, resolvedPagination.pageSize),
+      }
+
+      if (safePagination.pageSize !== prev.pageSize) {
+        writePageSizeToStorage(pageSizeStorageKey, safePagination.pageSize)
+      }
+
+      return safePagination
+    })
+  }, [pageSizeStorageKey])
+
   const resetToFirstPage = React.useCallback(() => {
-    setPagination(prev => ({ ...prev, pageIndex: 0 }))
-  }, [])
+    setPersistedPagination(prev => ({ ...prev, pageIndex: 0 }))
+  }, [setPersistedPagination])
 
   const setPageSize = React.useCallback((size: number) => {
     const safeSize = Math.max(1, size)
-    setPagination({ pageIndex: 0, pageSize: safeSize })
-  }, [])
+    setPersistedPagination({ pageIndex: 0, pageSize: safeSize })
+  }, [setPersistedPagination])
 
   const goToPage = React.useCallback((page: number) => {
     // Accept 1-based page, convert to 0-based internally
-    setPagination(prev => ({ ...prev, pageIndex: Math.max(0, page - 1) }))
-  }, [])
+    setPersistedPagination(prev => ({ ...prev, pageIndex: Math.max(0, page - 1) }))
+  }, [setPersistedPagination])
 
   // Memoize return object to prevent unnecessary re-renders in consumers
   return React.useMemo(() => ({
     pagination,
-    setPagination,
+    setPagination: setPersistedPagination,
     pageCount,
     displayPage: pagination.pageIndex + 1,
     resetToFirstPage,
@@ -57,5 +79,5 @@ export function usePaginationState({
     goToPage,
     canPreviousPage: pagination.pageIndex > 0,
     canNextPage: pagination.pageIndex < pageCount - 1,
-  }), [pagination, pageCount, resetToFirstPage, setPageSize, goToPage])
+  }), [pagination, setPersistedPagination, pageCount, resetToFirstPage, setPageSize, goToPage])
 }

--- a/src/hooks/usePaginationState.ts
+++ b/src/hooks/usePaginationState.ts
@@ -1,6 +1,6 @@
 import * as React from "react"
 import type { UsePaginationStateOptions, UsePaginationStateReturn } from "@/components/shared/DataTablePagination/types"
-import { readPageSizeFromStorage, writePageSizeToStorage } from "@/lib/page-size-storage"
+import { normalizePageSize, readPageSizeFromStorage, writePageSizeToStorage } from "@/lib/page-size-storage"
 
 type PaginationState = { pageIndex: number; pageSize: number }
 
@@ -11,10 +11,10 @@ export function usePaginationState({
   pageSizeStorageKey,
   resetKey,
 }: UsePaginationStateOptions): UsePaginationStateReturn {
-  const [pagination, setPagination] = React.useState({
+  const [pagination, setPagination] = React.useState(() => ({
     pageIndex: Math.max(0, initialPageIndex),
     pageSize: readPageSizeFromStorage(pageSizeStorageKey, initialPageSize),
-  })
+  }))
 
   const pageCount = Math.max(0, Math.ceil(totalCount / pagination.pageSize))
 
@@ -43,7 +43,7 @@ export function usePaginationState({
         : nextPagination
       const safePagination = {
         pageIndex: Math.max(0, resolvedPagination.pageIndex),
-        pageSize: Math.max(1, resolvedPagination.pageSize),
+        pageSize: normalizePageSize(resolvedPagination.pageSize),
       }
 
       if (safePagination.pageSize !== prev.pageSize) {
@@ -59,8 +59,7 @@ export function usePaginationState({
   }, [setPersistedPagination])
 
   const setPageSize = React.useCallback((size: number) => {
-    const safeSize = Math.max(1, size)
-    setPersistedPagination({ pageIndex: 0, pageSize: safeSize })
+    setPersistedPagination({ pageIndex: 0, pageSize: normalizePageSize(size) })
   }, [setPersistedPagination])
 
   const goToPage = React.useCallback((page: number) => {

--- a/src/hooks/useServerPagination.ts
+++ b/src/hooks/useServerPagination.ts
@@ -14,6 +14,7 @@ import { usePaginationState } from '@/hooks/usePaginationState'
 export interface UseServerPaginationOptions {
   totalCount: number
   initialPageSize?: number
+  pageSizeStorageKey?: string
   resetKey?: string | number | null
 }
 
@@ -38,11 +39,13 @@ export interface UseServerPaginationReturn {
 export function useServerPagination({
   totalCount,
   initialPageSize = 20,
+  pageSizeStorageKey,
   resetKey,
 }: UseServerPaginationOptions): UseServerPaginationReturn {
   const state = usePaginationState({
     totalCount,
     initialPageSize,
+    pageSizeStorageKey,
     resetKey: resetKey ?? undefined,
   })
 

--- a/src/lib/page-size-storage.ts
+++ b/src/lib/page-size-storage.ts
@@ -1,5 +1,9 @@
+export function normalizePageSize(value: number): number {
+  return Number.isFinite(value) ? Math.max(1, Math.trunc(value)) : 1
+}
+
 export function readPageSizeFromStorage(key: string | undefined, fallback: number): number {
-  const safeFallback = Math.max(1, fallback)
+  const safeFallback = normalizePageSize(fallback)
   if (!key || typeof window === "undefined") {
     return safeFallback
   }
@@ -24,7 +28,7 @@ export function writePageSizeToStorage(key: string | undefined, pageSize: number
   }
 
   try {
-    window.localStorage.setItem(key, String(Math.max(1, pageSize)))
+    window.localStorage.setItem(key, String(normalizePageSize(pageSize)))
   } catch (error) {
     console.warn(`Error writing page size storage key "${key}":`, error)
   }

--- a/src/lib/page-size-storage.ts
+++ b/src/lib/page-size-storage.ts
@@ -1,0 +1,31 @@
+export function readPageSizeFromStorage(key: string | undefined, fallback: number): number {
+  const safeFallback = Math.max(1, fallback)
+  if (!key || typeof window === "undefined") {
+    return safeFallback
+  }
+
+  try {
+    const storedValue = window.localStorage.getItem(key)
+    if (!storedValue) {
+      return safeFallback
+    }
+
+    const parsedValue = Number.parseInt(storedValue, 10)
+    return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : safeFallback
+  } catch (error) {
+    console.warn(`Error reading page size storage key "${key}":`, error)
+    return safeFallback
+  }
+}
+
+export function writePageSizeToStorage(key: string | undefined, pageSize: number): void {
+  if (!key || typeof window === "undefined") {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(key, String(Math.max(1, pageSize)))
+  } catch (error) {
+    console.warn(`Error writing page size storage key "${key}":`, error)
+  }
+}


### PR DESCRIPTION
## Summary
- Add shared page-jump controls for server/controlled DataTable pagination while keeping local TanStack tables unchanged.
- Persist only pageSize per server-paginated table key for maintenance plans, transfers, repair requests, and device quota unassigned equipment.
- Keep page resets on search/filter/tenant changes and avoid persisting currentPage.

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/components/__tests__/data-table-pagination.test.tsx src/hooks/__tests__/usePaginationState.test.ts src/hooks/__tests__/useServerPagination.test.ts 'src/app/(app)/maintenance/__tests__/use-maintenance-plan-list-controls.test.tsx' 'src/app/(app)/transfers/__tests__/useTransfersPageController.test.tsx' 'src/app/(app)/repair-requests/__tests__/useRepairRequestsData.test.ts' 'src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaUnassignedList.test.tsx' 'src/app/(app)/device-quota/mapping/__tests__/DeviceQuotaMappingContext.test.tsx' 'src/app/(app)/maintenance/__tests__/MaintenanceKpi.test.tsx'
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared page-jump control to DataTable pagination for server and controlled tables, and adds per-table pageSize persistence. Current page is never persisted and still resets on search/filter/tenant changes.

- New Features
  - Page jump in `DataTablePagination`: numeric input + button; clamps to valid pages; submits on Enter/click; no jump while typing; disabled while loading; stays in sync after controlled navigation.
  - `pageSizeStorageKey` in `usePaginationState` and `useServerPagination`: reads initial `pageSize` from `localStorage`, persists on change, never stores page index; normalizes invalid values via `normalizePageSize`.
  - Enabled persistence for: `datatable:maintenance-plans:page-size`, `datatable:transfers:page-size`, `datatable:repair-requests:page-size`, `datatable:device-quota-unassigned:page-size`.
  - Local TanStack-only tables remain unchanged.
  - Tests cover page jump (enter/click, clamping, no jump while typing, loading state, controlled sync) and pageSize persistence/normalization.

<sup>Written for commit 67f08ba7d35152adb5be50286a9618e6b8682dc5. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/511?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table pagination page-size preferences are now persisted and restored across sessions for device quota, maintenance, repair requests, and transfers tables.
  * Added page-jump functionality to pagination navigation, allowing users to navigate directly to a specific page number.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->