### PR TITLE
[AI] Harden distributed quota reservation metering

### DIFF
--- a/docs/plans/484-ai-quota-hardening.md
+++ b/docs/plans/484-ai-quota-hardening.md
@@ -25,8 +25,8 @@ Rev 2 — first round of code review fixes: cross-user locking for tenant/global
 
 ### Rev 3 additions
 10. **Global lock order to prevent deadlock** — across all paths the canonical order is **reservation rows first, then counter rows**. `ai_quota_reserve` runs the expired-release sweep (which follows this order) **before** locking the new request's counter rows. New reservation row is `INSERT`ed last (fresh PK; no contention). Finalize and `ai_quota_release_expired` already follow this order.
-11. **Explicit Postgres `interval` math** — all time math uses `p_now - (p_rate_window_ms * interval '1 millisecond')` and `p_now + (p_ttl_ms * interval '1 millisecond')`. No ad-hoc subtraction of integers from `timestamptz`.
-12. **JWT identity strictly enforced** — `ai_quota_reserve` requires `current_setting('request.jwt.claims', true)::json->>'user_id' = p_user_id`. **No `app_role='global'` override path** on `/api/chat`. The chat route always passes the authenticated user's own id; admins consume quota under their own user just like everyone else.
+11. **Explicit Postgres `interval` math** — all time math uses `v_now - (p_rate_window_ms * interval '1 millisecond')` and `v_now + (p_ttl_ms * interval '1 millisecond')`, where `v_now := now()` inside the RPC. No ad-hoc subtraction of integers from `timestamptz`, and no trust in caller-supplied clock values.
+12. **JWT identity strictly enforced** — `ai_quota_reserve` requires both non-empty `app_role` and `current_setting('request.jwt.claims', true)::json->>'user_id' = p_user_id`. **No `app_role='global'` override path** on `/api/chat`. The chat route always passes the authenticated user's own id; admins consume quota under their own user just like everyone else.
 13. **Mid-stream token-accounting fallback** — `tokens_in` / `tokens_out` are recorded **only when the provider reports usage** (`onFinish.usage` for completed streams; provider error payload's `usage` field for failures that consumed billing). When no provider usage is available (e.g., abort before first delta, network error before any token), the finalize call records `tokens_in=0, tokens_out=0, cost_usd=0` and the `count` increment alone reflects budget consumption for `success` / `error_with_usage`. **No token estimation** — accuracy over guesswork.
 
 ## Goals
@@ -89,8 +89,8 @@ CREATE TABLE public.ai_quota_reservations (
   expires_at    TIMESTAMPTZ NOT NULL,
   status        TEXT NOT NULL CHECK (status IN ('reserved','success','error_with_usage','error_no_usage','expired')),
   counter_refs  JSONB NOT NULL,               -- [{"scope":"user_daily","key":"u1","window_id":"2026-05-21"}, ...]
-  tokens_in     INTEGER,
-  tokens_out    INTEGER,
+  tokens_in     BIGINT,
+  tokens_out    BIGINT,
   cost_usd      NUMERIC(12,6)
 );
 CREATE INDEX idx_ai_quota_reservations_status_exp
@@ -116,19 +116,19 @@ ai_quota_reserve(
 ) RETURNS TABLE (allowed BOOLEAN, reservation_id UUID, reason TEXT, message TEXT)
 ```
 Algorithm:
-1. Validate JWT: require `current_setting('request.jwt.claims', true)::json->>'user_id' = p_user_id`. No `global` override — `/api/chat` always reserves under the authenticated user. Reject with `42501` on mismatch.
-2. **Lazy expired-release first** (preserves global lock order: reservations → counters). For each `ai_quota_reservations` row with `status='reserved' AND expires_at < p_now` touched by `p_user_id`, optionally `p_tenant_id`, or `'global'` keys: lock the reservation row, then decrement `reserved` on each row in its `counter_refs`, set status='expired'. This sweep follows the reservation→counter order strictly.
+1. Validate JWT: require non-empty `app_role` and `current_setting('request.jwt.claims', true)::json->>'user_id' = p_user_id`. No `global` override — `/api/chat` always reserves under the authenticated user. Reject with `42501` on mismatch.
+2. **Lazy expired-release first** (preserves global lock order: reservations → counters). Compute `v_now := now()` inside the RPC. For each `ai_quota_reservations` row with `status='reserved' AND expires_at < v_now` touched by `p_user_id`, optionally `p_tenant_id`, or `'global'` keys: lock the reservation row, then decrement `reserved` on each row in its `counter_refs`, set status='expired'. This sweep follows the reservation→counter order strictly.
 3. Compute target counter rows for the new request: `user_daily(p_user_id, today)`, optional `tenant_daily(p_tenant_id, today)`, `global_daily('global', today)`. UPSERT each (`INSERT … ON CONFLICT (scope,key,window_id) DO UPDATE SET reserved = ai_quota_counters.reserved RETURNING *`) driven by an ordered VALUES list to acquire row locks in canonical order: `ORDER BY scope, key, window_id`.
-4. Sliding rate check: first prune `ai_rate_events` where `user_id = p_user_id AND ts < p_now - (p_rate_window_ms * interval '1 millisecond')`. Then `SELECT count(*) FROM ai_rate_events WHERE user_id = p_user_id AND ts >= p_now - (p_rate_window_ms * interval '1 millisecond')`. If `>= p_rate_max` → return `(false, NULL, 'rate_limit', ...)`.
+4. Sliding rate check: first prune `ai_rate_events` where `user_id = p_user_id AND ts < v_now - (p_rate_window_ms * interval '1 millisecond')`. Then `SELECT count(*) FROM ai_rate_events WHERE user_id = p_user_id AND ts >= v_now - (p_rate_window_ms * interval '1 millisecond')`. If `>= p_rate_max` → return `(false, NULL, 'rate_limit', ...)`.
 5. For each locked counter row, check `count + reserved >= limit` against its scope's max → return `(false, NULL, '<scope>_quota', ...)`.
-6. Increment `reserved += 1` for each locked counter row. INSERT reservation with `counter_refs` JSONB listing those rows, `expires_at = p_now + (p_ttl_ms * interval '1 millisecond')`. INSERT `ai_rate_events(reservation_id, user_id, ts=p_now)`. Return `(true, reservation_id, NULL, NULL)`.
+6. Increment `reserved += 1` for each locked counter row. INSERT reservation with `counter_refs` JSONB listing those rows, `expires_at = v_now + (p_ttl_ms * interval '1 millisecond')`. INSERT `ai_rate_events(reservation_id, user_id, ts=v_now)`. Return `(true, reservation_id, NULL, NULL)`.
 
 ```sql
 ai_quota_finalize(
   p_reservation_id UUID,
   p_status         TEXT,                  -- 'success' | 'error_with_usage' | 'error_no_usage'
-  p_tokens_in      INTEGER,
-  p_tokens_out     INTEGER,
+  p_tokens_in      BIGINT,
+  p_tokens_out     BIGINT,
   p_cost_usd       NUMERIC
 ) RETURNS VOID
 ```
@@ -142,7 +142,9 @@ Algorithm:
 ```sql
 ai_quota_release_expired(p_now TIMESTAMPTZ DEFAULT now()) RETURNS INTEGER
 ```
-- For every `ai_quota_reservations` where `status='reserved' AND expires_at < p_now`: behave like finalize with `status='expired'`, decrement `reserved` per `counter_refs`, leave `ai_rate_events` (already-issued slot counted as used — conservative). Returns count of released reservations.
+- Privileged cleanup only: require `app_role`/`role` in `('global','service_role')`; grant only to `service_role`.
+- Ignore caller-supplied `p_now` for decisions; compute `v_now := now()` inside the RPC.
+- For every `ai_quota_reservations` where `status='reserved' AND expires_at < v_now`: behave like finalize with `status='expired'`, decrement `reserved` per `counter_refs`, leave `ai_rate_events` (already-issued slot counted as used — conservative). Returns count of released reservations.
 
 ### Server-side TS surface (`src/lib/ai/usage-metering.ts`)
 ```ts

--- a/docs/plans/484-ai-quota-hardening.md
+++ b/docs/plans/484-ai-quota-hardening.md
@@ -244,9 +244,9 @@ export async function finalizeUsage(
 - `get_advisors(security)` + `get_advisors(performance)` clean.
 
 ## Follow-ups Required (file before closing #484)
-1. **UI retry cooldown** — issue scope item 6, deferred.
-2. **DB-backed kill switch** — replace env-var with table-row toggle so admins can flip without redeploy (issue AC mandates "without redeploying code").
-3. **Cost-per-token config table** — replace hardcoded rates in `estimateCostUsd`.
+1. **UI retry cooldown** — issue scope item 6, deferred to #537.
+2. **DB-backed kill switch** — replace env-var with table-row toggle so admins can flip without redeploy (issue AC mandates "without redeploying code"); deferred to #538.
+3. **Cost-per-token config table** — replace hardcoded/static rates with configurable model cost data; deferred to #539.
 
 ## Risk Notes
 - **Env kill switch requires redeploy** — explicitly noted in PR description; tracked by follow-up #2 above.

--- a/docs/plans/484-ai-quota-hardening.md
+++ b/docs/plans/484-ai-quota-hardening.md
@@ -1,0 +1,183 @@
+# TDD Plan — Issue #484: AI Quota Hardening (Backend)
+
+## Decisions (locked in)
+- **Backend**: Supabase RPC (Postgres) — no new vendor dependency
+- **Kill switch**: Env var only (`AI_KILL_SWITCH=on`) — accepted deviation from issue AC
+- **Scope**: Items 1–5 from the issue (backend). UI retry cooldown (item 6) deferred to a separate issue
+- **Branch**: `feat/484-ai-quota-hardening`
+- **Methodology**: TDD — failing test first, minimum code to pass, refactor. One story per iteration (Ralph flow)
+
+## Goals
+1. Replace in-memory `Map` counters with durable counters in Postgres
+2. Atomic **reserve-before-execution** semantics in a single RPC
+3. **Finalize** after stream completion with actual tokens/cost
+4. Account for **cost-aware failures** (provider usage consumed even on error)
+5. Add **global daily cap** and **env-var kill switch**
+6. Preserve existing module API (`checkUsageLimits` / `recordUsage` / `confirmUsage`) so the route only swaps to reserve/finalize at the call sites
+
+## Critical Files
+- `src/lib/ai/usage-metering.ts` — replace internals; keep exported surface, add reserve/finalize
+- `src/lib/ai/limits.ts` — add `AI_DAILY_GLOBAL_QUOTA_REQUESTS`, `AI_KILL_SWITCH`, reservation TTL
+- `src/app/api/chat/route.ts` — switch to `reserveUsage` (pre-stream) and `finalizeUsage` (success / `error_with_usage` / `error_no_usage`)
+- `src/app/api/rpc/[fn]/route.ts` — add `ai_quota_reserve`, `ai_quota_finalize`, `ai_quota_release_expired` to `ALLOWED_FUNCTIONS`
+- `src/lib/rpc-client.ts` — used as-is for server-side calls from the chat route
+- `supabase/migrations/<ts>_ai_quota_hardening.sql` — schema + RPCs
+- Tests (vitest):
+  - `src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts` (update mocks)
+  - `src/lib/ai/__tests__/usage-metering.distributed.test.ts` (new)
+  - `src/app/api/chat/__tests__/route.kill-switch.test.ts` (new)
+  - `src/app/api/chat/__tests__/route.cost-aware-failure.test.ts` (new)
+
+## Architecture
+
+### Tables (single migration)
+```sql
+-- Durable counters bucketed by scope/key/window
+CREATE TABLE public.ai_quota_counters (
+  scope        TEXT NOT NULL CHECK (scope IN ('rate','user_daily','tenant_daily','global_daily')),
+  key          TEXT NOT NULL,                 -- userId | tenantId | 'global'
+  window_id    TEXT NOT NULL,                 -- minute bucket for rate, YYYY-MM-DD for daily
+  count        INTEGER NOT NULL DEFAULT 0,    -- confirmed
+  reserved     INTEGER NOT NULL DEFAULT 0,    -- in-flight
+  tokens_in    BIGINT  NOT NULL DEFAULT 0,
+  tokens_out   BIGINT  NOT NULL DEFAULT 0,
+  cost_usd     NUMERIC(12,6) NOT NULL DEFAULT 0,
+  expires_at   TIMESTAMPTZ NOT NULL,
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (scope, key, window_id)
+);
+CREATE INDEX idx_ai_quota_counters_expires ON public.ai_quota_counters(expires_at);
+
+-- One row per inflight/historical request (audit + finalize lookup)
+CREATE TABLE public.ai_quota_reservations (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       TEXT NOT NULL,
+  tenant_id     INTEGER,
+  reserved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at    TIMESTAMPTZ NOT NULL,
+  status        TEXT NOT NULL CHECK (status IN ('reserved','success','error_with_usage','error_no_usage','expired')),
+  tokens_in     INTEGER,
+  tokens_out    INTEGER,
+  cost_usd      NUMERIC(12,6)
+);
+CREATE INDEX idx_ai_quota_reservations_status_exp
+  ON public.ai_quota_reservations(status, expires_at);
+```
+
+### RPCs (SECURITY DEFINER, search_path locked)
+- `ai_quota_reserve(p_user_id text, p_tenant_id int, p_now timestamptz default now())`
+  - JWT claim guard (must be authenticated; user_id from JWT must match `p_user_id`)
+  - Single transaction; per-key advisory lock via `pg_advisory_xact_lock(hashtext(p_user_id))`
+  - UPSERT rate/user_daily/tenant_daily/global_daily counters with proper `window_id`
+  - Lazy purge of rows where `expires_at < p_now` (cheap, scoped to the keys touched)
+  - If `count + reserved >= limit` for any scope → return `{ allowed: false, reason, message }`
+  - Else `reserved := reserved + 1` for all scopes, INSERT reservation `status='reserved'` with TTL (default 30s)
+  - Returns `{ allowed: bool, reservation_id uuid, reason text }`
+- `ai_quota_finalize(p_reservation_id uuid, p_status text, p_tokens_in int, p_tokens_out int, p_cost_usd numeric)`
+  - Transaction; lock the reservation row
+  - If reservation not in `reserved` state → no-op (idempotent)
+  - For each scope counter touched by the reservation: `reserved := reserved - 1`
+  - If `p_status IN ('success','error_with_usage')` then `count := count + 1`, accumulate tokens/cost
+  - If `p_status = 'error_no_usage'` then only release `reserved`
+  - UPDATE reservation row with actuals + final status
+- `ai_quota_release_expired(p_now timestamptz default now())`
+  - Sweeper: marks reservations `expired` and decrements `reserved` for any reservation whose `expires_at < now()` AND status='reserved'. Safe to call lazily from `ai_quota_reserve`
+
+### TypeScript surface (`src/lib/ai/usage-metering.ts`)
+Keep existing types. Add:
+```ts
+export interface ReservationResult {
+  allowed: boolean
+  reservationId?: string
+  reason?: UsageLimitReason | 'kill_switch' | 'global_quota'
+  message?: string
+}
+export type FinalizeStatus = 'success' | 'error_with_usage' | 'error_no_usage'
+
+export async function reserveUsage(ctx: UsageContext): Promise<ReservationResult>
+export async function finalizeUsage(
+  reservationId: string,
+  status: FinalizeStatus,
+  record?: UsageRecord
+): Promise<void>
+```
+Implementation calls Supabase via existing server-side fetch path. Kill-switch check happens in TS before the RPC call (cheap short-circuit).
+
+In-memory functions stay only for backward-compat in tests that already exercise them; the chat route stops using them.
+
+## TDD Stories (Ralph one-per-iteration)
+
+> Every story ends with: `verify:no-explicit-any` → `verify:dedupe` → `typecheck` → targeted tests → react-doctor diff. Each story commits as `feat: [Sxxx] - <title>` and sets `passes: true` in `prd.json`.
+
+### S001 — Schema + RPCs (red→green)
+- **Tests (new)**: `supabase/tests/ai_quota_hardening.sql` or vitest integration shim that calls RPCs via `execute_sql` MCP fixtures. Cover:
+  - Reserve under limit succeeds; reservation row created
+  - Reserve at limit returns `allowed=false` with correct reason for each scope
+  - Two concurrent reserves at the boundary cannot both succeed (advisory lock + UPSERT)
+  - Finalize `success` increments `count`, decrements `reserved`, records tokens/cost
+  - Finalize `error_with_usage` increments `count` AND tokens/cost
+  - Finalize `error_no_usage` only releases `reserved`
+  - Finalize is idempotent (double-call no-op)
+  - Expired reservation is swept and `reserved` is released
+- **Impl**: single migration `ai_quota_hardening` applied via MCP `apply_migration`. Functions follow security template (`SECURITY DEFINER`, `SET search_path = public, pg_temp`, JWT claim guard)
+- **Post**: `get_advisors(security)` and `get_advisors(performance)` clean
+
+### S002 — TS wrapper `reserveUsage` / `finalizeUsage`
+- **Tests (new)** in `src/lib/ai/__tests__/usage-metering.distributed.test.ts`:
+  - Mocks `callRpc` and asserts payload shape for `ai_quota_reserve`
+  - Maps RPC `reason` → existing `UsageLimitReason` plus new `global_quota`
+  - `reserveUsage` short-circuits with `reason='kill_switch'` when `AI_KILL_SWITCH=on`
+  - `finalizeUsage` accepts all three statuses; missing reservationId is a no-op
+- **Impl**: add the two exports; keep legacy in-memory functions untouched (still used by old tests)
+- **Constraint**: zero `any` in the diff (`verify:no-explicit-any` gate)
+
+### S003 — Wire `/api/chat` to reserve/finalize
+- **Tests (update)**: `route.rate-limit-and-quota.test.ts`
+  - Replace `checkUsageLimits`/`recordUsage`/`confirmUsage` mocks with `reserveUsage`/`finalizeUsage`
+  - Assert reserve called BEFORE streaming, finalize called on stream finish
+  - Assert 429 body includes RPC `reason` and `message`
+  - Assert reservationId passed through to `onFinish` and `onError`
+- **Impl**:
+  - Replace lines 149–155 with `reserveUsage(...)`; on `!allowed` return 429 (including new `kill_switch` / `global_quota` reasons)
+  - Remove line 182 `recordUsage`
+  - In `onFinish`: call `finalizeUsage(reservationId, 'success', { inputTokens, outputTokens })`
+  - In `onError` / catch around stream: distinguish `error_with_usage` vs `error_no_usage` based on whether any tokens were emitted; for safety, default partial-stream errors to `error_with_usage`
+
+### S004 — Cost-aware failure accounting
+- **Tests (new)** `route.cost-aware-failure.test.ts`:
+  - Stream throws after first chunk → finalize called with `error_with_usage` and observed tokens
+  - Stream throws before any chunk → finalize called with `error_no_usage`
+  - 4xx/5xx from provider with `usage` in error payload → `error_with_usage`
+- **Impl**: refine the error branch from S003; centralize the classification in a small helper inside `usage-metering.ts`
+
+### S005 — Global daily cap + env-var kill switch
+- **Tests (new)** `route.kill-switch.test.ts`:
+  - `AI_KILL_SWITCH=on` → 429 with `reason='kill_switch'`, RPC not called
+  - `AI_DAILY_GLOBAL_QUOTA_REQUESTS=1` + two reserves → second returns `reason='global_quota'`
+- **Impl**:
+  - Add limits to `src/lib/ai/limits.ts`
+  - TS short-circuit for kill switch
+  - RPC enforces global cap (already included in S001 schema; flag-on with env-provided limit injected as parameter, not hardcoded in SQL)
+
+### S006 — Cleanup, docs, advisors
+- Remove now-unreachable code paths in `usage-metering.ts` (legacy daily Maps if no consumers remain). Keep `__resetUsageMeteringForTests` and update to clear new state where applicable.
+- `get_advisors(security)` and `get_advisors(performance)` clean after final apply
+- Update `docs/` if a runbook exists for AI quotas (read-only check first; do not create new docs unless one already exists)
+
+## Out of Scope (this plan)
+- UI retry cooldown (issue item 6) — separate issue
+- Migrating cost-per-token rates to a config table — separate issue
+- DB-backed kill switch — explicitly deferred (env var per user decision)
+
+## Risk Notes
+- **Env-var kill switch requires redeploy**, which deviates from the issue's "without redeploying code" AC. User accepted this trade-off; flag in PR description.
+- Advisory locks are per-user-key; cross-user contention is not serialized — intentional for throughput.
+- Reservation TTL (30s) must exceed worst-case stream time. Make it env-configurable (`AI_QUOTA_RESERVATION_TTL_MS`) with a sane default.
+
+## Verification Order (mandatory each story)
+1. `node scripts/npm-run.js run verify:no-explicit-any`
+2. `node scripts/npm-run.js run verify:dedupe`
+3. `node scripts/npm-run.js run typecheck`
+4. Focused vitest run for the story's test file(s)
+5. `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
+6. `get_advisors(security)` after any migration

--- a/docs/plans/484-ai-quota-hardening.md
+++ b/docs/plans/484-ai-quota-hardening.md
@@ -1,7 +1,9 @@
 # TDD Plan — Issue #484: AI Quota Hardening (Backend) — Revised
 
 ## Status
-Rev 2 — incorporates code review findings. Critical fixes: cross-user locking for tenant/global, RPC accepts limits as params (no env in SQL), sliding rate-limit semantics preserved, reservations record exact counter refs, dedicated server-side RPC helper, retry/abort paths release/finalize explicitly, TTL > route maxDuration.
+Rev 3 — incorporates second code review pass. Adds explicit global lock order (reservation rows before counter rows), concrete Postgres `interval` math, locks down JWT identity check (no `global` override on `/api/chat`), and defines mid-stream token-accounting fallback (provider-reported usage only; no estimation).
+
+Rev 2 — first round of code review fixes: cross-user locking for tenant/global, RPC accepts limits as params (no env in SQL), sliding rate-limit semantics preserved, reservations record exact counter refs, dedicated server-side RPC helper, retry/abort paths release/finalize explicitly, TTL > route maxDuration.
 
 ## Decisions (locked in)
 - **Backend**: Supabase RPC (Postgres) — no new vendor dependency
@@ -20,6 +22,12 @@ Rev 2 — incorporates code review findings. Critical fixes: cross-user locking 
 7. **TTL default raised** — default reservation TTL set to **120s** (route `maxDuration=60s` + artifact/draft work). Env-tunable via `AI_QUOTA_RESERVATION_TTL_MS`.
 8. **Deviation tracking** — env kill switch + UI cooldown deviations explicitly listed under "Follow-ups Required" and must be filed as issues before #484 is closed.
 9. **Ralph flow removed** — no `prd.json` updates; stories tracked here only.
+
+### Rev 3 additions
+10. **Global lock order to prevent deadlock** — across all paths the canonical order is **reservation rows first, then counter rows**. `ai_quota_reserve` runs the expired-release sweep (which follows this order) **before** locking the new request's counter rows. New reservation row is `INSERT`ed last (fresh PK; no contention). Finalize and `ai_quota_release_expired` already follow this order.
+11. **Explicit Postgres `interval` math** — all time math uses `p_now - (p_rate_window_ms * interval '1 millisecond')` and `p_now + (p_ttl_ms * interval '1 millisecond')`. No ad-hoc subtraction of integers from `timestamptz`.
+12. **JWT identity strictly enforced** — `ai_quota_reserve` requires `current_setting('request.jwt.claims', true)::json->>'user_id' = p_user_id`. **No `app_role='global'` override path** on `/api/chat`. The chat route always passes the authenticated user's own id; admins consume quota under their own user just like everyone else.
+13. **Mid-stream token-accounting fallback** — `tokens_in` / `tokens_out` are recorded **only when the provider reports usage** (`onFinish.usage` for completed streams; provider error payload's `usage` field for failures that consumed billing). When no provider usage is available (e.g., abort before first delta, network error before any token), the finalize call records `tokens_in=0, tokens_out=0, cost_usd=0` and the `count` increment alone reflects budget consumption for `success` / `error_with_usage`. **No token estimation** — accuracy over guesswork.
 
 ## Goals
 1. Replace in-memory `Map` counters with durable counters in Postgres
@@ -108,12 +116,12 @@ ai_quota_reserve(
 ) RETURNS TABLE (allowed BOOLEAN, reservation_id UUID, reason TEXT, message TEXT)
 ```
 Algorithm:
-1. Validate JWT: `app_role`, `user_id == p_user_id` (or `app_role='global'` override path if we keep one).
-2. Compute target counter rows: `user_daily`, optional `tenant_daily`, `global_daily`. Lock them in canonical order: UPSERT each row with `ON CONFLICT … DO UPDATE SET reserved = ai_quota_counters.reserved RETURNING *` then re-`SELECT … FOR UPDATE ORDER BY scope, key, window_id`. (Or single statement with `INSERT … ON CONFLICT DO UPDATE … RETURNING *` driven by an ordered VALUES list.)
-3. Lazy purge: delete `ai_rate_events` where `ts < p_now - p_rate_window_ms` for `p_user_id`; mark expired reservations (status='expired') and decrement their `counter_refs` (see also `ai_quota_release_expired`).
-4. Sliding rate check: `SELECT count(*) FROM ai_rate_events WHERE user_id = p_user_id AND ts >= p_now - p_rate_window_ms`. If `>= p_rate_max` → return `(false, NULL, 'rate_limit', ...)`.
-5. For each locked counter row, check `count + reserved >= limit` for its scope → return `(false, NULL, '<scope>_quota', ...)`.
-6. Increment `reserved += 1` for each locked counter row. INSERT reservation with `counter_refs` JSONB listing those rows, `expires_at = p_now + p_ttl_ms`. INSERT `ai_rate_events(reservation_id, user_id, ts=p_now)`. Return `(true, reservation_id, NULL, NULL)`.
+1. Validate JWT: require `current_setting('request.jwt.claims', true)::json->>'user_id' = p_user_id`. No `global` override — `/api/chat` always reserves under the authenticated user. Reject with `42501` on mismatch.
+2. **Lazy expired-release first** (preserves global lock order: reservations → counters). For each `ai_quota_reservations` row with `status='reserved' AND expires_at < p_now` touched by `p_user_id`, optionally `p_tenant_id`, or `'global'` keys: lock the reservation row, then decrement `reserved` on each row in its `counter_refs`, set status='expired'. This sweep follows the reservation→counter order strictly.
+3. Compute target counter rows for the new request: `user_daily(p_user_id, today)`, optional `tenant_daily(p_tenant_id, today)`, `global_daily('global', today)`. UPSERT each (`INSERT … ON CONFLICT (scope,key,window_id) DO UPDATE SET reserved = ai_quota_counters.reserved RETURNING *`) driven by an ordered VALUES list to acquire row locks in canonical order: `ORDER BY scope, key, window_id`.
+4. Sliding rate check: first prune `ai_rate_events` where `user_id = p_user_id AND ts < p_now - (p_rate_window_ms * interval '1 millisecond')`. Then `SELECT count(*) FROM ai_rate_events WHERE user_id = p_user_id AND ts >= p_now - (p_rate_window_ms * interval '1 millisecond')`. If `>= p_rate_max` → return `(false, NULL, 'rate_limit', ...)`.
+5. For each locked counter row, check `count + reserved >= limit` against its scope's max → return `(false, NULL, '<scope>_quota', ...)`.
+6. Increment `reserved += 1` for each locked counter row. INSERT reservation with `counter_refs` JSONB listing those rows, `expires_at = p_now + (p_ttl_ms * interval '1 millisecond')`. INSERT `ai_rate_events(reservation_id, user_id, ts=p_now)`. Return `(true, reservation_id, NULL, NULL)`.
 
 ```sql
 ai_quota_finalize(
@@ -180,6 +188,8 @@ export async function finalizeUsage(
 - Finalize is idempotent.
 - `ai_quota_release_expired` releases reserved counts for expired reservations, leaves rate events alone.
 - Day-boundary reservation: reserved on day N at 23:59 with finalize on day N+1 at 00:00 decrements the day-N counter (proves `counter_refs` immunity to window drift).
+- Lock-order deadlock probe: simultaneously run (a) `ai_quota_reserve` for user A (which triggers expired-release sweeping user B's old reservation) and (b) `ai_quota_finalize` of one of user B's active reservations sharing the same tenant counter. Neither transaction deadlocks; both complete in any order.
+- JWT identity guard: calling `ai_quota_reserve(p_user_id='other-uid')` while JWT claims `user_id='self'` raises `42501`; the counters and `ai_rate_events` are unchanged.
 
 **Impl**: single migration `ai_quota_hardening` applied via `apply_migration`. Functions follow security template; lock order strict.
 
@@ -196,12 +206,12 @@ export async function finalizeUsage(
 
 ### S003 — Wire `/api/chat` with finalize on every exit path
 **Red tests** (`route.rate-limit-and-quota.test.ts` updated + `route.retry-and-abort-finalize.test.ts` new):
-- Reserve called before `streamText`; finalize called on `onFinish` with `success`.
+- Reserve called before `streamText`; finalize called on `onFinish` with `success` and provider-reported `usage.inputTokens` / `usage.outputTokens`.
 - Reserve at limit → 429 with `reason`/`message` from RPC; no stream started.
 - Pre-stream retry `continue` (existing behavior at ~`route.ts:288`): each attempt that reserved MUST finalize as `error_no_usage` before the next attempt is reserved. Test forces the retry path and asserts finalize per attempt.
 - 500 thrown before stream after reserve → finalize `error_no_usage`.
-- Client abort mid-stream (`AbortSignal`) → finalize `error_with_usage` with observed tokens.
-- `onError` thrown after first chunk → finalize `error_with_usage`.
+- Client abort mid-stream (`AbortSignal`) → finalize `error_with_usage`; tokens recorded only if provider supplied usage, else zero.
+- `onError` thrown after first chunk → finalize `error_with_usage`; tokens from provider error payload if present, else zero.
 
 **Impl**:
 - Replace existing limit-check + `recordUsage` (`route.ts:149`, `:182`) with `reserveUsage`.
@@ -210,11 +220,12 @@ export async function finalizeUsage(
 
 ### S004 — Cost-aware failure accounting refinements
 **Red tests** (`route.cost-aware-failure.test.ts`):
-- Provider returns 5xx with `usage` payload (mock provider error) → `error_with_usage` with parsed tokens.
-- Stream throws after first delta → `error_with_usage` with `outputTokens >= 1`.
-- Stream throws before first delta → `error_no_usage`.
+- Provider returns 5xx with `usage` payload (mock provider error) → `error_with_usage` with parsed tokens from provider `usage`.
+- Stream throws after first delta, **provider reported usage in `onError`** → `error_with_usage` with provider tokens.
+- Stream throws after first delta, **no provider usage available** → `error_with_usage` with `tokens_in=0, tokens_out=0` (count still increments; cost remains 0).
+- Stream throws before first delta, no provider usage → `error_no_usage` with zeroed tokens.
 
-**Impl**: small classifier helper in `usage-metering.ts` (`classifyStreamFailure(stage, tokensObserved)`); wire it in S003's `finalizeOnce`.
+**Impl**: small classifier helper in `usage-metering.ts` (`classifyStreamFailure({ stage, providerUsage })`); wired into S003's `finalizeOnce`. **No token estimation** — only provider-reported usage is recorded.
 
 ### S005 — Global daily cap + env-var kill switch
 **Red tests** (`route.kill-switch.test.ts`):

--- a/docs/plans/484-ai-quota-hardening.md
+++ b/docs/plans/484-ai-quota-hardening.md
@@ -1,11 +1,25 @@
-# TDD Plan — Issue #484: AI Quota Hardening (Backend)
+# TDD Plan — Issue #484: AI Quota Hardening (Backend) — Revised
+
+## Status
+Rev 2 — incorporates code review findings. Critical fixes: cross-user locking for tenant/global, RPC accepts limits as params (no env in SQL), sliding rate-limit semantics preserved, reservations record exact counter refs, dedicated server-side RPC helper, retry/abort paths release/finalize explicitly, TTL > route maxDuration.
 
 ## Decisions (locked in)
 - **Backend**: Supabase RPC (Postgres) — no new vendor dependency
-- **Kill switch**: Env var only (`AI_KILL_SWITCH=on`) — accepted deviation from issue AC
-- **Scope**: Items 1–5 from the issue (backend). UI retry cooldown (item 6) deferred to a separate issue
+- **Kill switch**: Env var only (`AI_KILL_SWITCH=on`) — accepted deviation from issue AC (redeploy required). Follow-up issue MUST be opened to track a DB-backed switch before closing #484
+- **Scope**: Items 1–5 from the issue (backend). UI retry cooldown (item 6) deferred — follow-up issue MUST be opened before closing #484
 - **Branch**: `feat/484-ai-quota-hardening`
-- **Methodology**: TDD — failing test first, minimum code to pass, refactor. One story per iteration (Ralph flow)
+- **Methodology**: TDD — failing test first, minimum code to pass, refactor. **Ralph flow not used** for this plan (no `prd.json` integration; current `prd.json` is on `ralph/vercel-ai-sdk-strategic-spec`).
+
+## Code Review Findings Addressed
+1. **Cross-user locking for tenant/global** — drop user-only advisory lock as the sole guard. Use `SELECT … FOR UPDATE` on counter rows in **stable canonical order** (sorted by `scope`, then `key`, then `window_id`) so concurrent reserves across users serialize correctly on shared counters.
+2. **RPC accepts limits + TTL as parameters** — SQL cannot read app env. All limits and TTL passed by the TS caller, sourced from `src/lib/ai/limits.ts`. No hardcoded limits in SQL.
+3. **Sliding rate-limit preserved** — use a per-event table `ai_rate_events`, not a minute bucket. Matches existing in-memory semantics (`src/lib/ai/usage-metering.ts:74,114`).
+4. **Exact counter refs on reservations** — add `counter_refs JSONB` column listing `{scope,key,window_id}` tuples touched at reserve time. Finalize/sweeper decrement those exact rows, immune to window-boundary drift.
+5. **Server-side RPC helper** — `src/lib/rpc-client.ts` uses relative `fetch('/api/rpc/...')` and is unsuitable from server routes. Introduce `src/lib/ai/server-rpc.ts` that signs the JWT (same secret + claims as `src/app/api/rpc/[fn]/route.ts`) and calls Supabase PostgREST directly. Allowlist file is `src/app/api/rpc/[fn]/allowed-functions.ts` (corrected path).
+6. **Retry / abort paths finalize/release** — every exit path (pre-stream retry `continue`, 500 response, client abort, `onError`, `onFinish`) MUST call `finalizeUsage`. Reservation IDs tracked per attempt; no path relies on TTL sweep.
+7. **TTL default raised** — default reservation TTL set to **120s** (route `maxDuration=60s` + artifact/draft work). Env-tunable via `AI_QUOTA_RESERVATION_TTL_MS`.
+8. **Deviation tracking** — env kill switch + UI cooldown deviations explicitly listed under "Follow-ups Required" and must be filed as issues before #484 is closed.
+9. **Ralph flow removed** — no `prd.json` updates; stories tracked here only.
 
 ## Goals
 1. Replace in-memory `Map` counters with durable counters in Postgres
@@ -13,32 +27,34 @@
 3. **Finalize** after stream completion with actual tokens/cost
 4. Account for **cost-aware failures** (provider usage consumed even on error)
 5. Add **global daily cap** and **env-var kill switch**
-6. Preserve existing module API (`checkUsageLimits` / `recordUsage` / `confirmUsage`) so the route only swaps to reserve/finalize at the call sites
+6. Preserve sliding rate-limit semantics
 
 ## Critical Files
-- `src/lib/ai/usage-metering.ts` — replace internals; keep exported surface, add reserve/finalize
-- `src/lib/ai/limits.ts` — add `AI_DAILY_GLOBAL_QUOTA_REQUESTS`, `AI_KILL_SWITCH`, reservation TTL
-- `src/app/api/chat/route.ts` — switch to `reserveUsage` (pre-stream) and `finalizeUsage` (success / `error_with_usage` / `error_no_usage`)
-- `src/app/api/rpc/[fn]/route.ts` — add `ai_quota_reserve`, `ai_quota_finalize`, `ai_quota_release_expired` to `ALLOWED_FUNCTIONS`
-- `src/lib/rpc-client.ts` — used as-is for server-side calls from the chat route
+- `src/lib/ai/usage-metering.ts` — replace internals; new `reserveUsage` / `finalizeUsage`
+- `src/lib/ai/limits.ts` — add `AI_DAILY_GLOBAL_QUOTA_REQUESTS`, `AI_KILL_SWITCH`, `AI_QUOTA_RESERVATION_TTL_MS`
+- `src/lib/ai/server-rpc.ts` — **NEW** server-side RPC helper (JWT mint + direct PostgREST call)
+- `src/app/api/chat/route.ts` — switch to reserve/finalize; finalize on **every** exit path including retry `continue` (~line 288), client abort, 500
+- `src/app/api/rpc/[fn]/allowed-functions.ts` — add `ai_quota_reserve`, `ai_quota_finalize`, `ai_quota_release_expired` (only if any client-side path needs them — see S006)
 - `supabase/migrations/<ts>_ai_quota_hardening.sql` — schema + RPCs
 - Tests (vitest):
   - `src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts` (update mocks)
   - `src/lib/ai/__tests__/usage-metering.distributed.test.ts` (new)
+  - `src/lib/ai/__tests__/server-rpc.test.ts` (new)
   - `src/app/api/chat/__tests__/route.kill-switch.test.ts` (new)
   - `src/app/api/chat/__tests__/route.cost-aware-failure.test.ts` (new)
+  - `src/app/api/chat/__tests__/route.retry-and-abort-finalize.test.ts` (new)
 
 ## Architecture
 
 ### Tables (single migration)
 ```sql
--- Durable counters bucketed by scope/key/window
+-- Daily counters only (rate handled by events table below).
 CREATE TABLE public.ai_quota_counters (
-  scope        TEXT NOT NULL CHECK (scope IN ('rate','user_daily','tenant_daily','global_daily')),
+  scope        TEXT NOT NULL CHECK (scope IN ('user_daily','tenant_daily','global_daily')),
   key          TEXT NOT NULL,                 -- userId | tenantId | 'global'
-  window_id    TEXT NOT NULL,                 -- minute bucket for rate, YYYY-MM-DD for daily
-  count        INTEGER NOT NULL DEFAULT 0,    -- confirmed
-  reserved     INTEGER NOT NULL DEFAULT 0,    -- in-flight
+  window_id    TEXT NOT NULL,                 -- YYYY-MM-DD (UTC)
+  count        INTEGER NOT NULL DEFAULT 0,
+  reserved     INTEGER NOT NULL DEFAULT 0,
   tokens_in    BIGINT  NOT NULL DEFAULT 0,
   tokens_out   BIGINT  NOT NULL DEFAULT 0,
   cost_usd     NUMERIC(12,6) NOT NULL DEFAULT 0,
@@ -48,7 +64,15 @@ CREATE TABLE public.ai_quota_counters (
 );
 CREATE INDEX idx_ai_quota_counters_expires ON public.ai_quota_counters(expires_at);
 
--- One row per inflight/historical request (audit + finalize lookup)
+-- Sliding rate window. One row per reserved attempt; pruned on each reserve.
+CREATE TABLE public.ai_rate_events (
+  reservation_id UUID PRIMARY KEY,            -- FK to ai_quota_reservations.id
+  user_id        TEXT NOT NULL,
+  ts             TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_ai_rate_events_user_ts ON public.ai_rate_events(user_id, ts DESC);
+
+-- Reservations record exact counter rows touched, enabling precise finalize/release.
 CREATE TABLE public.ai_quota_reservations (
   id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id       TEXT NOT NULL,
@@ -56,35 +80,63 @@ CREATE TABLE public.ai_quota_reservations (
   reserved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   expires_at    TIMESTAMPTZ NOT NULL,
   status        TEXT NOT NULL CHECK (status IN ('reserved','success','error_with_usage','error_no_usage','expired')),
+  counter_refs  JSONB NOT NULL,               -- [{"scope":"user_daily","key":"u1","window_id":"2026-05-21"}, ...]
   tokens_in     INTEGER,
   tokens_out    INTEGER,
   cost_usd      NUMERIC(12,6)
 );
 CREATE INDEX idx_ai_quota_reservations_status_exp
   ON public.ai_quota_reservations(status, expires_at);
+ALTER TABLE public.ai_rate_events
+  ADD CONSTRAINT ai_rate_events_reservation_fk
+  FOREIGN KEY (reservation_id) REFERENCES public.ai_quota_reservations(id) ON DELETE CASCADE;
 ```
 
-### RPCs (SECURITY DEFINER, search_path locked)
-- `ai_quota_reserve(p_user_id text, p_tenant_id int, p_now timestamptz default now())`
-  - JWT claim guard (must be authenticated; user_id from JWT must match `p_user_id`)
-  - Single transaction; per-key advisory lock via `pg_advisory_xact_lock(hashtext(p_user_id))`
-  - UPSERT rate/user_daily/tenant_daily/global_daily counters with proper `window_id`
-  - Lazy purge of rows where `expires_at < p_now` (cheap, scoped to the keys touched)
-  - If `count + reserved >= limit` for any scope → return `{ allowed: false, reason, message }`
-  - Else `reserved := reserved + 1` for all scopes, INSERT reservation `status='reserved'` with TTL (default 30s)
-  - Returns `{ allowed: bool, reservation_id uuid, reason text }`
-- `ai_quota_finalize(p_reservation_id uuid, p_status text, p_tokens_in int, p_tokens_out int, p_cost_usd numeric)`
-  - Transaction; lock the reservation row
-  - If reservation not in `reserved` state → no-op (idempotent)
-  - For each scope counter touched by the reservation: `reserved := reserved - 1`
-  - If `p_status IN ('success','error_with_usage')` then `count := count + 1`, accumulate tokens/cost
-  - If `p_status = 'error_no_usage'` then only release `reserved`
-  - UPDATE reservation row with actuals + final status
-- `ai_quota_release_expired(p_now timestamptz default now())`
-  - Sweeper: marks reservations `expired` and decrements `reserved` for any reservation whose `expires_at < now()` AND status='reserved'. Safe to call lazily from `ai_quota_reserve`
+### RPCs (SECURITY DEFINER, `SET search_path = public, pg_temp`, JWT claim guard)
 
-### TypeScript surface (`src/lib/ai/usage-metering.ts`)
-Keep existing types. Add:
+```sql
+ai_quota_reserve(
+  p_user_id           TEXT,
+  p_tenant_id         INTEGER,           -- NULL allowed
+  p_rate_window_ms    INTEGER,
+  p_rate_max          INTEGER,
+  p_user_daily_max    INTEGER,
+  p_tenant_daily_max  INTEGER,
+  p_global_daily_max  INTEGER,
+  p_ttl_ms            INTEGER,
+  p_now               TIMESTAMPTZ DEFAULT now()
+) RETURNS TABLE (allowed BOOLEAN, reservation_id UUID, reason TEXT, message TEXT)
+```
+Algorithm:
+1. Validate JWT: `app_role`, `user_id == p_user_id` (or `app_role='global'` override path if we keep one).
+2. Compute target counter rows: `user_daily`, optional `tenant_daily`, `global_daily`. Lock them in canonical order: UPSERT each row with `ON CONFLICT … DO UPDATE SET reserved = ai_quota_counters.reserved RETURNING *` then re-`SELECT … FOR UPDATE ORDER BY scope, key, window_id`. (Or single statement with `INSERT … ON CONFLICT DO UPDATE … RETURNING *` driven by an ordered VALUES list.)
+3. Lazy purge: delete `ai_rate_events` where `ts < p_now - p_rate_window_ms` for `p_user_id`; mark expired reservations (status='expired') and decrement their `counter_refs` (see also `ai_quota_release_expired`).
+4. Sliding rate check: `SELECT count(*) FROM ai_rate_events WHERE user_id = p_user_id AND ts >= p_now - p_rate_window_ms`. If `>= p_rate_max` → return `(false, NULL, 'rate_limit', ...)`.
+5. For each locked counter row, check `count + reserved >= limit` for its scope → return `(false, NULL, '<scope>_quota', ...)`.
+6. Increment `reserved += 1` for each locked counter row. INSERT reservation with `counter_refs` JSONB listing those rows, `expires_at = p_now + p_ttl_ms`. INSERT `ai_rate_events(reservation_id, user_id, ts=p_now)`. Return `(true, reservation_id, NULL, NULL)`.
+
+```sql
+ai_quota_finalize(
+  p_reservation_id UUID,
+  p_status         TEXT,                  -- 'success' | 'error_with_usage' | 'error_no_usage'
+  p_tokens_in      INTEGER,
+  p_tokens_out     INTEGER,
+  p_cost_usd       NUMERIC
+) RETURNS VOID
+```
+Algorithm:
+1. `SELECT … FOR UPDATE` the reservation row. If status != 'reserved' → no-op (idempotent).
+2. For each ref in `counter_refs` (ordered canonical), `UPDATE ai_quota_counters SET reserved = reserved - 1 …` keyed by `(scope,key,window_id)`.
+3. If `p_status IN ('success','error_with_usage')`: also `count += 1`, `tokens_in += p_tokens_in`, `tokens_out += p_tokens_out`, `cost_usd += p_cost_usd`.
+4. If `p_status = 'error_no_usage'`: also delete the row's `ai_rate_events` entry so it does not count against the sliding window (failed-before-provider). Otherwise keep the event.
+5. UPDATE reservation row with status + actuals.
+
+```sql
+ai_quota_release_expired(p_now TIMESTAMPTZ DEFAULT now()) RETURNS INTEGER
+```
+- For every `ai_quota_reservations` where `status='reserved' AND expires_at < p_now`: behave like finalize with `status='expired'`, decrement `reserved` per `counter_refs`, leave `ai_rate_events` (already-issued slot counted as used — conservative). Returns count of released reservations.
+
+### Server-side TS surface (`src/lib/ai/usage-metering.ts`)
 ```ts
 export interface ReservationResult {
   allowed: boolean
@@ -101,78 +153,95 @@ export async function finalizeUsage(
   record?: UsageRecord
 ): Promise<void>
 ```
-Implementation calls Supabase via existing server-side fetch path. Kill-switch check happens in TS before the RPC call (cheap short-circuit).
+- `reserveUsage` reads limits from `src/lib/ai/limits.ts`, short-circuits with `reason='kill_switch'` when `AI_KILL_SWITCH=on` (no RPC call), otherwise calls `ai_quota_reserve` via the new server helper.
+- `finalizeUsage` is a safe no-op when `reservationId` is falsy or `kill_switch` was the cause.
+- Legacy in-memory functions (`checkUsageLimits`, `recordUsage`, `confirmUsage`) and `__resetUsageMeteringForTests` removed after S003 (no other consumers remain — confirm during exploration before deleting).
 
-In-memory functions stay only for backward-compat in tests that already exercise them; the chat route stops using them.
+### Server-side RPC helper (`src/lib/ai/server-rpc.ts` — NEW)
+- Reuses the JWT signing logic and claims shape from `src/app/api/rpc/[fn]/route.ts` (extract a small `mintSupabaseJwt(claims)` helper shared between proxy and server callers).
+- Calls Supabase PostgREST directly via `fetch(SUPABASE_URL + '/rest/v1/rpc/<fn>')` with `Authorization: Bearer <jwt>` and `apikey`.
+- No reliance on relative URLs; safe inside route handlers/server actions.
+- Strict, narrow generic types; zero `any` (passes `verify:no-explicit-any`).
 
-## TDD Stories (Ralph one-per-iteration)
+## TDD Stories
 
-> Every story ends with: `verify:no-explicit-any` → `verify:dedupe` → `typecheck` → targeted tests → react-doctor diff. Each story commits as `feat: [Sxxx] - <title>` and sets `passes: true` in `prd.json`.
+> Per-story verify chain: `verify:no-explicit-any` → `verify:dedupe` → `typecheck` → focused vitest run → react-doctor diff. Migration stories also require `get_advisors(security)` + `get_advisors(performance)` clean.
 
-### S001 — Schema + RPCs (red→green)
-- **Tests (new)**: `supabase/tests/ai_quota_hardening.sql` or vitest integration shim that calls RPCs via `execute_sql` MCP fixtures. Cover:
-  - Reserve under limit succeeds; reservation row created
-  - Reserve at limit returns `allowed=false` with correct reason for each scope
-  - Two concurrent reserves at the boundary cannot both succeed (advisory lock + UPSERT)
-  - Finalize `success` increments `count`, decrements `reserved`, records tokens/cost
-  - Finalize `error_with_usage` increments `count` AND tokens/cost
-  - Finalize `error_no_usage` only releases `reserved`
-  - Finalize is idempotent (double-call no-op)
-  - Expired reservation is swept and `reserved` is released
-- **Impl**: single migration `ai_quota_hardening` applied via MCP `apply_migration`. Functions follow security template (`SECURITY DEFINER`, `SET search_path = public, pg_temp`, JWT claim guard)
-- **Post**: `get_advisors(security)` and `get_advisors(performance)` clean
+### S001 — Schema + RPCs with cross-user locking & sliding rate
+**Red tests** (SQL fixtures via `execute_sql` MCP):
+- Reserve under all caps succeeds; counter rows + reservation + rate event created.
+- Reserve at user_daily, tenant_daily, global_daily limit each returns `(false, _, '<scope>_quota')`.
+- Concurrent reserves at tenant boundary for two different users: only one succeeds (canonical-order FOR UPDATE serializes on shared tenant row).
+- Concurrent reserves at global boundary across tenants: only one succeeds.
+- Sliding rate: N reserves in window pass, N+1 rejected; one event aged beyond window allows next reserve.
+- Finalize `success` increments `count`, decrements `reserved`, accumulates tokens/cost on **exactly** the rows in `counter_refs`.
+- Finalize `error_with_usage` increments `count` AND tokens/cost; rate event kept.
+- Finalize `error_no_usage` only releases `reserved`; rate event removed.
+- Finalize is idempotent.
+- `ai_quota_release_expired` releases reserved counts for expired reservations, leaves rate events alone.
+- Day-boundary reservation: reserved on day N at 23:59 with finalize on day N+1 at 00:00 decrements the day-N counter (proves `counter_refs` immunity to window drift).
 
-### S002 — TS wrapper `reserveUsage` / `finalizeUsage`
-- **Tests (new)** in `src/lib/ai/__tests__/usage-metering.distributed.test.ts`:
-  - Mocks `callRpc` and asserts payload shape for `ai_quota_reserve`
-  - Maps RPC `reason` → existing `UsageLimitReason` plus new `global_quota`
-  - `reserveUsage` short-circuits with `reason='kill_switch'` when `AI_KILL_SWITCH=on`
-  - `finalizeUsage` accepts all three statuses; missing reservationId is a no-op
-- **Impl**: add the two exports; keep legacy in-memory functions untouched (still used by old tests)
-- **Constraint**: zero `any` in the diff (`verify:no-explicit-any` gate)
+**Impl**: single migration `ai_quota_hardening` applied via `apply_migration`. Functions follow security template; lock order strict.
 
-### S003 — Wire `/api/chat` to reserve/finalize
-- **Tests (update)**: `route.rate-limit-and-quota.test.ts`
-  - Replace `checkUsageLimits`/`recordUsage`/`confirmUsage` mocks with `reserveUsage`/`finalizeUsage`
-  - Assert reserve called BEFORE streaming, finalize called on stream finish
-  - Assert 429 body includes RPC `reason` and `message`
-  - Assert reservationId passed through to `onFinish` and `onError`
-- **Impl**:
-  - Replace lines 149–155 with `reserveUsage(...)`; on `!allowed` return 429 (including new `kill_switch` / `global_quota` reasons)
-  - Remove line 182 `recordUsage`
-  - In `onFinish`: call `finalizeUsage(reservationId, 'success', { inputTokens, outputTokens })`
-  - In `onError` / catch around stream: distinguish `error_with_usage` vs `error_no_usage` based on whether any tokens were emitted; for safety, default partial-stream errors to `error_with_usage`
+### S002 — Server RPC helper + TS wrappers
+**Red tests** (`server-rpc.test.ts`, `usage-metering.distributed.test.ts`):
+- `mintSupabaseJwt` produces claims identical to RPC proxy for equivalent input (shared helper).
+- `serverCallRpc` posts to absolute PostgREST URL with correct headers; rejects non-allowlisted fn names.
+- `reserveUsage` payload includes all limit params and TTL from `src/lib/ai/limits.ts`.
+- `reserveUsage` short-circuits to `kill_switch` when `AI_KILL_SWITCH=on`; no fetch occurs.
+- `reserveUsage` maps RPC `reason` strings to `UsageLimitReason | 'global_quota' | 'kill_switch'`.
+- `finalizeUsage` accepts all three statuses; no-op on missing reservationId.
 
-### S004 — Cost-aware failure accounting
-- **Tests (new)** `route.cost-aware-failure.test.ts`:
-  - Stream throws after first chunk → finalize called with `error_with_usage` and observed tokens
-  - Stream throws before any chunk → finalize called with `error_no_usage`
-  - 4xx/5xx from provider with `usage` in error payload → `error_with_usage`
-- **Impl**: refine the error branch from S003; centralize the classification in a small helper inside `usage-metering.ts`
+**Impl**: extract `mintSupabaseJwt` from the proxy (Story S002 also updates `src/app/api/rpc/[fn]/route.ts` to use it — pure refactor, behavior-preserving). Add `server-rpc.ts` + new exports in `usage-metering.ts`.
+
+### S003 — Wire `/api/chat` with finalize on every exit path
+**Red tests** (`route.rate-limit-and-quota.test.ts` updated + `route.retry-and-abort-finalize.test.ts` new):
+- Reserve called before `streamText`; finalize called on `onFinish` with `success`.
+- Reserve at limit → 429 with `reason`/`message` from RPC; no stream started.
+- Pre-stream retry `continue` (existing behavior at ~`route.ts:288`): each attempt that reserved MUST finalize as `error_no_usage` before the next attempt is reserved. Test forces the retry path and asserts finalize per attempt.
+- 500 thrown before stream after reserve → finalize `error_no_usage`.
+- Client abort mid-stream (`AbortSignal`) → finalize `error_with_usage` with observed tokens.
+- `onError` thrown after first chunk → finalize `error_with_usage`.
+
+**Impl**:
+- Replace existing limit-check + `recordUsage` (`route.ts:149`, `:182`) with `reserveUsage`.
+- Track `currentReservationId` per attempt in the retry loop; centralize a `finalizeOnce(status, record?)` closure shared by all exit paths.
+- Wire to `onFinish`, `onError`, top-level `try/catch`, retry `continue`, and `AbortSignal` listener.
+
+### S004 — Cost-aware failure accounting refinements
+**Red tests** (`route.cost-aware-failure.test.ts`):
+- Provider returns 5xx with `usage` payload (mock provider error) → `error_with_usage` with parsed tokens.
+- Stream throws after first delta → `error_with_usage` with `outputTokens >= 1`.
+- Stream throws before first delta → `error_no_usage`.
+
+**Impl**: small classifier helper in `usage-metering.ts` (`classifyStreamFailure(stage, tokensObserved)`); wire it in S003's `finalizeOnce`.
 
 ### S005 — Global daily cap + env-var kill switch
-- **Tests (new)** `route.kill-switch.test.ts`:
-  - `AI_KILL_SWITCH=on` → 429 with `reason='kill_switch'`, RPC not called
-  - `AI_DAILY_GLOBAL_QUOTA_REQUESTS=1` + two reserves → second returns `reason='global_quota'`
-- **Impl**:
-  - Add limits to `src/lib/ai/limits.ts`
-  - TS short-circuit for kill switch
-  - RPC enforces global cap (already included in S001 schema; flag-on with env-provided limit injected as parameter, not hardcoded in SQL)
+**Red tests** (`route.kill-switch.test.ts`):
+- `AI_KILL_SWITCH=on` → 429, `reason='kill_switch'`, no RPC fetch.
+- With `AI_DAILY_GLOBAL_QUOTA_REQUESTS=1`: first reserve succeeds, second returns 429 `reason='global_quota'`.
+- TTL env override (`AI_QUOTA_RESERVATION_TTL_MS=200`) is passed through to RPC.
 
-### S006 — Cleanup, docs, advisors
-- Remove now-unreachable code paths in `usage-metering.ts` (legacy daily Maps if no consumers remain). Keep `__resetUsageMeteringForTests` and update to clear new state where applicable.
-- `get_advisors(security)` and `get_advisors(performance)` clean after final apply
-- Update `docs/` if a runbook exists for AI quotas (read-only check first; do not create new docs unless one already exists)
+**Impl**:
+- Add limits to `src/lib/ai/limits.ts` (`AI_DAILY_GLOBAL_QUOTA_REQUESTS`, `AI_KILL_SWITCH`, `AI_QUOTA_RESERVATION_TTL_MS` with default `120_000`).
+- TS short-circuit for kill switch in `reserveUsage`.
+- Global cap enforced by S001 RPC via the `p_global_daily_max` parameter.
 
-## Out of Scope (this plan)
-- UI retry cooldown (issue item 6) — separate issue
-- Migrating cost-per-token rates to a config table — separate issue
-- DB-backed kill switch — explicitly deferred (env var per user decision)
+### S006 — Cleanup, advisors, allowlist
+- Remove legacy in-memory functions + `__resetUsageMeteringForTests` once no consumers remain.
+- Allowlist update in `src/app/api/rpc/[fn]/allowed-functions.ts` only if any client-side call path needs the quota RPCs. With `server-rpc.ts`, the proxy is bypassed for these calls — so allowlist edit is likely unnecessary. Confirm and document.
+- `get_advisors(security)` + `get_advisors(performance)` clean.
+
+## Follow-ups Required (file before closing #484)
+1. **UI retry cooldown** — issue scope item 6, deferred.
+2. **DB-backed kill switch** — replace env-var with table-row toggle so admins can flip without redeploy (issue AC mandates "without redeploying code").
+3. **Cost-per-token config table** — replace hardcoded rates in `estimateCostUsd`.
 
 ## Risk Notes
-- **Env-var kill switch requires redeploy**, which deviates from the issue's "without redeploying code" AC. User accepted this trade-off; flag in PR description.
-- Advisory locks are per-user-key; cross-user contention is not serialized — intentional for throughput.
-- Reservation TTL (30s) must exceed worst-case stream time. Make it env-configurable (`AI_QUOTA_RESERVATION_TTL_MS`) with a sane default.
+- **Env kill switch requires redeploy** — explicitly noted in PR description; tracked by follow-up #2 above.
+- **Cross-user lock contention** — canonical-order FOR UPDATE serializes shared tenant/global rows. Throughput cost is acceptable for current scale; revisit if metrics show contention.
+- **Reservation TTL = 120s default** — must exceed worst-case stream + artifact work (`maxDuration=60s` + draft). Tunable via env.
+- **`ai_rate_events` growth** — pruned on each reserve for the requesting user, plus periodic sweep by `ai_quota_release_expired`. Add a scheduled job if growth becomes an issue.
 
 ## Verification Order (mandatory each story)
 1. `node scripts/npm-run.js run verify:no-explicit-any`
@@ -180,4 +249,4 @@ In-memory functions stay only for backward-compat in tests that already exercise
 3. `node scripts/npm-run.js run typecheck`
 4. Focused vitest run for the story's test file(s)
 5. `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
-6. `get_advisors(security)` after any migration
+6. `get_advisors(security)` + `get_advisors(performance)` after any migration

--- a/src/__tests__/react-doctor-p4-knip-exports.source.test.ts
+++ b/src/__tests__/react-doctor-p4-knip-exports.source.test.ts
@@ -192,10 +192,6 @@ const unusedExportSurface = [
     exports: ["hasWriteIntentToolName"],
   },
   {
-    file: "src/lib/ai/usage-metering.ts",
-    exports: ["__resetUsageMeteringForTests","getLatestUsage"],
-  },
-  {
     file: "src/lib/category-import-validation.ts",
     exports: ["HEADER_TO_DB_MAP","normalizeVietnamese"],
   },

--- a/src/app/api/chat/__tests__/route.attachment-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.attachment-tools.test.ts
@@ -7,9 +7,11 @@ const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -26,9 +28,13 @@ vi.mock('@/lib/ai/prompts/system', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -71,7 +77,6 @@ describe('/api/chat attachmentLookup tool', () => {
     })
     getChatModelMock.mockReturnValue(makeChatModel('google:gemini-3-flash-preview'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
   })

--- a/src/app/api/chat/__tests__/route.auth-and-schema.test.ts
+++ b/src/app/api/chat/__tests__/route.auth-and-schema.test.ts
@@ -6,6 +6,11 @@ const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -19,6 +24,16 @@ vi.mock('@/lib/ai/provider', () => ({
 
 vi.mock('@/lib/ai/prompts/system', () => ({
   buildSystemPrompt: (...args: unknown[]) => buildSystemPromptMock(...args),
+}))
+
+vi.mock('@/lib/ai/usage-metering', () => ({
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {

--- a/src/app/api/chat/__tests__/route.cost-aware-failure.test.ts
+++ b/src/app/api/chat/__tests__/route.cost-aware-failure.test.ts
@@ -97,11 +97,11 @@ describe('/api/chat cost-aware failure accounting', () => {
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
 
     expect(res.status).toBe(200)
-    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
       status: 'error_with_usage',
       inputTokens: 17,
       outputTokens: 19,
-    }))
+    })))
   })
 
   it('records zero tokens when the provider supplies no usage', async () => {
@@ -119,10 +119,10 @@ describe('/api/chat cost-aware failure accounting', () => {
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
 
     expect(res.status).toBe(200)
-    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
       status: 'error_with_usage',
       inputTokens: 0,
       outputTokens: 0,
-    }))
+    })))
   })
 })

