### PR TITLE
chore: add Python docstring gate

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,6 +5,8 @@ pre-commit:
       run: node scripts/npm-run.js run verify:no-explicit-any
     verify-dedupe:
       run: node scripts/npm-run.js run verify:dedupe
+    verify-python-docstrings:
+      run: node scripts/npm-run.js run verify:python-docstrings:changed
 
 pre-push:
   parallel: false
@@ -13,5 +15,7 @@ pre-push:
       run: node scripts/npm-run.js run verify:no-explicit-any
     verify-dedupe:
       run: node scripts/npm-run.js run verify:dedupe
+    verify-python-docstrings:
+      run: node scripts/npm-run.js run verify:python-docstrings:changed
     typecheck:
       run: node scripts/npm-run.js run typecheck

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "typecheck": "tsc --noEmit",
     "verify:no-explicit-any": "node scripts/check-no-explicit-any-in-diff.js",
     "verify:dedupe": "node scripts/check-sonarjs-duplication-in-diff.js",
+    "verify:python-docstrings": "node scripts/check-python-docstrings.js",
+    "verify:python-docstrings:changed": "node scripts/check-python-docstrings.js --changed",
     "prepare": "lefthook install",
     "hooks:install": "lefthook install",
     "test": "vitest",

--- a/scripts/check-python-docstrings.js
+++ b/scripts/check-python-docstrings.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs")
+const path = require("node:path")
+const { spawnSync } = require("node:child_process")
+const { collectChangedFiles, runGit } = require("./changed-files")
+
+const DEFAULT_BASE_REF = process.env.PYTHON_DOCSTRINGS_BASE || "main"
+const SERVICE_DIR = "services/device-quota-suggestion-service"
+const SERVICE_VENV_PYTHON = path.join(SERVICE_DIR, ".venv", "bin", "python")
+const PYTHON_SOURCE_DIRS = [
+  path.join(SERVICE_DIR, "app"),
+  path.join(SERVICE_DIR, "scripts"),
+]
+
+function isServicePythonSource(filePath) {
+  return (
+    filePath.endsWith(".py") &&
+    PYTHON_SOURCE_DIRS.some(
+      (sourceDir) => filePath === sourceDir || filePath.startsWith(`${sourceDir}/`)
+    )
+  )
+}
+
+function isPythonDocstringConfig(filePath) {
+  return filePath === path.join(SERVICE_DIR, "pyproject.toml")
+}
+
+function shouldRunForChangedFiles(baseRef = DEFAULT_BASE_REF, { runGitImpl = runGit } = {}) {
+  const changedFiles = collectChangedFiles(baseRef, {
+    runGitImpl,
+    includeFile: (filePath) => isServicePythonSource(filePath) || isPythonDocstringConfig(filePath),
+    fileExists: fs.existsSync,
+  })
+
+  return changedFiles.length > 0
+}
+
+function hasRuff(pythonExecutable) {
+  const result = spawnSync(pythonExecutable, ["-m", "ruff", "--version"], {
+    cwd: SERVICE_DIR,
+    stdio: "ignore",
+  })
+
+  return !result.error && result.status === 0
+}
+
+function resolvePythonExecutable() {
+  if (process.env.PYTHON) {
+    return process.env.PYTHON
+  }
+
+  if (fs.existsSync(SERVICE_VENV_PYTHON) && hasRuff(SERVICE_VENV_PYTHON)) {
+    return SERVICE_VENV_PYTHON
+  }
+
+  return "python3"
+}
+
+function runRuffDocstringCheck() {
+  if (!fs.existsSync(SERVICE_DIR)) {
+    console.log("Python docstring gate skipped: service directory is missing.")
+    return 0
+  }
+
+  const pythonExecutable = resolvePythonExecutable()
+  const result = spawnSync(
+    pythonExecutable,
+    ["-m", "ruff", "check", "app", "scripts"],
+    {
+      cwd: SERVICE_DIR,
+      stdio: "inherit",
+    }
+  )
+
+  if (result.error) {
+    console.error(`Unable to run Python docstring gate: ${result.error.message}`)
+    return 1
+  }
+
+  return result.status ?? 1
+}
+
+function main() {
+  const changedOnly = process.argv.includes("--changed")
+  const baseRef = process.argv
+    .slice(2)
+    .find((argument) => !argument.startsWith("--")) || DEFAULT_BASE_REF
+
+  if (changedOnly && !shouldRunForChangedFiles(baseRef)) {
+    console.log("Python docstring gate skipped: no changed service Python files.")
+    return
+  }
+
+  process.exitCode = runRuffDocstringCheck()
+}
+
+module.exports = {
+  isPythonDocstringConfig,
+  isServicePythonSource,
+  resolvePythonExecutable,
+  runRuffDocstringCheck,
+  shouldRunForChangedFiles,
+}
+
+if (require.main === module) {
+  main()
+}

