### PR TITLE
docs: lock aggregate search contract

### DIFF
--- a/openspec/changes/add-equipment-aggregate-global-search/design.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/design.md
@@ -189,11 +189,10 @@ The current equipment catalog RPC (`equipment_list_enhanced`) includes internal 
 
 Live DB inspection confirmed existing search/index support:
 
-- `public.thiet_bi` has trigram indexes for `ten_thiet_bi`, `model`, and `serial`.
-- `public.thiet_bi` has facility/scope indexes on `don_vi` and active/non-deleted reads.
-- `public.don_vi` has region/scope indexes on `dia_ban_id`.
-- `public.nhom_thiet_bi` has FTS/keyword indexes for equipment group search.
-- quota tables have active-decision and line-item indexes for facility quota joins.
+- `public.thiet_bi`: trigram indexes for `ten_thiet_bi`, `model`, and `serial`; facility/scope indexes on `don_vi` and active/non-deleted reads.
+- `public.don_vi`: region/scope indexes on `dia_ban_id`.
+- `public.nhom_thiet_bi`: FTS/keyword indexes for equipment group search.
+- quota tables: active-decision and line-item indexes for facility quota joins.
 
 The aggregate RPC should apply scope and soft-delete filters before or inside the matched-equipment CTE, then aggregate by `dia_ban` or `don_vi` in SQL. It must not fetch equipment rows to the browser for client-side filtering or grouping.
 

--- a/openspec/changes/add-equipment-aggregate-global-search/design.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/design.md
@@ -112,20 +112,20 @@ Global search must not offer actions to assign categories, edit quota decisions,
 
 ## Data Contract
 
-The aggregate search RPC should return grouped rows, not equipment rows.
+The aggregate search RPC returns grouped rows, not equipment rows. The final RPC name is `equipment_aggregate_search`.
 
-Suggested request:
+Request:
 
 ```ts
 type EquipmentAggregateSearchRequest = {
-  query: string
-  groupBy: "region" | "facility"
-  regionId?: number | null
-  limit?: number
+  p_query: string
+  p_group_by: "region" | "facility"
+  p_region_id?: number | null
+  p_limit?: number
 }
 ```
 
-Suggested response:
+Response:
 
 ```ts
 type EquipmentAggregateSearchRow = {
@@ -152,7 +152,7 @@ type EquipmentAggregateSearchRow = {
 }
 ```
 