--- a/src/app/api/chat/__tests__/route.cost-aware-failure.test.ts
+++ b/src/app/api/chat/__tests__/route.cost-aware-failure.test.ts
@@ -7,11 +7,8 @@ const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const reserveUsageMock = vi.fn(async () => ({
-  allowed: true,
-  reservationId: '00000000-0000-4000-8000-000000000484',
-}))
-const finalizeUsageMock = vi.fn(async () => undefined)
+const reserveUsageMock = vi.fn()
+const finalizeUsageMock = vi.fn()
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -68,53 +65,64 @@ function buildRequest(body: unknown) {
   })
 }
 
-describe('/api/chat usageHistory tool', () => {
+describe('/api/chat cost-aware failure accounting', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
     getServerSessionMock.mockResolvedValue({
-      user: { id: 'u1', role: 'to_qltb', don_vi: 2 },
+      user: { id: 'u1', role: 'admin', don_vi: 2 },
     })
-    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-3-flash-preview'))
+    getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
-    streamTextMock.mockReturnValue(makeReadyStreamTextResult())
+    reserveUsageMock.mockResolvedValue({
+      allowed: true,
+      reservationId: '00000000-0000-4000-8000-000000000484',
+    })
+    finalizeUsageMock.mockResolvedValue(undefined)
   })
 
-  it('accepts usageHistory when explicitly requested', async () => {
-    const res = await POST(
-      buildRequest({
-        messages: VALID_MESSAGES,
-        requestedTools: ['usageHistory'],
-      }) as never,
-    )
-
-    expect(res.status).toBe(200)
-    expect(streamTextMock).toHaveBeenCalledOnce()
-
-    const streamArgs = streamTextMock.mock.calls[0]?.[0] as {
-      tools?: Record<string, unknown>
-    }
-    expect(streamArgs?.tools).toHaveProperty('usageHistory')
-  })
-
-  it('blocks usageHistory without facility context for privileged role', async () => {
-    getServerSessionMock.mockResolvedValue({
-      user: { id: 'u1', role: 'global', don_vi: null },
+  it('records provider-reported usage for finishReason error', async () => {
+    streamTextMock.mockImplementation((opts: Record<string, unknown>) => {
+      const onFinish = opts.onFinish as
+        | ((result: { usage: { inputTokens: number; outputTokens: number }; finishReason: string }) => void)
+        | undefined
+      onFinish?.({
+        usage: { inputTokens: 17, outputTokens: 19 },
+        finishReason: 'error',
+      })
+      return makeReadyStreamTextResult()
     })
 
-    const res = await POST(
-      buildRequest({
-        messages: VALID_MESSAGES,
-        requestedTools: ['usageHistory'],
-      }) as never,
-    )
-    const text = await res.text()
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
 
-    expect(res.status).toBe(400)
-    expect(text).toBe(
-      'Anh/chị vui lòng chọn cơ sở y tế tại bộ lọc đơn vị trên thanh điều hướng (phía trên bên trái màn hình) trước khi sử dụng trợ lý tra cứu.',
-    )
-    expect(streamTextMock).not.toHaveBeenCalled()
+    expect(res.status).toBe(200)
+    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'error_with_usage',
+      inputTokens: 17,
+      outputTokens: 19,
+    }))
+  })
+
+  it('records zero tokens when the provider supplies no usage', async () => {
+    streamTextMock.mockImplementation((opts: Record<string, unknown>) => {
+      const onFinish = opts.onFinish as
+        | ((result: { usage: { inputTokens?: number; outputTokens?: number }; finishReason: string }) => void)
+        | undefined
+      onFinish?.({
+        usage: {},
+        finishReason: 'error',
+      })
+      return makeReadyStreamTextResult()
+    })
+
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
+
+    expect(res.status).toBe(200)
+    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'error_with_usage',
+      inputTokens: 0,
+      outputTokens: 0,
+    }))
   })
 })

