### PR TITLE
fix: restore equipment edit field parity

### DIFF
--- a/src/app/(app)/equipment/__tests__/equipment-detail-edit-form.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-detail-edit-form.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { FormProvider, useForm } from "react-hook-form"
 import { describe, expect, it, vi } from "vitest"
 
@@ -106,33 +107,18 @@ describe("EquipmentDetailEditForm", () => {
 
   it("submits maintenance schedule and depreciation fields", async () => {
     const onSubmit = vi.fn()
+    const user = userEvent.setup()
 
     render(<FormHarness onSubmit={onSubmit} />)
 
-    fireEvent.change(screen.getByLabelText("Năm tính hao mòn"), {
-      target: { value: "2026" },
-    })
-    fireEvent.change(screen.getByLabelText("Tỷ lệ hao mòn theo TT23"), {
-      target: { value: "10%" },
-    })
-    fireEvent.change(screen.getByLabelText("Chu kỳ BT định kỳ (ngày)"), {
-      target: { value: "90" },
-    })
-    fireEvent.change(screen.getByLabelText("Ngày BT tiếp theo"), {
-      target: { value: "01/04/2026" },
-    })
-    fireEvent.change(screen.getByLabelText("Chu kỳ HC định kỳ (ngày)"), {
-      target: { value: "180" },
-    })
-    fireEvent.change(screen.getByLabelText("Ngày HC tiếp theo"), {
-      target: { value: "15/04/2026" },
-    })
-    fireEvent.change(screen.getByLabelText("Chu kỳ KĐ định kỳ (ngày)"), {
-      target: { value: "365" },
-    })
-    fireEvent.change(screen.getByLabelText("Ngày KĐ tiếp theo"), {
-      target: { value: "30/04/2026" },
-    })
+    await user.type(screen.getByLabelText("Năm tính hao mòn"), "2026")
+    await user.type(screen.getByLabelText("Tỷ lệ hao mòn theo TT23"), "10%")
+    await user.type(screen.getByLabelText("Chu kỳ BT định kỳ (ngày)"), "90")
+    await user.type(screen.getByLabelText("Ngày BT tiếp theo"), "01/04/2026")
+    await user.type(screen.getByLabelText("Chu kỳ HC định kỳ (ngày)"), "180")
+    await user.type(screen.getByLabelText("Ngày HC tiếp theo"), "15/04/2026")
+    await user.type(screen.getByLabelText("Chu kỳ KĐ định kỳ (ngày)"), "365")
+    await user.type(screen.getByLabelText("Ngày KĐ tiếp theo"), "30/04/2026")
 
     fireEvent.submit(document.getElementById("equipment-inline-edit-form")!)
 

--- a/src/app/(app)/equipment/__tests__/equipment-detail-edit-form.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-detail-edit-form.test.tsx
@@ -40,6 +40,7 @@ import {
   type EquipmentFormValues,
 } from "../_components/EquipmentDetailDialog/EquipmentDetailTypes"
 import { DEFAULT_EQUIPMENT_FORM_VALUES } from "@/components/equipment-edit/EquipmentEditFormDefaults"
+import { EquipmentEditTextareaField } from "@/components/equipment-edit/EquipmentEditFieldControls"
 
 function FormHarness({
   initialStatus = "Hoạt động",
@@ -68,6 +69,18 @@ function FormHarness({
         initialStatus={initialStatus}
         onSubmit={onSubmit}
       />
+    </FormProvider>
+  )
+}
+
+function RequiredTextareaHarness() {
+  const form = useForm<EquipmentFormValues>({
+    defaultValues: DEFAULT_EQUIPMENT_FORM_VALUES,
+  })
+
+  return (
+    <FormProvider {...form}>
+      <EquipmentEditTextareaField name="ghi_chu" label="Ghi chú bắt buộc" required />
     </FormProvider>
   )
 }
@@ -138,6 +151,13 @@ describe("EquipmentDetailEditForm", () => {
         })
       )
     })
+  })
+
+  it("renders textarea required marker when requested", () => {
+    render(<RequiredTextareaHarness />)
+
+    expect(screen.getByRole("textbox", { name: /Ghi chú bắt buộc/ })).toBeInTheDocument()
+    expect(screen.getByLabelText("bắt buộc")).toBeInTheDocument()
   })
 
   it("auto-fills the decommission date on status transition and submits normalized values", async () => {

--- a/src/app/(app)/equipment/__tests__/equipment-detail-edit-form.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-detail-edit-form.test.tsx
@@ -79,8 +79,65 @@ describe("EquipmentDetailEditForm", () => {
     expect(screen.getByLabelText("Mã thiết bị")).toBeInTheDocument()
     expect(screen.getByLabelText("Tên thiết bị")).toBeInTheDocument()
     expect(screen.getByLabelText("Ngày ngừng sử dụng")).toBeInTheDocument()
+    expect(screen.getByLabelText("Năm tính hao mòn")).toBeInTheDocument()
+    expect(screen.getByLabelText("Tỷ lệ hao mòn theo TT23")).toBeInTheDocument()
+    expect(screen.getByLabelText("Chu kỳ BT định kỳ (ngày)")).toBeInTheDocument()
+    expect(screen.getByLabelText("Ngày BT tiếp theo")).toBeInTheDocument()
+    expect(screen.getByLabelText("Chu kỳ HC định kỳ (ngày)")).toBeInTheDocument()
+    expect(screen.getByLabelText("Ngày HC tiếp theo")).toBeInTheDocument()
+    expect(screen.getByLabelText("Chu kỳ KĐ định kỳ (ngày)")).toBeInTheDocument()
+    expect(screen.getByLabelText("Ngày KĐ tiếp theo")).toBeInTheDocument()
     expect(screen.getByText("Chọn tình trạng")).toBeInTheDocument()
     expect(screen.getByText("Chọn phân loại")).toBeInTheDocument()
+  })
+
+  it("submits maintenance schedule and depreciation fields", async () => {
+    const onSubmit = vi.fn()
+
+    render(<FormHarness onSubmit={onSubmit} />)
+
+    fireEvent.change(screen.getByLabelText("Năm tính hao mòn"), {
+      target: { value: "2026" },
+    })
+    fireEvent.change(screen.getByLabelText("Tỷ lệ hao mòn theo TT23"), {
+      target: { value: "10%" },
+    })
+    fireEvent.change(screen.getByLabelText("Chu kỳ BT định kỳ (ngày)"), {
+      target: { value: "90" },
+    })
+    fireEvent.change(screen.getByLabelText("Ngày BT tiếp theo"), {
+      target: { value: "01/04/2026" },
+    })
+    fireEvent.change(screen.getByLabelText("Chu kỳ HC định kỳ (ngày)"), {
+      target: { value: "180" },
+    })
+    fireEvent.change(screen.getByLabelText("Ngày HC tiếp theo"), {
+      target: { value: "15/04/2026" },
+    })
+    fireEvent.change(screen.getByLabelText("Chu kỳ KĐ định kỳ (ngày)"), {
+      target: { value: "365" },
+    })
+    fireEvent.change(screen.getByLabelText("Ngày KĐ tiếp theo"), {
+      target: { value: "30/04/2026" },
+    })
+
+    fireEvent.submit(document.getElementById("equipment-inline-edit-form")!)
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled()
+      expect(onSubmit.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({
+          nam_tinh_hao_mon: 2026,
+          ty_le_hao_mon: "10%",
+          chu_ky_bt_dinh_ky: 90,
+          ngay_bt_tiep_theo: "2026-04-01",
+          chu_ky_hc_dinh_ky: 180,
+          ngay_hc_tiep_theo: "2026-04-15",
+          chu_ky_kd_dinh_ky: 365,
+          ngay_kd_tiep_theo: "2026-04-30",
+        })
+      )
+    })
   })
 
   it("auto-fills the decommission date on status transition and submits normalized values", async () => {

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailAssignmentSection.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailAssignmentSection.tsx
@@ -1,62 +1,30 @@
 "use client"
 
 import * as React from "react"
-import { useFormContext } from "react-hook-form"
 
-import { Input } from "@/components/ui/input"
-import { FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form"
-import { RequiredFormLabel } from "@/components/ui/required-form-label"
+import { EquipmentEditTextField } from "@/components/equipment-edit/EquipmentEditFieldControls"
 
-import type { EquipmentFormValues } from "./EquipmentDetailTypes"
-
+/** Renders assignment and location fields in the equipment detail edit form. */
 export function EquipmentDetailAssignmentSection() {
-  const form = useFormContext<EquipmentFormValues>()
-
   return (
     <>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <FormField
-          control={form.control}
+        <EquipmentEditTextField
           name="khoa_phong_quan_ly"
-          render={({ field }) => (
-            <FormItem>
-              <RequiredFormLabel required>Khoa/Phòng quản lý</RequiredFormLabel>
-              <FormControl>
-                <Input {...field} value={field.value ?? ""} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          label="Khoa/Phòng quản lý"
+          required
         />
-        <FormField
-          control={form.control}
+        <EquipmentEditTextField
           name="vi_tri_lap_dat"
-          render={({ field }) => (
-            <FormItem>
-              <RequiredFormLabel required>Vị trí lắp đặt</RequiredFormLabel>
-              <FormControl>
-                <Input {...field} value={field.value ?? ""} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          label="Vị trí lắp đặt"
+          required
         />
       </div>
 
-      <FormField
-        control={form.control}
+      <EquipmentEditTextField
         name="nguoi_dang_truc_tiep_quan_ly"
-        render={({ field }) => (
-          <FormItem>
-            <RequiredFormLabel required>
-              Người trực tiếp quản lý (sử dụng)
-            </RequiredFormLabel>
-            <FormControl>
-              <Input {...field} value={field.value ?? ""} />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
+        label="Người trực tiếp quản lý (sử dụng)"
+        required
       />
     </>
   )

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailBasicInfoSection.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailBasicInfoSection.tsx
@@ -1,153 +1,46 @@
 "use client"
 
 import * as React from "react"
-import { useFormContext } from "react-hook-form"
 
-import { Input } from "@/components/ui/input"
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import {
+  EquipmentEditNullableNumberField,
+  EquipmentEditTextField,
+} from "@/components/equipment-edit/EquipmentEditFieldControls"
 
-import type { EquipmentFormValues } from "./EquipmentDetailTypes"
-
-function toNullableNumber(value: string): number | null {
-  return value === "" ? null : Number(value)
-}
-
+/** Renders core identifying and manufacturing fields in the equipment detail edit form. */
 export function EquipmentDetailBasicInfoSection() {
-  const form = useFormContext<EquipmentFormValues>()
-
   return (
     <>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <FormField
-          control={form.control}
+        <EquipmentEditTextField
           name="ma_thiet_bi"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Mã thiết bị</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="VD: EQP-001"
-                  {...field}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          label="Mã thiết bị"
+          placeholder="VD: EQP-001"
         />
-        <FormField
-          control={form.control}
+        <EquipmentEditTextField
           name="ten_thiet_bi"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Tên thiết bị</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="VD: Máy siêu âm"
-                  {...field}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          label="Tên thiết bị"
+          placeholder="VD: Máy siêu âm"
         />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <FormField
-          control={form.control}
-          name="model"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Model</FormLabel>
-              <FormControl>
-                <Input {...field} value={field.value ?? ""} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="serial"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Serial</FormLabel>
-              <FormControl>
-                <Input {...field} value={field.value ?? ""} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <EquipmentEditTextField name="model" label="Model" />
+        <EquipmentEditTextField name="serial" label="Serial" />
       </div>
 
-      <FormField
-        control={form.control}
+      <EquipmentEditTextField
         name="so_luu_hanh"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Số lưu hành</FormLabel>
-            <FormControl>
-              <Input
-                placeholder="VD: LH-2024-001"
-                {...field}
-                value={field.value ?? ""}
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
+        label="Số lưu hành"
+        placeholder="VD: LH-2024-001"
       />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <FormField
-          control={form.control}
-          name="hang_san_xuat"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Hãng sản xuất</FormLabel>
-              <FormControl>
-                <Input {...field} value={field.value ?? ""} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="noi_san_xuat"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Nơi sản xuất</FormLabel>
-              <FormControl>
-                <Input {...field} value={field.value ?? ""} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <EquipmentEditTextField name="hang_san_xuat" label="Hãng sản xuất" />
+        <EquipmentEditTextField name="noi_san_xuat" label="Nơi sản xuất" />
       </div>
 
-      <FormField
-        control={form.control}
-        name="nam_san_xuat"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Năm sản xuất</FormLabel>
-            <FormControl>
-              <Input
-                type="number"
-                {...field}
-                value={field.value ?? ""}
-                onChange={(event) => field.onChange(toNullableNumber(event.target.value))}
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      <EquipmentEditNullableNumberField name="nam_san_xuat" label="Năm sản xuất" />
     </>
   )
 }

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailConfigTab.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailConfigTab.tsx
@@ -7,20 +7,11 @@
 "use client"
 
 import * as React from "react"
-import { useFormContext } from "react-hook-form"
 
+import { EquipmentEditTextareaField } from "@/components/equipment-edit/EquipmentEditFieldControls"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Textarea } from "@/components/ui/textarea"
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form"
 import { columnLabels } from "@/components/equipment/equipment-table-columns"
 import type { Equipment } from "@/types/database"
-import type { EquipmentFormValues } from "./EquipmentDetailTypes"
 
 export interface EquipmentDetailConfigTabProps {
   /** Equipment data to display */
@@ -53,6 +44,7 @@ function LongTextField({
   )
 }
 
+/** Renders the equipment configuration tab in view or edit mode. */
 export function EquipmentDetailConfigTab({
   displayEquipment,
   isEditing,
@@ -83,51 +75,23 @@ export function EquipmentDetailConfigTab({
  * Uses useFormContext to access form from parent FormProvider
  */
 function ConfigEditForm(): React.ReactNode {
-  const form = useFormContext<EquipmentFormValues>()
-
   return (
     <ScrollArea className="h-full pr-4">
       <div className="space-y-6 py-4">
-        {/* Configuration */}
-        <FormField
-          control={form.control}
+        <EquipmentEditTextareaField
           name="cau_hinh_thiet_bi"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Cấu hình thiết bị</FormLabel>
-              <FormControl>
-                <Textarea
-                  rows={8}
-                  placeholder="Nhập cấu hình thiết bị…"
-                  className="resize-y min-h-[120px]"
-                  {...field}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          label="Cấu hình thiết bị"
+          rows={8}
+          placeholder="Nhập cấu hình thiết bị…"
+          className="resize-y min-h-[120px]"
         />
 
-        {/* Accessories */}
-        <FormField
-          control={form.control}
+        <EquipmentEditTextareaField
           name="phu_kien_kem_theo"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Phụ kiện kèm theo</FormLabel>
-              <FormControl>
-                <Textarea
-                  rows={6}
-                  placeholder="Nhập phụ kiện kèm theo…"
-                  className="resize-y min-h-[100px]"
-                  {...field}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          label="Phụ kiện kèm theo"
+          rows={6}
+          placeholder="Nhập phụ kiện kèm theo…"
+          className="resize-y min-h-[100px]"
         />
       </div>
     </ScrollArea>

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailDatesSection.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailDatesSection.tsx
@@ -1,127 +1,44 @@
 "use client"
 
 import * as React from "react"
-import { useFormContext } from "react-hook-form"
 
-import { Input } from "@/components/ui/input"
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
+import {
+  EquipmentEditNullableNumberField,
+  EquipmentEditTextField,
+} from "@/components/equipment-edit/EquipmentEditFieldControls"
 
-import type { EquipmentFormValues } from "./EquipmentDetailTypes"
-
-function toNullableNumber(value: string): number | null {
-  return value === "" ? null : Number(value)
-}
-
+/** Renders date and finance fields in the equipment detail edit form. */
 export function EquipmentDetailDatesSection() {
-  const form = useFormContext<EquipmentFormValues>()
-
   return (
     <>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <FormField
-          control={form.control}
+        <EquipmentEditTextField
           name="ngay_nhap"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Ngày nhập</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="DD/MM/YYYY hoặc MM/YYYY hoặc YYYY"
-                  {...field}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          label="Ngày nhập"
+          placeholder="DD/MM/YYYY hoặc MM/YYYY hoặc YYYY"
         />
-        <FormField
-          control={form.control}
+        <EquipmentEditTextField
           name="ngay_dua_vao_su_dung"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Ngày đưa vào sử dụng</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="DD/MM/YYYY hoặc MM/YYYY hoặc YYYY"
-                  {...field}
-                  value={field.value ?? ""}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          label="Ngày đưa vào sử dụng"
+          placeholder="DD/MM/YYYY hoặc MM/YYYY hoặc YYYY"
         />
       </div>
 
-      <FormField
-        control={form.control}
+      <EquipmentEditTextField
         name="ngay_ngung_su_dung"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Ngày ngừng sử dụng</FormLabel>
-            <FormControl>
-              <Input
-                placeholder="DD/MM/YYYY"
-                {...field}
-                value={field.value ?? ""}
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
+        label="Ngày ngừng sử dụng"
+        placeholder="DD/MM/YYYY"
       />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <FormField
-          control={form.control}
-          name="nguon_kinh_phi"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Nguồn kinh phí</FormLabel>
-              <FormControl>
-                <Input {...field} value={field.value ?? ""} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="gia_goc"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Giá gốc (VNĐ)</FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  {...field}
-                  value={field.value ?? ""}
-                  onChange={(event) => field.onChange(toNullableNumber(event.target.value))}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <EquipmentEditTextField name="nguon_kinh_phi" label="Nguồn kinh phí" />
+        <EquipmentEditNullableNumberField name="gia_goc" label="Giá gốc (VNĐ)" />
       </div>
 
-      <FormField
-        control={form.control}
+      <EquipmentEditTextField
         name="han_bao_hanh"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Hạn bảo hành</FormLabel>
-            <FormControl>
-              <Input
-                placeholder="DD/MM/YYYY"
-                {...field}
-                value={field.value ?? ""}
-              />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
+        label="Hạn bảo hành"
+        placeholder="DD/MM/YYYY"
       />
     </>
   )

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailEditForm.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailEditForm.tsx
@@ -15,6 +15,7 @@ import { useDecommissionDateAutofill } from "@/components/equipment-decommission
 import { EquipmentDetailAssignmentSection } from "./EquipmentDetailAssignmentSection"
 import { EquipmentDetailBasicInfoSection } from "./EquipmentDetailBasicInfoSection"
 import { EquipmentDetailDatesSection } from "./EquipmentDetailDatesSection"
+import { EquipmentDetailLifecycleSection } from "./EquipmentDetailLifecycleSection"
 import { EquipmentDetailStatusSection } from "./EquipmentDetailStatusSection"
 import type { EquipmentFormValues } from "./EquipmentDetailTypes"
 
@@ -24,6 +25,7 @@ export interface EquipmentDetailEditFormProps {
   onSubmit: (values: EquipmentFormValues) => void
 }
 
+/** Renders the inline equipment detail edit form inside the details tab. */
 export function EquipmentDetailEditForm({
   formId,
   initialStatus,
@@ -47,6 +49,7 @@ export function EquipmentDetailEditForm({
         <div className="space-y-4 py-4">
           <EquipmentDetailBasicInfoSection />
           <EquipmentDetailDatesSection />
+          <EquipmentDetailLifecycleSection />
           <EquipmentDetailAssignmentSection />
           <EquipmentDetailStatusSection />
         </div>

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailLifecycleSection.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailLifecycleSection.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import * as React from "react"
+
+import {
+  EquipmentEditNullableNumberField,
+  EquipmentEditTextField,
+} from "@/components/equipment-edit/EquipmentEditFieldControls"
+
+/** Renders depreciation and maintenance schedule fields in the equipment detail edit form. */
+export function EquipmentDetailLifecycleSection() {
+  return (
+    <>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <EquipmentEditNullableNumberField
+          name="nam_tinh_hao_mon"
+          label="Năm tính hao mòn"
+        />
+        <EquipmentEditTextField
+          name="ty_le_hao_mon"
+          label="Tỷ lệ hao mòn theo TT23"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <EquipmentEditNullableNumberField
+          name="chu_ky_bt_dinh_ky"
+          label="Chu kỳ BT định kỳ (ngày)"
+        />
+        <EquipmentEditTextField
+          name="ngay_bt_tiep_theo"
+          label="Ngày BT tiếp theo"
+          placeholder="DD/MM/YYYY"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <EquipmentEditNullableNumberField
+          name="chu_ky_hc_dinh_ky"
+          label="Chu kỳ HC định kỳ (ngày)"
+        />
+        <EquipmentEditTextField
+          name="ngay_hc_tiep_theo"
+          label="Ngày HC tiếp theo"
+          placeholder="DD/MM/YYYY"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <EquipmentEditNullableNumberField
+          name="chu_ky_kd_dinh_ky"
+          label="Chu kỳ KĐ định kỳ (ngày)"
+        />
+        <EquipmentEditTextField
+          name="ngay_kd_tiep_theo"
+          label="Ngày KĐ tiếp theo"
+          placeholder="DD/MM/YYYY"
+        />
+      </div>
+    </>
+  )
+}

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailStatusSection.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailStatusSection.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { useFormContext } from "react-hook-form"
 
+import { EquipmentEditTextareaField } from "@/components/equipment-edit/EquipmentEditFieldControls"
 import { equipmentStatusOptions } from "@/components/equipment/equipment-table-columns"
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { RequiredFormLabel } from "@/components/ui/required-form-label"
@@ -13,12 +14,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { Textarea } from "@/components/ui/textarea"
 
 import type { EquipmentFormValues } from "./EquipmentDetailTypes"
 
 const CLASSIFICATION_OPTIONS = ["A", "B", "C", "D"] as const
 
+/** Renders status, notes, and classification fields in the equipment detail edit form. */
 export function EquipmentDetailStatusSection() {
   const form = useFormContext<EquipmentFormValues>()
 
@@ -49,19 +50,7 @@ export function EquipmentDetailStatusSection() {
         )}
       />
 
-      <FormField
-        control={form.control}
-        name="ghi_chu"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>Ghi chú</FormLabel>
-            <FormControl>
-              <Textarea rows={3} {...field} value={field.value ?? ""} />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      <EquipmentEditTextareaField name="ghi_chu" label="Ghi chú" rows={3} />
 
       <FormField
         control={form.control}

--- a/src/components/__tests__/equipment-edit-shared-contract.test.ts
+++ b/src/components/__tests__/equipment-edit-shared-contract.test.ts
@@ -49,6 +49,8 @@ describe("equipment edit shared contract", () => {
         ty_le_hao_mon: "10%",
         chu_ky_bt_dinh_ky: 90,
         ngay_bt_tiep_theo: "2026-04-01",
+        ngay_hc_tiep_theo: "2026-04-15",
+        ngay_kd_tiep_theo: "2026-04-30",
       })
     ).toEqual(
       expect.objectContaining({
@@ -57,7 +59,9 @@ describe("equipment edit shared contract", () => {
         nam_tinh_hao_mon: 2026,
         ty_le_hao_mon: "10%",
         chu_ky_bt_dinh_ky: 90,
-        ngay_bt_tiep_theo: "2026-04-01",
+        ngay_bt_tiep_theo: "01/04/2026",
+        ngay_hc_tiep_theo: "15/04/2026",
+        ngay_kd_tiep_theo: "30/04/2026",
       })
     )
   })
@@ -104,5 +108,16 @@ describe("equipment edit shared contract", () => {
         useEquipmentEditUpdate: expect.any(Function),
       })
     )
+  })
+
+  it("keeps invalid nullable number input out of form state", async () => {
+    const mod = await importSharedEquipmentEditModule(
+      "../equipment-edit/EquipmentEditFieldUtils.ts"
+    )
+
+    expect(mod.toNullableNumber("")).toBeNull()
+    expect(mod.toNullableNumber("-")).toBeNull()
+    expect(mod.toNullableNumber("abc")).toBeNull()
+    expect(mod.toNullableNumber("90")).toBe(90)
   })
 })

--- a/src/components/__tests__/equipment-edit-shared-contract.test.ts
+++ b/src/components/__tests__/equipment-edit-shared-contract.test.ts
@@ -30,6 +30,10 @@ describe("equipment edit shared contract", () => {
       expect.objectContaining({
         ma_thiet_bi: "",
         ten_thiet_bi: "",
+        nam_tinh_hao_mon: null,
+        ty_le_hao_mon: null,
+        chu_ky_bt_dinh_ky: null,
+        ngay_bt_tiep_theo: null,
       })
     )
 
@@ -41,11 +45,53 @@ describe("equipment edit shared contract", () => {
         vi_tri_lap_dat: "Phòng 101",
         khoa_phong_quan_ly: "Khoa Nội",
         nguoi_dang_truc_tiep_quan_ly: "Nguyễn Văn A",
+        nam_tinh_hao_mon: 2026,
+        ty_le_hao_mon: "10%",
+        chu_ky_bt_dinh_ky: 90,
+        ngay_bt_tiep_theo: "2026-04-01",
       })
     ).toEqual(
       expect.objectContaining({
         ma_thiet_bi: "EQ-001",
         ten_thiet_bi: "Máy siêu âm",
+        nam_tinh_hao_mon: 2026,
+        ty_le_hao_mon: "10%",
+        chu_ky_bt_dinh_ky: 90,
+        ngay_bt_tiep_theo: "2026-04-01",
+      })
+    )
+  })
+
+  it("schema accepts depreciation and maintenance schedule fields", async () => {
+    const mod = await importSharedEquipmentEditModule("../equipment-edit/EquipmentEditTypes.ts")
+
+    const parsed = mod.equipmentFormSchema.parse({
+      ma_thiet_bi: "EQ-001",
+      ten_thiet_bi: "Máy siêu âm",
+      vi_tri_lap_dat: "Phòng 101",
+      khoa_phong_quan_ly: "Khoa Nội",
+      nguoi_dang_truc_tiep_quan_ly: "Nguyễn Văn A",
+      tinh_trang_hien_tai: "Hoạt động",
+      nam_tinh_hao_mon: "2026",
+      ty_le_hao_mon: "10%",
+      chu_ky_bt_dinh_ky: "90",
+      ngay_bt_tiep_theo: "01/04/2026",
+      chu_ky_hc_dinh_ky: "",
+      ngay_hc_tiep_theo: "",
+      chu_ky_kd_dinh_ky: "365",
+      ngay_kd_tiep_theo: "30/04/2026",
+    })
+
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        nam_tinh_hao_mon: 2026,
+        ty_le_hao_mon: "10%",
+        chu_ky_bt_dinh_ky: 90,
+        ngay_bt_tiep_theo: "2026-04-01",
+        chu_ky_hc_dinh_ky: null,
+        ngay_hc_tiep_theo: null,
+        chu_ky_kd_dinh_ky: 365,
+        ngay_kd_tiep_theo: "2026-04-30",
       })
     )
   })

--- a/src/components/equipment-edit/EquipmentEditFieldControls.tsx
+++ b/src/components/equipment-edit/EquipmentEditFieldControls.tsx
@@ -103,6 +103,7 @@ export function EquipmentEditTextareaField({
   name,
   label,
   placeholder,
+  required,
   rows = 3,
   className,
 }: EquipmentEditFieldProps & {
@@ -117,7 +118,7 @@ export function EquipmentEditTextareaField({
       name={name}
       render={({ field }) => (
         <FormItem>
-          <FormLabel>{label}</FormLabel>
+          <EquipmentEditLabel required={required}>{label}</EquipmentEditLabel>
           <FormControl>
             <Textarea
               rows={rows}

--- a/src/components/equipment-edit/EquipmentEditFieldControls.tsx
+++ b/src/components/equipment-edit/EquipmentEditFieldControls.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import * as React from "react"
+import { type Path, useFormContext } from "react-hook-form"
+
+import { RequiredFormLabel } from "@/components/ui/required-form-label"
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+import type { EquipmentFormValues } from "./EquipmentEditTypes"
+import { toNullableNumber } from "./EquipmentEditFieldUtils"
+
+interface EquipmentEditFieldProps {
+  name: Path<EquipmentFormValues>
+  label: string
+  placeholder?: string
+  required?: boolean
+}
+
+function EquipmentEditLabel({
+  children,
+  required,
+}: {
+  children: React.ReactNode
+  required?: boolean
+}) {
+  return required ? (
+    <RequiredFormLabel required>{children}</RequiredFormLabel>
+  ) : (
+    <FormLabel>{children}</FormLabel>
+  )
+}
+
+/** Renders a controlled text input bound to the shared equipment edit form. */
+export function EquipmentEditTextField({
+  name,
+  label,
+  placeholder,
+  required,
+}: EquipmentEditFieldProps) {
+  const form = useFormContext<EquipmentFormValues>()
+
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <EquipmentEditLabel required={required}>{label}</EquipmentEditLabel>
+          <FormControl>
+            <Input
+              placeholder={placeholder}
+              {...field}
+              value={field.value == null ? "" : String(field.value)}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+/** Renders a controlled number input that stores empty values as null. */
+export function EquipmentEditNullableNumberField({
+  name,
+  label,
+  required,
+}: EquipmentEditFieldProps) {
+  const form = useFormContext<EquipmentFormValues>()
+
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <EquipmentEditLabel required={required}>{label}</EquipmentEditLabel>
+          <FormControl>
+            <Input
+              type="number"
+              {...field}
+              value={field.value ?? ""}
+              onChange={(event) => field.onChange(toNullableNumber(event.target.value))}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+/** Renders a controlled textarea bound to the shared equipment edit form. */
+export function EquipmentEditTextareaField({
+  name,
+  label,
+  placeholder,
+  rows = 3,
+  className,
+}: EquipmentEditFieldProps & {
+  rows?: number
+  className?: string
+}) {
+  const form = useFormContext<EquipmentFormValues>()
+
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <Textarea
+              rows={rows}
+              placeholder={placeholder}
+              className={className}
+              {...field}
+              value={field.value == null ? "" : String(field.value)}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}

--- a/src/components/equipment-edit/EquipmentEditFieldUtils.ts
+++ b/src/components/equipment-edit/EquipmentEditFieldUtils.ts
@@ -1,0 +1,4 @@
+/** Converts an empty input string to null and numeric input to a number. */
+export function toNullableNumber(value: string): number | null {
+  return value === "" ? null : Number(value)
+}

--- a/src/components/equipment-edit/EquipmentEditFieldUtils.ts
+++ b/src/components/equipment-edit/EquipmentEditFieldUtils.ts
@@ -1,4 +1,7 @@
 /** Converts an empty input string to null and numeric input to a number. */
 export function toNullableNumber(value: string): number | null {
-  return value === "" ? null : Number(value)
+  if (value === "") return null
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
 }

--- a/src/components/equipment-edit/EquipmentEditFormDefaults.ts
+++ b/src/components/equipment-edit/EquipmentEditFormDefaults.ts
@@ -4,6 +4,7 @@ import type { Equipment } from "@/types/database"
 
 import type { EquipmentFormValues, EquipmentStatus } from "./EquipmentEditTypes"
 
+/** Empty values used when initializing the shared equipment edit form. */
 export const DEFAULT_EQUIPMENT_FORM_VALUES: EquipmentFormValues = {
   ma_thiet_bi: "",
   ten_thiet_bi: "",
@@ -29,6 +30,8 @@ export const DEFAULT_EQUIPMENT_FORM_VALUES: EquipmentFormValues = {
   ngay_kd_tiep_theo: null,
   nam_san_xuat: null,
   gia_goc: null,
+  nam_tinh_hao_mon: null,
+  ty_le_hao_mon: null,
   chu_ky_bt_dinh_ky: null,
   chu_ky_hc_dinh_ky: null,
   chu_ky_kd_dinh_ky: null,
@@ -43,6 +46,7 @@ function normalizeEquipmentStatus(
     : null
 }
 
+/** Converts an equipment record into display-ready edit form values. */
 export function equipmentToFormValues(
   equipment: Equipment | null | undefined
 ): EquipmentFormValues {
@@ -87,6 +91,8 @@ export function equipmentToFormValues(
       (equipment as Equipment & { ngay_kd_tiep_theo?: string }).ngay_kd_tiep_theo || null,
     nam_san_xuat: equipment.nam_san_xuat ?? null,
     gia_goc: equipment.gia_goc ?? null,
+    nam_tinh_hao_mon: equipment.nam_tinh_hao_mon ?? null,
+    ty_le_hao_mon: equipment.ty_le_hao_mon || null,
     chu_ky_bt_dinh_ky:
       (equipment as Equipment & { chu_ky_bt_dinh_ky?: number }).chu_ky_bt_dinh_ky ?? null,
     chu_ky_hc_dinh_ky:

--- a/src/components/equipment-edit/EquipmentEditFormDefaults.ts
+++ b/src/components/equipment-edit/EquipmentEditFormDefaults.ts
@@ -84,11 +84,17 @@ export function equipmentToFormValues(
       ) || null,
     han_bao_hanh: formatPartialDateToDisplay(equipment.han_bao_hanh) || null,
     ngay_bt_tiep_theo:
-      (equipment as Equipment & { ngay_bt_tiep_theo?: string }).ngay_bt_tiep_theo || null,
+      formatFullDateToDisplay(
+        (equipment as Equipment & { ngay_bt_tiep_theo?: string | null }).ngay_bt_tiep_theo
+      ) || null,
     ngay_hc_tiep_theo:
-      (equipment as Equipment & { ngay_hc_tiep_theo?: string }).ngay_hc_tiep_theo || null,
+      formatFullDateToDisplay(
+        (equipment as Equipment & { ngay_hc_tiep_theo?: string | null }).ngay_hc_tiep_theo
+      ) || null,
     ngay_kd_tiep_theo:
-      (equipment as Equipment & { ngay_kd_tiep_theo?: string }).ngay_kd_tiep_theo || null,
+      formatFullDateToDisplay(
+        (equipment as Equipment & { ngay_kd_tiep_theo?: string | null }).ngay_kd_tiep_theo
+      ) || null,
     nam_san_xuat: equipment.nam_san_xuat ?? null,
     gia_goc: equipment.gia_goc ?? null,
     nam_tinh_hao_mon: equipment.nam_tinh_hao_mon ?? null,

--- a/src/components/equipment-edit/EquipmentEditTypes.ts
+++ b/src/components/equipment-edit/EquipmentEditTypes.ts
@@ -17,7 +17,11 @@ export type EquipmentStatus = (typeof equipmentStatusOptions)[number]
 
 const nullableTextField = () => z.string().optional().nullable()
 
-const nullableNumberField = () => z.coerce.number().optional().nullable()
+const nullableNumberField = () =>
+  z.preprocess(
+    (value) => (value === "" ? null : value),
+    z.coerce.number().optional().nullable()
+  )
 
 const partialDateField = () =>
   z
@@ -33,6 +37,7 @@ const normalizedDateField = () =>
 const requiredTextField = (message: string) =>
   z.preprocess((value) => value ?? "", z.string().min(1, message))
 
+/** Shared schema for validating and normalizing equipment edit form submissions. */
 export const equipmentFormSchema = z
   .object({
     ma_thiet_bi: z.string().min(1, "Mã thiết bị là bắt buộc"),
@@ -53,6 +58,8 @@ export const equipmentFormSchema = z
       .transform(normalizeFullDateForForm),
     nguon_kinh_phi: nullableTextField(),
     gia_goc: nullableNumberField(),
+    nam_tinh_hao_mon: nullableNumberField(),
+    ty_le_hao_mon: nullableTextField(),
     han_bao_hanh: partialDateField(),
     vi_tri_lap_dat: requiredTextField("Vị trí lắp đặt là bắt buộc"),
     khoa_phong_quan_ly: requiredTextField("Khoa/Phòng quản lý là bắt buộc"),


### PR DESCRIPTION
## Summary
- restores equipment detail edit support for depreciation and BT/HC/KD maintenance schedule fields shown in view mode
- adds shared equipment edit field controls and nullable-number helper to reduce repeated FormField/Input boilerplate
- extends schema/default mapping coverage and regression tests for render + submit payload parity

## Tests
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test -- src/app/'(app)'/equipment/__tests__/equipment-detail-edit-form.test.tsx src/components/__tests__/equipment-edit-shared-contract.test.ts`
- `node scripts/npm-run.js run react-doctor`
- pre-push hooks passed on `git push -u origin codex/equipment-edit-field-parity`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores edit support for depreciation and BT/HC/KD maintenance schedule fields in the equipment detail form to match view-mode fields. Adds shared edit field components and schema updates to reduce boilerplate and ensure consistent value normalization.

- **Bug Fixes**
  - Re-enabled editing for depreciation (`nam_tinh_hao_mon`, `ty_le_hao_mon`) and maintenance schedules (`chu_ky_bt_dinh_ky`, `ngay_bt_tiep_theo`, `chu_ky_hc_dinh_ky`, `ngay_hc_tiep_theo`, `chu_ky_kd_dinh_ky`, `ngay_kd_tiep_theo`).
  - Ensured render/submit parity with schema normalization: empty and invalid numbers -> null; partial dates -> normalized ISO; next-date fields use full-date display.

- **Refactors**
  - Added shared controls: `EquipmentEditTextField`, `EquipmentEditNullableNumberField`, `EquipmentEditTextareaField`, and `toNullableNumber` (empty/invalid -> null); applied across Basic Info, Dates, Lifecycle, Assignment, Status, and Config.
  - Introduced `EquipmentDetailLifecycleSection` and wired it into the form.
  - Extended defaults and `equipmentFormSchema` with preprocessors and display mapping; expanded tests with `@testing-library/user-event` for lifecycle edits, required textarea marker, and invalid nullable-number input.

<sup>Written for commit 5dc287801809a17fab0e286f6f15dbee039154a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added depreciation year/rate and periodic maintenance cycle fields, including maintenance "next date" inputs, to the equipment editor.

* **Refactor**
  * Standardized equipment edit form controls to reusable text, nullable-number, and textarea fields for a more consistent editing experience.

* **Tests**
  * Expanded tests covering lifecycle fields, nullable-number behavior, date normalization/formatting, and required textarea handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->