### PR TITLE
fix: resolve remaining control labels

### DIFF
--- a/src/__tests__/react-doctor-control-labels.source.test.ts
+++ b/src/__tests__/react-doctor-control-labels.source.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = process.cwd()
+
+function readSource(relativePath: string) {
+  return readFileSync(join(repoRoot, relativePath), 'utf8')
+}
+
+describe('React Doctor control label source guards', () => {
+  it('keeps printable handover table fields accessible by name', () => {
+    const source = readSource('src/app/(app)/forms/handover/page.tsx')
+
+    expect(source).toMatch(/aria-label="Mã thiết bị bàn giao"/)
+    expect(source).toMatch(/aria-label="Tên thiết bị bàn giao"/)
+    expect(source).toMatch(/aria-label="Model thiết bị bàn giao"/)
+    expect(source).toMatch(/aria-label="Số serial thiết bị bàn giao"/)
+    expect(source).toMatch(/aria-label="Tài liệu, phụ kiện kèm theo"/)
+    expect(source).toMatch(/aria-label="Tình trạng thiết bị bàn giao"/)
+    expect(source).toMatch(/aria-label="Ghi chú bàn giao"/)
+  })
+
+  it('keeps printable maintenance plan controls accessible by name', () => {
+    const source = readSource('src/app/(app)/forms/maintenance/page.tsx')
+
+    expect(source).toMatch(/aria-label="Khoa phòng lập kế hoạch"/)
+    expect(source).toMatch(/aria-label="Năm kế hoạch bảo trì"/)
+    expect(source).toMatch(/aria-label="Số thứ tự dòng kế hoạch mẫu"/)
+    expect(source).toMatch(/aria-label="Mã thiết bị dòng kế hoạch mẫu"/)
+    expect(source).toMatch(/aria-label="Tên thiết bị dòng kế hoạch mẫu"/)
+    expect(source).toMatch(/aria-label="Khoa phòng sử dụng dòng kế hoạch mẫu"/)
+    expect(source).toMatch(/aria-label="Thực hiện nội bộ cho dòng kế hoạch mẫu"/)
+    expect(source).toMatch(/aria-label="Thuê ngoài cho dòng kế hoạch mẫu"/)
+
+    for (const month of Array.from({ length: 12 }, (_, index) => index + 1)) {
+      expect(source).toContain(`aria-label="Tháng ${month} cho dòng kế hoạch mẫu"`)
+    }
+
+    expect(source).toMatch(/aria-label="Điểm hiệu chuẩn kiểm định cho dòng kế hoạch mẫu"/)
+  })
+
+  it('keeps maintenance rejection and QR help controls accessible by name', () => {
+    const maintenanceDialogs = readSource(
+      'src/app/(app)/maintenance/_components/maintenance-dialogs.tsx',
+    )
+    const qrScanner = readSource('src/components/qr-scanner-camera.tsx')
+
+    expect(maintenanceDialogs).toMatch(/aria-label="Lý do không duyệt kế hoạch"/)
+    expect(qrScanner).toMatch(/aria-label="Mở hướng dẫn quét mã QR"/)
+    expect(qrScanner).toMatch(/aria-label="Khung camera quét mã QR"/)
+  })
+
+  it('keeps usage status datalist options accessible by label', () => {
+    const startUsage = readSource('src/components/start-usage-dialog.tsx')
+    const endUsage = readSource('src/components/end-usage-dialog.tsx')
+
+    expect(startUsage).toMatch(/<option key=\{status\} value=\{status\}>\s*\{status\}\s*<\/option>/)
+    expect(endUsage).toMatch(/<option key=\{status\} value=\{status\}>\s*\{status\}\s*<\/option>/)
+  })
+
+  it('keeps printable equipment log fields accessible by name', () => {
+    const source = readSource('src/components/log-template.tsx')
+
+    expect(source).toMatch(/aria-label="Khoa phòng quản lý nhật ký"/)
+    expect(source).toMatch(/aria-label="Người quản lý thiết bị"/)
+    expect(source).toMatch(/aria-label="Tên thiết bị"/)
+    expect(source).toMatch(/aria-label="Mã thiết bị"/)
+    expect(source).toMatch(/aria-label="Model thiết bị"/)
+    expect(source).toMatch(/aria-label="Số serial thiết bị"/)
+  })
+})

