### PR TITLE
fix: address issue 571 React Doctor follow-ups

### DIFF
--- a/src/__tests__/react-doctor-issue-571-markup-perf.source.test.ts
+++ b/src/__tests__/react-doctor-issue-571-markup-perf.source.test.ts
@@ -73,6 +73,7 @@ describe("React Doctor Issue #571 semantic markup and perf source guards", () =>
 
     expect(source).not.toMatch(/React\.useEffect\([\s\S]*setMaxReportDate\(now\)[\s\S]*\}, \[\]\)/)
     expect(source).toContain("React.useSyncExternalStore")
+    expect(source).toMatch(/maxReportDateSnapshot\s*=\s*new Date\(\)[\s\S]*onStoreChange\(\)[\s\S]*scheduleNextReportDateRefresh\(\)/)
   })
 
   it("uses an external-store snapshot for mobile breakpoint state", () => {
@@ -81,6 +82,8 @@ describe("React Doctor Issue #571 semantic markup and perf source guards", () =>
     expect(source).toContain("React.useSyncExternalStore")
     expect(source).not.toContain("React.useEffect")
     expect(source).not.toContain("setIsMobile")
+    expect(source).toContain("mql.addListener")
+    expect(source).toContain("mql.removeListener")
   })
 
   it("loads the language preference without mount-only state initialization", () => {
@@ -88,6 +91,23 @@ describe("React Doctor Issue #571 semantic markup and perf source guards", () =>
 
     expect(source).not.toContain("setCurrentLanguage(parsed)")
     expect(source).toContain("React.useSyncExternalStore")
+    expect(source).toContain("cachedLanguageStorageValue")
+    expect(source).toContain("cachedLanguageSnapshot")
+  })
+
+  it("opens the mobile bottom sheet as a modal dialog", () => {
+    const source = readSource("src/components/shared/mobile-bottom-sheet.tsx")
+
+    expect(source).toContain(".showModal()")
+    expect(source).not.toMatch(/<dialog[\s\S]{0,120}\sopen\b/)
+  })
+
+  it("keeps category select buttons free of block component children", () => {
+    const source = readSource("src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx")
+    const buttonBlocks = source.match(/<button[\s\S]*?<\/button>/g) ?? []
+
+    expect(buttonBlocks.some((block) => block.includes("<Badge"))).toBe(false)
+    expect(buttonBlocks.some((block) => block.includes("<QuotaProgressBar"))).toBe(false)
   })
 
   it("memoizes constructed context provider values", () => {

--- a/src/__tests__/react-doctor-issue-571-markup-perf.source.test.ts
+++ b/src/__tests__/react-doctor-issue-571-markup-perf.source.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const repoRoot = process.cwd()
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), "utf8")
+}
+
+describe("React Doctor Issue #571 semantic markup and perf source guards", () => {
+  it.each([
+    [
+      "src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx",
+      /<div[\s\S]*?role="button"/,
+    ],
+    [
+      "src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryTree.tsx",
+      /role="(?:list|listitem)"/,
+    ],
+    [
+      "src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaImportDialog.test.tsx",
+      /role="status"/,
+    ],
+    ["src/components/__tests__/import-equipment-dialog.test.tsx", /role="status"/],
+    ["src/components/bulk-import/BulkImportDialogParts.tsx", /role="status"/],
+    [
+      "src/components/equipment-linked-request/__tests__/LinkedRequestRowIndicator.test.tsx",
+      /<div[\s\S]*?role="button"/,
+    ],
+    ["src/components/mobile-equipment-list-item.tsx", /role="group"/],
+    ["src/components/transfers/TransfersSearchParamsBoundary.tsx", /role="status"/],
+    [
+      "src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx",
+      /role="status"/,
+    ],
+    ["src/components/shared/mobile-bottom-sheet.tsx", /role="dialog"/],
+    [
+      "src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx",
+      /role="dialog"/,
+    ],
+    ["src/components/transfers/TransferCard.tsx", /<div[\s\S]*?role="button"/],
+    ["src/components/transfers/TransfersKanbanCard.tsx", /<div[\s\S]*?role="button"/],
+  ])("uses native semantic elements instead of fallback roles in %s", (relativePath, forbidden) => {
+    expect(readSource(relativePath)).not.toMatch(forbidden)
+  })
+
+  it.each([
+    "src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietToolbar.tsx",
+    "src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx",
+    "src/components/equipment/equipment-actions-menu.tsx",
+    "src/components/mobile-equipment-list-item.tsx",
+  ])("destructures router methods for React Compiler in %s", (relativePath) => {
+    const source = readSource(relativePath)
+
+    expect(source).not.toMatch(/const\s+router\s*=\s*useRouter\(\)/)
+    expect(source).not.toMatch(/\brouter\.push\(/)
+    expect(source).toMatch(/const\s+\{\s*push\s*\}\s*=\s*useRouter\(\)/)
+  })
+
+  it("does not initialize repair request date state from a mount-only effect", () => {
+    const source = readSource(
+      "src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx",
+    )
+
+    expect(source).not.toContain("setMinimumSelectableDate")
+    expect(source).toContain("React.useState<Date>(() => getTodayStart())")
+  })
+
+  it("schedules inventory report date refreshes without a mount-only initial set", () => {
+    const source = readSource(
+      "src/app/(app)/reports/components/inventory-report-filter-section.tsx",
+    )
+
+    expect(source).not.toMatch(/React\.useEffect\([\s\S]*setMaxReportDate\(now\)[\s\S]*\}, \[\]\)/)
+    expect(source).toContain("React.useSyncExternalStore")
+  })
+
+  it("uses an external-store snapshot for mobile breakpoint state", () => {
+    const source = readSource("src/hooks/use-mobile.tsx")
+
+    expect(source).toContain("React.useSyncExternalStore")
+    expect(source).not.toContain("React.useEffect")
+    expect(source).not.toContain("setIsMobile")
+  })
+
+  it("loads the language preference without mount-only state initialization", () => {
+    const source = readSource("src/contexts/language-context.tsx")
+
+    expect(source).not.toContain("setCurrentLanguage(parsed)")
+    expect(source).toContain("React.useSyncExternalStore")
+  })
+
+  it("memoizes constructed context provider values", () => {
+    const formSource = readSource("src/components/ui/form.tsx")
+    const tooltipSource = readSource("src/test-utils/tooltip-mock.tsx")
+
+    expect(formSource).toContain("const fieldContextValue = React.useMemo")
+    expect(formSource).toContain("const itemContextValue = React.useMemo")
+    expect(tooltipSource).toContain("const tooltipContextValue = React.useMemo")
+  })
+
+  it.each([
+    "src/app/(app)/equipment/_components/EquipmentColumnsDialog.tsx",
+    "src/app/(app)/reports/components/inventory-charts.tsx",
+    "src/components/transfer-dialog.form-sections.tsx",
+  ])("avoids filter-map iteration chains in %s", (relativePath) => {
+    expect(readSource(relativePath)).not.toMatch(/\.filter\([\s\S]*?\)\s*\.map\(/)
+  })
+})

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoriesPage.test.tsx
@@ -191,10 +191,10 @@ describe('DeviceQuotaCategoriesPage', () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText('Nhóm 1')).toBeInTheDocument()
-      expect(screen.getByText('Nhóm 1.1')).toBeInTheDocument()
-      expect(screen.getByText('Nhóm 1.2')).toBeInTheDocument()
-      expect(screen.getByText('Child A')).toBeInTheDocument()
+      expect(screen.getAllByText('Nhóm 1').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Nhóm 1.1').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Nhóm 1.2').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('Child A').length).toBeGreaterThan(0)
     })
   })
 })

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -69,68 +69,65 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
 
     return (
         <div
-            role="button"
-            tabIndex={0}
-            aria-label={selectLabel}
-            aria-pressed={isSelected}
-            title={category.ten_nhom}
-            onClick={selectCategory}
-            onKeyDown={(event) => {
-                if (event.target !== event.currentTarget) {
-                    return
-                }
-                if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault()
-                    selectCategory()
-                }
-            }}
             className={cn(
-                "group relative cursor-pointer rounded-md border border-transparent px-4 py-2.5 transition-all duration-150",
-                "hover:bg-accent/50 hover:border-border/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                "group relative rounded-md border border-transparent px-4 py-2.5 transition-all duration-150",
+                "hover:border-border/50 hover:bg-accent/50",
                 isSelected && "border-primary/30 bg-primary/5 ring-1 ring-primary/20",
                 CATEGORY_GRID_COLS
             )}
         >
