### PR TITLE
fix: add same-origin guard to RPC proxy

### DIFF
--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -7,6 +7,10 @@ import { toAppRoleClaim } from '@/auth/server-claims'
 import { ALLOWED_FUNCTIONS } from './allowed-functions'
 import { sanitizeForLog } from '@/lib/log-sanitizer'
 import { mintSupabaseJwt } from '@/lib/ai/server-rpc'
+import {
+  SameOriginRequestError,
+  assertSameOriginRequest,
+} from '@/lib/same-origin-request'
 
 // SECURITY: Maximum request body size (2MB) to prevent DoS via memory exhaustion
 const MAX_BODY_SIZE = 2 * 1024 * 1024
@@ -47,6 +51,15 @@ function getErrorMessage(error: unknown): string {
 export async function POST(req: NextRequest, context: { params: Promise<{ fn: string }> }) {
   try {
     const { fn } = await context.params
+    try {
+      assertSameOriginRequest(req)
+    } catch (err: unknown) {
+      if (err instanceof SameOriginRequestError) {
+        return NextResponse.json({ error: err.message }, { status: err.status })
+      }
+      throw err
+    }
+
     if (!ALLOWED_FUNCTIONS.has(fn)) {
       return NextResponse.json({ error: 'Function not allowed' }, { status: 403 })
     }

--- a/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+const getServerSessionMock = vi.fn()
+const jwtSignMock = vi.fn()
+const fetchMock = vi.fn()
+
+vi.mock('next-auth', () => ({
+  getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
+}))
+
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    sign: (...args: unknown[]) => jwtSignMock(...args),
+  },
+}))
+
+import { POST } from '../[fn]/route'
+
+function buildRequest(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  const encodedBody = JSON.stringify(body)
+  return new Request('https://app.example.com/api/rpc/ai_equipment_lookup', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'content-length': String(Buffer.byteLength(encodedBody)),
+      host: 'app.example.com',
+      ...headers,
+    },
+    body: encodedBody,
+  })
+}
+
+describe('RPC proxy same-origin guard', () => {
+  beforeEach(() => {
+    vi.stubEnv('SUPABASE_JWT_SECRET', 'test-secret')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'test-anon-key')
+
+    getServerSessionMock.mockReset()
+    jwtSignMock.mockReset()
+    fetchMock.mockReset()
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    getServerSessionMock.mockResolvedValue({
+      user: {
+        id: '31',
+        role: 'to_qltb',
+        don_vi: 17,
+        dia_ban_id: 10,
+        khoa_phong: 'ICU',
+      },
+    })
+
+    jwtSignMock.mockReturnValue('signed-jwt')
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('rejects cross-origin POSTs before session or RPC forwarding', async () => {
+    const res = await POST(
+      buildRequest(
+        { query: 'SpO2' },
+        {
+          origin: 'https://evil.example.com',
+        },
+      ) as never,
+      { params: Promise.resolve({ fn: 'ai_equipment_lookup' }) },
+    )
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({
+      error: 'Cross-origin request rejected',
+    })
+    expect(getServerSessionMock).not.toHaveBeenCalled()
+    expect(jwtSignMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('allows missing-origin POSTs through the existing RPC flow', async () => {
+    const res = await POST(buildRequest({ query: 'SpO2' }) as never, {
+      params: Promise.resolve({ fn: 'ai_equipment_lookup' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(getServerSessionMock).toHaveBeenCalledOnce()
+    expect(jwtSignMock).toHaveBeenCalledOnce()
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('allows same-origin POSTs through the existing RPC flow', async () => {
+    const res = await POST(
+      buildRequest(
+        { query: 'SpO2' },
+        {
+          origin: 'https://app.example.com',
+        },
+      ) as never,
+      { params: Promise.resolve({ fn: 'ai_equipment_lookup' }) },
+    )
+
+    expect(res.status).toBe(200)
+    expect(getServerSessionMock).toHaveBeenCalledOnce()
+    expect(jwtSignMock).toHaveBeenCalledOnce()
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+})

--- a/src/lib/__tests__/same-origin-request.test.ts
+++ b/src/lib/__tests__/same-origin-request.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  SameOriginRequestError,
+  assertSameOriginRequest,
+} from '../same-origin-request'
+
+function buildRequest(headers: HeadersInit, url = 'https://app.example.com/api/rpc/test') {
+  return new Request(url, {
+    method: 'POST',
+    headers,
+  })
+}
+
+describe('assertSameOriginRequest', () => {
+  it('allows same-origin requests', () => {
+    const req = buildRequest({
+      origin: 'https://app.example.com',
+      host: 'app.example.com',
+    })
+
+    expect(() => assertSameOriginRequest(req)).not.toThrow()
+  })
+
+  it('allows missing origin requests for legacy callers and route tests', () => {
+    const req = buildRequest({
+      host: 'app.example.com',
+    })
+
+    expect(() => assertSameOriginRequest(req)).not.toThrow()
+  })
+
+  it('allows default port canonical matches', () => {
+    const req = buildRequest(
+      {
+        origin: 'https://app.example.com',
+        host: 'app.example.com:443',
+      },
+      'https://app.example.com:443/api/rpc/test',
+    )
+
+    expect(() => assertSameOriginRequest(req)).not.toThrow()
+  })
+
+  it('rejects cross-origin requests with spoofed forwarded headers', () => {
+    const req = buildRequest({
+      origin: 'https://evil.example.com',
+      host: 'app.example.com',
+      'x-forwarded-host': 'evil.example.com',
+      'x-forwarded-proto': 'https',
+    })
+
+    expect(() => assertSameOriginRequest(req)).toThrow(SameOriginRequestError)
+  })
+
+  it('rejects cross-origin requests', () => {
+    const req = buildRequest({
+      origin: 'https://evil.example.com',
+      host: 'app.example.com',
+    })
+
+    expect(() => assertSameOriginRequest(req)).toThrow(SameOriginRequestError)
+  })
+
+  it('rejects invalid origin headers', () => {
+    const req = buildRequest({
+      origin: 'not a valid origin',
+      host: 'app.example.com',
+    })
+
+    expect(() => assertSameOriginRequest(req)).toThrow(SameOriginRequestError)
+  })
+
+  it('ignores spoofed host headers when request URL origin matches', () => {
+    const req = buildRequest({
+      origin: 'https://app.example.com',
+      host: 'evil.example.com',
+    })
+
+    expect(() => assertSameOriginRequest(req)).not.toThrow()
+  })
+})

--- a/src/lib/same-origin-request.ts
+++ b/src/lib/same-origin-request.ts
@@ -1,0 +1,47 @@
+const SAME_ORIGIN_ERROR_MESSAGE = 'Cross-origin request rejected'
+
+/** Error raised when a state-changing route receives a non-same-origin request. */
+export class SameOriginRequestError extends Error {
+  readonly status = 403
+
+  constructor() {
+    super(SAME_ORIGIN_ERROR_MESSAGE)
+    this.name = 'SameOriginRequestError'
+  }
+}
+
+function readRequestOrigin(req: Request): URL {
+  try {
+    return new URL(req.url)
+  } catch {
+    throw new SameOriginRequestError()
+  }
+}
+
+function parseOrigin(value: string): URL {
+  try {
+    return new URL(value)
+  } catch {
+    throw new SameOriginRequestError()
+  }
+}
+
+function sameOrigin(a: URL, b: URL): boolean {
+  return a.origin.toLowerCase() === b.origin.toLowerCase()
+}
+
+/** Rejects cross-origin browser POSTs while preserving legacy requests without Origin. */
+export function assertSameOriginRequest(req: Request): void {
+  const originHeader = req.headers.get('origin')
+  // Some legacy clients and unit tests do not send Origin. Browsers send it for cross-origin POSTs.
+  if (!originHeader) {
+    return
+  }
+
+  const origin = parseOrigin(originHeader)
+  const requestOrigin = readRequestOrigin(req)
+
+  if (!sameOrigin(origin, requestOrigin)) {
+    throw new SameOriginRequestError()
+  }
+}


### PR DESCRIPTION
## Summary
- Add reusable same-origin request guard for cookie-authenticated route handlers
- Apply guard to the RPC proxy before body/session/JWT/Supabase forwarding
- Add focused helper and RPC route tests for same-origin, cross-origin, missing Origin, forwarded host/proto, and malformed headers

Closes #543

## Verification
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/lib/__tests__/same-origin-request.test.ts src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts src/app/api/rpc/__tests__/rpc-jwt-skew.unit.test.ts
- node scripts/npm-run.js run react-doctor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a same-origin guard to the RPC proxy to block cross-origin POSTs before any auth or forwarding. Prevents CSRF on cookie-authenticated endpoints with a 403 JSON error response and closes #543.

- **Bug Fixes**
  - Introduced `assertSameOriginRequest` and `SameOriginRequestError`; compares the Origin header to the request URL origin and allows missing Origin for legacy callers.
  - Applied the guard in `src/app/api/rpc/[fn]/route.ts` with early JSON error return on `SameOriginRequestError`.
  - Added unit tests for same-origin, cross-origin, missing Origin, default-port canonical matches, and spoofed `X-Forwarded-*`/Host headers.

<sup>Written for commit d7b54928d220bf4439dba45d79d815523df0cda1. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/577?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented origin validation for API requests to prevent unauthorized cross-origin access to the RPC endpoint, strengthening security and protecting against potential attacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->