### PR TITLE
feat: add equipment aggregate search RPC

### DIFF
--- a/scripts/verify-equipment-aggregate-search-rpc.sql
+++ b/scripts/verify-equipment-aggregate-search-rpc.sql
@@ -1,0 +1,183 @@
+begin;
+
+do $$
+declare
+  v_region_a bigint := -627001;
+  v_region_b bigint := -627002;
+  v_fac_over bigint := -627101;
+  v_fac_not_in_quota bigint := -627102;
+  v_fac_no_quota bigint := -627103;
+  v_fac_unassigned bigint := -627104;
+  v_fac_below bigint := -627105;
+  v_fac_within bigint := -627106;
+  v_group_over bigint := -627201;
+  v_group_not_in_quota bigint := -627202;
+  v_group_other bigint := -627203;
+  v_group_no_quota bigint := -627204;
+  v_group_below bigint := -627205;
+  v_group_within bigint := -627206;
+  v_qd_over bigint := -627301;
+  v_qd_not_in_quota bigint := -627302;
+  v_qd_unassigned bigint := -627303;
+  v_qd_below bigint := -627304;
+  v_qd_within bigint := -627305;
+  v_result jsonb;
+  v_rows jsonb;
+  v_summary jsonb;
+  v_row jsonb;
+begin
+  insert into public.dia_ban (id, ma_dia_ban, ten_dia_ban, active)
+  values
+    (v_region_a, 'AGG-R-A-627', 'Aggregate Region A 627', true),
+    (v_region_b, 'AGG-R-B-627', 'Aggregate Region B 627', true);
+
+  insert into public.don_vi (id, code, name, active, dia_ban_id)
+  values
+    (v_fac_over, 'AGG-F-OVER-627', 'Aggregate Facility Over 627', true, v_region_a),
+    (v_fac_not_in_quota, 'AGG-F-NOT-IN-627', 'Aggregate Facility Not In Quota 627', true, v_region_a),
+    (v_fac_no_quota, 'AGG-F-NO-QUOTA-627', 'Aggregate Facility No Quota 627', true, v_region_b),
+    (v_fac_unassigned, 'AGG-F-UNASSIGNED-627', 'Aggregate Facility Unassigned 627', true, v_region_b),
+    (v_fac_below, 'AGG-F-BELOW-627', 'Aggregate Facility Below 627', true, v_region_b),
+    (v_fac_within, 'AGG-F-WITHIN-627', 'Aggregate Facility Within 627', true, v_region_b);
+
+  insert into public.nhom_thiet_bi (id, don_vi_id, ma_nhom, ten_nhom)
+  values
+    (v_group_over, v_fac_over, 'AGG-G-OVER-627', 'Aggregate Pump Group 627'),
+    (v_group_not_in_quota, v_fac_not_in_quota, 'AGG-G-NOT-IN-627', 'Aggregate Serial Group 627'),
+    (v_group_other, v_fac_not_in_quota, 'AGG-G-OTHER-627', 'Aggregate Other Group 627'),
+    (v_group_no_quota, v_fac_no_quota, 'AGG-G-NO-QUOTA-627', 'Aggregate Category Group 627'),
+    (v_group_below, v_fac_below, 'AGG-G-BELOW-627', 'Aggregate Below Group 627'),
+    (v_group_within, v_fac_within, 'AGG-G-WITHIN-627', 'Aggregate Within Group 627');
+
+  insert into public.quyet_dinh_dinh_muc
+    (id, don_vi_id, so_quyet_dinh, ngay_ban_hanh, ngay_hieu_luc, nguoi_ky, chuc_vu_nguoi_ky, trang_thai)
+  values
+    (v_qd_over, v_fac_over, 'AGG-QD-OVER-627', current_date, current_date, 'Tester', 'Tester', 'active'),
+    (v_qd_not_in_quota, v_fac_not_in_quota, 'AGG-QD-NOT-IN-627', current_date, current_date, 'Tester', 'Tester', 'active'),
+    (v_qd_unassigned, v_fac_unassigned, 'AGG-QD-UNASSIGNED-627', current_date, current_date, 'Tester', 'Tester', 'active'),
+    (v_qd_below, v_fac_below, 'AGG-QD-BELOW-627', current_date, current_date, 'Tester', 'Tester', 'active'),
+    (v_qd_within, v_fac_within, 'AGG-QD-WITHIN-627', current_date, current_date, 'Tester', 'Tester', 'active');
+
+  insert into public.chi_tiet_dinh_muc
+    (quyet_dinh_id, nhom_thiet_bi_id, so_luong_toi_da, so_luong_toi_thieu)
+  values
+    (v_qd_over, v_group_over, 1, 0),
+    (v_qd_not_in_quota, v_group_other, 5, 0),
+    (v_qd_unassigned, v_group_over, 5, 0),
+    (v_qd_below, v_group_below, 5, 2),
+    (v_qd_within, v_group_within, 2, 1);
+
+  insert into public.thiet_bi
+    (id, ma_thiet_bi, ten_thiet_bi, model, serial, don_vi, nhom_thiet_bi_id, is_deleted)
+  values
+    (-627401, 'AGG-CODE-ONLY-627', 'Aggregate Alpha Pump 627', 'AGG-MODEL-627', 'AGG-SERIAL-OVER-627', v_fac_over, v_group_over, false),
+    (-627402, 'AGG-CODE-SECOND-627', 'Aggregate Alpha Pump 627 Second', 'AGG-MODEL-627-B', 'AGG-SERIAL-OVER-627-B', v_fac_over, v_group_over, false),
+    (-627403, 'AGG-CODE-NOT-IN-627', 'Not In Quota Equipment 627', 'OTHER-MODEL-627', 'AGG-SERIAL-NOT-IN-627', v_fac_not_in_quota, v_group_not_in_quota, false),
+    (-627404, 'AGG-CODE-NO-QUOTA-627', 'Category Field Equipment 627', 'OTHER-MODEL-627', 'OTHER-SERIAL-627', v_fac_no_quota, v_group_no_quota, false),
+    (-627405, 'AGG-CODE-UNASSIGNED-627', 'Aggregate Unassigned Match 627', 'OTHER-MODEL-627', 'OTHER-SERIAL-627', v_fac_unassigned, null, false),
+    (-627406, 'AGG-CODE-BELOW-627', 'Aggregate Below Match 627', 'OTHER-MODEL-627', 'OTHER-SERIAL-627', v_fac_below, v_group_below, false),
+    (-627407, 'AGG-CODE-WITHIN-627', 'Aggregate Within Match 627', 'OTHER-MODEL-627', 'OTHER-SERIAL-627', v_fac_within, v_group_within, false),
+    (-627408, 'AGG-CODE-ONLY-NEVER-MATCH-627', 'No Keyword Here', 'NO-MODEL-HERE', 'NO-SERIAL-HERE', v_fac_within, v_group_within, false);
+
+  perform set_config('request.jwt.claims', jsonb_build_object(
+    'app_role', 'admin',
+    'user_id', 'agg-admin-627'
+  )::text, true);
+
+  v_result := public.equipment_aggregate_search('AGG-MODEL-627', 'region', null, 10);
+  v_rows := v_result -> 'rows';
+  v_summary := v_result -> 'summary';
+  if jsonb_array_length(v_rows) <> 1 then
+    raise exception 'expected one region row for model match, got %', v_rows;
+  end if;
+  v_row := v_rows -> 0;
+  if (v_row ->> 'groupType') <> 'region'
+     or (v_row ->> 'groupId')::bigint <> v_region_a
+     or (v_row ->> 'equipmentCount')::int <> 2
+     or (v_row ->> 'facilityCount')::int <> 1 then
+    raise exception 'unexpected region row for model match: %', v_row;
+  end if;
+  if (v_summary ->> 'totalEquipmentCount')::int <> 2
+     or (v_summary ->> 'regionCount')::int <> 1
+     or (v_summary ->> 'facilityCount')::int <> 1 then
+    raise exception 'unexpected summary for model match: %', v_summary;
+  end if;
+
+  v_result := public.equipment_aggregate_search('AGG-CODE-ONLY-NEVER-MATCH-627', 'facility', null, 10);
+  if jsonb_array_length(v_result -> 'rows') <> 0 then
+    raise exception 'internal equipment code must not be a search predicate: %', v_result;
+  end if;
+
+  v_result := public.equipment_aggregate_search('AGG-SERIAL-NOT-IN-627', 'facility', null, 10);
+  v_row := v_result -> 'rows' -> 0;
+  if (v_row ->> 'groupId')::bigint <> v_fac_not_in_quota
+     or (v_row ->> 'quotaStatus') <> 'not_in_unit_quota' then
+    raise exception 'expected serial match with not_in_unit_quota, got %', v_row;
+  end if;
+
+  v_result := public.equipment_aggregate_search('Aggregate Category Group 627', 'facility', null, 10);
+  v_row := v_result -> 'rows' -> 0;
+  if (v_row ->> 'groupId')::bigint <> v_fac_no_quota
+     or (v_row ->> 'quotaStatus') <> 'no_active_quota' then
+    raise exception 'expected category match with no_active_quota, got %', v_row;
+  end if;
+
+  v_result := public.equipment_aggregate_search('Aggregate Unassigned Match 627', 'facility', null, 10);
+  v_row := v_result -> 'rows' -> 0;
+  if (v_row ->> 'groupId')::bigint <> v_fac_unassigned
+     or (v_row ->> 'quotaStatus') <> 'unassigned_category' then
+    raise exception 'expected unassigned_category, got %', v_row;
+  end if;
+
+  v_result := public.equipment_aggregate_search('Aggregate Below Match 627', 'facility', null, 10);
+  v_row := v_result -> 'rows' -> 0;
+  if (v_row ->> 'quotaStatus') <> 'below_minimum'
+     or (v_row ->> 'quotaCurrentCount')::int <> 1
+     or (v_row ->> 'quotaMinCount')::int <> 2
+     or (v_row ->> 'quotaMaxCount')::int <> 5 then
+    raise exception 'expected below_minimum quota context, got %', v_row;
+  end if;
+
+  v_result := public.equipment_aggregate_search('Aggregate Within Match 627', 'facility', null, 10);
+  v_row := v_result -> 'rows' -> 0;
+  if (v_row ->> 'quotaStatus') <> 'within_limit' then
+    raise exception 'expected within_limit, got %', v_row;
+  end if;
+
+  perform set_config('request.jwt.claims', jsonb_build_object(
+    'app_role', 'regional_leader',
+    'user_id', 'agg-regional-627',
+    'dia_ban', v_region_a
+  )::text, true);
+
+  v_result := public.equipment_aggregate_search('Aggregate', 'facility', v_region_b, 20);
+  if jsonb_array_length(v_result -> 'rows') <> 0 then
+    raise exception 'regional leader region param expanded scope: %', v_result;
+  end if;
+
+  v_result := public.equipment_aggregate_search('Aggregate', 'facility', v_region_a, 20);
+  if exists (
+    select 1
+    from jsonb_array_elements(v_result -> 'rows') as row(value)
+    where (row.value ->> 'parentRegionId')::bigint <> v_region_a
+  ) then
+    raise exception 'regional leader leaked outside assigned region: %', v_result;
+  end if;
+
+  perform set_config('request.jwt.claims', jsonb_build_object(
+    'app_role', 'user',
+    'user_id', 'agg-user-627',
+    'don_vi', v_fac_over
+  )::text, true);
+
+  begin
+    perform public.equipment_aggregate_search('Aggregate', 'facility', null, 10);
+    raise exception 'unsupported role user was not rejected';
+  exception
+    when insufficient_privilege then
+      null;
+  end;
+end;
+$$;
+
+rollback;

