### PR TITLE
Fix maintenance add-tasks equipment pagination

### DIFF
--- a/src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx
+++ b/src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx
@@ -11,49 +11,67 @@ import "@testing-library/jest-dom"
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
+type MockChildrenProps = { children?: React.ReactNode }
+type MockOpenProps = MockChildrenProps & { open?: boolean }
+type MockTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean
+    open?: boolean
+    setOpen?: (open: boolean) => void
+}
+type MockCheckboxItemProps = React.ButtonHTMLAttributes<HTMLButtonElement> & MockChildrenProps & {
+    checked?: boolean
+    onCheckedChange?: (checked: boolean) => void
+    onSelect?: (event: { preventDefault: () => void }) => void
+}
+type RpcRequest = {
+    fn: string
+    args?: Record<string, unknown>
+}
+
 /**
  * Mock radix DropdownMenu for inline rendering in jsdom
  */
 vi.mock('@/components/ui/dropdown-menu', () => {
     return {
-        DropdownMenu: ({ children }: any) => {
+        DropdownMenu: ({ children }: MockChildrenProps) => {
             const [open, setOpen] = React.useState(false)
             return (
                 <div data-testid="dropdown-menu">
-                    {React.Children.map(children, (child: any) =>
+                    {React.Children.map(children, (child: React.ReactNode) =>
                         React.isValidElement(child)
-                            ? React.cloneElement(child as React.ReactElement<any>, { open, setOpen })
+                            ? React.cloneElement(child as React.ReactElement<MockTriggerProps>, { open, setOpen })
                             : child
                     )}
                 </div>
             )
         },
-        DropdownMenuTrigger: ({ children, asChild, open, setOpen, ...rest }: any) => {
+        DropdownMenuTrigger: ({ children, asChild, open, setOpen, ...rest }: MockTriggerProps) => {
             const handleClick = () => setOpen?.(!open)
             if (asChild && React.isValidElement(children)) {
-                return React.cloneElement(children as React.ReactElement<any>, {
+                const child = children as React.ReactElement<React.ButtonHTMLAttributes<HTMLButtonElement>>
+                return React.cloneElement(child, {
                     ...rest,
-                    onClick: (...args: any[]) => {
+                    onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
                         handleClick()
-                            ; (children as any).props?.onClick?.(...args)
+                        child.props.onClick?.(event)
                     },
                 })
             }
             return <button {...rest} onClick={handleClick}>{children}</button>
         },
-        DropdownMenuContent: ({ children, open, ...rest }: any) => {
+        DropdownMenuContent: ({ children, open, ...rest }: MockOpenProps & React.HTMLAttributes<HTMLDivElement>) => {
             if (!open) return null
             return <div data-testid="dropdown-content" {...rest}>{children}</div>
         },
-        DropdownMenuCheckboxItem: ({ children, checked, onCheckedChange, onSelect, ...rest }: any) => (
+        DropdownMenuCheckboxItem: ({ children, checked, onCheckedChange, onSelect, ...rest }: MockCheckboxItemProps) => (
             <button {...rest} onClick={() => { onSelect?.({ preventDefault: () => { } }); onCheckedChange?.(!checked) }}>
                 {children}
             </button>
         ),
-        DropdownMenuLabel: ({ children, ...rest }: any) => <div {...rest}>{children}</div>,
+        DropdownMenuLabel: ({ children, ...rest }: MockChildrenProps & React.HTMLAttributes<HTMLDivElement>) => <div {...rest}>{children}</div>,
         DropdownMenuSeparator: () => <hr />,
-        DropdownMenuItem: ({ children, onSelect, ...rest }: any) => (
-            <button {...rest} onClick={onSelect}>{children}</button>
+        DropdownMenuItem: ({ children, onClick, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement> & MockChildrenProps) => (
+            <button {...rest} onClick={onClick}>{children}</button>
         ),
     }
 })
@@ -62,19 +80,19 @@ vi.mock('@/components/ui/dropdown-menu', () => {
  * Mock radix Dialog for inline rendering in jsdom
  */
 vi.mock('@/components/ui/dialog', () => ({
-    Dialog: ({ children, open }: any) => open ? <div data-testid="dialog">{children}</div> : null,
-    DialogContent: ({ children, ...rest }: any) => <div data-testid="dialog-content" {...rest}>{children}</div>,
-    DialogHeader: ({ children }: any) => <div>{children}</div>,
-    DialogTitle: ({ children }: any) => <h2>{children}</h2>,
-    DialogDescription: ({ children }: any) => <p>{children}</p>,
-    DialogFooter: ({ children }: any) => <div data-testid="dialog-footer">{children}</div>,
+    Dialog: ({ children, open }: MockOpenProps) => open ? <div data-testid="dialog">{children}</div> : null,
+    DialogContent: ({ children, ...rest }: MockChildrenProps & React.HTMLAttributes<HTMLDivElement>) => <div data-testid="dialog-content" {...rest}>{children}</div>,
+    DialogHeader: ({ children }: MockChildrenProps) => <div>{children}</div>,
+    DialogTitle: ({ children }: MockChildrenProps) => <h2>{children}</h2>,
+    DialogDescription: ({ children }: MockChildrenProps) => <p>{children}</p>,
+    DialogFooter: ({ children }: MockChildrenProps) => <div data-testid="dialog-footer">{children}</div>,
 }))
 
 /**
  * Mock scroll area for inline rendering
  */
 vi.mock('@/components/ui/scroll-area', () => ({
-    ScrollArea: ({ children }: any) => <div>{children}</div>,
+    ScrollArea: ({ children }: MockChildrenProps) => <div>{children}</div>,
 }))
 
 /**
@@ -94,6 +112,7 @@ vi.mock('@/hooks/use-debounce', () => ({
 
 import { AddTasksDialog } from '../add-tasks-dialog'
 import { callRpc } from '@/lib/rpc-client'
+import type { MaintenancePlan } from '@/lib/data'
 
 const mockCallRpc = vi.mocked(callRpc)
 
@@ -122,18 +141,67 @@ const MOCK_EQUIPMENT = Array.from({ length: 15 }, (_, i) => ({
     vi_tri_lap_dat: `Room ${i + 1}`,
 }))
 
+const MOCK_FILTER_BUCKETS = {
+    department: [
+        { name: 'ICU', count: 5 },
+        { name: 'Surgery', count: 5 },
+        { name: 'Radiology', count: 5 },
+    ],
+    user: [
+        { name: 'User A', count: 8 },
+        { name: 'User B', count: 7 },
+    ],
+    location: [
+        { name: 'Room 1', count: 1 },
+        { name: 'Room 2', count: 1 },
+    ],
+}
+
+function mockRpcByPage() {
+    mockCallRpc.mockImplementation((request: RpcRequest) => {
+        const { fn, args } = request
+        if (fn === 'equipment_filter_buckets') {
+            return Promise.resolve(MOCK_FILTER_BUCKETS)
+        }
+        if (fn === 'equipment_list_enhanced') {
+            const page = Number(args?.p_page ?? 1)
+            const pageSize = Number(args?.p_page_size ?? 10)
+            const start = (page - 1) * pageSize
+            return Promise.resolve({
+                data: MOCK_EQUIPMENT.slice(start, start + pageSize),
+                total: 1947,
+                page,
+                pageSize,
+            })
+        }
+        return Promise.resolve(null)
+    })
+}
+
 describe('AddTasksDialog filters and pagination', () => {
     const baseProps = {
         open: true,
         onOpenChange: vi.fn(),
-        plan: { id: 1, ten_ke_hoach: 'Test Plan' } as any,
+        plan: {
+            id: 1,
+            created_at: '2026-01-01T00:00:00Z',
+            ten_ke_hoach: 'Test Plan',
+            nam: 2026,
+            khoa_phong: null,
+            trang_thai: 'Bản nháp',
+            ngay_phe_duyet: null,
+            nguoi_duyet: null,
+            nguoi_lap_ke_hoach: null,
+            loai_cong_viec: 'Bảo trì',
+            don_vi: 17,
+        } satisfies MaintenancePlan,
         existingEquipmentIds: [] as number[],
         onSuccess: vi.fn(),
     }
 
     beforeEach(() => {
         vi.clearAllMocks()
-        mockCallRpc.mockResolvedValue(MOCK_EQUIPMENT as any)
+        mockRpcByPage()
     })
 
     it('renders SearchInput with type="search" attribute', async () => {
@@ -187,5 +255,47 @@ describe('AddTasksDialog filters and pagination', () => {
         // At least some checkboxes should be disabled (3 existing equipment)
         const disabledCheckboxes = checkboxes.filter(cb => cb.hasAttribute('disabled') || cb.getAttribute('data-disabled') !== null)
         expect(disabledCheckboxes.length).toBeGreaterThan(0)
+    })
+
+    it('requests server-side equipment pages within the plan tenant scope', async () => {
+        renderWithQueryClient(<AddTasksDialog {...baseProps} />)
+
+        await waitFor(() => {
+            expect(screen.getByText('TB-001')).toBeInTheDocument()
+        })
+
+        expect(mockCallRpc).toHaveBeenCalledWith(expect.objectContaining({
+            fn: 'equipment_list_enhanced',
+            args: expect.objectContaining({
+                p_page: 1,
+                p_page_size: 10,
+                p_don_vi: 17,
+            }),
+        }))
+        expect(screen.getByText('Đã chọn 0 trên 1947 thiết bị phù hợp.')).toBeInTheDocument()
+    })
+
+    it('keeps selected equipment across server pages', async () => {
+        const onSuccess = vi.fn()
+        renderWithQueryClient(<AddTasksDialog {...baseProps} onSuccess={onSuccess} />)
+
+        await waitFor(() => {
+            expect(screen.getByText('TB-001')).toBeInTheDocument()
+        })
+
+        fireEvent.click(screen.getAllByRole('checkbox', { name: 'Select row' })[0])
+        fireEvent.click(screen.getByRole('button', { name: /Trang tiếp/i }))
+
+        await waitFor(() => {
+            expect(screen.getByText('TB-011')).toBeInTheDocument()
+        })
+
+        fireEvent.click(screen.getAllByRole('checkbox', { name: 'Select row' })[0])
+        fireEvent.click(screen.getByRole('button', { name: /Thêm 2 thiết bị/i }))
+
+        expect(onSuccess).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 1 }),
+            expect.objectContaining({ id: 11 }),
+        ])
     })
 })

--- a/src/components/add-tasks-dialog.tsx
+++ b/src/components/add-tasks-dialog.tsx
@@ -10,9 +10,7 @@
 import * as React from "react"
 import type {
   ColumnDef,
-  ColumnFiltersState,
   PaginationState,
-  RowSelectionState,
   SortingState,
   Updater,
   VisibilityState,
@@ -20,11 +18,6 @@ import type {
 import {
   flexRender,
   getCoreRowModel,
-  getFacetedRowModel,
-  getFacetedUniqueValues,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table"
 import { Loader2, FilterX, ChevronDown } from "lucide-react"
@@ -57,13 +50,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { useAddTasksEquipment } from "@/hooks/useAddTasksEquipment"
+import type { AddTasksEquipmentFilters } from "@/hooks/useAddTasksEquipment"
 import type { Equipment, MaintenancePlan } from "@/lib/data"
 import { ScrollArea } from "./ui/scroll-area"
 import { useSearchDebounce } from "@/hooks/use-debounce"
 import { SearchInput } from "@/components/shared/SearchInput"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { DataTablePagination } from "@/components/shared/DataTablePagination"
-import { buildAddTasksFilterOptions } from "./add-tasks-dialog-filter-options"
 
 interface AddTasksDialogProps {
   open: boolean
@@ -74,36 +67,38 @@ interface AddTasksDialogProps {
 }
 
 interface AddTasksTableState {
-  columnFilters: ColumnFiltersState
+  filters: AddTasksEquipmentFilters
   columnVisibility: VisibilityState
   pagination: PaginationState
-  rowSelection: RowSelectionState
   searchTerm: string
   sorting: SortingState
 }
 
 type AddTasksTableAction =
   | { type: "reset-dialog" }
-  | { type: "set-column-filters"; updater: Updater<ColumnFiltersState> }
   | { type: "set-column-visibility"; updater: Updater<VisibilityState> }
+  | { type: "set-filter"; key: keyof AddTasksEquipmentFilters; values: string[] }
+  | { type: "clear-filters" }
   | { type: "set-pagination"; updater: Updater<PaginationState> }
-  | { type: "set-row-selection"; updater: Updater<RowSelectionState> }
   | { type: "set-search-term"; value: string }
   | { type: "set-sorting"; updater: Updater<SortingState> }
 
 const initialAddTasksTableState: AddTasksTableState = {
-  columnFilters: [],
+  filters: {
+    departments: [],
+    users: [],
+    locations: [],
+  },
   columnVisibility: {
     "nguoi_dang_truc_tiep_quan_ly": false,
     "vi_tri_lap_dat": false,
   },
   pagination: { pageIndex: 0, pageSize: 10 },
-  rowSelection: {},
   searchTerm: "",
   sorting: [],
 }
 
-const EMPTY_ADD_TASKS_EQUIPMENT: Equipment[] = []
+const DEFAULT_ADD_TASKS_SORT = "id.asc"
 
 function resolveUpdater<T>(updater: Updater<T>, current: T): T {
   if (typeof updater !== "function") {
@@ -121,25 +116,50 @@ function addTasksTableReducer(
     case "reset-dialog":
       return {
         ...initialAddTasksTableState,
-        columnFilters: [...initialAddTasksTableState.columnFilters],
+        filters: {
+          departments: [],
+          users: [],
+          locations: [],
+        },
         columnVisibility: { ...initialAddTasksTableState.columnVisibility },
         pagination: { ...initialAddTasksTableState.pagination },
-        rowSelection: { ...initialAddTasksTableState.rowSelection },
         sorting: [...initialAddTasksTableState.sorting],
       }
-    case "set-column-filters":
-      return { ...state, columnFilters: resolveUpdater(action.updater, state.columnFilters) }
     case "set-column-visibility":
       return { ...state, columnVisibility: resolveUpdater(action.updater, state.columnVisibility) }
+    case "set-filter":
+      return {
+        ...state,
+        filters: { ...state.filters, [action.key]: action.values },
+        pagination: { ...state.pagination, pageIndex: 0 },
+      }
+    case "clear-filters":
+      return {
+        ...state,
+        filters: {
+          departments: [],
+          users: [],
+          locations: [],
+        },
+        pagination: { ...state.pagination, pageIndex: 0 },
+      }
     case "set-pagination":
       return { ...state, pagination: resolveUpdater(action.updater, state.pagination) }
-    case "set-row-selection":
-      return { ...state, rowSelection: resolveUpdater(action.updater, state.rowSelection) }
     case "set-search-term":
-      return { ...state, searchTerm: action.value }
+      return { ...state, searchTerm: action.value, pagination: { ...state.pagination, pageIndex: 0 } }
     case "set-sorting":
-      return { ...state, sorting: resolveUpdater(action.updater, state.sorting) }
+      return {
+        ...state,
+        sorting: resolveUpdater(action.updater, state.sorting),
+        pagination: { ...state.pagination, pageIndex: 0 },
+      }
   }
+}
+
+function getAddTasksSortParam(sorting: SortingState): string {
+  const [primarySort] = sorting
+  if (!primarySort) return DEFAULT_ADD_TASKS_SORT
+  return `${primarySort.id}.${primarySort.desc ? "desc" : "asc"}`
 }
 
 /** Renders the dialog for adding available equipment to a maintenance plan. */
@@ -150,14 +170,48 @@ export function AddTasksDialog({
   existingEquipmentIds,
   onSuccess,
 }: AddTasksDialogProps) {
-  const { data, isLoading, error } = useAddTasksEquipment(open)
-  const equipment = data ?? EMPTY_ADD_TASKS_EQUIPMENT
   const [tableState, dispatchTable] = React.useReducer(
     addTasksTableReducer,
     initialAddTasksTableState,
   )
+  const [selectedEquipmentById, setSelectedEquipmentById] = React.useState<Map<number, Equipment>>(
+    () => new Map(),
+  )
 
   const debouncedSearch = useSearchDebounce(tableState.searchTerm)
+  const sortParam = React.useMemo(() => getAddTasksSortParam(tableState.sorting), [tableState.sorting])
+  const planDonVi = plan?.don_vi ?? null
+  const missingPlanTenant = open && plan !== null && planDonVi === null
+  const existingEquipmentIdSet = React.useMemo(
+    () => new Set(existingEquipmentIds),
+    [existingEquipmentIds],
+  )
+  const {
+    equipment,
+    total,
+    isLoading,
+    isFetching,
+    error,
+    filterOptions,
+  } = useAddTasksEquipment({
+    open,
+    planDonVi,
+    search: debouncedSearch,
+    pagination: tableState.pagination,
+    sort: sortParam,
+    filters: tableState.filters,
+  })
+  const selectedEquipment = React.useMemo(
+    () => Array.from(selectedEquipmentById.values()),
+    [selectedEquipmentById],
+  )
+  const rowSelection = React.useMemo(
+    () => Object.fromEntries(
+      equipment.flatMap((item) => selectedEquipmentById.has(item.id) ? [[String(item.id), true]] : []),
+    ),
+    [equipment, selectedEquipmentById],
+  )
+  const totalPages = Math.max(0, Math.ceil(total / tableState.pagination.pageSize))
 
   const columns: ColumnDef<Equipment>[] = React.useMemo(
     () => [
@@ -185,67 +239,56 @@ export function AddTasksDialog({
       { accessorKey: "ma_thiet_bi", header: "Mã thiết bị" },
       { accessorKey: "ten_thiet_bi", header: "Tên thiết bị" },
       { accessorKey: "model", header: "Model" },
-      {
-        accessorKey: "khoa_phong_quan_ly",
-        header: "Khoa/Phòng",
-        filterFn: (row, id, value) => {
-          const rowValue = row.getValue(id) as string | null
-          return rowValue ? value.includes(rowValue.trim()) : false
-        },
-      },
-      {
-        accessorKey: "nguoi_dang_truc_tiep_quan_ly",
-        header: "Người quản lý",
-        filterFn: (row, id, value) => {
-          const rowValue = row.getValue(id) as string | null
-          return rowValue ? value.includes(rowValue.trim()) : false
-        },
-      },
-      {
-        accessorKey: "vi_tri_lap_dat",
-        header: "Vị trí lắp đặt",
-        filterFn: (row, id, value) => {
-          const rowValue = row.getValue(id) as string | null
-          return rowValue ? value.includes(rowValue.trim()) : false
-        },
-      },
+      { accessorKey: "khoa_phong_quan_ly", header: "Khoa/Phòng" },
+      { accessorKey: "nguoi_dang_truc_tiep_quan_ly", header: "Người quản lý" },
+      { accessorKey: "vi_tri_lap_dat", header: "Vị trí lắp đặt" },
     ], [])
 
   const table = useReactTable({
     data: equipment,
     columns,
+    getRowId: (row) => String(row.id),
     state: {
       sorting: tableState.sorting,
-      columnFilters: tableState.columnFilters,
-      globalFilter: debouncedSearch,
-      rowSelection: tableState.rowSelection,
+      rowSelection,
       columnVisibility: tableState.columnVisibility,
       pagination: tableState.pagination,
     },
-    enableRowSelection: (row) => !existingEquipmentIds.includes(row.original.id),
-    onRowSelectionChange: (updater) => dispatchTable({ type: "set-row-selection", updater }),
+    enableRowSelection: (row) => !existingEquipmentIdSet.has(row.original.id),
+    manualFiltering: true,
+    manualPagination: true,
+    manualSorting: true,
+    pageCount: totalPages,
+    onRowSelectionChange: (updater) => {
+      const nextRowSelection = resolveUpdater(updater, rowSelection)
+      setSelectedEquipmentById((currentSelection) => {
+        const nextSelection = new Map(currentSelection)
+        for (const item of equipment) {
+          if (existingEquipmentIdSet.has(item.id)) continue
+          if (nextRowSelection[String(item.id)]) {
+            nextSelection.set(item.id, item)
+          } else {
+            nextSelection.delete(item.id)
+          }
+        }
+        return nextSelection
+      })
+    },
     onSortingChange: (updater) => dispatchTable({ type: "set-sorting", updater }),
-    onColumnFiltersChange: (updater) => dispatchTable({ type: "set-column-filters", updater }),
     onColumnVisibilityChange: (updater) => dispatchTable({ type: "set-column-visibility", updater }),
     onPaginationChange: (updater) => dispatchTable({ type: "set-pagination", updater }),
-    onGlobalFilterChange: (value: string) => dispatchTable({ type: "set-search-term", value }),
     getCoreRowModel: getCoreRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFacetedRowModel: getFacetedRowModel(),
-    getFacetedUniqueValues: getFacetedUniqueValues(),
   })
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       dispatchTable({ type: "reset-dialog" })
+      setSelectedEquipmentById(new Map())
     }
     onOpenChange(nextOpen)
   }
 
   const handleAdd = () => {
-    const selectedEquipment = table.getFilteredSelectedRowModel().rows.map(row => row.original);
     if (selectedEquipment.length === 0) {
       return;
     }
@@ -253,11 +296,11 @@ export function AddTasksDialog({
     handleOpenChange(false);
   }
 
-  const filterOptions = React.useMemo(() => buildAddTasksFilterOptions(equipment), [equipment])
-
-  const isFiltered = table.getState().columnFilters.length > 0 || (debouncedSearch?.length ?? 0) > 0;
-
-  const totalSelectableRows = table.getFilteredRowModel().rows.filter(row => row.getCanSelect()).length
+  const hasActiveFilters =
+    tableState.filters.departments.length > 0 ||
+    tableState.filters.users.length > 0 ||
+    tableState.filters.locations.length > 0
+  const isFiltered = hasActiveFilters || (debouncedSearch?.length ?? 0) > 0
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -278,26 +321,29 @@ export function AddTasksDialog({
               className="h-8 w-[150px] lg:w-[250px]"
             />
             <FacetedMultiSelectFilter
-              column={table.getColumn("khoa_phong_quan_ly")}
               title="Khoa/Phòng"
               options={filterOptions.departments}
+              value={tableState.filters.departments}
+              onChange={(values) => dispatchTable({ type: "set-filter", key: "departments", values })}
             />
             <FacetedMultiSelectFilter
-              column={table.getColumn("nguoi_dang_truc_tiep_quan_ly")}
               title="Người quản lý"
               options={filterOptions.users}
+              value={tableState.filters.users}
+              onChange={(values) => dispatchTable({ type: "set-filter", key: "users", values })}
             />
             <FacetedMultiSelectFilter
-              column={table.getColumn("vi_tri_lap_dat")}
               title="Vị trí"
               options={filterOptions.locations}
+              value={tableState.filters.locations}
+              onChange={(values) => dispatchTable({ type: "set-filter", key: "locations", values })}
             />
             {isFiltered && (
               <Button
                 variant="ghost"
                 onClick={() => {
-                  table.resetColumnFilters();
-                  dispatchTable({ type: "set-search-term", value: "" });
+                  dispatchTable({ type: "clear-filters" })
+                  dispatchTable({ type: "set-search-term", value: "" })
                 }}
                 className="h-8 px-2 lg:px-3"
               >
@@ -359,7 +405,13 @@ export function AddTasksDialog({
                   ))}
                 </TableHeader>
                 <TableBody>
-                  {error ? (
+                  {missingPlanTenant ? (
+                    <TableRow>
+                      <TableCell colSpan={columns.length} className="h-24 text-center text-destructive">
+                        Không xác định được đơn vị của kế hoạch.
+                      </TableCell>
+                    </TableRow>
+                  ) : error ? (
                     <TableRow>
                       <TableCell colSpan={columns.length} className="h-24 text-center text-destructive">
                         Không thể tải thiết bị: {error.message}
@@ -398,14 +450,32 @@ export function AddTasksDialog({
           </div>
           <div className="flex items-center justify-between">
             <div className="text-sm text-muted-foreground">
-              Đã chọn {table.getFilteredSelectedRowModel().rows.length} trên{" "}
-              {totalSelectableRows} thiết bị (có thể thêm).
+              Đã chọn {selectedEquipment.length} trên {total} thiết bị phù hợp.
             </div>
             <DataTablePagination
               table={table}
-              totalCount={table.getFilteredRowModel().rows.length}
+              totalCount={total}
               entity={{ singular: "thiết bị" }}
+              paginationMode={{
+                mode: "server",
+                currentPage: tableState.pagination.pageIndex + 1,
+                totalPages,
+                pageSize: tableState.pagination.pageSize,
+                onPageChange: (page) => {
+                  dispatchTable({
+                    type: "set-pagination",
+                    updater: (current) => ({ ...current, pageIndex: Math.max(0, page - 1) }),
+                  })
+                },
+                onPageSizeChange: (pageSize) => {
+                  dispatchTable({
+                    type: "set-pagination",
+                    updater: { pageIndex: 0, pageSize },
+                  })
+                },
+              }}
               pageSizeOptions={[10, 20, 50]}
+              isLoading={isFetching}
             />
           </div>
         </div>
@@ -414,8 +484,8 @@ export function AddTasksDialog({
           <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Hủy
           </Button>
-          <Button onClick={handleAdd} disabled={table.getFilteredSelectedRowModel().rows.length === 0}>
-            Thêm {table.getFilteredSelectedRowModel().rows.length > 0 ? `${table.getFilteredSelectedRowModel().rows.length} thiết bị` : ''}
+          <Button onClick={handleAdd} disabled={selectedEquipment.length === 0}>
+            Thêm {selectedEquipment.length > 0 ? `${selectedEquipment.length} thiết bị` : ''}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/hooks/__tests__/useAddTasksEquipment.test.ts
+++ b/src/hooks/__tests__/useAddTasksEquipment.test.ts
@@ -2,7 +2,7 @@
  * useAddTasksEquipment.test.ts
  *
  * TDD RED phase: tests for the useAddTasksEquipment hook.
- * Verifies Equipment[] typing, enabled/disabled states, and typed Error handling.
+ * Verifies server-side pagination, filter buckets, enabled states, and typed Error handling.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -54,6 +54,25 @@ const MOCK_EQUIPMENT: Equipment[] = [
   },
 ]
 
+const MOCK_FILTER_BUCKETS = {
+  department: [{ name: 'ICU', count: 5 }],
+  user: [{ name: 'User A', count: 3 }],
+  location: [{ name: 'Room 101', count: 2 }],
+}
+
+const DEFAULT_PARAMS = {
+  open: true,
+  planDonVi: 17,
+  search: '',
+  pagination: { pageIndex: 0, pageSize: 10 },
+  sort: 'id.asc',
+  filters: {
+    departments: [] as string[],
+    users: [] as string[],
+    locations: [] as string[],
+  },
+}
+
 function createTestQueryClient() {
   return new QueryClient({
     defaultOptions: {
@@ -74,25 +93,59 @@ function createWrapper() {
 describe('useAddTasksEquipment', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCallRpc.mockImplementation(({ fn }) => {
+      if (fn === 'equipment_filter_buckets') {
+        return Promise.resolve(MOCK_FILTER_BUCKETS)
+      }
+      return Promise.resolve({
+        data: MOCK_EQUIPMENT,
+        total: 1947,
+        page: 1,
+        pageSize: 10,
+      })
+    })
   })
 
-  it('returns Equipment[] data when dialog is open', async () => {
-    mockCallRpc.mockResolvedValue(MOCK_EQUIPMENT)
-
-    const { result } = renderHook(() => useAddTasksEquipment(true), {
+  it('fetches equipment with server-side pagination and plan tenant scope', async () => {
+    const { result } = renderHook(() => useAddTasksEquipment({
+      ...DEFAULT_PARAMS,
+      search: 'monitor',
+      pagination: { pageIndex: 2, pageSize: 25 },
+      sort: 'ma_thiet_bi.desc',
+      filters: {
+        departments: ['ICU'],
+        users: ['User A'],
+        locations: ['Room 101'],
+      },
+    }), {
       wrapper: createWrapper(),
     })
 
     await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true)
+      expect(result.current.equipment).toEqual(MOCK_EQUIPMENT)
     })
 
-    expect(result.current.data).toEqual(MOCK_EQUIPMENT)
-    expect(result.current.data?.[0].ma_thiet_bi).toBe('TB-001')
+    expect(result.current.total).toBe(1947)
+    expect(mockCallRpc).toHaveBeenCalledWith(expect.objectContaining({
+      fn: 'equipment_list_enhanced',
+      args: {
+        p_q: 'monitor',
+        p_sort: 'ma_thiet_bi.desc',
+        p_page: 3,
+        p_page_size: 25,
+        p_don_vi: 17,
+        p_khoa_phong_array: ['ICU'],
+        p_nguoi_su_dung_array: ['User A'],
+        p_vi_tri_lap_dat_array: ['Room 101'],
+      },
+    }))
   })
 
   it('does not fetch when dialog is closed', () => {
-    const { result } = renderHook(() => useAddTasksEquipment(false), {
+    const { result } = renderHook(() => useAddTasksEquipment({
+      ...DEFAULT_PARAMS,
+      open: false,
+    }), {
       wrapper: createWrapper(),
     })
 
@@ -101,9 +154,14 @@ describe('useAddTasksEquipment', () => {
   })
 
   it('returns typed Error on RPC failure', async () => {
-    mockCallRpc.mockRejectedValue(new Error('Network error'))
+    mockCallRpc.mockImplementation(({ fn }) => {
+      if (fn === 'equipment_filter_buckets') {
+        return Promise.resolve(MOCK_FILTER_BUCKETS)
+      }
+      return Promise.reject(new Error('Network error'))
+    })
 
-    const { result } = renderHook(() => useAddTasksEquipment(true), {
+    const { result } = renderHook(() => useAddTasksEquipment(DEFAULT_PARAMS), {
       wrapper: createWrapper(),
     })
 
@@ -115,41 +173,33 @@ describe('useAddTasksEquipment', () => {
     expect(result.current.error?.message).toBe('Network error')
   })
 
-  it('warns when returned data count hits the fetch limit', async () => {
-    const { EQUIPMENT_FETCH_LIMIT } = await import('../useAddTasksEquipment')
-    const atLimitData = Array.from({ length: EQUIPMENT_FETCH_LIMIT }, (_, i) => ({
-      ...MOCK_EQUIPMENT[0],
-      id: i + 1,
-      ma_thiet_bi: `TB-${String(i + 1).padStart(3, '0')}`,
-    }))
-    mockCallRpc.mockResolvedValue(atLimitData)
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-    const { result } = renderHook(() => useAddTasksEquipment(true), {
+  it('fetches filter buckets for the entire plan tenant scope', async () => {
+    const { result } = renderHook(() => useAddTasksEquipment(DEFAULT_PARAMS), {
       wrapper: createWrapper(),
     })
 
     await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true)
+      expect(result.current.filterOptions.departments).toEqual([{ label: 'ICU', value: 'ICU' }])
     })
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('equipment_list returned'),
-    )
-    warnSpy.mockRestore()
+    expect(result.current.filterOptions.users).toEqual([{ label: 'User A', value: 'User A' }])
+    expect(result.current.filterOptions.locations).toEqual([{ label: 'Room 101', value: 'Room 101' }])
+    expect(mockCallRpc).toHaveBeenCalledWith(expect.objectContaining({
+      fn: 'equipment_filter_buckets',
+      args: { p_don_vi: 17 },
+    }))
   })
 
-  it('returns empty array when RPC returns null', async () => {
-    mockCallRpc.mockResolvedValue(null)
-
-    const { result } = renderHook(() => useAddTasksEquipment(true), {
+  it('does not fetch when plan tenant is missing', () => {
+    const { result } = renderHook(() => useAddTasksEquipment({
+      ...DEFAULT_PARAMS,
+      planDonVi: null,
+    }), {
       wrapper: createWrapper(),
     })
 
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true)
-    })
-
-    expect(result.current.data).toEqual([])
+    expect(result.current.equipment).toEqual([])
+    expect(result.current.total).toBe(0)
+    expect(mockCallRpc).not.toHaveBeenCalled()
   })
 })

--- a/src/hooks/useAddTasksEquipment.ts
+++ b/src/hooks/useAddTasksEquipment.ts
@@ -1,48 +1,151 @@
 /**
  * useAddTasksEquipment.ts
  *
- * TanStack Query hook to fetch all equipment for the add-tasks dialog.
- * Replaces the useState+useEffect fetch pattern with proper caching and typing.
+ * TanStack Query hook for the add-tasks dialog equipment picker.
+ * Uses server-side pagination/search/filtering to avoid Supabase REST row caps.
  */
 
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { callRpc } from '@/lib/rpc-client'
 import type { Equipment } from '@/lib/data'
 
-/**
- * Upper bound for the client-side "load-all" fetch.
- * The add-tasks dialog needs all equipment in memory for client-side
- * faceted filtering, global search, and row selection.
- * If the dataset hits this limit, a console.warn fires so operators
- * know to consider server-side pagination.
- */
-export const EQUIPMENT_FETCH_LIMIT = 10_000
+export interface AddTasksEquipmentFilters {
+  departments: string[]
+  users: string[]
+  locations: string[]
+}
 
-export function useAddTasksEquipment(open: boolean) {
-  return useQuery<Equipment[], Error>({
-    queryKey: ['equipment_list', 'add-tasks'],
-    queryFn: async () => {
-      const raw = await callRpc<Equipment[] | null>({
-        fn: 'equipment_list',
-        args: {
-          p_q: null,
-          p_sort: 'id.asc',
-          p_page: 1,
-          p_page_size: EQUIPMENT_FETCH_LIMIT,
-        },
-      })
-      const data = raw ?? []
+export interface UseAddTasksEquipmentParams {
+  open: boolean
+  planDonVi: number | null | undefined
+  search: string
+  pagination: { pageIndex: number; pageSize: number }
+  sort: string
+  filters: AddTasksEquipmentFilters
+}
 
-      if (data.length >= EQUIPMENT_FETCH_LIMIT) {
-        console.warn(
-          `[useAddTasksEquipment] equipment_list returned ${data.length} rows, ` +
-          `hitting the ${EQUIPMENT_FETCH_LIMIT} limit. Some equipment may be missing. ` +
-          `Consider migrating to server-side pagination.`,
-        )
-      }
+interface EquipmentListResponse {
+  data?: Equipment[] | null
+  total?: number | null
+  page?: number | null
+  pageSize?: number | null
+}
 
-      return data
-    },
-    enabled: open,
+interface EquipmentFilterBucket {
+  name?: string | null
+  count?: number | null
+}
+
+type EquipmentFilterBucketsResponse = Partial<{
+  department: EquipmentFilterBucket[]
+  user: EquipmentFilterBucket[]
+  location: EquipmentFilterBucket[]
+}>
+
+interface AddTasksFilterOption {
+  label: string
+  value: string
+}
+
+interface AddTasksFilterOptions {
+  departments: AddTasksFilterOption[]
+  users: AddTasksFilterOption[]
+  locations: AddTasksFilterOption[]
+}
+
+const EMPTY_EQUIPMENT: Equipment[] = []
+const EMPTY_FILTER_OPTIONS: AddTasksFilterOptions = {
+  departments: [],
+  users: [],
+  locations: [],
+}
+
+function bucketToOptions(bucket: EquipmentFilterBucket[] | undefined): AddTasksFilterOption[] {
+  if (!bucket) return []
+  return bucket.flatMap((item) => {
+    const name = (item.name ?? '').trim()
+    return name ? [{ label: name, value: name }] : []
   })
+}
+
+/** Fetches paginated equipment and filter buckets for the maintenance add-tasks dialog. */
+export function useAddTasksEquipment({
+  open,
+  planDonVi,
+  search,
+  pagination,
+  sort,
+  filters,
+}: UseAddTasksEquipmentParams) {
+  const canFetch = open && typeof planDonVi === 'number' && Number.isFinite(planDonVi)
+  const page = pagination.pageIndex + 1
+
+  const equipmentQuery = useQuery<EquipmentListResponse, Error>({
+    queryKey: [
+      'equipment_list_enhanced',
+      'add-tasks',
+      {
+        planDonVi,
+        search: search || null,
+        page,
+        pageSize: pagination.pageSize,
+        sort,
+        filters,
+      },
+    ],
+    queryFn: async ({ signal }) => {
+      const result = await callRpc<EquipmentListResponse | null>({
+        fn: 'equipment_list_enhanced',
+        args: {
+          p_q: search || null,
+          p_sort: sort,
+          p_page: page,
+          p_page_size: pagination.pageSize,
+          p_don_vi: planDonVi,
+          p_khoa_phong_array: filters.departments.length > 0 ? filters.departments : null,
+          p_nguoi_su_dung_array: filters.users.length > 0 ? filters.users : null,
+          p_vi_tri_lap_dat_array: filters.locations.length > 0 ? filters.locations : null,
+        },
+        signal,
+      })
+
+      return result ?? { data: EMPTY_EQUIPMENT, total: 0, page, pageSize: pagination.pageSize }
+    },
+    enabled: canFetch,
+    placeholderData: keepPreviousData,
+  })
+
+  const filterBucketsQuery = useQuery<EquipmentFilterBucketsResponse, Error>({
+    queryKey: ['equipment_filter_buckets', 'add-tasks', { planDonVi }],
+    queryFn: async ({ signal }) => {
+      const result = await callRpc<EquipmentFilterBucketsResponse | null>({
+        fn: 'equipment_filter_buckets',
+        args: { p_don_vi: planDonVi },
+        signal,
+      })
+      return result ?? {}
+    },
+    enabled: canFetch,
+    staleTime: 300_000,
+    gcTime: 10 * 60_000,
+  })
+
+  const buckets = filterBucketsQuery.data
+  const filterOptions = buckets
+    ? {
+        departments: bucketToOptions(buckets.department),
+        users: bucketToOptions(buckets.user),
+        locations: bucketToOptions(buckets.location),
+      }
+    : EMPTY_FILTER_OPTIONS
+
+  return {
+    equipment: equipmentQuery.data?.data ?? EMPTY_EQUIPMENT,
+    total: equipmentQuery.data?.total ?? 0,
+    isLoading: equipmentQuery.isLoading,
+    isFetching: equipmentQuery.isFetching,
+    isError: equipmentQuery.isError,
+    error: equipmentQuery.error,
+    filterOptions,
+  }
 }


### PR DESCRIPTION
## Summary\n- Switch maintenance add-tasks equipment picker from load-all `equipment_list` to server-side `equipment_list_enhanced` pagination scoped by plan tenant.\n- Reuse `equipment_filter_buckets` for full-tenant filter options.\n- Preserve selected equipment across server pages and keep existing-plan equipment disabled.\n\n## Verification\n- `node scripts/npm-run.js run verify:no-explicit-any`\n- `node scripts/npm-run.js run verify:dedupe`\n- `node scripts/npm-run.js run typecheck`\n- `node scripts/npm-run.js run test:run -- src/hooks/__tests__/useAddTasksEquipment.test.ts src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx --reporter=verbose`\n- `node scripts/npm-run.js run react-doctor`\n\n## Notes\n- React Doctor reports one residual maintainability warning for `AddTasksDialog` size; follow-up filed as #606.\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/607" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the maintenance add‑tasks equipment picker to server‑side pagination scoped by the plan’s tenant, fixing missing results and speeding up loading. Added server-driven filters and kept selections across pages.

- **Bug Fixes**
  - Moved from `equipment_list` to `equipment_list_enhanced` with `p_don_vi`, search, sort, page, and page size; shows server total and uses server pagination in `DataTablePagination`.
  - Reused `equipment_filter_buckets` to populate department/user/location filters for the whole tenant; changing search, filters, or sorting resets to page 1.
  - Preserved selected equipment across pages and kept equipment already in the plan disabled; shows an inline error when the plan’s `don_vi` is missing.

- **Refactors**
  - `useAddTasksEquipment` now takes params and returns `{ equipment, total, filterOptions }`, using `keepPreviousData` for smooth paging.
  - Table now uses manual sorting/filtering/pagination; client-side faceting removed and replaced with lightweight local filter state. Tests updated for pagination, filters, and selection.

<sup>Written for commit 3ff58cdcc3bcb1c6599c20cdec0a877e753935dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Equipment list now runs in server mode with pagination, sorting, and filters (departments, users, locations).
  * Equipment selection persists across pages, with an updated “selected / total matching equipment” summary.
  * When plan tenant info is missing, the dialog shows a dedicated empty-state message.

* **Tests**
  * Expanded and strengthened coverage for server-side pagination, cross-page selection, and filter behavior.
  * Improved mock type-safety and assertion precision for RPC-driven results and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->