### PR TITLE
feat: add hybrid DQSS suggestion trigger

### DIFF
--- a/docs/plans/2026-05-19-issue-517-dqss-hybrid-trigger-plan.md
+++ b/docs/plans/2026-05-19-issue-517-dqss-hybrid-trigger-plan.md
@@ -4,13 +4,13 @@
 
 Use a hybrid no-cron trigger for Device Quota suggested mapping jobs.
 
-When the user clicks `Gợi ý phân loại`, the web UI creates or reuses a suggestion job, then keeps bounded server work moving while the dialog/page remains active. The UI polls job state through that same active session until the job succeeds or fails.
+When the user clicks `Gợi ý phân loại`, the web UI creates or reuses a suggestion job, then processes 1-5 chunks per request while the dialog/page remains active. The UI polls job state through that same active session until the job succeeds or fails. Processing stops when the user closes the dialog or leaves the active session.
 
 No Vercel cron is added for this phase. Vercel Hobby cron is still unsuitable for this workflow because the current cron usage/pricing documentation limits Hobby cron to once per day with hourly precision:
 
 - https://vercel.com/docs/cron-jobs/usage-and-pricing
 
-The existing synchronous `/api/device-quota/mapping/suggest` path remains as the explicit opt-out fallback when async suggestion jobs are disabled by config.
+The existing synchronous `/api/device-quota/mapping/suggest` path remains as the explicit opt-out fallback when async suggestion jobs are disabled with `NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS=false`.
 
 ## UX Contract
 
@@ -24,7 +24,7 @@ The existing synchronous `/api/device-quota/mapping/suggest` path remains as the
 ## Implementation Scope
 
 - Add `POST /api/device-quota/mapping/suggest/jobs/[jobId]/process`.
-- Process only a bounded number of chunks per request.
+- Process 1-5 chunks per request, with the exact limit determined by request parameters or defaults.
 - Verify the current user can read the target job before processing its chunks.
 - Do not add scheduler, cron, or new persistence schema unless existing job/chunk records cannot support job-scoped selection.
 - Keep DQSS provider/ranking behavior unchanged.

--- a/docs/plans/2026-05-19-issue-517-dqss-hybrid-trigger-plan.md
+++ b/docs/plans/2026-05-19-issue-517-dqss-hybrid-trigger-plan.md
@@ -1,0 +1,41 @@
+# Issue 517 Phase 4D - DQSS Hybrid Job Trigger
+
+## Decision
+
+Use a hybrid no-cron trigger for Device Quota suggested mapping jobs.
+
+When the user clicks `Gợi ý phân loại`, the web UI creates or reuses a suggestion job, then keeps bounded server work moving while the dialog/page remains active. The UI polls job state through that same active session until the job succeeds or fails.
+
+No Vercel cron is added for this phase. Vercel Hobby cron is still unsuitable for this workflow because the current cron usage/pricing documentation limits Hobby cron to once per day with hourly precision:
+
+- https://vercel.com/docs/cron-jobs/usage-and-pricing
+
+The existing synchronous `/api/device-quota/mapping/suggest` path remains as the explicit opt-out fallback when async suggestion jobs are disabled by config.
+
+## UX Contract
+
+- The dialog must enter a processing state immediately after open/click.
+- Existing queued or processing jobs must be shown as processing, not as cooldown or an error.
+- Progress must use the job's processed unique-name count against total unique names when available.
+- Copy must be honest: processing continues while this dialog/session is active.
+- Failed jobs must show a safe actionable error and expose a retry action.
+- The grouped review and save flow remains unchanged after suggestions are ready.
+
+## Implementation Scope
+
+- Add `POST /api/device-quota/mapping/suggest/jobs/[jobId]/process`.
+- Process only a bounded number of chunks per request.
+- Verify the current user can read the target job before processing its chunks.
+- Do not add scheduler, cron, or new persistence schema unless existing job/chunk records cannot support job-scoped selection.
+- Keep DQSS provider/ranking behavior unchanged.
+
+## Verification
+
+- TDD first for route, service, hook, and dialog behavior.
+- Required gates for TypeScript/React diffs:
+  - `node scripts/npm-run.js run verify:no-explicit-any`
+  - `node scripts/npm-run.js run verify:dedupe`
+  - `node scripts/npm-run.js run typecheck`
+  - focused Vitest for affected hook/dialog/routes/services
+  - React Doctor diff against `main`
+  - `next build` if route/UI changes remain non-trivial

