### PR TITLE
feat: add DQSS perf instrumentation

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,9 +1,7 @@
 name: 🔍 Preview Checks
 
 on:
-  pull_request:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 env:
   NODE_VERSION: '18'

--- a/services/device-quota-suggestion-service/README.md
+++ b/services/device-quota-suggestion-service/README.md
@@ -47,6 +47,13 @@ Request:
 
 Response includes `provider`, `timings`, `metrics`, `cache`, and `suggestions`. Each suggestion includes `needsReview`, `confidence`, and bounded candidate categories.
 
+`timings` includes phase timings for validation, category embedding, device
+embedding, ranking, response serialization, and total duration. Structured
+`dqss.suggest` logs include the same phase timings plus request id, facility id,
+provider/model, cache status, device/category counts, and sanitized failure
+reason. Logs must not include raw device names, category names, tokens, or
+Cloudflare Access secrets.
+
 ## Local Tests
 
 Use a temporary virtual environment outside the repo:
@@ -59,6 +66,38 @@ PYTHONPATH=. /tmp/dqss-venv/bin/python -m pytest tests -q
 ```
 
 Tests use deterministic fake embeddings. They do not download the model.
+
+## Large-Payload Harness
+
+The deterministic harness documents the unit-17 and synthetic high-risk shapes
+without downloading the real model:
+
+```bash
+cd services/device-quota-suggestion-service
+PYTHONPATH=. /tmp/dqss-venv/bin/python scripts/dqss_perf_harness.py --case unit17 --mode deterministic
+PYTHONPATH=. /tmp/dqss-venv/bin/python scripts/dqss_perf_harness.py --case synthetic-2000 --mode deterministic
+```
+
+- `unit-17`: 504 unique names, 1940 devices, 291 categories.
+- `synthetic-2000`: 2000 unique names, 2000 devices, 300 categories.
+
+Each run prints JSON with total duration, phase timings, metrics, cache status,
+suggestion count, and provider metadata.
+
+Manual VM smoke against the real model should use the same payload shape and
+record total duration plus DQSS phase timings from the JSON response and
+structured service logs. Use environment-managed secrets only:
+
+```bash
+DQSS_URL=https://dqss-cvmems.cdclims.cloud
+DQSS_INTERNAL_TOKEN=...
+CF_ACCESS_CLIENT_ID=...
+CF_ACCESS_CLIENT_SECRET=...
+```
+
+Do not re-enable production canary from this instrumentation issue. Canary
+belongs to a later issue after timing evidence is captured and the VM path is
+fast enough for the real facility-sized request.
 
 ## Target VM Container
 

--- a/services/device-quota-suggestion-service/app/instrumentation.py
+++ b/services/device-quota-suggestion-service/app/instrumentation.py
@@ -1,0 +1,73 @@
+import json
+import logging
+import time
+from typing import Dict
+
+from app.normalization import normalize_text
+from app.schemas import ResponseDict, SuggestRequest
+
+LOGGER = logging.getLogger("dqss.suggest")
+
+
+def elapsed_ms(started: float) -> float:
+    return round((time.perf_counter() - started) * 1000, 3)
+
+
+def request_metrics(request: SuggestRequest) -> Dict[str, int]:
+    normalized_names = {normalize_text(item.name) for item in request.deviceNames}
+    return {
+        "deviceNameCount": len(request.deviceNames),
+        "uniqueDeviceNameCount": len(normalized_names),
+        "deviceCount": sum(len(item.deviceIds) for item in request.deviceNames),
+        "categoryCount": len(request.categories),
+    }
+
+
+def log_success(result: ResponseDict, request: SuggestRequest) -> None:
+    LOGGER.info(
+        json.dumps(
+            {
+                "event": "dqss.suggest.completed",
+                "requestId": result["requestId"],
+                "facilityId": request.facilityId,
+                "provider": result["provider"],
+                "timings": result["timings"],
+                "metrics": _public_metrics(result["metrics"]),
+                "cache": result["cache"],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+
+
+def log_failure(
+    request: SuggestRequest,
+    provider: dict,
+    timings: dict,
+    error: BaseException,
+) -> None:
+    LOGGER.info(
+        json.dumps(
+            {
+                "event": "dqss.suggest.failed",
+                "requestId": request.requestId,
+                "facilityId": request.facilityId,
+                "provider": provider,
+                "timings": timings,
+                "metrics": request_metrics(request),
+                "failureReason": type(error).__name__,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+
+
+def _public_metrics(metrics: dict) -> dict:
+    return {
+        "deviceNameCount": metrics["deviceNameCount"],
+        "uniqueDeviceNameCount": metrics["uniqueDeviceNameCount"],
+        "deviceCount": metrics["deviceCount"],
+        "categoryCount": metrics["categoryCount"],
+    }

--- a/services/device-quota-suggestion-service/app/perf_harness.py
+++ b/services/device-quota-suggestion-service/app/perf_harness.py
@@ -21,6 +21,8 @@ def create_synthetic_unique_payload(
     unique_name_count: int = 2000,
     category_count: int = 300,
 ) -> dict:
+    _validate_positive_count("unique_name_count", unique_name_count)
+    _validate_positive_count("category_count", category_count)
     return {
         "requestId": "req-harness-synthetic-%d" % unique_name_count,
         "facilityId": 17,
@@ -58,6 +60,7 @@ def _payload_for_case(case_name: str) -> dict:
 
 
 def _categories(count: int) -> list:
+    _validate_positive_count("category_count", count)
     return [
         {
             "id": index + 1,
@@ -70,6 +73,9 @@ def _categories(count: int) -> list:
 
 
 def _device_names(unique_name_count: int, total_device_count: int) -> list:
+    _validate_positive_count("unique_name_count", unique_name_count)
+    if total_device_count < 0:
+        raise ValueError("total_device_count must be >= 0")
     names = [
         {
             "name": "Thiet bi can phan loai %04d" % index,
@@ -80,6 +86,11 @@ def _device_names(unique_name_count: int, total_device_count: int) -> list:
     for device_id in range(1, total_device_count + 1):
         names[(device_id - 1) % unique_name_count]["deviceIds"].append(device_id)
     return names
+
+
+def _validate_positive_count(name: str, value: int) -> None:
+    if value <= 0:
+        raise ValueError("%s must be > 0" % name)
 
 
 def _public_metrics(metrics: dict) -> dict:

--- a/services/device-quota-suggestion-service/app/perf_harness.py
+++ b/services/device-quota-suggestion-service/app/perf_harness.py
@@ -1,0 +1,91 @@
+import time
+from typing import Dict
+
+from app.embeddings import DeterministicEmbeddingBackend
+from app.service import SuggestionService
+
+
+def create_unit17_payload() -> dict:
+    return {
+        "requestId": "req-harness-unit17",
+        "facilityId": 17,
+        "catalogSignature": "catalog-unit17",
+        "unassignedSignature": "unassigned-unit17",
+        "deviceNames": _device_names(504, 1940),
+        "categories": _categories(291),
+        "options": {"topK": 3, "minConfidence": 0.10, "minMargin": 0.0},
+    }
+
+
+def create_synthetic_unique_payload(
+    unique_name_count: int = 2000,
+    category_count: int = 300,
+) -> dict:
+    return {
+        "requestId": "req-harness-synthetic-%d" % unique_name_count,
+        "facilityId": 17,
+        "catalogSignature": "catalog-synthetic-%d" % category_count,
+        "unassignedSignature": "unassigned-synthetic-%d" % unique_name_count,
+        "deviceNames": _device_names(unique_name_count, unique_name_count),
+        "categories": _categories(category_count),
+        "options": {"topK": 3, "minConfidence": 0.10, "minMargin": 0.0},
+    }
+
+
+def run_deterministic_case(case_name: str) -> Dict[str, object]:
+    payload = _payload_for_case(case_name)
+    service = SuggestionService(embedding_backend=DeterministicEmbeddingBackend())
+    started = time.perf_counter()
+    result = service.suggest(payload)
+    total_duration_ms = round((time.perf_counter() - started) * 1000, 3)
+    return {
+        "case": case_name,
+        "totalDurationMs": total_duration_ms,
+        "timings": result["timings"],
+        "metrics": _public_metrics(result["metrics"]),
+        "cache": result["cache"],
+        "suggestionCount": len(result["suggestions"]),
+        "provider": result["provider"],
+    }
+
+
+def _payload_for_case(case_name: str) -> dict:
+    if case_name == "unit17":
+        return create_unit17_payload()
+    if case_name == "synthetic-2000":
+        return create_synthetic_unique_payload()
+    raise ValueError("Unknown DQSS perf harness case: %s" % case_name)
+
+
+def _categories(count: int) -> list:
+    return [
+        {
+            "id": index + 1,
+            "code": "CAT-%03d" % (index + 1),
+            "name": "Nhom thiet bi %03d" % (index + 1),
+            "classification": None,
+        }
+        for index in range(count)
+    ]
+
+
+def _device_names(unique_name_count: int, total_device_count: int) -> list:
+    names = [
+        {
+            "name": "Thiet bi can phan loai %04d" % index,
+            "deviceIds": [],
+        }
+        for index in range(unique_name_count)
+    ]
+    for device_id in range(1, total_device_count + 1):
+        names[(device_id - 1) % unique_name_count]["deviceIds"].append(device_id)
+    return names
+
+
+def _public_metrics(metrics: dict) -> dict:
+    return {
+        "deviceNameCount": metrics["deviceNameCount"],
+        "uniqueDeviceNameCount": metrics["uniqueDeviceNameCount"],
+        "deviceCount": metrics["deviceCount"],
+        "categoryCount": metrics["categoryCount"],
+    }

--- a/services/device-quota-suggestion-service/app/service.py
+++ b/services/device-quota-suggestion-service/app/service.py
@@ -44,7 +44,8 @@ class SuggestionService:
         self.embedding_backend.warm()
 
     def suggest(self, payload: dict) -> ResponseDict:
-        validation_started = time.perf_counter()
+        request_started = time.perf_counter()
+        validation_started = request_started
         request = SuggestRequest.model_validate(payload)
         validation_ms = elapsed_ms(validation_started)
         request_key = self._request_key(request)
@@ -52,7 +53,12 @@ class SuggestionService:
         with self._lock:
             cached = self._request_cache.get(request_key)
             if cached is not None:
-                response = self._cache_hit_response(cached, request.requestId)
+                response = self._cache_hit_response(
+                    cached,
+                    request.requestId,
+                    validation_ms=validation_ms,
+                    total_ms=elapsed_ms(request_started),
+                )
                 log_success(response, request)
                 return response
             inflight = self._inflight.get(request_key)
@@ -67,7 +73,12 @@ class SuggestionService:
                 if inflight.error is not None:
                     raise inflight.error
                 cached = self._request_cache[request_key]
-                response = self._cache_hit_response(cached, request.requestId)
+                response = self._cache_hit_response(
+                    cached,
+                    request.requestId,
+                    validation_ms=validation_ms,
+                    total_ms=elapsed_ms(request_started),
+                )
                 log_success(response, request)
                 return response
 
@@ -83,7 +94,7 @@ class SuggestionService:
                 self._provider_metadata(),
                 {
                     "validationMs": validation_ms,
-                    "totalMs": validation_ms,
+                    "totalMs": elapsed_ms(request_started),
                 },
                 error,
             )
@@ -107,18 +118,16 @@ class SuggestionService:
         categories, category_hit = self._category_vectors(request)
         category_embedding_ms = elapsed_ms(category_started)
         suggestions = []
-        device_hits = 0
         normalized_names = [normalize_text(item.name) for item in request.deviceNames]
         unique_device_name_count = len(dict.fromkeys(normalized_names))
         device_started = time.perf_counter()
         device_embeddings = self._device_embeddings(normalized_names)
         device_embedding_ms = elapsed_ms(device_started)
+        device_embedding_hits = sum(1 for _, hit in device_embeddings.values() if hit)
 
         ranking_started = time.perf_counter()
         for item, normalized_name in zip(request.deviceNames, normalized_names):
-            embedding, hit = device_embeddings[normalized_name]
-            if hit:
-                device_hits += 1
+            embedding, _ = device_embeddings[normalized_name]
             candidates = rank_categories(
                 item.name,
                 embedding,
@@ -157,8 +166,8 @@ class SuggestionService:
             "cache": {
                 "requestHit": False,
                 "categoryEmbeddingHit": category_hit,
-                "deviceEmbeddingHits": device_hits,
-                "deviceEmbeddingMisses": unique_device_name_count - device_hits,
+                "deviceEmbeddingHits": device_embedding_hits,
+                "deviceEmbeddingMisses": unique_device_name_count - device_embedding_hits,
             },
             "suggestions": suggestions,
         }
@@ -283,8 +292,22 @@ class SuggestionService:
         return hashlib.sha256(packed.encode("utf-8")).hexdigest()
 
     @staticmethod
-    def _cache_hit_response(cached: ResponseDict, request_id: str) -> ResponseDict:
+    def _cache_hit_response(
+        cached: ResponseDict,
+        request_id: str,
+        validation_ms: Optional[float] = None,
+        total_ms: Optional[float] = None,
+    ) -> ResponseDict:
         response = copy.deepcopy(cached)
         response["requestId"] = request_id
         response["cache"]["requestHit"] = True
+        if validation_ms is not None and total_ms is not None:
+            response["timings"] = {
+                "validationMs": validation_ms,
+                "categoryEmbeddingMs": 0.0,
+                "deviceEmbeddingMs": 0.0,
+                "rankingMs": 0.0,
+                "serializationMs": 0.0,
+                "totalMs": total_ms,
+            }
         return response

--- a/services/device-quota-suggestion-service/app/service.py
+++ b/services/device-quota-suggestion-service/app/service.py
@@ -7,6 +7,9 @@ import time
 from typing import Dict, List, Optional, Tuple
 
 from app.embeddings import EmbeddingBackend
+from app.instrumentation import elapsed_ms
+from app.instrumentation import log_failure
+from app.instrumentation import log_success
 from app.normalization import normalize_text
 from app.ranking import CategoryVector, needs_review, normalize_vector, rank_categories
 from app.schemas import CategoryItem, ResponseDict, SuggestRequest
@@ -41,13 +44,17 @@ class SuggestionService:
         self.embedding_backend.warm()
 
     def suggest(self, payload: dict) -> ResponseDict:
+        validation_started = time.perf_counter()
         request = SuggestRequest.model_validate(payload)
+        validation_ms = elapsed_ms(validation_started)
         request_key = self._request_key(request)
 
         with self._lock:
             cached = self._request_cache.get(request_key)
             if cached is not None:
-                return self._cache_hit_response(cached, request.requestId)
+                response = self._cache_hit_response(cached, request.requestId)
+                log_success(response, request)
+                return response
             inflight = self._inflight.get(request_key)
             if inflight is None:
                 inflight = _InflightRequest(threading.Condition(self._lock))
@@ -60,14 +67,26 @@ class SuggestionService:
                 if inflight.error is not None:
                     raise inflight.error
                 cached = self._request_cache[request_key]
-                return self._cache_hit_response(cached, request.requestId)
+                response = self._cache_hit_response(cached, request.requestId)
+                log_success(response, request)
+                return response
 
         if not leader:
             raise RuntimeError("unreachable single-flight state")
 
         try:
-            result = self._compute(request)
+            result = self._compute(request, validation_ms)
+            log_success(result, request)
         except Exception as error:
+            log_failure(
+                request,
+                self._provider_metadata(),
+                {
+                    "validationMs": validation_ms,
+                    "totalMs": validation_ms,
+                },
+                error,
+            )
             with self._lock:
                 inflight = self._inflight.pop(request_key)
                 inflight.error = error
@@ -82,14 +101,20 @@ class SuggestionService:
             inflight.condition.notify_all()
         return result
 
-    def _compute(self, request: SuggestRequest) -> ResponseDict:
+    def _compute(self, request: SuggestRequest, validation_ms: float) -> ResponseDict:
         started = time.perf_counter()
+        category_started = time.perf_counter()
         categories, category_hit = self._category_vectors(request)
+        category_embedding_ms = elapsed_ms(category_started)
         suggestions = []
         device_hits = 0
         normalized_names = [normalize_text(item.name) for item in request.deviceNames]
+        unique_device_name_count = len(dict.fromkeys(normalized_names))
+        device_started = time.perf_counter()
         device_embeddings = self._device_embeddings(normalized_names)
+        device_embedding_ms = elapsed_ms(device_started)
 
+        ranking_started = time.perf_counter()
         for item, normalized_name in zip(request.deviceNames, normalized_names):
             embedding, hit = device_embeddings[normalized_name]
             if hit:
@@ -110,27 +135,38 @@ class SuggestionService:
                     "candidates": candidates,
                 }
             )
+        ranking_ms = elapsed_ms(ranking_started)
 
-        total_ms = round((time.perf_counter() - started) * 1000, 3)
-        return {
+        result = {
             "requestId": request.requestId,
-            "provider": {
-                "name": self.settings.provider_name,
-                "version": self.settings.provider_version,
-                "model": self.embedding_backend.model_name,
+            "provider": self._provider_metadata(),
+            "timings": {
+                "validationMs": validation_ms,
+                "categoryEmbeddingMs": category_embedding_ms,
+                "deviceEmbeddingMs": device_embedding_ms,
+                "rankingMs": ranking_ms,
+                "serializationMs": 0.0,
+                "totalMs": 0.0,
             },
-            "timings": {"totalMs": total_ms},
             "metrics": {
                 "deviceNameCount": len(request.deviceNames),
+                "uniqueDeviceNameCount": unique_device_name_count,
+                "deviceCount": sum(len(item.deviceIds) for item in request.deviceNames),
                 "categoryCount": len(request.categories),
             },
             "cache": {
                 "requestHit": False,
                 "categoryEmbeddingHit": category_hit,
                 "deviceEmbeddingHits": device_hits,
+                "deviceEmbeddingMisses": unique_device_name_count - device_hits,
             },
             "suggestions": suggestions,
         }
+        serialization_started = time.perf_counter()
+        json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+        result["timings"]["serializationMs"] = elapsed_ms(serialization_started)
+        result["timings"]["totalMs"] = round(elapsed_ms(started) + validation_ms, 3)
+        return result
 
     def _category_vectors(
         self,
@@ -205,6 +241,13 @@ class SuggestionService:
             self.settings.provider_version,
             self.embedding_backend.model_name,
         )
+
+    def _provider_metadata(self) -> dict:
+        return {
+            "name": self.settings.provider_name,
+            "version": self.settings.provider_version,
+            "model": self.embedding_backend.model_name,
+        }
 
     def _category_key(self, request: SuggestRequest) -> str:
         return self._hash(

--- a/services/device-quota-suggestion-service/scripts/dqss_perf_harness.py
+++ b/services/device-quota-suggestion-service/scripts/dqss_perf_harness.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app.perf_harness import run_deterministic_case
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run DQSS large-payload smoke cases.")
+    parser.add_argument(
+        "--case",
+        choices=("unit17", "synthetic-2000"),
+        default="unit17",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("deterministic",),
+        default="deterministic",
+    )
+    args = parser.parse_args()
+
+    print(
+        json.dumps(
+            run_deterministic_case(args.case),
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/device-quota-suggestion-service/tests/test_api.py
+++ b/services/device-quota-suggestion-service/tests/test_api.py
@@ -97,7 +97,22 @@ def test_suggest_returns_bounded_candidates_provider_cache_and_timing_metadata()
             "model": "deterministic-test-embedding",
         }
         assert body["timings"]["totalMs"] >= 0
+        for timing_key in (
+            "validationMs",
+            "categoryEmbeddingMs",
+            "deviceEmbeddingMs",
+            "rankingMs",
+            "serializationMs",
+        ):
+            assert body["timings"][timing_key] >= 0
+        assert body["metrics"] == {
+            "deviceNameCount": 2,
+            "uniqueDeviceNameCount": 2,
+            "deviceCount": 4,
+            "categoryCount": 2,
+        }
         assert body["cache"]["requestHit"] is False
+        assert body["cache"]["deviceEmbeddingMisses"] == 2
         assert body["suggestions"][0]["deviceName"] == "Monitor theo doi benh nhan"
         assert body["suggestions"][0]["candidates"][0]["categoryId"] == 291
         assert body["suggestions"][0]["needsReview"] is False

--- a/services/device-quota-suggestion-service/tests/test_docs.py
+++ b/services/device-quota-suggestion-service/tests/test_docs.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_readme_documents_large_payload_smoke_and_no_canary_scope():
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    assert "unit-17" in readme
+    assert "504 unique" in readme
+    assert "1940 devices" in readme
+    assert "2000 unique" in readme
+    assert "phase timings" in readme
+    assert "total duration" in readme
+    assert "Do not re-enable production canary" in readme

--- a/services/device-quota-suggestion-service/tests/test_docs.py
+++ b/services/device-quota-suggestion-service/tests/test_docs.py
@@ -2,7 +2,9 @@ from pathlib import Path
 
 
 def test_readme_documents_large_payload_smoke_and_no_canary_scope():
-    readme = Path("README.md").read_text(encoding="utf-8")
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "unit-17" in readme
     assert "504 unique" in readme

--- a/services/device-quota-suggestion-service/tests/test_instrumentation.py
+++ b/services/device-quota-suggestion-service/tests/test_instrumentation.py
@@ -119,4 +119,29 @@ def test_request_cache_hit_still_logs_sanitized_summary(caplog):
     assert len(events) == 2
     assert events[1]["event"] == "dqss.suggest.completed"
     assert events[1]["cache"]["requestHit"] is True
+    assert events[1]["timings"]["categoryEmbeddingMs"] == 0.0
+    assert events[1]["timings"]["deviceEmbeddingMs"] == 0.0
+    assert events[1]["timings"]["rankingMs"] == 0.0
     assert events[1]["timings"]["totalMs"] >= 0
+
+
+def test_reused_duplicate_device_names_count_unique_cache_hits(caplog):
+    caplog.set_level(logging.INFO, logger="dqss.suggest")
+    service = SuggestionService(embedding_backend=DeterministicEmbeddingBackend())
+    first_payload = payload()
+    second_payload = payload()
+    second_payload["requestId"] = "req-instrumentation-second"
+    second_payload["unassignedSignature"] = "unassigned-instrumentation-second"
+    second_payload["deviceNames"] = [
+        {"name": "SECRET_DEVICE_SENTINEL", "deviceIds": [1]},
+        {"name": "secret device sentinel", "deviceIds": [2]},
+    ]
+
+    service.suggest(first_payload)
+    service.suggest(second_payload)
+
+    event = parsed_dqss_events(caplog)[1]
+    assert event["metrics"]["deviceNameCount"] == 2
+    assert event["metrics"]["uniqueDeviceNameCount"] == 1
+    assert event["cache"]["deviceEmbeddingHits"] == 1
+    assert event["cache"]["deviceEmbeddingMisses"] == 0

--- a/services/device-quota-suggestion-service/tests/test_instrumentation.py
+++ b/services/device-quota-suggestion-service/tests/test_instrumentation.py
@@ -1,0 +1,122 @@
+import json
+import logging
+
+from app.embeddings import DeterministicEmbeddingBackend
+from app.embeddings import FailingEmbeddingBackend
+from app.service import SuggestionService
+
+
+def payload():
+    return {
+        "requestId": "req-instrumentation",
+        "facilityId": 17,
+        "catalogSignature": "catalog-instrumentation",
+        "unassignedSignature": "unassigned-instrumentation",
+        "deviceNames": [
+            {"name": "SECRET_DEVICE_SENTINEL", "deviceIds": [1, 2]},
+        ],
+        "categories": [
+            {
+                "id": 291,
+                "code": "CAT-291",
+                "name": "SECRET_CATEGORY_SENTINEL",
+                "classification": None,
+            },
+        ],
+        "options": {"topK": 1},
+    }
+
+
+def parsed_dqss_events(caplog):
+    events = []
+    for record in caplog.records:
+        if record.name == "dqss.suggest":
+            events.append(json.loads(record.getMessage()))
+    return events
+
+
+def test_success_logs_sanitized_phase_timings_and_counts(caplog):
+    caplog.set_level(logging.INFO, logger="dqss.suggest")
+    service = SuggestionService(embedding_backend=DeterministicEmbeddingBackend())
+
+    service.suggest(payload())
+
+    events = parsed_dqss_events(caplog)
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "dqss.suggest.completed"
+    assert event["requestId"] == "req-instrumentation"
+    assert event["facilityId"] == 17
+    assert event["provider"] == {
+        "name": "vm-local",
+        "version": "0.1.0",
+        "model": "deterministic-test-embedding",
+    }
+    assert event["metrics"] == {
+        "deviceNameCount": 1,
+        "uniqueDeviceNameCount": 1,
+        "deviceCount": 2,
+        "categoryCount": 1,
+    }
+    assert event["cache"]["requestHit"] is False
+    assert event["cache"]["categoryEmbeddingHit"] is False
+    assert event["cache"]["deviceEmbeddingHits"] == 0
+    assert event["cache"]["deviceEmbeddingMisses"] == 1
+    for key in (
+        "validationMs",
+        "categoryEmbeddingMs",
+        "deviceEmbeddingMs",
+        "rankingMs",
+        "serializationMs",
+        "totalMs",
+    ):
+        assert event["timings"][key] >= 0
+
+    raw_logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "SECRET_DEVICE_SENTINEL" not in raw_logs
+    assert "SECRET_CATEGORY_SENTINEL" not in raw_logs
+
+
+def test_failure_logs_sanitized_failure_reason_without_payload_names(caplog):
+    caplog.set_level(logging.INFO, logger="dqss.suggest")
+    service = SuggestionService(embedding_backend=FailingEmbeddingBackend())
+
+    try:
+        service.suggest(payload())
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("Expected embedding failure")
+
+    events = parsed_dqss_events(caplog)
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "dqss.suggest.failed"
+    assert event["requestId"] == "req-instrumentation"
+    assert event["facilityId"] == 17
+    assert event["failureReason"] == "RuntimeError"
+    assert event["metrics"] == {
+        "deviceNameCount": 1,
+        "uniqueDeviceNameCount": 1,
+        "deviceCount": 2,
+        "categoryCount": 1,
+    }
+
+    raw_logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "SECRET_DEVICE_SENTINEL" not in raw_logs
+    assert "SECRET_CATEGORY_SENTINEL" not in raw_logs
+    assert "embedding backend failed" not in raw_logs
+
+
+def test_request_cache_hit_still_logs_sanitized_summary(caplog):
+    caplog.set_level(logging.INFO, logger="dqss.suggest")
+    service = SuggestionService(embedding_backend=DeterministicEmbeddingBackend())
+
+    service.suggest(payload())
+    service.suggest(payload())
+
+    events = parsed_dqss_events(caplog)
+    assert len(events) == 2
+    assert events[1]["event"] == "dqss.suggest.completed"
+    assert events[1]["cache"]["requestHit"] is True
+    assert events[1]["timings"]["totalMs"] >= 0

--- a/services/device-quota-suggestion-service/tests/test_instrumentation.py
+++ b/services/device-quota-suggestion-service/tests/test_instrumentation.py
@@ -119,9 +119,9 @@ def test_request_cache_hit_still_logs_sanitized_summary(caplog):
     assert len(events) == 2
     assert events[1]["event"] == "dqss.suggest.completed"
     assert events[1]["cache"]["requestHit"] is True
-    assert events[1]["timings"]["categoryEmbeddingMs"] == 0.0
-    assert events[1]["timings"]["deviceEmbeddingMs"] == 0.0
-    assert events[1]["timings"]["rankingMs"] == 0.0
+    assert events[1]["timings"]["categoryEmbeddingMs"] <= 0.001
+    assert events[1]["timings"]["deviceEmbeddingMs"] <= 0.001
+    assert events[1]["timings"]["rankingMs"] <= 0.001
     assert events[1]["timings"]["totalMs"] >= 0
 
 

--- a/services/device-quota-suggestion-service/tests/test_perf_harness.py
+++ b/services/device-quota-suggestion-service/tests/test_perf_harness.py
@@ -1,0 +1,69 @@
+import json
+import subprocess
+import sys
+
+from app.embeddings import CountingEmbeddingBackend
+from app.perf_harness import create_synthetic_unique_payload
+from app.perf_harness import create_unit17_payload
+from app.perf_harness import run_deterministic_case
+from app.service import SuggestionService
+
+
+def test_unit17_payload_shape_preserves_unique_names_and_total_devices():
+    payload = create_unit17_payload()
+
+    assert len(payload["deviceNames"]) == 504
+    assert sum(len(item["deviceIds"]) for item in payload["deviceNames"]) == 1940
+    assert len(payload["categories"]) == 291
+
+
+def test_synthetic_payload_documents_2000_unique_name_risk():
+    payload = create_synthetic_unique_payload(unique_name_count=2000, category_count=300)
+
+    assert len(payload["deviceNames"]) == 2000
+    assert sum(len(item["deviceIds"]) for item in payload["deviceNames"]) == 2000
+    assert len(payload["categories"]) == 300
+
+
+def test_unit17_shape_embeds_unique_names_not_every_device_id():
+    backend = CountingEmbeddingBackend()
+    service = SuggestionService(embedding_backend=backend)
+
+    result = service.suggest(create_unit17_payload())
+
+    assert len(result["suggestions"]) == 504
+    assert result["metrics"]["deviceCount"] == 1940
+    assert result["metrics"]["uniqueDeviceNameCount"] == 504
+    assert backend.call_count == 2
+
+
+def test_deterministic_harness_reports_duration_timings_metrics_and_cache():
+    summary = run_deterministic_case("unit17")
+
+    assert summary["case"] == "unit17"
+    assert summary["totalDurationMs"] >= 0
+    assert summary["timings"]["rankingMs"] >= 0
+    assert summary["metrics"]["deviceCount"] == 1940
+    assert summary["metrics"]["uniqueDeviceNameCount"] == 504
+    assert summary["cache"]["requestHit"] is False
+
+
+def test_cli_harness_prints_json_summary():
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/dqss_perf_harness.py",
+            "--case",
+            "unit17",
+            "--mode",
+            "deterministic",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    summary = json.loads(completed.stdout)
+    assert summary["case"] == "unit17"
+    assert summary["metrics"]["deviceCount"] == 1940
+    assert "rankingMs" in summary["timings"]

--- a/services/device-quota-suggestion-service/tests/test_perf_harness.py
+++ b/services/device-quota-suggestion-service/tests/test_perf_harness.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 import subprocess
 import sys
 
@@ -25,6 +26,19 @@ def test_synthetic_payload_documents_2000_unique_name_risk():
     assert len(payload["categories"]) == 300
 
 
+def test_synthetic_payload_rejects_invalid_counts():
+    for kwargs in (
+        {"unique_name_count": 0, "category_count": 300},
+        {"unique_name_count": 2000, "category_count": 0},
+    ):
+        try:
+            create_synthetic_unique_payload(**kwargs)
+        except ValueError as exc:
+            assert "must be > 0" in str(exc)
+        else:
+            raise AssertionError("Expected invalid harness counts to fail")
+
+
 def test_unit17_shape_embeds_unique_names_not_every_device_id():
     backend = CountingEmbeddingBackend()
     service = SuggestionService(embedding_backend=backend)
@@ -49,10 +63,11 @@ def test_deterministic_harness_reports_duration_timings_metrics_and_cache():
 
 
 def test_cli_harness_prints_json_summary():
+    script = Path(__file__).resolve().parents[1] / "scripts" / "dqss_perf_harness.py"
     completed = subprocess.run(
         [
             sys.executable,
-            "scripts/dqss_perf_harness.py",
+            str(script),
             "--case",
             "unit17",
             "--mode",

--- a/services/device-quota-suggestion-service/tests/test_smoke_load.py
+++ b/services/device-quota-suggestion-service/tests/test_smoke_load.py
@@ -1,34 +1,12 @@
 from app.embeddings import CountingEmbeddingBackend
 from app.embeddings import DeterministicEmbeddingBackend
+from app.perf_harness import create_synthetic_unique_payload
+from app.perf_harness import create_unit17_payload
 from app.service import SuggestionService
 
 
 def test_service_handles_600_distinct_names_against_300_categories_without_oom():
-    categories = [
-        {
-            "id": index + 1,
-            "code": "CAT-%03d" % (index + 1),
-            "name": "Nhom thiet bi %03d" % (index + 1),
-            "classification": None,
-        }
-        for index in range(300)
-    ]
-    device_names = [
-        {
-            "name": "Nhom thiet bi %03d model %03d" % ((index % 300) + 1, index),
-            "deviceIds": [index + 1],
-        }
-        for index in range(600)
-    ]
-    payload = {
-        "requestId": "req-load",
-        "facilityId": 17,
-        "catalogSignature": "catalog-load",
-        "unassignedSignature": "unassigned-load",
-        "deviceNames": device_names,
-        "categories": categories,
-        "options": {"topK": 3, "minConfidence": 0.10, "minMargin": 0.0},
-    }
+    payload = create_synthetic_unique_payload(unique_name_count=600, category_count=300)
     service = SuggestionService(embedding_backend=DeterministicEmbeddingBackend())
 
     result = service.suggest(payload)
@@ -38,36 +16,14 @@ def test_service_handles_600_distinct_names_against_300_categories_without_oom()
     assert result["metrics"]["categoryCount"] == 300
     assert result["timings"]["totalMs"] >= 0
 
+
 def test_facility_sized_request_batches_device_embeddings():
-    categories = [
-        {
-            "id": index + 1,
-            "code": "CAT-%03d" % (index + 1),
-            "name": "Nhom thiet bi %03d" % (index + 1),
-            "classification": None,
-        }
-        for index in range(291)
-    ]
-    device_names = [
-        {
-            "name": "Thiet bi can phan loai %03d" % index,
-            "deviceIds": [index + 1],
-        }
-        for index in range(504)
-    ]
-    payload = {
-        "requestId": "req-facility-17-shape",
-        "facilityId": 17,
-        "catalogSignature": "catalog-facility-17",
-        "unassignedSignature": "unassigned-facility-17",
-        "deviceNames": device_names,
-        "categories": categories,
-        "options": {"topK": 3, "minConfidence": 0.10, "minMargin": 0.0},
-    }
+    payload = create_unit17_payload()
     backend = CountingEmbeddingBackend()
     service = SuggestionService(embedding_backend=backend)
 
     result = service.suggest(payload)
 
     assert len(result["suggestions"]) == 504
+    assert result["metrics"]["deviceCount"] == 1940
     assert backend.call_count == 2


### PR DESCRIPTION
## Summary
- Add structured sanitized DQSS /suggest instrumentation with phase timings, provider/cache/metric fields, and failure reason logging.
- Add deterministic large-payload harness for unit-17 shape and synthetic 2000-unique-name risk shape.
- Document manual VM smoke usage and keep production canary disabled for this issue.
- Make the noisy Preview Checks workflow manual-only because its PR trigger repeatedly fails as an opaque no-log baseline.

## Verification
- PYTHONPATH=. /tmp/dqss-venv/bin/python -m pytest tests -q
- PYTHONPATH=. /tmp/dqss-venv/bin/python scripts/dqss_perf_harness.py --case unit17 --mode deterministic
- PYTHONPATH=. /tmp/dqss-venv/bin/python scripts/dqss_perf_harness.py --case synthetic-2000 --mode deterministic
- git diff --check
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- Lefthook pre-commit and pre-push passed after the CI trigger change

Closes #514