### PR TITLE
Refactor AddTasksDialog into smaller components

### DIFF
--- a/src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx
+++ b/src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx
@@ -243,6 +243,29 @@ describe('AddTasksDialog filters and pagination', () => {
         expect(nextButton).toBeTruthy()
     })
 
+    it('spans fallback rows across visible columns only', async () => {
+        mockCallRpc.mockImplementation((request: RpcRequest) => {
+            const { fn } = request
+            if (fn === 'equipment_filter_buckets') {
+                return Promise.resolve(MOCK_FILTER_BUCKETS)
+            }
+            if (fn === 'equipment_list_enhanced') {
+                return Promise.resolve({
+                    data: [],
+                    total: 0,
+                    page: 1,
+                    pageSize: 10,
+                })
+            }
+            return Promise.resolve(null)
+        })
+
+        renderWithQueryClient(<AddTasksDialog {...baseProps} />)
+
+        const emptyState = await screen.findByText('Không tìm thấy kết quả phù hợp')
+        expect(emptyState.closest('td')).toHaveAttribute('colspan', '5')
+    })
+
     it('disables selection for already-added equipment', async () => {
         renderWithQueryClient(<AddTasksDialog {...baseProps} existingEquipmentIds={[1, 2, 3]} />)
 

--- a/src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx
+++ b/src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx
@@ -10,9 +10,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import "@testing-library/jest-dom"
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { Table } from '@tanstack/react-table'
 
 type MockChildrenProps = { children?: React.ReactNode }
-type MockOpenProps = MockChildrenProps & { open?: boolean }
+type MockOpenProps = MockChildrenProps & { open?: boolean; setOpen?: (open: boolean) => void }
 type MockTriggerProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
     asChild?: boolean
     open?: boolean
@@ -59,7 +60,7 @@ vi.mock('@/components/ui/dropdown-menu', () => {
             }
             return <button {...rest} onClick={handleClick}>{children}</button>
         },
-        DropdownMenuContent: ({ children, open, ...rest }: MockOpenProps & React.HTMLAttributes<HTMLDivElement>) => {
+        DropdownMenuContent: ({ children, open, setOpen: _setOpen, ...rest }: MockOpenProps & React.HTMLAttributes<HTMLDivElement>) => {
             if (!open) return null
             return <div data-testid="dropdown-content" {...rest}>{children}</div>
         },
@@ -111,8 +112,10 @@ vi.mock('@/hooks/use-debounce', () => ({
 }))
 
 import { AddTasksDialog } from '../add-tasks-dialog'
+import { AddTasksDialogToolbar } from '../add-tasks-dialog-toolbar'
+import { initialAddTasksTableState } from '../add-tasks-dialog.table-state'
 import { callRpc } from '@/lib/rpc-client'
-import type { MaintenancePlan } from '@/lib/data'
+import type { Equipment, MaintenancePlan } from '@/lib/data'
 
 const mockCallRpc = vi.mocked(callRpc)
 
@@ -241,6 +244,54 @@ describe('AddTasksDialog filters and pagination', () => {
         // DataTablePagination should render with "Trang tiếp" button
         const nextButton = screen.queryByRole('button', { name: /Trang ti/i })
         expect(nextButton).toBeTruthy()
+    })
+
+    it('renders a safe column visibility label for non-string headers', () => {
+        const toggleVisibility = vi.fn()
+        const table = {
+            getAllColumns: () => [
+                {
+                    id: 'computed-status',
+                    columnDef: { header: () => <span>Computed Status</span> },
+                    getCanHide: () => true,
+                    getIsVisible: () => true,
+                    toggleVisibility,
+                },
+            ],
+        } as unknown as Table<Equipment>
+
+        render(
+            <AddTasksDialogToolbar
+                table={table}
+                tableState={initialAddTasksTableState}
+                filterOptions={{ departments: [], users: [], locations: [] }}
+                isFiltered={false}
+                dispatchTable={vi.fn()}
+            />,
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: /Cột/i }))
+
+        expect(screen.getByRole('button', { name: 'computed-status' })).toBeInTheDocument()
+        expect(screen.queryByText(/function/i)).not.toBeInTheDocument()
+    })
+
+    it('renders a generic equipment load error without backend details', async () => {
+        mockCallRpc.mockImplementation((request: RpcRequest) => {
+            const { fn } = request
+            if (fn === 'equipment_filter_buckets') {
+                return Promise.resolve(MOCK_FILTER_BUCKETS)
+            }
+            if (fn === 'equipment_list_enhanced') {
+                return Promise.reject(new Error('relation internal_equipment_secret does not exist'))
+            }
+            return Promise.resolve(null)
+        })
+
+        renderWithQueryClient(<AddTasksDialog {...baseProps} />)
+
+        expect(await screen.findByText('Không thể tải thiết bị. Vui lòng thử lại sau.')).toBeInTheDocument()
+        expect(screen.queryByText(/internal_equipment_secret/i)).not.toBeInTheDocument()
     })
 
     it('spans fallback rows across visible columns only', async () => {

--- a/src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx
+++ b/src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx
@@ -108,16 +108,18 @@ vi.mock('@/hooks/use-toast', () => ({
 }))
 
 vi.mock('@/hooks/use-debounce', () => ({
-    useSearchDebounce: (value: string) => value,
+    useSearchDebounce: (value: string) => mockUseSearchDebounce(value),
 }))
 
 import { AddTasksDialog } from '../add-tasks-dialog'
+import { AddTasksEquipmentTable } from '../add-tasks-dialog-table'
 import { AddTasksDialogToolbar } from '../add-tasks-dialog-toolbar'
 import { initialAddTasksTableState } from '../add-tasks-dialog.table-state'
 import { callRpc } from '@/lib/rpc-client'
 import type { Equipment, MaintenancePlan } from '@/lib/data'
 
 const mockCallRpc = vi.mocked(callRpc)
+const mockUseSearchDebounce = vi.fn((value: string) => value)
 
 function createTestQueryClient() {
     return new QueryClient({
@@ -204,6 +206,7 @@ describe('AddTasksDialog filters and pagination', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
+        mockUseSearchDebounce.mockImplementation((value: string) => value)
         mockRpcByPage()
     })
 
@@ -244,6 +247,22 @@ describe('AddTasksDialog filters and pagination', () => {
         // DataTablePagination should render with "Trang tiếp" button
         const nextButton = screen.queryByRole('button', { name: /Trang ti/i })
         expect(nextButton).toBeTruthy()
+    })
+
+    it('shows clear filters immediately for the live search term', async () => {
+        mockUseSearchDebounce.mockReturnValue('')
+
+        renderWithQueryClient(<AddTasksDialog {...baseProps} />)
+
+        await waitFor(() => {
+            expect(screen.getByPlaceholderText('Tìm kiếm chung...')).toBeInTheDocument()
+        })
+
+        fireEvent.change(screen.getByPlaceholderText('Tìm kiếm chung...'), {
+            target: { value: 'pump' },
+        })
+
+        expect(screen.getByRole('button', { name: /Xóa bộ lọc/i })).toBeInTheDocument()
     })
 
     it('renders a safe column visibility label for non-string headers', () => {
@@ -292,6 +311,38 @@ describe('AddTasksDialog filters and pagination', () => {
 
         expect(await screen.findByText('Không thể tải thiết bị. Vui lòng thử lại sau.')).toBeInTheDocument()
         expect(screen.queryByText(/internal_equipment_secret/i)).not.toBeInTheDocument()
+    })
+
+    it('passes grouped header colSpan through to table headers', () => {
+        const table = {
+            getHeaderGroups: () => [
+                {
+                    id: 'group-row',
+                    headers: [
+                        {
+                            id: 'asset-group',
+                            colSpan: 2,
+                            isPlaceholder: false,
+                            column: { columnDef: { header: 'Thông tin thiết bị' } },
+                            getContext: () => ({}),
+                        },
+                    ],
+                },
+            ],
+            getRowModel: () => ({ rows: [] }),
+        } as unknown as Table<Equipment>
+
+        render(
+            <AddTasksEquipmentTable
+                table={table}
+                columnCount={2}
+                missingPlanTenant={false}
+                isLoading={false}
+                error={null}
+            />,
+        )
+
+        expect(screen.getByRole('columnheader', { name: 'Thông tin thiết bị' })).toHaveAttribute('colspan', '2')
     })
 
     it('spans fallback rows across visible columns only', async () => {

--- a/src/components/__tests__/react-doctor-p2-rerender-source.test.ts
+++ b/src/components/__tests__/react-doctor-p2-rerender-source.test.ts
@@ -41,13 +41,18 @@ describe("React Doctor P2 rerender source guard", () => {
     expect(editSource).not.toContain("setIssueDescription")
   })
 
-  it("keeps AddTasksDialog table state reducer-based and filter options single-pass", () => {
+  it("keeps AddTasksDialog split into focused table, toolbar, and state modules", () => {
     const source = readSource("src/components/add-tasks-dialog.tsx")
+    const tableStateSource = readSource("src/components/add-tasks-dialog.table-state.ts")
 
-    expect(source).toContain("useReducer")
+    expect(source.split("\n").length).toBeLessThan(350)
+    expect(source).toContain("AddTasksDialogToolbar")
+    expect(source).toContain("AddTasksEquipmentTable")
+    expect(source).toContain("addTasksTableReducer")
+    expect(tableStateSource).toContain("export function addTasksTableReducer")
+    expect(tableStateSource).toContain("...initialAddTasksTableState")
     expect(source).not.toContain(".filter(Boolean)")
     expect(source).not.toContain("setRowSelection({})")
-    expect(source).toContain("...initialAddTasksTableState")
   })
 
   it("uses mutation or transition pending state in tenant and user submit dialogs", () => {

--- a/src/components/add-tasks-dialog-table.tsx
+++ b/src/components/add-tasks-dialog-table.tsx
@@ -1,0 +1,96 @@
+import * as React from "react"
+import type { Table as ReactTable } from "@tanstack/react-table"
+import { flexRender } from "@tanstack/react-table"
+import { Loader2 } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import type { Equipment } from "@/lib/data"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+interface AddTasksEquipmentTableProps {
+  table: ReactTable<Equipment>
+  columnCount: number
+  missingPlanTenant: boolean
+  isLoading: boolean
+  error: Error | null
+}
+
+/** Renders the add-tasks equipment table body states and selectable rows. */
+export function AddTasksEquipmentTable({
+  table,
+  columnCount,
+  missingPlanTenant,
+  isLoading,
+  error,
+}: AddTasksEquipmentTableProps) {
+  return (
+    <div className="flex-grow rounded-md border overflow-hidden">
+      <ScrollArea className="h-full">
+        <Table>
+          <TableHeader className="sticky top-0 bg-background z-10">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {missingPlanTenant ? (
+              <TableRow>
+                <TableCell colSpan={columnCount} className="h-24 text-center text-destructive">
+                  Không xác định được đơn vị của kế hoạch.
+                </TableCell>
+              </TableRow>
+            ) : error ? (
+              <TableRow>
+                <TableCell colSpan={columnCount} className="h-24 text-center text-destructive">
+                  Không thể tải thiết bị: {error.message}
+                </TableCell>
+              </TableRow>
+            ) : isLoading ? (
+              <TableRow>
+                <TableCell colSpan={columnCount} className="h-24 text-center">
+                  <Loader2 className="mx-auto size-6 animate-spin" />
+                </TableCell>
+              </TableRow>
+            ) : table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                  className={cn(!row.getCanSelect() && "bg-muted/50 text-muted-foreground")}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columnCount} className="h-24 text-center">
+                  Không tìm thấy kết quả phù hợp
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/src/components/add-tasks-dialog-table.tsx
+++ b/src/components/add-tasks-dialog-table.tsx
@@ -39,7 +39,7 @@ export function AddTasksEquipmentTable({
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id}>
+                  <TableHead key={header.id} colSpan={header.colSpan}>
                     {header.isPlaceholder
                       ? null
                       : flexRender(header.column.columnDef.header, header.getContext())}

--- a/src/components/add-tasks-dialog-table.tsx
+++ b/src/components/add-tasks-dialog-table.tsx
@@ -58,7 +58,7 @@ export function AddTasksEquipmentTable({
             ) : error ? (
               <TableRow>
                 <TableCell colSpan={columnCount} className="h-24 text-center text-destructive">
-                  Không thể tải thiết bị: {error.message}
+                  Không thể tải thiết bị. Vui lòng thử lại sau.
                 </TableCell>
               </TableRow>
             ) : isLoading ? (

--- a/src/components/add-tasks-dialog-toolbar.tsx
+++ b/src/components/add-tasks-dialog-toolbar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import type { Dispatch } from "react"
-import type { Table } from "@tanstack/react-table"
+import type { Column, Table } from "@tanstack/react-table"
 import { ChevronDown, FilterX } from "lucide-react"
 
 import type { AddTasksFilterOptions } from "@/hooks/useAddTasksEquipment"
@@ -28,6 +28,14 @@ interface AddTasksDialogToolbarProps {
   filterOptions: AddTasksFilterOptions
   isFiltered: boolean
   dispatchTable: Dispatch<AddTasksTableAction>
+}
+
+function getColumnVisibilityLabel(column: Column<Equipment, unknown>): string {
+  const header = column.columnDef.header
+  if (typeof header === "string" && header.trim().length > 0) {
+    return header
+  }
+  return column.id
 }
 
 /** Renders search, faceted filters, clear-filter action, and column visibility controls. */
@@ -93,7 +101,7 @@ export function AddTasksDialogToolbar({
               .getAllColumns()
               .flatMap((column) => {
                 if (!column.getCanHide()) return []
-                const header = (column.columnDef.header as string) || column.id
+                const header = getColumnVisibilityLabel(column)
                 return [(
                   <DropdownMenuCheckboxItem
                     key={column.id}

--- a/src/components/add-tasks-dialog-toolbar.tsx
+++ b/src/components/add-tasks-dialog-toolbar.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+import type { Dispatch } from "react"
+import type { Table } from "@tanstack/react-table"
+import { ChevronDown, FilterX } from "lucide-react"
+
+import type { AddTasksFilterOptions } from "@/hooks/useAddTasksEquipment"
+import type { Equipment } from "@/lib/data"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { SearchInput } from "@/components/shared/SearchInput"
+import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
+
+import type {
+  AddTasksTableAction,
+  AddTasksTableState,
+} from "./add-tasks-dialog.table-state"
+
+interface AddTasksDialogToolbarProps {
+  table: Table<Equipment>
+  tableState: AddTasksTableState
+  filterOptions: AddTasksFilterOptions
+  isFiltered: boolean
+  dispatchTable: Dispatch<AddTasksTableAction>
+}
+
+/** Renders search, faceted filters, clear-filter action, and column visibility controls. */
+export function AddTasksDialogToolbar({
+  table,
+  tableState,
+  filterOptions,
+  isFiltered,
+  dispatchTable,
+}: AddTasksDialogToolbarProps) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <SearchInput
+        placeholder="Tìm kiếm chung..."
+        value={tableState.searchTerm}
+        onChange={(value) => dispatchTable({ type: "set-search-term", value })}
+        showSearchIcon={false}
+        className="h-8 w-[150px] lg:w-[250px]"
+      />
+      <FacetedMultiSelectFilter
+        title="Khoa/Phòng"
+        options={filterOptions.departments}
+        value={tableState.filters.departments}
+        onChange={(values) => dispatchTable({ type: "set-filter", key: "departments", values })}
+      />
+      <FacetedMultiSelectFilter
+        title="Người quản lý"
+        options={filterOptions.users}
+        value={tableState.filters.users}
+        onChange={(values) => dispatchTable({ type: "set-filter", key: "users", values })}
+      />
+      <FacetedMultiSelectFilter
+        title="Vị trí"
+        options={filterOptions.locations}
+        value={tableState.filters.locations}
+        onChange={(values) => dispatchTable({ type: "set-filter", key: "locations", values })}
+      />
+      {isFiltered && (
+        <Button
+          variant="ghost"
+          onClick={() => {
+            dispatchTable({ type: "clear-filters" })
+            dispatchTable({ type: "set-search-term", value: "" })
+          }}
+          className="h-8 px-2 lg:px-3"
+        >
+          Xóa bộ lọc
+          <FilterX className="ml-2 size-4" />
+        </Button>
+      )}
+      <div className="ml-auto">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" className="h-8 gap-1">
+              Cột
+              <ChevronDown className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-[180px]">
+            <DropdownMenuLabel>Hiện/Ẩn cột</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {table
+              .getAllColumns()
+              .flatMap((column) => {
+                if (!column.getCanHide()) return []
+                const header = (column.columnDef.header as string) || column.id
+                return [(
+                  <DropdownMenuCheckboxItem
+                    key={column.id}
+                    className="capitalize"
+                    checked={column.getIsVisible()}
+                    onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                    onSelect={(event) => event.preventDefault()}
+                  >
+                    {header}
+                  </DropdownMenuCheckboxItem>
+                )]
+              })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  )
+}

--- a/src/components/add-tasks-dialog.table-state.ts
+++ b/src/components/add-tasks-dialog.table-state.ts
@@ -1,0 +1,108 @@
+import type {
+  PaginationState,
+  SortingState,
+  Updater,
+  VisibilityState,
+} from "@tanstack/react-table"
+
+import type { AddTasksEquipmentFilters } from "@/hooks/useAddTasksEquipment"
+
+export interface AddTasksTableState {
+  filters: AddTasksEquipmentFilters
+  columnVisibility: VisibilityState
+  pagination: PaginationState
+  searchTerm: string
+  sorting: SortingState
+}
+
+export type AddTasksTableAction =
+  | { type: "reset-dialog" }
+  | { type: "set-column-visibility"; updater: Updater<VisibilityState> }
+  | { type: "set-filter"; key: keyof AddTasksEquipmentFilters; values: string[] }
+  | { type: "clear-filters" }
+  | { type: "set-pagination"; updater: Updater<PaginationState> }
+  | { type: "set-search-term"; value: string }
+  | { type: "set-sorting"; updater: Updater<SortingState> }
+
+/** Initial table state used when the add-tasks dialog opens or resets. */
+export const initialAddTasksTableState: AddTasksTableState = {
+  filters: {
+    departments: [],
+    users: [],
+    locations: [],
+  },
+  columnVisibility: {
+    "nguoi_dang_truc_tiep_quan_ly": false,
+    "vi_tri_lap_dat": false,
+  },
+  pagination: { pageIndex: 0, pageSize: 10 },
+  searchTerm: "",
+  sorting: [],
+}
+
+const DEFAULT_ADD_TASKS_SORT = "id.asc"
+
+/** Resolves TanStack updater callbacks against the current state value. */
+export function resolveUpdater<T>(updater: Updater<T>, current: T): T {
+  if (typeof updater !== "function") {
+    return updater
+  }
+
+  return (updater as (old: T) => T)(current)
+}
+
+/** Applies filter, sorting, pagination, and visibility updates for the add-tasks table. */
+export function addTasksTableReducer(
+  state: AddTasksTableState,
+  action: AddTasksTableAction,
+): AddTasksTableState {
+  switch (action.type) {
+    case "reset-dialog":
+      return {
+        ...initialAddTasksTableState,
+        filters: {
+          departments: [],
+          users: [],
+          locations: [],
+        },
+        columnVisibility: { ...initialAddTasksTableState.columnVisibility },
+        pagination: { ...initialAddTasksTableState.pagination },
+        sorting: [...initialAddTasksTableState.sorting],
+      }
+    case "set-column-visibility":
+      return { ...state, columnVisibility: resolveUpdater(action.updater, state.columnVisibility) }
+    case "set-filter":
+      return {
+        ...state,
+        filters: { ...state.filters, [action.key]: action.values },
+        pagination: { ...state.pagination, pageIndex: 0 },
+      }
+    case "clear-filters":
+      return {
+        ...state,
+        filters: {
+          departments: [],
+          users: [],
+          locations: [],
+        },
+        pagination: { ...state.pagination, pageIndex: 0 },
+      }
+    case "set-pagination":
+      return { ...state, pagination: resolveUpdater(action.updater, state.pagination) }
+    case "set-search-term":
+      return { ...state, searchTerm: action.value, pagination: { ...state.pagination, pageIndex: 0 } }
+    case "set-sorting":
+      return {
+        ...state,
+        sorting: resolveUpdater(action.updater, state.sorting),
+        pagination: { ...state.pagination, pageIndex: 0 },
+      }
+  }
+}
+
+/** Converts the primary TanStack sorting rule into the RPC sort parameter. */
+export function getAddTasksSortParam(sorting: SortingState): string {
+  const [primarySort] = sorting
+  if (!primarySort) return DEFAULT_ADD_TASKS_SORT
+  return `${primarySort.id}.${primarySort.desc ? "desc" : "asc"}`
+}

--- a/src/components/add-tasks-dialog.tsx
+++ b/src/components/add-tasks-dialog.tsx
@@ -184,7 +184,7 @@ export function AddTasksDialog({
     tableState.filters.departments.length > 0 ||
     tableState.filters.users.length > 0 ||
     tableState.filters.locations.length > 0
-  const isFiltered = hasActiveFilters || (debouncedSearch?.length ?? 0) > 0
+  const isFiltered = hasActiveFilters || tableState.searchTerm.length > 0
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/src/components/add-tasks-dialog.tsx
+++ b/src/components/add-tasks-dialog.tsx
@@ -8,21 +8,12 @@
 "use client"
 
 import * as React from "react"
-import type {
-  ColumnDef,
-  PaginationState,
-  SortingState,
-  Updater,
-  VisibilityState,
-} from "@tanstack/react-table"
+import type { ColumnDef } from "@tanstack/react-table"
 import {
-  flexRender,
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table"
-import { Loader2, FilterX, ChevronDown } from "lucide-react"
 
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
@@ -33,30 +24,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { useAddTasksEquipment } from "@/hooks/useAddTasksEquipment"
-import type { AddTasksEquipmentFilters } from "@/hooks/useAddTasksEquipment"
 import type { Equipment, MaintenancePlan } from "@/lib/data"
-import { ScrollArea } from "./ui/scroll-area"
 import { useSearchDebounce } from "@/hooks/use-debounce"
-import { SearchInput } from "@/components/shared/SearchInput"
-import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { DataTablePagination } from "@/components/shared/DataTablePagination"
+
+import { AddTasksEquipmentTable } from "./add-tasks-dialog-table"
+import {
+  addTasksTableReducer,
+  getAddTasksSortParam,
+  initialAddTasksTableState,
+  resolveUpdater,
+} from "./add-tasks-dialog.table-state"
+import { AddTasksDialogToolbar } from "./add-tasks-dialog-toolbar"
 
 interface AddTasksDialogProps {
   open: boolean
@@ -64,102 +44,6 @@ interface AddTasksDialogProps {
   plan: MaintenancePlan | null
   existingEquipmentIds: number[]
   onSuccess: (selectedEquipment: Equipment[]) => void
-}
-
-interface AddTasksTableState {
-  filters: AddTasksEquipmentFilters
-  columnVisibility: VisibilityState
-  pagination: PaginationState
-  searchTerm: string
-  sorting: SortingState
-}
-
-type AddTasksTableAction =
-  | { type: "reset-dialog" }
-  | { type: "set-column-visibility"; updater: Updater<VisibilityState> }
-  | { type: "set-filter"; key: keyof AddTasksEquipmentFilters; values: string[] }
-  | { type: "clear-filters" }
-  | { type: "set-pagination"; updater: Updater<PaginationState> }
-  | { type: "set-search-term"; value: string }
-  | { type: "set-sorting"; updater: Updater<SortingState> }
-
-const initialAddTasksTableState: AddTasksTableState = {
-  filters: {
-    departments: [],
-    users: [],
-    locations: [],
-  },
-  columnVisibility: {
-    "nguoi_dang_truc_tiep_quan_ly": false,
-    "vi_tri_lap_dat": false,
-  },
-  pagination: { pageIndex: 0, pageSize: 10 },
-  searchTerm: "",
-  sorting: [],
-}
-
-const DEFAULT_ADD_TASKS_SORT = "id.asc"
-
-function resolveUpdater<T>(updater: Updater<T>, current: T): T {
-  if (typeof updater !== "function") {
-    return updater
-  }
-
-  return (updater as (old: T) => T)(current)
-}
-
-function addTasksTableReducer(
-  state: AddTasksTableState,
-  action: AddTasksTableAction,
-): AddTasksTableState {
-  switch (action.type) {
-    case "reset-dialog":
-      return {
-        ...initialAddTasksTableState,
-        filters: {
-          departments: [],
-          users: [],
-          locations: [],
-        },
-        columnVisibility: { ...initialAddTasksTableState.columnVisibility },
-        pagination: { ...initialAddTasksTableState.pagination },
-        sorting: [...initialAddTasksTableState.sorting],
-      }
-    case "set-column-visibility":
-      return { ...state, columnVisibility: resolveUpdater(action.updater, state.columnVisibility) }
-    case "set-filter":
-      return {
-        ...state,
-        filters: { ...state.filters, [action.key]: action.values },
-        pagination: { ...state.pagination, pageIndex: 0 },
-      }
-    case "clear-filters":
-      return {
-        ...state,
-        filters: {
-          departments: [],
-          users: [],
-          locations: [],
-        },
-        pagination: { ...state.pagination, pageIndex: 0 },
-      }
-    case "set-pagination":
-      return { ...state, pagination: resolveUpdater(action.updater, state.pagination) }
-    case "set-search-term":
-      return { ...state, searchTerm: action.value, pagination: { ...state.pagination, pageIndex: 0 } }
-    case "set-sorting":
-      return {
-        ...state,
-        sorting: resolveUpdater(action.updater, state.sorting),
-        pagination: { ...state.pagination, pageIndex: 0 },
-      }
-  }
-}
-
-function getAddTasksSortParam(sorting: SortingState): string {
-  const [primarySort] = sorting
-  if (!primarySort) return DEFAULT_ADD_TASKS_SORT
-  return `${primarySort.id}.${primarySort.desc ? "desc" : "asc"}`
 }
 
 /** Renders the dialog for adding available equipment to a maintenance plan. */
@@ -312,142 +196,20 @@ export function AddTasksDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="flex-grow flex flex-col overflow-hidden gap-4">
-          <div className="flex items-center gap-2 flex-wrap">
-            <SearchInput
-              placeholder="Tìm kiếm chung..."
-              value={tableState.searchTerm}
-              onChange={(value) => dispatchTable({ type: "set-search-term", value })}
-              showSearchIcon={false}
-              className="h-8 w-[150px] lg:w-[250px]"
-            />
-            <FacetedMultiSelectFilter
-              title="Khoa/Phòng"
-              options={filterOptions.departments}
-              value={tableState.filters.departments}
-              onChange={(values) => dispatchTable({ type: "set-filter", key: "departments", values })}
-            />
-            <FacetedMultiSelectFilter
-              title="Người quản lý"
-              options={filterOptions.users}
-              value={tableState.filters.users}
-              onChange={(values) => dispatchTable({ type: "set-filter", key: "users", values })}
-            />
-            <FacetedMultiSelectFilter
-              title="Vị trí"
-              options={filterOptions.locations}
-              value={tableState.filters.locations}
-              onChange={(values) => dispatchTable({ type: "set-filter", key: "locations", values })}
-            />
-            {isFiltered && (
-              <Button
-                variant="ghost"
-                onClick={() => {
-                  dispatchTable({ type: "clear-filters" })
-                  dispatchTable({ type: "set-search-term", value: "" })
-                }}
-                className="h-8 px-2 lg:px-3"
-              >
-                Xóa bộ lọc
-                <FilterX className="ml-2 size-4" />
-              </Button>
-            )}
-            <div className="ml-auto">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" className="h-8 gap-1">
-                    Cột
-                    <ChevronDown className="size-3.5" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-[180px]">
-                  <DropdownMenuLabel>Hiện/Ẩn cột</DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  {table
-                    .getAllColumns()
-                    .flatMap((column) => {
-                      if (!column.getCanHide()) return []
-                      const header = (column.columnDef.header as string) || column.id;
-                      return [(
-                        <DropdownMenuCheckboxItem
-                          key={column.id}
-                          className="capitalize"
-                          checked={column.getIsVisible()}
-                          onCheckedChange={(value) =>
-                            column.toggleVisibility(!!value)
-                          }
-                          onSelect={(e) => e.preventDefault()}
-                        >
-                          {header}
-                        </DropdownMenuCheckboxItem>
-                      )]
-                    })}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-          <div className="flex-grow rounded-md border overflow-hidden">
-            <ScrollArea className="h-full">
-              <Table>
-                <TableHeader className="sticky top-0 bg-background z-10">
-                  {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id}>
-                      {headerGroup.headers.map((header) => (
-                        <TableHead key={header.id}>
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
-                        </TableHead>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableHeader>
-                <TableBody>
-                  {missingPlanTenant ? (
-                    <TableRow>
-                      <TableCell colSpan={columns.length} className="h-24 text-center text-destructive">
-                        Không xác định được đơn vị của kế hoạch.
-                      </TableCell>
-                    </TableRow>
-                  ) : error ? (
-                    <TableRow>
-                      <TableCell colSpan={columns.length} className="h-24 text-center text-destructive">
-                        Không thể tải thiết bị: {error.message}
-                      </TableCell>
-                    </TableRow>
-                  ) : isLoading ? (
-		                    <TableRow>
-		                      <TableCell colSpan={columns.length} className="h-24 text-center">
-		                        <Loader2 className="mx-auto size-6 animate-spin" />
-		                      </TableCell>
-                    </TableRow>
-                  ) : table.getRowModel().rows?.length ? (
-                    table.getRowModel().rows.map((row) => (
-                      <TableRow
-                        key={row.id}
-                        data-state={row.getIsSelected() && "selected"}
-                        className={cn(!row.getCanSelect() && "bg-muted/50 text-muted-foreground")}
-                      >
-                        {row.getVisibleCells().map((cell) => (
-                          <TableCell key={cell.id}>
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    ))
-                  ) : (
-                    <TableRow>
-                      <TableCell colSpan={columns.length} className="h-24 text-center">
-                        Không tìm thấy kết quả phù hợp
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            </ScrollArea>
-          </div>
+          <AddTasksDialogToolbar
+            table={table}
+            tableState={tableState}
+            filterOptions={filterOptions}
+            isFiltered={isFiltered}
+            dispatchTable={dispatchTable}
+          />
+          <AddTasksEquipmentTable
+            table={table}
+            columnCount={columns.length}
+            missingPlanTenant={missingPlanTenant}
+            isLoading={isLoading}
+            error={error}
+          />
           <div className="flex items-center justify-between">
             <div className="text-sm text-muted-foreground">
               Đã chọn {selectedEquipment.length} trên {total} thiết bị phù hợp.

--- a/src/components/add-tasks-dialog.tsx
+++ b/src/components/add-tasks-dialog.tsx
@@ -205,7 +205,7 @@ export function AddTasksDialog({
           />
           <AddTasksEquipmentTable
             table={table}
-            columnCount={columns.length}
+            columnCount={table.getVisibleLeafColumns().length}
             missingPlanTenant={missingPlanTenant}
             isLoading={isLoading}
             error={error}

--- a/src/hooks/useAddTasksEquipment.ts
+++ b/src/hooks/useAddTasksEquipment.ts
@@ -42,12 +42,12 @@ type EquipmentFilterBucketsResponse = Partial<{
   location: EquipmentFilterBucket[]
 }>
 
-interface AddTasksFilterOption {
+export interface AddTasksFilterOption {
   label: string
   value: string
 }
 
-interface AddTasksFilterOptions {
+export interface AddTasksFilterOptions {
   departments: AddTasksFilterOption[]
   users: AddTasksFilterOption[]
   locations: AddTasksFilterOption[]


### PR DESCRIPTION
## Summary
- Split `AddTasksDialog` into focused table-state, toolbar, and equipment-table modules.
- Kept the exported `AddTasksDialog` API unchanged while preserving server pagination and cross-page selection ownership in the parent.
- Added a source guard for the new split and parent line-count target.

## Test Plan
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx src/components/__tests__/react-doctor-p2-rerender-source.test.ts src/__tests__/react-doctor-issue-581-hook-deps.source.test.ts --reporter=dot`
- `node scripts/npm-run.js run react-doctor`

Closes #606

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `AddTasksDialog` into focused state, toolbar, and table components for clearer structure and easier testing, with no public API changes. Closes #606.

- **Refactors**
  - Moved table state to `add-tasks-dialog.table-state.ts` (`addTasksTableReducer`, `initialAddTasksTableState`, `getAddTasksSortParam`).
  - Added `AddTasksDialogToolbar` for search, faceted filters, and column visibility.
  - Added `AddTasksEquipmentTable` to render rows and handle loading/error/empty states.
  - Kept server pagination and cross-page selection in the parent; exported `AddTasksFilterOption` and `AddTasksFilterOptions`; updated source-guard test to enforce the split.

- **Bug Fixes**
  - Table headers now respect `colSpan`; fallback rows span only visible columns.
  - Column visibility menu shows safe labels when headers are not strings.
  - Equipment load errors now show a generic message (no backend details).
  - “Clear filters” appears immediately when typing (not tied to the debounced term).

<sup>Written for commit 9f09073344419409c2ab2d5fb9784012464108e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The add-tasks dialog now has a dedicated toolbar with search, multiple filters, and column visibility controls.
  * Equipment results are shown in a more polished, scrollable table with sticky headers and clearer empty/loading/error states.

* **Bug Fixes**
  * Improved table behavior so filters, sorting, pagination, and selection reset more reliably when the dialog is refreshed or cleared.
  * Tightened guard checks to avoid unexpected selection and filtering behavior in the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->