--- a/src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.async-jobs.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.async-jobs.test.tsx
@@ -1,0 +1,139 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+const mockUseSuggestMapping = vi.fn()
+vi.mock("../_hooks/useSuggestMapping", () => ({
+  useSuggestMapping: (...args: unknown[]) => mockUseSuggestMapping(...args),
+}))
+
+const mockToast = vi.hoisted(() => vi.fn())
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+import type { SuggestMappingStatus, SaveStatus } from "../_hooks/useSuggestMapping"
+import { SuggestedMappingPreviewDialog } from "../_components/SuggestedMappingPreviewDialog"
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    React.createElement(QueryClientProvider, { client: queryClient }, ui),
+  )
+}
+
+function setupHook(overrides: {
+  canRetry?: boolean
+  error?: string | null
+  processedUniqueNames?: number
+  progress?: number
+  retryFailedJob?: () => void
+  saveStatus?: SaveStatus
+  status?: SuggestMappingStatus
+  totalUniqueNames?: number
+} = {}) {
+  const reset = vi.fn()
+  const saveBatch = vi.fn()
+  mockUseSuggestMapping.mockReturnValue({
+    canRetry: false,
+    error: null,
+    processedUniqueNames: 0,
+    progress: 0,
+    reset,
+    result: null,
+    retryFailedJob: vi.fn(),
+    saveBatch,
+    saveError: null,
+    saveResult: null,
+    saveStatus: "idle",
+    status: "starting-job",
+    totalUniqueNames: 0,
+    ...overrides,
+  })
+}
+
+describe("SuggestedMappingPreviewDialog async job UX", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockToast.mockClear()
+  })
+
+  it("shows immediate loading progress while starting async job", () => {
+    setupHook({ status: "starting-job" })
+
+    renderWithQueryClient(
+      <SuggestedMappingPreviewDialog
+        open={true}
+        onOpenChange={() => { }}
+        donViId={1}
+        userRole="admin"
+      />,
+    )
+
+    expect(screen.getByText(/đang chuẩn bị gợi ý/i)).toBeInTheDocument()
+    expect(screen.getByText(/chỉ tiếp tục khi hộp thoại/i)).toBeInTheDocument()
+  })
+
+  it("shows unique-name progress while processing async job", () => {
+    setupHook({
+      processedUniqueNames: 2,
+      progress: 40,
+      status: "processing",
+      totalUniqueNames: 5,
+    })
+
+    renderWithQueryClient(
+      <SuggestedMappingPreviewDialog
+        open={true}
+        onOpenChange={() => { }}
+        donViId={1}
+        userRole="admin"
+      />,
+    )
+
+    expect(screen.getByText(/đang xử lý gợi ý/i)).toBeInTheDocument()
+    expect(screen.getByText(/2.*\/.*5.*tên thiết bị/i)).toBeInTheDocument()
+  })
+
+  it("shows retry action for failed async jobs", () => {
+    const retryFailedJob = vi.fn()
+    setupHook({
+      canRetry: true,
+      error: "VM timeout",
+      retryFailedJob,
+      status: "error",
+    })
+
+    renderWithQueryClient(
+      <SuggestedMappingPreviewDialog
+        open={true}
+        onOpenChange={() => { }}
+        donViId={1}
+        userRole="admin"
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /thử lại/i }))
+
+    expect(retryFailedJob).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.async-jobs.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.async-jobs.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 beforeAll(() => {
-  Object.defineProperty(window, "matchMedia", {
+  Object.defineProperty(globalThis, "matchMedia", {
     writable: true,
     value: vi.fn().mockImplementation((query: string) => ({
       matches: false,

--- a/src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.async-jobs.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.async-jobs.test.tsx
@@ -111,7 +111,7 @@ describe("SuggestedMappingPreviewDialog async job UX", () => {
     )
 
     expect(screen.getByText(/đang xử lý gợi ý/i)).toBeInTheDocument()
-    expect(screen.getByText(/2.*\/.*5.*tên thiết bị/i)).toBeInTheDocument()
+    expect(screen.getByText("2 / 5 tên thiết bị")).toBeInTheDocument()
   })
 
   it("shows retry action for failed async jobs", () => {

--- a/src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.test.tsx
+++ b/src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.test.tsx
@@ -96,13 +96,17 @@ const DONE_RESULT: SuggestMappingResult = {
 }
 
 function setupHook(overrides: {
+    canRetry?: boolean
     status?: SuggestMappingStatus
     result?: SuggestMappingResult | null
     error?: string | null
     progress?: number
+    processedUniqueNames?: number
+    retryFailedJob?: () => void
     saveStatus?: SaveStatus
     saveResult?: BatchSaveResult | null
     saveError?: string | null
+    totalUniqueNames?: number
 } = {}) {
     const reset = vi.fn()
     const saveBatch = vi.fn()
@@ -110,12 +114,16 @@ function setupHook(overrides: {
         status: 'done',
         result: DONE_RESULT,
         error: null,
+        canRetry: false,
         progress: 100,
+        processedUniqueNames: 3,
+        retryFailedJob: vi.fn(),
         reset,
         saveBatch,
         saveStatus: 'idle',
         saveResult: null,
         saveError: null,
+        totalUniqueNames: 3,
         ...overrides,
     })
     return { reset, saveBatch }
@@ -263,21 +271,6 @@ describe('SuggestedMappingPreviewDialog', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockToast.mockClear()
-    })
-
-    it('shows loading progress during pipeline', () => {
-        setupHook({ status: 'embedding', result: null, progress: 33 })
-
-        renderWithQueryClient(
-            <SuggestedMappingPreviewDialog
-                open={true}
-                onOpenChange={() => { }}
-                donViId={1}
-                userRole="admin"
-            />
-        )
-
-        expect(screen.getByText(/đang tạo embedding/i)).toBeInTheDocument()
     })
 
     it('renders grouped suggestions after pipeline completes', () => {
@@ -630,4 +623,3 @@ describe('SuggestedMappingPreviewDialog', () => {
         )
     })
 })
-

--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.async-jobs.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.async-jobs.test.ts
@@ -318,4 +318,56 @@ describe("useSuggestMapping async jobs", () => {
       expect.objectContaining({ method: "POST" }),
     )
   })
+
+  test("clears stale retry job id when a fresh async job startup fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            job: {
+              id: "job-1",
+              processedUniqueNames: 0,
+              status: "queued",
+              totalUniqueNames: 3,
+            },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            failed: 1,
+            job: {
+              error: "VM timeout",
+              id: "job-1",
+              processedUniqueNames: 1,
+              status: "failed",
+              totalUniqueNames: 3,
+            },
+            processed: 0,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+
+    const { result, rerender } = renderHook(
+      ({ donViId }: { donViId: number }) =>
+        useSuggestMapping({ donViId, enabled: true }),
+      { initialProps: { donViId: 1 }, wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error")
+    })
+    expect(result.current.canRetry).toBe(true)
+
+    fetchMock.mockRejectedValueOnce(new Error("startup failed"))
+    rerender({ donViId: 2 })
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("startup failed")
+    })
+    expect(result.current.canRetry).toBe(false)
+  })
 })

--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.async-jobs.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.async-jobs.test.ts
@@ -1,0 +1,321 @@
+import { describe, test, expect, vi, beforeEach } from "vitest"
+import { renderHook, waitFor, act } from "@testing-library/react"
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+const callRpcMock = vi.fn()
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: (...args: unknown[]) => callRpcMock(...args),
+}))
+
+const fetchMock = vi.fn()
+vi.stubGlobal("fetch", fetchMock)
+
+import { useSuggestMapping } from "../_hooks/useSuggestMapping"
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+const PREVIEW_RESULT = {
+  groups: [
+    {
+      nhom_id: 10,
+      nhom_label: "Máy thở chức năng cao",
+      nhom_code: "A.01",
+      phan_loai: "Loại B",
+      rrf_score: 0.95,
+      device_names: ["Máy thở"],
+      device_ids: [1, 2, 3],
+      device_name_to_ids: { "Máy thở": [1, 2, 3] },
+    },
+  ],
+  unmatched: [{ device_name: "Máy X-quang", device_ids: [6] }],
+  totalDevices: 4,
+  matchedDevices: 3,
+}
+
+function setupAsyncPipeline() {
+  fetchMock
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          job: {
+            id: "job-1",
+            processedUniqueNames: 0,
+            status: "queued",
+            totalUniqueNames: 3,
+          },
+          requestId: "req-job",
+        }),
+        { status: 202, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          failed: 0,
+          job: {
+            id: "job-1",
+            processedUniqueNames: 1,
+            status: "processing",
+            totalUniqueNames: 3,
+          },
+          processed: 1,
+          requestId: "req-process-1",
+        }),
+        { status: 202, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          failed: 0,
+          job: {
+            id: "job-1",
+            processedUniqueNames: 3,
+            result: PREVIEW_RESULT,
+            status: "succeeded",
+            totalUniqueNames: 3,
+          },
+          processed: 1,
+          requestId: "req-process-2",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+}
+
+describe("useSuggestMapping async jobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  test("creates an async suggestion job and transitions into processing immediately", async () => {
+    let resolveJob!: (value: Response) => void
+    fetchMock.mockImplementationOnce(
+      () => new Promise<Response>((resolve) => {
+        resolveJob = resolve
+      }),
+    )
+    fetchMock.mockImplementationOnce(() => new Promise<Response>(() => undefined))
+
+    const { result } = renderHook(() =>
+      useSuggestMapping({ donViId: 1, enabled: true }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("starting-job")
+    })
+
+    await act(async () => {
+      resolveJob(
+        new Response(
+          JSON.stringify({
+            job: {
+              id: "job-1",
+              processedUniqueNames: 0,
+              status: "queued",
+              totalUniqueNames: 3,
+            },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("processing")
+    })
+    expect(result.current.processedUniqueNames).toBe(0)
+    expect(result.current.totalUniqueNames).toBe(3)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/device-quota/mapping/suggest/jobs",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ donViId: 1 }),
+      }),
+    )
+  })
+
+  test("processes and polls an async job until success", async () => {
+    setupAsyncPipeline()
+
+    const { result } = renderHook(() =>
+      useSuggestMapping({ donViId: 1, enabled: true }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("done")
+    })
+
+    expect(result.current.result).toEqual(PREVIEW_RESULT)
+    expect(result.current.progress).toBe(100)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/device-quota/mapping/suggest/jobs",
+      expect.objectContaining({ method: "POST" }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/device-quota/mapping/suggest/jobs/job-1/process",
+      expect.objectContaining({ method: "POST" }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "/api/device-quota/mapping/suggest/jobs/job-1/process",
+      expect.objectContaining({ method: "POST" }),
+    )
+  })
+
+  test("reuses an existing running async job as processing", async () => {
+    let resolveProcess!: (value: Response) => void
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            job: {
+              id: "job-existing",
+              processedUniqueNames: 2,
+              status: "processing",
+              totalUniqueNames: 3,
+            },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockImplementationOnce(
+        () => new Promise<Response>((resolve) => {
+          resolveProcess = resolve
+        }),
+      )
+
+    const { result } = renderHook(() =>
+      useSuggestMapping({ donViId: 1, enabled: true }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("processing")
+    })
+    expect(result.current.processedUniqueNames).toBe(2)
+
+    await act(async () => {
+      resolveProcess(
+        new Response(
+          JSON.stringify({
+            failed: 0,
+            job: {
+              id: "job-existing",
+              processedUniqueNames: 3,
+              result: PREVIEW_RESULT,
+              status: "succeeded",
+              totalUniqueNames: 3,
+            },
+            processed: 1,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("done")
+    })
+    expect(result.current.result).toEqual(PREVIEW_RESULT)
+  })
+
+  test("failed async jobs expose a retry action that resumes processing", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            job: {
+              id: "job-1",
+              processedUniqueNames: 0,
+              status: "queued",
+              totalUniqueNames: 3,
+            },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            failed: 1,
+            job: {
+              error: "VM timeout",
+              id: "job-1",
+              processedUniqueNames: 1,
+              status: "failed",
+              totalUniqueNames: 3,
+            },
+            processed: 0,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            job: {
+              id: "job-1",
+              processedUniqueNames: 1,
+              status: "processing",
+              totalUniqueNames: 3,
+            },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            failed: 0,
+            job: {
+              id: "job-1",
+              processedUniqueNames: 3,
+              result: PREVIEW_RESULT,
+              status: "succeeded",
+              totalUniqueNames: 3,
+            },
+            processed: 1,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+
+    const { result } = renderHook(() =>
+      useSuggestMapping({ donViId: 1, enabled: true }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error")
+    })
+    expect(result.current.error).toBe("VM timeout")
+    expect(result.current.canRetry).toBe(true)
+
+    await act(async () => {
+      result.current.retryFailedJob()
+    })
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("done")
+    })
+    expect(result.current.result).toEqual(PREVIEW_RESULT)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/device-quota/mapping/suggest/jobs/job-1/retry",
+      expect.objectContaining({ method: "POST" }),
+    )
+  })
+})

