### PR TITLE
feat: add DB-backed AI kill switch

### DIFF
--- a/src/app/api/chat/__tests__/route.kill-switch.test.ts
+++ b/src/app/api/chat/__tests__/route.kill-switch.test.ts
@@ -4,6 +4,7 @@ vi.mock('server-only', () => ({}))
 
 const getServerSessionMock = vi.fn()
 const callServerRpcMock = vi.fn()
+const isAiKillSwitchActiveMock = vi.fn()
 const streamTextMock = vi.fn()
 const stepCountIsMock = vi.fn()
 
@@ -13,6 +14,10 @@ vi.mock('next-auth', () => ({
 
 vi.mock('@/lib/ai/server-rpc', () => ({
   callServerRpc: (...args: unknown[]) => callServerRpcMock(...args),
+}))
+
+vi.mock('@/lib/ai/kill-switch', () => ({
+  isAiKillSwitchActive: (...args: unknown[]) => isAiKillSwitchActiveMock(...args),
 }))
 
 vi.mock('@/lib/ai/provider', () => ({
@@ -58,6 +63,7 @@ describe('/api/chat kill switch and global quota', () => {
     getServerSessionMock.mockResolvedValue({
       user: { id: 'u1', role: 'admin', don_vi: 2 },
     })
+    isAiKillSwitchActiveMock.mockResolvedValue({ active: false, source: 'db' })
     stepCountIsMock.mockReturnValue('STOP_WHEN_SENTINEL')
   })
 
@@ -65,15 +71,71 @@ describe('/api/chat kill switch and global quota', () => {
     vi.unstubAllEnvs()
   })
 
-  it('returns 429 without calling quota RPC when AI_KILL_SWITCH is on', async () => {
-    vi.stubEnv('AI_KILL_SWITCH', 'on')
+  it('returns 429 without calling quota RPC when DB kill switch is on', async () => {
+    isAiKillSwitchActiveMock.mockResolvedValue({
+      active: true,
+      source: 'db',
+      reason: 'maintenance',
+    })
 
     const { POST } = await import('../route')
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
-    const text = await res.text()
+    const body = await res.json()
 
     expect(res.status).toBe(429)
-    expect(text).toBe('AI usage is temporarily disabled.')
+    expect(body).toEqual({
+      error: {
+        code: 'ai_usage_limited',
+        reason: 'kill_switch',
+        message: 'maintenance',
+        retryAfterMs: 60_000,
+      },
+    })
+    expect(res.headers.get('Retry-After')).toBe('60')
+    expect(isAiKillSwitchActiveMock).toHaveBeenCalledOnce()
+    expect(callServerRpcMock).not.toHaveBeenCalled()
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 429 with default message when env kill switch is on', async () => {
+    isAiKillSwitchActiveMock.mockResolvedValue({
+      active: true,
+      source: 'env',
+    })
+
+    const { POST } = await import('../route')
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
+    const body = await res.json()
+
+    expect(res.status).toBe(429)
+    expect(body.error).toEqual({
+      code: 'ai_usage_limited',
+      reason: 'kill_switch',
+      message: 'AI usage is temporarily disabled.',
+      retryAfterMs: 60_000,
+    })
+    expect(res.headers.get('Retry-After')).toBe('60')
+    expect(callServerRpcMock).not.toHaveBeenCalled()
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the DB kill-switch read fails', async () => {
+    isAiKillSwitchActiveMock.mockResolvedValue({
+      active: true,
+      source: 'db_error_fail_closed',
+    })
+
+    const { POST } = await import('../route')
+    const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
+    const body = await res.json()
+
+    expect(res.status).toBe(429)
+    expect(body.error).toEqual({
+      code: 'ai_usage_limited',
+      reason: 'kill_switch',
+      message: 'AI usage is temporarily disabled.',
+      retryAfterMs: 60_000,
+    })
     expect(callServerRpcMock).not.toHaveBeenCalled()
     expect(streamTextMock).not.toHaveBeenCalled()
   })
@@ -91,10 +153,15 @@ describe('/api/chat kill switch and global quota', () => {
 
     const { POST } = await import('../route')
     const res = await POST(buildRequest({ messages: VALID_MESSAGES }) as never)
-    const text = await res.text()
+    const body = await res.json()
 
     expect(res.status).toBe(429)
-    expect(text).toBe('AI daily quota exceeded')
+    expect(body.error).toEqual({
+      code: 'ai_usage_limited',
+      reason: 'global_quota',
+      message: 'AI daily quota exceeded',
+      retryAfterMs: 60_000,
+    })
     expect(streamTextMock).not.toHaveBeenCalled()
     expect(callServerRpcMock).toHaveBeenCalledWith(
       'ai_quota_reserve',

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -86,6 +86,8 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'ai_quota_compliance_summary',
   'ai_category_suggestion',
   'ai_department_list',
+  'ai_kill_switch_status',
+  'ai_kill_switch_set',
   'assistant_query_database_audit_log',
   // Tenants + Users
   'tenant_list',

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
 
 import { POST } from '../[fn]/route'
 
@@ -90,6 +92,8 @@ describe('RPC proxy whitelist', () => {
     'ai_quota_compliance_summary',
     'ai_category_suggestion',
     'ai_department_list',
+    'ai_kill_switch_status',
+    'ai_kill_switch_set',
   ])('allows AI RPC "%s" through whitelist checks', async (fn) => {
     const res = await invokeRpcProxy(fn)
 

--- a/src/lib/ai/__tests__/kill-switch.test.ts
+++ b/src/lib/ai/__tests__/kill-switch.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+const callServerRpcMock = vi.fn()
+
+vi.mock('@/lib/ai/server-rpc', () => ({
+  callServerRpc: (...args: unknown[]) => callServerRpcMock(...args),
+}))
+
+describe('AI kill switch status', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-23T00:00:00.000Z'))
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    callServerRpcMock.mockReset()
+
+    const { __resetKillSwitchCache } = await import('../kill-switch')
+    __resetKillSwitchCache()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it('uses env override without calling the RPC', async () => {
+    vi.stubEnv('AI_KILL_SWITCH', 'on')
+
+    const { isAiKillSwitchActive } = await import('../kill-switch')
+    await expect(isAiKillSwitchActive()).resolves.toEqual({
+      active: true,
+      source: 'env',
+    })
+    expect(callServerRpcMock).not.toHaveBeenCalled()
+  })
+
+  it('returns active db status with reason', async () => {
+    callServerRpcMock.mockResolvedValue([{ enabled: true, reason: 'maintenance' }])
+
+    const { isAiKillSwitchActive } = await import('../kill-switch')
+    await expect(isAiKillSwitchActive()).resolves.toEqual({
+      active: true,
+      source: 'db',
+      reason: 'maintenance',
+    })
+  })
+
+  it('returns inactive db status', async () => {
+    callServerRpcMock.mockResolvedValue([{ enabled: false, reason: null }])
+
+    const { isAiKillSwitchActive } = await import('../kill-switch')
+    await expect(isAiKillSwitchActive()).resolves.toEqual({
+      active: false,
+      source: 'db',
+    })
+  })
+
+  it('caches db status inside the normal TTL', async () => {
+    callServerRpcMock.mockResolvedValue([{ enabled: false, reason: null }])
+
+    const { isAiKillSwitchActive } = await import('../kill-switch')
+    await isAiKillSwitchActive()
+    vi.advanceTimersByTime(7_999)
+    await isAiKillSwitchActive()
+
+    expect(callServerRpcMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fetches db status after the normal TTL expires', async () => {
+    callServerRpcMock
+      .mockResolvedValueOnce([{ enabled: false, reason: null }])
+      .mockResolvedValueOnce([{ enabled: true, reason: 'after ttl' }])
+
+    const { isAiKillSwitchActive } = await import('../kill-switch')
+    await expect(isAiKillSwitchActive()).resolves.toEqual({ active: false, source: 'db' })
+    vi.advanceTimersByTime(8_000)
+    await expect(isAiKillSwitchActive()).resolves.toEqual({
+      active: true,
+      source: 'db',
+      reason: 'after ttl',
+    })
+    expect(callServerRpcMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('env override beats cached db false without another RPC call', async () => {
+    callServerRpcMock.mockResolvedValue([{ enabled: false, reason: null }])
+
+    const { isAiKillSwitchActive } = await import('../kill-switch')
+    await expect(isAiKillSwitchActive()).resolves.toEqual({ active: false, source: 'db' })
+
+    vi.stubEnv('AI_KILL_SWITCH', 'on')
+    await expect(isAiKillSwitchActive()).resolves.toEqual({ active: true, source: 'env' })
+    expect(callServerRpcMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed and caches RPC errors for the short TTL', async () => {
+    callServerRpcMock
+      .mockRejectedValueOnce(new Error('db unavailable'))
+      .mockResolvedValueOnce([{ enabled: false, reason: null }])
+
+    const { isAiKillSwitchActive } = await import('../kill-switch')
+    await expect(isAiKillSwitchActive()).resolves.toEqual({
+      active: true,
+      source: 'db_error_fail_closed',
+    })
+    vi.advanceTimersByTime(1_999)
+    await expect(isAiKillSwitchActive()).resolves.toEqual({
+      active: true,
+      source: 'db_error_fail_closed',
+    })
+    expect(callServerRpcMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1)
+    await expect(isAiKillSwitchActive()).resolves.toEqual({ active: false, source: 'db' })
+    expect(callServerRpcMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats empty RPC rows as inactive db status', async () => {
+    callServerRpcMock.mockResolvedValue([])
+
+    const { isAiKillSwitchActive } = await import('../kill-switch')
+    await expect(isAiKillSwitchActive()).resolves.toEqual({
+      active: false,
+      source: 'db',
+    })
+  })
+})

--- a/src/lib/ai/__tests__/usage-metering.distributed.test.ts
+++ b/src/lib/ai/__tests__/usage-metering.distributed.test.ts
@@ -3,9 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 vi.mock('server-only', () => ({}))
 
 const callServerRpcMock = vi.fn()
+const isAiKillSwitchActiveMock = vi.fn()
 
 vi.mock('@/lib/ai/server-rpc', () => ({
   callServerRpc: (...args: unknown[]) => callServerRpcMock(...args),
+}))
+
+vi.mock('@/lib/ai/kill-switch', () => ({
+  isAiKillSwitchActive: (...args: unknown[]) => isAiKillSwitchActiveMock(...args),
 }))
 
 describe('distributed AI usage metering', () => {
@@ -18,6 +23,8 @@ describe('distributed AI usage metering', () => {
     vi.stubEnv('AI_DAILY_GLOBAL_QUOTA_REQUESTS', '6')
     vi.stubEnv('AI_QUOTA_RESERVATION_TTL_MS', '120000')
     callServerRpcMock.mockReset()
+    isAiKillSwitchActiveMock.mockReset()
+    isAiKillSwitchActiveMock.mockResolvedValue({ active: false, source: 'db' })
   })
 
   afterEach(() => {
@@ -65,13 +72,33 @@ describe('distributed AI usage metering', () => {
     )
   })
 
-  it('short-circuits when AI_KILL_SWITCH is on', async () => {
-    vi.stubEnv('AI_KILL_SWITCH', 'on')
+  it('short-circuits when the AI kill switch is active', async () => {
+    isAiKillSwitchActiveMock.mockResolvedValue({
+      active: true,
+      source: 'db',
+      reason: 'maintenance',
+    })
 
     const { reserveUsage } = await import('../usage-metering')
     const result = await reserveUsage({ userId: 'u1', tenantId: 2 })
 
     expect(result).toEqual({
+      allowed: false,
+      reason: 'kill_switch',
+      message: 'maintenance',
+    })
+    expect(isAiKillSwitchActiveMock).toHaveBeenCalledOnce()
+    expect(callServerRpcMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the default kill-switch message when no reason is configured', async () => {
+    isAiKillSwitchActiveMock.mockResolvedValue({
+      active: true,
+      source: 'env',
+    })
+
+    const { reserveUsage } = await import('../usage-metering')
+    await expect(reserveUsage({ userId: 'u1', tenantId: 2 })).resolves.toEqual({
       allowed: false,
       reason: 'kill_switch',
       message: 'AI usage is temporarily disabled.',

--- a/src/lib/ai/kill-switch.ts
+++ b/src/lib/ai/kill-switch.ts
@@ -1,0 +1,84 @@
+import 'server-only'
+
+import { callServerRpc, type SupabaseRpcUser } from '@/lib/ai/server-rpc'
+
+const NORMAL_CACHE_TTL_MS = 8_000
+const FAIL_CLOSED_CACHE_TTL_MS = 2_000
+const DEFAULT_INACTIVE_STATUS: AiKillSwitchStatus = { active: false, source: 'db' }
+
+type AiKillSwitchRpcRow = {
+  enabled?: boolean | null
+  reason?: string | null
+}
+
+export type AiKillSwitchStatus =
+  | { active: true; source: 'env'; reason?: undefined }
+  | { active: true; source: 'db'; reason?: string }
+  | { active: true; source: 'db_error_fail_closed'; reason?: undefined }
+  | { active: false; source: 'db'; reason?: undefined }
+
+type CacheEntry = {
+  value: AiKillSwitchStatus
+  expiresAt: number
+}
+
+const SYSTEM_RPC_USER: SupabaseRpcUser = {
+  id: 'system:ai-kill-switch-reader',
+  role: 'global',
+}
+
+let cache: CacheEntry | null = null
+
+function isEnvKillSwitchOn(): boolean {
+  return process.env.AI_KILL_SWITCH?.toLowerCase() === 'on'
+}
+
+function firstStatusRow(
+  payload: AiKillSwitchRpcRow | AiKillSwitchRpcRow[] | null | undefined,
+): AiKillSwitchRpcRow | null {
+  const row = Array.isArray(payload) ? payload[0] : payload
+  return row ?? null
+}
+
+function normalizeDbStatus(row: AiKillSwitchRpcRow | null): AiKillSwitchStatus {
+  if (!row?.enabled) {
+    return DEFAULT_INACTIVE_STATUS
+  }
+
+  const reason = typeof row.reason === 'string' ? row.reason.trim() : ''
+  return reason
+    ? { active: true, source: 'db', reason }
+    : { active: true, source: 'db' }
+}
+
+/** Clears the in-process kill-switch cache for deterministic unit tests. */
+export function __resetKillSwitchCache(): void {
+  cache = null
+}
+
+/** Reads the current AI kill-switch state, preferring the env emergency override. */
+export async function isAiKillSwitchActive(): Promise<AiKillSwitchStatus> {
+  if (isEnvKillSwitchOn()) {
+    return { active: true, source: 'env' }
+  }
+
+  const now = Date.now()
+  if (cache && cache.expiresAt > now) {
+    return cache.value
+  }
+
+  try {
+    const row = firstStatusRow(await callServerRpc<AiKillSwitchRpcRow | AiKillSwitchRpcRow[]>(
+      'ai_kill_switch_status',
+      {},
+      SYSTEM_RPC_USER,
+    ))
+    const value = normalizeDbStatus(row)
+    cache = { value, expiresAt: now + NORMAL_CACHE_TTL_MS }
+    return value
+  } catch {
+    const value: AiKillSwitchStatus = { active: true, source: 'db_error_fail_closed' }
+    cache = { value, expiresAt: now + FAIL_CLOSED_CACHE_TTL_MS }
+    return value
+  }
+}

--- a/src/lib/ai/usage-metering.ts
+++ b/src/lib/ai/usage-metering.ts
@@ -2,11 +2,11 @@ import {
   AI_DAILY_GLOBAL_QUOTA_REQUESTS,
   AI_DAILY_TENANT_QUOTA_REQUESTS,
   AI_DAILY_USER_QUOTA_REQUESTS,
-  AI_KILL_SWITCH,
   AI_QUOTA_RESERVATION_TTL_MS,
   AI_RATE_LIMIT_MAX_REQUESTS,
   AI_RATE_LIMIT_WINDOW_MS,
 } from '@/lib/ai/limits'
+import { isAiKillSwitchActive } from '@/lib/ai/kill-switch'
 import { callServerRpc, type SupabaseRpcUser } from '@/lib/ai/server-rpc'
 
 export type UsageLimitReason =
@@ -117,11 +117,12 @@ function firstReserveRow(
 
 /** Reserves distributed AI quota before starting a provider request. */
 export async function reserveUsage(context: UsageContext): Promise<UsageReservationResult> {
-  if (AI_KILL_SWITCH) {
+  const killSwitch = await isAiKillSwitchActive()
+  if (killSwitch.active) {
     return {
       allowed: false,
       reason: 'kill_switch',
-      message: 'AI usage is temporarily disabled.',
+      message: killSwitch.reason ?? 'AI usage is temporarily disabled.',
     }
   }
 

--- a/supabase/migrations/20251122000000_create_internal_settings_table.sql
+++ b/supabase/migrations/20251122000000_create_internal_settings_table.sql
@@ -1,0 +1,32 @@
+-- Bootstrap internal settings store used by server-side operational toggles.
+-- Live databases may already have this table from MCP-applied migrations; keep this idempotent
+-- so fresh local resets and production both converge safely.
+
+CREATE TABLE IF NOT EXISTS public.internal_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE public.internal_settings ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.internal_settings FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.internal_settings TO service_role;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'internal_settings'
+      AND policyname = 'service_role can manage internal settings'
+  ) THEN
+    CREATE POLICY "service_role can manage internal settings"
+      ON public.internal_settings
+      FOR ALL
+      TO public
+      USING ((SELECT auth.role()) = 'service_role')
+      WITH CHECK ((SELECT auth.role()) = 'service_role');
+  END IF;
+END $$;

--- a/supabase/migrations/20260523100000_ai_kill_switch_db_toggle.sql
+++ b/supabase/migrations/20260523100000_ai_kill_switch_db_toggle.sql
@@ -1,0 +1,145 @@
+-- Issue #538: DB-backed AI kill switch stored in public.internal_settings.
+
+INSERT INTO public.internal_settings(key, value, updated_at)
+VALUES ('ai_kill_switch.enabled', 'false', now())
+ON CONFLICT (key) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public.ai_kill_switch_status()
+RETURNS TABLE (
+  enabled BOOLEAN,
+  reason TEXT,
+  updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims_text TEXT := current_setting('request.jwt.claims', true);
+  v_claims JSONB;
+  v_role TEXT;
+  v_user_id TEXT;
+  v_enabled_text TEXT;
+  v_enabled_updated_at TIMESTAMPTZ;
+  v_reason_updated_at TIMESTAMPTZ;
+BEGIN
+  IF v_claims_text IS NULL OR btrim(v_claims_text) = '' THEN
+    RAISE EXCEPTION 'Missing JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_claims := v_claims_text::jsonb;
+  v_role := NULLIF(v_claims->>'app_role', '');
+  v_user_id := NULLIF(v_claims->>'user_id', '');
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role IS NULL THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT s.value, s.updated_at
+  INTO v_enabled_text, v_enabled_updated_at
+  FROM public.internal_settings s
+  WHERE s.key = 'ai_kill_switch.enabled';
+
+  SELECT NULLIF(btrim(s.value), ''), s.updated_at
+  INTO reason, v_reason_updated_at
+  FROM public.internal_settings s
+  WHERE s.key = 'ai_kill_switch.reason';
+
+  enabled := lower(COALESCE(v_enabled_text, 'false')) IN ('true', '1', 'on', 'yes', 'enabled');
+  updated_at := GREATEST(v_enabled_updated_at, v_reason_updated_at);
+
+  RETURN NEXT;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ai_kill_switch_set(
+  p_enabled BOOLEAN,
+  p_reason TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  enabled BOOLEAN,
+  reason TEXT,
+  updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims_text TEXT := current_setting('request.jwt.claims', true);
+  v_claims JSONB;
+  v_role TEXT;
+  v_user_id TEXT;
+  v_reason TEXT := NULLIF(btrim(COALESCE(p_reason, '')), '');
+  v_enabled_updated_at TIMESTAMPTZ;
+  v_reason_updated_at TIMESTAMPTZ;
+BEGIN
+  IF p_enabled IS NULL THEN
+    RAISE EXCEPTION 'p_enabled is required' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_claims_text IS NULL OR btrim(v_claims_text) = '' THEN
+    RAISE EXCEPTION 'Missing JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_claims := v_claims_text::jsonb;
+  v_role := NULLIF(v_claims->>'app_role', '');
+  v_user_id := NULLIF(v_claims->>'user_id', '');
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role IS NULL THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role NOT IN ('global', 'service_role') THEN
+    RAISE EXCEPTION 'Insufficient privileges to set AI kill switch' USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.internal_settings(key, value, updated_at)
+  VALUES ('ai_kill_switch.enabled', CASE WHEN p_enabled THEN 'true' ELSE 'false' END, now())
+  ON CONFLICT (key) DO UPDATE
+  SET value = EXCLUDED.value,
+      updated_at = EXCLUDED.updated_at
+  RETURNING public.internal_settings.updated_at INTO v_enabled_updated_at;
+
+  IF v_reason IS NULL THEN
+    DELETE FROM public.internal_settings
+    WHERE key = 'ai_kill_switch.reason';
+    v_reason_updated_at := NULL;
+  ELSE
+    INSERT INTO public.internal_settings(key, value, updated_at)
+    VALUES ('ai_kill_switch.reason', v_reason, now())
+    ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value,
+        updated_at = EXCLUDED.updated_at
+    RETURNING public.internal_settings.value, public.internal_settings.updated_at
+    INTO reason, v_reason_updated_at;
+  END IF;
+
+  enabled := p_enabled;
+  updated_at := GREATEST(v_enabled_updated_at, v_reason_updated_at);
+
+  RETURN NEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ai_kill_switch_status() FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.ai_kill_switch_set(BOOLEAN, TEXT) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.ai_kill_switch_status() TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.ai_kill_switch_set(BOOLEAN, TEXT) TO authenticated, service_role;

--- a/supabase/migrations/20260523114000_ai_kill_switch_role_claim_fallback.sql
+++ b/supabase/migrations/20260523114000_ai_kill_switch_role_claim_fallback.sql
@@ -1,8 +1,4 @@
--- Issue #538: DB-backed AI kill switch stored in public.internal_settings.
-
-INSERT INTO public.internal_settings(key, value, updated_at)
-VALUES ('ai_kill_switch.enabled', 'false', now())
-ON CONFLICT (key) DO NOTHING;
+-- Issue #538 review follow-up: accept standard service-role JWT claims.
 
 CREATE OR REPLACE FUNCTION public.ai_kill_switch_status()
 RETURNS TABLE (

--- a/supabase/migrations/20260523120500_ai_kill_switch_claim_scope_and_consistent_status.sql
+++ b/supabase/migrations/20260523120500_ai_kill_switch_claim_scope_and_consistent_status.sql
@@ -1,8 +1,5 @@
--- Issue #538: DB-backed AI kill switch stored in public.internal_settings.
-
-INSERT INTO public.internal_settings(key, value, updated_at)
-VALUES ('ai_kill_switch.enabled', 'false', now())
-ON CONFLICT (key) DO NOTHING;
+-- Issue #538 review follow-up: keep historical migrations immutable and reassert
+-- service-role-only top-level role fallback plus consistent settings reads.
 
 CREATE OR REPLACE FUNCTION public.ai_kill_switch_status()
 RETURNS TABLE (
@@ -29,6 +26,9 @@ BEGIN
 
   v_claims := v_claims_text::jsonb;
   v_role := NULLIF(v_claims->>'app_role', '');
+  IF v_role IS NULL AND NULLIF(v_claims->>'role', '') = 'service_role' THEN
+    v_role := 'service_role';
+  END IF;
   v_user_id := NULLIF(v_claims->>'user_id', '');
 
   IF v_role = 'admin' THEN
@@ -39,19 +39,18 @@ BEGIN
     RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
   END IF;
 
-  IF v_user_id IS NULL THEN
+  IF v_role <> 'service_role' AND v_user_id IS NULL THEN
     RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
   END IF;
 
-  SELECT s.value, s.updated_at
-  INTO v_enabled_text, v_enabled_updated_at
+  SELECT
+    MAX(s.value) FILTER (WHERE s.key = 'ai_kill_switch.enabled'),
+    MAX(s.updated_at) FILTER (WHERE s.key = 'ai_kill_switch.enabled'),
+    MAX(NULLIF(btrim(s.value), '')) FILTER (WHERE s.key = 'ai_kill_switch.reason'),
+    MAX(s.updated_at) FILTER (WHERE s.key = 'ai_kill_switch.reason')
+  INTO v_enabled_text, v_enabled_updated_at, reason, v_reason_updated_at
   FROM public.internal_settings s
-  WHERE s.key = 'ai_kill_switch.enabled';
-
-  SELECT NULLIF(btrim(s.value), ''), s.updated_at
-  INTO reason, v_reason_updated_at
-  FROM public.internal_settings s
-  WHERE s.key = 'ai_kill_switch.reason';
+  WHERE s.key IN ('ai_kill_switch.enabled', 'ai_kill_switch.reason');
 
   enabled := lower(COALESCE(v_enabled_text, 'false')) IN ('true', '1', 'on', 'yes', 'enabled');
   updated_at := GREATEST(v_enabled_updated_at, v_reason_updated_at);
@@ -92,6 +91,9 @@ BEGIN
 
   v_claims := v_claims_text::jsonb;
   v_role := NULLIF(v_claims->>'app_role', '');
+  IF v_role IS NULL AND NULLIF(v_claims->>'role', '') = 'service_role' THEN
+    v_role := 'service_role';
+  END IF;
   v_user_id := NULLIF(v_claims->>'user_id', '');
 
   IF v_role = 'admin' THEN
@@ -102,7 +104,7 @@ BEGIN
     RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
   END IF;
 
-  IF v_user_id IS NULL THEN
+  IF v_role <> 'service_role' AND v_user_id IS NULL THEN
     RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
   END IF;
 
@@ -115,12 +117,17 @@ BEGIN
   ON CONFLICT (key) DO UPDATE
   SET value = EXCLUDED.value,
       updated_at = EXCLUDED.updated_at
-  RETURNING public.internal_settings.updated_at INTO v_enabled_updated_at;
+  RETURNING public.internal_settings.updated_at
+  INTO v_enabled_updated_at;
 
   IF v_reason IS NULL THEN
     DELETE FROM public.internal_settings
-    WHERE key = 'ai_kill_switch.reason';
-    v_reason_updated_at := NULL;
+    WHERE key = 'ai_kill_switch.reason'
+    RETURNING public.internal_settings.updated_at
+    INTO v_reason_updated_at;
+
+    reason := NULL;
+    v_reason_updated_at := COALESCE(v_reason_updated_at, v_enabled_updated_at);
   ELSE
     INSERT INTO public.internal_settings(key, value, updated_at)
     VALUES ('ai_kill_switch.reason', v_reason, now())

--- a/supabase/tests/ai_kill_switch_smoke.sql
+++ b/supabase/tests/ai_kill_switch_smoke.sql
@@ -87,6 +87,35 @@ END $$;
 DO $$
 DECLARE
   v_status RECORD;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'service_role')::TEXT,
+    TRUE
+  );
+
+  SELECT *
+  INTO v_status
+  FROM public.ai_kill_switch_set(TRUE, 'service role automation')
+  LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM TRUE OR v_status.reason IS DISTINCT FROM 'service role automation' THEN
+    RAISE EXCEPTION 'Expected standard service_role claim to write kill switch without app_role/user_id';
+  END IF;
+
+  SELECT *
+  INTO v_status
+  FROM public.ai_kill_switch_status()
+  LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM TRUE OR v_status.reason IS DISTINCT FROM 'service role automation' THEN
+    RAISE EXCEPTION 'Expected standard service_role claim to read kill switch status';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_status RECORD;
   v_sqlstate TEXT;
 BEGIN
   PERFORM set_config(
@@ -132,16 +161,31 @@ BEGIN
 
   PERFORM set_config(
     'request.jwt.claims',
-    jsonb_build_object('role', 'authenticated', 'user_id', 'issue538-missing-role')::TEXT,
+    jsonb_build_object('user_id', 'issue538-missing-role')::TEXT,
     TRUE
   );
   BEGIN
     PERFORM * FROM public.ai_kill_switch_status();
-    RAISE EXCEPTION 'Expected missing app_role claim to be denied';
+    RAISE EXCEPTION 'Expected missing role claim to be denied';
   EXCEPTION WHEN OTHERS THEN
     GET STACKED DIAGNOSTICS v_sqlstate = RETURNED_SQLSTATE;
     IF v_sqlstate <> '42501' THEN
-      RAISE EXCEPTION 'Expected missing app_role SQLSTATE 42501, got %', v_sqlstate;
+      RAISE EXCEPTION 'Expected missing role SQLSTATE 42501, got %', v_sqlstate;
+    END IF;
+  END;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated')::TEXT,
+    TRUE
+  );
+  BEGIN
+    PERFORM * FROM public.ai_kill_switch_status();
+    RAISE EXCEPTION 'Expected non-service role missing user_id claim to be denied';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_sqlstate = RETURNED_SQLSTATE;
+    IF v_sqlstate <> '42501' THEN
+      RAISE EXCEPTION 'Expected missing user_id SQLSTATE 42501, got %', v_sqlstate;
     END IF;
   END;
 END $$;

--- a/supabase/tests/ai_kill_switch_smoke.sql
+++ b/supabase/tests/ai_kill_switch_smoke.sql
@@ -1,0 +1,195 @@
+BEGIN;
+
+DELETE FROM public.internal_settings
+WHERE key IN ('ai_kill_switch.enabled', 'ai_kill_switch.reason');
+
+DO $$
+DECLARE
+  v_status RECORD;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated', 'app_role', 'global', 'user_id', 'issue538-global')::TEXT,
+    TRUE
+  );
+
+  SELECT *
+  INTO v_status
+  FROM public.ai_kill_switch_status()
+  LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM FALSE THEN
+    RAISE EXCEPTION 'Expected default AI kill switch status to be disabled';
+  END IF;
+
+  IF v_status.reason IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected default AI kill switch reason to be NULL, got %', v_status.reason;
+  END IF;
+
+  IF v_status.updated_at IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected default AI kill switch updated_at to be NULL before first write';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_status RECORD;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated', 'app_role', 'global', 'user_id', 'issue538-global')::TEXT,
+    TRUE
+  );
+
+  SELECT *
+  INTO v_status
+  FROM public.ai_kill_switch_set(TRUE, 'maintenance window')
+  LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM TRUE THEN
+    RAISE EXCEPTION 'Expected global role to enable AI kill switch';
+  END IF;
+
+  IF v_status.reason IS DISTINCT FROM 'maintenance window' THEN
+    RAISE EXCEPTION 'Expected global role to set reason, got %', v_status.reason;
+  END IF;
+
+  SELECT *
+  INTO v_status
+  FROM public.ai_kill_switch_status()
+  LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM TRUE OR v_status.reason IS DISTINCT FROM 'maintenance window' THEN
+    RAISE EXCEPTION 'Expected status to reflect enabled state and reason after write';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_status RECORD;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated', 'app_role', 'admin', 'user_id', 'issue538-admin')::TEXT,
+    TRUE
+  );
+
+  SELECT *
+  INTO v_status
+  FROM public.ai_kill_switch_set(TRUE, 'admin normalized')
+  LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM TRUE OR v_status.reason IS DISTINCT FROM 'admin normalized' THEN
+    RAISE EXCEPTION 'Expected admin role to normalize to global and write kill switch';
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_status RECORD;
+  v_sqlstate TEXT;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated', 'app_role', 'to_qltb', 'user_id', 'issue538-reader')::TEXT,
+    TRUE
+  );
+
+  SELECT *
+  INTO v_status
+  FROM public.ai_kill_switch_status()
+  LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM TRUE THEN
+    RAISE EXCEPTION 'Expected non-global authenticated role to read kill switch status';
+  END IF;
+
+  BEGIN
+    PERFORM * FROM public.ai_kill_switch_set(FALSE, NULL);
+    RAISE EXCEPTION 'Expected non-global role to be denied write access';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_sqlstate = RETURNED_SQLSTATE;
+    IF v_sqlstate <> '42501' THEN
+      RAISE EXCEPTION 'Expected non-global write denial SQLSTATE 42501, got %', v_sqlstate;
+    END IF;
+  END;
+END $$;
+
+DO $$
+DECLARE
+  v_sqlstate TEXT;
+BEGIN
+  PERFORM set_config('request.jwt.claims', NULL, TRUE);
+  BEGIN
+    PERFORM * FROM public.ai_kill_switch_status();
+    RAISE EXCEPTION 'Expected missing JWT claims to be denied';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_sqlstate = RETURNED_SQLSTATE;
+    IF v_sqlstate <> '42501' THEN
+      RAISE EXCEPTION 'Expected missing claims SQLSTATE 42501, got %', v_sqlstate;
+    END IF;
+  END;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated', 'user_id', 'issue538-missing-role')::TEXT,
+    TRUE
+  );
+  BEGIN
+    PERFORM * FROM public.ai_kill_switch_status();
+    RAISE EXCEPTION 'Expected missing app_role claim to be denied';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_sqlstate = RETURNED_SQLSTATE;
+    IF v_sqlstate <> '42501' THEN
+      RAISE EXCEPTION 'Expected missing app_role SQLSTATE 42501, got %', v_sqlstate;
+    END IF;
+  END;
+END $$;
+
+DO $$
+DECLARE
+  v_sqlstate TEXT;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated', 'app_role', 'global', 'user_id', 'issue538-global')::TEXT,
+    TRUE
+  );
+
+  BEGIN
+    PERFORM * FROM public.ai_kill_switch_set(NULL, 'invalid');
+    RAISE EXCEPTION 'Expected NULL p_enabled to be rejected';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_sqlstate = RETURNED_SQLSTATE;
+    IF v_sqlstate <> '22023' THEN
+      RAISE EXCEPTION 'Expected NULL p_enabled SQLSTATE 22023, got %', v_sqlstate;
+    END IF;
+  END;
+END $$;
+
+DO $$
+DECLARE
+  v_status RECORD;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated', 'app_role', 'global', 'user_id', 'issue538-global')::TEXT,
+    TRUE
+  );
+
+  PERFORM * FROM public.ai_kill_switch_set(TRUE, 'clear me');
+  SELECT * INTO v_status FROM public.ai_kill_switch_set(TRUE, '   ') LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM TRUE OR v_status.reason IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected blank reason to clear reason while preserving enabled state';
+  END IF;
+
+  PERFORM * FROM public.ai_kill_switch_set(TRUE, 'clear me again');
+  SELECT * INTO v_status FROM public.ai_kill_switch_set(TRUE, NULL) LIMIT 1;
+
+  IF v_status.enabled IS DISTINCT FROM TRUE OR v_status.reason IS NOT NULL THEN
+    RAISE EXCEPTION 'Expected NULL reason to clear reason while preserving enabled state';
+  END IF;
+END $$;
+
+ROLLBACK;

--- a/supabase/tests/ai_kill_switch_smoke.sql
+++ b/supabase/tests/ai_kill_switch_smoke.sql
@@ -115,6 +115,27 @@ END $$;
 
 DO $$
 DECLARE
+  v_sqlstate TEXT;
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('role', 'authenticated', 'user_id', 'issue538-no-app-role')::TEXT,
+    TRUE
+  );
+
+  BEGIN
+    PERFORM * FROM public.ai_kill_switch_status();
+    RAISE EXCEPTION 'Expected authenticated token without app_role to be denied status access';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_sqlstate = RETURNED_SQLSTATE;
+    IF v_sqlstate <> '42501' THEN
+      RAISE EXCEPTION 'Expected missing app_role denial SQLSTATE 42501, got %', v_sqlstate;
+    END IF;
+  END;
+END $$;
+
+DO $$
+DECLARE
   v_status RECORD;
   v_sqlstate TEXT;
 BEGIN


### PR DESCRIPTION
## Summary
- Adds DB-backed AI kill switch state in `public.internal_settings` with `ai_kill_switch_status()` and `ai_kill_switch_set()` RPCs.
- Keeps `AI_KILL_SWITCH=on` as immediate env override while `reserveUsage()` now checks DB state before quota reservation.
- Reconciles local migration source by adding an idempotent `internal_settings` bootstrap before older migrations reference it.

## Test Plan
- [x] Supabase MCP `apply_migration`: `create_internal_settings_table_bootstrap`
- [x] Supabase MCP `apply_migration`: `ai_kill_switch_db_toggle`
- [x] Supabase MCP transaction smoke: `supabase/tests/ai_kill_switch_smoke.sql`
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test -- src/lib/ai/__tests__/kill-switch.test.ts src/lib/ai/__tests__/usage-metering.distributed.test.ts src/app/api/chat/__tests__/route.kill-switch.test.ts src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts --run`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

## Notes
- Live `ai_kill_switch.enabled` remains `false` after smoke verification.
- Supabase advisors still report existing baseline findings unrelated to this PR.

Closes #538

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a DB-backed AI kill switch used by chat and usage metering to block requests globally, with an env override for emergencies. Implements the toggle requested in #538, fails closed on DB read errors, and accepts standard `service_role` claims.

- **New Features**
  - Store kill switch in `public.internal_settings`; add RPCs `ai_kill_switch_status` and `ai_kill_switch_set` (authenticated read; `global`/`admin`→`global` and `service_role` can write; accepts standard `service_role` JWT claims).
  - Add `isAiKillSwitchActive()` with 8s cache and 2s fail-closed cache; `AI_KILL_SWITCH=on` always wins; optional reason message.
  - Check the kill switch before quota in `reserveUsage()` and `/api/chat`; return 429 with `ai_usage_limited`, a clear reason/message, and `Retry-After: 60`.
  - Allowlist the new RPCs.

- **Migration**
  - Run Supabase migrations: `20251122000000_create_internal_settings_table.sql`, `20260523100000_ai_kill_switch_db_toggle.sql`, `20260523114000_ai_kill_switch_role_claim_fallback.sql`, and `20260523120500_ai_kill_switch_claim_scope_and_consistent_status.sql` (preserves earlier migrations and ensures consistent settings reads with service-role fallback).
  - No config changes required; `AI_KILL_SWITCH=on` remains an immediate override.

<sup>Written for commit 8817093597bddfded7afc8adf00d2ab27f91be3a. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/553?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DB-backed AI kill-switch with env override, admin controls, and reason/updated-at tracking.
  * Exposed endpoints to check and set kill-switch state for management.

* **Behavior Changes**
  * AI usage reservations now honor the kill-switch and immediately deny requests with structured messages.
  * Error responses and retry headers improved when AI is disabled or DB/read fails.

* **Tests**
  * End-to-end and unit tests added/expanded to cover kill-switch scenarios and caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->