### PR TITLE
Add diff-aware TS JSDoc gate

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,6 +5,8 @@ pre-commit:
       run: node scripts/npm-run.js run verify:no-explicit-any
     verify-dedupe:
       run: node scripts/npm-run.js run verify:dedupe
+    verify-ts-docstrings:
+      run: node scripts/npm-run.js run verify:ts-docstrings
     verify-python-docstrings:
       run: node scripts/npm-run.js run verify:python-docstrings:changed
 
@@ -15,6 +17,8 @@ pre-push:
       run: node scripts/npm-run.js run verify:no-explicit-any
     verify-dedupe:
       run: node scripts/npm-run.js run verify:dedupe
+    verify-ts-docstrings:
+      run: node scripts/npm-run.js run verify:ts-docstrings
     verify-python-docstrings:
       run: node scripts/npm-run.js run verify:python-docstrings:changed
     typecheck:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit",
     "verify:no-explicit-any": "node scripts/check-no-explicit-any-in-diff.js",
     "verify:dedupe": "node scripts/check-sonarjs-duplication-in-diff.js",
+    "verify:ts-docstrings": "node scripts/check-ts-docstrings-in-diff.js",
     "verify:python-docstrings": "node scripts/check-python-docstrings.js",
     "verify:python-docstrings:changed": "node scripts/check-python-docstrings.js --changed",
     "prepare": "lefthook install",
@@ -34,6 +35,7 @@
     "n:typecheck": "node scripts/npm-run.js run typecheck",
     "n:verify:no-explicit-any": "node scripts/npm-run.js run verify:no-explicit-any",
     "n:verify:dedupe": "node scripts/npm-run.js run verify:dedupe",
+    "n:verify:ts-docstrings": "node scripts/npm-run.js run verify:ts-docstrings",
     "n:build": "node scripts/npm-run.js run build",
     "n:lint": "node scripts/npm-run.js run lint",
     "n:test": "node scripts/npm-run.js run test:run"

--- a/scripts/__tests__/check-ts-docstrings-in-diff.test.ts
+++ b/scripts/__tests__/check-ts-docstrings-in-diff.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  collectChangedJavaScriptTypeScriptFiles,
+  findMissingJsDocViolations,
+  formatViolations,
+} from "../check-ts-docstrings-in-diff"
+
+describe("check-ts-docstrings-in-diff", () => {
+  it("flags exported JavaScript and TypeScript declarations without JSDoc", () => {
+    const source = `
+      export function buildFilter() {
+        return {}
+      }
+
+      export class DeviceMapper {}
+
+      export const useDeviceRows = () => []
+
+      const normalizeStatus = () => "active"
+      export { normalizeStatus }
+    `
+
+    const violations = findMissingJsDocViolations(source, "src/lib/device-utils.ts")
+
+    expect(formatViolations(violations)).toContain(
+      "src/lib/device-utils.ts:2:7 exported function buildFilter requires JSDoc"
+    )
+    expect(formatViolations(violations)).toContain(
+      "src/lib/device-utils.ts:8:7 exported variable useDeviceRows requires JSDoc"
+    )
+    expect(violations.map((violation) => violation.name)).toEqual([
+      "buildFilter",
+      "DeviceMapper",
+      "useDeviceRows",
+      "normalizeStatus",
+    ])
+  })
+
+  it("accepts JSDoc on exported declarations", () => {
+    const source = `
+      /**
+       * Builds stable filter params for report RPCs.
+       */
+      export function buildReportFilters() {
+        return {}
+      }
+
+      /**
+       * Maps raw rows into table rows.
+       */
+      const mapRows = () => []
+      export { mapRows }
+    `
+
+    expect(findMissingJsDocViolations(source, "src/lib/report-utils.ts")).toEqual([])
+  })
+
+  it("does not require JSDoc for private helpers, component-local handlers, callbacks, or test files", () => {
+    const componentSource = `
+      export function EquipmentDialog() {
+        const handleSave = () => null
+        return rows.map((row) => row.id).join(",")
+      }
+
+      function privateHelper() {
+        return "hidden"
+      }
+    `
+
+    expect(
+      findMissingJsDocViolations(componentSource, "src/components/equipment-dialog.test.tsx")
+    ).toEqual([])
+
+    expect(
+      findMissingJsDocViolations(componentSource, "src/components/equipment-dialog.tsx")
+    ).toHaveLength(1)
+  })
+
+  it("collects only changed JavaScript and TypeScript source files", () => {
+    const runGitImpl = (args: string[]) => {
+      const command = args.join(" ")
+
+      if (command === "diff --name-only --diff-filter=ACMR main...HEAD") {
+        return [
+          "src/lib/report-utils.ts",
+          "src/components/report-panel.tsx",
+          "src/components/report-panel.test.tsx",
+          "scripts/check-docs.js",
+          "README.md",
+        ]
+      }
+
+      if (command === "diff --name-only --diff-filter=ACMR") {
+        return ["src/app/page.jsx"]
+      }
+
+      if (command === "diff --cached --name-only --diff-filter=ACMR") {
+        return ["src/app/api/route.js"]
+      }
+
+      if (command === "ls-files --others --exclude-standard") {
+        return ["src/lib/new-helper.mts", "src/lib/new-helper.ts"]
+      }
+
+      return []
+    }
+
+    expect(
+      collectChangedJavaScriptTypeScriptFiles("main", {
+        runGitImpl,
+        fileExists: () => true,
+      })
+    ).toEqual([
+      "scripts/check-docs.js",
+      "src/app/api/route.js",
+      "src/app/page.jsx",
+      "src/components/report-panel.tsx",
+      "src/lib/new-helper.ts",
+      "src/lib/report-utils.ts",
+    ])
+  })
+})

