### PR TITLE
Fix issue 580 shared dialog state effects

### DIFF
--- a/src/components/__tests__/change-password-dialog.signout.test.tsx
+++ b/src/components/__tests__/change-password-dialog.signout.test.tsx
@@ -214,6 +214,27 @@ describe("ChangePasswordDialog forced signout", () => {
     })
   })
 
+  it("clears sensitive draft fields when the parent closes the controlled dialog", () => {
+    const { rerender } = render(<ChangePasswordDialog open onOpenChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText("Mật khẩu hiện tại *"), {
+      target: { value: "old-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+    fireEvent.change(screen.getByLabelText("Xác nhận mật khẩu mới *"), {
+      target: { value: "new-password" },
+    })
+
+    rerender(<ChangePasswordDialog open={false} onOpenChange={vi.fn()} />)
+    rerender(<ChangePasswordDialog open onOpenChange={vi.fn()} />)
+
+    expect(screen.getByLabelText("Mật khẩu hiện tại *")).toHaveValue("")
+    expect(screen.getByLabelText("Mật khẩu mới *")).toHaveValue("")
+    expect(screen.getByLabelText("Xác nhận mật khẩu mới *")).toHaveValue("")
+  })
+
   it("shows a logout-specific error if post-change signout fails after the password update succeeds", async () => {
     vi.useFakeTimers()
     mocks.signOut.mockRejectedValueOnce(new Error("redirect failed"))

--- a/src/components/__tests__/user-tenant-dialog-state.test.tsx
+++ b/src/components/__tests__/user-tenant-dialog-state.test.tsx
@@ -1,0 +1,195 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { describe, expect, it, vi } from "vitest"
+
+import type { UserSummary } from "@/types/database"
+import { EditTenantDialog, type TenantRow } from "../edit-tenant-dialog"
+import { EditUserDialog } from "../edit-user-dialog"
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: vi.fn(),
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+    type,
+  }: {
+    children: React.ReactNode
+    disabled?: boolean
+    onClick?: React.MouseEventHandler<HTMLButtonElement>
+    type?: "button" | "submit" | "reset"
+  }) => (
+    <button disabled={disabled} onClick={onClick} type={type}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/input", () => ({
+  Input: ({
+    disabled,
+    id,
+    onChange,
+    placeholder,
+    type,
+    value,
+  }: {
+    disabled?: boolean
+    id: string
+    onChange?: React.ChangeEventHandler<HTMLInputElement>
+    placeholder?: string
+    type?: string
+    value?: string
+  }) => (
+    <input
+      disabled={disabled}
+      id={id}
+      onChange={onChange}
+      placeholder={placeholder}
+      type={type}
+      value={value}
+    />
+  ),
+}))
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({
+    children,
+    htmlFor,
+  }: {
+    children: React.ReactNode
+    htmlFor?: string
+  }) => <label htmlFor={htmlFor}>{children}</label>,
+}))
+
+vi.mock("@/components/ui/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    disabled,
+    id,
+    onCheckedChange,
+  }: {
+    checked?: boolean
+    disabled?: boolean
+    id?: string
+    onCheckedChange?: (checked: boolean) => void
+  }) => (
+    <input
+      checked={checked}
+      disabled={disabled}
+      id={id}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+      type="checkbox"
+    />
+  ),
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+}))
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {ui}
+    </QueryClientProvider>
+  )
+}
+
+const user: UserSummary = {
+  id: 7,
+  username: "nva",
+  full_name: "Nguyen Van A",
+  role: "user",
+  khoa_phong: "Khoa A",
+  created_at: "2026-05-28T00:00:00Z",
+}
+
+const tenant: TenantRow = {
+  id: 3,
+  code: "BV-A",
+  name: "Bệnh viện A",
+  active: true,
+  membership_quota: 10,
+  logo_url: null,
+  google_drive_folder_url: null,
+  used_count: 1,
+}
+
+describe("shared edit dialogs preserve in-progress drafts", () => {
+  it("does not overwrite an edited user draft when the same user prop refreshes", () => {
+    const { rerender } = renderWithQueryClient(
+      <EditUserDialog open onOpenChange={vi.fn()} onSuccess={vi.fn()} user={user} />
+    )
+
+    fireEvent.change(screen.getByLabelText("Tên đăng nhập *"), {
+      target: { value: "draft-username" },
+    })
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <EditUserDialog
+          open
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          user={{ ...user, full_name: "Nguyen Van A refreshed" }}
+        />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByLabelText("Tên đăng nhập *")).toHaveValue("draft-username")
+  })
+
+  it("does not overwrite an edited tenant draft when the same tenant prop refreshes", () => {
+    const { rerender } = renderWithQueryClient(
+      <EditTenantDialog open onOpenChange={vi.fn()} onSuccess={vi.fn()} tenant={tenant} />
+    )
+
+    fireEvent.change(screen.getByLabelText("Tên đơn vị *"), {
+      target: { value: "Tên đơn vị đang nhập" },
+    })
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <EditTenantDialog
+          open
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+          tenant={{ ...tenant, code: "BV-A-REFRESH" }}
+        />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByLabelText("Tên đơn vị *")).toHaveValue("Tên đơn vị đang nhập")
+  })
+})

--- a/src/components/add-tenant-dialog.tsx
+++ b/src/components/add-tenant-dialog.tsx
@@ -18,23 +18,30 @@ interface AddTenantDialogProps {
   onSuccess: () => void
 }
 
