### PR TITLE
Add async Device Quota suggestion jobs

### DIFF
--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
@@ -51,6 +51,35 @@ describe("device quota suggestion job routes", () => {
     expect(createSuggestionJobMock).not.toHaveBeenCalled()
   })
 
+  test("POST /jobs rejects sessions without a role before creating a job", async () => {
+    getServerSessionMock.mockResolvedValue({ user: { id: "user-1" } })
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs", {
+        body: JSON.stringify({ donViId: 17 }),
+        method: "POST",
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(createSuggestionJobMock).not.toHaveBeenCalled()
+  })
+
+  test("POST /jobs rejects null JSON bodies without throwing", async () => {
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs", {
+        body: "null",
+        method: "POST",
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(createSuggestionJobMock).not.toHaveBeenCalled()
+  })
+
   test("POST /jobs returns queued job metadata quickly", async () => {
     createSuggestionJobMock.mockResolvedValue({
       id: "job-1",
@@ -121,5 +150,23 @@ describe("device quota suggestion job routes", () => {
 
     expect(response.status).toBe(202)
     expect(retrySuggestionJobMock).toHaveBeenCalledWith(expect.objectContaining({ jobId: "job-1" }))
+  })
+
+  test("POST /jobs/[jobId]/retry logs unexpected failures before returning sanitized errors", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    retrySuggestionJobMock.mockRejectedValue(new Error("database unavailable"))
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1/retry", {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({ error: "Internal server error" })
+    expect(errorSpy).toHaveBeenCalledWith("Suggestion job retry failed", expect.any(Error))
+    errorSpy.mockRestore()
   })
 })

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
@@ -37,6 +37,7 @@ const FORBIDDEN_SESSION = {
 describe("device quota suggestion job routes", () => {
   beforeEach(() => {
     vi.resetModules()
+    vi.doUnmock("@/lib/rbac")
     getServerSessionMock.mockReset()
     createSuggestionJobMock.mockReset()
     getSuggestionJobMock.mockReset()
@@ -86,6 +87,26 @@ describe("device quota suggestion job routes", () => {
     )
 
     expect(response.status).toBe(403)
+    expect(createSuggestionJobMock).not.toHaveBeenCalled()
+  })
+
+  test("POST /jobs sanitizes unexpected auth guard failures", async () => {
+    vi.doMock("@/lib/rbac", () => ({
+      canAccessDeviceQuotaModule: () => {
+        throw new Error("rbac store unavailable")
+      },
+    }))
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs", {
+        body: JSON.stringify({ donViId: 17 }),
+        method: "POST",
+      }),
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({ error: "Internal server error" })
     expect(createSuggestionJobMock).not.toHaveBeenCalled()
   })
 

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
@@ -26,6 +26,14 @@ const SESSION = {
   },
 }
 
+const FORBIDDEN_SESSION = {
+  user: {
+    id: "user-1",
+    role: "qltb_khoa",
+    don_vi: "17",
+  },
+}
+
 describe("device quota suggestion job routes", () => {
   beforeEach(() => {
     vi.resetModules()
@@ -63,6 +71,21 @@ describe("device quota suggestion job routes", () => {
     )
 
     expect(response.status).toBe(401)
+    expect(createSuggestionJobMock).not.toHaveBeenCalled()
+  })
+
+  test("POST /jobs rejects forbidden roles before creating a job", async () => {
+    getServerSessionMock.mockResolvedValue(FORBIDDEN_SESSION)
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs", {
+        body: JSON.stringify({ donViId: 17 }),
+        method: "POST",
+      }),
+    )
+
+    expect(response.status).toBe(403)
     expect(createSuggestionJobMock).not.toHaveBeenCalled()
   })
 
@@ -132,6 +155,19 @@ describe("device quota suggestion job routes", () => {
     })
   })
 