--- a/scripts/check-ts-docstrings-in-diff.js
+++ b/scripts/check-ts-docstrings-in-diff.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs")
+const path = require("node:path")
+const ts = require("typescript")
+const { collectChangedFiles, getCommittedChangedFiles, runGit } = require("./changed-files")
+
+const DEFAULT_BASE_REF = process.env.TS_DOCSTRINGS_BASE || "main"
+const JAVASCRIPT_TYPESCRIPT_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx"])
+
+// Diff-only policy: require JSDoc on public/exported runtime declarations, not local callbacks or tests.
+function isJavaScriptTypeScriptFile(filePath) {
+  return JAVASCRIPT_TYPESCRIPT_EXTENSIONS.has(path.extname(filePath))
+}
+
+function isTestFile(filePath) {
+  return /(^|[/\\])__tests__([/\\]|$)/.test(filePath) || /\.(test|spec)\.[jt]sx?$/.test(filePath)
+}
+
+function getScriptKind(filePath) {
+  if (filePath.endsWith(".tsx")) {
+    return ts.ScriptKind.TSX
+  }
+  if (filePath.endsWith(".jsx")) {
+    return ts.ScriptKind.JSX
+  }
+  if (filePath.endsWith(".js")) {
+    return ts.ScriptKind.JS
+  }
+  return ts.ScriptKind.TS
+}
+
+function hasExportModifier(node) {
+  return Boolean(
+    node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+  )
+}
+
+function getIdentifierText(name) {
+  return name && ts.isIdentifier(name) ? name.text : null
+}
+
+function getVariableStatement(node) {
+  return ts.isVariableDeclaration(node) &&
+    node.parent &&
+    ts.isVariableDeclarationList(node.parent) &&
+    node.parent.parent &&
+    ts.isVariableStatement(node.parent.parent)
+    ? node.parent.parent
+    : null
+}
+
+function hasJsDoc(node) {
+  const commentTargets = [node]
+  const variableStatement = getVariableStatement(node)
+
+  if (variableStatement) {
+    commentTargets.push(variableStatement)
+  }
+
+  return commentTargets.some((target) => ts.getJSDocCommentsAndTags(target).length > 0)
+}
+
+function declarationKind(node) {
+  if (ts.isFunctionDeclaration(node)) {
+    return "function"
+  }
+  if (ts.isClassDeclaration(node)) {
+    return "class"
+  }
+  if (ts.isVariableDeclaration(node)) {
+    return "variable"
+  }
+  return "declaration"
+}
+
+function declarationStartNode(node) {
+  return getVariableStatement(node) || node
+}
+
+function makeViolation(sourceFile, node, filePath, name) {
+  const startNode = declarationStartNode(node)
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(startNode.getStart(sourceFile))
+
+  return {
+    filePath,
+    line: line + 1,
+    column: character + 1,
+    kind: declarationKind(node),
+    name,
+  }
+}
+
+function collectTopLevelDeclarations(sourceFile) {
+  const declarations = new Map()
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement)) {
+      const name = getIdentifierText(statement.name)
+
+      if (name) {
+        declarations.set(name, statement)
+      }
+      continue
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        const name = getIdentifierText(declaration.name)
+
+        if (name) {
+          declarations.set(name, declaration)
+        }
+      }
+    }
+  }
+
+  return declarations
+}
+
+function findMissingJsDocViolations(source, filePath) {
+  if (isTestFile(filePath)) {
+    return []
+  }
+
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(filePath)
+  )
+  const topLevelDeclarations = collectTopLevelDeclarations(sourceFile)
+  const violations = []
+  const visited = new Set()
+
+  function addViolation(node, name) {
+    const key = `${node.pos}:${name}`
+
+    if (visited.has(key) || hasJsDoc(node)) {
+      return
+    }
+
+    visited.add(key)
+    violations.push(makeViolation(sourceFile, node, filePath, name))
+  }
+
+  for (const statement of sourceFile.statements) {
+    if ((ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement)) && hasExportModifier(statement)) {
+      addViolation(statement, getIdentifierText(statement.name) || "default")
+      continue
+    }
+
+    if (ts.isVariableStatement(statement) && hasExportModifier(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        const name = getIdentifierText(declaration.name)
+
+        if (name) {
+          addViolation(declaration, name)
+        }
+      }
+      continue
+    }
+
+    if (
+      ts.isExportDeclaration(statement) &&
+      statement.exportClause &&
+      ts.isNamedExports(statement.exportClause) &&
+      !statement.moduleSpecifier
+    ) {
+      for (const element of statement.exportClause.elements) {
+        const localName = (element.propertyName || element.name).text
+        const exportedDeclaration = topLevelDeclarations.get(localName)
+
+        if (exportedDeclaration) {
+          addViolation(exportedDeclaration, localName)
+        }
+      }
+    }
+  }
+
+  return violations
+}
+
+function formatViolations(violations) {
+  return violations
+    .map(
+      (violation) =>
+        `${violation.filePath}:${violation.line}:${violation.column} exported ${violation.kind} ${violation.name} requires JSDoc`
+    )
+    .join("\n")
+}
+
+function collectChangedJavaScriptTypeScriptFiles(
+  baseRef = DEFAULT_BASE_REF,
+  { runGitImpl = runGit, fileExists = fs.existsSync } = {}
+) {
+  return collectChangedFiles(baseRef, {
+    runGitImpl,
+    includeFile: (filePath) => isJavaScriptTypeScriptFile(filePath) && !isTestFile(filePath),
+    fileExists,
+  })
+}
+
+function scanFiles(filePaths) {
+  return filePaths.flatMap((filePath) => {
+    const source = fs.readFileSync(filePath, "utf8")
+    return findMissingJsDocViolations(source, filePath)
+  })
+}
+
+function main() {
+  let filePaths
+
+  try {
+    filePaths = collectChangedJavaScriptTypeScriptFiles(process.argv[2] || DEFAULT_BASE_REF)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Unable to determine changed JavaScript/TypeScript source files: ${message}`)
+    process.exitCode = 1
+    return
+  }
+
+  if (filePaths.length === 0) {
+    console.log("No changed JavaScript/TypeScript source files to scan for exported JSDoc.")
+    return
+  }
+
+  const violations = scanFiles(filePaths)
+
+  if (violations.length === 0) {
+    console.log("No missing exported JSDoc found in changed JavaScript/TypeScript source files.")
+    console.log(
+      "Policy: this diff-only gate requires JSDoc only for public/exported functions, classes, and variables; private helpers, component-local callbacks, and tests are ignored."
+    )
+    return
+  }
+
+  console.error(formatViolations(violations))
+  console.error(
+    `Found ${violations.length} exported declaration${violations.length === 1 ? "" : "s"} without JSDoc in changed JavaScript/TypeScript source files.`
+  )
+  process.exitCode = 1
+}
+
+module.exports = {
+  collectChangedJavaScriptTypeScriptFiles,
+  findMissingJsDocViolations,
+  formatViolations,
+  getCommittedChangedFiles,
+  isJavaScriptTypeScriptFile,
+  isTestFile,
+  runGit,
+  scanFiles,
+}
+
+if (require.main === module) {
+  main()
+}


### PR DESCRIPTION
## Summary
- add a diff-aware `verify:ts-docstrings` gate for changed `.ts`, `.tsx`, `.js`, and `.jsx` source files
- require JSDoc only for public/exported runtime declarations while skipping tests and component-local/private callbacks
- wire the gate into Lefthook pre-commit and pre-push

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- scripts/__tests__/check-ts-docstrings-in-diff.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` (skipped: no changed app source files)
- `git diff --check`
- `npx lefthook run pre-commit`
- `git push` pre-push hook

Fixes #523

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a diff-aware gate that enforces JSDoc on exported JS/TS declarations in changed files and runs in pre-commit and pre-push to keep public APIs documented. Fixes #523.

- **New Features**
  - Added `verify:ts-docstrings` to require JSDoc on exported functions, classes, and variables in changed `.ts`, `.tsx`, `.js`, and `.jsx` files; ignores tests and local/private callbacks.
  - Implemented in `scripts/check-ts-docstrings-in-diff.js` with tests in `scripts/__tests__/check-ts-docstrings-in-diff.test.ts`.
  - Wired into `lefthook` pre-commit and pre-push; npm scripts added: `verify:ts-docstrings` and `n:verify:ts-docstrings`.

<sup>Written for commit ee59ed7b22037681276c2acd71a7fcc3358fd271. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/531?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