--- a/services/device-quota-suggestion-service/app/embeddings.py
+++ b/services/device-quota-suggestion-service/app/embeddings.py
@@ -1,3 +1,5 @@
+"""Embedding backend implementations for deterministic tests and VM runtime use."""
+
 import hashlib
 import math
 import os
@@ -10,22 +12,30 @@ from app.settings import Settings
 
 
 class EmbeddingBackend:
+    """Interface for embedding providers used by the suggestion service."""
+
     model_name = "unknown"
 
     def is_ready(self) -> bool:
+        """Return whether the backend can serve embedding requests without warming."""
         return True
 
     def warm(self) -> None:
+        """Perform a minimal embedding call to initialize backend resources."""
         self.embed(["warmup"])
 
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Return one normalized embedding vector for each input text."""
         raise NotImplementedError
 
 
 class DeterministicEmbeddingBackend(EmbeddingBackend):
+    """Generate stable hash-derived embeddings for tests and local harnesses."""
+
     model_name = "deterministic-test-embedding"
 
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Embed texts with deterministic normalized vectors."""
         return [self._embed_one(text) for text in texts]
 
     @staticmethod
@@ -41,6 +51,8 @@ class DeterministicEmbeddingBackend(EmbeddingBackend):
 
 
 class MappingEmbeddingBackend(EmbeddingBackend):
+    """Return configured vectors with deterministic fallback for unknown texts."""
+
     model_name = "mapping-test-embedding"
 
     def __init__(self, mapping: Dict[str, List[float]]):
@@ -51,6 +63,7 @@ class MappingEmbeddingBackend(EmbeddingBackend):
         self._fallback = DeterministicEmbeddingBackend()
 
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Embed texts from the mapping or deterministic fallback backend."""
         vectors = []
         for text in texts:
             normalized = normalize_text(text)
@@ -67,12 +80,15 @@ class MappingEmbeddingBackend(EmbeddingBackend):
 
 
 class CountingEmbeddingBackend(DeterministicEmbeddingBackend):
+    """Deterministic backend that counts embedding calls for cache tests."""
+
     def __init__(self, delay_seconds: float = 0.0):
         self.delay_seconds = delay_seconds
         self.call_count = 0
         self._lock = threading.Lock()
 
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Count the call, optionally delay, and return deterministic vectors."""
         with self._lock:
             self.call_count += 1
         if self.delay_seconds:
@@ -81,19 +97,24 @@ class CountingEmbeddingBackend(DeterministicEmbeddingBackend):
 
 
 class SentenceTransformerEmbeddingBackend(EmbeddingBackend):
+    """Lazy-loading sentence-transformers backend for VM model inference."""
+
     def __init__(self, model_name: str):
         self.model_name = model_name
         self._model = None
         self._model_lock = threading.Lock()
 
     def is_ready(self) -> bool:
+        """Return whether the sentence-transformer model is already loaded."""
         return self._model is not None
 
     def warm(self) -> None:
