### PR TITLE
Fix transfer_request_delete missing don_vi guard

### DIFF
--- a/supabase/migrations/20260621025009_fix_transfer_request_delete_missing_don_vi_guard.sql
+++ b/supabase/migrations/20260621025009_fix_transfer_request_delete_missing_don_vi_guard.sql
@@ -1,0 +1,49 @@
+-- Fix transfer_request_delete fail-open tenant guard when JWT don_vi is missing.
+
+CREATE OR REPLACE FUNCTION public.transfer_request_delete(
+  p_id INTEGER
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims JSONB;
+  v_role TEXT;
+  v_don_vi TEXT;
+  v_req RECORD;
+BEGIN
+  v_claims := COALESCE(current_setting('request.jwt.claims', true), '{}')::jsonb;
+  v_role := COALESCE(NULLIF(v_claims->>'app_role',''), NULLIF(v_claims->>'role',''));
+  v_don_vi := NULLIF(v_claims->>'don_vi','');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Regional leaders have read-only access to transfers' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT t.*, tb.don_vi AS tb_don_vi
+  INTO v_req
+  FROM public.yeu_cau_luan_chuyen t
+  JOIN public.thiet_bi tb ON tb.id = t.thiet_bi_id
+  WHERE t.id = p_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Yêu cầu không tồn tại' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role IS DISTINCT FROM 'global'
+    AND (v_don_vi IS NULL OR v_req.tb_don_vi::text IS DISTINCT FROM v_don_vi)
+  THEN
+    RAISE EXCEPTION 'Không có quyền xóa yêu cầu này' USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.yeu_cau_luan_chuyen WHERE id = p_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.transfer_request_delete(INTEGER) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.transfer_request_delete(INTEGER) FROM PUBLIC;

--- a/supabase/migrations/20260621030916_harden_transfer_request_delete_user_guard_and_lock.sql
+++ b/supabase/migrations/20260621030916_harden_transfer_request_delete_user_guard_and_lock.sql
@@ -1,0 +1,60 @@
+-- Harden transfer_request_delete user claim guard and row locking.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.transfer_request_delete(
+  p_id INTEGER
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims JSONB;
+  v_role TEXT;
+  v_user_id TEXT;
+  v_don_vi TEXT;
+  v_req RECORD;
+BEGIN
+  v_claims := COALESCE(current_setting('request.jwt.claims', true), '{}')::jsonb;
+  v_role := COALESCE(NULLIF(v_claims->>'app_role',''), NULLIF(v_claims->>'role',''));
+  v_user_id := NULLIF(v_claims->>'user_id','');
+  v_don_vi := NULLIF(v_claims->>'don_vi','');
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Regional leaders have read-only access to transfers' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT t.*, tb.don_vi AS tb_don_vi
+  INTO v_req
+  FROM public.yeu_cau_luan_chuyen t
+  JOIN public.thiet_bi tb ON tb.id = t.thiet_bi_id
+  WHERE t.id = p_id
+  FOR UPDATE OF t, tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Yêu cầu không tồn tại' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role IS DISTINCT FROM 'global'
+    AND (v_don_vi IS NULL OR v_req.tb_don_vi::text IS DISTINCT FROM v_don_vi)
+  THEN
+    RAISE EXCEPTION 'Không có quyền xóa yêu cầu này' USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.yeu_cau_luan_chuyen WHERE id = p_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.transfer_request_delete(INTEGER) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.transfer_request_delete(INTEGER) FROM PUBLIC;
+
+COMMIT;

--- a/supabase/tests/transfer_request_delete_tenant_cast_smoke.sql
+++ b/supabase/tests/transfer_request_delete_tenant_cast_smoke.sql
@@ -1,5 +1,5 @@
 -- supabase/tests/transfer_request_delete_tenant_cast_smoke.sql
--- Purpose: prove to_qltb can delete a pending transfer request when don_vi claim is text.
+-- Purpose: prove transfer_request_delete enforces fail-closed tenant isolation.
 -- Non-destructive: wrapped in transaction and rolled back.
 
 BEGIN;
@@ -8,10 +8,20 @@ DO $$
 DECLARE
   v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
   v_tenant_id bigint;
+  v_other_tenant_id bigint;
   v_user_id bigint;
   v_equipment_id bigint;
+  v_missing_claim_equipment_id bigint;
+  v_mismatch_equipment_id bigint;
+  v_global_equipment_id bigint;
   v_request_id bigint;
+  v_missing_claim_request_id bigint;
+  v_mismatch_request_id bigint;
+  v_global_request_id bigint;
   v_remaining_count integer;
+  v_failed boolean;
+  v_sqlstate text;
+  v_sqlerrm text;
 BEGIN
   PERFORM pg_advisory_xact_lock(hashtext('transfer_request_delete_tenant_cast_smoke'));
 
@@ -30,6 +40,10 @@ BEGIN
   VALUES ('Transfer Delete Cast Smoke ' || v_suffix, true)
   RETURNING id INTO v_tenant_id;
 
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Transfer Delete Cast Smoke Other ' || v_suffix, true)
+  RETURNING id INTO v_other_tenant_id;
+
   INSERT INTO public.thiet_bi(
     ma_thiet_bi,
     ten_thiet_bi,
@@ -47,6 +61,60 @@ BEGIN
     false
   )
   RETURNING id INTO v_equipment_id;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-TRF-DEL-MISS-' || v_suffix,
+    'Transfer Delete Missing Claim Smoke Equipment ' || v_suffix,
+    v_tenant_id,
+    'Khoa Hien Tai ' || v_suffix,
+    'Hoat dong',
+    false
+  )
+  RETURNING id INTO v_missing_claim_equipment_id;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-TRF-DEL-MIS-' || v_suffix,
+    'Transfer Delete Mismatch Smoke Equipment ' || v_suffix,
+    v_tenant_id,
+    'Khoa Hien Tai ' || v_suffix,
+    'Hoat dong',
+    false
+  )
+  RETURNING id INTO v_mismatch_equipment_id;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    is_deleted
+  )
+  VALUES (
+    'SMK-TRF-DEL-GLOB-' || v_suffix,
+    'Transfer Delete Global Smoke Equipment ' || v_suffix,
+    v_tenant_id,
+    'Khoa Hien Tai ' || v_suffix,
+    'Hoat dong',
+    false
+  )
+  RETURNING id INTO v_global_equipment_id;
 
   PERFORM set_config(
     'request.jwt.claims',
@@ -70,6 +138,131 @@ BEGIN
     )
   );
 
