### PR TITLE
fix: harden login RPC boundary

### DIFF
--- a/src/auth/__tests__/auth-config.authorize-events.test.ts
+++ b/src/auth/__tests__/auth-config.authorize-events.test.ts
@@ -237,6 +237,36 @@ describe("authOptions authorize + auth lifecycle events", () => {
     expect(JSON.stringify(authLifecycleLogs(consoleInfoSpy))).not.toContain("super-secret")
   })
 
+  it("fails closed without falling back to anon key when the service role key is missing", async () => {
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "")
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key")
+
+    const authorize = getAuthorizeHandler()
+    const result = await authorize({
+      username: "NQMinh",
+      password: "super-secret",
+    }, buildAuthorizeRequest())
+
+    expect(result).toBeNull()
+    expect(authLifecycleLogs(consoleInfoSpy)).toEqual([
+      expect.objectContaining({
+        event: "login_failure",
+        source: "authorize",
+        reason_code: "config_error",
+        username: "nqminh",
+        request_id: "req-123",
+        ip_address: "203.0.113.1",
+        user_agent: "VitestBrowser/1.0",
+      }),
+    ])
+    expect(supabaseState.rpcCalls).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fn: "authenticate_user_dual_mode" }),
+      ])
+    )
+    expect(JSON.stringify(authLifecycleLogs(consoleInfoSpy))).not.toContain("super-secret")
+  })
+
   it("emits tenant_inactive when rpc auth says tenant is inactive", async () => {
     supabaseState.authRpcRows = [{
       is_authenticated: false,

--- a/src/auth/__tests__/auth-login-rpc-boundary-migration.test.ts
+++ b/src/auth/__tests__/auth-login-rpc-boundary-migration.test.ts
@@ -1,0 +1,36 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+describe("auth login RPC boundary migration", () => {
+  it("revokes direct login RPC execution from public PostgREST roles", () => {
+    const migrationsDir = join(process.cwd(), "supabase/migrations")
+    const migrationFile = readdirSync(migrationsDir)
+      .filter((file) => file.includes("harden_authenticate_user_dual_mode_execute"))
+      .sort()
+      .at(-1)
+
+    if (!migrationFile) {
+      throw new Error("Missing harden_authenticate_user_dual_mode_execute migration")
+    }
+
+    const migrationSource = readFileSync(join(migrationsDir, migrationFile), "utf8")
+
+    expect(migrationSource).toContain(
+      "REVOKE EXECUTE ON FUNCTION public.authenticate_user_dual_mode(TEXT, TEXT) FROM PUBLIC;"
+    )
+    expect(migrationSource).toContain(
+      "REVOKE EXECUTE ON FUNCTION public.authenticate_user_dual_mode(TEXT, TEXT) FROM anon;"
+    )
+    expect(migrationSource).toContain(
+      "REVOKE EXECUTE ON FUNCTION public.authenticate_user_dual_mode(TEXT, TEXT) FROM authenticated;"
+    )
+    expect(migrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public.authenticate_user_dual_mode(TEXT, TEXT) TO service_role;"
+    )
+    expect(migrationSource).not.toMatch(
+      /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.authenticate_user_dual_mode/i
+    )
+  })
+})

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -46,7 +46,7 @@ export const authOptions: NextAuthOptions = {
         if (!username || !password) return null
 
         const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-        const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+        const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
         if (!supabaseUrl || !serviceKey) {
           console.error("Supabase env not configured")
           await recordAuthLifecycleEvent({

--- a/supabase/migrations/20260526032000_harden_authenticate_user_dual_mode_execute.sql
+++ b/supabase/migrations/20260526032000_harden_authenticate_user_dual_mode_execute.sql
@@ -1,0 +1,7 @@
+-- Harden the login RPC boundary: credentials login must go through the
+-- server-side NextAuth authorize() path using SUPABASE_SERVICE_ROLE_KEY.
+REVOKE EXECUTE ON FUNCTION public.authenticate_user_dual_mode(TEXT, TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.authenticate_user_dual_mode(TEXT, TEXT) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.authenticate_user_dual_mode(TEXT, TEXT) FROM authenticated;
+
+GRANT EXECUTE ON FUNCTION public.authenticate_user_dual_mode(TEXT, TEXT) TO service_role;


### PR DESCRIPTION
## Summary
- Remove the silent anon-key fallback from NextAuth Credentials authorize(); login now requires SUPABASE_SERVICE_ROLE_KEY server-side.
- Add a migration to revoke direct EXECUTE on public.authenticate_user_dual_mode(TEXT, TEXT) from PUBLIC, anon, and authenticated while preserving service_role execution.
- Add regression coverage for the fail-closed authorize path and migration privilege contract.

## Verification
- RED confirmed: authorize fallback test failed with invalid_credentials before the code change.
- RED confirmed: migration test failed before the migration file existed.
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run src/auth/__tests__/auth-config.authorize-events.test.ts src/auth/__tests__/auth-config.jwt-rpc.test.ts src/auth/__tests__/auth-login-rpc-boundary-migration.test.ts
- node scripts/npm-run.js run react-doctor
- git push pre-push hook: typecheck, verify:dedupe, verify:no-explicit-any, verify:python-docstrings:changed, verify:ts-docstrings

## Live migration status
- Supabase MCP migration has not been applied yet.
- Pre-apply Vercel env check found SUPABASE_SERVICE_ROLE_KEY for Production only. Preview was not listed, so applying the live grant revoke now could break preview login against the hardened live RPC.
- After Preview env is configured, apply supabase/migrations/20260526032000_harden_authenticate_user_dual_mode_execute.sql via Supabase MCP, then inspect function grants and run Supabase security advisors.

Closes #541

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the login RPC boundary per #541. Credentials login now requires `SUPABASE_SERVICE_ROLE_KEY` and never falls back to the anon key; direct EXECUTE of `public.authenticate_user_dual_mode(TEXT, TEXT)` is restricted to `service_role`, enforced by tests.

- **Migration**
  - Set `SUPABASE_SERVICE_ROLE_KEY` in all environments (Preview and Production).
  - Apply `supabase/migrations/20260526032000_harden_authenticate_user_dual_mode_execute.sql` via Supabase MCP.
  - Verify function grants and run Supabase security advisors.

<sup>Written for commit d893d9caa7966478df99eb367d8a2f806ee6e159. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/575?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted authentication RPC access to service role only, preventing unauthorized execution and strengthening security boundaries.
  * Improved error handling when required credentials are missing, ensuring secure failure with appropriate logging.
  * Prevented sensitive data from appearing in lifecycle logs.

* **Tests**
  * Added authorization behavior tests for missing credentials scenarios.
  * Added database permission verification tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->