--- a/src/app/(app)/forms/handover/page.tsx
+++ b/src/app/(app)/forms/handover/page.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { FormBrandingHeader } from "@/components/form-branding-header"
 
+/** Renders the printable equipment handover form template. */
 export default function HandoverFormPage() {
   return (
     <div className="min-h-screen bg-gray-100 p-4">
@@ -42,13 +43,13 @@ export default function HandoverFormPage() {
               <tbody id="device-table-body">
                 <tr>
                   <td>1</td>
-                  <td><span className="form-input-line"></span></td>
-                  <td><span className="form-input-line"></span></td>
-                  <td><span className="form-input-line"></span></td>
-                  <td><span className="form-input-line"></span></td>
-                  <td className="editable-cell" contentEditable data-placeholder="Nhập tài liệu/phụ kiện kèm theo…"></td>
-                  <td className="editable-cell" contentEditable data-placeholder="Nhập tình trạng thiết bị…"></td>
-                  <td className="editable-cell" contentEditable data-placeholder="Nhập ghi chú…"></td>
+                  <td><span className="form-input-line" aria-label="Mã thiết bị bàn giao"></span></td>
+                  <td><span className="form-input-line" aria-label="Tên thiết bị bàn giao"></span></td>
+                  <td><span className="form-input-line" aria-label="Model thiết bị bàn giao"></span></td>
+                  <td><span className="form-input-line" aria-label="Số serial thiết bị bàn giao"></span></td>
+                  <td className="editable-cell" contentEditable aria-label="Tài liệu, phụ kiện kèm theo" data-placeholder="Nhập tài liệu/phụ kiện kèm theo…"></td>
+                  <td className="editable-cell" contentEditable aria-label="Tình trạng thiết bị bàn giao" data-placeholder="Nhập tình trạng thiết bị…"></td>
+                  <td className="editable-cell" contentEditable aria-label="Ghi chú bàn giao" data-placeholder="Nhập ghi chú…"></td>
                 </tr>
               </tbody>
             </table>

--- a/src/app/(app)/forms/maintenance/page.tsx
+++ b/src/app/(app)/forms/maintenance/page.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { FormBrandingHeader } from "@/components/form-branding-header"
 
+/** Renders the printable maintenance planning form template. */
 export default function MaintenanceFormPage() {
   return (
     <div className="min-h-screen bg-gray-100 p-4">
@@ -24,7 +25,12 @@ export default function MaintenanceFormPage() {
                 <h2 className="title-sub uppercase font-semibold">TRUNG TÂM KIỂM SOÁT BỆNH TẬT THÀNH PHỐ CẦN THƠ</h2>
                 <div className="flex items-baseline justify-center font-bold">
                   <label htmlFor="department-name">KHOA/PHÒNG:</label>
-                  <input type="text" id="department-name" className="form-input-line flex-grow ml-2" />
+                  <input
+                    type="text"
+                    id="department-name"
+                    className="form-input-line flex-grow ml-2"
+                    aria-label="Khoa phòng lập kế hoạch"
+                  />
                 </div>
               </div>
               <div className="w-1/4"></div> {/* Spacer */}
@@ -32,7 +38,7 @@ export default function MaintenanceFormPage() {
             <div className="text-center mt-4">
               <h1 className="title-main uppercase font-semibold flex justify-center items-baseline">
                 KẾ HOẠCH BẢO TRÌ HIỆU CHUẨN/KIỂM ĐỊNH THIẾT BỊ NĂM
-                <input type="text" className="form-input-line w-24 ml-2" />
+                <input type="text" className="form-input-line w-24 ml-2" aria-label="Năm kế hoạch bảo trì" />
               </h1>
             </div>
           </header>
@@ -70,25 +76,25 @@ export default function MaintenanceFormPage() {
               <tbody id="plan-table-body">
                 {/* Example empty row */}
                 <tr>
-                  <td></td>
-                  <td></td>
-                  <td></td>
-                  <td></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="checkbox" /></td>
-                  <td><input type="text" /></td>
+                  <td aria-label="Số thứ tự dòng kế hoạch mẫu"></td>
+                  <td aria-label="Mã thiết bị dòng kế hoạch mẫu"></td>
+                  <td aria-label="Tên thiết bị dòng kế hoạch mẫu"></td>
+                  <td aria-label="Khoa phòng sử dụng dòng kế hoạch mẫu"></td>
+                  <td><input type="checkbox" aria-label="Thực hiện nội bộ cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Thuê ngoài cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 1 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 2 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 3 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 4 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 5 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 6 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 7 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 8 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 9 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 10 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 11 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="checkbox" aria-label="Tháng 12 cho dòng kế hoạch mẫu" /></td>
+                  <td><input type="text" aria-label="Điểm hiệu chuẩn kiểm định cho dòng kế hoạch mẫu" /></td>
                 </tr>
               </tbody>
             </table>

--- a/src/app/(app)/maintenance/_components/maintenance-dialogs.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-dialogs.tsx
@@ -21,6 +21,7 @@ import {
 import type { MaintenancePlan as DialogMaintenancePlan } from "@/lib/data"
 import { useMaintenanceContext } from "../_hooks/useMaintenanceContext"
 
+/** Renders maintenance action dialogs for approval, rejection, and deletion flows. */
 export function MaintenanceDialogs() {
   const ctx = useMaintenanceContext()
 
@@ -132,6 +133,7 @@ export function MaintenanceDialogs() {
             <textarea
               className="w-full min-h-[100px] p-3 border border-input rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
               placeholder="Nhập lý do không duyệt kế hoạch này…"
+              aria-label="Lý do không duyệt kế hoạch"
               value={operations.confirmDialog.rejectionReason}
               onChange={(e) => operations.setRejectionReason(e.target.value)}
               disabled={operations.isRejecting}

--- a/src/components/end-usage-dialog.tsx
+++ b/src/components/end-usage-dialog.tsx
@@ -55,6 +55,7 @@ interface EndUsageDialogProps {
   usageLog: UsageLog | null
 }
 
+/** Renders the dialog for closing an active equipment usage session. */
 export function EndUsageDialog({
   open,
   onOpenChange,
@@ -177,7 +178,9 @@ export function EndUsageDialog({
                   </FormControl>
                   <datalist id="end-usage-status-options">
                     {equipmentStatusOptions.map((status) => (
-                      <option key={status} value={status} />
+                      <option key={status} value={status}>
+                        {status}
+                      </option>
                     ))}
                   </datalist>
                   <FormMessage />

--- a/src/components/log-template.tsx
+++ b/src/components/log-template.tsx
@@ -28,6 +28,7 @@ interface UsageLogDisplayRow extends UsageLogEntry {
 
 const EMPTY_USAGE_LOGS: UsageLogEntry[] = []
 
+/** Renders the printable equipment usage log template. */
 export function LogTemplate({
   department = "",
   deviceManager = "",
@@ -106,6 +107,7 @@ export function LogTemplate({
                       id="log-template-department"
                       type="text" 
                       className="form-input-line"
+                      aria-label="Khoa phòng quản lý nhật ký"
                       defaultValue={formatValue(department)}
                     />
                   </div>
@@ -126,6 +128,7 @@ export function LogTemplate({
                 id="log-template-device-manager"
                 type="text" 
                 className="form-input-line ml-2"
+                aria-label="Người quản lý thiết bị"
                 defaultValue={formatValue(deviceManager)}
               />
             </div>
@@ -135,6 +138,7 @@ export function LogTemplate({
                 id="log-template-device-name"
                 type="text" 
                 className="form-input-line ml-2"
+                aria-label="Tên thiết bị"
                 defaultValue={formatValue(deviceName)}
               />
             </div>
@@ -145,6 +149,7 @@ export function LogTemplate({
                   id="log-template-device-code"
                   type="text" 
                   className="form-input-line ml-2"
+                  aria-label="Mã thiết bị"
                   defaultValue={formatValue(deviceCode)}
                 />
               </div>
@@ -154,6 +159,7 @@ export function LogTemplate({
                   id="log-template-model"
                   type="text" 
                   className="form-input-line ml-2"
+                  aria-label="Model thiết bị"
                   defaultValue={formatValue(model)}
                 />
               </div>
@@ -163,6 +169,7 @@ export function LogTemplate({
                   id="log-template-serial"
                   type="text" 
                   className="form-input-line ml-2"
+                  aria-label="Số serial thiết bị"
                   defaultValue={formatValue(serial)}
                 />
               </div>

--- a/src/components/qr-scanner-camera.tsx
+++ b/src/components/qr-scanner-camera.tsx
@@ -20,6 +20,7 @@ type TorchMediaTrackConstraintSet = MediaTrackConstraintSet & {
   torch: boolean
 }
 
+/** Renders the camera scanner used to capture QR codes. */
 export function QRScannerCamera({ onScanSuccess, onClose, isActive }: QRScannerCameraProps) {
   const { toast } = useToast()
   const videoRef = React.useRef<HTMLVideoElement>(null)
@@ -318,6 +319,7 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
             size="icon"
             onClick={() => setShowInstructions(true)}
             className="text-white hover:bg-white/20"
+            aria-label="Mở hướng dẫn quét mã QR"
           >
             <HelpCircle className="size-6" />
           </Button>
@@ -335,6 +337,7 @@ Hiện tại bạn đang truy cập qua: ${location.origin}
                 className="w-full h-auto min-h-[300px] object-cover"
                 playsInline
                 muted
+                aria-label="Khung camera quét mã QR"
               />
               
               {/* Scanning Overlay */}

--- a/src/components/start-usage-dialog.tsx
+++ b/src/components/start-usage-dialog.tsx
@@ -57,6 +57,7 @@ interface StartUsageDialogProps {
   equipment: EquipmentForStart | null
 }
 
+/** Renders the dialog for starting a new equipment usage session. */
 export function StartUsageDialog({
   open,
   onOpenChange,
@@ -174,7 +175,9 @@ export function StartUsageDialog({
                   </FormControl>
                   <datalist id="start-usage-status-options">
                     {equipmentStatusOptions.map((status) => (
-                      <option key={status} value={status} />
+                      <option key={status} value={status}>
+                        {status}
+                      </option>
                     ))}
                   </datalist>
                   <FormMessage />


### PR DESCRIPTION
## Summary
- Resolve the remaining React Doctor `control-has-associated-label` findings from #567 across printable forms, usage dialogs, QR camera, and log templates.
- Add source guards for each changed control group and keep changes limited to accessible names/text.
- Leave state/effect/component-shape React Doctor warnings to existing follow-ups #569 and #570.

## Verification
- RED: `node scripts/npm-run.js run test:run -- src/__tests__/react-doctor-control-labels.source.test.ts` failed 5/5 before implementation, then failed 3/5 for the remaining groups before the second fix.
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/__tests__/react-doctor-control-labels.source.test.ts`
- `node scripts/npm-run.js npx -y -p node@22 -p react-doctor@latest react-doctor . --verbose --project nextn --offline --full` reported `control-has-associated-label: none`.
- `node scripts/npm-run.js run react-doctor` reports no label findings; remaining diff warnings are out of #568 scope and tracked by #569/#570.

Closes #568

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remaining missing control labels by adding aria-labels and visible option text across forms, dialogs, and the QR scanner so `react-doctor` reports zero control-has-associated-label issues. Adds source guards to prevent regressions and completes #568.

- **Bug Fixes**
  - Printable forms: added aria-labels for handover fields, maintenance plan fields (including months 1–12), and usage log fields.
  - Dialogs and QR scanner: labeled the maintenance rejection textarea, QR help button, and camera frame; datalist options in start/end usage dialogs now include visible labels.
  - Tests: added source-level tests to enforce labels across updated files.

<sup>Written for commit cc80091a581af4e11d3cddafbba8553fa5a6d8cf. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced screen reader support across multiple forms and components including handover forms, maintenance planning, equipment dialogs, and QR scanner with improved accessibility labels for form fields and interactive elements.
  * Fixed datalist option rendering for better accessibility.

* **Tests**
  * Added comprehensive test coverage validating accessibility labels and markup structure across all updated components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->