### PR TITLE
fix: show exact notification badge counts

### DIFF
--- a/src/components/__tests__/app-sidebar-nav.test.tsx
+++ b/src/components/__tests__/app-sidebar-nav.test.tsx
@@ -44,9 +44,9 @@ describe("AppSidebarNav", () => {
 
     expect(within(repairLink!).getByText("2")).toBeInTheDocument()
     expect(within(transferLink!).getByText("4")).toBeInTheDocument()
-    expect(within(maintenanceLink!).getByText("9+")).toBeInTheDocument()
+    expect(within(maintenanceLink!).getByText("12")).toBeInTheDocument()
     expect(within(dashboardLink!).queryByText("2")).not.toBeInTheDocument()
     expect(within(dashboardLink!).queryByText("4")).not.toBeInTheDocument()
-    expect(within(dashboardLink!).queryByText("9+")).not.toBeInTheDocument()
+    expect(within(dashboardLink!).queryByText("12")).not.toBeInTheDocument()
   })
 })

--- a/src/components/__tests__/notification-bell-dialog.test.tsx
+++ b/src/components/__tests__/notification-bell-dialog.test.tsx
@@ -65,7 +65,7 @@ describe("NotificationBellDialog", () => {
     )
   })
 
-  it("caps the total badge at 9+", () => {
+  it("shows the exact total badge count above 9", () => {
     render(
       <NotificationBellDialog
         repairCount={4}
@@ -74,7 +74,7 @@ describe("NotificationBellDialog", () => {
       />
     )
 
-    expect(screen.getByText("9+")).toBeInTheDocument()
+    expect(screen.getByText("12")).toBeInTheDocument()
   })
 
   it("closes the dialog after clicking a detail link", async () => {

--- a/src/components/app-notification-badge.tsx
+++ b/src/components/app-notification-badge.tsx
@@ -11,6 +11,7 @@ interface AppNotificationBadgeProps {
   className?: string
 }
 
+/** Renders an app notification count badge for navigation and header alerts. */
 export function AppNotificationBadge({
   count,
   active = false,
@@ -23,14 +24,17 @@ export function AppNotificationBadge({
     return null
   }
 
+  const isLongFloatingBadge = mode === "floating" && label.length >= 3
+
   return (
     <Badge
       variant="destructive"
       className={cn(
-        "border-transparent text-[11px] font-semibold leading-none",
+        "shrink-0 whitespace-nowrap border-transparent text-[11px] font-semibold leading-none tabular-nums",
         mode === "inline"
           ? "ml-auto h-5 min-w-[1.25rem] justify-center rounded-full px-1.5"
           : "absolute right-1 top-1 h-5 min-w-[1.25rem] justify-center rounded-full px-1.5",
+        isLongFloatingBadge ? "px-1 text-[10px]" : null,
         active ? "ring-2 ring-white/30" : null,
         className
       )}

--- a/src/lib/__tests__/app-notification-counts.test.ts
+++ b/src/lib/__tests__/app-notification-counts.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+
+import { formatNotificationBadgeCount } from "@/lib/app-notification-counts"
+
+describe("formatNotificationBadgeCount", () => {
+  it("returns null for counts that should not render a badge", () => {
+    expect(formatNotificationBadgeCount(0)).toBeNull()
+    expect(formatNotificationBadgeCount(-1)).toBeNull()
+    expect(formatNotificationBadgeCount(Number.NaN)).toBeNull()
+    expect(formatNotificationBadgeCount(Number.POSITIVE_INFINITY)).toBeNull()
+  })
+
+  it("renders the exact normalized count without an upper display cap", () => {
+    expect(formatNotificationBadgeCount(1)).toBe("1")
+    expect(formatNotificationBadgeCount(9)).toBe("9")
+    expect(formatNotificationBadgeCount(10)).toBe("10")
+    expect(formatNotificationBadgeCount(12)).toBe("12")
+    expect(formatNotificationBadgeCount(123)).toBe("123")
+    expect(formatNotificationBadgeCount(12.8)).toBe("12")
+  })
+})

--- a/src/lib/app-notification-counts.ts
+++ b/src/lib/app-notification-counts.ts
@@ -6,18 +6,19 @@ export interface AppNotificationCounts {
 
 export type AppNotificationBadgeKey = keyof AppNotificationCounts
 
+/** Empty notification count state used before scoped counts are loaded. */
 export const EMPTY_APP_NOTIFICATION_COUNTS: AppNotificationCounts = {
   repair: 0,
   transfer: 0,
   maintenance: 0,
 }
 
-const BADGE_CAP = 9
-
+/** Converts unknown RPC count values into non-negative integer badge counts. */
 export function normalizeNotificationCount(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
 }
 
+/** Formats a normalized app notification count for badge display. */
 export function formatNotificationBadgeCount(count: number): string | null {
   const normalizedCount = normalizeNotificationCount(count)
 
@@ -25,9 +26,10 @@ export function formatNotificationBadgeCount(count: number): string | null {
     return null
   }
 
-  return normalizedCount > BADGE_CAP ? "9+" : String(normalizedCount)
+  return String(normalizedCount)
 }
 
+/** Sums selected notification count fields using the shared count normalizer. */
 export function sumNotificationBadgeCounts(
   keys: readonly AppNotificationBadgeKey[],
   counts: AppNotificationCounts


### PR DESCRIPTION
## Summary
- Remove the 9+ display cap from app notification badges so repair, transfer, and maintenance counts show exact values.
- Update sidebar and notification bell coverage for counts above 9.
- Add direct formatter tests for exact count display and invalid count handling.

## Test Plan
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/lib/__tests__/app-notification-counts.test.ts src/components/__tests__/app-sidebar-nav.test.tsx src/components/__tests__/notification-bell-dialog.test.tsx
- node scripts/npm-run.js run react-doctor
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show exact notification badge counts by removing the “9+” cap. Also guard the badge UI so 3+ digit totals render cleanly in the bell and sidebar.

- **Bug Fixes**
  - Removed the 9+ cap; badges show exact counts in sidebar and bell.
  - Guarded long (3+ digits) floating badges to prevent overflow; added tabular numerals and no-wrap.
  - Added `normalizeNotificationCount` and `formatNotificationBadgeCount` to sanitize values; invalid or non-positive counts return null. Updated tests.

<sup>Written for commit 6a7a4dab1b71a4d6776820286ab7b81af7e5b2a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Notification badges now show exact counts (no longer cap the display at “9+”), including maintenance, transfers, and repair-related totals.
  * Floating notification badges adjust sizing/padding when labels are longer, improving readability.

* **Tests**
  * Updated and expanded test coverage to reflect exact badge counts and verify formatting behavior across edge cases (e.g., zero/invalid values and truncation rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->