### PR TITLE
Phase 2: Convert transfer detail to side sheet

### DIFF
--- a/src/app/(app)/transfers/__tests__/TransfersDialogs.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersDialogs.test.tsx
@@ -1,12 +1,28 @@
 import * as React from "react"
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TransfersDialogs } from "@/app/(app)/transfers/_components/TransfersDialogs"
 import type { TransferListItem } from "@/types/transfers-data-grid"
 
 const mocks = vi.hoisted(() => ({
   ReturnLocationDialog: vi.fn(() => <div data-testid="return-location-dialog" />),
+  TransferDetailDialog: vi.fn(
+    ({
+      open,
+      onOpenChange,
+    }: {
+      open: boolean
+      onOpenChange: (open: boolean) => void
+      transfer: unknown
+    }) =>
+      open ? (
+        <button type="button" onClick={() => onOpenChange(false)}>
+          close transfer detail
+        </button>
+      ) : null,
+  ),
 }))
 
 vi.mock("@/components/add-transfer-dialog", () => ({
@@ -22,7 +38,11 @@ vi.mock("@/components/handover-preview-dialog", () => ({
 }))
 
 vi.mock("@/components/transfer-detail-dialog", () => ({
-  TransferDetailDialog: () => null,
+  TransferDetailDialog: (props: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    transfer: unknown
+  }) => mocks.TransferDetailDialog(props),
 }))
 
 vi.mock("@/components/transfers/FilterModal", () => ({
@@ -75,6 +95,10 @@ function makeTransferListItem(
 }
 
 describe("TransfersDialogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it("mounts ReturnLocationDialog when the dialog is open", () => {
     const returnTransfer = makeTransferListItem()
     const onConfirmReturn = vi.fn().mockResolvedValue(undefined)
@@ -119,5 +143,53 @@ describe("TransfersDialogs", () => {
         onConfirm: onConfirmReturn,
       }),
     )
+  })
+
+  it("passes the selected transfer and close handler to TransferDetailDialog", async () => {
+    const detailTransfer = makeTransferListItem({ id: 42, ma_yeu_cau: "LC-0042" })
+    const onDetailDialogOpenChange = vi.fn()
+
+    render(
+      <TransfersDialogs
+        isAddDialogOpen={false}
+        onAddDialogOpenChange={vi.fn()}
+        onAddSuccess={vi.fn()}
+        isEditDialogOpen={false}
+        onEditDialogOpenChange={vi.fn()}
+        onEditSuccess={vi.fn()}
+        editingTransfer={null}
+        detailDialogOpen
+        onDetailDialogOpenChange={onDetailDialogOpenChange}
+        detailTransfer={detailTransfer}
+        handoverDialogOpen={false}
+        onHandoverDialogOpenChange={vi.fn()}
+        handoverTransfer={null}
+        deleteDialogOpen={false}
+        onDeleteDialogOpenChange={vi.fn()}
+        onConfirmDelete={vi.fn()}
+        returnLocationDialogOpen={false}
+        onReturnLocationDialogOpenChange={vi.fn()}
+        returnTransfer={null}
+        isReturning={false}
+        onConfirmReturn={vi.fn()}
+        isFilterModalOpen={false}
+        onFilterModalOpenChange={vi.fn()}
+        filterValue={{ statuses: [], dateRange: null }}
+        onFilterChange={vi.fn()}
+        filterVariant="dialog"
+      />,
+    )
+
+    expect(mocks.TransferDetailDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        open: true,
+        onOpenChange: onDetailDialogOpenChange,
+        transfer: detailTransfer,
+      }),
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "close transfer detail" }))
+
+    expect(onDetailDialogOpenChange).toHaveBeenCalledWith(false)
   })
 })

--- a/src/components/__tests__/transfer-detail-dialog.test.tsx
+++ b/src/components/__tests__/transfer-detail-dialog.test.tsx
@@ -15,23 +15,38 @@ vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: mockToast }),
 }))
 
