### PR TITLE
Refactor category import dialog state

### DIFF
--- a/src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
+++ b/src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
@@ -72,6 +72,35 @@ function extractEffectBodies(source: string): string[] {
 }
 
 describe("device quota context React Doctor state guards", () => {
+  it("keeps category import dialog state in a reducer instead of scattered useState calls", () => {
+    const source = readSource(
+      "src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog.tsx"
+    )
+    const dialogSource = extractFunctionSource(source, "DeviceQuotaCategoryImportDialog")
+
+    expect(dialogSource).toMatch(/\b(?:React\.)?useReducer\s*\(/)
+    expect(dialogSource.match(/\b(?:React\.)?useState\s*\(/g) ?? []).toHaveLength(0)
+  })
+
+  it("keeps category import dialog effects to at most one state mutation per effect", () => {
+    const source = readSource(
+      "src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog.tsx"
+    )
+    const dialogSource = extractFunctionSource(source, "DeviceQuotaCategoryImportDialog")
+    const effectBodies = extractEffectBodies(dialogSource)
+
+    expect(effectBodies.length).toBeGreaterThan(0)
+    for (const body of effectBodies) {
+      const stateMutationCount =
+        (body.match(/\bset(?!Timeout\()[A-Z]\w*\(/g) ?? []).length +
+        (body.match(/\bdispatch\(/g) ?? []).length +
+        (body.match(/resetToFirstPage\(/g) ?? []).length +
+        (body.match(/resetParsedState\(/g) ?? []).length
+
+      expect(stateMutationCount).toBeLessThanOrEqual(1)
+    }
+  })
+
   it("keeps category provider UI state in a reducer instead of scattered useState calls", () => {
     const source = readSource(
       "src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryContext.tsx"
@@ -91,7 +120,7 @@ describe("device quota context React Doctor state guards", () => {
     expect(effectBodies.length).toBeGreaterThan(0)
     for (const body of effectBodies) {
       const stateMutationCount =
-        (body.match(/\bset[A-Z][A-Za-z0-9_]*\(/g) ?? []).length +
+        (body.match(/\bset(?!Timeout\()[A-Z]\w*\(/g) ?? []).length +
         (body.match(/resetToFirstPage\(/g) ?? []).length
 
       expect(stateMutationCount).toBeLessThanOrEqual(1)

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryImportDialogState.test.ts
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryImportDialogState.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest"
+
+import type { ImportResult, ParsedCategoryRow } from "@/lib/category-import-validation"
+
+import {
+  importDialogReducer,
+  initialImportDialogState,
+} from "../_components/DeviceQuotaCategoryImportDialogState"
+
+const parsedRow: ParsedCategoryRow = {
+  ma_nhom: "A.01",
+  ten_nhom: "May xet nghiem",
+  parent_ma_nhom: null,
+  phan_loai: null,
+  don_vi_tinh: null,
+  thu_tu_hien_thi: null,
+  mo_ta: null,
+  dinh_muc_toi_da: 5,
+  toi_thieu: 1,
+}
+
+const importResult: ImportResult = {
+  success: true,
+  inserted: 1,
+  failed: 0,
+  total: 1,
+  details: [],
+}
+
+describe("DeviceQuotaCategoryImportDialogState", () => {
+  it("resets all parse and import state", () => {
+    const dirtyState = importDialogReducer(initialImportDialogState, {
+      type: "parse-succeeded",
+      rows: [parsedRow],
+      errors: ["Dong 2 loi"],
+      warnings: ["Trung ma"],
+    })
+
+    expect(importDialogReducer(dirtyState, { type: "reset" })).toEqual(initialImportDialogState)
+  })
+
+  it("stores parsed rows, validation errors, and validation warnings together", () => {
+    const nextState = importDialogReducer(initialImportDialogState, {
+      type: "parse-succeeded",
+      rows: [parsedRow],
+      errors: ["Dong 2 loi"],
+      warnings: ["Trung ma"],
+    })
+
+    expect(nextState).toMatchObject({
+      status: "parsed",
+      parsedRows: [parsedRow],
+      parseError: null,
+      validationErrors: ["Dong 2 loi"],
+      validationWarnings: ["Trung ma"],
+      importResult: null,
+    })
+  })
+
+  it("stores parse failures without stale parsed data", () => {
+    const parsedState = importDialogReducer(initialImportDialogState, {
+      type: "parse-succeeded",
+      rows: [parsedRow],
+      errors: [],
+      warnings: [],
+    })
+
+    expect(importDialogReducer(parsedState, { type: "parse-failed", message: "File bi hong" })).toEqual({
+      ...initialImportDialogState,
+      status: "error",
+      parseError: "File bi hong",
+    })
+  })
+
+  it("tracks import success and partial success from a single result payload", () => {
+    const importingState = importDialogReducer(initialImportDialogState, {
+      type: "import-started",
+      result: importResult,
+    })
+
+    expect(importingState).toMatchObject({
+      status: "importing",
+      importResult,
+    })
+    expect(importDialogReducer(importingState, { type: "import-finished", partial: false }).status).toBe(
+      "success"
+    )
+    expect(importDialogReducer(importingState, { type: "import-finished", partial: true }).status).toBe(
+      "partial_success"
+    )
+  })
+})

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialog.tsx
@@ -9,7 +9,7 @@
  */
 
 import * as React from "react"
-import { FileSpreadsheet, Loader2, Upload, AlertTriangle, CheckCircle2, AlertCircle } from "lucide-react"
+import { FileSpreadsheet, Loader2, Upload } from "lucide-react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 import { Button } from "@/components/ui/button"
@@ -23,22 +23,23 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { useToast } from "@/hooks/use-toast"
 import { callRpc } from "@/lib/rpc-client"
 import { readExcelFile, worksheetToJson } from "@/lib/excel-utils"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
 import { translateRpcError } from "@/lib/error-translations"
-import { toKeyedTexts } from "@/lib/list-key-utils"
 import {
   type ParsedCategoryRow,
   type ImportResult,
-  type ImportStatus,
   validateParsedRows,
   transformExcelHeaders,
 } from "@/lib/category-import-validation"
 import { useDeviceQuotaCategoryContext } from "../_hooks/useDeviceQuotaCategoryContext"
+import { DeviceQuotaCategoryImportDialogAlerts } from "./DeviceQuotaCategoryImportDialogAlerts"
+import {
+  importDialogReducer,
+  initialImportDialogState,
+} from "./DeviceQuotaCategoryImportDialogState"
 
 // ============================================
 // Component
@@ -52,20 +53,8 @@ export function DeviceQuotaCategoryImportDialog() {
   const queryClient = useQueryClient()
   const fileInputRef = React.useRef<HTMLInputElement>(null)
 
-  // State
-  const [status, setStatus] = React.useState<ImportStatus>("idle")
-  const [parsedRows, setParsedRows] = React.useState<ParsedCategoryRow[]>([])
-  const [parseError, setParseError] = React.useState<string | null>(null)
-  const [validationErrors, setValidationErrors] = React.useState<string[]>([])
-  const [validationWarnings, setValidationWarnings] = React.useState<string[]>([])
-  const [importResult, setImportResult] = React.useState<ImportResult | null>(null)
-
-  const resetParsedState = React.useCallback((): void => {
-    setParsedRows([])
-    setParseError(null)
-    setValidationErrors([])
-    setValidationWarnings([])
-  }, [])
+  const [state, dispatch] = React.useReducer(importDialogReducer, initialImportDialogState)
+  const { status, parsedRows, parseError, validationErrors, validationWarnings, importResult } = state
 
   // Existing category codes for duplicate detection
   const existingCodes = React.useMemo(() => {
@@ -76,24 +65,21 @@ export function DeviceQuotaCategoryImportDialog() {
   React.useEffect(() => {
     if (!isImportDialogOpen) {
       const timer = setTimeout(() => {
-        setStatus("idle")
-        resetParsedState()
-        setImportResult(null)
+        dispatch({ type: "reset" })
         if (fileInputRef.current) {
           fileInputRef.current.value = ""
         }
       }, 200)
       return () => clearTimeout(timer)
     }
-  }, [isImportDialogOpen, resetParsedState])
+  }, [isImportDialogOpen])
 
   // File change handler
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0]
     if (!file) return
 
-    setStatus("parsing")
-    resetParsedState()
+    dispatch({ type: "parse-started" })
 
     try {
       const workbook = await readExcelFile(file)
@@ -126,14 +112,18 @@ export function DeviceQuotaCategoryImportDialog() {
 
       const { validRows, errors, warnings } = validateParsedRows(transformedData, existingCodes)
 
-      setParsedRows(validRows)
-      setValidationErrors(errors)
-      setValidationWarnings(warnings)
-      setStatus("parsed")
+      dispatch({
+        type: "parse-succeeded",
+        rows: validRows,
+        errors,
+        warnings,
+      })
     } catch (error) {
       console.error("Failed to parse Excel file:", error)
-      setParseError(getUnknownErrorMessage(error, "Loi doc file Excel"))
-      setStatus("error")
+      dispatch({
+        type: "parse-failed",
+        message: getUnknownErrorMessage(error, "Loi doc file Excel"),
+      })
     }
   }
 
@@ -155,8 +145,7 @@ export function DeviceQuotaCategoryImportDialog() {
       return result
     },
     onSuccess: async (result) => {
-      setStatus("importing")
-      setImportResult(result)
+      dispatch({ type: "import-started", result })
 
       // Check if any rows have quota data for unified import
       const quotaRows = parsedRows.filter(r => r.dinh_muc_toi_da !== null && r.dinh_muc_toi_da > 0)
@@ -202,13 +191,13 @@ export function DeviceQuotaCategoryImportDialog() {
         })
       }
 
-      setStatus(quotaImportFailed ? "partial_success" : "success")
+      dispatch({ type: "import-finished", partial: quotaImportFailed })
 
       // Invalidate queries to refresh category list
       queryClient.invalidateQueries({ queryKey: ["dinh_muc_nhom_list"] })
     },
     onError: (error: Error) => {
-      setStatus("error")
+      dispatch({ type: "import-failed" })
       toast({
         variant: "destructive",
         title: "Nhập thất bại",
@@ -259,130 +248,15 @@ export function DeviceQuotaCategoryImportDialog() {
             />
           </div>
 
-          {/* Parsing indicator */}
-          {status === "parsing" && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="size-4 animate-spin" />
-              Đang đọc file…
-            </div>
-          )}
-
-          {/* Parse error */}
-          {parseError && (
-            <Alert variant="destructive">
-              <AlertTriangle className="size-4" />
-              <AlertTitle>Lỗi đọc file</AlertTitle>
-              <AlertDescription>{parseError}</AlertDescription>
-            </Alert>
-          )}
-
-          {/* Validation errors (blocking - rows were skipped) */}
-          {validationErrors.length > 0 && (
-            <Alert variant="destructive">
-              <AlertTriangle className="size-4" />
-              <AlertTitle>Lỗi dữ liệu - {validationErrors.length} dòng bị bỏ qua</AlertTitle>
-              <AlertDescription>
-                <ScrollArea className="h-32 mt-2">
-                  <ul className="list-disc list-inside space-y-1 text-sm">
-                    {toKeyedTexts(validationErrors.slice(0, 20)).map(({ key, text }) => (
-                      <li key={key}>{text}</li>
-                    ))}
-                    {validationErrors.length > 20 && (
-                      <li className="text-muted-foreground">
-                        … và {validationErrors.length - 20} lỗi khác
-                      </li>
-                    )}
-                  </ul>
-                </ScrollArea>
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* Validation warnings (non-blocking) */}
-          {validationWarnings.length > 0 && (
-            <Alert className="border-yellow-200 bg-yellow-50">
-              <AlertCircle className="size-4 text-yellow-600" />
-              <AlertTitle className="text-yellow-800">Cảnh báo ({validationWarnings.length})</AlertTitle>
-              <AlertDescription className="text-yellow-700">
-                <ScrollArea className="h-24 mt-2">
-                  <ul className="list-disc list-inside space-y-1 text-sm">
-                    {toKeyedTexts(validationWarnings.slice(0, 10)).map(({ key, text }) => (
-                      <li key={key}>{text}</li>
-                    ))}
-                    {validationWarnings.length > 10 && (
-                      <li className="text-yellow-600">
-                        … và {validationWarnings.length - 10} cảnh báo khác
-                      </li>
-                    )}
-                  </ul>
-                </ScrollArea>
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* Parsed successfully */}
-          {status === "parsed" && parsedRows.length > 0 && (
-            <Alert className={validationErrors.length > 0 ? "border-yellow-200 bg-yellow-50" : ""}>
-              <CheckCircle2 className={`size-4 ${validationErrors.length > 0 ? "text-yellow-600" : "text-green-600"}`} />
-              <AlertTitle className={validationErrors.length > 0 ? "text-yellow-800" : ""}>
-                {validationErrors.length > 0 ? "Sẵn sàng nhập (một phần)" : "Sẵn sàng nhập"}
-              </AlertTitle>
-              <AlertDescription className={validationErrors.length > 0 ? "text-yellow-700" : ""}>
-                Đã đọc được {parsedRows.length} danh mục hợp lệ từ file Excel.
-                {validationErrors.length > 0 && (
-                  <span className="text-red-600"> ({validationErrors.length} dòng bị bỏ qua do lỗi.)</span>
-                )}
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* No valid rows */}
-          {status === "parsed" && parsedRows.length === 0 && validationErrors.length > 0 && (
-            <Alert variant="destructive">
-              <AlertTriangle className="size-4" />
-              <AlertTitle>Không có dữ liệu hợp lệ</AlertTitle>
-              <AlertDescription>
-                Tất cả các dòng trong file đều có lỗi. Vui lòng sửa file và thử lại.
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* Import success */}
-          {status === "success" && importResult && (
-            <Alert className="border-green-200 bg-green-50">
-              <CheckCircle2 className="size-4 text-green-600" />
-              <AlertTitle className="text-green-800">Nhập thành công</AlertTitle>
-              <AlertDescription className="text-green-700">
-                Đã thêm {importResult.inserted} danh mục vào hệ thống.
-                {importResult.failed > 0 && (
-                  <span className="text-red-600">
-                    {" "}
-                    {importResult.failed} danh mục thất bại.
-                  </span>
-                )}
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* Partial success – categories OK but quota import failed */}
-          {status === "partial_success" && importResult && (
-            <Alert className="border-yellow-200 bg-yellow-50">
-              <AlertTriangle className="size-4 text-yellow-600" />
-              <AlertTitle className="text-yellow-800">Nhập thành công một phần</AlertTitle>
-              <AlertDescription className="text-yellow-700">
-                Đã thêm {importResult.inserted} danh mục nhưng nhập định mức thất bại.
-                Vui lòng thử nhập định mức riêng.
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {/* Submitting indicator */}
-          {isSubmitting && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="size-4 animate-spin" />
-              Đang nhập dữ liệu…
-            </div>
-          )}
+          <DeviceQuotaCategoryImportDialogAlerts
+            status={status}
+            parsedRowsCount={parsedRows.length}
+            parseError={parseError}
+            validationErrors={validationErrors}
+            validationWarnings={validationWarnings}
+            importResult={importResult}
+            isSubmitting={isSubmitting}
+          />
         </div>
 
         <DialogFooter>

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialogAlerts.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialogAlerts.tsx
@@ -1,0 +1,152 @@
+import * as React from "react"
+import { AlertCircle, AlertTriangle, CheckCircle2, Loader2 } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import type { ImportResult, ImportStatus } from "@/lib/category-import-validation"
+import { toKeyedTexts } from "@/lib/list-key-utils"
+
+interface DeviceQuotaCategoryImportDialogAlertsProps {
+  status: ImportStatus
+  parsedRowsCount: number
+  parseError: string | null
+  validationErrors: string[]
+  validationWarnings: string[]
+  importResult: ImportResult | null
+  isSubmitting: boolean
+}
+
+/** Renders status, validation, and result feedback for the category import dialog. */
+export function DeviceQuotaCategoryImportDialogAlerts({
+  status,
+  parsedRowsCount,
+  parseError,
+  validationErrors,
+  validationWarnings,
+  importResult,
+  isSubmitting,
+}: DeviceQuotaCategoryImportDialogAlertsProps) {
+  return (
+    <>
+      {status === "parsing" && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          Đang đọc file…
+        </div>
+      )}
+
+      {parseError && (
+        <Alert variant="destructive">
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Lỗi đọc file</AlertTitle>
+          <AlertDescription>{parseError}</AlertDescription>
+        </Alert>
+      )}
+
+      {validationErrors.length > 0 && (
+        <Alert variant="destructive">
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Lỗi dữ liệu - {validationErrors.length} dòng bị bỏ qua</AlertTitle>
+          <AlertDescription>
+            <ScrollArea className="h-32 mt-2">
+              <ul className="list-disc list-inside space-y-1 text-sm">
+                {toKeyedTexts(validationErrors.slice(0, 20)).map(({ key, text }) => (
+                  <li key={key}>{text}</li>
+                ))}
+                {validationErrors.length > 20 && (
+                  <li className="text-muted-foreground">
+                    … và {validationErrors.length - 20} lỗi khác
+                  </li>
+                )}
+              </ul>
+            </ScrollArea>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {validationWarnings.length > 0 && (
+        <Alert className="border-yellow-200 bg-yellow-50">
+          <AlertCircle className="size-4 text-yellow-600" />
+          <AlertTitle className="text-yellow-800">
+            Cảnh báo ({validationWarnings.length})
+          </AlertTitle>
+          <AlertDescription className="text-yellow-700">
+            <ScrollArea className="h-24 mt-2">
+              <ul className="list-disc list-inside space-y-1 text-sm">
+                {toKeyedTexts(validationWarnings.slice(0, 10)).map(({ key, text }) => (
+                  <li key={key}>{text}</li>
+                ))}
+                {validationWarnings.length > 10 && (
+                  <li className="text-yellow-600">
+                    … và {validationWarnings.length - 10} cảnh báo khác
+                  </li>
+                )}
+              </ul>
+            </ScrollArea>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {status === "parsed" && parsedRowsCount > 0 && (
+        <Alert className={validationErrors.length > 0 ? "border-yellow-200 bg-yellow-50" : ""}>
+          <CheckCircle2
+            className={`size-4 ${validationErrors.length > 0 ? "text-yellow-600" : "text-green-600"}`}
+          />
+          <AlertTitle className={validationErrors.length > 0 ? "text-yellow-800" : ""}>
+            {validationErrors.length > 0 ? "Sẵn sàng nhập (một phần)" : "Sẵn sàng nhập"}
+          </AlertTitle>
+          <AlertDescription className={validationErrors.length > 0 ? "text-yellow-700" : ""}>
+            Đã đọc được {parsedRowsCount} danh mục hợp lệ từ file Excel.
+            {validationErrors.length > 0 && (
+              <span className="text-red-600">
+                {" "}
+                ({validationErrors.length} dòng bị bỏ qua do lỗi.)
+              </span>
+            )}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {status === "parsed" && parsedRowsCount === 0 && validationErrors.length > 0 && (
+        <Alert variant="destructive">
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Không có dữ liệu hợp lệ</AlertTitle>
+          <AlertDescription>
+            Tất cả các dòng trong file đều có lỗi. Vui lòng sửa file và thử lại.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {status === "success" && importResult && (
+        <Alert className="border-green-200 bg-green-50">
+          <CheckCircle2 className="size-4 text-green-600" />
+          <AlertTitle className="text-green-800">Nhập thành công</AlertTitle>
+          <AlertDescription className="text-green-700">
+            Đã thêm {importResult.inserted} danh mục vào hệ thống.
+            {importResult.failed > 0 && (
+              <span className="text-red-600"> {importResult.failed} danh mục thất bại.</span>
+            )}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {status === "partial_success" && importResult && (
+        <Alert className="border-yellow-200 bg-yellow-50">
+          <AlertTriangle className="size-4 text-yellow-600" />
+          <AlertTitle className="text-yellow-800">Nhập thành công một phần</AlertTitle>
+          <AlertDescription className="text-yellow-700">
+            Đã thêm {importResult.inserted} danh mục nhưng nhập định mức thất bại. Vui lòng thử
+            nhập định mức riêng.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {isSubmitting && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          Đang nhập dữ liệu…
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialogState.ts
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryImportDialogState.ts
@@ -1,0 +1,87 @@
+import type {
+  ImportResult,
+  ImportStatus,
+  ParsedCategoryRow,
+} from "@/lib/category-import-validation"
+
+export interface ImportDialogState {
+  status: ImportStatus
+  parsedRows: ParsedCategoryRow[]
+  parseError: string | null
+  validationErrors: string[]
+  validationWarnings: string[]
+  importResult: ImportResult | null
+}
+
+export type ImportDialogAction =
+  | { type: "reset" }
+  | { type: "parse-started" }
+  | {
+      type: "parse-succeeded"
+      rows: ParsedCategoryRow[]
+      errors: string[]
+      warnings: string[]
+    }
+  | { type: "parse-failed"; message: string }
+  | { type: "import-started"; result: ImportResult }
+  | { type: "import-finished"; partial: boolean }
+  | { type: "import-failed" }
+
+/** Initial empty state for the category Excel import dialog. */
+export const initialImportDialogState: ImportDialogState = {
+  status: "idle",
+  parsedRows: [],
+  parseError: null,
+  validationErrors: [],
+  validationWarnings: [],
+  importResult: null,
+}
+
+/** Applies a single import dialog transition so related state changes stay atomic. */
+export function importDialogReducer(
+  state: ImportDialogState,
+  action: ImportDialogAction
+): ImportDialogState {
+  switch (action.type) {
+    case "reset":
+      return initialImportDialogState
+    case "parse-started":
+      return {
+        ...initialImportDialogState,
+        status: "parsing",
+      }
+    case "parse-succeeded":
+      return {
+        status: "parsed",
+        parsedRows: action.rows,
+        parseError: null,
+        validationErrors: action.errors,
+        validationWarnings: action.warnings,
+        importResult: null,
+      }
+    case "parse-failed":
+      return {
+        ...initialImportDialogState,
+        status: "error",
+        parseError: action.message,
+      }
+    case "import-started":
+      return {
+        ...state,
+        status: "importing",
+        importResult: action.result,
+      }
+    case "import-finished":
+      return {
+        ...state,
+        status: action.partial ? "partial_success" : "success",
+      }
+    case "import-failed":
+      return {
+        ...state,
+        status: "error",
+      }
+    default:
+      return state
+  }
+}


### PR DESCRIPTION
## Summary
- Refactor DeviceQuotaCategoryImportDialog to use a reducer for import/parse state
- Extract status/validation/result alerts into a focused child component
- Add reducer tests and React Doctor source guards for issue #535

Fixes #535

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run src/lib/__tests__/category-import-validation.test.ts
- node scripts/npm-run.js run test:run src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryImportDialogState.test.ts
- node scripts/npm-run.js run test:run src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryImportDialog.test.tsx
- node scripts/npm-run.js run test:run src/app/(app)/device-quota/__tests__/react-doctor-context-state.test.ts
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the category import dialog to a reducer-driven state in a separate module and extracted alert UI into `DeviceQuotaCategoryImportDialogAlerts` for simpler logic and easier testing. Adds reducer tests and stricter `react-doctor` guards to meet Linear #535.

- **Refactors**
  - Moved state to `importDialogReducer`/`initialImportDialogState` in `DeviceQuotaCategoryImportDialogState.ts` with clear actions (parse/import start, success, failure, reset/partial).
  - Replaced `useState` with `useReducer` in the dialog and dispatched actions from parse/import flows.
  - Added reducer transition tests and dialog-specific `react-doctor` guards to enforce `useReducer` and at most one state mutation per effect.

<sup>Written for commit 27fdd51c4059361a408954a9e0dc6cca75a41226. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/536?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the device quota category import dialog's internal state management for better reliability.

* **Bug Fixes**
  * Fixed dialog state reset behavior when closing the import dialog.

* **Improvements**
  * Enhanced feedback and alert messaging during file parsing and import validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->