+  v_missing_claim_request_id := public.transfer_request_create(
+    jsonb_build_object(
+      'thiet_bi_id', v_missing_claim_equipment_id,
+      'loai_hinh', 'noi_bo',
+      'ly_do_luan_chuyen', 'Smoke delete missing claim ' || v_suffix,
+      'khoa_phong_hien_tai', 'Khoa Hien Tai ' || v_suffix,
+      'khoa_phong_nhan', 'Khoa Nhan ' || v_suffix
+    )
+  );
+
+  v_mismatch_request_id := public.transfer_request_create(
+    jsonb_build_object(
+      'thiet_bi_id', v_mismatch_equipment_id,
+      'loai_hinh', 'noi_bo',
+      'ly_do_luan_chuyen', 'Smoke delete mismatch ' || v_suffix,
+      'khoa_phong_hien_tai', 'Khoa Hien Tai ' || v_suffix,
+      'khoa_phong_nhan', 'Khoa Nhan ' || v_suffix
+    )
+  );
+
+  v_global_request_id := public.transfer_request_create(
+    jsonb_build_object(
+      'thiet_bi_id', v_global_equipment_id,
+      'loai_hinh', 'noi_bo',
+      'ly_do_luan_chuyen', 'Smoke delete global ' || v_suffix,
+      'khoa_phong_hien_tai', 'Khoa Hien Tai ' || v_suffix,
+      'khoa_phong_nhan', 'Khoa Nhan ' || v_suffix
+    )
+  );
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.transfer_request_delete(v_missing_claim_request_id::integer);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected transfer_request_delete to fail closed for missing don_vi claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected missing-claim transfer_request_delete to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT count(*)
+  INTO v_remaining_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE id = v_missing_claim_request_id;
+
+  IF v_remaining_count IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Missing-claim transfer delete deny should keep request %, remaining count %',
+      v_missing_claim_request_id,
+      v_remaining_count;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_other_tenant_id::text
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.transfer_request_delete(v_mismatch_request_id::integer);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected transfer_request_delete to deny mismatched don_vi claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected mismatched transfer_request_delete to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT count(*)
+  INTO v_remaining_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE id = v_mismatch_request_id;
+
+  IF v_remaining_count IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Mismatched transfer delete deny should keep request %, remaining count %',
+      v_mismatch_request_id,
+      v_remaining_count;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text,
+      'don_vi', v_tenant_id::text
+    )::text,
+    true
+  );
+
   PERFORM public.transfer_request_delete(v_request_id::integer);
 
   SELECT count(*)
@@ -80,6 +273,30 @@ BEGIN
   IF v_remaining_count IS DISTINCT FROM 0 THEN
     RAISE EXCEPTION 'Expected transfer_request_delete to remove pending request %, remaining count %',
       v_request_id,
