### PR TITLE
Refactor repair requests React Doctor shape findings

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestRowActions.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestRowActions.test.tsx
@@ -3,8 +3,10 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
-import { RepairRequestsMobileList } from "../_components/RepairRequestsMobileList"
-import type { RepairRequestColumnOptions } from "../_components/RepairRequestsColumns"
+import {
+  RepairRequestRowActions,
+  type RepairRequestColumnOptions,
+} from "../_components/RepairRequestsColumns"
 import type { AuthUser, RepairRequestWithEquipment } from "../types"
 
 function makeRepairRequest(): RepairRequestWithEquipment {
@@ -62,50 +64,31 @@ function makeColumnOptions(): RepairRequestColumnOptions {
   }
 }
 
-describe("RepairRequestsMobileList accessibility", () => {
-  it("opens a repair request card with keyboard activation", async () => {
+describe("RepairRequestRowActions", () => {
+  it("calls the row-specific action callbacks for the selected request", async () => {
     const user = userEvent.setup()
     const request = makeRepairRequest()
-    const setRequestToView = vi.fn()
+    const options = makeColumnOptions()
 
-    render(
-      <RepairRequestsMobileList
-        requests={[request]}
-        isLoading={false}
-        setRequestToView={setRequestToView}
-        columnOptions={makeColumnOptions()}
-      />,
-    )
-
-    const card = screen.getByRole("button", { name: /Máy siêu âm/ })
-    card.focus()
-
-    await user.keyboard("{Enter}")
-    expect(setRequestToView).toHaveBeenCalledWith(request)
-
-    await user.keyboard(" ")
-    expect(setRequestToView).toHaveBeenCalledTimes(2)
-  })
-
-  it("does not open a repair request card from action controls", async () => {
-    const user = userEvent.setup()
-    const request = makeRepairRequest()
-    const setRequestToView = vi.fn()
-    const columnOptions = makeColumnOptions()
-
-    render(
-      <RepairRequestsMobileList
-        requests={[request]}
-        isLoading={false}
-        setRequestToView={setRequestToView}
-        columnOptions={columnOptions}
-      />,
-    )
+    render(<RepairRequestRowActions request={request} options={options} />)
 
     await user.click(screen.getByRole("button", { name: "Mở menu" }))
     await user.click(screen.getByRole("menuitem", { name: "Xem phiếu yêu cầu" }))
+    expect(options.onGenerateSheet).toHaveBeenCalledWith(request)
 
-    expect(columnOptions.onGenerateSheet).toHaveBeenCalledWith(request)
-    expect(setRequestToView).not.toHaveBeenCalled()
+    await user.click(screen.getByRole("button", { name: "Mở menu" }))
+    await user.click(screen.getByRole("menuitem", { name: "Sửa" }))
+    expect(options.setEditingRequest).toHaveBeenCalledWith(request)
+  })
+
+  it("hides actions for read-only regional leaders", () => {
+    render(
+      <RepairRequestRowActions
+        request={makeRepairRequest()}
+        options={{ ...makeColumnOptions(), isRegionalLeader: true }}
+      />,
+    )
+
+    expect(screen.queryByRole("button", { name: "Mở menu" })).not.toBeInTheDocument()
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsDetailView.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsDetailView.test.tsx
@@ -32,6 +32,7 @@ Object.defineProperty(window, "matchMedia", {
 const mockUseRepairRequestHistory = vi.fn()
 const mockMapRepairRequestHistoryEntries = vi.fn()
 const mockDetailTabs = vi.fn()
+const mockUseRepairRequestsContext = vi.fn()
 
 vi.mock("next-auth/react", () => ({
   useSession: () => ({
@@ -47,6 +48,10 @@ vi.mock("next-auth/react", () => ({
 
 vi.mock("../_hooks/useRepairRequestHistory", () => ({
   useRepairRequestHistory: (options: unknown) => mockUseRepairRequestHistory(options),
+}))
+
+vi.mock("../_hooks/useRepairRequestsContext", () => ({
+  useRepairRequestsContext: () => mockUseRepairRequestsContext(),
 }))
 
 vi.mock("../_lib/repairRequestHistoryAdapter", () => ({
@@ -106,8 +111,8 @@ vi.mock("@/components/shared/SideSheetShell", () => ({
     onOpenChange: (open: boolean) => void
     title: React.ReactNode
   }) => (
-    <section
-      role="dialog"
+    <dialog
+      open
       data-testid="shared-side-sheet"
       data-body-class={bodyClassName}
       data-content-class={contentClassName}
@@ -119,7 +124,7 @@ vi.mock("@/components/shared/SideSheetShell", () => ({
       </button>
       {children}
       {footer}
-    </section>
+    </dialog>
   ),
 }))
 
@@ -186,6 +191,10 @@ describe("RepairRequestsDetailView", () => {
       error: null,
     })
     mockMapRepairRequestHistoryEntries.mockReturnValue(mappedEntries)
+    mockUseRepairRequestsContext.mockReturnValue({
+      dialogState: { requestToView: mockRequest },
+      closeAllDialogs: vi.fn(),
+    })
   })
 
   afterEach(() => {
@@ -193,15 +202,18 @@ describe("RepairRequestsDetailView", () => {
   })
 
   it("renders nothing when requestToView is null", () => {
-    const { container } = render(
-      <RepairRequestsDetailView requestToView={null} onClose={vi.fn()} />,
-    )
+    mockUseRepairRequestsContext.mockReturnValue({
+      dialogState: { requestToView: null },
+      closeAllDialogs: vi.fn(),
+    })
+
+    const { container } = render(<RepairRequestsDetailView />)
 
     expect(container.innerHTML).toBe("")
   })
 
   it("renders a shared side-sheet shell with responsive sizing and mapped history tabs", () => {
-    render(<RepairRequestsDetailView requestToView={mockRequest} onClose={vi.fn()} />)
+    render(<RepairRequestsDetailView />)
 
     expect(screen.getByText("Chi tiết yêu cầu sửa chữa")).toBeInTheDocument()
     expect(
@@ -240,8 +252,6 @@ describe("RepairRequestsDetailView", () => {
   it("renders extension content inside the dialog portal", () => {
     render(
       <RepairRequestsDetailView
-        requestToView={mockRequest}
-        onClose={vi.fn()}
         contentHeader={<div data-testid="linked-request-header">Header extension</div>}
         footerContent={<Link href="/repair-requests?equipmentId=100">Footer extension</Link>}
       />,
@@ -253,9 +263,7 @@ describe("RepairRequestsDetailView", () => {
   })
 
   it("renders footerContent when it is zero", () => {
-    render(
-      <RepairRequestsDetailView requestToView={mockRequest} onClose={vi.fn()} footerContent={0} />,
-    )
+    render(<RepairRequestsDetailView footerContent={0} />)
 
     const dialogEl = screen.getByRole("dialog")
     expect(dialogEl).toHaveTextContent("0")
@@ -269,7 +277,7 @@ describe("RepairRequestsDetailView", () => {
       error: new Error("RPC repair_request_change_history_list failed (500)"),
     })
 
-    render(<RepairRequestsDetailView requestToView={mockRequest} onClose={vi.fn()} />)
+    render(<RepairRequestsDetailView />)
 
     expect(mockMapRepairRequestHistoryEntries).not.toHaveBeenCalled()
     expect(mockDetailTabs).toHaveBeenCalledWith({
@@ -290,13 +298,17 @@ describe("RepairRequestsDetailView", () => {
   })
 
   it("calls onClose when the close button is clicked", async () => {
-    const onClose = vi.fn()
+    const closeAllDialogs = vi.fn()
     const user = userEvent.setup()
+    mockUseRepairRequestsContext.mockReturnValue({
+      dialogState: { requestToView: mockRequest },
+      closeAllDialogs,
+    })
 
-    render(<RepairRequestsDetailView requestToView={mockRequest} onClose={onClose} />)
+    render(<RepairRequestsDetailView />)
 
     await user.click(screen.getByRole("button", { name: /close shared sheet/i }))
 
-    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(closeAllDialogs).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
@@ -108,4 +108,22 @@ describe("RepairRequestsMobileList accessibility", () => {
     expect(columnOptions.onGenerateSheet).toHaveBeenCalledWith(request)
     expect(setRequestToView).not.toHaveBeenCalled()
   })
+
+  it("keeps block card content outside the activation button", () => {
+    const request = makeRepairRequest()
+
+    render(
+      <RepairRequestsMobileList
+        requests={[request]}
+        isLoading={false}
+        setRequestToView={vi.fn()}
+        columnOptions={makeColumnOptions()}
+      />,
+    )
+
+    const activationButton = screen.getByRole("button", { name: /Máy siêu âm/ })
+
+    expect(activationButton.querySelector(".mobile-repair-card-content")).toBeNull()
+    expect(screen.getByText("Người yêu cầu").closest("button")).not.toBe(activationButton)
+  })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx
@@ -156,7 +156,7 @@ import RepairRequestsPageClient from "../_components/RepairRequestsPageClient"
 describe("RepairRequestsPage Suspense boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    window.localStorage.clear()
+    globalThis.localStorage.clear()
   })
 
   it("renders the loading skeletons when useSearchParams suspends", async () => {
@@ -215,7 +215,7 @@ describe("RepairRequestsPage Suspense boundary", () => {
       storedFilters: { status: [], dateRange: null },
     },
   ])("marks the page filtered for an active $name", ({ selectedFacilityId, storedFilters }) => {
-    window.localStorage.setItem("rr_filter_state", JSON.stringify(storedFilters))
+    globalThis.localStorage.setItem("rr_filter_state", JSON.stringify(storedFilters))
 
     mocks.useSession.mockReturnValue({
       data: {

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 
 const pendingSearchParams = new Promise<never>(() => {})
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   toast: vi.fn(),
   useRouter: vi.fn(),
   useSearchParams: vi.fn(),
+  layoutProps: vi.fn(),
 }))
 
 vi.mock("@tanstack/react-query", () => ({
@@ -91,6 +92,10 @@ vi.mock("../_hooks/useRepairRequestsData", () => ({
   }),
 }))
 
+vi.mock("../_hooks/useRepairRequestsDeepLink", () => ({
+  useRepairRequestsDeepLink: vi.fn(),
+}))
+
 vi.mock("../_hooks/useRepairRequestsSummary", () => ({
   useRepairRequestsSummary: () => ({ summaryItems: [] }),
 }))
@@ -119,8 +124,20 @@ vi.mock("../_components/RepairRequestsDetailView", () => ({
   RepairRequestsDetailView: () => null,
 }))
 
+vi.mock("../_components/RepairRequestsPageDialogs", () => ({
+  RepairRequestsPageDialogs: () => null,
+}))
+
 vi.mock("../_components/RepairRequestsPageLayout", () => ({
-  RepairRequestsPageLayout: () => null,
+  RepairRequestsPageLayout: (props: { filterState: { isFiltered: boolean } }) => {
+    mocks.layoutProps(props)
+    return (
+      <div
+        data-testid="repair-requests-page-layout"
+        data-is-filtered={String(props.filterState.isFiltered)}
+      />
+    )
+  },
 }))
 
 vi.mock("@/components/error-boundary", () => ({
@@ -134,8 +151,14 @@ vi.mock("@/components/ui/skeleton", () => ({
 }))
 
 import RepairRequestsPage from "../page"
+import RepairRequestsPageClient from "../_components/RepairRequestsPageClient"
 
 describe("RepairRequestsPage Suspense boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+  })
+
   it("renders the loading skeletons when useSearchParams suspends", async () => {
     mocks.useSession.mockReturnValue({
       data: {
@@ -178,5 +201,60 @@ describe("RepairRequestsPage Suspense boundary", () => {
     expect(skeletons).toHaveLength(2)
     expect(skeletons[0]).toHaveAttribute("data-classname", "h-8 w-32 mx-auto")
     expect(skeletons[1]).toHaveAttribute("data-classname", "h-4 w-48 mx-auto")
+  })
+
+  it.each([
+    {
+      name: "status filter",
+      selectedFacilityId: undefined,
+      storedFilters: { status: ["Chờ xử lý"], dateRange: null },
+    },
+    {
+      name: "facility filter",
+      selectedFacilityId: 1,
+      storedFilters: { status: [], dateRange: null },
+    },
+  ])("marks the page filtered for an active $name", ({ selectedFacilityId, storedFilters }) => {
+    window.localStorage.setItem("rr_filter_state", JSON.stringify(storedFilters))
+
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: 1,
+          role: "global",
+          don_vi: null,
+          dia_ban_id: null,
+          name: "Global Admin",
+        },
+      },
+      status: "authenticated",
+    })
+
+    mocks.useTenantSelection.mockReturnValue({
+      selectedFacilityId,
+      setSelectedFacilityId: vi.fn(),
+      facilities: [{ id: 1, name: "Bệnh viện A" }],
+      showSelector: true,
+      shouldFetchData: true,
+      isLoading: false,
+    })
+
+    mocks.useQueryClient.mockReturnValue({
+      invalidateQueries: vi.fn(),
+    })
+
+    mocks.useRouter.mockReturnValue({
+      push: vi.fn(),
+      replace: vi.fn(),
+    })
+
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams())
+
+    render(<RepairRequestsPageClient />)
+
+    expect(screen.getByTestId("repair-requests-page-layout")).toHaveAttribute(
+      "data-is-filtered",
+      "true",
+    )
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
@@ -50,10 +50,12 @@ vi.mock('../_components/RepairRequestsCreateSheet', () => ({
 }))
 
 vi.mock('../_components/RepairRequestsToolbar', () => ({
-  RepairRequestsToolbar: ({ tenantControl }: { tenantControl?: React.ReactNode }) => (
-    <div data-testid="repair-toolbar">
+  RepairRequestsToolbar: ({ showFacilityFilter }: { showFacilityFilter: boolean }) => (
+    <div
+      data-testid="repair-toolbar"
+      data-show-facility-filter={String(showFacilityFilter)}
+    >
       toolbar
-      {tenantControl ? <div data-testid="toolbar-tenant-slot">{tenantControl}</div> : null}
     </div>
   ),
 }))
@@ -186,11 +188,12 @@ describe('RepairRequestsPageLayout', () => {
     expect(screen.getByTestId('kpi-total')).toHaveAttribute('data-value', '42')
   })
 
-  it('places the tenant selector in the toolbar slot like Equipment', () => {
+  it('passes facility selector visibility to the toolbar like Equipment', () => {
     render(<RepairRequestsPageLayout {...withAccessState({ showFacilityFilter: true })} />)
 
-    expect(screen.getByTestId('toolbar-tenant-slot')).toContainElement(
-      screen.getByTestId('tenant-selector')
+    expect(screen.getByTestId('repair-toolbar')).toHaveAttribute(
+      'data-show-facility-filter',
+      'true'
     )
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageState.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageState.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import type { ColumnFiltersState } from "@tanstack/react-table"
+
+import {
+  createRepairRequestsPageState,
+  repairRequestsPageStateReducer,
+} from "../_components/RepairRequestsPageState"
+
+describe("repairRequestsPageStateReducer", () => {
+  it("updates related table and filter state without dropping existing preferences", () => {
+    const initial = createRepairRequestsPageState({
+      uiFilters: { status: ["Chờ xử lý"], dateRange: null },
+      columnVisibility: { trang_thai: false },
+    })
+
+    const withSearch = repairRequestsPageStateReducer(initial, {
+      type: "set-search-term",
+      value: "máy siêu âm",
+    })
+    const withFilters = repairRequestsPageStateReducer(withSearch, {
+      type: "set-column-filters",
+      updater: (current: ColumnFiltersState) => [
+        ...current,
+        { id: "trang_thai", value: ["Chờ xử lý"] },
+      ],
+    })
+    const withModalOpen = repairRequestsPageStateReducer(withFilters, {
+      type: "set-filter-modal-open",
+      value: true,
+    })
+
+    expect(withModalOpen).toMatchObject({
+      searchTerm: "máy siêu âm",
+      columnFilters: [{ id: "trang_thai", value: ["Chờ xử lý"] }],
+      columnVisibility: { trang_thai: false },
+      isFilterModalOpen: true,
+      uiFilters: { status: ["Chờ xử lý"], dateRange: null },
+    })
+  })
+})

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
@@ -16,7 +16,7 @@ const baseProps = {
   uiFilters: { status: [], dateRange: null },
   selectedFacilityName: null,
   selectedFacilityId: null,
-  showFacilityFilter: true,
+  showFacilityFilter: false,
   onFilterChange: vi.fn(),
   onRemoveFilter: vi.fn(),
   compactFilters: false,

--- a/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
@@ -1,5 +1,5 @@
 import type { ColumnDef } from "@tanstack/react-table"
-import { useMemo } from "react"
+import * as React from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
@@ -34,15 +34,19 @@ export interface RepairRequestColumnOptions {
   isRegionalLeader: boolean
 }
 
+interface RepairRequestRowActionsProps {
+  readonly request: RepairRequestWithEquipment
+  readonly options: RepairRequestColumnOptions
+}
+
 /**
  * Renders the actions dropdown menu for a repair request row.
  * Actions vary based on request status and user permissions.
- * Exported for use in mobile card view.
  */
-export function renderActions(
-  request: RepairRequestWithEquipment,
-  options: RepairRequestColumnOptions
-) {
+export function RepairRequestRowActions({
+  request,
+  options,
+}: RepairRequestRowActionsProps) {
   const {
     onGenerateSheet,
     setEditingRequest,
@@ -116,7 +120,7 @@ export function renderActions(
  * Uses useMemo to prevent unnecessary re-renders.
  */
 export function useRepairRequestColumns(options: RepairRequestColumnOptions): ColumnDef<RepairRequestWithEquipment>[] {
-  const columns = useMemo<ColumnDef<RepairRequestWithEquipment>[]>(() => [
+  const columns = React.useMemo<ColumnDef<RepairRequestWithEquipment>[]>(() => [
     // 1. Thiết bị (với mô tả sự cố)
     {
       accessorFn: (row) => {
@@ -294,7 +298,7 @@ export function useRepairRequestColumns(options: RepairRequestColumnOptions): Co
           onKeyDown={(event) => event.stopPropagation()}
           role="presentation"
         >
-          {renderActions(row.original, options)}
+          <RepairRequestRowActions request={row.original} options={options} />
         </div>
       ),
     },

--- a/src/app/(app)/repair-requests/_components/RepairRequestsDetailView.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsDetailView.tsx
@@ -9,11 +9,18 @@ import {
 import { mapRepairRequestHistoryEntries } from "@/app/(app)/repair-requests/_lib/repairRequestHistoryAdapter"
 import { useRepairRequestHistory } from "@/app/(app)/repair-requests/_hooks/useRepairRequestHistory"
 import type { RepairRequestWithEquipment } from "@/app/(app)/repair-requests/types"
+import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
 import { RepairRequestsDetailTabs } from "./RepairRequestsDetailTabs"
 
-interface RepairRequestsDetailViewProps {
+interface ControlledRepairRequestsDetailViewProps {
   requestToView: RepairRequestWithEquipment | null
   onClose: () => void
+  contentHeader?: React.ReactNode
+  footerContent?: React.ReactNode
+  renderSheetShell?: boolean
+}
+
+interface RepairRequestsDetailViewProps {
   contentHeader?: React.ReactNode
   footerContent?: React.ReactNode
   renderSheetShell?: boolean
@@ -38,15 +45,15 @@ function getSafeHistoryErrorMessage(error: unknown) {
 }
 
 /**
- * Detail view for a repair request — unified Sheet shell with tabs for details and history.
+ * Controlled detail view for callers outside the repair-requests dialog context.
  */
-export const RepairRequestsDetailView = React.memo(function RepairRequestsDetailView({
+export const ControlledRepairRequestsDetailView = React.memo(function ControlledRepairRequestsDetailView({
   requestToView,
   onClose,
   contentHeader,
   footerContent,
   renderSheetShell = true,
-}: RepairRequestsDetailViewProps) {
+}: ControlledRepairRequestsDetailViewProps) {
   const hasFooterContent = footerContent !== null && footerContent !== undefined
   const [activeTab, setActiveTab] = React.useState("details")
 
@@ -149,5 +156,29 @@ export const RepairRequestsDetailView = React.memo(function RepairRequestsDetail
       {contentHeader}
       {detailTabs}
     </SideSheetShell>
+  )
+})
+
+/**
+ * Detail view for the repair-requests page dialog context.
+ */
+export const RepairRequestsDetailView = React.memo(function RepairRequestsDetailView({
+  contentHeader,
+  footerContent,
+  renderSheetShell = true,
+}: RepairRequestsDetailViewProps) {
+  const {
+    dialogState: { requestToView },
+    closeAllDialogs,
+  } = useRepairRequestsContext()
+
+  return (
+    <ControlledRepairRequestsDetailView
+      requestToView={requestToView}
+      onClose={closeAllDialogs}
+      contentHeader={contentHeader}
+      footerContent={footerContent}
+      renderSheetShell={renderSheetShell}
+    />
   )
 })

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
@@ -9,6 +9,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import type { RepairRequestWithEquipment } from "../types"
 import { getStatusVariant } from "../utils"
 import { DaysRemainingBar } from "./DaysRemainingBar"
+import {
+  RepairRequestRowActions,
+  type RepairRequestColumnOptions,
+} from "./RepairRequestsColumns"
 
 /**
  * Props for the MobileRequestList component.
@@ -20,8 +24,8 @@ export interface MobileRequestListProps {
   isLoading: boolean
   /** Callback to view request details */
   setRequestToView: (req: RepairRequestWithEquipment | null) => void
-  /** Render function for actions dropdown */
-  renderActions: (req: RepairRequestWithEquipment) => React.ReactNode
+  /** Shared row action options */
+  columnOptions: RepairRequestColumnOptions
 }
 
 /**
@@ -32,18 +36,8 @@ export function RepairRequestsMobileList({
   requests,
   isLoading,
   setRequestToView,
-  renderActions
+  columnOptions,
 }: MobileRequestListProps) {
-  const openRequestFromKeyboard = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>, request: RepairRequestWithEquipment) => {
-      if (event.key !== "Enter" && event.key !== " ") return
-
-      event.preventDefault()
-      setRequestToView(request)
-    },
-    [setRequestToView],
-  )
-
   const stopActionPropagation = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
       event.stopPropagation()
@@ -75,12 +69,10 @@ export function RepairRequestsMobileList({
           key={request.id}
           className="mobile-repair-card relative hover:bg-muted/50"
         >
-          <div
-            className="cursor-pointer rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          <button
+            type="button"
+            className="block w-full cursor-pointer rounded-lg bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             onClick={() => setRequestToView(request)}
-            onKeyDown={(event) => openRequestFromKeyboard(event, request)}
-            role="button"
-            tabIndex={0}
             aria-label={`Xem yêu cầu sửa chữa ${request.thiet_bi?.ten_thiet_bi || 'N/A'}`}
           >
           <CardHeader className="mobile-repair-card-header flex flex-row items-start justify-between">
@@ -148,14 +140,14 @@ export function RepairRequestsMobileList({
               </div>
             )}
           </CardContent>
-          </div>
+          </button>
           <div
             className="absolute right-6 top-6 flex-shrink-0"
             onClick={stopActionPropagation}
             onKeyDown={stopActionPropagation}
             role="presentation"
           >
-            {renderActions(request)}
+            <RepairRequestRowActions request={request} options={columnOptions} />
           </div>
         </Card>
       ))}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
@@ -71,12 +71,12 @@ export function RepairRequestsMobileList({
         >
           <button
             type="button"
-            className="block w-full cursor-pointer rounded-lg bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="absolute inset-0 z-0 cursor-pointer rounded-lg bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             onClick={() => setRequestToView(request)}
             aria-label={`Xem yêu cầu sửa chữa ${request.thiet_bi?.ten_thiet_bi || 'N/A'}`}
-          >
-          <CardHeader className="mobile-repair-card-header flex flex-row items-start justify-between">
-            <div className="flex-1 min-w-0 pr-12">
+          />
+          <CardHeader className="mobile-repair-card-header pointer-events-none relative z-10 flex flex-row items-start justify-between">
+            <div className="min-w-0 flex-1 pr-12">
               <CardTitle className="mobile-repair-card-title truncate line-clamp-1">
                 {request.thiet_bi?.ten_thiet_bi || 'N/A'}
               </CardTitle>
@@ -85,7 +85,7 @@ export function RepairRequestsMobileList({
               </CardDescription>
             </div>
           </CardHeader>
-          <CardContent className="mobile-repair-card-content">
+          <CardContent className="mobile-repair-card-content pointer-events-none relative z-10">
             {/* Người yêu cầu */}
             {request.nguoi_yeu_cau && (
               <div className="mobile-repair-card-field">
@@ -140,9 +140,8 @@ export function RepairRequestsMobileList({
               </div>
             )}
           </CardContent>
-          </button>
           <div
-            className="absolute right-6 top-6 flex-shrink-0"
+            className="absolute right-6 top-6 z-20 flex-shrink-0"
             onClick={stopActionPropagation}
             onKeyDown={stopActionPropagation}
             role="presentation"

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -12,7 +12,6 @@ import {
 } from "@tanstack/react-table"
 import { useQueryClient } from "@tanstack/react-query"
 import { useToast } from "@/hooks/use-toast"
-import { Skeleton } from "@/components/ui/skeleton"
 import { format } from "date-fns"
 import { useSession } from "next-auth/react"
 import { useTenantBranding } from "@/hooks/use-tenant-branding"
@@ -23,13 +22,10 @@ import { useSearchDebounce } from "@/hooks/use-debounce"
 import { useTenantSelection } from "@/contexts/TenantSelectionContext"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { ErrorBoundary } from "@/components/error-boundary"
-import { RepairRequestsDetailView } from "./RepairRequestsDetailView"
-import { RepairRequestsEditDialog } from "./RepairRequestsEditDialog"
-import { RepairRequestsDeleteDialog } from "./RepairRequestsDeleteDialog"
-import { RepairRequestsApproveDialog } from "./RepairRequestsApproveDialog"
-import { RepairRequestsCompleteDialog } from "./RepairRequestsCompleteDialog"
 import { RepairRequestsProvider } from "./RepairRequestsContext"
 import { RepairRequestsPageLayout } from "./RepairRequestsPageLayout"
+import { RepairRequestsPageDialogs } from "./RepairRequestsPageDialogs"
+import { RepairRequestsPageLoadingFallback } from "./RepairRequestsPageLoadingFallback"
 import type { FilterModalValue } from "./RepairRequestsFilterModal"
 import type { RepairRequestWithEquipment } from "../types"
 import { useRepairRequestsData } from "../_hooks/useRepairRequestsData"
@@ -40,12 +36,16 @@ import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
 import { useRepairRequestUIHandlers } from "../_hooks/useRepairRequestUIHandlers"
 import { useRepairRequestColumns } from "./RepairRequestsColumns"
 import {
+  createRepairRequestsPageState,
+  repairRequestsPageStateReducer,
+  resolveRepairRequestsPageUpdater,
+} from "./RepairRequestsPageState"
+import {
   getUiFilters,
   setUiFilters,
   getColumnVisibility,
   setColumnVisibility,
   type UiFilters as UiFiltersPrefs,
-  type ColumnVisibility as ColumnVisibilityPrefs,
 } from "@/lib/rr-prefs"
 
 /**
@@ -63,7 +63,6 @@ function RepairRequestsPageClientInner() {
   const isSheetMobile = useMediaQuery("(max-width: 1279px)")
   const queryClient = useQueryClient()
 
-  // Context values
   const {
     isRegionalLeader,
     dialogState,
@@ -79,33 +78,53 @@ function RepairRequestsPageClientInner() {
 
   const searchParams = useSearchParams()
 
-  // Table state
-  const [sorting, setSorting] = React.useState<SortingState>([
-    { id: "ngay_yeu_cau", desc: true },
-  ]);
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
-  const [searchTerm, setSearchTerm] = React.useState("");
+  const [pageState, dispatchPageState] = React.useReducer(
+    repairRequestsPageStateReducer,
+    undefined,
+    () =>
+      createRepairRequestsPageState({
+        uiFilters: getUiFilters(),
+        columnVisibility: getColumnVisibility(),
+      }),
+  )
+
+  const {
+    sorting,
+    columnFilters,
+    searchTerm,
+    uiFilters,
+    isFilterModalOpen,
+    columnVisibility,
+  } = pageState
+
   const debouncedSearch = useSearchDebounce(searchTerm);
-
-  // UI filters (status/date) persisted
-  const [uiFilters, setUiFiltersState] = React.useState<UiFiltersPrefs>(() => getUiFilters());
-  const [isFilterModalOpen, setIsFilterModalOpen] = React.useState(false);
-
-  // Table presentation preferences
-  const [columnVisibility, setColumnVisibilityState] = React.useState<ColumnVisibilityPrefs>(() => getColumnVisibility() || {});
 
   const searchInputRef = React.useRef<HTMLInputElement | null>(null)
 
-  // UI handlers (sheet generation, etc.)
+  const setSearchTerm = React.useCallback((value: string) => {
+    dispatchPageState({ type: "set-search-term", value })
+  }, [])
+
+  const setUiFiltersState = React.useCallback((value: UiFiltersPrefs) => {
+    dispatchPageState({ type: "set-ui-filters", value })
+  }, [])
+
+  const persistUiFiltersState = React.useCallback((value: UiFiltersPrefs) => {
+    setUiFiltersState(value)
+    setUiFilters(value)
+  }, [setUiFiltersState])
+
+  const setFilterModalOpen = React.useCallback((value: boolean) => {
+    dispatchPageState({ type: "set-filter-modal-open", value })
+  }, [])
+
   const { handleGenerateRequestSheet } = useRepairRequestUIHandlers({
     branding,
     toast,
   })
 
-  // Regional leader facility filtering via TenantSelectionContext
   const effectiveTenantKey = user?.don_vi ?? user?.current_don_vi ?? 'none';
 
-  // Get facility selection from shared context
   const {
     selectedFacilityId,
     setSelectedFacilityId,
@@ -114,7 +133,6 @@ function RepairRequestsPageClientInner() {
     shouldFetchData,
   } = useTenantSelection()
 
-  // Data fetching (list query, status counts, pagination)
   const {
     requests,
     isLoading,
@@ -142,7 +160,6 @@ function RepairRequestsPageClientInner() {
     return facility?.name ?? null;
   }, [selectedFacilityId, facilityOptions]);
 
-  // Deep-link handling (equipment fetch, URL params, action=create)
   useRepairRequestsDeepLink({
     searchParams,
     router,
@@ -156,7 +173,6 @@ function RepairRequestsPageClientInner() {
     queryClient,
   })
 
-  // Adapter functions to bridge context (non-null) with column options (nullable)
   const setEditingRequestAdapter = React.useCallback((req: RepairRequestWithEquipment | null) => {
     if (req) openEditDialog(req)
   }, [openEditDialog])
@@ -169,7 +185,6 @@ function RepairRequestsPageClientInner() {
     if (req) openViewDialog(req)
   }, [openViewDialog])
 
-  // Table columns
   const columnOptions = React.useMemo(() => ({
     onGenerateSheet: handleGenerateRequestSheet,
     setEditingRequest: setEditingRequestAdapter,
@@ -193,10 +208,7 @@ function RepairRequestsPageClientInner() {
   const columns = useRepairRequestColumns(columnOptions)
   const tableData = requests;
 
-  // Keep the table subtree stable across pagination/filter result-size changes.
-  const tableKey = React.useMemo(() => {
-    return `${selectedFacilityId ?? 'all'}`;
-  }, [selectedFacilityId]);
+  const tableKey = `${selectedFacilityId ?? 'all'}`;
 
   const pageCount = repairPagination.pageCount
 
@@ -212,16 +224,17 @@ function RepairRequestsPageClientInner() {
     },
     pageCount,
     manualPagination: true,
-    onSortingChange: setSorting,
-    onColumnFiltersChange: (updater: Updater<ColumnFiltersState>) => {
-      const next = typeof updater === 'function' ? updater(columnFilters) : updater
-      setColumnFilters(next)
+    onSortingChange: (updater: Updater<SortingState>) => {
+      dispatchPageState({ type: "set-sorting", updater })
     },
-    onGlobalFilterChange: (value: string) => setSearchTerm(value),
+    onColumnFiltersChange: (updater: Updater<ColumnFiltersState>) => {
+      dispatchPageState({ type: "set-column-filters", updater })
+    },
+    onGlobalFilterChange: setSearchTerm,
     onPaginationChange: repairPagination.setPagination,
     onColumnVisibilityChange: (updater: Updater<VisibilityState>) => {
-      const next = typeof updater === 'function' ? updater(columnVisibility) : updater
-      setColumnVisibilityState(next)
+      const next = resolveRepairRequestsPageUpdater(updater, columnVisibility)
+      dispatchPageState({ type: "set-column-visibility", updater })
       setColumnVisibility(next)
     },
     getCoreRowModel: getCoreRowModel(),
@@ -237,7 +250,6 @@ function RepairRequestsPageClientInner() {
     Boolean(uiFilters.dateRange?.from || uiFilters.dateRange?.to)
   );
 
-  // Keyboard shortcuts: '/', 'n'
   useRepairRequestShortcuts({
     searchInputRef,
     onCreate: openCreateSheet,
@@ -246,31 +258,26 @@ function RepairRequestsPageClientInner() {
 
 
 
-  // Toolbar handlers
   const handleClearFilters = React.useCallback(() => {
     table.resetColumnFilters();
-    setUiFiltersState({ status: [], dateRange: null });
-    setUiFilters({ status: [], dateRange: null });
+    persistUiFiltersState({ status: [], dateRange: null });
     if (showFacilityFilter) setSelectedFacilityId(null);
     setSearchTerm("");
-  }, [table, setUiFiltersState, showFacilityFilter, setSelectedFacilityId]);
+  }, [persistUiFiltersState, table, showFacilityFilter, setSelectedFacilityId, setSearchTerm]);
 
   const handleRemoveFilter = React.useCallback((key: "status" | "facilityName" | "dateRange", sub?: string) => {
     if (key === 'status' && sub) {
       const next = uiFilters.status.filter(s => s !== sub);
       const updated = { ...uiFilters, status: next };
-      setUiFiltersState(updated);
-      setUiFilters(updated);
+      persistUiFiltersState(updated);
     } else if (key === 'facilityName') {
       setSelectedFacilityId(null);
     } else if (key === 'dateRange') {
       const updated = { ...uiFilters, dateRange: null };
-      setUiFiltersState(updated);
-      setUiFilters(updated);
+      persistUiFiltersState(updated);
     }
-  }, [uiFilters, setUiFiltersState, setSelectedFacilityId]);
+  }, [persistUiFiltersState, uiFilters, setSelectedFacilityId]);
 
-  // Filter modal change handler
   const handleFilterChange = React.useCallback((v: FilterModalValue) => {
     if (showFacilityFilter) setSelectedFacilityId(v.facilityId ?? null)
     const updated: UiFiltersPrefs = {
@@ -280,18 +287,13 @@ function RepairRequestsPageClientInner() {
         to: v.dateRange.to ? format(v.dateRange.to, 'yyyy-MM-dd') : null,
       } : null,
     }
-    setUiFiltersState(updated); setUiFilters(updated)
-  }, [showFacilityFilter, setSelectedFacilityId, setUiFiltersState])
+    persistUiFiltersState(updated)
+  }, [persistUiFiltersState, showFacilityFilter, setSelectedFacilityId])
 
   return (
     <ErrorBoundary>
       <>
-        <RepairRequestsEditDialog />
-        <RepairRequestsDeleteDialog />
-        <RepairRequestsApproveDialog />
-        <RepairRequestsCompleteDialog />
-
-        <RepairRequestsDetailView
+        <RepairRequestsPageDialogs
           requestToView={dialogState.requestToView}
           onClose={closeAllDialogs}
         />
@@ -307,7 +309,7 @@ function RepairRequestsPageClientInner() {
           onSearchChange={setSearchTerm}
           searchInputRef={searchInputRef}
           onClearFilters={handleClearFilters}
-          onFilterModalOpenChange={setIsFilterModalOpen}
+          onFilterModalOpenChange={setFilterModalOpen}
           uiFilters={uiFilters}
           onFilterChange={handleFilterChange}
           selectedFacilityId={selectedFacilityId ?? null}
@@ -328,19 +330,13 @@ function RepairRequestsPageClientInner() {
   )
 }
 
+/** Renders the authenticated repair-requests feature client. */
 export default function RepairRequestsPageClient() {
   const { status } = useSession()
 
   // The page wrapper owns unauthenticated access; keep the skeleton as a defensive fallback.
   if (status === "loading" || status === "unauthenticated") {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="text-center space-y-2">
-          <Skeleton className="h-8 w-32 mx-auto" />
-          <Skeleton className="h-4 w-48 mx-auto" />
-        </div>
-      </div>
-    )
+    return <RepairRequestsPageLoadingFallback />
   }
 
   return (

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -293,10 +293,7 @@ function RepairRequestsPageClientInner() {
   return (
     <ErrorBoundary>
       <>
-        <RepairRequestsPageDialogs
-          requestToView={dialogState.requestToView}
-          onClose={closeAllDialogs}
-        />
+        <RepairRequestsPageDialogs />
 
         <RepairRequestsPageLayout
           selectedFacilityName={selectedFacilityName}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -65,14 +65,12 @@ function RepairRequestsPageClientInner() {
 
   const {
     isRegionalLeader,
-    dialogState,
     openEditDialog,
     openDeleteDialog,
     openApproveDialog,
     openCompleteDialog,
     openViewDialog,
     openCreateSheet,
-    closeAllDialogs,
     applyAssistantDraft,
   } = useRepairRequestsContext()
 

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -247,6 +247,8 @@ function RepairRequestsPageClientInner() {
   const isFiltered = (
     table.getState().columnFilters.length > 0 ||
     debouncedSearch.length > 0 ||
+    uiFilters.status.length > 0 ||
+    (selectedFacilityId !== null && selectedFacilityId !== undefined) ||
     Boolean(uiFilters.dateRange?.from || uiFilters.dateRange?.to)
   );
 

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageDialogs.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageDialogs.tsx
@@ -5,18 +5,9 @@ import { RepairRequestsCompleteDialog } from "./RepairRequestsCompleteDialog"
 import { RepairRequestsDeleteDialog } from "./RepairRequestsDeleteDialog"
 import { RepairRequestsDetailView } from "./RepairRequestsDetailView"
 import { RepairRequestsEditDialog } from "./RepairRequestsEditDialog"
-import type { RepairRequestWithEquipment } from "../types"
-
-interface RepairRequestsPageDialogsProps {
-  readonly requestToView: RepairRequestWithEquipment | null
-  readonly onClose: () => void
-}
 
 /** Renders the repair-requests dialog stack owned by the page client. */
-export function RepairRequestsPageDialogs({
-  requestToView,
-  onClose,
-}: RepairRequestsPageDialogsProps) {
+export function RepairRequestsPageDialogs() {
   return (
     <>
       <RepairRequestsEditDialog />
@@ -24,10 +15,7 @@ export function RepairRequestsPageDialogs({
       <RepairRequestsApproveDialog />
       <RepairRequestsCompleteDialog />
 
-      <RepairRequestsDetailView
-        requestToView={requestToView}
-        onClose={onClose}
-      />
+      <RepairRequestsDetailView />
     </>
   )
 }

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageDialogs.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageDialogs.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { RepairRequestsApproveDialog } from "./RepairRequestsApproveDialog"
+import { RepairRequestsCompleteDialog } from "./RepairRequestsCompleteDialog"
+import { RepairRequestsDeleteDialog } from "./RepairRequestsDeleteDialog"
+import { RepairRequestsDetailView } from "./RepairRequestsDetailView"
+import { RepairRequestsEditDialog } from "./RepairRequestsEditDialog"
+import type { RepairRequestWithEquipment } from "../types"
+
+interface RepairRequestsPageDialogsProps {
+  readonly requestToView: RepairRequestWithEquipment | null
+  readonly onClose: () => void
+}
+
+/** Renders the repair-requests dialog stack owned by the page client. */
+export function RepairRequestsPageDialogs({
+  requestToView,
+  onClose,
+}: RepairRequestsPageDialogsProps) {
+  return (
+    <>
+      <RepairRequestsEditDialog />
+      <RepairRequestsDeleteDialog />
+      <RepairRequestsApproveDialog />
+      <RepairRequestsCompleteDialog />
+
+      <RepairRequestsDetailView
+        requestToView={requestToView}
+        onClose={onClose}
+      />
+    </>
+  )
+}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
@@ -14,7 +14,6 @@ import { parseISO } from "date-fns"
 import { KpiStatusBar, REPAIR_STATUS_CONFIGS } from "@/components/kpi"
 import type { RepairStatus } from "@/components/kpi"
 import { RepairRequestAlert } from "@/components/repair-request-alert"
-import { TenantSelector } from "@/components/shared/TenantSelector"
 import { DataTablePagination } from "@/components/shared/DataTablePagination"
 import { FloatingActionButton } from "@/components/shared/FloatingActionButton"
 import { RepairRequestsFilterModal, type FilterModalValue } from "./RepairRequestsFilterModal"
@@ -22,7 +21,7 @@ import { RepairRequestsCreateSheet } from "./RepairRequestsCreateSheet"
 import { RepairRequestsToolbar } from "./RepairRequestsToolbar"
 import { RepairRequestsTable } from "./RepairRequestsTable"
 import { RepairRequestsMobileList } from "./RepairRequestsMobileList"
-import { renderActions, type RepairRequestColumnOptions } from "./RepairRequestsColumns"
+import type { RepairRequestColumnOptions } from "./RepairRequestsColumns"
 import type {
   RepairRequestOverdueSummary,
   RepairRequestWithEquipment,
@@ -188,7 +187,6 @@ export function RepairRequestsPageLayout({
               </CardHeader>
               <CardContent className="p-3 md:p-6 gap-3 md:gap-4">
                 <RepairRequestsToolbar
-                  tenantControl={showFacilityFilter ? <TenantSelector className="w-full" /> : null}
                   searchTerm={searchTerm}
                   onSearchChange={onSearchChange}
                   searchInputRef={searchInputRef}
@@ -230,7 +228,7 @@ export function RepairRequestsPageLayout({
                         requests={table.getRowModel().rows.map((row) => row.original)}
                         isLoading={isLoading || isFetching}
                         setRequestToView={setRequestToView}
-                        renderActions={(req: RepairRequestWithEquipment) => renderActions(req, columnOptions)}
+                        columnOptions={columnOptions}
                       />
                     ) : (
                       /* Desktop Table View */

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageLoadingFallback.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageLoadingFallback.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import * as React from "react"
+import { Skeleton } from "@/components/ui/skeleton"
+
+/** Renders the defensive loading fallback for the repair-requests feature client. */
+export function RepairRequestsPageLoadingFallback() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="text-center space-y-2">
+        <Skeleton className="h-8 w-32 mx-auto" />
+        <Skeleton className="h-4 w-48 mx-auto" />
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageState.ts
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageState.ts
@@ -1,0 +1,95 @@
+import type {
+  ColumnFiltersState,
+  SortingState,
+  Updater,
+  VisibilityState,
+} from "@tanstack/react-table"
+import type {
+  ColumnVisibility as ColumnVisibilityPrefs,
+  UiFilters as UiFiltersPrefs,
+} from "@/lib/rr-prefs"
+
+const INITIAL_SORTING: SortingState = [{ id: "ngay_yeu_cau", desc: true }]
+
+export interface RepairRequestsPageState {
+  readonly sorting: SortingState
+  readonly columnFilters: ColumnFiltersState
+  readonly searchTerm: string
+  readonly uiFilters: UiFiltersPrefs
+  readonly isFilterModalOpen: boolean
+  readonly columnVisibility: ColumnVisibilityPrefs
+}
+
+export type RepairRequestsPageAction =
+  | { type: "set-sorting"; updater: Updater<SortingState> }
+  | { type: "set-column-filters"; updater: Updater<ColumnFiltersState> }
+  | { type: "set-search-term"; value: string }
+  | { type: "set-ui-filters"; value: UiFiltersPrefs }
+  | { type: "set-filter-modal-open"; value: boolean }
+  | { type: "set-column-visibility"; updater: Updater<VisibilityState> }
+
+/** Resolves a TanStack updater against the current page state value. */
+export function resolveRepairRequestsPageUpdater<T>(
+  updater: Updater<T>,
+  current: T,
+): T {
+  if (typeof updater !== "function") {
+    return updater
+  }
+
+  return (updater as (old: T) => T)(current)
+}
+
+/** Creates the initial repair-requests page UI/table state from persisted preferences. */
+export function createRepairRequestsPageState({
+  uiFilters,
+  columnVisibility,
+}: {
+  readonly uiFilters: UiFiltersPrefs
+  readonly columnVisibility: ColumnVisibilityPrefs | null
+}): RepairRequestsPageState {
+  return {
+    sorting: [...INITIAL_SORTING],
+    columnFilters: [],
+    searchTerm: "",
+    uiFilters,
+    isFilterModalOpen: false,
+    columnVisibility: columnVisibility ?? {},
+  }
+}
+
+/** Applies repair-requests page UI/table state updates. */
+export function repairRequestsPageStateReducer(
+  state: RepairRequestsPageState,
+  action: RepairRequestsPageAction,
+): RepairRequestsPageState {
+  switch (action.type) {
+    case "set-sorting":
+      return {
+        ...state,
+        sorting: resolveRepairRequestsPageUpdater(action.updater, state.sorting),
+      }
+    case "set-column-filters":
+      return {
+        ...state,
+        columnFilters: resolveRepairRequestsPageUpdater(
+          action.updater,
+          state.columnFilters,
+        ),
+      }
+    case "set-search-term":
+      return { ...state, searchTerm: action.value }
+    case "set-ui-filters":
+      return { ...state, uiFilters: action.value }
+    case "set-filter-modal-open":
+      return { ...state, isFilterModalOpen: action.value }
+    case "set-column-visibility":
+      return {
+        ...state,
+        columnVisibility: resolveRepairRequestsPageUpdater(
+          action.updater,
+          state.columnVisibility,
+        ),
+      }
+  }
+}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
@@ -7,6 +7,7 @@ import { Calendar as CalendarIcon, FilterX } from "lucide-react"
 import { Calendar } from "@/components/ui/calendar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
+import { TenantSelector } from "@/components/shared/TenantSelector"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { cn } from "@/lib/utils"
 import { RepairRequestsFilterChips, type FilterChipsValue } from "./RepairRequestsFilterChips"
@@ -150,10 +151,18 @@ export function RepairRequestsToolbar({
     />
   ), [onRemoveFilter, selectedFacilityName, showFacilityFilter, uiFilters.dateRange, uiFilters.status])
 
+  const resolvedTenantControl = React.useMemo(() => {
+    if (tenantControl !== undefined) {
+      return tenantControl
+    }
+
+    return showFacilityFilter ? <TenantSelector className="w-full" /> : null
+  }, [showFacilityFilter, tenantControl])
+
   return (
     <ListFilterSearchCard
       surface="plain"
-      tenantControl={tenantControl}
+      tenantControl={resolvedTenantControl}
       searchInputRef={searchInputRef}
       searchValue={searchTerm}
       onSearchChange={onSearchChange}

--- a/src/components/equipment-linked-request/__tests__/repairRequestSheetAdapter.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/repairRequestSheetAdapter.test.tsx
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/app/(app)/repair-requests/_components/RepairRequestsDetailView', () => ({
-  RepairRequestsDetailView: ({
+  ControlledRepairRequestsDetailView: ({
     requestToView,
     onClose,
     contentHeader,
@@ -23,10 +23,10 @@ vi.mock('@/app/(app)/repair-requests/_components/RepairRequestsDetailView', () =
   }) => {
     mocks.detailView({ requestToView, onClose, contentHeader, footerContent })
     return (
-      <div role="dialog" data-testid="detail-view">
+      <dialog open data-testid="detail-view">
         <div data-testid="content-header">{contentHeader}</div>
         <div data-testid="footer-content">{footerContent}</div>
-      </div>
+      </dialog>
     )
   },
 }))

--- a/src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx
+++ b/src/components/equipment-linked-request/adapters/repairRequestSheetAdapter.tsx
@@ -7,7 +7,7 @@ import {
   buildRepairRequestViewHref,
   buildRepairRequestsByEquipmentHref,
 } from '@/lib/repair-request-deep-link'
-import { RepairRequestsDetailView } from '@/app/(app)/repair-requests/_components/RepairRequestsDetailView'
+import { ControlledRepairRequestsDetailView } from '@/app/(app)/repair-requests/_components/RepairRequestsDetailView'
 import type { RepairRequestWithEquipment } from '@/app/(app)/repair-requests/types'
 import { STRINGS } from '@/components/equipment-linked-request/strings'
 
@@ -52,7 +52,7 @@ export default function RepairRequestSheetAdapter({
   )
 
   return (
-    <RepairRequestsDetailView
+    <ControlledRepairRequestsDetailView
       requestToView={request}
       onClose={onClose}
       contentHeader={contentHeader}


### PR DESCRIPTION
## Summary
- Refactors the repair-requests slice for Issue #570 component-shape/API findings.
- Replaces `renderActions` render helper with `RepairRequestRowActions` and passes stable row action options through mobile/desktop views.
- Groups repair-requests page UI/table state in a reducer and extracts page dialogs/loading fallback to keep `RepairRequestsPageClient` below the repo line threshold.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsPageClient.auth.test.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestRowActions.test.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsPageState.test.ts`
- `node scripts/npm-run.js run react-doctor` exits 0; remaining diff warning is `nextjs-no-use-search-params-without-suspense` on `RepairRequestsPageClient`, covered by the existing `<React.Suspense>` wrapper in `page.tsx` and `RepairRequestsPageClient.suspense.test.tsx`.

Refs #570

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the repair-requests feature to align with React Doctor shape findings from Linear #570. Centralizes UI state, moves dialogs and the detail view into context, unifies row actions, improves mobile a11y, and adds a defensive loading fallback.

- **Refactors**
  - Move `RepairRequestsDetailView` into context; add `ControlledRepairRequestsDetailView` and update the equipment-linked adapter to use it.
  - Replace `renderActions` with `RepairRequestRowActions`, shared by table and mobile; hides actions for regional leaders.
  - Add `RepairRequestsPageState` reducer (sorting, filters, search, column visibility, filter modal); persist `uiFilters` and column visibility via `rr-prefs`.
  - Extract `RepairRequestsPageDialogs` and `RepairRequestsPageLoadingFallback`; remove unused dialog bindings from the page client.
  - Make mobile cards use an overlay activation button for keyboard access; keep card content outside the button and stop event propagation for the action menu.
  - Update `RepairRequestsToolbar` to auto-render `TenantSelector` when `showFacilityFilter` is true; `RepairRequestsPageLayout` now passes `showFacilityFilter` and `columnOptions`.

- **Bug Fixes**
  - Mark the page as filtered when status or facility filters are active (reads stored `rr_filter_state`).
  - Use native dialog semantics in the detail view for better accessibility.

<sup>Written for commit 7d5b0d26078059b4bcf1e06a94072e84052a88cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/586?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and tightened tests for repair-request actions, mobile accessibility, page state reducer, dialogs, and detail view behavior.

* **New Features**
  * Added a dedicated loading fallback UI for the repair-requests page.

* **Refactor**
  * Reworked mobile list interaction for better keyboard/activation semantics.
  * Centralized page UI state into a reducer for consistent persistence.
  * Split/detail dialogs and detail view into clearer, context-driven components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->