### PR TITLE
fix: hard-delete DQSS runtime fallback

### DIFF
--- a/docs/device-quota/device-quota-suggestion-service-vm.md
+++ b/docs/device-quota/device-quota-suggestion-service-vm.md
@@ -220,16 +220,18 @@ debug. Qdrant can be added later if one of these becomes true:
 The production rollout path is now:
 
 - `DEVICE_QUOTA_SUGGESTION_PROVIDER=vm` for all facilities.
-- `DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase` only as an operator rollback
-  switch.
-- `NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS` remains unset so async jobs
-  stay enabled by default.
+- Async suggestion jobs are always used by the mapping UI.
+- Supabase remains the source of truth for reading names/categories and for the
+  final `dinh_muc_thiet_bi_link_batch` write path.
 
 In `vm` mode, VM timeout, repeated 5xx, or open-circuit failures must return a
 controlled error to the caller. The route must not automatically runtime-fallback
 to Supabase because that can reintroduce the original Supabase Edge/AI pressure.
-Hard-deleting the old Supabase runtime fallback is tracked separately in #528
-after the all-facility VM rollout has clean soak evidence.
+After #528, this codebase no longer contains the Supabase Edge embedding or
+`hybrid_search_category_batch` suggestion runtime path. Operator rollback means
+redeploying a known-good pre-cleanup release or restoring the previous env and
+release together; the current release cannot be switched back with
+`DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase`.
 
 ### Step 1: Baseline Current Flow
 
@@ -250,11 +252,11 @@ unassigned names.
 
 Add an app-level feature flag:
 
-- `DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase`
 - `DEVICE_QUOTA_SUGGESTION_PROVIDER=vm`
 
-The existing flow remains available only as an operator rollback path by setting
-`DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase`.
+Historical pre-#528 releases could switch back to the Supabase runtime provider.
+Current releases are VM-only; keep a tagged pre-cleanup release available if an
+operator rollback is required.
 
 ### Step 3: Server-Side Route Integration
 
@@ -291,7 +293,8 @@ Go/no-go checks:
 - matched count is comparable to current flow
 - suggestion duration is materially lower
 - no VM OOM or process restart
-- rollback to Supabase provider works by changing the operator env
+- rollback procedure points to a pre-cleanup release, not a runtime provider
+  switch in the current release
 
 ### Step 5: Optional Persistent Cache
 
@@ -316,8 +319,8 @@ Cache invalidation can follow category create/update/import events.
   - regional leaders can preview only within allowed facilities
   - restricted roles cannot call the suggestion route
 - Existing `dinh_muc_thiet_bi_link_batch` remains the only batch write path.
-- A feature flag can switch back to the current Supabase path without redeploying
-  DB schema.
+- Rollback instructions identify the pre-cleanup release/env pair needed to
+  restore the removed Supabase runtime path if an operator rollback is required.
 - VM call behavior is implemented with timeout, bounded retry/backoff, circuit
   breaker, and controlled degraded responses on timeout/5xx/open circuit.
 - Logs include request ID, facility ID, item counts, duration, provider, and
@@ -332,7 +335,7 @@ Cache invalidation can follow category create/update/import events.
   Mitigation: keep all auth/facility checks in the Next.js route and do not give
   the VM service Supabase credentials in phase 1.
 - VM service may become an unmonitored dependency. Mitigation: add health check,
-  uptime monitor, structured logs, restart policy, and fallback provider.
+  uptime monitor, structured logs, restart policy, and release-level rollback.
 - Network latency from app host to VM can offset gains if app remains on Vercel.
   Mitigation: still worthwhile because current flow is many calls; if app later
   moves to Coolify, service and app can sit near each other.

--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
@@ -46,21 +46,35 @@ const PREVIEW_RESULT = {
   matchedDevices: 5,
 }
 
-function setupSuccessfulPipeline() {
-  fetchMock.mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        result: PREVIEW_RESULT,
-        meta: {
-          requestId: "req-1",
-          provider: "supabase",
-          itemCounts: { unassignedNames: 3, unassignedDevices: 6, categories: 2 },
-          catalogSignature: "v1-test",
-        },
-      }),
-      { status: 200, headers: { "Content-Type": "application/json" } }
+function setupSuccessfulPipeline(result = PREVIEW_RESULT) {
+  fetchMock
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          job: {
+            id: "job-1",
+            processedUniqueNames: 0,
+            status: "queued",
+            totalUniqueNames: 3,
+          },
+        }),
+        { status: 202, headers: { "Content-Type": "application/json" } },
+      ),
     )
-  )
+    .mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          job: {
+            id: "job-1",
+            processedUniqueNames: 3,
+            result,
+            status: "succeeded",
+            totalUniqueNames: 3,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
 }
 
 describe("useSuggestMapping", () => {
@@ -92,7 +106,7 @@ describe("useSuggestMapping", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  test("falls back to the synchronous preview route when async jobs are disabled", async () => {
+  test("uses async jobs even when the old opt-out env is false", async () => {
     vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
@@ -105,24 +119,23 @@ describe("useSuggestMapping", () => {
       expect(result.current.status).toBe("done")
     })
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/device-quota/mapping/suggest",
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/device-quota/mapping/suggest/jobs",
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ donViId: 1 }),
-      })
+      }),
     )