+const EMPTY_TENANT_FORM = {
+  code: "",
+  name: "",
+  active: true,
+  membership_quota: "" as string,
+  logo_url: "",
+  google_drive_folder_url: "",
+}
+
+/** Renders the tenant creation dialog and clears draft state when it closes. */
 export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDialogProps) {
   const { toast } = useToast()
   const qc = useQueryClient()
-  const [form, setForm] = React.useState({
-    code: "",
-    name: "",
-    active: true,
-    membership_quota: "" as string,
-    logo_url: "",
-    google_drive_folder_url: "",
-  })
+  const [form, setForm] = React.useState(EMPTY_TENANT_FORM)
 
-  React.useEffect(() => {
-    if (!open) {
-      setForm({ code: "", name: "", active: true, membership_quota: "", logo_url: "", google_drive_folder_url: "" })
-    }
-  }, [open])
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        setForm(EMPTY_TENANT_FORM)
+      }
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange]
+  )
 
   const createMutation = useMutation({
     mutationFn: async (): Promise<TenantRow> => {
@@ -66,7 +73,7 @@ export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDial
 	      })
 	      toast({ title: "Thành công", description: "Đã tạo đơn vị mới" })
 	      onSuccess?.()
-	      onOpenChange(false)
+	      handleOpenChange(false)
 	    },
 	    onError: (error: unknown) => {
 	      const description = error instanceof Error ? error.message : "Không thể tạo đơn vị"
@@ -85,7 +92,7 @@ export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDial
 	  }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[480px]">
         <DialogHeader>
           <DialogTitle>Thêm đơn vị</DialogTitle>
@@ -120,7 +127,7 @@ export function AddTenantDialog({ open, onOpenChange, onSuccess }: AddTenantDial
             </div>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>Hủy</Button>
+            <Button type="button" variant="outline" onClick={() => handleOpenChange(false)} disabled={isPending}>Hủy</Button>
             <Button type="submit" disabled={isPending}>{isPending && <Loader2 className="mr-2 size-4 animate-spin" />}Tạo</Button>
           </DialogFooter>
         </form>

--- a/src/components/add-user-dialog.tsx
+++ b/src/components/add-user-dialog.tsx
@@ -22,7 +22,7 @@ import { USER_ROLES, type UserRole } from "@/types/database"
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { fetchTenantList, type AddEquipmentTenantOption } from "./add-equipment-dialog.queries"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 interface AddUserDialogProps {
   open: boolean
@@ -30,10 +30,10 @@ interface AddUserDialogProps {
   onSuccess: () => void
 }
 
+/** Renders the user creation dialog and resets draft state when it closes. */
 export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogProps) {
   const { toast } = useToast()
   const queryClient = useQueryClient()
-  const [tenants, setTenants] = React.useState<AddEquipmentTenantOption[]>([])
   const [memberships, setMemberships] = React.useState<number[]>([])
   
   const [formData, setFormData] = React.useState({
@@ -49,27 +49,34 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
     setMemberships([])
   }, [])
 
-  React.useEffect(() => {
-    if (!open) {
-      resetForm()
-    }
-  }, [open, resetForm])
-
-  React.useEffect(() => {
-    const run = async () => {
-      if (!open) return
-      try {
-        setTenants(await fetchTenantList())
-      } catch (error: unknown) {
-        toast({
-          variant: 'destructive',
-          title: 'Lỗi tải danh sách đơn vị',
-          description: getUnknownErrorMessage(error),
-        })
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        resetForm()
       }
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange, resetForm]
+  )
+
+  const loadTenants = React.useCallback(async (): Promise<AddEquipmentTenantOption[]> => {
+    try {
+      return await fetchTenantList()
+    } catch (error: unknown) {
+      toast({
+        variant: 'destructive',
+        title: 'Lỗi tải danh sách đơn vị',
+        description: getUnknownErrorMessage(error),
+      })
+      return []
     }
-    run()
-  }, [open, toast])
+  }, [toast])
+
+  const { data: tenants = [] } = useQuery({
+    queryKey: ["add-user-dialog-tenants"],
+    queryFn: loadTenants,
+    enabled: open,
+  })
 
   const createUserMutation = useMutation({
     mutationFn: async () => {
@@ -103,7 +110,7 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
       }
       toast({ title: 'Thành công', description: 'Đã tạo tài khoản người dùng mới.' })
       onSuccess()
-      onOpenChange(false)
+      handleOpenChange(false)
     },
     onError: (error: unknown) => {
       console.error('Error creating user:', error)
@@ -132,7 +139,7 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>Thêm người dùng mới</DialogTitle>
@@ -253,7 +260,7 @@ export function AddUserDialog({ open, onOpenChange, onSuccess }: AddUserDialogPr
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={() => handleOpenChange(false)}
               disabled={isPending}
             >
               Hủy

--- a/src/components/bulk-schedule-dialog.tsx
+++ b/src/components/bulk-schedule-dialog.tsx
@@ -21,8 +21,13 @@ interface BulkScheduleDialogProps {
   onApply: (months: Record<string, boolean>) => void
 }
 
+/** Renders the bulk schedule dialog and resets selected months on close/apply. */
 export function BulkScheduleDialog({ open, onOpenChange, onApply }: BulkScheduleDialogProps) {
   const [selectedMonths, setSelectedMonths] = React.useState<Record<string, boolean>>({});
+
+  const resetSelectedMonths = React.useCallback(() => {
+    setSelectedMonths({});
+  }, []);
 
   const handleMonthChange = (monthIndex: number, checked: boolean) => {
     setSelectedMonths(prev => ({ ...prev, [`thang_${monthIndex}`]: checked }));
@@ -30,17 +35,21 @@ export function BulkScheduleDialog({ open, onOpenChange, onApply }: BulkSchedule
 
   const handleSubmit = () => {
     onApply(selectedMonths);
-    setSelectedMonths({});
+    resetSelectedMonths();
   };
 
-  React.useEffect(() => {
-    if (!open) {
-      setSelectedMonths({});
-    }
-  }, [open]);
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        resetSelectedMonths();
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, resetSelectedMonths]
+  );
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Lên lịch hàng loạt</DialogTitle>
@@ -63,7 +72,7 @@ export function BulkScheduleDialog({ open, onOpenChange, onApply }: BulkSchedule
           ))}
         </div>
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
             Hủy
           </Button>
           <Button type="button" onClick={handleSubmit}>

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -51,6 +51,7 @@ function getPasswordChangeErrorMessage(error: unknown): string {
   return getUnknownErrorMessage(error, "Có lỗi xảy ra khi thay đổi mật khẩu.")
 }
 
+/** Renders the password change dialog and clears sensitive draft values on close. */
 export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
   const { toast } = useToast()
   const { data: session, update } = useSession()
@@ -91,11 +92,15 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
     })
   }, [])
 
