### PR TITLE
docs: add ZBS phone notification OpenSpec

### DIFF
--- a/openspec/changes/add-zalo-repair-request-group-notifications/design.md
+++ b/openspec/changes/add-zalo-repair-request-group-notifications/design.md
@@ -1,3 +1,5 @@
+> Superseded: This Zalo Bot group-chat design is retained only as historical context. The current approved direction is ZBS phone-number delivery in `openspec/changes/add-zalo-repair-request-zbs-phone-notifications/`.
+
 ## Context
 The target workflow is narrow: when a user creates a repair request through the existing `repair_request_create` RPC, the hospital's existing Zalo group should receive one text alert.
 
@@ -33,4 +35,3 @@ The current hospital group exists, but the Zalo Bot does not. The implementation
 - Before implementation, verify the real Zalo setup manually: bot created, webhook configured over HTTPS, bot added to the group, inbound group event received, group `chat.id` captured, and a test `sendMessage` succeeds.
 - For SQL/DB changes, use Supabase MCP only, preserve `SECURITY DEFINER`, `SET search_path = public, pg_temp`, grants/revokes, JWT guards, and run Supabase security advisor after applying migrations.
 - For TypeScript/React route/client changes, run repo gates in the required order: `verify:no-explicit-any`, `typecheck`, focused tests, and React Doctor diff scan.
-

--- a/openspec/changes/add-zalo-repair-request-group-notifications/proposal.md
+++ b/openspec/changes/add-zalo-repair-request-group-notifications/proposal.md
@@ -1,3 +1,5 @@
+> Superseded: This Zalo Bot group-chat direction is no longer the current rollout plan. Use `openspec/changes/add-zalo-repair-request-zbs-phone-notifications/` as the source of truth for the approved ZBS phone-number notification direction.
+
 ## Why
 Repair requests currently rely on users opening the application to notice new work. The hospital already has a responsible Zalo group chat, so new repair requests should also create an operational alert in that fixed group.
 
@@ -25,4 +27,3 @@ Zalo Bot group support is currently documented as Beta/internal trial, and the b
   - Route handler tests for webhook secret validation and group `chat.id` parsing.
   - Unit tests for Zalo message formatting, outbound API error handling, idempotency, and retry status transitions.
   - Manual live smoke test against a real Zalo Bot/group before enabling production notification dispatch.
-

--- a/openspec/changes/add-zalo-repair-request-group-notifications/tasks.md
+++ b/openspec/changes/add-zalo-repair-request-group-notifications/tasks.md
@@ -1,3 +1,5 @@
+> Superseded: Do not implement these Zalo Bot group-chat tasks. Use `openspec/changes/add-zalo-repair-request-zbs-phone-notifications/tasks.md` for the active ZBS phone-number roadmap.
+
 ## 1. Zalo Bot Onboarding
 - [ ] 1.1 Create the Zalo Bot and capture the `BOT_TOKEN` in the deployment secret store.
 - [ ] 1.2 Configure a production HTTPS webhook with `setWebhook` and a generated `ZALO_WEBHOOK_SECRET_TOKEN`.
@@ -33,4 +35,3 @@
 - [ ] 5.5 Run focused route-handler and dispatcher tests.
 - [ ] 5.6 Run `node scripts/npm-run.js npx react-doctor@latest . --verbose -y --project nextn --offline --diff main` if any React/Next app code changes.
 - [ ] 5.7 Run `openspec validate add-zalo-repair-request-group-notifications --strict`.
-

