### PR TITLE
Fix dashboard badge department scope

### DIFF
--- a/supabase/migrations/20260518152809_scope_dashboard_badges_to_user_department.sql
+++ b/supabase/migrations/20260518152809_scope_dashboard_badges_to_user_department.sql
@@ -1,0 +1,432 @@
+-- Scope Dashboard KPI and notification badge counts to role=user department.
+--
+-- Issue #512:
+-- - Preserve tenant/facility behavior for global/admin, regional_leader, to_qltb,
+--   qltb_khoa, and technician.
+-- - Add the same strict normalized department equality used by equipment reads
+--   for role=user.
+-- - Fail closed to zero/empty payloads when role=user has no valid khoa_phong
+--   claim.
+BEGIN;
+CREATE OR REPLACE FUNCTION public.dashboard_equipment_total()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_allowed_don_vi bigint[];
+  v_department_scope text;
+  result integer;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+  IF v_role <> 'global'
+     AND (v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL) THEN
+    RETURN 0;
+  END IF;
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN 0;
+    END IF;
+  END IF;
+  SELECT COUNT(*)::integer INTO result
+  FROM public.thiet_bi tb
+  WHERE tb.is_deleted = false
+    AND (
+      v_role = 'global'
+      OR tb.don_vi = ANY(v_allowed_don_vi)
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+    );
+  RETURN COALESCE(result, 0);
+END;
+$function$;
+CREATE OR REPLACE FUNCTION public.dashboard_maintenance_count()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_allowed_don_vi bigint[];
+  v_department_scope text;
+  result integer;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+  IF v_role <> 'global'
+     AND (v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL) THEN
+    RETURN 0;
+  END IF;
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN 0;
+    END IF;
+  END IF;
+  SELECT COUNT(*)::integer INTO result
+  FROM public.thiet_bi tb
+  WHERE (
+      v_role = 'global'
+      OR tb.don_vi = ANY(v_allowed_don_vi)
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+    )
+    AND (
+      tb.tinh_trang_hien_tai ILIKE '%Chờ bảo trì%'
+      OR tb.tinh_trang_hien_tai ILIKE '%Chờ hiệu chuẩn%'
+      OR tb.tinh_trang_hien_tai ILIKE '%Chờ kiểm định%'
+      OR tb.tinh_trang_hien_tai ILIKE '%bảo trì%'
+      OR tb.tinh_trang_hien_tai ILIKE '%hiệu chuẩn%'
+      OR tb.tinh_trang_hien_tai ILIKE '%kiểm định%'
+    );
+  RETURN COALESCE(result, 0);
+END;
+$function$;
+CREATE OR REPLACE FUNCTION public.dashboard_repair_request_stats()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_allowed_don_vi bigint[];
+  v_department_scope text;
+  result jsonb;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+  IF v_role <> 'global'
+     AND (v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL) THEN
+    RETURN jsonb_build_object('total', 0, 'pending', 0, 'approved', 0, 'completed', 0);
+  END IF;
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('total', 0, 'pending', 0, 'approved', 0, 'completed', 0);
+    END IF;
+  END IF;
+  WITH repair_counts AS (
+    SELECT
+      COUNT(*) FILTER (WHERE yc.trang_thai = 'Chờ xử lý') AS pending,
+      COUNT(*) FILTER (WHERE yc.trang_thai = 'Đã duyệt') AS approved,
+      COUNT(*) FILTER (WHERE yc.trang_thai IN ('Hoàn thành', 'Không HT')) AS completed
+    FROM public.yeu_cau_sua_chua yc
+    INNER JOIN public.thiet_bi tb ON tb.id = yc.thiet_bi_id
+    WHERE (
+        v_role = 'global'
+        OR tb.don_vi = ANY(v_allowed_don_vi)
+      )
+      AND (
+        v_role <> 'user'
+        OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+      )
+  )
+  SELECT jsonb_build_object(
+    'total', COALESCE(rc.pending + rc.approved, 0),
+    'pending', COALESCE(rc.pending, 0),
+    'approved', COALESCE(rc.approved, 0),
+    'completed', COALESCE(rc.completed, 0)
+  )
+  INTO result
+  FROM repair_counts rc;
+  RETURN COALESCE(result, jsonb_build_object('total', 0, 'pending', 0, 'approved', 0, 'completed', 0));
+END;
+$function$;
+CREATE OR REPLACE FUNCTION public.dashboard_maintenance_plan_stats()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_allowed_don_vi bigint[];
+  v_department_scope text;
+  result jsonb;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+  IF v_role <> 'global'
+     AND (v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL) THEN
+    RETURN jsonb_build_object('total', 0, 'draft', 0, 'approved', 0, 'plans', '[]'::jsonb);
+  END IF;
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('total', 0, 'draft', 0, 'approved', 0, 'plans', '[]'::jsonb);
+    END IF;
+  END IF;
+  WITH tenant_filtered_plans AS (
+    SELECT kh.*
+    FROM public.ke_hoach_bao_tri kh
+    WHERE (
+        v_role = 'global'
+        OR kh.don_vi = ANY(v_allowed_don_vi)
+      )
+      AND (
+        v_role <> 'user'
+        OR public._normalize_department_scope(kh.khoa_phong) = v_department_scope
+      )
+  ),
+  plan_counts AS (
+    SELECT
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE trang_thai = 'Bản nháp') AS draft,
+      COUNT(*) FILTER (WHERE trang_thai = 'Đã duyệt') AS approved
+    FROM tenant_filtered_plans
+  ),
+  recent_plans AS (
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'id', tfp.id,
+        'ten_ke_hoach', tfp.ten_ke_hoach,
+        'nam', tfp.nam,
+        'khoa_phong', tfp.khoa_phong,
+        'loai_cong_viec', tfp.loai_cong_viec,
+        'trang_thai', tfp.trang_thai,
+        'created_at', tfp.created_at
+      ) ORDER BY tfp.created_at DESC
+    ) AS plans
+    FROM (
+      SELECT *
+      FROM tenant_filtered_plans
+      ORDER BY created_at DESC
+      LIMIT 10
+    ) tfp
+  )
+  SELECT jsonb_build_object(
+    'total', COALESCE(pc.total, 0),
+    'draft', COALESCE(pc.draft, 0),
+    'approved', COALESCE(pc.approved, 0),
+    'plans', COALESCE(rp.plans, '[]'::jsonb)
+  )
+  INTO result
+  FROM plan_counts pc
+  CROSS JOIN recent_plans rp;
+  RETURN COALESCE(result, jsonb_build_object('total', 0, 'draft', 0, 'approved', 0, 'plans', '[]'::jsonb));
+END;
+$function$;
+CREATE OR REPLACE FUNCTION public.header_notifications_summary(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_is_global boolean := false;
+  v_allowed_don_vi bigint[];
+  v_filter_don_vi bigint := NULL;
+  v_department_scope text;
+  v_repairs bigint := 0;
+  v_transfers bigint := 0;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_is_global := v_role = 'global';
+  IF NOT v_is_global THEN
+    v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+    IF v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL THEN
+      RETURN jsonb_build_object('pending_repairs', 0, 'pending_transfers', 0);
+    END IF;
+    IF p_don_vi IS NOT NULL AND NOT (p_don_vi = ANY(v_allowed_don_vi)) THEN
+      RETURN jsonb_build_object('pending_repairs', 0, 'pending_transfers', 0);
+    END IF;
+  END IF;
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('pending_repairs', 0, 'pending_transfers', 0);
+    END IF;
+  END IF;
+  IF p_don_vi IS NOT NULL THEN
+    v_filter_don_vi := p_don_vi;
+  END IF;
+  SELECT COUNT(*) INTO v_repairs
+  FROM public.yeu_cau_sua_chua r
+  INNER JOIN public.thiet_bi tb ON tb.id = r.thiet_bi_id
+  WHERE r.trang_thai IN ('Chờ xử lý', 'Đã duyệt')
+    AND (
+      (v_filter_don_vi IS NOT NULL AND tb.don_vi = v_filter_don_vi)
+      OR (v_filter_don_vi IS NULL AND v_is_global)
+      OR (v_filter_don_vi IS NULL AND NOT v_is_global AND tb.don_vi = ANY(v_allowed_don_vi))
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+    );
+  SELECT COUNT(*) INTO v_transfers
+  FROM public.yeu_cau_luan_chuyen t
+  INNER JOIN public.thiet_bi tb ON tb.id = t.thiet_bi_id
+  WHERE t.trang_thai IN ('cho_duyet', 'da_duyet')
+    AND (
+      (v_filter_don_vi IS NOT NULL AND tb.don_vi = v_filter_don_vi)
+      OR (v_filter_don_vi IS NULL AND v_is_global)
+      OR (v_filter_don_vi IS NULL AND NOT v_is_global AND tb.don_vi = ANY(v_allowed_don_vi))
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+    );
+  RETURN jsonb_build_object(
+    'pending_repairs', COALESCE(v_repairs, 0),
+    'pending_transfers', COALESCE(v_transfers, 0)
+  );
+END;
+$function$;
+CREATE OR REPLACE FUNCTION public.maintenance_plan_status_counts(p_don_vi bigint DEFAULT NULL::bigint, p_q text DEFAULT NULL::text)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_don_vi bigint;
+  v_is_global boolean := false;
+  v_allowed_don_vi bigint[];
+  v_department_scope text;
+  v_result jsonb;
+  v_sanitized_q text;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+  v_don_vi := NULLIF(v_jwt_claims->>'don_vi', '')::bigint;
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_is_global := v_role = 'global';
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim' USING ERRCODE = '42501';
+  END IF;
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+  IF NOT v_is_global AND (v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL) THEN
+    RETURN jsonb_build_object('Bản nháp', 0, 'Đã duyệt', 0, 'Không duyệt', 0);
+  END IF;
+  IF NOT v_is_global AND p_don_vi IS NOT NULL AND NOT (p_don_vi = ANY(v_allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Access denied to facility %', p_don_vi
+      USING ERRCODE = '42501',
+            HINT = 'You do not have permission to access this facility';
+  END IF;
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('Bản nháp', 0, 'Đã duyệt', 0, 'Không duyệt', 0);
+    END IF;
+  END IF;
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+  SELECT jsonb_build_object(
+    'Bản nháp', COALESCE(SUM(CASE WHEN kh.trang_thai = 'Bản nháp' THEN 1 ELSE 0 END), 0),
+    'Đã duyệt', COALESCE(SUM(CASE WHEN kh.trang_thai = 'Đã duyệt' THEN 1 ELSE 0 END), 0),
+    'Không duyệt', COALESCE(SUM(CASE WHEN kh.trang_thai = 'Không duyệt' THEN 1 ELSE 0 END), 0)
+  )
+  INTO v_result
+  FROM public.ke_hoach_bao_tri kh
+  LEFT JOIN public.don_vi dv ON kh.don_vi = dv.id
+  WHERE (
+      v_sanitized_q IS NULL
+      OR kh.ten_ke_hoach ILIKE '%' || v_sanitized_q || '%'
+      OR COALESCE(kh.khoa_phong, '') ILIKE '%' || v_sanitized_q || '%'
+      OR COALESCE(kh.nguoi_lap_ke_hoach, '') ILIKE '%' || v_sanitized_q || '%'
+      OR COALESCE(kh.loai_cong_viec, '') ILIKE '%' || v_sanitized_q || '%'
+      OR COALESCE(dv.name, '') ILIKE '%' || v_sanitized_q || '%'
+      OR CAST(kh.nam AS text) ILIKE '%' || v_sanitized_q || '%'
+    )
+    AND (
+      CASE
+        WHEN p_don_vi IS NOT NULL THEN kh.don_vi = p_don_vi
+        ELSE v_is_global OR kh.don_vi = ANY(v_allowed_don_vi)
+      END
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(kh.khoa_phong) = v_department_scope
+    );
+  RETURN COALESCE(v_result, jsonb_build_object('Bản nháp', 0, 'Đã duyệt', 0, 'Không duyệt', 0));
+END;
+$function$;
+COMMIT;

--- a/supabase/migrations/20260518155220_fix_dashboard_badges_soft_delete_and_regional_scope.sql
+++ b/supabase/migrations/20260518155220_fix_dashboard_badges_soft_delete_and_regional_scope.sql
@@ -1,0 +1,344 @@
+-- Fix Issue #512 follow-up after review:
+-- - keep dashboard_maintenance_count aligned with dashboard_equipment_total by
+--   excluding soft-deleted equipment
+-- - keep repair/header badge counts from including requests linked to
+--   soft-deleted equipment
+-- - preserve the regional_leader null-don_vi contract in
+--   maintenance_plan_status_counts
+--
+-- The original Issue #512 migration was already applied as
+-- 20260518152809_scope_dashboard_badges_to_user_department. This follow-up
+-- preserves that applied migration and supersedes only the affected RPC.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.dashboard_maintenance_count()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_allowed_don_vi bigint[];
+  v_department_scope text;
+  result integer;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF v_role <> 'global'
+     AND (v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL) THEN
+    RETURN 0;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN 0;
+    END IF;
+  END IF;
+
+  SELECT COUNT(*)::integer INTO result
+  FROM public.thiet_bi tb
+  WHERE tb.is_deleted = false
+    AND (
+      v_role = 'global'
+      OR tb.don_vi = ANY(v_allowed_don_vi)
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+    )
+    AND (
+      tb.tinh_trang_hien_tai ILIKE '%Chờ bảo trì%'
+      OR tb.tinh_trang_hien_tai ILIKE '%Chờ hiệu chuẩn%'
+      OR tb.tinh_trang_hien_tai ILIKE '%Chờ kiểm định%'
+      OR tb.tinh_trang_hien_tai ILIKE '%bảo trì%'
+      OR tb.tinh_trang_hien_tai ILIKE '%hiệu chuẩn%'
+      OR tb.tinh_trang_hien_tai ILIKE '%kiểm định%'
+    );
+
+  RETURN COALESCE(result, 0);
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.dashboard_repair_request_stats()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_allowed_don_vi bigint[];
+  v_department_scope text;
+  result jsonb;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF v_role <> 'global'
+     AND (v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL) THEN
+    RETURN jsonb_build_object('total', 0, 'pending', 0, 'approved', 0, 'completed', 0);
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('total', 0, 'pending', 0, 'approved', 0, 'completed', 0);
+    END IF;
+  END IF;
+
+  WITH repair_counts AS (
+    SELECT
+      COUNT(*) FILTER (WHERE yc.trang_thai = 'Chờ xử lý') AS pending,
+      COUNT(*) FILTER (WHERE yc.trang_thai = 'Đã duyệt') AS approved,
+      COUNT(*) FILTER (WHERE yc.trang_thai IN ('Hoàn thành', 'Không HT')) AS completed
+    FROM public.yeu_cau_sua_chua yc
+    INNER JOIN public.thiet_bi tb ON tb.id = yc.thiet_bi_id
+    WHERE tb.is_deleted = false
+      AND (
+        v_role = 'global'
+        OR tb.don_vi = ANY(v_allowed_don_vi)
+      )
+      AND (
+        v_role <> 'user'
+        OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+      )
+  )
+  SELECT jsonb_build_object(
+    'total', COALESCE(rc.pending + rc.approved, 0),
+    'pending', COALESCE(rc.pending, 0),
+    'approved', COALESCE(rc.approved, 0),
+    'completed', COALESCE(rc.completed, 0)
+  )
+  INTO result
+  FROM repair_counts rc;
+
+  RETURN COALESCE(result, jsonb_build_object('total', 0, 'pending', 0, 'approved', 0, 'completed', 0));
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.header_notifications_summary(p_don_vi bigint DEFAULT NULL::bigint)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_is_global boolean := false;
+  v_allowed_don_vi bigint[];
+  v_filter_don_vi bigint := NULL;
+  v_department_scope text;
+  v_repairs bigint := 0;
+  v_transfers bigint := 0;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_is_global := v_role = 'global';
+
+  IF NOT v_is_global THEN
+    v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+    IF v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL THEN
+      RETURN jsonb_build_object('pending_repairs', 0, 'pending_transfers', 0);
+    END IF;
+
+    IF p_don_vi IS NOT NULL AND NOT (p_don_vi = ANY(v_allowed_don_vi)) THEN
+      RETURN jsonb_build_object('pending_repairs', 0, 'pending_transfers', 0);
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('pending_repairs', 0, 'pending_transfers', 0);
+    END IF;
+  END IF;
+
+  IF p_don_vi IS NOT NULL THEN
+    v_filter_don_vi := p_don_vi;
+  END IF;
+
+  SELECT COUNT(*) INTO v_repairs
+  FROM public.yeu_cau_sua_chua r
+  INNER JOIN public.thiet_bi tb ON tb.id = r.thiet_bi_id
+  WHERE r.trang_thai IN ('Chờ xử lý', 'Đã duyệt')
+    AND tb.is_deleted = false
+    AND (
+      (v_filter_don_vi IS NOT NULL AND tb.don_vi = v_filter_don_vi)
+      OR (v_filter_don_vi IS NULL AND v_is_global)
+      OR (v_filter_don_vi IS NULL AND NOT v_is_global AND tb.don_vi = ANY(v_allowed_don_vi))
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+    );
+
+  SELECT COUNT(*) INTO v_transfers
+  FROM public.yeu_cau_luan_chuyen t
+  INNER JOIN public.thiet_bi tb ON tb.id = t.thiet_bi_id
+  WHERE t.trang_thai IN ('cho_duyet', 'da_duyet')
+    AND tb.is_deleted = false
+    AND (
+      (v_filter_don_vi IS NOT NULL AND tb.don_vi = v_filter_don_vi)
+      OR (v_filter_don_vi IS NULL AND v_is_global)
+      OR (v_filter_don_vi IS NULL AND NOT v_is_global AND tb.don_vi = ANY(v_allowed_don_vi))
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+    );
+
+  RETURN jsonb_build_object(
+    'pending_repairs', COALESCE(v_repairs, 0),
+    'pending_transfers', COALESCE(v_transfers, 0)
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.maintenance_plan_status_counts(p_don_vi bigint DEFAULT NULL::bigint, p_q text DEFAULT NULL::text)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_jwt_claims jsonb;
+  v_role text;
+  v_user_id text;
+  v_don_vi bigint;
+  v_is_global boolean := false;
+  v_allowed_don_vi bigint[];
+  v_department_scope text;
+  v_result jsonb;
+  v_sanitized_q text;
+BEGIN
+  v_jwt_claims := COALESCE(NULLIF(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb);
+  v_role := lower(COALESCE(v_jwt_claims->>'app_role', v_jwt_claims->>'role', ''));
+  v_user_id := NULLIF(COALESCE(v_jwt_claims->>'user_id', v_jwt_claims->>'sub'), '');
+  v_don_vi := NULLIF(v_jwt_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_is_global := v_role = 'global';
+
+  IF v_role NOT IN ('global', 'regional_leader') AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim' USING ERRCODE = '42501';
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF NOT v_is_global AND (v_allowed_don_vi IS NULL OR array_length(v_allowed_don_vi, 1) IS NULL) THEN
+    RETURN jsonb_build_object('Bản nháp', 0, 'Đã duyệt', 0, 'Không duyệt', 0);
+  END IF;
+
+  IF NOT v_is_global AND p_don_vi IS NOT NULL AND NOT (p_don_vi = ANY(v_allowed_don_vi)) THEN
+    RAISE EXCEPTION 'Access denied to facility %', p_don_vi
+      USING ERRCODE = '42501',
+            HINT = 'You do not have permission to access this facility';
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims->>'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object('Bản nháp', 0, 'Đã duyệt', 0, 'Không duyệt', 0);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  SELECT jsonb_build_object(
+    'Bản nháp', COALESCE(SUM(CASE WHEN kh.trang_thai = 'Bản nháp' THEN 1 ELSE 0 END), 0),
+    'Đã duyệt', COALESCE(SUM(CASE WHEN kh.trang_thai = 'Đã duyệt' THEN 1 ELSE 0 END), 0),
+    'Không duyệt', COALESCE(SUM(CASE WHEN kh.trang_thai = 'Không duyệt' THEN 1 ELSE 0 END), 0)
+  )
+  INTO v_result
+  FROM public.ke_hoach_bao_tri kh
+  LEFT JOIN public.don_vi dv ON kh.don_vi = dv.id
+  WHERE (
+      v_sanitized_q IS NULL
+      OR kh.ten_ke_hoach ILIKE '%' || v_sanitized_q || '%'
+      OR COALESCE(kh.khoa_phong, '') ILIKE '%' || v_sanitized_q || '%'
+      OR COALESCE(kh.nguoi_lap_ke_hoach, '') ILIKE '%' || v_sanitized_q || '%'
+      OR COALESCE(kh.loai_cong_viec, '') ILIKE '%' || v_sanitized_q || '%'
+      OR COALESCE(dv.name, '') ILIKE '%' || v_sanitized_q || '%'
+      OR CAST(kh.nam AS text) ILIKE '%' || v_sanitized_q || '%'
+    )
+    AND (
+      CASE
+        WHEN p_don_vi IS NOT NULL THEN kh.don_vi = p_don_vi
+        ELSE v_is_global OR kh.don_vi = ANY(v_allowed_don_vi)
+      END
+    )
+    AND (
+      v_role <> 'user'
+      OR public._normalize_department_scope(kh.khoa_phong) = v_department_scope
+    );
+
+  RETURN COALESCE(v_result, jsonb_build_object('Bản nháp', 0, 'Đã duyệt', 0, 'Không duyệt', 0));
+END;
+$function$;
+
+COMMIT;

--- a/supabase/tests/dashboard_badges_department_scope_smoke.sql
+++ b/supabase/tests/dashboard_badges_department_scope_smoke.sql
@@ -7,10 +7,12 @@ BEGIN;
 DO $$
 DECLARE
   v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_region bigint;
   v_tenant bigint;
   v_other_tenant bigint;
   v_allowed_equipment bigint;
   v_blocked_equipment bigint;
+  v_deleted_equipment bigint;
   v_other_equipment bigint;
   v_dashboard jsonb;
   v_header jsonb;
@@ -20,12 +22,21 @@ DECLARE
   v_sqlerrm text;
   v_proconfig text[];
 BEGIN
-  INSERT INTO public.don_vi(name, active)
-  VALUES ('Smoke Issue 512 Tenant ' || v_suffix, true)
+  INSERT INTO public.dia_ban(ma_dia_ban, ten_dia_ban, so_luong_don_vi_truc_thuoc, active)
+  VALUES (
+    'SMK-512-' || v_suffix,
+    'Smoke Issue 512 Region ' || v_suffix,
+    2,
+    true
+  )
+  RETURNING id INTO v_region;
+
+  INSERT INTO public.don_vi(code, name, active, dia_ban_id)
+  VALUES ('SMK-512-A-' || v_suffix, 'Smoke Issue 512 Tenant ' || v_suffix, true, v_region)
   RETURNING id INTO v_tenant;
 
-  INSERT INTO public.don_vi(name, active)
-  VALUES ('Smoke Issue 512 Other Tenant ' || v_suffix, true)
+  INSERT INTO public.don_vi(code, name, active, dia_ban_id)
+  VALUES ('SMK-512-B-' || v_suffix, 'Smoke Issue 512 Other Tenant ' || v_suffix, true, v_region)
   RETURNING id INTO v_other_tenant;
 
   INSERT INTO public.thiet_bi(
@@ -73,6 +84,24 @@ BEGIN
     is_deleted
   )
   VALUES (
+    'SMK-512-DELETED-' || v_suffix,
+    'Smoke Issue 512 Deleted ' || v_suffix,
+    v_tenant,
+    'Nội thận - Tiết niệu',
+    'Chờ bảo trì',
+    true
+  )
+  RETURNING id INTO v_deleted_equipment;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
     'SMK-512-OTHER-' || v_suffix,
     'Smoke Issue 512 Other Tenant ' || v_suffix,
     v_other_tenant,
@@ -94,6 +123,7 @@ BEGIN
   VALUES
     (v_allowed_equipment, 'Smoke Issue 512 repair allowed', 'Smoke repair', CURRENT_DATE + 1, 'Smoke User', 'Chờ xử lý', 'noi_bo'),
     (v_blocked_equipment, 'Smoke Issue 512 repair blocked', 'Smoke repair', CURRENT_DATE + 1, 'Smoke User', 'Chờ xử lý', 'noi_bo'),
+    (v_deleted_equipment, 'Smoke Issue 512 repair deleted', 'Smoke repair', CURRENT_DATE + 1, 'Smoke User', 'Chờ xử lý', 'noi_bo'),
     (v_other_equipment, 'Smoke Issue 512 repair other tenant', 'Smoke repair', CURRENT_DATE + 1, 'Smoke User', 'Chờ xử lý', 'noi_bo');
 
   INSERT INTO public.yeu_cau_luan_chuyen(
@@ -107,6 +137,7 @@ BEGIN
   VALUES
     ('YCLC-512-ALLOW-' || v_suffix, v_allowed_equipment, 'noi_bo', 'cho_duyet', 'Smoke transfer allowed ' || v_suffix, now()),
     ('YCLC-512-BLOCK-' || v_suffix, v_blocked_equipment, 'noi_bo', 'cho_duyet', 'Smoke transfer blocked ' || v_suffix, now()),
+    ('YCLC-512-DELETED-' || v_suffix, v_deleted_equipment, 'noi_bo', 'cho_duyet', 'Smoke transfer deleted ' || v_suffix, now()),
     ('YCLC-512-OTHER-' || v_suffix, v_other_equipment, 'noi_bo', 'cho_duyet', 'Smoke transfer other tenant ' || v_suffix, now());
 
   INSERT INTO public.ke_hoach_bao_tri(
@@ -146,7 +177,7 @@ BEGIN
   END IF;
 
   IF COALESCE((v_dashboard->>'maintenanceCount')::integer, 0) <> 1 THEN
-    RAISE EXCEPTION 'dashboard maintenanceCount should count only role=user department rows, got %', v_dashboard;
+    RAISE EXCEPTION 'dashboard maintenanceCount should count only active role=user department rows, got %', v_dashboard;
   END IF;
 
   IF COALESCE((v_dashboard->'repairRequests'->>'pending')::integer, 0) <> 1
@@ -172,7 +203,6 @@ BEGIN
   END IF;
 
   v_header := public.header_notifications_summary(v_other_tenant);
-  v_plan_counts := public.maintenance_plan_status_counts(v_other_tenant, NULL::text);
 
   IF COALESCE((v_header->>'pending_repairs')::integer, 0) <> 0
      OR COALESCE((v_header->>'pending_transfers')::integer, 0) <> 0 THEN
@@ -269,6 +299,26 @@ BEGIN
   IF COALESCE((v_plan_counts->>'Bản nháp')::integer, 0) <> 1
      OR COALESCE((v_plan_counts->>'Đã duyệt')::integer, 0) <> 0 THEN
     RAISE EXCEPTION 'global selected other-facility maintenance badges should not leak tenant A, got %', v_plan_counts;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'regional_leader',
+      'role', 'authenticated',
+      'user_id', 'smoke-512-regional-' || v_suffix,
+      'sub', 'smoke-512-regional-' || v_suffix,
+      'dia_ban', v_region::text,
+      'don_vi', NULL
+    )::text,
+    true
+  );
+
+  v_plan_counts := public.maintenance_plan_status_counts(NULL::bigint, NULL::text);
+
+  IF COALESCE((v_plan_counts->>'Bản nháp')::integer, 0) <> 3
+     OR COALESCE((v_plan_counts->>'Đã duyệt')::integer, 0) <> 2 THEN
+    RAISE EXCEPTION 'regional_leader maintenance badges should work with NULL don_vi claim, got %', v_plan_counts;
   END IF;
 
   FOR v_proconfig IN

--- a/supabase/tests/dashboard_badges_department_scope_smoke.sql
+++ b/supabase/tests/dashboard_badges_department_scope_smoke.sql
@@ -1,0 +1,297 @@
+-- supabase/tests/dashboard_badges_department_scope_smoke.sql
+-- Purpose: lock Dashboard KPI and notification badge counts to role=user department scope.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_allowed_equipment bigint;
+  v_blocked_equipment bigint;
+  v_other_equipment bigint;
+  v_dashboard jsonb;
+  v_header jsonb;
+  v_plan_counts jsonb;
+  v_failed boolean;
+  v_sqlstate text;
+  v_sqlerrm text;
+  v_proconfig text[];
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Issue 512 Tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Issue 512 Other Tenant ' || v_suffix, true)
+  RETURNING id INTO v_other_tenant;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-512-ALLOW-' || v_suffix,
+    'Smoke Issue 512 Allowed ' || v_suffix,
+    v_tenant,
+    '  Nội thận - Tiết niệu  ',
+    'Chờ bảo trì',
+    false
+  )
+  RETURNING id INTO v_allowed_equipment;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-512-BLOCK-' || v_suffix,
+    'Smoke Issue 512 Blocked ' || v_suffix,
+    v_tenant,
+    'Khoa Ngoại ' || v_suffix,
+    'Chờ bảo trì',
+    false
+  )
+  RETURNING id INTO v_blocked_equipment;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-512-OTHER-' || v_suffix,
+    'Smoke Issue 512 Other Tenant ' || v_suffix,
+    v_other_tenant,
+    'Nội thận - Tiết niệu',
+    'Chờ bảo trì',
+    false
+  )
+  RETURNING id INTO v_other_equipment;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien
+  )
+  VALUES
+    (v_allowed_equipment, 'Smoke Issue 512 repair allowed', 'Smoke repair', CURRENT_DATE + 1, 'Smoke User', 'Chờ xử lý', 'noi_bo'),
+    (v_blocked_equipment, 'Smoke Issue 512 repair blocked', 'Smoke repair', CURRENT_DATE + 1, 'Smoke User', 'Chờ xử lý', 'noi_bo'),
+    (v_other_equipment, 'Smoke Issue 512 repair other tenant', 'Smoke repair', CURRENT_DATE + 1, 'Smoke User', 'Chờ xử lý', 'noi_bo');
+
+  INSERT INTO public.yeu_cau_luan_chuyen(
+    ma_yeu_cau,
+    thiet_bi_id,
+    loai_hinh,
+    trang_thai,
+    ly_do_luan_chuyen,
+    created_at
+  )
+  VALUES
+    ('YCLC-512-ALLOW-' || v_suffix, v_allowed_equipment, 'noi_bo', 'cho_duyet', 'Smoke transfer allowed ' || v_suffix, now()),
+    ('YCLC-512-BLOCK-' || v_suffix, v_blocked_equipment, 'noi_bo', 'cho_duyet', 'Smoke transfer blocked ' || v_suffix, now()),
+    ('YCLC-512-OTHER-' || v_suffix, v_other_equipment, 'noi_bo', 'cho_duyet', 'Smoke transfer other tenant ' || v_suffix, now());
+
+  INSERT INTO public.ke_hoach_bao_tri(
+    ten_ke_hoach,
+    nam,
+    don_vi,
+    khoa_phong,
+    loai_cong_viec,
+    trang_thai
+  )
+  VALUES
+    ('Smoke Issue 512 Plan Draft Allowed ' || v_suffix, EXTRACT(YEAR FROM current_date)::integer, v_tenant, 'Nội thận - Tiết niệu', 'Bảo trì', 'Bản nháp'),
+    ('Smoke Issue 512 Plan Approved Allowed ' || v_suffix, EXTRACT(YEAR FROM current_date)::integer, v_tenant, 'Nội thận - Tiết niệu', 'Bảo trì', 'Đã duyệt'),
+    ('Smoke Issue 512 Plan Draft Blocked ' || v_suffix, EXTRACT(YEAR FROM current_date)::integer, v_tenant, 'Khoa Ngoại ' || v_suffix, 'Bảo trì', 'Bản nháp'),
+    ('Smoke Issue 512 Plan Approved Blocked ' || v_suffix, EXTRACT(YEAR FROM current_date)::integer, v_tenant, 'Khoa Ngoại ' || v_suffix, 'Bảo trì', 'Đã duyệt'),
+    ('Smoke Issue 512 Plan Other Tenant ' || v_suffix, EXTRACT(YEAR FROM current_date)::integer, v_other_tenant, 'Nội thận - Tiết niệu', 'Bảo trì', 'Bản nháp');
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', 'smoke-512-user-' || v_suffix,
+      'sub', 'smoke-512-user-' || v_suffix,
+      'don_vi', v_tenant::text,
+      'khoa_phong', ' ' || chr(160) || E'NỘI\nTHẬN\t  - TIẾT   NIỆU '
+    )::text,
+    true
+  );
+
+  v_dashboard := public.dashboard_kpi_summary();
+  v_header := public.header_notifications_summary(NULL::bigint);
+  v_plan_counts := public.maintenance_plan_status_counts(NULL::bigint, NULL::text);
+
+  IF COALESCE((v_dashboard->>'totalEquipment')::integer, 0) <> 1 THEN
+    RAISE EXCEPTION 'dashboard totalEquipment should count only role=user department rows, got %', v_dashboard;
+  END IF;
+
+  IF COALESCE((v_dashboard->>'maintenanceCount')::integer, 0) <> 1 THEN
+    RAISE EXCEPTION 'dashboard maintenanceCount should count only role=user department rows, got %', v_dashboard;
+  END IF;
+
+  IF COALESCE((v_dashboard->'repairRequests'->>'pending')::integer, 0) <> 1
+     OR COALESCE((v_dashboard->'repairRequests'->>'total')::integer, 0) <> 1 THEN
+    RAISE EXCEPTION 'dashboard repairRequests should count only role=user department rows, got %', v_dashboard;
+  END IF;
+
+  IF COALESCE((v_dashboard->'maintenancePlans'->>'total')::integer, 0) <> 2
+     OR COALESCE((v_dashboard->'maintenancePlans'->>'draft')::integer, 0) <> 1
+     OR COALESCE((v_dashboard->'maintenancePlans'->>'approved')::integer, 0) <> 1 THEN
+    RAISE EXCEPTION 'dashboard maintenancePlans should count only role=user department rows, got %', v_dashboard;
+  END IF;
+
+  IF COALESCE((v_header->>'pending_repairs')::integer, 0) <> 1
+     OR COALESCE((v_header->>'pending_transfers')::integer, 0) <> 1 THEN
+    RAISE EXCEPTION 'header notification counts should count only role=user department rows, got %', v_header;
+  END IF;
+
+  IF COALESCE((v_plan_counts->>'Bản nháp')::integer, 0) <> 1
+     OR COALESCE((v_plan_counts->>'Đã duyệt')::integer, 0) <> 1
+     OR COALESCE((v_plan_counts->>'Không duyệt')::integer, 0) <> 0 THEN
+    RAISE EXCEPTION 'maintenance badge counts should count only role=user department rows, got %', v_plan_counts;
+  END IF;
+
+  v_header := public.header_notifications_summary(v_other_tenant);
+  v_plan_counts := public.maintenance_plan_status_counts(v_other_tenant, NULL::text);
+
+  IF COALESCE((v_header->>'pending_repairs')::integer, 0) <> 0
+     OR COALESCE((v_header->>'pending_transfers')::integer, 0) <> 0 THEN
+    RAISE EXCEPTION 'role=user must not widen notification badges to another tenant, got %', v_header;
+  END IF;
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.maintenance_plan_status_counts(v_other_tenant, NULL::text);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'role=user must not widen maintenance badges to another tenant';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'role=user cross-tenant maintenance badge should deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', 'smoke-512-blank-user-' || v_suffix,
+      'sub', 'smoke-512-blank-user-' || v_suffix,
+      'don_vi', v_tenant::text,
+      'khoa_phong', ''
+    )::text,
+    true
+  );
+
+  v_dashboard := public.dashboard_kpi_summary();
+  v_header := public.header_notifications_summary(NULL::bigint);
+  v_plan_counts := public.maintenance_plan_status_counts(NULL::bigint, NULL::text);
+
+  IF COALESCE((v_dashboard->>'totalEquipment')::integer, 0) <> 0
+     OR COALESCE((v_dashboard->>'maintenanceCount')::integer, 0) <> 0
+     OR COALESCE((v_dashboard->'repairRequests'->>'total')::integer, 0) <> 0
+     OR COALESCE((v_dashboard->'maintenancePlans'->>'total')::integer, 0) <> 0 THEN
+    RAISE EXCEPTION 'dashboard KPI summary should fail closed for blank role=user department scope, got %', v_dashboard;
+  END IF;
+
+  IF COALESCE((v_header->>'pending_repairs')::integer, 0) <> 0
+     OR COALESCE((v_header->>'pending_transfers')::integer, 0) <> 0 THEN
+    RAISE EXCEPTION 'header notification counts should fail closed for blank role=user department scope, got %', v_header;
+  END IF;
+
+  IF COALESCE((v_plan_counts->>'Bản nháp')::integer, 0) <> 0
+     OR COALESCE((v_plan_counts->>'Đã duyệt')::integer, 0) <> 0
+     OR COALESCE((v_plan_counts->>'Không duyệt')::integer, 0) <> 0 THEN
+    RAISE EXCEPTION 'maintenance badge counts should fail closed for blank role=user department scope, got %', v_plan_counts;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'global',
+      'role', 'authenticated',
+      'user_id', 'smoke-512-global-' || v_suffix,
+      'sub', 'smoke-512-global-' || v_suffix,
+      'don_vi', NULL
+    )::text,
+    true
+  );
+
+  v_header := public.header_notifications_summary(v_tenant);
+  v_plan_counts := public.maintenance_plan_status_counts(v_tenant, NULL::text);
+
+  IF COALESCE((v_header->>'pending_repairs')::integer, 0) <> 2
+     OR COALESCE((v_header->>'pending_transfers')::integer, 0) <> 2 THEN
+    RAISE EXCEPTION 'global selected-facility badges should keep tenant-wide behavior, got %', v_header;
+  END IF;
+
+  IF COALESCE((v_plan_counts->>'Bản nháp')::integer, 0) <> 2
+     OR COALESCE((v_plan_counts->>'Đã duyệt')::integer, 0) <> 2 THEN
+    RAISE EXCEPTION 'global selected-facility maintenance badges should keep tenant-wide behavior, got %', v_plan_counts;
+  END IF;
+
+  v_header := public.header_notifications_summary(v_other_tenant);
+  v_plan_counts := public.maintenance_plan_status_counts(v_other_tenant, NULL::text);
+
+  IF COALESCE((v_header->>'pending_repairs')::integer, 0) <> 1
+     OR COALESCE((v_header->>'pending_transfers')::integer, 0) <> 1 THEN
+    RAISE EXCEPTION 'global selected other-facility badges should not leak tenant A, got %', v_header;
+  END IF;
+
+  IF COALESCE((v_plan_counts->>'Bản nháp')::integer, 0) <> 1
+     OR COALESCE((v_plan_counts->>'Đã duyệt')::integer, 0) <> 0 THEN
+    RAISE EXCEPTION 'global selected other-facility maintenance badges should not leak tenant A, got %', v_plan_counts;
+  END IF;
+
+  FOR v_proconfig IN
+    SELECT p.proconfig
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname IN (
+        'dashboard_equipment_total',
+        'dashboard_maintenance_count',
+        'dashboard_repair_request_stats',
+        'dashboard_maintenance_plan_stats',
+        'header_notifications_summary',
+        'maintenance_plan_status_counts'
+      )
+  LOOP
+    IF v_proconfig IS NULL
+       OR array_position(v_proconfig, 'search_path=public, pg_temp') IS NULL THEN
+      RAISE EXCEPTION 'Issue #512 scoped RPCs must pin search_path to public, pg_temp';
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE 'OK: dashboard and badge department scope smoke passed';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- scope Dashboard KPI and notification badge RPCs to role=user normalized khoa/phong
- preserve tenant/facility isolation for global/regional/non-user roles
- add rollback-safe SQL smoke coverage for department scope, blank department fail-closed, and cross-tenant isolation