--- a/src/app/api/chat/__tests__/route.equipment-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.equipment-tools.test.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 describe('equipmentLookup contract shape', () => {
   it('maps to ai_equipment_lookup RPC', async () => {

--- a/src/app/api/chat/__tests__/route.error-safety.test.ts
+++ b/src/app/api/chat/__tests__/route.error-safety.test.ts
@@ -7,9 +7,11 @@ const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -26,9 +28,13 @@ vi.mock('@/lib/ai/prompts/system', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -70,7 +76,10 @@ describe('/api/chat error safety — non-stream contract', () => {
 
     getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
+    reserveUsageMock.mockResolvedValue({
+      allowed: true,
+      reservationId: '00000000-0000-4000-8000-000000000484',
+    })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
   })
@@ -118,8 +127,9 @@ describe('/api/chat error safety — non-stream contract', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'admin', don_vi: 2 },
     })
-    checkUsageLimitsMock.mockReturnValue({
+    reserveUsageMock.mockResolvedValue({
       allowed: false,
+      reason: 'rate_limit',
       message: 'Too many requests. Please try again later.',
     })
 
@@ -162,7 +172,10 @@ describe('/api/chat error safety — sanitization', () => {
     })
     getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
+    reserveUsageMock.mockResolvedValue({
+      allowed: true,
+      reservationId: '00000000-0000-4000-8000-000000000484',
+    })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
   })
 

--- a/src/app/api/chat/__tests__/route.intent-routing.test.ts
+++ b/src/app/api/chat/__tests__/route.intent-routing.test.ts
@@ -7,9 +7,11 @@ const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 const executeAuditedAssistantSqlMock = vi.fn()
 
 vi.mock('next-auth', () => ({
@@ -27,9 +29,13 @@ vi.mock('@/lib/ai/prompts/system', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('@/lib/ai/sql/audited-executor', () => ({
@@ -105,7 +111,6 @@ describe('/api/chat intent routing + clarification guard', () => {
     })
     getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
     executeAuditedAssistantSqlMock.mockResolvedValue({

--- a/src/app/api/chat/__tests__/route.key-rotation.test.ts
+++ b/src/app/api/chat/__tests__/route.key-rotation.test.ts
@@ -27,9 +27,11 @@ const getChatModelMock = vi.fn()
 const getKeyPoolSizeMock = vi.fn()
 const handleProviderQuotaErrorMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -46,9 +48,13 @@ vi.mock('@/lib/ai/prompts/system', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -203,9 +209,7 @@ describe('/api/chat — API key rotation integration', () => {
     })
 
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
-    recordUsageMock.mockReturnValue(undefined)
   })
 
   // -----------------------------------------------------------------

--- a/src/app/api/chat/__tests__/route.kill-switch.test.ts
+++ b/src/app/api/chat/__tests__/route.kill-switch.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+const getServerSessionMock = vi.fn()
+const callServerRpcMock = vi.fn()
+const streamTextMock = vi.fn()
+const stepCountIsMock = vi.fn()
+
+vi.mock('next-auth', () => ({
+  getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
+}))
+
+vi.mock('@/lib/ai/server-rpc', () => ({
+  callServerRpc: (...args: unknown[]) => callServerRpcMock(...args),
+}))
+
+vi.mock('@/lib/ai/provider', () => ({
+  getChatModel: vi.fn(),
+  getKeyPoolSize: () => 1,
+  handleProviderQuotaError: () => false,
+}))
+
+vi.mock('@/lib/ai/prompts/system', () => ({
+  buildSystemPrompt: () => 'SYSTEM_PROMPT_V1',
+}))
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai')
+  return {
+    ...actual,
+    streamText: (...args: unknown[]) => streamTextMock(...args),
+    stepCountIs: (...args: unknown[]) => stepCountIsMock(...args),
+  }
+})
+
+const VALID_MESSAGES = [
+  {
+    id: 'msg_1',
+    role: 'user',
+    parts: [{ type: 'text', text: 'Xin chao' }],
+  },
+]
+
+function buildRequest(body: unknown) {
+  return new Request('http://localhost/api/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/chat kill switch and global quota', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    getServerSessionMock.mockResolvedValue({
+      user: { id: 'u1', role: 'admin', don_vi: 2 },
+    })
+    stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns 429 without calling quota RPC when AI_KILL_SWITCH is on', async () => {
+    vi.stubEnv('AI_KILL_SWITCH', 'on')
+
+    const { POST } = await import('../route')
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
+    const text = await res.text()
+
+    expect(res.status).toBe(429)
+    expect(text).toBe('AI usage is temporarily disabled.')
+    expect(callServerRpcMock).not.toHaveBeenCalled()
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
+  it('passes global daily quota to reserve RPC and returns its global quota denial', async () => {
+    vi.stubEnv('AI_DAILY_GLOBAL_QUOTA_REQUESTS', '1')
+    callServerRpcMock.mockResolvedValue([
+      {
+        allowed: false,
+        reservation_id: null,
+        reason: 'global_quota',
+        message: 'AI daily quota exceeded',
+      },
+    ])
+
+    const { POST } = await import('../route')
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
+    const text = await res.text()
+
+    expect(res.status).toBe(429)
+    expect(text).toBe('AI daily quota exceeded')
+    expect(streamTextMock).not.toHaveBeenCalled()
+    expect(callServerRpcMock).toHaveBeenCalledWith(
+      'ai_quota_reserve',
+      expect.objectContaining({
+        p_global_daily_max: 1,
+      }),
+      expect.objectContaining({
+        id: 'u1',
+        don_vi: 2,
+      }),
+    )
+  })
+})

--- a/src/app/api/chat/__tests__/route.limits.test.ts
+++ b/src/app/api/chat/__tests__/route.limits.test.ts
@@ -6,9 +6,11 @@ const stepCountIsMock = vi.fn()
 const convertToModelMessagesMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 const ORIGINAL_ENV = { ...process.env }
 
@@ -58,9 +60,13 @@ vi.mock('@/lib/ai/limits', async (importOriginal) => {
 })
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -110,7 +116,6 @@ describe('/api/chat limits', () => {
     )
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     convertToModelMessagesMock.mockResolvedValue([
       { role: 'user', content: 'converted-message-sentinel' },
     ])

--- a/src/app/api/chat/__tests__/route.query-database-grounding.test.ts
+++ b/src/app/api/chat/__tests__/route.query-database-grounding.test.ts
@@ -6,9 +6,11 @@ const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -21,9 +23,13 @@ vi.mock('@/lib/ai/provider', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -58,7 +64,6 @@ describe('/api/chat query_database grounding payload', () => {
       user: { id: 'u1', role: 'to_qltb', don_vi: 17 },
     })
     getChatModelMock.mockReturnValue(makeChatModel('google/gemini-3.1-flash-lite-preview'))
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
   })

--- a/src/app/api/chat/__tests__/route.quota-tools.test.ts
+++ b/src/app/api/chat/__tests__/route.quota-tools.test.ts
@@ -10,9 +10,11 @@ const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -29,9 +31,13 @@ vi.mock('@/lib/ai/prompts/system', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -74,7 +80,6 @@ describe('/api/chat quota tools', () => {
     })
     getChatModelMock.mockReturnValue(makeChatModel('google:gemini-3-flash-preview'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V2')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
   })

--- a/src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts
+++ b/src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts
@@ -149,11 +149,11 @@ describe('/api/chat rate limit and quota', () => {
       streamTextMock.mock.invocationCallOrder[0],
     )
     expect(streamTextMock).toHaveBeenCalledTimes(1)
-    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
       reservationId: '00000000-0000-4000-8000-000000000484',
       status: 'success',
       inputTokens: 100,
       outputTokens: 50,
-    }))
+    })))
   })
 })