--- a/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/design.md
+++ b/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/design.md
@@ -1,0 +1,103 @@
+# Design: ZBS phone notifications for repair requests
+
+## Context
+The target workflow is narrow: when `repair_request_create` successfully creates a row in `yeu_cau_sua_chua`, the system should notify one or more configured Zalo recipients by phone number for the same tenant (`don_vi_id`) as that repair request.
+
+Official ZBS docs separate the main choices:
+- Phone delivery uses `POST https://business.openapi.zalo.me/message/template` with `phone`, `template_id`, `template_data`, and `tracking_id`.
+- UID delivery uses `POST https://openapi.zalo.me/v3.0/oa/message/template` with `user_id`, `template_id`, and `template_data`.
+- ZBS templates are structured messages registered and reviewed by Zalo Business Solutions. A template can be used for both phone and UID delivery, but each send request must match the approved template data shape.
+- Webhooks are inbound events from Zalo to the app. For phone sends, delivery events include `event_name=user_received_message`, recipient phone, `msg_id`, `tracking_id`, and delivery time, signed by `X-ZEvent-Signature`.
+
+## Goals / Non-Goals
+Goals:
+- Send repair-request creation notifications through ZBS to specific normalized phone numbers.
+- Avoid blocking repair request creation when Zalo is unavailable.
+- Preserve one logical notification per repair request recipient.
+- Preserve tenant isolation: a repair request from tenant A must only notify tenant A recipients.
+- Keep the outbox schema reusable for future event types, while implementing only repair-request creation now.
+- Keep Zalo secrets and access tokens server-side.
+- Record provider IDs, delivery events, retries, and failure metadata for operations.
+
+Non-goals:
+- Zalo Bot group chat delivery.
+- Capturing group `chat.id`.
+- UID sending in the first implementation.
+- Per-department, role, or shift routing inside a tenant.
+- Cross-tenant fallback recipient routing.
+- Transfer-request notification behavior.
+- In-app notification UI.
+- Enqueueing notifications for other event types.
+
+## Decisions
+- Primary channel: ZBS Template Message via phone number.
+  - Reason: the requirement is to send to a specific Zalo phone number, and official ZBS phone docs support that directly.
+- Recipient identity: normalized phone number in Vietnam country format.
+  - Example accepted by docs: `84987654321` or `+84987654321`.
+  - Store only values needed for dispatch and audit. Avoid logging access tokens or full raw provider payloads if they contain sensitive data.
+- Recipient routing: configure recipients by tenant and event type.
+  - A recipient configuration row should include `don_vi_id`, `event_type='repair_request_created'`, normalized `recipient_phone`, active status, and optional display/owner metadata.
+  - Multiple active recipient configuration rows are allowed for the same `don_vi_id` and `event_type`.
+  - Each active recipient gets an independent outbox row and send attempt.
+  - Do not store comma-separated phone lists. Each phone number must be stored as one recipient configuration row.
+  - Department-level routing inside a tenant is intentionally out of scope.
+  - Do not use a global fallback recipient. If no active recipient exists for the repair request's `don_vi_id`, leave the event unsent/inspectable rather than notifying the wrong tenant.
+- Event model: keep the outbox generic enough for future ZBS events.
+  - Use `event_type`, `source_type`, and `source_id` instead of hardcoding only `repair_request_id`.
+  - This change only enqueues `event_type='repair_request_created'` with `source_type='repair_request'`.
+  - A future transfer notification can add `event_type='transfer_request_created'` and `source_type='transfer_request'` without replacing the outbox schema.
+- Template dependency: production dispatch stays disabled until the OA/ZBS template is approved and `template_id` plus expected `template_data` fields are configured.
+  - A repair-request template should likely be Tag 2 `CUSTOMER_CARE`, because it is a service/operational notification rather than marketing.
+- Enqueue point: update the latest `repair_request_create` implementation to insert outbox rows after the repair request insert/audit work succeeds.
+  - The RPC signature should remain unchanged.
+  - Enqueue must derive `don_vi_id` from the created repair request row, not from unaudited client input.
+  - Enqueue must join active recipient configuration on the same `don_vi_id` and `event_type`.
+  - Enqueue must be idempotent on `(event_type, source_type, source_id, recipient_config_id)` or an equivalent logical key.
+  - One recipient failure must not block or roll back other recipients for the same source event after the repair request has been created.
+- Dispatch shape:
+  - Dispatcher reads pending outbox rows.
+  - Builds `template_data` from repair request and equipment context.
+  - Calls the phone endpoint with `tracking_id` derived from the outbox event ID.
+  - Stores Zalo `msg_id`, send timestamp, quota metadata when returned, and provider response status.
+- Delivery webhook:
+  - Webhook is not the trigger that sends notifications. It is only the inbound callback path after our dispatcher has sent a ZBS message.
+  - Implement only after the outbound send path has stable tracking IDs.
+  - Validate `X-ZEvent-Signature` using the documented SHA-256 signature input before trusting payloads.
+  - Match delivery events by `tracking_id` first, then `msg_id` as secondary metadata.
+- UID path:
+  - Do not implement in this change. UID requires OA-scoped `user_id`, which the current requirement does not provide.
+  - If added later, model it as a second recipient identifier type rather than replacing phone delivery.
+
+## Data Flow
+1. User creates a repair request in the app.
+2. Existing client/API flow calls `repair_request_create`.
+3. RPC validates tenant/role claims and creates the repair request as it does today.
+4. RPC reads the created repair request's `don_vi_id`.
+5. RPC enqueues one pending ZBS phone notification for each active recipient configured for that same `don_vi_id` and `event_type='repair_request_created'`.
+6. If no active recipient exists for that `don_vi_id`, no cross-tenant fallback is used.
+7. A server-side dispatcher sends pending rows through the ZBS phone endpoint.
+8. Zalo returns success or failure; dispatcher updates outbox status and retry metadata.
+9. Zalo later posts delivery webhook events; webhook route validates the signature and updates delivery status.
+
+## Slice Boundaries
+- Slice 0, Zalo readiness: no repository runtime code is required. The output is approved operational inputs: permission, template ID, template field list, credentials owner, and one test recipient phone.
+- Slice 1, tenant-scoped data contract: recipient configuration by `don_vi_id` and `event_type`, generic outbox schema, and `repair_request_create` enqueue behavior only. No outbound HTTP client is introduced in this slice.
+- Slice 2, dispatcher dry-run: request construction and data mapping only. The dispatcher can produce the exact ZBS request payload for inspection, but production sending remains gated off.
+- Slice 3, live send: outbound HTTP is enabled behind the dispatch feature gate and limited to configured recipients. This slice owns provider response persistence and retry transitions.
+- Slice 4, delivery webhook: inbound callback processing is added after stable `tracking_id` behavior exists.
+- Slice 5, rollout/ops: production enablement is treated as an operational slice with runbook, monitoring, smoke test, and rollback path.
+
+## Risks / Trade-offs
+- Phone delivery requires the recipient phone number to be linked to a Zalo account. Invalid or unlinked phone numbers must fail visibly in the outbox.
+- Tenant-scoped routing is safety-critical. The enqueue tests must prove tenant A repair requests cannot notify tenant B recipients.
+- Multiple recipients in one tenant mean partial delivery is possible. Status and retry metadata must be per recipient, not per source event only.
+- ZBS requires approved templates. Implementation cannot be fully production-ready until the real template and field names are known.
+- Zalo access tokens and OA secret material are operational dependencies. Token rotation and secret storage need a runbook before production enablement.
+- Webhook delivery time is distinct from webhook receipt time; store both if callback support is implemented.
+- Delayed notification is safer than duplicate notification for this workflow; retries must preserve idempotency.
+
+## Verification
+- Validate the OpenSpec change with `openspec validate add-zalo-repair-request-zbs-phone-notifications --strict`.
+- During implementation, follow repo gates for TypeScript/React and SQL changes.
+- Apply any DB migration through Supabase MCP only.
+- Before enabling production dispatch, perform a live smoke test to a controlled phone number using the approved template.

