### PR TITLE
feat: add repair request print prefill choice

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx
@@ -14,9 +14,7 @@ const mocks = vi.hoisted(() => ({
   deepLinkHandler: vi.fn(),
   layoutProps: vi.fn(),
   columnOptions: vi.fn(),
-  pageDialogsProps: vi.fn(),
   openPrintOptionsDialog: vi.fn(),
-  handleGenerateRequestSheet: vi.fn(),
 }))
 
 vi.mock("@tanstack/react-query", () => ({
@@ -71,12 +69,6 @@ vi.mock("../_hooks/useRepairRequestsContext", () => ({
     openCreateSheet: vi.fn(),
     closeAllDialogs: vi.fn(),
     applyAssistantDraft: vi.fn(),
-  }),
-}))
-
-vi.mock("../_hooks/useRepairRequestUIHandlers", () => ({
-  useRepairRequestUIHandlers: () => ({
-    handleGenerateRequestSheet: mocks.handleGenerateRequestSheet,
   }),
 }))
 
@@ -140,10 +132,7 @@ vi.mock("../_components/RepairRequestsDetailView", () => ({
 }))
 
 vi.mock("../_components/RepairRequestsPageDialogs", () => ({
-  RepairRequestsPageDialogs: (props: unknown) => {
-    mocks.pageDialogsProps(props)
-    return null
-  },
+  RepairRequestsPageDialogs: () => null,
 }))
 
 vi.mock("../_components/RepairRequestsPageLayout", () => ({
@@ -277,7 +266,7 @@ describe("RepairRequestsPage Suspense boundary", () => {
     )
   })
 
-  it("routes print action through the prefill choice dialog before generating the sheet", () => {
+  it("routes print action through the prefill choice dialog", () => {
     mocks.useSession.mockReturnValue({
       data: {
         user: {
@@ -318,8 +307,5 @@ describe("RepairRequestsPage Suspense boundary", () => {
         onGenerateSheet: mocks.openPrintOptionsDialog,
       }),
     )
-    expect(mocks.pageDialogsProps).toHaveBeenCalledWith({
-      onGenerateSheet: mocks.handleGenerateRequestSheet,
-    })
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx
@@ -13,6 +13,10 @@ const mocks = vi.hoisted(() => ({
   useSearchParams: vi.fn(),
   deepLinkHandler: vi.fn(),
   layoutProps: vi.fn(),
+  columnOptions: vi.fn(),
+  pageDialogsProps: vi.fn(),
+  openPrintOptionsDialog: vi.fn(),
+  handleGenerateRequestSheet: vi.fn(),
 }))
 
 vi.mock("@tanstack/react-query", () => ({
@@ -63,6 +67,7 @@ vi.mock("../_hooks/useRepairRequestsContext", () => ({
     openApproveDialog: vi.fn(),
     openCompleteDialog: vi.fn(),
     openViewDialog: vi.fn(),
+    openPrintOptionsDialog: mocks.openPrintOptionsDialog,
     openCreateSheet: vi.fn(),
     closeAllDialogs: vi.fn(),
     applyAssistantDraft: vi.fn(),
@@ -70,7 +75,9 @@ vi.mock("../_hooks/useRepairRequestsContext", () => ({
 }))
 
 vi.mock("../_hooks/useRepairRequestUIHandlers", () => ({
-  useRepairRequestUIHandlers: () => ({ handleGenerateRequestSheet: vi.fn() }),
+  useRepairRequestUIHandlers: () => ({
+    handleGenerateRequestSheet: mocks.handleGenerateRequestSheet,
+  }),
 }))
 
 vi.mock("../_hooks/useRepairRequestShortcuts", () => ({
@@ -106,7 +113,10 @@ vi.mock("../_hooks/useRepairRequestsSummary", () => ({
 }))
 
 vi.mock("../_components/RepairRequestsColumns", () => ({
-  useRepairRequestColumns: () => [],
+  useRepairRequestColumns: (options: unknown) => {
+    mocks.columnOptions(options)
+    return []
+  },
 }))
 
 vi.mock("../_components/RepairRequestsEditDialog", () => ({
@@ -130,7 +140,10 @@ vi.mock("../_components/RepairRequestsDetailView", () => ({
 }))
 
 vi.mock("../_components/RepairRequestsPageDialogs", () => ({
-  RepairRequestsPageDialogs: () => null,
+  RepairRequestsPageDialogs: (props: unknown) => {
+    mocks.pageDialogsProps(props)
+    return null
+  },
 }))
 
 vi.mock("../_components/RepairRequestsPageLayout", () => ({
@@ -262,5 +275,51 @@ describe("RepairRequestsPage Suspense boundary", () => {
       "data-is-filtered",
       "true",
     )
+  })
+
+  it("routes print action through the prefill choice dialog before generating the sheet", () => {
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: 1,
+          role: "global",
+          don_vi: null,
+          dia_ban_id: null,
+          name: "Global Admin",
+        },
+      },
+      status: "authenticated",
+    })
+
+    mocks.useTenantSelection.mockReturnValue({
+      selectedFacilityId: undefined,
+      setSelectedFacilityId: vi.fn(),
+      facilities: [],
+      showSelector: false,
+      shouldFetchData: true,
+      isLoading: false,
+    })
+
+    mocks.useQueryClient.mockReturnValue({
+      invalidateQueries: vi.fn(),
+    })
+
+    mocks.useRouter.mockReturnValue({
+      push: vi.fn(),
+      replace: vi.fn(),
+    })
+
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams())
+
+    render(<RepairRequestsPageClient />)
+
+    expect(mocks.columnOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onGenerateSheet: mocks.openPrintOptionsDialog,
+      }),
+    )
+    expect(mocks.pageDialogsProps).toHaveBeenCalledWith({
+      onGenerateSheet: mocks.handleGenerateRequestSheet,
+    })
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPrintOptionsDialog.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPrintOptionsDialog.test.tsx
@@ -9,10 +9,31 @@ import type { RepairRequestWithEquipment } from "../types"
 const mockCloseAllDialogs = vi.fn()
 const mockContext = vi.hoisted(() => ({
   useRepairRequestsContext: vi.fn(),
+  handleGenerateRequestSheet: vi.fn(),
+  toast: vi.fn(),
 }))
 
 vi.mock("../_hooks/useRepairRequestsContext", () => ({
   useRepairRequestsContext: () => mockContext.useRepairRequestsContext(),
+}))
+
+vi.mock("../_hooks/useRepairRequestUIHandlers", () => ({
+  useRepairRequestUIHandlers: () => ({
+    handleGenerateRequestSheet: mockContext.handleGenerateRequestSheet,
+  }),
+}))
+
+vi.mock("@/hooks/use-tenant-branding", () => ({
+  useTenantBranding: () => ({
+    data: {
+      name: "CDC Cần Thơ",
+      logo_url: "https://example.com/logo.png",
+    },
+  }),
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockContext.toast }),
 }))
 
 vi.mock("@/components/ui/button", () => ({
@@ -90,34 +111,53 @@ describe("RepairRequestsPrintOptionsDialog", () => {
 
   it("prints with requester name prefilled from the primary action", async () => {
     const user = userEvent.setup()
-    const onGenerateSheet = vi.fn()
+    mockContext.handleGenerateRequestSheet.mockReturnValue(true)
     setupContext()
 
-    render(<RepairRequestsPrintOptionsDialog onGenerateSheet={onGenerateSheet} />)
+    render(<RepairRequestsPrintOptionsDialog />)
 
     await user.click(screen.getByRole("button", { name: "Điền sẵn tên" }))
 
-    expect(onGenerateSheet).toHaveBeenCalledWith(requestToPrint, { prefillRequesterName: true })
+    expect(mockContext.handleGenerateRequestSheet).toHaveBeenCalledWith(requestToPrint, {
+      prefillRequesterName: true,
+    })
     expect(mockCloseAllDialogs).toHaveBeenCalledTimes(1)
   })
 
   it("prints with the requester signature name blank from the secondary action", async () => {
     const user = userEvent.setup()
-    const onGenerateSheet = vi.fn()
+    mockContext.handleGenerateRequestSheet.mockReturnValue(true)
     setupContext()
 
-    render(<RepairRequestsPrintOptionsDialog onGenerateSheet={onGenerateSheet} />)
+    render(<RepairRequestsPrintOptionsDialog />)
 
     await user.click(screen.getByRole("button", { name: "Bỏ trống tên" }))
 
-    expect(onGenerateSheet).toHaveBeenCalledWith(requestToPrint, { prefillRequesterName: false })
+    expect(mockContext.handleGenerateRequestSheet).toHaveBeenCalledWith(requestToPrint, {
+      prefillRequesterName: false,
+    })
     expect(mockCloseAllDialogs).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the dialog open when sheet generation fails", async () => {
+    const user = userEvent.setup()
+    mockContext.handleGenerateRequestSheet.mockReturnValue(false)
+    setupContext()
+
+    render(<RepairRequestsPrintOptionsDialog />)
+
+    await user.click(screen.getByRole("button", { name: "Điền sẵn tên" }))
+
+    expect(mockContext.handleGenerateRequestSheet).toHaveBeenCalledWith(requestToPrint, {
+      prefillRequesterName: true,
+    })
+    expect(mockCloseAllDialogs).not.toHaveBeenCalled()
   })
 
   it("does not render when no request is pending print", () => {
     setupContext(null)
 
-    render(<RepairRequestsPrintOptionsDialog onGenerateSheet={vi.fn()} />)
+    render(<RepairRequestsPrintOptionsDialog />)
 
     expect(screen.queryByTestId("print-options-dialog")).not.toBeInTheDocument()
   })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPrintOptionsDialog.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPrintOptionsDialog.test.tsx
@@ -1,0 +1,124 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { RepairRequestsPrintOptionsDialog } from "../_components/RepairRequestsPrintOptionsDialog"
+import type { RepairRequestWithEquipment } from "../types"
+
+const mockCloseAllDialogs = vi.fn()
+const mockContext = vi.hoisted(() => ({
+  useRepairRequestsContext: vi.fn(),
+}))
+
+vi.mock("../_hooks/useRepairRequestsContext", () => ({
+  useRepairRequestsContext: () => mockContext.useRepairRequestsContext(),
+}))
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    variant,
+  }: {
+    readonly children: React.ReactNode
+    readonly onClick?: () => void
+    readonly variant?: string
+  }) => (
+    <button data-variant={variant} onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    children,
+    open,
+  }: {
+    readonly children: React.ReactNode
+    readonly open: boolean
+    readonly onOpenChange: (open: boolean) => void
+  }) => (open ? <div data-testid="print-options-dialog">{children}</div> : null),
+  DialogContent: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { readonly children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { readonly children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+const requestToPrint: RepairRequestWithEquipment = {
+  id: 7,
+  thiet_bi_id: 55,
+  ngay_yeu_cau: "2026-05-01",
+  trang_thai: "Chờ xử lý",
+  mo_ta_su_co: "Không lên nguồn",
+  hang_muc_sua_chua: null,
+  ngay_mong_muon_hoan_thanh: null,
+  nguoi_yeu_cau: "Nguyễn Văn A",
+  ngay_duyet: null,
+  ngay_hoan_thanh: null,
+  nguoi_duyet: null,
+  nguoi_xac_nhan: null,
+  chi_phi_sua_chua: null,
+  don_vi_thuc_hien: "noi_bo",
+  ten_don_vi_thue: null,
+  ket_qua_sua_chua: null,
+  ly_do_khong_hoan_thanh: null,
+  thiet_bi: {
+    ten_thiet_bi: "Monitor",
+    ma_thiet_bi: "TB-55",
+    model: "M1",
+    serial: "SN55",
+    khoa_phong_quan_ly: "Khoa A",
+    facility_name: "BV A",
+    facility_id: 1,
+  },
+}
+
+function setupContext(request: RepairRequestWithEquipment | null = requestToPrint) {
+  mockContext.useRepairRequestsContext.mockReturnValue({
+    dialogState: { requestToPrint: request },
+    closeAllDialogs: mockCloseAllDialogs,
+  })
+}
+
+describe("RepairRequestsPrintOptionsDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("prints with requester name prefilled from the primary action", async () => {
+    const user = userEvent.setup()
+    const onGenerateSheet = vi.fn()
+    setupContext()
+
+    render(<RepairRequestsPrintOptionsDialog onGenerateSheet={onGenerateSheet} />)
+
+    await user.click(screen.getByRole("button", { name: "Điền sẵn tên" }))
+
+    expect(onGenerateSheet).toHaveBeenCalledWith(requestToPrint, { prefillRequesterName: true })
+    expect(mockCloseAllDialogs).toHaveBeenCalledTimes(1)
+  })
+
+  it("prints with the requester signature name blank from the secondary action", async () => {
+    const user = userEvent.setup()
+    const onGenerateSheet = vi.fn()
+    setupContext()
+
+    render(<RepairRequestsPrintOptionsDialog onGenerateSheet={onGenerateSheet} />)
+
+    await user.click(screen.getByRole("button", { name: "Bỏ trống tên" }))
+
+    expect(onGenerateSheet).toHaveBeenCalledWith(requestToPrint, { prefillRequesterName: false })
+    expect(mockCloseAllDialogs).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not render when no request is pending print", () => {
+    setupContext(null)
+
+    render(<RepairRequestsPrintOptionsDialog onGenerateSheet={vi.fn()} />)
+
+    expect(screen.queryByTestId("print-options-dialog")).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/repair-requests/__tests__/request-sheet.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/request-sheet.test.ts
@@ -146,6 +146,26 @@ describe("buildRepairRequestSheetHtml", () => {
     expect(requesterSection).not.toContain('class="sig-name"')
   })
 
+  it("leaves the requester signature name blank when prefill is disabled", () => {
+    const html = buildRepairRequestSheetHtml(
+      request,
+      {
+        organizationName: "CDC Cần Thơ",
+        logoUrl: "https://example.com/logo.png",
+      },
+      { prefillRequesterName: false }
+    )
+
+    const requesterSection = html.slice(
+      html.indexOf("NGƯỜI ĐỀ NGHỊ"),
+      html.indexOf("BAN GIÁM ĐỐC")
+    )
+
+    expect(requesterSection).toContain('<div class="sig-line"></div>')
+    expect(requesterSection).not.toContain("Nguyễn Văn A")
+    expect(html).not.toContain("Nguyễn Văn A")
+  })
+
   it("centers the department name in the department field", () => {
     const deptValueBlock = REPAIR_SHEET_STYLES.slice(
       REPAIR_SHEET_STYLES.indexOf(".dept-row .dept-value"),

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestUIHandlers.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestUIHandlers.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useRepairRequestUIHandlers } from "../_hooks/useRepairRequestUIHandlers"
+import { buildRepairRequestSheetHtml } from "../request-sheet"
+import type { RepairRequestWithEquipment } from "../types"
 
 const mocks = vi.hoisted(() => ({
   toast: vi.fn(),
@@ -12,9 +16,6 @@ vi.mock("@/hooks/use-toast", () => ({
 vi.mock("../request-sheet", () => ({
   buildRepairRequestSheetHtml: vi.fn(),
 }))
-
-import { useRepairRequestUIHandlers } from "../_hooks/useRepairRequestUIHandlers"
-import { buildRepairRequestSheetHtml } from "../request-sheet"
 
 const mockBuildRepairRequestSheetHtml = vi.mocked(buildRepairRequestSheetHtml)
 
@@ -48,5 +49,42 @@ describe("useRepairRequestUIHandlers", () => {
         description: "Thiếu thông tin thiết bị",
       })
     )
+  })
+
+  it("passes requester prefill options to the print template builder", () => {
+    mockBuildRepairRequestSheetHtml.mockReturnValue("<html><body>print</body></html>")
+
+    const documentMock = {
+      close: vi.fn(),
+      open: vi.fn(),
+      write: vi.fn(),
+    }
+    const windowOpenSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue({ document: documentMock } as unknown as Window)
+    const request = { id: 7 } as RepairRequestWithEquipment
+
+    const { result } = renderHook(() =>
+      useRepairRequestUIHandlers({
+        branding: {
+          name: "CDC Cần Thơ",
+          logo_url: "https://example.com/logo.png",
+        },
+        toast: mocks.toast,
+      })
+    )
+
+    result.current.handleGenerateRequestSheet(request, { prefillRequesterName: false })
+
+    expect(mockBuildRepairRequestSheetHtml).toHaveBeenCalledWith(
+      request,
+      {
+        organizationName: "CDC Cần Thơ",
+        logoUrl: "https://example.com/logo.png",
+      },
+      { prefillRequesterName: false }
+    )
+    expect(windowOpenSpy).toHaveBeenCalledWith("", "_blank")
+    expect(documentMock.write).toHaveBeenCalledWith("<html><body>print</body></html>")
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/useRepairRequestUIHandlers.test.ts
+++ b/src/app/(app)/repair-requests/__tests__/useRepairRequestUIHandlers.test.ts
@@ -36,8 +36,9 @@ describe("useRepairRequestUIHandlers", () => {
       })
     )
 
+    let didPrint: boolean | undefined
     act(() => {
-      result.current.handleGenerateRequestSheet({
+      didPrint = result.current.handleGenerateRequestSheet({
         id: 1,
         thiet_bi: { id: 2, ma_thiet_bi: "TB001", ten_thiet_bi: "Máy A" },
       } as never)
@@ -49,6 +50,7 @@ describe("useRepairRequestUIHandlers", () => {
         description: "Thiếu thông tin thiết bị",
       })
     )
+    expect(didPrint).toBe(false)
   })
 
   it("passes requester prefill options to the print template builder", () => {
@@ -74,7 +76,9 @@ describe("useRepairRequestUIHandlers", () => {
       })
     )
 
-    result.current.handleGenerateRequestSheet(request, { prefillRequesterName: false })
+    const didPrint = result.current.handleGenerateRequestSheet(request, {
+      prefillRequesterName: false,
+    })
 
     expect(mockBuildRepairRequestSheetHtml).toHaveBeenCalledWith(
       request,
@@ -86,5 +90,6 @@ describe("useRepairRequestUIHandlers", () => {
     )
     expect(windowOpenSpy).toHaveBeenCalledWith("", "_blank")
     expect(documentMock.write).toHaveBeenCalledWith("<html><body>print</body></html>")
+    expect(didPrint).toBe(true)
   })
 })

--- a/src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsContext.tsx
@@ -30,6 +30,7 @@ interface DialogState {
   requestToApprove: RepairRequestWithEquipment | null
   requestToComplete: RepairRequestWithEquipment | null
   requestToView: RepairRequestWithEquipment | null
+  requestToPrint: RepairRequestWithEquipment | null
   completionType: 'Hoàn thành' | 'Không HT' | null
   isCreateOpen: boolean
   preSelectedEquipment: EquipmentSelectItem | null
@@ -50,6 +51,7 @@ interface RepairRequestsContextValue {
   openApproveDialog: (request: RepairRequestWithEquipment) => void
   openCompleteDialog: (request: RepairRequestWithEquipment, type: 'Hoàn thành' | 'Không HT') => void
   openViewDialog: (request: RepairRequestWithEquipment) => void
+  openPrintOptionsDialog: (request: RepairRequestWithEquipment) => void
   openCreateSheet: (equipment?: EquipmentSelectItem) => void
   closeAllDialogs: () => void
 
@@ -70,6 +72,7 @@ interface RepairRequestsContextValue {
 }
 
 // ============================================
+/** Shared context for repair-request page state, dialogs, and mutations. */
 const RepairRequestsContext = React.createContext<RepairRequestsContextValue | null>(null)
 
 // ============================================
@@ -80,6 +83,7 @@ interface RepairRequestsProviderProps {
   children: React.ReactNode
 }
 
+/** Provides repair-request page state, dialog actions, mutations, and assistant draft state. */
 export function RepairRequestsProvider({ children }: RepairRequestsProviderProps) {
   const { toast } = useToast()
   const queryClient = useQueryClient()
@@ -105,6 +109,7 @@ export function RepairRequestsProvider({ children }: RepairRequestsProviderProps
     requestToApprove: null,
     requestToComplete: null,
     requestToView: null,
+    requestToPrint: null,
     completionType: null,
     isCreateOpen: false,
     preSelectedEquipment: null,
@@ -155,6 +160,10 @@ export function RepairRequestsProvider({ children }: RepairRequestsProviderProps
     setDialogState(prev => ({ ...prev, requestToView: request }))
   }, [])
 
+  const openPrintOptionsDialog = React.useCallback((request: RepairRequestWithEquipment) => {
+    setDialogState(prev => ({ ...prev, requestToPrint: request }))
+  }, [])
+
   const openCreateSheet = React.useCallback((equipment?: EquipmentSelectItem) => {
     setDialogState(prev => ({
       ...prev,
@@ -170,6 +179,7 @@ export function RepairRequestsProvider({ children }: RepairRequestsProviderProps
       requestToApprove: null,
       requestToComplete: null,
       requestToView: null,
+      requestToPrint: null,
       completionType: null,
       isCreateOpen: false,
       preSelectedEquipment: null,
@@ -187,6 +197,7 @@ export function RepairRequestsProvider({ children }: RepairRequestsProviderProps
     openApproveDialog,
     openCompleteDialog,
     openViewDialog,
+    openPrintOptionsDialog,
     openCreateSheet,
     closeAllDialogs,
     createMutation,
@@ -208,6 +219,7 @@ export function RepairRequestsProvider({ children }: RepairRequestsProviderProps
     openApproveDialog,
     openCompleteDialog,
     openViewDialog,
+    openPrintOptionsDialog,
     openCreateSheet,
     closeAllDialogs,
     createMutation,

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -14,7 +14,6 @@ import { useQueryClient } from "@tanstack/react-query"
 import { useToast } from "@/hooks/use-toast"
 import { format } from "date-fns"
 import { useSession } from "next-auth/react"
-import { useTenantBranding } from "@/hooks/use-tenant-branding"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { useSearchDebounce } from "@/hooks/use-debounce"
 import { useTenantSelection } from "@/contexts/TenantSelectionContext"
@@ -31,7 +30,6 @@ import { useRepairRequestsData } from "../_hooks/useRepairRequestsData"
 
 import { useRepairRequestShortcuts } from "../_hooks/useRepairRequestShortcuts"
 import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
-import { useRepairRequestUIHandlers } from "../_hooks/useRepairRequestUIHandlers"
 import { useRepairRequestColumns } from "./RepairRequestsColumns"
 import {
   createRepairRequestsPageState,
@@ -53,7 +51,6 @@ import {
 function RepairRequestsPageClientInner() {
   const { toast } = useToast()
   const { data: session } = useSession()
-  const { data: branding } = useTenantBranding()
   const user = session?.user
   const isMobile = useIsMobile()
   const isSheetMobile = useMediaQuery("(max-width: 1279px)")
@@ -110,11 +107,6 @@ function RepairRequestsPageClientInner() {
   const setFilterModalOpen = React.useCallback((value: boolean) => {
     dispatchPageState({ type: "set-filter-modal-open", value })
   }, [])
-
-  const { handleGenerateRequestSheet } = useRepairRequestUIHandlers({
-    branding,
-    toast,
-  })
 
   const effectiveTenantKey = user?.don_vi ?? user?.current_don_vi ?? 'none';
 
@@ -283,7 +275,7 @@ function RepairRequestsPageClientInner() {
         applyAssistantDraft={applyAssistantDraft}
         queryClient={queryClient}
       >
-        <RepairRequestsPageDialogs onGenerateSheet={handleGenerateRequestSheet} />
+        <RepairRequestsPageDialogs />
 
         <RepairRequestsPageLayout
           selectedFacilityName={selectedFacilityName}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -66,6 +66,7 @@ function RepairRequestsPageClientInner() {
     openApproveDialog,
     openCompleteDialog,
     openViewDialog,
+    openPrintOptionsDialog,
     openCreateSheet,
     applyAssistantDraft,
   } = useRepairRequestsContext()
@@ -165,7 +166,7 @@ function RepairRequestsPageClientInner() {
   }, [openViewDialog])
 
   const columnOptions = React.useMemo(() => ({
-    onGenerateSheet: handleGenerateRequestSheet,
+    onGenerateSheet: openPrintOptionsDialog,
     setEditingRequest: setEditingRequestAdapter,
     setRequestToDelete: setRequestToDeleteAdapter,
     handleApproveRequest: openApproveDialog,
@@ -174,7 +175,7 @@ function RepairRequestsPageClientInner() {
     user,
     isRegionalLeader
   }), [
-    handleGenerateRequestSheet,
+    openPrintOptionsDialog,
     setEditingRequestAdapter,
     setRequestToDeleteAdapter,
     openApproveDialog,
@@ -282,7 +283,7 @@ function RepairRequestsPageClientInner() {
         applyAssistantDraft={applyAssistantDraft}
         queryClient={queryClient}
       >
-        <RepairRequestsPageDialogs />
+        <RepairRequestsPageDialogs onGenerateSheet={handleGenerateRequestSheet} />
 
         <RepairRequestsPageLayout
           selectedFacilityName={selectedFacilityName}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageDialogs.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageDialogs.tsx
@@ -5,15 +5,26 @@ import { RepairRequestsCompleteDialog } from "./RepairRequestsCompleteDialog"
 import { RepairRequestsDeleteDialog } from "./RepairRequestsDeleteDialog"
 import { RepairRequestsDetailView } from "./RepairRequestsDetailView"
 import { RepairRequestsEditDialog } from "./RepairRequestsEditDialog"
+import { RepairRequestsPrintOptionsDialog } from "./RepairRequestsPrintOptionsDialog"
+import type { RepairRequestWithEquipment } from "../types"
+import type { RepairRequestSheetOptions } from "../request-sheet"
+
+interface RepairRequestsPageDialogsProps {
+  readonly onGenerateSheet: (
+    request: RepairRequestWithEquipment,
+    options?: RepairRequestSheetOptions
+  ) => void
+}
 
 /** Renders the repair-requests dialog stack owned by the page client. */
-export function RepairRequestsPageDialogs() {
+export function RepairRequestsPageDialogs({ onGenerateSheet }: RepairRequestsPageDialogsProps) {
   return (
     <>
       <RepairRequestsEditDialog />
       <RepairRequestsDeleteDialog />
       <RepairRequestsApproveDialog />
       <RepairRequestsCompleteDialog />
+      <RepairRequestsPrintOptionsDialog onGenerateSheet={onGenerateSheet} />
 
       <RepairRequestsDetailView />
     </>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageDialogs.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageDialogs.tsx
@@ -6,25 +6,16 @@ import { RepairRequestsDeleteDialog } from "./RepairRequestsDeleteDialog"
 import { RepairRequestsDetailView } from "./RepairRequestsDetailView"
 import { RepairRequestsEditDialog } from "./RepairRequestsEditDialog"
 import { RepairRequestsPrintOptionsDialog } from "./RepairRequestsPrintOptionsDialog"
-import type { RepairRequestWithEquipment } from "../types"
-import type { RepairRequestSheetOptions } from "../request-sheet"
-
-interface RepairRequestsPageDialogsProps {
-  readonly onGenerateSheet: (
-    request: RepairRequestWithEquipment,
-    options?: RepairRequestSheetOptions
-  ) => void
-}
 
 /** Renders the repair-requests dialog stack owned by the page client. */
-export function RepairRequestsPageDialogs({ onGenerateSheet }: RepairRequestsPageDialogsProps) {
+export function RepairRequestsPageDialogs() {
   return (
     <>
       <RepairRequestsEditDialog />
       <RepairRequestsDeleteDialog />
       <RepairRequestsApproveDialog />
       <RepairRequestsCompleteDialog />
-      <RepairRequestsPrintOptionsDialog onGenerateSheet={onGenerateSheet} />
+      <RepairRequestsPrintOptionsDialog />
 
       <RepairRequestsDetailView />
     </>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPrintOptionsDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPrintOptionsDialog.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import type { RepairRequestSheetOptions } from "../request-sheet"
+import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
+import type { RepairRequestWithEquipment } from "../types"
+
+interface RepairRequestsPrintOptionsDialogProps {
+  readonly onGenerateSheet: (
+    request: RepairRequestWithEquipment,
+    options?: RepairRequestSheetOptions
+  ) => void
+}
+
+/** Lets users choose whether the printable request sheet pre-fills requester name. */
+export function RepairRequestsPrintOptionsDialog({
+  onGenerateSheet,
+}: RepairRequestsPrintOptionsDialogProps) {
+  const {
+    dialogState: { requestToPrint },
+    closeAllDialogs,
+  } = useRepairRequestsContext()
+
+  const handlePrint = (options: RepairRequestSheetOptions) => {
+    if (!requestToPrint) return
+    onGenerateSheet(requestToPrint, options)
+    closeAllDialogs()
+  }
+
+  return (
+    <Dialog open={!!requestToPrint} onOpenChange={(open) => !open && closeAllDialogs()}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>In phiếu yêu cầu sửa chữa</DialogTitle>
+          <DialogDescription>
+            Chọn cách hiển thị tên người yêu cầu ở phần ký tên của phiếu in.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handlePrint({ prefillRequesterName: false })}
+          >
+            Bỏ trống tên
+          </Button>
+          <Button
+            type="button"
+            onClick={() => handlePrint({ prefillRequesterName: true })}
+          >
+            Điền sẵn tên
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPrintOptionsDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPrintOptionsDialog.tsx
@@ -2,6 +2,8 @@
 
 import * as React from "react"
 import { Button } from "@/components/ui/button"
+import { useTenantBranding } from "@/hooks/use-tenant-branding"
+import { useToast } from "@/hooks/use-toast"
 import {
   Dialog,
   DialogContent,
@@ -11,20 +13,17 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import type { RepairRequestSheetOptions } from "../request-sheet"
+import { useRepairRequestUIHandlers } from "../_hooks/useRepairRequestUIHandlers"
 import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
-import type { RepairRequestWithEquipment } from "../types"
-
-interface RepairRequestsPrintOptionsDialogProps {
-  readonly onGenerateSheet: (
-    request: RepairRequestWithEquipment,
-    options?: RepairRequestSheetOptions
-  ) => void
-}
 
 /** Lets users choose whether the printable request sheet pre-fills requester name. */
-export function RepairRequestsPrintOptionsDialog({
-  onGenerateSheet,
-}: RepairRequestsPrintOptionsDialogProps) {
+export function RepairRequestsPrintOptionsDialog() {
+  const { data: branding } = useTenantBranding()
+  const { toast } = useToast()
+  const { handleGenerateRequestSheet } = useRepairRequestUIHandlers({
+    branding,
+    toast,
+  })
   const {
     dialogState: { requestToPrint },
     closeAllDialogs,
@@ -32,8 +31,9 @@ export function RepairRequestsPrintOptionsDialog({
 
   const handlePrint = (options: RepairRequestSheetOptions) => {
     if (!requestToPrint) return
-    onGenerateSheet(requestToPrint, options)
-    closeAllDialogs()
+    if (handleGenerateRequestSheet(requestToPrint, options)) {
+      closeAllDialogs()
+    }
   }
 
   return (

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestUIHandlers.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestUIHandlers.ts
@@ -17,7 +17,7 @@ export interface UIHandlersActions {
   handleGenerateRequestSheet: (
     request: RepairRequestWithEquipment,
     options?: RepairRequestSheetOptions
-  ) => void
+  ) => boolean
 }
 
 /**
@@ -34,7 +34,7 @@ export function useRepairRequestUIHandlers(
   const handleGenerateRequestSheet = (
     request: RepairRequestWithEquipment,
     options?: RepairRequestSheetOptions
-  ): void => {
+  ): boolean => {
     const organizationName = branding?.name || "TRUNG TÂM KIỂM SOÁT BỆNH TẬT THÀNH PHỐ CẦN THƠ"
     const logoUrl =
       branding?.logo_url ||
@@ -52,6 +52,7 @@ export function useRepairRequestUIHandlers(
         newWindow.document.write(htmlContent)
         newWindow.document.close()
       }
+      return true
     } catch (error) {
       const errorMessage = getUnknownErrorMessage(error, "Không thể tạo phiếu yêu cầu.")
       toast({
@@ -59,6 +60,7 @@ export function useRepairRequestUIHandlers(
         title: "Lỗi",
         description: errorMessage,
       })
+      return false
     }
   }
 

--- a/src/app/(app)/repair-requests/_hooks/useRepairRequestUIHandlers.ts
+++ b/src/app/(app)/repair-requests/_hooks/useRepairRequestUIHandlers.ts
@@ -1,5 +1,8 @@
 import type { RepairRequestWithEquipment } from "../types"
-import { buildRepairRequestSheetHtml } from "../request-sheet"
+import {
+  buildRepairRequestSheetHtml,
+  type RepairRequestSheetOptions,
+} from "../request-sheet"
 import { getUnknownErrorMessage } from "@/lib/error-utils"
 
 /** External dependencies for UI handlers */
@@ -11,7 +14,10 @@ export interface UIHandlersDeps {
 /** Returned UI handlers */
 export interface UIHandlersActions {
   /** Generate and open repair request sheet in new window */
-  handleGenerateRequestSheet: (request: RepairRequestWithEquipment) => void
+  handleGenerateRequestSheet: (
+    request: RepairRequestWithEquipment,
+    options?: RepairRequestSheetOptions
+  ) => void
 }
 
 /**
@@ -25,7 +31,10 @@ export function useRepairRequestUIHandlers(
 ): UIHandlersActions {
   const { branding, toast } = deps
 
-  const handleGenerateRequestSheet = (request: RepairRequestWithEquipment): void => {
+  const handleGenerateRequestSheet = (
+    request: RepairRequestWithEquipment,
+    options?: RepairRequestSheetOptions
+  ): void => {
     const organizationName = branding?.name || "TRUNG TÂM KIỂM SOÁT BỆNH TẬT THÀNH PHỐ CẦN THƠ"
     const logoUrl =
       branding?.logo_url ||
@@ -35,7 +44,7 @@ export function useRepairRequestUIHandlers(
       const htmlContent = buildRepairRequestSheetHtml(request, {
         organizationName,
         logoUrl,
-      })
+      }, options)
 
       const newWindow = window.open("", "_blank")
       if (newWindow) {

--- a/src/app/(app)/repair-requests/request-sheet.ts
+++ b/src/app/(app)/repair-requests/request-sheet.ts
@@ -7,6 +7,10 @@ export type RepairRequestSheetBranding = {
   logoUrl: string
 }
 
+export interface RepairRequestSheetOptions {
+  readonly prefillRequesterName?: boolean
+}
+
 /* ── Shared helpers ── */
 
 const formatValue = (value: unknown) => (value ?? '')
@@ -24,12 +28,14 @@ function buildPage1(
   branding: RepairRequestSheetBranding,
   date: { day: string; month: string; year: string },
   derived: { completionDateValue: string },
+  options: RepairRequestSheetOptions,
 ): string {
   const { organizationName, logoUrl } = branding
   const { day, month, year } = date
   const { completionDateValue } = derived
   const eq = request.thiet_bi!
-  const requesterName = formatValue(request.nguoi_yeu_cau)
+  const requesterName =
+    options.prefillRequesterName === false ? '' : formatValue(request.nguoi_yeu_cau)
 
   return `
     <div class="a4-page">
@@ -147,9 +153,11 @@ function buildPage1(
 
 /* ── Main entry point ── */
 
+/** Builds the printable repair-request sheet HTML for a selected request. */
 export function buildRepairRequestSheetHtml(
   request: RepairRequestWithEquipment,
   branding: RepairRequestSheetBranding,
+  options: RepairRequestSheetOptions = {},
 ): string {
   if (!request || !request.thiet_bi) {
     throw new Error('Không đủ thông tin để tạo phiếu yêu cầu.')
@@ -178,7 +186,7 @@ export function buildRepairRequestSheetHtml(
     <style>${REPAIR_SHEET_STYLES}</style>
 </head>
 <body>
-    ${buildPage1(request, branding, date, derived)}
+    ${buildPage1(request, branding, date, derived, options)}
 </body>
 </html>
   `


### PR DESCRIPTION
## Summary
- Add a repair-request print dialog that asks whether to prefill the requester signature name
- Keep the current prefilled behavior as the primary/default action
- Allow printing the same sheet with the requester signature name left blank

## Verification
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/app/(app)/repair-requests/__tests__/request-sheet.test.ts src/app/(app)/repair-requests/__tests__/RepairRequestsPrintOptionsDialog.test.tsx src/app/(app)/repair-requests/__tests__/RepairRequestRowActions.test.tsx src/app/(app)/repair-requests/__tests__/RepairRequestsPageClient.suspense.test.tsx src/app/(app)/repair-requests/__tests__/useRepairRequestUIHandlers.test.ts
- node scripts/npm-run.js run react-doctor

## Notes
- Reuses the existing shared dialog primitives and repair-request dialog stack; no duplicate dialog framework added.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a print options dialog for repair requests that lets users choose whether to prefill the requester’s signature name. Prefilled remains the default; users can also print with the name left blank.

- **New Features**
  - Added `RepairRequestsPrintOptionsDialog` to the dialog stack.
  - Added `requestToPrint` state and `openPrintOptionsDialog` in context; table actions route through this dialog.
  - `handleGenerateRequestSheet` now accepts `RepairRequestSheetOptions` and returns a boolean; passes `prefillRequesterName` to `buildRepairRequestSheetHtml`.
  - Updated sheet template to honor `prefillRequesterName`; tests cover both paths.

- **Bug Fixes**
  - Improved print flow error handling: keep the dialog open if sheet generation fails and close only on success.

<sup>Written for commit cd18d4dba6b7a05b6d78db376eb543c5f2b8dd23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a print options dialog when generating repair request sheets, allowing users to choose whether to prefill the requester's name on the document or leave it blank for manual entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->