--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
@@ -2,17 +2,13 @@ import { describe, test, expect, vi, beforeEach } from "vitest"
 import { renderHook, waitFor, act } from "@testing-library/react"
 import React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-
 const callRpcMock = vi.fn()
 vi.mock("@/lib/rpc-client", () => ({
   callRpc: (...args: unknown[]) => callRpcMock(...args),
 }))
-
 const fetchMock = vi.fn()
 vi.stubGlobal("fetch", fetchMock)
-
 import { useSuggestMapping } from "../_hooks/useSuggestMapping"
-
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { mutations: { retry: false } },
@@ -70,6 +66,7 @@ function setupSuccessfulPipeline() {
 describe("useSuggestMapping", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
   test("stays idle when not enabled", () => {
@@ -95,7 +92,8 @@ describe("useSuggestMapping", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  test("requests server-side suggested mapping once when enabled with valid donViId", async () => {
+  test("falls back to the synchronous preview route when async jobs are disabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -124,6 +122,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("merges results into groups by nhom_id", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -149,6 +148,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("separates unmatched devices", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -167,6 +167,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("tracks total and matched device counts", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -184,6 +185,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("sets error status on network error", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     fetchMock.mockRejectedValue(new Error("Network error"))
 
     const { result } = renderHook(() =>
@@ -199,6 +201,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("sets error status on server-side preview failure", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ error: "Preview failed", requestId: "req-err" }), {
         status: 500,
@@ -219,6 +222,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("reset clears result and returns to idle", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -240,6 +244,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("passes the server-side preview result through unchanged", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     const serverResult = {
       groups: [
         {
@@ -281,6 +286,7 @@ describe("useSuggestMapping", () => {
   })
 
   test("auto-resets to idle when enabled becomes false after pipeline started", async () => {
+    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const wrapper = createWrapper()
@@ -315,6 +321,7 @@ describe("useSuggestMapping", () => {
     }
 
     test("calls dinh_muc_thiet_bi_link_batch RPC with correct payload", async () => {
+      vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.resolve(SAVE_RESULT)
@@ -351,6 +358,7 @@ describe("useSuggestMapping", () => {
     })
 
     test("transitions through saving → saved status lifecycle", async () => {
+      vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
       setupSuccessfulPipeline()
 
       let resolveSave: (value: unknown) => void
@@ -387,6 +395,7 @@ describe("useSuggestMapping", () => {
     })
 
     test("exposes save result with affected and skipped counts", async () => {
+      vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.resolve(SAVE_RESULT)
@@ -412,6 +421,7 @@ describe("useSuggestMapping", () => {
     })
 
     test("sets saveError on RPC failure", async () => {
+      vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.reject(new Error("Permission denied"))

--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMappingJobClient.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMappingJobClient.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { waitForNextJobTick } from "../_hooks/useSuggestMappingJobClient"
+
+describe("useSuggestMappingJobClient", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("removes abort listener after a successful polling tick", async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    const removeEventListenerSpy = vi.spyOn(controller.signal, "removeEventListener")
+
+    const tick = waitForNextJobTick(controller.signal)
+    await vi.advanceTimersByTimeAsync(0)
+    await tick
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function))
+  })
+})

--- a/src/app/(app)/device-quota/mapping/_components/SuggestedMappingPreviewDialog.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/SuggestedMappingPreviewDialog.tsx
@@ -41,12 +41,10 @@ export interface SuggestedMappingPreviewDialogProps {
 
 function getStatusLabel(status: SuggestMappingStatus): string {
     switch (status) {
-        case "fetching-names":
-            return "Đang tải danh sách thiết bị..."
-        case "embedding":
-            return "Đang tạo embedding..."
-        case "searching":
-            return "Đang tìm kiếm danh mục phù hợp..."
+        case "starting-job":
+            return "Đang chuẩn bị gợi ý phân loại..."
+        case "processing":
+            return "Đang xử lý gợi ý phân loại..."
         default:
             return ""
     }
@@ -67,7 +65,21 @@ export function SuggestedMappingPreviewDialog({
     donViId,
     userRole,
 }: SuggestedMappingPreviewDialogProps) {
-    const { status, result, error, progress, reset, saveBatch, saveStatus, saveError, saveResult } = useSuggestMapping({
+    const {
+        canRetry,
+        status,
+        result,
+        error,
+        progress,
+        processedUniqueNames,
+        totalUniqueNames,
+        retryFailedJob,
+        reset,
+        saveBatch,
+        saveStatus,
+        saveError,
+        saveResult,
+    } = useSuggestMapping({
         donViId,
         enabled: open,
     })
@@ -135,20 +147,23 @@ export function SuggestedMappingPreviewDialog({
     const handleConfirmSave = React.useCallback(() => {
         if (!result) return
 
-        const mappings: SaveMapping[] = result.groups
-            .filter((g) => !excludedGroups.has(g.nhom_id))
-            .map((g) => {
-                const groupExcludedNames = excludedDeviceNames.get(g.nhom_id) ?? new Set()
-                // Filter device_ids via name→ID mapping, removing excluded names
-                const filteredIds = Object.entries(g.device_name_to_ids)
-                    .filter(([name]) => !groupExcludedNames.has(name))
-                    .flatMap(([, ids]) => ids)
-                return {
-                    nhom_id: g.nhom_id,
+        const mappings: SaveMapping[] = []
+        for (const group of result.groups) {
+            if (excludedGroups.has(group.nhom_id)) continue
+
+            const groupExcludedNames = excludedDeviceNames.get(group.nhom_id) ?? new Set()
+            const filteredIds: number[] = []
+            for (const [name, ids] of Object.entries(group.device_name_to_ids)) {
+                if (!groupExcludedNames.has(name)) filteredIds.push(...ids)
+            }
+
+            if (filteredIds.length > 0) {
+                mappings.push({
+                    nhom_id: group.nhom_id,
                     thiet_bi_ids: filteredIds,
-                }
-            })
-            .filter((m) => m.thiet_bi_ids.length > 0)
+                })
+            }
+        }
 
         if (mappings.length === 0) {
             toast({
@@ -200,9 +215,12 @@ export function SuggestedMappingPreviewDialog({
         }).length
         : 0
 
-    const isLoading = status === "fetching-names" || status === "embedding" || status === "searching"
+    const isLoading = status === "starting-job" || status === "processing"
     const canWrite = isEquipmentManagerRole(userRole)
     const isRegionalLeader = isRegionalLeaderRole(userRole)
+    const progressLabel = totalUniqueNames > 0
+        ? `${processedUniqueNames} / ${totalUniqueNames} tên thiết bị`
+        : `${progress}%`
 
     return (
         <Dialog open={open} onOpenChange={(val) => { if (!val) handleClose() }}>
@@ -222,7 +240,7 @@ export function SuggestedMappingPreviewDialog({
                     <div className="space-y-3">
                         <div className="flex items-center justify-between text-sm text-muted-foreground">
                             <span>{getStatusLabel(status)}</span>
-                            <span>{progress}%</span>
+                            <span>{progressLabel}</span>
                         </div>
                         <div className="w-full bg-muted rounded-full h-2">
                             <div
@@ -230,15 +248,30 @@ export function SuggestedMappingPreviewDialog({
                                 style={{ width: `${progress}%` }}
                             />
                         </div>
+                        <p className="text-xs text-muted-foreground">
+                            Quá trình chỉ tiếp tục khi hộp thoại hoặc phiên làm việc này còn mở.
+                        </p>
                         <MappingPreviewLoadingState />
                     </div>
                 )}
 
                 {/* Error state */}
                 {status === "error" && (
-                    <div className="flex items-center gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-                        <AlertTriangle className="size-4 shrink-0" />
-                        <span>{error}</span>
+                    <div className="space-y-3 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                        <div className="flex items-center gap-2">
+                            <AlertTriangle className="size-4 shrink-0" />
+                            <span>{error}</span>
+                        </div>
+                        {canRetry && (
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={retryFailedJob}
+                            >
+                                Thử lại
+                            </Button>
+                        )}
                     </div>
                 )}
 

--- a/src/app/(app)/device-quota/mapping/_hooks/useSuggestMapping.ts
+++ b/src/app/(app)/device-quota/mapping/_hooks/useSuggestMapping.ts
@@ -130,6 +130,7 @@ export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions
         setProgress(0)
         setProcessedUniqueNames(0)
         setTotalUniqueNames(0)
+        if (!retryJobId) setCurrentJobId(null)
       }
 
       if (retryJobId) {

--- a/src/app/(app)/device-quota/mapping/_hooks/useSuggestMapping.ts
+++ b/src/app/(app)/device-quota/mapping/_hooks/useSuggestMapping.ts
@@ -1,10 +1,22 @@
 // Orchestration hook for suggested mapping preview.
-// Browser calls one server-side route; the route owns payload bundling,
-// embedding/search provider orchestration, auth, and facility-scope checks.
+// Browser calls server-side routes; the routes own auth, facility scope,
+// payload bundling, provider orchestration, and bounded job processing.
 
 import { useState, useEffect, useCallback, useRef } from "react"
 import { useMutation } from "@tanstack/react-query"
 import { callRpc } from "@/lib/rpc-client"
+import {
+  createSuggestionJobRequest,
+  fetchSuggestedMapping,
+  getJobFailureMessage,
+  getJobResult,
+  getProgressPercent,
+  isAsyncSuggestionJobEnabled,
+  processSuggestionJobRequest,
+  retrySuggestionJobRequest,
+  waitForNextJobTick,
+  type SuggestionJob,
+} from "./useSuggestMappingJobClient"
 
 // ============================================
 // Types
@@ -30,9 +42,8 @@ export interface SuggestMappingResult {
 
 export type SuggestMappingStatus =
   | "idle"
-  | "fetching-names"
-  | "embedding"
-  | "searching"
+  | "starting-job"
+  | "processing"
   | "done"
   | "error"
 
@@ -55,47 +66,6 @@ interface UseSuggestMappingOptions {
   enabled: boolean
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
-function getRouteErrorMessage(status: number, payload: unknown): string {
-  if (isRecord(payload) && typeof payload.error === "string" && payload.error) {
-    return payload.error
-  }
-  return `Suggestion preview failed (${status})`
-}
-
-function getRouteResult(payload: unknown): SuggestMappingResult {
-  if (isRecord(payload) && isRecord(payload.result)) {
-    return payload.result as unknown as SuggestMappingResult
-  }
-  throw new Error("Invalid suggestion preview response")
-}
-
-async function fetchSuggestedMapping(
-  donViId: number,
-  signal: AbortSignal,
-): Promise<SuggestMappingResult> {
-  const response = await fetch("/api/device-quota/mapping/suggest", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ donViId }),
-    signal,
-  })
-
-  let payload: unknown = null
-  try {
-    payload = await response.json()
-  } catch {}
-
-  if (!response.ok) {
-    throw new Error(getRouteErrorMessage(response.status, payload))
-  }
-
-  return getRouteResult(payload)
-}
-
 // ============================================
 // Hook
 // ============================================
@@ -103,27 +73,87 @@ async function fetchSuggestedMapping(
 export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions) {
   const [pipelineStatus, setPipelineStatus] = useState<SuggestMappingStatus>("idle")
   const [progress, setProgress] = useState(0)
+  const [processedUniqueNames, setProcessedUniqueNames] = useState(0)
+  const [totalUniqueNames, setTotalUniqueNames] = useState(0)
+  const [currentJobId, setCurrentJobId] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
 
+  const updateJobProgress = useCallback((job: SuggestionJob) => {
+    setCurrentJobId(job.id)
+    setProcessedUniqueNames(job.processedUniqueNames)
+    setTotalUniqueNames(job.totalUniqueNames)
+    setProgress(getProgressPercent(job))
+  }, [])
+
+  const waitForSuggestionJob = useCallback(
+    async (initialJob: SuggestionJob, signal: AbortSignal): Promise<SuggestMappingResult> => {
+      let job = initialJob
+      updateJobProgress(job)
+
+      while (!signal.aborted) {
+        if (job.status === "succeeded") {
+          setPipelineStatus("done")
+          setProgress(100)
+          return getJobResult(job)
+        }
+
+        if (job.status === "failed") {
+          throw new Error(getJobFailureMessage(job))
+        }
+
+        setPipelineStatus("processing")
+        job = await processSuggestionJobRequest(job.id, signal)
+        updateJobProgress(job)
+
+        if (job.status === "queued" || job.status === "processing") {
+          await waitForNextJobTick(signal)
+        }
+      }
+
+      throw new DOMException("Aborted", "AbortError")
+    },
+    [updateJobProgress],
+  )
+
   const mutation = useMutation({
-    mutationFn: async (dvId: number): Promise<SuggestMappingResult> => {
+    mutationFn: async ({
+      dvId,
+      retryJobId,
+    }: {
+      dvId: number
+      retryJobId?: string
+    }): Promise<SuggestMappingResult> => {
       const signal = abortRef.current!.signal
 
-      if (!signal.aborted) setPipelineStatus("fetching-names")
-      if (!signal.aborted) setProgress(0)
+      if (!signal.aborted) {
+        setPipelineStatus("starting-job")
+        setProgress(0)
+        setProcessedUniqueNames(0)
+        setTotalUniqueNames(0)
+      }
 
+      if (retryJobId) {
+        const retryJob = await retrySuggestionJobRequest(retryJobId, signal)
+        return waitForSuggestionJob(retryJob, signal)
+      }
+
+      if (isAsyncSuggestionJobEnabled()) {
+        const job = await createSuggestionJobRequest(dvId, signal)
+        return waitForSuggestionJob(job, signal)
+      }
+
+      setPipelineStatus("processing")
       const result = await fetchSuggestedMapping(dvId, signal)
       if (signal.aborted) throw new DOMException("Aborted", "AbortError")
       return result
     },
-    onSuccess: (_data, _vars, _ctx) => {
+    onSuccess: () => {
       if (!abortRef.current?.signal.aborted) {
         setPipelineStatus("done")
         setProgress(100)
       }
     },
     onError: (err) => {
-      // Don't set error state for intentional aborts
       if (err instanceof DOMException && err.name === "AbortError") return
       if (!abortRef.current?.signal.aborted) {
         setPipelineStatus("error")
@@ -138,6 +168,9 @@ export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions
       abortRef.current = null
       setPipelineStatus("idle")
       setProgress(0)
+      setProcessedUniqueNames(0)
+      setTotalUniqueNames(0)
+      setCurrentJobId(null)
       mutation.reset()
       return
     }
@@ -146,7 +179,7 @@ export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions
     abortRef.current?.abort()
     abortRef.current = new AbortController()
 
-    mutation.mutate(donViId)
+    mutation.mutate({ dvId: donViId })
 
     return () => {
       abortRef.current?.abort()
@@ -174,7 +207,7 @@ export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions
     (mappings: SaveMapping[]) => {
       saveMutation.mutate(mappings)
     },
-    [saveMutation]
+    [saveMutation],
   )
 
   const reset = useCallback(() => {
@@ -184,7 +217,17 @@ export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions
     saveMutation.reset()
     setPipelineStatus("idle")
     setProgress(0)
+    setProcessedUniqueNames(0)
+    setTotalUniqueNames(0)
+    setCurrentJobId(null)
   }, [mutation, saveMutation])
+
+  const retryFailedJob = useCallback(() => {
+    if (donViId === null || currentJobId === null) return
+    abortRef.current?.abort()
+    abortRef.current = new AbortController()
+    mutation.mutate({ dvId: donViId, retryJobId: currentJobId })
+  }, [currentJobId, donViId, mutation])
 
   const saveStatus: SaveStatus = saveMutation.isPending
     ? "saving"
@@ -204,10 +247,14 @@ export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions
         : "idle"
 
   return {
+    canRetry: status === "error" && currentJobId !== null,
     status,
     result: mutation.data ?? null,
     error: mutation.error?.message ?? null,
     progress,
+    processedUniqueNames,
+    totalUniqueNames,
+    retryFailedJob,
     reset,
     saveBatch,
     saveStatus,

--- a/src/app/(app)/device-quota/mapping/_hooks/useSuggestMappingJobClient.ts
+++ b/src/app/(app)/device-quota/mapping/_hooks/useSuggestMappingJobClient.ts
@@ -112,15 +112,15 @@ export function waitForNextJobTick(signal: AbortSignal): Promise<void> {
       return
     }
 
-    const timer = setTimeout(resolve, delayMs)
-    signal.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer)
-        reject(new DOMException("Aborted", "AbortError"))
-      },
-      { once: true },
-    )
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(new DOMException("Aborted", "AbortError"))
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort)
+      resolve()
+    }, delayMs)
+    signal.addEventListener("abort", onAbort, { once: true })
   })
 }
 

--- a/src/app/(app)/device-quota/mapping/_hooks/useSuggestMappingJobClient.ts
+++ b/src/app/(app)/device-quota/mapping/_hooks/useSuggestMappingJobClient.ts
@@ -1,0 +1,180 @@
+import type { SuggestMappingResult } from "./useSuggestMapping"
+
+export type SuggestionJobStatus = "queued" | "processing" | "succeeded" | "failed"
+
+export interface SuggestionJob {
+  id: string
+  status: SuggestionJobStatus
+  processedUniqueNames: number
+  totalUniqueNames: number
+  result: SuggestMappingResult | null
+  error: string | null
+}
+
+const SUGGESTION_JOB_STATUSES = new Set<string>(["queued", "processing", "succeeded", "failed"])
+
+function isSuggestionJobStatus(value: string): value is SuggestionJobStatus {
+  return SUGGESTION_JOB_STATUSES.has(value)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function getRouteErrorMessage(status: number, payload: unknown): string {
+  if (isRecord(payload) && typeof payload.error === "string" && payload.error) {
+    return payload.error
+  }
+  return `Suggestion preview failed (${status})`
+}
+
+function getRouteResult(payload: unknown): SuggestMappingResult {
+  if (isRecord(payload) && isRecord(payload.result)) {
+    return payload.result as unknown as SuggestMappingResult
+  }
+  throw new Error("Invalid suggestion preview response")
+}
+
+function getRouteJob(payload: unknown): SuggestionJob {
+  if (!isRecord(payload) || !isRecord(payload.job)) {
+    throw new Error("Invalid suggestion job response")
+  }
+
+  const job = payload.job
+  if (
+    typeof job.id !== "string" ||
+    typeof job.status !== "string" ||
+    !isSuggestionJobStatus(job.status) ||
+    typeof job.processedUniqueNames !== "number" ||
+    typeof job.totalUniqueNames !== "number"
+  ) {
+    throw new Error("Invalid suggestion job response")
+  }
+
+  return {
+    error: typeof job.error === "string" ? job.error : null,
+    id: job.id,
+    processedUniqueNames: job.processedUniqueNames,
+    result: isRecord(job.result) ? (job.result as unknown as SuggestMappingResult) : null,
+    status: job.status,
+    totalUniqueNames: job.totalUniqueNames,
+  }
+}
+
+async function postJson(
+  url: string,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal,
+  })
+
+  let payload: unknown = null
+  try {
+    payload = await response.json()
+  } catch {}
+
+  if (!response.ok) {
+    throw new Error(getRouteErrorMessage(response.status, payload))
+  }
+
+  return payload
+}
+
+export function isAsyncSuggestionJobEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS !== "false"
+}
+
+export function getProgressPercent(job: SuggestionJob): number {
+  if (job.status === "succeeded") return 100
+  if (job.totalUniqueNames <= 0) return 0
+  return Math.min(99, Math.round((job.processedUniqueNames / job.totalUniqueNames) * 100))
+}
+
+export function getJobResult(job: SuggestionJob): SuggestMappingResult {
+  if (job.result) return job.result
+  throw new Error("Suggestion job completed without a result")
+}
+
+export function getJobFailureMessage(job: SuggestionJob): string {
+  return job.error ?? "Không thể tạo gợi ý phân loại. Vui lòng thử lại."
+}
+
+export function waitForNextJobTick(signal: AbortSignal): Promise<void> {
+  const delayMs = process.env.NODE_ENV === "test" ? 0 : 800
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"))
+      return
+    }
+
+    const timer = setTimeout(resolve, delayMs)
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer)
+        reject(new DOMException("Aborted", "AbortError"))
+      },
+      { once: true },
+    )
+  })
+}
+
+export async function fetchSuggestedMapping(
+  donViId: number,
+  signal: AbortSignal,
+): Promise<SuggestMappingResult> {
+  const response = await fetch("/api/device-quota/mapping/suggest", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ donViId }),
+    signal,
+  })
+
+  let payload: unknown = null
+  try {
+    payload = await response.json()
+  } catch {}
+
+  if (!response.ok) {
+    throw new Error(getRouteErrorMessage(response.status, payload))
+  }
+
+  return getRouteResult(payload)
+}
+
+export async function createSuggestionJobRequest(
+  donViId: number,
+  signal: AbortSignal,
+): Promise<SuggestionJob> {
+  const payload = await postJson("/api/device-quota/mapping/suggest/jobs", { donViId }, signal)
+  return getRouteJob(payload)
+}
+
+export async function processSuggestionJobRequest(
+  jobId: string,
+  signal: AbortSignal,
+): Promise<SuggestionJob> {
+  const payload = await postJson(
+    `/api/device-quota/mapping/suggest/jobs/${encodeURIComponent(jobId)}/process`,
+    { limit: 2 },
+    signal,
+  )
+  return getRouteJob(payload)
+}
+
+export async function retrySuggestionJobRequest(
+  jobId: string,
+  signal: AbortSignal,
+): Promise<SuggestionJob> {
+  const payload = await postJson(
+    `/api/device-quota/mapping/suggest/jobs/${encodeURIComponent(jobId)}/retry`,
+    {},
+    signal,
+  )
+  return getRouteJob(payload)
+}

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
@@ -11,10 +11,12 @@ vi.mock("@/auth/config", () => ({
 
 const createSuggestionJobMock = vi.fn()
 const getSuggestionJobMock = vi.fn()
+const processSuggestionJobChunksForJobMock = vi.fn()
 const retrySuggestionJobMock = vi.fn()
 vi.mock("@/app/api/device-quota/mapping/suggest/suggestion-job-service", () => ({
   createSuggestionJob: (...args: unknown[]) => createSuggestionJobMock(...args),
   getSuggestionJob: (...args: unknown[]) => getSuggestionJobMock(...args),
+  processSuggestionJobChunksForJob: (...args: unknown[]) => processSuggestionJobChunksForJobMock(...args),
   retrySuggestionJob: (...args: unknown[]) => retrySuggestionJobMock(...args),
 }))
 
@@ -41,6 +43,7 @@ describe("device quota suggestion job routes", () => {
     getServerSessionMock.mockReset()
     createSuggestionJobMock.mockReset()
     getSuggestionJobMock.mockReset()
+    processSuggestionJobChunksForJobMock.mockReset()
     retrySuggestionJobMock.mockReset()
     getServerSessionMock.mockResolvedValue(SESSION)
   })
@@ -207,6 +210,98 @@ describe("device quota suggestion job routes", () => {
 
     expect(response.status).toBe(202)
     expect(retrySuggestionJobMock).toHaveBeenCalledWith(expect.objectContaining({ jobId: "job-1" }))
+  })
+
+  test("POST /jobs/[jobId]/process rejects unauthenticated users before processing", async () => {
+    getServerSessionMock.mockResolvedValue(null)
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1/process", {
+        body: JSON.stringify({ limit: 2 }),
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(401)
+    expect(processSuggestionJobChunksForJobMock).not.toHaveBeenCalled()
+  })
+
+  test("POST /jobs/[jobId]/process rejects forbidden roles before processing", async () => {
+    getServerSessionMock.mockResolvedValue(FORBIDDEN_SESSION)
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1/process", {
+        body: JSON.stringify({ limit: 2 }),
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(403)
+    expect(processSuggestionJobChunksForJobMock).not.toHaveBeenCalled()
+  })
+
+  test("POST /jobs/[jobId]/process clamps bounded work and returns 202 while processing", async () => {
+    processSuggestionJobChunksForJobMock.mockResolvedValue({
+      failed: 0,
+      job: {
+        id: "job-1",
+        processedUniqueNames: 2,
+        status: "processing",
+        totalUniqueNames: 5,
+      },
+      processed: 2,
+    })
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1/process", {
+        body: JSON.stringify({ limit: 99 }),
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(202)
+    expect(processSuggestionJobChunksForJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-1", limit: 5 }),
+    )
+    await expect(response.json()).resolves.toMatchObject({
+      failed: 0,
+      job: { id: "job-1", status: "processing" },
+      processed: 2,
+      requestId: expect.any(String),
+    })
+  })
+
+  test("POST /jobs/[jobId]/process returns 200 when processing completes the job", async () => {
+    processSuggestionJobChunksForJobMock.mockResolvedValue({
+      failed: 0,
+      job: {
+        id: "job-1",
+        processedUniqueNames: 5,
+        status: "succeeded",
+        totalUniqueNames: 5,
+      },
+      processed: 1,
+    })
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1/process", {
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      job: { id: "job-1", status: "succeeded" },
+      processed: 1,
+    })
   })
 
   test("POST /jobs/[jobId]/retry rejects forbidden roles before retrying a job", async () => {

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts
@@ -228,6 +228,28 @@ describe("device quota suggestion job routes", () => {
     expect(processSuggestionJobChunksForJobMock).not.toHaveBeenCalled()
   })
 
+  test("POST /jobs/[jobId]/process sanitizes session retrieval failures", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    getServerSessionMock.mockRejectedValue(new Error("session store unavailable"))
+    const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route")
+
+    const response = await mod.POST(
+      new Request("https://example.test/api/device-quota/mapping/suggest/jobs/job-1/process", {
+        body: JSON.stringify({ limit: 2 }),
+        method: "POST",
+      }),
+      { params: Promise.resolve({ jobId: "job-1" }) },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Internal server error",
+      requestId: expect.any(String),
+    })
+    expect(processSuggestionJobChunksForJobMock).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
   test("POST /jobs/[jobId]/process rejects forbidden roles before processing", async () => {
     getServerSessionMock.mockResolvedValue(FORBIDDEN_SESSION)
     const mod = await import("@/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route")

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
@@ -389,6 +389,31 @@ describe("device quota suggestion job service", () => {
     expect(store.markChunkSucceeded).not.toHaveBeenCalled()
   })
 
+  test("stops job-scoped processing after the first chunk failure", async () => {
+    const store = createStore()
+    vi.mocked(store.getJobChunks).mockResolvedValue([
+      createChunk({ id: "chunk-1", chunkIndex: 0, status: "queued" }),
+      createChunk({ id: "chunk-2", chunkIndex: 1, status: "queued" }),
+    ])
+    vi.mocked(store.getJob)
+      .mockResolvedValueOnce(createJob({ status: "processing" }))
+      .mockResolvedValueOnce(createJob({ status: "processing" }))
+      .mockResolvedValueOnce(createJob({ error: "VM timeout", status: "failed" }))
+
+    const result = await processSuggestionJobChunksForJob({
+      jobId: "job-1",
+      limit: 2,
+      store,
+      suggestChunk: vi.fn(async () => Promise.reject(new Error("VM timeout"))),
+      user: USER,
+    })
+
+    expect(result).toEqual({ failed: 1, job: createJob({ error: "VM timeout", status: "failed" }), processed: 0 })
+    expect(store.markChunkProcessing).toHaveBeenCalledTimes(1)
+    expect(store.markChunkProcessing).toHaveBeenCalledWith("chunk-1")
+    expect(store.markChunkProcessing).not.toHaveBeenCalledWith("chunk-2")
+  })
+
   test("does not count chunks skipped after a lost atomic claim as processed", async () => {
     const store = createStore()
     vi.mocked(store.listQueuedChunks).mockResolvedValue([

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
@@ -404,7 +404,7 @@ describe("device quota suggestion job service", () => {
       jobId: "job-1",
       limit: 2,
       store,
-      suggestChunk: vi.fn(async () => Promise.reject(new Error("VM timeout"))),
+      suggestChunk: vi.fn(async () => { throw new Error("VM timeout") }),
       user: USER,
     })
 

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts
@@ -5,6 +5,7 @@ import { callVmSuggest } from "@/app/api/device-quota/mapping/suggest/suggestion
 import {
   createSuggestionJob,
   getSuggestionJob,
+  processSuggestionJobChunksForJob,
   processSuggestionJobChunk,
   processNextSuggestionJobChunks,
   retrySuggestionJob,
@@ -341,6 +342,51 @@ describe("device quota suggestion job service", () => {
     expect(result).toEqual({ failed: 0, processed: 2 })
     expect(store.listQueuedChunks).toHaveBeenCalledWith(2)
     expect(store.markChunkSucceeded).toHaveBeenCalledTimes(2)
+  })
+
+  test("processes only queued chunks for the authorized job", async () => {
+    const store = createStore()
+    vi.mocked(store.getJobChunks).mockResolvedValue([
+      createChunk({ id: "chunk-1", chunkIndex: 0, status: "queued", uniqueNameCount: 1 }),
+      createChunk({ id: "chunk-2", chunkIndex: 1, status: "succeeded", uniqueNameCount: 1 }),
+      createChunk({ id: "chunk-3", chunkIndex: 2, status: "queued", uniqueNameCount: 1 }),
+    ])
+
+    const result = await processSuggestionJobChunksForJob({
+      jobId: "job-1",
+      limit: 1,
+      store,
+      suggestChunk: vi.fn(async () => ({ results: [] })),
+      user: USER,
+    })
+
+    expect(result).toEqual({
+      failed: 0,
+      job: createJob(),
+      processed: 1,
+    })
+    expect(store.getJob).toHaveBeenCalledWith("job-1")
+    expect(store.getJobChunks).toHaveBeenCalledWith("job-1")
+    expect(store.markChunkSucceeded).toHaveBeenCalledTimes(1)
+    expect(store.markChunkSucceeded).toHaveBeenCalledWith("chunk-1", expect.any(Object))
+  })
+
+  test("does not process chunks for inaccessible jobs", async () => {
+    const store = createStore()
+    vi.mocked(store.getJob).mockResolvedValue(createJob({ scopeKey: "user:other-user" }))
+
+    await expect(
+      processSuggestionJobChunksForJob({
+        jobId: "job-1",
+        limit: 1,
+        store,
+        suggestChunk: vi.fn(async () => ({ results: [] })),
+        user: USER,
+      }),
+    ).rejects.toMatchObject({ status: 404 })
+
+    expect(store.getJobChunks).not.toHaveBeenCalled()
+    expect(store.markChunkSucceeded).not.toHaveBeenCalled()
   })
 
   test("does not count chunks skipped after a lost atomic claim as processed", async () => {

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/auth/config"
+import { processSuggestionJobChunksForJob } from "@/app/api/device-quota/mapping/suggest/suggestion-job-service"
+import {
+  assertSuggestionRouteUser,
+  getErrorMessage,
+  getErrorStatus,
+} from "@/app/api/device-quota/mapping/suggest/suggestion-route-utils"
+import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+
+export const runtime = "nodejs"
+
+const DEFAULT_PROCESS_LIMIT = 1
+const MAX_PROCESS_LIMIT = 5
+
+function createRequestId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `job-process-${Date.now().toString(36)}`
+}
+
+function clampProcessLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return DEFAULT_PROCESS_LIMIT
+  }
+  return Math.min(value, MAX_PROCESS_LIMIT)
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+async function readOptionalJsonBody(request: Request): Promise<Record<string, unknown>> {
+  const text = await request.text()
+  if (text.trim() === "") return {}
+
+  const parsed = JSON.parse(text) as unknown
+  if (!isJsonRecord(parsed)) {
+    throw new Error("Invalid JSON body")
+  }
+  return parsed
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  const requestId = createRequestId()
+  const session = await getServerSession(authOptions)
+  const user = session?.user as SuggestionAccessUser | undefined
+
+  try {
+    assertSuggestionRouteUser(user)
+  } catch (error) {
+    const status = getErrorStatus(error)
+    const message = getErrorMessage(error, status)
+    return NextResponse.json({ error: message, requestId }, { status })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await readOptionalJsonBody(request)
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body", requestId }, { status: 400 })
+  }
+
+  try {
+    const { jobId } = await params
+    const result = await processSuggestionJobChunksForJob({
+      jobId,
+      limit: clampProcessLimit(body.limit),
+      user,
+    })
+    const status = result.job.status === "queued" || result.job.status === "processing" ? 202 : 200
+    return NextResponse.json({ ...result, requestId }, { status })
+  } catch (error) {
+    const status = getErrorStatus(error)
+    if (status >= 500) {
+      console.error("Suggestion job processing failed", error)
+    }
+    const message = getErrorMessage(error, status)
+    return NextResponse.json({ error: message, requestId }, { status })
+  }
+}

--- a/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/jobs/[jobId]/process/route.ts
@@ -48,10 +48,11 @@ export async function POST(
   { params }: { params: Promise<{ jobId: string }> },
 ) {
   const requestId = createRequestId()
-  const session = await getServerSession(authOptions)
-  const user = session?.user as SuggestionAccessUser | undefined
+  let user: SuggestionAccessUser | undefined
 
   try {
+    const session = await getServerSession(authOptions)
+    user = session?.user as SuggestionAccessUser | undefined
     assertSuggestionRouteUser(user)
   } catch (error) {
     const status = getErrorStatus(error)

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
@@ -276,6 +276,49 @@ export async function processNextSuggestionJobChunks({
   return { failed, processed }
 }
 
+export async function processSuggestionJobChunksForJob({
+  jobId,
+  limit = 1,
+  store = createServerSuggestionJobStore(),
+  suggestChunk,
+  user,
+}: {
+  jobId: string
+  limit?: number
+  store?: SuggestionJobStore
+  suggestChunk?: (args: {
+    chunk: SuggestionJobChunkRecord
+    job: SuggestionJobRecord
+  }) => Promise<{ results: SearchResult[] }>
+  user: SuggestionAccessUser
+}): Promise<{ failed: number; job: SuggestionJobRecord; processed: number }> {
+  const job = await getSuggestionJob({ jobId, store, user })
+  if (job.status === "failed" || job.status === "succeeded") {
+    return { failed: 0, job, processed: 0 }
+  }
+
+  const chunks = await store.getJobChunks(job.id)
+  const queuedChunks = chunks
+    .filter((chunk) => chunk.status === "queued")
+    .sort((a, b) => a.chunkIndex - b.chunkIndex)
+    .slice(0, limit)
+
+  let failed = 0
+  let processed = 0
+
+  for (const chunk of queuedChunks) {
+    try {
+      const didProcess = await processSuggestionJobChunk({ chunkId: chunk.id, store, suggestChunk })
+      if (didProcess) processed += 1
+    } catch {
+      failed += 1
+    }
+  }
+
+  const updatedJob = await getSuggestionJob({ jobId, store, user })
+  return { failed, job: updatedJob, processed }
+}
+
 export function mergeCompletedJobChunks(chunks: SuggestionJobChunkRecord[]) {
   const names = chunks.flatMap((chunk) => chunk.deviceNames)
   const results = chunks.flatMap((chunk) => chunk.result?.results ?? [])

--- a/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-job-service.ts
@@ -312,6 +312,7 @@ export async function processSuggestionJobChunksForJob({
       if (didProcess) processed += 1
     } catch {
       failed += 1
+      break
     }
   }
 


### PR DESCRIPTION
## Summary
- Document the Phase 4D hybrid no-cron trigger decision for DQSS suggestion jobs.
- Add job-scoped bounded processing via `POST /api/device-quota/mapping/suggest/jobs/[jobId]/process`.
- Update `useSuggestMapping` and dialog UX to create/reuse async jobs, process while active, show unique-name progress, retry failed jobs, and keep sync fallback behind `NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS=false`.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js exec vitest run 'src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts' 'src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.async-jobs.test.ts' 'src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.test.tsx' 'src/app/(app)/device-quota/mapping/__tests__/SuggestedMappingPreviewDialog.async-jobs.test.tsx' 'src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-service.test.ts' 'src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts' --runInBand`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- `node scripts/npm-run.js run build`

Closes #517

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a hybrid no-cron trigger for DQSS suggestions: the UI creates/reuses an async job, processes small chunks while the dialog stays open, and shows live progress by unique device names. Keeps a sync fallback and safer retries to meet issue #517.

- New Features
  - Added POST /api/device-quota/mapping/suggest/jobs/[jobId]/process for job-scoped, bounded work (limit clamped 1–5) with auth/role checks; returns 202 while processing and 200 on completion.
  - Introduced `useSuggestMappingJobClient` and updated `useSuggestMapping` with `starting-job`/`processing` states, processed/total unique-name progress, retry support, and async default unless `NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS=false`.
  - Updated `SuggestedMappingPreviewDialog` to show immediate loading, a unique-name progress label, a “continues while dialog is open” note, a retry button on safe failures, and a simpler save payload build.
  - Service adds `processSuggestionJobChunksForJob` to process only queued chunks for a job and enforce access; docs and tests added.

- Bug Fixes
  - Retry flow: expose `canRetry`/`retryFailedJob`, reuse running jobs, and clear stale retry job IDs on fresh startup failures.
  - Polling: remove abort listeners after each tick and handle aborts correctly to avoid leaks.
  - Routes: sanitize session failures, clamp process limits, return request IDs, and improve error messages.

<sup>Written for commit d204646e16d699bde684a99e44f3d0774209d69c. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/525?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hybrid async device-quota mapping suggestions with no-cron triggering, real-time progress (counts/percent), honest in-dialog messaging, retry for failures, and synchronous fallback when async is disabled; preserves grouped review/save flow.

* **Tests**
  * Expanded coverage for async job lifecycles, dialog states (starting/processing/error), retry behavior, abort/cleanup, and job-processing scenarios.

* **Documentation**
  * Added plan and verification steps describing UX contract, processing scope, and verification commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->