-            {/* Column 1: Category name */}
-            <div className="relative min-w-0" style={{ paddingLeft: `${indentPx}px` }}>
-                {category.level > 2 && (
-                    <div
-                        className="absolute top-0 bottom-0 border-l-2 border-muted-foreground/15"
-                        style={{ left: `${Math.max(0, category.level - 3) * 20}px` }}
-                        aria-hidden="true"
+            <button
+                type="button"
+                aria-label={selectLabel}
+                aria-pressed={isSelected}
+                title={category.ten_nhom}
+                onClick={selectCategory}
+                className={cn(
+                    "col-span-3 grid grid-cols-[minmax(0,1fr)_5rem_12rem] items-center gap-x-4 rounded-sm bg-transparent p-0 text-left text-foreground",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                )}
+            >
+                {/* Column 1: Category name */}
+                <span className="relative min-w-0" style={{ paddingLeft: `${indentPx}px` }}>
+                    {category.level > 2 && (
+                        <span
+                            className="absolute top-0 bottom-0 border-l-2 border-muted-foreground/15"
+                            style={{ left: `${Math.max(0, category.level - 3) * 20}px` }}
+                            aria-hidden="true"
+                        />
+                    )}
+                    <span className="flex items-baseline gap-2">
+                        <span className="shrink-0 text-sm font-semibold text-primary/80">
+                            {category.ma_nhom}
+                        </span>
+                        <span className="line-clamp-2 text-sm text-foreground/80">
+                            {category.ten_nhom}
+                        </span>
+                    </span>
+                    {category.mo_ta && (
+                        <span className="mt-1 block line-clamp-2 text-xs italic text-muted-foreground">
+                            {category.mo_ta}
+                        </span>
+                    )}
+                </span>
+
+                {/* Column 2: Classification badge */}
+                <span>
+                    {classStyle && (
+                        <Badge variant="outline" className={cn("text-xs font-medium", classStyle.className)}>
+                            {classStyle.label}
+                        </Badge>
+                    )}
+                </span>
+
+                {/* Column 3: Quota progress bar */}
+                <span aria-label={isLeaf ? "Danh mục lá" : "Danh mục cha"}>
+                    <QuotaProgressBar
+                        current={aggregatedCount}
+                        max={quotaMax}
                     />
-                )}
-                <div className="flex items-baseline gap-2">
-                    <span className="shrink-0 text-sm font-semibold text-primary/80">
-                        {category.ma_nhom}
-                    </span>
-                    <span className="line-clamp-2 text-sm text-foreground/80">
-                        {category.ten_nhom}
-                    </span>
-                </div>
-                {category.mo_ta && (
-                    <p className="mt-1 line-clamp-2 text-xs italic text-muted-foreground">
-                        {category.mo_ta}
-                    </p>
-                )}
-            </div>
-
-            {/* Column 2: Classification badge */}
-            <div>
-                {classStyle && (
-                    <Badge variant="outline" className={cn("text-xs font-medium", classStyle.className)}>
-                        {classStyle.label}
-                    </Badge>
-                )}
-            </div>
-
-            {/* Column 3: Quota progress bar */}
-            <div aria-label={isLeaf ? "Danh mục lá" : "Danh mục cha"}>
-                <QuotaProgressBar
-                    current={aggregatedCount}
-                    max={quotaMax}
-                />
-            </div>
+                </span>
+            </button>
 
             {/* Column 4: Actions */}
             <CategoryActionMenu
@@ -161,6 +158,7 @@ interface CategoryGroupProps {
     onSelectCategory: (category: CategoryListItem) => void
 }
 
