### PR TITLE
refactor: extract destructive confirm dialog

### DIFF
--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryDeleteDialog.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryDeleteDialog.test.tsx
@@ -2,28 +2,110 @@ import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+import type { CategoryListItem } from '../_types/categories'
 import { DeviceQuotaCategoryDeleteDialog } from '../_components/DeviceQuotaCategoryDeleteDialog'
 import { useDeviceQuotaCategoryContext } from '../_hooks/useDeviceQuotaCategoryContext'
+
+vi.mock('lucide-react', () => ({
+  Loader2: ({ className }: { readonly className?: string }) => (
+    <svg aria-hidden="true" className={className} data-testid="pending-spinner" />
+  ),
+}))
 
 vi.mock('../_hooks/useDeviceQuotaCategoryContext', () => ({
   useDeviceQuotaCategoryContext: vi.fn(),
 }))
 
 vi.mock('@/components/ui/alert-dialog', () => ({
-  AlertDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div data-testid="alert-dialog">{children}</div> : null,
-  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  AlertDialogCancel: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
-  AlertDialogAction: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
-    <button onClick={onClick}>{children}</button>
+  AlertDialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    readonly open: boolean
+    readonly onOpenChange: (open: boolean) => void
+    readonly children: React.ReactNode
+  }) =>
+    open ? (
+      <div data-testid="alert-dialog">
+        <button type="button" onClick={() => onOpenChange(false)}>
+          mock close
+        </button>
+        {children}
+      </div>
+    ) : null,
+  AlertDialogContent: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({
+    children,
+    disabled,
+  }: {
+    readonly children: React.ReactNode
+    readonly disabled?: boolean
+  }) => (
+    <button type="button" disabled={disabled}>
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({
+    children,
+    className,
+    disabled,
+    onClick,
+  }: {
+    readonly children: React.ReactNode
+    readonly className?: string
+    readonly disabled?: boolean
+    readonly onClick?: () => void
+  }) => (
+    <button type="button" className={className} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
   ),
 }))
 
 const mockUseContext = vi.mocked(useDeviceQuotaCategoryContext)
