### PR TITLE
[AI] Add retry cooldown UI for quota responses

### DIFF
--- a/src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts
+++ b/src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/lib/ai/limits', () => ({
   AI_MAX_MESSAGES: 20,
   AI_MAX_INPUT_CHARS: 20_000,
   AI_MAX_COMPACTED_INPUT_CHARS: 10_000,
+  AI_RATE_LIMIT_WINDOW_MS: 45_000,
   calculateInputChars: (messages: unknown[]) => JSON.stringify(messages).length,
 }))
 
@@ -104,7 +105,7 @@ describe('/api/chat rate limit and quota', () => {
     })
   })
 
-  it('returns 429 when rate-limited', async () => {
+  it('returns structured 429 metadata when rate-limited', async () => {
     reserveUsageMock.mockResolvedValue({
       allowed: false,
       reason: 'rate_limit',
@@ -112,26 +113,49 @@ describe('/api/chat rate limit and quota', () => {
     })
 
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
-    const text = await res.text()
+    const body = await res.json()
 
     expect(res.status).toBe(429)
-    expect(text).toBe('Too many requests. Please try again later.')
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(res.headers.get('retry-after')).toBe('45')
+    expect(body).toEqual({
+      error: {
+        code: 'ai_usage_limited',
+        reason: 'rate_limit',
+        message: 'Too many requests. Please try again later.',
+        retryAfterMs: 45_000,
+      },
+    })
     expect(streamTextMock).not.toHaveBeenCalled()
     expect(finalizeUsageMock).not.toHaveBeenCalled()
   })
 
-  it('returns 429 when quota is exceeded', async () => {
+  it.each([
+    ['user_quota', 'AI usage quota exceeded for this user.'],
+    ['tenant_quota', 'AI usage quota exceeded for this facility.'],
+    ['global_quota', 'AI daily quota exceeded'],
+    ['kill_switch', 'AI usage is temporarily disabled.'],
+  ] as const)('returns structured 429 metadata for %s denials', async (reason, message) => {
     reserveUsageMock.mockResolvedValue({
       allowed: false,
-      reason: 'tenant_quota',
-      message: 'AI usage quota exceeded for this facility.',
+      reason,
+      message,
     })
 
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
-    const text = await res.text()
+    const body = await res.json()
 
     expect(res.status).toBe(429)
-    expect(text).toBe('AI usage quota exceeded for this facility.')
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(res.headers.get('retry-after')).toBe('60')
+    expect(body).toEqual({
+      error: {
+        code: 'ai_usage_limited',
+        reason,
+        message,
+        retryAfterMs: 60_000,
+      },
+    })
     expect(streamTextMock).not.toHaveBeenCalled()
     expect(finalizeUsageMock).not.toHaveBeenCalled()
   })

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -22,6 +22,7 @@ import {
   AI_MAX_MESSAGES,
   AI_MAX_OUTPUT_TOKENS,
   AI_MAX_TOOL_STEPS,
+  AI_RATE_LIMIT_WINDOW_MS,
   calculateInputChars,
 } from '@/lib/ai/limits'
 import { getChatModel, getKeyPoolSize, handleProviderQuotaError } from '@/lib/ai/provider'
@@ -37,6 +38,8 @@ import {
   reserveUsage,
   type UsageContext,
   type UsageFinalizeStatus,
+  type UsageLimitReason,
+  type UsageReservationResult,
 } from '@/lib/ai/usage-metering'
 import { isProviderQuotaError, sanitizeErrorForClient } from '@/lib/ai/errors'
 import { ROLES } from '@/lib/rbac'
@@ -50,6 +53,37 @@ function plainError(message: string, status: number) {
   return new Response(message, {
     status,
     headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+}
+
+const DEFAULT_USAGE_LIMIT_RETRY_AFTER_MS = 60_000
+
+function retryAfterMsForUsageLimit(reason: UsageLimitReason): number {
+  if (reason === 'rate_limit') {
+    return AI_RATE_LIMIT_WINDOW_MS
+  }
+
+  return DEFAULT_USAGE_LIMIT_RETRY_AFTER_MS
+}
+
+function usageLimitResponse(usageReservation: UsageReservationResult) {
+  const reason = usageReservation.reason ?? 'user_quota'
+  const retryAfterMs = retryAfterMsForUsageLimit(reason)
+  const retryAfterSeconds = Math.max(1, Math.ceil(retryAfterMs / 1000))
+
+  return new Response(JSON.stringify({
+    error: {
+      code: 'ai_usage_limited',
+      reason,
+      message: usageReservation.message ?? 'AI usage limit exceeded.',
+      retryAfterMs,
+    },
+  }), {
+    status: 429,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Retry-After': String(retryAfterSeconds),
+    },
   })
 }
 
@@ -173,7 +207,7 @@ export async function POST(request: Request) {
   }
   const usageReservation = await reserveUsage(usageContext)
   if (!usageReservation.allowed) {
-    return plainError(usageReservation.message ?? 'AI usage limit exceeded.', 429)
+    return usageLimitResponse(usageReservation)
   }
 
   let finalized = false

--- a/src/components/assistant/AssistantPanel.tsx
+++ b/src/components/assistant/AssistantPanel.tsx
@@ -16,7 +16,7 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog"
 import { useTenantSelection } from "@/contexts/TenantSelectionContext"
-import { parseErrorMessage } from "@/lib/ai/errors"
+import { parseAiUsageLimitError, parseErrorMessage } from "@/lib/ai/errors"
 import { compactUIMessages } from "@/lib/ai/compact-ui-messages"
 import { buildRepairRequestCreateIntentHref } from "@/lib/repair-request-deep-link"
 import { cn } from "@/lib/utils"
@@ -32,6 +32,26 @@ import "@/components/assistant/assistant-styles.css"
 interface AssistantPanelProps {
     isOpen: boolean
     onClose: () => void
+}
+
+type CooldownState = {
+    until: number | null
+    now: number
+}
+
+type CooldownAction =
+    | { type: "clear"; now: number }
+    | { type: "start"; until: number; now: number }
+    | { type: "tick"; until: number; now: number }
+
+function cooldownReducer(_state: CooldownState, action: CooldownAction): CooldownState {
+    switch (action.type) {
+        case "clear":
+            return { until: null, now: action.now }
+        case "start":
+        case "tick":
+            return { until: action.until, now: action.now }
+    }
 }
 
 /** All tool names available for the assistant. */
@@ -61,6 +81,11 @@ const REQUESTED_TOOLS = [
 export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
     const { selectedFacilityId, facilities = [] } = useTenantSelection()
     const [input, setInput] = React.useState("")
+    const [cooldown, dispatchCooldown] = React.useReducer(
+        cooldownReducer,
+        undefined,
+        () => ({ until: null, now: Date.now() }),
+    )
 
     const facilityRef = React.useRef(selectedFacilityId)
     facilityRef.current = selectedFacilityId
@@ -93,42 +118,79 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
     })
 
     const queryClient = useQueryClient()
-    const router = useRouter()
+    const { push } = useRouter()
 
     const isStreaming = status === "streaming"
     const isReady = status === "ready"
+    const usageLimitError = React.useMemo(
+        () => parseAiUsageLimitError(error?.message),
+        [error?.message],
+    )
+    const cooldownRemainingMs = cooldown.until
+        ? Math.max(0, cooldown.until - cooldown.now)
+        : 0
+    const isCooldownActive = cooldownRemainingMs > 0
+    const cooldownSeconds = Math.max(1, Math.ceil(cooldownRemainingMs / 1000))
+    const canSend = isReady && !isCooldownActive
+
+    React.useEffect(() => {
+        if (!usageLimitError?.retryAfterMs) {
+            dispatchCooldown({ type: "clear", now: Date.now() })
+            return
+        }
+
+        const current = Date.now()
+        const expiresAt = current + usageLimitError.retryAfterMs
+        dispatchCooldown({ type: "start", until: expiresAt, now: current })
+
+        const interval = window.setInterval(() => {
+            const tickNow = Date.now()
+            dispatchCooldown({ type: "tick", until: expiresAt, now: tickNow })
+            if (tickNow >= expiresAt) {
+                window.clearInterval(interval)
+            }
+        }, 1000)
+
+        return () => window.clearInterval(interval)
+    }, [error?.message, usageLimitError?.retryAfterMs])
 
     const handleSend = React.useCallback(() => {
         const trimmed = input.trim()
-        if (!trimmed || !isReady) return
+        if (!trimmed || !canSend) return
 
         sendMessage({ text: trimmed })
         setInput("")
-    }, [input, isReady, sendMessage])
+    }, [canSend, input, sendMessage])
 
     const handleSuggestionClick = React.useCallback(
         (text: string) => {
-            if (!isReady) return
+            if (!canSend) return
             sendMessage({ text })
         },
-        [isReady, sendMessage],
+        [canSend, sendMessage],
     )
 
     const handleReset = React.useCallback(() => {
+        dispatchCooldown({ type: "clear", now: Date.now() })
         clearError()
         setMessages([])
         setInput("")
     }, [clearError, setMessages])
+
+    const handleRetry = React.useCallback(() => {
+        if (isCooldownActive) return
+        regenerate()
+    }, [isCooldownActive, regenerate])
 
     /** TanStack Query bridge for draft handoff to /repair-requests */
     const handleApplyDraft = React.useCallback(
         (draft: RepairRequestDraft | TroubleshootingDraft) => {
             if (draft.kind === "repairRequestDraft") {
                 queryClient.setQueryData(["assistant-draft"], draft)
-                router.push(buildRepairRequestCreateIntentHref())
+                push(buildRepairRequestCreateIntentHref())
             }
         },
-        [queryClient, router],
+        [push, queryClient],
     )
 
     if (!isOpen) return null
@@ -188,7 +250,7 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
                     <div className="flex-1 overflow-y-auto px-4 py-3">
                         <AssistantEmptyState
                             onSuggestionClick={handleSuggestionClick}
-                            isReady={isReady}
+                            isReady={canSend}
                         />
                     </div>
                 ) : (
@@ -213,12 +275,13 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
                         <Button
                             variant="ghost"
                             size="sm"
-                            onClick={() => regenerate()}
+                            onClick={handleRetry}
+                            disabled={isCooldownActive}
                             className="shrink-0 h-7 px-2 text-xs text-destructive hover:text-destructive"
-                            aria-label="Thử lại"
+                            aria-label={isCooldownActive ? `Thử lại sau ${cooldownSeconds} giây` : "Thử lại"}
                         >
                             <RefreshCw className="size-3 mr-1" />
-                            Thử lại
+                            {isCooldownActive ? `Thử lại sau ${cooldownSeconds} giây` : "Thử lại"}
                         </Button>
                     </div>
                 )}
@@ -229,7 +292,7 @@ export function AssistantPanel({ isOpen, onClose }: AssistantPanelProps) {
                     onSend={handleSend}
                     onStop={() => stop()}
                     isStreaming={isStreaming}
-                    isReady={isReady}
+                    isReady={canSend}
                 />
 
                 <div className="px-4 pb-3 shrink-0">

--- a/src/components/assistant/__tests__/AssistantPanel.error-state.test.tsx
+++ b/src/components/assistant/__tests__/AssistantPanel.error-state.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -77,6 +77,7 @@ import { AssistantPanel } from '../AssistantPanel'
 
 describe('AssistantPanel error state', () => {
     beforeEach(() => {
+        vi.useRealTimers()
         vi.clearAllMocks()
         mocks.useChatState.messages = []
         mocks.useChatState.status = 'ready'
@@ -126,6 +127,47 @@ describe('AssistantPanel error state', () => {
         fireEvent.click(retryButton)
 
         expect(mocks.regenerate).toHaveBeenCalledTimes(1)
+    })
+
+    it('blocks retry while an AI usage cooldown is active', () => {
+        vi.useFakeTimers()
+        mocks.useChatState.error = new Error(JSON.stringify({
+            error: {
+                code: 'ai_usage_limited',
+                reason: 'rate_limit',
+                message: 'Too many requests. Please try again later.',
+                retryAfterMs: 2_000,
+            },
+        }))
+        mocks.useChatState.status = 'error'
+
+        render(<AssistantPanel isOpen={true} onClose={vi.fn()} />)
+
+        const retryButton = screen.getByRole('button', { name: /thử lại sau 2 giây/i })
+        expect(retryButton).toBeDisabled()
+        fireEvent.click(retryButton)
+        expect(mocks.regenerate).not.toHaveBeenCalled()
+
+        act(() => {
+            vi.advanceTimersByTime(2_000)
+        })
+        expect(screen.getByRole('button', { name: /thử lại/i })).not.toBeDisabled()
+    })
+
+    it('blocks sending new prompts while an AI usage cooldown is active', () => {
+        mocks.useChatState.error = new Error(JSON.stringify({
+            error: {
+                code: 'ai_usage_limited',
+                reason: 'tenant_quota',
+                message: 'AI usage quota exceeded for this facility.',
+                retryAfterMs: 60_000,
+            },
+        }))
+        mocks.useChatState.status = 'error'
+
+        render(<AssistantPanel isOpen={true} onClose={vi.fn()} />)
+
+        expect(screen.getByPlaceholderText('Hỏi AI về thiết bị, bảo trì…')).toBeDisabled()
     })
 
     it('does not render error banner when error is null', () => {

--- a/src/lib/ai/__tests__/errors.test.ts
+++ b/src/lib/ai/__tests__/errors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   GENERIC_CHAT_ERROR_MESSAGE,
   isProviderQuotaError,
+  parseAiUsageLimitError,
   parseErrorMessage,
   sanitizeErrorForClient,
 } from '../errors'
@@ -36,6 +37,38 @@ describe('ai errors sanitization', () => {
 
     expect(sanitizeErrorForClient(raw)).toBe(GENERIC_CHAT_ERROR_MESSAGE)
   })
+
+  it('parses whitelisted AI usage-limit JSON metadata', () => {
+    const raw = JSON.stringify({
+      error: {
+        code: 'ai_usage_limited',
+        reason: 'rate_limit',
+        message: 'Too many requests. Please try again later.',
+        retryAfterMs: 45_000,
+      },
+    })
+
+    expect(parseAiUsageLimitError(raw)).toEqual({
+      reason: 'rate_limit',
+      message: 'Too many requests. Please try again later.',
+      retryAfterMs: 45_000,
+    })
+    expect(parseErrorMessage(raw)).toBe('Too many requests. Please try again later.')
+  })
+
+  it('rejects untrusted usage-limit JSON metadata', () => {
+    const raw = JSON.stringify({
+      error: {
+        code: 'ai_usage_limited',
+        reason: 'debug_dump',
+        message: 'stack=secret',
+        retryAfterMs: 45_000,
+      },
+    })
+
+    expect(parseAiUsageLimitError(raw)).toBeNull()
+    expect(parseErrorMessage(raw)).toBe(GENERIC_CHAT_ERROR_MESSAGE)
+  })
 })
 
 describe('isProviderQuotaError', () => {
@@ -68,4 +101,3 @@ describe('isProviderQuotaError', () => {
     expect(isProviderQuotaError(42)).toBe(false)
   })
 })
-

--- a/src/lib/ai/errors.ts
+++ b/src/lib/ai/errors.ts
@@ -7,6 +7,20 @@
 export const GENERIC_CHAT_ERROR_MESSAGE = 'Đã xảy ra lỗi. Vui lòng thử lại.'
 const MODEL_PROVIDER_QUOTA_MESSAGE =
   'Model AI đang vượt hạn mức sử dụng của nhà cung cấp.'
+const AI_USAGE_LIMIT_ERROR_CODE = 'ai_usage_limited'
+
+export type AiUsageLimitReason =
+  | 'rate_limit'
+  | 'user_quota'
+  | 'tenant_quota'
+  | 'global_quota'
+  | 'kill_switch'
+
+export interface AiUsageLimitError {
+  reason: AiUsageLimitReason
+  message: string
+  retryAfterMs?: number
+}
 
 const PROVIDER_QUOTA_PATTERNS = [
   /exceeded your current quota/i,
@@ -51,6 +65,71 @@ const SAFE_CLIENT_MESSAGE_RULES: Array<{ pattern: RegExp; message: string }> = [
     message: 'Request exceeds input size limit',
   },
 ]
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeAiUsageLimitReason(value: unknown): AiUsageLimitReason | null {
+  switch (value) {
+    case 'rate_limit':
+    case 'user_quota':
+    case 'tenant_quota':
+    case 'global_quota':
+    case 'kill_switch':
+      return value
+    default:
+      return null
+  }
+}
+
+function normalizeRetryAfterMs(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined
+  }
+
+  return Math.ceil(value)
+}
+
+/** Parses the whitelisted `/api/chat` quota cooldown error contract. */
+export function parseAiUsageLimitError(raw: string | undefined): AiUsageLimitError | null {
+  if (!raw || raw.trim() === '') {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!isRecord(parsed) || !isRecord(parsed.error)) {
+      return null
+    }
+
+    const error = parsed.error
+    if (error.code !== AI_USAGE_LIMIT_ERROR_CODE) {
+      return null
+    }
+
+    const reason = normalizeAiUsageLimitReason(error.reason)
+    if (!reason) {
+      return null
+    }
+
+    const message =
+      typeof error.message === 'string'
+        ? extractSafeClientMessage(error.message)
+        : null
+    if (!message) {
+      return null
+    }
+
+    return {
+      reason,
+      message,
+      retryAfterMs: normalizeRetryAfterMs(error.retryAfterMs),
+    }
+  } catch {
+    return null
+  }
+}
 
 function formatProviderQuotaMessage(raw: string): string | null {
   if (!PROVIDER_QUOTA_PATTERNS.some(pattern => pattern.test(raw))) {
@@ -127,6 +206,11 @@ export function sanitizeErrorForClient(_error: unknown): string {
 export function parseErrorMessage(raw: string | undefined): string {
   if (!raw || raw.trim() === '') {
     return GENERIC_CHAT_ERROR_MESSAGE
+  }
+
+  const usageLimitError = parseAiUsageLimitError(raw)
+  if (usageLimitError) {
+    return usageLimitError.message
   }
 
   const safeRawMessage = extractSafeClientMessage(raw)


### PR DESCRIPTION
## Summary
- return structured /api/chat 429 metadata for AI usage denials, including reason and retry cooldown
- parse the quota cooldown contract safely on the client while preserving deny-by-default error handling
- disable assistant retry/send actions during cooldown and show a countdown label

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/app/api/chat/__tests__/route.rate-limit-and-quota.test.ts src/lib/ai/__tests__/errors.test.ts src/components/assistant/__tests__/AssistantPanel.error-state.test.tsx
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main
- pre-commit lefthook
- pre-push lefthook

Closes #537

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured 429 JSON from `/api/chat` with retry metadata and a cooldown UI that blocks sending and retry with a countdown. Addresses #537 by preventing rapid retries after rate limit or quota denials.

- **New Features**
  - API: On usage denials, return `{ error: { code: 'ai_usage_limited', reason, message, retryAfterMs } }` and `Retry-After` (seconds). `rate_limit` uses `AI_RATE_LIMIT_WINDOW_MS`; others default to 60s. Supported reasons: `rate_limit`, `user_quota`, `tenant_quota`, `global_quota`, `kill_switch`.
  - Client: Safely parse usage-limit errors via `parseAiUsageLimitError`, show a countdown, and disable Retry, input, Send, and suggestions during cooldown; auto re-enable when it ends.
  - Safety: Only accept the whitelisted `'ai_usage_limited'` contract and reasons; untrusted payloads fall back to generic errors.

<sup>Written for commit 9290fb99c9d80c19642ec9167859f4b906b82c1b. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/552?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat now enforces cooldown windows after rate limits are hit, preventing message sends and retries. UI displays a countdown timer showing when retry becomes available.
  * Chat API returns structured JSON error responses for rate limits with specific retry-after timing.

* **Tests**
  * Enhanced test coverage for rate-limit behavior, error handling, and cooldown mechanics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->