### PR TITLE
docs: add equipment aggregate global search spec

### DIFF
--- a/openspec/changes/add-equipment-aggregate-global-search/design.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/design.md
@@ -1,0 +1,177 @@
+# Equipment Aggregate Global Search Design
+
+## Context
+
+The feature serves elevated users who need system-level visibility across facilities. The key user question is not "which exact rows match?" but "which regions or facilities have how many matching devices?"
+
+The UI must avoid duplicating the equipment catalog. Global search is a summary and navigation layer; device-level operations remain in the existing equipment page.
+
+## Goals
+
+- Provide a header search entry point for elevated users.
+- Support repeated keyword searches without leaving the result workspace.
+- Show aggregate counts by region first for admin/global users.
+- Drill from region aggregate to facility aggregate.
+- Show regional leader users only their permitted scope.
+- Visualize aggregate counts with an interactive horizontal bar chart.
+- Deep-link to the existing equipment page for device-level inspection.
+
+## Non-Goals
+
+- Autocomplete, live search, or command-palette behavior.
+- Device-detail rendering inside global search.
+- Manual filter controls beyond keyword and role scope.
+- Cross-entity search.
+- Export or historical trend analysis.
+
+## UX Flow
+
+### Header Entry
+
+The header shows a compact search input only for `admin`/`global` and `regional_leader`.
+
+- Placeholder: `Tim thiet bi toan he thong...`
+- Submit triggers only on Enter or the search button.
+- Submit navigates to `/global-search?q=<keyword>`.
+- Empty or whitespace-only submit does not navigate.
+
+### Search Workspace
+
+`/global-search` is the primary analysis workspace.
+
+- It has a larger search input at the top.
+- It reads the initial keyword from `q`.
+- Submitting a new keyword updates URL query state and refreshes aggregate data in place.
+- The page shows a scope badge:
+  - `Toan he thong` for admin/global.
+  - `Khu vuc: <region name>` for single-scope regional leaders.
+  - `Pham vi duoc phan quyen` for multi-region scoped users.
+
+### Admin/Global Result Hierarchy
+
+Level 1 groups by region:
+
+- Bar label: region name.
+- Value: matching equipment count.
+- Summary: total matching equipment, number of regions, number of facilities.
+- Clicking a region drills into Level 2.
+
+Level 2 groups by facility within the selected region:
+
+- Breadcrumb: `Toan he thong / <Region>`.
+- Bar label: facility name.
+- Value: matching equipment count.
+- Table action: `Xem thiet bi`.
+- Clicking `Xem thiet bi` deep-links to the equipment page with keyword and selected facility/region params.
+
+### Regional Leader Result Hierarchy
+
+If the user has one region scope, the page opens directly at facility grouping.
+
+If the user has multiple region scopes, the page uses the same region-first hierarchy as admin/global, but only for regions in the user's allowed scope.
+
+### Empty and Small-Result States
+
+- No matches: show `Khong co thiet bi phu hop trong pham vi cua ban`.
+- One facility match: show the aggregate row and make `Xem thiet bi` prominent.
+- Errors: show a retry affordance and avoid exposing raw database errors.
+
+## Data Contract
+
+The aggregate search RPC should return grouped rows, not equipment rows.
+
+Suggested request:
+
+```ts
+type EquipmentAggregateSearchRequest = {
+  query: string
+  groupBy: "region" | "facility"
+  regionId?: number | null
+  limit?: number
+}
+```
+
+Suggested response:
+
+```ts
+type EquipmentAggregateSearchRow = {
+  groupType: "region" | "facility"
+  groupId: number
+  groupName: string
+  parentRegionId: number | null
+  parentRegionName: string | null
+  equipmentCount: number
+  facilityCount: number
+}
+```
+
+Suggested summary:
+
+```ts
+type EquipmentAggregateSearchSummary = {
+  totalEquipmentCount: number
+  regionCount: number
+  facilityCount: number
+  query: string
+  scopeLabel: string
+}
+```
+
+## Search Semantics
+
+The keyword matches:
+
+- equipment name
+- model
+- serial
+- equipment group/category
+
+The keyword does not match:
+
+- internal equipment code, because codes are facility-defined and not comparable across the system
+
+Implementation may use accent-insensitive matching if the existing database helpers support it, but the v1 user contract is aggregate scope and field selection, not generalized full-text search.
+
+## Authorization
+
+The database function must validate JWT claims before aggregating.
+
+- Treat `admin` as `global` where role checks happen outside the RPC proxy.
+- Admin/global users may aggregate across all facilities.
+- Regional leaders may aggregate only facilities allowed by their regional scope.
+- Other roles must be rejected for this aggregate global search RPC/page.
+- Client-supplied `regionId` is a drill-down hint, not an authority boundary.
+
+## UI Components
+
+- Header search entry component.
+- Global search page shell.
+- Search form.
+- Scope/summary strip.
+- Drill-down breadcrumb.
+- Horizontal bar chart.
+- Results table mirroring chart data.
+- Empty/error/loading states.
+
+Chart and table must use the same normalized data source to prevent count drift.
+
+## Deep-Linking
+
+The global search page does not render device rows. It deep-links into the existing equipment page:
+
+- Region context: `/equipment?search=<q>&region=<regionId>`
+- Facility context: `/equipment?search=<q>&facility=<facilityId>`
+
+If the equipment page does not currently support one of these query params, implementation must add route-sync support there rather than building a duplicate detail list.
+
+## Testing Strategy
+
+- Unit-test query param parsing and role-based visibility helpers.
+- Add RPC tests or SQL verification for admin/global, regional leader, and unauthorized roles.
+- Add focused React tests for:
+  - header submit navigation
+  - search page submit updates URL
+  - admin region-to-facility drill-down
+  - regional leader facility-level default
+  - deep-link action construction
+- Run mandatory TypeScript/React gates for changed TS/TSX files.

