### PR TITLE
feat: redesign mobile dashboard navigation

### DIFF
--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -61,6 +61,9 @@ type AppLayoutShellProps = {
   user: AppLayoutUser
 }
 
+/**
+ * Wraps authenticated app pages with shared navigation, header actions, and mobile footer state.
+ */
 export function AppLayoutShell({ children, user }: AppLayoutShellProps) {
   return (
     <TenantSelectionProvider>
@@ -149,13 +152,13 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
             open={isChangePasswordOpen}
             onOpenChange={(isOpen) => dispatchUi({ type: "setChangePasswordOpen", isOpen })}
           />
-          <div
-            className={cn(
-              "grid min-h-screen w-full transition-all pt-14 pb-20 md:pt-0 md:pb-0",
-              isSidebarOpen ? "md:grid-cols-[220px_1fr]" : "md:grid-cols-[72px_1fr]"
+            <div
+              className={cn(
+              "grid min-h-screen w-full transition-all pt-14 pb-20 lg:pt-0 lg:pb-0",
+              isSidebarOpen ? "lg:grid-cols-[220px_1fr]" : "lg:grid-cols-[72px_1fr]"
             )}
           >
-            <div className="hidden border-r border-border bg-white md:block shadow-[2px_0_8px_rgba(0,0,0,0.04)]">
+            <div className="hidden border-r border-border bg-white shadow-[2px_0_8px_rgba(0,0,0,0.04)] lg:block">
               <div className="flex h-full max-h-screen flex-col">
                 <div className="flex h-auto flex-col items-center gap-4 border-b border-border p-4">
                   <Link href="/" className="flex flex-col items-center gap-3 font-semibold text-primary" data-tour="sidebar-logo">
@@ -179,7 +182,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
               </div>
             </div>
             <div className="flex flex-col">
-              <header className="fixed top-0 left-0 right-0 z-40 flex h-14 items-center gap-4 bg-white px-4 shadow-md md:relative md:z-auto lg:h-[60px] lg:px-6">
+              <header className="fixed top-0 left-0 right-0 z-40 flex h-14 items-center gap-4 bg-white px-4 shadow-md lg:relative lg:z-auto lg:h-[60px] lg:px-6">
                 <Sheet open={isMobileSheetOpen} onOpenChange={(isOpen) => dispatchUi({ type: "setMobileSheetOpen", isOpen })}>
                   <SheetTrigger asChild>
                     <Button
@@ -220,7 +223,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
                 <Button
                   variant="outline"
                   size="icon"
-                  className="hidden shrink-0 touch-target md:flex"
+                  className="hidden shrink-0 touch-target lg:flex"
                   onClick={() => dispatchUi({ type: "toggleSidebar" })}
                   data-tour="sidebar-toggle"
                 >
@@ -239,7 +242,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
                     ) : (
                       <TenantName
                         name={branding.data?.name ?? null}
-                        className="max-w-[calc(100vw-120px)] truncate text-sm sm:max-w-[400px] sm:text-base md:max-w-none lg:text-lg"
+                        className="max-w-[calc(100vw-120px)] truncate text-sm sm:max-w-[400px] sm:text-base lg:max-w-none lg:text-lg"
                       />
                     )}
                   </div>
@@ -293,7 +296,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
                   </DropdownMenuContent>
                 </DropdownMenu>
               </header>
-              <main className="flex flex-1 flex-col gap-4 bg-background p-4 pb-24 md:pb-4 lg:gap-8 lg:p-8">
+              <main className="flex flex-1 flex-col gap-4 bg-background p-4 pb-24 lg:gap-8 lg:p-8 lg:pb-8">
                 <MainContentTransition>
                   {children}
                 </MainContentTransition>

--- a/src/app/(app)/dashboard/__tests__/dashboard-no-legacy-dialog.test.tsx
+++ b/src/app/(app)/dashboard/__tests__/dashboard-no-legacy-dialog.test.tsx
@@ -27,6 +27,7 @@ vi.mock("next-auth/react", () => ({
                 id: 1,
                 username: "admin",
                 full_name: "Admin User",
+                khoa_phong: "Phòng ICU",
                 role: "admin",
             },
         },
@@ -164,6 +165,34 @@ describe("Dashboard: no legacy EditEquipmentDialog", () => {
 
         expect(screen.getByTestId("calendar-widget")).toBeInTheDocument()
         expect(screen.getByTestId("recent-activities-card")).toBeInTheDocument()
+    })
+
+    it("renders the redesigned welcome banner with department and current date", () => {
+        render(<Dashboard />)
+
+        expect(screen.getByText(/Admin User/i)).toBeInTheDocument()
+        expect(screen.getByText("Phòng ICU")).toBeInTheDocument()
+        expect(screen.getByText(/Thứ|Chủ nhật/i)).toBeInTheDocument()
+    })
+
+    it("keeps maintenance planning as the third quick action", () => {
+        const { container } = render(<Dashboard />)
+        const quickActions = container.querySelector('[data-tour="quick-actions"]')
+        expect(quickActions).not.toBeNull()
+
+        const quickActionText = quickActions?.textContent ?? ""
+        const quickActionLabels = ["Báo sửa chữa", "Thêm thiết bị", "Lập kế hoạch", "Quét mã QR"]
+        const quickActionIndexes = quickActionLabels.map((label) => quickActionText.indexOf(label))
+
+        expect(quickActionIndexes.every((index) => index >= 0)).toBe(true)
+        expect(quickActionIndexes).toEqual([...quickActionIndexes].sort((a, b) => a - b))
+        expect(quickActionIndexes[2]).toBeGreaterThan(quickActionIndexes[1])
+
+        expect(screen.getByRole("link", { name: /lập kế hoạch/i })).toHaveAttribute(
+            "href",
+            "/maintenance?action=create"
+        )
+        expect(screen.queryByText(/kiểm kê/i)).not.toBeInTheDocument()
     })
 
     it("does not navigate when update-status is triggered without equipment", async () => {

--- a/src/app/(app)/dashboard/__tests__/dashboard-no-legacy-dialog.test.tsx
+++ b/src/app/(app)/dashboard/__tests__/dashboard-no-legacy-dialog.test.tsx
@@ -186,8 +186,8 @@ describe("Dashboard: no legacy EditEquipmentDialog", () => {
             month: "2-digit",
             year: "numeric",
         })
-        const beforeMidnight = new Date("2026-05-23T23:59:30.000Z")
-        const afterMidnight = new Date("2026-05-24T00:00:05.000Z")
+        const beforeMidnight = new Date(2026, 4, 23, 23, 59, 30)
+        const afterMidnight = new Date(2026, 4, 24, 0, 0, 5)
 
         vi.useFakeTimers()
         vi.setSystemTime(beforeMidnight)

--- a/src/app/(app)/dashboard/__tests__/dashboard-no-legacy-dialog.test.tsx
+++ b/src/app/(app)/dashboard/__tests__/dashboard-no-legacy-dialog.test.tsx
@@ -8,8 +8,8 @@
 
 import * as React from "react"
 import "@testing-library/jest-dom"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 
 // ============================================
 // Mocks
@@ -148,6 +148,10 @@ describe("Dashboard: no legacy EditEquipmentDialog", () => {
         })
     })
 
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
     it("navigates to /equipment?highlight={id} on update-status action", async () => {
         render(<Dashboard />)
 
@@ -173,6 +177,30 @@ describe("Dashboard: no legacy EditEquipmentDialog", () => {
         expect(screen.getByText(/Admin User/i)).toBeInTheDocument()
         expect(screen.getByText("Phòng ICU")).toBeInTheDocument()
         expect(screen.getByText(/Thứ|Chủ nhật/i)).toBeInTheDocument()
+    })
+
+    it("refreshes the welcome banner date after local midnight", () => {
+        const formatter = new Intl.DateTimeFormat("vi-VN", {
+            weekday: "long",
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+        })
+        const beforeMidnight = new Date("2026-05-23T23:59:30.000Z")
+        const afterMidnight = new Date("2026-05-24T00:00:05.000Z")
+
+        vi.useFakeTimers()
+        vi.setSystemTime(beforeMidnight)
+
+        render(<Dashboard />)
+        expect(screen.getByText(formatter.format(beforeMidnight))).toBeInTheDocument()
+
+        vi.setSystemTime(afterMidnight)
+        act(() => {
+            vi.advanceTimersByTime(35_000)
+        })
+
+        expect(screen.getByText(formatter.format(afterMidnight))).toBeInTheDocument()
     })
 
     it("keeps maintenance planning as the third quick action", () => {

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -38,6 +38,24 @@ const QRActionSheet = dynamic(
 )
 
 
+const dashboardDateFormatter = new Intl.DateTimeFormat("vi-VN", {
+  weekday: "long",
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+})
+
+function formatDashboardDate(date = new Date()) {
+  return dashboardDateFormatter.format(date)
+}
+
+function getMillisecondsUntilNextLocalMidnight(date = new Date()) {
+  const nextMidnight = new Date(date)
+  nextMidnight.setHours(24, 0, 0, 0)
+
+  return Math.max(nextMidnight.getTime() - date.getTime(), 1_000)
+}
+
 /**
  * Renders the authenticated dashboard overview, quick actions, and QR scan entry points.
  */
@@ -56,16 +74,26 @@ export default function Dashboard() {
 
   // Check if user is regional leader
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
-  const todayLabel = React.useMemo(
-    () =>
-      new Intl.DateTimeFormat("vi-VN", {
-        weekday: "long",
-        day: "2-digit",
-        month: "2-digit",
-        year: "numeric",
-      }).format(new Date()),
-    []
-  )
+  const [todayLabel, setTodayLabel] = React.useState(() => formatDashboardDate())
+
+  React.useEffect(() => {
+    let timerId: number
+
+    const refreshDateAndReschedule = () => {
+      const now = new Date()
+      setTodayLabel(formatDashboardDate(now))
+      timerId = window.setTimeout(
+        refreshDateAndReschedule,
+        getMillisecondsUntilNextLocalMidnight(now)
+      )
+    }
+
+    timerId = window.setTimeout(refreshDateAndReschedule, getMillisecondsUntilNextLocalMidnight())
+
+    return () => {
+      window.clearTimeout(timerId)
+    }
+  }, [])
 
   // Get greeting based on time of day
   const getGreeting = () => {

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -38,18 +38,18 @@ const QRActionSheet = dynamic(
 )
 
 
-const dashboardDateFormatter = new Intl.DateTimeFormat("vi-VN", {
+const dashboardDateFormatter: Intl.DateTimeFormat = new Intl.DateTimeFormat("vi-VN", {
   weekday: "long",
   day: "2-digit",
   month: "2-digit",
   year: "numeric",
 })
 
-function formatDashboardDate(date = new Date()) {
+function formatDashboardDate(date = new Date()): string {
   return dashboardDateFormatter.format(date)
 }
 
-function getMillisecondsUntilNextLocalMidnight(date = new Date()) {
+function getMillisecondsUntilNextLocalMidnight(date = new Date()): number {
   const nextMidnight = new Date(date)
   nextMidnight.setHours(24, 0, 0, 0)
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -4,16 +4,12 @@ import * as React from "react"
 import Link from "next/link"
 import dynamic from "next/dynamic"
 import { useRouter } from "next/navigation"
-import { Plus, QrCode, ClipboardList, Sparkles, Wrench } from "lucide-react"
+import { Activity, Plus, QrCode, ClipboardList, Wrench } from "lucide-react"
 import { useSession } from "next-auth/react"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
 } from "@/components/ui/card"
 import { CalendarWidget } from "@/components/ui/calendar-widget"
 import { RecentActivitiesCard } from "@/components/dashboard/RecentActivitiesCard"
@@ -42,9 +38,12 @@ const QRActionSheet = dynamic(
 )
 
 
+/**
+ * Renders the authenticated dashboard overview, quick actions, and QR scan entry points.
+ */
 export default function Dashboard() {
   // useDashboardRealtimeSync()
-  const router = useRouter()
+  const { push } = useRouter()
   const { toast } = useToast()
   const { data: session } = useSession()
   const user = session?.user
@@ -57,6 +56,16 @@ export default function Dashboard() {
 
   // Check if user is regional leader
   const isRegionalLeader = isRegionalLeaderRole(user?.role)
+  const todayLabel = React.useMemo(
+    () =>
+      new Intl.DateTimeFormat("vi-VN", {
+        weekday: "long",
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+      }).format(new Date()),
+    []
+  )
 
   // Get greeting based on time of day
   const getGreeting = () => {
@@ -111,31 +120,26 @@ export default function Dashboard() {
     switch (action) {
       case 'usage-log':
         if (equipment) {
-          router.push(`/equipment?highlight=${equipment.id}&tab=usage`)
+          push(`/equipment?highlight=${equipment.id}&tab=usage`)
         }
         break
 
       case 'view-details':
+      case 'update-status':
         if (equipment) {
-          router.push(`/equipment?highlight=${equipment.id}`)
+          push(`/equipment?highlight=${equipment.id}`)
         }
         break
 
       case 'view-history':
         if (equipment) {
-          router.push(`/equipment?highlight=${equipment.id}&tab=history`)
+          push(`/equipment?highlight=${equipment.id}&tab=history`)
         }
         break
 
       case 'create-repair':
         if (equipment) {
-          router.push(buildRepairRequestCreateIntentHref(equipment.id))
-        }
-        break
-
-      case 'update-status':
-        if (equipment) {
-          router.push(`/equipment?highlight=${equipment.id}`)
+          push(buildRepairRequestCreateIntentHref(equipment.id))
         }
         break
 
@@ -177,23 +181,38 @@ export default function Dashboard() {
 
 
       {/* Welcome Banner */}
-      <Card data-tour="welcome-banner" className="overflow-hidden border-none shadow-[0_4px_20px_-4px_rgba(0,0,0,0.1)] bg-white rounded-3xl">
-        <CardContent className="p-6 md:p-8">
-          <div className="flex items-center justify-between">
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Sparkles className="size-5 text-primary" />
-                <h1 className="text-xl md:text-2xl font-semibold text-slate-800">
-                  {getGreeting()}, {user?.full_name || user?.username}!
-                </h1>
+      <Card
+        data-tour="welcome-banner"
+        className="overflow-hidden rounded-[1.75rem] border border-white/70 bg-gradient-to-br from-cyan-50 via-white to-teal-50 shadow-[0_18px_45px_rgba(15,118,110,0.14)]"
+      >
+        <CardContent className="relative min-h-[168px] p-6 md:min-h-[190px] md:p-8">
+          <div className="pointer-events-none absolute inset-0 opacity-70">
+            <div className="absolute -left-8 -top-10 size-40 rounded-full bg-cyan-200/35 blur-3xl" />
+            <div className="absolute bottom-2 right-8 size-24 rounded-full bg-teal-200/40 blur-2xl" />
+            <div className="absolute right-0 top-8 hidden h-24 w-72 rounded-l-full bg-white/45 md:block" />
+          </div>
+          <div className="relative flex h-full flex-col justify-between gap-8 md:flex-row md:items-center">
+            <div className="space-y-3">
+              <div className="inline-flex items-center rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-primary shadow-sm ring-1 ring-primary/10">
+                MediAsset Pro
               </div>
-              <p className="text-slate-500 text-sm md:text-base">
-                Chào mừng bạn đến với Hệ thống Quản lý Thiết bị Y tế
-              </p>
+              <div className="space-y-1">
+                <h1 className="text-2xl font-semibold leading-tight tracking-normal text-slate-950 md:text-4xl">
+                  {getGreeting()},
+                  <span className="block text-primary">{user?.full_name || user?.username}</span>
+                </h1>
+                <p className="text-base font-medium text-slate-700 md:text-lg">
+                  {user?.khoa_phong || "Chưa có khoa/phòng"}
+                </p>
+              </div>
             </div>
-            <div className="hidden md:block">
-              <div className="size-20 rounded-full bg-primary/5 flex items-center justify-center">
-                <Sparkles className="size-10 text-primary/40" />
+            <div className="flex items-center justify-between gap-6 md:flex-col md:items-end">
+              <p className="text-sm font-medium capitalize text-slate-700 md:text-base">
+                {todayLabel}
+              </p>
+              <div className="flex items-center gap-3 text-primary/60">
+                <div className="hidden h-px w-20 bg-primary/30 md:block" />
+                <Activity className="size-12 md:size-16" strokeWidth={1.5} />
               </div>
             </div>
           </div>
@@ -207,12 +226,15 @@ export default function Dashboard() {
 
 
       {/* Quick Actions Section - Native App Style */}
-      <div data-tour="quick-actions" className="md:mt-6 md:space-y-5">
-        <div className="mb-4 px-1">
-          <h2 className="text-lg font-semibold text-slate-900 mb-1">Thao tác nhanh</h2>
+      <div
+        data-tour="quick-actions"
+        className="rounded-[1.75rem] border border-white/75 bg-white/95 p-5 shadow-[0_18px_45px_rgba(15,23,42,0.08)] md:mt-6 md:p-6"
+      >
+        <div className="mb-5 px-1">
+          <h2 className="text-xl font-semibold tracking-normal text-slate-950 md:text-2xl">Thao tác nhanh</h2>
         </div>
         <div className={cn(
-          "grid gap-4 md:gap-6",
+          "grid gap-x-8 gap-y-6 md:gap-6",
           isRegionalLeader ? "grid-cols-2 md:grid-cols-4" : "grid-cols-2 sm:grid-cols-4"
         )}>
           {/* Quick Actions: Restricted for regional leaders */}
@@ -221,50 +243,50 @@ export default function Dashboard() {
               {/* Báo sửa chữa (New) */}
               <Link href={buildRepairRequestCreateIntentHref()} className="group">
                 <div className="flex flex-col items-center gap-3">
-                  <div className="size-[72px] md:size-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
-                    <div className="size-11 md:size-14 rounded-xl bg-red-50 flex items-center justify-center">
+                  <div className="flex size-[72px] items-center justify-center rounded-3xl bg-white shadow-[0_12px_30px_rgba(15,23,42,0.10)] ring-1 ring-slate-200/70 transition-transform group-active:scale-95 md:size-[88px]">
+                    <div className="flex size-11 items-center justify-center rounded-2xl bg-red-50 md:size-14">
                       <Wrench className="size-[26px] md:size-8 text-red-600" />
                     </div>
                   </div>
-                  <span className="text-xs md:text-sm font-medium text-slate-700 text-center">Báo sửa chữa</span>
+                  <span className="text-center text-sm font-semibold leading-tight text-slate-800">Báo sửa chữa</span>
                 </div>
               </Link>
 
               {/* Add Equipment Card */}
               <Link href="/equipment?action=add" className="group">
                 <div className="flex flex-col items-center gap-3">
-                  <div className="size-[72px] md:size-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
-                    <div className="size-11 md:size-14 rounded-xl bg-blue-50 flex items-center justify-center">
+                  <div className="flex size-[72px] items-center justify-center rounded-3xl bg-white shadow-[0_12px_30px_rgba(15,23,42,0.10)] ring-1 ring-slate-200/70 transition-transform group-active:scale-95 md:size-[88px]">
+                    <div className="flex size-11 items-center justify-center rounded-2xl bg-blue-50 md:size-14">
                       <Plus className="size-[26px] md:size-8 text-blue-600" />
                     </div>
                   </div>
-                  <span className="text-xs md:text-sm font-medium text-slate-700 text-center">Thêm thiết bị</span>
+                  <span className="text-center text-sm font-semibold leading-tight text-slate-800">Thêm thiết bị</span>
                 </div>
               </Link>
 
               {/* Create Maintenance Plan Card */}
               <Link href="/maintenance?action=create" className="group">
                 <div className="flex flex-col items-center gap-3">
-                  <div className="size-[72px] md:size-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
-                    <div className="size-11 md:size-14 rounded-xl bg-emerald-50 flex items-center justify-center">
+                  <div className="flex size-[72px] items-center justify-center rounded-3xl bg-white shadow-[0_12px_30px_rgba(15,23,42,0.10)] ring-1 ring-slate-200/70 transition-transform group-active:scale-95 md:size-[88px]">
+                    <div className="flex size-11 items-center justify-center rounded-2xl bg-emerald-50 md:size-14">
                       <ClipboardList className="size-[26px] md:size-8 text-emerald-600" />
                     </div>
                   </div>
-                  <span className="text-xs md:text-sm font-medium text-slate-700 text-center">Lập kế hoạch</span>
+                  <span className="text-center text-sm font-semibold leading-tight text-slate-800">Lập kế hoạch</span>
                 </div>
               </Link>
             </>
           )}
 
           {/* QR Scanner Card: Always available - opens scanner directly */}
-          <button data-tour="qr-scanner" onClick={handleStartScanning} className="group">
+          <button type="button" data-tour="qr-scanner" onClick={handleStartScanning} className="group">
             <div className="flex flex-col items-center gap-3">
-              <div className="size-[72px] md:size-[88px] rounded-2xl bg-white shadow-[0_8px_30px_rgba(0,0,0,0.12)] flex items-center justify-center transition-transform group-active:scale-95">
-                <div className="size-11 md:size-14 rounded-xl bg-sky-50 flex items-center justify-center">
+              <div className="flex size-[72px] items-center justify-center rounded-3xl bg-white shadow-[0_12px_30px_rgba(15,23,42,0.10)] ring-1 ring-slate-200/70 transition-transform group-active:scale-95 md:size-[88px]">
+                <div className="flex size-11 items-center justify-center rounded-2xl bg-sky-50 md:size-14">
                   <QrCode className="size-[26px] md:size-8 text-sky-600" />
                 </div>
               </div>
-              <span className="text-xs md:text-sm font-medium text-slate-700 text-center">Quét mã QR</span>
+              <span className="text-center text-sm font-semibold leading-tight text-slate-800">Quét mã QR</span>
             </div>
           </button>
         </div>

--- a/src/app/(app)/qr-scanner/__tests__/qr-scanner-no-legacy-dialog.test.tsx
+++ b/src/app/(app)/qr-scanner/__tests__/qr-scanner-no-legacy-dialog.test.tsx
@@ -18,6 +18,7 @@ import * as React from "react"
 const mockPush = vi.fn()
 vi.mock("next/navigation", () => ({
     useRouter: () => ({ push: mockPush }),
+    useSearchParams: () => new URLSearchParams(window.location.search),
 }))
 
 // Intercept next/dynamic to render components synchronously
@@ -109,6 +110,7 @@ import QRScannerPage from "../page"
 describe("QR Scanner: no legacy EditEquipmentDialog", () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        window.history.replaceState(null, "", "/qr-scanner")
         vi.stubGlobal("navigator", {
             mediaDevices: {
                 getUserMedia: vi.fn(),
@@ -126,6 +128,14 @@ describe("QR Scanner: no legacy EditEquipmentDialog", () => {
         await waitFor(() => {
             expect(mockPush).toHaveBeenCalledWith("/equipment?highlight=42")
         })
+    })
+
+    it("opens the camera immediately when autoStart=1 is present", async () => {
+        window.history.replaceState(null, "", "/qr-scanner?autoStart=1")
+
+        render(<QRScannerPage />)
+
+        expect(await screen.findByTestId("qr-camera")).toBeInTheDocument()
     })
 
     it("does not navigate when update-status is triggered without equipment", async () => {

--- a/src/app/(app)/qr-scanner/page.tsx
+++ b/src/app/(app)/qr-scanner/page.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import dynamic from "next/dynamic"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { ArrowLeft, Camera, QrCode, Smartphone } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { QRScannerErrorBoundary } from "@/components/qr-scanner-error-boundary"
@@ -30,14 +30,27 @@ const QRActionSheet = dynamic(
 )
 
 
+/**
+ * Renders the standalone QR scanner page and supports direct camera auto-start links.
+ */
 export default function QRScannerPage() {
-  const router = useRouter()
+  return (
+    <React.Suspense fallback={null}>
+      <QRScannerPageContent />
+    </React.Suspense>
+  )
+}
+
+function QRScannerPageContent() {
+  const { push } = useRouter()
+  const searchParams = useSearchParams()
   const { toast } = useToast()
   const [isCameraActive, setIsCameraActive] = React.useState(false)
   const [scannedCode, setScannedCode] = React.useState<string>("")
   const [showActionSheet, setShowActionSheet] = React.useState(false)
+  const hasAutoStartedRef = React.useRef(false)
 
-  const handleStartScanning = () => {
+  const handleStartScanning = React.useCallback(() => {
     // Check if we're in browser environment
     if (typeof window === "undefined") {
       toast({
@@ -59,7 +72,16 @@ export default function QRScannerPage() {
     }
 
     setIsCameraActive(true)
-  }
+  }, [toast])
+
+  React.useEffect(() => {
+    if (hasAutoStartedRef.current || searchParams.get("autoStart") !== "1") {
+      return
+    }
+
+    hasAutoStartedRef.current = true
+    setIsCameraActive(true)
+  }, [searchParams])
 
   const handleScanSuccess = (result: string) => {
     setScannedCode(result)
@@ -84,31 +106,26 @@ export default function QRScannerPage() {
       switch (action) {
         case 'usage-log':
           if (equipment) {
-            router.push(`/equipment?highlight=${equipment.id}&tab=usage`)
+            push(`/equipment?highlight=${equipment.id}&tab=usage`)
           }
           break
 
         case 'view-details':
+        case 'update-status':
           if (equipment) {
-            router.push(`/equipment?highlight=${equipment.id}`)
+            push(`/equipment?highlight=${equipment.id}`)
           }
           break
 
         case 'view-history':
           if (equipment) {
-            router.push(`/equipment?highlight=${equipment.id}&tab=history`)
+            push(`/equipment?highlight=${equipment.id}&tab=history`)
           }
           break
 
         case 'create-repair':
           if (equipment) {
-            router.push(buildRepairRequestCreateIntentHref(equipment.id))
-          }
-          break
-
-        case 'update-status':
-          if (equipment) {
-            router.push(`/equipment?highlight=${equipment.id}`)
+            push(buildRepairRequestCreateIntentHref(equipment.id))
           }
           break
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -174,11 +174,6 @@
     z-index: 40;
   }
 
-  /* Mobile KPI Cards optimization */
-  .mobile-kpi-card {
-    @apply min-h-[120px] md:min-h-[140px];
-  }
-
   /* Mobile quick actions optimization */
   .mobile-quick-action {
     @apply flex h-full min-h-[96px] flex-col items-center justify-center gap-2 rounded-2xl p-3 text-center transition-all hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 md:min-h-[112px] md:rounded-xl md:p-4 md:gap-3;

--- a/src/components/__tests__/app-navigation.test.ts
+++ b/src/components/__tests__/app-navigation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { getAppNavigationItems, getMobileFooterMoreNavItems } from "@/components/app-navigation"
+import {
+  getAppNavigationItems,
+  getMobileFooterMainNavItems,
+  getMobileFooterMoreNavItems,
+} from "@/components/app-navigation"
 
 const restrictedRoles = ["user", "qltb_khoa", "technician"] as const
 const allowedRoles = ["to_qltb", "regional_leader", "global", "admin"] as const
@@ -26,13 +30,25 @@ describe("app-navigation role filtering", () => {
     }
   })
 
-  it("applies the same device quota filtering to the mobile more menu", () => {
+  it("does not expose device quota in the removed mobile more menu", () => {
     for (const role of restrictedRoles) {
       expect(getMoreHrefs(role)).not.toContain("/device-quota")
     }
 
     for (const role of allowedRoles) {
-      expect(getMoreHrefs(role)).toContain("/device-quota")
+      expect(getMoreHrefs(role)).not.toContain("/device-quota")
     }
+  })
+
+  it("limits the small-screen footer to the field-work routes", () => {
+    expect(getMobileFooterMainNavItems("admin").map((item) => item.href)).toEqual([
+      "/dashboard",
+      "/equipment",
+      "/repair-requests",
+      "/transfers",
+      "/qr-scanner?autoStart=1",
+    ])
+
+    expect(getMobileFooterMoreNavItems("admin")).toEqual([])
   })
 })

--- a/src/components/__tests__/mobile-footer-nav.test.tsx
+++ b/src/components/__tests__/mobile-footer-nav.test.tsx
@@ -54,6 +54,8 @@ describe("MobileFooterNav", () => {
     expect(transferLink).toHaveAttribute("href", "/transfers")
     expect(qrLink).not.toBeNull()
     expect(qrLink).toHaveAttribute("href", "/qr-scanner?autoStart=1")
+    expect(qrLink!.querySelector("svg")).toHaveClass("text-white")
+    expect(qrLink!.querySelector("svg")).not.toHaveClass("text-slate-500")
 
     expect(within(repairLink!).getByText("2")).toBeInTheDocument()
     expect(within(transferLink!).getByText("4")).toBeInTheDocument()

--- a/src/components/__tests__/mobile-footer-nav.test.tsx
+++ b/src/components/__tests__/mobile-footer-nav.test.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { render, screen, within } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
@@ -32,9 +31,7 @@ describe("MobileFooterNav", () => {
     })
   })
 
-  it("shows repair badge on the tab and aggregates hidden counts on the more button", async () => {
-    const user = userEvent.setup()
-
+  it("shows the five field-work tabs without an overflow menu", () => {
     render(
       <MobileFooterNav
         notificationCounts={{
@@ -46,23 +43,23 @@ describe("MobileFooterNav", () => {
     )
 
     const repairLink = screen.getByText("Sửa chữa").closest("a")
-    const moreButton = screen.getByRole("button", { name: /thêm tùy chọn/i })
-
-    expect(repairLink).not.toBeNull()
-    expect(within(repairLink!).getByText("2")).toBeInTheDocument()
-    expect(within(moreButton).getByText("9+")).toBeInTheDocument()
-    expect(moreButton).toHaveClass("relative")
-    expect(moreButton).toHaveAttribute("aria-expanded", "false")
-
-    await user.click(moreButton)
-
     const transferLink = screen.getByText("Luân chuyển").closest("a")
-    const maintenanceLink = screen.getByText("Bảo trì").closest("a")
+    const qrLink = screen.getByText("Quét QR").closest("a")
 
+    expect(screen.getByText("Tổng quan").closest("a")).toHaveAttribute("href", "/dashboard")
+    expect(screen.getByText("Thiết bị").closest("a")).toHaveAttribute("href", "/equipment")
+    expect(repairLink).not.toBeNull()
+    expect(repairLink).toHaveAttribute("href", "/repair-requests")
     expect(transferLink).not.toBeNull()
-    expect(maintenanceLink).not.toBeNull()
+    expect(transferLink).toHaveAttribute("href", "/transfers")
+    expect(qrLink).not.toBeNull()
+    expect(qrLink).toHaveAttribute("href", "/qr-scanner?autoStart=1")
+
+    expect(within(repairLink!).getByText("2")).toBeInTheDocument()
     expect(within(transferLink!).getByText("4")).toBeInTheDocument()
-    expect(within(maintenanceLink!).getByText("8")).toBeInTheDocument()
-    expect(moreButton).toHaveAttribute("aria-expanded", "true")
+
+    expect(screen.queryByRole("button", { name: /thêm tùy chọn/i })).not.toBeInTheDocument()
+    expect(screen.queryByText("Bảo trì")).not.toBeInTheDocument()
+    expect(screen.queryByText("Báo cáo")).not.toBeInTheDocument()
   })
 })

--- a/src/components/app-navigation.tsx
+++ b/src/components/app-navigation.tsx
@@ -26,6 +26,14 @@ export interface AppNavItem {
   requiresDeviceQuotaAccess?: boolean
 }
 
+const MOBILE_FOOTER_HREFS = [
+  "/dashboard",
+  "/equipment",
+  "/repair-requests",
+  "/transfers",
+  "/qr-scanner",
+] as const
+
 const APP_NAV_ITEMS: AppNavItem[] = [
   { href: "/dashboard", icon: Home, label: "Tổng quan", mobileSection: "main" },
   { href: "/equipment", icon: Package, label: "Thiết bị", mobileSection: "main" },
@@ -70,6 +78,9 @@ const APP_NAV_ITEMS: AppNavItem[] = [
   },
 ]
 
+/**
+ * Returns role-filtered navigation items for the desktop sidebar and sheet menu.
+ */
 export function getAppNavigationItems(role?: string): AppNavItem[] {
   return APP_NAV_ITEMS.filter((item) => {
     if (item.requiresGlobal && !isGlobalRole(role)) {
@@ -84,18 +95,40 @@ export function getAppNavigationItems(role?: string): AppNavItem[] {
   })
 }
 
+/**
+ * Returns the fixed small-screen footer routes for field-work navigation.
+ */
 export function getMobileFooterMainNavItems(role?: string): AppNavItem[] {
-  return getAppNavigationItems(role).filter((item) => item.mobileSection === "main")
+  return MOBILE_FOOTER_HREFS.flatMap((href) => {
+    const item = getAppNavigationItems(role).find((navItem) => navItem.href === href)
+    if (!item) {
+      return []
+    }
+
+    if (item.href === "/qr-scanner") {
+      return [{ ...item, href: "/qr-scanner?autoStart=1" }]
+    }
+
+    return [item]
+  })
 }
 
+/**
+ * Returns overflow footer routes; intentionally empty because small screens use direct tabs only.
+ */
 export function getMobileFooterMoreNavItems(role?: string): AppNavItem[] {
-  return getAppNavigationItems(role).filter((item) => item.mobileSection === "more")
+  return []
 }
 
+/**
+ * Checks active route state while ignoring query parameters on navigation links.
+ */
 export function isAppNavItemActive(pathname: string, href: string): boolean {
-  if (href === "/dashboard") {
-    return pathname === href
+  const hrefPathname = href.split("?")[0]
+
+  if (hrefPathname === "/dashboard") {
+    return pathname === hrefPathname
   }
 
-  return pathname === href || pathname.startsWith(`${href}/`)
+  return pathname === hrefPathname || pathname.startsWith(`${hrefPathname}/`)
 }

--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -17,7 +17,7 @@ const plansSkeletonClass = "h-4 w-24 md:w-24"
 
 // Base card styles - will be extended per card with custom gradients
 const cardBaseClass =
-  "mobile-kpi-card border-white/80 bg-white/95 rounded-[1.35rem] shadow-[0_14px_34px_rgba(15,23,42,0.08)] ring-1 ring-slate-200/70 md:rounded-2xl md:shadow-[0_12px_30px_rgba(15,23,42,0.06)]"
+  "min-h-[120px] border-white/80 bg-white/95 rounded-[1.35rem] shadow-[0_14px_34px_rgba(15,23,42,0.08)] ring-1 ring-slate-200/70 md:min-h-[140px] md:rounded-2xl md:shadow-[0_12px_30px_rgba(15,23,42,0.06)]"
 
 // Elegant vibrant gradient backgrounds for each KPI card
 const equipmentCardClass = `${cardBaseClass}`

--- a/src/components/dashboard/kpi-cards.tsx
+++ b/src/components/dashboard/kpi-cards.tsx
@@ -17,7 +17,7 @@ const plansSkeletonClass = "h-4 w-24 md:w-24"
 
 // Base card styles - will be extended per card with custom gradients
 const cardBaseClass =
-  "mobile-kpi-card bg-white rounded-2xl shadow-[0_4px_20px_-4px_rgba(0,0,0,0.1)] ring-1 ring-black/5 mb-4 md:rounded-xl md:shadow-none md:ring-0 md:mb-0"
+  "mobile-kpi-card border-white/80 bg-white/95 rounded-[1.35rem] shadow-[0_14px_34px_rgba(15,23,42,0.08)] ring-1 ring-slate-200/70 md:rounded-2xl md:shadow-[0_12px_30px_rgba(15,23,42,0.06)]"
 
 // Elegant vibrant gradient backgrounds for each KPI card
 const equipmentCardClass = `${cardBaseClass}`
@@ -25,18 +25,18 @@ const maintenanceCardClass = `${cardBaseClass}`
 const repairCardClass = `${cardBaseClass}`
 const planCardClass = `${cardBaseClass}`
 const headerClass =
-  "flex flex-row items-center justify-between p-4 pb-2 md:p-6 md:pb-2 gap-3 md:gap-2"
-const titleClass = "text-sm font-semibold truncate md:text-sm md:font-medium text-slate-600"
+  "flex flex-row items-start justify-between gap-3 p-4 pb-2 md:p-5 md:pb-2"
+const titleClass = "text-sm font-semibold leading-tight text-slate-900"
 // Icon colors matching card gradients - more vibrant
 const equipmentIconClass = "size-5 text-blue-600 md:size-4 flex-shrink-0"
 const maintenanceIconClass = "size-5 text-emerald-600 md:size-4 flex-shrink-0"
 const repairIconClass = "size-5 text-sky-600 md:size-4 flex-shrink-0"
 const planIconClass = "size-5 text-purple-600 md:size-4 flex-shrink-0"
-const contentClass = "p-4 pt-0 space-y-2 md:p-6 md:pt-0"
+const contentClass = "space-y-2 p-4 pt-0 md:p-5 md:pt-0"
 const metricClass =
-  "text-4xl font-bold leading-tight tracking-tight md:text-2xl md:leading-snug md:tracking-normal text-slate-900"
+  "text-4xl font-bold leading-tight tracking-normal text-slate-950 md:text-3xl md:leading-snug"
 const descriptionClass =
-  "text-sm text-neutral-500 leading-snug md:text-xs md:text-muted-foreground md:leading-tight"
+  "text-sm leading-snug text-neutral-600 md:text-sm md:leading-tight"
 
 function TotalEquipmentCard() {
   const { data: totalDevices, isLoading, error } = useTotalEquipment()
@@ -195,9 +195,12 @@ function MaintenancePlansCard() {
   )
 }
 
+/**
+ * Renders the dashboard KPI summary cards from the shared dashboard stats hooks.
+ */
 export function KPICards() {
   return (
-    <div className="grid gap-3 grid-cols-2 md:grid-cols-2 md:gap-10 md:pb-6 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-2 md:gap-4 md:pb-2 lg:grid-cols-4">
       <TotalEquipmentCard />
       <MaintenanceCountCard />
       <RepairRequestsCard />

--- a/src/components/mobile-footer-nav.tsx
+++ b/src/components/mobile-footer-nav.tsx
@@ -3,21 +3,10 @@
 import * as React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import {
-  MoreHorizontal,
-} from "lucide-react"
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { Button } from "@/components/ui/button"
 import { useSession } from "next-auth/react"
 import {
   EMPTY_APP_NOTIFICATION_COUNTS,
-  sumNotificationBadgeCounts,
   type AppNotificationCounts,
 } from "@/lib/app-notification-counts"
 import { cn } from "@/lib/utils"
@@ -25,7 +14,6 @@ import { cn } from "@/lib/utils"
 import { AppNotificationBadge } from "./app-notification-badge"
 import {
   getMobileFooterMainNavItems,
-  getMobileFooterMoreNavItems,
   isAppNavItemActive,
 } from "./app-navigation"
 
@@ -33,6 +21,9 @@ interface MobileFooterNavProps {
   notificationCounts?: AppNotificationCounts
 }
 
+/**
+ * Renders the tablet/mobile bottom navigation for field-work routes.
+ */
 export function MobileFooterNav({
   notificationCounts = EMPTY_APP_NOTIFICATION_COUNTS,
 }: Readonly<MobileFooterNavProps>) {
@@ -41,111 +32,54 @@ export function MobileFooterNav({
   const user = session?.user as { role?: string } | undefined
 
   const mainNavItems = React.useMemo(() => getMobileFooterMainNavItems(user?.role), [user?.role])
-  const moreNavItems = React.useMemo(() => getMobileFooterMoreNavItems(user?.role), [user?.role])
-
-  // Check if any item in "More" dropdown is active
-  const isMoreActive = React.useMemo(() => {
-    return moreNavItems.some((item) => isAppNavItemActive(pathname, item.href))
-  }, [pathname, moreNavItems])
-
-  const moreBadgeCount = React.useMemo(
-    () =>
-      sumNotificationBadgeCounts(
-        moreNavItems
-          .map((item) => item.badgeKey)
-          .filter((badgeKey): badgeKey is keyof AppNotificationCounts => Boolean(badgeKey)),
-        notificationCounts
-      ),
-    [moreNavItems, notificationCounts]
-  )
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 mobile-footer-z border-t border-slate-200 bg-white shadow-[0_-2px_10px_rgba(0,0,0,0.08)] md:hidden lg:hidden">
-      <nav className="grid h-16 grid-cols-4 items-center px-2" aria-label="Điều hướng chính">
+    <div className="fixed inset-x-3 bottom-3 mobile-footer-z rounded-3xl border border-white/70 bg-white/90 shadow-[0_16px_40px_rgba(15,23,42,0.18)] backdrop-blur-xl lg:hidden">
+      <nav className="grid h-16 grid-cols-5 items-center px-1.5" aria-label="Điều hướng chính">
         {mainNavItems.map(({ href, icon: Icon, label, mobileLabel, badgeKey }) => {
           const isActive = isAppNavItemActive(pathname, href)
           const badgeCount = badgeKey ? notificationCounts[badgeKey] : 0
+          const isQrAction = href.startsWith("/qr-scanner")
           return (
             <Link
               key={href}
               href={href}
               className={cn(
-                "relative flex flex-col items-center justify-center gap-1 rounded-xl mx-1 py-2 transition-all duration-200 touch-target focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-                isActive
+                "relative flex flex-col items-center justify-center gap-1 rounded-2xl py-2 transition-all duration-200 touch-target focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                isQrAction
+                  ? "-mt-7 min-h-[76px] text-white"
+                  : "min-h-[56px]",
+                isActive && !isQrAction
                   ? "bg-gradient-to-br from-primary to-primary/90 text-white shadow-lg shadow-primary/20"
-                  : "text-slate-600 hover:bg-slate-50 active:bg-slate-100"
+                  : "text-slate-600 hover:bg-slate-50 active:bg-slate-100",
+                isQrAction && "hover:bg-transparent active:bg-transparent"
               )}
               aria-label={mobileLabel ?? label}
               aria-current={isActive ? "page" : undefined}
             >
-              <Icon className={cn(
-                "size-5 transition-colors",
-                isActive ? "text-white" : "text-slate-500"
-              )} />
+              <span
+                className={cn(
+                  "relative flex items-center justify-center rounded-2xl transition-all",
+                  isQrAction
+                    ? "size-16 border-4 border-white bg-gradient-to-br from-primary to-cyan-600 shadow-[0_12px_28px_rgba(8,145,178,0.35)]"
+                    : "size-6"
+                )}
+              >
+                <Icon className={cn(
+                  "transition-colors",
+                  isQrAction ? "size-8 text-white" : "size-5",
+                  isActive && !isQrAction ? "text-white" : "text-slate-500"
+                )} />
+              </span>
               <AppNotificationBadge count={badgeCount} active={isActive} mode="floating" />
               <span className={cn(
-                "text-xs font-medium transition-colors",
-                isActive ? "text-white" : "text-slate-600"
+                "text-[11px] font-medium leading-none transition-colors sm:text-xs",
+                isQrAction ? "mt-0.5 text-primary" : "",
+                isActive && !isQrAction ? "text-white" : "text-slate-600"
               )}>{mobileLabel ?? label}</span>
             </Link>
           )
         })}
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              className={cn(
-                "relative flex flex-col items-center justify-center gap-1 rounded-xl mx-1 py-2 transition-all duration-200 touch-target h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-                isMoreActive
-                  ? "bg-gradient-to-br from-primary to-primary/90 text-white shadow-lg shadow-primary/20"
-                  : "text-slate-600 hover:bg-slate-50 active:bg-slate-100"
-              )}
-              aria-label="Thêm tùy chọn"
-            >
-              <MoreHorizontal className={cn(
-                "size-5 transition-colors",
-                isMoreActive ? "text-white" : "text-slate-500"
-              )} />
-              <AppNotificationBadge count={moreBadgeCount} active={isMoreActive} mode="floating" />
-              <span className={cn(
-                "text-xs font-medium transition-colors",
-                isMoreActive ? "text-white" : "text-slate-600"
-              )}>Thêm</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="end"
-            className="mb-3 min-w-[200px] bg-white border border-slate-200 shadow-xl rounded-xl p-2"
-            sideOffset={12}
-          >
-            {moreNavItems.map(({ href, icon: Icon, label, mobileLabel, badgeKey }) => {
-              const isActive = isAppNavItemActive(pathname, href)
-              const badgeCount = badgeKey ? notificationCounts[badgeKey] : 0
-              return (
-                <DropdownMenuItem key={label} asChild>
-                  <Link
-                    href={href}
-                    className={cn(
-                      "flex items-center gap-3 w-full touch-target-sm rounded-xl px-3 py-2.5 transition-all duration-200",
-                      isActive
-                        ? "bg-gradient-to-r from-primary to-primary/90 text-white font-semibold"
-                        : "hover:bg-slate-50 text-slate-700"
-                    )}
-                    aria-current={isActive ? "page" : undefined}
-                  >
-                    <Icon className={cn(
-                      "size-5 transition-colors",
-                      isActive ? "text-white" : "text-slate-500"
-                    )} />
-                    <span className="text-sm">{mobileLabel ?? label}</span>
-                    <AppNotificationBadge count={badgeCount} active={isActive} />
-                  </Link>
-                </DropdownMenuItem>
-              )
-            })}
-          </DropdownMenuContent>
-        </DropdownMenu>
       </nav>
     </div>
   )

--- a/src/components/mobile-footer-nav.tsx
+++ b/src/components/mobile-footer-nav.tsx
@@ -67,8 +67,9 @@ export function MobileFooterNav({
               >
                 <Icon className={cn(
                   "transition-colors",
-                  isQrAction ? "size-8 text-white" : "size-5",
-                  isActive && !isQrAction ? "text-white" : "text-slate-500"
+                  isQrAction
+                    ? "size-8 text-white"
+                    : cn("size-5", isActive ? "text-white" : "text-slate-500")
                 )} />
               </span>
               <AppNotificationBadge count={badgeCount} active={isActive} mode="floating" />


### PR DESCRIPTION
## Summary
- Redesign dashboard welcome banner across breakpoints and refresh mobile KPI/quick-action styling.
- Simplify mobile/tablet bottom nav to Tổng quan, Thiết bị, Sửa chữa, Luân chuyển, and Quét QR.
- Add QR auto-start support for `/qr-scanner?autoStart=1` while preserving manual start on plain `/qr-scanner`.

## Test Plan
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/components/__tests__/app-navigation.test.ts src/components/__tests__/mobile-footer-nav.test.tsx 'src/app/(app)/qr-scanner/__tests__/qr-scanner-no-legacy-dialog.test.tsx' 'src/app/(app)/dashboard/__tests__/dashboard-no-legacy-dialog.test.tsx' 'src/app/(app)/__tests__/AppLayoutShell.test.tsx'`
- [x] `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the mobile dashboard and bottom nav for faster field‑work. Added a richer welcome banner with department and an auto‑refreshing date, plus QR scanner auto‑start via URL; fixed the QR tab icon to stay white.

- **New Features**
  - Welcome banner shows user name, department, and today’s date; date auto‑refreshes after local midnight.
  - Floating 5‑tab bottom nav: Tổng quan, Thiết bị, Sửa chữa, Luân chuyển, Quét QR (links to `/qr-scanner?autoStart=1`); no overflow menu.
  - QR scanner auto‑starts the camera when `?autoStart=1` is present; manual start remains on `/qr-scanner`. Quick‑actions keep “Lập kế hoạch” as the third action; KPI cards refreshed.

- **Refactors**
  - Navigation helpers: fixed mobile tab list; `isAppNavItemActive` ignores query params; removed “More” menu and device quota from mobile footer.
  - Routing: use `push` consistently; treat `update-status` like view details for equipment redirects (dashboard and QR scanner).
  - Layout: move desktop sidebar/header breakpoints to `lg`; adjust paddings and mobile footer styling (elevated QR tab, QR icon stays white). Added date helpers and scheduling for banner refresh; small polish from review feedback.

<sup>Written for commit 8167e1c5e339fccefd24722d5f35e0b7fd7cd1e3. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/554?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QR scanner supports automatic activation via URL parameter.
  * Mobile footer navigation simplified to a fixed 5-column layout; QR entry deep-link includes auto-start.

* **UI Improvements**
  * Dashboard welcome banner refreshed with new styling and updated date display.
  * KPI cards refined with improved visuals and typography.
  * Layout breakpoints adjusted for better responsive behavior.

* **Tests**
  * Expanded dashboard, QR scanner, and navigation tests to cover date, auto-start, and mobile nav behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->