## Verification
- RED: Supabase MCP execute_sql smoke failed before migration with tenant-wide dashboard count leak
- GREEN: Supabase MCP apply_migration scope_dashboard_badges_to_user_department succeeded
- GREEN: Supabase MCP execute_sql dashboard_badges_department_scope_smoke passed after apply
- Supabase MCP get_advisors(security) run; returned existing baseline lints outside this issue scope
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

Fixes #512

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes dashboard KPI counts and header notification badges to the signed-in user’s department for `role=user` and filters out soft-deleted equipment. Keeps existing tenant/facility behavior for other roles, fixes `regional_leader` NULL `don_vi`, and returns zero when the department claim is missing. Fixes #512.

- **Bug Fixes**
  - Applied strict, normalized department matching for `role=user` across dashboard and badge RPCs; fail-closed when `khoa_phong` is missing.
  - Excluded soft-deleted equipment from maintenance counts and from repair/transfer badge queries.
  - Preserved tenant/facility filtering for global/admin, regional, technician; allowed `regional_leader` with NULL `don_vi` in `maintenance_plan_status_counts`.
  - Pinned `search_path` and kept `SECURITY DEFINER` logic tight to prevent cross-tenant access.
  - Added rollback-safe SQL smoke tests covering department scoping, soft-delete filtering, regional-leader NULL `don_vi`, blank-department fail-closed, and cross-tenant isolation.

<sup>Written for commit 9f14a854048c7c7e2d974c2f236e54f3dcb7df22. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/519?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard KPI counts, notification badges, and maintenance plan status information are now properly scoped by user department. Users will only see data relevant to their assigned department, preventing unauthorized visibility across departments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->