--- a/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/proposal.md
+++ b/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/proposal.md
@@ -1,0 +1,65 @@
+# Change: ZBS phone notifications for repair requests
+
+## Why
+Repair requests currently rely on users opening the application to notice new work. The hospital now has a Zalo Official Account and wants an automatic Zalo notification sent to a specific Zalo phone number when a repair request is created.
+
+The existing draft `add-zalo-repair-request-group-notifications` targets Zalo Bot group chat delivery. This change intentionally replaces that rollout direction with ZBS Template Message delivery to individual recipients by phone number.
+
+## What Changes
+- Add a ZBS Template Message notification path for newly created repair requests.
+- Use the official ZBS "Gửi tin Template qua SĐT" API as the primary outbound channel:
+  - `POST https://business.openapi.zalo.me/message/template`
+  - `access_token` header
+  - `phone`, `template_id`, `template_data`, and `tracking_id` request fields
+- Store target recipients as normalized phone numbers for the initial rollout.
+- Configure recipients per tenant (`don_vi_id`) and event type.
+- Support multiple active recipient phone numbers within the same tenant and event type.
+- Use a generic event outbox shape (`event_type`, `source_type`, `source_id`) so later ZBS notifications, such as transfer-request creation, can reuse the same infrastructure.
+- Implement only `repair_request_created` in this change.
+- Enqueue notifications only for active recipients whose `don_vi_id` matches the created repair request's `don_vi_id`.
+- Require an approved ZBS template before production dispatch is enabled.
+- Add a durable notification outbox/log so repair request creation does not depend on Zalo API availability.
+- Add a ZBS webhook endpoint for delivery events and quota/status diagnostics where useful.
+- Keep UID-based sending as a later enhancement only if the system later stores OA-scoped `user_id` values.
+
+## Out of Scope
+- Zalo Bot group chat notifications and `chat_id` capture.
+- Free-form OA consultation messages.
+- Per-department recipient routing.
+- Cross-tenant fallback recipients.
+- Implementing transfer-request notifications; this change only keeps the schema ready for that future event type.
+- User subscription preferences.
+- Two-way repair workflow commands in Zalo.
+- Notifications for transfers, maintenance plans, or inventory events.
+
+## Roadmap / Review Slices
+This change should be implemented in small reviewable slices:
+
+1. Zalo readiness only: confirm OA/App/ZBS linkage, phone-send permission, approved template, exact `template_data` fields, and a controlled test phone number.
+2. Tenant-scoped data contract only: add recipient configuration by `don_vi_id` and `event_type`, add the generic outbox/log schema, and update `repair_request_create` to enqueue one `repair_request_created` event per matching active recipient, without outbound Zalo calls.
+3. Dispatcher dry-run only: implement phone normalization, template-data mapping, request construction, and tests behind a dry-run/disabled dispatch gate.
+4. Live send path: call the ZBS phone endpoint behind the feature gate, persist `msg_id`/send metadata, classify errors, and retry safely.
+5. Delivery webhook: validate ZBS webhook signatures and update delivery status from `user_received_message` events.
+6. Rollout/ops: document env vars, token rotation, template setup, smoke testing, monitoring queries, and rollback by disabling dispatch.
+
+## Impact
+- Affected specs: `zalo-repair-zbs-notifications` (new capability)
+- Affected code in future implementation:
+  - Supabase migration for tenant-scoped ZBS recipient configuration and a generic ZBS notification outbox/log table.
+  - `repair_request_create` SQL flow to enqueue one pending `repair_request_created` ZBS notification event per active recipient phone in the same tenant as the created repair request.
+  - Server-side ZBS client/dispatcher for the phone API.
+  - Next.js route handler for ZBS webhook event validation and delivery-status updates.
+  - Environment configuration for Zalo App/OA credentials, template ID, ZBS access token handling, webhook secret material, and dispatch feature gate.
+  - Runbook for template approval, phone normalization, recipient setup, and live smoke testing.
+- Testing in future implementation:
+  - SQL smoke coverage for tenant-scoped outbox enqueue behavior and idempotency.
+  - Unit tests for ZBS message template-data mapping, phone normalization, request construction, provider error handling, retry status transitions, and delivery webhook signature validation.
+  - Manual live smoke test to a controlled phone number before enabling production dispatch.
+
+## Official Docs Reviewed
+- ZBS Template Message overview: `https://developers.zalo.me/docs/zbs-template-message/bat-dau/gioi-thieu-zbs-template-message`
+- ZBS API gửi tin qua SĐT: `https://developers.zalo.me/docs/zbs-template-message/gui-tin-template-qua-sdt/api-gui-tin-qua-sdt/api-gui-tin`
+- ZBS API gửi tin qua UID: `https://developers.zalo.me/docs/zbs-template-message/gui-tin-template-qua-uid/api-gui-tin-qua-uid`
+- ZBS webhook sự kiện người dùng nhận tin qua SĐT: `https://developers.zalo.me/docs/zbs-template-message/gui-tin-template-qua-sdt/webhook-gui-tin-qua-sdt/su-kien-nguoi-dung-nhan-tin-qua-sdt`
+- Template overview: `https://developers.zalo.me/docs/zbs-template-message/quan-ly-template/bat-dau/gioi-thieu-chung-ve-template`
+- OA webhook overview: `https://developers.zalo.me/docs/official-account/webhook/tong-quan`