-Suggested summary:
+Summary:
 
 ```ts
 type EquipmentAggregateSearchSummary = {
@@ -166,6 +166,10 @@ type EquipmentAggregateSearchSummary = {
 
 ## Search Semantics
 
+V1 uses deterministic SQL keyword matching. It does not use vector search, semantic ranking, autocomplete, or live suggestions.
+
+The RPC must trim the keyword, reject empty input, and sanitize LIKE/ILIKE input with `public._sanitize_ilike_pattern()` before building any search predicate.
+
 The keyword matches:
 
 - equipment name
@@ -178,6 +182,24 @@ The keyword does not match:
 - internal equipment code, because codes are facility-defined and not comparable across the system
 
 Implementation may use accent-insensitive matching if the existing database helpers support it, but the v1 user contract is aggregate scope and field selection, not generalized full-text search.
+
+The current equipment catalog RPC (`equipment_list_enhanced`) includes internal equipment code in its search predicate. The aggregate search RPC must not reuse that predicate unchanged.
+
+## Performance Contract
+
+Live DB inspection confirmed existing search/index support:
+
+- `public.thiet_bi` has trigram indexes for `ten_thiet_bi`, `model`, and `serial`.
+- `public.thiet_bi` has facility/scope indexes on `don_vi` and active/non-deleted reads.
+- `public.don_vi` has region/scope indexes on `dia_ban_id`.
+- `public.nhom_thiet_bi` has FTS/keyword indexes for equipment group search.
+- quota tables have active-decision and line-item indexes for facility quota joins.
+
+The aggregate RPC should apply scope and soft-delete filters before or inside the matched-equipment CTE, then aggregate by `dia_ban` or `don_vi` in SQL. It must not fetch equipment rows to the browser for client-side filtering or grouping.
+
+Before adding any new index in Phase 2, run `EXPLAIN (FORMAT JSON)` for representative `region` and `facility` mode queries. If the planner still uses sequential scans at expected production scale, prefer query-shape changes first: split indexed equipment-field matches from category matches with `UNION`/CTEs, preserve deduplication by equipment id, then add narrowly-scoped indexes only when the plan proves they are needed.
+
+Vector search is explicitly out of scope for v1. It can be revisited as a separate hybrid-search follow-up only if product requirements expand to natural-language synonym discovery. Exact keyword/trigram matching remains the primary path for model, serial, and auditable aggregate counts.
 
 ## Authorization
 

--- a/openspec/changes/add-equipment-aggregate-global-search/specs/equipment-aggregate-search/spec.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/specs/equipment-aggregate-search/spec.md
@@ -231,7 +231,7 @@ The system SHALL display a concise summary of aggregate equipment search results
 
 ### Requirement: Aggregate Search Performance
 
-The system SHALL compute aggregate search results without returning equipment rows to the client.
+The system SHALL compute aggregate search results in server-side SQL using deterministic keyword predicates and shall not use vector search in v1.
 
 #### Scenario: Aggregated RPC response
 - **WHEN** the client requests aggregate search results
@@ -241,3 +241,18 @@ The system SHALL compute aggregate search results without returning equipment ro
 #### Scenario: Query stays server-side
 - **WHEN** a keyword matches many equipment records
 - **THEN** aggregation happens in SQL/server-side logic before the response is sent to the browser
+
+#### Scenario: Deterministic keyword search
+- **WHEN** the aggregate search RPC evaluates a keyword
+- **THEN** it uses sanitized SQL keyword predicates over the approved match fields
+- **AND** does not depend on vector embeddings, semantic ranking, autocomplete, or client-side search
+
+#### Scenario: Scope applied before aggregation
+- **WHEN** the aggregate search RPC computes counts for a global or regional leader user
+- **THEN** role scope and soft-delete filters are applied before grouped counts are returned
+- **AND** the browser cannot expand scope by filtering returned equipment rows
+
+#### Scenario: Index changes require query-plan evidence
+- **WHEN** implementation proposes a new search or join index for aggregate search
+- **THEN** the implementation first captures representative `EXPLAIN (FORMAT JSON)` plans for `region` and `facility` grouping
+- **AND** documents why existing trigram, FTS, facility, region, and quota indexes are insufficient

--- a/openspec/changes/add-equipment-aggregate-global-search/tasks.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/tasks.md
@@ -13,12 +13,13 @@
 
 ## Phase 1 - Discovery And Contracts (#626)
 
-- [ ] 1.1 Inspect current equipment list search fields, route query params, and facility/region filters.
-- [ ] 1.2 Inspect live schema/RPC patterns for `thiet_bi`, `don_vi`, `dia_ban`, equipment group/category, and regional leader scoping.
-- [ ] 1.3 Confirm whether existing equipment page supports `search`, `region`, and `facility` deep-link params.
-- [ ] 1.4 Inspect existing quota schema/RPCs for `quyet_dinh_dinh_muc`, `chi_tiet_dinh_muc`, `nhom_thiet_bi`, and compliance status labels.
-- [ ] 1.5 Define final RPC name, request shape, response shape, quota fields, and TypeScript types.
-- [ ] 1.6 Confirm existing indexes and query plan before adding new indexes.
+- [x] 1.1 Inspect current equipment list search fields, route query params, and facility/region filters.
+- [x] 1.2 Inspect live schema/RPC patterns for `thiet_bi`, `don_vi`, `dia_ban`, equipment group/category, and regional leader scoping.
+- [x] 1.3 Confirm whether existing equipment page supports `search`, `region`, and `facility` deep-link params.
+- [x] 1.4 Inspect existing quota schema/RPCs for `quyet_dinh_dinh_muc`, `chi_tiet_dinh_muc`, `nhom_thiet_bi`, and compliance status labels.
+- [x] 1.5 Define final RPC name, request shape, response shape, quota fields, and TypeScript types.
+- [x] 1.6 Confirm existing indexes and query plan before adding new indexes.
+- [x] 1.7 Document the v1 search algorithm and performance contract: deterministic SQL keyword search, no vector search, and `EXPLAIN` evidence before new indexes.
 
 ## Phase 2 - Backend Aggregate Search (#627)
 
@@ -28,15 +29,19 @@
 - [ ] 2.4 Enforce admin/global all-facility scope.
 - [ ] 2.5 Enforce regional leader allowed-region/facility scope server-side.
 - [ ] 2.6 Reject unsupported roles for this RPC.
-- [ ] 2.7 Match keyword against equipment name, model, serial, and equipment group/category.
+- [ ] 2.7 Match keyword against equipment name, model, serial, and equipment group/category using sanitized SQL keyword predicates.
 - [ ] 2.8 Exclude internal equipment code from search matching.
-- [ ] 2.9 Join active quota decisions and quota details to compute facility-level quota context for matched equipment.
-- [ ] 2.10 Return grouped aggregate counts for `region` and `facility` modes, with matching equipment count as the primary value.
-- [ ] 2.11 Return quota display fields for facility mode: current count, min, max, status, notes, and multi-group indicator where applicable.
-- [ ] 2.12 Return clear states for no active quota, unassigned equipment category, and equipment groups not assigned into the unit quota decision.
-- [ ] 2.13 Grant execute permission only as required by the app's RPC pattern.
-- [ ] 2.14 Add the RPC to the API proxy allowlist if the app calls it through `/api/rpc/[fn]`.
-- [ ] 2.15 Run Supabase MCP security advisors after applying the migration.
+- [ ] 2.9 Keep vector search, semantic ranking, autocomplete, and client-side filtering out of the v1 backend RPC.
+- [ ] 2.10 Apply role scope and soft-delete filters before grouping; do not return equipment rows for browser-side aggregation.
+- [ ] 2.11 Join active quota decisions and quota details to compute facility-level quota context for matched equipment.
+- [ ] 2.12 Return grouped aggregate counts for `region` and `facility` modes, with matching equipment count as the primary value.
+- [ ] 2.13 Return quota display fields for facility mode: current count, min, max, status, notes, and multi-group indicator where applicable.
+- [ ] 2.14 Return clear states for no active quota, unassigned equipment category, and equipment groups not assigned into the unit quota decision.
+- [ ] 2.15 Capture representative `EXPLAIN (FORMAT JSON)` plans for `region` and `facility` grouping before adding new indexes.
+- [ ] 2.16 Prefer query-shape fixes such as indexed-field/category CTEs or `UNION` before adding new indexes; add indexes only with plan evidence.
+- [ ] 2.17 Grant execute permission only as required by the app's RPC pattern.
+- [ ] 2.18 Add the RPC to the API proxy allowlist if the app calls it through `/api/rpc/[fn]`.
+- [ ] 2.19 Run Supabase MCP security advisors after applying the migration.
 
 ## Phase 3 - Client Data Layer (#628)
 
@@ -84,7 +89,7 @@
 - [ ] 7.7 Run `node scripts/npm-run.js run verify:no-explicit-any`.
 - [ ] 7.8 Run `node scripts/npm-run.js run verify:dedupe`.
 - [ ] 7.9 Run `node scripts/npm-run.js run typecheck`.
-- [ ] 7.10 Run focused backend/RPC verification for role scopes, field matching, quota joining, and unassigned/not-in-quota/no-active-quota states.
+- [ ] 7.10 Run focused backend/RPC verification for role scopes, field matching, quota joining, unassigned/not-in-quota/no-active-quota states, and representative `EXPLAIN` plans.
 - [ ] 7.11 Run focused React tests for changed UI behavior and quota status labels.
 - [ ] 7.12 Verify global-search URL hydration by loading `/global-search?q=...` directly and confirming the query and selected scope restore after refresh or back navigation.
 - [ ] 7.13 Run `node scripts/npm-run.js run react-doctor`.


### PR DESCRIPTION
## Summary
- Lock the aggregate search RPC contract and request shape for Phase 1.
- Document v1 search as deterministic SQL keyword search, explicitly excluding vector search and internal equipment code matching.
- Add performance acceptance criteria requiring server-side aggregation, scope-first filtering, and `EXPLAIN (FORMAT JSON)` evidence before any new indexes.

## Test Plan
- [x] `openspec validate add-equipment-aggregate-global-search --strict`
- [x] `git diff --check`
- [x] pre-commit hooks: `verify:dedupe`, `verify:no-explicit-any`, docstring gates
- [x] pre-push hooks: `typecheck`, `verify:dedupe`, `verify:no-explicit-any`, docstring gates

Closes #626

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the v1 aggregate search contract for `equipment_aggregate_search` with deterministic SQL keyword search, server-side aggregation, and a documented index inventory. Aligns Phase 1 of #626 by finalizing the RPC shape and tightening performance gates; vector/semantic search stays out of v1.

- **Refactors**
  - Finalizes RPC and types: `equipment_aggregate_search` with `p_query`, `p_group_by`, `p_region_id`, `p_limit`.
  - Clarifies v1 behavior: trim and sanitize keywords via `public._sanitize_ilike_pattern()`, reject empty input, match name/model/serial/group; exclude internal equipment code and any vector/semantic/autocomplete features.
  - Expands performance criteria: document existing trigram/FTS/scope/quota indexes, apply role/soft-delete filters before grouping, keep aggregation in SQL (no client-side), and capture `EXPLAIN (FORMAT JSON)` plans before any new indexes; updates Phase 1 as done and adjusts Phase 2 tasks/tests accordingly.

<sup>Written for commit 282af52caf5e488abf863055b741c95f145673c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the global equipment search contract, including the final RPC name and updated request/response fields.
  * Documented that search results are grouped summaries with equipment and facility counts plus quota status details.
  * Added stricter search rules: deterministic keyword matching, input trimming, and sanitization.
  * Expanded performance guidance to ensure filtering and grouping happen server-side for consistent, faster results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->