+/** Renders a root category group with selectable semantic rows and action controls. */
 const CategoryGroup = React.memo(function CategoryGroup({
     root,
     childCategories,
@@ -218,22 +216,15 @@ const CategoryGroup = React.memo(function CategoryGroup({
                             <ChevronDown className="size-4" />
                         )}
                     </Button>
-                    <div
-                        role="button"
-                        tabIndex={0}
+                    <button
+                        type="button"
                         aria-label={rootSelectLabel}
                         aria-pressed={rootSelected}
                         title={root.ten_nhom}
                         onClick={selectRoot}
-                        onKeyDown={(event) => {
-                            if (event.key === "Enter" || event.key === " ") {
-                                event.preventDefault()
-                                selectRoot()
-                            }
-                        }}
-                        className="min-w-0 flex-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        className="min-w-0 flex-1 rounded-sm bg-transparent p-0 text-left text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
-                        <div className="flex items-baseline gap-2">
+                        <span className="flex items-baseline gap-2">
                             <span className="text-sm font-bold text-primary">
                                 {root.ma_nhom}
                             </span>
@@ -243,8 +234,8 @@ const CategoryGroup = React.memo(function CategoryGroup({
                             <span className="text-xs text-muted-foreground whitespace-nowrap shrink-0">
                                 · {childCategories.length} mục con
                             </span>
-                        </div>
-                    </div>
+                        </span>
+                    </button>
                 </div>
 
                 {/* Column 2: Classification badge */}

--- a/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
+++ b/src/app/(app)/device-quota/categories/_components/CategoryGroup.tsx
@@ -83,7 +83,7 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
                 title={category.ten_nhom}
                 onClick={selectCategory}
                 className={cn(
-                    "col-span-3 grid grid-cols-[minmax(0,1fr)_5rem_12rem] items-center gap-x-4 rounded-sm bg-transparent p-0 text-left text-foreground",
+                    "min-w-0 rounded-sm bg-transparent p-0 text-left text-foreground",
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 )}
             >
@@ -111,23 +111,24 @@ const CategoryChildRow = React.memo(function CategoryChildRow({
                     )}
                 </span>
 
-                {/* Column 2: Classification badge */}
-                <span>
-                    {classStyle && (
-                        <Badge variant="outline" className={cn("text-xs font-medium", classStyle.className)}>
-                            {classStyle.label}
-                        </Badge>
-                    )}
-                </span>
-
-                {/* Column 3: Quota progress bar */}
-                <span aria-label={isLeaf ? "Danh mục lá" : "Danh mục cha"}>
-                    <QuotaProgressBar
-                        current={aggregatedCount}
-                        max={quotaMax}
-                    />
-                </span>
             </button>
+
+            {/* Column 2: Classification badge */}
+            <div>
+                {classStyle && (
+                    <Badge variant="outline" className={cn("text-xs font-medium", classStyle.className)}>
+                        {classStyle.label}
+                    </Badge>
+                )}
+            </div>
+
+            {/* Column 3: Quota progress bar */}
+            <div aria-label={isLeaf ? "Danh mục lá" : "Danh mục cha"}>
+                <QuotaProgressBar
+                    current={aggregatedCount}
+                    max={quotaMax}
+                />
+            </div>
 
             {/* Column 4: Actions */}
             <CategoryActionMenu

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryTree.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryTree.tsx
@@ -35,6 +35,7 @@ function findDefaultCategory(
   )
 }
 
+/** Renders the device quota category tree and detail pane. */
 export function DeviceQuotaCategoryTree() {
   const {
     categories,
@@ -68,29 +69,23 @@ export function DeviceQuotaCategoryTree() {
     [allCategories]
   )
 
-  const [selectedCategoryId, setSelectedCategoryId] = React.useState<number | null>(null)
+  const [explicitSelectedCategoryId, setExplicitSelectedCategoryId] = React.useState<number | null>(null)
 
   const defaultCategory = React.useMemo(
     () => findDefaultCategory(categories, aggregatedCounts, leafIds),
     [aggregatedCounts, categories, leafIds]
   )
 
-  const visibleSelectedCategory = React.useMemo(
-    () => categories.find((category) => category.id === selectedCategoryId) ?? null,
-    [categories, selectedCategoryId]
+  const explicitSelectedCategory = React.useMemo(
+    () => categories.find((category) => category.id === explicitSelectedCategoryId) ?? null,
+    [categories, explicitSelectedCategoryId]
   )
 
-  const selectedCategory = visibleSelectedCategory ?? defaultCategory
-
-  React.useEffect(() => {
-    const nextSelectedId = selectedCategory?.id ?? null
-    if (selectedCategoryId !== nextSelectedId) {
-      setSelectedCategoryId(nextSelectedId)
-    }
-  }, [selectedCategory?.id, selectedCategoryId])
+  const selectedCategory = explicitSelectedCategory ?? defaultCategory
+  const selectedCategoryId = selectedCategory?.id ?? null
 
   const handleSelectCategory = React.useCallback((category: CategoryListItem) => {
-    setSelectedCategoryId(category.id)
+    setExplicitSelectedCategoryId(category.id)
   }, [])
 
   const rootCount = roots.length
@@ -140,13 +135,12 @@ export function DeviceQuotaCategoryTree() {
               <span /> {/* Actions column */}
             </div>
 
-            <div
-              role="list"
+            <ul
               aria-label="Tiêu chuẩn, định mức thiết bị"
               className="space-y-3"
             >
               {roots.map((root) => (
-                <div key={root.id} role="listitem">
+                <li key={root.id}>
                   <CategoryGroup
                     root={root}
                     childCategories={childrenMap.get(root.id) || []}
@@ -159,9 +153,9 @@ export function DeviceQuotaCategoryTree() {
                     selectedCategoryId={selectedCategory?.id ?? null}
                     onSelectCategory={handleSelectCategory}
                   />
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           </div>
         )}
       </CardContent>

--- a/src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietToolbar.tsx
+++ b/src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietToolbar.tsx
@@ -53,7 +53,7 @@ function StatusBadge({ status }: { status: 'draft' | 'active' | 'inactive' }) {
  * - Decision status badge
  */
 export function DeviceQuotaChiTietToolbar() {
-  const router = useRouter()
+  const { push } = useRouter()
   const { toast } = useToast()
   const {
     decision,
@@ -118,7 +118,7 @@ export function DeviceQuotaChiTietToolbar() {
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => router.push('/device-quota/decisions')}
+            onClick={() => push('/device-quota/decisions')}
             aria-label="Quay lại danh sách quyết định"
             className="size-9"
           >

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx
@@ -216,8 +216,9 @@ function ActionsDropdown({ decision, onView, onEdit, onActivate, onDelete }: Act
 // Main Table Component
 // ============================================
 
+/** Renders quota decisions with row-level view, activate, and delete actions. */
 export function DeviceQuotaDecisionsTable() {
-  const router = useRouter()
+  const { push } = useRouter()
   const {
     decisions,
     isLoading,
@@ -232,8 +233,8 @@ export function DeviceQuotaDecisionsTable() {
 
   // Navigate to decision detail page
   const handleViewDetails = React.useCallback((decisionId: number) => {
-    router.push(`/device-quota/decisions/${decisionId}`)
-  }, [router])
+    push(`/device-quota/decisions/${decisionId}`)
+  }, [push])
 
   const handleActivateConfirm = React.useCallback(() => {
     if (!activateDialog) return

--- a/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaImportDialog.test.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaImportDialog.test.tsx
@@ -111,10 +111,10 @@ vi.mock('@/components/bulk-import', () => ({
     fileName: string
     recordCount: number
   }) => (
-    <div data-testid="success-message" role="status" aria-live="polite">
+    <output data-testid="success-message" aria-live="polite">
       <span>{fileName}</span>
       <span>{recordCount}</span>
-    </div>
+    </output>
   ),
   BulkImportSubmitButton: ({
     isSubmitting,

--- a/src/app/(app)/equipment/__tests__/EquipmentRowLinkedRequest.integration.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentRowLinkedRequest.integration.test.tsx
@@ -27,7 +27,7 @@ vi.mock("@/hooks/use-toast", () => ({
 }))
 
 vi.mock("@/components/ui/tooltip", async () => {
-  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock")
+  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock-module")
   return tooltipMockModule
 })
 

--- a/src/app/(app)/equipment/__tests__/equipment-content.desktop-interactions.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-content.desktop-interactions.test.tsx
@@ -10,7 +10,7 @@ import type { Equipment } from "@/types/database"
 import { EquipmentContent } from "../equipment-content"
 
 vi.mock("@/components/ui/tooltip", async () => {
-  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock")
+  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock-module")
   return tooltipMockModule
 })
 

--- a/src/app/(app)/equipment/__tests__/equipment-content.selection.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-content.selection.test.tsx
@@ -38,7 +38,7 @@ import type { Equipment } from "@/types/database"
 import { EquipmentContent } from "../equipment-content"
 
 vi.mock("@/components/ui/tooltip", async () => {
-  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock")
+  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock-module")
   return tooltipMockModule
 })
 

--- a/src/app/(app)/equipment/_components/EquipmentColumnsDialog.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentColumnsDialog.tsx
@@ -20,10 +20,20 @@ interface EquipmentColumnsDialogProps {
   table: Table<Equipment>
 }
 
+/** Renders the equipment table column visibility dialog. */
 export function EquipmentColumnsDialog({
   table,
 }: EquipmentColumnsDialogProps) {
   const { dialogState, closeColumnsDialog } = useEquipmentContext()
+  const hideableColumns = React.useMemo(() => {
+    const columns: ReturnType<typeof table.getAllColumns> = []
+    for (const column of table.getAllColumns()) {
+      if (column.getCanHide()) {
+        columns.push(column)
+      }
+    }
+    return columns
+  }, [table])
 
   return (
     <Dialog open={dialogState.isColumnsOpen} onOpenChange={(open) => !open && closeColumnsDialog()}>
@@ -33,10 +43,7 @@ export function EquipmentColumnsDialog({
           <DialogDescription>Chọn các cột muốn hiển thị trong bảng.</DialogDescription>
         </DialogHeader>
         <div className="max-h-[50vh] overflow-y-auto space-y-1">
-          {table
-            .getAllColumns()
-            .filter((column) => column.getCanHide())
-            .map((column) => (
+          {hideableColumns.map((column) => (
               <div key={column.id} className="flex items-center justify-between py-1">
                 <span className="text-sm text-muted-foreground">
                   {columnLabels[column.id as keyof Equipment] || column.id}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx
@@ -23,6 +23,12 @@ import type { EquipmentSelectItem, RepairUnit } from "../types"
 import { RepairRequestsCreateSheetActions } from "./RepairRequestsCreateSheetActions"
 import { RepairRequestsEquipmentSearchField } from "./RepairRequestsEquipmentSearchField"
 
+function getTodayStart(): Date {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  return today
+}
+
 interface RepairRequestsCreateSheetFormProps {
   canSetRepairUnit: boolean
   desiredDate: Date | undefined
@@ -46,6 +52,7 @@ interface RepairRequestsCreateSheetFormProps {
   shouldShowNoResults: boolean
 }
 
+/** Renders the repair request create sheet form fields and actions. */
 export function RepairRequestsCreateSheetForm({
   canSetRepairUnit,
   desiredDate,
@@ -68,16 +75,10 @@ export function RepairRequestsCreateSheetForm({
   onRepairUnitChange,
   shouldShowNoResults,
 }: RepairRequestsCreateSheetFormProps) {
-  const [minimumSelectableDate, setMinimumSelectableDate] = React.useState<Date | null>(null)
-
-  React.useEffect(() => {
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-    setMinimumSelectableDate(today)
-  }, [])
+  const [minimumSelectableDate] = React.useState<Date>(() => getTodayStart())
 
   const isDateDisabled = React.useCallback(
-    (date: Date) => (minimumSelectableDate ? date < minimumSelectableDate : false),
+    (date: Date) => date < minimumSelectableDate,
     [minimumSelectableDate],
   )
 

--- a/src/app/(app)/reports/components/inventory-charts.tsx
+++ b/src/app/(app)/reports/components/inventory-charts.tsx
@@ -29,6 +29,7 @@ const INVENTORY_CHART_SKELETON_KEYS = [
   "inventory-chart-skeleton-4",
 ] as const
 
+/** Renders inventory trend, department, source, and transfer-purpose charts. */
 export function InventoryCharts({ data, isLoading }: InventoryChartsProps) {
   // Process data for different chart types
   const processedData = React.useMemo(() => {
@@ -89,7 +90,9 @@ export function InventoryCharts({ data, isLoading }: InventoryChartsProps) {
 
     // Group by source for imports
     const sourceMap: Record<string, number> = {}
-    data.filter(item => item.type === 'import').forEach(item => {
+    data.forEach(item => {
+      if (item.type !== 'import') return
+
       const source = item.source === 'manual' ? 'Thêm thủ công' : 
                      item.source === 'excel' ? 'Import Excel' : 'Khác'
       sourceMap[source] = (sourceMap[source] || 0) + 1
@@ -98,7 +101,9 @@ export function InventoryCharts({ data, isLoading }: InventoryChartsProps) {
 
     // Group by transfer purpose for exports
     const purposeMap: Record<string, number> = {}
-    data.filter(item => item.type === 'export').forEach(item => {
+    data.forEach(item => {
+      if (item.type !== 'export') return
+
       let purpose = 'Khác';
       if (item.source === 'transfer_internal') {
         purpose = 'Luân chuyển nội bộ';

--- a/src/app/(app)/reports/components/inventory-report-filter-section.tsx
+++ b/src/app/(app)/reports/components/inventory-report-filter-section.tsx
@@ -23,6 +23,11 @@ function getMaxReportDateSnapshot(): Date {
 function subscribeToMaxReportDate(onStoreChange: () => void) {
   let refreshTimer: ReturnType<typeof setTimeout>
 
+  const refreshMaxReportDateSnapshot = () => {
+    maxReportDateSnapshot = new Date()
+    onStoreChange()
+  }
+
   const scheduleNextReportDateRefresh = () => {
     const now = new Date()
     const nextLocalMidnight = new Date(now)
@@ -30,14 +35,14 @@ function subscribeToMaxReportDate(onStoreChange: () => void) {
 
     refreshTimer = setTimeout(
       () => {
-        maxReportDateSnapshot = new Date()
-        onStoreChange()
+        refreshMaxReportDateSnapshot()
         scheduleNextReportDateRefresh()
       },
       Math.max(nextLocalMidnight.getTime() - now.getTime(), 1000)
     )
   }
 
+  refreshMaxReportDateSnapshot()
   scheduleNextReportDateRefresh()
 
   return () => clearTimeout(refreshTimer)

--- a/src/app/(app)/reports/components/inventory-report-filter-section.tsx
+++ b/src/app/(app)/reports/components/inventory-report-filter-section.tsx
@@ -14,6 +14,34 @@ import { cn } from "@/lib/utils"
 import type { DateRange } from "../hooks/use-report-filters"
 
 const MIN_REPORT_DATE = new Date("1900-01-01")
+let maxReportDateSnapshot = new Date()
+
+function getMaxReportDateSnapshot(): Date {
+  return maxReportDateSnapshot
+}
+
+function subscribeToMaxReportDate(onStoreChange: () => void) {
+  let refreshTimer: ReturnType<typeof setTimeout>
+
+  const scheduleNextReportDateRefresh = () => {
+    const now = new Date()
+    const nextLocalMidnight = new Date(now)
+    nextLocalMidnight.setHours(24, 0, 0, 0)
+
+    refreshTimer = setTimeout(
+      () => {
+        maxReportDateSnapshot = new Date()
+        onStoreChange()
+        scheduleNextReportDateRefresh()
+      },
+      Math.max(nextLocalMidnight.getTime() - now.getTime(), 1000)
+    )
+  }
+
+  scheduleNextReportDateRefresh()
+
+  return () => clearTimeout(refreshTimer)
+}
 
 interface InventoryReportFilterSectionProps {
   readonly dateRange: DateRange
@@ -29,6 +57,7 @@ interface InventoryReportFilterSectionProps {
   readonly onExport: () => void
 }
 
+/** Renders inventory report filters, refresh, and export controls. */
 export function InventoryReportFilterSection({
   dateRange,
   onDateRangeChange,
@@ -42,27 +71,11 @@ export function InventoryReportFilterSection({
   onRefresh,
   onExport,
 }: InventoryReportFilterSectionProps) {
-  const [maxReportDate, setMaxReportDate] = React.useState(() => new Date())
-
-  React.useEffect(() => {
-    let refreshTimer: ReturnType<typeof setTimeout>
-
-    const refreshMaxReportDate = () => {
-      const now = new Date()
-      const nextLocalMidnight = new Date(now)
-      nextLocalMidnight.setHours(24, 0, 0, 0)
-
-      setMaxReportDate(now)
-      refreshTimer = setTimeout(
-        refreshMaxReportDate,
-        Math.max(nextLocalMidnight.getTime() - now.getTime(), 1000)
-      )
-    }
-
-    refreshMaxReportDate()
-
-    return () => clearTimeout(refreshTimer)
-  }, [])
+  const maxReportDate = React.useSyncExternalStore(
+    subscribeToMaxReportDate,
+    getMaxReportDateSnapshot,
+    getMaxReportDateSnapshot,
+  )
 
   const filterControls = (
     <>

--- a/src/components/__tests__/equipment-table-columns.selection.test.tsx
+++ b/src/components/__tests__/equipment-table-columns.selection.test.tsx
@@ -8,7 +8,7 @@ import { TooltipTestProvider } from "@/test-utils/tooltip-mock"
 import type { Equipment } from "@/types/database"
 
 vi.mock("@/components/ui/tooltip", async () => {
-  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock")
+  const { tooltipMockModule } = await import("@/test-utils/tooltip-mock-module")
   return tooltipMockModule
 })
 

--- a/src/components/__tests__/import-equipment-dialog.test.tsx
+++ b/src/components/__tests__/import-equipment-dialog.test.tsx
@@ -131,10 +131,10 @@ vi.mock('@/components/bulk-import', () => ({
     fileName: string
     recordCount: number
   }) => (
-    <div data-testid="success-message" role="status" aria-live="polite">
+    <output data-testid="success-message" aria-live="polite">
       <span>{fileName}</span>
       <span data-testid="record-count">{recordCount}</span>
-    </div>
+    </output>
   ),
   BulkImportSubmitButton: ({
     isSubmitting,

--- a/src/components/__tests__/transfer-dialog.components.test.tsx
+++ b/src/components/__tests__/transfer-dialog.components.test.tsx
@@ -31,8 +31,8 @@ vi.mock("@/components/ui/select", () => ({
   SelectTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   SelectValue: () => null,
   SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
-    <option value={value}>{typeof children === "string" ? children : value}</option>
+  SelectItem: ({ value }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{value}</option>
   ),
 }))
 
@@ -40,8 +40,8 @@ import { TransferDialogEquipmentSearch } from "@/components/transfer-dialog.equi
 import {
   TransferInternalInputFields,
   TransferInternalSelectFields,
-  toLocalDateInputValue,
 } from "@/components/transfer-dialog.form-sections"
+import { toLocalDateInputValue } from "@/components/transfer-dialog.date-utils"
 import { createEmptyTransferDialogFormData } from "@/components/transfer-dialog.shared"
 
 const equipmentOption = {

--- a/src/components/bulk-import/BulkImportDialogParts.tsx
+++ b/src/components/bulk-import/BulkImportDialogParts.tsx
@@ -19,6 +19,7 @@ export interface BulkImportFileInputProps {
   label?: string
 }
 
+/** Renders the file picker area for a bulk import dialog. */
 export function BulkImportFileInput({
   id,
   fileInputRef,
@@ -49,6 +50,7 @@ export interface BulkImportErrorAlertProps {
   error: string | null
 }
 
+/** Renders a dismiss-free validation or parsing error alert. */
 export function BulkImportErrorAlert({ error }: BulkImportErrorAlertProps): JSX.Element | null {
   if (!error) return null
 
@@ -68,6 +70,7 @@ export interface BulkImportValidationErrorsProps {
   maxHeight?: string
 }
 
+/** Renders row-level validation errors for parsed bulk import records. */
 export function BulkImportValidationErrors({
   errors,
   maxHeight = '10rem'
@@ -100,21 +103,21 @@ export interface BulkImportSuccessMessageProps {
   recordCount: number
 }
 
+/** Renders the successful bulk import file parsing summary. */
 export function BulkImportSuccessMessage({
   fileName,
   recordCount
 }: BulkImportSuccessMessageProps): JSX.Element {
   return (
-    <div
+    <output
       className="flex items-center gap-2 text-sm text-primary bg-primary/10 p-3 rounded-md"
-      role="status"
       aria-live="polite"
     >
       <FileCheck className="size-4 flex-shrink-0" aria-hidden="true" />
       <span>
         Đã đọc file <strong>{fileName}</strong>. Tìm thấy <strong>{recordCount}</strong> bản ghi hợp lệ.
       </span>
-    </div>
+    </output>
   )
 }
 
@@ -130,6 +133,7 @@ export interface BulkImportSubmitButtonProps {
   onClick: () => void
 }
 
+/** Renders the submit button for parsed bulk import records. */
 export function BulkImportSubmitButton({
   isSubmitting,
   disabled,

--- a/src/components/equipment-linked-request/__tests__/LinkedRequestRowIndicator.test.tsx
+++ b/src/components/equipment-linked-request/__tests__/LinkedRequestRowIndicator.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@/lib/rpc-client', () => ({
 }))
 
 vi.mock('@/components/ui/tooltip', async () => {
-  const { tooltipMockModule } = await import('@/test-utils/tooltip-mock')
+  const { tooltipMockModule } = await import('@/test-utils/tooltip-mock-module')
   return tooltipMockModule
 })
 
@@ -29,26 +29,17 @@ function renderIndicator(
   equipment: Pick<Equipment, 'id' | 'ma_thiet_bi' | 'tinh_trang_hien_tai' | 'active_repair_request_id'> = baseEquipment,
   onParentClick = vi.fn(),
 ) {
-  const handleParentKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      onParentClick()
-    }
-  }
-
   return {
     onParentClick,
     ...render(
       <LinkedRequestProvider>
-        <div
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
           onClick={onParentClick}
-          onKeyDown={handleParentKeyDown}
         >
           parent
           <LinkedRequestRowIndicator equipment={equipment} />
-        </div>
+        </button>
       </LinkedRequestProvider>,
     ),
   }

--- a/src/components/equipment/equipment-actions-menu.tsx
+++ b/src/components/equipment/equipment-actions-menu.tsx
@@ -33,12 +33,13 @@ export interface EquipmentActionsMenuProps {
   isLoadingActiveUsage: boolean
 }
 
+/** Renders the desktop equipment actions menu with status-aware commands. */
 export function EquipmentActionsMenu({
   equipment,
   activeUsageLogs,
   isLoadingActiveUsage,
 }: EquipmentActionsMenuProps) {
-  const router = useRouter()
+  const { push } = useRouter()
   const {
     user,
     isGlobal,
@@ -88,8 +89,8 @@ export function EquipmentActionsMenu({
 
   const handleCreateRepairRequest = React.useCallback(() => {
     if (isGlobal || isRegionalLeader) return
-    router.push(buildRepairRequestCreateIntentHref(equipment.id))
-  }, [router, equipment.id, isGlobal, isRegionalLeader])
+    push(buildRepairRequestCreateIntentHref(equipment.id))
+  }, [push, equipment.id, isGlobal, isRegionalLeader])
 
   return (
     <DropdownMenu>

--- a/src/components/mobile-equipment-list-item.tsx
+++ b/src/components/mobile-equipment-list-item.tsx
@@ -55,32 +55,36 @@ const getStatusStyle = (status: Equipment["tinh_trang_hien_tai"]) => {
 const isOutOfService = (status: Equipment["tinh_trang_hien_tai"]) =>
   status === "Ngưng sử dụng" || status === "Chưa có nhu cầu sử dụng"
 
+/** Renders a compact mobile equipment card with status-aware actions. */
 export function MobileEquipmentListItem({
   equipment,
   onShowDetails,
 }: MobileEquipmentListItemProps) {
-  const router = useRouter()
+  const { push } = useRouter()
 
   const status = equipment.tinh_trang_hien_tai
   const statusStyle = getStatusStyle(status)
   const outOfService = isOutOfService(status)
 
-  const handleCardClick = () => {
+  const handleCardClick = (event: React.MouseEvent) => {
+    if (event.target instanceof Element && event.target.closest("[data-mobile-equipment-actions]")) {
+      return
+    }
     onShowDetails(equipment)
   }
 
   const handleCreateRepairRequest = React.useCallback(
     (equipmentId: number) => {
-      router.push(buildRepairRequestCreateIntentHref(equipmentId))
+      push(buildRepairRequestCreateIntentHref(equipmentId))
     },
-    [router],
+    [push],
   )
 
   const handleViewRepairDetails = React.useCallback(
     (equipmentId: number) => {
-      router.push(buildRepairRequestsByEquipmentHref(equipmentId))
+      push(buildRepairRequestsByEquipmentHref(equipmentId))
     },
-    [router],
+    [push],
   )
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -164,14 +168,6 @@ function MobileEquipmentActionButtons({
 }: MobileEquipmentActionButtonsProps) {
   const buttonBase = "flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-[11px] font-bold transition-all active:scale-95 duration-150"
   const ghostBtn = `${buttonBase} bg-muted/60 hover:bg-muted text-muted-foreground`
-  const handleActionGroupClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation()
-  }
-
-  const handleActionGroupKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    event.stopPropagation()
-  }
-
   const handleCreateRepairRequestClick = () => {
     onCreateRepairRequest(equipment.id)
   }
@@ -183,13 +179,11 @@ function MobileEquipmentActionButtons({
   // Ngưng sử dụng → "Xem chi tiết" only
   if (outOfService) {
     return (
-      <div
-        className="flex gap-2 pt-0.5"
-        role="group"
-        aria-label={`Hành động cho ${equipment.ten_thiet_bi}`}
-        onClick={handleActionGroupClick}
-        onKeyDown={handleActionGroupKeyDown}
+      <fieldset
+        data-mobile-equipment-actions
+        className="flex min-w-0 gap-2 border-0 p-0 pt-0.5"
       >
+        <legend className="sr-only">{`Hành động cho ${equipment.ten_thiet_bi}`}</legend>
         <button
           type="button"
           className={ghostBtn}
@@ -198,20 +192,18 @@ function MobileEquipmentActionButtons({
           <Eye className="size-3.5" />
           Xem chi tiết
         </button>
-      </div>
+      </fieldset>
     )
   }
 
   // Chờ sửa chữa → "Chi tiết sự cố" (red) + disabled play
   if (status === "Chờ sửa chữa") {
     return (
-      <div
-        className="flex gap-2 pt-0.5"
-        role="group"
-        aria-label={`Hành động cho ${equipment.ten_thiet_bi}`}
-        onClick={handleActionGroupClick}
-        onKeyDown={handleActionGroupKeyDown}
+      <fieldset
+        data-mobile-equipment-actions
+        className="flex min-w-0 gap-2 border-0 p-0 pt-0.5"
       >
+        <legend className="sr-only">{`Hành động cho ${equipment.ten_thiet_bi}`}</legend>
         <button
           type="button"
           className={`${buttonBase} flex-[2] bg-destructive text-destructive-foreground hover:opacity-90`}
@@ -221,20 +213,18 @@ function MobileEquipmentActionButtons({
           Chi tiết sự cố
         </button>
         <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
-      </div>
+      </fieldset>
     )
   }
 
   // Chờ bảo trì / Chờ hiệu chuẩn → "Xem chi tiết" + "Sử dụng"
   if (status === "Chờ bảo trì" || status === "Chờ hiệu chuẩn/kiểm định") {
     return (
-      <div
-        className="flex gap-2 pt-0.5"
-        role="group"
-        aria-label={`Hành động cho ${equipment.ten_thiet_bi}`}
-        onClick={handleActionGroupClick}
-        onKeyDown={handleActionGroupKeyDown}
+      <fieldset
+        data-mobile-equipment-actions
+        className="flex min-w-0 gap-2 border-0 p-0 pt-0.5"
       >
+        <legend className="sr-only">{`Hành động cho ${equipment.ten_thiet_bi}`}</legend>
         <button
           type="button"
           className={ghostBtn}
@@ -244,19 +234,17 @@ function MobileEquipmentActionButtons({
           Xem chi tiết
         </button>
         <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
-      </div>
+      </fieldset>
     )
   }
 
   // Default (Hoạt động) → "Báo sửa chữa" + "Sử dụng"
   return (
-    <div
-      className="flex gap-2 pt-0.5"
-      role="group"
-      aria-label={`Hành động cho ${equipment.ten_thiet_bi}`}
-      onClick={handleActionGroupClick}
-      onKeyDown={handleActionGroupKeyDown}
+    <fieldset
+      data-mobile-equipment-actions
+      className="flex min-w-0 gap-2 border-0 p-0 pt-0.5"
     >
+      <legend className="sr-only">{`Hành động cho ${equipment.ten_thiet_bi}`}</legend>
       <button
         type="button"
         className={ghostBtn}
@@ -266,6 +254,6 @@ function MobileEquipmentActionButtons({
         Báo sửa chữa
       </button>
       <MobileUsageActions equipment={equipment} className="flex-1 h-auto py-2 text-[11px]" />
-    </div>
+    </fieldset>
   )
 }

--- a/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
+++ b/src/components/shared/DataTablePagination/DataTablePaginationNavigation.tsx
@@ -127,6 +127,7 @@ const DataTablePaginationPageJump = React.memo(function DataTablePaginationPageJ
   )
 })
 
+/** Renders accessible pagination controls for the shared data table. */
 export const DataTablePaginationNavigation = React.memo(function DataTablePaginationNavigation({
   currentPage,
   totalPages,
@@ -163,14 +164,13 @@ export const DataTablePaginationNavigation = React.memo(function DataTablePagina
 
   return (
     <div className={cn("flex flex-col items-center gap-2", stackClass, className)}>
-      <div
+      <output
         className="text-sm font-medium"
-        role="status"
         aria-live="polite"
         aria-atomic="true"
       >
         {resolvedLabels.pageIndicator} {currentPage} {resolvedLabels.pageSeparator} {totalPages}
-      </div>
+      </output>
       {onPageJump ? (
         <DataTablePaginationPageJump
           key={currentPage}

--- a/src/components/shared/__tests__/mobile-bottom-sheet.test.tsx
+++ b/src/components/shared/__tests__/mobile-bottom-sheet.test.tsx
@@ -1,15 +1,46 @@
 import * as React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MobileBottomSheet } from '../mobile-bottom-sheet'
 
 describe('MobileBottomSheet', () => {
+    let showModal: ReturnType<typeof vi.fn>
+    let close: ReturnType<typeof vi.fn>
+
     const defaultProps = {
         open: true,
         onOpenChange: vi.fn(),
         ariaLabel: 'Test bottom sheet',
     }
+
+    beforeEach(() => {
+        showModal = vi.fn(function (this: HTMLDialogElement) {
+            this.setAttribute('open', '')
+        })
+        close = vi.fn(function (this: HTMLDialogElement) {
+            this.removeAttribute('open')
+        })
+        Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+            configurable: true,
+            value: showModal,
+        })
+        Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+            configurable: true,
+            value: close,
+        })
+    })
+
+    it('opens the native dialog modally when open', () => {
+        render(
+            <MobileBottomSheet {...defaultProps}>
+                <p>Sheet content</p>
+            </MobileBottomSheet>,
+        )
+
+        expect(showModal).toHaveBeenCalledTimes(1)
+        expect(close).not.toHaveBeenCalled()
+    })
 
     it('renders children when open', () => {
         render(
@@ -31,7 +62,7 @@ describe('MobileBottomSheet', () => {
         expect(screen.queryByText('Sheet content')).not.toBeInTheDocument()
     })
 
-    it('calls onOpenChange(false) on Escape key press', () => {
+    it('calls onOpenChange(false) when the native dialog is cancelled', () => {
         const onOpenChange = vi.fn()
 
         render(
@@ -40,7 +71,7 @@ describe('MobileBottomSheet', () => {
             </MobileBottomSheet>,
         )
 
-        fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+        fireEvent(screen.getByRole('dialog'), new Event('cancel', { cancelable: true }))
         expect(onOpenChange).toHaveBeenCalledWith(false)
     })
 

--- a/src/components/shared/mobile-bottom-sheet.tsx
+++ b/src/components/shared/mobile-bottom-sheet.tsx
@@ -28,31 +28,44 @@ export function MobileBottomSheet({
     const dialogRef = React.useRef<HTMLDialogElement>(null)
     const previousActiveElement = React.useRef<HTMLElement | null>(null)
 
-    // Focus management: move focus into dialog when opened, restore on close
+    // Focus management: open modally, move focus into dialog, and restore on close.
     React.useEffect(() => {
-        if (open) {
-            previousActiveElement.current = document.activeElement as HTMLElement
+        const dialog = dialogRef.current
+        if (!open || !dialog) return
 
-            const timer = setTimeout(() => {
-                if (!dialogRef.current) return
+        previousActiveElement.current = document.activeElement as HTMLElement
 
-                const firstFocusable = dialogRef.current.querySelector<HTMLElement>(
-                    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-                )
-
-                if (firstFocusable) {
-                    firstFocusable.focus()
-                } else {
-                    dialogRef.current.focus()
-                }
-            }, 100)
-
-            return () => clearTimeout(timer)
+        if (typeof dialog.showModal === "function" && !dialog.open) {
+            dialog.showModal()
+        } else if (!dialog.hasAttribute("open")) {
+            dialog.setAttribute("open", "")
         }
 
-        if (previousActiveElement.current) {
-            previousActiveElement.current.focus()
-            previousActiveElement.current = null
+        const timer = setTimeout(() => {
+            const firstFocusable = dialog.querySelector<HTMLElement>(
+                'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+            )
+
+            if (firstFocusable) {
+                firstFocusable.focus()
+            } else {
+                dialog.focus()
+            }
+        }, 100)
+
+        return () => {
+            clearTimeout(timer)
+
+            if (dialog.open && typeof dialog.close === "function") {
+                dialog.close()
+            } else {
+                dialog.removeAttribute("open")
+            }
+
+            if (previousActiveElement.current) {
+                previousActiveElement.current.focus()
+                previousActiveElement.current = null
+            }
         }
     }, [open])
 
@@ -65,7 +78,6 @@ export function MobileBottomSheet({
 
     return (
         <dialog
-            open
             ref={dialogRef}
             className="fixed inset-0 z-[1002] m-0 flex h-auto max-h-none max-w-none items-end border-0 bg-transparent p-0"
             onCancel={handleCancel}

--- a/src/components/shared/mobile-bottom-sheet.tsx
+++ b/src/components/shared/mobile-bottom-sheet.tsx
@@ -25,7 +25,7 @@ export function MobileBottomSheet({
     children,
     className,
 }: MobileBottomSheetProps) {
-    const dialogRef = React.useRef<HTMLDivElement>(null)
+    const dialogRef = React.useRef<HTMLDialogElement>(null)
     const previousActiveElement = React.useRef<HTMLElement | null>(null)
 
     // Focus management: move focus into dialog when opened, restore on close
@@ -56,43 +56,19 @@ export function MobileBottomSheet({
         }
     }, [open])
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === "Escape") {
-            onOpenChange(false)
-            return
-        }
-
-        // Focus trap: keep Tab navigation inside the dialog
-        if (e.key === "Tab" && dialogRef.current) {
-            const focusableElements = dialogRef.current.querySelectorAll<HTMLElement>(
-                'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-            )
-            const focusableArray = Array.from(focusableElements)
-            const firstFocusable = focusableArray[0]
-            const lastFocusable = focusableArray[focusableArray.length - 1]
-
-            if (e.shiftKey) {
-                if (document.activeElement === firstFocusable) {
-                    e.preventDefault()
-                    lastFocusable?.focus()
-                }
-            } else {
-                if (document.activeElement === lastFocusable) {
-                    e.preventDefault()
-                    firstFocusable?.focus()
-                }
-            }
-        }
+    const handleCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
+        event.preventDefault()
+        onOpenChange(false)
     }
 
     if (!open) return null
 
     return (
-        <div
+        <dialog
+            open
             ref={dialogRef}
-            className="fixed inset-0 z-[1002] flex items-end"
-            onKeyDown={handleKeyDown}
-            role="dialog"
+            className="fixed inset-0 z-[1002] m-0 flex h-auto max-h-none max-w-none items-end border-0 bg-transparent p-0"
+            onCancel={handleCancel}
             aria-modal="true"
             aria-label={ariaLabel}
             tabIndex={-1}
@@ -125,6 +101,6 @@ export function MobileBottomSheet({
 
                 {children}
             </div>
-        </div>
+        </dialog>
     )
 }

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
@@ -62,7 +62,7 @@ vi.mock('@/components/ui/popover', () => {
         PopoverTrigger: Trigger,
         PopoverContent: ({ children, open, setOpen: _setOpen, ...rest }: PopoverContentProps) => {
             if (!open) return null
-            return <div data-testid="popover-content" role="dialog" {...rest}>{children}</div>
+            return <dialog data-testid="popover-content" open {...rest}>{children}</dialog>
         },
     }
 })

--- a/src/components/transfer-dialog.date-utils.ts
+++ b/src/components/transfer-dialog.date-utils.ts
@@ -1,0 +1,8 @@
+/** Formats a date as the local yyyy-MM-dd value expected by date inputs. */
+export function toLocalDateInputValue(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+
+  return `${year}-${month}-${day}`
+}

--- a/src/components/transfer-dialog.form-sections.tsx
+++ b/src/components/transfer-dialog.form-sections.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
+import { toLocalDateInputValue } from "@/components/transfer-dialog.date-utils"
 import type { TransferDialogFormData } from "@/components/transfer-dialog.shared"
 
 type SetFormData = React.Dispatch<React.SetStateAction<TransferDialogFormData>>
@@ -29,14 +30,7 @@ function updateCurrentDepartmentFields(
   }
 }
 
-export function toLocalDateInputValue(date: Date): string {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, "0")
-  const day = String(date.getDate()).padStart(2, "0")
-
-  return `${year}-${month}-${day}`
-}
-
+/** Renders the transfer type select field. */
 export function TransferTypeField({
   disabled,
   formData,
@@ -85,6 +79,7 @@ export function TransferTypeField({
   )
 }
 
+/** Renders internal transfer department selects. */
 export function TransferInternalSelectFields({
   departments,
   disabled,
@@ -98,6 +93,16 @@ export function TransferInternalSelectFields({
   setFormData: SetFormData
   lockCurrentDepartment: boolean
 }) {
+  const destinationDepartments = React.useMemo(() => {
+    const options: string[] = []
+    for (const department of departments) {
+      if (department !== formData.khoa_phong_hien_tai) {
+        options.push(department)
+      }
+    }
+    return options
+  }, [departments, formData.khoa_phong_hien_tai])
+
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
       <div className="space-y-2">
@@ -135,9 +140,7 @@ export function TransferInternalSelectFields({
             <SelectValue placeholder="Chọn khoa/phòng nhận" />
           </SelectTrigger>
           <SelectContent>
-            {departments
-              .filter((department) => department !== formData.khoa_phong_hien_tai)
-              .map((department) => (
+            {destinationDepartments.map((department) => (
                 <SelectItem key={department} value={department}>
                   {department}
                 </SelectItem>
@@ -149,6 +152,7 @@ export function TransferInternalSelectFields({
   )
 }
 
+/** Renders locked internal transfer department inputs. */
 export function TransferInternalInputFields({
   disabled,
   formData,
@@ -195,6 +199,7 @@ export function TransferInternalInputFields({
   )
 }
 
+/** Renders external transfer destination and return fields. */
 export function TransferExternalFields({
   disabled,
   formData,
@@ -304,6 +309,7 @@ export function TransferExternalFields({
   )
 }
 
+/** Renders the transfer reason textarea. */
 export function TransferReasonField({
   disabled,
   formData,

--- a/src/components/transfers/TransferCard.tsx
+++ b/src/components/transfers/TransferCard.tsx
@@ -100,6 +100,7 @@ interface TransferCardProps {
   referenceDate?: Date
 }
 
+/** Renders a transfer list card with semantic open and action regions. */
 export const TransferCard = React.memo(function TransferCard({
   transfer,
   onClick,
@@ -109,16 +110,6 @@ export const TransferCard = React.memo(function TransferCard({
   const openTransferFromCard = React.useCallback(() => {
     onClick?.(transfer)
   }, [onClick, transfer])
-
-  const openTransferFromKeyboard = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key !== "Enter" && event.key !== " ") return
-
-      event.preventDefault()
-      onClick?.(transfer)
-    },
-    [onClick, transfer],
-  )
 
   const stopActionPropagation = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
@@ -135,28 +126,26 @@ export const TransferCard = React.memo(function TransferCard({
   return (
     <Card className="shadow-sm transition-shadow hover:shadow-md">
       <CardContent className="space-y-4 p-4">
-        <div
-          className="cursor-pointer space-y-4 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        <button
+          type="button"
+          className="block w-full cursor-pointer space-y-4 rounded-md bg-transparent p-0 text-left text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           onClick={openTransferFromCard}
-          onKeyDown={openTransferFromKeyboard}
-          role="button"
-          tabIndex={0}
           aria-label={`Mở yêu cầu luân chuyển ${transfer.ma_yeu_cau}`}
         >
-        <div className="flex items-start justify-between gap-3">
-          <div className="space-y-2">
-            <p className="text-sm font-semibold leading-none">{transfer.ma_yeu_cau}</p>
-            <Badge variant={TYPE_VARIANTS[transfer.loai_hinh]}>
-              {TRANSFER_TYPES[transfer.loai_hinh]}
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-2">
+              <p className="text-sm font-semibold leading-none">{transfer.ma_yeu_cau}</p>
+              <Badge variant={TYPE_VARIANTS[transfer.loai_hinh]}>
+                {TRANSFER_TYPES[transfer.loai_hinh]}
+              </Badge>
+            </div>
+            <Badge
+              variant={STATUS_VARIANTS[transfer.trang_thai]}
+              className="self-start text-[11px] uppercase tracking-wide"
+            >
+              {TRANSFER_STATUSES[transfer.trang_thai]}
             </Badge>
           </div>
-          <Badge
-            variant={STATUS_VARIANTS[transfer.trang_thai]}
-            className="self-start text-[11px] uppercase tracking-wide"
-          >
-            {TRANSFER_STATUSES[transfer.trang_thai]}
-          </Badge>
-        </div>
 
         <div className="space-y-3">
           <div className="space-y-1">
@@ -190,8 +179,7 @@ export const TransferCard = React.memo(function TransferCard({
             </p>
           </div>
         </div>
-
-        </div>
+        </button>
 
         <div className="mt-4 flex items-center justify-between gap-3 border-t pt-4">
           <div className="flex-1">

--- a/src/components/transfers/TransfersKanbanCard.tsx
+++ b/src/components/transfers/TransfersKanbanCard.tsx
@@ -62,16 +62,6 @@ function TransfersKanbanCardComponent({
     [onClick, transfer]
   )
 
-  const openTransferFromKeyboard = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key !== 'Enter' && event.key !== ' ') return
-
-      event.preventDefault()
-      onClick(transfer)
-    },
-    [onClick, transfer]
-  )
-
   const stopActionPropagation = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
       event.stopPropagation()
@@ -82,23 +72,21 @@ function TransfersKanbanCardComponent({
   return (
     <Card className="mb-2 hover:shadow-md transition-shadow">
       <CardContent className="p-3 space-y-2">
-        <div
-          className="cursor-pointer space-y-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        <button
+          type="button"
+          className="block w-full cursor-pointer space-y-2 rounded-md bg-transparent p-0 text-left text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           onClick={openTransferFromCard}
-          onKeyDown={openTransferFromKeyboard}
-          role="button"
-          tabIndex={0}
           aria-label={`Mở yêu cầu luân chuyển ${transfer.ma_yeu_cau}`}
         >
-        {/* Header: Transfer code + type badge */}
-        <div className="flex items-start justify-between gap-2">
-          <span className="font-medium text-sm truncate">
-            {transfer.ma_yeu_cau}
-          </span>
-          <Badge variant={getTypeVariant(transfer.loai_hinh)} className="shrink-0">
-            {getTypeLabel(transfer.loai_hinh)}
-          </Badge>
-        </div>
+          {/* Header: Transfer code + type badge */}
+          <div className="flex items-start justify-between gap-2">
+            <span className="font-medium text-sm truncate">
+              {transfer.ma_yeu_cau}
+            </span>
+            <Badge variant={getTypeVariant(transfer.loai_hinh)} className="shrink-0">
+              {getTypeLabel(transfer.loai_hinh)}
+            </Badge>
+          </div>
 
         {/* Equipment info */}
         <div className="space-y-1">
@@ -129,8 +117,7 @@ function TransfersKanbanCardComponent({
             </Badge>
           )}
         </div>
-
-        </div>
+        </button>
 
         {/* Actions menu */}
         <div
@@ -146,5 +133,5 @@ function TransfersKanbanCardComponent({
   )
 }
 
-// Memoize to prevent re-renders when parent virtual scroller updates
+/** Renders a memoized transfer card for kanban columns. */
 export const TransfersKanbanCard = React.memo(TransfersKanbanCardComponent)

--- a/src/components/transfers/TransfersSearchParamsBoundary.tsx
+++ b/src/components/transfers/TransfersSearchParamsBoundary.tsx
@@ -7,20 +7,20 @@ interface TransfersSearchParamsBoundaryProps {
   children: React.ReactNode
 }
 
+/** Wraps transfer search-param handling in a Suspense boundary. */
 export function TransfersSearchParamsBoundary({
   children,
 }: TransfersSearchParamsBoundaryProps) {
   return (
     <React.Suspense
       fallback={
-        <div
+        <output
           className="flex min-h-[50vh] items-center justify-center"
-          role="status"
           aria-label="Đang tải bộ lọc điều chuyển"
           aria-live="polite"
         >
           <Loader2 className="size-6 animate-spin text-muted-foreground" />
-        </div>
+        </output>
       }
     >
       {children}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
 
+/** Provides react-hook-form context to form fields. */
 const Form = FormProvider
 
 type FormFieldContextValue<
@@ -28,14 +29,20 @@ const FormFieldContext = React.createContext<FormFieldContextValue>(
   {} as FormFieldContextValue
 )
 
+/** Binds a controlled field name into the form field context. */
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
 >({
   ...props
 }: ControllerProps<TFieldValues, TName>) => {
+  const fieldContextValue = React.useMemo(
+    () => ({ name: props.name }),
+    [props.name],
+  )
+
   return (
-    <FormFieldContext.Provider value={{ name: props.name }}>
+    <FormFieldContext.Provider value={fieldContextValue}>
       <Controller {...props} />
     </FormFieldContext.Provider>
   )
@@ -72,20 +79,23 @@ const FormItemContext = React.createContext<FormItemContextValue>(
   {} as FormItemContextValue
 )
 
+/** Provides a stable generated id for a form item. */
 const FormItem = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
   const id = React.useId()
+  const itemContextValue = React.useMemo(() => ({ id }), [id])
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={itemContextValue}>
       <div ref={ref} className={cn("space-y-2", className)} {...props} />
     </FormItemContext.Provider>
   )
 })
 FormItem.displayName = "FormItem"
 
+/** Renders a label wired to the active form item id. */
 const FormLabel = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
@@ -103,6 +113,7 @@ const FormLabel = React.forwardRef<
 })
 FormLabel.displayName = "FormLabel"
 
+/** Renders the slotted form control with ARIA state. */
 const FormControl = React.forwardRef<
   React.ElementRef<typeof Slot>,
   React.ComponentPropsWithoutRef<typeof Slot>
@@ -125,6 +136,7 @@ const FormControl = React.forwardRef<
 })
 FormControl.displayName = "FormControl"
 
+/** Renders descriptive text associated with a form item. */
 const FormDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
@@ -142,6 +154,7 @@ const FormDescription = React.forwardRef<
 })
 FormDescription.displayName = "FormDescription"
 
+/** Renders validation feedback for the active form item. */
 const FormMessage = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>

--- a/src/contexts/language-context.tsx
+++ b/src/contexts/language-context.tsx
@@ -21,6 +21,8 @@ const DEFAULT_LANGUAGE: Language = {
   code: "vi",
   name: "Tiếng Việt",
 }
+let cachedLanguageStorageValue: string | null | undefined
+let cachedLanguageSnapshot: Language = DEFAULT_LANGUAGE
 
 const translations = {
   en: {
@@ -76,7 +78,14 @@ function parseStoredLanguage(value: string | null): Language {
 
 function getLanguageSnapshot(): Language {
   if (typeof window === "undefined") return DEFAULT_LANGUAGE
-  return parseStoredLanguage(window.localStorage.getItem(LANGUAGE_STORAGE_KEY))
+
+  const storageValue = window.localStorage.getItem(LANGUAGE_STORAGE_KEY)
+  if (storageValue !== cachedLanguageStorageValue) {
+    cachedLanguageStorageValue = storageValue
+    cachedLanguageSnapshot = parseStoredLanguage(storageValue)
+  }
+
+  return cachedLanguageSnapshot
 }
 
 function subscribeToLanguageStorage(onStoreChange: () => void) {

--- a/src/contexts/language-context.tsx
+++ b/src/contexts/language-context.tsx
@@ -16,6 +16,11 @@ interface LanguageContextType {
 const LanguageContext = React.createContext<LanguageContextType | undefined>(undefined)
 
 const LANGUAGE_STORAGE_KEY = "preferred_language"
+const LANGUAGE_STORAGE_EVENT = "qltbyt-language-storage-change"
+const DEFAULT_LANGUAGE: Language = {
+  code: "vi",
+  name: "Tiếng Việt",
+}
 
 const translations = {
   en: {
@@ -52,28 +57,50 @@ const translations = {
   },
 }
 
-export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [currentLanguage, setCurrentLanguage] = React.useState<Language>({
-    code: "vi",
-    name: "Tiếng Việt",
-  })
+function parseStoredLanguage(value: string | null): Language {
+  if (!value) return DEFAULT_LANGUAGE
 
-  React.useEffect(() => {
-    try {
-      const savedLanguage = localStorage.getItem(LANGUAGE_STORAGE_KEY)
-      if (savedLanguage) {
-        const parsed = JSON.parse(savedLanguage) as Language
-        setCurrentLanguage(parsed)
-      }
-    } catch (error) {
-      console.error("Failed to load language preference:", error)
-    }
-  }, [])
+  try {
+    const parsed = JSON.parse(value) as Partial<Language>
+    return parsed.code === "en" || parsed.code === "vi"
+      ? {
+          code: parsed.code,
+          name: typeof parsed.name === "string" ? parsed.name : DEFAULT_LANGUAGE.name,
+        }
+      : DEFAULT_LANGUAGE
+  } catch (error) {
+    console.error("Failed to load language preference:", error)
+    return DEFAULT_LANGUAGE
+  }
+}
+
+function getLanguageSnapshot(): Language {
+  if (typeof window === "undefined") return DEFAULT_LANGUAGE
+  return parseStoredLanguage(window.localStorage.getItem(LANGUAGE_STORAGE_KEY))
+}
+
+function subscribeToLanguageStorage(onStoreChange: () => void) {
+  window.addEventListener("storage", onStoreChange)
+  window.addEventListener(LANGUAGE_STORAGE_EVENT, onStoreChange)
+
+  return () => {
+    window.removeEventListener("storage", onStoreChange)
+    window.removeEventListener(LANGUAGE_STORAGE_EVENT, onStoreChange)
+  }
+}
+
+/** Provides the persisted UI language preference to client components. */
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const currentLanguage = React.useSyncExternalStore(
+    subscribeToLanguageStorage,
+    getLanguageSnapshot,
+    () => DEFAULT_LANGUAGE,
+  )
 
   const setLanguage = React.useCallback((language: Language) => {
-    setCurrentLanguage(language)
     try {
-      localStorage.setItem(LANGUAGE_STORAGE_KEY, JSON.stringify(language))
+      window.localStorage.setItem(LANGUAGE_STORAGE_KEY, JSON.stringify(language))
+      window.dispatchEvent(new Event(LANGUAGE_STORAGE_EVENT))
     } catch (error) {
       console.error("Failed to save language preference:", error)
     }
@@ -95,6 +122,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
   return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>
 }
 
+/** Reads the current language context. */
 export function useLanguage() {
   // react-doctor-disable-next-line react-doctor/no-react19-deprecated-apis -- React 18.3.1 does not support React.use() for context reads.
   const context = React.useContext(LanguageContext)

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -5,9 +5,15 @@ const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
 
 function subscribeToMobileBreakpoint(onStoreChange: () => void) {
   const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
-  mql.addEventListener("change", onStoreChange)
+  if (typeof mql.addEventListener === "function") {
+    mql.addEventListener("change", onStoreChange)
 
-  return () => mql.removeEventListener("change", onStoreChange)
+    return () => mql.removeEventListener("change", onStoreChange)
+  }
+
+  mql.addListener(onStoreChange)
+
+  return () => mql.removeListener(onStoreChange)
 }
 
 function getMobileBreakpointSnapshot() {

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,23 +1,28 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
 
+function subscribeToMobileBreakpoint(onStoreChange: () => void) {
+  const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
+  mql.addEventListener("change", onStoreChange)
+
+  return () => mql.removeEventListener("change", onStoreChange)
+}
+
+function getMobileBreakpointSnapshot() {
+  return window.matchMedia(MOBILE_MEDIA_QUERY).matches
+}
+
+function getServerMobileBreakpointSnapshot() {
+  return false
+}
+
+/** Returns whether the current viewport matches the mobile breakpoint. */
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = (e: MediaQueryListEvent) => {
-      setIsMobile(e.matches)
-    }
-
-    // Set initial value
-    setIsMobile(mql.matches)
-
-    // Use the more efficient addEventListener
-    mql.addEventListener("change", onChange)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(
+    subscribeToMobileBreakpoint,
+    getMobileBreakpointSnapshot,
+    getServerMobileBreakpointSnapshot,
+  )
 }

--- a/src/test-utils/tooltip-mock-module.ts
+++ b/src/test-utils/tooltip-mock-module.ts
@@ -1,0 +1,14 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip-mock"
+
+/** Provides a module-shaped tooltip mock for vi.mock factories. */
+export const tooltipMockModule = {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+}

--- a/src/test-utils/tooltip-mock.tsx
+++ b/src/test-utils/tooltip-mock.tsx
@@ -5,7 +5,8 @@ const TooltipContext = React.createContext<
   { open: boolean; setOpen: (open: boolean) => void } | null
 >(null)
 
-function TooltipProvider({ children }: { children: React.ReactNode }) {
+/** Provides tooltip state for tooltip component tests. */
+export function TooltipProvider({ children }: { children: React.ReactNode }) {
   return (
     <TooltipProviderContext.Provider value={true}>
       {children}
@@ -13,7 +14,8 @@ function TooltipProvider({ children }: { children: React.ReactNode }) {
   )
 }
 
-function Tooltip({ children }: { children: React.ReactNode }) {
+/** Wraps tooltip trigger and content state for tests. */
+export function Tooltip({ children }: { children: React.ReactNode }) {
   const hasProvider = React.useContext(TooltipProviderContext)
 
   if (!hasProvider) {
@@ -21,11 +23,16 @@ function Tooltip({ children }: { children: React.ReactNode }) {
   }
 
   const [open, setOpen] = React.useState(false)
+  const tooltipContextValue = React.useMemo(
+    () => ({ open, setOpen }),
+    [open],
+  )
 
-  return <TooltipContext.Provider value={{ open, setOpen }}>{children}</TooltipContext.Provider>
+  return <TooltipContext.Provider value={tooltipContextValue}>{children}</TooltipContext.Provider>
 }
 
-const TooltipTrigger = React.forwardRef<
+/** Renders a test trigger that opens the tooltip on hover or focus. */
+export const TooltipTrigger = React.forwardRef<
   HTMLSpanElement,
   React.HTMLAttributes<HTMLSpanElement> & { asChild?: boolean }
 >(({ asChild, children, onBlur, onFocus, onMouseEnter, onMouseLeave, ...props }, ref) => {
@@ -67,18 +74,13 @@ const TooltipTrigger = React.forwardRef<
 })
 TooltipTrigger.displayName = "TooltipTrigger"
 
-function TooltipContent({ children }: { children: React.ReactNode }) {
+/** Renders tooltip content while the test tooltip is open. */
+export function TooltipContent({ children }: { children: React.ReactNode }) {
   const context = React.useContext(TooltipContext)
   if (!context?.open) return null
 
   return <div role="tooltip">{children}</div>
 }
 
-export const tooltipMockModule = {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-}
-
+/** Test provider alias for table and equipment tests. */
 export { TooltipProvider as TooltipTestProvider }


### PR DESCRIPTION
## Summary
- Fixes React Doctor #571 semantic markup, router destructuring, state initialization, constructed context values, and local iteration-chain findings without suppressing rules.
- Adds Issue #571 source guards and adjusts focused a11y/component coverage for changed UI semantics.
- Keeps the already-resolved `useSearchParams` Suspense boundary rule clean.

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- Focused vitest suite: 17 files / 187 tests passed
- `node scripts/npm-run.js run react-doctor` -> No issues found, 100/100
- Full React Doctor target-rule check for #571 emitted no target-rule findings

Fixes #571


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes React Doctor issue #571 by replacing ARIA role fallbacks with native elements and removing mount-only state. Improves performance with external stores and memoization, and adds tests to guard these patterns.

- **Bug Fixes**
  - Replaced role fallbacks with native elements: div→button (CategoryGroup, TransferCard, TransfersKanbanCard, LinkedRequestRowIndicator), role=list/listitem→ul/li (DeviceQuotaCategoryTree), status indicators→output (bulk import success, pagination, Suspense fallback), popover test→dialog, bottom sheet uses `<dialog>`.
  - Improved mobile item actions: use fieldset/legend and mark action region to avoid unintended card opens.
  - Destructured router methods for React Compiler (chi tiết toolbar, decisions table, equipment actions menu, mobile item).
  - Tests updated to reflect semantic changes; tooltip vi.mock now imports from `@/test-utils/tooltip-mock-module`; resilient assertions in DeviceQuotaCategoriesPage.

- **Performance**
  - Removed mount-only state: lazy date init in repair-request form; inventory report max date, language preference, and mobile breakpoint now use `React.useSyncExternalStore`.
  - Reduced iteration chains and work: single-pass loops in inventory charts; precomputed `hideableColumns`; precomputed destination departments; date formatter moved to `transfer-dialog.date-utils`.
  - Memoized constructed context values to prevent re-renders (`form.tsx`, tooltip mock).
  - Added `react-doctor-issue-571-markup-perf.source.test.ts` to enforce semantics, router destructuring, external-store use, and iteration rules.

<sup>Written for commit 3c9647ce0fcf41bdc06d74573c6dc0b578a2139a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Replaced non-semantic controls with native buttons and dialogs; improved focus handling and keyboard interaction.
  * Switched several live-status containers to semantic outputs with appropriate ARIA for screen readers.

* **Performance Optimizations**
  * Reduced re-renders via memoized context/values and centralized external-store patterns for mobile/language/date state.
  * Simplified data grouping loops for chart/report processing.

* **Tests**
  * Added repository-level source-guard tests and updated tooltip/test mocks across suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->