### PR TITLE
perf: optimize DQSS ranking hot path

### DIFF
--- a/services/device-quota-suggestion-service/app/ranking.py
+++ b/services/device-quota-suggestion-service/app/ranking.py
@@ -1,7 +1,8 @@
 import math
 from dataclasses import dataclass
 from difflib import SequenceMatcher
-from typing import List, Optional
+import heapq
+from typing import FrozenSet, List, Optional
 
 from app.normalization import normalize_text
 from app.schemas import CategoryItem, SuggestOptions
@@ -12,6 +13,7 @@ class CategoryVector:
     category: CategoryItem
     normalized_name: str
     embedding: List[float]
+    tokens: Optional[FrozenSet[str]] = None
 
 
 def cosine_similarity(left: List[float], right: List[float]) -> float:
@@ -74,13 +76,30 @@ def rank_categories(
     options: SuggestOptions,
 ) -> List[dict]:
     device_normalized = normalize_text(device_name)
+    device_tokens = frozenset(device_normalized.split())
+    shortlist = _shortlist_category_indices(
+        device_normalized,
+        device_tokens,
+        device_embedding,
+        categories,
+        options,
+    )
     ranked = []
-    for category_vector in categories:
-        lexical = lexical_similarity_normalized(
+    for category_index in shortlist:
+        category_vector = categories[category_index]
+        lexical = _exact_or_contains_score(
             device_normalized,
             category_vector.normalized_name,
         )
-        semantic = normalized_dot_similarity(device_embedding, category_vector.embedding)
+        if lexical is None:
+            lexical = lexical_similarity_normalized(
+                device_normalized,
+                category_vector.normalized_name,
+            )
+        semantic = normalized_dot_similarity(
+            device_embedding,
+            category_vector.embedding,
+        )
         score = fused_score(lexical, semantic, options)
         ranked.append(
             {
@@ -102,6 +121,93 @@ def rank_categories(
         )
     )
     return ranked[: options.topK]
+
+
+def _shortlist_category_indices(
+    device_normalized: str,
+    device_tokens: FrozenSet[str],
+    device_embedding: List[float],
+    categories: List[CategoryVector],
+    options: SuggestOptions,
+) -> List[int]:
+    limit = _shortlist_limit(options)
+    selected = set()
+    semantic_scores = []
+    cheap_lexical_scores = []
+
+    for index, category_vector in enumerate(categories):
+        category_tokens = category_vector.tokens or frozenset(
+            category_vector.normalized_name.split()
+        )
+        exact_or_contains = _exact_or_contains_score(
+            device_normalized,
+            category_vector.normalized_name,
+        )
+        if exact_or_contains is not None:
+            selected.add(index)
+            cheap_lexical = exact_or_contains
+        else:
+            cheap_lexical = _token_overlap_score(device_tokens, category_tokens)
+
+        semantic = normalized_dot_similarity(device_embedding, category_vector.embedding)
+        semantic_scores.append((index, semantic, category_vector))
+        if cheap_lexical > 0:
+            cheap_lexical_scores.append((index, cheap_lexical, category_vector))
+
+    selected.update(
+        index
+        for index, _, _ in heapq.nsmallest(
+            limit,
+            semantic_scores,
+            key=lambda item: (
+                -item[1],
+                item[2].category.code or "",
+                item[2].category.id,
+            ),
+        )
+    )
+    selected.update(
+        index
+        for index, _, _ in heapq.nsmallest(
+            limit,
+            cheap_lexical_scores,
+            key=lambda item: (
+                -item[1],
+                item[2].category.code or "",
+                item[2].category.id,
+            ),
+        )
+    )
+    return sorted(selected)
+
+
+def _shortlist_limit(options: SuggestOptions) -> int:
+    return min(max(options.topK * 3, 8), 24)
+
+
+def _exact_or_contains_score(
+    left_normalized: str,
+    right_normalized: str,
+) -> Optional[float]:
+    if not left_normalized or not right_normalized:
+        return None
+    if left_normalized == right_normalized:
+        return 1.0
+    if left_normalized in right_normalized or right_normalized in left_normalized:
+        return 0.86
+    return None
+
+
+def _token_overlap_score(
+    left_tokens: FrozenSet[str],
+    right_tokens: FrozenSet[str],
+) -> float:
+    if not left_tokens or not right_tokens:
+        return 0.0
+    overlap = len(left_tokens & right_tokens)
+    if overlap == 0:
+        return 0.0
+    return overlap / max(len(left_tokens), len(right_tokens))
 
 
 def needs_review(candidates: List[dict], options: SuggestOptions) -> bool:

--- a/services/device-quota-suggestion-service/app/ranking.py
+++ b/services/device-quota-suggestion-service/app/ranking.py
@@ -14,6 +14,7 @@ class CategoryVector:
     normalized_name: str
     embedding: List[float]
     tokens: Optional[FrozenSet[str]] = None
+    char_grams: Optional[FrozenSet[str]] = None
 
 
 def cosine_similarity(left: List[float], right: List[float]) -> float:
@@ -77,9 +78,11 @@ def rank_categories(
 ) -> List[dict]:
     device_normalized = normalize_text(device_name)
     device_tokens = frozenset(device_normalized.split())
+    device_char_grams = character_ngrams(device_normalized)
     shortlist = _shortlist_category_indices(
         device_normalized,
         device_tokens,
+        device_char_grams,
         device_embedding,
         categories,
         options,
@@ -126,6 +129,7 @@ def rank_categories(
 def _shortlist_category_indices(
     device_normalized: str,
     device_tokens: FrozenSet[str],
+    device_char_grams: FrozenSet[str],
     device_embedding: List[float],
     categories: List[CategoryVector],
     options: SuggestOptions,
@@ -139,6 +143,9 @@ def _shortlist_category_indices(
         category_tokens = category_vector.tokens or frozenset(
             category_vector.normalized_name.split()
         )
+        category_char_grams = category_vector.char_grams or character_ngrams(
+            category_vector.normalized_name
+        )
         exact_or_contains = _exact_or_contains_score(
             device_normalized,
             category_vector.normalized_name,
@@ -147,7 +154,10 @@ def _shortlist_category_indices(
             selected.add(index)
             cheap_lexical = exact_or_contains
         else:
-            cheap_lexical = _token_overlap_score(device_tokens, category_tokens)
+            cheap_lexical = max(
+                _token_overlap_score(device_tokens, category_tokens),
+                _character_ngram_score(device_char_grams, category_char_grams),
+            )
 
         semantic = normalized_dot_similarity(device_embedding, category_vector.embedding)
         semantic_scores.append((index, semantic, category_vector))
@@ -208,6 +218,25 @@ def _token_overlap_score(
     if overlap == 0:
         return 0.0
     return overlap / max(len(left_tokens), len(right_tokens))
+
+
+def _character_ngram_score(
+    left_grams: FrozenSet[str],
+    right_grams: FrozenSet[str],
+) -> float:
+    if not left_grams or not right_grams:
+        return 0.0
+    overlap = len(left_grams & right_grams)
+    if overlap == 0:
+        return 0.0
+    return overlap / max(len(left_grams), len(right_grams))
+
+
+def character_ngrams(value: str) -> FrozenSet[str]:
+    compact = value.replace(" ", "")
+    if len(compact) < 2:
+        return frozenset([compact]) if compact else frozenset()
+    return frozenset(compact[index : index + 2] for index in range(len(compact) - 1))
 
 
 def needs_review(candidates: List[dict], options: SuggestOptions) -> bool:

--- a/services/device-quota-suggestion-service/app/service.py
+++ b/services/device-quota-suggestion-service/app/service.py
@@ -199,6 +199,7 @@ class SuggestionService:
                 category=category,
                 normalized_name=normalized_name,
                 embedding=normalize_vector(embedding),
+                tokens=frozenset(normalized_name.split()),
             )
             for category, normalized_name, embedding in zip(
                 request.categories,

--- a/services/device-quota-suggestion-service/app/service.py
+++ b/services/device-quota-suggestion-service/app/service.py
@@ -11,7 +11,11 @@ from app.instrumentation import elapsed_ms
 from app.instrumentation import log_failure
 from app.instrumentation import log_success
 from app.normalization import normalize_text
-from app.ranking import CategoryVector, needs_review, normalize_vector, rank_categories
+from app.ranking import CategoryVector
+from app.ranking import character_ngrams
+from app.ranking import needs_review
+from app.ranking import normalize_vector
+from app.ranking import rank_categories
 from app.schemas import CategoryItem, ResponseDict, SuggestRequest
 from app.settings import Settings
 
@@ -200,6 +204,7 @@ class SuggestionService:
                 normalized_name=normalized_name,
                 embedding=normalize_vector(embedding),
                 tokens=frozenset(normalized_name.split()),
+                char_grams=character_ngrams(normalized_name),
             )
             for category, normalized_name, embedding in zip(
                 request.categories,

--- a/services/device-quota-suggestion-service/tests/test_ranking.py
+++ b/services/device-quota-suggestion-service/tests/test_ranking.py
@@ -1,5 +1,10 @@
+import app.ranking as ranking
 from app.embeddings import MappingEmbeddingBackend
 from app.embeddings import ShortEmbeddingBackend
+from app.ranking import CategoryVector
+from app.ranking import rank_categories
+from app.schemas import CategoryItem
+from app.schemas import SuggestOptions
 from app.service import SuggestionService
 
 
@@ -40,6 +45,40 @@ def test_exact_and_fuzzy_matches_rank_first_with_bounded_top_k():
     assert len(suggestion["candidates"]) == 2
 
 
+def test_fuzzy_typo_match_can_rank_first_after_shortlisting():
+    options = SuggestOptions(topK=2)
+    candidates = rank_categories(
+        "monitor theo doi benh nhn",
+        [1.0, 0.0],
+        [
+            CategoryVector(
+                category=CategoryItem(
+                    id=10,
+                    code="A",
+                    name="Monitor theo doi benh nhan",
+                    classification=None,
+                ),
+                normalized_name="monitor theo doi benh nhan",
+                embedding=[1.0, 0.0],
+            ),
+            CategoryVector(
+                category=CategoryItem(id=20, code="B", name="May sieu am", classification=None),
+                normalized_name="may sieu am",
+                embedding=[1.0, 0.0],
+            ),
+            CategoryVector(
+                category=CategoryItem(id=30, code="C", name="Bom tiem dien", classification=None),
+                normalized_name="bom tiem dien",
+                embedding=[1.0, 0.0],
+            ),
+        ],
+        options,
+    )
+
+    assert candidates[0]["categoryId"] == 10
+    assert candidates[0]["lexicalScore"] > candidates[1]["lexicalScore"]
+
+
 def test_semantic_similarity_can_rank_when_lexical_match_is_weak():
     backend = MappingEmbeddingBackend(
         {
@@ -61,6 +100,74 @@ def test_semantic_similarity_can_rank_when_lexical_match_is_weak():
     )
 
     assert result["suggestions"][0]["candidates"][0]["categoryId"] == 20
+
+
+def test_deterministic_tie_breaking_uses_code_then_id():
+    options = SuggestOptions(topK=3)
+    candidates = rank_categories(
+        "alpha",
+        [1.0, 0.0],
+        [
+            CategoryVector(
+                category=CategoryItem(id=30, code="C", name="beta", classification=None),
+                normalized_name="beta",
+                embedding=[1.0, 0.0],
+            ),
+            CategoryVector(
+                category=CategoryItem(id=20, code="B", name="beta", classification=None),
+                normalized_name="beta",
+                embedding=[1.0, 0.0],
+            ),
+            CategoryVector(
+                category=CategoryItem(id=10, code="B", name="beta", classification=None),
+                normalized_name="beta",
+                embedding=[1.0, 0.0],
+            ),
+        ],
+        options,
+    )
+
+    assert [candidate["categoryId"] for candidate in candidates] == [10, 20, 30]
+
+
+def test_fuzzy_matching_is_bounded_to_shortlist(monkeypatch):
+    fuzzy_call_count = 0
+    real_sequence_matcher = ranking.SequenceMatcher
+
+    class CountingSequenceMatcher:
+        def __init__(self, *args, **kwargs):
+            self._matcher = real_sequence_matcher(*args, **kwargs)
+
+        def ratio(self):
+            nonlocal fuzzy_call_count
+            fuzzy_call_count += 1
+            return self._matcher.ratio()
+
+    monkeypatch.setattr(ranking, "SequenceMatcher", CountingSequenceMatcher)
+    options = SuggestOptions(topK=3)
+    categories = [
+        CategoryVector(
+            category=CategoryItem(
+                id=index + 1,
+                code=f"C{index:03d}",
+                name=f"nhom vat tu {index:03d}",
+                classification=None,
+            ),
+            normalized_name=f"nhom vat tu {index:03d}",
+            embedding=[1.0, 0.0] if index < 8 else [0.0, 1.0],
+        )
+        for index in range(80)
+    ]
+
+    candidates = rank_categories(
+        "monitor tim mach",
+        [1.0, 0.0],
+        categories,
+        options,
+    )
+
+    assert len(candidates) == 3
+    assert fuzzy_call_count <= 16
 
 
 def test_low_confidence_or_small_margin_requires_review():

--- a/services/device-quota-suggestion-service/tests/test_ranking.py
+++ b/services/device-quota-suggestion-service/tests/test_ranking.py
@@ -79,6 +79,39 @@ def test_fuzzy_typo_match_can_rank_first_after_shortlisting():
     assert candidates[0]["lexicalScore"] > candidates[1]["lexicalScore"]
 
 
+def test_lexical_only_typo_match_can_enter_shortlist_without_token_overlap():
+    options = SuggestOptions(topK=1, semanticWeight=0.0, lexicalWeight=1.0)
+    categories = [
+        CategoryVector(
+            category=CategoryItem(
+                id=index + 1,
+                code=f"C{index:03d}",
+                name=f"zzzzzz {index:03d}",
+                classification=None,
+            ),
+            normalized_name=f"zzzzzz {index:03d}",
+            embedding=[1.0, 0.0],
+        )
+        for index in range(40)
+    ]
+    categories.append(
+        CategoryVector(
+            category=CategoryItem(id=99, code="M", name="abcxef", classification=None),
+            normalized_name="abcxef",
+            embedding=[1.0, 0.0],
+        )
+    )
+
+    candidates = rank_categories(
+        "abcdef",
+        [0.0, 1.0],
+        categories,
+        options,
+    )
+
+    assert candidates[0]["categoryId"] == 99
+
+
 def test_semantic_similarity_can_rank_when_lexical_match_is_weak():
     backend = MappingEmbeddingBackend(
         {


### PR DESCRIPTION
## Summary
- Closes #515
- Optimizes DQSS ranking by shortlisting categories with exact/contains, token overlap, character n-gram similarity, and semantic top candidates before running expensive fuzzy matching.
- Preserves the existing `/suggest` response shape, deterministic final ordering, lexical-only fuzzy typo behavior, and `needsReview` behavior.
- Keeps production canary/provider settings unchanged.

## Evidence
- RED first: `test_fuzzy_matching_is_bounded_to_shortlist` failed with `assert 80 <= 16` before implementation.
- Review RED: lexical-only typo without token overlap failed with `assert 1 == 99`; fixed with bounded character n-gram shortlisting.
- Local service tests: `PYTHONPATH=. /tmp/dqss-venv/bin/python -m pytest tests -q` -> `38 passed`.
- Local `unit17` deterministic: baseline `rankingMs ~= 3199ms`; final `rankingMs=582.934ms`, `totalDurationMs=620.149ms`.
- Local `synthetic-2000` deterministic: `rankingMs=2325.191ms`, `totalDurationMs=2456.715ms`.
- VM2 deployed image `device-quota-suggestion-service:issue-515` to container `dqss-issue-508`, still bound to `127.0.0.1:18080` and healthy.
- VM2 unit17-shaped cold-cache smoke: HTTP 200, `504 x 291`, `rankingMs=8694.73ms`, `totalMs=21056.461ms`.
- VM2 unit17-shaped hot-cache smoke: HTTP 200, category/device cache hit, `rankingMs=8757.729ms`, `totalMs=8772.243ms`.

## Verification
- `git diff --check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- Pre-commit and pre-push Lefthook gates passed.

## Non-goals Kept
- No async job lifecycle.
- No final save RPC contract change.
- No browser exposure of VM service.
- No Supabase Edge embed/search calls introduced in normal VM path.
