### PR TITLE
Fix AddTransferDialog reset effect

### DIFF
--- a/src/components/__tests__/add-transfer-dialog.side-sheet.test.tsx
+++ b/src/components/__tests__/add-transfer-dialog.side-sheet.test.tsx
@@ -59,7 +59,7 @@ vi.mock("@/components/shared/SideSheetShell", () => ({
         <h2>{title}</h2>
         <p>{description}</p>
         <button type="button" onClick={() => onOpenChange(false)}>
-          shell-close
+          close add transfer sheet
         </button>
         <div data-testid="sheet-body">{children}</div>
         <div data-testid="sheet-footer">{footer}</div>
@@ -108,6 +108,24 @@ function createWrapper() {
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   }
+}
+
+function AddTransferDialogHarness() {
+  const [open, setOpen] = React.useState(true)
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        reopen add transfer
+      </button>
+      <button type="button" onClick={() => setOpen(false)}>
+        external close add transfer
+      </button>
+      {open ? (
+        <AddTransferDialog open={open} onOpenChange={setOpen} onSuccess={vi.fn()} />
+      ) : null}
+    </>
+  )
 }
 
 describe("AddTransferDialog side sheet presentation", () => {
@@ -162,5 +180,34 @@ describe("AddTransferDialog side sheet presentation", () => {
     await user.click(screen.getByRole("button", { name: "Hủy" }))
 
     expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("resets draft state when the parent closes and remounts the add transfer sheet", async () => {
+    const user = userEvent.setup()
+
+    render(<AddTransferDialogHarness />, { wrapper: createWrapper() })
+
+    await user.type(screen.getByLabelText("Lý do luân chuyển *"), "Draft reason")
+    expect(screen.getByLabelText("Lý do luân chuyển *")).toHaveValue("Draft reason")
+
+    await user.click(screen.getByRole("button", { name: "external close add transfer" }))
+    await user.click(screen.getByRole("button", { name: "reopen add transfer" }))
+
+    expect(screen.getByLabelText("Lý do luân chuyển *")).toHaveValue("")
+  })
+
+  it.each([
+    ["footer cancel", "Hủy"],
+    ["sheet close", "close add transfer sheet"],
+  ])("resets draft state after %s closes the sheet", async (_label, buttonName) => {
+    const user = userEvent.setup()
+
+    render(<AddTransferDialogHarness />, { wrapper: createWrapper() })
+
+    await user.type(screen.getByLabelText("Lý do luân chuyển *"), "Draft reason")
+    await user.click(screen.getByRole("button", { name: buttonName }))
+    await user.click(screen.getByRole("button", { name: "reopen add transfer" }))
+
+    expect(screen.getByLabelText("Lý do luân chuyển *")).toHaveValue("")
   })
 })

--- a/src/components/add-transfer-dialog.tsx
+++ b/src/components/add-transfer-dialog.tsx
@@ -57,12 +57,6 @@ export function AddTransferDialog({ open, onOpenChange, onSuccess }: AddTransfer
     dispatch({ type: "FORM_DATA_CHANGED", value })
   }, [])
 
-  React.useEffect(() => {
-    if (!open) {
-      dispatch({ type: "RESET" })
-    }
-  }, [open])
-
   const { departments, isLoadingDepartments } = useTransferDepartments({ open })
   const selectedValueLabel = selectedEquipment
     ? `${selectedEquipment.ten_thiet_bi} (${selectedEquipment.ma_thiet_bi})`


### PR DESCRIPTION
## Summary
- Remove the AddTransferDialog reset-on-close effect flagged by React Doctor.
- Add regression coverage for parent/external close, footer cancel, and sheet close remount reset semantics.
- Keep submit/cancel close wiring unchanged and rely on the existing TransfersDialogs conditional mount.

Fixes #562

## Verification
- Mutation proof: reset tests fail when the dialog stays mounted and reset is disabled; textarea remains `Draft reason`.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/add-transfer-dialog.side-sheet.test.tsx`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/transfer-dialogs.payload.test.tsx`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/transfer-dialog.data-fetching.test.tsx`
- `npx -y -p node@22 -p react-doctor@latest react-doctor . --verbose -y --project nextn --offline --diff main` → No issues found

## Note
- The repo's standard `node scripts/npm-run.js npx react-doctor@latest ...` currently crashes on system Node v20.20.1 because React Doctor v0.2.4 requires Node >=22.13.0. The same latest React Doctor scan was run through a temporary Node 22 package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the reset-on-close effect in `AddTransferDialog` and relies on remount to clear form state, addressing Linear #562. This makes reset behavior consistent across close paths and avoids unnecessary state mutations.

- **Bug Fixes**
  - Removed the `useEffect` that dispatched `RESET` when `open` became false.
  - Added tests to confirm draft resets after parent/external close + reopen, footer Cancel, and sheet close + reopen.
  - Kept submit/cancel close wiring unchanged; resets are handled by the existing conditional mount in `TransfersDialogs`.

<sup>Written for commit 90d415945b63604a6da4b2de1c609fc96dcb38fc. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/564?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced transfer dialog test coverage with draft reset verification scenarios.
  * Added tests confirming form data clears when the dialog is closed and reopened.

* **Accessibility**
  * Improved accessible naming for the sheet close button.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->