--- a/openspec/changes/add-equipment-aggregate-global-search/proposal.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/proposal.md
@@ -1,0 +1,58 @@
+# Add Equipment Aggregate Global Search
+
+## Why
+
+Admin/global and regional leader users need a fast way to answer "where are matching devices located?" without opening each facility's equipment list. The current equipment search is list-oriented and facility-oriented, so it does not support cross-region comparison or aggregate discovery.
+
+This change adds a role-scoped equipment aggregate search experience: users submit a keyword from the app header, view counts grouped by region or facility, inspect an interactive bar chart, then deep-link into the existing equipment page when they need device-level detail.
+
+## What Changes
+
+- Add a header global equipment search entry point for `admin`/`global` and `regional_leader` users.
+- Add a dedicated `/global-search` workspace that supports repeated submit-based searches through the page search box and URL query state.
+- Add an equipment aggregate search RPC/API contract that returns grouped counts, not device rows.
+- Match equipment by equipment name, model, serial, and equipment group/category.
+- Exclude internal facility-defined equipment codes from matching.
+- Scope results by role:
+  - `admin`/`global`: all accessible regions and facilities.
+  - `regional_leader`: only facilities in assigned region/scope.
+  - other roles: no header entry point and no page access.
+- Present admin/global results first by region, then drill down to facilities within a selected region.
+- Present regional leader results by facility when the user has a single region scope; use region grouping only when their scope spans multiple regions.
+- Render an interactive horizontal bar chart and a table from the same aggregate data.
+- Use deep-links into the existing equipment page for detail inspection instead of rendering device rows in global search.
+
+## Non-Goals
+
+- No autocomplete or live suggestions in v1.
+- No status, category, region, facility, or date filters beyond keyword and role scope.
+- No device-detail list inside global search.
+- No multi-entity search across repairs, transfers, maintenance, or users.
+- No export, trend, or historical comparison.
+
+## Impact
+
+- Affected specs:
+  - `equipment-aggregate-search` (new)
+- Affected database/API areas:
+  - New Supabase RPC for grouped equipment counts, likely exposed through `/api/rpc/[fn]`.
+  - Equipment search SQL over `thiet_bi`, facility (`don_vi`), region (`dia_ban`), and equipment group/category data.
+  - Role guard logic must preserve `admin` -> `global` normalization outside the RPC proxy where applicable.
+- Affected frontend areas:
+  - App header/navigation search entry point.
+  - New `/global-search` route/page.
+  - Global search hook/client data layer.
+  - Chart/table components using existing Recharts dependency.
+  - Equipment page route-sync/deep-link handling for `search`, `region`, and `facility` query params if not already supported.
+- Security:
+  - RPC must validate JWT claims and enforce region/facility scope server-side.
+  - Regional leader scope must be derived from allowed facilities/regions, not trusted from client params.
+  - Other roles must not receive aggregate counts outside their facility.
+- Performance:
+  - Search must aggregate in SQL with pagination/limits on groups where needed.
+  - Query should avoid returning device rows to the client.
+  - Search predicates should use existing indexes where possible and add targeted indexes only after inspecting live schema/query plans.
+
+## Relationship To Existing Proposals
+
+`openspec/changes/add-vietnamese-global-search` is an older active proposal for cross-entity, full-text, list-style global search. This proposal is intentionally narrower and different: equipment-only, aggregate-first, chart-oriented, and deep-linking to the existing equipment list for details.