+        """Load the model and run a warmup embedding."""
         self._ensure_model()
         self.embed(["warmup"])
 
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Prepare Vietnamese text and encode it as normalized float vectors."""
         model = self._ensure_model()
         prepared = [self._prepare(text) for text in texts]
         encoded = model.encode(prepared, normalize_embeddings=True)
@@ -126,6 +147,7 @@ class SentenceTransformerEmbeddingBackend(EmbeddingBackend):
 
 
 def create_runtime_embedding_backend(settings: Settings) -> EmbeddingBackend:
+    """Create the production embedding backend from service settings."""
     cache_home = os.path.join(settings.cache_dir, "huggingface")
     os.environ.setdefault("HF_HOME", cache_home)
     os.environ.setdefault("TRANSFORMERS_CACHE", cache_home)
@@ -133,6 +155,8 @@ def create_runtime_embedding_backend(settings: Settings) -> EmbeddingBackend:
 
 
 class LazyInitCountingBackend(SentenceTransformerEmbeddingBackend):
+    """Sentence-transformer test backend that tracks lazy model initialization."""
+
     def __init__(self, delay_seconds: float = 0.0):
         super().__init__("lazy-init-counting-test")
         self.delay_seconds = delay_seconds
@@ -148,31 +172,42 @@ class LazyInitCountingBackend(SentenceTransformerEmbeddingBackend):
         return object()
 
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Initialize once and delegate embedding to the deterministic fallback."""
         self._ensure_model()
         return self._fallback.embed(texts)
 
 
 class RecordingEmbeddingBackend(DeterministicEmbeddingBackend):
+    """Deterministic backend that records every requested text batch."""
+
     def __init__(self):
         self.seen_text_batches: List[List[str]] = []
 
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Store the batch before returning deterministic embeddings."""
         batch = list(texts)
         self.seen_text_batches.append(batch)
         return super().embed(batch)
 
     def flattened_seen_texts(self) -> List[str]:
+        """Return all observed texts in request order across batches."""
         return [text for batch in self.seen_text_batches for text in batch]
 
 
 class ShortEmbeddingBackend(DeterministicEmbeddingBackend):
+    """Backend that intentionally returns too few vectors for error-path tests."""
+
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Return one fewer vector than requested."""
         vectors = super().embed(texts)
         return vectors[:-1]
 
 
 class FailingEmbeddingBackend(EmbeddingBackend):
+    """Backend that raises on every embedding call for failure-path tests."""
+
     model_name = "failing-test-embedding"
 
     def embed(self, texts: Iterable[str]) -> List[List[float]]:
+        """Raise the configured embedding failure."""
         raise RuntimeError("embedding backend failed")

--- a/services/device-quota-suggestion-service/app/instrumentation.py
+++ b/services/device-quota-suggestion-service/app/instrumentation.py
@@ -1,3 +1,5 @@
+"""Structured logging helpers for suggestion requests."""
+
 import json
 import logging
 import time
@@ -10,10 +12,12 @@ LOGGER = logging.getLogger("dqss.suggest")
 
 
 def elapsed_ms(started: float) -> float:
+    """Return elapsed milliseconds from a perf-counter timestamp."""
     return round((time.perf_counter() - started) * 1000, 3)
 
 
 def request_metrics(request: SuggestRequest) -> Dict[str, int]:
