### PR TITLE
feat: add equipment department summary

### DIFF
--- a/src/app/(app)/equipment/__tests__/EquipmentDialogContext.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentDialogContext.test.tsx
@@ -4,7 +4,10 @@ import * as React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { Equipment, UsageLog } from '../types'
 
-const mockUseSession = vi.fn()
+const { mockInvalidateQueries, mockUseSession } = vi.hoisted(() => ({
+  mockInvalidateQueries: vi.fn(),
+  mockUseSession: vi.fn(),
+}))
 
 // Mock next-auth
 vi.mock('next-auth/react', () => ({
@@ -17,7 +20,7 @@ vi.mock('@tanstack/react-query', async () => {
   return {
     ...actual,
     useQueryClient: () => ({
-      invalidateQueries: vi.fn(),
+      invalidateQueries: mockInvalidateQueries,
     }),
   }
 })
@@ -88,6 +91,32 @@ describe('EquipmentDialogContext', () => {
       expect(result.current.dialogState.deleteTarget).toBeNull()
       expect(result.current.dialogState.deleteSource).toBeNull()
       expect(result.current.dialogState.isDeleteOpen).toBe(false)
+    })
+  })
+
+  describe('Cache Invalidation', () => {
+    it('invalidates equipment list and department distribution queries for the active tenant', () => {
+      const { result } = renderHook(() => useEquipmentContext(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.onDataMutationSuccess()
+      })
+
+      const equipmentInvalidation = mockInvalidateQueries.mock.calls.find(
+        ([options]) => typeof options?.predicate === 'function'
+      )?.[0]
+
+      expect(equipmentInvalidation?.predicate({
+        queryKey: ['equipment_list_enhanced', { tenant: '5' }],
+      })).toBe(true)
+      expect(equipmentInvalidation?.predicate({
+        queryKey: ['equipment_department_distribution', { tenant: '5' }],
+      })).toBe(true)
+      expect(equipmentInvalidation?.predicate({
+        queryKey: ['equipment_department_distribution', { tenant: '6' }],
+      })).toBe(false)
     })
   })
 

--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx
@@ -1,0 +1,187 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { useEquipmentPage } from "../use-equipment-page"
+
+type EquipmentPageState = ReturnType<typeof useEquipmentPage>
+
+const state = vi.hoisted(() => ({
+  pageState: null as EquipmentPageState | null,
+}))
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  setColumnFilters: vi.fn(),
+  setPagination: vi.fn(),
+  clearPendingAction: vi.fn(),
+  openAddDialog: vi.fn(),
+  openImportDialog: vi.fn(),
+  openColumnsDialog: vi.fn(),
+  openDetailDialog: vi.fn(),
+}))
+
+vi.mock("../use-equipment-page", () => ({
+  useEquipmentPage: () => state.pageState,
+}))
+
+vi.mock("../_hooks/useEquipmentContext", () => ({
+  useEquipmentContext: () => ({
+    openAddDialog: mocks.openAddDialog,
+    openImportDialog: mocks.openImportDialog,
+    openColumnsDialog: mocks.openColumnsDialog,
+    openDetailDialog: mocks.openDetailDialog,
+    openEditDialog: vi.fn(),
+  }),
+}))
+
+vi.mock("../_components/EquipmentDialogContext", () => ({
+  EquipmentDialogProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("../equipment-content", () => ({
+  EquipmentContent: () => <section aria-label="equipment table" />,
+}))
+
+vi.mock("../equipment-dialogs", () => ({
+  EquipmentDialogs: () => null,
+}))
+
+vi.mock("../_components/EquipmentColumnsDialog", () => ({
+  EquipmentColumnsDialog: () => null,
+}))
+
+vi.mock("../_components/EquipmentBulkDeleteBar", () => ({
+  EquipmentBulkDeleteBar: () => null,
+}))
+
+vi.mock("@/components/equipment/equipment-toolbar", () => ({
+  EquipmentToolbar: () => <section aria-label="equipment toolbar" />,
+}))
+
+vi.mock("@/components/equipment/filter-bottom-sheet", () => ({
+  FilterBottomSheet: () => null,
+}))
+
+vi.mock("@/components/shared/DataTablePagination", () => ({
+  DataTablePagination: () => null,
+}))
+
+vi.mock("@/components/shared/TenantSelector", () => ({
+  TenantSelector: () => null,
+}))
+
+import { EquipmentPageClient } from "../_components/EquipmentPageClient"
+
+function createPageState(overrides?: Partial<EquipmentPageState>): EquipmentPageState {
+  return {
+    status: "authenticated",
+    router: { push: mocks.push, replace: vi.fn() } as EquipmentPageState["router"],
+    effectiveTenantKey: "5",
+    user: { id: 1, role: "to_qltb" } as EquipmentPageState["user"],
+    pendingAction: null,
+    clearPendingAction: mocks.clearPendingAction,
+    isFetchingHighlight: false,
+    isGlobal: false,
+    isRegionalLeader: false,
+    data: [],
+    total: 9,
+    departmentDistribution: [
+      { department: "Khoa Ngoại", label: "Khoa Ngoại", count: 7 },
+      { department: null, label: "Chưa cập nhật", count: 2 },
+    ],
+    isLoading: false,
+    isFetching: false,
+    shouldFetchEquipment: true,
+    table: {
+      getFilteredRowModel: () => ({ rows: [] }),
+    } as EquipmentPageState["table"],
+    columns: [],
+    pagination: { pageIndex: 0, pageSize: 20 },
+    setPagination: mocks.setPagination,
+    pageCount: 1,
+    columnVisibility: {},
+    setColumnVisibility: vi.fn(),
+    searchTerm: "",
+    setSearchTerm: vi.fn(),
+    columnFilters: [],
+    setColumnFilters: mocks.setColumnFilters,
+    isFiltered: false,
+    departments: [],
+    users: [],
+    locations: [],
+    statuses: [],
+    classifications: [],
+    fundingSources: [],
+    filterData: {
+      status: [],
+      department: [],
+      location: [],
+      user: [],
+      classification: [],
+      fundingSource: [],
+    },
+    showFacilityFilter: false,
+    facilities: [],
+    selectedFacilityId: null,
+    setSelectedFacilityId: vi.fn(),
+    activeFacility: null,
+    hasFacilityFilter: false,
+    isFacilitiesLoading: false,
+    handleFacilityClear: vi.fn(),
+    isFilterSheetOpen: false,
+    setIsFilterSheetOpen: vi.fn(),
+    handleDownloadTemplate: vi.fn(),
+    handleExportData: vi.fn(),
+    handleGenerateProfileSheet: vi.fn(),
+    handleGenerateDeviceLabel: vi.fn(),
+    onDataMutationSuccess: vi.fn(),
+    onDataMutationSuccessWithStatePreservation: vi.fn(),
+    isMobile: false,
+    isCardView: false,
+    useTabletFilters: false,
+    canBulkSelect: true,
+    isExporting: false,
+    tenantBranding: undefined,
+    ...overrides,
+  }
+}
+
+describe("EquipmentPageClient department summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.pageState = createPageState()
+  })
+
+  it("renders department distribution counts between the toolbar and table", () => {
+    render(<EquipmentPageClient />)
+
+    const summary = screen.getByRole("region", { name: "Phân bố theo khoa/phòng" })
+
+    expect(summary).toHaveTextContent("Phân bố theo khoa/phòng")
+    expect(within(summary).getByRole("button", { name: /Khoa Ngoại 7 thiết bị/ })).toBeInTheDocument()
+    expect(within(summary).getByText("Chưa cập nhật")).toBeInTheDocument()
+    expect(screen.getByRole("region", { name: "equipment toolbar" })).toBeInTheDocument()
+    expect(screen.getByRole("region", { name: "equipment table" })).toBeInTheDocument()
+  })
+
+  it("clicking a department summary item applies the existing department filter", async () => {
+    const user = userEvent.setup()
+    render(<EquipmentPageClient />)
+
+    await user.click(screen.getByRole("button", { name: /Khoa Ngoại 7 thiết bị/ }))
+
+    const updater = mocks.setColumnFilters.mock.calls[0][0] as EquipmentPageState["setColumnFilters"]
+    expect(typeof updater).toBe("function")
+    expect(
+      (updater as (current: EquipmentPageState["columnFilters"]) => EquipmentPageState["columnFilters"])([
+        { id: "tinh_trang_hien_tai", value: ["Hoạt động"] },
+      ])
+    ).toEqual([
+      { id: "tinh_trang_hien_tai", value: ["Hoạt động"] },
+      { id: "khoa_phong_quan_ly", value: ["Khoa Ngoại"] },
+    ])
+  })
+})