--- a/scripts/verify-equipment-aggregate-search-rpc.sql
+++ b/scripts/verify-equipment-aggregate-search-rpc.sql
@@ -210,7 +210,7 @@ begin
   if exists (
     select 1
     from jsonb_array_elements(v_result -> 'rows') as row(value)
-    where (row.value ->> 'parentRegionId')::bigint <> v_region_a
+    where ((row.value ->> 'parentRegionId')::bigint) is distinct from v_region_a
   ) then
     raise exception 'regional leader leaked outside assigned region: %', v_result;
   end if;

--- a/scripts/verify-equipment-aggregate-search-rpc.sql
+++ b/scripts/verify-equipment-aggregate-search-rpc.sql
@@ -10,12 +10,14 @@ declare
   v_fac_unassigned bigint := -627104;
   v_fac_below bigint := -627105;
   v_fac_within bigint := -627106;
+  v_fac_no_region bigint := -627107;
   v_group_over bigint := -627201;
   v_group_not_in_quota bigint := -627202;
   v_group_other bigint := -627203;
   v_group_no_quota bigint := -627204;
   v_group_below bigint := -627205;
   v_group_within bigint := -627206;
+  v_group_no_region bigint := -627207;
   v_qd_over bigint := -627301;
   v_qd_not_in_quota bigint := -627302;
   v_qd_unassigned bigint := -627303;