--- a/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/proposal.md
+++ b/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/proposal.md
@@ -3,7 +3,7 @@
 ## Why
 Repair requests currently rely on users opening the application to notice new work. The hospital now has a Zalo Official Account and wants an automatic Zalo notification sent to a specific Zalo phone number when a repair request is created.
 
-The existing draft `add-zalo-repair-request-group-notifications` targets Zalo Bot group chat delivery. This change intentionally replaces that rollout direction with ZBS Template Message delivery to individual recipients by phone number.
+The existing draft `add-zalo-repair-request-group-notifications` targets Zalo Bot group chat delivery. This change supersedes that rollout direction with ZBS Template Message delivery to individual recipients by phone number.
 
 ## What Changes
 - Add a ZBS Template Message notification path for newly created repair requests.

--- a/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/specs/zalo-repair-zbs-notifications/spec.md
+++ b/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/specs/zalo-repair-zbs-notifications/spec.md
@@ -1,0 +1,159 @@
+## ADDED Requirements
+
+### Requirement: ZBS template readiness
+The system SHALL keep repair-request ZBS phone notification dispatch disabled until an approved ZBS template and recipient configuration are available.
+
+#### Scenario: Missing approved template
+- **GIVEN** no approved ZBS repair-request template ID is configured
+- **WHEN** a repair request is created successfully
+- **THEN** the system does not call the Zalo API
+- **AND** the system records or exposes configuration status so operators can complete setup.
+
+#### Scenario: Template data shape is explicit
+- **GIVEN** an approved ZBS template is configured
+- **WHEN** the dispatcher prepares a notification
+- **THEN** the generated `template_data` matches the configured template field names
+- **AND** required fields are present before any outbound API call is attempted.
+
+### Requirement: Repair request creation enqueues ZBS phone notification
+The system SHALL enqueue a ZBS phone notification event whenever a repair request is created successfully and active ZBS phone notification recipients are configured for the same tenant as the created repair request.
+
+#### Scenario: New repair request creates pending phone notifications
+- **WHEN** `repair_request_create` successfully inserts a new row into `yeu_cau_sua_chua`
+- **THEN** the system derives notification scope from the created repair request's `don_vi_id`
+- **AND** records one pending ZBS notification event for each active recipient phone number configured for that same `don_vi_id` and `event_type`
+- **AND** each event includes `event_type`, `source_type`, `source_id`, `don_vi_id`, recipient configuration ID, normalized recipient phone, template ID, template-data snapshot, and tracking ID
+- **AND** existing repair request creation behavior, returned request ID, audit logging, and equipment status sync remain compatible.
+
+#### Scenario: Multiple same-tenant recipients are supported
+- **GIVEN** tenant A has two active ZBS repair-request recipients
+- **WHEN** a repair request is created for tenant A
+- **THEN** the system enqueues two pending ZBS notification events
+- **AND** each event references a different recipient configuration
+- **AND** each event can be sent, retried, or failed independently.
+
+#### Scenario: Recipient phones are stored one per row
+- **WHEN** recipient configuration is stored
+- **THEN** each phone number is represented by one recipient configuration row
+- **AND** the system does not store multiple recipient phone numbers in a comma-separated field.
+
+#### Scenario: Notification enqueue is idempotent
+- **GIVEN** a ZBS notification event already exists for an event type, source record, and tenant-scoped recipient configuration
+- **WHEN** enqueue logic is retried for the same repair request and recipient
+- **THEN** the system does not create a duplicate logical notification event.
+
+### Requirement: Tenant-scoped ZBS recipient isolation
+The system SHALL route repair-request ZBS notifications only to active recipients configured for the same tenant (`don_vi_id`) as the created repair request.
+
+#### Scenario: Tenant A request notifies only tenant A recipients
+- **GIVEN** tenant A has an active ZBS repair-request recipient
+- **AND** tenant B has an active ZBS repair-request recipient
+- **WHEN** a repair request is created for tenant A
+- **THEN** the system enqueues notification events only for tenant A recipients
+- **AND** no event is enqueued for tenant B recipients.
+
+#### Scenario: Tenant B request notifies only tenant B recipients
+- **GIVEN** tenant A has an active ZBS repair-request recipient
+- **AND** tenant B has an active ZBS repair-request recipient
+- **WHEN** a repair request is created for tenant B
+- **THEN** the system enqueues notification events only for tenant B recipients
+- **AND** no event is enqueued for tenant A recipients.
+
+#### Scenario: Tenant has no active recipient
+- **GIVEN** a repair request is created for tenant A
+- **AND** tenant A has no active ZBS repair-request recipient
+- **WHEN** enqueue logic runs
+- **THEN** no ZBS notification event is enqueued
+- **AND** the system does not fall back to another tenant or global recipient.
+
+#### Scenario: Inactive recipient is ignored
+- **GIVEN** tenant A has an inactive ZBS repair-request recipient
+- **WHEN** a repair request is created for tenant A
+- **THEN** no notification event is enqueued for the inactive recipient.
+
+### Requirement: Generic ZBS notification event model
+The system SHALL model ZBS notification outbox rows by event type and source record so future event types can reuse the same delivery infrastructure.
+
+#### Scenario: Repair request uses generic event identity
+- **WHEN** a repair request creation notification is enqueued
+- **THEN** the outbox row records `event_type` as `repair_request_created`
+- **AND** records `source_type` as `repair_request`
+- **AND** records `source_id` as the created repair request ID.
+
+#### Scenario: Transfer notification is not implemented yet
+- **GIVEN** a transfer request is created
+- **WHEN** this change is implemented
+- **THEN** no `transfer_request_created` ZBS notification is enqueued
+- **AND** adding that event later does not require replacing the outbox identity model.
+
+### Requirement: ZBS phone notification dispatch
+The system SHALL send pending repair-request notifications using the official ZBS phone Template Message API.
+
+#### Scenario: Pending notification sends successfully
+- **GIVEN** a pending notification has a normalized recipient phone number, approved template ID, valid template data, and Zalo credentials
+- **WHEN** the dispatcher sends the notification
+- **THEN** it calls `POST https://business.openapi.zalo.me/message/template`
+- **AND** it sends `access_token` in the request header
+- **AND** the request body includes `phone`, `template_id`, `template_data`, and `tracking_id`
+- **AND** the notification is marked sent with provider `msg_id`, provider send timestamp, and quota metadata when returned.
+
+#### Scenario: Zalo API is unavailable
+- **GIVEN** a repair request is created successfully
+- **AND** Zalo returns a retryable error or cannot be reached
+- **WHEN** the dispatcher attempts to send the pending notification
+- **THEN** the repair request remains created
+- **AND** the notification event records failure metadata and remains retryable according to retry policy.
+
+#### Scenario: One recipient send fails while another succeeds
+- **GIVEN** two pending notifications exist for the same source event and tenant
+- **WHEN** the dispatcher sends both notifications
+- **AND** one recipient send succeeds while the other fails
+- **THEN** each outbox row records its own status and provider metadata
+- **AND** the failed recipient remains retryable according to retry policy
+- **AND** the successful recipient is not resent only because another recipient failed.
+
+#### Scenario: Dispatch is not enabled
+- **GIVEN** ZBS dispatch is disabled by feature gate
+- **WHEN** a repair request notification is pending
+- **THEN** no outbound Zalo API call is made
+- **AND** the pending event remains inspectable for operators.
+
+### Requirement: ZBS repair message content
+The system SHALL generate approved-template data for a concise Vietnamese repair request notification.
+
+#### Scenario: Template data includes repair context
+- **GIVEN** a pending notification has access to the created repair request and related equipment context
+- **WHEN** the dispatcher maps data for the approved ZBS template
+- **THEN** template data includes the repair request ID, equipment name or code, requester name when available, facility or department when available, issue summary, and an app link when a stable detail URL is available.
+
+#### Scenario: Optional fields are missing
+- **GIVEN** optional context such as requester name, department, or equipment display name is unavailable
+- **WHEN** the dispatcher maps template data
+- **THEN** it uses documented fallbacks
+- **AND** it does not send malformed required template data to Zalo.
+
+### Requirement: ZBS delivery webhook processing
+The system SHALL support ZBS delivery webhook processing for phone notification delivery status. Webhooks SHALL NOT be used as the trigger for creating outbound repair-request notifications.
+
+#### Scenario: Valid delivery webhook updates notification status
+- **GIVEN** Zalo sends a phone-delivery webhook event with `event_name` of `user_received_message`
+- **AND** the event signature is valid
+- **WHEN** the webhook route processes the event
+- **THEN** it matches the notification by `tracking_id`
+- **AND** it records provider `msg_id`, recipient phone metadata, provider delivery time, webhook receipt time, and delivered status.
+
+#### Scenario: Invalid webhook signature is rejected
+- **GIVEN** a caller sends a webhook request with a missing or invalid `X-ZEvent-Signature`
+- **WHEN** the webhook route receives the request
+- **THEN** the system rejects the request
+- **AND** no notification status is updated.
+
+### Requirement: UID sending is excluded from initial rollout
+The system SHALL NOT require OA-scoped `user_id` values for the initial ZBS phone notification rollout.
+
+#### Scenario: Phone recipient is configured but UID is absent
+- **GIVEN** a valid recipient phone number is configured
+- **AND** no OA-scoped `user_id` is stored for that recipient
+- **WHEN** a repair request is created
+- **THEN** the phone-based ZBS notification path remains valid
+- **AND** no UID send attempt is made.