-vi.mock("@/components/ui/dialog", () => ({
-  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div data-testid="dialog">{children}</div> : null,
-  DialogContent: ({
+vi.mock("@/components/shared/SideSheetShell", () => ({
+  SideSheetShell: ({
+    open,
+    onOpenChange,
+    title,
+    description,
     children,
-    className,
+    contentClassName,
+    bodyClassName,
   }: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    title?: React.ReactNode
+    description?: React.ReactNode
     children: React.ReactNode
-    className?: string
-  }) => (
-    <div data-testid="dialog-content" className={className}>
-      {children}
-    </div>
-  ),
-  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    contentClassName?: string
+    bodyClassName?: string
+  }) =>
+    open ? (
+      <section
+        data-testid="shared-side-sheet"
+        data-content-class={contentClassName}
+        data-body-class={bodyClassName}
+      >
+        <h2>{title}</h2>
+        <p>{description}</p>
+        <button type="button" onClick={() => onOpenChange(false)}>
+          close shared sheet
+        </button>
+        <div className={bodyClassName}>{children}</div>
+      </section>
+    ) : null,
 }))
 
 vi.mock("@/components/ui/badge", () => ({
@@ -412,7 +427,9 @@ describe("TransferDetailDialog related people", () => {
     expect(screen.getByRole("tab", { name: "Tiến trình" })).toBeInTheDocument()
   })
 
-  it("uses a constrained flex layout so overview content remains scrollable inside the dialog", async () => {
+  it("uses the shared side sheet shell with a constrained flex layout for scrollable tabs", async () => {
+    const onOpenChange = vi.fn()
+
     mockCallRpc.mockImplementation(async ({ fn }) => {
       if (fn === "transfer_request_get") {
         return makeTransferRow()
@@ -424,25 +441,33 @@ describe("TransferDetailDialog related people", () => {
     })
 
     render(
-      <TransferDetailDialog open onOpenChange={vi.fn()} transfer={makeTransferRow()} />,
+      <TransferDetailDialog open onOpenChange={onOpenChange} transfer={makeTransferRow()} />,
       { wrapper: createWrapper() },
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId("dialog-content")).toBeInTheDocument()
+      expect(screen.getByTestId("shared-side-sheet")).toBeInTheDocument()
     })
 
-    expect(screen.getByTestId("dialog-content")).toHaveClass(
-      "h-[90vh]",
-      "max-h-[90vh]",
-      "max-w-4xl",
-      "overflow-hidden",
-      "flex",
-      "flex-col",
+    expect(screen.getByTestId("shared-side-sheet")).toHaveAttribute(
+      "data-content-class",
+      "sm:max-w-xl md:max-w-2xl lg:max-w-4xl",
     )
+    expect(screen.getByTestId("shared-side-sheet")).toHaveAttribute(
+      "data-body-class",
+      "flex flex-col overflow-hidden p-4",
+    )
+    expect(screen.getByText("Chi tiết yêu cầu luân chuyển - LC-0011")).toBeInTheDocument()
+    expect(
+      screen.getByText("Thông tin chi tiết và lịch sử của yêu cầu luân chuyển thiết bị"),
+    ).toBeInTheDocument()
     expect(screen.getByRole("tablist").parentElement).toHaveClass("flex", "min-h-0", "flex-1", "flex-col")
     expect(screen.getByRole("tabpanel")).toHaveClass("mt-0", "min-h-0", "flex-1", "overflow-hidden")
     expect(screen.getByTestId("scroll-area")).toHaveClass("h-full")
+
+    await userEvent.click(screen.getByRole("button", { name: "close shared sheet" }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it("refetches detail on open when a fresh same-id cache entry is missing related people", async () => {

--- a/src/components/transfer-detail-dialog.tsx
+++ b/src/components/transfer-detail-dialog.tsx
@@ -3,16 +3,10 @@
 import * as React from "react"
 import { Package } from "lucide-react"
 
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ChangeHistoryTab } from "@/components/change-history/ChangeHistoryTab"
+import { SideSheetShell } from "@/components/shared/SideSheetShell"
 import { useTransferDetailDialogData } from "@/components/transfer-detail-dialog.data"
 import {
   mapTransferHistoryEntries,
@@ -87,6 +81,9 @@ function resolveDisplayTransfer(
   }
 }
 
+/**
+ * Shows transfer request detail, history, and progress inside the shared side-sheet shell.
+ */
 export function TransferDetailDialog({
   open,
   onOpenChange,
@@ -115,51 +112,51 @@ export function TransferDetailDialog({
   if (!displayTransfer) return null
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="h-[90vh] max-h-[90vh] max-w-4xl overflow-hidden flex flex-col">
-        <DialogHeader className="shrink-0">
-          <DialogTitle className="flex items-center gap-2">
-            <Package className="size-5" />
-            Chi tiết yêu cầu luân chuyển - {displayTransfer.ma_yeu_cau}
-          </DialogTitle>
-          <DialogDescription>
-            Thông tin chi tiết và lịch sử của yêu cầu luân chuyển thiết bị
-          </DialogDescription>
-        </DialogHeader>
+    <SideSheetShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={
+        <span className="flex items-center gap-2">
+          <Package className="size-5" />
+          Chi tiết yêu cầu luân chuyển - {displayTransfer.ma_yeu_cau}
+        </span>
+      }
+      description="Thông tin chi tiết và lịch sử của yêu cầu luân chuyển thiết bị"
+      contentClassName="sm:max-w-xl md:max-w-2xl lg:max-w-4xl"
+      bodyClassName="flex flex-col overflow-hidden p-4"
+    >
+      <Tabs defaultValue="overview" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <TabsList className="shrink-0 self-start">
+          <TabsTrigger value="overview">Tổng quan</TabsTrigger>
+          <TabsTrigger value="history">Lịch sử</TabsTrigger>
+          <TabsTrigger value="progress">Tiến trình</TabsTrigger>
+        </TabsList>
 
-        <Tabs defaultValue="overview" className="mt-4 flex min-h-0 flex-1 flex-col overflow-hidden">
-          <TabsList className="shrink-0 self-start">
-            <TabsTrigger value="overview">Tổng quan</TabsTrigger>
-            <TabsTrigger value="history">Lịch sử</TabsTrigger>
-            <TabsTrigger value="progress">Tiến trình</TabsTrigger>
-          </TabsList>
+        <TabsContent value="overview" className="mt-0 min-h-0 flex-1 overflow-hidden">
+          <ScrollArea className="h-full pr-4">
+            <TransferDetailOverview transfer={displayTransfer} relatedPeople={relatedPeople} />
+          </ScrollArea>
+        </TabsContent>
 
-          <TabsContent value="overview" className="mt-0 min-h-0 flex-1 overflow-hidden">
-            <ScrollArea className="h-full pr-4">
-              <TransferDetailOverview transfer={displayTransfer} relatedPeople={relatedPeople} />
-            </ScrollArea>
-          </TabsContent>
+        <TabsContent value="history" className="mt-0 min-h-0 flex-1 overflow-hidden">
+          <ScrollArea className="h-full pr-4">
+            <ChangeHistoryTab entries={historyEntries} isLoading={isLoadingHistory} />
+          </ScrollArea>
+        </TabsContent>
 
-          <TabsContent value="history" className="mt-0 min-h-0 flex-1 overflow-hidden">
-            <ScrollArea className="h-full pr-4">
-              <ChangeHistoryTab entries={historyEntries} isLoading={isLoadingHistory} />
-            </ScrollArea>
-          </TabsContent>
-
-          <TabsContent value="progress" className="mt-0 min-h-0 flex-1 overflow-hidden">
-            <ScrollArea className="h-full pr-4">
-              <div className="py-4">
+        <TabsContent value="progress" className="mt-0 min-h-0 flex-1 overflow-hidden">
+          <ScrollArea className="h-full pr-4">
+            <div className="py-4">
               <h3 className="mb-4 text-lg font-semibold">Tiến trình xử lý</h3>
               <TransferStatusProgress
                 type={displayTransfer.loai_hinh}
                 currentStatus={displayTransfer.trang_thai}
                 className="py-2"
               />
-              </div>
-            </ScrollArea>
-          </TabsContent>
-        </Tabs>
-      </DialogContent>
-    </Dialog>
+            </div>
+          </ScrollArea>
+        </TabsContent>
+      </Tabs>
+    </SideSheetShell>
   )
 }


### PR DESCRIPTION
## Summary
- Convert transfer detail presentation from Dialog to the shared SideSheetShell
- Preserve transfer detail data hooks, tabs, related-people fallback, and progress/history rendering
- Add focused coverage for side-sheet rendering, close forwarding, scroll layout, and TransfersDialogs prop flow

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/components/__tests__/transfer-detail-dialog.test.tsx src/app/'(app)'/transfers/__tests__/TransfersDialogs.test.tsx
- node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main

Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Transfer detail dialog layout updated to use side sheet instead of modal dialog.

* **Tests**
  * Updated test suites for TransfersDialogs and transfer-detail-dialog components to verify new side sheet-based layout and interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->