### PR TITLE
fix: add scroll to category detail pane

### DIFF
--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryDetailPane.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryDetailPane.test.tsx
@@ -1,0 +1,58 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { describe, expect, it, vi } from "vitest"
+
+import { DeviceQuotaCategoryDetailPane } from "../_components/DeviceQuotaCategoryDetailPane"
+import type { CategoryListItem } from "../_types/categories"
+
+vi.mock("../_components/DeviceQuotaCategoryAssignedEquipment", () => ({
+  DeviceQuotaCategoryAssignedEquipment: ({
+    nhomId,
+    variant,
+  }: {
+    nhomId: number
+    variant?: string
+  }) => (
+    <div data-testid="assigned-equipment-panel" data-nhom-id={nhomId} data-variant={variant}>
+      Equipment panel
+    </div>
+  ),
+}))
+
+const leafCategory: CategoryListItem = {
+  id: 10,
+  parent_id: null,
+  ma_nhom: "R",
+  ten_nhom: "Root Leaf",
+  phan_loai: "A",
+  don_vi_tinh: null,
+  thu_tu_hien_thi: 1,
+  level: 1,
+  so_luong_hien_co: 2,
+  so_luong_toi_da: 5,
+  so_luong_toi_thieu: null,
+  mo_ta: null,
+}
+
+describe("DeviceQuotaCategoryDetailPane", () => {
+  it("keeps the assigned equipment area in an internal vertical scroll region", () => {
+    render(
+      <DeviceQuotaCategoryDetailPane
+        category={leafCategory}
+        allCategories={[leafCategory]}
+        aggregatedCount={2}
+        aggregatedQuota={{ total: 5, hasUnknown: false }}
+        isLeaf
+        donViId={1}
+      />
+    )
+
+    const detailPane = screen.getByTestId("device-quota-category-detail-pane")
+    const assignedPanel = screen.getByTestId("assigned-equipment-panel")
+    const scrollRegion = assignedPanel.parentElement
+
+    expect(detailPane).toHaveClass("h-full", "flex", "flex-col", "overflow-hidden")
+    expect(scrollRegion).toHaveClass("min-h-0", "flex-1", "overflow-y-auto")
+  })
+})

--- a/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
+++ b/src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render, screen, fireEvent, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import "@testing-library/jest-dom"
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
@@ -407,7 +408,7 @@ describe('DeviceQuotaCategoryTree', () => {
     const row = screen.getByRole('button', { name: /Chọn danh mục 01\.01: Leaf A/i })
     expect(row).toHaveAttribute('aria-pressed', 'true')
     expect(row).toHaveAttribute('title', 'Leaf A')
-    expect(row).toHaveTextContent('2/5')
+    expect(row).toHaveAccessibleName(/Tình trạng 2\/5/i)
   })
 
   it('clicking a category row updates the detail pane without rendering equipment inline', () => {
@@ -429,7 +430,7 @@ describe('DeviceQuotaCategoryTree', () => {
     renderWithThreeLevelTree()
 
     const leafBRow = screen.getByRole('button', { name: /Chọn danh mục 01\.02: Leaf B/i })
-    const leafBMenu = within(leafBRow).getByRole('button', { name: /Mở menu danh mục Leaf B/i })
+    const leafBMenu = screen.getByRole('button', { name: /Mở menu danh mục Leaf B/i })
 
     fireEvent.keyDown(leafBMenu, { key: 'Enter' })
 
@@ -438,18 +439,21 @@ describe('DeviceQuotaCategoryTree', () => {
     expect(leafBMenu).not.toHaveClass('opacity-0')
   })
 
-  it('selects a focused category row with Enter or Space', () => {
+  it('selects a focused category row with Enter or Space', async () => {
+    const user = userEvent.setup()
     renderWithThreeLevelTree()
 
     const detailPane = screen.getByTestId('device-quota-category-detail-pane')
     const emptyLeaf = screen.getByRole('button', { name: /Chọn danh mục 02\.01: Empty Leaf A/i })
     const emptyLeafB = screen.getByRole('button', { name: /Chọn danh mục 02\.02: Empty Leaf B/i })
 
-    fireEvent.keyDown(emptyLeaf, { key: 'Enter' })
+    emptyLeaf.focus()
+    await user.keyboard('{Enter}')
     expect(emptyLeaf).toHaveAttribute('aria-pressed', 'true')
     expect(within(detailPane).getByText('Empty Leaf A')).toBeInTheDocument()
 
-    fireEvent.keyDown(emptyLeafB, { key: ' ' })
+    emptyLeafB.focus()
+    await user.keyboard(' ')
     expect(emptyLeafB).toHaveAttribute('aria-pressed', 'true')
     expect(within(detailPane).getByText('Empty Leaf B')).toBeInTheDocument()
   })

--- a/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDetailPane.tsx
+++ b/src/app/(app)/device-quota/categories/_components/DeviceQuotaCategoryDetailPane.tsx
@@ -46,6 +46,7 @@ function buildCategoryPath(
   return path
 }
 
+/** Shows quota metadata and assigned equipment for the selected category. */
 export function DeviceQuotaCategoryDetailPane({
   category,
   allCategories,
@@ -77,9 +78,9 @@ export function DeviceQuotaCategoryDetailPane({
   return (
     <Card
       data-testid="device-quota-category-detail-pane"
-      className="h-full overflow-hidden"
+      className="h-full flex flex-col overflow-hidden"
     >
-      <CardHeader className="space-y-3 pb-4">
+      <CardHeader className="shrink-0 space-y-3 pb-4">
         <CardDescription className="line-clamp-1">
           {parentPath.length > 0
             ? parentPath.map((item) => item.ten_nhom).join(" / ")
@@ -120,7 +121,7 @@ export function DeviceQuotaCategoryDetailPane({
           <QuotaProgressBar current={aggregatedCount} max={quotaMax} />
         </div>
       </CardHeader>
-      <CardContent className="pt-0">
+      <CardContent className="min-h-0 flex-1 overflow-y-auto pt-0">
         {isLeaf ? (
           <DeviceQuotaCategoryAssignedEquipment
             nhomId={category.id}


### PR DESCRIPTION
## Summary
- Add an internal vertical scroll region to the device-quota category detail panel
- Keep the detail header fixed while long assigned-equipment content scrolls
- Fix existing category tree tests for accessible name/menu querying and native keyboard activation

## Tests
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js npx vitest run "src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryDetailPane.test.tsx"
- node scripts/npm-run.js npx vitest run "src/app/(app)/device-quota/categories/__tests__/DeviceQuotaCategoryTree.test.tsx"
- node scripts/npm-run.js run react-doctor
- pre-commit and pre-push lefthook gates passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal vertical scroll to the device-quota category detail pane so long equipment lists scroll while the header stays fixed. Also updates tests for accessible names and native keyboard interactions.

- **Bug Fixes**
  - Converted the detail pane to a flex layout with a fixed header and an internal vertical scroll region for assigned equipment.
  - Updated tests: added a scroll-region test, switched to accessible name queries, and used `@testing-library/user-event` for Enter/Space selection.

<sup>Written for commit ceaee9279bcf9ac1770e1df82d5f094026f9516d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the device quota category detail panel layout so its contents scroll correctly within the panel.
  * Refined keyboard selection behavior in category lists, including Enter and Space interactions.
  * Adjusted row accessibility feedback so selected category details update more reliably when navigating with the keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->