--- a/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/tasks.md
+++ b/openspec/changes/add-zalo-repair-request-zbs-phone-notifications/tasks.md
@@ -1,0 +1,49 @@
+## 0. Zalo Readiness
+- [ ] 0.1 Confirm the OA, Zalo App, and ZBS Account are linked and enabled for ZBS Template Message.
+- [ ] 0.2 Request/approve the repair-request notification template.
+- [ ] 0.3 Record the approved `template_id` and exact `template_data` field names in deployment configuration.
+- [ ] 0.4 Confirm the app has the "Gửi tin qua số điện thoại" permission.
+- [ ] 0.5 Configure a controlled recipient phone number in normalized country-code format for smoke testing.
+- [ ] 0.6 Stop before implementation if the approved template and field list are unavailable.
+
+## 1. Tenant-Scoped Data Contract / SQL
+- [ ] 1.1 Add failing SQL smoke coverage proving a tenant A repair request enqueues notifications only for active tenant A recipients.
+- [ ] 1.2 Add failing SQL smoke coverage proving a tenant B repair request does not enqueue tenant A recipients.
+- [ ] 1.3 Add failing SQL smoke coverage proving no cross-tenant fallback occurs when the created repair request's tenant has no active recipients.
+- [ ] 1.4 Add failing SQL smoke coverage proving multiple active recipients in the same tenant each receive one independent outbox row.
+- [ ] 1.5 Add a tenant-scoped ZBS recipient configuration schema with `don_vi_id`, `event_type`, one normalized recipient phone per row, active status, and audit timestamps.
+- [ ] 1.6 Add an idempotent generic ZBS notification outbox/log schema with `event_type`, `source_type`, `source_id`, `don_vi_id`, recipient configuration ID, recipient phone, template ID, template data snapshot, tracking ID, status, retry metadata, provider response metadata, and timestamps.
+- [ ] 1.7 Update the latest `repair_request_create` implementation to derive `don_vi_id` from the created repair request row and enqueue pending `repair_request_created` ZBS phone notifications only for matching active recipient configuration without changing the RPC signature.
+- [ ] 1.8 Preserve existing repair request tenant/department guards, `SECURITY DEFINER`, `SET search_path = public, pg_temp`, grants/revokes, and audit behavior.
+- [ ] 1.9 Apply migration through Supabase MCP only, then run focused SQL smoke tests and `get_advisors(security)`.
+
+## 2. Dispatcher Dry-Run
+- [ ] 2.1 Add failing unit tests for phone normalization and rejection of invalid/unconfigured recipients.
+- [ ] 2.2 Add failing unit tests for mapping repair request context to the approved ZBS `template_data` fields.
+- [ ] 2.3 Add failing unit tests for ZBS phone API request construction: endpoint, method, `access_token` header, `phone`, `template_id`, `template_data`, and `tracking_id`.
+- [ ] 2.4 Implement dispatcher request construction behind a dry-run or disabled-dispatch feature gate.
+- [ ] 2.5 Verify dry-run output without making outbound Zalo API calls.
+
+## 3. Live Send Path
+- [ ] 3.1 Add tests for successful ZBS phone API responses and persisted provider metadata.
+- [ ] 3.2 Add tests for retryable and non-retryable provider/network errors.
+- [ ] 3.3 Add tests proving one failed recipient send does not mark other recipients for the same source event as failed.
+- [ ] 3.4 Enable outbound calls to `POST https://business.openapi.zalo.me/message/template` behind the dispatch feature gate.
+- [ ] 3.5 Store successful `msg_id`, provider send timestamp, quota metadata when returned, and raw error classification per outbox row without logging secrets.
+- [ ] 3.6 Implement retry transitions for retryable provider/network failures per outbox row.
+- [ ] 3.7 Run a controlled live smoke test to the configured test phone number before any production enablement.
+
+## 4. Webhook / Delivery Status
+- [ ] 4.1 Add route-handler tests for validating `X-ZEvent-Signature`.
+- [ ] 4.2 Add route-handler tests for `event_name=user_received_message` delivery events with `msg_id`, `tracking_id`, recipient phone, and delivery time.
+- [ ] 4.3 Implement the ZBS delivery webhook route.
+- [ ] 4.4 Match webhook events to outbox rows by `tracking_id` first.
+- [ ] 4.5 Document webhook URL setup and secret rotation.
+
+## 5. Runbook / Production Rollout
+- [ ] 5.1 Document required env vars and secret ownership.
+- [ ] 5.2 Document template approval, recipient phone normalization, and smoke-test steps.
+- [ ] 5.3 Document monitoring queries for pending, failed, sent, and delivered notification rows.
+- [ ] 5.4 Document rollback: disable dispatch feature gate while preserving outbox rows.
+- [ ] 5.5 Run quality gates required by the touched files.
+- [ ] 5.6 Record rollout decision: enable production dispatch only after smoke test succeeds and monitoring path is confirmed.