--- a/openspec/changes/add-equipment-aggregate-global-search/specs/equipment-aggregate-search/spec.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/specs/equipment-aggregate-search/spec.md
@@ -1,0 +1,183 @@
+# Equipment Aggregate Global Search Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Header Aggregate Search Entry
+
+The system SHALL provide a header search entry point for equipment aggregate global search to users with `admin`, `global`, or `regional_leader` roles.
+
+#### Scenario: Elevated user sees header search
+- **WHEN** a user with role `admin`, `global`, or `regional_leader` views the authenticated app shell
+- **THEN** the header shows a compact equipment global search input
+
+#### Scenario: Unsupported role does not see header search
+- **WHEN** a user with role other than `admin`, `global`, or `regional_leader` views the authenticated app shell
+- **THEN** the header does not show the equipment global search input
+
+#### Scenario: Header submit opens search workspace
+- **WHEN** an allowed user submits a non-empty keyword with Enter or the search button
+- **THEN** the system navigates to `/global-search?q=<keyword>`
+
+#### Scenario: Header does not autocomplete
+- **WHEN** an allowed user types in the header search input
+- **THEN** the system does not show autocomplete, suggestions, or live result previews in v1
+
+### Requirement: Search Workspace
+
+The system SHALL provide a `/global-search` workspace for repeated aggregate equipment searches.
+
+#### Scenario: Initial query from URL
+- **WHEN** a user opens `/global-search?q=May%20X-quang`
+- **THEN** the page search input is populated with `May X-quang`
+- **AND** aggregate results are loaded for that keyword within the user's role scope
+
+#### Scenario: Repeated search in workspace
+- **WHEN** a user submits a new keyword from the search workspace
+- **THEN** the page updates the URL query
+- **AND** refreshes the chart and table in place without returning to the previous page
+
+#### Scenario: Empty workspace query
+- **WHEN** the search workspace has no non-empty keyword
+- **THEN** the page prompts the user to enter a keyword
+- **AND** does not execute aggregate search
+
+### Requirement: Equipment Match Fields
+
+The system SHALL match aggregate equipment search keywords against equipment name, model, serial, and equipment group/category fields.
+
+#### Scenario: Match equipment name
+- **WHEN** an allowed user searches for `May X-quang`
+- **THEN** equipment whose name matches `May X-quang` contributes to aggregate counts
+
+#### Scenario: Match model
+- **WHEN** an allowed user searches for a model value
+- **THEN** equipment whose model matches the keyword contributes to aggregate counts
+
+#### Scenario: Match serial
+- **WHEN** an allowed user searches for a serial value
+- **THEN** equipment whose serial matches the keyword contributes to aggregate counts
+
+#### Scenario: Match equipment group
+- **WHEN** an allowed user searches for an equipment group/category name
+- **THEN** equipment in matching groups/categories contributes to aggregate counts
+
+#### Scenario: Exclude internal equipment code
+- **WHEN** an allowed user searches for a facility-defined internal equipment code
+- **THEN** the internal code field is not used as a search predicate
+
+### Requirement: Role-Scoped Aggregate Authorization
+
+The system SHALL enforce role-based scope for aggregate equipment search on the server side.
+
+#### Scenario: Admin alias has global scope
+- **WHEN** a user with legacy role `admin` performs aggregate equipment search
+- **THEN** the system treats the user as global for this feature
+
+#### Scenario: Global user sees all regions
+- **WHEN** a user with role `global` searches without a selected drill-down region
+- **THEN** results include matching equipment from all regions and facilities
+
+#### Scenario: Regional leader sees assigned scope only
+- **WHEN** a user with role `regional_leader` searches
+- **THEN** results include only matching equipment from regions/facilities assigned to that user
+
+#### Scenario: Other roles are rejected
+- **WHEN** a user with an unsupported role opens or calls aggregate equipment search
+- **THEN** the system denies access and returns no aggregate counts
+
+#### Scenario: Client region parameter does not expand scope
+- **WHEN** a regional leader submits a region or facility parameter outside their allowed scope
+- **THEN** the system rejects or ignores the unauthorized scope server-side
+
+### Requirement: Admin Region-First Aggregation
+
+The system SHALL show admin/global users aggregate search results grouped by region before facility-level drill-down.
+
+#### Scenario: Region-level results
+- **WHEN** an admin/global user searches for a keyword
+- **THEN** the first result level groups matching equipment counts by region
+
+#### Scenario: Region drill-down
+- **WHEN** an admin/global user selects a region result
+- **THEN** the workspace shows matching equipment counts grouped by facility within that region
+
+#### Scenario: Breadcrumb returns to all regions
+- **WHEN** an admin/global user is viewing facility results for a selected region
+- **THEN** the breadcrumb allows returning to the all-regions view for the same keyword
+
+### Requirement: Regional Leader Facility Aggregation
+
+The system SHALL optimize regional leader results for their assigned scope.
+
+#### Scenario: Single-region leader opens facility level
+- **WHEN** a regional leader assigned to one region searches
+- **THEN** the workspace shows matching equipment counts grouped by facility in that region
+
+#### Scenario: Multi-region leader opens region level
+- **WHEN** a regional leader assigned to multiple regions searches
+- **THEN** the workspace first groups matching equipment counts by the allowed regions
+
+### Requirement: Aggregate Chart And Table
+
+The system SHALL render aggregate equipment search results as both an interactive horizontal bar chart and a table using the same data source.
+
+#### Scenario: Chart shows sorted bars
+- **WHEN** aggregate results are loaded
+- **THEN** the chart displays horizontal bars sorted by matching equipment count descending
+
+#### Scenario: Table mirrors chart
+- **WHEN** aggregate results are loaded
+- **THEN** the table shows the same region or facility groups and counts as the chart
+
+#### Scenario: Chart drill-down interaction
+- **WHEN** a user clicks a region bar at region level
+- **THEN** the workspace drills down to facility-level results for that region
+
+#### Scenario: Small result state
+- **WHEN** a keyword matches equipment in only one facility
+- **THEN** the workspace still shows the aggregate row and provides a prominent detail deep-link
+
+#### Scenario: Empty result state
+- **WHEN** no equipment matches the keyword within the user's allowed scope
+- **THEN** the workspace displays an empty state instead of an empty chart
+
+### Requirement: Equipment Detail Deep Links
+
+The system SHALL link aggregate search results to the existing equipment page for device-level detail inspection.
+
+#### Scenario: Region deep-link
+- **WHEN** a user chooses to view equipment for a region aggregate result
+- **THEN** the system links to the equipment page with the current keyword and region parameter
+
+#### Scenario: Facility deep-link
+- **WHEN** a user chooses to view equipment for a facility aggregate result
+- **THEN** the system links to the equipment page with the current keyword and facility parameter
+
+#### Scenario: No device rows in global search
+- **WHEN** aggregate search results are shown
+- **THEN** the global search workspace does not render a device-detail list
+
+### Requirement: Aggregate Search Summary
+
+The system SHALL display a concise summary of aggregate equipment search results.
+
+#### Scenario: Summary counts
+- **WHEN** aggregate results are loaded
+- **THEN** the page displays total matching equipment count, number of matching regions, and number of matching facilities within scope
+
+#### Scenario: Scope badge
+- **WHEN** aggregate search results are displayed
+- **THEN** the page displays a scope badge describing whether results are global or region-scoped
+
+### Requirement: Aggregate Search Performance
+
+The system SHALL compute aggregate search results without returning equipment rows to the client.
+
+#### Scenario: Aggregated RPC response
+- **WHEN** the client requests aggregate search results
+- **THEN** the server returns grouped counts and summary metadata
+- **AND** does not return individual equipment records
+
+#### Scenario: Query stays server-side
+- **WHEN** a keyword matches many equipment records
+- **THEN** aggregation happens in SQL/server-side logic before the response is sent to the browser

