### PR TITLE
feat: add equipment aggregate search data layer

### DIFF
--- a/openspec/changes/add-equipment-aggregate-global-search/design.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/design.md
@@ -4,12 +4,12 @@
 
 The feature serves elevated users who need system-level visibility across facilities. The key user question is not "which exact rows match?" but "which regions or facilities have how many matching devices?"
 
-The UI must avoid duplicating the equipment catalog. Global search is a summary and navigation layer; device-level operations remain in the existing equipment page.
+The UI must avoid duplicating the equipment catalog. The Reports equipment search tab is a summary and navigation layer; device-level operations remain in the existing equipment page.
 
 ## Goals
 
 - Provide a header search entry point for elevated users.
-- Support repeated keyword searches without leaving the result workspace.
+- Support repeated keyword searches without leaving the Reports page.
 - Show aggregate equipment counts by region first for admin/global users.
 - Drill from region aggregate to facility aggregate.
 - At facility level, show the matching equipment count first and quota status second.
@@ -34,15 +34,16 @@ The header shows a compact search input only for `admin`/`global` and `regional_
 
 - Placeholder: `Tim thiet bi toan he thong...`
 - Submit triggers only on Enter or the search button.
-- Submit URL-encodes the keyword and navigates to `/global-search?q=<encodedKeyword>`.
+- Submit URL-encodes the keyword and navigates to `/reports?tab=equipment-search&q=<encodedKeyword>`.
 - Empty or whitespace-only submit does not navigate.
 
-### Search Workspace
+### Reports Equipment Search Tab
 
-`/global-search` is the primary analysis workspace.
+The existing Reports page hosts a dedicated `equipment-search` tab. The tab is user-facing as `Tìm kiếm thiết bị`.
 
 - It has a larger search input at the top.
 - It reads the initial keyword from `q`.
+- The active Reports tab is represented by `tab=equipment-search`.
 - Submitting a new keyword updates URL query state and refreshes aggregate data in place.
 - The page shows a scope badge:
   - `Toan he thong` for admin/global.
@@ -85,13 +86,13 @@ If the user has multiple region scopes, the page uses the same region-first hier
 
 Facility rows use this simple shape:
 
-| Don vi | So luong hien co | Dinh muc | Trang thai | Ghi chu |
-| --- | ---: | ---: | --- | --- |
-| Benh vien A | 100 | 100/150 | Trong gioi han dinh muc | - |
-| Benh vien B | 160 | 160/150 | Vuot gioi han dinh muc | Vuot 10 |
-| Benh vien C | 5 | 5/10-150 | Duoi muc toi thieu | Thieu 5 so voi toi thieu |
-| Benh vien D | 40 | - | Chua co dinh muc | Don vi chua co quyet dinh dinh muc active |
-| Benh vien E | 25 | - | Chua gan danh muc dinh muc | So lieu dinh muc chua day du |
+| Don vi      | So luong hien co | Dinh muc | Trang thai                 | Ghi chu                                   |
+| ----------- | ---------------: | -------: | -------------------------- | ----------------------------------------- |
+| Benh vien A |              100 |  100/150 | Trong gioi han dinh muc    | -                                         |
+| Benh vien B |              160 |  160/150 | Vuot gioi han dinh muc     | Vuot 10                                   |
+| Benh vien C |                5 | 5/10-150 | Duoi muc toi thieu         | Thieu 5 so voi toi thieu                  |
+| Benh vien D |               40 |        - | Chua co dinh muc           | Don vi chua co quyet dinh dinh muc active |
+| Benh vien E |               25 |        - | Chua gan danh muc dinh muc | So lieu dinh muc chua day du              |
 
 User-facing status labels:
 
@@ -108,7 +109,7 @@ If some matching equipment is not assigned to `nhom_thiet_bi_id`, the row still 
 
 If matching equipment is assigned to a group that is not present in the facility's active quota decision, use `Chưa được gán vào định mức của đơn vị`.
 
-Global search must not offer actions to assign categories, edit quota decisions, or otherwise fix facility data. Those tasks remain in the existing unit-level quota management flows.
+The Reports search tab must not offer actions to assign categories, edit quota decisions, or otherwise fix facility data. Those tasks remain in the existing unit-level quota management flows.
 
 ## Data Contract
 
@@ -207,13 +208,13 @@ The database function must validate JWT claims before aggregating.
 - Treat `admin` as `global` where role checks happen outside the RPC proxy.
 - Admin/global users may aggregate across all facilities.
 - Regional leaders may aggregate only facilities allowed by their regional scope.
-- Other roles must be rejected for this aggregate global search RPC/page.
+- Other roles must be rejected for this aggregate search RPC/tab.
 - Client-supplied `regionId` is a drill-down hint, not an authority boundary.
 
 ## UI Components
 
 - Header search entry component.
-- Global search page shell.
+- Reports page `equipment-search` tab shell.
 - Search form.
 - Scope/summary strip.
 - Drill-down breadcrumb.
@@ -227,14 +228,14 @@ At facility level, chart bars represent `equipmentCount`. Quota maximum may be r
 
 ## Deep-Linking
 
-The global search page does not render device rows. It deep-links into the existing equipment page:
+The Reports search tab does not render device rows. It deep-links into the existing equipment page:
 
 - Region context: `/equipment?search=<q>&region=<regionId>`
 - Facility context: `/equipment?search=<q>&facility=<facilityId>`
 
 If the equipment page does not currently support one of these query params, implementation must add route-sync support there rather than building a duplicate detail list.
 
-Global search must not deep-link to quota assignment or quota management actions.
+The Reports search tab must not deep-link to quota assignment or quota management actions.
 
 ## Testing Strategy
 
@@ -242,7 +243,7 @@ Global search must not deep-link to quota assignment or quota management actions
 - Add RPC tests or SQL verification for admin/global, regional leader, and unauthorized roles.
 - Add focused React tests for:
   - header submit navigation
-  - search page submit updates URL
+  - Reports search tab submit updates URL
   - admin region-to-facility drill-down
   - regional leader facility-level default
   - facility quota display labels

--- a/openspec/changes/add-equipment-aggregate-global-search/proposal.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/proposal.md
@@ -9,7 +9,7 @@ This change adds a role-scoped equipment aggregate search experience: users subm
 ## What Changes
 
 - Add a header global equipment search entry point for `admin`/`global` and `regional_leader` users.
-- Add a dedicated `/global-search` workspace that supports repeated submit-based searches through the page search box and URL query state.
+- Add a dedicated equipment search tab inside the existing Reports page, reachable at `/reports?tab=equipment-search&q=<encodedKeyword>`, that supports repeated submit-based searches through the tab search box and URL query state.
 - Add an equipment aggregate search RPC/API contract that returns grouped counts, not device rows.
 - Include quota context for each facility result using the existing equipment group and device quota data.
 - Match equipment by equipment name, model, serial, and equipment group/category.
@@ -22,16 +22,16 @@ This change adds a role-scoped equipment aggregate search experience: users subm
 - Present regional leader results by facility when the user has a single region scope; use region grouping only when their scope spans multiple regions.
 - Render an interactive horizontal bar chart and a table from the same aggregate data.
 - Keep the facility row centered on the actual matching equipment count; quota display and status are supplementary.
-- Use deep-links into the existing equipment page for read-only detail inspection instead of rendering device rows in global search.
+- Use deep-links into the existing equipment page for read-only detail inspection instead of rendering device rows in the Reports search tab.
 
 ## Non-Goals
 
 - No autocomplete or live suggestions in v1.
 - No status, category, region, facility, or date filters beyond keyword and role scope.
-- No device-detail list inside global search.
+- No device-detail list inside the Reports search tab.
 - No multi-entity search across repairs, transfers, maintenance, or users.
 - No export, trend, or historical comparison.
-- No editing, assigning equipment to quota categories, or managing quota decisions from global search.
+- No editing, assigning equipment to quota categories, or managing quota decisions from the Reports search tab.
 
 ## Impact
 
@@ -43,7 +43,7 @@ This change adds a role-scoped equipment aggregate search experience: users subm
   - Role guard logic must preserve `admin` -> `global` normalization outside the RPC proxy where applicable.
 - Affected frontend areas:
   - App header/navigation search entry point.
-  - New `/global-search` route/page.
+  - New `equipment-search` tab in the existing Reports page.
   - Global search hook/client data layer.
   - Chart/table components using existing Recharts dependency, with quota limit markers or labels where available.
   - Equipment page route-sync/deep-link handling for `search`, `region`, and `facility` query params if not already supported.

--- a/openspec/changes/add-equipment-aggregate-global-search/specs/equipment-aggregate-search/spec.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/specs/equipment-aggregate-search/spec.md
@@ -7,37 +7,45 @@
 The system SHALL provide a header search entry point for equipment aggregate global search to users with `admin`, `global`, or `regional_leader` roles.
 
 #### Scenario: Elevated user sees header search
+
 - **WHEN** a user with role `admin`, `global`, or `regional_leader` views the authenticated app shell
 - **THEN** the header shows a compact equipment global search input
 
 #### Scenario: Unsupported role does not see header search
+
 - **WHEN** a user with role other than `admin`, `global`, or `regional_leader` views the authenticated app shell
 - **THEN** the header does not show the equipment global search input
 
 #### Scenario: Header submit opens search workspace
+
 - **WHEN** an allowed user submits a non-empty keyword with Enter or the search button
-- **THEN** the system URL-encodes the keyword and navigates to `/global-search?q=<encodedKeyword>`
+- **THEN** the system URL-encodes the keyword and navigates to `/reports?tab=equipment-search&q=<encodedKeyword>`
 
 #### Scenario: Header does not autocomplete
+
 - **WHEN** an allowed user types in the header search input
 - **THEN** the system does not show autocomplete, suggestions, or live result previews in v1
 
-### Requirement: Search Workspace
+### Requirement: Reports Equipment Search Tab
 
-The system SHALL provide a `/global-search` workspace for repeated aggregate equipment searches.
+The system SHALL provide a dedicated equipment search tab inside the existing Reports page for repeated aggregate equipment searches.
 
 #### Scenario: Initial query from URL
-- **WHEN** a user opens `/global-search?q=May%20X-quang`
-- **THEN** the page search input is populated with `May X-quang`
+
+- **WHEN** a user opens `/reports?tab=equipment-search&q=May%20X-quang`
+- **THEN** the Reports page activates the `Tìm kiếm thiết bị` tab
+- **AND** the tab search input is populated with `May X-quang`
 - **AND** aggregate results are loaded for that keyword within the user's role scope
 
-#### Scenario: Repeated search in workspace
-- **WHEN** a user submits a new keyword from the search workspace
-- **THEN** the page updates the URL query
+#### Scenario: Repeated search in Reports tab
+
+- **WHEN** a user submits a new keyword from the Reports equipment search tab
+- **THEN** the page updates the URL query with `tab=equipment-search` and the encoded keyword
 - **AND** refreshes the chart and table in place without returning to the previous page
 
-#### Scenario: Empty workspace query
-- **WHEN** the search workspace has no non-empty keyword
+#### Scenario: Empty Reports tab query
+
+- **WHEN** the Reports equipment search tab has no non-empty keyword
 - **THEN** the page prompts the user to enter a keyword
 - **AND** does not execute aggregate search
 
@@ -46,22 +54,27 @@ The system SHALL provide a `/global-search` workspace for repeated aggregate equ
 The system SHALL match aggregate equipment search keywords against equipment name, model, serial, and equipment group/category fields.
 
 #### Scenario: Match equipment name
+
 - **WHEN** an allowed user searches for `May X-quang`
 - **THEN** equipment whose name matches `May X-quang` contributes to aggregate counts
 
 #### Scenario: Match model
+
 - **WHEN** an allowed user searches for a model value
 - **THEN** equipment whose model matches the keyword contributes to aggregate counts
 
 #### Scenario: Match serial
+
 - **WHEN** an allowed user searches for a serial value
 - **THEN** equipment whose serial matches the keyword contributes to aggregate counts
 
 #### Scenario: Match equipment group
+
 - **WHEN** an allowed user searches for an equipment group/category name
 - **THEN** equipment in matching groups/categories contributes to aggregate counts
 
 #### Scenario: Exclude internal equipment code
+
 - **WHEN** an allowed user searches for a facility-defined internal equipment code
 - **THEN** the internal code field is not used as a search predicate
 
@@ -70,22 +83,27 @@ The system SHALL match aggregate equipment search keywords against equipment nam
 The system SHALL enforce role-based scope for aggregate equipment search on the server side.
 
 #### Scenario: Admin alias has global scope
+
 - **WHEN** a user with legacy role `admin` performs aggregate equipment search
 - **THEN** the system treats the user as global for this feature
 
 #### Scenario: Global user sees all regions
+
 - **WHEN** a user with role `global` searches without a selected drill-down region
 - **THEN** results include matching equipment from all regions and facilities
 
 #### Scenario: Regional leader sees assigned scope only
+
 - **WHEN** a user with role `regional_leader` searches
 - **THEN** results include only matching equipment from regions/facilities assigned to that user
 
 #### Scenario: Other roles are rejected
+
 - **WHEN** a user with an unsupported role opens or calls aggregate equipment search
 - **THEN** the system denies access and returns no aggregate counts
 
 #### Scenario: Client region parameter does not expand scope
+
 - **WHEN** a regional leader submits a region or facility parameter outside their allowed scope
 - **THEN** the system rejects or ignores the unauthorized scope server-side
 
@@ -94,14 +112,17 @@ The system SHALL enforce role-based scope for aggregate equipment search on the 
 The system SHALL show admin/global users aggregate search results grouped by region before facility-level drill-down.
 
 #### Scenario: Region-level results
+
 - **WHEN** an admin/global user searches for a keyword
 - **THEN** the first result level groups matching equipment counts by region
 
 #### Scenario: Region drill-down
+
 - **WHEN** an admin/global user selects a region result
 - **THEN** the workspace shows matching equipment counts grouped by facility within that region
 
 #### Scenario: Breadcrumb returns to all regions
+
 - **WHEN** an admin/global user is viewing facility results for a selected region
 - **THEN** the breadcrumb allows returning to the all-regions view for the same keyword
 
@@ -110,10 +131,12 @@ The system SHALL show admin/global users aggregate search results grouped by reg
 The system SHALL optimize regional leader results for their assigned scope.
 
 #### Scenario: Single-region leader opens facility level
+
 - **WHEN** a regional leader assigned to one region searches
 - **THEN** the workspace shows matching equipment counts grouped by facility in that region
 
 #### Scenario: Multi-region leader opens region level
+
 - **WHEN** a regional leader assigned to multiple regions searches
 - **THEN** the workspace first groups matching equipment counts by the allowed regions
 
@@ -122,23 +145,28 @@ The system SHALL optimize regional leader results for their assigned scope.
 The system SHALL render aggregate equipment search results as both an interactive horizontal bar chart and a table using the same data source.
 
 #### Scenario: Chart shows sorted bars
+
 - **WHEN** aggregate results are loaded
 - **THEN** the chart displays horizontal bars sorted by matching equipment count descending
 
 #### Scenario: Table mirrors chart
+
 - **WHEN** aggregate results are loaded
 - **THEN** the table shows the same region or facility groups and counts as the chart
 - **AND** facility-level rows show the matching equipment count as the primary value
 
 #### Scenario: Chart drill-down interaction
+
 - **WHEN** a user clicks a region bar at region level
-- **THEN** the workspace drills down to facility-level results for that region
+- **THEN** the Reports equipment search tab drills down to facility-level results for that region
 
 #### Scenario: Small result state
+
 - **WHEN** a keyword matches equipment in only one facility
 - **THEN** the workspace still shows the aggregate row and provides a prominent detail deep-link
 
 #### Scenario: Empty result state
+
 - **WHEN** no equipment matches the keyword within the user's allowed scope
 - **THEN** the workspace displays an empty state instead of an empty chart
 
@@ -147,43 +175,52 @@ The system SHALL render aggregate equipment search results as both an interactiv
 The system SHALL include quota context in facility-level aggregate search results without replacing the matching equipment count.
 
 #### Scenario: Facility row shows count and quota
+
 - **WHEN** a facility has matching equipment with quota data
 - **THEN** the facility row displays the matching equipment count
 - **AND** displays quota context in the form `<current>/<maximum>` or `<current>/<minimum>-<maximum>` when a minimum applies
 
 #### Scenario: Count remains primary
+
 - **WHEN** quota context is displayed for a facility
 - **THEN** the matching equipment count remains visible as its own primary column
 - **AND** quota context is displayed as supplementary information
 
 #### Scenario: Within quota limit wording
+
 - **WHEN** the matching equipment count is within the configured quota range
 - **THEN** the user-facing status is `Trong giới hạn định mức`
 
 #### Scenario: Below minimum wording
+
 - **WHEN** the matching equipment count is lower than the configured minimum
 - **THEN** the user-facing status is `Dưới mức tối thiểu`
 
 #### Scenario: Over limit wording
+
 - **WHEN** the matching equipment count is higher than the configured maximum
 - **THEN** the user-facing status is `Vượt giới hạn định mức`
 
 #### Scenario: No active quota decision
+
 - **WHEN** a facility has matching equipment but no active quota decision
 - **THEN** the quota column displays no ratio
 - **AND** the user-facing status is `Chưa có định mức`
 
 #### Scenario: Unassigned equipment category
+
 - **WHEN** matching equipment has no assigned equipment quota category
 - **THEN** those devices are included in the matching equipment count
 - **AND** the row clearly shows `Chưa gán danh mục định mức`
 
 #### Scenario: Group not in unit quota
+
 - **WHEN** matching equipment is assigned to an equipment group that is not present in the unit's active quota decision
 - **THEN** those devices are included in the matching equipment count
 - **AND** the row clearly shows `Chưa được gán vào định mức của đơn vị`
 
 #### Scenario: Multiple quota groups matched
+
 - **WHEN** one facility has matching equipment across multiple quota groups
 - **THEN** the facility row may aggregate current count and maximum quota across those groups
 - **AND** the row clearly shows `Gồm nhiều nhóm định mức`
@@ -193,10 +230,12 @@ The system SHALL include quota context in facility-level aggregate search result
 The system SHALL present quota information in global search as read-only context for management lookup.
 
 #### Scenario: No quota editing actions
+
 - **WHEN** a facility row has missing quota assignment, missing active quota, or over-limit status
-- **THEN** global search does not show actions to assign equipment categories, edit quota decisions, or otherwise fix unit data
+- **THEN** the Reports equipment search tab does not show actions to assign equipment categories, edit quota decisions, or otherwise fix unit data
 
 #### Scenario: Existing equipment detail link only
+
 - **WHEN** a user chooses to inspect matching equipment
 - **THEN** global search links only to the existing equipment page with the relevant keyword and region/facility context
 
@@ -205,27 +244,32 @@ The system SHALL present quota information in global search as read-only context
 The system SHALL link aggregate search results to the existing equipment page for device-level detail inspection.
 
 #### Scenario: Region deep-link
+
 - **WHEN** a user chooses to view equipment for a region aggregate result
 - **THEN** the system links to the equipment page with the current keyword and region parameter
 
 #### Scenario: Facility deep-link
+
 - **WHEN** a user chooses to view equipment for a facility aggregate result
 - **THEN** the system links to the equipment page with the current keyword and facility parameter
 
 #### Scenario: No device rows in global search
+
 - **WHEN** aggregate search results are shown
-- **THEN** the global search workspace does not render a device-detail list
+- **THEN** the Reports equipment search tab does not render a device-detail list
 
 ### Requirement: Aggregate Search Summary
 
 The system SHALL display a concise summary of aggregate equipment search results.
 
 #### Scenario: Summary counts
+
 - **WHEN** aggregate results are loaded
 - **THEN** the page displays total matching equipment count, number of matching regions, and number of matching facilities within scope
 - **AND** does not replace facility-level equipment counts with quota ratios
 
 #### Scenario: Scope badge
+
 - **WHEN** aggregate search results are displayed
 - **THEN** the page displays a scope badge describing whether results are global or region-scoped
 
@@ -234,25 +278,30 @@ The system SHALL display a concise summary of aggregate equipment search results
 The system SHALL compute aggregate search results in server-side SQL using deterministic keyword predicates and shall not use vector search in v1.
 
 #### Scenario: Aggregated RPC response
+
 - **WHEN** the client requests aggregate search results
 - **THEN** the server returns grouped counts, quota context, and summary metadata
 - **AND** does not return individual equipment records
 
 #### Scenario: Query stays server-side
+
 - **WHEN** a keyword matches many equipment records
 - **THEN** aggregation happens in SQL/server-side logic before the response is sent to the browser
 
 #### Scenario: Deterministic keyword search
+
 - **WHEN** the aggregate search RPC evaluates a keyword
 - **THEN** it uses sanitized SQL keyword predicates over the approved match fields
 - **AND** does not depend on vector embeddings, semantic ranking, autocomplete, or client-side search
 
 #### Scenario: Scope applied before aggregation
+
 - **WHEN** the aggregate search RPC computes counts for a global or regional leader user
 - **THEN** role scope and soft-delete filters are applied before grouped counts are returned
 - **AND** the browser cannot expand scope by filtering returned equipment rows
 
 #### Scenario: Index changes require query-plan evidence
+
 - **WHEN** implementation proposes a new search or join index for aggregate search
 - **THEN** the implementation first captures representative `EXPLAIN (FORMAT JSON)` plans for `region` and `facility` grouping
 - **AND** documents why existing trigram, FTS, facility, region, and quota indexes are insufficient

--- a/openspec/changes/add-equipment-aggregate-global-search/specs/equipment-aggregate-search/spec.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/specs/equipment-aggregate-search/spec.md
@@ -4,17 +4,17 @@
 
 ### Requirement: Header Aggregate Search Entry
 
-The system SHALL provide a header search entry point for equipment aggregate global search to users with `admin`, `global`, or `regional_leader` roles.
+The system SHALL provide a header search entry point for aggregate equipment search to users with `admin`, `global`, or `regional_leader` roles.
 
 #### Scenario: Elevated user sees header search
 
 - **WHEN** a user with role `admin`, `global`, or `regional_leader` views the authenticated app shell
-- **THEN** the header shows a compact equipment global search input
+- **THEN** the header shows a compact aggregate equipment search input
 
 #### Scenario: Unsupported role does not see header search
 
 - **WHEN** a user with role other than `admin`, `global`, or `regional_leader` views the authenticated app shell
-- **THEN** the header does not show the equipment global search input
+- **THEN** the header does not show the aggregate equipment search input
 
 #### Scenario: Header submit opens search workspace
 
@@ -227,7 +227,7 @@ The system SHALL include quota context in facility-level aggregate search result
 
 ### Requirement: Read-Only Quota Overlay
 
-The system SHALL present quota information in global search as read-only context for management lookup.
+The system SHALL present quota information in the Reports equipment search tab as read-only context for management lookup.
 
 #### Scenario: No quota editing actions
 
@@ -237,7 +237,7 @@ The system SHALL present quota information in global search as read-only context
 #### Scenario: Existing equipment detail link only
 
 - **WHEN** a user chooses to inspect matching equipment
-- **THEN** global search links only to the existing equipment page with the relevant keyword and region/facility context
+- **THEN** the Reports equipment search tab links only to the existing equipment page with the relevant keyword and region/facility context
 
 ### Requirement: Equipment Detail Deep Links
 
@@ -253,7 +253,7 @@ The system SHALL link aggregate search results to the existing equipment page fo
 - **WHEN** a user chooses to view equipment for a facility aggregate result
 - **THEN** the system links to the equipment page with the current keyword and facility parameter
 
-#### Scenario: No device rows in global search
+#### Scenario: No device rows in Reports equipment search tab
 
 - **WHEN** aggregate search results are shown
 - **THEN** the Reports equipment search tab does not render a device-detail list

--- a/openspec/changes/add-equipment-aggregate-global-search/tasks.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/tasks.md
@@ -7,7 +7,7 @@
 - Phase 2 backend RPC: #627
 - Phase 3 client data layer: #628
 - Phase 4 header entry: #629
-- Phase 5 global-search workspace: #630
+- Phase 5 Reports equipment-search tab: #630
 - Phase 6 read-only quota context rendering: #631
 - Phase 7 equipment deep-links and final rollout: #632
 
@@ -45,23 +45,24 @@
 
 ## Phase 3 - Client Data Layer (#628)
 
-- [ ] 3.1 Add TypeScript request/response types for aggregate equipment search, including quota fields and status enum.
-- [ ] 3.2 Add a TanStack Query hook with stable query keys.
-- [ ] 3.3 Gate the hook on non-empty trimmed query and allowed role.
-- [ ] 3.4 Normalize API errors into existing UI error patterns.
+- [x] 3.1 Add TypeScript request/response types for aggregate equipment search, including quota fields and status enum.
+- [x] 3.2 Add a TanStack Query hook with stable query keys.
+- [x] 3.3 Gate the hook on non-empty trimmed query and allowed role.
+- [x] 3.4 Normalize API errors into existing UI error patterns.
+- [x] 3.5 Keep the data layer route-agnostic so the Reports tab can consume it without coupling to a page path.
 
 ## Phase 4 - Header Entry Point (#629)
 
 - [ ] 4.1 Add a compact header search input for `admin`/`global` and `regional_leader`.
 - [ ] 4.2 Hide the entry point for all other roles.
 - [ ] 4.3 Submit only on Enter or search button click.
-- [ ] 4.4 URL-encode the keyword and navigate to `/global-search?q=<encodedKeyword>` on valid submit.
+- [ ] 4.4 URL-encode the keyword and navigate to `/reports?tab=equipment-search&q=<encodedKeyword>` on valid submit.
 - [ ] 4.5 Add focused tests for visibility, submit behavior, and encoded navigation for spaces/reserved characters.
 
-## Phase 5 - Global Search Workspace Count-First Flow (#630)
+## Phase 5 - Reports Equipment Search Tab Count-First Flow (#630)
 
-- [ ] 5.1 Add `/global-search` page/route.
-- [ ] 5.2 Read and update keyword from URL query state.
+- [ ] 5.1 Add a dedicated `equipment-search` tab to the existing Reports page with user-facing label `Tìm kiếm thiết bị`.
+- [ ] 5.2 Read and update `tab=equipment-search` and `q=<keyword>` from Reports URL query state.
 - [ ] 5.3 Render top search form, scope badge, summary, chart, table, breadcrumb, loading, error, and empty states.
 - [ ] 5.4 Implement admin/global region-first view.
 - [ ] 5.5 Implement region drill-down to facility grouping.
@@ -91,13 +92,13 @@
 - [ ] 7.9 Run `node scripts/npm-run.js run typecheck`.
 - [ ] 7.10 Run focused backend/RPC verification for role scopes, field matching, quota joining, unassigned/not-in-quota/no-active-quota states, and representative `EXPLAIN` plans.
 - [ ] 7.11 Run focused React tests for changed UI behavior and quota status labels.
-- [ ] 7.12 Verify global-search URL hydration by loading `/global-search?q=...` directly and confirming the query and selected scope restore after refresh or back navigation.
+- [ ] 7.12 Verify Reports tab URL hydration by loading `/reports?tab=equipment-search&q=...` directly and confirming the query and selected scope restore after refresh or back navigation.
 - [ ] 7.13 Run `node scripts/npm-run.js run react-doctor`.
 - [ ] 7.14 Manually verify header search, chart rendering, drill-down, quota labels, and equipment deep-links in browser.
 
 ## Release Notes
 
 - [ ] 8.1 Document that v1 is submit-only and has no autocomplete.
-- [ ] 8.2 Document that global search aggregates equipment counts only.
+- [ ] 8.2 Document that the Reports equipment search tab aggregates equipment counts only.
 - [ ] 8.3 Document that detail inspection happens through existing equipment page deep-links.
 - [ ] 8.4 Document that quota information is read-only in global search and unit-level quota assignment remains outside this workflow.

--- a/src/app/(app)/reports/hooks/__tests__/use-equipment-aggregate-search.test.tsx
+++ b/src/app/(app)/reports/hooks/__tests__/use-equipment-aggregate-search.test.tsx
@@ -62,10 +62,14 @@ describe("equipment aggregate search types", () => {
       quotaMinCount: 2,
       quotaMaxCount: 4,
       quotaStatus,
-      quotaNotes: ["not_in_unit_quota"],
+      quotaNotes: ["Gồm nhiều nhóm định mức"],
+    }
+    const rowWithoutNotes: EquipmentAggregateSearchRow = {
+      ...row,
+      quotaNotes: undefined,
     }
     const data: EquipmentAggregateSearchData = {
-      rows: [row],
+      rows: [row, rowWithoutNotes],
       summary: {
         totalEquipmentCount: 5,
         regionCount: 1,
@@ -77,6 +81,8 @@ describe("equipment aggregate search types", () => {
 
     expect(request.groupBy).toBe("facility")
     expect(data.rows[0]?.quotaStatus).toBe("not_in_unit_quota")
+    expect(data.rows[0]?.quotaNotes?.[0]).toBe("Gồm nhiều nhóm định mức")
+    expect(data.rows[1]?.quotaNotes).toBeUndefined()
   })
 })
 
@@ -179,6 +185,107 @@ describe("useEquipmentAggregateSearch", () => {
         signal: expect.any(AbortSignal),
       })
     )
+  })
+
+  it("normalizes invalid and oversized limits before keying and calling the RPC", async () => {
+    mocks.callRpc.mockResolvedValueOnce({
+      rows: [],
+      summary: {
+        totalEquipmentCount: 0,
+        regionCount: 0,
+        facilityCount: 0,
+        query: "Máy thở",
+        scopeLabel: "Toàn hệ thống",
+      },
+    })
+
+    const queryClient = createQueryClient()
+
+    renderHook(
+      () =>
+        useEquipmentAggregateSearch({
+          query: "Máy thở",
+          groupBy: "region",
+          role: "global",
+          limit: 250,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await waitFor(() => expect(mocks.callRpc).toHaveBeenCalledTimes(1))
+
+    expect(
+      buildEquipmentAggregateSearchQueryKey({
+        query: "Máy thở",
+        groupBy: "region",
+        role: "global",
+        limit: Number.NaN,
+      })[2].limit
+    ).toBe(50)
+    expect(
+      buildEquipmentAggregateSearchQueryKey({
+        query: "Máy thở",
+        groupBy: "region",
+        role: "global",
+        limit: 0,
+      })[2].limit
+    ).toBe(1)
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.objectContaining({
+          p_limit: 100,
+        }),
+      })
+    )
+  })
+
+  it("does not keep previous aggregate rows when the query becomes disabled", async () => {
+    mocks.callRpc.mockResolvedValueOnce({
+      rows: [
+        {
+          groupType: "region",
+          groupId: 1,
+          groupName: "Miền Bắc",
+          parentRegionId: null,
+          parentRegionName: null,
+          equipmentCount: 2,
+          facilityCount: 1,
+          quotaCurrentCount: null,
+          quotaMinCount: null,
+          quotaMaxCount: null,
+          quotaStatus: null,
+          quotaNotes: [],
+        },
+      ],
+      summary: {
+        totalEquipmentCount: 2,
+        regionCount: 1,
+        facilityCount: 1,
+        query: "Máy thở",
+        scopeLabel: "Toàn hệ thống",
+      },
+    } satisfies EquipmentAggregateSearchData)
+
+    const queryClient = createQueryClient()
+    const { result, rerender } = renderHook(
+      ({ query }) =>
+        useEquipmentAggregateSearch({
+          query,
+          groupBy: "region",
+          role: "global",
+        }),
+      {
+        initialProps: { query: "Máy thở" },
+        wrapper: createWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.data?.rows).toHaveLength(1))
+
+    rerender({ query: "   " })
+
+    expect(result.current.fetchStatus).toBe("idle")
+    expect(result.current.data?.rows).toEqual([])
   })
 
   it("normalizes unknown API errors for UI display", () => {

--- a/src/app/(app)/reports/hooks/__tests__/use-equipment-aggregate-search.test.tsx
+++ b/src/app/(app)/reports/hooks/__tests__/use-equipment-aggregate-search.test.tsx
@@ -1,0 +1,193 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  EquipmentAggregateSearchData,
+  EquipmentAggregateSearchRequest,
+  EquipmentAggregateSearchRow,
+  EquipmentAggregateSearchQuotaStatus,
+} from "../use-equipment-aggregate-search.types"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: mocks.callRpc,
+}))
+
+import {
+  buildEquipmentAggregateSearchQueryKey,
+  canUseEquipmentAggregateSearch,
+  normalizeEquipmentAggregateSearchError,
+  useEquipmentAggregateSearch,
+} from "../use-equipment-aggregate-search"
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+describe("equipment aggregate search types", () => {
+  it("describes the RPC request and response contract", () => {
+    const request: EquipmentAggregateSearchRequest = {
+      query: "Máy thở",
+      groupBy: "facility",
+      regionId: 12,
+      limit: 25,
+    }
+    const quotaStatus: EquipmentAggregateSearchQuotaStatus = "not_in_unit_quota"
+    const row: EquipmentAggregateSearchRow = {
+      groupType: "facility",
+      groupId: 34,
+      groupName: "Bệnh viện A",
+      parentRegionId: 12,
+      parentRegionName: "Miền Bắc",
+      equipmentCount: 5,
+      facilityCount: null,
+      quotaCurrentCount: 5,
+      quotaMinCount: 2,
+      quotaMaxCount: 4,
+      quotaStatus,
+      quotaNotes: ["not_in_unit_quota"],
+    }
+    const data: EquipmentAggregateSearchData = {
+      rows: [row],
+      summary: {
+        totalEquipmentCount: 5,
+        regionCount: 1,
+        facilityCount: 1,
+        query: "Máy thở",
+        scopeLabel: "Theo địa bàn",
+      },
+    }
+
+    expect(request.groupBy).toBe("facility")
+    expect(data.rows[0]?.quotaStatus).toBe("not_in_unit_quota")
+  })
+})
+
+describe("useEquipmentAggregateSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("keeps the query disabled for blank keywords", () => {
+    const queryClient = createQueryClient()
+
+    const { result } = renderHook(
+      () =>
+        useEquipmentAggregateSearch({
+          query: "   ",
+          groupBy: "region",
+          role: "global",
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    expect(result.current.fetchStatus).toBe("idle")
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+
+  it("keeps the query disabled for unsupported roles", () => {
+    const queryClient = createQueryClient()
+
+    const { result } = renderHook(
+      () =>
+        useEquipmentAggregateSearch({
+          query: "Máy thở",
+          groupBy: "region",
+          role: "to_qltb",
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    expect(result.current.fetchStatus).toBe("idle")
+    expect(canUseEquipmentAggregateSearch("to_qltb")).toBe(false)
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+
+  it("calls the aggregate search RPC with trimmed keyword and stable params", async () => {
+    mocks.callRpc.mockResolvedValueOnce({
+      rows: [],
+      summary: {
+        totalEquipmentCount: 0,
+        regionCount: 0,
+        facilityCount: 0,
+        query: "Máy thở/ICU",
+        scopeLabel: "Toàn hệ thống",
+      },
+    })
+
+    const queryClient = createQueryClient()
+
+    renderHook(
+      () =>
+        useEquipmentAggregateSearch({
+          query: "  Máy thở/ICU  ",
+          groupBy: "region",
+          role: "admin",
+          regionId: null,
+          limit: 50,
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    await waitFor(() => expect(mocks.callRpc).toHaveBeenCalledTimes(1))
+
+    expect(
+      buildEquipmentAggregateSearchQueryKey({
+        query: "  Máy thở/ICU  ",
+        groupBy: "region",
+        role: "admin",
+        regionId: null,
+        limit: 50,
+      })
+    ).toEqual([
+      "reports",
+      "equipment-aggregate-search",
+      {
+        query: "Máy thở/ICU",
+        groupBy: "region",
+        role: "admin",
+        regionId: null,
+        limit: 50,
+      },
+    ])
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fn: "equipment_aggregate_search",
+        args: {
+          p_query: "Máy thở/ICU",
+          p_group_by: "region",
+          p_region_id: null,
+          p_limit: 50,
+        },
+        signal: expect.any(AbortSignal),
+      })
+    )
+  })
+
+  it("normalizes unknown API errors for UI display", () => {
+    expect(normalizeEquipmentAggregateSearchError(new Error("RPC failed"))).toBe("RPC failed")
+    expect(normalizeEquipmentAggregateSearchError({ message: "Permission denied" })).toBe(
+      "Permission denied"
+    )
+    expect(normalizeEquipmentAggregateSearchError(null)).toBe(
+      "Không thể tải kết quả tìm kiếm thiết bị"
+    )
+  })
+})

--- a/src/app/(app)/reports/hooks/use-equipment-aggregate-search.ts
+++ b/src/app/(app)/reports/hooks/use-equipment-aggregate-search.ts
@@ -1,0 +1,88 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { getUnknownErrorMessage } from "@/lib/error-utils"
+import { isGlobalRole, isRegionalLeaderRole } from "@/lib/rbac"
+import { callRpc } from "@/lib/rpc-client"
+
+import type {
+  EquipmentAggregateSearchData,
+  EquipmentAggregateSearchGroupBy,
+  EquipmentAggregateSearchRequest,
+  EquipmentAggregateSearchRpcArgs,
+} from "./use-equipment-aggregate-search.types"
+
+const DEFAULT_LIMIT = 50
+const EMPTY_EQUIPMENT_AGGREGATE_SEARCH: EquipmentAggregateSearchData = {
+  rows: [],
+  summary: {
+    totalEquipmentCount: 0,
+    regionCount: 0,
+    facilityCount: 0,
+    query: "",
+    scopeLabel: "",
+  },
+}
+
+export interface UseEquipmentAggregateSearchParams extends EquipmentAggregateSearchRequest {
+  role: string | null | undefined
+}
+
+/** Returns true when the current role can use the aggregate equipment search UI/data layer. */
+export function canUseEquipmentAggregateSearch(role: string | null | undefined): boolean {
+  return isGlobalRole(role) || isRegionalLeaderRole(role)
+}
+
+/** Converts aggregate-search query errors into a stable Vietnamese UI message. */
+export function normalizeEquipmentAggregateSearchError(error: unknown): string {
+  return getUnknownErrorMessage(error, "Không thể tải kết quả tìm kiếm thiết bị")
+}
+
+/** Builds the stable TanStack Query key for Reports equipment aggregate search. */
+export function buildEquipmentAggregateSearchQueryKey(params: UseEquipmentAggregateSearchParams) {
+  return [
+    "reports",
+    "equipment-aggregate-search",
+    {
+      query: params.query.trim(),
+      groupBy: params.groupBy,
+      role: params.role ?? null,
+      regionId: params.regionId ?? null,
+      limit: params.limit ?? DEFAULT_LIMIT,
+    },
+  ] as const
+}
+
+function buildEquipmentAggregateSearchRpcArgs(
+  params: UseEquipmentAggregateSearchParams
+): EquipmentAggregateSearchRpcArgs {
+  return {
+    p_query: params.query.trim(),
+    p_group_by: params.groupBy,
+    p_region_id: params.regionId ?? null,
+    p_limit: params.limit ?? DEFAULT_LIMIT,
+  }
+}
+
+/** Fetches grouped equipment aggregate search data for the Reports equipment-search tab. */
+export function useEquipmentAggregateSearch(params: UseEquipmentAggregateSearchParams) {
+  const trimmedQuery = params.query.trim()
+  const enabled = trimmedQuery.length > 0 && canUseEquipmentAggregateSearch(params.role)
+
+  return useQuery({
+    queryKey: buildEquipmentAggregateSearchQueryKey(params),
+    queryFn: async ({ signal }) => {
+      return callRpc<EquipmentAggregateSearchData, EquipmentAggregateSearchRpcArgs>({
+        fn: "equipment_aggregate_search",
+        args: buildEquipmentAggregateSearchRpcArgs(params),
+        signal,
+      })
+    },
+    enabled,
+    placeholderData: (previousData) => previousData ?? EMPTY_EQUIPMENT_AGGREGATE_SEARCH,
+    staleTime: 60_000,
+  })
+}
+
+export type { EquipmentAggregateSearchGroupBy }

--- a/src/app/(app)/reports/hooks/use-equipment-aggregate-search.ts
+++ b/src/app/(app)/reports/hooks/use-equipment-aggregate-search.ts
@@ -14,6 +14,7 @@ import type {
 } from "./use-equipment-aggregate-search.types"
 
 const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 100
 const EMPTY_EQUIPMENT_AGGREGATE_SEARCH: EquipmentAggregateSearchData = {
   rows: [],
   summary: {
@@ -41,6 +42,8 @@ export function normalizeEquipmentAggregateSearchError(error: unknown): string {
 
 /** Builds the stable TanStack Query key for Reports equipment aggregate search. */
 export function buildEquipmentAggregateSearchQueryKey(params: UseEquipmentAggregateSearchParams) {
+  const limit = normalizeEquipmentAggregateSearchLimit(params.limit)
+
   return [
     "reports",
     "equipment-aggregate-search",
@@ -49,9 +52,21 @@ export function buildEquipmentAggregateSearchQueryKey(params: UseEquipmentAggreg
       groupBy: params.groupBy,
       role: params.role ?? null,
       regionId: params.regionId ?? null,
-      limit: params.limit ?? DEFAULT_LIMIT,
+      limit,
     },
   ] as const
+}
+
+function normalizeEquipmentAggregateSearchLimit(limit: number | null | undefined): number {
+  if (limit === null || limit === undefined) {
+    return DEFAULT_LIMIT
+  }
+
+  if (!Number.isFinite(limit)) {
+    return DEFAULT_LIMIT
+  }
+
+  return Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT)
 }
 
 function buildEquipmentAggregateSearchRpcArgs(
@@ -61,7 +76,7 @@ function buildEquipmentAggregateSearchRpcArgs(
     p_query: params.query.trim(),
     p_group_by: params.groupBy,
     p_region_id: params.regionId ?? null,
-    p_limit: params.limit ?? DEFAULT_LIMIT,
+    p_limit: normalizeEquipmentAggregateSearchLimit(params.limit),
   }
 }
 
@@ -80,7 +95,10 @@ export function useEquipmentAggregateSearch(params: UseEquipmentAggregateSearchP
       })
     },
     enabled,
-    placeholderData: (previousData) => previousData ?? EMPTY_EQUIPMENT_AGGREGATE_SEARCH,
+    placeholderData: (previousData) =>
+      enabled
+        ? (previousData ?? EMPTY_EQUIPMENT_AGGREGATE_SEARCH)
+        : EMPTY_EQUIPMENT_AGGREGATE_SEARCH,
     staleTime: 60_000,
   })
 }

--- a/src/app/(app)/reports/hooks/use-equipment-aggregate-search.types.ts
+++ b/src/app/(app)/reports/hooks/use-equipment-aggregate-search.types.ts
@@ -1,0 +1,54 @@
+export type EquipmentAggregateSearchGroupBy = "region" | "facility"
+
+export type EquipmentAggregateSearchGroupType = EquipmentAggregateSearchGroupBy
+
+export type EquipmentAggregateSearchQuotaStatus =
+  | "no_active_quota"
+  | "unassigned_category"
+  | "not_in_unit_quota"
+  | "below_minimum"
+  | "over_limit"
+  | "within_limit"
+  | "mixed"
+
+export interface EquipmentAggregateSearchRequest {
+  query: string
+  groupBy: EquipmentAggregateSearchGroupBy
+  regionId?: number | null
+  limit?: number
+}
+
+export interface EquipmentAggregateSearchRpcArgs extends Record<string, unknown> {
+  p_query: string
+  p_group_by: EquipmentAggregateSearchGroupBy
+  p_region_id: number | null
+  p_limit: number
+}
+
+export interface EquipmentAggregateSearchRow {
+  groupType: EquipmentAggregateSearchGroupType
+  groupId: number | null
+  groupName: string
+  parentRegionId: number | null
+  parentRegionName: string | null
+  equipmentCount: number
+  facilityCount: number | null
+  quotaCurrentCount: number | null
+  quotaMinCount: number | null
+  quotaMaxCount: number | null
+  quotaStatus: EquipmentAggregateSearchQuotaStatus | null
+  quotaNotes: EquipmentAggregateSearchQuotaStatus[]
+}
+
+export interface EquipmentAggregateSearchSummary {
+  totalEquipmentCount: number
+  regionCount: number
+  facilityCount: number
+  query: string
+  scopeLabel: string
+}
+
+export interface EquipmentAggregateSearchData {
+  rows: EquipmentAggregateSearchRow[]
+  summary: EquipmentAggregateSearchSummary
+}

--- a/src/app/(app)/reports/hooks/use-equipment-aggregate-search.types.ts
+++ b/src/app/(app)/reports/hooks/use-equipment-aggregate-search.types.ts
@@ -37,7 +37,7 @@ export interface EquipmentAggregateSearchRow {
   quotaMinCount: number | null
   quotaMaxCount: number | null
   quotaStatus: EquipmentAggregateSearchQuotaStatus | null
-  quotaNotes: EquipmentAggregateSearchQuotaStatus[]
+  quotaNotes?: string[]
 }
 
 export interface EquipmentAggregateSearchSummary {


### PR DESCRIPTION
## Summary
- Add Reports-owned typed data layer for equipment aggregate search RPC.
- Add TanStack Query hook with stable keys, role/blank-query gating, and UI error normalization helper.
- Update OpenSpec and GitHub issues #628/#629/#630 to move future UI from /global-search to the Reports `equipment-search` tab at `/reports?tab=equipment-search&q=...`.

## Verification
- openspec validate add-equipment-aggregate-global-search --strict
- node scripts/npm-run.js run test -- 'src/app/(app)/reports/hooks/__tests__/use-equipment-aggregate-search.test.tsx'
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run react-doctor

Closes #628
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed, role-gated data layer and `@tanstack/react-query` hook for equipment aggregate search, powering the Reports `equipment-search` tab. Finalizes the `equipment_aggregate_search` RPC contract, adds limit normalization, and updates OpenSpec to use `/reports?tab=equipment-search`. Closes #628.

- **New Features**
  - Added TypeScript request/response types and RPC args, including quota fields and status.
  - Introduced `useEquipmentAggregateSearch` with stable keys, trimmed keyword guard, role gating (`global`/`admin`/`regional_leader`), placeholder data, and 60s stale time.
  - Added limit normalization (default 50, min 1, max 100) applied to keys and RPC (`p_limit`).
  - Added error normalization and tests for role gating, key building, RPC args, limit handling, disabled-state clearing, and error messages.
  - Updated OpenSpec/proposal/tasks to move from `/global-search` to the Reports `equipment-search` tab with `tab=equipment-search&q=...`, aligning with #629 and #630.

<sup>Written for commit e888464f00b5fb840722a841381a0bcfae6b512c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an equipment search experience inside the Reports page, with URL-based search state and repeatable keyword searches.
  * Search results now support region/facility grouping, drill-down navigation, and quota-aware status summaries.
  * Header search now routes users directly to the Reports equipment search tab.

* **Bug Fixes**
  * Improved handling for empty searches, unsupported roles, and unknown search errors.
  * Tightened result matching to relevant equipment fields and excluded internal codes from matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->