### PR TITLE
Refactor auth claim normalization

### DIFF
--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 export const runtime = 'nodejs'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../../../../auth/config'
+import { toAppRoleClaim } from '@/auth/server-claims'
 import { ALLOWED_FUNCTIONS } from './allowed-functions'
 import { sanitizeForLog } from '@/lib/log-sanitizer'
 import { mintSupabaseJwt } from '@/lib/ai/server-rpc'
@@ -93,13 +94,11 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
 
   const rawRole = sessionUser.role ?? ''
   const role = typeof rawRole === 'string' ? rawRole : String(rawRole)
-  const roleLower = role.toLowerCase()
-  const donVi = sessionUser.don_vi ? String(sessionUser.don_vi) : ''
-  const diaBan = sessionUser.dia_ban_id ? String(sessionUser.dia_ban_id) : ''
-  const khoaPhong = sessionUser.khoa_phong ? String(sessionUser.khoa_phong) : ''
-  const userId = sessionUser.id ? String(sessionUser.id) : ''
-  // Normalize to expected app roles used by SQL. Always lowercase; treat 'admin' as 'global'.
-  const appRole = roleLower === 'admin' ? 'global' : roleLower
+  const donVi = sessionUser.don_vi != null ? String(sessionUser.don_vi) : ''
+  const diaBan = sessionUser.dia_ban_id != null ? String(sessionUser.dia_ban_id) : ''
+  const khoaPhong = sessionUser.khoa_phong != null ? String(sessionUser.khoa_phong) : ''
+  const userId = sessionUser.id != null ? String(sessionUser.id) : ''
+  const appRole = toAppRoleClaim(role)
   // (debug removed)
 
     // Sanitize tenant parameter for non-global users to enforce isolation

--- a/src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts
@@ -101,4 +101,58 @@ describe('RPC proxy JWT signing', () => {
     // exp should be 2 minutes from actual signing time, not from backdated iat
     expect(claims.exp).toBe(now + 120)
   })