@@ -38,7 +40,8 @@ begin
     (v_fac_no_quota, 'AGG-F-NO-QUOTA-627', 'Aggregate Facility No Quota 627', true, v_region_b),
     (v_fac_unassigned, 'AGG-F-UNASSIGNED-627', 'Aggregate Facility Unassigned 627', true, v_region_b),
     (v_fac_below, 'AGG-F-BELOW-627', 'Aggregate Facility Below 627', true, v_region_b),
-    (v_fac_within, 'AGG-F-WITHIN-627', 'Aggregate Facility Within 627', true, v_region_b);
+    (v_fac_within, 'AGG-F-WITHIN-627', 'Aggregate Facility Within 627', true, v_region_b),
+    (v_fac_no_region, 'AGG-F-NO-REGION-627', 'Aggregate Facility No Region 627', true, null);
 
   insert into public.nhom_thiet_bi (id, don_vi_id, ma_nhom, ten_nhom)
   values
@@ -47,7 +50,8 @@ begin
     (v_group_other, v_fac_not_in_quota, 'AGG-G-OTHER-627', 'Aggregate Other Group 627'),
     (v_group_no_quota, v_fac_no_quota, 'AGG-G-NO-QUOTA-627', 'Aggregate Category Group 627'),
     (v_group_below, v_fac_below, 'AGG-G-BELOW-627', 'Aggregate Below Group 627'),
-    (v_group_within, v_fac_within, 'AGG-G-WITHIN-627', 'Aggregate Within Group 627');
+    (v_group_within, v_fac_within, 'AGG-G-WITHIN-627', 'Aggregate Within Group 627'),
+    (v_group_no_region, v_fac_no_region, 'AGG-G-NO-REGION-627', 'Aggregate No Region Group 627');
 
   insert into public.quyet_dinh_dinh_muc
     (id, don_vi_id, so_quyet_dinh, ngay_ban_hanh, ngay_hieu_luc, nguoi_ky, chuc_vu_nguoi_ky, trang_thai)
@@ -77,7 +81,8 @@ begin
     (-627405, 'AGG-CODE-UNASSIGNED-627', 'Aggregate Unassigned Match 627', 'OTHER-MODEL-627', 'OTHER-SERIAL-627', v_fac_unassigned, null, false),
     (-627406, 'AGG-CODE-BELOW-627', 'Aggregate Below Match 627', 'OTHER-MODEL-627', 'OTHER-SERIAL-627', v_fac_below, v_group_below, false),
     (-627407, 'AGG-CODE-WITHIN-627', 'Aggregate Within Match 627', 'OTHER-MODEL-627', 'OTHER-SERIAL-627', v_fac_within, v_group_within, false),
