### PR TITLE
Roll out DQSS VM provider to all units

### DIFF
--- a/docs/device-quota/device-quota-suggestion-service-vm.md
+++ b/docs/device-quota/device-quota-suggestion-service-vm.md
@@ -215,6 +215,22 @@ debug. Qdrant can be added later if one of these becomes true:
 
 ## Rollout Plan
 
+### Current Rollout State
+
+The production rollout path is now:
+
+- `DEVICE_QUOTA_SUGGESTION_PROVIDER=vm` for all facilities.
+- `DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase` only as an operator rollback
+  switch.
+- `NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS` remains unset so async jobs
+  stay enabled by default.
+
+In `vm` mode, VM timeout, repeated 5xx, or open-circuit failures must return a
+controlled error to the caller. The route must not automatically runtime-fallback
+to Supabase because that can reintroduce the original Supabase Edge/AI pressure.
+Hard-deleting the old Supabase runtime fallback is tracked separately in #528
+after the all-facility VM rollout has clean soak evidence.
+
 ### Step 1: Baseline Current Flow
 
 Measure the current flow before changing it:
@@ -237,7 +253,8 @@ Add an app-level feature flag:
 - `DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase`
 - `DEVICE_QUOTA_SUGGESTION_PROVIDER=vm`
 
-The existing flow remains the fallback path.
+The existing flow remains available only as an operator rollback path by setting
+`DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase`.
 
 ### Step 3: Server-Side Route Integration
 
@@ -259,10 +276,10 @@ The VM call policy should be configurable through app env values such as:
 - `DEVICE_QUOTA_VM_CIRCUIT_THRESHOLD`
 - `DEVICE_QUOTA_VM_CIRCUIT_WINDOW_MS`
 
-The route should fall back immediately to the `supabase` provider when the VM
-request times out, exhausts its retry budget, returns repeated 5xx responses, or
-the circuit is open. Logs/metrics should include timeout, retry count, provider,
-circuit state, and fallback reason.
+The route should return a controlled degraded response when the VM request times
+out, exhausts its retry budget, returns repeated 5xx responses, or the circuit is
+open. Logs/metrics should include timeout, retry count, provider, circuit state,
+and failure reason.
 
 ### Step 4: Canary
 
@@ -274,7 +291,7 @@ Go/no-go checks:
 - matched count is comparable to current flow
 - suggestion duration is materially lower
 - no VM OOM or process restart
-- fallback to Supabase provider works
+- rollback to Supabase provider works by changing the operator env
 
 ### Step 5: Optional Persistent Cache
 
@@ -302,8 +319,7 @@ Cache invalidation can follow category create/update/import events.
 - A feature flag can switch back to the current Supabase path without redeploying
   DB schema.
 - VM call behavior is implemented with timeout, bounded retry/backoff, circuit
-  breaker, and fast fallback to the `supabase` provider on timeout/5xx/open
-  circuit.
+  breaker, and controlled degraded responses on timeout/5xx/open circuit.
 - Logs include request ID, facility ID, item counts, duration, provider, and
   failure reason without logging secrets.
 - Basic load test and one real facility smoke test are documented.

--- a/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
@@ -194,6 +194,28 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     )
   })
 
+  test("selects the VM provider for non-canary facilities during all-unit rollout", async () => {
+    vi.stubEnv("DEVICE_QUOTA_SUGGESTION_PROVIDER", "vm")
+
+    const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
+    const response = await POST(createRequest({ donViId: 21 }))
+
+    expect(response.status).toBe(200)
+    expect(runSuggestMappingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        donViId: 21,
+        provider: "vm",
+      })
+    )
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          provider: "vm",
+        }),
+      })
+    )
+  })
+
   test("uses VM only for canary allow-listed facilities", async () => {
     vi.stubEnv("DEVICE_QUOTA_SUGGESTION_PROVIDER", "canary")
     vi.stubEnv("DEVICE_QUOTA_SUGGESTION_CANARY_DON_VI_IDS", "17,21")


### PR DESCRIPTION
## Summary
- Lock the DQSS route contract that `DEVICE_QUOTA_SUGGESTION_PROVIDER=vm` selects the VM provider for non-canary facilities such as `donViId=21`.
- Update the VM suggestion service rollout docs to make all-facility VM rollout and Supabase operator rollback explicit.
- Split hard-delete of the old Supabase runtime fallback into #528 and clarify #527 is quality/polish, not a rollout blocker.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js exec vitest run 'src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts' 'src/app/api/device-quota/mapping/suggest/__tests__/suggestion-job-routes.test.ts' 'src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.async-jobs.test.ts' 'src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts' --runInBand` — 50/50 tests passed
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` — no issues found
- Lefthook pre-commit and pre-push passed

## Rollout / Rollback
- Rollout env: `DEVICE_QUOTA_SUGGESTION_PROVIDER=vm`
- Keep async jobs enabled: do not set `NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS=false`
- Rollback env: `DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase`

Refs #527
Refs #528


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls out the VM suggestion provider to all units by selecting `vm` when `DEVICE_QUOTA_SUGGESTION_PROVIDER=vm`. Updates docs to make rollback explicit and adds a test to ensure non‑canary facilities (e.g., `donViId=21`) use the VM provider.

- **Migration**
  - Rollout: set `DEVICE_QUOTA_SUGGESTION_PROVIDER=vm`.
  - Leave `NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS` unset (async jobs stay on).
  - Rollback: set `DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase`.

<sup>Written for commit 5f2f5504f953f59ad8660a9a8624143cae026d89. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/529?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated device quota suggestion rollout documentation with VM provider support and controlled failure handling strategies.

* **Tests**
  * Added test coverage for VM provider selection in device quota suggestion workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->