--- a/src/app/api/chat/__tests__/route.repair-request-draft-orchestration.test.ts
+++ b/src/app/api/chat/__tests__/route.repair-request-draft-orchestration.test.ts
@@ -5,9 +5,11 @@ const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 const generateObjectMock = vi.fn()
 
 vi.mock('server-only', () => ({}))
@@ -27,9 +29,13 @@ vi.mock('@/lib/ai/prompts/system', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -100,7 +106,6 @@ describe('/api/chat repair-request draft orchestration', () => {
     })
     getChatModelMock.mockReturnValue(makeChatModel('gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
   })
 

--- a/src/app/api/chat/__tests__/route.retry-and-abort-finalize.test.ts
+++ b/src/app/api/chat/__tests__/route.retry-and-abort-finalize.test.ts
@@ -6,6 +6,8 @@ const getServerSessionMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
+const getKeyPoolSizeMock = vi.fn()
+const handleProviderQuotaErrorMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
 const reserveUsageMock = vi.fn()
 const finalizeUsageMock = vi.fn()
@@ -16,21 +18,12 @@ vi.mock('next-auth', () => ({
 
 vi.mock('@/lib/ai/provider', () => ({
   getChatModel: (...args: unknown[]) => getChatModelMock(...args),
-  getKeyPoolSize: () => 1,
-  handleProviderQuotaError: () => false,
+  getKeyPoolSize: (...args: unknown[]) => getKeyPoolSizeMock(...args),
+  handleProviderQuotaError: (...args: unknown[]) => handleProviderQuotaErrorMock(...args),
 }))
 
 vi.mock('@/lib/ai/prompts/system', () => ({
   buildSystemPrompt: (...args: unknown[]) => buildSystemPromptMock(...args),
-}))
-
-vi.mock('@/lib/ai/limits', () => ({
-  AI_MAX_OUTPUT_TOKENS: 256,
-  AI_MAX_TOOL_STEPS: 4,
-  AI_MAX_MESSAGES: 20,
-  AI_MAX_INPUT_CHARS: 20_000,
-  AI_MAX_COMPACTED_INPUT_CHARS: 10_000,
-  calculateInputChars: (messages: unknown[]) => JSON.stringify(messages).length,
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
@@ -58,14 +51,6 @@ import {
   makeReadyStreamTextResult,
 } from './stream-text-result-test-helpers'
 
-function buildRequest(body: unknown) {
-  return new Request('http://localhost/api/chat', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-}
-
 const VALID_MESSAGES = [
   {
     id: 'msg_1',
@@ -74,13 +59,22 @@ const VALID_MESSAGES = [
   },
 ]
 
-describe('/api/chat rate limit and quota', () => {
+function buildRequest(body: unknown) {
+  return new Request('http://localhost/api/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/chat quota finalize on retry and errors', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'admin', don_vi: 2 },
     })
+    getKeyPoolSizeMock.mockReturnValue(1)
     getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
@@ -89,71 +83,58 @@ describe('/api/chat rate limit and quota', () => {
       reservationId: '00000000-0000-4000-8000-000000000484',
     })
     finalizeUsageMock.mockResolvedValue(undefined)
-    streamTextMock.mockImplementation((opts: Record<string, unknown>) => {
-      // Simulate onFinish callback firing with mock usage data
-      const onFinish = opts.onFinish as
-        | ((result: { usage: { inputTokens: number; outputTokens: number }; finishReason: string }) => void)
-        | undefined
-      if (onFinish) {
-        onFinish({
-          usage: { inputTokens: 100, outputTokens: 50 },
+    handleProviderQuotaErrorMock.mockReturnValue(false)
+  })
+
+  it('finalizes error_no_usage when the provider fails before a stream starts', async () => {
+    streamTextMock.mockImplementation(() => {
+      throw new Error('Network timeout before stream')
+    })
+
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
+
+    expect(res.status).toBe(500)
+    expect(finalizeUsageMock).toHaveBeenCalledOnce()
+    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+      reservationId: '00000000-0000-4000-8000-000000000484',
+      status: 'error_no_usage',
+      inputTokens: 0,
+      outputTokens: 0,
+    }))
+  })
+
+  it('keeps one reservation across provider retry and finalizes once on success', async () => {
+    getKeyPoolSizeMock.mockReturnValue(2)
+    getChatModelMock
+      .mockReturnValueOnce(makeChatModel('google:gemini-2.5-flash', undefined))
+      .mockReturnValueOnce(makeChatModel('google:gemini-2.5-flash', undefined))
+    handleProviderQuotaErrorMock.mockReturnValueOnce(true)
+    streamTextMock
+      .mockImplementationOnce(() => {
+        throw new Error('You exceeded your current quota')
+      })
+      .mockImplementationOnce((opts: Record<string, unknown>) => {
+        const onFinish = opts.onFinish as
+          | ((result: { usage: { inputTokens: number; outputTokens: number }; finishReason: string }) => void)
+          | undefined
+        onFinish?.({
+          usage: { inputTokens: 7, outputTokens: 5 },
           finishReason: 'stop',
         })
-      }
-      return makeReadyStreamTextResult()
-    })
-  })
+        return makeReadyStreamTextResult()
+      })
 
-  it('returns 429 when rate-limited', async () => {
-    reserveUsageMock.mockResolvedValue({
-      allowed: false,
-      reason: 'rate_limit',
-      message: 'Too many requests. Please try again later.',
-    })
-
-    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
-    const text = await res.text()
-
-    expect(res.status).toBe(429)
-    expect(text).toBe('Too many requests. Please try again later.')
-    expect(streamTextMock).not.toHaveBeenCalled()
-    expect(finalizeUsageMock).not.toHaveBeenCalled()
-  })
-
-  it('returns 429 when quota is exceeded', async () => {
-    reserveUsageMock.mockResolvedValue({
-      allowed: false,
-      reason: 'tenant_quota',
-      message: 'AI usage quota exceeded for this facility.',
-    })
-
-    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
-    const text = await res.text()
-
-    expect(res.status).toBe(429)
-    expect(text).toBe('AI usage quota exceeded for this facility.')
-    expect(streamTextMock).not.toHaveBeenCalled()
-    expect(finalizeUsageMock).not.toHaveBeenCalled()
-  })
-
-  it('reserves before stream and finalizes provider-reported usage on finish', async () => {
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
 
     expect(res.status).toBe(200)
-    expect(reserveUsageMock).toHaveBeenCalledWith(expect.objectContaining({
-      userId: 'u1',
-      tenantId: 2,
-      role: 'admin',
-    }))
-    expect(reserveUsageMock.mock.invocationCallOrder[0]).toBeLessThan(
-      streamTextMock.mock.invocationCallOrder[0],
-    )
-    expect(streamTextMock).toHaveBeenCalledTimes(1)
+    expect(reserveUsageMock).toHaveBeenCalledOnce()
+    expect(streamTextMock).toHaveBeenCalledTimes(2)
+    expect(finalizeUsageMock).toHaveBeenCalledOnce()
     expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
       reservationId: '00000000-0000-4000-8000-000000000484',
       status: 'success',
-      inputTokens: 100,
-      outputTokens: 50,
+      inputTokens: 7,
+      outputTokens: 5,
     }))
   })
 })

--- a/src/app/api/chat/__tests__/route.retry-and-abort-finalize.test.ts
+++ b/src/app/api/chat/__tests__/route.retry-and-abort-finalize.test.ts
@@ -45,7 +45,7 @@ vi.mock('ai', async () => {
   }
 })
 
-import { POST } from '../route'
+import { POST } from '@/app/api/chat/route'
 import {
   makeChatModel,
   makeReadyStreamTextResult,
@@ -106,8 +106,8 @@ describe('/api/chat quota finalize on retry and errors', () => {
   it('keeps one reservation across provider retry and finalizes once on success', async () => {
     getKeyPoolSizeMock.mockReturnValue(2)
     getChatModelMock
-      .mockReturnValueOnce(makeChatModel('google:gemini-2.5-flash', undefined))
-      .mockReturnValueOnce(makeChatModel('google:gemini-2.5-flash', undefined))
+      .mockReturnValueOnce(makeChatModel('google:gemini-2.5-flash'))
+      .mockReturnValueOnce(makeChatModel('google:gemini-2.5-flash'))
     handleProviderQuotaErrorMock.mockReturnValueOnce(true)
     streamTextMock
       .mockImplementationOnce(() => {
@@ -135,6 +135,71 @@ describe('/api/chat quota finalize on retry and errors', () => {
       status: 'success',
       inputTokens: 7,
       outputTokens: 5,
+    }))
+  })
+
+  it('allows a later finalize callback to retry after a transient finalize failure', async () => {
+    let onFinish:
+      | ((result: { usage: { inputTokens: number; outputTokens: number }; finishReason: string }) => void)
+      | undefined
+    finalizeUsageMock
+      .mockRejectedValueOnce(new Error('temporary quota finalize failure'))
+      .mockResolvedValueOnce(undefined)
+    streamTextMock.mockImplementation((opts: Record<string, unknown>) => {
+      onFinish = opts.onFinish as typeof onFinish
+      onFinish?.({
+        usage: { inputTokens: 7, outputTokens: 5 },
+        finishReason: 'stop',
+      })
+      return makeReadyStreamTextResult()
+    })
+
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
+
+    expect(res.status).toBe(200)
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledTimes(1))
+
+    onFinish?.({
+      usage: { inputTokens: 7, outputTokens: 5 },
+      finishReason: 'stop',
+    })
+
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('keeps readiness failures in error_no_usage before any stream part is ready', async () => {
+    streamTextMock.mockReturnValue({
+      fullStream: {
+        [Symbol.asyncIterator]() {
+          let index = 0
+          const parts = [{ type: 'start' }]
+
+          return {
+            async next() {
+              if (index >= parts.length) {
+                return { done: true, value: undefined }
+              }
+              return { done: false, value: parts[index++] }
+            },
+            async return() {
+              return { done: true, value: undefined }
+            },
+          }
+        },
+      },
+      toUIMessageStream: () => {
+        throw new Error('should not build UI stream')
+      },
+      steps: Promise.resolve([]),
+    })
+
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
+
+    expect(res.status).toBe(500)
+    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'error_no_usage',
+      inputTokens: 0,
+      outputTokens: 0,
     }))
   })
 })

--- a/src/app/api/chat/__tests__/route.retry-and-abort-finalize.test.ts
+++ b/src/app/api/chat/__tests__/route.retry-and-abort-finalize.test.ts
@@ -94,13 +94,13 @@ describe('/api/chat quota finalize on retry and errors', () => {
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
 
     expect(res.status).toBe(500)
-    expect(finalizeUsageMock).toHaveBeenCalledOnce()
-    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
       reservationId: '00000000-0000-4000-8000-000000000484',
       status: 'error_no_usage',
       inputTokens: 0,
       outputTokens: 0,
-    }))
+    })))
   })
 
   it('keeps one reservation across provider retry and finalizes once on success', async () => {
@@ -129,13 +129,13 @@ describe('/api/chat quota finalize on retry and errors', () => {
     expect(res.status).toBe(200)
     expect(reserveUsageMock).toHaveBeenCalledOnce()
     expect(streamTextMock).toHaveBeenCalledTimes(2)
-    expect(finalizeUsageMock).toHaveBeenCalledOnce()
-    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
       reservationId: '00000000-0000-4000-8000-000000000484',
       status: 'success',
       inputTokens: 7,
       outputTokens: 5,
-    }))
+    })))
   })
 
   it('allows a later finalize callback to retry after a transient finalize failure', async () => {
@@ -196,10 +196,10 @@ describe('/api/chat quota finalize on retry and errors', () => {
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
 
     expect(res.status).toBe(500)
-    expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
+    await vi.waitFor(() => expect(finalizeUsageMock).toHaveBeenCalledWith(expect.objectContaining({
       status: 'error_no_usage',
       inputTokens: 0,
       outputTokens: 0,
-    }))
+    })))
   })
 })