### PR DESCRIPTION
## Summary

- Add OpenSpec proposal/design/tasks/spec for tenant-scoped ZBS phone notifications on repair request creation.
- Capture key decisions: ZBS phone API, tenant-scoped recipients by `don_vi_id`, one recipient phone per config row, generic event outbox identity, and delivery webhook as callback only.
- Link tracking issues: umbrella #616 and phase issues #617-#622.

## Source of truth

- `openspec/changes/add-zalo-repair-request-zbs-phone-notifications/proposal.md`
- `openspec/changes/add-zalo-repair-request-zbs-phone-notifications/design.md`
- `openspec/changes/add-zalo-repair-request-zbs-phone-notifications/tasks.md`
- `openspec/changes/add-zalo-repair-request-zbs-phone-notifications/specs/zalo-repair-zbs-notifications/spec.md`

## Verification

- [x] `npx openspec validate add-zalo-repair-request-zbs-phone-notifications --strict`
- [x] pre-commit hooks passed on docs commit
- [x] pre-push hooks passed, including `typecheck`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenSpec for tenant-scoped ZBS phone notifications on repair-request creation; supersedes the older Zalo Bot group-chat spec and retains it only as historical context.

- New Features
  - Send via ZBS phone Template Message (`/message/template`) with `template_id`, `template_data`, and `tracking_id`.
  - Tenant-routed recipients; one normalized phone per row; no cross-tenant fallback.
  - Enqueue on `repair_request_create` into a generic outbox (`event_type='repair_request_created'`, `source_type='repair_request'`); idempotent per recipient.
  - Dispatcher stores provider metadata; delivery webhook validates `X-ZEvent-Signature` and updates status; webhook is callback-only.
  - Feature-gated rollout; live send requires an approved template and configured recipients.

<sup>Written for commit 559f14851e7ee51a5a9050ebf4fb99eba33b85ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending Zalo Business Solutions phone notifications when a repair request is created.
  * Notifications now follow tenant-scoped recipient settings and can target multiple phone numbers.
  * Added delivery tracking and status updates for sent notifications.

* **Bug Fixes**
  * Improved reliability with idempotent notification queuing and retry handling.
  * Added validation for incoming delivery callbacks to reject invalid signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->