-  React.useEffect(() => {
-    if (!open) {
-      resetForm()
-    }
-  }, [open, resetForm])
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        resetForm()
+      }
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange, resetForm]
+  )
 
   const handlePostChangeSignOut = React.useCallback(async () => {
     try {
@@ -179,7 +184,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
         description: data.message || "Đã thay đổi mật khẩu thành công với mã hóa bảo mật."
       })
 
-      onOpenChange(false)
+      handleOpenChange(false)
       passwordChanged = true
     } catch (error: unknown) {
       if (isPasswordChangeUnavailableError(error)) {
@@ -209,7 +214,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>Thay đổi mật khẩu</DialogTitle>
@@ -311,7 +316,7 @@ export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialo
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={() => handleOpenChange(false)}
               disabled={isSubmitting}
             >
               Hủy

--- a/src/components/change-password-dialog.tsx
+++ b/src/components/change-password-dialog.tsx
@@ -53,6 +53,14 @@ function getPasswordChangeErrorMessage(error: unknown): string {
 
 /** Renders the password change dialog and clears sensitive draft values on close. */
 export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
+  if (!open) {
+    return <Dialog open={open} onOpenChange={onOpenChange} />
+  }
+
+  return <ChangePasswordDialogContent open={open} onOpenChange={onOpenChange} />
+}
+
+function ChangePasswordDialogContent({ open, onOpenChange }: ChangePasswordDialogProps) {
   const { toast } = useToast()
   const { data: session, update } = useSession()
   const user = session?.user

--- a/src/components/edit-tenant-dialog.tsx
+++ b/src/components/edit-tenant-dialog.tsx
@@ -29,33 +29,50 @@ interface EditTenantDialogProps {
   tenant: TenantRow | null
 }
 
+const EMPTY_TENANT_FORM = {
+  code: "",
+  name: "",
+  active: true,
+  membership_quota: "" as string,
+  logo_url: "",
+  google_drive_folder_url: "",
+}
+
+function getTenantForm(tenant: TenantRow | null) {
+  if (!tenant) return EMPTY_TENANT_FORM
+  return {
+    code: tenant.code || "",
+    name: tenant.name,
+    active: !!tenant.active,
+    membership_quota: tenant.membership_quota === null ? "" : String(tenant.membership_quota),
+    logo_url: tenant.logo_url || "",
+    google_drive_folder_url: tenant.google_drive_folder_url || "",
+  }
+}
+
+/** Renders the tenant edit dialog without overwriting in-progress drafts on refresh. */
 export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: EditTenantDialogProps) {
   const { toast } = useToast()
   const qc = useQueryClient()
-  const [form, setForm] = React.useState({
-    code: "",
-    name: "",
-    active: true,
-    membership_quota: "" as string,
-    logo_url: "",
-    google_drive_folder_url: "",
-  })
+  const activeTenantId = open ? tenant?.id ?? null : null
+  const loadedTenantIdRef = React.useRef<number | null>(activeTenantId)
+  const [form, setForm] = React.useState(() => getTenantForm(open ? tenant : null))
 
-  React.useEffect(() => {
-    if (open && tenant) {
-      setForm({
-        code: tenant.code || "",
-        name: tenant.name,
-        active: !!tenant.active,
-        membership_quota: tenant.membership_quota === null ? "" : String(tenant.membership_quota),
-        logo_url: tenant.logo_url || "",
-        google_drive_folder_url: tenant.google_drive_folder_url || "",
-      })
-    }
-    if (!open) {
-      setForm({ code: "", name: "", active: true, membership_quota: "", logo_url: "", google_drive_folder_url: "" })
-    }
-  }, [open, tenant])
+  if (loadedTenantIdRef.current !== activeTenantId) {
+    loadedTenantIdRef.current = activeTenantId
+    setForm(getTenantForm(open ? tenant : null))
+  }
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        loadedTenantIdRef.current = null
+        setForm(EMPTY_TENANT_FORM)
+      }
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange]
+  )
 
   const updateMutation = useMutation({
     mutationFn: async (): Promise<TenantRow> => {
@@ -95,7 +112,7 @@ export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: Edit
 	      })
 	      toast({ title: "Thành công", description: "Đã cập nhật đơn vị" })
 	      onSuccess?.()
-	      onOpenChange(false)
+	      handleOpenChange(false)
 	    },
 	    onError: (error: unknown) => {
 	      const description = error instanceof Error ? error.message : "Không thể cập nhật đơn vị"
@@ -115,7 +132,7 @@ export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: Edit
 	  }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[480px]">
         <DialogHeader>
           <DialogTitle>Sửa đơn vị</DialogTitle>
