### PR TITLE
Fix equipment detail dialog state reset

### DIFF
--- a/src/__tests__/react-doctor-p1-equipment-detail-dialog-state.source.test.ts
+++ b/src/__tests__/react-doctor-p1-equipment-detail-dialog-state.source.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const repoRoot = process.cwd()
+const EQUIPMENT_DETAIL_DIALOG_PATH =
+  "src/app/(app)/equipment/_components/EquipmentDetailDialog/index.tsx"
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), "utf8")
+}
+
+describe("React Doctor P1 EquipmentDetailDialog state boundary", () => {
+  it("does not reset dialog state from an open prop change effect", () => {
+    const source = readSource(EQUIPMENT_DETAIL_DIALOG_PATH)
+
+    expect(source).not.toMatch(
+      /React\.useEffect\(\(\) => \{\s*if \(!open\) \{[\s\S]*?setSavedValues\(null\)[\s\S]*?\}, \[open\]\)/
+    )
+  })
+
+  it("uses a keyed state component so parent-controlled close remounts local state", () => {
+    const source = readSource(EQUIPMENT_DETAIL_DIALOG_PATH)
+
+    expect(source).toContain("function EquipmentDetailDialogState")
+    expect(source).toContain("key={dialogStateKey}")
+  })
+})

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/index.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/index.tsx
@@ -52,7 +52,18 @@ export interface EquipmentDetailDialogProps {
   onEquipmentUpdated: () => void
 }
 
-export function EquipmentDetailDialog({
+/**
+ * Renders the equipment detail dialog with a keyed state boundary for close/reopen resets.
+ */
+export function EquipmentDetailDialog(props: EquipmentDetailDialogProps): React.ReactNode {
+  const { equipment, open } = props
+  const dialogStateKey =
+    open && equipment ? `equipment-detail-${equipment.id}` : "equipment-detail-closed"
+
+  return <EquipmentDetailDialogState key={dialogStateKey} {...props} />
+}
+
+function EquipmentDetailDialogState({
   equipment,
   open,
   onOpenChange,
@@ -89,14 +100,6 @@ export function EquipmentDetailDialog({
 
   // Track previous equipment ID to only reset form when viewing different equipment
   const prevEquipmentIdRef = React.useRef<number | null>(null)
-
-  // Clear state when dialog closes to ensure fresh data on reopen
-  React.useEffect(() => {
-    if (!open) {
-      prevEquipmentIdRef.current = null
-      setSavedValues(null)
-    }
-  }, [open])
 
   // Reset form only when equipment ID changes (new equipment loaded)
   // This prevents form reset when toggling edit mode, preserving user edits after save


### PR DESCRIPTION
## Summary
- Fix React Doctor P1 `no-adjust-state-on-prop-change` in `EquipmentDetailDialog` by remounting local dialog state through a keyed state boundary.
- Add a source guard that locks the close/reopen reset away from prop-change effects.

## Test Plan
- [x] RED source guard failed before implementation
- [x] `node scripts/npm-run.js run test -- --run src/__tests__/react-doctor-p1-equipment-detail-dialog-state.source.test.ts`
- [x] `node scripts/npm-run.js run test -- --run 'src/app/(app)/equipment/__tests__/equipment-detail-dialog-decommission-date.test.tsx'`
- [x] Full React Doctor: `85 / 100`, `137 issues`, `no-adjust-state-on-prop-change=false`
- [x] `node scripts/npm-run.js run react-doctor` -> `100 / 100`, no diff issues
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run verify:ts-docstrings`
- [x] `node scripts/npm-run.js run typecheck`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `EquipmentDetailDialog` state resets by remounting local state via a keyed boundary. State now resets only on close/reopen or when switching equipment, not on prop changes.

- **Bug Fixes**
  - Added a keyed `EquipmentDetailDialogState` wrapper to remount local state; key derives from `open` and `equipment.id`.
  - Removed the `open`-effect that cleared state to satisfy React Doctor P1 “no-adjust-state-on-prop-change”.
  - Added a source test to enforce the keyed boundary and prevent prop-driven resets.

<sup>Written for commit 6f4b8b0306a7e544b93a42c65d342c73534aa2a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Added comprehensive test coverage for equipment detail dialog state management, verifying correct behavior during open/close transitions.

* **Bug Fixes**
  - Enhanced equipment detail dialog state reset functionality to properly handle form state when the dialog opens and closes, improving consistency when switching between different equipment or edit modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thienchi2109/qltbyt-nam-phong/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->