--- a/src/app/api/chat/__tests__/route.runtime.test.ts
+++ b/src/app/api/chat/__tests__/route.runtime.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 import { maxDuration, runtime } from '../route'
 

--- a/src/app/api/chat/__tests__/route.setup.test.ts
+++ b/src/app/api/chat/__tests__/route.setup.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 
 vi.mock('next-auth', () => ({

--- a/src/app/api/chat/__tests__/route.tenant-policy.test.ts
+++ b/src/app/api/chat/__tests__/route.tenant-policy.test.ts
@@ -7,9 +7,11 @@ const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -26,9 +28,13 @@ vi.mock('@/lib/ai/prompts/system', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -68,7 +74,6 @@ describe('/api/chat tenant policy', () => {
 
     getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
   })

--- a/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
+++ b/src/app/api/chat/__tests__/route.tools-allowlist.test.ts
@@ -7,9 +7,11 @@ const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 const getChatModelMock = vi.fn()
 const buildSystemPromptMock = vi.fn()
-const checkUsageLimitsMock = vi.fn()
-const recordUsageMock = vi.fn()
-const confirmUsageMock = vi.fn()
+const reserveUsageMock = vi.fn(async () => ({
+  allowed: true,
+  reservationId: '00000000-0000-4000-8000-000000000484',
+}))
+const finalizeUsageMock = vi.fn(async () => undefined)
 
 vi.mock('next-auth', () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -26,9 +28,13 @@ vi.mock('@/lib/ai/prompts/system', () => ({
 }))
 
 vi.mock('@/lib/ai/usage-metering', () => ({
-  checkUsageLimits: (...args: unknown[]) => checkUsageLimitsMock(...args),
-  recordUsage: (...args: unknown[]) => recordUsageMock(...args),
-  confirmUsage: (...args: unknown[]) => confirmUsageMock(...args),
+  classifyStreamFailure: ({ providerUsage }: { providerUsage?: { inputTokens?: number; outputTokens?: number } }) => ({
+    status: 'error_with_usage',
+    inputTokens: providerUsage?.inputTokens ?? 0,
+    outputTokens: providerUsage?.outputTokens ?? 0,
+  }),
+  reserveUsage: (...args: unknown[]) => reserveUsageMock(...args),
+  finalizeUsage: (...args: unknown[]) => finalizeUsageMock(...args),
 }))
 
 vi.mock('ai', async () => {
@@ -71,7 +77,6 @@ describe('/api/chat tools allowlist policy', () => {
     })
     getChatModelMock.mockReturnValue(makeChatModel('google:gemini-2.5-flash'))
     buildSystemPromptMock.mockReturnValue('SYSTEM_PROMPT_V1')
-    checkUsageLimitsMock.mockReturnValue({ allowed: true })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
     streamTextMock.mockReturnValue(makeReadyStreamTextResult())
   })

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -8,6 +8,7 @@ import {
   validateUIMessages,
 } from 'ai'
 import { getServerSession } from 'next-auth'
+import { after } from 'next/server'
 
 import { authOptions } from '@/auth/config'
 import { chatRequestSchema } from '@/lib/ai/chat-request-schema'
@@ -176,25 +177,31 @@ export async function POST(request: Request) {
   }
 
   let finalized = false
+  let finalizePromise: Promise<void> | null = null
   const finalizeOnce = async (details: {
     status: UsageFinalizeStatus
     inputTokens?: number
     outputTokens?: number
     costUsd?: number
   }) => {
-    if (finalized) {
-      return
+    if (finalized || finalizePromise) {
+      return finalizePromise
     }
-    finalized = true
-    try {
-      await finalizeUsage({
-        ...usageContext,
-        reservationId: usageReservation.reservationId,
-        ...details,
-      })
-    } catch (error) {
-      console.error('[chat] Usage finalize error:', error)
-    }
+    finalizePromise = (async () => {
+      try {
+        await finalizeUsage({
+          ...usageContext,
+          reservationId: usageReservation.reservationId,
+          ...details,
+        })
+        finalized = true
+      } catch (error) {
+        console.error('[chat] Usage finalize error:', error)
+      } finally {
+        finalizePromise = null
+      }
+    })()
+    return finalizePromise
   }
 
   const promptContext: SystemPromptContext = {
@@ -260,21 +267,21 @@ export async function POST(request: Request) {
         providerOptions: chatModel.providerOptions,
         onFinish({ usage, finishReason }) {
           const failureUsage = classifyStreamFailure({ providerUsage: usage })
-          void finalizeOnce(finishReason === 'error'
+          after(() => finalizeOnce(finishReason === 'error'
             ? failureUsage
             : {
                 status: 'success',
                 inputTokens: usage.inputTokens ?? 0,
                 outputTokens: usage.outputTokens ?? 0,
-              })
+              }))
         },
       })
-      streamStarted = true
 
       await waitForStreamReady(result, isProviderQuotaError)
+      streamStarted = true
 
       const handleStreamError = (error: unknown) => {
-        void finalizeOnce(classifyStreamFailure({ providerUsage: undefined }))
+        after(() => finalizeOnce(classifyStreamFailure({ providerUsage: undefined })))
         // Mid-stream quota errors can't be retried (response already in-flight),
         // but rotate the key for future requests so they don't hit the same quota.
         if (isProviderQuotaError(error)) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -30,11 +30,19 @@ import { routeChatIntent } from '@/lib/ai/intent-routing'
 import { resolveAssistantScope } from '@/lib/ai/sql/scope'
 import { extractEquipmentLookupHints } from '@/lib/ai/tools/equipment-lookup-identifiers'
 import { buildToolRegistry, validateRequestedTools } from '@/lib/ai/tools/registry'
-import { checkUsageLimits, confirmUsage, recordUsage } from '@/lib/ai/usage-metering'
+import {
+  classifyStreamFailure,
+  finalizeUsage,
+  reserveUsage,
+  type UsageContext,
+  type UsageFinalizeStatus,
+} from '@/lib/ai/usage-metering'
 import { isProviderQuotaError, sanitizeErrorForClient } from '@/lib/ai/errors'
 import { ROLES } from '@/lib/rbac'
 
+/** Run chat streaming on the Node.js runtime because provider SDKs and server RPCs need Node APIs. */
 export const runtime = 'nodejs'
+/** Hard cap for the route execution window; quota reservation TTL must exceed this. */
 export const maxDuration = 60
 
 function plainError(message: string, status: number) {
@@ -72,6 +80,14 @@ function hasAllowedChatRole(value: unknown): boolean {
   return ALLOWED_CHAT_ROLES.has(value.trim().toLowerCase())
 }
 
+function numberOrStringClaim(value: unknown): number | string | null {
+  if (typeof value === 'number' || typeof value === 'string') {
+    return value
+  }
+  return null
+}
+
+/** Handles authenticated AI chat requests with quota reservation and stream finalization. */
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions)
 
@@ -146,12 +162,39 @@ export async function POST(request: Request) {
     selectedFacilityId,
     usageUserId,
   } = scopeResolution
-  const usageLimit = checkUsageLimits({
+
+  const usageContext: UsageContext = {
     userId: usageUserId,
     tenantId: selectedFacilityId,
-  })
-  if (!usageLimit.allowed) {
-    return plainError(usageLimit.message ?? 'AI usage limit exceeded.', 429)
+    role,
+    diaBanId: numberOrStringClaim(user.dia_ban_id),
+    khoaPhong: typeof user.khoa_phong === 'string' ? user.khoa_phong : null,
+  }
+  const usageReservation = await reserveUsage(usageContext)
+  if (!usageReservation.allowed) {
+    return plainError(usageReservation.message ?? 'AI usage limit exceeded.', 429)
+  }
+
+  let finalized = false
+  const finalizeOnce = async (details: {
+    status: UsageFinalizeStatus
+    inputTokens?: number
+    outputTokens?: number
+    costUsd?: number
+  }) => {
+    if (finalized) {
+      return
+    }
+    finalized = true
+    try {
+      await finalizeUsage({
+        ...usageContext,
+        reservationId: usageReservation.reservationId,
+        ...details,
+      })
+    } catch (error) {
+      console.error('[chat] Usage finalize error:', error)
+    }
   }
 
   const promptContext: SystemPromptContext = {
@@ -163,7 +206,6 @@ export async function POST(request: Request) {
   const systemPrompt = buildSystemPrompt(promptContext)
   const equipmentLookupHints = extractEquipmentLookupHints(validatedMessages)
 
-  const usageContext = { userId: usageUserId, tenantId: selectedFacilityId }
   const shouldAttemptRepairRequestDraft =
     effectiveRequestedTools.includes('generateRepairRequestDraft')
   const tools =
@@ -177,15 +219,16 @@ export async function POST(request: Request) {
           equipmentLookupHints,
         })
       : undefined
-
-  // Record in rate-limit sliding window upfront (anti-abuse).
-  recordUsage(usageContext)
-
   let modelMessages: Awaited<ReturnType<typeof convertToModelMessages>>
   try {
     modelMessages = await convertToModelMessages(compactedMessages)
   } catch (error) {
     console.error('[chat] Message conversion error:', error)
+    await finalizeOnce({
+      status: 'error_no_usage',
+      inputTokens: 0,
+      outputTokens: 0,
+    })
     return plainError(sanitizeErrorForClient(error), 500)
   }
 
@@ -194,6 +237,7 @@ export async function POST(request: Request) {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     let keyIndex = 0
     let configuredModel = 'unknown'
+    let streamStarted = false
 
     try {
       const chatModel = getChatModel()
@@ -215,19 +259,22 @@ export async function POST(request: Request) {
         tools,
         providerOptions: chatModel.providerOptions,
         onFinish({ usage, finishReason }) {
-          // Only increment daily quotas after a successful completion.
-          if (finishReason !== 'error') {
-            confirmUsage(usageContext, {
-              inputTokens: usage.inputTokens ?? 0,
-              outputTokens: usage.outputTokens ?? 0,
-            })
-          }
+          const failureUsage = classifyStreamFailure({ providerUsage: usage })
+          void finalizeOnce(finishReason === 'error'
+            ? failureUsage
+            : {
+                status: 'success',
+                inputTokens: usage.inputTokens ?? 0,
+                outputTokens: usage.outputTokens ?? 0,
+              })
         },
       })
+      streamStarted = true
 
       await waitForStreamReady(result, isProviderQuotaError)
 
       const handleStreamError = (error: unknown) => {
+        void finalizeOnce(classifyStreamFailure({ providerUsage: undefined }))
         // Mid-stream quota errors can't be retried (response already in-flight),
         // but rotate the key for future requests so they don't hit the same quota.
         if (isProviderQuotaError(error)) {
@@ -300,6 +347,12 @@ export async function POST(request: Request) {
         )
         continue
       }
+
+      await finalizeOnce({
+        status: streamStarted ? 'error_with_usage' : 'error_no_usage',
+        inputTokens: 0,
+        outputTokens: 0,
+      })
 
       console.error(
         '[chat] Pre-stream error',

--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
+/** Run the RPC proxy on Node.js so JWT signing uses the server crypto stack. */
 export const runtime = 'nodejs'
-import jwt from 'jsonwebtoken'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../../../../auth/config'
 import { ALLOWED_FUNCTIONS } from './allowed-functions'
 import { sanitizeForLog } from '@/lib/log-sanitizer'
+import { mintSupabaseJwt } from '@/lib/ai/server-rpc'
 
 // SECURITY: Maximum request body size (2MB) to prevent DoS via memory exhaustion
 const MAX_BODY_SIZE = 2 * 1024 * 1024
-const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
 
 type RpcProxySessionUser = {
   role?: unknown
@@ -42,6 +42,7 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'Unexpected error'
 }
 
+/** Proxies allowlisted Supabase RPC calls with JWT claims derived from the server session. */
 export async function POST(req: NextRequest, context: { params: Promise<{ fn: string }> }) {
   try {
     const { fn } = await context.params
@@ -101,26 +102,6 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
   const appRole = roleLower === 'admin' ? 'global' : roleLower
   // (debug removed)
 
-    // Build JWT claims for PostgREST. We keep db role = authenticated; app role in app_role.
-    // IMPORTANT: Convert empty strings to null to prevent BIGINT conversion errors
-    // iat is backdated to handle clock skew between this server and Supabase.
-    // exp is set explicitly (not via expiresIn) because jsonwebtoken computes
-    // exp = iat + expiresIn, which would halve the effective lifetime.
-    const now = Math.floor(Date.now() / 1000)
-    const issuedAt = now - SUPABASE_JWT_CLOCK_SKEW_SECONDS
-    const expiresAt = now + 120 // 2 minutes from actual signing time
-    const claims: Record<string, string | number | null> = {
-      role: 'authenticated',
-      iat: issuedAt,
-      exp: expiresAt,
-      sub: userId, // CRITICAL: 'sub' is required for auth.uid() in PostgreSQL
-      app_role: appRole,
-      don_vi: donVi || null,  // Convert empty string to null for global users
-      user_id: userId,
-      dia_ban: diaBan || null,  // Convert empty string to null
-      khoa_phong: khoaPhong || null,
-    }
-
     // Sanitize tenant parameter for non-global users to enforce isolation
     // EXCEPTION: regional_leader users can see multiple tenants, don't override p_don_vi
     let body: Record<string, unknown> =
@@ -140,8 +121,13 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
       } catch {}
     }
 
-    const secret = getEnv('SUPABASE_JWT_SECRET')
-  const token = jwt.sign(claims, secret, { algorithm: 'HS256' })
+    const token = mintSupabaseJwt({
+      id: userId,
+      role,
+      don_vi: donVi,
+      dia_ban_id: diaBan,
+      khoa_phong: khoaPhong,
+    })
 
     const urlBase = getEnv('NEXT_PUBLIC_SUPABASE_URL')
     const url = `${urlBase}/rest/v1/rpc/${encodeURIComponent(fn)}`

--- a/src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('server-only', () => ({}))
+
 const getServerSessionMock = vi.fn()
 const jwtSignMock = vi.fn()
 const fetchMock = vi.fn()

--- a/src/lib/ai/__tests__/server-rpc.test.ts
+++ b/src/lib/ai/__tests__/server-rpc.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+const jwtSignMock = vi.fn()
+const fetchMock = vi.fn()
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    sign: (...args: unknown[]) => jwtSignMock(...args),
+  },
+}))
+
+import { callServerRpc, mintSupabaseJwt } from '../server-rpc'
+
+describe('AI server RPC helper', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-21T08:00:00.000Z'))
+    vi.stubEnv('SUPABASE_JWT_SECRET', 'test-secret')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'test-anon-key')
+    vi.stubGlobal('fetch', fetchMock)
+
+    jwtSignMock.mockReset()
+    jwtSignMock.mockReturnValue('signed-jwt')
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ allowed: true }]), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('mints Supabase JWT claims with the same shape as the RPC proxy', () => {
+    const token = mintSupabaseJwt({
+      id: '31',
+      role: 'admin',
+      don_vi: 17,
+      dia_ban_id: 10,
+      khoa_phong: 'ICU',
+    })
+
+    expect(token).toBe('signed-jwt')
+    expect(jwtSignMock).toHaveBeenCalledOnce()
+
+    const [claims, secret, options] = jwtSignMock.mock.calls[0] as [
+      Record<string, unknown>,
+      string,
+      Record<string, unknown>,
+    ]
+
+    expect(secret).toBe('test-secret')
+    expect(options).toEqual({ algorithm: 'HS256' })
+    expect(claims).toMatchObject({
+      role: 'authenticated',
+      app_role: 'global',
+      don_vi: '17',
+      user_id: '31',
+      dia_ban: '10',
+      khoa_phong: 'ICU',
+      sub: '31',
+    })
+
+    const now = Math.floor(Date.now() / 1000)
+    expect(claims.iat).toBe(now - 60)
+    expect(claims.exp).toBe(now + 120)
+  })
+
+  it('calls Supabase PostgREST RPC with the minted JWT and anon API key', async () => {
+    await expect(
+      callServerRpc('ai_quota_reserve', { p_user_id: 'u1' }, {
+        id: 'u1',
+        role: 'user',
+        don_vi: 2,
+      }),
+    ).resolves.toEqual([{ allowed: true }])
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.supabase.co/rest/v1/rpc/ai_quota_reserve',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ p_user_id: 'u1' }),
+        headers: expect.objectContaining({
+          Authorization: 'Bearer signed-jwt',
+          apikey: 'test-anon-key',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    )
+  })
+})

--- a/src/lib/ai/__tests__/server-rpc.test.ts
+++ b/src/lib/ai/__tests__/server-rpc.test.ts
@@ -74,6 +74,13 @@ describe('AI server RPC helper', () => {
     expect(claims.exp).toBe(now + 120)
   })
 
+  it('rejects missing user id before minting a Supabase JWT', () => {
+    expect(() => mintSupabaseJwt({ role: 'user' })).toThrow(
+      'Cannot mint Supabase RPC JWT without user id',
+    )
+    expect(jwtSignMock).not.toHaveBeenCalled()
+  })
+
   it('calls Supabase PostgREST RPC with the minted JWT and anon API key', async () => {
     await expect(
       callServerRpc('ai_quota_reserve', { p_user_id: 'u1' }, {

--- a/src/lib/ai/__tests__/usage-metering.distributed.test.ts
+++ b/src/lib/ai/__tests__/usage-metering.distributed.test.ts
@@ -99,6 +99,19 @@ describe('distributed AI usage metering', () => {
     })
   })
 
+  it('fails closed when reserve RPC returns no row', async () => {
+    callServerRpcMock.mockResolvedValue([])
+
+    const { reserveUsage } = await import('../usage-metering')
+    const result = await reserveUsage({ userId: 'u1', tenantId: 2 })
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'user_quota',
+      message: 'Unable to reserve AI usage quota.',
+    })
+  })
+
   it('classifies stream failures using only provider-reported usage', async () => {
     const { classifyStreamFailure } = await import('../usage-metering')
 

--- a/src/lib/ai/__tests__/usage-metering.distributed.test.ts
+++ b/src/lib/ai/__tests__/usage-metering.distributed.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+const callServerRpcMock = vi.fn()
+
+vi.mock('@/lib/ai/server-rpc', () => ({
+  callServerRpc: (...args: unknown[]) => callServerRpcMock(...args),
+}))
+
+describe('distributed AI usage metering', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('AI_RATE_LIMIT_WINDOW_MS', '1234')
+    vi.stubEnv('AI_RATE_LIMIT_MAX_REQUESTS', '3')
+    vi.stubEnv('AI_DAILY_USER_QUOTA_REQUESTS', '4')
+    vi.stubEnv('AI_DAILY_TENANT_QUOTA_REQUESTS', '5')
+    vi.stubEnv('AI_DAILY_GLOBAL_QUOTA_REQUESTS', '6')
+    vi.stubEnv('AI_QUOTA_RESERVATION_TTL_MS', '120000')
+    callServerRpcMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('passes every quota limit and TTL to ai_quota_reserve', async () => {
+    callServerRpcMock.mockResolvedValue([
+      {
+        allowed: true,
+        reservation_id: '00000000-0000-4000-8000-000000000484',
+        reason: null,
+        message: null,
+      },
+    ])
+
+    const { reserveUsage } = await import('../usage-metering')
+    const result = await reserveUsage({
+      userId: 'u1',
+      tenantId: 2,
+      role: 'admin',
+    })
+
+    expect(result).toEqual({
+      allowed: true,
+      reservationId: '00000000-0000-4000-8000-000000000484',
+    })
+    expect(callServerRpcMock).toHaveBeenCalledWith(
+      'ai_quota_reserve',
+      {
+        p_user_id: 'u1',
+        p_tenant_id: 2,
+        p_rate_window_ms: 1234,
+        p_rate_max: 3,
+        p_user_daily_max: 4,
+        p_tenant_daily_max: 5,
+        p_global_daily_max: 6,
+        p_ttl_ms: 120000,
+      },
+      expect.objectContaining({
+        id: 'u1',
+        role: 'admin',
+        don_vi: 2,
+      }),
+    )
+  })
+
+  it('short-circuits when AI_KILL_SWITCH is on', async () => {
+    vi.stubEnv('AI_KILL_SWITCH', 'on')
+
+    const { reserveUsage } = await import('../usage-metering')
+    const result = await reserveUsage({ userId: 'u1', tenantId: 2 })
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'kill_switch',
+      message: 'AI usage is temporarily disabled.',
+    })
+    expect(callServerRpcMock).not.toHaveBeenCalled()
+  })
+
+  it('maps RPC global quota failures to usage limit reasons', async () => {
+    callServerRpcMock.mockResolvedValue([
+      {
+        allowed: false,
+        reservation_id: null,
+        reason: 'global_quota',
+        message: 'AI daily quota exceeded',
+      },
+    ])
+
+    const { reserveUsage } = await import('../usage-metering')
+    const result = await reserveUsage({ userId: 'u1', tenantId: 2 })
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'global_quota',
+      message: 'AI daily quota exceeded',
+    })
+  })
+
+  it('classifies stream failures using only provider-reported usage', async () => {
+    const { classifyStreamFailure } = await import('../usage-metering')
+
+    expect(classifyStreamFailure({
+      providerUsage: { inputTokens: 11, outputTokens: 13 },
+    })).toEqual({
+      status: 'error_with_usage',
+      inputTokens: 11,
+      outputTokens: 13,
+    })
+
+    expect(classifyStreamFailure({ providerUsage: undefined })).toEqual({
+      status: 'error_with_usage',
+      inputTokens: 0,
+      outputTokens: 0,
+    })
+  })
+})

--- a/src/lib/ai/limits.ts
+++ b/src/lib/ai/limits.ts
@@ -17,7 +17,9 @@ export const AI_MAX_OUTPUT_TOKENS = readPositiveIntEnv(
   'AI_MAX_OUTPUT_TOKENS',
   2048,
 )
+/** Maximum AI SDK tool-loop steps allowed per chat response. */
 export const AI_MAX_TOOL_STEPS = readPositiveIntEnv('AI_MAX_TOOL_STEPS', 5)
+/** Maximum number of UI messages accepted in one chat request. */
 export const AI_MAX_MESSAGES = readPositiveIntEnv('AI_MAX_MESSAGES', 40)
 /**
  * Phase 0 mitigation (Batch 1): raised from 40K to 120K to stop
@@ -35,6 +37,7 @@ export const AI_MAX_COMPACTED_INPUT_CHARS = readPositiveIntEnv(
   40_000,
 )
 
+/** Sliding rate-limit window used by distributed AI quota reservation. */
 export const AI_RATE_LIMIT_WINDOW_MS = readPositiveIntEnv(
   'AI_RATE_LIMIT_WINDOW_MS',
   60_000,
@@ -54,6 +57,18 @@ export const AI_DAILY_TENANT_QUOTA_REQUESTS = readPositiveIntEnv(
   'AI_DAILY_TENANT_QUOTA_REQUESTS',
   1_500,
 )
+/** 5000 req/ngày/global: hard stop shared across all tenants. */
+export const AI_DAILY_GLOBAL_QUOTA_REQUESTS = readPositiveIntEnv(
+  'AI_DAILY_GLOBAL_QUOTA_REQUESTS',
+  5_000,
+)
+/** Must exceed /api/chat maxDuration plus post-stream artifact work. */
+export const AI_QUOTA_RESERVATION_TTL_MS = readPositiveIntEnv(
+  'AI_QUOTA_RESERVATION_TTL_MS',
+  120_000,
+)
+/** Emergency process-level switch that rejects AI usage before quota RPC calls. */
+export const AI_KILL_SWITCH = process.env.AI_KILL_SWITCH?.toLowerCase() === 'on'
 
 // ---------------------------------------------------------------------------
 // Budget measurement
@@ -70,4 +85,3 @@ export function calculateInputChars(messages: unknown[]): number {
     return Number.MAX_SAFE_INTEGER
   }
 }
-

--- a/src/lib/ai/server-rpc.ts
+++ b/src/lib/ai/server-rpc.ts
@@ -1,0 +1,92 @@
+import 'server-only'
+
+import jwt from 'jsonwebtoken'
+
+const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
+
+export type SupabaseRpcUser = {
+  id?: unknown
+  role?: unknown
+  don_vi?: unknown
+  dia_ban_id?: unknown
+  khoa_phong?: unknown
+}
+
+function getRequiredEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} is not set`)
+  }
+  return value
+}
+
+function stringifyClaim(value: unknown): string {
+  return typeof value === 'string' ? value : String(value ?? '')
+}
+
+function nullableStringClaim(value: unknown): string | null {
+  const stringValue = stringifyClaim(value)
+  return stringValue ? stringValue : null
+}
+
+function normalizeAppRole(role: unknown): string {
+  const roleValue = stringifyClaim(role).toLowerCase()
+  return roleValue === 'admin' ? 'global' : roleValue
+}
+
+/** Mints a short-lived Supabase-compatible JWT from trusted server-side user claims. */
+export function mintSupabaseJwt(user: SupabaseRpcUser): string {
+  const userId = stringifyClaim(user.id)
+  const now = Math.floor(Date.now() / 1000)
+  const issuedAt = now - SUPABASE_JWT_CLOCK_SKEW_SECONDS
+  const expiresAt = now + 120
+  const claims: Record<string, string | number | null> = {
+    role: 'authenticated',
+    iat: issuedAt,
+    exp: expiresAt,
+    sub: userId,
+    app_role: normalizeAppRole(user.role),
+    don_vi: nullableStringClaim(user.don_vi),
+    user_id: userId,
+    dia_ban: nullableStringClaim(user.dia_ban_id),
+    khoa_phong: nullableStringClaim(user.khoa_phong),
+  }
+
+  return jwt.sign(claims, getRequiredEnv('SUPABASE_JWT_SECRET'), {
+    algorithm: 'HS256',
+  })
+}
+
+/** Calls a Supabase PostgREST RPC endpoint with server-minted authenticated claims. */
+export async function callServerRpc<TResponse = unknown>(
+  fn: string,
+  args: Record<string, unknown>,
+  user: SupabaseRpcUser,
+): Promise<TResponse> {
+  const token = mintSupabaseJwt(user)
+  const supabaseUrl = getRequiredEnv('NEXT_PUBLIC_SUPABASE_URL')
+  const response = await fetch(`${supabaseUrl}/rest/v1/rpc/${encodeURIComponent(fn)}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      apikey: getRequiredEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY'),
+    },
+    body: JSON.stringify(args),
+  })
+
+  const text = await response.text()
+  const isJson = response.headers.get('content-type')?.includes('application/json')
+  const payload = isJson ? JSON.parse(text || 'null') : text
+
+  if (!response.ok) {
+    const message =
+      payload && typeof payload === 'object' && 'message' in payload
+        ? String(payload.message)
+        : `Supabase RPC ${fn} failed (${response.status})`
+    throw new Error(message)
+  }
+
+  return payload as TResponse
+}