@@ -152,7 +169,7 @@ export function EditTenantDialog({ open, onOpenChange, onSuccess, tenant }: Edit
             </div>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>Hủy</Button>
+            <Button type="button" variant="outline" onClick={() => handleOpenChange(false)} disabled={isPending}>Hủy</Button>
             <Button type="submit" disabled={isPending}>{isPending && <Loader2 className="mr-2 size-4 animate-spin" />}Lưu</Button>
           </DialogFooter>
         </form>

--- a/src/components/edit-user-dialog.tsx
+++ b/src/components/edit-user-dialog.tsx
@@ -28,33 +28,46 @@ interface EditUserDialogProps {
   user: UserSummary | null
 }
 
+const EMPTY_EDIT_USER_FORM = {
+  username: "",
+  full_name: "",
+  role: "" as UserRole | "",
+  khoa_phong: ""
+}
+
+function getEditUserForm(user: UserSummary | null) {
+  if (!user) return EMPTY_EDIT_USER_FORM
+  return {
+    username: user.username,
+    full_name: user.full_name,
+    role: user.role,
+    khoa_phong: user.khoa_phong || ""
+  }
+}
+
+/** Renders the user edit dialog without overwriting in-progress drafts on refresh. */
 export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUserDialogProps) {
   const { toast } = useToast()
   const queryClient = useQueryClient()
-  const [formData, setFormData] = React.useState({
-    username: "",
-    full_name: "",
-    role: "" as UserRole | "",
-    khoa_phong: ""
-  })
+  const activeUserId = open ? user?.id ?? null : null
+  const loadedUserIdRef = React.useRef<number | null>(activeUserId)
+  const [formData, setFormData] = React.useState(() => getEditUserForm(open ? user : null))
 
-  React.useEffect(() => {
-    if (user && open) {
-      setFormData({
-        username: user.username,
-        full_name: user.full_name,
-        role: user.role,
-        khoa_phong: user.khoa_phong || ""
-      })
-    } else if (!open) {
-      setFormData({
-        username: "",
-        full_name: "",
-        role: "",
-        khoa_phong: ""
-      })
-    }
-  }, [user, open])
+  if (loadedUserIdRef.current !== activeUserId) {
+    loadedUserIdRef.current = activeUserId
+    setFormData(getEditUserForm(open ? user : null))
+  }
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        loadedUserIdRef.current = null
+        setFormData(EMPTY_EDIT_USER_FORM)
+      }
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange]
+  )
 
   const updateUserMutation = useMutation({
     mutationFn: async () => {
@@ -88,7 +101,7 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
         description: "Đã cập nhật thông tin người dùng."
       })
       onSuccess()
-      onOpenChange(false)
+      handleOpenChange(false)
     },
     onError: (error: unknown) => {
       toast({
@@ -116,7 +129,7 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>Chỉnh sửa người dùng</DialogTitle>
@@ -184,7 +197,7 @@ export function EditUserDialog({ open, onOpenChange, onSuccess, user }: EditUser
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={() => handleOpenChange(false)}
               disabled={isPending}
             >
               Hủy

--- a/src/components/equipment/filter-bottom-sheet.tsx
+++ b/src/components/equipment/filter-bottom-sheet.tsx
@@ -29,6 +29,17 @@ interface FilterBottomSheetProps {
   onClearAll: () => void
 }
 
+function getLocalFilters(columnFilters: ColumnFiltersState): Record<string, string[]> {
+  const initial: Record<string, string[]> = {}
+  columnFilters.forEach((filter) => {
+    if (Array.isArray(filter.value)) {
+      initial[filter.id] = filter.value as string[]
+    }
+  })
+  return initial
+}
+
+/** Renders the mobile equipment filter sheet with an apply-only local draft. */
 export function FilterBottomSheet({
   open,
   onOpenChange,
@@ -37,20 +48,29 @@ export function FilterBottomSheet({
   onApply,
   onClearAll,
 }: FilterBottomSheetProps) {
-  const [localFilters, setLocalFilters] = React.useState<Record<string, string[]>>({})
+  const [localFilters, setLocalFilters] = React.useState<Record<string, string[]>>(() =>
+    open ? getLocalFilters(columnFilters) : {}
+  )
+  const wasOpenRef = React.useRef(open)
 
-  // Initialize local filters from columnFilters when sheet opens
-  React.useEffect(() => {
+  if (wasOpenRef.current !== open) {
+    wasOpenRef.current = open
     if (open) {
-      const initial: Record<string, string[]> = {}
-      columnFilters.forEach((filter) => {
-        if (Array.isArray(filter.value)) {
-          initial[filter.id] = filter.value as string[]
-        }
-      })
-      setLocalFilters(initial)
+      setLocalFilters(getLocalFilters(columnFilters))
+    } else {
+      setLocalFilters({})
     }
-  }, [open, columnFilters])
+  }
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        setLocalFilters({})
+      }
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange]
+  )
 
   const toggleFilter = (category: string, value: string) => {
     setLocalFilters((prev) => {
@@ -71,16 +91,19 @@ export function FilterBottomSheet({
   }, [localFilters])
 
   const handleApply = () => {
-    const next: ColumnFiltersState = Object.entries(localFilters)
-      .filter(([_, values]) => values.length > 0)
-      .map(([id, value]) => ({ id, value }))
+    const next: ColumnFiltersState = []
+    for (const [id, value] of Object.entries(localFilters)) {
+      if (value.length > 0) {
+        next.push({ id, value })
+      }
+    }
     onApply(next)
-    onOpenChange(false)
+    handleOpenChange(false)
   }
 
   const handleClearAll = () => {
     onClearAll()
-    onOpenChange(false)
+    handleOpenChange(false)
   }
 
   const filterSections = [
@@ -93,7 +116,7 @@ export function FilterBottomSheet({
   ]
 
   return (
-    <MobileBottomSheet open={open} onOpenChange={onOpenChange} ariaLabel="Bộ lọc thiết bị">
+    <MobileBottomSheet open={open} onOpenChange={handleOpenChange} ariaLabel="Bộ lọc thiết bị">
       {/* Header */}
       <div className="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
         <h2 className="text-lg font-semibold text-foreground">
@@ -102,7 +125,7 @@ export function FilterBottomSheet({
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => onOpenChange(false)}
+          onClick={() => handleOpenChange(false)}
           className="size-10 rounded-full"
           aria-label="Đóng bộ lọc"
         >

--- a/src/components/shared/TenantSelectorSheet.tsx
+++ b/src/components/shared/TenantSelectorSheet.tsx
@@ -29,6 +29,7 @@ export interface TenantSelectorSheetProps {
   hideAllOption?: boolean
 }
 
+/** Renders the mobile tenant selector sheet and clears search when closed. */
 export function TenantSelectorSheet({
   open,
   onOpenChange,
@@ -43,12 +44,15 @@ export function TenantSelectorSheet({
 
   const [searchTerm, setSearchTerm] = React.useState("")
 
-  // Clear search when sheet closes
-  React.useEffect(() => {
-    if (!open) {
-      setSearchTerm("")
-    }
-  }, [open])
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        setSearchTerm("")
+      }
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange]
+  )
 
   // Memoize filtered facilities (per rerender-memo)
   const filteredFacilities = React.useMemo(() => {
@@ -68,13 +72,13 @@ export function TenantSelectorSheet({
   const handleSelect = React.useCallback(
     (facilityId: number | null) => {
       setSelectedFacilityId(facilityId)
-      onOpenChange(false)
+      handleOpenChange(false)
     },
-    [setSelectedFacilityId, onOpenChange]
+    [setSelectedFacilityId, handleOpenChange]
   )
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    <Sheet open={open} onOpenChange={handleOpenChange}>
       <SheetContent
         side="bottom"
         className="flex h-[70vh] max-h-[70vh] flex-col rounded-t-3xl border-border/60 bg-background px-6 pb-6 pt-4"

--- a/src/components/shared/__tests__/TenantSelectorSheet.test.tsx
+++ b/src/components/shared/__tests__/TenantSelectorSheet.test.tsx
@@ -48,7 +48,7 @@ describe("TenantSelectorSheet", () => {
     const user = userEvent.setup()
     renderSheet()
 
-    await user.type(screen.getByPlaceholderText("Tìm kiếm cơ sở..."), "can tho")
+    await user.type(screen.getByPlaceholderText(/Tìm kiếm cơ sở/), "can tho")
 
     expect(screen.getByRole("button", { name: /Bệnh viện Đa khoa Cần Thơ/ })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /Bệnh viện Đa khoa An Giang/ })).not.toBeInTheDocument()
@@ -58,7 +58,7 @@ describe("TenantSelectorSheet", () => {
     const user = userEvent.setup()
     renderSheet()
 
-    await user.type(screen.getByPlaceholderText("Tìm kiếm cơ sở..."), "Ca\u0302\u0300n tho")
+    await user.type(screen.getByPlaceholderText(/Tìm kiếm cơ sở/), "Ca\u0302\u0300n tho")
 
     expect(screen.getByRole("button", { name: /Bệnh viện Đa khoa Cần Thơ/ })).toBeInTheDocument()
   })

--- a/src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
+++ b/src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
@@ -53,4 +53,25 @@ describe('FilterBottomSheet (regression)', () => {
 
         expect(screen.queryByText('Trạng thái')).not.toBeInTheDocument()
     })
+
+    it('keeps the local draft when parent filters refresh while open', () => {
+        const { rerender } = render(
+            <FilterBottomSheet
+                {...defaultProps}
+                columnFilters={[{ id: 'tinh_trang_hien_tai', value: ['active'] }]}
+            />
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: /Đang sử dụng/ }))
+
+        rerender(
+            <FilterBottomSheet
+                {...defaultProps}
+                columnFilters={[{ id: 'tinh_trang_hien_tai', value: ['active'] }]}
+            />
+        )
+        fireEvent.click(screen.getByRole('button', { name: /Áp dụng/ }))
+
+        expect(defaultProps.onApply).toHaveBeenCalledWith([])
+    })
 })

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -57,6 +57,7 @@ export interface FacetedMultiSelectFilterProps<TData, TValue> {
     contentClassName?: string
 }
 
+/** Renders a searchable faceted multi-select filter in column or controlled mode. */
 export function FacetedMultiSelectFilter<TData, TValue>({
     column,
     title,
@@ -77,10 +78,12 @@ export function FacetedMultiSelectFilter<TData, TValue>({
 
     // Resolve selected values from either column mode or controlled mode
     const isControlled = controlledValue !== undefined
-    const selectedValues = new Set(
-        isControlled
-            ? controlledValue
-            : (column?.getFilterValue() as string[]) || []
+    const selectedFilterValue = isControlled
+        ? controlledValue
+        : (column?.getFilterValue() as string[] | undefined)
+    const selectedValues = React.useMemo(
+        () => new Set(selectedFilterValue || []),
+        [selectedFilterValue]
     )
 
     const visibleOptions = React.useMemo(() => {
@@ -92,12 +95,15 @@ export function FacetedMultiSelectFilter<TData, TValue>({
         )
     }, [debouncedOptionSearch, options])
 
-    React.useEffect(() => {
-        if (!open) {
+    const handleOpenChange = React.useCallback((nextOpen: boolean) => {
+        if (!nextOpen) {
             setOptionSearch("")
-            return
         }
+        setOpen(nextOpen)
+    }, [])
 
+    React.useEffect(() => {
+        if (!open) return
         if (!searchable) return
 
         const timer = window.setTimeout(() => {
@@ -138,7 +144,7 @@ export function FacetedMultiSelectFilter<TData, TValue>({
     }, [])
 
     return (
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover open={open} onOpenChange={handleOpenChange}>
             <PopoverTrigger asChild>
                 <Button
                     type="button"

--- a/src/contexts/EquipmentFilterContext.tsx
+++ b/src/contexts/EquipmentFilterContext.tsx
@@ -4,6 +4,20 @@ import * as React from "react"
 import type { ColumnFiltersState, SortingState } from "@tanstack/react-table"
 import { useSearchDebounce } from "@/hooks/use-debounce"
 import { useTenantSelection } from "@/contexts/TenantSelectionContext"
+import {
+  buildEquipmentFilterStorageKey,
+  EMPTY_STORED_FILTERS,
+  getStoredFilters,
+  persistStoredFilters,
+  resolveStateAction,
+  type ProviderFilterState,
+  type StoredFilterState,
+} from "@/contexts/EquipmentFilterStorage"
+
+export {
+  clearAllEquipmentFilters,
+  EQUIPMENT_FILTER_STORAGE_KEY_PREFIX,
+} from "@/contexts/EquipmentFilterStorage"
 
 // =============================================================================
 // Types
@@ -37,87 +51,6 @@ export interface EquipmentFilterContextValue {
 }
 
 // =============================================================================
-// Constants
-// =============================================================================
-
-export const EQUIPMENT_FILTER_STORAGE_KEY_PREFIX = "eq_filters"
-
-/** Build a tenant-scoped storage key. `null` = "all", `undefined` = no tenant yet. */
-function buildStorageKey(tenantId: number | null | undefined): string | null {
-  if (tenantId === undefined) return null
-  const suffix = tenantId === null ? "_all" : `_${tenantId}`
-  return `${EQUIPMENT_FILTER_STORAGE_KEY_PREFIX}${suffix}`
-}
-
-// =============================================================================
-// Storage helpers (SSR-safe)
-// =============================================================================
-
-interface StoredFilterState {
-  searchTerm: string
-  sorting: SortingState
-  columnFilters: ColumnFiltersState
-}
-
-function readStoredFilters(key: string): StoredFilterState | null {
-  if (typeof window === "undefined") return null
-  try {
-    const stored = sessionStorage.getItem(key)
-    if (!stored) return null
-    const parsed = JSON.parse(stored) as StoredFilterState
-    // Basic shape validation
-    if (
-      typeof parsed.searchTerm !== "string" ||
-      !Array.isArray(parsed.sorting) ||
-      !Array.isArray(parsed.columnFilters)
-    ) {
-      return null
-    }
-    return parsed
-  } catch {
-    return null
-  }
-}
-
-function writeStoredFilters(key: string, state: StoredFilterState): void {
-  if (typeof window === "undefined") return
-  try {
-    sessionStorage.setItem(key, JSON.stringify(state))
-  } catch {
-    // Ignore storage errors (quota, etc.)
-  }
-}
-
-function clearStoredFilters(key: string): void {
-  if (typeof window === "undefined") return
-  try {
-    sessionStorage.removeItem(key)
-  } catch {
-    // Ignore storage errors
-  }
-}
-
-/**
- * Clear ALL tenant-scoped eq_filters keys from sessionStorage.
- * Called on logout from AppLayout (before provider unmounts).
- */
-export function clearAllEquipmentFilters(): void {
-  if (typeof window === "undefined") return
-  try {
-    const keysToRemove: string[] = []
-    for (let i = 0; i < sessionStorage.length; i++) {
-      const k = sessionStorage.key(i)
-      if (k?.startsWith(EQUIPMENT_FILTER_STORAGE_KEY_PREFIX)) {
-        keysToRemove.push(k)
-      }
-    }
-    keysToRemove.forEach((k) => sessionStorage.removeItem(k))
-  } catch {
-    // Ignore storage errors
-  }
-}
-
-// =============================================================================
 // Context
 // =============================================================================
 
@@ -128,6 +61,7 @@ const EquipmentFilterContext =
 // Provider
 // =============================================================================
 
+/** Provides tenant-scoped equipment filter state and sessionStorage persistence. */
 export function EquipmentFilterProvider({
   children,
 }: {
@@ -137,63 +71,73 @@ export function EquipmentFilterProvider({
 
   // Build tenant-scoped storage key
   const storageKey = React.useMemo(
-    () => buildStorageKey(selectedFacilityId),
+    () => buildEquipmentFilterStorageKey(selectedFacilityId),
     [selectedFacilityId]
   )
 
-  // Track previous storage key for tenant-change detection
-  const prevStorageKeyRef = React.useRef<string | null>(storageKey)
-  const skipPersistRef = React.useRef(false)
+  const [filterState, setFilterState] = React.useState<ProviderFilterState>(() => ({
+    storageKey,
+    ...getStoredFilters(storageKey),
+  }))
 
-  // Hydrate from sessionStorage on mount
-  const initial = React.useMemo(
-    () => (storageKey ? readStoredFilters(storageKey) : null),
-    [] // eslint-disable-line react-hooks/exhaustive-deps
+  if (filterState.storageKey !== storageKey) {
+    setFilterState({
+      storageKey,
+      ...getStoredFilters(storageKey),
+    })
+  }
+
+  const updateStoredFilterState = React.useCallback(
+    (updater: (current: StoredFilterState) => StoredFilterState) => {
+      setFilterState((current) => {
+        const base =
+          current.storageKey === storageKey
+            ? current
+            : { storageKey, ...getStoredFilters(storageKey) }
+        const next = updater({
+          searchTerm: base.searchTerm,
+          sorting: base.sorting,
+          columnFilters: base.columnFilters,
+        })
+        persistStoredFilters(base.storageKey, next)
+        return { storageKey: base.storageKey, ...next }
+      })
+    },
+    [storageKey]
   )
 
-  // Search state
-  const [searchTerm, setSearchTerm] = React.useState(
-    initial?.searchTerm ?? ""
+  const setSearchTerm = React.useCallback<React.Dispatch<React.SetStateAction<string>>>(
+    (action) => {
+      updateStoredFilterState((current) => ({
+        ...current,
+        searchTerm: resolveStateAction(action, current.searchTerm),
+      }))
+    },
+    [updateStoredFilterState]
   )
+
+  const setSorting = React.useCallback<React.Dispatch<React.SetStateAction<SortingState>>>(
+    (action) => {
+      updateStoredFilterState((current) => ({
+        ...current,
+        sorting: resolveStateAction(action, current.sorting),
+      }))
+    },
+    [updateStoredFilterState]
+  )
+
+  const setColumnFilters = React.useCallback<React.Dispatch<React.SetStateAction<ColumnFiltersState>>>(
+    (action) => {
+      updateStoredFilterState((current) => ({
+        ...current,
+        columnFilters: resolveStateAction(action, current.columnFilters),
+      }))
+    },
+    [updateStoredFilterState]
+  )
+
+  const { searchTerm, sorting, columnFilters } = filterState
   const debouncedSearch = useSearchDebounce(searchTerm)
-
-  // Sorting state
-  const [sorting, setSorting] = React.useState<SortingState>(
-    initial?.sorting ?? []
-  )
-
-  // Column filters state
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    initial?.columnFilters ?? []
-  )
-
-  // Reset filters + hydrate from new tenant's storage when tenant changes
-  React.useEffect(() => {
-    if (prevStorageKeyRef.current !== storageKey) {
-      prevStorageKeyRef.current = storageKey
-      const newInitial = storageKey ? readStoredFilters(storageKey) : null
-      skipPersistRef.current = true
-      setSearchTerm(newInitial?.searchTerm ?? "")
-      setSorting(newInitial?.sorting ?? [])
-      setColumnFilters(newInitial?.columnFilters ?? [])
-    }
-  }, [storageKey])
-
-  // Persist to sessionStorage on change
-  React.useEffect(() => {
-    if (skipPersistRef.current) {
-      skipPersistRef.current = false
-      return
-    }
-    if (!storageKey) return
-    const isEmpty =
-      searchTerm === "" && sorting.length === 0 && columnFilters.length === 0
-    if (isEmpty) {
-      clearStoredFilters(storageKey)
-      return
-    }
-    writeStoredFilters(storageKey, { searchTerm, sorting, columnFilters })
-  }, [storageKey, searchTerm, sorting, columnFilters])
 
   // Memoized sort parameter for queries
   const sortParam = React.useMemo(() => {
@@ -240,13 +184,8 @@ export function EquipmentFilterProvider({
 
   // Reset all filters + clear storage
   const resetFilters = React.useCallback(() => {
-    skipPersistRef.current = true
-    setColumnFilters([])
-    setSearchTerm("")
-    setSorting([])
-    if (storageKey) {
-      clearStoredFilters(storageKey)
-    }
+    persistStoredFilters(storageKey, EMPTY_STORED_FILTERS)
+    setFilterState({ storageKey, ...EMPTY_STORED_FILTERS })
   }, [storageKey])
 
   // Memoized context value (rerender-memo best practice)
@@ -271,9 +210,12 @@ export function EquipmentFilterProvider({
     [
       searchTerm,
       debouncedSearch,
+      setSearchTerm,
       sorting,
+      setSorting,
       sortParam,
       columnFilters,
+      setColumnFilters,
       resetFilters,
       selectedDepartments,
       selectedUsers,

--- a/src/contexts/EquipmentFilterStorage.ts
+++ b/src/contexts/EquipmentFilterStorage.ts
@@ -56,7 +56,7 @@ export function resolveStateAction<T>(action: React.SetStateAction<T>, current: 
  * Called on logout from AppLayout (before provider unmounts).
  */
 export function clearAllEquipmentFilters(): void {
-  if (typeof window === "undefined") return
+  if (typeof globalThis.window === "undefined") return
   try {
     const keysToRemove: string[] = []
     for (let i = 0; i < sessionStorage.length; i++) {
@@ -80,7 +80,7 @@ function isEmptyStoredFilters(state: StoredFilterState): boolean {
 }
 
 function readStoredFilters(key: string): StoredFilterState | null {
-  if (typeof window === "undefined") return null
+  if (typeof globalThis.window === "undefined") return null
   try {
     const stored = sessionStorage.getItem(key)
     if (!stored) return null
@@ -99,7 +99,7 @@ function readStoredFilters(key: string): StoredFilterState | null {
 }
 
 function writeStoredFilters(key: string, state: StoredFilterState): void {
-  if (typeof window === "undefined") return
+  if (typeof globalThis.window === "undefined") return
   try {
     sessionStorage.setItem(key, JSON.stringify(state))
   } catch {
@@ -108,7 +108,7 @@ function writeStoredFilters(key: string, state: StoredFilterState): void {
 }
 
 function clearStoredFilters(key: string): void {
-  if (typeof window === "undefined") return
+  if (typeof globalThis.window === "undefined") return
   try {
     sessionStorage.removeItem(key)
   } catch {

--- a/src/contexts/EquipmentFilterStorage.ts
+++ b/src/contexts/EquipmentFilterStorage.ts
@@ -1,0 +1,117 @@
+import type * as React from "react"
+import type { ColumnFiltersState, SortingState } from "@tanstack/react-table"
+
+/** Prefix for tenant-scoped equipment filter sessionStorage keys. */
+export const EQUIPMENT_FILTER_STORAGE_KEY_PREFIX = "eq_filters"
+
+export interface StoredFilterState {
+  searchTerm: string
+  sorting: SortingState
+  columnFilters: ColumnFiltersState
+}
+
+export type ProviderFilterState = StoredFilterState & {
+  storageKey: string | null
+}
+
+/** Empty persisted equipment filter state. */
+export const EMPTY_STORED_FILTERS: StoredFilterState = {
+  searchTerm: "",
+  sorting: [],
+  columnFilters: [],
+}
+
+/** Build a tenant-scoped storage key. `null` = "all", `undefined` = no tenant yet. */
+export function buildEquipmentFilterStorageKey(tenantId: number | null | undefined): string | null {
+  if (tenantId === undefined) return null
+  const suffix = tenantId === null ? "_all" : `_${tenantId}`
+  return `${EQUIPMENT_FILTER_STORAGE_KEY_PREFIX}${suffix}`
+}
+
+/** Reads validated equipment filters from sessionStorage, falling back to empty state. */
+export function getStoredFilters(key: string | null): StoredFilterState {
+  if (!key) return EMPTY_STORED_FILTERS
+  return readStoredFilters(key) ?? EMPTY_STORED_FILTERS
+}
+
+/** Persists non-empty equipment filters or clears the scoped storage key. */
+export function persistStoredFilters(key: string | null, state: StoredFilterState): void {
+  if (!key) return
+  if (isEmptyStoredFilters(state)) {
+    clearStoredFilters(key)
+    return
+  }
+  writeStoredFilters(key, state)
+}
+
+/** Resolves a React state action against the current value. */
+export function resolveStateAction<T>(action: React.SetStateAction<T>, current: T): T {
+  return typeof action === "function"
+    ? (action as (previous: T) => T)(current)
+    : action
+}
+
+/**
+ * Clear ALL tenant-scoped eq_filters keys from sessionStorage.
+ * Called on logout from AppLayout (before provider unmounts).
+ */
+export function clearAllEquipmentFilters(): void {
+  if (typeof window === "undefined") return
+  try {
+    const keysToRemove: string[] = []
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const k = sessionStorage.key(i)
+      if (k?.startsWith(EQUIPMENT_FILTER_STORAGE_KEY_PREFIX)) {
+        keysToRemove.push(k)
+      }
+    }
+    keysToRemove.forEach((k) => sessionStorage.removeItem(k))
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+function isEmptyStoredFilters(state: StoredFilterState): boolean {
+  return (
+    state.searchTerm === "" &&
+    state.sorting.length === 0 &&
+    state.columnFilters.length === 0
+  )
+}
+
+function readStoredFilters(key: string): StoredFilterState | null {
+  if (typeof window === "undefined") return null
+  try {
+    const stored = sessionStorage.getItem(key)
+    if (!stored) return null
+    const parsed = JSON.parse(stored) as StoredFilterState
+    if (
+      typeof parsed.searchTerm !== "string" ||
+      !Array.isArray(parsed.sorting) ||
+      !Array.isArray(parsed.columnFilters)
+    ) {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeStoredFilters(key: string, state: StoredFilterState): void {
+  if (typeof window === "undefined") return
+  try {
+    sessionStorage.setItem(key, JSON.stringify(state))
+  } catch {
+    // Ignore storage errors (quota, etc.)
+  }
+}
+
+function clearStoredFilters(key: string): void {
+  if (typeof window === "undefined") return
+  try {
+    sessionStorage.removeItem(key)
+  } catch {
+    // Ignore storage errors
+  }
+}


### PR DESCRIPTION
## Summary
- Fix #580 shared dialog/filter state-effect findings with event-handler close/reset flows.
- Preserve edit dialog drafts across same-entity prop refreshes and keep equipment filter sheet local draft stable while open.
- Extract equipment filter storage helpers to keep `EquipmentFilterContext` below repo size thresholds.

## Test Plan
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/components/__tests__/user-tenant-dialog-state.test.tsx src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx src/components/shared/__tests__/TenantSelectorSheet.test.tsx src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx 'src/app/(app)/equipment/__tests__/EquipmentFilterContext.test.tsx' src/components/__tests__/change-password-dialog.signout.test.tsx
- node scripts/npm-run.js run react-doctor

Closes #580

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #580 by stabilizing shared dialog and filter state and close/reset flows. Edit dialogs preserve in-progress drafts on prop refresh; equipment filters use an apply-only local draft that stays stable while open. Password dialog now clears sensitive fields on close.

- **Bug Fixes**
  - Edit dialogs (`EditUserDialog`, `EditTenantDialog`) keep in-progress drafts when same-entity props refresh; reset only on close.
  - Add dialogs, bulk schedule, and change-password dialogs clear local state via centralized `onOpenChange`; change-password clears sensitive fields on close (including parent-controlled close).
  - Equipment filter bottom sheet keeps its local draft while open, ignores parent `columnFilters` refreshes, and resets on close; Apply/Clear now close the sheet.
  - Tenant selector sheet clears search on close; selecting an item closes the sheet.
  - Faceted multi-select filter clears its search only on close and handles controlled/uncontrolled values consistently.
  - Added tests for edit dialog draft preservation, filter sheet regression, and change-password field clearing.

- **Refactors**
  - Extracted tenant-scoped filter storage into `EquipmentFilterStorage` (SSR-safe `sessionStorage` helpers, `EQUIPMENT_FILTER_STORAGE_KEY_PREFIX`, `clearAllEquipmentFilters`).
  - Rewrote `EquipmentFilterProvider` to a single persisted state (`ProviderFilterState`) with key switching, `persistStoredFilters`, and action resolvers; simplified reset to stored-empty.
  - Switched tenant loading in add-user dialog to `useQuery`; minor memoization and handler cleanups.

<sup>Written for commit b507113b327114068d4eae4e0dfb72f30cdd5edd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/584?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Form drafts in dialogs (add/edit user, add/edit tenant, change password) are now preserved when the dialog refreshes or reopens, preventing loss of in-progress edits.
  * Filter selections in bottom sheets are preserved while the sheet remains open.
  * Form state is now properly cleared when dialogs and filter sheets are closed.

* **Tests**
  * Added regression tests to verify form draft persistence across dialog property updates.
  * Added regression tests for filter selection preservation in filter sheets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->