+      v_remaining_count;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'global',
+      'role', 'authenticated',
+      'user_id', v_user_id::text,
+      'sub', v_user_id::text
+    )::text,
+    true
+  );
+
+  PERFORM public.transfer_request_delete(v_global_request_id::integer);
+
+  SELECT count(*)
+  INTO v_remaining_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE id = v_global_request_id;
+
+  IF v_remaining_count IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'Expected global transfer_request_delete to remove pending request %, remaining count %',
+      v_global_request_id,
       v_remaining_count;
   END IF;
 END $$;

--- a/supabase/tests/transfer_request_delete_tenant_cast_smoke.sql
+++ b/supabase/tests/transfer_request_delete_tenant_cast_smoke.sql
@@ -256,6 +256,46 @@ BEGIN
     json_build_object(
       'app_role', 'to_qltb',
       'role', 'authenticated',
+      'don_vi', v_tenant_id::text
+    )::text,
+    true
+  );
+
+  v_failed := false;
+  v_sqlstate := NULL;
+  v_sqlerrm := NULL;
+  BEGIN
+    PERFORM public.transfer_request_delete(v_request_id::integer);
+  EXCEPTION WHEN OTHERS THEN
+    v_failed := true;
+    v_sqlstate := SQLSTATE;
+    v_sqlerrm := SQLERRM;
+  END;
+
+  IF NOT v_failed THEN
+    RAISE EXCEPTION 'Expected transfer_request_delete to fail closed for missing user_id claim';
+  END IF;
+
+  IF v_sqlstate IS DISTINCT FROM '42501' THEN
+    RAISE EXCEPTION 'Expected missing-user transfer_request_delete to deny with 42501, got % (%)', v_sqlstate, v_sqlerrm;
+  END IF;
+
+  SELECT count(*)
+  INTO v_remaining_count
+  FROM public.yeu_cau_luan_chuyen
+  WHERE id = v_request_id;
+
+  IF v_remaining_count IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'Missing-user transfer delete deny should keep request %, remaining count %',
+      v_request_id,
+      v_remaining_count;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    json_build_object(
+      'app_role', 'to_qltb',
+      'role', 'authenticated',
       'user_id', v_user_id::text,
       'sub', v_user_id::text,
       'don_vi', v_tenant_id::text


### PR DESCRIPTION
## Summary
- Adds a superseding migration for `transfer_request_delete` so non-global users fail closed when `don_vi` is missing.
- Expands the SQL smoke test to cover missing, mismatched, matching, and global claim behavior.

Closes #602.
Follow-up filed: #608 for the separate live `anon` EXECUTE grant review.

## Verification
- RED via Supabase MCP `execute_sql`: missing-`don_vi` delete failed the assertion against the old live function (`Expected transfer_request_delete to fail closed for missing don_vi claim`).
- Applied migration via Supabase MCP `apply_migration`: `fix_transfer_request_delete_missing_don_vi_guard`.
- GREEN via Supabase MCP `execute_sql`: missing `don_vi`, mismatched `don_vi`, matching `don_vi`, and global paths all exercised successfully.
- Executed `supabase/tests/transfer_request_delete_tenant_cast_smoke.sql` through Supabase MCP; returned no errors and rolled back smoke data.
- Live function inspection confirms `SECURITY DEFINER`, `search_path=public, pg_temp`, and fail-closed guard.
- Supabase MCP `get_advisors(security)` ran; returned existing baseline advisories.
- `git diff --check` clean for tracked diff and untracked migration before commit.
- Code Review Graph `detect_changes` risk score 0.00 for the SQL-only diff.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transfer deletion authorization to fail closed when JWT claims are missing or mismatched. Adds `user_id` guard and row locking to prevent unauthorized or racy deletes.

- **Bug Fixes**
  - Replaces `public.transfer_request_delete(integer)` with a SECURITY DEFINER that checks `app_role`, `user_id`, and `don_vi`; denies `regional_leader`, allows `global`; sets `search_path` to `public, pg_temp`; locks `yeu_cau_luan_chuyen` and `thiet_bi` rows FOR UPDATE.
  - Grants `EXECUTE` to `authenticated` and revokes from `PUBLIC`.
  - Extends the smoke test to assert deny on missing `don_vi`, mismatched `don_vi`, and missing `user_id` (SQLSTATE 42501), and allow on matching tenant and `global`.

<sup>Written for commit 5a0de78723316ea675ac23be16f6c8df75e863f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Security**
  * Hardened transfer request deletion with strict JWT claim validation and fail-closed tenant scoping.
  * Added locking to safely delete requests and their related device records.
  * Regional leaders remain restricted to read-only (cannot delete transfer requests).
* **Tests**
  * Expanded smoke test coverage to verify denial scenarios (missing/mismatched tenant claims and access controls) and successful deletion for global roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->