--- a/src/lib/ai/server-rpc.ts
+++ b/src/lib/ai/server-rpc.ts
@@ -21,7 +21,13 @@ function getRequiredEnv(name: string): string {
 }
 
 function stringifyClaim(value: unknown): string {
-  return typeof value === 'string' ? value : String(value ?? '')
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  return ''
 }
 
 function nullableStringClaim(value: unknown): string | null {
@@ -37,6 +43,10 @@ function normalizeAppRole(role: unknown): string {
 /** Mints a short-lived Supabase-compatible JWT from trusted server-side user claims. */
 export function mintSupabaseJwt(user: SupabaseRpcUser): string {
   const userId = stringifyClaim(user.id)
+  if (!userId) {
+    throw new Error('Cannot mint Supabase RPC JWT without user id')
+  }
+
   const now = Math.floor(Date.now() / 1000)
   const issuedAt = now - SUPABASE_JWT_CLOCK_SKEW_SECONDS
   const expiresAt = now + 120

--- a/src/lib/ai/usage-metering.ts
+++ b/src/lib/ai/usage-metering.ts
@@ -101,8 +101,18 @@ function normalizeUsageLimitReason(reason: string | null | undefined): UsageLimi
   }
 }
 
-function firstReserveRow(payload: AiQuotaReserveRow | AiQuotaReserveRow[]): AiQuotaReserveRow {
-  return Array.isArray(payload) ? payload[0] : payload
+function firstReserveRow(
+  payload: AiQuotaReserveRow | AiQuotaReserveRow[] | null | undefined,
+): AiQuotaReserveRow {
+  const row = Array.isArray(payload) ? payload[0] : payload
+  if (!row) {
+    return {
+      allowed: false,
+      reason: 'user_quota',
+      message: 'Unable to reserve AI usage quota.',
+    }
+  }
+  return row
 }
 
 /** Reserves distributed AI quota before starting a provider request. */

--- a/src/lib/ai/usage-metering.ts
+++ b/src/lib/ai/usage-metering.ts
@@ -1,15 +1,27 @@
 import {
+  AI_DAILY_GLOBAL_QUOTA_REQUESTS,
   AI_DAILY_TENANT_QUOTA_REQUESTS,
   AI_DAILY_USER_QUOTA_REQUESTS,
+  AI_KILL_SWITCH,
+  AI_QUOTA_RESERVATION_TTL_MS,
   AI_RATE_LIMIT_MAX_REQUESTS,
   AI_RATE_LIMIT_WINDOW_MS,
 } from '@/lib/ai/limits'
+import { callServerRpc, type SupabaseRpcUser } from '@/lib/ai/server-rpc'
 
-type UsageLimitReason = 'rate_limit' | 'user_quota' | 'tenant_quota'
+export type UsageLimitReason =
+  | 'rate_limit'
+  | 'user_quota'
+  | 'tenant_quota'
+  | 'global_quota'
+  | 'kill_switch'
 
 export interface UsageContext {
   userId: string
   tenantId?: number
+  role?: string
+  diaBanId?: number | string | null
+  khoaPhong?: string | null
 }
 
 export interface UsageLimitCheckResult {
@@ -18,89 +30,90 @@ export interface UsageLimitCheckResult {
   message?: string
 }
 
-export interface UsageRecord {
+export interface UsageReservationResult extends UsageLimitCheckResult {
+  reservationId?: string
+}
+
+type AiQuotaReserveRow = {
+  allowed: boolean
+  reservation_id?: string | null
+  reason?: string | null
+  message?: string | null
+}
+
+export type UsageFinalizeStatus =
+  | 'success'
+  | 'error_with_usage'
+  | 'error_no_usage'
+
+export interface UsageFinalizeInput extends UsageContext {
+  reservationId?: string | null
+  status: UsageFinalizeStatus
   inputTokens?: number
   outputTokens?: number
-  estimatedCostUsd?: number
+  costUsd?: number
 }
 
-const recentRequestsByUser = new Map<string, number[]>()
-const dailyUserRequests = new Map<string, number>()
-const dailyTenantRequests = new Map<string, number>()
-const latestUsageByUser = new Map<
-  string,
-  UsageRecord & { estimatedCostUsd: number; timestamp: number }
->()
+type ProviderUsage = {
+  inputTokens?: number
+  outputTokens?: number
+}
 
-/** Tracks the last calendar day we ran cleanup on. */
-let lastCleanupDay = ''
-
-/**
- * Removes entries from dailyUserRequests and dailyTenantRequests whose
- * date suffix does not match the current day. This runs lazily — only
- * on the first request of each new calendar day — so there is no timer.
- */
-function pruneStaleDailyEntries(now: number): void {
-  const today = dayKey(now)
-  if (lastCleanupDay === today) {
-    return
+/** Converts stream failure usage into finalize payload tokens without estimating missing usage. */
+export function classifyStreamFailure(input: {
+  providerUsage?: ProviderUsage
+}): {
+  status: 'error_with_usage'
+  inputTokens: number
+  outputTokens: number
+} {
+  return {
+    status: 'error_with_usage',
+    inputTokens: Math.max(0, input.providerUsage?.inputTokens ?? 0),
+    outputTokens: Math.max(0, input.providerUsage?.outputTokens ?? 0),
   }
-  lastCleanupDay = today
-
-  for (const key of dailyUserRequests.keys()) {
-    if (!key.endsWith(today)) {
-      dailyUserRequests.delete(key)
-    }
-  }
-  for (const key of dailyTenantRequests.keys()) {
-    if (!key.endsWith(today)) {
-      dailyTenantRequests.delete(key)
-    }
-  }
-}
-
-function dayKey(timestamp: number): string {
-  return new Date(timestamp).toISOString().slice(0, 10)
-}
-
-function userDayKey(userId: string, timestamp: number): string {
-  return `${userId}:${dayKey(timestamp)}`
-}
-
-function tenantDayKey(tenantId: number, timestamp: number): string {
-  return `${tenantId}:${dayKey(timestamp)}`
-}
-
-function pruneRateWindow(userId: string, now: number): number[] {
-  const start = now - AI_RATE_LIMIT_WINDOW_MS
-  const current = recentRequestsByUser.get(userId) ?? []
-  const pruned = current.filter(ts => ts >= start)
-  recentRequestsByUser.set(userId, pruned)
-  return pruned
 }
 
 function hasTenantId(value: number | undefined): value is number {
   return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
 }
 
-function estimateCostUsd(record: UsageRecord): number {
-  if (typeof record.estimatedCostUsd === 'number' && record.estimatedCostUsd >= 0) {
-    return record.estimatedCostUsd
+function toRpcUser(context: UsageContext): SupabaseRpcUser {
+  return {
+    id: context.userId,
+    role: context.role ?? 'user',
+    don_vi: context.tenantId,
+    dia_ban_id: context.diaBanId,
+    khoa_phong: context.khoaPhong,
   }
-
-  const inputTokens = Math.max(0, record.inputTokens ?? 0)
-  const outputTokens = Math.max(0, record.outputTokens ?? 0)
-
-  const inputCostUsd = (inputTokens / 1_000) * 0.0001
-  const outputCostUsd = (outputTokens / 1_000) * 0.0004
-  return Number((inputCostUsd + outputCostUsd).toFixed(8))
 }
 
-export function checkUsageLimits(
-  context: UsageContext,
-  now: number = Date.now(),
-): UsageLimitCheckResult {
-  pruneStaleDailyEntries(now)
+function normalizeUsageLimitReason(reason: string | null | undefined): UsageLimitReason | undefined {
+  switch (reason) {
+    case 'rate_limit':
+    case 'user_quota':
+    case 'tenant_quota':
+    case 'global_quota':
+    case 'kill_switch':
+      return reason
+    default:
+      return undefined
+  }
+}
+
+function firstReserveRow(payload: AiQuotaReserveRow | AiQuotaReserveRow[]): AiQuotaReserveRow {
+  return Array.isArray(payload) ? payload[0] : payload
+}
+
+/** Reserves distributed AI quota before starting a provider request. */
+export async function reserveUsage(context: UsageContext): Promise<UsageReservationResult> {
+  if (AI_KILL_SWITCH) {
+    return {
+      allowed: false,
+      reason: 'kill_switch',
+      message: 'AI usage is temporarily disabled.',
+    }
+  }
 
   const userId = context.userId.trim()
   if (!userId) {
@@ -111,95 +124,40 @@ export function checkUsageLimits(
     }
   }
 
-  const inWindow = pruneRateWindow(userId, now)
-  if (inWindow.length >= AI_RATE_LIMIT_MAX_REQUESTS) {
-    return {
-      allowed: false,
-      reason: 'rate_limit',
-      message: 'Too many requests. Please try again later.',
-    }
-  }
+  const row = firstReserveRow(await callServerRpc<AiQuotaReserveRow | AiQuotaReserveRow[]>(
+    'ai_quota_reserve',
+    {
+      p_user_id: userId,
+      p_tenant_id: hasTenantId(context.tenantId) ? context.tenantId : null,
+      p_rate_window_ms: AI_RATE_LIMIT_WINDOW_MS,
+      p_rate_max: AI_RATE_LIMIT_MAX_REQUESTS,
+      p_user_daily_max: AI_DAILY_USER_QUOTA_REQUESTS,
+      p_tenant_daily_max: AI_DAILY_TENANT_QUOTA_REQUESTS,
+      p_global_daily_max: AI_DAILY_GLOBAL_QUOTA_REQUESTS,
+      p_ttl_ms: AI_QUOTA_RESERVATION_TTL_MS,
+    },
+    toRpcUser({ ...context, userId }),
+  ))
 
-  const userCount = dailyUserRequests.get(userDayKey(userId, now)) ?? 0
-  if (userCount >= AI_DAILY_USER_QUOTA_REQUESTS) {
-    return {
-      allowed: false,
-      reason: 'user_quota',
-      message: 'AI usage quota exceeded for this user.',
-    }
+  return {
+    allowed: row.allowed,
+    reservationId: row.reservation_id ?? undefined,
+    reason: normalizeUsageLimitReason(row.reason),
+    message: row.message ?? undefined,
   }
-
-  if (hasTenantId(context.tenantId)) {
-    const tenantCount = dailyTenantRequests.get(tenantDayKey(context.tenantId, now)) ?? 0
-    if (tenantCount >= AI_DAILY_TENANT_QUOTA_REQUESTS) {
-      return {
-        allowed: false,
-        reason: 'tenant_quota',
-        message: 'AI usage quota exceeded for this facility.',
-      }
-    }
-  }
-
-  return { allowed: true }
 }
 
-/**
- * Records a request in the rate-limit sliding window.
- * Safe to call upfront (anti-abuse) — does NOT increment daily quotas.
- */
-export function recordUsage(
-  context: UsageContext,
-  now: number = Date.now(),
-): void {
-  pruneStaleDailyEntries(now)
-
-  const userId = context.userId.trim()
-  if (!userId) {
+/** Finalizes a reserved AI quota record exactly once with provider-reported usage. */
+export async function finalizeUsage(input: UsageFinalizeInput): Promise<void> {
+  if (!input.reservationId) {
     return
   }
 
-  const inWindow = pruneRateWindow(userId, now)
-  inWindow.push(now)
-  recentRequestsByUser.set(userId, inWindow)
-}
-
-/**
- * Confirms a successful AI response and increments daily quotas.
- * Call this only after the stream finishes successfully.
- */
-export function confirmUsage(
-  context: UsageContext,
-  record: UsageRecord = {},
-  now: number = Date.now(),
-): void {
-  const userId = context.userId.trim()
-  if (!userId) {
-    return
-  }
-
-  const userKey = userDayKey(userId, now)
-  dailyUserRequests.set(userKey, (dailyUserRequests.get(userKey) ?? 0) + 1)
-
-  if (hasTenantId(context.tenantId)) {
-    const tenantKey = tenantDayKey(context.tenantId, now)
-    dailyTenantRequests.set(tenantKey, (dailyTenantRequests.get(tenantKey) ?? 0) + 1)
-  }
-
-  latestUsageByUser.set(userId, {
-    ...record,
-    estimatedCostUsd: estimateCostUsd(record),
-    timestamp: now,
-  })
-}
-
-function getLatestUsage(userId: string) {
-  return latestUsageByUser.get(userId)
-}
-
-function __resetUsageMeteringForTests() {
-  recentRequestsByUser.clear()
-  dailyUserRequests.clear()
-  dailyTenantRequests.clear()
-  latestUsageByUser.clear()
-  lastCleanupDay = ''
+  await callServerRpc('ai_quota_finalize', {
+    p_reservation_id: input.reservationId,
+    p_status: input.status,
+    p_tokens_in: Math.max(0, input.inputTokens ?? 0),
+    p_tokens_out: Math.max(0, input.outputTokens ?? 0),
+    p_cost_usd: Math.max(0, input.costUsd ?? 0),
+  }, toRpcUser(input))
 }

--- a/supabase/migrations/20260521143000_ai_quota_hardening.sql
+++ b/supabase/migrations/20260521143000_ai_quota_hardening.sql
@@ -1,0 +1,458 @@
+-- Issue #484: durable AI quota reservation/finalization.
+
+CREATE TABLE IF NOT EXISTS public.ai_quota_counters (
+  scope      TEXT NOT NULL CHECK (scope IN ('user_daily', 'tenant_daily', 'global_daily')),
+  key        TEXT NOT NULL,
+  window_id  TEXT NOT NULL,
+  count      INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+  reserved   INTEGER NOT NULL DEFAULT 0 CHECK (reserved >= 0),
+  tokens_in  BIGINT NOT NULL DEFAULT 0 CHECK (tokens_in >= 0),
+  tokens_out BIGINT NOT NULL DEFAULT 0 CHECK (tokens_out >= 0),
+  cost_usd   NUMERIC(12,6) NOT NULL DEFAULT 0 CHECK (cost_usd >= 0),
+  expires_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (scope, key, window_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_quota_counters_expires
+  ON public.ai_quota_counters(expires_at);
+
+CREATE TABLE IF NOT EXISTS public.ai_quota_reservations (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      TEXT NOT NULL,
+  tenant_id    INTEGER,
+  reserved_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at   TIMESTAMPTZ NOT NULL,
+  status       TEXT NOT NULL CHECK (status IN (
+    'reserved',
+    'success',
+    'error_with_usage',
+    'error_no_usage',
+    'expired'
+  )),
+  counter_refs JSONB NOT NULL,
+  tokens_in    INTEGER,
+  tokens_out   INTEGER,
+  cost_usd     NUMERIC(12,6)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_quota_reservations_status_exp
+  ON public.ai_quota_reservations(status, expires_at);
+
+CREATE TABLE IF NOT EXISTS public.ai_rate_events (
+  reservation_id UUID PRIMARY KEY,
+  user_id        TEXT NOT NULL,
+  ts             TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_rate_events_user_ts
+  ON public.ai_rate_events(user_id, ts DESC);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ai_rate_events_reservation_fk'
+      AND conrelid = 'public.ai_rate_events'::regclass
+  ) THEN
+    ALTER TABLE public.ai_rate_events
+      ADD CONSTRAINT ai_rate_events_reservation_fk
+      FOREIGN KEY (reservation_id)
+      REFERENCES public.ai_quota_reservations(id)
+      ON DELETE CASCADE
+      DEFERRABLE INITIALLY DEFERRED;
+  END IF;
+END $$;
+
+ALTER TABLE public.ai_quota_counters ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ai_quota_reservations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ai_rate_events ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.ai_quota_counters FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.ai_quota_reservations FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.ai_rate_events FROM PUBLIC, anon, authenticated;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.ai_quota_counters TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.ai_quota_reservations TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.ai_rate_events TO service_role;
+
+CREATE OR REPLACE FUNCTION public.ai_quota_reserve(
+  p_user_id TEXT,
+  p_tenant_id INTEGER,
+  p_rate_window_ms INTEGER,
+  p_rate_max INTEGER,
+  p_user_daily_max INTEGER,
+  p_tenant_daily_max INTEGER,
+  p_global_daily_max INTEGER,
+  p_ttl_ms INTEGER,
+  p_now TIMESTAMPTZ DEFAULT now()
+)
+RETURNS TABLE (
+  allowed BOOLEAN,
+  reservation_id UUID,
+  reason TEXT,
+  message TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims_text TEXT := current_setting('request.jwt.claims', true);
+  v_claims JSONB;
+  v_claim_user_id TEXT;
+  v_window_id TEXT;
+  v_window_expires_at TIMESTAMPTZ;
+  v_counter_refs JSONB;
+  v_reservation_id UUID := gen_random_uuid();
+  v_rate_count INTEGER;
+  v_counter RECORD;
+  v_expired RECORD;
+  v_ref RECORD;
+  v_limit INTEGER;
+BEGIN
+  IF p_user_id IS NULL OR btrim(p_user_id) = '' THEN
+    RAISE EXCEPTION 'Missing user id' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_rate_window_ms IS NULL OR p_rate_window_ms <= 0
+     OR p_rate_max IS NULL OR p_rate_max < 0
+     OR p_user_daily_max IS NULL OR p_user_daily_max < 0
+     OR p_tenant_daily_max IS NULL OR p_tenant_daily_max < 0
+     OR p_global_daily_max IS NULL OR p_global_daily_max < 0
+     OR p_ttl_ms IS NULL OR p_ttl_ms <= 0 THEN
+    RAISE EXCEPTION 'Invalid AI quota limit parameter' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_claims_text IS NULL OR btrim(v_claims_text) = '' THEN
+    RAISE EXCEPTION 'Missing JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_claims := v_claims_text::jsonb;
+  v_claim_user_id := NULLIF(v_claims->>'user_id', '');
+
+  IF v_claim_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_claim_user_id IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'user_id claim mismatch' USING ERRCODE = '42501';
+  END IF;
+
+  v_window_id := to_char(p_now AT TIME ZONE 'UTC', 'YYYY-MM-DD');
+  v_window_expires_at := (
+    date_trunc('day', p_now AT TIME ZONE 'UTC') + interval '1 day'
+  ) AT TIME ZONE 'UTC';
+
+  v_counter_refs := jsonb_build_array(jsonb_build_object(
+    'scope', 'user_daily',
+    'key', p_user_id,
+    'window_id', v_window_id
+  ));
+
+  IF p_tenant_id IS NOT NULL THEN
+    v_counter_refs := v_counter_refs || jsonb_build_array(jsonb_build_object(
+      'scope', 'tenant_daily',
+      'key', p_tenant_id::text,
+      'window_id', v_window_id
+    ));
+  END IF;
+
+  v_counter_refs := v_counter_refs || jsonb_build_array(jsonb_build_object(
+    'scope', 'global_daily',
+    'key', 'global',
+    'window_id', v_window_id
+  ));
+
+  -- Preserve global lock order: reservations first, then counters.
+  FOR v_expired IN
+    SELECT *
+    FROM public.ai_quota_reservations
+    WHERE status = 'reserved'
+      AND expires_at < p_now
+      AND (
+        counter_refs @> jsonb_build_array(jsonb_build_object('scope', 'user_daily', 'key', p_user_id))
+        OR (p_tenant_id IS NOT NULL AND counter_refs @> jsonb_build_array(jsonb_build_object('scope', 'tenant_daily', 'key', p_tenant_id::text)))
+        OR counter_refs @> jsonb_build_array(jsonb_build_object('scope', 'global_daily', 'key', 'global'))
+      )
+    ORDER BY id
+    FOR UPDATE
+  LOOP
+    FOR v_ref IN
+      SELECT ref->>'scope' AS scope, ref->>'key' AS key, ref->>'window_id' AS window_id
+      FROM jsonb_array_elements(v_expired.counter_refs) AS ref
+      ORDER BY ref->>'scope', ref->>'key', ref->>'window_id'
+    LOOP
+      UPDATE public.ai_quota_counters
+      SET reserved = GREATEST(reserved - 1, 0),
+          updated_at = p_now
+      WHERE scope = v_ref.scope
+        AND key = v_ref.key
+        AND window_id = v_ref.window_id;
+    END LOOP;
+
+    UPDATE public.ai_quota_reservations
+    SET status = 'expired'
+    WHERE id = v_expired.id;
+  END LOOP;
+
+  DELETE FROM public.ai_rate_events
+  WHERE user_id = p_user_id
+    AND ts < p_now - (p_rate_window_ms * interval '1 millisecond');
+
+  SELECT count(*)::integer
+  INTO v_rate_count
+  FROM public.ai_rate_events
+  WHERE user_id = p_user_id
+    AND ts >= p_now - (p_rate_window_ms * interval '1 millisecond');
+
+  IF v_rate_count >= p_rate_max THEN
+    allowed := false;
+    reservation_id := NULL;
+    reason := 'rate_limit';
+    message := 'AI rate limit exceeded';
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  WITH refs AS (
+    SELECT r.scope, r.key, r.window_id
+    FROM jsonb_to_recordset(v_counter_refs) AS r(scope TEXT, key TEXT, window_id TEXT)
+    ORDER BY r.scope, r.key, r.window_id
+  )
+  INSERT INTO public.ai_quota_counters(scope, key, window_id, expires_at, updated_at)
+  SELECT refs.scope, refs.key, refs.window_id, v_window_expires_at, p_now
+  FROM refs
+  ON CONFLICT (scope, key, window_id) DO UPDATE
+  SET expires_at = GREATEST(public.ai_quota_counters.expires_at, EXCLUDED.expires_at),
+      updated_at = p_now;
+
+  FOR v_counter IN
+    SELECT c.*
+    FROM public.ai_quota_counters c
+    JOIN jsonb_to_recordset(v_counter_refs) AS r(scope TEXT, key TEXT, window_id TEXT)
+      ON r.scope = c.scope
+     AND r.key = c.key
+     AND r.window_id = c.window_id
+    ORDER BY c.scope, c.key, c.window_id
+    FOR UPDATE OF c
+  LOOP
+    v_limit := CASE v_counter.scope
+      WHEN 'user_daily' THEN p_user_daily_max
+      WHEN 'tenant_daily' THEN p_tenant_daily_max
+      WHEN 'global_daily' THEN p_global_daily_max
+      ELSE 0
+    END;
+
+    IF v_counter.count + v_counter.reserved >= v_limit THEN
+      allowed := false;
+      reservation_id := NULL;
+      reason := CASE v_counter.scope
+        WHEN 'user_daily' THEN 'user_quota'
+        WHEN 'tenant_daily' THEN 'tenant_quota'
+        WHEN 'global_daily' THEN 'global_quota'
+        ELSE 'quota'
+      END;
+      message := 'AI daily quota exceeded';
+      RETURN NEXT;
+      RETURN;
+    END IF;
+  END LOOP;
+
+  FOR v_ref IN
+    SELECT ref->>'scope' AS scope, ref->>'key' AS key, ref->>'window_id' AS window_id
+    FROM jsonb_array_elements(v_counter_refs) AS ref
+    ORDER BY ref->>'scope', ref->>'key', ref->>'window_id'
+  LOOP
+    UPDATE public.ai_quota_counters
+    SET reserved = reserved + 1,
+        updated_at = p_now
+    WHERE scope = v_ref.scope
+      AND key = v_ref.key
+      AND window_id = v_ref.window_id;
+  END LOOP;
+
+  INSERT INTO public.ai_rate_events(reservation_id, user_id, ts)
+  VALUES (v_reservation_id, p_user_id, p_now);
+
+  INSERT INTO public.ai_quota_reservations(
+    id,
+    user_id,
+    tenant_id,
+    reserved_at,
+    expires_at,
+    status,
+    counter_refs
+  )
+  VALUES (
+    v_reservation_id,
+    p_user_id,
+    p_tenant_id,
+    p_now,
+    p_now + (p_ttl_ms * interval '1 millisecond'),
+    'reserved',
+    v_counter_refs
+  );
+
+  allowed := true;
+  reservation_id := v_reservation_id;
+  reason := NULL;
+  message := NULL;
+  RETURN NEXT;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ai_quota_finalize(
+  p_reservation_id UUID,
+  p_status TEXT,
+  p_tokens_in INTEGER,
+  p_tokens_out INTEGER,
+  p_cost_usd NUMERIC
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_reservation public.ai_quota_reservations%ROWTYPE;
+  v_ref RECORD;
+  v_tokens_in INTEGER := GREATEST(COALESCE(p_tokens_in, 0), 0);
+  v_tokens_out INTEGER := GREATEST(COALESCE(p_tokens_out, 0), 0);
+  v_cost_usd NUMERIC(12,6) := GREATEST(COALESCE(p_cost_usd, 0), 0);
+  v_now TIMESTAMPTZ := now();
+BEGIN
+  IF p_status NOT IN ('success', 'error_with_usage', 'error_no_usage') THEN
+    RAISE EXCEPTION 'Invalid AI quota finalize status' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT *
+  INTO v_reservation
+  FROM public.ai_quota_reservations
+  WHERE id = p_reservation_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_reservation.status <> 'reserved' THEN
+    RETURN;
+  END IF;
+
+  FOR v_ref IN
+    SELECT ref->>'scope' AS scope, ref->>'key' AS key, ref->>'window_id' AS window_id
+    FROM jsonb_array_elements(v_reservation.counter_refs) AS ref
+    ORDER BY ref->>'scope', ref->>'key', ref->>'window_id'
+  LOOP
+    UPDATE public.ai_quota_counters
+    SET reserved = GREATEST(reserved - 1, 0),
+        count = count + CASE WHEN p_status IN ('success', 'error_with_usage') THEN 1 ELSE 0 END,
+        tokens_in = tokens_in + CASE WHEN p_status IN ('success', 'error_with_usage') THEN v_tokens_in ELSE 0 END,
+        tokens_out = tokens_out + CASE WHEN p_status IN ('success', 'error_with_usage') THEN v_tokens_out ELSE 0 END,
+        cost_usd = cost_usd + CASE WHEN p_status IN ('success', 'error_with_usage') THEN v_cost_usd ELSE 0 END,
+        updated_at = v_now
+    WHERE scope = v_ref.scope
+      AND key = v_ref.key
+      AND window_id = v_ref.window_id;
+  END LOOP;
+
+  IF p_status = 'error_no_usage' THEN
+    DELETE FROM public.ai_rate_events
+    WHERE reservation_id = p_reservation_id;
+  END IF;
+
+  UPDATE public.ai_quota_reservations
+  SET status = p_status,
+      tokens_in = v_tokens_in,
+      tokens_out = v_tokens_out,
+      cost_usd = v_cost_usd
+  WHERE id = p_reservation_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ai_quota_release_expired(
+  p_now TIMESTAMPTZ DEFAULT now()
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims_text TEXT := current_setting('request.jwt.claims', true);
+  v_claims JSONB;
+  v_expired RECORD;
+  v_ref RECORD;
+  v_released INTEGER := 0;
+BEGIN
+  IF v_claims_text IS NULL OR btrim(v_claims_text) = '' THEN
+    RAISE EXCEPTION 'Missing JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_claims := v_claims_text::jsonb;
+
+  IF NULLIF(v_claims->>'app_role', '') IS NULL THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  FOR v_expired IN
+    SELECT *
+    FROM public.ai_quota_reservations
+    WHERE status = 'reserved'
+      AND expires_at < p_now
+    ORDER BY id
+    FOR UPDATE
+  LOOP
+    FOR v_ref IN
+      SELECT ref->>'scope' AS scope, ref->>'key' AS key, ref->>'window_id' AS window_id
+      FROM jsonb_array_elements(v_expired.counter_refs) AS ref
+      ORDER BY ref->>'scope', ref->>'key', ref->>'window_id'
+    LOOP
+      UPDATE public.ai_quota_counters
+      SET reserved = GREATEST(reserved - 1, 0),
+          updated_at = p_now
+      WHERE scope = v_ref.scope
+        AND key = v_ref.key
+        AND window_id = v_ref.window_id;
+    END LOOP;
+
+    UPDATE public.ai_quota_reservations
+    SET status = 'expired'
+    WHERE id = v_expired.id;
+
+    v_released := v_released + 1;
+  END LOOP;
+
+  RETURN v_released;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ai_quota_reserve(
+  TEXT,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  TIMESTAMPTZ
+) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.ai_quota_finalize(UUID, TEXT, INTEGER, INTEGER, NUMERIC)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.ai_quota_release_expired(TIMESTAMPTZ)
+  FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.ai_quota_reserve(
+  TEXT,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  TIMESTAMPTZ
+) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ai_quota_finalize(UUID, TEXT, INTEGER, INTEGER, NUMERIC)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ai_quota_release_expired(TIMESTAMPTZ)
+  TO authenticated, service_role;

--- a/supabase/migrations/20260521144500_restrict_ai_quota_rpc_anon.sql
+++ b/supabase/migrations/20260521144500_restrict_ai_quota_rpc_anon.sql
@@ -1,0 +1,37 @@
+-- Issue #484 follow-up: quota RPCs are server/authenticated-only, never anon.
+
+REVOKE ALL ON FUNCTION public.ai_quota_reserve(
+  TEXT,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  TIMESTAMPTZ
+) FROM PUBLIC, anon;
+
+REVOKE ALL ON FUNCTION public.ai_quota_finalize(UUID, TEXT, INTEGER, INTEGER, NUMERIC)
+  FROM PUBLIC, anon;
+
+REVOKE ALL ON FUNCTION public.ai_quota_release_expired(TIMESTAMPTZ)
+  FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.ai_quota_reserve(
+  TEXT,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  TIMESTAMPTZ
+) TO authenticated, service_role;
+
+GRANT EXECUTE ON FUNCTION public.ai_quota_finalize(UUID, TEXT, INTEGER, INTEGER, NUMERIC)
+  TO authenticated, service_role;
+
+GRANT EXECUTE ON FUNCTION public.ai_quota_release_expired(TIMESTAMPTZ)
+  TO authenticated, service_role;

--- a/supabase/migrations/20260521154307_ai_quota_review_hardening.sql
+++ b/supabase/migrations/20260521154307_ai_quota_review_hardening.sql
@@ -1,0 +1,437 @@
+-- Supersede the live MCP-applied AI quota functions after PR review fixes.
+-- The earlier live migrations were applied before the review hardening changes.
+
+ALTER TABLE public.ai_quota_reservations
+  ALTER COLUMN tokens_in TYPE BIGINT USING tokens_in::BIGINT,
+  ALTER COLUMN tokens_out TYPE BIGINT USING tokens_out::BIGINT;
+
+DROP FUNCTION IF EXISTS public.ai_quota_finalize(UUID, TEXT, INTEGER, INTEGER, NUMERIC);
+
+CREATE OR REPLACE FUNCTION public.ai_quota_reserve(
+  p_user_id TEXT,
+  p_tenant_id INTEGER,
+  p_rate_window_ms INTEGER,
+  p_rate_max INTEGER,
+  p_user_daily_max INTEGER,
+  p_tenant_daily_max INTEGER,
+  p_global_daily_max INTEGER,
+  p_ttl_ms INTEGER,
+  p_now TIMESTAMPTZ DEFAULT now()
+)
+RETURNS TABLE (
+  allowed BOOLEAN,
+  reservation_id UUID,
+  reason TEXT,
+  message TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims_text TEXT := current_setting('request.jwt.claims', true);
+  v_claims JSONB;
+  v_claim_user_id TEXT;
+  v_role TEXT;
+  v_now TIMESTAMPTZ := now();
+  v_window_id TEXT;
+  v_window_expires_at TIMESTAMPTZ;
+  v_counter_refs JSONB;
+  v_reservation_id UUID := gen_random_uuid();
+  v_rate_count INTEGER;
+  v_counter RECORD;
+  v_expired RECORD;
+  v_ref RECORD;
+  v_limit INTEGER;
+BEGIN
+  IF p_user_id IS NULL OR btrim(p_user_id) = '' THEN
+    RAISE EXCEPTION 'Missing user id' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_rate_window_ms IS NULL OR p_rate_window_ms <= 0
+     OR p_rate_max IS NULL OR p_rate_max < 0
+     OR p_user_daily_max IS NULL OR p_user_daily_max < 0
+     OR p_tenant_daily_max IS NULL OR p_tenant_daily_max < 0
+     OR p_global_daily_max IS NULL OR p_global_daily_max < 0
+     OR p_ttl_ms IS NULL OR p_ttl_ms <= 0 THEN
+    RAISE EXCEPTION 'Invalid AI quota limit parameter' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_claims_text IS NULL OR btrim(v_claims_text) = '' THEN
+    RAISE EXCEPTION 'Missing JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_claims := v_claims_text::jsonb;
+  v_claim_user_id := NULLIF(v_claims->>'user_id', '');
+  v_role := NULLIF(v_claims->>'app_role', '');
+
+  IF v_claim_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role IS NULL THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_claim_user_id IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'user_id claim mismatch' USING ERRCODE = '42501';
+  END IF;
+
+  v_window_id := to_char(v_now AT TIME ZONE 'UTC', 'YYYY-MM-DD');
+  v_window_expires_at := (
+    date_trunc('day', v_now AT TIME ZONE 'UTC') + interval '1 day'
+  ) AT TIME ZONE 'UTC';
+
+  v_counter_refs := jsonb_build_array(jsonb_build_object(
+    'scope', 'user_daily',
+    'key', p_user_id,
+    'window_id', v_window_id
+  ));
+
+  IF p_tenant_id IS NOT NULL THEN
+    v_counter_refs := v_counter_refs || jsonb_build_array(jsonb_build_object(
+      'scope', 'tenant_daily',
+      'key', p_tenant_id::text,
+      'window_id', v_window_id
+    ));
+  END IF;
+
+  v_counter_refs := v_counter_refs || jsonb_build_array(jsonb_build_object(
+    'scope', 'global_daily',
+    'key', 'global',
+    'window_id', v_window_id
+  ));
+
+  -- Preserve global lock order: reservations first, then counters.
+  FOR v_expired IN
+    SELECT *
+    FROM public.ai_quota_reservations
+    WHERE status = 'reserved'
+      AND expires_at < v_now
+      AND (
+        counter_refs @> jsonb_build_array(jsonb_build_object('scope', 'user_daily', 'key', p_user_id))
+        OR (p_tenant_id IS NOT NULL AND counter_refs @> jsonb_build_array(jsonb_build_object('scope', 'tenant_daily', 'key', p_tenant_id::text)))
+        OR counter_refs @> jsonb_build_array(jsonb_build_object('scope', 'global_daily', 'key', 'global'))
+      )
+    ORDER BY id
+    FOR UPDATE
+  LOOP
+    FOR v_ref IN
+      SELECT ref->>'scope' AS scope, ref->>'key' AS key, ref->>'window_id' AS window_id
+      FROM jsonb_array_elements(v_expired.counter_refs) AS ref
+      ORDER BY ref->>'scope', ref->>'key', ref->>'window_id'
+    LOOP
+      UPDATE public.ai_quota_counters
+      SET reserved = GREATEST(reserved - 1, 0),
+          updated_at = v_now
+      WHERE scope = v_ref.scope
+        AND key = v_ref.key
+        AND window_id = v_ref.window_id;
+    END LOOP;
+
+    UPDATE public.ai_quota_reservations
+    SET status = 'expired'
+    WHERE id = v_expired.id;
+  END LOOP;
+
+  DELETE FROM public.ai_rate_events
+  WHERE user_id = p_user_id
+    AND ts < v_now - (p_rate_window_ms * interval '1 millisecond');
+
+  WITH refs AS (
+    SELECT r.scope, r.key, r.window_id
+    FROM jsonb_to_recordset(v_counter_refs) AS r(scope TEXT, key TEXT, window_id TEXT)
+    ORDER BY r.scope, r.key, r.window_id
+  )
+  INSERT INTO public.ai_quota_counters(scope, key, window_id, expires_at, updated_at)
+  SELECT refs.scope, refs.key, refs.window_id, v_window_expires_at, v_now
+  FROM refs
+  ON CONFLICT (scope, key, window_id) DO UPDATE
+  SET expires_at = GREATEST(public.ai_quota_counters.expires_at, EXCLUDED.expires_at),
+      updated_at = v_now;
+
+  -- Lock the per-user daily counter before checking the sliding rate window.
+  -- This serializes reservations for the same user without a separate lock table.
+  PERFORM 1
+  FROM public.ai_quota_counters c
+  WHERE c.scope = 'user_daily'
+    AND c.key = p_user_id
+    AND c.window_id = v_window_id
+  FOR UPDATE;
+
+  SELECT count(*)::integer
+  INTO v_rate_count
+  FROM public.ai_rate_events
+  WHERE user_id = p_user_id
+    AND ts >= v_now - (p_rate_window_ms * interval '1 millisecond');
+
+  IF v_rate_count >= p_rate_max THEN
+    allowed := false;
+    reservation_id := NULL;
+    reason := 'rate_limit';
+    message := 'AI rate limit exceeded';
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  FOR v_counter IN
+    SELECT c.*
+    FROM public.ai_quota_counters c
+    JOIN jsonb_to_recordset(v_counter_refs) AS r(scope TEXT, key TEXT, window_id TEXT)
+      ON r.scope = c.scope
+     AND r.key = c.key
+     AND r.window_id = c.window_id
+    ORDER BY c.scope, c.key, c.window_id
+    FOR UPDATE OF c
+  LOOP
+    v_limit := CASE v_counter.scope
+      WHEN 'user_daily' THEN p_user_daily_max
+      WHEN 'tenant_daily' THEN p_tenant_daily_max
+      WHEN 'global_daily' THEN p_global_daily_max
+      ELSE 0
+    END;
+
+    IF v_counter.count + v_counter.reserved >= v_limit THEN
+      allowed := false;
+      reservation_id := NULL;
+      reason := CASE v_counter.scope
+        WHEN 'user_daily' THEN 'user_quota'
+        WHEN 'tenant_daily' THEN 'tenant_quota'
+        WHEN 'global_daily' THEN 'global_quota'
+        ELSE 'quota'
+      END;
+      message := 'AI daily quota exceeded';
+      RETURN NEXT;
+      RETURN;
+    END IF;
+  END LOOP;
+
+  FOR v_ref IN
+    SELECT ref->>'scope' AS scope, ref->>'key' AS key, ref->>'window_id' AS window_id
+    FROM jsonb_array_elements(v_counter_refs) AS ref
+    ORDER BY ref->>'scope', ref->>'key', ref->>'window_id'
+  LOOP
+    UPDATE public.ai_quota_counters
+    SET reserved = reserved + 1,
+        updated_at = v_now
+    WHERE scope = v_ref.scope
+      AND key = v_ref.key
+      AND window_id = v_ref.window_id;
+  END LOOP;
+
+  INSERT INTO public.ai_rate_events(reservation_id, user_id, ts)
+  VALUES (v_reservation_id, p_user_id, v_now);
+
+  INSERT INTO public.ai_quota_reservations(
+    id,
+    user_id,
+    tenant_id,
+    reserved_at,
+    expires_at,
+    status,
+    counter_refs
+  )
+  VALUES (
+    v_reservation_id,
+    p_user_id,
+    p_tenant_id,
+    v_now,
+    v_now + (p_ttl_ms * interval '1 millisecond'),
+    'reserved',
+    v_counter_refs
+  );
+
+  allowed := true;
+  reservation_id := v_reservation_id;
+  reason := NULL;
+  message := NULL;
+  RETURN NEXT;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ai_quota_finalize(
+  p_reservation_id UUID,
+  p_status TEXT,
+  p_tokens_in BIGINT,
+  p_tokens_out BIGINT,
+  p_cost_usd NUMERIC
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims_text TEXT := current_setting('request.jwt.claims', true);
+  v_claims JSONB;
+  v_claim_user_id TEXT;
+  v_role TEXT;
+  v_reservation public.ai_quota_reservations%ROWTYPE;
+  v_ref RECORD;
+  v_tokens_in BIGINT := GREATEST(COALESCE(p_tokens_in, 0), 0);
+  v_tokens_out BIGINT := GREATEST(COALESCE(p_tokens_out, 0), 0);
+  v_cost_usd NUMERIC(12,6) := GREATEST(COALESCE(p_cost_usd, 0), 0);
+  v_now TIMESTAMPTZ := now();
+BEGIN
+  IF p_status NOT IN ('success', 'error_with_usage', 'error_no_usage') THEN
+    RAISE EXCEPTION 'Invalid AI quota finalize status' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_claims_text IS NULL OR btrim(v_claims_text) = '' THEN
+    RAISE EXCEPTION 'Missing JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_claims := v_claims_text::jsonb;
+  v_claim_user_id := NULLIF(v_claims->>'user_id', '');
+  v_role := NULLIF(v_claims->>'app_role', '');
+
+  IF v_claim_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role IS NULL THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT *
+  INTO v_reservation
+  FROM public.ai_quota_reservations
+  WHERE id = p_reservation_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_reservation.status <> 'reserved' THEN
+    RETURN;
+  END IF;
+
+  IF v_reservation.user_id IS DISTINCT FROM v_claim_user_id THEN
+    RAISE EXCEPTION 'reservation user_id claim mismatch' USING ERRCODE = '42501';
+  END IF;
+
+  FOR v_ref IN
+    SELECT ref->>'scope' AS scope, ref->>'key' AS key, ref->>'window_id' AS window_id
+    FROM jsonb_array_elements(v_reservation.counter_refs) AS ref
+    ORDER BY ref->>'scope', ref->>'key', ref->>'window_id'
+  LOOP
+    UPDATE public.ai_quota_counters
+    SET reserved = GREATEST(reserved - 1, 0),
+        count = count + CASE WHEN p_status IN ('success', 'error_with_usage') THEN 1 ELSE 0 END,
+        tokens_in = tokens_in + CASE WHEN p_status IN ('success', 'error_with_usage') THEN v_tokens_in ELSE 0 END,
+        tokens_out = tokens_out + CASE WHEN p_status IN ('success', 'error_with_usage') THEN v_tokens_out ELSE 0 END,
+        cost_usd = cost_usd + CASE WHEN p_status IN ('success', 'error_with_usage') THEN v_cost_usd ELSE 0 END,
+        updated_at = v_now
+    WHERE scope = v_ref.scope
+      AND key = v_ref.key
+      AND window_id = v_ref.window_id;
+  END LOOP;
+
+  IF p_status = 'error_no_usage' THEN
+    DELETE FROM public.ai_rate_events
+    WHERE reservation_id = p_reservation_id;
+  END IF;
+
+  UPDATE public.ai_quota_reservations
+  SET status = p_status,
+      tokens_in = v_tokens_in,
+      tokens_out = v_tokens_out,
+      cost_usd = v_cost_usd
+  WHERE id = p_reservation_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ai_quota_release_expired(
+  p_now TIMESTAMPTZ DEFAULT now()
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims_text TEXT := current_setting('request.jwt.claims', true);
+  v_claims JSONB;
+  v_role TEXT;
+  v_now TIMESTAMPTZ := now();
+  v_expired RECORD;
+  v_ref RECORD;
+  v_released INTEGER := 0;
+BEGIN
+  IF v_claims_text IS NULL OR btrim(v_claims_text) = '' THEN
+    RAISE EXCEPTION 'Missing JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_claims := v_claims_text::jsonb;
+  v_role := COALESCE(NULLIF(v_claims->>'app_role', ''), NULLIF(v_claims->>'role', ''));
+
+  IF v_role IS NULL THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role NOT IN ('global', 'service_role') THEN
+    RAISE EXCEPTION 'Insufficient privileges to release AI quota reservations' USING ERRCODE = '42501';
+  END IF;
+
+  FOR v_expired IN
+    SELECT *
+    FROM public.ai_quota_reservations
+    WHERE status = 'reserved'
+      AND expires_at < v_now
+    ORDER BY id
+    FOR UPDATE
+  LOOP
+    FOR v_ref IN
+      SELECT ref->>'scope' AS scope, ref->>'key' AS key, ref->>'window_id' AS window_id
+      FROM jsonb_array_elements(v_expired.counter_refs) AS ref
+      ORDER BY ref->>'scope', ref->>'key', ref->>'window_id'
+    LOOP
+      UPDATE public.ai_quota_counters
+      SET reserved = GREATEST(reserved - 1, 0),
+          updated_at = v_now
+      WHERE scope = v_ref.scope
+        AND key = v_ref.key
+        AND window_id = v_ref.window_id;
+    END LOOP;
+
+    UPDATE public.ai_quota_reservations
+    SET status = 'expired'
+    WHERE id = v_expired.id;
+
+    v_released := v_released + 1;
+  END LOOP;
+
+  RETURN v_released;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ai_quota_reserve(
+  TEXT,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  TIMESTAMPTZ
+)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.ai_quota_finalize(UUID, TEXT, BIGINT, BIGINT, NUMERIC)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.ai_quota_release_expired(TIMESTAMPTZ)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.ai_quota_reserve(
+  TEXT,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  INTEGER,
+  TIMESTAMPTZ
+)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ai_quota_finalize(UUID, TEXT, BIGINT, BIGINT, NUMERIC)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ai_quota_release_expired(TIMESTAMPTZ)
+  TO service_role;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom/vitest'
+import { vi } from 'vitest'
+
+type NextAfterTask = Promise<unknown> | (() => unknown | Promise<unknown>)
+
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/server')>()
+  return {
+    ...actual,
+    after: (task: NextAfterTask) => {
+      if (typeof task === 'function') {
+        void task()
+        return
+      }
+      void task
+    },
+  }
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -8,11 +8,13 @@ vi.mock('next/server', async (importOriginal) => {
   return {
     ...actual,
     after: (task: NextAfterTask) => {
-      if (typeof task === 'function') {
-        void task()
-        return
-      }
-      void task
+      setTimeout(() => {
+        if (typeof task === 'function') {
+          void task()
+          return
+        }
+        void task
+      }, 0)
     },
   }
 })


### PR DESCRIPTION
## Summary
- Add durable Supabase-backed AI quota reservation/finalize RPCs with sliding rate events, daily user/tenant/global caps, TTL release, and JWT claim guards.
- Replace `/api/chat` in-memory quota accounting with reserve/finalize flow, retry-safe `finalizeOnce`, provider-reported token accounting, and server-side RPC JWT minting.
- Add focused SQL/TS/route tests for reservation params, kill switch, global cap, retry/abort finalize, cost-aware failures, and JWT skew handling.

## Verification
- Supabase MCP migrations applied: `20260521143000_ai_quota_hardening`, `20260521144500_restrict_ai_quota_rpc_anon`.
- Supabase MCP advisors run. New quota-table advisories are intentional INFO only: RLS enabled with no policies for deny-by-default quota tables; new `idx_ai_quota_counters_expires` unused because fresh.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/lib/ai/__tests__/server-rpc.test.ts src/lib/ai/__tests__/usage-metering.distributed.test.ts src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts src/app/api/chat/__tests__/route.retry-and-abort-finalize.test.ts src/app/api/chat/__tests__/route.cost-aware-failure.test.ts src/app/api/chat/__tests__/route.kill-switch.test.ts src/app/api/chat/__tests__/route.error-safety.test.ts src/app/api/chat/__tests__/route.key-rotation.test.ts src/app/api/chat/__tests__/route.tools-allowlist.test.ts src/app/api/chat/__tests__/route.quota-tools.test.ts src/app/api/chat/__tests__/route.usage-tools.test.ts src/app/api/chat/__tests__/route.tenant-policy.test.ts src/app/api/chat/__tests__/route.query-database-grounding.test.ts src/app/api/chat/__tests__/route.attachment-tools.test.ts src/app/api/chat/__tests__/route.intent-routing.test.ts src/app/api/chat/__tests__/route.limits.test.ts src/app/api/chat/__tests__/route.repair-request-draft-orchestration.test.ts`
- `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`
- Full chat route suite checked; only existing baseline prompt-version assertions fail (`v2.5.1` expected, `v2.6.1` actual) in `route.draft-output.test.ts` and `route.troubleshooting.test.ts`.

## Follow-ups filed
- #537 UI retry cooldown
- #538 DB-backed kill switch without redeploy
- #539 Configurable model cost rates

Closes #484
EOF 2>&1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened distributed quota metering by moving chat usage to Supabase-backed reserve/finalize RPCs with sliding rate limits and user/tenant/global daily caps. Replaces in-memory counters in `/api/chat`, adds strict server-signed RPC JWTs, queues finalize with `next/server` `after`, and uses provider-reported token usage for accurate, cost-aware billing (addresses #484).

- **New Features**
  - Durable RPCs: `ai_quota_reserve`, `ai_quota_finalize`, `ai_quota_release_expired` with cross-scope caps, sliding window, TTL release, deadlock-safe locking; token counters use BIGINT.
  - Integrated `reserveUsage`/`finalizeUsage` in `/api/chat`; retry-safe finalize-once with abort paths; finalize runs via `after` to avoid blocking the response; failures count only provider-reported usage.
  - New server helper `callServerRpc` and `mintSupabaseJwt`; RPC proxy runs on Node and enforces strict JWT identity (no `global` override); anon access revoked; clock-skew tolerant signing.
  - Env kill switch `AI_KILL_SWITCH=on` to disable `/api/chat`.

- **Migration**
  - Apply migrations: `20260521143000_ai_quota_hardening.sql`, `20260521144500_restrict_ai_quota_rpc_anon.sql`, `20260521154307_ai_quota_review_hardening.sql`.
  - Set envs: `AI_RATE_LIMIT_WINDOW_MS`, `AI_RATE_LIMIT_MAX_REQUESTS`, `AI_DAILY_USER_QUOTA_REQUESTS`, `AI_DAILY_TENANT_QUOTA_REQUESTS`, `AI_DAILY_GLOBAL_QUOTA_REQUESTS`, `AI_QUOTA_RESERVATION_TTL_MS`, optional `AI_KILL_SWITCH`.
  - Ensure Supabase server JWT config: `SUPABASE_JWT_SECRET`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`.

<sup>Written for commit e389bf78743d292dba3dbcaaf1cdc01c16a54b39. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/540?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reserve-then-finalize AI usage model with sliding rate limits, global daily caps, and a kill-switch; server-side RPC proxying with minted service tokens.

* **Bug Fixes**
  * Improved error classification so token usage is recorded/handled consistently on failures.

* **Documentation**
  * Added full technical plan and verification steps for AI quota hardening.

* **Chores**
  * Updated tests across chat and RPC paths to exercise the new metering flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->