+    """Return non-sensitive request size metrics for logs."""
     normalized_names = {normalize_text(item.name) for item in request.deviceNames}
     return {
         "deviceNameCount": len(request.deviceNames),
@@ -24,6 +28,7 @@ def request_metrics(request: SuggestRequest) -> Dict[str, int]:
 
 
 def log_success(result: ResponseDict, request: SuggestRequest) -> None:
+    """Log a successful suggestion response without raw device names."""
     LOGGER.info(
         json.dumps(
             {
@@ -47,6 +52,7 @@ def log_failure(
     timings: dict,
     error: BaseException,
 ) -> None:
+    """Log a failed suggestion request without exposing raw device names."""
     LOGGER.info(
         json.dumps(
             {

--- a/services/device-quota-suggestion-service/app/main.py
+++ b/services/device-quota-suggestion-service/app/main.py
@@ -1,3 +1,5 @@
+"""FastAPI entrypoint for the internal device quota suggestion service."""
+
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, Header, HTTPException
@@ -12,6 +14,7 @@ def create_app(
     settings: Settings = None,
     embedding_backend: EmbeddingBackend = None,
 ) -> FastAPI:
+    """Create the FastAPI application with runtime settings and backend wiring."""
     actual_settings = settings or load_settings()
     backend = embedding_backend or create_runtime_embedding_backend(actual_settings)
     suggestion_service = SuggestionService(
@@ -21,6 +24,7 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(_: FastAPI):
+        """Warm the suggestion service during application startup."""
         suggestion_service.warm()
         yield
 
@@ -32,6 +36,7 @@ def create_app(
     def require_internal_token(
         x_internal_token: str = Header(default=""),
     ) -> None:
+        """Reject requests that do not carry the configured internal token."""
         if not x_internal_token:
             raise HTTPException(status_code=401, detail="Missing internal token")
         if not actual_settings.internal_token:
@@ -41,14 +46,17 @@ def create_app(
 
     @app.get("/healthz")
     def healthz() -> dict:
+        """Return a basic process health response."""
         return {"status": "ok"}
 
     @app.get("/readyz")
     def readyz() -> dict:
+        """Return whether the embedding backend is ready to serve suggestions."""
         return {"ready": suggestion_service.is_ready()}
 
     @app.post("/suggest", dependencies=[Depends(require_internal_token)])
     def suggest(payload: SuggestRequest) -> dict:
+        """Return category suggestions for a validated request payload."""
         return suggestion_service.suggest(payload.model_dump())
 
     return app

--- a/services/device-quota-suggestion-service/app/normalization.py
+++ b/services/device-quota-suggestion-service/app/normalization.py
@@ -1,3 +1,5 @@
+"""Vietnamese-insensitive text normalization for category matching."""
+
 import re
 import unicodedata
 
@@ -7,6 +9,7 @@ _SPACE_RE = re.compile(r"\s+")
 
 
 def normalize_text(value: str) -> str:
+    """Fold accents, punctuation, and spacing into a lowercase ASCII search key."""
     vietnamese_d = value.replace("đ", "d").replace("Đ", "D")
     decomposed = unicodedata.normalize("NFKD", vietnamese_d)
     without_marks = "".join(

--- a/services/device-quota-suggestion-service/app/perf_harness.py
+++ b/services/device-quota-suggestion-service/app/perf_harness.py
@@ -1,3 +1,5 @@
+"""Deterministic payload builders for DQSS smoke and performance checks."""
+
 import time
 from typing import Dict
 
@@ -6,6 +8,7 @@ from app.service import SuggestionService
 
 
 def create_unit17_payload() -> dict:
+    """Return a deterministic payload shaped like the Unit 17 production case."""
     return {
         "requestId": "req-harness-unit17",
         "facilityId": 17,
@@ -21,6 +24,7 @@ def create_synthetic_unique_payload(
     unique_name_count: int = 2000,
     category_count: int = 300,
 ) -> dict:
+    """Return a large synthetic payload with configurable unique-name cardinality."""
     _validate_positive_count("unique_name_count", unique_name_count)
     _validate_positive_count("category_count", category_count)
     return {
@@ -35,6 +39,7 @@ def create_synthetic_unique_payload(
 
 
 def run_deterministic_case(case_name: str) -> Dict[str, object]:
+    """Run a named deterministic harness case and return summary metrics."""
     payload = _payload_for_case(case_name)
     service = SuggestionService(embedding_backend=DeterministicEmbeddingBackend())
     started = time.perf_counter()

--- a/services/device-quota-suggestion-service/app/ranking.py
+++ b/services/device-quota-suggestion-service/app/ranking.py
@@ -1,3 +1,5 @@
+"""Ranking helpers for matching device names to quota categories."""
+
 import math
 from dataclasses import dataclass
 from difflib import SequenceMatcher
@@ -10,6 +12,8 @@ from app.schemas import CategoryItem, SuggestOptions
 
 @dataclass(frozen=True)
 class CategoryVector:
+    """Precomputed category representation used during candidate ranking."""
+
     category: CategoryItem
     normalized_name: str
     embedding: List[float]
@@ -18,6 +22,7 @@ class CategoryVector:
 
 
 def cosine_similarity(left: List[float], right: List[float]) -> float:
+    """Return cosine similarity for two vectors, or zero for invalid inputs."""
     if not left or not right or len(left) != len(right):
         return 0.0
     dot = sum(a * b for a, b in zip(left, right))
@@ -28,10 +33,12 @@ def cosine_similarity(left: List[float], right: List[float]) -> float:
     return max(0.0, min(1.0, dot / (left_norm * right_norm)))
 
 def normalize_vector(vector: List[float]) -> List[float]:
+    """Return a unit-length copy of a numeric vector."""
     norm = math.sqrt(sum(value * value for value in vector)) or 1.0
     return [value / norm for value in vector]
 
 def normalized_dot_similarity(left: List[float], right: List[float]) -> float:
+    """Return clamped dot similarity for already normalized vectors."""
     if not left or not right or len(left) != len(right):
         return 0.0
     dot = sum(a * b for a, b in zip(left, right))
@@ -39,6 +46,7 @@ def normalized_dot_similarity(left: List[float], right: List[float]) -> float:
 
 
 def lexical_similarity(left: str, right: str) -> float:
+    """Normalize two labels and return their lexical similarity."""
     return lexical_similarity_normalized(
         normalize_text(left),
         normalize_text(right),
@@ -46,6 +54,7 @@ def lexical_similarity(left: str, right: str) -> float:
 
 
 def lexical_similarity_normalized(left_normalized: str, right_normalized: str) -> float:
+    """Return lexical similarity for two already-normalized labels."""
     if not left_normalized or not right_normalized:
         return 0.0
     if left_normalized == right_normalized:
@@ -60,6 +69,7 @@ def fused_score(
     semantic_score: float,
     options: SuggestOptions,
 ) -> float:
+    """Blend lexical and semantic scores according to request weights."""
     total_weight = options.lexicalWeight + options.semanticWeight
     if total_weight <= 0:
         return 0.0
@@ -76,6 +86,7 @@ def rank_categories(
     categories: List[CategoryVector],
     options: SuggestOptions,
 ) -> List[dict]:
+    """Rank likely category candidates for a device name."""
     device_normalized = normalize_text(device_name)
     device_tokens = frozenset(device_normalized.split())
     device_char_grams = character_ngrams(device_normalized)
@@ -233,6 +244,7 @@ def _character_ngram_score(
 
 
 def character_ngrams(value: str) -> FrozenSet[str]:
+    """Return compact two-character grams for cheap lexical shortlisting."""
     compact = value.replace(" ", "")
     if len(compact) < 2:
         return frozenset([compact]) if compact else frozenset()
@@ -240,6 +252,7 @@ def character_ngrams(value: str) -> FrozenSet[str]:
 
 
 def needs_review(candidates: List[dict], options: SuggestOptions) -> bool:
+    """Return whether the top candidate is too weak or too close to the runner-up."""
     if not candidates:
         return True
     top_score = candidates[0]["score"]

--- a/services/device-quota-suggestion-service/app/schemas.py
+++ b/services/device-quota-suggestion-service/app/schemas.py
@@ -1,21 +1,28 @@
+"""Pydantic request and response schemas for the suggestion service."""
+
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class DeviceNameItem(BaseModel):
+    """A device name plus the inventory identifiers that share that name."""
+
     name: str = Field(min_length=1)
     deviceIds: List[int] = Field(default_factory=list)
 
     @field_validator("deviceIds")
     @classmethod
     def device_ids_must_be_positive(cls, value: List[int]) -> List[int]:
+        """Reject non-positive inventory identifiers."""
         if any(item <= 0 for item in value):
             raise ValueError("deviceIds must contain positive integers")
         return value
 
 
 class CategoryItem(BaseModel):
+    """A quota category candidate from the application catalog."""
+
     id: int = Field(gt=0)
     code: Optional[str] = None
     name: str = Field(min_length=1)
@@ -23,6 +30,8 @@ class CategoryItem(BaseModel):
 
 
 class SuggestOptions(BaseModel):
+    """Ranking controls supplied by the caller."""
+
     topK: int = Field(default=3, ge=1, le=10)
     semanticWeight: float = Field(default=1.0, ge=0.0)
     lexicalWeight: float = Field(default=1.0, ge=0.0)
@@ -31,12 +40,15 @@ class SuggestOptions(BaseModel):
 
     @model_validator(mode="after")
     def at_least_one_weight(self) -> "SuggestOptions":
+        """Ensure the ranking formula has at least one positive signal."""
         if self.semanticWeight == 0 and self.lexicalWeight == 0:
             raise ValueError("at least one ranking weight must be positive")
         return self
 
 
 class SuggestRequest(BaseModel):
+    """Request payload for ranking unassigned device names against categories."""
+
     requestId: str = Field(min_length=1)
     facilityId: int = Field(gt=0)
     catalogSignature: str = Field(min_length=1)

--- a/services/device-quota-suggestion-service/app/service.py
+++ b/services/device-quota-suggestion-service/app/service.py
@@ -1,3 +1,5 @@
+"""Request orchestration for device quota category suggestions."""
+
 import copy
 from dataclasses import dataclass
 import hashlib
@@ -28,6 +30,8 @@ class _InflightRequest:
 
 
 class SuggestionService:
+    """Coordinate validation, embeddings, ranking, caching, and instrumentation."""
+
     def __init__(
         self,
         embedding_backend: EmbeddingBackend,
@@ -42,12 +46,15 @@ class SuggestionService:
         self._lock = threading.Lock()
 
     def is_ready(self) -> bool:
+        """Return whether the embedding backend has completed runtime initialization."""
         return self.embedding_backend.is_ready()
 
     def warm(self) -> None:
+        """Preload the embedding backend so readiness checks can turn true."""
         self.embedding_backend.warm()
 
     def suggest(self, payload: dict) -> ResponseDict:
+        """Validate a raw request payload and return ranked category suggestions."""
         request_started = time.perf_counter()
         validation_started = request_started
         request = SuggestRequest.model_validate(payload)

--- a/services/device-quota-suggestion-service/app/settings.py
+++ b/services/device-quota-suggestion-service/app/settings.py
@@ -1,9 +1,13 @@
+"""Environment-backed settings for the suggestion service."""
+
 import os
 from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
 class Settings:
+    """Runtime configuration for model loading and internal authentication."""
+
     internal_token: str = ""
     provider_name: str = "vm-local"
     provider_version: str = "0.1.0"
@@ -12,6 +16,7 @@ class Settings:
 
 
 def load_settings() -> Settings:
+    """Load settings from environment variables and require the internal token."""
     internal_token = os.environ.get("DQSS_INTERNAL_TOKEN", "")
     if not internal_token:
         raise ValueError("DQSS_INTERNAL_TOKEN must be configured")

--- a/services/device-quota-suggestion-service/pyproject.toml
+++ b/services/device-quota-suggestion-service/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest==8.3.5",
+  "ruff==0.8.6",
 ]
 model = [
   "numpy==1.26.4; python_version >= '3.9'",
@@ -28,6 +29,12 @@ model = [
 testpaths = ["tests"]
 pythonpath = ["."]
 addopts = "-q"
+
+[tool.ruff]
+target-version = "py38"
+
+[tool.ruff.lint]
+select = ["D100", "D101", "D102", "D103"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/services/device-quota-suggestion-service/scripts/dqss_perf_harness.py
+++ b/services/device-quota-suggestion-service/scripts/dqss_perf_harness.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+"""Command-line runner for deterministic DQSS performance harness cases."""
+
 import argparse
 import json
 import os
@@ -10,6 +12,7 @@ from app.perf_harness import run_deterministic_case
 
 
 def main() -> None:
+    """Parse command-line options and print one deterministic case summary."""
     parser = argparse.ArgumentParser(description="Run DQSS large-payload smoke cases.")
     parser.add_argument(
         "--case",


### PR DESCRIPTION
## Summary
- add a Ruff-based Python docstring verification gate for the DQSS service
- wire the gate into Lefthook pre-commit/pre-push with changed-file skipping
- document the current Python service public modules/classes/functions so the new gate starts green

## Follow-up
- Opened #523 for a diff-aware TypeScript/JSX JSDoc gate that avoids full-repo scanning and broad React callback noise.

## Verification
- `node scripts/npm-run.js run verify:python-docstrings`
- `node scripts/npm-run.js run verify:python-docstrings:changed`
- `python3 -m pytest` in `services/device-quota-suggestion-service` => 38 passed
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `git diff --check`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` => no changed React source files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `ruff`-based Python docstring gate for the Device Quota Suggestion Service, wired into `lefthook` pre-commit/push with a diff-aware runner. Documented public modules, classes, and functions so the gate starts green.

- **New Features**
  - Docstring linting with `ruff` (D100–D103) for `app` and `scripts`.
  - New `scripts/check-python-docstrings.js` with `--changed` mode; exposed via `verify:python-docstrings` scripts and hooked into `lefthook`.
  - Added concise docstrings across service modules to satisfy the gate.

- **Dependencies**
  - Added `ruff==0.8.6` to the service `dev` extras and configured `pyproject.toml` (target `py38`, selected rules).

<sup>Written for commit 74b7067e4bf6086d428487468ef0167700e684bd. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/524?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced service documentation with comprehensive docstrings across the codebase.

* **Chores**
  * Added development tooling to verify documentation standards in code reviews.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->