+
+const categoryToDelete: CategoryListItem = {
+  id: 10,
+  parent_id: null,
+  ma_nhom: 'VT',
+  ten_nhom: 'Nhóm 10',
+  phan_loai: 'A',
+  don_vi_tinh: 'cái',
+  thu_tu_hien_thi: 1,
+  level: 0,
+  so_luong_hien_co: 0,
+  so_luong_toi_da: null,
+  so_luong_toi_thieu: null,
+  mo_ta: null,
+}
+
+function setupContext({
+  isPending = false,
+  mutatingCategoryId = null,
+}: {
+  readonly isPending?: boolean
+  readonly mutatingCategoryId?: number | null
+} = {}) {
+  const closeDeleteDialog = vi.fn()
+  const deleteMutate = vi.fn()
+
+  mockUseContext.mockReturnValue({
+    categoryToDelete,
+    closeDeleteDialog,
+    deleteMutation: {
+      mutate: deleteMutate,
+      isPending,
+    },
+    mutatingCategoryId,
+  } as ReturnType<typeof useDeviceQuotaCategoryContext>)
+
+  return { closeDeleteDialog, deleteMutate }
+}
 
 describe('DeviceQuotaCategoryDeleteDialog', () => {
   beforeEach(() => {
@@ -31,14 +113,7 @@ describe('DeviceQuotaCategoryDeleteDialog', () => {
   })
 
   it('calls delete mutation when confirming', async () => {
-    const deleteMutate = vi.fn()
-
-    mockUseContext.mockReturnValue({
-      categoryToDelete: { id: 10, ten_nhom: 'Nhóm 10' },
-      closeDeleteDialog: vi.fn(),
-      deleteMutation: { mutate: deleteMutate, isPending: false },
-      mutatingCategoryId: null,
-    } as any)
+    const { deleteMutate } = setupContext()
 
     render(<DeviceQuotaCategoryDeleteDialog />)
 
@@ -47,5 +122,35 @@ describe('DeviceQuotaCategoryDeleteDialog', () => {
     await waitFor(() => {
       expect(deleteMutate).toHaveBeenCalledWith(10)
     })
+  })
+
+  it('forwards close changes to close the delete dialog', () => {
+    const { closeDeleteDialog } = setupContext()
+
+    render(<DeviceQuotaCategoryDeleteDialog />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'mock close' }))
+
+    expect(closeDeleteDialog).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables actions while the delete mutation is pending', () => {
+    setupContext({ isPending: true })
+
+    render(<DeviceQuotaCategoryDeleteDialog />)
+
+    expect(screen.getByRole('button', { name: 'Hủy' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Xóa danh mục' })).toBeDisabled()
+    expect(screen.getByTestId('pending-spinner')).toHaveClass('animate-spin')
+  })
+
+  it('disables actions while the selected category is mutating', () => {
+    setupContext({ mutatingCategoryId: 10 })
+
+    render(<DeviceQuotaCategoryDeleteDialog />)
+
+    expect(screen.getByRole('button', { name: 'Hủy' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Xóa danh mục' })).toBeDisabled()
+    expect(screen.getByTestId('pending-spinner')).toHaveClass('animate-spin')
   })
 })

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDeleteDialog.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDeleteDialog.tsx
@@ -1,20 +1,13 @@
 "use client"
 
 import * as React from "react"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-import { Loader2 } from "lucide-react"
 
+import { DestructiveConfirmDialog } from "@/components/shared/DestructiveConfirmDialog"
 import { useDeviceQuotaCategoryContext } from "../_hooks/useDeviceQuotaCategoryContext"
 
+/**
+ * Delete confirmation dialog for the selected device quota category.
+ */
 export function DeviceQuotaCategoryDeleteDialog() {
   const {
     categoryToDelete,
@@ -32,28 +25,20 @@ export function DeviceQuotaCategoryDeleteDialog() {
   }
 
   return (
-    <AlertDialog open={!!categoryToDelete} onOpenChange={(open) => !open && closeDeleteDialog()}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Bạn có chắc chắn muốn xóa?</AlertDialogTitle>
-          <AlertDialogDescription>
-            Hành động này không thể hoàn tác. Danh mục
-            <strong> {categoryToDelete.ten_nhom} </strong>
-            sẽ bị xóa vĩnh viễn nếu không có ràng buộc.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>Hủy</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleConfirm}
-            disabled={isPending}
-            className="bg-destructive hover:bg-destructive/90"
-          >
-            {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
-            Xóa danh mục
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <DestructiveConfirmDialog
+      open={!!categoryToDelete}
+      onOpenChange={(open) => !open && closeDeleteDialog()}
+      title="Bạn có chắc chắn muốn xóa?"
+      description={
+        <>
+          Hành động này không thể hoàn tác. Danh mục
+          <strong> {categoryToDelete.ten_nhom} </strong>
+          sẽ bị xóa vĩnh viễn nếu không có ràng buộc.
+        </>
+      }
+      confirmLabel="Xóa danh mục"
+      isPending={isPending}
+      onConfirm={handleConfirm}
+    />
   )
 }

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsDeleteDialog.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsDeleteDialog.test.tsx
@@ -1,0 +1,159 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { RepairRequestWithEquipment } from "../types"
+import { RepairRequestsDeleteDialog } from "../_components/RepairRequestsDeleteDialog"
+import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
+
+vi.mock("lucide-react", () => ({
+  Loader2: ({ className }: { readonly className?: string }) => (
+    <svg aria-hidden="true" className={className} data-testid="pending-spinner" />
+  ),
+}))
+
+vi.mock("../_hooks/useRepairRequestsContext", () => ({
+  useRepairRequestsContext: vi.fn(),
+}))
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    readonly open: boolean
+    readonly onOpenChange: (open: boolean) => void
+    readonly children: React.ReactNode
+  }) =>
+    open ? (
+      <div data-testid="alert-dialog">
+        <button type="button" onClick={() => onOpenChange(false)}>
+          mock close
+        </button>
+        {children}
+      </div>
+    ) : null,
+  AlertDialogContent: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { readonly children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { readonly children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogFooter: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({
+    children,
+    disabled,
+  }: {
+    readonly children: React.ReactNode
+    readonly disabled?: boolean
+  }) => (
+    <button type="button" disabled={disabled}>
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({
+    children,
+    className,
+    disabled,
+    onClick,
+  }: {
+    readonly children: React.ReactNode
+    readonly className?: string
+    readonly disabled?: boolean
+    readonly onClick?: () => void
+  }) => (
+    <button type="button" className={className} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}))
+
+const mockUseRepairRequestsContext = vi.mocked(useRepairRequestsContext)
+
+const requestToDelete: RepairRequestWithEquipment = {
+  id: 7,
+  thiet_bi_id: 55,
+  ngay_yeu_cau: "2026-05-01",
+  trang_thai: "Chờ xử lý",
+  mo_ta_su_co: "Không lên nguồn",
+  hang_muc_sua_chua: null,
+  ngay_mong_muon_hoan_thanh: null,
+  nguoi_yeu_cau: null,
+  ngay_duyet: null,
+  ngay_hoan_thanh: null,
+  nguoi_duyet: null,
+  nguoi_xac_nhan: null,
+  chi_phi_sua_chua: null,
+  don_vi_thuc_hien: "noi_bo",
+  ten_don_vi_thue: null,
+  ket_qua_sua_chua: null,
+  ly_do_khong_hoan_thanh: null,
+  thiet_bi: {
+    ten_thiet_bi: "Monitor",
+    ma_thiet_bi: "TB-55",
+    model: "M1",
+    serial: "SN55",
+    khoa_phong_quan_ly: "Khoa A",
+    facility_name: "BV A",
+    facility_id: 1,
+  },
+}
+
+function setupContext({
+  isPending = false,
+  request = requestToDelete,
+}: {
+  readonly isPending?: boolean
+  readonly request?: RepairRequestWithEquipment | null
+} = {}) {
+  const closeAllDialogs = vi.fn()
+  const deleteMutate = vi.fn()
+
+  mockUseRepairRequestsContext.mockReturnValue({
+    dialogState: { requestToDelete: request },
+    closeAllDialogs,
+    deleteMutation: {
+      mutate: deleteMutate,
+      isPending,
+    },
+  } as ReturnType<typeof useRepairRequestsContext>)
+
+  return { closeAllDialogs, deleteMutate }
+}
+
+describe("RepairRequestsDeleteDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("calls delete mutation with close callback when confirming", () => {
+    const { closeAllDialogs, deleteMutate } = setupContext()
+
+    render(<RepairRequestsDeleteDialog />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Xóa" }))
+
+    expect(deleteMutate).toHaveBeenCalledWith(7, { onSuccess: closeAllDialogs })
+  })
+
+  it("forwards close changes to close all dialogs", () => {
+    const { closeAllDialogs } = setupContext()
+
+    render(<RepairRequestsDeleteDialog />)
+
+    fireEvent.click(screen.getByRole("button", { name: "mock close" }))
+
+    expect(closeAllDialogs).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables actions and keeps the destructive label while pending", () => {
+    setupContext({ isPending: true })
+
+    render(<RepairRequestsDeleteDialog />)
+
+    expect(screen.getByRole("button", { name: "Hủy" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Xóa" })).toBeDisabled()
+    expect(screen.getByTestId("pending-spinner")).toHaveClass("animate-spin")
+  })
+})

--- a/src/app/(app)/repair-requests/_components/RepairRequestsDeleteDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsDeleteDialog.tsx
@@ -1,18 +1,13 @@
 "use client"
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
-import { Loader2 } from "lucide-react"
+import * as React from "react"
+
+import { DestructiveConfirmDialog } from "@/components/shared/DestructiveConfirmDialog"
 import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
 
+/**
+ * Delete confirmation dialog for the selected repair request.
+ */
 export function RepairRequestsDeleteDialog() {
   const {
     dialogState: { requestToDelete },
@@ -28,28 +23,20 @@ export function RepairRequestsDeleteDialog() {
   if (!requestToDelete) return null
 
   return (
-    <AlertDialog open={!!requestToDelete} onOpenChange={(open) => !open && closeAllDialogs()}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Bạn có chắc chắn muốn xóa?</AlertDialogTitle>
-          <AlertDialogDescription>
-            Hành động này không thể hoàn tác. Yêu cầu sửa chữa cho thiết bị
-            <strong> {requestToDelete.thiet_bi?.ten_thiet_bi} </strong>
-            sẽ bị xóa vĩnh viễn.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={deleteMutation.isPending}>Hủy</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleConfirm}
-            disabled={deleteMutation.isPending}
-            className="bg-destructive hover:bg-destructive/90"
-          >
-            {deleteMutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
-            Xóa
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <DestructiveConfirmDialog
+      open={!!requestToDelete}
+      onOpenChange={(open) => !open && closeAllDialogs()}
+      title="Bạn có chắc chắn muốn xóa?"
+      description={
+        <>
+          Hành động này không thể hoàn tác. Yêu cầu sửa chữa cho thiết bị
+          <strong> {requestToDelete.thiet_bi?.ten_thiet_bi} </strong>
+          sẽ bị xóa vĩnh viễn.
+        </>
+      }
+      confirmLabel="Xóa"
+      isPending={deleteMutation.isPending}
+      onConfirm={handleConfirm}
+    />
   )
 }

--- a/src/components/shared/DestructiveConfirmDialog.tsx
+++ b/src/components/shared/DestructiveConfirmDialog.tsx
@@ -36,8 +36,16 @@ export function DestructiveConfirmDialog({
   isPending,
   onConfirm,
 }: DestructiveConfirmDialogProps): React.JSX.Element {
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (isPending && !nextOpen) return
+      onOpenChange(nextOpen)
+    },
+    [isPending, onOpenChange]
+  )
+
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>

--- a/src/components/shared/DestructiveConfirmDialog.tsx
+++ b/src/components/shared/DestructiveConfirmDialog.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import * as React from "react"
+import { Loader2 } from "lucide-react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+export interface DestructiveConfirmDialogProps {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly title: React.ReactNode
+  readonly description: React.ReactNode
+  readonly confirmLabel: React.ReactNode
+  readonly isPending: boolean
+  readonly onConfirm: () => void
+}
+
+/**
+ * Shared destructive confirmation shell for feature-owned delete flows.
+ */
+export function DestructiveConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  isPending,
+  onConfirm,
+}: DestructiveConfirmDialogProps): React.JSX.Element {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Hủy</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isPending}
+            className="bg-destructive hover:bg-destructive/90"
+          >
+            {isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/shared/DestructiveConfirmDialog.tsx
+++ b/src/components/shared/DestructiveConfirmDialog.tsx
@@ -3,9 +3,9 @@
 import * as React from "react"
 import { Loader2 } from "lucide-react"
 
+import { Button } from "@/components/ui/button"
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -45,14 +45,15 @@ export function DestructiveConfirmDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isPending}>Hủy</AlertDialogCancel>
-          <AlertDialogAction
+          <Button
+            type="button"
             onClick={onConfirm}
             disabled={isPending}
             className="bg-destructive hover:bg-destructive/90"
           >
             {isPending ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
             {confirmLabel}
-          </AlertDialogAction>
+          </Button>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/shared/__tests__/DestructiveConfirmDialog.test.tsx
+++ b/src/components/shared/__tests__/DestructiveConfirmDialog.test.tsx
@@ -106,7 +106,26 @@ describe("DestructiveConfirmDialog", () => {
     expect(onOpenChange).not.toHaveBeenCalled()
   })
 
-  it("forwards close changes and disables actions while pending", () => {
+  it("forwards close changes when not pending", () => {
+    const onOpenChange = vi.fn()
+
+    render(
+      <DestructiveConfirmDialog
+        open
+        title="Xóa danh mục"
+        description="Không thể hoàn tác."
+        confirmLabel="Xóa danh mục"
+        isPending={false}
+        onConfirm={vi.fn()}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "mock close" }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("keeps the dialog open and disables actions while pending", () => {
     const onOpenChange = vi.fn()
 
     render(
@@ -126,6 +145,6 @@ describe("DestructiveConfirmDialog", () => {
     expect(screen.getByTestId("pending-spinner")).toHaveClass("animate-spin")
 
     fireEvent.click(screen.getByRole("button", { name: "mock close" }))
-    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(onOpenChange).not.toHaveBeenCalled()
   })
 })

--- a/src/components/shared/__tests__/DestructiveConfirmDialog.test.tsx
+++ b/src/components/shared/__tests__/DestructiveConfirmDialog.test.tsx
@@ -1,0 +1,114 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { DestructiveConfirmDialog } from "../DestructiveConfirmDialog"
+
+vi.mock("lucide-react", () => ({
+  Loader2: ({ className }: { readonly className?: string }) => (
+    <svg aria-hidden="true" className={className} data-testid="pending-spinner" />
+  ),
+}))
+
+vi.mock("@/components/ui/alert-dialog", () => ({
+  AlertDialog: ({
+    open,
+    onOpenChange,
+    children,
+  }: {
+    readonly open: boolean
+    readonly onOpenChange: (open: boolean) => void
+    readonly children: React.ReactNode
+  }) =>
+    open ? (
+      <div data-testid="alert-dialog">
+        <button type="button" onClick={() => onOpenChange(false)}>
+          mock close
+        </button>
+        {children}
+      </div>
+    ) : null,
+  AlertDialogContent: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { readonly children: React.ReactNode }) => <h2>{children}</h2>,
+  AlertDialogDescription: ({ children }: { readonly children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AlertDialogFooter: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({
+    children,
+    disabled,
+  }: {
+    readonly children: React.ReactNode
+    readonly disabled?: boolean
+  }) => (
+    <button type="button" disabled={disabled}>
+      {children}
+    </button>
+  ),
+  AlertDialogAction: ({
+    children,
+    className,
+    disabled,
+    onClick,
+  }: {
+    readonly children: React.ReactNode
+    readonly className?: string
+    readonly disabled?: boolean
+    readonly onClick?: () => void
+  }) => (
+    <button type="button" className={className} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}))
+
+describe("DestructiveConfirmDialog", () => {
+  it("renders the confirmation copy and calls the confirm action", () => {
+    const onConfirm = vi.fn()
+
+    render(
+      <DestructiveConfirmDialog
+        open
+        title="Bạn có chắc chắn muốn xóa?"
+        description={<span>Xóa bản ghi này vĩnh viễn.</span>}
+        confirmLabel="Xóa"
+        isPending={false}
+        onConfirm={onConfirm}
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("heading", { name: "Bạn có chắc chắn muốn xóa?" })).toBeInTheDocument()
+    expect(screen.getByText("Xóa bản ghi này vĩnh viễn.")).toBeInTheDocument()
+
+    const confirmButton = screen.getByRole("button", { name: "Xóa" })
+    expect(confirmButton).toHaveClass("bg-destructive")
+
+    fireEvent.click(confirmButton)
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it("forwards close changes and disables actions while pending", () => {
+    const onOpenChange = vi.fn()
+
+    render(
+      <DestructiveConfirmDialog
+        open
+        title="Xóa danh mục"
+        description="Không thể hoàn tác."
+        confirmLabel="Xóa danh mục"
+        isPending
+        onConfirm={vi.fn()}
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Hủy" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Xóa danh mục" })).toBeDisabled()
+    expect(screen.getByTestId("pending-spinner")).toHaveClass("animate-spin")
+
+    fireEvent.click(screen.getByRole("button", { name: "mock close" }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/components/shared/__tests__/DestructiveConfirmDialog.test.tsx
+++ b/src/components/shared/__tests__/DestructiveConfirmDialog.test.tsx
@@ -10,6 +10,10 @@ vi.mock("lucide-react", () => ({
   ),
 }))
 
+const alertDialogMockState = vi.hoisted(() => ({
+  onOpenChange: undefined as ((open: boolean) => void) | undefined,
+}))
+
 vi.mock("@/components/ui/alert-dialog", () => ({
   AlertDialog: ({
     open,
@@ -19,15 +23,18 @@ vi.mock("@/components/ui/alert-dialog", () => ({
     readonly open: boolean
     readonly onOpenChange: (open: boolean) => void
     readonly children: React.ReactNode
-  }) =>
-    open ? (
+  }) => {
+    alertDialogMockState.onOpenChange = onOpenChange
+
+    return open ? (
       <div data-testid="alert-dialog">
         <button type="button" onClick={() => onOpenChange(false)}>
           mock close
         </button>
         {children}
       </div>
-    ) : null,
+    ) : null
+  },
   AlertDialogContent: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
   AlertDialogHeader: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
   AlertDialogTitle: ({ children }: { readonly children: React.ReactNode }) => <h2>{children}</h2>,
@@ -57,7 +64,15 @@ vi.mock("@/components/ui/alert-dialog", () => ({
     readonly disabled?: boolean
     readonly onClick?: () => void
   }) => (
-    <button type="button" className={className} disabled={disabled} onClick={onClick}>
+    <button
+      type="button"
+      className={className}
+      disabled={disabled}
+      onClick={() => {
+        onClick?.()
+        alertDialogMockState.onOpenChange?.(false)
+      }}
+    >
       {children}
     </button>
   ),
@@ -66,6 +81,7 @@ vi.mock("@/components/ui/alert-dialog", () => ({
 describe("DestructiveConfirmDialog", () => {
   it("renders the confirmation copy and calls the confirm action", () => {
     const onConfirm = vi.fn()
+    const onOpenChange = vi.fn()
 
     render(
       <DestructiveConfirmDialog
@@ -75,7 +91,7 @@ describe("DestructiveConfirmDialog", () => {
         confirmLabel="Xóa"
         isPending={false}
         onConfirm={onConfirm}
-        onOpenChange={vi.fn()}
+        onOpenChange={onOpenChange}
       />
     )
 
@@ -87,6 +103,7 @@ describe("DestructiveConfirmDialog", () => {
 
     fireEvent.click(confirmButton)
     expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).not.toHaveBeenCalled()
   })
 
   it("forwards close changes and disables actions while pending", () => {


### PR DESCRIPTION
## Summary
- Add a shared `DestructiveConfirmDialog` shell for simple destructive confirmations.
- Migrate repair request and device quota category delete dialogs while preserving caller-owned mutation, close, pending, and labels.
- Add focused regression coverage for the shared shell and both migrated callers.

Closes #596

## Verification
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/shared/__tests__/DestructiveConfirmDialog.test.tsx`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/RepairRequestsDeleteDialog.test.tsx'`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryDeleteDialog.test.tsx'`
- `node scripts/npm-run.js run react-doctor`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable `DestructiveConfirmDialog` and migrated repair request and device quota category deletes to use it, standardizing UX and reducing duplication. The dialog now blocks all close actions while delete is pending and stays open until the mutation finishes (closes #596).

- **Refactors**
  - Added shared `DestructiveConfirmDialog` with title, description, confirm label, pending state, confirm callback, and guarded `onOpenChange`.
  - Migrated `RepairRequestsDeleteDialog` and `DeviceQuotaCategoryDeleteDialog` to the shared dialog.
  - Pending/UX: keep the dialog open while pending (blocks close events and confirm auto-close), disable actions with a spinner, forward close when not pending; added focused tests.

<sup>Written for commit 6d909501a3a416b0fbf3ed8b5242392100c646b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared destructive confirmation dialog for consistent delete UX, including a pending-state spinner and disabled actions while deletion is in progress.
* **Bug Fixes / UX**
  * Ensure cancel/confirm buttons are properly disabled and show a spinner during ongoing delete operations.
* **Tests**
  * Added comprehensive tests validating dialog behavior, pending states, and close/confirm interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->