--- a/openspec/changes/add-equipment-aggregate-global-search/tasks.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/tasks.md
@@ -1,0 +1,75 @@
+# Implementation Tasks
+
+## 1. Discovery And Contracts
+
+- [ ] 1.1 Inspect current equipment list search fields, route query params, and facility/region filters.
+- [ ] 1.2 Inspect live schema/RPC patterns for `thiet_bi`, `don_vi`, `dia_ban`, equipment group/category, and regional leader scoping.
+- [ ] 1.3 Confirm whether existing equipment page supports `search`, `region`, and `facility` deep-link params.
+- [ ] 1.4 Define final RPC name, request shape, response shape, and TypeScript types.
+- [ ] 1.5 Confirm existing indexes and query plan before adding new indexes.
+
+## 2. Backend Aggregate Search
+
+- [ ] 2.1 Create Supabase migration for the aggregate equipment search RPC.
+- [ ] 2.2 Validate JWT role/user claims inside the RPC.
+- [ ] 2.3 Normalize `admin` to `global` where needed.
+- [ ] 2.4 Enforce admin/global all-facility scope.
+- [ ] 2.5 Enforce regional leader allowed-region/facility scope server-side.
+- [ ] 2.6 Reject unsupported roles for this RPC.
+- [ ] 2.7 Match keyword against equipment name, model, serial, and equipment group/category.
+- [ ] 2.8 Exclude internal equipment code from search matching.
+- [ ] 2.9 Return grouped aggregate counts for `region` and `facility` modes.
+- [ ] 2.10 Grant execute permission only as required by the app's RPC pattern.
+- [ ] 2.11 Add the RPC to the API proxy allowlist if the app calls it through `/api/rpc/[fn]`.
+- [ ] 2.12 Run Supabase MCP security advisors after applying the migration.
+
+## 3. Client Data Layer
+
+- [ ] 3.1 Add TypeScript request/response types for aggregate equipment search.
+- [ ] 3.2 Add a TanStack Query hook with stable query keys.
+- [ ] 3.3 Gate the hook on non-empty trimmed query and allowed role.
+- [ ] 3.4 Normalize API errors into existing UI error patterns.
+
+## 4. Header Entry Point
+
+- [ ] 4.1 Add a compact header search input for `admin`/`global` and `regional_leader`.
+- [ ] 4.2 Hide the entry point for all other roles.
+- [ ] 4.3 Submit only on Enter or search button click.
+- [ ] 4.4 Navigate to `/global-search?q=<keyword>` on valid submit.
+- [ ] 4.5 Add focused tests for visibility and submit behavior.
+
+## 5. Global Search Page
+
+- [ ] 5.1 Add `/global-search` page/route.
+- [ ] 5.2 Read and update keyword from URL query state.
+- [ ] 5.3 Render top search form, scope badge, summary, chart, table, breadcrumb, loading, error, and empty states.
+- [ ] 5.4 Implement admin/global region-first view.
+- [ ] 5.5 Implement region drill-down to facility grouping.
+- [ ] 5.6 Implement regional leader default facility grouping for single-region scope.
+- [ ] 5.7 Implement multi-region regional leader hierarchy when applicable.
+- [ ] 5.8 Build deep-links to the existing equipment page for region/facility context.
+- [ ] 5.9 Add focused tests for drill-down, URL updates, and deep-link construction.
+
+## 6. Equipment Page Deep-Link Support
+
+- [ ] 6.1 Add or verify support for `search=<keyword>`.
+- [ ] 6.2 Add or verify support for `region=<regionId>`.
+- [ ] 6.3 Add or verify support for `facility=<facilityId>`.
+- [ ] 6.4 Preserve existing equipment page behavior for normal users.
+- [ ] 6.5 Add focused tests for query-param hydration if new support is required.
+
+## 7. Verification
+
+- [ ] 7.1 Run `node scripts/npm-run.js run verify:no-explicit-any`.
+- [ ] 7.2 Run `node scripts/npm-run.js run verify:dedupe`.
+- [ ] 7.3 Run `node scripts/npm-run.js run typecheck`.
+- [ ] 7.4 Run focused backend/RPC verification for role scopes and field matching.
+- [ ] 7.5 Run focused React tests for changed UI behavior.
+- [ ] 7.6 Run `node scripts/npm-run.js run react-doctor`.
+- [ ] 7.7 Manually verify chart rendering and drill-down in browser.
+
+## 8. Release Notes
+
+- [ ] 8.1 Document that v1 is submit-only and has no autocomplete.
+- [ ] 8.2 Document that global search aggregates equipment counts only.
+- [ ] 8.3 Document that detail inspection happens through existing equipment page deep-links.


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal/design/tasks for equipment aggregate global search
- Define role-scoped region/facility aggregation and chart drill-down UX
- Keep device details in existing equipment page via deep-links