-    (-627408, 'AGG-CODE-ONLY-NEVER-MATCH-627', 'No Keyword Here', 'NO-MODEL-HERE', 'NO-SERIAL-HERE', v_fac_within, v_group_within, false);
+    (-627408, 'AGG-CODE-ONLY-NEVER-MATCH-627', 'No Keyword Here', 'NO-MODEL-HERE', 'NO-SERIAL-HERE', v_fac_within, v_group_within, false),
+    (-627409, 'AGG-CODE-NO-REGION-627', 'Aggregate No Region Match 627', 'OTHER-MODEL-627', 'OTHER-SERIAL-627', v_fac_no_region, v_group_no_region, false);
 
   perform set_config('request.jwt.claims', jsonb_build_object(
     'app_role', 'admin',
@@ -108,29 +113,71 @@ begin
     raise exception 'internal equipment code must not be a search predicate: %', v_result;
   end if;
 
+  v_result := public.equipment_aggregate_search('Aggregate No Region Match 627', 'region', null, 10);
+  v_rows := v_result -> 'rows';
+  v_summary := v_result -> 'summary';
+  if jsonb_array_length(v_rows) <> 1 then
+    raise exception 'expected one no-region row, got %', v_rows;
+  end if;
+  v_row := v_rows -> 0;
+  if (v_row ->> 'groupId') is not null
+     or (v_row ->> 'groupName') <> 'Chưa phân vùng'
+     or (v_summary ->> 'regionCount')::int <> 1 then
+    raise exception 'expected no-region bucket counted in summary, got row %, summary %', v_row, v_summary;
+  end if;
+
+  v_result := public.equipment_aggregate_search('AGG-MODEL-627', 'facility', null, 10);
+  v_rows := v_result -> 'rows';
+  if jsonb_array_length(v_rows) <> 1 then
+    raise exception 'expected one over-limit facility row, got %', v_rows;
+  end if;
+  v_row := v_rows -> 0;
+  if (v_row ->> 'groupId')::bigint <> v_fac_over
+     or (v_row ->> 'quotaStatus') <> 'over_limit'
+     or (v_row ->> 'quotaCurrentCount')::int <> 2
+     or (v_row ->> 'quotaMaxCount')::int <> 1 then
+    raise exception 'expected over_limit quota context, got %', v_row;
+  end if;
+
   v_result := public.equipment_aggregate_search('AGG-SERIAL-NOT-IN-627', 'facility', null, 10);
-  v_row := v_result -> 'rows' -> 0;
+  v_rows := v_result -> 'rows';
+  if jsonb_array_length(v_rows) <> 1 then
+    raise exception 'expected one serial match row, got %', v_rows;
+  end if;
+  v_row := v_rows -> 0;
   if (v_row ->> 'groupId')::bigint <> v_fac_not_in_quota
      or (v_row ->> 'quotaStatus') <> 'not_in_unit_quota' then
     raise exception 'expected serial match with not_in_unit_quota, got %', v_row;
   end if;
 
   v_result := public.equipment_aggregate_search('Aggregate Category Group 627', 'facility', null, 10);
-  v_row := v_result -> 'rows' -> 0;
+  v_rows := v_result -> 'rows';
+  if jsonb_array_length(v_rows) <> 1 then
+    raise exception 'expected one category match row, got %', v_rows;
+  end if;
+  v_row := v_rows -> 0;
   if (v_row ->> 'groupId')::bigint <> v_fac_no_quota
      or (v_row ->> 'quotaStatus') <> 'no_active_quota' then
     raise exception 'expected category match with no_active_quota, got %', v_row;
   end if;
 
   v_result := public.equipment_aggregate_search('Aggregate Unassigned Match 627', 'facility', null, 10);
-  v_row := v_result -> 'rows' -> 0;
+  v_rows := v_result -> 'rows';
+  if jsonb_array_length(v_rows) <> 1 then
+    raise exception 'expected one unassigned match row, got %', v_rows;
+  end if;
+  v_row := v_rows -> 0;
   if (v_row ->> 'groupId')::bigint <> v_fac_unassigned
      or (v_row ->> 'quotaStatus') <> 'unassigned_category' then
     raise exception 'expected unassigned_category, got %', v_row;
   end if;
 
   v_result := public.equipment_aggregate_search('Aggregate Below Match 627', 'facility', null, 10);
-  v_row := v_result -> 'rows' -> 0;
+  v_rows := v_result -> 'rows';
+  if jsonb_array_length(v_rows) <> 1 then
+    raise exception 'expected one below-minimum match row, got %', v_rows;
+  end if;
+  v_row := v_rows -> 0;
   if (v_row ->> 'quotaStatus') <> 'below_minimum'
      or (v_row ->> 'quotaCurrentCount')::int <> 1
      or (v_row ->> 'quotaMinCount')::int <> 2
@@ -139,7 +186,11 @@ begin
   end if;
 
   v_result := public.equipment_aggregate_search('Aggregate Within Match 627', 'facility', null, 10);
-  v_row := v_result -> 'rows' -> 0;
+  v_rows := v_result -> 'rows';
+  if jsonb_array_length(v_rows) <> 1 then
+    raise exception 'expected one within-limit match row, got %', v_rows;
+  end if;
+  v_row := v_rows -> 0;
   if (v_row ->> 'quotaStatus') <> 'within_limit' then
     raise exception 'expected within_limit, got %', v_row;
   end if;

--- a/scripts/verify-equipment-aggregate-search-rpc.sql
+++ b/scripts/verify-equipment-aggregate-search-rpc.sql
@@ -67,7 +67,6 @@ begin
   values
     (v_qd_over, v_group_over, 1, 0),
     (v_qd_not_in_quota, v_group_other, 5, 0),
-    (v_qd_unassigned, v_group_over, 5, 0),
     (v_qd_below, v_group_below, 5, 2),
     (v_qd_within, v_group_within, 2, 1);
 

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -29,6 +29,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   'equipment_funding_sources_list_for_tenant',
   'equipment_filter_buckets',
   'equipment_department_distribution',
+  'equipment_aggregate_search',
   'equipment_bulk_import',
   // Repairs
   'repair_request_list',

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -75,6 +75,7 @@ describe('RPC proxy whitelist', () => {
     'equipment_filter_buckets',
     'equipment_department_distribution',
     'dashboard_kpi_summary',
+    'equipment_aggregate_search',
   ])('allows performance RPC "%s" through whitelist checks', async (fn) => {
     const res = await invokeRpcProxy(fn)
 

--- a/supabase/migrations/20260628094000_add_equipment_aggregate_search_rpc.sql
+++ b/supabase/migrations/20260628094000_add_equipment_aggregate_search_rpc.sql
@@ -1,0 +1,302 @@
+-- Phase 2 of add-equipment-aggregate-global-search.
+-- EXPLAIN (FORMAT JSON) was captured before this migration; no new indexes are added.
+
+CREATE OR REPLACE FUNCTION public.equipment_aggregate_search(
+  p_query text,
+  p_group_by text DEFAULT 'region',
+  p_region_id bigint DEFAULT NULL,
+  p_limit integer DEFAULT 50
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text := lower(COALESCE(public._get_jwt_claim('app_role'), public._get_jwt_claim('role'), ''));
+  v_user_id text := NULLIF(COALESCE(public._get_jwt_claim('user_id'), public._get_jwt_claim('sub')), '');
+  v_query text := NULLIF(BTRIM(COALESCE(p_query, '')), '');
+  v_sanitized_query text;
+  v_group_by text := COALESCE(lower(NULLIF(BTRIM(COALESCE(p_group_by, 'region')), '')), 'region');
+  v_limit integer := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
+  v_allowed_facilities bigint[] := NULL;
+  v_rows jsonb := '[]'::jsonb;
+  v_summary jsonb := '{}'::jsonb;
+  v_scope_label text;
+BEGIN
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_role NOT IN ('global', 'regional_leader') THEN
+    RAISE EXCEPTION 'Access denied for role %', v_role USING ERRCODE = '42501';
+  END IF;
+
+  IF v_query IS NULL THEN
+    RAISE EXCEPTION 'Search query is required' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_group_by NOT IN ('region', 'facility') THEN
+    RAISE EXCEPTION 'Unsupported group_by %', p_group_by USING ERRCODE = '22023';
+  END IF;
+
+  v_sanitized_query := public._sanitize_ilike_pattern(v_query);
+  IF v_sanitized_query IS NULL THEN
+    RAISE EXCEPTION 'Search query is required' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    v_allowed_facilities := public.allowed_don_vi_for_session_safe();
+    IF v_allowed_facilities IS NULL OR cardinality(v_allowed_facilities) = 0 THEN
+      v_allowed_facilities := ARRAY[]::bigint[];
+    END IF;
+  END IF;
+
+  WITH scoped_facilities AS (
+    SELECT
+      dv.id AS facility_id,
+      dv.name AS facility_name,
+      dv.dia_ban_id AS region_id,
+      db.ten_dia_ban AS region_name
+    FROM public.don_vi dv
+    LEFT JOIN public.dia_ban db ON db.id = dv.dia_ban_id
+    WHERE dv.active = true
+      AND (v_role = 'global' OR dv.id = ANY(v_allowed_facilities))
+      AND (p_region_id IS NULL OR dv.dia_ban_id = p_region_id)
+  ),
+  matched_equipment AS (
+    SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
+    FROM scoped_facilities sf
+    JOIN public.thiet_bi tb ON tb.don_vi = sf.facility_id
+    WHERE tb.is_deleted = false
+      AND tb.ten_thiet_bi ILIKE ('%' || v_sanitized_query || '%')
+
+    UNION
+
+    SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
+    FROM scoped_facilities sf
+    JOIN public.thiet_bi tb ON tb.don_vi = sf.facility_id
+    WHERE tb.is_deleted = false
+      AND tb.model ILIKE ('%' || v_sanitized_query || '%')
+
+    UNION
+
+    SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
+    FROM scoped_facilities sf
+    JOIN public.thiet_bi tb ON tb.don_vi = sf.facility_id
+    WHERE tb.is_deleted = false
+      AND tb.serial ILIKE ('%' || v_sanitized_query || '%')
+
+    UNION
+
+    SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
+    FROM scoped_facilities sf
+    JOIN public.thiet_bi tb ON tb.don_vi = sf.facility_id
+    JOIN public.nhom_thiet_bi ntb ON ntb.id = tb.nhom_thiet_bi_id AND ntb.don_vi_id = tb.don_vi
+    WHERE tb.is_deleted = false
+      AND (
+        ntb.ten_nhom ILIKE ('%' || v_sanitized_query || '%')
+        OR EXISTS (
+          SELECT 1
+          FROM unnest(COALESCE(ntb.tu_khoa, ARRAY[]::text[])) AS kw(keyword)
+          WHERE kw.keyword ILIKE ('%' || v_sanitized_query || '%')
+        )
+      )
+  ),
+  active_decisions AS (
+    SELECT DISTINCT ON (qd.don_vi_id)
+      qd.don_vi_id AS facility_id,
+      qd.id AS decision_id
+    FROM public.quyet_dinh_dinh_muc qd
+    JOIN (SELECT DISTINCT facility_id FROM matched_equipment) mf ON mf.facility_id = qd.don_vi_id
+    WHERE qd.trang_thai = 'active'
+    ORDER BY qd.don_vi_id, qd.ngay_hieu_luc DESC NULLS LAST, qd.id DESC
+  ),
+  matched_groups AS (
+    SELECT
+      me.facility_id,
+      me.nhom_thiet_bi_id,
+      COUNT(*)::bigint AS matched_count
+    FROM matched_equipment me
+    GROUP BY me.facility_id, me.nhom_thiet_bi_id
+  ),
+  group_current_counts AS (
+    SELECT
+      mg.facility_id,
+      mg.nhom_thiet_bi_id,
+      COUNT(tb.id)::bigint AS current_count
+    FROM matched_groups mg
+    JOIN public.thiet_bi tb
+      ON tb.don_vi = mg.facility_id
+     AND tb.nhom_thiet_bi_id = mg.nhom_thiet_bi_id
+     AND tb.is_deleted = false
+    WHERE mg.nhom_thiet_bi_id IS NOT NULL
+    GROUP BY mg.facility_id, mg.nhom_thiet_bi_id
+  ),
+  group_quota_status AS (
+    SELECT
+      mg.facility_id,
+      mg.nhom_thiet_bi_id,
+      mg.matched_count,
+      ad.decision_id,
+      cd.so_luong_toi_thieu,
+      cd.so_luong_toi_da,
+      COALESCE(gcc.current_count, 0)::bigint AS current_count,
+      CASE
+        WHEN ad.decision_id IS NULL THEN 'no_active_quota'
+        WHEN mg.nhom_thiet_bi_id IS NULL THEN 'unassigned_category'
+        WHEN cd.nhom_thiet_bi_id IS NULL THEN 'not_in_unit_quota'
+        WHEN COALESCE(gcc.current_count, 0) < cd.so_luong_toi_thieu THEN 'below_minimum'
+        WHEN COALESCE(gcc.current_count, 0) > cd.so_luong_toi_da THEN 'over_limit'
+        ELSE 'within_limit'
+      END AS quota_status
+    FROM matched_groups mg
+    LEFT JOIN active_decisions ad ON ad.facility_id = mg.facility_id
+    LEFT JOIN public.chi_tiet_dinh_muc cd
+      ON cd.quyet_dinh_id = ad.decision_id
+     AND cd.nhom_thiet_bi_id = mg.nhom_thiet_bi_id
+    LEFT JOIN group_current_counts gcc
+      ON gcc.facility_id = mg.facility_id
+     AND gcc.nhom_thiet_bi_id = mg.nhom_thiet_bi_id
+  ),
+  facility_quota AS (
+    SELECT
+      gqs.facility_id,
+      CASE
+        WHEN COUNT(DISTINCT gqs.quota_status) > 1 THEN 'mixed'
+        ELSE MIN(gqs.quota_status)
+      END AS quota_status,
+      SUM(gqs.current_count) FILTER (WHERE gqs.so_luong_toi_da IS NOT NULL)::bigint AS quota_current_count,
+      SUM(gqs.so_luong_toi_thieu) FILTER (WHERE gqs.so_luong_toi_thieu IS NOT NULL)::bigint AS quota_min_count,
+      SUM(gqs.so_luong_toi_da) FILTER (WHERE gqs.so_luong_toi_da IS NOT NULL)::bigint AS quota_max_count,
+      array_agg(DISTINCT gqs.quota_status ORDER BY gqs.quota_status) AS quota_notes
+    FROM group_quota_status gqs
+    GROUP BY gqs.facility_id
+  ),
+  region_rows AS (
+    SELECT
+      'region'::text AS group_type,
+      me.region_id AS group_id,
+      COALESCE(me.region_name, 'Chưa phân vùng') AS group_name,
+      NULL::bigint AS parent_region_id,
+      NULL::text AS parent_region_name,
+      COUNT(me.id)::bigint AS equipment_count,
+      COUNT(DISTINCT me.facility_id)::bigint AS facility_count,
+      NULL::bigint AS quota_current_count,
+      NULL::bigint AS quota_min_count,
+      NULL::bigint AS quota_max_count,
+      NULL::text AS quota_status,
+      ARRAY[]::text[] AS quota_notes
+    FROM matched_equipment me
+    GROUP BY me.region_id, me.region_name
+  ),
+  facility_rows AS (
+    SELECT
+      'facility'::text AS group_type,
+      me.facility_id AS group_id,
+      me.facility_name AS group_name,
+      me.region_id AS parent_region_id,
+      me.region_name AS parent_region_name,
+      COUNT(me.id)::bigint AS equipment_count,
+      1::bigint AS facility_count,
+      fq.quota_current_count,
+      fq.quota_min_count,
+      fq.quota_max_count,
+      fq.quota_status,
+      COALESCE(fq.quota_notes, ARRAY[]::text[]) AS quota_notes
+    FROM matched_equipment me
+    LEFT JOIN facility_quota fq ON fq.facility_id = me.facility_id
+    GROUP BY
+      me.facility_id,
+      me.facility_name,
+      me.region_id,
+      me.region_name,
+      fq.quota_current_count,
+      fq.quota_min_count,
+      fq.quota_max_count,
+      fq.quota_status,
+      fq.quota_notes
+  ),
+  selected_rows AS (
+    SELECT *
+    FROM region_rows
+    WHERE v_group_by = 'region'
+    UNION ALL
+    SELECT *
+    FROM facility_rows
+    WHERE v_group_by = 'facility'
+  ),
+  limited_rows AS (
+    SELECT *
+    FROM selected_rows
+    ORDER BY equipment_count DESC, group_name ASC, group_id ASC
+    LIMIT v_limit
+  ),
+  totals AS (
+    SELECT
+      COUNT(*)::bigint AS total_equipment_count,
+      COUNT(DISTINCT region_id)::bigint AS region_count,
+      COUNT(DISTINCT facility_id)::bigint AS facility_count
+    FROM matched_equipment
+  )
+  SELECT
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'groupType', lr.group_type,
+          'groupId', lr.group_id,
+          'groupName', lr.group_name,
+          'parentRegionId', lr.parent_region_id,
+          'parentRegionName', lr.parent_region_name,
+          'equipmentCount', lr.equipment_count,
+          'facilityCount', lr.facility_count,
+          'quotaCurrentCount', lr.quota_current_count,
+          'quotaMinCount', lr.quota_min_count,
+          'quotaMaxCount', lr.quota_max_count,
+          'quotaStatus', lr.quota_status,
+          'quotaNotes', lr.quota_notes
+        )
+        ORDER BY lr.equipment_count DESC, lr.group_name ASC, lr.group_id ASC
+      ) FILTER (WHERE lr.group_type IS NOT NULL),
+      '[]'::jsonb
+    ),
+    jsonb_build_object(
+      'totalEquipmentCount', COALESCE(MAX(t.total_equipment_count), 0),
+      'regionCount', COALESCE(MAX(t.region_count), 0),
+      'facilityCount', COALESCE(MAX(t.facility_count), 0),
+      'query', v_query,
+      'scopeLabel', v_scope_label
+    )
+  INTO v_rows, v_summary
+  FROM totals t
+  LEFT JOIN limited_rows lr ON true;
+
+  IF v_role = 'global' THEN
+    v_scope_label := CASE WHEN p_region_id IS NULL THEN 'Toàn hệ thống' ELSE 'Theo địa bàn' END;
+  ELSE
+    v_scope_label := 'Địa bàn phụ trách';
+  END IF;
+
+  v_summary := jsonb_set(v_summary, '{scopeLabel}', to_jsonb(v_scope_label));
+
+  RETURN jsonb_build_object(
+    'rows', v_rows,
+    'summary', v_summary
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.equipment_aggregate_search(text, text, bigint, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.equipment_aggregate_search(text, text, bigint, integer) TO authenticated;
+
+COMMENT ON FUNCTION public.equipment_aggregate_search(text, text, bigint, integer)
+IS 'Role-scoped deterministic aggregate equipment keyword search for global/admin and regional leader users.';

--- a/supabase/migrations/20260628094000_add_equipment_aggregate_search_rpc.sql
+++ b/supabase/migrations/20260628094000_add_equipment_aggregate_search_rpc.sql
@@ -63,6 +63,12 @@ BEGIN
     END IF;
   END IF;
 
+  IF v_role = 'global' THEN
+    v_scope_label := CASE WHEN p_region_id IS NULL THEN 'Toàn hệ thống' ELSE 'Theo địa bàn' END;
+  ELSE
+    v_scope_label := 'Địa bàn phụ trách';
+  END IF;
+
   WITH scoped_facilities AS (
     SELECT
       dv.id AS facility_id,
@@ -75,14 +81,14 @@ BEGIN
       AND (v_role = 'global' OR dv.id = ANY(v_allowed_facilities))
       AND (p_region_id IS NULL OR dv.dia_ban_id = p_region_id)
   ),
-  matched_equipment AS (
+  raw_matched_equipment AS (
     SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
     FROM scoped_facilities sf
     JOIN public.thiet_bi tb ON tb.don_vi = sf.facility_id
     WHERE tb.is_deleted = false
       AND tb.ten_thiet_bi ILIKE ('%' || v_sanitized_query || '%')
 
-    UNION
+    UNION ALL
 
     SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
     FROM scoped_facilities sf
@@ -90,7 +96,7 @@ BEGIN
     WHERE tb.is_deleted = false
       AND tb.model ILIKE ('%' || v_sanitized_query || '%')
 
-    UNION
+    UNION ALL
 
     SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
     FROM scoped_facilities sf
@@ -98,7 +104,7 @@ BEGIN
     WHERE tb.is_deleted = false
       AND tb.serial ILIKE ('%' || v_sanitized_query || '%')
 
-    UNION
+    UNION ALL
 
     SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
     FROM scoped_facilities sf
@@ -113,6 +119,11 @@ BEGIN
           WHERE kw.keyword ILIKE ('%' || v_sanitized_query || '%')
         )
       )
+  ),
+  matched_equipment AS (
+    SELECT DISTINCT ON (id) id, facility_id, nhom_thiet_bi_id, region_id, region_name, facility_name
+    FROM raw_matched_equipment
+    ORDER BY id
   ),
   active_decisions AS (
     SELECT DISTINCT ON (qd.don_vi_id)
@@ -320,14 +331,6 @@ BEGIN
   INTO v_rows, v_summary
   FROM totals t
   LEFT JOIN limited_rows lr ON true;
-
-  IF v_role = 'global' THEN
-    v_scope_label := CASE WHEN p_region_id IS NULL THEN 'Toàn hệ thống' ELSE 'Theo địa bàn' END;
-  ELSE
-    v_scope_label := 'Địa bàn phụ trách';
-  END IF;
-
-  v_summary := jsonb_set(v_summary, '{scopeLabel}', to_jsonb(v_scope_label));
 
   RETURN jsonb_build_object(
     'rows', v_rows,

--- a/supabase/migrations/20260628094000_add_equipment_aggregate_search_rpc.sql
+++ b/supabase/migrations/20260628094000_add_equipment_aggregate_search_rpc.sql
@@ -86,23 +86,11 @@ BEGIN
     FROM scoped_facilities sf
     JOIN public.thiet_bi tb ON tb.don_vi = sf.facility_id
     WHERE tb.is_deleted = false
-      AND tb.ten_thiet_bi ILIKE ('%' || v_sanitized_query || '%')
-
-    UNION ALL
-
-    SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
-    FROM scoped_facilities sf
-    JOIN public.thiet_bi tb ON tb.don_vi = sf.facility_id
-    WHERE tb.is_deleted = false
-      AND tb.model ILIKE ('%' || v_sanitized_query || '%')
-
-    UNION ALL
-
-    SELECT tb.id, tb.don_vi AS facility_id, tb.nhom_thiet_bi_id, sf.region_id, sf.region_name, sf.facility_name
-    FROM scoped_facilities sf
-    JOIN public.thiet_bi tb ON tb.don_vi = sf.facility_id
-    WHERE tb.is_deleted = false
-      AND tb.serial ILIKE ('%' || v_sanitized_query || '%')
+      AND (
+        tb.ten_thiet_bi ILIKE ('%' || v_sanitized_query || '%')
+        OR tb.model ILIKE ('%' || v_sanitized_query || '%')
+        OR tb.serial ILIKE ('%' || v_sanitized_query || '%')
+      )
 
     UNION ALL
 

--- a/supabase/migrations/20260628094000_add_equipment_aggregate_search_rpc.sql
+++ b/supabase/migrations/20260628094000_add_equipment_aggregate_search_rpc.sql
@@ -1,6 +1,8 @@
 -- Phase 2 of add-equipment-aggregate-global-search.
 -- EXPLAIN (FORMAT JSON) was captured before this migration; no new indexes are added.
 
+BEGIN;
+
 CREATE OR REPLACE FUNCTION public.equipment_aggregate_search(
   p_query text,
   p_group_by text DEFAULT 'region',
@@ -29,7 +31,7 @@ BEGIN
     v_role := 'global';
   END IF;
 
-  IF v_role IS NULL OR v_role = '' THEN
+  IF v_role = '' THEN
     RAISE EXCEPTION 'Missing role claim' USING ERRCODE = '42501';
   END IF;
 
@@ -227,16 +229,52 @@ BEGIN
       fq.quota_notes
   ),
   selected_rows AS (
-    SELECT *
+    SELECT
+      group_type,
+      group_id,
+      group_name,
+      parent_region_id,
+      parent_region_name,
+      equipment_count,
+      facility_count,
+      quota_current_count,
+      quota_min_count,
+      quota_max_count,
+      quota_status,
+      quota_notes
     FROM region_rows
     WHERE v_group_by = 'region'
     UNION ALL
-    SELECT *
+    SELECT
+      group_type,
+      group_id,
+      group_name,
+      parent_region_id,
+      parent_region_name,
+      equipment_count,
+      facility_count,
+      quota_current_count,
+      quota_min_count,
+      quota_max_count,
+      quota_status,
+      quota_notes
     FROM facility_rows
     WHERE v_group_by = 'facility'
   ),
   limited_rows AS (
-    SELECT *
+    SELECT
+      group_type,
+      group_id,
+      group_name,
+      parent_region_id,
+      parent_region_name,
+      equipment_count,
+      facility_count,
+      quota_current_count,
+      quota_min_count,
+      quota_max_count,
+      quota_status,
+      quota_notes
     FROM selected_rows
     ORDER BY equipment_count DESC, group_name ASC, group_id ASC
     LIMIT v_limit
@@ -244,7 +282,10 @@ BEGIN
   totals AS (
     SELECT
       COUNT(*)::bigint AS total_equipment_count,
-      COUNT(DISTINCT region_id)::bigint AS region_count,
+      (
+        COUNT(DISTINCT region_id)
+        + CASE WHEN COUNT(*) FILTER (WHERE region_id IS NULL) > 0 THEN 1 ELSE 0 END
+      )::bigint AS region_count,
       COUNT(DISTINCT facility_id)::bigint AS facility_count
     FROM matched_equipment
   )
@@ -300,3 +341,5 @@ GRANT EXECUTE ON FUNCTION public.equipment_aggregate_search(text, text, bigint, 
 
 COMMENT ON FUNCTION public.equipment_aggregate_search(text, text, bigint, integer)
 IS 'Role-scoped deterministic aggregate equipment keyword search for global/admin and regional leader users.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Add the `equipment_aggregate_search` Supabase migration for Phase 2 aggregate keyword search.
- Add the RPC proxy allowlist entry and focused whitelist regression coverage.
- Add a rollback SQL verification script for the post-review/post-apply SQL checks.

## Scope
- Backend/RPC only for #627.
- No client/UI work for #628+.
- No vector search, semantic ranking, autocomplete, or client-side aggregation.
- Migration is committed for review but intentionally not applied yet.

## Migration Notes
- Uses deterministic SQL keyword search with `public._sanitize_ilike_pattern()`.
- Matches equipment name, model, serial, and equipment group/category text/keywords.
- Does not match `thiet_bi.ma_thiet_bi` internal facility equipment code.
- Enforces server-side scope for `admin`/`global` and `regional_leader` via `allowed_don_vi_for_session_safe()`.
- Captured `EXPLAIN (FORMAT JSON)` for region and facility grouping before adding indexes; no new indexes were added.

## Verification
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `openspec validate add-equipment-aggregate-global-search --strict`
- [x] `node scripts/npm-run.js run test:run -- src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts`
- [x] `node scripts/npm-run.js run react-doctor`
- [ ] Deferred until migration approval/apply: `scripts/verify-equipment-aggregate-search-rpc.sql`
- [ ] Deferred until migration apply: Supabase MCP `get_advisors(security)`

Refs #627
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `equipment_aggregate_search` RPC for Phase 2 aggregate keyword search, grouping results by region or facility with quota context and de‑duplicated matches. Backend-only for #627.

- **New Features**
  - Searches name, model, serial, and group name/keywords; never matches internal equipment code.
  - Consolidates matches across asset fields and group/category keywords to avoid double counting.
  - Groups by `region` or `facility`; returns equipment/facility counts. Facility rows include `quotaStatus`, `quotaCurrentCount`, `quotaMinCount`, `quotaMaxCount`, and `quotaNotes`, plus `parentRegionId` and `parentRegionName`. Role-scoped to `admin/global` and `regional_leader`; optional region filter; summary echoes `query` and `scopeLabel` and counts a no-region bucket.

- **Migration**
  - Adds Supabase SQL function; `anon` revoked, `authenticated` granted.
  - Updates RPC proxy allowlist and tests (whitelist coverage and smoke fixture alignment).
  - Adds `scripts/verify-equipment-aggregate-search-rpc.sql` for post-apply checks, covering deduped matches, region leader scope/region filter, quota statuses, and unsupported role rejection.

<sup>Written for commit 93d0c486b060e6cfa0be19e9bc55a85a4430926e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `equipment_aggregate_search` RPC to aggregate active equipment results grouped by **region** or **facility**, including summary totals and quota status.
  * Results are scoped according to the caller’s JWT role, with special handling for regional leaders and an explicit “unassigned” region bucket.
* **Bug Fixes**
  * Improved request validation and access control, returning clearer errors for unsupported roles, invalid group-by options, and missing headers.
* **Tests**
  * Added/updated RPC whitelist and automated verification coverage for grouping, scoping, and quota-related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->