+  test("GET /jobs/[jobId] rejects forbidden roles before loading a job", async () => {
+    getServerSessionMock.mockResolvedValue(FORBIDDEN_SESSION)
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/route")
+
+    const response = await mod.GET(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1"),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(403)
+    expect(getSuggestionJobMock).not.toHaveBeenCalled()
+  })
+
   test("POST /jobs/[jobId]/retry resets failed chunks", async () => {
     retrySuggestionJobMock.mockResolvedValue({
       id: "job-1",
@@ -150,6 +186,21 @@ describe("device quota suggestion job routes", () => {
 
     expect(response.status).toBe(202)
     expect(retrySuggestionJobMock).toHaveBeenCalledWith(expect.objectContaining({ jobId: "job-1" }))
+  })
+
+  test("POST /jobs/[jobId]/retry rejects forbidden roles before retrying a job", async () => {
+    getServerSessionMock.mockResolvedValue(FORBIDDEN_SESSION)
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1/retry", {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(403)
+    expect(retrySuggestionJobMock).not.toHaveBeenCalled()
   })
 
   test("POST /jobs/[jobId]/retry logs unexpected failures before returning sanitized errors", async () => {

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const getServerSessionMock = vi.fn()
+vi.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
+}))
+
+vi.mock("@/auth/config", () => ({
+  authOptions: {},
+}))
+
+const createSuggestionJobMock = vi.fn()
+const getSuggestionJobMock = vi.fn()
+const retrySuggestionJobMock = vi.fn()
+vi.mock("@/app/api/device-quota/mapping/suggest/suggestion-job-service", () => ({
+  createSuggestionJob: (...args: unknown[]) => createSuggestionJobMock(...args),
+  getSuggestionJob: (...args: unknown[]) => getSuggestionJobMock(...args),
+  retrySuggestionJob: (...args: unknown[]) => retrySuggestionJobMock(...args),
+}))
+
+const SESSION = {
+  user: {
+    id: "user-1",
+    role: "to_qltb",
+    don_vi: "17",
+  },
+}
+
+describe("device quota suggestion job routes", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    getServerSessionMock.mockReset()
+    createSuggestionJobMock.mockReset()
+    getSuggestionJobMock.mockReset()
+    retrySuggestionJobMock.mockReset()
+    getServerSessionMock.mockResolvedValue(SESSION)
+  })
+
+  test("POST /jobs rejects unauthenticated users before creating a job", async () => {
+    getServerSessionMock.mockResolvedValue(null)
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs", {
+        body: JSON.stringify({ donViId: 17 }),
+        method: "POST",
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(createSuggestionJobMock).not.toHaveBeenCalled()
+  })
+
+  test("POST /jobs returns queued job metadata quickly", async () => {
+    createSuggestionJobMock.mockResolvedValue({
+      id: "job-1",
+      status: "queued",
+      processedUniqueNames: 0,
+      totalUniqueNames: 3,
+    })
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs", {
+        body: JSON.stringify({ donViId: 17 }),
+        method: "POST",
+      }),
+    )
+
+    expect(response.status).toBe(202)
+    await expect(response.json()).resolves.toMatchObject({
+      job: {
+        id: "job-1",
+        status: "queued",
+        processedUniqueNames: 0,
+        totalUniqueNames: 3,
+      },
+    })
+  })
+
+  test("GET /jobs/[jobId] returns job progress for authorized users", async () => {
+    getSuggestionJobMock.mockResolvedValue({
+      id: "job-1",
+      status: "processing",
+      processedUniqueNames: 2,
+      totalUniqueNames: 3,
+    })
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/route")
+
+    const response = await mod.GET(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1"),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      job: {
+        id: "job-1",
+        processedUniqueNames: 2,
+        status: "processing",
+        totalUniqueNames: 3,
+      },
+    })
+  })
+
+  test("POST /jobs/[jobId]/retry resets failed chunks", async () => {
+    retrySuggestionJobMock.mockResolvedValue({
+      id: "job-1",
+      status: "queued",
+      processedUniqueNames: 1,
+      totalUniqueNames: 3,
+    })
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1/retry", {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(202)
+    expect(retrySuggestionJobMock).toHaveBeenCalledWith(expect.objectContaining({ jobId: "job-1" }))
+  })
+})

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test, vi } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { callVmSuggest } from "@/app/api/device-quota/mapping/suggest/suggestion-vm-client"
 
 import {
   createSuggestionJob,
@@ -17,6 +19,10 @@ import type {
   SuggestionAccessUser,
   UnassignedName,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+vi.mock("@/app/api/device-quota/mapping/suggest/suggestion-vm-client", () => ({
+  callVmSuggest: vi.fn(async () => ({ suggestions: [] })),
+}))
 
 const USER: SuggestionAccessUser = {
   id: "user-1",
@@ -83,7 +89,7 @@ function createStore(): SuggestionJobStore {
     getJobChunks: vi.fn(async () => [createChunk()]),
     listQueuedChunks: vi.fn(async () => [createChunk()]),
     markChunkFailed: vi.fn(async () => undefined),
-    markChunkProcessing: vi.fn(async () => undefined),
+    markChunkProcessing: vi.fn(async () => true),
     markChunkSucceeded: vi.fn(async () => undefined),
     markJobFailed: vi.fn(async () => undefined),
     markJobProcessing: vi.fn(async () => undefined),
@@ -94,6 +100,10 @@ function createStore(): SuggestionJobStore {
 }
 
 describe("device quota suggestion job service", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   test("creates a queued job with chunks grouped by unique device names", async () => {
     const store = createStore()
 
@@ -120,6 +130,42 @@ describe("device quota suggestion job service", () => {
         job: expect.objectContaining({
           dataSignature: expect.any(String),
           totalUniqueNames: 3,
+        }),
+      }),
+    )
+  })
+
+  test("completes empty-input jobs immediately", async () => {
+    const store = createStore()
+    vi.mocked(store.createJobWithChunks).mockResolvedValue(
+      createJob({
+        processedUniqueNames: 0,
+        result: { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 },
+        status: "succeeded",
+        totalUniqueNames: 0,
+      }),
+    )
+
+    const job = await createSuggestionJob({
+      donViId: 17,
+      requestId: "req-1",
+      store,
+      user: USER,
+      fetchInputs: vi.fn(async () => ({
+        categories: CATEGORIES,
+        names: [],
+      })),
+    })
+
+    expect(job.status).toBe("succeeded")
+    expect(store.createJobWithChunks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chunks: [],
+        job: expect.objectContaining({
+          processedUniqueNames: 0,
+          result: { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 },
+          status: "succeeded",
+          totalUniqueNames: 0,
         }),
       }),
     )
@@ -189,6 +235,7 @@ describe("device quota suggestion job service", () => {
 
   test("retry resets failed chunks only", async () => {
     const store = createStore()
+    vi.mocked(store.getJob).mockResolvedValue(createJob({ status: "failed" }))
 
     const job = await retrySuggestionJob({
       jobId: "job-1",
@@ -199,6 +246,51 @@ describe("device quota suggestion job service", () => {
     expect(job.id).toBe("job-1")
     expect(store.resetFailedChunks).toHaveBeenCalledWith("job-1")
     expect(store.markJobProcessing).toHaveBeenCalledWith("job-1")
+  })
+
+  test("retry rejects jobs that are not failed", async () => {
+    const store = createStore()
+    vi.mocked(store.getJob).mockResolvedValue(createJob({ status: "processing" }))
+
+    await expect(
+      retrySuggestionJob({
+        jobId: "job-1",
+        store,
+        user: USER,
+      }),
+    ).rejects.toMatchObject({ status: 409 })
+
+    expect(store.resetFailedChunks).not.toHaveBeenCalled()
+    expect(store.markJobProcessing).not.toHaveBeenCalled()
+  })
+
+  test("skips a chunk when atomic claim loses the race", async () => {
+    const store = createStore()
+    const suggestChunk = vi.fn(async () => ({ results: [] }))
+    vi.mocked(store.markChunkProcessing).mockResolvedValue(false)
+
+    await processSuggestionJobChunk({
+      chunkId: "chunk-1",
+      store,
+      suggestChunk,
+    })
+
+    expect(suggestChunk).not.toHaveBeenCalled()
+    expect(store.markChunkSucceeded).not.toHaveBeenCalled()
+  })
+
+  test("validates VM payload size before processing a chunk", async () => {
+    vi.stubEnv("DEVICE_QUOTA_VM_MAX_PAYLOAD_BYTES", "10")
+    const store = createStore()
+
+    await expect(
+      processSuggestionJobChunk({
+        chunkId: "chunk-1",
+        store,
+      }),
+    ).rejects.toMatchObject({ status: 413 })
+
+    expect(callVmSuggest).not.toHaveBeenCalled()
   })
 
   test("processes only the queued chunks selected by the store", async () => {

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
@@ -300,12 +300,13 @@ describe("device quota suggestion job service", () => {
     const suggestChunk = vi.fn(async () => ({ results: [] }))
     vi.mocked(store.markChunkProcessing).mockResolvedValue(false)
 
-    await processSuggestionJobChunk({
+    const processed = await processSuggestionJobChunk({
       chunkId: "chunk-1",
       store,
       suggestChunk,
     })
 
+    expect(processed).toBe(false)
     expect(suggestChunk).not.toHaveBeenCalled()
     expect(store.markChunkSucceeded).not.toHaveBeenCalled()
   })
@@ -340,6 +341,26 @@ describe("device quota suggestion job service", () => {
     expect(result).toEqual({ failed: 0, processed: 2 })
     expect(store.listQueuedChunks).toHaveBeenCalledWith(2)
     expect(store.markChunkSucceeded).toHaveBeenCalledTimes(2)
+  })
+
+  test("does not count chunks skipped after a lost atomic claim as processed", async () => {
+    const store = createStore()
+    vi.mocked(store.listQueuedChunks).mockResolvedValue([
+      createChunk({ id: "chunk-1", chunkIndex: 0 }),
+      createChunk({ id: "chunk-2", chunkIndex: 1 }),
+    ])
+    vi.mocked(store.markChunkProcessing)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+
+    const result = await processNextSuggestionJobChunks({
+      limit: 2,
+      suggestChunk: vi.fn(async () => ({ results: [] })),
+      store,
+    })
+
+    expect(result).toEqual({ failed: 0, processed: 1 })
+    expect(store.markChunkSucceeded).toHaveBeenCalledTimes(1)
   })
 
   test("does not expose inaccessible jobs", async () => {

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
@@ -135,6 +135,37 @@ describe("device quota suggestion job service", () => {
     )
   })
 
+  test("splits chunks when device IDs exceed the secondary chunk limit", async () => {
+    const store = createStore()
+    const deviceHeavyNames: UnassignedName[] = [
+      { ten_thiet_bi: "Máy thở A", device_count: 2, device_ids: [101, 102] },
+      { ten_thiet_bi: "Máy thở B", device_count: 2, device_ids: [103, 104] },
+      { ten_thiet_bi: "Máy siêu âm", device_count: 1, device_ids: [105] },
+    ]
+
+    await createSuggestionJob({
+      donViId: 17,
+      maxDeviceIdsPerChunk: 3,
+      maxUniqueNamesPerChunk: 10,
+      requestId: "req-1",
+      store,
+      user: USER,
+      fetchInputs: vi.fn(async () => ({
+        categories: CATEGORIES,
+        names: deviceHeavyNames,
+      })),
+    })
+
+    expect(store.createJobWithChunks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chunks: [
+          expect.objectContaining({ deviceNameCount: 2, uniqueNameCount: 1 }),
+          expect.objectContaining({ deviceNameCount: 3, uniqueNameCount: 2 }),
+        ],
+      }),
+    )
+  })
+
   test("completes empty-input jobs immediately", async () => {
     const store = createStore()
     vi.mocked(store.createJobWithChunks).mockResolvedValue(

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test, vi } from "vitest"
+
+import {
+  createSuggestionJob,
+  getSuggestionJob,
+  processSuggestionJobChunk,
+  processNextSuggestionJobChunks,
+  retrySuggestionJob,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-job-service"
+import type {
+  SuggestionJobChunkRecord,
+  SuggestionJobRecord,
+  SuggestionJobStore,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-job-types"
+import type {
+  CategoryCatalogItem,
+  SuggestionAccessUser,
+  UnassignedName,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+const USER: SuggestionAccessUser = {
+  id: "user-1",
+  role: "to_qltb",
+  don_vi: "17",
+}
+
+const CATEGORIES: CategoryCatalogItem[] = [
+  { id: 11, ma_nhom: "MAY-THO", phan_loai: "medical", ten_nhom: "Máy thở" },
+  { id: 12, ma_nhom: "MAY-SIEU-AM", phan_loai: "medical", ten_nhom: "Máy siêu âm" },
+]
+
+const UNASSIGNED_NAMES: UnassignedName[] = [
+  { ten_thiet_bi: "Máy thở A", device_count: 2, device_ids: [101, 102] },
+  { ten_thiet_bi: "Máy thở B", device_count: 1, device_ids: [103] },
+  { ten_thiet_bi: "Máy siêu âm", device_count: 3, device_ids: [104, 105, 106] },
+]
+
+function createJob(overrides: Partial<SuggestionJobRecord> = {}): SuggestionJobRecord {
+  return {
+    id: "job-1",
+    donViId: 17,
+    scopeKey: "user:user-1",
+    dataSignature: "signature-1",
+    status: "queued",
+    provider: "vm",
+    processedUniqueNames: 0,
+    totalUniqueNames: 3,
+    itemCounts: {
+      categories: 2,
+      unassignedDevices: 6,
+      unassignedNames: 3,
+    },
+    result: null,
+    error: null,
+    createdAt: "2026-05-19T00:00:00.000Z",
+    updatedAt: "2026-05-19T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function createChunk(overrides: Partial<SuggestionJobChunkRecord> = {}): SuggestionJobChunkRecord {
+  return {
+    id: "chunk-1",
+    jobId: "job-1",
+    chunkIndex: 0,
+    status: "queued",
+    uniqueNameCount: 2,
+    deviceNameCount: 3,
+    deviceNames: UNASSIGNED_NAMES.slice(0, 2),
+    result: null,
+    error: null,
+    attempts: 0,
+    ...overrides,
+  }
+}
+
+function createStore(): SuggestionJobStore {
+  return {
+    createJobWithChunks: vi.fn(async () => createJob()),
+    findActiveJob: vi.fn(async () => null),
+    getChunk: vi.fn(async () => createChunk()),
+    getJob: vi.fn(async () => createJob()),
+    getJobChunks: vi.fn(async () => [createChunk()]),
+    listQueuedChunks: vi.fn(async () => [createChunk()]),
+    markChunkFailed: vi.fn(async () => undefined),
+    markChunkProcessing: vi.fn(async () => undefined),
+    markChunkSucceeded: vi.fn(async () => undefined),
+    markJobFailed: vi.fn(async () => undefined),
+    markJobProcessing: vi.fn(async () => undefined),
+    markJobSucceeded: vi.fn(async () => undefined),
+    resetFailedChunks: vi.fn(async () => undefined),
+    updateJobProgress: vi.fn(async () => undefined),
+  }
+}
+
+describe("device quota suggestion job service", () => {
+  test("creates a queued job with chunks grouped by unique device names", async () => {
+    const store = createStore()
+
+    const job = await createSuggestionJob({
+      donViId: 17,
+      maxDeviceIdsPerChunk: 4,
+      maxUniqueNamesPerChunk: 2,
+      requestId: "req-1",
+      store,
+      user: USER,
+      fetchInputs: vi.fn(async () => ({
+        categories: CATEGORIES,
+        names: UNASSIGNED_NAMES,
+      })),
+    })
+
+    expect(job.status).toBe("queued")
+    expect(store.createJobWithChunks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chunks: [
+          expect.objectContaining({ uniqueNameCount: 2 }),
+          expect.objectContaining({ uniqueNameCount: 1 }),
+        ],
+        job: expect.objectContaining({
+          dataSignature: expect.any(String),
+          totalUniqueNames: 3,
+        }),
+      }),
+    )
+  })
+
+  test("returns an existing active job for the same scope and data signature", async () => {
+    const existingJob = createJob({ id: "job-existing", status: "processing" })
+    const store = createStore()
+    vi.mocked(store.findActiveJob).mockResolvedValue(existingJob)
+
+    const job = await createSuggestionJob({
+      donViId: 17,
+      maxUniqueNamesPerChunk: 2,
+      requestId: "req-1",
+      store,
+      user: USER,
+      fetchInputs: vi.fn(async () => ({
+        categories: CATEGORIES,
+        names: UNASSIGNED_NAMES,
+      })),
+    })
+
+    expect(job).toEqual(existingJob)
+    expect(store.createJobWithChunks).not.toHaveBeenCalled()
+  })
+
+  test("processes one chunk and updates progress without touching completed chunks", async () => {
+    const store = createStore()
+
+    await processSuggestionJobChunk({
+      chunkId: "chunk-1",
+      store,
+      suggestChunk: vi.fn(async () => ({
+        results: [
+          {
+            query_text: "Máy thở A",
+            results: [{ id: 11, ma_nhom: "MAY-THO", ten_nhom: "Máy thở", rrf_score: 0.9 }],
+          },
+        ],
+      })),
+    })
+
+    expect(store.markChunkProcessing).toHaveBeenCalledWith("chunk-1")
+    expect(store.markChunkSucceeded).toHaveBeenCalledWith(
+      "chunk-1",
+      expect.objectContaining({ results: expect.any(Array) }),
+    )
+    expect(store.updateJobProgress).toHaveBeenCalledWith("job-1")
+  })
+
+  test("marks only the failed chunk when VM work fails", async () => {
+    const store = createStore()
+
+    await expect(
+      processSuggestionJobChunk({
+        chunkId: "chunk-1",
+        store,
+        suggestChunk: vi.fn(async () => {
+          throw new Error("VM timeout")
+        }),
+      }),
+    ).rejects.toThrow("VM timeout")
+
+    expect(store.markChunkFailed).toHaveBeenCalledWith("chunk-1", "VM timeout")
+    expect(store.markJobFailed).toHaveBeenCalledWith("job-1", "VM timeout")
+  })
+
+  test("retry resets failed chunks only", async () => {
+    const store = createStore()
+
+    const job = await retrySuggestionJob({
+      jobId: "job-1",
+      store,
+      user: USER,
+    })
+
+    expect(job.id).toBe("job-1")
+    expect(store.resetFailedChunks).toHaveBeenCalledWith("job-1")
+    expect(store.markJobProcessing).toHaveBeenCalledWith("job-1")
+  })
+
+  test("processes only the queued chunks selected by the store", async () => {
+    const store = createStore()
+    vi.mocked(store.listQueuedChunks).mockResolvedValue([
+      createChunk({ id: "chunk-1", chunkIndex: 0 }),
+      createChunk({ id: "chunk-2", chunkIndex: 1 }),
+    ])
+
+    const result = await processNextSuggestionJobChunks({
+      limit: 2,
+      suggestChunk: vi.fn(async () => ({ results: [] })),
+      store,
+    })
+
+    expect(result).toEqual({ failed: 0, processed: 2 })
+    expect(store.listQueuedChunks).toHaveBeenCalledWith(2)
+    expect(store.markChunkSucceeded).toHaveBeenCalledTimes(2)
+  })
+
+  test("does not expose inaccessible jobs", async () => {
+    const store = createStore()
+    vi.mocked(store.getJob).mockResolvedValue(createJob({ scopeKey: "user:other-user" }))
+
+    await expect(
+      getSuggestionJob({
+        jobId: "job-1",
+        store,
+        user: USER,
+      }),
+    ).rejects.toMatchObject({ status: 404 })
+  })
+})

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-store.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-store.test.ts
@@ -1,0 +1,68 @@
+import fs from "fs"
+import path from "path"
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const rpcMock = vi.fn()
+const fromMock = vi.fn()
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({
+    from: fromMock,
+    rpc: rpcMock,
+  })),
+}))
+
+describe("device quota suggestion job store", () => {
+  beforeEach(() => {
+    rpcMock.mockReset()
+    fromMock.mockReset()
+    vi.resetModules()
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://supabase.test")
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role")
+  })
+
+  test("uses RPC-only persistence instead of direct table access", async () => {
+    rpcMock.mockResolvedValue({
+      data: {
+        catalog_signature: "catalog",
+        category_snapshot: [],
+        created_at: "2026-05-19T00:00:00.000Z",
+        data_signature: "signature",
+        don_vi_id: 17,
+        error: null,
+        id: "job-1",
+        item_counts: { categories: 0, unassignedDevices: 0, unassignedNames: 0 },
+        processed_unique_names: 0,
+        provider: "vm",
+        result: null,
+        scope_key: "user:user-1",
+        status: "queued",
+        total_unique_names: 0,
+        updated_at: "2026-05-19T00:00:00.000Z",
+      },
+      error: null,
+    })
+    const { createServerSuggestionJobStore } = await import(
+      "@/app/api/device-quota/mapping/suggest/suggestion-job-store"
+    )
+
+    await createServerSuggestionJobStore().getJob("job-1")
+
+    expect(rpcMock).toHaveBeenCalledWith("device_quota_suggestion_job_store_rpc", {
+      p_action: "get_job",
+      p_payload: { job_id: "job-1" },
+    })
+    expect(fromMock).not.toHaveBeenCalled()
+  })
+
+  test("does not contain direct Supabase table queries", () => {
+    const filePath = path.join(
+      process.cwd(),
+      "src/app/api/device-quota/mapping/suggest/suggestion-job-store.ts",
+    )
+    const source = fs.readFileSync(filePath, "utf8")
+
+    expect(source).not.toContain(".from(")
+  })
+})

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route.ts
@@ -25,7 +25,7 @@ export async function POST(
   const session = await getServerSession(authOptions)
   const user = session?.user as SuggestionAccessUser | undefined
 
-  if (!user?.id) {
+  if (!user?.id || !user.role) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 
@@ -35,6 +35,9 @@ export async function POST(
     return NextResponse.json({ job }, { status: 202 })
   } catch (error) {
     const status = getErrorStatus(error)
+    if (status >= 500) {
+      console.error("Suggestion job retry failed", error)
+    }
     const message = status < 500 ? getErrorMessage(error) : "Internal server error"
     return NextResponse.json({ error: message }, { status })
   }

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/auth/config"
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { retrySuggestionJob } from "@/app/api/device-quota/mapping/suggest/suggestion-job-service"
+import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+export const runtime = "nodejs"
+
+function getErrorStatus(error: unknown): number {
+  if (error instanceof SuggestionRouteError) return error.status
+  return 500
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  return "Internal server error"
+}
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  const session = await getServerSession(authOptions)
+  const user = session?.user as SuggestionAccessUser | undefined
+
+  if (!user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  try {
+    const { jobId } = await params
+    const job = await retrySuggestionJob({ jobId, user })
+    return NextResponse.json({ job }, { status: 202 })
+  } catch (error) {
+    const status = getErrorStatus(error)
+    const message = status < 500 ? getErrorMessage(error) : "Internal server error"
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route.ts
@@ -2,21 +2,15 @@ import { NextResponse } from "next/server"
 import { getServerSession } from "next-auth"
 
 import { authOptions } from "@/auth/config"
-import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
 import { retrySuggestionJob } from "@/app/api/device-quota/mapping/suggest/suggestion-job-service"
+import {
+  assertSuggestionRouteUser,
+  getErrorMessage,
+  getErrorStatus,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-route-utils"
 import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 
 export const runtime = "nodejs"
-
-function getErrorStatus(error: unknown): number {
-  if (error instanceof SuggestionRouteError) return error.status
-  return 500
-}
-
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message
-  return "Internal server error"
-}
 
 export async function POST(
   _request: Request,
@@ -25,8 +19,12 @@ export async function POST(
   const session = await getServerSession(authOptions)
   const user = session?.user as SuggestionAccessUser | undefined
 
-  if (!user?.id || !user.role) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  try {
+    assertSuggestionRouteUser(user)
+  } catch (error) {
+    const status = getErrorStatus(error)
+    const message = getErrorMessage(error)
+    return NextResponse.json({ error: message }, { status })
   }
 
   try {

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/retry/route.ts
@@ -23,7 +23,7 @@ export async function POST(
     assertSuggestionRouteUser(user)
   } catch (error) {
     const status = getErrorStatus(error)
-    const message = getErrorMessage(error)
+    const message = getErrorMessage(error, status)
     return NextResponse.json({ error: message }, { status })
   }
 
@@ -36,7 +36,7 @@ export async function POST(
     if (status >= 500) {
       console.error("Suggestion job retry failed", error)
     }
-    const message = status < 500 ? getErrorMessage(error) : "Internal server error"
+    const message = getErrorMessage(error, status)
     return NextResponse.json({ error: message }, { status })
   }
 }

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/route.ts
@@ -2,21 +2,15 @@ import { NextResponse } from "next/server"
 import { getServerSession } from "next-auth"
 
 import { authOptions } from "@/auth/config"
-import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
 import { getSuggestionJob } from "@/app/api/device-quota/mapping/suggest/suggestion-job-service"
+import {
+  assertSuggestionRouteUser,
+  getErrorMessage,
+  getErrorStatus,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-route-utils"
 import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 
 export const runtime = "nodejs"
-
-function getErrorStatus(error: unknown): number {
-  if (error instanceof SuggestionRouteError) return error.status
-  return 500
-}
-
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message
-  return "Internal server error"
-}
 
 export async function GET(
   _request: Request,
@@ -25,8 +19,12 @@ export async function GET(
   const session = await getServerSession(authOptions)
   const user = session?.user as SuggestionAccessUser | undefined
 
-  if (!user?.id || !user.role) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  try {
+    assertSuggestionRouteUser(user)
+  } catch (error) {
+    const status = getErrorStatus(error)
+    const message = getErrorMessage(error)
+    return NextResponse.json({ error: message }, { status })
   }
 
   try {

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/route.ts
@@ -25,7 +25,7 @@ export async function GET(
   const session = await getServerSession(authOptions)
   const user = session?.user as SuggestionAccessUser | undefined
 
-  if (!user?.id) {
+  if (!user?.id || !user.role) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
   }
 

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/auth/config"
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { getSuggestionJob } from "@/app/api/device-quota/mapping/suggest/suggestion-job-service"
+import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+export const runtime = "nodejs"
+
+function getErrorStatus(error: unknown): number {
+  if (error instanceof SuggestionRouteError) return error.status
+  return 500
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  return "Internal server error"
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  const session = await getServerSession(authOptions)
+  const user = session?.user as SuggestionAccessUser | undefined
+
+  if (!user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  try {
+    const { jobId } = await params
+    const job = await getSuggestionJob({ jobId, user })
+    return NextResponse.json({ job }, { status: 200 })
+  } catch (error) {
+    const status = getErrorStatus(error)
+    const message = status < 500 ? getErrorMessage(error) : "Internal server error"
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/route.ts
@@ -23,7 +23,7 @@ export async function GET(
     assertSuggestionRouteUser(user)
   } catch (error) {
     const status = getErrorStatus(error)
-    const message = getErrorMessage(error)
+    const message = getErrorMessage(error, status)
     return NextResponse.json({ error: message }, { status })
   }
 
@@ -33,7 +33,7 @@ export async function GET(
     return NextResponse.json({ job }, { status: 200 })
   } catch (error) {
     const status = getErrorStatus(error)
-    const message = status < 500 ? getErrorMessage(error) : "Internal server error"
+    const message = getErrorMessage(error, status)
     return NextResponse.json({ error: message }, { status })
   }
 }

--- a/src/app/api/device-quota/mapping/suggest/jobs/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/route.ts
@@ -22,6 +22,10 @@ function parsePositiveInteger(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined
 }
 
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
 function getErrorStatus(error: unknown): number {
   if (error instanceof SuggestionRouteError) return error.status
   return 500
@@ -37,21 +41,17 @@ export async function POST(request: Request) {
   const session = await getServerSession(authOptions)
   const user = session?.user as SuggestionAccessUser | undefined
 
-  if (!user?.id) {
+  if (!user?.id || !user.role) {
     return NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 })
   }
 
-  let body: {
-    donViId?: unknown
-    maxDeviceIdsPerChunk?: unknown
-    maxUniqueNamesPerChunk?: unknown
-  }
+  let body: Record<string, unknown>
   try {
-    body = (await request.json()) as {
-      donViId?: unknown
-      maxDeviceIdsPerChunk?: unknown
-      maxUniqueNamesPerChunk?: unknown
+    const parsedBody = (await request.json()) as unknown
+    if (!isJsonRecord(parsedBody)) {
+      return NextResponse.json({ error: "Invalid JSON body", requestId }, { status: 400 })
     }
+    body = parsedBody
   } catch {
     return NextResponse.json({ error: "Invalid JSON body", requestId }, { status: 400 })
   }

--- a/src/app/api/device-quota/mapping/suggest/jobs/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: Request) {
     assertSuggestionRouteUser(user)
   } catch (error) {
     const status = getErrorStatus(error)
-    const message = getErrorMessage(error)
+    const message = getErrorMessage(error, status)
     return NextResponse.json({ error: message, requestId }, { status })
   }
 
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ job, requestId }, { status })
   } catch (error) {
     const status = getErrorStatus(error)
-    const message = status < 500 ? getErrorMessage(error) : "Internal server error"
+    const message = getErrorMessage(error, status)
     return NextResponse.json({ error: message, requestId }, { status })
   }
 }

--- a/src/app/api/device-quota/mapping/suggest/jobs/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/auth/config"
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { createSuggestionJob } from "@/app/api/device-quota/mapping/suggest/suggestion-job-service"
+import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+export const runtime = "nodejs"
+
+function createRequestId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `job-${Date.now().toString(36)}`
+}
+
+function parseDonViId(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined
+}
+
+function getErrorStatus(error: unknown): number {
+  if (error instanceof SuggestionRouteError) return error.status
+  return 500
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  return "Internal server error"
+}
+
+export async function POST(request: Request) {
+  const requestId = createRequestId()
+  const session = await getServerSession(authOptions)
+  const user = session?.user as SuggestionAccessUser | undefined
+
+  if (!user?.id) {
+    return NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 })
+  }
+
+  let body: {
+    donViId?: unknown
+    maxDeviceIdsPerChunk?: unknown
+    maxUniqueNamesPerChunk?: unknown
+  }
+  try {
+    body = (await request.json()) as {
+      donViId?: unknown
+      maxDeviceIdsPerChunk?: unknown
+      maxUniqueNamesPerChunk?: unknown
+    }
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body", requestId }, { status: 400 })
+  }
+
+  const donViId = parseDonViId(body.donViId)
+  if (donViId === null) {
+    return NextResponse.json({ error: "donViId must be a positive integer", requestId }, { status: 400 })
+  }
+
+  try {
+    const job = await createSuggestionJob({
+      donViId,
+      maxDeviceIdsPerChunk: parsePositiveInteger(body.maxDeviceIdsPerChunk),
+      maxUniqueNamesPerChunk: parsePositiveInteger(body.maxUniqueNamesPerChunk),
+      requestId,
+      user,
+    })
+    const status = job.status === "succeeded" ? 200 : 202
+    return NextResponse.json({ job, requestId }, { status })
+  } catch (error) {
+    const status = getErrorStatus(error)
+    const message = status < 500 ? getErrorMessage(error) : "Internal server error"
+    return NextResponse.json({ error: message, requestId }, { status })
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/jobs/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/route.ts
@@ -2,8 +2,12 @@ import { NextResponse } from "next/server"
 import { getServerSession } from "next-auth"
 
 import { authOptions } from "@/auth/config"
-import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
 import { createSuggestionJob } from "@/app/api/device-quota/mapping/suggest/suggestion-job-service"
+import {
+  assertSuggestionRouteUser,
+  getErrorMessage,
+  getErrorStatus,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-route-utils"
 import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 
 export const runtime = "nodejs"
@@ -26,23 +30,17 @@ function isJsonRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value)
 }
 
-function getErrorStatus(error: unknown): number {
-  if (error instanceof SuggestionRouteError) return error.status
-  return 500
-}
-
-function getErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message
-  return "Internal server error"
-}
-
 export async function POST(request: Request) {
   const requestId = createRequestId()
   const session = await getServerSession(authOptions)
   const user = session?.user as SuggestionAccessUser | undefined
 
-  if (!user?.id || !user.role) {
-    return NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 })
+  try {
+    assertSuggestionRouteUser(user)
+  } catch (error) {
+    const status = getErrorStatus(error)
+    const message = getErrorMessage(error)
+    return NextResponse.json({ error: message, requestId }, { status })
   }
 
   let body: Record<string, unknown>

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
@@ -1,0 +1,271 @@
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { createCatalogSignature, mergeSuggestionResults } from "@/app/api/device-quota/mapping/suggest/suggestion-merge"
+import { assertSuggestionAccess } from "@/app/api/device-quota/mapping/suggest/suggestion-supabase-provider"
+import {
+  createUnassignedSignature,
+  fetchVmSuggestionInputs,
+  toSearchResults,
+  toVmRequest,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-vm-provider"
+import { callVmSuggest } from "@/app/api/device-quota/mapping/suggest/suggestion-vm-client"
+import {
+  createServerSuggestionJobStore,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-job-store"
+import type {
+  SuggestionJobChunkRecord,
+  SuggestionJobRecord,
+  SuggestionJobStore,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-job-types"
+import type {
+  DinhMucNhomRow,
+  SearchResult,
+  SuggestionAccessUser,
+  UnassignedName,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+const DEFAULT_MAX_UNIQUE_NAMES_PER_CHUNK = 50
+const DEFAULT_MAX_DEVICE_IDS_PER_CHUNK = 500
+
+type SuggestionInputs = {
+  categories: DinhMucNhomRow[]
+  names: UnassignedName[]
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function getUserScopeKey(user: SuggestionAccessUser): string {
+  const id = typeof user.id === "number" || typeof user.id === "string" ? String(user.id) : ""
+  if (id === "") {
+    throw new SuggestionRouteError("Unauthorized", 401)
+  }
+  return `user:${id}`
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : "Suggestion job failed"
+}
+
+function chunkUnassignedNames({
+  maxDeviceIdsPerChunk,
+  maxUniqueNamesPerChunk,
+  names,
+}: {
+  maxDeviceIdsPerChunk: number
+  maxUniqueNamesPerChunk: number
+  names: UnassignedName[]
+}): UnassignedName[][] {
+  const chunks: UnassignedName[][] = []
+  let current: UnassignedName[] = []
+  let currentDeviceIds = 0
+
+  for (const name of names) {
+    const nextDeviceIds = currentDeviceIds + name.device_ids.length
+    const uniqueLimitReached = current.length >= maxUniqueNamesPerChunk
+    const deviceLimitReached = current.length > 0 && nextDeviceIds > maxDeviceIdsPerChunk
+
+    if (uniqueLimitReached || deviceLimitReached) {
+      chunks.push(current)
+      current = []
+      currentDeviceIds = 0
+    }
+
+    current.push(name)
+    currentDeviceIds += name.device_ids.length
+  }
+
+  if (current.length > 0) chunks.push(current)
+  return chunks
+}
+
+export async function createSuggestionJob({
+  donViId,
+  fetchInputs = fetchVmSuggestionInputs,
+  maxDeviceIdsPerChunk = parsePositiveInteger(
+    process.env.DEVICE_QUOTA_SUGGESTION_JOB_MAX_DEVICE_IDS_PER_CHUNK,
+    DEFAULT_MAX_DEVICE_IDS_PER_CHUNK,
+  ),
+  maxUniqueNamesPerChunk = parsePositiveInteger(
+    process.env.DEVICE_QUOTA_SUGGESTION_JOB_MAX_UNIQUE_NAMES_PER_CHUNK,
+    DEFAULT_MAX_UNIQUE_NAMES_PER_CHUNK,
+  ),
+  requestId,
+  store = createServerSuggestionJobStore(),
+  user,
+}: {
+  donViId: number
+  fetchInputs?: (args: { donViId: number; user: SuggestionAccessUser }) => Promise<SuggestionInputs>
+  maxDeviceIdsPerChunk?: number
+  maxUniqueNamesPerChunk?: number
+  requestId: string
+  store?: SuggestionJobStore
+  user: SuggestionAccessUser
+}): Promise<SuggestionJobRecord> {
+  await assertSuggestionAccess(user, donViId)
+
+  const scopeKey = getUserScopeKey(user)
+  const { categories, names } = await fetchInputs({ donViId, user })
+  const catalogSignature = createCatalogSignature(categories)
+  const dataSignature = `${catalogSignature}:${createUnassignedSignature(names)}`
+  const existingJob = await store.findActiveJob({ dataSignature, donViId, scopeKey })
+
+  if (existingJob) return existingJob
+
+  const chunks = chunkUnassignedNames({
+    maxDeviceIdsPerChunk,
+    maxUniqueNamesPerChunk,
+    names,
+  })
+
+  return store.createJobWithChunks({
+    chunks: chunks.map((chunk, chunkIndex) => ({
+      chunkIndex,
+      deviceNameCount: chunk.reduce((sum, name) => sum + name.device_ids.length, 0),
+      deviceNames: chunk,
+      uniqueNameCount: chunk.length,
+    })),
+    job: {
+      catalogSignature,
+      categorySnapshot: categories,
+      dataSignature,
+      donViId,
+      error: null,
+      itemCounts: {
+        categories: categories.length,
+        unassignedDevices: names.reduce((sum, name) => sum + name.device_ids.length, 0),
+        unassignedNames: names.length,
+      },
+      processedUniqueNames: 0,
+      provider: "vm",
+      scopeKey,
+      status: "queued",
+      totalUniqueNames: names.length,
+    },
+  })
+}
+
+function canAccessJob(job: SuggestionJobRecord, user: SuggestionAccessUser): boolean {
+  return job.scopeKey === getUserScopeKey(user)
+}
+
+export async function getSuggestionJob({
+  jobId,
+  store = createServerSuggestionJobStore(),
+  user,
+}: {
+  jobId: string
+  store?: SuggestionJobStore
+  user: SuggestionAccessUser
+}): Promise<SuggestionJobRecord> {
+  const job = await store.getJob(jobId)
+  if (!job || !canAccessJob(job, user)) {
+    throw new SuggestionRouteError("Suggestion job not found", 404)
+  }
+  return job
+}
+
+export async function retrySuggestionJob({
+  jobId,
+  store = createServerSuggestionJobStore(),
+  user,
+}: {
+  jobId: string
+  store?: SuggestionJobStore
+  user: SuggestionAccessUser
+}): Promise<SuggestionJobRecord> {
+  const job = await getSuggestionJob({ jobId, store, user })
+  await store.resetFailedChunks(job.id)
+  await store.markJobProcessing(job.id)
+  return { ...job, error: null, status: "processing" }
+}
+
+export async function processSuggestionJobChunk({
+  chunkId,
+  store = createServerSuggestionJobStore(),
+  suggestChunk,
+}: {
+  chunkId: string
+  store?: SuggestionJobStore
+  suggestChunk?: (args: {
+    chunk: SuggestionJobChunkRecord
+    job: SuggestionJobRecord
+  }) => Promise<{ results: SearchResult[] }>
+}): Promise<void> {
+  const chunk = await store.getChunk(chunkId)
+  if (!chunk || chunk.status === "succeeded") return
+
+  const job = await store.getJob(chunk.jobId)
+  if (!job) {
+    throw new SuggestionRouteError("Suggestion job not found", 404)
+  }
+
+  await store.markChunkProcessing(chunk.id)
+  await store.markJobProcessing(job.id)
+
+  try {
+    const result = await (suggestChunk ?? suggestChunkWithVm)({ chunk, job })
+    await store.markChunkSucceeded(chunk.id, result)
+    await store.updateJobProgress(job.id)
+  } catch (error) {
+    const message = getErrorMessage(error)
+    await store.markChunkFailed(chunk.id, message)
+    await store.markJobFailed(job.id, message)
+    throw error
+  }
+}
+
+async function suggestChunkWithVm({
+  chunk,
+  job,
+}: {
+  chunk: SuggestionJobChunkRecord
+  job: SuggestionJobRecord
+}): Promise<{ results: SearchResult[] }> {
+  const categories = job.categorySnapshot ?? []
+  const catalogSignature = job.catalogSignature ?? job.dataSignature.split(":")[0] ?? ""
+  const vmRequest = toVmRequest({
+    catalogSignature,
+    categories,
+    donViId: job.donViId,
+    names: chunk.deviceNames,
+    requestId: `${job.id}:${chunk.chunkIndex}`,
+  })
+  const response = await callVmSuggest(vmRequest)
+  return { results: toSearchResults(response) }
+}
+
+export async function processNextSuggestionJobChunks({
+  limit = 1,
+  suggestChunk,
+  store = createServerSuggestionJobStore(),
+}: {
+  limit?: number
+  suggestChunk?: (args: {
+    chunk: SuggestionJobChunkRecord
+    job: SuggestionJobRecord
+  }) => Promise<{ results: SearchResult[] }>
+  store?: SuggestionJobStore
+} = {}): Promise<{ failed: number; processed: number }> {
+  const chunks = await store.listQueuedChunks(limit)
+  let failed = 0
+  let processed = 0
+
+  for (const chunk of chunks) {
+    try {
+      await processSuggestionJobChunk({ chunkId: chunk.id, store, suggestChunk })
+      processed += 1
+    } catch {
+      failed += 1
+    }
+  }
+
+  return { failed, processed }
+}
+
+export function mergeCompletedJobChunks(chunks: SuggestionJobChunkRecord[]) {
+  const names = chunks.flatMap((chunk) => chunk.deviceNames)
+  const results = chunks.flatMap((chunk) => chunk.result?.results ?? [])
+  return mergeSuggestionResults(names, results)
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
@@ -4,6 +4,7 @@ import { assertSuggestionAccess } from "@/app/api/device-quota/mapping/suggest/s
 import {
   createUnassignedSignature,
   fetchVmSuggestionInputs,
+  assertPayloadSize,
   toSearchResults,
   toVmRequest,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-vm-provider"
@@ -92,7 +93,7 @@ export async function createSuggestionJob({
     DEFAULT_MAX_UNIQUE_NAMES_PER_CHUNK,
   ),
   requestId,
-  store = createServerSuggestionJobStore(),
+  store,
   user,
 }: {
   donViId: number
@@ -104,22 +105,24 @@ export async function createSuggestionJob({
   user: SuggestionAccessUser
 }): Promise<SuggestionJobRecord> {
   await assertSuggestionAccess(user, donViId)
+  const jobStore = store ?? createServerSuggestionJobStore(user)
 
   const scopeKey = getUserScopeKey(user)
   const { categories, names } = await fetchInputs({ donViId, user })
   const catalogSignature = createCatalogSignature(categories)
   const dataSignature = `${catalogSignature}:${createUnassignedSignature(names)}`
-  const existingJob = await store.findActiveJob({ dataSignature, donViId, scopeKey })
+  const existingJob = await jobStore.findActiveJob({ dataSignature, donViId, scopeKey })
 
   if (existingJob) return existingJob
 
+  const emptyResult = { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 }
   const chunks = chunkUnassignedNames({
     maxDeviceIdsPerChunk,
     maxUniqueNamesPerChunk,
     names,
   })
 
-  return store.createJobWithChunks({
+  return jobStore.createJobWithChunks({
     chunks: chunks.map((chunk, chunkIndex) => ({
       chunkIndex,
       deviceNameCount: chunk.reduce((sum, name) => sum + name.device_ids.length, 0),
@@ -139,8 +142,9 @@ export async function createSuggestionJob({
       },
       processedUniqueNames: 0,
       provider: "vm",
+      result: names.length === 0 ? emptyResult : null,
       scopeKey,
-      status: "queued",
+      status: names.length === 0 ? "succeeded" : "queued",
       totalUniqueNames: names.length,
     },
   })
@@ -152,14 +156,15 @@ function canAccessJob(job: SuggestionJobRecord, user: SuggestionAccessUser): boo
 
 export async function getSuggestionJob({
   jobId,
-  store = createServerSuggestionJobStore(),
+  store,
   user,
 }: {
   jobId: string
   store?: SuggestionJobStore
   user: SuggestionAccessUser
 }): Promise<SuggestionJobRecord> {
-  const job = await store.getJob(jobId)
+  const jobStore = store ?? createServerSuggestionJobStore(user)
+  const job = await jobStore.getJob(jobId)
   if (!job || !canAccessJob(job, user)) {
     throw new SuggestionRouteError("Suggestion job not found", 404)
   }
@@ -168,16 +173,20 @@ export async function getSuggestionJob({
 
 export async function retrySuggestionJob({
   jobId,
-  store = createServerSuggestionJobStore(),
+  store,
   user,
 }: {
   jobId: string
   store?: SuggestionJobStore
   user: SuggestionAccessUser
 }): Promise<SuggestionJobRecord> {
-  const job = await getSuggestionJob({ jobId, store, user })
-  await store.resetFailedChunks(job.id)
-  await store.markJobProcessing(job.id)
+  const jobStore = store ?? createServerSuggestionJobStore(user)
+  const job = await getSuggestionJob({ jobId, store: jobStore, user })
+  if (job.status !== "failed") {
+    throw new SuggestionRouteError("Only failed suggestion jobs can be retried", 409)
+  }
+  await jobStore.resetFailedChunks(job.id)
+  await jobStore.markJobProcessing(job.id)
   return { ...job, error: null, status: "processing" }
 }
 
@@ -201,7 +210,8 @@ export async function processSuggestionJobChunk({
     throw new SuggestionRouteError("Suggestion job not found", 404)
   }
 
-  await store.markChunkProcessing(chunk.id)
+  const claimed = await store.markChunkProcessing(chunk.id)
+  if (!claimed) return
   await store.markJobProcessing(job.id)
 
   try {
@@ -232,6 +242,7 @@ async function suggestChunkWithVm({
     names: chunk.deviceNames,
     requestId: `${job.id}:${chunk.chunkIndex}`,
   })
+  assertPayloadSize(vmRequest)
   const response = await callVmSuggest(vmRequest)
   return { results: toSearchResults(response) }
 }

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
@@ -201,9 +201,9 @@ export async function processSuggestionJobChunk({
     chunk: SuggestionJobChunkRecord
     job: SuggestionJobRecord
   }) => Promise<{ results: SearchResult[] }>
-}): Promise<void> {
+}): Promise<boolean> {
   const chunk = await store.getChunk(chunkId)
-  if (!chunk || chunk.status === "succeeded") return
+  if (!chunk || chunk.status === "succeeded") return false
 
   const job = await store.getJob(chunk.jobId)
   if (!job) {
@@ -211,13 +211,14 @@ export async function processSuggestionJobChunk({
   }
 
   const claimed = await store.markChunkProcessing(chunk.id)
-  if (!claimed) return
+  if (!claimed) return false
   await store.markJobProcessing(job.id)
 
   try {
     const result = await (suggestChunk ?? suggestChunkWithVm)({ chunk, job })
     await store.markChunkSucceeded(chunk.id, result)
     await store.updateJobProgress(job.id)
+    return true
   } catch (error) {
     const message = getErrorMessage(error)
     await store.markChunkFailed(chunk.id, message)
@@ -265,8 +266,8 @@ export async function processNextSuggestionJobChunks({
 
   for (const chunk of chunks) {
     try {
-      await processSuggestionJobChunk({ chunkId: chunk.id, store, suggestChunk })
-      processed += 1
+      const didProcess = await processSuggestionJobChunk({ chunkId: chunk.id, store, suggestChunk })
+      if (didProcess) processed += 1
     } catch {
       failed += 1
     }

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-store.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-store.ts
@@ -1,0 +1,306 @@
+import { createClient } from "@supabase/supabase-js"
+
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import { mergeSuggestionResults } from "@/app/api/device-quota/mapping/suggest/suggestion-merge"
+import type {
+  CreateSuggestionJobPayload,
+  SuggestionJobChunkRecord,
+  SuggestionJobRecord,
+  SuggestionJobStatus,
+  SuggestionJobStore,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-job-types"
+import type {
+  DinhMucNhomRow,
+  SearchResult,
+  SuggestMappingResult,
+  SuggestionItemCounts,
+  UnassignedName,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+const JOBS_TABLE = "device_quota_suggestion_jobs"
+const CHUNKS_TABLE = "device_quota_suggestion_job_chunks"
+
+type JsonRecord = Record<string, unknown>
+
+type SuggestionJobRow = {
+  catalog_signature: string
+  category_snapshot: DinhMucNhomRow[] | null
+  created_at: string
+  data_signature: string
+  don_vi_id: number
+  error: string | null
+  id: string
+  item_counts: SuggestionItemCounts
+  processed_unique_names: number
+  provider: "vm"
+  result: SuggestMappingResult | null
+  scope_key: string
+  status: SuggestionJobStatus
+  total_unique_names: number
+  updated_at: string
+}
+
+type SuggestionJobChunkRow = {
+  attempts: number
+  chunk_index: number
+  device_name_count: number
+  device_names: UnassignedName[]
+  error: string | null
+  id: string
+  job_id: string
+  result: { results: SearchResult[] } | null
+  status: SuggestionJobStatus
+  unique_name_count: number
+}
+
+function createSupabaseAdminClient() {
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new SuggestionRouteError("Missing Supabase service configuration", 500)
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  })
+}
+
+function mapJob(row: SuggestionJobRow): SuggestionJobRecord {
+  return {
+    catalogSignature: row.catalog_signature,
+    categorySnapshot: row.category_snapshot ?? undefined,
+    createdAt: row.created_at,
+    dataSignature: row.data_signature,
+    donViId: row.don_vi_id,
+    error: row.error,
+    id: row.id,
+    itemCounts: row.item_counts,
+    processedUniqueNames: row.processed_unique_names,
+    provider: row.provider,
+    result: row.result,
+    scopeKey: row.scope_key,
+    status: row.status,
+    totalUniqueNames: row.total_unique_names,
+    updatedAt: row.updated_at,
+  }
+}
+
+function mapChunk(row: SuggestionJobChunkRow): SuggestionJobChunkRecord {
+  return {
+    attempts: row.attempts,
+    chunkIndex: row.chunk_index,
+    deviceNameCount: row.device_name_count,
+    deviceNames: row.device_names,
+    error: row.error,
+    id: row.id,
+    jobId: row.job_id,
+    result: row.result,
+    status: row.status,
+    uniqueNameCount: row.unique_name_count,
+  }
+}
+
+function getDbErrorMessage(error: { message?: string } | null): string {
+  return error?.message ?? "Database operation failed"
+}
+
+function toJobInsert(payload: CreateSuggestionJobPayload): JsonRecord {
+  return {
+    catalog_signature: payload.job.catalogSignature ?? payload.job.dataSignature,
+    category_snapshot: payload.job.categorySnapshot ?? [],
+    data_signature: payload.job.dataSignature,
+    don_vi_id: payload.job.donViId,
+    error: payload.job.error,
+    item_counts: payload.job.itemCounts,
+    processed_unique_names: payload.job.processedUniqueNames,
+    provider: payload.job.provider,
+    scope_key: payload.job.scopeKey,
+    status: payload.job.status,
+    total_unique_names: payload.job.totalUniqueNames,
+  }
+}
+
+function toChunkInsert(jobId: string, payload: CreateSuggestionJobPayload): JsonRecord[] {
+  return payload.chunks.map((chunk) => ({
+    chunk_index: chunk.chunkIndex,
+    device_name_count: chunk.deviceNameCount,
+    device_names: chunk.deviceNames,
+    job_id: jobId,
+    status: "queued",
+    unique_name_count: chunk.uniqueNameCount,
+  }))
+}
+
+async function requireJob(store: SuggestionJobStore, jobId: string): Promise<SuggestionJobRecord> {
+  const job = await store.getJob(jobId)
+  if (!job) throw new SuggestionRouteError("Suggestion job not found", 404)
+  return job
+}
+
+export function createServerSuggestionJobStore(): SuggestionJobStore {
+  const supabase = createSupabaseAdminClient()
+
+  return {
+    async createJobWithChunks(payload) {
+      const { data: jobRow, error: jobError } = await supabase
+        .from(JOBS_TABLE)
+        .insert(toJobInsert(payload))
+        .select("*")
+        .single()
+
+      if (jobError || !jobRow) {
+        throw new SuggestionRouteError(getDbErrorMessage(jobError), 500)
+      }
+
+      const job = mapJob(jobRow as SuggestionJobRow)
+      const chunkRows = toChunkInsert(job.id, payload)
+      if (chunkRows.length > 0) {
+        const { error: chunkError } = await supabase.from(CHUNKS_TABLE).insert(chunkRows)
+        if (chunkError) {
+          await supabase.from(JOBS_TABLE).delete().eq("id", job.id)
+          throw new SuggestionRouteError(getDbErrorMessage(chunkError), 500)
+        }
+      }
+
+      return job
+    },
+
+    async findActiveJob({ dataSignature, donViId, scopeKey }) {
+      const { data, error } = await supabase
+        .from(JOBS_TABLE)
+        .select("*")
+        .eq("don_vi_id", donViId)
+        .eq("scope_key", scopeKey)
+        .eq("data_signature", dataSignature)
+        .in("status", ["queued", "processing", "succeeded"])
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      return data ? mapJob(data as SuggestionJobRow) : null
+    },
+
+    async getChunk(chunkId) {
+      const { data, error } = await supabase
+        .from(CHUNKS_TABLE)
+        .select("*")
+        .eq("id", chunkId)
+        .maybeSingle()
+
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      return data ? mapChunk(data as SuggestionJobChunkRow) : null
+    },
+
+    async getJob(jobId) {
+      const { data, error } = await supabase.from(JOBS_TABLE).select("*").eq("id", jobId).maybeSingle()
+
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      return data ? mapJob(data as SuggestionJobRow) : null
+    },
+
+    async getJobChunks(jobId) {
+      const { data, error } = await supabase
+        .from(CHUNKS_TABLE)
+        .select("*")
+        .eq("job_id", jobId)
+        .order("chunk_index", { ascending: true })
+
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      return (data ?? []).map((row) => mapChunk(row as SuggestionJobChunkRow))
+    },
+
+    async listQueuedChunks(limit) {
+      const { data, error } = await supabase
+        .from(CHUNKS_TABLE)
+        .select("*")
+        .eq("status", "queued")
+        .order("created_at", { ascending: true })
+        .limit(limit)
+
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      return (data ?? []).map((row) => mapChunk(row as SuggestionJobChunkRow))
+    },
+
+    async markChunkFailed(chunkId, error) {
+      const { error: updateError } = await supabase
+        .from(CHUNKS_TABLE)
+        .update({ error, status: "failed" })
+        .eq("id", chunkId)
+      if (updateError) throw new SuggestionRouteError(getDbErrorMessage(updateError), 500)
+    },
+
+    async markChunkProcessing(chunkId) {
+      const chunk = await this.getChunk(chunkId)
+      const attempts = (chunk?.attempts ?? 0) + 1
+      const { error } = await supabase
+        .from(CHUNKS_TABLE)
+        .update({ attempts, status: "processing" })
+        .eq("id", chunkId)
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+    },
+
+    async markChunkSucceeded(chunkId, result) {
+      const { error } = await supabase
+        .from(CHUNKS_TABLE)
+        .update({ error: null, result, status: "succeeded" })
+        .eq("id", chunkId)
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+    },
+
+    async markJobFailed(jobId, error) {
+      const { error: updateError } = await supabase
+        .from(JOBS_TABLE)
+        .update({ error, status: "failed" })
+        .eq("id", jobId)
+      if (updateError) throw new SuggestionRouteError(getDbErrorMessage(updateError), 500)
+    },
+
+    async markJobProcessing(jobId) {
+      const { error } = await supabase
+        .from(JOBS_TABLE)
+        .update({ error: null, status: "processing" })
+        .eq("id", jobId)
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+    },
+
+    async markJobSucceeded(jobId, result) {
+      const { error } = await supabase
+        .from(JOBS_TABLE)
+        .update({ error: null, result, status: "succeeded" })
+        .eq("id", jobId)
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+    },
+
+    async resetFailedChunks(jobId) {
+      const { error } = await supabase
+        .from(CHUNKS_TABLE)
+        .update({ error: null, status: "queued" })
+        .eq("job_id", jobId)
+        .eq("status", "failed")
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+    },
+
+    async updateJobProgress(jobId) {
+      const job = await requireJob(this, jobId)
+      const chunks = await this.getJobChunks(jobId)
+      const processedUniqueNames = chunks
+        .filter((chunk) => chunk.status === "succeeded")
+        .reduce((sum, chunk) => sum + chunk.uniqueNameCount, 0)
+      const allSucceeded = chunks.length > 0 && chunks.every((chunk) => chunk.status === "succeeded")
+
+      if (allSucceeded) {
+        const names = chunks.flatMap((chunk) => chunk.deviceNames)
+        const results = chunks.flatMap((chunk) => chunk.result?.results ?? [])
+        const result = mergeSuggestionResults(names, results)
+        await this.markJobSucceeded(job.id, result)
+      }
+
+      const { error } = await supabase
+        .from(JOBS_TABLE)
+        .update({ processed_unique_names: processedUniqueNames })
+        .eq("id", jobId)
+      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+    },
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-store.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-store.ts
@@ -14,11 +14,11 @@ import type {
   SearchResult,
   SuggestMappingResult,
   SuggestionItemCounts,
+  SuggestionAccessUser,
   UnassignedName,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 
-const JOBS_TABLE = "device_quota_suggestion_jobs"
-const CHUNKS_TABLE = "device_quota_suggestion_job_chunks"
+const JOB_STORE_RPC = "device_quota_suggestion_job_store_rpc"
 
 type JsonRecord = Record<string, unknown>
 
@@ -100,8 +100,8 @@ function mapChunk(row: SuggestionJobChunkRow): SuggestionJobChunkRecord {
   }
 }
 
-function getDbErrorMessage(error: { message?: string } | null): string {
-  return error?.message ?? "Database operation failed"
+function getRpcErrorMessage(error: { message?: string } | null): string {
+  return error?.message ?? "Suggestion job store operation failed"
 }
 
 function toJobInsert(payload: CreateSuggestionJobPayload): JsonRecord {
@@ -120,165 +120,104 @@ function toJobInsert(payload: CreateSuggestionJobPayload): JsonRecord {
   }
 }
 
-function toChunkInsert(jobId: string, payload: CreateSuggestionJobPayload): JsonRecord[] {
-  return payload.chunks.map((chunk) => ({
-    chunk_index: chunk.chunkIndex,
-    device_name_count: chunk.deviceNameCount,
-    device_names: chunk.deviceNames,
-    job_id: jobId,
-    status: "queued",
-    unique_name_count: chunk.uniqueNameCount,
-  }))
-}
-
 async function requireJob(store: SuggestionJobStore, jobId: string): Promise<SuggestionJobRecord> {
   const job = await store.getJob(jobId)
   if (!job) throw new SuggestionRouteError("Suggestion job not found", 404)
   return job
 }
 
-export function createServerSuggestionJobStore(): SuggestionJobStore {
+export function createServerSuggestionJobStore(_user?: SuggestionAccessUser): SuggestionJobStore {
   const supabase = createSupabaseAdminClient()
+
+  async function callStoreRpc<T>(action: string, payload: JsonRecord = {}): Promise<T | null> {
+    const { data, error } = await supabase.rpc(JOB_STORE_RPC, {
+      p_action: action,
+      p_payload: payload,
+    })
+    if (error) throw new SuggestionRouteError(getRpcErrorMessage(error), 500)
+    return (data ?? null) as T | null
+  }
+
+  async function callRequiredRpc<T>(action: string, payload: JsonRecord = {}): Promise<T> {
+    const data = await callStoreRpc<T>(action, payload)
+    if (data === null) {
+      throw new SuggestionRouteError("Suggestion job store operation returned no data", 500)
+    }
+    return data
+  }
 
   return {
     async createJobWithChunks(payload) {
-      const { data: jobRow, error: jobError } = await supabase
-        .from(JOBS_TABLE)
-        .insert(toJobInsert(payload))
-        .select("*")
-        .single()
-
-      if (jobError || !jobRow) {
-        throw new SuggestionRouteError(getDbErrorMessage(jobError), 500)
-      }
-
-      const job = mapJob(jobRow as SuggestionJobRow)
-      const chunkRows = toChunkInsert(job.id, payload)
-      if (chunkRows.length > 0) {
-        const { error: chunkError } = await supabase.from(CHUNKS_TABLE).insert(chunkRows)
-        if (chunkError) {
-          await supabase.from(JOBS_TABLE).delete().eq("id", job.id)
-          throw new SuggestionRouteError(getDbErrorMessage(chunkError), 500)
-        }
-      }
-
-      return job
+      const row = await callRequiredRpc<SuggestionJobRow>("create_job", {
+        chunks: payload.chunks.map((chunk) => ({
+          chunk_index: chunk.chunkIndex,
+          device_name_count: chunk.deviceNameCount,
+          device_names: chunk.deviceNames,
+          unique_name_count: chunk.uniqueNameCount,
+        })),
+        job: toJobInsert(payload),
+      })
+      return mapJob(row)
     },
 
     async findActiveJob({ dataSignature, donViId, scopeKey }) {
-      const { data, error } = await supabase
-        .from(JOBS_TABLE)
-        .select("*")
-        .eq("don_vi_id", donViId)
-        .eq("scope_key", scopeKey)
-        .eq("data_signature", dataSignature)
-        .in("status", ["queued", "processing", "succeeded"])
-        .order("created_at", { ascending: false })
-        .limit(1)
-        .maybeSingle()
-
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
-      return data ? mapJob(data as SuggestionJobRow) : null
+      const row = await callStoreRpc<SuggestionJobRow>("find_active_job", {
+        data_signature: dataSignature,
+        don_vi_id: donViId,
+        scope_key: scopeKey,
+      })
+      return row ? mapJob(row) : null
     },
 
     async getChunk(chunkId) {
-      const { data, error } = await supabase
-        .from(CHUNKS_TABLE)
-        .select("*")
-        .eq("id", chunkId)
-        .maybeSingle()
-
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
-      return data ? mapChunk(data as SuggestionJobChunkRow) : null
+      const row = await callStoreRpc<SuggestionJobChunkRow>("get_chunk", { chunk_id: chunkId })
+      return row ? mapChunk(row) : null
     },
 
     async getJob(jobId) {
-      const { data, error } = await supabase.from(JOBS_TABLE).select("*").eq("id", jobId).maybeSingle()
-
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
-      return data ? mapJob(data as SuggestionJobRow) : null
+      const row = await callStoreRpc<SuggestionJobRow>("get_job", { job_id: jobId })
+      return row ? mapJob(row) : null
     },
 
     async getJobChunks(jobId) {
-      const { data, error } = await supabase
-        .from(CHUNKS_TABLE)
-        .select("*")
-        .eq("job_id", jobId)
-        .order("chunk_index", { ascending: true })
-
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
-      return (data ?? []).map((row) => mapChunk(row as SuggestionJobChunkRow))
+      const rows = await callRequiredRpc<SuggestionJobChunkRow[]>("get_job_chunks", { job_id: jobId })
+      return rows.map((row) => mapChunk(row))
     },
 
     async listQueuedChunks(limit) {
-      const { data, error } = await supabase
-        .from(CHUNKS_TABLE)
-        .select("*")
-        .eq("status", "queued")
-        .order("created_at", { ascending: true })
-        .limit(limit)
-
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
-      return (data ?? []).map((row) => mapChunk(row as SuggestionJobChunkRow))
+      const rows = await callRequiredRpc<SuggestionJobChunkRow[]>("list_queued_chunks", { limit })
+      return rows.map((row) => mapChunk(row))
     },
 
     async markChunkFailed(chunkId, error) {
-      const { error: updateError } = await supabase
-        .from(CHUNKS_TABLE)
-        .update({ error, status: "failed" })
-        .eq("id", chunkId)
-      if (updateError) throw new SuggestionRouteError(getDbErrorMessage(updateError), 500)
+      await callRequiredRpc<JsonRecord>("mark_chunk_failed", { chunk_id: chunkId, error })
     },
 
     async markChunkProcessing(chunkId) {
-      const chunk = await this.getChunk(chunkId)
-      const attempts = (chunk?.attempts ?? 0) + 1
-      const { error } = await supabase
-        .from(CHUNKS_TABLE)
-        .update({ attempts, status: "processing" })
-        .eq("id", chunkId)
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      const result = await callRequiredRpc<{ claimed?: boolean }>("mark_chunk_processing", {
+        chunk_id: chunkId,
+      })
+      return result.claimed === true
     },
 
     async markChunkSucceeded(chunkId, result) {
-      const { error } = await supabase
-        .from(CHUNKS_TABLE)
-        .update({ error: null, result, status: "succeeded" })
-        .eq("id", chunkId)
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      await callRequiredRpc<JsonRecord>("mark_chunk_succeeded", { chunk_id: chunkId, result })
     },
 
     async markJobFailed(jobId, error) {
-      const { error: updateError } = await supabase
-        .from(JOBS_TABLE)
-        .update({ error, status: "failed" })
-        .eq("id", jobId)
-      if (updateError) throw new SuggestionRouteError(getDbErrorMessage(updateError), 500)
+      await callRequiredRpc<JsonRecord>("mark_job_failed", { error, job_id: jobId })
     },
 
     async markJobProcessing(jobId) {
-      const { error } = await supabase
-        .from(JOBS_TABLE)
-        .update({ error: null, status: "processing" })
-        .eq("id", jobId)
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      await callRequiredRpc<JsonRecord>("mark_job_processing", { job_id: jobId })
     },
 
     async markJobSucceeded(jobId, result) {
-      const { error } = await supabase
-        .from(JOBS_TABLE)
-        .update({ error: null, result, status: "succeeded" })
-        .eq("id", jobId)
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      await callRequiredRpc<JsonRecord>("mark_job_succeeded", { job_id: jobId, result })
     },
 
     async resetFailedChunks(jobId) {
-      const { error } = await supabase
-        .from(CHUNKS_TABLE)
-        .update({ error: null, status: "queued" })
-        .eq("job_id", jobId)
-        .eq("status", "failed")
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      await callRequiredRpc<JsonRecord>("reset_failed_chunks", { job_id: jobId })
     },
 
     async updateJobProgress(jobId) {
@@ -296,11 +235,10 @@ export function createServerSuggestionJobStore(): SuggestionJobStore {
         await this.markJobSucceeded(job.id, result)
       }
 
-      const { error } = await supabase
-        .from(JOBS_TABLE)
-        .update({ processed_unique_names: processedUniqueNames })
-        .eq("id", jobId)
-      if (error) throw new SuggestionRouteError(getDbErrorMessage(error), 500)
+      await callRequiredRpc<JsonRecord>("update_job_progress", {
+        job_id: jobId,
+        processed_unique_names: processedUniqueNames,
+      })
     },
   }
 }

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-types.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-types.ts
@@ -1,0 +1,71 @@
+import type {
+  DinhMucNhomRow,
+  SearchResult,
+  SuggestMappingResult,
+  SuggestionItemCounts,
+  UnassignedName,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+export type SuggestionJobStatus = "queued" | "processing" | "succeeded" | "failed"
+
+export type SuggestionJobRecord = {
+  id: string
+  donViId: number
+  scopeKey: string
+  dataSignature: string
+  catalogSignature?: string
+  status: SuggestionJobStatus
+  provider: "vm"
+  processedUniqueNames: number
+  totalUniqueNames: number
+  itemCounts: SuggestionItemCounts
+  result: SuggestMappingResult | null
+  error: string | null
+  createdAt: string
+  updatedAt: string
+  categorySnapshot?: DinhMucNhomRow[]
+}
+
+export type SuggestionJobChunkRecord = {
+  id: string
+  jobId: string
+  chunkIndex: number
+  status: SuggestionJobStatus
+  uniqueNameCount: number
+  deviceNameCount: number
+  deviceNames: UnassignedName[]
+  result: { results: SearchResult[] } | null
+  error: string | null
+  attempts: number
+}
+
+export type CreateSuggestionJobPayload = {
+  chunks: {
+    chunkIndex: number
+    deviceNameCount: number
+    deviceNames: UnassignedName[]
+    uniqueNameCount: number
+  }[]
+  job: Omit<SuggestionJobRecord, "createdAt" | "id" | "result" | "updatedAt">
+}
+
+export type SuggestionJobStore = {
+  createJobWithChunks(payload: CreateSuggestionJobPayload): Promise<SuggestionJobRecord>
+  findActiveJob(args: {
+    dataSignature: string
+    donViId: number
+    scopeKey: string
+  }): Promise<SuggestionJobRecord | null>
+  getChunk(chunkId: string): Promise<SuggestionJobChunkRecord | null>
+  getJob(jobId: string): Promise<SuggestionJobRecord | null>
+  getJobChunks(jobId: string): Promise<SuggestionJobChunkRecord[]>
+  listQueuedChunks(limit: number): Promise<SuggestionJobChunkRecord[]>
+  markChunkFailed(chunkId: string, error: string): Promise<void>
+  markChunkProcessing(chunkId: string): Promise<void>
+  markChunkSucceeded(chunkId: string, result: { results: SearchResult[] }): Promise<void>
+  markJobFailed(jobId: string, error: string): Promise<void>
+  markJobProcessing(jobId: string): Promise<void>
+  markJobSucceeded(jobId: string, result: SuggestMappingResult): Promise<void>
+  resetFailedChunks(jobId: string): Promise<void>
+  updateJobProgress(jobId: string): Promise<void>
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-types.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-types.ts
@@ -46,7 +46,7 @@ export type CreateSuggestionJobPayload = {
     deviceNames: UnassignedName[]
     uniqueNameCount: number
   }[]
-  job: Omit<SuggestionJobRecord, "createdAt" | "id" | "result" | "updatedAt">
+  job: Omit<SuggestionJobRecord, "createdAt" | "id" | "updatedAt">
 }
 
 export type SuggestionJobStore = {
@@ -61,7 +61,7 @@ export type SuggestionJobStore = {
   getJobChunks(jobId: string): Promise<SuggestionJobChunkRecord[]>
   listQueuedChunks(limit: number): Promise<SuggestionJobChunkRecord[]>
   markChunkFailed(chunkId: string, error: string): Promise<void>
-  markChunkProcessing(chunkId: string): Promise<void>
+  markChunkProcessing(chunkId: string): Promise<boolean>
   markChunkSucceeded(chunkId: string, result: { results: SearchResult[] }): Promise<void>
   markJobFailed(jobId: string, error: string): Promise<void>
   markJobProcessing(jobId: string): Promise<void>

--- a/src/app/api/device-quota/mapping/suggest/suggestion-route-utils.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-route-utils.ts
@@ -1,0 +1,25 @@
+import { SuggestionRouteError } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
+import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+import { canAccessDeviceQuotaModule } from "@/lib/rbac"
+
+export function assertSuggestionRouteUser(
+  user: SuggestionAccessUser | undefined,
+): asserts user is SuggestionAccessUser {
+  if (!user?.id || !user.role) {
+    throw new SuggestionRouteError("Unauthorized", 401)
+  }
+
+  if (!canAccessDeviceQuotaModule(user.role)) {
+    throw new SuggestionRouteError("Forbidden", 403)
+  }
+}
+
+export function getErrorStatus(error: unknown): number {
+  if (error instanceof SuggestionRouteError) return error.status
+  return 500
+}
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  return "Internal server error"
+}

--- a/src/app/api/device-quota/mapping/suggest/suggestion-route-utils.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-route-utils.ts
@@ -19,7 +19,8 @@ export function getErrorStatus(error: unknown): number {
   return 500
 }
 
-export function getErrorMessage(error: unknown): string {
+export function getErrorMessage(error: unknown, status: number): string {
+  if (status >= 500) return "Internal server error"
   if (error instanceof Error && error.message) return error.message
   return "Internal server error"
 }

--- a/src/app/api/device-quota/mapping/suggest/suggestion-vm-provider.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-vm-provider.ts
@@ -35,7 +35,7 @@ function stableHash(value: unknown): string {
   return hash.toString(36)
 }
 
-function createUnassignedSignature(names: UnassignedName[]): string {
+export function createUnassignedSignature(names: UnassignedName[]): string {
   const normalized = names
     .map((name) => ({
       name: name.ten_thiet_bi,
@@ -45,14 +45,14 @@ function createUnassignedSignature(names: UnassignedName[]): string {
   return `v1-${normalized.length}-${stableHash(normalized)}`
 }
 
-function createEmptyCategoryResult(names: UnassignedName[]): SearchResult[] {
+export function createEmptyCategoryResult(names: UnassignedName[]): SearchResult[] {
   return names.map((name) => ({
     query_text: name.ten_thiet_bi,
     results: [],
   }))
 }
 
-function toVmRequest({
+export function toVmRequest({
   requestId,
   donViId,
   names,
@@ -90,7 +90,7 @@ function toVmRequest({
   }
 }
 
-function assertPayloadSize(request: VmSuggestRequest): void {
+export function assertPayloadSize(request: VmSuggestRequest): void {
   const maxBytes = parsePositiveInteger(
     process.env.DEVICE_QUOTA_VM_MAX_PAYLOAD_BYTES,
     DEFAULT_VM_MAX_PAYLOAD_BYTES,
@@ -104,7 +104,7 @@ function assertPayloadSize(request: VmSuggestRequest): void {
   }
 }
 
-function toSearchResults(response: Awaited<ReturnType<typeof callVmSuggest>>): SearchResult[] {
+export function toSearchResults(response: Awaited<ReturnType<typeof callVmSuggest>>): SearchResult[] {
   return response.suggestions.map((suggestion) => ({
     query_text: suggestion.deviceName,
     results: suggestion.candidates.map((candidate) => ({
@@ -126,14 +126,7 @@ export async function runVmSuggestMapping({
   requestId: string
   user: SuggestionAccessUser
 }): Promise<SuggestionProviderResult> {
-  const [names, categories] = await Promise.all([
-    callSupabaseRpc<UnassignedName[]>(
-      "dinh_muc_thiet_bi_unassigned_names",
-      { p_don_vi: donViId },
-      user,
-    ),
-    callSupabaseRpc<DinhMucNhomRow[]>("dinh_muc_nhom_list", { p_don_vi: donViId }, user),
-  ])
+  const { categories, names } = await fetchVmSuggestionInputs({ donViId, user })
 
   const catalogSignature = createCatalogSignature(categories)
   const unassignedSignature = createUnassignedSignature(names)
@@ -197,4 +190,23 @@ export async function runVmSuggestMapping({
     }
     throw error
   }
+}
+
+export async function fetchVmSuggestionInputs({
+  donViId,
+  user,
+}: {
+  donViId: number
+  user: SuggestionAccessUser
+}): Promise<{ categories: DinhMucNhomRow[]; names: UnassignedName[] }> {
+  const [names, categories] = await Promise.all([
+    callSupabaseRpc<UnassignedName[]>(
+      "dinh_muc_thiet_bi_unassigned_names",
+      { p_don_vi: donViId },
+      user,
+    ),
+    callSupabaseRpc<DinhMucNhomRow[]>("dinh_muc_nhom_list", { p_don_vi: donViId }, user),
+  ])
+
+  return { categories, names }
 }

--- a/supabase/migrations/20260519090000_add_device_quota_suggestion_jobs.sql
+++ b/supabase/migrations/20260519090000_add_device_quota_suggestion_jobs.sql
@@ -1,0 +1,91 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.device_quota_suggestion_jobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  don_vi_id BIGINT NOT NULL REFERENCES public.don_vi(id) ON DELETE CASCADE,
+  scope_key TEXT NOT NULL,
+  data_signature TEXT NOT NULL,
+  catalog_signature TEXT NOT NULL,
+  provider TEXT NOT NULL DEFAULT 'vm' CHECK (provider = 'vm'),
+  status TEXT NOT NULL DEFAULT 'queued'
+    CHECK (status IN ('queued', 'processing', 'succeeded', 'failed')),
+  processed_unique_names INTEGER NOT NULL DEFAULT 0 CHECK (processed_unique_names >= 0),
+  total_unique_names INTEGER NOT NULL CHECK (total_unique_names >= 0),
+  item_counts JSONB NOT NULL DEFAULT '{}'::jsonb,
+  category_snapshot JSONB NOT NULL DEFAULT '[]'::jsonb,
+  result JSONB,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.device_quota_suggestion_job_chunks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id UUID NOT NULL REFERENCES public.device_quota_suggestion_jobs(id) ON DELETE CASCADE,
+  chunk_index INTEGER NOT NULL CHECK (chunk_index >= 0),
+  status TEXT NOT NULL DEFAULT 'queued'
+    CHECK (status IN ('queued', 'processing', 'succeeded', 'failed')),
+  unique_name_count INTEGER NOT NULL CHECK (unique_name_count >= 0),
+  device_name_count INTEGER NOT NULL CHECK (device_name_count >= 0),
+  device_names JSONB NOT NULL DEFAULT '[]'::jsonb,
+  result JSONB,
+  error TEXT,
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (job_id, chunk_index)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS device_quota_suggestion_jobs_active_unique
+  ON public.device_quota_suggestion_jobs (don_vi_id, scope_key, data_signature)
+  WHERE status IN ('queued', 'processing', 'succeeded');
+
+CREATE INDEX IF NOT EXISTS device_quota_suggestion_jobs_scope_idx
+  ON public.device_quota_suggestion_jobs (scope_key, don_vi_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS device_quota_suggestion_job_chunks_queue_idx
+  ON public.device_quota_suggestion_job_chunks (status, created_at, id)
+  WHERE status = 'queued';
+
+CREATE INDEX IF NOT EXISTS device_quota_suggestion_job_chunks_job_idx
+  ON public.device_quota_suggestion_job_chunks (job_id, chunk_index);
+
+CREATE OR REPLACE FUNCTION public.touch_device_quota_suggestion_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_device_quota_suggestion_jobs_updated_at
+  ON public.device_quota_suggestion_jobs;
+CREATE TRIGGER trg_device_quota_suggestion_jobs_updated_at
+BEFORE UPDATE ON public.device_quota_suggestion_jobs
+FOR EACH ROW
+EXECUTE FUNCTION public.touch_device_quota_suggestion_updated_at();
+
+DROP TRIGGER IF EXISTS trg_device_quota_suggestion_job_chunks_updated_at
+  ON public.device_quota_suggestion_job_chunks;
+CREATE TRIGGER trg_device_quota_suggestion_job_chunks_updated_at
+BEFORE UPDATE ON public.device_quota_suggestion_job_chunks
+FOR EACH ROW
+EXECUTE FUNCTION public.touch_device_quota_suggestion_updated_at();
+
+ALTER TABLE public.device_quota_suggestion_jobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.device_quota_suggestion_job_chunks ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.device_quota_suggestion_jobs FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON public.device_quota_suggestion_job_chunks FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.touch_device_quota_suggestion_updated_at() FROM PUBLIC, anon, authenticated;
+
+COMMENT ON TABLE public.device_quota_suggestion_jobs IS
+  'Server-only async Device Quota suggestion jobs. Access is through Next.js job APIs using service role after server-side auth.';
+
+COMMENT ON TABLE public.device_quota_suggestion_job_chunks IS
+  'Server-only async Device Quota suggestion job chunks split by unique device-name count.';
+
+COMMIT;

--- a/supabase/migrations/20260519091000_add_device_quota_suggestion_job_deny_policies.sql
+++ b/supabase/migrations/20260519091000_add_device_quota_suggestion_job_deny_policies.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+DROP POLICY IF EXISTS device_quota_suggestion_jobs_no_client_access
+  ON public.device_quota_suggestion_jobs;
+CREATE POLICY device_quota_suggestion_jobs_no_client_access
+  ON public.device_quota_suggestion_jobs
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+DROP POLICY IF EXISTS device_quota_suggestion_job_chunks_no_client_access
+  ON public.device_quota_suggestion_job_chunks;
+CREATE POLICY device_quota_suggestion_job_chunks_no_client_access
+  ON public.device_quota_suggestion_job_chunks
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+COMMIT;

--- a/supabase/migrations/20260519104500_add_device_quota_suggestion_job_store_rpc.sql
+++ b/supabase/migrations/20260519104500_add_device_quota_suggestion_job_store_rpc.sql
@@ -1,0 +1,318 @@
+BEGIN;
+
+ALTER TABLE public.device_quota_suggestion_jobs
+  DROP CONSTRAINT IF EXISTS device_quota_suggestion_jobs_processed_lte_total;
+
+ALTER TABLE public.device_quota_suggestion_jobs
+  ADD CONSTRAINT device_quota_suggestion_jobs_processed_lte_total
+  CHECK (processed_unique_names <= total_unique_names);
+
+CREATE OR REPLACE FUNCTION public.device_quota_suggestion_job_store_rpc(
+  p_action TEXT,
+  p_payload JSONB DEFAULT '{}'::jsonb
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims JSONB := NULLIF(current_setting('request.jwt.claims', true), '')::jsonb;
+  v_role TEXT := '';
+  v_user_id TEXT := NULL;
+  v_scope_key TEXT := NULL;
+  v_is_service_role BOOLEAN := FALSE;
+  v_allowed_don_vi BIGINT[] := NULL;
+  v_job JSONB := '{}'::jsonb;
+  v_chunks JSONB := '[]'::jsonb;
+  v_job_id UUID := NULL;
+  v_chunk_id UUID := NULL;
+  v_don_vi_id BIGINT := NULL;
+  v_row public.device_quota_suggestion_jobs%ROWTYPE;
+  v_chunk public.device_quota_suggestion_job_chunks%ROWTYPE;
+  v_rows JSONB := '[]'::jsonb;
+BEGIN
+  IF p_action IS NULL OR btrim(p_action) = '' THEN
+    RAISE EXCEPTION 'Missing action' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_claims IS NULL THEN
+    RAISE EXCEPTION 'Missing JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_role := lower(COALESCE(v_claims->>'app_role', v_claims->>'role', ''));
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+  v_is_service_role := v_role = 'service_role';
+
+  IF v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT v_is_service_role THEN
+    v_user_id := NULLIF(COALESCE(v_claims->>'user_id', v_claims->>'sub'), '');
+    IF v_user_id IS NULL THEN
+      RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+    END IF;
+    v_scope_key := 'user:' || v_user_id;
+    v_allowed_don_vi := public.allowed_don_vi_for_session();
+  END IF;
+
+  IF p_action = 'create_job' THEN
+    v_job := COALESCE(p_payload->'job', '{}'::jsonb);
+    v_chunks := COALESCE(p_payload->'chunks', '[]'::jsonb);
+    v_don_vi_id := NULLIF(v_job->>'don_vi_id', '')::bigint;
+
+    IF NOT v_is_service_role THEN
+      IF v_job->>'scope_key' IS DISTINCT FROM v_scope_key THEN
+        RAISE EXCEPTION 'scope_key claim mismatch' USING ERRCODE = '42501';
+      END IF;
+      IF v_don_vi_id IS NULL OR NOT (v_don_vi_id = ANY(v_allowed_don_vi)) THEN
+        RAISE EXCEPTION 'Facility scope denied' USING ERRCODE = '42501';
+      END IF;
+    END IF;
+
+    INSERT INTO public.device_quota_suggestion_jobs (
+      catalog_signature,
+      category_snapshot,
+      data_signature,
+      don_vi_id,
+      error,
+      item_counts,
+      processed_unique_names,
+      provider,
+      result,
+      scope_key,
+      status,
+      total_unique_names
+    )
+    VALUES (
+      v_job->>'catalog_signature',
+      COALESCE(v_job->'category_snapshot', '[]'::jsonb),
+      v_job->>'data_signature',
+      v_don_vi_id,
+      v_job->>'error',
+      COALESCE(v_job->'item_counts', '{}'::jsonb),
+      COALESCE(NULLIF(v_job->>'processed_unique_names', '')::integer, 0),
+      COALESCE(v_job->>'provider', 'vm'),
+      v_job->'result',
+      v_job->>'scope_key',
+      COALESCE(v_job->>'status', 'queued'),
+      COALESCE(NULLIF(v_job->>'total_unique_names', '')::integer, 0)
+    )
+    RETURNING * INTO v_row;
+
+    INSERT INTO public.device_quota_suggestion_job_chunks (
+      chunk_index,
+      device_name_count,
+      device_names,
+      job_id,
+      status,
+      unique_name_count
+    )
+    SELECT
+      chunk_index,
+      device_name_count,
+      COALESCE(device_names, '[]'::jsonb),
+      v_row.id,
+      'queued',
+      unique_name_count
+    FROM jsonb_to_recordset(v_chunks) AS chunk_rows(
+      chunk_index INTEGER,
+      device_name_count INTEGER,
+      device_names JSONB,
+      unique_name_count INTEGER
+    );
+
+    RETURN to_jsonb(v_row);
+  END IF;
+
+  IF p_action = 'find_active_job' THEN
+    v_don_vi_id := NULLIF(p_payload->>'don_vi_id', '')::bigint;
+    IF NOT v_is_service_role THEN
+      IF p_payload->>'scope_key' IS DISTINCT FROM v_scope_key THEN
+        RAISE EXCEPTION 'scope_key claim mismatch' USING ERRCODE = '42501';
+      END IF;
+      IF v_don_vi_id IS NULL OR NOT (v_don_vi_id = ANY(v_allowed_don_vi)) THEN
+        RAISE EXCEPTION 'Facility scope denied' USING ERRCODE = '42501';
+      END IF;
+    END IF;
+
+    SELECT *
+    INTO v_row
+    FROM public.device_quota_suggestion_jobs
+    WHERE don_vi_id = v_don_vi_id
+      AND scope_key = p_payload->>'scope_key'
+      AND data_signature = p_payload->>'data_signature'
+      AND status IN ('queued', 'processing', 'succeeded')
+    ORDER BY created_at DESC
+    LIMIT 1;
+
+    RETURN CASE WHEN v_row.id IS NULL THEN NULL ELSE to_jsonb(v_row) END;
+  END IF;
+
+  IF p_action = 'get_job' THEN
+    v_job_id := NULLIF(p_payload->>'job_id', '')::uuid;
+    SELECT * INTO v_row
+    FROM public.device_quota_suggestion_jobs
+    WHERE id = v_job_id;
+
+    IF v_row.id IS NULL THEN
+      RETURN NULL;
+    END IF;
+    IF NOT v_is_service_role AND v_row.scope_key IS DISTINCT FROM v_scope_key THEN
+      RETURN NULL;
+    END IF;
+    RETURN to_jsonb(v_row);
+  END IF;
+
+  IF p_action = 'get_chunk' THEN
+    v_chunk_id := NULLIF(p_payload->>'chunk_id', '')::uuid;
+    SELECT c.*
+    INTO v_chunk
+    FROM public.device_quota_suggestion_job_chunks c
+    JOIN public.device_quota_suggestion_jobs j ON j.id = c.job_id
+    WHERE c.id = v_chunk_id
+      AND (v_is_service_role OR j.scope_key = v_scope_key);
+
+    RETURN CASE WHEN v_chunk.id IS NULL THEN NULL ELSE to_jsonb(v_chunk) END;
+  END IF;
+
+  IF p_action = 'get_job_chunks' THEN
+    v_job_id := NULLIF(p_payload->>'job_id', '')::uuid;
+    SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.chunk_index), '[]'::jsonb)
+    INTO v_rows
+    FROM public.device_quota_suggestion_job_chunks c
+    JOIN public.device_quota_suggestion_jobs j ON j.id = c.job_id
+    WHERE c.job_id = v_job_id
+      AND (v_is_service_role OR j.scope_key = v_scope_key);
+
+    RETURN v_rows;
+  END IF;
+
+  IF p_action = 'list_queued_chunks' THEN
+    IF NOT v_is_service_role THEN
+      RAISE EXCEPTION 'Worker action requires service role' USING ERRCODE = '42501';
+    END IF;
+
+    SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.created_at, c.id), '[]'::jsonb)
+    INTO v_rows
+    FROM (
+      SELECT *
+      FROM public.device_quota_suggestion_job_chunks
+      WHERE status = 'queued'
+      ORDER BY created_at, id
+      LIMIT GREATEST(1, LEAST(COALESCE(NULLIF(p_payload->>'limit', '')::integer, 1), 25))
+    ) c;
+
+    RETURN v_rows;
+  END IF;
+
+  IF p_action = 'mark_chunk_processing' THEN
+    v_chunk_id := NULLIF(p_payload->>'chunk_id', '')::uuid;
+    UPDATE public.device_quota_suggestion_job_chunks
+    SET attempts = attempts + 1,
+        status = 'processing',
+        error = NULL
+    WHERE id = v_chunk_id
+      AND status = 'queued'
+    RETURNING * INTO v_chunk;
+
+    RETURN jsonb_build_object('claimed', v_chunk.id IS NOT NULL);
+  END IF;
+
+  IF p_action = 'mark_chunk_failed' THEN
+    v_chunk_id := NULLIF(p_payload->>'chunk_id', '')::uuid;
+    UPDATE public.device_quota_suggestion_job_chunks
+    SET error = p_payload->>'error',
+        status = 'failed'
+    WHERE id = v_chunk_id;
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  IF p_action = 'mark_chunk_succeeded' THEN
+    v_chunk_id := NULLIF(p_payload->>'chunk_id', '')::uuid;
+    UPDATE public.device_quota_suggestion_job_chunks
+    SET error = NULL,
+        result = p_payload->'result',
+        status = 'succeeded'
+    WHERE id = v_chunk_id;
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  v_job_id := NULLIF(p_payload->>'job_id', '')::uuid;
+
+  IF NOT v_is_service_role AND p_action IN (
+    'mark_job_failed',
+    'mark_job_processing',
+    'mark_job_succeeded',
+    'reset_failed_chunks',
+    'update_job_progress'
+  ) THEN
+    PERFORM 1
+    FROM public.device_quota_suggestion_jobs
+    WHERE id = v_job_id
+      AND scope_key = v_scope_key;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Suggestion job not found' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF p_action = 'mark_job_failed' THEN
+    UPDATE public.device_quota_suggestion_jobs
+    SET error = p_payload->>'error',
+        status = 'failed'
+    WHERE id = v_job_id;
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  IF p_action = 'mark_job_processing' THEN
+    UPDATE public.device_quota_suggestion_jobs
+    SET error = NULL,
+        status = 'processing'
+    WHERE id = v_job_id;
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  IF p_action = 'mark_job_succeeded' THEN
+    UPDATE public.device_quota_suggestion_jobs
+    SET error = NULL,
+        result = p_payload->'result',
+        status = 'succeeded'
+    WHERE id = v_job_id;
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  IF p_action = 'reset_failed_chunks' THEN
+    UPDATE public.device_quota_suggestion_job_chunks
+    SET error = NULL,
+        status = 'queued'
+    WHERE job_id = v_job_id
+      AND status = 'failed';
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  IF p_action = 'update_job_progress' THEN
+    UPDATE public.device_quota_suggestion_jobs
+    SET processed_unique_names = COALESCE(
+      NULLIF(p_payload->>'processed_unique_names', '')::integer,
+      processed_unique_names
+    )
+    WHERE id = v_job_id;
+    RETURN jsonb_build_object('ok', true);
+  END IF;
+
+  RAISE EXCEPTION 'Unknown suggestion job store action: %', p_action USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.device_quota_suggestion_job_store_rpc(TEXT, JSONB)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.device_quota_suggestion_job_store_rpc(TEXT, JSONB)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.device_quota_suggestion_job_store_rpc(TEXT, JSONB) IS
+  'RPC-only persistence boundary for async Device Quota suggestion jobs. Adds claim-safe chunk processing and JWT/service-role guards. Rollback by adding a later migration that drops this function and reverts callers to the prior store contract if needed.';
+
+COMMIT;

--- a/supabase/migrations/20260519105500_restrict_device_quota_suggestion_job_store_rpc.sql
+++ b/supabase/migrations/20260519105500_restrict_device_quota_suggestion_job_store_rpc.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+REVOKE ALL ON FUNCTION public.device_quota_suggestion_job_store_rpc(TEXT, JSONB)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.device_quota_suggestion_job_store_rpc(TEXT, JSONB)
+  TO service_role;
+
+COMMENT ON FUNCTION public.device_quota_suggestion_job_store_rpc(TEXT, JSONB) IS
+  'Service-role-only RPC persistence boundary for async Device Quota suggestion jobs. Client/user access remains through Next.js job APIs, which validate session access before invoking this function. Rollback by adding a later migration that restores the previous grant contract if needed.';
+
+COMMIT;

--- a/supabase/tests/device_quota_suggestion_jobs_schema_smoke.sql
+++ b/supabase/tests/device_quota_suggestion_jobs_schema_smoke.sql
@@ -48,5 +48,33 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'device_quota_suggestion_job_chunks deny policy is missing';
   END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'device_quota_suggestion_jobs_processed_lte_total'
+  ) THEN
+    RAISE EXCEPTION 'processed_unique_names <= total_unique_names constraint is missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'device_quota_suggestion_job_store_rpc'
+  ) THEN
+    RAISE EXCEPTION 'device_quota_suggestion_job_store_rpc is missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.routine_privileges
+    WHERE routine_schema = 'public'
+      AND routine_name = 'device_quota_suggestion_job_store_rpc'
+      AND grantee IN ('anon', 'authenticated')
+  ) THEN
+    RAISE EXCEPTION 'device_quota_suggestion_job_store_rpc must be service-role only';
+  END IF;
 END;
 $$;

--- a/supabase/tests/device_quota_suggestion_jobs_schema_smoke.sql
+++ b/supabase/tests/device_quota_suggestion_jobs_schema_smoke.sql
@@ -1,0 +1,52 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'device_quota_suggestion_jobs'
+  ) THEN
+    RAISE EXCEPTION 'device_quota_suggestion_jobs table is missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'device_quota_suggestion_job_chunks'
+  ) THEN
+    RAISE EXCEPTION 'device_quota_suggestion_job_chunks table is missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.role_table_grants
+    WHERE table_schema = 'public'
+      AND table_name IN (
+        'device_quota_suggestion_jobs',
+        'device_quota_suggestion_job_chunks'
+      )
+      AND grantee IN ('anon', 'authenticated')
+  ) THEN
+    RAISE EXCEPTION 'suggestion job tables must not grant direct client access';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'device_quota_suggestion_jobs'
+      AND policyname = 'device_quota_suggestion_jobs_no_client_access'
+  ) THEN
+    RAISE EXCEPTION 'device_quota_suggestion_jobs deny policy is missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'device_quota_suggestion_job_chunks'
+      AND policyname = 'device_quota_suggestion_job_chunks_no_client_access'
+  ) THEN
+    RAISE EXCEPTION 'device_quota_suggestion_job_chunks deny policy is missing';
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Add async Device Quota suggestion job backend contract: create/status/retry routes, job service, and Supabase-backed store.
- Add migration + schema smoke test for suggestion job/chunk persistence with explicit deny policies.
- Reuse VM suggestion input/request helpers for callable worker processing.

## Scope notes
- No Vercel cron route or schedule is included in this phase.
- No UI polling, canary re-enable, or final save RPC changes are included.
- Phase 4D decides the runtime trigger strategy for processing jobs.

## Test Plan
- [x] node scripts/npm-run.js run verify:no-explicit-any
- [x] node scripts/npm-run.js run verify:dedupe
- [x] node scripts/npm-run.js run typecheck
- [x] node scripts/npm-run.js run test:run src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts src/app/api/device-quota/mapping/suggest/__tests__/vm-client.test.ts src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
- [x] node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
- [x] node scripts/npm-run.js run build

Fixes #516

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds async Device Quota suggestion jobs with create/status/retry APIs and a service-role-only RPC-backed Supabase store. This fulfills #516 by enabling chunked, resumable processing with strict auth, validated inputs, and sanitized errors.

- New Features
  - API routes: POST `/api/device-quota/mapping/suggest/jobs`, GET `/api/device-quota/mapping/suggest/jobs/[jobId]`, POST `/api/device-quota/mapping/suggest/jobs/[jobId]/retry` with strict role checks (401/403), robust JSON validation, POST includes `requestId`, 200 for immediate results, 202 for queued, and centralized error helpers (sanitize 500s, log unexpected failures).
  - Job service: dedupes by user+data signature, chunks by unique-name and device-id limits, atomically claims chunks (skips if race lost), validates VM payload size, processes via VM, updates progress, supports retry that resets only failed chunks, and counts only claimed chunks as processed when running batch workers.
  - Supabase store: new `device_quota_suggestion_jobs` and `device_quota_suggestion_job_chunks` with RLS deny policies and active-job unique index; all reads/writes go through service-role-only RPC `device_quota_suggestion_job_store_rpc` (job/chunk get, queue listing, status updates); schema smoke test added.
  - VM integration: reused helpers (`toVmRequest`, `toSearchResults`, `createUnassignedSignature`) and new `fetchVmSuggestionInputs`.

- Migration
  - Apply new Supabase migrations and set `SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`; optional tuning: `DEVICE_QUOTA_SUGGESTION_JOB_MAX_UNIQUE_NAMES_PER_CHUNK`, `DEVICE_QUOTA_SUGGESTION_JOB_MAX_DEVICE_IDS_PER_CHUNK`, `DEVICE_QUOTA_VM_MAX_PAYLOAD_BYTES`.

<sup>Written for commit 4937462809565761555c048c0a3d5de27b72b3b8. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/522?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous suggestion jobs for device-quota mapping with persisted server-side job/chunk storage
  * Endpoints to create jobs, fetch job status, and trigger job retry; request validation and payload-size checks with proper HTTP responses
  * Improved authorization checks and sanitized error responses for route handlers

* **Tests**
  * Extensive tests covering routes, service logic, store behavior, chunk processing, retries, and error cases

* **Migrations**
  * Database schema and RPC added to support queued jobs and worker-safe operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->