## Validation
- openspec validate add-equipment-aggregate-global-search --strict
- pre-commit hooks passed
- pre-push hooks passed, including typecheck

Implementation is intentionally not started until this proposal is reviewed and approved.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenSpec design/spec/tasks for an equipment aggregate global search with region/facility summaries and deep-links into the existing equipment page.

- **New Features**
  - Header search for `admin`/`global` and `regional_leader`; submit-only, no autocomplete.
  - Region-first view for admin/global; drill into facilities. Regional leaders see only their scope and default to facility groups when single-region.
  - Horizontal bar chart and table share the same aggregate data; clickable bars drill down.
  - Server-side RPC returns grouped counts only; matches name/model/serial/group; excludes internal codes.
  - Authorization enforces role and region/facility scope; deep-link to `/equipment` with `search`, `region`, or `facility` params.

<sup>Written for commit 621049f140d779a448300e63dd306d28ea06ed5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new global equipment search workspace with role-based access from the header.
  * Search now shows aggregated results by region and facility, with chart/table views and drill-down navigation.
  * Results include a summary count and deep-link into the existing equipment page for device-level details.

* **Bug Fixes**
  * Improved search behavior by matching equipment names, models, serials, and categories while excluding internal codes.
  * Added clearer empty, single-result, and error-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->