### PR TITLE
Fix Issue 578 React Doctor state/effect findings

### DIFF
--- a/src/__tests__/react-doctor-issue-578-state-effects.source.test.ts
+++ b/src/__tests__/react-doctor-issue-578-state-effects.source.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const repoRoot = process.cwd()
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), "utf8")
+}
+
+describe("React Doctor Issue #578 state/effect source guards", () => {
+  it.each([
+    "src/components/transfers/ReturnLocationDialog.tsx",
+    "src/app/(app)/transfers/_components/useTransfersRowActions.tsx",
+    "src/app/(app)/equipment/_components/EquipmentBulkDeleteBar.tsx",
+  ])("does not use effects to reset dialog state in %s", (relativePath) => {
+    expect(readSource(relativePath)).not.toContain("React.useEffect")
+  })
+
+  it("keeps TransfersKanbanView mobile status valid without effect-driven reset", () => {
+    const source = readSource("src/components/transfers/TransfersKanbanView.tsx")
+
+    expect(source).not.toContain("setMobileSelectedStatus(allColumns[0])")
+    expect(source).not.toContain("[allColumns, mobileSelectedStatus]")
+  })
+
+  it("builds return location suggestions in one pass", () => {
+    const source = readSource("src/components/transfers/ReturnLocationDialog.tsx")
+
+    expect(source).not.toMatch(/\.map\([\s\S]*?\.filter\([\s\S]*?\.filter\(/)
+  })
+})

--- a/src/app/(app)/equipment/_components/EquipmentBulkDeleteBar.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentBulkDeleteBar.tsx
@@ -26,12 +26,12 @@ interface EquipmentBulkDeleteBarProps {
   isCardView: boolean
 }
 
+/** Renders the floating bulk-delete action for selected equipment rows. */
 export function EquipmentBulkDeleteBar({
   table,
   canBulkSelect,
   isCardView,
-}: EquipmentBulkDeleteBarProps) {
-  const [isConfirmOpen, setIsConfirmOpen] = React.useState(false)
+}: EquipmentBulkDeleteBarProps): React.ReactElement | null {
   const { mutate: bulkDelete, isPending: isDeleting } = useBulkDeleteEquipment()
 
   const selectedRows = table.getFilteredSelectedRowModel().rows
@@ -49,12 +49,6 @@ export function EquipmentBulkDeleteBar({
   }, [selectedRows])
   const selectedCount = selectedIds.length
 
-  React.useEffect(() => {
-    if (selectedCount === 0 && isConfirmOpen) {
-      setIsConfirmOpen(false)
-    }
-  }, [selectedCount, isConfirmOpen])
-
   const handleConfirmDelete = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.preventDefault()
@@ -63,7 +57,6 @@ export function EquipmentBulkDeleteBar({
 
       bulkDelete(selectedIds, {
         onSuccess: () => {
-          setIsConfirmOpen(false)
           table.resetRowSelection()
         },
       })
@@ -87,7 +80,7 @@ export function EquipmentBulkDeleteBar({
           entityLabel="thiết bị"
           className="border-border bg-card shadow-lg"
         >
-          <AlertDialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+          <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button type="button" size="sm" variant="destructive" disabled={isDeleting}>
                 {EQUIPMENT_BULK_DELETE_LABEL}
@@ -104,7 +97,6 @@ export function EquipmentBulkDeleteBar({
                 <AlertDialogCancel
                   onClick={(event) => {
                     event.stopPropagation()
-                    setIsConfirmOpen(false)
                   }}
                 >
                   Hủy

--- a/src/app/(app)/transfers/_components/useTransfersRowActions.tsx
+++ b/src/app/(app)/transfers/_components/useTransfersRowActions.tsx
@@ -56,6 +56,12 @@ export interface UseTransfersRowActionsResult {
   renderRowActions: (item: TransferListItem) => React.ReactNode
 }
 
+type ReturnLocationDialogState = Readonly<{
+  open: boolean
+  transfer: TransferListItem | null
+}>
+
+/** Coordinates transfer row action handlers and their supporting dialog state. */
 export function useTransfersRowActions({
   approveTransfer,
   startTransfer,
@@ -77,8 +83,8 @@ export function useTransfersRowActions({
   const [detailTransfer, setDetailTransfer] = React.useState<TransferRequest | null>(null)
   const [isHandoverDialogOpen, setIsHandoverDialogOpen] = React.useState(false)
   const [handoverTransfer, setHandoverTransfer] = React.useState<TransferRequest | null>(null)
-  const [isReturnLocationDialogOpen, setIsReturnLocationDialogOpen] = React.useState(false)
-  const [returnTransfer, setReturnTransfer] = React.useState<TransferListItem | null>(null)
+  const [returnLocationDialog, setReturnLocationDialog] =
+    React.useState<ReturnLocationDialogState>({ open: false, transfer: null })
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false)
   const [deletingTransfer, setDeletingTransfer] = React.useState<TransferListItem | null>(null)
 
@@ -109,31 +115,34 @@ export function useTransfersRowActions({
   }, [])
 
   const handleOpenReturnDialog = React.useCallback((item: TransferListItem) => {
-    setReturnTransfer(item)
-    setIsReturnLocationDialogOpen(true)
+    setReturnLocationDialog({ open: true, transfer: item })
   }, [])
+
+  const setIsReturnLocationDialogOpen = React.useCallback(
+    (openOrUpdater: React.SetStateAction<boolean>) => {
+      setReturnLocationDialog((current) => {
+        const nextOpen =
+          typeof openOrUpdater === "function" ? openOrUpdater(current.open) : openOrUpdater
+
+        return nextOpen ? { ...current, open: true } : { open: false, transfer: null }
+      })
+    },
+    [],
+  )
 
   const handleConfirmReturn = React.useCallback(
     async (viTriHoanTra: string) => {
-      if (!returnTransfer) return
+      if (!returnLocationDialog.transfer) return
 
       try {
-        await returnFromExternal(returnTransfer, viTriHoanTra)
-        setReturnTransfer(null)
-        setIsReturnLocationDialogOpen(false)
+        await returnFromExternal(returnLocationDialog.transfer, viTriHoanTra)
+        setReturnLocationDialog({ open: false, transfer: null })
       } catch {
         // Mutation onError already surfaces the failure; keep the dialog open.
       }
     },
-    [returnFromExternal, returnTransfer],
+    [returnFromExternal, returnLocationDialog.transfer],
   )
-
-  React.useEffect(() => {
-    // Reset returnTransfer when the dialog is closed via cancel or overlay click.
-    if (!isReturnLocationDialogOpen && returnTransfer) {
-      setReturnTransfer(null)
-    }
-  }, [isReturnLocationDialogOpen, returnTransfer])
 
   const handleConfirmDelete = React.useCallback(async () => {
     if (!deletingTransfer) return
@@ -217,9 +226,9 @@ export function useTransfersRowActions({
     isHandoverDialogOpen,
     setIsHandoverDialogOpen,
     handoverTransfer,
-    isReturnLocationDialogOpen,
+    isReturnLocationDialogOpen: returnLocationDialog.open,
     setIsReturnLocationDialogOpen,
-    returnTransfer,
+    returnTransfer: returnLocationDialog.transfer,
     isDeleteDialogOpen,
     setIsDeleteDialogOpen,
     deletingTransfer,

--- a/src/components/transfers/ReturnLocationDialog.tsx
+++ b/src/components/transfers/ReturnLocationDialog.tsx
@@ -47,6 +47,7 @@ function getValidationMessage(value: string): string | null {
   return null
 }
 
+/** Collects and validates the destination location before completing an external return. */
 export function ReturnLocationDialog({
   open,
   isSubmitting,
@@ -54,20 +55,31 @@ export function ReturnLocationDialog({
   transfer,
   onConfirm,
 }: ReturnLocationDialogProps) {
+  const resetKey = open ? String(transfer?.id ?? "none") : "closed"
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <ReturnLocationDialogContent
+        key={resetKey}
+        open={open}
+        isSubmitting={isSubmitting}
+        onCancel={() => onOpenChange(false)}
+        transfer={transfer}
+        onConfirm={onConfirm}
+      />
+    </Dialog>
+  )
+}
+
+function ReturnLocationDialogContent({
+  open,
+  isSubmitting,
+  onCancel,
+  transfer,
+  onConfirm,
+}: Omit<ReturnLocationDialogProps, "onOpenChange"> & { onCancel: () => void }) {
   const [location, setLocation] = React.useState("")
   const [validationMessage, setValidationMessage] = React.useState<string | null>(null)
-
-  React.useEffect(() => {
-    if (!open) {
-      setLocation("")
-      setValidationMessage(null)
-    }
-  }, [open])
-
-  React.useEffect(() => {
-    setLocation("")
-    setValidationMessage(null)
-  }, [transfer?.id])
 
   const suggestionsQuery = useQuery({
     queryKey: ["equipment-location-suggestions", transfer?.id],
@@ -82,16 +94,20 @@ export function ReturnLocationDialog({
 
   const suggestions = React.useMemo(() => {
     const seen = new Set<string>()
+    const nextSuggestions: string[] = []
 
-    return (suggestionsQuery.data ?? [])
-      .map((item) => normalizeLocationValue(item.vi_tri ?? ""))
-      .filter((item) => item.length > 0)
-      .filter((item) => {
-        const key = item.toLocaleLowerCase("vi-VN")
-        if (seen.has(key)) return false
-        seen.add(key)
-        return true
-      })
+    for (const item of suggestionsQuery.data ?? []) {
+      const suggestion = normalizeLocationValue(item.vi_tri ?? "")
+      if (suggestion.length === 0) continue
+
+      const key = suggestion.toLocaleLowerCase("vi-VN")
+      if (seen.has(key)) continue
+
+      seen.add(key)
+      nextSuggestions.push(suggestion)
+    }
+
+    return nextSuggestions
   }, [suggestionsQuery.data])
 
   const handleLocationChange = React.useCallback(
@@ -129,7 +145,6 @@ export function ReturnLocationDialog({
   }, [location, onConfirm])
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Xác nhận vị trí hoàn trả</DialogTitle>
@@ -189,7 +204,7 @@ export function ReturnLocationDialog({
             type="button"
             variant="outline"
             disabled={isSubmitting}
-            onClick={() => onOpenChange(false)}
+            onClick={onCancel}
           >
             Hủy
           </Button>
@@ -198,6 +213,5 @@ export function ReturnLocationDialog({
           </Button>
         </DialogFooter>
       </DialogContent>
-    </Dialog>
   )
 }

--- a/src/components/transfers/TransfersKanbanView.tsx
+++ b/src/components/transfers/TransfersKanbanView.tsx
@@ -144,11 +144,17 @@ function TransfersKanbanBoard({
   }, [])
 
   const columns = data?.columns || {}
-  const activeColumns: TransferStatus[] = ACTIVE_TRANSFER_STATUSES
-  const allColumns = showCompleted
-    ? ([...activeColumns, 'hoan_thanh'] as TransferStatus[])
-    : activeColumns
-  const currentMobileIndex = allColumns.indexOf(mobileSelectedStatus)
+  const allColumns = React.useMemo<TransferStatus[]>(
+    () =>
+      showCompleted
+        ? ([...ACTIVE_TRANSFER_STATUSES, 'hoan_thanh'] as TransferStatus[])
+        : [...ACTIVE_TRANSFER_STATUSES],
+    [showCompleted],
+  )
+  const visibleMobileStatus = allColumns.includes(mobileSelectedStatus)
+    ? mobileSelectedStatus
+    : allColumns[0]
+  const currentMobileIndex = allColumns.indexOf(visibleMobileStatus)
   const canGoPrev = currentMobileIndex > 0
   const canGoNext = currentMobileIndex < allColumns.length - 1
 
@@ -163,12 +169,6 @@ function TransfersKanbanBoard({
       setMobileSelectedStatus(allColumns[currentMobileIndex + 1])
     }
   }, [canGoNext, allColumns, currentMobileIndex])
-
-  React.useEffect(() => {
-    if (!allColumns.includes(mobileSelectedStatus)) {
-      setMobileSelectedStatus(allColumns[0])
-    }
-  }, [allColumns, mobileSelectedStatus])
 
   if (isLoading) {
     return (
@@ -187,7 +187,7 @@ function TransfersKanbanBoard({
         <Button
           variant="outline"
           size="sm"
-          onClick={() => setShowCompleted(!showCompleted)}
+          onClick={() => setShowCompleted((current) => !current)}
         >
           {showCompleted ? 'Ẩn' : 'Hiện'} hoàn thành
         </Button>
@@ -198,7 +198,7 @@ function TransfersKanbanBoard({
           {allColumns.map((status) => {
             const columnData = columns[status] ?? { tasks: [], total: 0 }
             const count = columnData.total || 0
-            const isActive = status === mobileSelectedStatus
+            const isActive = status === visibleMobileStatus
 
             return (
               <button
@@ -260,11 +260,11 @@ function TransfersKanbanBoard({
 
           <div className="min-h-[calc(100vh-380px)]">
             {(() => {
-              const columnData = columns[mobileSelectedStatus] ?? { tasks: [], total: 0, hasMore: false }
+              const columnData = columns[visibleMobileStatus] ?? { tasks: [], total: 0, hasMore: false }
               return (
                 <KanbanColumnWithInfiniteScroll
-                  key={mobileSelectedStatus}
-                  status={mobileSelectedStatus}
+                  key={visibleMobileStatus}
+                  status={visibleMobileStatus}
                   filters={filters}
                   initialTasks={columnData.tasks || []}
                   initialTotal={columnData.total || 0}

--- a/src/components/transfers/__tests__/TransfersKanbanView.infinite-scroll.test.tsx
+++ b/src/components/transfers/__tests__/TransfersKanbanView.infinite-scroll.test.tsx
@@ -170,4 +170,20 @@ describe("TransfersKanbanView infinite scroll", () => {
     expect(taskCodes.filter((code) => code === "LC-PAGE-1-1")).toHaveLength(1)
     expect(taskCodes).toHaveLength(31)
   })
+
+  it("falls back to the first active mobile column when completed columns are hidden", async () => {
+    const user = userEvent.setup()
+
+    renderKanbanView()
+
+    await user.click(screen.getByRole("button", { name: "Hiện hoàn thành" }))
+    await user.click(screen.getAllByRole("button", { name: "Hoàn thành" })[0])
+
+    expect(screen.getAllByTestId("kanban-column-hoan_thanh").length).toBeGreaterThan(0)
+
+    await user.click(screen.getByRole("button", { name: "Ẩn hoàn thành" }))
+
+    expect(screen.queryAllByTestId("kanban-column-hoan_thanh")).toHaveLength(0)
+    expect(screen.getAllByTestId("kanban-column-cho_duyet").length).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
## Summary

- Refactors Issue #578 transfer/equipment state resets away from effect-driven patterns.
- Keeps return-location dialog reset behavior via keyed dialog content and combines return dialog open/transfer state in row actions.
- Derives the visible mobile kanban status when completed columns are hidden and removes controlled bulk-delete reset effects.
- Adds Issue #578 source guards and focused mobile kanban regression coverage.

## Verification

- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js test -- run src/__tests__/react-doctor-issue-578-state-effects.source.test.ts src/components/transfers/__tests__/TransfersKanbanView.infinite-scroll.test.tsx src/components/transfers/__tests__/ReturnLocationDialog.test.tsx src/app/(app)/transfers/__tests__/useTransfersRowActions.test.tsx src/app/(app)/equipment/__tests__/EquipmentBulkDeleteBar.test.tsx`
- `node scripts/npm-run.js run react-doctor` - No issues found, 100/100 diff scan.

Closes #578

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Issue #578 by removing effect-driven state resets and stabilizing dialog and mobile Kanban behavior. Improves predictability and adds tests to prevent regressions.

- **Bug Fixes**
  - Return location dialog: resets via keyed content; builds and deduplicates suggestions in one pass; simple cancel handling.
  - Transfers row actions: unify return dialog `open` + `transfer` state; auto-clear on close; keep dialog open on mutation error.
  - Mobile Kanban: derive visible status when completed columns are hidden; no effect-based reset; functional toggle updates.
  - Equipment bulk delete: remove effect-driven confirm state; rely on `AlertDialog`; clear selection on success.
  - Tests/guards: add source guards against effect-based resets; add mobile fallback test; extend infinite scroll coverage.

<sup>Written for commit 0a9c282967718458ebcccd57c76abd550f6fa5b2. Summary will update on new commits. <a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/582?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk delete confirmation dialog no longer auto-closes unexpectedly.
  * Mobile kanban column selection now stays consistent when columns change.
  * Return location suggestions are normalized and deduplicated; cancel now reliably resets dialog content.

* **Tests**
  * Added tests validating UI kanban visibility and identifying undesirable React patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->