--- a/src/app/(app)/equipment/__tests__/equipment-content.desktop-interactions.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-content.desktop-interactions.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { LinkedRequestProvider } from "@/components/equipment-linked-request"
 import { createEquipmentColumns } from "@/components/equipment/equipment-table-columns"
+import type { DepartmentColorClasses } from "@/components/equipment/equipment-department-grouping"
 import type { Equipment } from "@/types/database"
 import { EquipmentContent } from "../equipment-content"
 
@@ -21,14 +22,26 @@ function EquipmentContentHarness({
 }: {
   equipment: Equipment
   onShowDetails: (equipment: Equipment) => void
-  departmentColorClassByLabel?: Record<string, string>
+  departmentColorClassByLabel?: Record<string, DepartmentColorClasses>
 }) {
   const columns = React.useMemo(
     () =>
       createEquipmentColumns({
         renderActions: () => null,
+        departmentColorClassByLabel,
       }),
-    []
+    [departmentColorClassByLabel]
+  )
+
+  const rowColorClassByLabel = React.useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(departmentColorClassByLabel ?? {}).map(([label, colors]) => [
+          label,
+          colors.rowClassName,
+        ])
+      ),
+    [departmentColorClassByLabel]
   )
 
   const table = useReactTable({
@@ -49,7 +62,7 @@ function EquipmentContentHarness({
         table={table}
         columns={columns}
         onShowDetails={onShowDetails}
-        departmentColorClassByLabel={departmentColorClassByLabel}
+        departmentColorClassByLabel={rowColorClassByLabel}
       />
     </LinkedRequestProvider>
   )
@@ -126,10 +139,42 @@ describe("EquipmentContent desktop interactions", () => {
       <EquipmentContentHarness
         equipment={equipment}
         onShowDetails={vi.fn()}
-        departmentColorClassByLabel={{ "Khoa Ngoại": "bg-sky-50/60 hover:bg-sky-50" }}
+        departmentColorClassByLabel={{
+          "Khoa Ngoại": {
+            rowClassName: "bg-sky-50/60 hover:bg-sky-50",
+            chipClassName: "border-sky-200 bg-sky-50 text-sky-800 hover:bg-sky-100",
+            badgeClassName: "border-sky-200 bg-sky-100 text-sky-800",
+          },
+        }}
       />
     )
 
     expect(screen.getByRole("row", { name: /TB-303/ })).toHaveClass("bg-sky-50/60")
+  })
+
+  it("renders missing managing departments with the normalized department badge", () => {
+    const equipment: Equipment = {
+      id: 304,
+      ma_thiet_bi: "TB-304",
+      ten_thiet_bi: "Máy thở",
+      khoa_phong_quan_ly: "",
+      tinh_trang_hien_tai: "Hoạt động",
+    }
+
+    render(
+      <EquipmentContentHarness
+        equipment={equipment}
+        onShowDetails={vi.fn()}
+        departmentColorClassByLabel={{
+          "Chưa cập nhật": {
+            rowClassName: "bg-slate-50/70 hover:bg-slate-100/70",
+            chipClassName: "border-slate-200 bg-slate-50 text-slate-700 hover:bg-slate-100",
+            badgeClassName: "border-slate-200 bg-slate-100 text-slate-700",
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByText("Chưa cập nhật")).toHaveClass("border-slate-200")
   })
 })

--- a/src/app/(app)/equipment/__tests__/equipment-content.desktop-interactions.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-content.desktop-interactions.test.tsx
@@ -17,9 +17,11 @@ vi.mock("@/components/ui/tooltip", async () => {
 function EquipmentContentHarness({
   equipment,
   onShowDetails,
+  departmentColorClassByLabel,
 }: {
   equipment: Equipment
   onShowDetails: (equipment: Equipment) => void
+  departmentColorClassByLabel?: Record<string, string>
 }) {
   const columns = React.useMemo(
     () =>
@@ -47,6 +49,7 @@ function EquipmentContentHarness({
         table={table}
         columns={columns}
         onShowDetails={onShowDetails}
+        departmentColorClassByLabel={departmentColorClassByLabel}
       />
     </LinkedRequestProvider>
   )
@@ -108,5 +111,25 @@ describe("EquipmentContent desktop interactions", () => {
 
     await user.click(within(screen.getByRole("table")).getByText(equipment.ma_thiet_bi))
     expect(onShowDetails).toHaveBeenCalledWith(equipment)
+  })
+
+  it("applies subtle department color classes to desktop rows", () => {
+    const equipment: Equipment = {
+      id: 303,
+      ma_thiet_bi: "TB-303",
+      ten_thiet_bi: "Bơm tiêm điện",
+      khoa_phong_quan_ly: "Khoa Ngoại",
+      tinh_trang_hien_tai: "Hoạt động",
+    }
+
+    render(
+      <EquipmentContentHarness
+        equipment={equipment}
+        onShowDetails={vi.fn()}
+        departmentColorClassByLabel={{ "Khoa Ngoại": "bg-sky-50/60 hover:bg-sky-50" }}
+      />
+    )
+
+    expect(screen.getByRole("row", { name: /TB-303/ })).toHaveClass("bg-sky-50/60")
   })
 })

--- a/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
@@ -76,6 +76,8 @@ describe('useEquipmentData', () => {
           return Promise.resolve([])
         case 'equipment_filter_buckets':
           return Promise.resolve({})
+        case 'equipment_department_distribution':
+          return Promise.resolve([])
         case 'get_facilities_with_equipment_count':
           return Promise.resolve([])
         default:
@@ -327,6 +329,64 @@ describe('useEquipmentData', () => {
   })
 
   describe('Filter Options Queries', () => {
+    it('fetches department distribution using current search and filters without pagination', async () => {
+      const mockDistribution = [
+        { department: 'Khoa Ngoai', label: 'Khoa Ngoai', count: 7 },
+        { department: null, label: 'Chưa cập nhật', count: 2 },
+      ]
+
+      mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
+        if (fn === 'equipment_list_enhanced') {
+          return Promise.resolve({ data: [], total: 9 })
+        }
+        if (fn === 'equipment_filter_buckets') {
+          return Promise.resolve({})
+        }
+        if (fn === 'equipment_department_distribution') {
+          return Promise.resolve(mockDistribution)
+        }
+        return Promise.resolve([])
+      })
+
+      const { result } = renderHook(
+        () =>
+          useEquipmentData(
+            createDefaultParams({
+              debouncedSearch: 'bom tiem dien',
+              pagination: { pageIndex: 3, pageSize: 25 },
+              selectedDepartments: ['Khoa Ngoai'],
+              selectedUsers: ['Nguyen Van A'],
+              selectedLocations: ['Phong 101'],
+              selectedStatuses: ['Hoat dong'],
+              selectedClassifications: ['May loai A'],
+              selectedFundingSources: ['Ngan sach'],
+            })
+          ),
+        { wrapper: createWrapper() }
+      )
+
+      await waitFor(() => {
+        expect(result.current.departmentDistribution).toEqual(mockDistribution)
+      })
+
+      const distributionCall = mockCallRpc.mock.calls.find(
+        (call) => call[0].fn === 'equipment_department_distribution'
+      )?.[0]
+
+      expect(distributionCall?.args).toEqual({
+        p_q: 'bom tiem dien',
+        p_don_vi: 5,
+        p_khoa_phong_array: ['Khoa Ngoai'],
+        p_nguoi_su_dung_array: ['Nguyen Van A'],
+        p_vi_tri_lap_dat_array: ['Phong 101'],
+        p_tinh_trang_array: ['Hoat dong'],
+        p_phan_loai_array: ['May loai A'],
+        p_nguon_kinh_phi_array: ['Ngan sach'],
+      })
+      expect(distributionCall?.args).not.toHaveProperty('p_page')
+      expect(distributionCall?.args).not.toHaveProperty('p_page_size')
+    })
+
     it('should fetch all filter option buckets with a single RPC', async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
         if (fn === 'equipment_list_enhanced') {

--- a/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
@@ -662,6 +662,9 @@ describe('useEquipmentData', () => {
       const callCountBeforeEvent = mockCallRpc.mock.calls.filter(
         (call) => call[0].fn === 'equipment_list_enhanced'
       ).length
+      const distributionCallCountBeforeEvent = mockCallRpc.mock.calls.filter(
+        (call) => call[0].fn === 'equipment_department_distribution'
+      ).length
 
       // Dispatch event
       window.dispatchEvent(new CustomEvent('equipment-cache-invalidated'))
@@ -672,6 +675,11 @@ describe('useEquipmentData', () => {
           (call) => call[0].fn === 'equipment_list_enhanced'
         ).length
         expect(callCountAfterEvent).toBeGreaterThan(callCountBeforeEvent)
+
+        const distributionCallCountAfterEvent = mockCallRpc.mock.calls.filter(
+          (call) => call[0].fn === 'equipment_department_distribution'
+        ).length
+        expect(distributionCallCountAfterEvent).toBeGreaterThan(distributionCallCountBeforeEvent)
       })
     })
   })

--- a/src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx
+++ b/src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx
@@ -61,6 +61,7 @@ type FiltersState = {
 type DataState = {
   data: { id: number }[]
   total: number
+  departmentDistribution: { department: string | null; label: string; count: number }[]
   isLoading: boolean
   isFetching: boolean
   shouldFetchData: boolean
@@ -222,6 +223,7 @@ function createDataState(overrides?: Partial<DataState>): DataState {
   return {
     data: [],
     total: 0,
+    departmentDistribution: [],
     isLoading: false,
     isFetching: false,
     shouldFetchData: true,
@@ -359,5 +361,17 @@ describe('useEquipmentPage tenant switching', () => {
     expect(mocks.setColumnFilters).toHaveBeenCalledWith([
       { id: 'tinh_trang_hien_tai', value: ['Chờ sửa chữa'] },
     ])
+  })
+
+  it('exposes department distribution from equipment data', () => {
+    const departmentDistribution = [
+      { department: 'Khoa Ngoai', label: 'Khoa Ngoai', count: 7 },
+      { department: null, label: 'Chưa cập nhật', count: 2 },
+    ]
+    state.data = createDataState({ departmentDistribution })
+
+    const { result } = renderHook(() => useEquipmentPage())
+
+    expect(result.current.departmentDistribution).toEqual(departmentDistribution)
   })
 })

--- a/src/app/(app)/equipment/_components/EquipmentDepartmentSummary.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDepartmentSummary.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
-import type { EquipmentDepartmentDistributionItem } from "../types"
+import type { EquipmentDepartmentDistributionItem } from "@/app/(app)/equipment/types"
 import type { DepartmentColorClasses } from "@/components/equipment/equipment-department-grouping"
 
 interface EquipmentDepartmentSummaryProps {

--- a/src/app/(app)/equipment/_components/EquipmentDepartmentSummary.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDepartmentSummary.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import * as React from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+import type { EquipmentDepartmentDistributionItem } from "../types"
+import type { DepartmentColorClasses } from "@/components/equipment/equipment-department-grouping"
+
+interface EquipmentDepartmentSummaryProps {
+  items: EquipmentDepartmentDistributionItem[]
+  colorClassByLabel: Record<string, DepartmentColorClasses>
+  selectedDepartments: string[]
+  onSelectDepartment: (department: string) => void
+}
+
+/** Renders department distribution chips for the current equipment result set. */
+export function EquipmentDepartmentSummary({
+  items,
+  colorClassByLabel,
+  selectedDepartments,
+  onSelectDepartment,
+}: EquipmentDepartmentSummaryProps) {
+  if (items.length === 0) return null
+
+  return (
+    <section
+      aria-label="Phân bố theo khoa/phòng"
+      className="rounded-md border bg-muted/20 px-3 py-2"
+    >
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm font-medium text-foreground">Phân bố theo khoa/phòng</div>
+        <div className="text-xs text-muted-foreground">
+          {items.length} khoa/phòng
+        </div>
+      </div>
+      <div className="max-h-24 overflow-y-auto pr-1">
+        <div className="flex flex-wrap gap-2">
+          {items.map((item) => {
+            const isSelectable = Boolean(item.department)
+            const isSelected = item.department
+              ? selectedDepartments.includes(item.department)
+              : false
+            const colors = colorClassByLabel[item.label]
+            return (
+              <Button
+                key={`${item.department ?? "__missing"}-${item.label}`}
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!isSelectable}
+                aria-label={`${item.label} ${item.count} thiết bị`}
+                onClick={() => {
+                  if (item.department) onSelectDepartment(item.department)
+                }}
+                className={cn(
+                  "h-8 gap-2 rounded-full border px-2.5 text-xs font-medium shadow-none",
+                  colors?.chipClassName,
+                  isSelected && "ring-1 ring-primary/40",
+                  !isSelectable && "cursor-default opacity-80"
+                )}
+              >
+                <span className="max-w-[12rem] truncate">{item.label}</span>
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "h-5 min-w-5 justify-center rounded-full border bg-background/80 px-1.5 text-[11px]",
+                    colors?.badgeClassName
+                  )}
+                >
+                  {item.count}
+                </Badge>
+              </Button>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/equipment/_components/EquipmentDialogContext.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDialogContext.tsx
@@ -77,6 +77,7 @@ export interface EquipmentDialogContextValue {
 // Context
 // ============================================
 
+/** Context for equipment page dialog state and mutation invalidation callbacks. */
 const EquipmentDialogContext = React.createContext<EquipmentDialogContextValue | null>(null)
 
 // ============================================
@@ -88,6 +89,7 @@ interface EquipmentDialogProviderProps {
   effectiveTenantKey: string
 }
 
+/** Provides equipment dialog orchestration state for the Equipment page. */
 export function EquipmentDialogProvider({
   children,
   effectiveTenantKey,
@@ -123,7 +125,7 @@ export function EquipmentDialogProvider({
       predicate: (q) => {
         const key = q.queryKey
         if (!Array.isArray(key)) return false
-        if (key[0] !== "equipment_list_enhanced") return false
+        if (key[0] !== "equipment_list_enhanced" && key[0] !== "equipment_department_distribution") return false
         const params = key[1] as Record<string, unknown>
         return params?.tenant === effectiveTenantKey
       },

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import type { ColumnFiltersState } from "@tanstack/react-table"
 import { Plus } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -33,7 +34,9 @@ import { EquipmentDialogs } from "../equipment-dialogs"
 import { EquipmentDialogProvider } from "./EquipmentDialogContext"
 import { EquipmentColumnsDialog } from "./EquipmentColumnsDialog"
 import { EquipmentBulkDeleteBar } from "./EquipmentBulkDeleteBar"
+import { EquipmentDepartmentSummary } from "./EquipmentDepartmentSummary"
 import { useEquipmentContext } from "../_hooks/useEquipmentContext"
+import { buildDepartmentColorClassByLabel } from "@/components/equipment/equipment-department-grouping"
 
 const EQUIPMENT_ENTITY = { singular: "thiết bị" } as const
 
@@ -121,6 +124,7 @@ function EquipmentPageContent({
 
     // Data
     total,
+    departmentDistribution,
     isLoading,
     isFetching,
     shouldFetchEquipment,
@@ -184,6 +188,33 @@ function EquipmentPageContent({
     canBulkSelect &&
     !isCardView &&
     floatingBarSelectionCount > 0
+  const departmentColorClassByLabel = React.useMemo(
+    () => buildDepartmentColorClassByLabel(departmentDistribution),
+    [departmentDistribution]
+  )
+  const rowDepartmentColorClassByLabel = React.useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(departmentColorClassByLabel).map(([label, colors]) => [
+          label,
+          colors.rowClassName,
+        ])
+      ),
+    [departmentColorClassByLabel]
+  )
+  const selectedDepartments = React.useMemo(() => {
+    const value = columnFilters.find((filter) => filter.id === "khoa_phong_quan_ly")?.value
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []
+  }, [columnFilters])
+  const handleSelectDepartmentSummary = React.useCallback(
+    (department: string) => {
+      setColumnFilters((current: ColumnFiltersState) => {
+        const withoutDepartment = current.filter((filter) => filter.id !== "khoa_phong_quan_ly")
+        return [...withoutDepartment, { id: "khoa_phong_quan_ly", value: [department] }]
+      })
+    },
+    [setColumnFilters]
+  )
 
   // Handle route sync pending actions using context
   React.useEffect(() => {
@@ -259,6 +290,13 @@ function EquipmentPageContent({
           onShowEquipmentDetails={(eq) => openDetailDialog(eq)}
         />
 
+        <EquipmentDepartmentSummary
+          items={departmentDistribution}
+          colorClassByLabel={departmentColorClassByLabel}
+          selectedDepartments={selectedDepartments}
+          onSelectDepartment={handleSelectDepartmentSummary}
+        />
+
         <Card>
           <CardContent className="space-y-4 px-4 pt-4 md:px-6">
             <EquipmentColumnsDialog table={table} />
@@ -272,6 +310,7 @@ function EquipmentPageContent({
               table={table}
               columns={columns}
               onShowDetails={(eq) => openDetailDialog(eq)}
+              departmentColorClassByLabel={rowDepartmentColorClassByLabel}
             />
           </CardContent>
 

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -331,7 +331,7 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
       predicate: (q) => {
         const key = q.queryKey
         if (!Array.isArray(key)) return false
-        if (key[0] !== "equipment_list_enhanced") return false
+        if (key[0] !== "equipment_list_enhanced" && key[0] !== "equipment_department_distribution") return false
         const queryParams = key[1] as Record<string, unknown>
         return (
           queryParams?.tenant === effectiveTenantKey &&

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -5,7 +5,12 @@ import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-quer
 import { callRpc } from "@/lib/rpc-client"
 import { useActiveUsageLogs } from "@/hooks/use-usage-logs"
 import type { Equipment } from "../types"
-import type { FilterBottomSheetData, FacilityOption, EquipmentListResponse } from "../types"
+import type {
+  EquipmentDepartmentDistributionItem,
+  EquipmentListResponse,
+  FacilityOption,
+  FilterBottomSheetData,
+} from "../types"
 
 export interface UseEquipmentDataParams {
   isGlobal: boolean
@@ -36,6 +41,7 @@ export interface UseEquipmentDataReturn {
   // Equipment data
   data: Equipment[]
   total: number
+  departmentDistribution: EquipmentDepartmentDistributionItem[]
   isLoading: boolean
   isFetching: boolean
 
@@ -87,6 +93,7 @@ function normalizeBucket(data: EquipmentFilterBucketsResponse | undefined, key: 
   return data?.[key] ?? EMPTY_FILTER_BUCKET
 }
 
+/** Loads equipment table data, filter buckets, and department distribution for the current scope. */
 export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDataReturn {
   const {
     isGlobal,
@@ -214,6 +221,48 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
   const total = equipmentRes?.total ?? 0
   const isLoading = isEqLoading
 
+  const { data: departmentDistributionData } = useQuery<EquipmentDepartmentDistributionItem[]>({
+    queryKey: [
+      "equipment_department_distribution",
+      {
+        tenant: effectiveTenantKey,
+        role: userRole,
+        diaBan: userDiaBanId,
+        donVi: effectiveSelectedDonVi,
+        q: debouncedSearch || null,
+        khoa_phong_array: selectedDepartments,
+        nguoi_su_dung_array: selectedUsers,
+        vi_tri_lap_dat_array: selectedLocations,
+        tinh_trang_array: selectedStatuses,
+        phan_loai_array: selectedClassifications,
+        nguon_kinh_phi_array: selectedFundingSources,
+      },
+    ],
+    queryFn: async ({ signal }) => {
+      const result = await callRpc<EquipmentDepartmentDistributionItem[]>({
+        fn: "equipment_department_distribution",
+        args: {
+          p_q: debouncedSearch || null,
+          p_don_vi: effectiveSelectedDonVi,
+          p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
+          p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
+          p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
+          p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
+          p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
+          p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
+        },
+        signal,
+      })
+      return result ?? []
+    },
+    enabled: shouldFetchData,
+    staleTime: 120_000,
+    gcTime: 10 * 60_000,
+    refetchOnWindowFocus: false,
+  })
+
+  const departmentDistribution = departmentDistributionData ?? []
+
   // Map context facilities to FacilityOption format
   const facilities: FacilityOption[] = React.useMemo(() => {
     if (!showSelector || !contextFacilities) return []
@@ -313,6 +362,7 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
     () => ({
       data,
       total,
+      departmentDistribution,
       isLoading,
       isFetching,
       shouldFetchData,
@@ -337,6 +387,7 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
     [
       data,
       total,
+      departmentDistribution,
       isLoading,
       isFetching,
       shouldFetchData,

--- a/src/app/(app)/equipment/equipment-content.tsx
+++ b/src/app/(app)/equipment/equipment-content.tsx
@@ -18,6 +18,8 @@ import {
 } from "@/components/ui/table"
 import { MobileEquipmentListItem } from "@/components/mobile-equipment-list-item"
 import type { Equipment } from "@/types/database"
+import { cn } from "@/lib/utils"
+import { getEquipmentDepartmentLabel } from "@/components/equipment/equipment-department-grouping"
 
 export interface EquipmentContentProps {
   isGlobal: boolean
@@ -29,8 +31,10 @@ export interface EquipmentContentProps {
   table: Table<Equipment>
   columns: ColumnDef<Equipment>[]
   onShowDetails: (equipment: Equipment) => void
+  departmentColorClassByLabel?: Record<string, string>
 }
 
+/** Renders the equipment results as desktop table rows or mobile cards. */
 export function EquipmentContent({
   isGlobal,
   isRegionalLeader,
@@ -41,6 +45,7 @@ export function EquipmentContent({
   table,
   columns,
   onShowDetails,
+  departmentColorClassByLabel,
 }: EquipmentContentProps) {
   // Global users and regional leaders must select a tenant/facility first
   if ((isGlobal || isRegionalLeader) && !shouldFetchEquipment) {
@@ -159,7 +164,12 @@ export function EquipmentContent({
                 key={row.id}
                 data-state={row.getIsSelected() && "selected"}
                 data-equipment-id={row.original.id}
-                className="hover:bg-muted cursor-pointer"
+                className={cn(
+                  "cursor-pointer hover:bg-muted",
+                  departmentColorClassByLabel?.[
+                    getEquipmentDepartmentLabel(row.original.khoa_phong_quan_ly)
+                  ]
+                )}
                 onClick={() => onShowDetails(row.original)}
               >
                 {row.getVisibleCells().map((cell) => (

--- a/src/app/(app)/equipment/types.ts
+++ b/src/app/(app)/equipment/types.ts
@@ -104,6 +104,12 @@ export interface EquipmentListResponse {
   pageSize: number
 }
 
+export interface EquipmentDepartmentDistributionItem {
+  department: string | null
+  label: string
+  count: number
+}
+
 /**
  * Main hook return value interface
  * Dialog state is now managed by EquipmentDialogContext
@@ -126,6 +132,7 @@ export interface UseEquipmentPageReturn {
   // Data
   data: Equipment[]
   total: number
+  departmentDistribution: EquipmentDepartmentDistributionItem[]
   isLoading: boolean
   isFetching: boolean
   shouldFetchEquipment: boolean

--- a/src/app/(app)/equipment/use-equipment-page.tsx
+++ b/src/app/(app)/equipment/use-equipment-page.tsx
@@ -14,6 +14,7 @@ import { useEquipmentData } from "./_hooks/useEquipmentData"
 import { useEquipmentTable } from "./_hooks/useEquipmentTable"
 import { useEquipmentExport } from "./_hooks/useEquipmentExport"
 import { useEquipmentRouteSync } from "./_hooks/useEquipmentRouteSync"
+import { buildDepartmentColorClassByLabel } from "@/components/equipment/equipment-department-grouping"
 
 // Re-export hook return type
 export type { UseEquipmentPageReturn } from "./types"
@@ -116,10 +117,15 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
     [auth.user?.role]
   )
 
+  const departmentColorClassByLabel = React.useMemo(
+    () => buildDepartmentColorClassByLabel(data.departmentDistribution),
+    [data.departmentDistribution]
+  )
+
   // Columns definition
   const columns = React.useMemo(
-    () => createEquipmentColumns({ renderActions, canBulkSelect }),
-    [renderActions, canBulkSelect]
+    () => createEquipmentColumns({ renderActions, canBulkSelect, departmentColorClassByLabel }),
+    [renderActions, canBulkSelect, departmentColorClassByLabel]
   )
 
   // Table hook
@@ -273,6 +279,7 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
       // Data
       data: data.data,
       total: data.total,
+      departmentDistribution: data.departmentDistribution,
       isLoading: data.isLoading,
       isFetching: data.isFetching,
       shouldFetchEquipment: data.shouldFetchData,

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -28,6 +28,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'equipment_statuses_list_for_tenant',
   'equipment_funding_sources_list_for_tenant',
   'equipment_filter_buckets',
+  'equipment_department_distribution',
   'equipment_bulk_import',
   // Repairs
   'repair_request_list',

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -73,6 +73,7 @@ describe('RPC proxy whitelist', () => {
 
   it.each([
     'equipment_filter_buckets',
+    'equipment_department_distribution',
     'dashboard_kpi_summary',
   ])('allows performance RPC "%s" through whitelist checks', async (fn) => {
     const res = await invokeRpcProxy(fn)

--- a/src/components/equipment/__tests__/equipment-department-grouping.test.ts
+++ b/src/components/equipment/__tests__/equipment-department-grouping.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildDepartmentColorClassByLabel,
+  getEquipmentDepartmentLabel,
+  UNKNOWN_DEPARTMENT_LABEL,
+} from '../equipment-department-grouping'
+
+describe('equipment-department-grouping', () => {
+  it('normalizes empty department labels', () => {
+    expect(getEquipmentDepartmentLabel(null)).toBe(UNKNOWN_DEPARTMENT_LABEL)
+    expect(getEquipmentDepartmentLabel('   ')).toBe(UNKNOWN_DEPARTMENT_LABEL)
+  })
+
+  it('keeps color assignment stable when distribution order changes', () => {
+    const first = buildDepartmentColorClassByLabel([
+      { label: 'Khoa Ngoại' },
+      { label: 'Khoa Nội' },
+    ])
+    const second = buildDepartmentColorClassByLabel([
+      { label: 'Khoa Nội' },
+      { label: 'Khoa Ngoại' },
+    ])
+
+    expect(second['Khoa Ngoại']).toBe(first['Khoa Ngoại'])
+    expect(second['Khoa Nội']).toBe(first['Khoa Nội'])
+  })
+})

--- a/src/components/equipment/equipment-department-grouping.ts
+++ b/src/components/equipment/equipment-department-grouping.ts
@@ -54,18 +54,26 @@ const DEPARTMENT_COLOR_PALETTE: DepartmentColorClasses[] = [
   },
 ]
 
+function getStablePaletteIndex(label: string): number {
+  let hash = 0
+  for (let index = 0; index < label.length; index += 1) {
+    hash = (hash * 31 + label.charCodeAt(index)) >>> 0
+  }
+  return hash % DEPARTMENT_COLOR_PALETTE.length
+}
+
 /** Returns a display-safe department label for grouping and coloring equipment rows. */
-export function getEquipmentDepartmentLabel(value: string | null | undefined) {
+export function getEquipmentDepartmentLabel(value: string | null | undefined): string {
   const trimmed = value?.trim()
   return trimmed ? trimmed : UNKNOWN_DEPARTMENT_LABEL
 }
 
-/** Assigns stable pastel color classes to department labels in result order. */
+/** Assigns stable pastel color classes to department labels. */
 export function buildDepartmentColorClassByLabel(
   distribution: DepartmentDistributionLike[]
-) {
-  return distribution.reduce<Record<string, DepartmentColorClasses>>((acc, item, index) => {
-    acc[item.label] = DEPARTMENT_COLOR_PALETTE[index % DEPARTMENT_COLOR_PALETTE.length]
+): Record<string, DepartmentColorClasses> {
+  return distribution.reduce<Record<string, DepartmentColorClasses>>((acc, item) => {
+    acc[item.label] = DEPARTMENT_COLOR_PALETTE[getStablePaletteIndex(item.label)]
     return acc
   }, {})
 }

--- a/src/components/equipment/equipment-department-grouping.ts
+++ b/src/components/equipment/equipment-department-grouping.ts
@@ -1,0 +1,71 @@
+/** Fallback label for equipment rows without a managing department. */
+export const UNKNOWN_DEPARTMENT_LABEL = "Chưa cập nhật"
+
+interface DepartmentDistributionLike {
+  label: string
+}
+
+export interface DepartmentColorClasses {
+  rowClassName: string
+  chipClassName: string
+  badgeClassName: string
+}
+
+const DEPARTMENT_COLOR_PALETTE: DepartmentColorClasses[] = [
+  {
+    rowClassName: "bg-sky-50/60 hover:bg-sky-50",
+    chipClassName: "border-sky-200 bg-sky-50 text-sky-800 hover:bg-sky-100",
+    badgeClassName: "border-sky-200 bg-sky-100 text-sky-800",
+  },
+  {
+    rowClassName: "bg-emerald-50/60 hover:bg-emerald-50",
+    chipClassName: "border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100",
+    badgeClassName: "border-emerald-200 bg-emerald-100 text-emerald-800",
+  },
+  {
+    rowClassName: "bg-violet-50/60 hover:bg-violet-50",
+    chipClassName: "border-violet-200 bg-violet-50 text-violet-800 hover:bg-violet-100",
+    badgeClassName: "border-violet-200 bg-violet-100 text-violet-800",
+  },
+  {
+    rowClassName: "bg-amber-50/60 hover:bg-amber-50",
+    chipClassName: "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100",
+    badgeClassName: "border-amber-200 bg-amber-100 text-amber-800",
+  },
+  {
+    rowClassName: "bg-cyan-50/60 hover:bg-cyan-50",
+    chipClassName: "border-cyan-200 bg-cyan-50 text-cyan-800 hover:bg-cyan-100",
+    badgeClassName: "border-cyan-200 bg-cyan-100 text-cyan-800",
+  },
+  {
+    rowClassName: "bg-rose-50/60 hover:bg-rose-50",
+    chipClassName: "border-rose-200 bg-rose-50 text-rose-800 hover:bg-rose-100",
+    badgeClassName: "border-rose-200 bg-rose-100 text-rose-800",
+  },
+  {
+    rowClassName: "bg-lime-50/60 hover:bg-lime-50",
+    chipClassName: "border-lime-200 bg-lime-50 text-lime-800 hover:bg-lime-100",
+    badgeClassName: "border-lime-200 bg-lime-100 text-lime-800",
+  },
+  {
+    rowClassName: "bg-slate-50/70 hover:bg-slate-100/70",
+    chipClassName: "border-slate-200 bg-slate-50 text-slate-700 hover:bg-slate-100",
+    badgeClassName: "border-slate-200 bg-slate-100 text-slate-700",
+  },
+]
+
+/** Returns a display-safe department label for grouping and coloring equipment rows. */
+export function getEquipmentDepartmentLabel(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : UNKNOWN_DEPARTMENT_LABEL
+}
+
+/** Assigns stable pastel color classes to department labels in result order. */
+export function buildDepartmentColorClassByLabel(
+  distribution: DepartmentDistributionLike[]
+) {
+  return distribution.reduce<Record<string, DepartmentColorClasses>>((acc, item, index) => {
+    acc[item.label] = DEPARTMENT_COLOR_PALETTE[index % DEPARTMENT_COLOR_PALETTE.length]
+    return acc
+  }, {})
+}

--- a/src/components/equipment/equipment-table-columns.tsx
+++ b/src/components/equipment/equipment-table-columns.tsx
@@ -215,24 +215,23 @@ export function createEquipmentColumns(
           return <div className="truncate max-w-xs">{formatted}</div>
         }
 
-        if (value === null || value === undefined || value === "") {
-          return <div className="italic text-muted-foreground">Chưa có dữ liệu</div>
+        if (key === "khoa_phong_quan_ly") {
+          const label = getEquipmentDepartmentLabel(
+            typeof value === "string" ? value : value == null ? null : String(value)
+          )
+          const colors = departmentColorClassByLabel?.[label]
+          return (
+            <Badge
+              variant="outline"
+              className={cn("max-w-xs truncate border font-medium", colors?.badgeClassName)}
+            >
+              {label}
+            </Badge>
+          )
         }
 
-        if (key === "khoa_phong_quan_ly") {
-          const label = getEquipmentDepartmentLabel(String(value))
-          const colors = departmentColorClassByLabel?.[label]
-
-          if (colors) {
-            return (
-              <Badge
-                variant="outline"
-                className={cn("max-w-xs truncate border font-medium", colors.badgeClassName)}
-              >
-                {label}
-              </Badge>
-            )
-          }
+        if (value === null || value === undefined || value === "") {
+          return <div className="italic text-muted-foreground">Chưa có dữ liệu</div>
         }
 
         if (key === "ma_thiet_bi") {

--- a/src/components/equipment/equipment-table-columns.tsx
+++ b/src/components/equipment/equipment-table-columns.tsx
@@ -15,6 +15,9 @@ import { LinkedRequestRowIndicator } from "@/components/equipment-linked-request
 import { createSelectionColumn } from "@/components/ui/data-table-selection"
 import { TruncatedText } from "@/components/ui/truncated-text"
 import type { Equipment } from "@/types/database"
+import type { DepartmentColorClasses } from "@/components/equipment/equipment-department-grouping"
+import { getEquipmentDepartmentLabel } from "@/components/equipment/equipment-department-grouping"
+import { cn } from "@/lib/utils"
 import {
   formatFullDateToDisplay,
   formatPartialDateToDisplay,
@@ -131,6 +134,7 @@ const filterableColumns: (keyof Equipment)[] = [
 interface CreateEquipmentColumnsConfig {
   renderActions: (equipment: Equipment) => React.ReactNode
   canBulkSelect?: boolean
+  departmentColorClassByLabel?: Record<string, DepartmentColorClasses>
 }
 
 /**
@@ -141,7 +145,7 @@ interface CreateEquipmentColumnsConfig {
 export function createEquipmentColumns(
   config: CreateEquipmentColumnsConfig
 ): ColumnDef<Equipment>[] {
-  const { renderActions, canBulkSelect = false } = config
+  const { renderActions, canBulkSelect = false, departmentColorClassByLabel } = config
 
   const dataColumns = (Object.keys(columnLabels) as Array<keyof Equipment>).map((key) => {
     const columnDef: ColumnDef<Equipment> = {
@@ -213,6 +217,22 @@ export function createEquipmentColumns(
 
         if (value === null || value === undefined || value === "") {
           return <div className="italic text-muted-foreground">Chưa có dữ liệu</div>
+        }
+
+        if (key === "khoa_phong_quan_ly") {
+          const label = getEquipmentDepartmentLabel(String(value))
+          const colors = departmentColorClassByLabel?.[label]
+
+          if (colors) {
+            return (
+              <Badge
+                variant="outline"
+                className={cn("max-w-xs truncate border font-medium", colors.badgeClassName)}
+              >
+                {label}
+              </Badge>
+            )
+          }
         }
 
         if (key === "ma_thiet_bi") {

--- a/src/hooks/__tests__/use-cached-equipment.mutation-invalidation.test.ts
+++ b/src/hooks/__tests__/use-cached-equipment.mutation-invalidation.test.ts
@@ -31,6 +31,7 @@ import {
   useBulkDeleteEquipment,
   useDeleteEquipment,
   useRestoreEquipment,
+  useUpdateEquipment,
 } from '@/hooks/use-cached-equipment'
 
 describe('use-cached-equipment mutation invalidation', () => {
@@ -39,6 +40,7 @@ describe('use-cached-equipment mutation invalidation', () => {
   })
 
   it.each([
+    ['update', useUpdateEquipment, undefined, { id: '1' }],
     ['delete', useDeleteEquipment, undefined, undefined],
     ['restore', useRestoreEquipment, undefined, undefined],
     ['bulk delete', useBulkDeleteEquipment, { deleted_count: 2 }, [1, 2]],

--- a/src/hooks/__tests__/use-cached-equipment.mutation-invalidation.test.ts
+++ b/src/hooks/__tests__/use-cached-equipment.mutation-invalidation.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockInvalidateQueries, mockUseMutation } = vi.hoisted(() => ({
+  mockInvalidateQueries: vi.fn(),
+  mockUseMutation: vi.fn((options: unknown) => options),
+}))
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query')
+  return {
+    ...actual,
+    useMutation: (options: unknown) => mockUseMutation(options),
+    useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  }
+})
+
+vi.mock('@/hooks/use-toast', () => ({
+  toast: vi.fn(),
+}))
+
+vi.mock('@/lib/rpc-client', () => ({
+  callRpc: vi.fn(),
+}))
+
+type MutationWithSuccess = {
+  onSuccess: (data?: { deleted_count?: number }, ids?: number[]) => void
+}
+
+import {
+  useBulkDeleteEquipment,
+  useDeleteEquipment,
+  useRestoreEquipment,
+} from '@/hooks/use-cached-equipment'
+
+describe('use-cached-equipment mutation invalidation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ['delete', useDeleteEquipment, undefined, undefined],
+    ['restore', useRestoreEquipment, undefined, undefined],
+    ['bulk delete', useBulkDeleteEquipment, { deleted_count: 2 }, [1, 2]],
+  ] as const)('invalidates department distribution after %s mutation', (_label, useHook, data, ids) => {
+    const { result } = renderHook(() => useHook())
+
+    act(() => {
+      ;(result.current as MutationWithSuccess).onSuccess(data, ids)
+    })
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['equipment_department_distribution'],
+      refetchType: 'active',
+    })
+  })
+})

--- a/src/hooks/use-cached-equipment.ts
+++ b/src/hooks/use-cached-equipment.ts
@@ -107,6 +107,8 @@ export function useUpdateEquipment() {
     },
     onSuccess: (_result, params) => {
       // Invalidate and refetch equipment lists
+      queryClient.invalidateQueries({ queryKey: ['equipment_list_enhanced'], refetchType: 'active' })
+      queryClient.invalidateQueries({ queryKey: ['equipment_department_distribution'], refetchType: 'active' })
       queryClient.invalidateQueries({ queryKey: ['equipment'] })
       // Refetch the edited equipment detail instead of writing an unknown boolean payload into cache
       queryClient.invalidateQueries({ queryKey: equipmentKeys.detail(String(params.id)) })
@@ -139,6 +141,8 @@ function useCreateEquipment() {
     },
     onSuccess: () => {
       // Invalidate all equipment queries to refetch data
+      queryClient.invalidateQueries({ queryKey: ['equipment_list_enhanced'], refetchType: 'active' })
+      queryClient.invalidateQueries({ queryKey: ['equipment_department_distribution'], refetchType: 'active' })
       queryClient.invalidateQueries({ queryKey: ['equipment'] })
       // Invalidate dashboard stats to update KPI cards
       queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })

--- a/src/hooks/use-cached-equipment.ts
+++ b/src/hooks/use-cached-equipment.ts
@@ -9,6 +9,7 @@ import type { Equipment, User, UserRole } from '@/types/database'
 import { USER_ROLES } from '@/types/database'
 
 // Phase 3: Use advanced cache keys from cache manager
+/** Cache key helpers for legacy cached equipment hooks. */
 export const equipmentKeys = CacheKeys.equipment
 
 type EquipmentPayload = Record<string, unknown>
@@ -34,6 +35,7 @@ function toCacheScopeUser(user: Session['user'] | null | undefined): CacheScopeU
 }
 
 // Phase 3: Enhanced equipment fetching with advanced caching
+/** Loads legacy cached equipment data with user-scoped cache keys. */
 export function useEquipment(filters?: {
   search?: string
   phong_ban?: string
@@ -95,6 +97,7 @@ function useEquipmentDetail(id: string | null) {
 }
 
 // Update equipment mutation with cache invalidation
+/** Updates equipment records and invalidates dependent equipment caches. */
 export function useUpdateEquipment() {
   const queryClient = useQueryClient()
 
@@ -156,6 +159,7 @@ function useCreateEquipment() {
 }
 
 // Delete equipment mutation
+/** Deletes an equipment record and invalidates active equipment result caches. */
 export function useDeleteEquipment() {
   const queryClient = useQueryClient()
 
@@ -166,6 +170,7 @@ export function useDeleteEquipment() {
     onSuccess: () => {
       // Invalidate main equipment table queries and refetch active pages immediately
       queryClient.invalidateQueries({ queryKey: ['equipment_list_enhanced'], refetchType: 'active' })
+      queryClient.invalidateQueries({ queryKey: ['equipment_department_distribution'], refetchType: 'active' })
       // Keep legacy cache family invalidation for older screens
       queryClient.invalidateQueries({ queryKey: ['equipment'] })
       // Keep active usage status in sync with table actions
@@ -191,6 +196,7 @@ export function useDeleteEquipment() {
 }
 
 // Restore equipment mutation
+/** Restores a deleted equipment record and invalidates active equipment result caches. */
 export function useRestoreEquipment() {
   const queryClient = useQueryClient()
 
@@ -201,6 +207,7 @@ export function useRestoreEquipment() {
     onSuccess: () => {
       // Invalidate main equipment table queries and refetch active pages immediately
       queryClient.invalidateQueries({ queryKey: ['equipment_list_enhanced'], refetchType: 'active' })
+      queryClient.invalidateQueries({ queryKey: ['equipment_department_distribution'], refetchType: 'active' })
       // Keep legacy cache family invalidation for older screens
       queryClient.invalidateQueries({ queryKey: ['equipment'] })
       // Keep active usage status in sync with table actions
@@ -226,6 +233,7 @@ export function useRestoreEquipment() {
 }
 
 // Bulk delete equipment mutation
+/** Deletes multiple equipment records and invalidates active equipment result caches. */
 export function useBulkDeleteEquipment() {
   const queryClient = useQueryClient()
 
@@ -239,6 +247,7 @@ export function useBulkDeleteEquipment() {
     onSuccess: (data, ids) => {
       // Invalidate main equipment table queries and refetch active pages immediately
       queryClient.invalidateQueries({ queryKey: ['equipment_list_enhanced'], refetchType: 'active' })
+      queryClient.invalidateQueries({ queryKey: ['equipment_department_distribution'], refetchType: 'active' })
       // Keep legacy cache family invalidation for older screens
       queryClient.invalidateQueries({ queryKey: ['equipment'] })
       // Keep active usage status in sync with table actions

--- a/supabase/migrations/20260624131500_add_equipment_department_distribution.sql
+++ b/supabase/migrations/20260624131500_add_equipment_department_distribution.sql
@@ -5,6 +5,9 @@
 --
 -- Verification: run
 -- supabase/tests/equipment_department_distribution_smoke.sql.
+--
+-- Forward-only rollback: add a follow-up migration that revokes execute and
+-- drops public.equipment_department_distribution with the same signature.
 
 BEGIN;
 

--- a/supabase/migrations/20260624131500_add_equipment_department_distribution.sql
+++ b/supabase/migrations/20260624131500_add_equipment_department_distribution.sql
@@ -1,0 +1,264 @@
+-- Add filtered department distribution for the Equipment page summary.
+--
+-- The RPC mirrors equipment_list_enhanced filtering and tenant guards, but
+-- returns aggregate department counts for the full filtered result set.
+--
+-- Verification: run
+-- supabase/tests/equipment_department_distribution_smoke.sql.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.equipment_department_distribution(
+  p_q text DEFAULT NULL::text,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung text DEFAULT NULL::text,
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat text DEFAULT NULL::text,
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang text DEFAULT NULL::text,
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai text DEFAULT NULL::text,
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi text DEFAULT NULL::text,
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]
+)
+RETURNS TABLE(department text, label text, "count" integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := '';
+  v_user_id TEXT := NULL;
+  v_claim_donvi BIGINT := NULL;
+  v_allowed_don_vi BIGINT[];
+  v_effective_donvi BIGINT := NULL;
+  v_department_scope TEXT;
+  v_where TEXT := '1=1 AND is_deleted = false';
+  v_jwt_claims JSONB;
+  v_sanitized_q TEXT;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := COALESCE(
+    v_jwt_claims ->>'app_role',
+    v_jwt_claims ->>'role',
+    ''
+  );
+  v_user_id := NULLIF(v_jwt_claims ->>'user_id', '');
+  v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF lower(v_role) IN ('global', 'admin') THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective_donvi := p_don_vi;
+    ELSE
+      v_effective_donvi := NULL;
+    END IF;
+  ELSE
+    IF v_allowed_don_vi IS NOT NULL AND array_length(v_allowed_don_vi, 1) > 0 THEN
+      IF p_don_vi IS NOT NULL THEN
+        IF p_don_vi = ANY(v_allowed_don_vi) THEN
+          v_effective_donvi := p_don_vi;
+        ELSE
+          RETURN;
+        END IF;
+      ELSE
+        v_effective_donvi := NULL;
+      END IF;
+    ELSE
+      RETURN;
+    END IF;
+  END IF;
+
+  IF lower(v_role) = 'user' AND v_department_scope IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF v_effective_donvi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ' || v_effective_donvi;
+  END IF;
+
+  IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin') AND v_allowed_don_vi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = '
+      || quote_literal(v_department_scope);
+  END IF;
+
+  IF p_khoa_phong_array IS NOT NULL AND array_length(p_khoa_phong_array, 1) > 0 THEN
+    v_where := v_where || ' AND khoa_phong_quan_ly = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_khoa_phong_array) AS x), ',') || '])';
+  ELSIF p_khoa_phong IS NOT NULL AND trim(p_khoa_phong) != '' THEN
+    v_where := v_where || ' AND khoa_phong_quan_ly = ' || quote_literal(p_khoa_phong);
+  END IF;
+
+  IF p_nguoi_su_dung_array IS NOT NULL AND array_length(p_nguoi_su_dung_array, 1) > 0 THEN
+    v_where := v_where || ' AND nguoi_dang_truc_tiep_quan_ly = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguoi_su_dung_array) AS x), ',') || '])';
+  ELSIF p_nguoi_su_dung IS NOT NULL AND trim(p_nguoi_su_dung) != '' THEN
+    v_where := v_where || ' AND nguoi_dang_truc_tiep_quan_ly = ' || quote_literal(p_nguoi_su_dung);
+  END IF;
+
+  IF p_vi_tri_lap_dat_array IS NOT NULL AND array_length(p_vi_tri_lap_dat_array, 1) > 0 THEN
+    v_where := v_where || ' AND vi_tri_lap_dat = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_vi_tri_lap_dat_array) AS x), ',') || '])';
+  ELSIF p_vi_tri_lap_dat IS NOT NULL AND trim(p_vi_tri_lap_dat) != '' THEN
+    v_where := v_where || ' AND vi_tri_lap_dat = ' || quote_literal(p_vi_tri_lap_dat);
+  END IF;
+
+  IF p_tinh_trang_array IS NOT NULL AND array_length(p_tinh_trang_array, 1) > 0 THEN
+    v_where := v_where || ' AND tinh_trang_hien_tai = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_tinh_trang_array) AS x), ',') || '])';
+  ELSIF p_tinh_trang IS NOT NULL AND trim(p_tinh_trang) != '' THEN
+    v_where := v_where || ' AND tinh_trang_hien_tai = ' || quote_literal(p_tinh_trang);
+  END IF;
+
+  IF p_phan_loai_array IS NOT NULL AND array_length(p_phan_loai_array, 1) > 0 THEN
+    v_where := v_where || ' AND phan_loai_theo_nd98 = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_phan_loai_array) AS x), ',') || '])';
+  ELSIF p_phan_loai IS NOT NULL AND trim(p_phan_loai) != '' THEN
+    v_where := v_where || ' AND phan_loai_theo_nd98 = ' || quote_literal(p_phan_loai);
+  END IF;
+
+  IF p_nguon_kinh_phi_array IS NOT NULL AND array_length(p_nguon_kinh_phi_array, 1) > 0 THEN
+    IF 'Chưa có' = ANY(p_nguon_kinh_phi_array) THEN
+      DECLARE v_non_empty_sources TEXT[];
+      BEGIN
+        SELECT ARRAY(SELECT x FROM unnest(p_nguon_kinh_phi_array) AS x WHERE x != 'Chưa có') INTO v_non_empty_sources;
+        IF v_non_empty_sources IS NOT NULL AND array_length(v_non_empty_sources, 1) > 0 THEN
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''' OR TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+            array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(v_non_empty_sources) AS x), ',') || ']))';
+        ELSE
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+        END IF;
+      END;
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+        array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguon_kinh_phi_array) AS x), ',') || '])';
+    END IF;
+  ELSIF p_nguon_kinh_phi IS NOT NULL AND trim(p_nguon_kinh_phi) != '' THEN
+    IF p_nguon_kinh_phi = 'Chưa có' THEN
+      v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ' || quote_literal(p_nguon_kinh_phi);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_where := v_where || ' AND (ten_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR ma_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR serial ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR so_luu_hanh ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR model ILIKE ' || quote_literal('%' || v_sanitized_q || '%') || ')';
+  END IF;
+
+  RETURN QUERY EXECUTE format(
+    'SELECT department,
+            COALESCE(department, ''Chưa cập nhật'') AS label,
+            COUNT(*)::integer AS "count"
+       FROM (
+         SELECT NULLIF(BTRIM(khoa_phong_quan_ly), '''') AS department
+         FROM public.thiet_bi
+         WHERE %s
+       ) scoped
+       GROUP BY department
+       ORDER BY COUNT(*) DESC, label ASC',
+    v_where
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.equipment_department_distribution(
+  text,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.equipment_department_distribution(
+  text,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.equipment_department_distribution(
+  text,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) TO service_role;
+
+COMMENT ON FUNCTION public.equipment_department_distribution(
+  text,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) IS
+  'Returns department distribution counts for the full Equipment search/filter result set.';
+
+COMMIT;

--- a/supabase/tests/equipment_department_distribution_smoke.sql
+++ b/supabase/tests/equipment_department_distribution_smoke.sql
@@ -1,0 +1,200 @@
+-- supabase/tests/equipment_department_distribution_smoke.sql
+-- Purpose: smoke-test filtered equipment department distribution.
+-- Non-destructive: wrapped in transaction and rolled back.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_suffix text := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_tenant bigint;
+  v_other_tenant bigint;
+  v_count integer;
+BEGIN
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Department Distribution Tenant ' || v_suffix, true)
+  RETURNING id INTO v_tenant;
+
+  INSERT INTO public.don_vi(name, active)
+  VALUES ('Smoke Department Distribution Other Tenant ' || v_suffix, true)
+  RETURNING id INTO v_other_tenant;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    model,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai,
+    nguoi_dang_truc_tiep_quan_ly,
+    vi_tri_lap_dat,
+    phan_loai_theo_nd98,
+    nguon_kinh_phi,
+    is_deleted
+  )
+  VALUES
+    (
+      'SMK-DEPT-DIST-NGOAI-1-' || v_suffix,
+      'Bom tiem dien ' || v_suffix,
+      'BTD-100',
+      v_tenant,
+      'Khoa Ngoai ' || v_suffix,
+      'Hoat dong',
+      'User A ' || v_suffix,
+      'Room 101 ' || v_suffix,
+      'Class A ' || v_suffix,
+      'Fund A ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-DEPT-DIST-NGOAI-2-' || v_suffix,
+      'Bom tiem dien ' || v_suffix,
+      'BTD-200',
+      v_tenant,
+      'Khoa Ngoai ' || v_suffix,
+      'Hoat dong',
+      'User B ' || v_suffix,
+      'Room 102 ' || v_suffix,
+      'Class A ' || v_suffix,
+      'Fund A ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-DEPT-DIST-NOI-' || v_suffix,
+      'Bom tiem dien ' || v_suffix,
+      'BTD-300',
+      v_tenant,
+      'Khoa Noi ' || v_suffix,
+      'Hoat dong',
+      'User C ' || v_suffix,
+      'Room 103 ' || v_suffix,
+      'Class A ' || v_suffix,
+      'Fund A ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-DEPT-DIST-MISSING-' || v_suffix,
+      'Bom tiem dien ' || v_suffix,
+      'BTD-400',
+      v_tenant,
+      NULL,
+      'Hoat dong',
+      'User D ' || v_suffix,
+      'Room 104 ' || v_suffix,
+      'Class A ' || v_suffix,
+      'Fund A ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-DEPT-DIST-SEARCH-OUT-' || v_suffix,
+      'May tho khac ' || v_suffix,
+      'BTD-500',
+      v_tenant,
+      'Khoa Ngoai ' || v_suffix,
+      'Hoat dong',
+      'User E ' || v_suffix,
+      'Room 105 ' || v_suffix,
+      'Class A ' || v_suffix,
+      'Fund A ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-DEPT-DIST-OTHER-' || v_suffix,
+      'Bom tiem dien ' || v_suffix,
+      'BTD-600',
+      v_other_tenant,
+      'Khoa Ngoai ' || v_suffix,
+      'Hoat dong',
+      'User Other ' || v_suffix,
+      'Room Other ' || v_suffix,
+      'Class A ' || v_suffix,
+      'Fund A ' || v_suffix,
+      false
+    );
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'to_qltb',
+      'user_id', '900001',
+      'don_vi', v_tenant
+    )::text,
+    true
+  );
+
+  SELECT count
+  INTO v_count
+  FROM public.equipment_department_distribution(
+    p_q => 'Bom tiem dien ' || v_suffix,
+    p_don_vi => v_tenant
+  )
+  WHERE department = 'Khoa Ngoai ' || v_suffix;
+
+  IF v_count IS DISTINCT FROM 2 THEN
+    RAISE EXCEPTION 'expected Khoa Ngoai count 2, got %', v_count;
+  END IF;
+
+  SELECT count
+  INTO v_count
+  FROM public.equipment_department_distribution(
+    p_q => 'Bom tiem dien ' || v_suffix,
+    p_don_vi => v_tenant
+  )
+  WHERE department = 'Khoa Noi ' || v_suffix;
+
+  IF v_count IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'expected Khoa Noi count 1, got %', v_count;
+  END IF;
+
+  SELECT count
+  INTO v_count
+  FROM public.equipment_department_distribution(
+    p_q => 'Bom tiem dien ' || v_suffix,
+    p_don_vi => v_tenant
+  )
+  WHERE department IS NULL
+    AND label = 'Chưa cập nhật';
+
+  IF v_count IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'expected missing department count 1, got %', v_count;
+  END IF;
+
+  SELECT count(*)
+  INTO v_count
+  FROM public.equipment_department_distribution(
+    p_q => 'Bom tiem dien ' || v_suffix,
+    p_don_vi => v_tenant,
+    p_khoa_phong_array => ARRAY['Khoa Ngoai ' || v_suffix]
+  );
+
+  IF v_count IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'department filter should return one distribution bucket, got %', v_count;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'user',
+      'user_id', '900002',
+      'don_vi', v_tenant,
+      'khoa_phong', 'Khoa Ngoai ' || v_suffix
+    )::text,
+    true
+  );
+
+  SELECT count(*)
+  INTO v_count
+  FROM public.equipment_department_distribution(
+    p_q => 'Bom tiem dien ' || v_suffix,
+    p_don_vi => v_tenant
+  );
+
+  IF v_count IS DISTINCT FROM 1 THEN
+    RAISE EXCEPTION 'role=user should see one department bucket, got %', v_count;
+  END IF;
+
+  RAISE NOTICE 'equipment_department_distribution smoke: PASSED';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Add department distribution summary chips for filtered/searched equipment results.
- Add subtle pastel department coloring for desktop rows and matching summary badges.
- Add `equipment_department_distribution` RPC, whitelist entry, migration, and SQL smoke test.

## Test Plan
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test -- src/app/(app)/equipment/__tests__/useEquipmentData.test.ts src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx src/app/(app)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx src/app/(app)/equipment/__tests__/equipment-content.desktop-interactions.test.tsx src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts`
- `node scripts/npm-run.js run react-doctor`

## Database
- Migration: `supabase/migrations/20260624131500_add_equipment_department_distribution.sql`
- Smoke test: `supabase/tests/equipment_department_distribution_smoke.sql`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds department distribution summary chips to the Equipment page and subtle pastel row/badge coloring to make it easier to scan and filter by department. Also ensures `equipment_department_distribution` is invalidated on write mutations via both dialog context and legacy `use-cached-equipment` hooks.

- **New Features**
  - Department summary chips show counts for the current search/filters; clicking a chip applies `khoa_phong_quan_ly` without resetting other filters.
  - Stable pastel colors for desktop rows and matching badges; missing departments display as “Chưa cập nhật”.
  - `departmentDistribution` is exposed from `useEquipmentData` and `useEquipmentPage`; added `EquipmentDepartmentSummary`, color mapping via `equipment-department-grouping`, and column badge styling.
  - Cache invalidation updates both `equipment_list_enhanced` and `equipment_department_distribution` after mutations (dialog context and legacy `use-cached-equipment`), scoped to the active tenant.

- **Migration**
  - Apply Supabase migration `supabase/migrations/20260624131500_add_equipment_department_distribution.sql` (creates and grants `equipment_department_distribution`; whitelisted in `allowed-functions.ts`).
  - Optional: run smoke test `supabase/tests/equipment_department_distribution_smoke.sql`.

<sup>Written for commit 3294d21ba26c23cb8eebe861c8749b99952231b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a department distribution summary on the equipment page with clickable chips showing counts.
  * Equipment table rows and department badges now use department-based visual styling for easier scanning.

* **Bug Fixes**
  * Selecting a department chip applies the correct department filter while preserving existing filters.
  * When department data is missing, the UI shows the fallback label (“Chưa cập nhật”) with consistent styling.

* **Tests / Verification**
  * Added automated interaction/unit coverage and a backend smoke test for the department distribution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->