+
+  it('rejects sessions without an app role before signing a Supabase JWT', async () => {
+    getServerSessionMock.mockResolvedValue({
+      user: {
+        id: '31',
+        role: '',
+        don_vi: 17,
+      },
+    })
+
+    const res = await POST(buildRequest({ query: 'SpO2' }) as never, {
+      params: Promise.resolve({ fn: 'ai_equipment_lookup' }),
+    })
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({
+      error: 'Cannot mint Supabase RPC JWT without app_role',
+    })
+    expect(jwtSignMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('preserves explicit zero-valued session claims when proxying RPC requests', async () => {
+    getServerSessionMock.mockResolvedValue({
+      user: {
+        id: 0,
+        role: 'to_qltb',
+        don_vi: 0,
+        dia_ban_id: 0,
+        khoa_phong: 0,
+      },
+    })
+
+    const res = await POST(buildRequest({ p_don_vi: 999, p_dia_ban: 888 }) as never, {
+      params: Promise.resolve({ fn: 'ai_equipment_lookup' }),
+    })
+
+    expect(res.status).toBe(200)
+
+    const [claims] = jwtSignMock.mock.calls[0] as [Record<string, unknown>]
+    expect(claims).toMatchObject({
+      sub: '0',
+      user_id: '0',
+      don_vi: '0',
+      dia_ban: '0',
+      khoa_phong: '0',
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      p_don_vi: 0,
+      p_dia_ban: 0,
+    })
+  })
 })

--- a/src/auth/__tests__/auth-config.jwt-rpc.test.ts
+++ b/src/auth/__tests__/auth-config.jwt-rpc.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import jwt from "jsonwebtoken"
 
+vi.mock("server-only", () => ({}))
+
 type RpcProfileRow = {
   password_changed_at: string | null
   current_don_vi: number | null

--- a/src/auth/__tests__/server-claims.test.ts
+++ b/src/auth/__tests__/server-claims.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("server-only", () => ({}))
+
+import {
+  buildSessionProfileJwtClaims,
+  buildSupabaseRpcJwtClaims,
+  toAppRoleClaim,
+  toNullableJwtClaim,
+  toRequiredUserIdClaim,
+} from "../server-claims"
+
+describe("server auth claims", () => {
+  it("normalizes app roles for Postgres app_role claims", () => {
+    expect(toAppRoleClaim("admin")).toBe("global")
+    expect(toAppRoleClaim(" ADMIN ")).toBe("global")
+    expect(toAppRoleClaim("GLOBAL")).toBe("global")
+    expect(toAppRoleClaim(" To_Qltb ")).toBe("to_qltb")
+  })
+
+  it("rejects missing required user id claims", () => {
+    expect(() => toRequiredUserIdClaim(undefined)).toThrow(
+      "Cannot mint Supabase RPC JWT without user id",
+    )
+    expect(() => toRequiredUserIdClaim("")).toThrow(
+      "Cannot mint Supabase RPC JWT without user id",
+    )
+  })
+
+  it("maps optional JWT claims to strings or null", () => {
+    expect(toNullableJwtClaim(17)).toBe("17")
+    expect(toNullableJwtClaim(" ICU ")).toBe("ICU")
+    expect(toNullableJwtClaim(null)).toBeNull()
+    expect(toNullableJwtClaim("")).toBeNull()
+  })
+
+  it("builds session profile refresh claims with normalized app role", () => {
+    expect(
+      buildSessionProfileJwtClaims({
+        userId: "42",
+        role: "admin",
+        issuedAt: 100,
+        expiresAt: 220,
+      }),
+    ).toEqual({
+      role: "authenticated",
+      iat: 100,
+      exp: 220,
+      sub: "42",
+      user_id: "42",
+      app_role: "global",
+    })
+  })
+
+  it("builds Supabase RPC JWT claims with the Postgres claim names", () => {
+    expect(
+      buildSupabaseRpcJwtClaims({
+        user: {
+          id: "31",
+          role: "to_qltb",
+          don_vi: 17,
+          dia_ban_id: 10,
+          khoa_phong: undefined,
+        },
+        issuedAt: 100,
+        expiresAt: 220,
+      }),
+    ).toEqual({
+      role: "authenticated",
+      iat: 100,
+      exp: 220,
+      sub: "31",
+      app_role: "to_qltb",
+      don_vi: "17",
+      user_id: "31",
+      dia_ban: "10",
+      khoa_phong: null,
+    })
+  })
+
+  it("rejects missing role before building RPC JWT claims", () => {
+    expect(() =>
+      buildSupabaseRpcJwtClaims({
+        user: { id: "31", role: "" },
+        issuedAt: 100,
+        expiresAt: 220,
+      }),
+    ).toThrow("Cannot mint Supabase RPC JWT without app_role")
+  })
+})

--- a/src/auth/next-auth-callbacks.ts
+++ b/src/auth/next-auth-callbacks.ts
@@ -14,7 +14,6 @@ import {
   AuthRefreshConfigError,
   buildSessionProfileJwt,
   firstProfileRow,
-  normalizeSessionProfileAppRole,
   PROFILE_REFRESH_INTERVAL_MS,
   requireRefreshEnv,
 } from "./session-profile-refresh"
@@ -25,6 +24,7 @@ import {
   readRuntimeRequestContext,
 } from "./request-context"
 
+/** NextAuth callbacks that keep JWT/session fields synchronized with profile state. */
 export const authCallbacks: NonNullable<NextAuthOptions["callbacks"]> = {
   async jwt({ token, user, trigger, session }) {
     const now = Date.now()
@@ -112,12 +112,7 @@ export const authCallbacks: NonNullable<NextAuthOptions["callbacks"]> = {
     try {
       const supabaseUrl = requireRefreshEnv("NEXT_PUBLIC_SUPABASE_URL")
       const anonKey = requireRefreshEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY")
-      const appRole = normalizeSessionProfileAppRole(token.role)
-      if (!appRole) {
-        throw new AuthRefreshConfigError("JWT app_role is not configured")
-      }
-
-      const sessionProfileJwt = buildSessionProfileJwt(userId, appRole)
+      const sessionProfileJwt = buildSessionProfileJwt(userId, token.role)
       token.lastRefreshAttemptAt = now
       const supabase = createClient(supabaseUrl, anonKey, {
         global: {

--- a/src/auth/server-claims.ts
+++ b/src/auth/server-claims.ts
@@ -1,0 +1,116 @@
+import "server-only"
+
+export type SupabaseRpcUser = {
+  id?: unknown
+  role?: unknown
+  don_vi?: unknown
+  dia_ban_id?: unknown
+  khoa_phong?: unknown
+}
+
+type AuthJwtClaimValue = string | number | null
+
+type TimeBoundClaimInput = {
+  issuedAt: number
+  expiresAt: number
+}
+
+type SessionProfileJwtClaimInput = TimeBoundClaimInput & {
+  userId: unknown
+  role: unknown
+}
+
+type SupabaseRpcJwtClaimInput = TimeBoundClaimInput & {
+  user: SupabaseRpcUser
+}
+
+function toStringClaim(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim()
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value)
+  }
+
+  return ""
+}
+
+/** Converts optional session values to nullable string JWT claims. */
+export function toNullableJwtClaim(value: unknown): string | null {
+  const stringValue = toStringClaim(value)
+  return stringValue ? stringValue : null
+}
+
+/** Normalizes application roles into the Postgres app_role claim. */
+export function toAppRoleClaim(role: unknown): string {
+  const roleValue = toStringClaim(role).toLowerCase()
+  return roleValue === "admin" ? "global" : roleValue
+}
+
+/** Returns a required user_id claim or fails closed before JWT signing. */
+export function toRequiredUserIdClaim(
+  userId: unknown,
+  message = "Cannot mint Supabase RPC JWT without user id",
+): string {
+  const userIdClaim = toStringClaim(userId)
+  if (!userIdClaim) {
+    throw new Error(message)
+  }
+
+  return userIdClaim
+}
+
+function toRequiredAppRoleClaim(
+  role: unknown,
+  message = "Cannot mint Supabase RPC JWT without app_role",
+): string {
+  const appRole = toAppRoleClaim(role)
+  if (!appRole) {
+    throw new Error(message)
+  }
+
+  return appRole
+}
+
+/** Builds the minimal JWT claims used to refresh a NextAuth session profile. */
+export function buildSessionProfileJwtClaims({
+  userId,
+  role,
+  issuedAt,
+  expiresAt,
+}: SessionProfileJwtClaimInput): Record<string, AuthJwtClaimValue> {
+  const userIdClaim = toRequiredUserIdClaim(userId, "JWT user_id is not configured")
+  const appRole = toRequiredAppRoleClaim(role, "JWT app_role is not configured")
+
+  return {
+    role: "authenticated",
+    iat: issuedAt,
+    exp: expiresAt,
+    sub: userIdClaim,
+    user_id: userIdClaim,
+    app_role: appRole,
+  }
+}
+
+/** Builds Supabase PostgREST RPC JWT claims from a trusted server session user. */
+export function buildSupabaseRpcJwtClaims({
+  user,
+  issuedAt,
+  expiresAt,
+}: SupabaseRpcJwtClaimInput): Record<string, AuthJwtClaimValue> {
+  const userId = toRequiredUserIdClaim(user.id)
+  const appRole = toRequiredAppRoleClaim(user.role)
+
+  return {
+    role: "authenticated",
+    iat: issuedAt,
+    exp: expiresAt,
+    sub: userId,
+    app_role: appRole,
+    don_vi: toNullableJwtClaim(user.don_vi),
+    user_id: userId,
+    dia_ban: toNullableJwtClaim(user.dia_ban_id),
+    khoa_phong: toNullableJwtClaim(user.khoa_phong),
+  }
+}

--- a/src/auth/session-profile-refresh.ts
+++ b/src/auth/session-profile-refresh.ts
@@ -1,11 +1,14 @@
 import jwt from "jsonwebtoken"
 
+import { buildSessionProfileJwtClaims } from "./server-claims"
 import type { AuthProfileRow } from "./types"
 
 const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
 
+/** Minimum time between automatic session profile refresh attempts. */
 export const PROFILE_REFRESH_INTERVAL_MS = 60_000
 
+/** Raised when session profile refresh cannot be configured safely. */
 export class AuthRefreshConfigError extends Error {
   constructor(message: string) {
     super(message)
@@ -13,6 +16,7 @@ export class AuthRefreshConfigError extends Error {
   }
 }
 
+/** Reads a required environment variable for session profile refresh. */
 export function requireRefreshEnv(
   name: "NEXT_PUBLIC_SUPABASE_URL" | "NEXT_PUBLIC_SUPABASE_ANON_KEY" | "SUPABASE_JWT_SECRET"
 ): string {
@@ -24,32 +28,34 @@ export function requireRefreshEnv(
   return value
 }
 
-export function normalizeSessionProfileAppRole(role: unknown): string {
-  if (typeof role !== "string") {
-    return ""
-  }
-
-  const normalizedRole = role.trim().toLowerCase()
-  return normalizedRole === "admin" ? "global" : normalizedRole
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "JWT app_role is not configured"
 }
 
-export function buildSessionProfileJwt(userId: string, appRole: string): string {
+/** Signs a short-lived JWT for the session profile refresh RPC. */
+export function buildSessionProfileJwt(userId: string, role: unknown): string {
   const secret = requireRefreshEnv("SUPABASE_JWT_SECRET")
   const now = Math.floor(Date.now() / 1000)
+  let claims: Record<string, string | number | null>
+  try {
+    claims = buildSessionProfileJwtClaims({
+      userId,
+      role,
+      issuedAt: now - SUPABASE_JWT_CLOCK_SKEW_SECONDS,
+      expiresAt: now + 120,
+    })
+  } catch (error: unknown) {
+    throw new AuthRefreshConfigError(getErrorMessage(error))
+  }
+
   return jwt.sign(
-    {
-      role: "authenticated",
-      iat: now - SUPABASE_JWT_CLOCK_SKEW_SECONDS,
-      exp: now + 120,
-      sub: userId,
-      user_id: userId,
-      app_role: appRole,
-    },
+    claims,
     secret,
     { algorithm: "HS256" }
   )
 }
 
+/** Extracts the first profile row returned by the profile refresh RPC. */
 export function firstProfileRow(data: unknown): AuthProfileRow | null {
   if (Array.isArray(data)) {
     return (data[0] as AuthProfileRow | undefined) ?? null

--- a/src/lib/ai/__tests__/server-rpc.test.ts
+++ b/src/lib/ai/__tests__/server-rpc.test.ts
@@ -81,6 +81,13 @@ describe('AI server RPC helper', () => {
     expect(jwtSignMock).not.toHaveBeenCalled()
   })
 
+  it('rejects missing role before minting a Supabase JWT', () => {
+    expect(() => mintSupabaseJwt({ id: '31', role: '' })).toThrow(
+      'Cannot mint Supabase RPC JWT without app_role',
+    )
+    expect(jwtSignMock).not.toHaveBeenCalled()
+  })
+
   it('calls Supabase PostgREST RPC with the minted JWT and anon API key', async () => {
     await expect(
       callServerRpc('ai_quota_reserve', { p_user_id: 'u1' }, {

--- a/src/lib/ai/server-rpc.ts
+++ b/src/lib/ai/server-rpc.ts
@@ -2,15 +2,14 @@ import 'server-only'
 
 import jwt from 'jsonwebtoken'
 
-const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
+import {
+  buildSupabaseRpcJwtClaims,
+  type SupabaseRpcUser,
+} from '@/auth/server-claims'
 
-export type SupabaseRpcUser = {
-  id?: unknown
-  role?: unknown
-  don_vi?: unknown
-  dia_ban_id?: unknown
-  khoa_phong?: unknown
-}
+export type { SupabaseRpcUser } from '@/auth/server-claims'
+
+const SUPABASE_JWT_CLOCK_SKEW_SECONDS = 60
 
 function getRequiredEnv(name: string): string {
   const value = process.env[name]
@@ -20,47 +19,12 @@ function getRequiredEnv(name: string): string {
   return value
 }
 
-function stringifyClaim(value: unknown): string {
-  if (typeof value === 'string') {
-    return value
-  }
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return String(value)
-  }
-  return ''
-}
-
-function nullableStringClaim(value: unknown): string | null {
-  const stringValue = stringifyClaim(value)
-  return stringValue ? stringValue : null
-}
-
-function normalizeAppRole(role: unknown): string {
-  const roleValue = stringifyClaim(role).toLowerCase()
-  return roleValue === 'admin' ? 'global' : roleValue
-}
-
 /** Mints a short-lived Supabase-compatible JWT from trusted server-side user claims. */
 export function mintSupabaseJwt(user: SupabaseRpcUser): string {
-  const userId = stringifyClaim(user.id)
-  if (!userId) {
-    throw new Error('Cannot mint Supabase RPC JWT without user id')
-  }
-
   const now = Math.floor(Date.now() / 1000)
   const issuedAt = now - SUPABASE_JWT_CLOCK_SKEW_SECONDS
   const expiresAt = now + 120
-  const claims: Record<string, string | number | null> = {
-    role: 'authenticated',
-    iat: issuedAt,
-    exp: expiresAt,
-    sub: userId,
-    app_role: normalizeAppRole(user.role),
-    don_vi: nullableStringClaim(user.don_vi),
-    user_id: userId,
-    dia_ban: nullableStringClaim(user.dia_ban_id),
-    khoa_phong: nullableStringClaim(user.khoa_phong),
-  }
+  const claims = buildSupabaseRpcJwtClaims({ user, issuedAt, expiresAt })
 
   return jwt.sign(claims, getRequiredEnv('SUPABASE_JWT_SECRET'), {
     algorithm: 'HS256',


### PR DESCRIPTION
## Summary
- Centralize server-side auth claim normalization and Supabase RPC JWT claim construction in `src/auth/server-claims.ts`
- Reuse the shared helper from session profile refresh, AI server RPC JWT minting, and the `/api/rpc/[fn]` proxy
- Fail closed before JWT signing when required `user_id` or `app_role` claims are missing

Closes #542

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/auth/__tests__/server-claims.test.ts src/lib/ai/__tests__/server-rpc.test.ts src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts src/auth/__tests__/auth-config.jwt-rpc.test.ts`
- `node scripts/npm-run.js run react-doctor`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized server-side auth claim normalization and JWT claim building in `src/auth/server-claims.ts`, and now fail closed when required claims are missing. This makes RPC and session flows consistent and closes #542.

- **Refactors**
  - Added shared helpers: `toAppRoleClaim`, `toNullableJwtClaim`, `toRequiredUserIdClaim`, `buildSessionProfileJwtClaims`, `buildSupabaseRpcJwtClaims`.
  - Reused helpers in session profile refresh JWT signing, AI server RPC JWT minting, and the `/api/rpc/[fn]` proxy.
  - Removed duplicate normalization logic and simplified NextAuth callbacks and `server-rpc`.

- **Bug Fixes**
  - Reject missing `app_role` or `user_id` before signing or making RPC calls.
  - Normalize roles consistently (trim, lowercase, map 'admin' → 'global').
  - Ensure JWT `exp` is 2 minutes from signing time (independent of backdated `iat`).
  - Preserve explicit zero-valued claims (0) in JWTs and proxied RPC payloads.

<sup>Written for commit f9288661daee5df9eb966c175b13c875f81728b8. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/576?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated JWT claim-building logic for improved maintainability and consistency across authentication flows.

* **Tests**
  * Added comprehensive unit tests for JWT claim normalization and RPC authentication validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->