-    expect(callRpcMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ fn: "dinh_muc_thiet_bi_unassigned_names" })
-    )
-    expect(callRpcMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({ fn: "hybrid_search_category_batch" })
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/device-quota/mapping/suggest/jobs/job-1/process",
+      expect.objectContaining({ method: "POST" }),
     )
   })
 
   test("merges results into groups by nhom_id", async () => {
-    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -148,7 +161,6 @@ describe("useSuggestMapping", () => {
   })
 
   test("separates unmatched devices", async () => {
-    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -167,7 +179,6 @@ describe("useSuggestMapping", () => {
   })
 
   test("tracks total and matched device counts", async () => {
-    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -185,7 +196,6 @@ describe("useSuggestMapping", () => {
   })
 
   test("sets error status on network error", async () => {
-    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     fetchMock.mockRejectedValue(new Error("Network error"))
 
     const { result } = renderHook(() =>
@@ -200,8 +210,7 @@ describe("useSuggestMapping", () => {
     expect(result.current.error).toBe("Network error")
   })
 
-  test("sets error status on server-side preview failure", async () => {
-    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
+  test("sets error status on server-side job failure", async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ error: "Preview failed", requestId: "req-err" }), {
         status: 500,
@@ -222,7 +231,6 @@ describe("useSuggestMapping", () => {
   })
 
   test("reset clears result and returns to idle", async () => {
-    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const { result } = renderHook(() =>
@@ -243,8 +251,7 @@ describe("useSuggestMapping", () => {
     expect(result.current.error).toBeNull()
   })
 
-  test("passes the server-side preview result through unchanged", async () => {
-    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
+  test("passes the server-side job result through unchanged", async () => {
     const serverResult = {
       groups: [
         {
@@ -265,12 +272,7 @@ describe("useSuggestMapping", () => {
       totalDevices: 6,
       matchedDevices: 5,
     }
-    fetchMock.mockResolvedValue(
-      new Response(
-        JSON.stringify({ result: serverResult }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      )
-    )
+    setupSuccessfulPipeline(serverResult)
 
     const { result } = renderHook(() =>
       useSuggestMapping({ donViId: 1, enabled: true }),
@@ -286,7 +288,6 @@ describe("useSuggestMapping", () => {
   })
 
   test("auto-resets to idle when enabled becomes false after pipeline started", async () => {
-    vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
     setupSuccessfulPipeline()
 
     const wrapper = createWrapper()
@@ -321,7 +322,6 @@ describe("useSuggestMapping", () => {
     }
 
     test("calls dinh_muc_thiet_bi_link_batch RPC with correct payload", async () => {
-      vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.resolve(SAVE_RESULT)
@@ -358,7 +358,6 @@ describe("useSuggestMapping", () => {
     })
 
     test("transitions through saving → saved status lifecycle", async () => {
-      vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
       setupSuccessfulPipeline()
 
       let resolveSave: (value: unknown) => void
@@ -395,7 +394,6 @@ describe("useSuggestMapping", () => {
     })
 
     test("exposes save result with affected and skipped counts", async () => {
-      vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.resolve(SAVE_RESULT)
@@ -421,7 +419,6 @@ describe("useSuggestMapping", () => {
     })
 
     test("sets saveError on RPC failure", async () => {
-      vi.stubEnv("NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS", "false")
       setupSuccessfulPipeline()
       callRpcMock.mockImplementation(({ fn }: { fn: string }) => {
         if (fn === "dinh_muc_thiet_bi_link_batch") return Promise.reject(new Error("Permission denied"))

--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMapping.test.ts
@@ -211,12 +211,26 @@ describe("useSuggestMapping", () => {
   })
 
   test("sets error status on server-side job failure", async () => {
-    fetchMock.mockResolvedValue(
-      new Response(JSON.stringify({ error: "Preview failed", requestId: "req-err" }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      })
-    )
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            job: {
+              id: "job-1",
+              processedUniqueNames: 0,
+              status: "queued",
+              totalUniqueNames: 3,
+            },
+          }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Preview failed", requestId: "req-err" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
 
     const { result } = renderHook(() =>
       useSuggestMapping({ donViId: 1, enabled: true }),

--- a/src/app/(app)/device-quota/mapping/__tests__/useSuggestMappingJobClient.test.ts
+++ b/src/app/(app)/device-quota/mapping/__tests__/useSuggestMappingJobClient.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test, vi } from "vitest"
 
-import { waitForNextJobTick } from "../_hooks/useSuggestMappingJobClient"
+import {
+  getJobResult,
+  waitForNextJobTick,
+  type SuggestionJob,
+} from "../_hooks/useSuggestMappingJobClient"
 
 describe("useSuggestMappingJobClient", () => {
   afterEach(() => {
@@ -17,5 +21,18 @@ describe("useSuggestMappingJobClient", () => {
     await tick
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function))
+  })
+
+  test("rejects completed jobs with malformed result payloads", () => {
+    const job = {
+      error: null,
+      id: "job-1",
+      processedUniqueNames: 1,
+      result: { groups: [], unmatched: [] },
+      status: "succeeded",
+      totalUniqueNames: 1,
+    } as unknown as SuggestionJob
+
+    expect(() => getJobResult(job)).toThrow("Suggestion job completed without a valid result")
   })
 })

--- a/src/app/(app)/device-quota/mapping/_hooks/useSuggestMapping.ts
+++ b/src/app/(app)/device-quota/mapping/_hooks/useSuggestMapping.ts
@@ -7,11 +7,9 @@ import { useMutation } from "@tanstack/react-query"
 import { callRpc } from "@/lib/rpc-client"
 import {
   createSuggestionJobRequest,
-  fetchSuggestedMapping,
   getJobFailureMessage,
   getJobResult,
   getProgressPercent,
-  isAsyncSuggestionJobEnabled,
   processSuggestionJobRequest,
   retrySuggestionJobRequest,
   waitForNextJobTick,
@@ -70,6 +68,7 @@ interface UseSuggestMappingOptions {
 // Hook
 // ============================================
 
+/** Runs the device-quota suggestion preview through the async job pipeline. */
 export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions) {
   const [pipelineStatus, setPipelineStatus] = useState<SuggestMappingStatus>("idle")
   const [progress, setProgress] = useState(0)
@@ -138,15 +137,8 @@ export function useSuggestMapping({ donViId, enabled }: UseSuggestMappingOptions
         return waitForSuggestionJob(retryJob, signal)
       }
 
-      if (isAsyncSuggestionJobEnabled()) {
-        const job = await createSuggestionJobRequest(dvId, signal)
-        return waitForSuggestionJob(job, signal)
-      }
-
-      setPipelineStatus("processing")
-      const result = await fetchSuggestedMapping(dvId, signal)
-      if (signal.aborted) throw new DOMException("Aborted", "AbortError")
-      return result
+      const job = await createSuggestionJobRequest(dvId, signal)
+      return waitForSuggestionJob(job, signal)
     },
     onSuccess: () => {
       if (!abortRef.current?.signal.aborted) {

--- a/src/app/(app)/device-quota/mapping/_hooks/useSuggestMappingJobClient.ts
+++ b/src/app/(app)/device-quota/mapping/_hooks/useSuggestMappingJobClient.ts
@@ -28,13 +28,6 @@ function getRouteErrorMessage(status: number, payload: unknown): string {
   return `Suggestion preview failed (${status})`
 }
 
-function getRouteResult(payload: unknown): SuggestMappingResult {
-  if (isRecord(payload) && isRecord(payload.result)) {
-    return payload.result as unknown as SuggestMappingResult
-  }
-  throw new Error("Invalid suggestion preview response")
-}
-
 function getRouteJob(payload: unknown): SuggestionJob {
   if (!isRecord(payload) || !isRecord(payload.job)) {
     throw new Error("Invalid suggestion job response")
@@ -85,25 +78,25 @@ async function postJson(
   return payload
 }
 
-export function isAsyncSuggestionJobEnabled(): boolean {
-  return process.env.NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS !== "false"
-}
-
+/** Converts job progress counters into a bounded UI progress percentage. */
 export function getProgressPercent(job: SuggestionJob): number {
   if (job.status === "succeeded") return 100
   if (job.totalUniqueNames <= 0) return 0
   return Math.min(99, Math.round((job.processedUniqueNames / job.totalUniqueNames) * 100))
 }
 
+/** Returns the completed job result or raises when the server contract is invalid. */
 export function getJobResult(job: SuggestionJob): SuggestMappingResult {
   if (job.result) return job.result
   throw new Error("Suggestion job completed without a result")
 }
 
+/** Returns a localized fallback message for failed suggestion jobs. */
 export function getJobFailureMessage(job: SuggestionJob): string {
   return job.error ?? "Không thể tạo gợi ý phân loại. Vui lòng thử lại."
 }
 
+/** Waits before the next job polling tick while honoring cancellation. */
 export function waitForNextJobTick(signal: AbortSignal): Promise<void> {
   const delayMs = process.env.NODE_ENV === "test" ? 0 : 800
   return new Promise((resolve, reject) => {
@@ -124,29 +117,7 @@ export function waitForNextJobTick(signal: AbortSignal): Promise<void> {
   })
 }
 
-export async function fetchSuggestedMapping(
-  donViId: number,
-  signal: AbortSignal,
-): Promise<SuggestMappingResult> {
-  const response = await fetch("/api/device-quota/mapping/suggest", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ donViId }),
-    signal,
-  })
-
-  let payload: unknown = null
-  try {
-    payload = await response.json()
-  } catch {}
-
-  if (!response.ok) {
-    throw new Error(getRouteErrorMessage(response.status, payload))
-  }
-
-  return getRouteResult(payload)
-}
-
+/** Creates or reuses a server-side suggestion job for one facility. */
 export async function createSuggestionJobRequest(
   donViId: number,
   signal: AbortSignal,
@@ -155,6 +126,7 @@ export async function createSuggestionJobRequest(
   return getRouteJob(payload)
 }
 
+/** Advances one bounded processing slice for an existing suggestion job. */
 export async function processSuggestionJobRequest(
   jobId: string,
   signal: AbortSignal,
@@ -167,6 +139,7 @@ export async function processSuggestionJobRequest(
   return getRouteJob(payload)
 }
 
+/** Retries a failed suggestion job so the UI can resume polling. */
 export async function retrySuggestionJobRequest(
   jobId: string,
   signal: AbortSignal,

--- a/src/app/(app)/device-quota/mapping/_hooks/useSuggestMappingJobClient.ts
+++ b/src/app/(app)/device-quota/mapping/_hooks/useSuggestMappingJobClient.ts
@@ -48,10 +48,20 @@ function getRouteJob(payload: unknown): SuggestionJob {
     error: typeof job.error === "string" ? job.error : null,
     id: job.id,
     processedUniqueNames: job.processedUniqueNames,
-    result: isRecord(job.result) ? (job.result as unknown as SuggestMappingResult) : null,
+    result: isSuggestMappingResult(job.result) ? job.result : null,
     status: job.status,
     totalUniqueNames: job.totalUniqueNames,
   }
+}
+
+function isSuggestMappingResult(value: unknown): value is SuggestMappingResult {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.groups) &&
+    Array.isArray(value.unmatched) &&
+    typeof value.totalDevices === "number" &&
+    typeof value.matchedDevices === "number"
+  )
 }
 
 async function postJson(
@@ -87,8 +97,8 @@ export function getProgressPercent(job: SuggestionJob): number {
 
 /** Returns the completed job result or raises when the server contract is invalid. */
 export function getJobResult(job: SuggestionJob): SuggestMappingResult {
-  if (job.result) return job.result
-  throw new Error("Suggestion job completed without a result")
+  if (isSuggestMappingResult(job.result)) return job.result
+  throw new Error("Suggestion job completed without a valid result")
 }
 
 /** Returns a localized fallback message for failed suggestion jobs. */

--- a/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
@@ -156,7 +156,6 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).toHaveBeenCalledWith(
       expect.objectContaining({
         donViId: 17,
-        provider: "vm",
       })
     )
 
@@ -182,7 +181,6 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).toHaveBeenCalledWith(
       expect.objectContaining({
         donViId: 17,
-        provider: "vm",
       })
     )
     expect(await response.json()).toEqual(
@@ -204,7 +202,6 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).toHaveBeenCalledWith(
       expect.objectContaining({
         donViId: 21,
-        provider: "vm",
       })
     )
     expect(await response.json()).toEqual(
@@ -227,7 +224,6 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).toHaveBeenCalledWith(
       expect.objectContaining({
         donViId: 17,
-        provider: "vm",
       })
     )
     expect(await response.json()).toEqual(
@@ -250,7 +246,6 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).toHaveBeenCalledWith(
       expect.objectContaining({
         donViId: 18,
-        provider: "vm",
       })
     )
     expect(await response.json()).toEqual(

--- a/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts
@@ -147,7 +147,7 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).not.toHaveBeenCalled()
   })
 
-  test("invokes the Supabase provider once and preserves preview semantics", async () => {
+  test("invokes the VM provider once by default and preserves preview semantics", async () => {
     const { POST } = await import("@/app/api/device-quota/mapping/suggest/route")
     const response = await POST(createRequest({ donViId: 17 }))
 
@@ -156,7 +156,7 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).toHaveBeenCalledWith(
       expect.objectContaining({
         donViId: 17,
-        provider: "supabase",
+        provider: "vm",
       })
     )
 
@@ -164,7 +164,7 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(body.result).toEqual(PREVIEW_RESULT)
     expect(body.meta).toEqual(
       expect.objectContaining({
-        provider: "supabase",
+        provider: "vm",
         requestId: expect.any(String),
         catalogSignature: "catalog-123",
         itemCounts: { unassignedNames: 1, unassignedDevices: 2, categories: 3 },
@@ -239,7 +239,7 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     )
   })
 
-  test("keeps Supabase for canary facilities outside the allow-list", async () => {
+  test("uses VM for canary facilities outside the allow-list after all-unit rollout", async () => {
     vi.stubEnv("DEVICE_QUOTA_SUGGESTION_PROVIDER", "canary")
     vi.stubEnv("DEVICE_QUOTA_SUGGESTION_CANARY_DON_VI_IDS", "17,21")
 
@@ -250,13 +250,13 @@ describe("POST /api/device-quota/mapping/suggest", () => {
     expect(runSuggestMappingMock).toHaveBeenCalledWith(
       expect.objectContaining({
         donViId: 18,
-        provider: "supabase",
+        provider: "vm",
       })
     )
     expect(await response.json()).toEqual(
       expect.objectContaining({
         meta: expect.objectContaining({
-          provider: "supabase",
+          provider: "vm",
         }),
       })
     )
@@ -272,7 +272,7 @@ describe("POST /api/device-quota/mapping/suggest", () => {
         requestId: expect.any(String),
         donViId: 17,
         role: "to_qltb",
-        provider: "supabase",
+        provider: "vm",
         status: "success",
         durationMs: expect.any(Number),
       })
@@ -293,7 +293,7 @@ describe("POST /api/device-quota/mapping/suggest", () => {
         requestId: expect.any(String),
         donViId: 17,
         role: "to_qltb",
-        provider: "supabase",
+        provider: "vm",
         status: "error",
         failureReason: "provider failed",
         durationMs: expect.any(Number),

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-guardrails.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-guardrails.test.ts
@@ -93,7 +93,7 @@ describe("device quota suggestion guardrails", () => {
       ],
     })
 
-    const result = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    const result = await runSuggestMapping({ donViId: 17, user: USER })
 
     expect(result.result.groups).toEqual([])
     expect(result.result.unmatched).toEqual([
@@ -138,7 +138,7 @@ describe("device quota suggestion guardrails", () => {
       ],
     })
 
-    const result = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    const result = await runSuggestMapping({ donViId: 17, user: USER })
 
     expect(result.result.groups).toEqual([])
     expect(result.result.unmatched).toEqual([

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 import fs from "fs"
+import path from "path"
 
 const callVmSuggestMock = vi.hoisted(() => vi.fn())
 vi.mock("@/app/api/device-quota/mapping/suggest/suggestion-vm-client", () => ({
@@ -26,6 +27,17 @@ const USER = {
   role: "to_qltb",
   don_vi: "17",
   dia_ban_id: null,
+}
+
+function collectSuggestionSourceFiles(dirPath: string): string[] {
+  return fs.readdirSync(dirPath, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === "__tests__") return []
+
+    const entryPath = path.join(dirPath, entry.name)
+    if (entry.isDirectory()) return collectSuggestionSourceFiles(entryPath)
+    if (entry.isFile() && /\.[tj]sx?$/.test(entry.name)) return [entryPath]
+    return []
+  })
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -143,7 +155,6 @@ describe("device quota suggestion service", () => {
 
     expect(selectSuggestionProvider(17)).toMatchObject({
       configuredProvider: "vm",
-      provider: "vm",
       policy: "default",
     })
   })
@@ -154,7 +165,6 @@ describe("device quota suggestion service", () => {
 
     expect(selectSuggestionProvider(17)).toMatchObject({
       configuredProvider: "canary",
-      provider: "vm",
       policy: "canary-vm-default",
     })
   })
@@ -301,7 +311,7 @@ describe("device quota suggestion service", () => {
       .mockResolvedValueOnce(jsonResponse([]))
 
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({
       message: "RPC policy denied",
       details: { code: "42501" },
@@ -344,7 +354,7 @@ describe("device quota suggestion service", () => {
       ],
     })
 
-    const result = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    const result = await runSuggestMapping({ donViId: 17, user: USER })
 
     expect(callVmSuggestMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -390,7 +400,7 @@ describe("device quota suggestion service", () => {
       )
 
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({
       message: "VM suggestion payload is too large",
       status: 413,
@@ -407,10 +417,10 @@ describe("device quota suggestion service", () => {
     queueVmCatalogResponse({})
 
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({ status: 413 })
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({ status: 413 })
 
     expect(callVmSuggestMock).not.toHaveBeenCalled()
@@ -425,13 +435,13 @@ describe("device quota suggestion service", () => {
     )
 
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({ status: 503 })
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({ status: 503 })
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({
       message: "VM suggestion provider circuit is open",
       status: 503,
@@ -452,8 +462,8 @@ describe("device quota suggestion service", () => {
     queueVmCatalogResponses(2)
     callVmSuggestMock.mockResolvedValue(successfulVmResponse())
 
-    const first = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
-    const second = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    const first = await runSuggestMapping({ donViId: 17, user: USER })
+    const second = await runSuggestMapping({ donViId: 17, user: USER })
 
     expect(second).toEqual(first)
     expect(fetchMock).toHaveBeenCalledTimes(4)
@@ -468,8 +478,8 @@ describe("device quota suggestion service", () => {
     })
     callVmSuggestMock.mockResolvedValue(successfulVmResponse())
 
-    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
-    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    await runSuggestMapping({ donViId: 17, user: USER })
+    await runSuggestMapping({ donViId: 17, user: USER })
 
     expect(fetchMock).toHaveBeenCalledTimes(4)
     expect(callVmSuggestMock).toHaveBeenCalledTimes(2)
@@ -480,7 +490,7 @@ describe("device quota suggestion service", () => {
       categories: [],
     })
 
-    const result = await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    const result = await runSuggestMapping({ donViId: 17, user: USER })
 
     expect(callVmSuggestMock).not.toHaveBeenCalled()
     expect(result.result).toEqual({
@@ -499,10 +509,10 @@ describe("device quota suggestion service", () => {
     )
 
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({ status: 503 })
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({
       message: "Suggestion request cooldown is active",
       status: 429,
@@ -519,10 +529,10 @@ describe("device quota suggestion service", () => {
     queueVmCatalogResponses(3)
     callVmSuggestMock.mockResolvedValue(successfulVmResponse())
 
-    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
-    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    await runSuggestMapping({ donViId: 17, user: USER })
+    await runSuggestMapping({ donViId: 17, user: USER })
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+      runSuggestMapping({ donViId: 17, user: USER })
     ).rejects.toMatchObject({
       message: "Suggestion request rate limit exceeded",
       status: 429,
@@ -541,13 +551,12 @@ describe("device quota suggestion service", () => {
     queueVmCatalogResponse({})
     callVmSuggestMock.mockResolvedValue(successfulVmResponse())
 
-    await runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
+    await runSuggestMapping({ donViId: 17, user: USER })
     expect(getSuggestionRuntimeStateSizeForTests().throttleEntries).toBe(1)
 
     vi.setSystemTime(new Date("2026-05-18T00:00:02Z"))
     await runSuggestMapping({
       donViId: 18,
-      provider: "vm",
       user: { ...USER, id: "2", don_vi: "18" },
     })
 
@@ -555,12 +564,9 @@ describe("device quota suggestion service", () => {
   })
 
   test("has no Supabase Edge embedding or hybrid-search suggestion runtime path", () => {
-    const source = [
-      "src/app/api/device-quota/mapping/suggest/suggestion-service.ts",
-      "src/app/api/device-quota/mapping/suggest/suggestion-supabase-provider.ts",
-      "src/app/api/device-quota/mapping/suggest/suggestion-types.ts",
-    ]
-      .map((filePath) => fs.readFileSync(`${process.cwd()}/${filePath}`, "utf8"))
+    const suggestSourceDir = path.join(process.cwd(), "src/app/api/device-quota/mapping/suggest")
+    const source = collectSuggestionSourceFiles(suggestSourceDir)
+      .map((filePath) => fs.readFileSync(filePath, "utf8"))
       .join("\n")
 
     expect(source).not.toContain("runSupabaseSuggestMapping")

--- a/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
+++ b/src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import fs from "fs"
 
 const callVmSuggestMock = vi.hoisted(() => vi.fn())
 vi.mock("@/app/api/device-quota/mapping/suggest/suggestion-vm-client", () => ({
@@ -300,30 +301,11 @@ describe("device quota suggestion service", () => {
       .mockResolvedValueOnce(jsonResponse([]))
 
     await expect(
-      runSuggestMapping({ donViId: 17, provider: "supabase", user: USER })
+      runSuggestMapping({ donViId: 17, provider: "vm", user: USER })
     ).rejects.toMatchObject({
       message: "RPC policy denied",
       details: { code: "42501" },
     })
-  })
-
-  test("fails before search when embedding response count is incomplete", async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse([
-          { ten_thiet_bi: "May tho", device_count: 1, device_ids: [1] },
-          { ten_thiet_bi: "Bom tiem", device_count: 1, device_ids: [2] },
-        ])
-      )
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse({ embeddings: [[0.1, 0.2]] }))
-      .mockResolvedValueOnce(jsonResponse([]))
-
-    await expect(
-      runSuggestMapping({ donViId: 17, provider: "supabase", user: USER })
-    ).rejects.toThrow("Embedding response count mismatch")
-
-    expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
   test("bundles minimal VM payload and does not call Supabase embedding or hybrid search", async () => {
@@ -570,5 +552,20 @@ describe("device quota suggestion service", () => {
     })
 
     expect(getSuggestionRuntimeStateSizeForTests().throttleEntries).toBe(1)
+  })
+
+  test("has no Supabase Edge embedding or hybrid-search suggestion runtime path", () => {
+    const source = [
+      "src/app/api/device-quota/mapping/suggest/suggestion-service.ts",
+      "src/app/api/device-quota/mapping/suggest/suggestion-supabase-provider.ts",
+      "src/app/api/device-quota/mapping/suggest/suggestion-types.ts",
+    ]
+      .map((filePath) => fs.readFileSync(`${process.cwd()}/${filePath}`, "utf8"))
+      .join("\n")
+
+    expect(source).not.toContain("runSupabaseSuggestMapping")
+    expect(source).not.toContain("/functions/v1/embed-device-name")
+    expect(source).not.toContain("hybrid_search_category_batch")
+    expect(source).not.toContain('"supabase" | "vm"')
   })
 })

--- a/src/app/api/device-quota/mapping/suggest/route.ts
+++ b/src/app/api/device-quota/mapping/suggest/route.ts
@@ -10,6 +10,7 @@ import {
 import { selectSuggestionProvider } from "@/app/api/device-quota/mapping/suggest/suggestion-config"
 import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 
+/** Runs suggestion preview on the Node.js runtime because it calls internal services. */
 export const runtime = "nodejs"
 
 function createRequestId(): string {
@@ -56,6 +57,7 @@ function getUserRole(user: SuggestionAccessUser | null): string | null {
   return typeof user?.role === "string" ? user.role.toLowerCase() : null
 }
 
+/** Handles a synchronous suggestion preview request through the VM-backed provider. */
 export async function POST(request: NextRequest) {
   const requestId = createRequestId()
   const startedAt = Date.now()
@@ -90,7 +92,6 @@ export async function POST(request: NextRequest) {
     const providerSelection = selectSuggestionProvider(donViId)
     const providerResult = await runSuggestMapping({
       donViId,
-      provider: providerSelection.provider,
       requestId,
       user,
     })

--- a/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
@@ -3,7 +3,6 @@ import { createCatalogSignature, mergeSuggestionResults } from "@/app/api/device
 import {
   assertSuggestionAccess,
   lookupAccessibleFacilityIds,
-  runSupabaseSuggestMapping,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-supabase-provider"
 import {
   getSuggestionRuntimeStateSizeForTests,
@@ -21,9 +20,9 @@ export { createCatalogSignature, mergeSuggestionResults }
 export { assertSuggestionAccess, lookupAccessibleFacilityIds }
 export { getSuggestionRuntimeStateSizeForTests, resetSuggestionRuntimeStateForTests }
 
+/** Runs the VM-backed suggestion provider for the requested facility. */
 export async function runSuggestMapping({
   donViId,
-  provider,
   requestId,
   user,
 }: {
@@ -32,10 +31,6 @@ export async function runSuggestMapping({
   requestId?: string
   user: SuggestionAccessUser
 }): Promise<SuggestionProviderResult> {
-  if (provider === "supabase") {
-    return runSupabaseSuggestMapping({ donViId, user })
-  }
-
   return runVmSuggestMapping({
     donViId,
     requestId: requestId ?? `dqss-${Date.now().toString(36)}`,

--- a/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-service.ts
@@ -11,7 +11,6 @@ import {
 import { runVmSuggestMapping } from "@/app/api/device-quota/mapping/suggest/suggestion-vm-provider"
 import type {
   SuggestionAccessUser,
-  SuggestionProvider,
   SuggestionProviderResult,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 
@@ -27,7 +26,6 @@ export async function runSuggestMapping({
   user,
 }: {
   donViId: number
-  provider: SuggestionProvider
   requestId?: string
   user: SuggestionAccessUser
 }): Promise<SuggestionProviderResult> {

--- a/src/app/api/device-quota/mapping/suggest/suggestion-supabase-provider.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-supabase-provider.ts
@@ -6,18 +6,9 @@ import {
   getPayloadMessage,
   SuggestionRouteError,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-errors"
-import { createCatalogSignature, mergeSuggestionResults } from "@/app/api/device-quota/mapping/suggest/suggestion-merge"
-import type {
-  DinhMucNhomRow,
-  SearchResult,
-  SuggestionAccessUser,
-  SuggestionProviderResult,
-  UnassignedName,
-} from "@/app/api/device-quota/mapping/suggest/suggestion-types"
+import type { SuggestionAccessUser } from "@/app/api/device-quota/mapping/suggest/suggestion-types"
 import {
-  chunkArray,
   getRequiredEnv,
-  SUPABASE_SEARCH_CHUNK_SIZE,
   toNumber,
   toRole,
 } from "@/app/api/device-quota/mapping/suggest/suggestion-utils"
@@ -91,6 +82,7 @@ async function fetchWithTimeout(
   }
 }
 
+/** Calls a Supabase RPC with the user's scoped JWT claims. */
 export async function callSupabaseRpc<TRes>(
   fn: string,
   args: Record<string, unknown>,
@@ -127,6 +119,7 @@ export async function callSupabaseRpc<TRes>(
   return (await response.json()) as TRes
 }
 
+/** Lists facilities the current user may access for suggestion preview. */
 export async function lookupAccessibleFacilityIds(user: SuggestionAccessUser): Promise<number[]> {
   const rows = await callSupabaseRpc<unknown>("get_accessible_facilities", {}, user)
   if (!Array.isArray(rows)) return []
@@ -140,6 +133,7 @@ export async function lookupAccessibleFacilityIds(user: SuggestionAccessUser): P
   return ids
 }
 
+/** Enforces role and facility scope before suggestion work starts. */
 export async function assertSuggestionAccess(
   user: SuggestionAccessUser,
   donViId: number,
@@ -170,110 +164,5 @@ export async function assertSuggestionAccess(
 
   if (toNumber(user.don_vi) !== donViId) {
     throw new SuggestionRouteError("Forbidden: facility scope denied", 403)
-  }
-}
-
-async function fetchEmbeddings(texts: string[]): Promise<number[][]> {
-  const supabaseUrl = getRequiredEnv("NEXT_PUBLIC_SUPABASE_URL")
-  const serviceRoleKey = getRequiredEnv("SUPABASE_SERVICE_ROLE_KEY")
-  const embeddings: number[][] = []
-
-  for (const chunk of chunkArray(texts, SUPABASE_SEARCH_CHUNK_SIZE)) {
-    const response = await fetchWithTimeout(
-      `${supabaseUrl}/functions/v1/embed-device-name`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${serviceRoleKey}`,
-        },
-        body: JSON.stringify({ texts: chunk }),
-      },
-      "Supabase embedding generation timed out",
-    )
-
-    if (!response.ok) {
-      throw new Error(`Embedding generation failed (${response.status})`)
-    }
-
-    const body = (await response.json()) as { embeddings?: number[][] }
-    if (!Array.isArray(body.embeddings)) {
-      throw new Error("Invalid embedding response")
-    }
-    embeddings.push(...body.embeddings)
-  }
-
-  return embeddings
-}
-
-async function searchCategories(
-  queries: { text: string; embedding: number[] }[],
-  donViId: number,
-  user: SuggestionAccessUser,
-): Promise<SearchResult[]> {
-  const allResults: SearchResult[] = []
-  for (const chunk of chunkArray(queries, SUPABASE_SEARCH_CHUNK_SIZE)) {
-    const p_queries = chunk.map((query) => ({
-      text: query.text,
-      embedding: query.embedding,
-    }))
-    const results = await callSupabaseRpc<SearchResult[]>(
-      "hybrid_search_category_batch",
-      { p_queries, p_don_vi: donViId },
-      user,
-    )
-    allResults.push(...(results ?? []))
-  }
-  return allResults
-}
-
-export async function runSupabaseSuggestMapping({
-  donViId,
-  user,
-}: {
-  donViId: number
-  user: SuggestionAccessUser
-}): Promise<SuggestionProviderResult> {
-  const [names, categories] = await Promise.all([
-    callSupabaseRpc<UnassignedName[]>(
-      "dinh_muc_thiet_bi_unassigned_names",
-      { p_don_vi: donViId },
-      user,
-    ),
-    callSupabaseRpc<DinhMucNhomRow[]>("dinh_muc_nhom_list", { p_don_vi: donViId }, user),
-  ])
-
-  const catalogSignature = createCatalogSignature(categories)
-  const itemCounts = {
-    unassignedNames: names.length,
-    unassignedDevices: names.reduce((sum, name) => sum + name.device_ids.length, 0),
-    categories: categories.length,
-  }
-
-  if (names.length === 0) {
-    return {
-      result: { groups: [], unmatched: [], totalDevices: 0, matchedDevices: 0 },
-      itemCounts,
-      catalogSignature,
-    }
-  }
-
-  const texts = names.map((name) => name.ten_thiet_bi)
-  const embeddings = await fetchEmbeddings(texts)
-  if (embeddings.length !== texts.length) {
-    throw new Error(
-      `Embedding response count mismatch: expected ${texts.length}, received ${embeddings.length}`,
-    )
-  }
-  const searchResults = await searchCategories(
-    texts.map((text, index) => ({ text, embedding: embeddings[index]! })),
-    donViId,
-    user,
-  )
-
-  return {
-    result: mergeSuggestionResults(names, searchResults),
-    itemCounts,
-    catalogSignature,
   }
 }

--- a/src/app/api/device-quota/mapping/suggest/suggestion-types.ts
+++ b/src/app/api/device-quota/mapping/suggest/suggestion-types.ts
@@ -1,4 +1,4 @@
-export type SuggestionProvider = "supabase" | "vm"
+export type SuggestionProvider = "vm"
 export type SuggestionProviderMode = SuggestionProvider | "canary"
 
 export type SuggestionAccessUser = {


### PR DESCRIPTION
## Summary
- Remove the Supabase Edge embedding/hybrid-search runtime suggestion provider path.
- Force the mapping UI through async suggestion jobs and remove the old sync opt-out branch.
- Update DQSS rollout/rollback docs so rollback points to a pre-cleanup release, not `DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase` in the current release.

Fixes #528

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/app/api/device-quota/mapping/suggest/__tests__/route.test.ts src/app/api/device-quota/mapping/suggest/__tests__/suggestion-service.test.ts src/app/'(app)'/device-quota/mapping/__tests__/useSuggestMapping.test.ts src/app/'(app)'/device-quota/mapping/__tests__/useSuggestMapping.async-jobs.test.ts
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hard-delete the Supabase runtime fallback for the Device Quota Suggestion Service; the mapping UI now always uses VM-backed async jobs and the server path is VM-only. Docs and tests updated; rollback now requires deploying a pre-cleanup release. Completes the DQSS runtime cleanup in #528.

- **Refactors**
  - Remove Supabase Edge embedding/hybrid-search runtime; `SuggestionProvider` is `"vm"` only and the provider arg is removed across service/route/tests.
  - Force async jobs in the mapping UI; delete the sync preview path, `isAsyncSuggestionJobEnabled`, and `fetchSuggestedMapping`; use `/suggest/jobs` endpoints and honor aborts.
  - Harden job client: validate result shape in `getJobResult`, bound progress, clearer failure messages, and tidy abort listener cleanup.
  - Route/service default to VM on the Node.js runtime; logs/meta report provider `"vm"`; add a guard test ensuring no Supabase runtime code remains.
  - Docs clarify VM-only runtime; Supabase remains SoT for reads and final `dinh_muc_thiet_bi_link_batch` writes.

- **Migration**
  - `DEVICE_QUOTA_SUGGESTION_PROVIDER=supabase` is no longer supported; canary resolves to VM.
  - `NEXT_PUBLIC_DEVICE_QUOTA_SUGGESTION_ASYNC_JOBS` is ignored; remove it.
  - Rollback requires redeploying a pre-cleanup release with the previous env; no runtime switch in current releases.

<sup>Written for commit c72aacd7c278a90d1d0f96df5150964da0616170. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/532?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device quota mapping suggestions now processed through async job pipeline for improved performance and reliability.

* **Documentation**
  * Updated feature flag guidance and rollout instructions for device quota suggestions to reflect VM-only provider implementation, with clarified failure handling and rollback procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->