### PR TITLE
Add header equipment search entry

### DIFF
--- a/openspec/changes/add-equipment-aggregate-global-search/tasks.md
+++ b/openspec/changes/add-equipment-aggregate-global-search/tasks.md
@@ -53,11 +53,11 @@
 
 ## Phase 4 - Header Entry Point (#629)
 
-- [ ] 4.1 Add a compact header search input for `admin`/`global` and `regional_leader`.
-- [ ] 4.2 Hide the entry point for all other roles.
-- [ ] 4.3 Submit only on Enter or search button click.
-- [ ] 4.4 URL-encode the keyword and navigate to `/reports?tab=equipment-search&q=<encodedKeyword>` on valid submit.
-- [ ] 4.5 Add focused tests for visibility, submit behavior, and encoded navigation for spaces/reserved characters.
+- [x] 4.1 Add a compact header search input for `admin`/`global` and `regional_leader`.
+- [x] 4.2 Hide the entry point for all other roles.
+- [x] 4.3 Submit only on Enter or search button click.
+- [x] 4.4 URL-encode the keyword and navigate to `/reports?tab=equipment-search&q=<encodedKeyword>` on valid submit.
+- [x] 4.5 Add focused tests for visibility, submit behavior, and encoded navigation for spaces/reserved characters.
 
 ## Phase 5 - Reports Equipment Search Tab Count-First Flow (#630)
 

--- a/src/app/(app)/__tests__/AppLayoutShell.logout-stale.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.logout-stale.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   useSession: vi.fn(),
   updateSession: vi.fn(),
   usePathname: vi.fn(),
+  routerPush: vi.fn(),
   useTenantSelection: vi.fn(),
   useTenantBranding: vi.fn(),
   useAppNotificationCounts: vi.fn(),
@@ -17,6 +18,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mocks.usePathname(),
+  useRouter: () => ({
+    push: mocks.routerPush,
+  }),
 }))
 
 vi.mock("next-auth/react", () => ({
@@ -25,9 +29,10 @@ vi.mock("next-auth/react", () => ({
 }))
 
 vi.mock("next/dynamic", () => ({
-  default: () => function DynamicStub() {
-    return null
-  },
+  default: () =>
+    function DynamicStub() {
+      return null
+    },
 }))
 
 vi.mock("@/contexts/TenantSelectionContext", () => ({

--- a/src/app/(app)/__tests__/AppLayoutShell.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.test.tsx
@@ -84,10 +84,15 @@ vi.mock("@/components/ui/button", () => ({
   Button: ({
     children,
     onClick,
+    ...props
   }: {
     children: React.ReactNode
     onClick?: React.MouseEventHandler<HTMLButtonElement>
-  }) => <button onClick={onClick}>{children}</button>,
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
 }))
 
 vi.mock("@/components/ui/badge", () => ({
@@ -441,5 +446,22 @@ describe("AppLayoutShell", () => {
 
     expect(screen.getAllByTestId("skeleton")).toHaveLength(3)
     expect(screen.queryByText("CVMEMS")).not.toBeInTheDocument()
+  })
+
+  it("keeps the mobile navigation trigger visible", () => {
+    render(
+      <AppLayoutShell
+        user={{
+          role: "global",
+          full_name: "Test User",
+          username: "tester",
+          khoa_phong: "IT",
+        }}
+      >
+        <div>Child Content</div>
+      </AppLayoutShell>
+    )
+
+    expect(screen.getByRole("button", { name: /toggle navigation menu/i })).toBeVisible()
   })
 })

--- a/src/app/(app)/__tests__/AppLayoutShell.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.test.tsx
@@ -462,6 +462,10 @@ describe("AppLayoutShell", () => {
       </AppLayoutShell>
     )
 
-    expect(screen.getByRole("button", { name: /toggle navigation menu/i })).toBeVisible()
+    const mobileNavTrigger = screen.getByRole("button", { name: /toggle navigation menu/i })
+
+    expect(mobileNavTrigger).toHaveClass("shrink-0", "touch-target", "lg:hidden")
+    expect(mobileNavTrigger).not.toHaveClass("hidden")
+    expect(mobileNavTrigger).not.toHaveStyle({ display: "none" })
   })
 })

--- a/src/app/(app)/__tests__/AppLayoutShell.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   useSession: vi.fn(),
   updateSession: vi.fn(),
   usePathname: vi.fn(),
+  routerPush: vi.fn(),
   useTenantSelection: vi.fn(),
   useTenantBranding: vi.fn(),
   useAppNotificationCounts: vi.fn(),
@@ -17,6 +18,9 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mocks.usePathname(),
+  useRouter: () => ({
+    push: mocks.routerPush,
+  }),
 }))
 
 vi.mock("next-auth/react", () => ({
@@ -25,9 +29,10 @@ vi.mock("next-auth/react", () => ({
 }))
 
 vi.mock("next/dynamic", () => ({
-  default: () => function DynamicStub() {
-    return null
-  },
+  default: () =>
+    function DynamicStub() {
+      return null
+    },
 }))
 
 vi.mock("@/contexts/TenantSelectionContext", () => ({

--- a/src/app/(app)/__tests__/HeaderEquipmentSearchEntry.test.tsx
+++ b/src/app/(app)/__tests__/HeaderEquipmentSearchEntry.test.tsx
@@ -1,0 +1,77 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.routerPush,
+  }),
+}))
+
+import { HeaderEquipmentSearchEntry } from "@/app/(app)/_components/HeaderEquipmentSearchEntry"
+
+describe("HeaderEquipmentSearchEntry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows the entry only to admin, global, and regional leader users", () => {
+    const elevatedRoles = ["admin", "global", "regional_leader"] as const
+    const unsupportedRoles = ["to_qltb", "qltb_khoa", "technician", "user"] as const
+
+    for (const role of elevatedRoles) {
+      const { unmount } = render(<HeaderEquipmentSearchEntry role={role} />)
+
+      expect(screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i })).toBeInTheDocument()
+      unmount()
+    }
+
+    for (const role of unsupportedRoles) {
+      const { unmount } = render(<HeaderEquipmentSearchEntry role={role} />)
+
+      expect(
+        screen.queryByRole("searchbox", { name: /tìm kiếm thiết bị/i })
+      ).not.toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it("navigates to the Reports equipment-search tab with an encoded keyword on Enter submit", async () => {
+    const user = userEvent.setup()
+    render(<HeaderEquipmentSearchEntry role="global" />)
+
+    await user.type(
+      screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i }),
+      "Máy X-quang & CT{Enter}"
+    )
+
+    expect(mocks.routerPush).toHaveBeenCalledWith(
+      "/reports?tab=equipment-search&q=M%C3%A1y+X-quang+%26+CT"
+    )
+  })
+
+  it("navigates to the Reports equipment-search tab with an encoded keyword on button submit", async () => {
+    const user = userEvent.setup()
+    render(<HeaderEquipmentSearchEntry role="regional_leader" />)
+
+    await user.type(screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i }), "Monitor% khoa")
+    await user.click(screen.getByRole("button", { name: /tìm kiếm thiết bị/i }))
+
+    expect(mocks.routerPush).toHaveBeenCalledWith("/reports?tab=equipment-search&q=Monitor%25+khoa")
+  })
+
+  it("does not navigate while the user is only typing", async () => {
+    const user = userEvent.setup()
+    render(<HeaderEquipmentSearchEntry role="admin" />)
+
+    await user.type(screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i }), "Máy thở")
+
+    expect(mocks.routerPush).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/__tests__/HeaderEquipmentSearchEntry.test.tsx
+++ b/src/app/(app)/__tests__/HeaderEquipmentSearchEntry.test.tsx
@@ -26,14 +26,14 @@ describe("HeaderEquipmentSearchEntry", () => {
     const unsupportedRoles = ["to_qltb", "qltb_khoa", "technician", "user"] as const
 
     for (const role of elevatedRoles) {
-      const { unmount } = render(<HeaderEquipmentSearchEntry role={role} />)
+      const { unmount } = render(<HeaderEquipmentSearchEntry userRole={role} />)
 
       expect(screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i })).toBeInTheDocument()
       unmount()
     }
 
     for (const role of unsupportedRoles) {
-      const { unmount } = render(<HeaderEquipmentSearchEntry role={role} />)
+      const { unmount } = render(<HeaderEquipmentSearchEntry userRole={role} />)
 
       expect(
         screen.queryByRole("searchbox", { name: /tìm kiếm thiết bị/i })
@@ -44,7 +44,7 @@ describe("HeaderEquipmentSearchEntry", () => {
 
   it("navigates to the Reports equipment-search tab with an encoded keyword on Enter submit", async () => {
     const user = userEvent.setup()
-    render(<HeaderEquipmentSearchEntry role="global" />)
+    render(<HeaderEquipmentSearchEntry userRole="global" />)
 
     await user.type(
       screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i }),
@@ -56,9 +56,23 @@ describe("HeaderEquipmentSearchEntry", () => {
     )
   })
 
+  it("clears the header launcher after a successful submit because the Reports URL owns the query", async () => {
+    const user = userEvent.setup()
+    render(<HeaderEquipmentSearchEntry userRole="global" />)
+
+    const searchbox = screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i })
+
+    await user.type(searchbox, "Máy thở{Enter}")
+
+    expect(mocks.routerPush).toHaveBeenCalledWith(
+      "/reports?tab=equipment-search&q=M%C3%A1y+th%E1%BB%9F"
+    )
+    expect(searchbox).toHaveValue("")
+  })
+
   it("navigates to the Reports equipment-search tab with an encoded keyword on button submit", async () => {
     const user = userEvent.setup()
-    render(<HeaderEquipmentSearchEntry role="regional_leader" />)
+    render(<HeaderEquipmentSearchEntry userRole="regional_leader" />)
 
     await user.type(screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i }), "Monitor% khoa")
     await user.click(screen.getByRole("button", { name: /tìm kiếm thiết bị/i }))
@@ -68,7 +82,7 @@ describe("HeaderEquipmentSearchEntry", () => {
 
   it("does not navigate while the user is only typing", async () => {
     const user = userEvent.setup()
-    render(<HeaderEquipmentSearchEntry role="admin" />)
+    render(<HeaderEquipmentSearchEntry userRole="admin" />)
 
     await user.type(screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i }), "Máy thở")
 

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -270,7 +270,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
               </div>
             </div>
 
-            <HeaderEquipmentSearchEntry role={user.role} />
+            <HeaderEquipmentSearchEntry userRole={user.role} />
 
             <RealtimeStatus variant="icon" className="hidden md:flex" />
             <HelpButton className="hidden md:flex" />

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -203,12 +203,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
               onOpenChange={(isOpen) => dispatchUi({ type: "setMobileSheetOpen", isOpen })}
             >
               <SheetTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="hidden shrink-0 touch-target"
-                  style={{ display: "none" }}
-                >
+                <Button variant="outline" size="icon" className="shrink-0 touch-target lg:hidden">
                   <Menu className="size-5" />
                   <span className="sr-only">Toggle navigation menu</span>
                 </Button>

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -33,20 +33,25 @@ import { MobileFooterNav } from "@/components/mobile-footer-nav"
 import { HelpButton } from "@/components/onboarding/HelpButton"
 import { USER_ROLES } from "@/types/database"
 import { TenantSelectionProvider, useTenantSelection } from "@/contexts/TenantSelectionContext"
-import { EquipmentFilterProvider, clearAllEquipmentFilters } from "@/contexts/EquipmentFilterContext"
+import {
+  EquipmentFilterProvider,
+  clearAllEquipmentFilters,
+} from "@/contexts/EquipmentFilterContext"
 import { AppSidebarNav } from "@/components/app-sidebar-nav"
 import { getAppNavigationItems } from "@/components/app-navigation"
 import { useAppNotificationCounts } from "@/hooks/useAppNotificationCounts"
 import { signOutWithReason } from "@/lib/auth-signout"
 import { appLayoutUiReducer, initialAppLayoutUiState } from "./AppLayoutShellState"
+import { HeaderEquipmentSearchEntry } from "./HeaderEquipmentSearchEntry"
 
 const AssistantTriggerButton = dynamic(
-  () => import("@/components/assistant/AssistantTriggerButton").then(m => m.AssistantTriggerButton),
-  { ssr: false },
+  () =>
+    import("@/components/assistant/AssistantTriggerButton").then((m) => m.AssistantTriggerButton),
+  { ssr: false }
 )
 const AssistantPanel = dynamic(
-  () => import("@/components/assistant/AssistantPanel").then(m => m.AssistantPanel),
-  { ssr: false },
+  () => import("@/components/assistant/AssistantPanel").then((m) => m.AssistantPanel),
+  { ssr: false }
 )
 
 type AppLayoutUser = {
@@ -80,7 +85,8 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
   const { selectedFacilityId, shouldFetchData } = useTenantSelection()
   const hasHandledSessionExitRef = React.useRef(false)
   const [uiState, dispatchUi] = React.useReducer(appLayoutUiReducer, initialAppLayoutUiState)
-  const { isSidebarOpen, isMobileSheetOpen, isChangePasswordOpen, isAssistantOpen, isSigningOut } = uiState
+  const { isSidebarOpen, isMobileSheetOpen, isChangePasswordOpen, isAssistantOpen, isSigningOut } =
+    uiState
   const branding = useTenantBranding()
   const { counts: notificationCounts } = useAppNotificationCounts({
     enabled: status === "authenticated" && shouldFetchData,
@@ -148,178 +154,203 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
     <AuthenticatedPageSpinnerFallback />
   ) : (
     <>
-          <ChangePasswordDialog
-            open={isChangePasswordOpen}
-            onOpenChange={(isOpen) => dispatchUi({ type: "setChangePasswordOpen", isOpen })}
-          />
-            <div
-              className={cn(
-              "grid min-h-screen w-full transition-all pt-14 pb-20 lg:pt-0 lg:pb-0",
-              isSidebarOpen ? "lg:grid-cols-[220px_1fr]" : "lg:grid-cols-[72px_1fr]"
-            )}
-          >
-            <div className="hidden border-r border-border bg-white shadow-[2px_0_8px_rgba(0,0,0,0.04)] lg:block">
-              <div className="flex h-full max-h-screen flex-col">
-                <div className="flex h-auto flex-col items-center gap-4 border-b border-border p-4">
-                  <Link href="/" className="flex flex-col items-center gap-3 font-semibold text-primary" data-tour="sidebar-logo">
-                    {branding.isLoading ? (
-                      <Skeleton className={isSidebarOpen ? "size-16" : "size-8"} />
-                    ) : (
-                      <TenantLogo src={branding.data?.logo_url ?? null} name={branding.data?.name ?? null} size={isSidebarOpen ? 64 : 32} className={isSidebarOpen ? "" : "mt-2"} />
-                    )}
-                  </Link>
-                </div>
-                <div className="flex-1 overflow-auto py-4">
-                  <AppSidebarNav
-                    items={navItems}
-                    pathname={pathname}
-                    isSidebarOpen={isSidebarOpen}
-                    notificationCounts={notificationCounts}
-                    tourAttributes={tourAttributes}
-                    className={cn("px-3", !isSidebarOpen && "justify-items-center px-0")}
+      <ChangePasswordDialog
+        open={isChangePasswordOpen}
+        onOpenChange={(isOpen) => dispatchUi({ type: "setChangePasswordOpen", isOpen })}
+      />
+      <div
+        className={cn(
+          "grid min-h-screen w-full transition-all pt-14 pb-20 lg:pt-0 lg:pb-0",
+          isSidebarOpen ? "lg:grid-cols-[220px_1fr]" : "lg:grid-cols-[72px_1fr]"
+        )}
+      >
+        <div className="hidden border-r border-border bg-white shadow-[2px_0_8px_rgba(0,0,0,0.04)] lg:block">
+          <div className="flex h-full max-h-screen flex-col">
+            <div className="flex h-auto flex-col items-center gap-4 border-b border-border p-4">
+              <Link
+                href="/"
+                className="flex flex-col items-center gap-3 font-semibold text-primary"
+                data-tour="sidebar-logo"
+              >
+                {branding.isLoading ? (
+                  <Skeleton className={isSidebarOpen ? "size-16" : "size-8"} />
+                ) : (
+                  <TenantLogo
+                    src={branding.data?.logo_url ?? null}
+                    name={branding.data?.name ?? null}
+                    size={isSidebarOpen ? 64 : 32}
+                    className={isSidebarOpen ? "" : "mt-2"}
                   />
-                </div>
-              </div>
+                )}
+              </Link>
             </div>
-            <div className="flex flex-col">
-              <header className="fixed top-0 left-0 right-0 z-40 flex h-14 items-center gap-4 bg-white px-4 shadow-md lg:relative lg:z-auto lg:h-[60px] lg:px-6">
-                <Sheet open={isMobileSheetOpen} onOpenChange={(isOpen) => dispatchUi({ type: "setMobileSheetOpen", isOpen })}>
-                  <SheetTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className="hidden shrink-0 touch-target"
-                      style={{ display: "none" }}
-                    >
-                      <Menu className="size-5" />
-                      <span className="sr-only">Toggle navigation menu</span>
-                    </Button>
-                  </SheetTrigger>
-                  <SheetContent side="left" className="flex flex-col bg-white p-0">
-                    <SheetHeader className="sr-only">
-                      <SheetTitle>Menu Điều Hướng</SheetTitle>
-                    </SheetHeader>
-                    <div className="flex h-auto flex-col items-center gap-4 border-b border-border p-4">
-                      <Link
-                        href="/"
-                        className="flex flex-col items-center gap-3 font-semibold text-primary"
-                        onClick={() => dispatchUi({ type: "setMobileSheetOpen", isOpen: false })}
-                      >
-                        <Logo />
-                        <span className="text-center heading-responsive-h3">QUẢN LÝ TBYT - CDC</span>
-                      </Link>
-                    </div>
-                    <AppSidebarNav
-                      items={navItems}
-                      pathname={pathname}
-                      isSidebarOpen
-                      notificationCounts={notificationCounts}
-                      variant="sheet"
-                      className="p-3"
-                      onNavigate={() => dispatchUi({ type: "setMobileSheetOpen", isOpen: false })}
-                    />
-                  </SheetContent>
-                </Sheet>
+            <div className="flex-1 overflow-auto py-4">
+              <AppSidebarNav
+                items={navItems}
+                pathname={pathname}
+                isSidebarOpen={isSidebarOpen}
+                notificationCounts={notificationCounts}
+                tourAttributes={tourAttributes}
+                className={cn("px-3", !isSidebarOpen && "justify-items-center px-0")}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col">
+          <header className="fixed top-0 left-0 right-0 z-40 flex h-14 items-center gap-4 bg-white px-4 shadow-md lg:relative lg:z-auto lg:h-[60px] lg:px-6">
+            <Sheet
+              open={isMobileSheetOpen}
+              onOpenChange={(isOpen) => dispatchUi({ type: "setMobileSheetOpen", isOpen })}
+            >
+              <SheetTrigger asChild>
                 <Button
                   variant="outline"
                   size="icon"
-                  className="hidden shrink-0 touch-target lg:flex"
-                  onClick={() => dispatchUi({ type: "toggleSidebar" })}
-                  data-tour="sidebar-toggle"
+                  className="hidden shrink-0 touch-target"
+                  style={{ display: "none" }}
                 >
                   <Menu className="size-5" />
-                  <span className="sr-only">Toggle sidebar</span>
+                  <span className="sr-only">Toggle navigation menu</span>
                 </Button>
-                <div className="flex w-full flex-1 items-center">
-                  <div className="flex items-center gap-3">
-                    {branding.isLoading ? (
-                      <Skeleton className="size-7 rounded-full" />
-                    ) : (
-                      <TenantLogo src={branding.data?.logo_url ?? null} name={branding.data?.name ?? null} size={28} />
-                    )}
-                    {branding.isLoading ? (
-                      <Skeleton className="h-5 w-48" />
-                    ) : (
-                      <TenantName
-                        name={branding.data?.name ?? null}
-                        className="max-w-[calc(100vw-120px)] truncate text-sm sm:max-w-[400px] sm:text-base lg:max-w-none lg:text-lg"
-                      />
-                    )}
-                  </div>
+              </SheetTrigger>
+              <SheetContent side="left" className="flex flex-col bg-white p-0">
+                <SheetHeader className="sr-only">
+                  <SheetTitle>Menu Điều Hướng</SheetTitle>
+                </SheetHeader>
+                <div className="flex h-auto flex-col items-center gap-4 border-b border-border p-4">
+                  <Link
+                    href="/"
+                    className="flex flex-col items-center gap-3 font-semibold text-primary"
+                    onClick={() => dispatchUi({ type: "setMobileSheetOpen", isOpen: false })}
+                  >
+                    <Logo />
+                    <span className="text-center heading-responsive-h3">QUẢN LÝ TBYT - CDC</span>
+                  </Link>
                 </div>
-
-                <RealtimeStatus variant="icon" className="hidden md:flex" />
-                <HelpButton className="hidden md:flex" />
-
-                <NotificationBellDialog
-                  repairCount={notificationCounts.repair}
-                  transferCount={notificationCounts.transfer}
-                  maintenanceCount={notificationCounts.maintenance}
+                <AppSidebarNav
+                  items={navItems}
+                  pathname={pathname}
+                  isSidebarOpen
+                  notificationCounts={notificationCounts}
+                  variant="sheet"
+                  className="p-3"
+                  onNavigate={() => dispatchUi({ type: "setMobileSheetOpen", isOpen: false })}
                 />
-
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="secondary"
-                      size="icon"
-                      className="rounded-full touch-target"
-                      onClick={(event) => event.stopPropagation()}
-                    >
-                      <User className="size-5" />
-                      <span className="sr-only">Toggle user menu</span>
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-56">
-                    <DropdownMenuLabel className="pb-2">
-                      <div className="flex flex-col gap-y-1">
-                        <p className="text-sm font-medium leading-none">{user.full_name || user.username}</p>
-                        <div className="flex items-center gap-2">
-                          <Badge variant="outline" className="text-xs">
-                            {USER_ROLES[user.role as keyof typeof USER_ROLES]}
-                          </Badge>
-                        </div>
-                        {user.khoa_phong ? (
-                          <p className="text-xs leading-none text-muted-foreground">{user.khoa_phong}</p>
-                        ) : null}
-                      </div>
-                    </DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onClick={() => dispatchUi({ type: "setChangePasswordOpen", isOpen: true })}>
-                      <KeyRound className="mr-2 size-4" />
-                      Thay đổi mật khẩu
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onClick={handleSignOut}>
-                      <LogOut className="mr-2 size-4" />
-                      Đăng xuất
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </header>
-              <main className="flex flex-1 flex-col gap-4 bg-background p-4 pb-24 lg:gap-8 lg:p-8 lg:pb-8">
-                <MainContentTransition>
-                  {children}
-                </MainContentTransition>
-              </main>
-
-              <MobileFooterNav notificationCounts={notificationCounts} />
-
-              <AssistantTriggerButton
-                isOpen={isAssistantOpen}
-                onToggle={() => dispatchUi({ type: "toggleAssistant" })}
-              />
-              {isAssistantOpen ? (
-                <AssistantPanel isOpen={isAssistantOpen} onClose={() => dispatchUi({ type: "setAssistantOpen", isOpen: false })} />
-              ) : null}
-
-              <footer className="hidden flex-col items-center gap-1 border-t border-border bg-muted p-4 text-center caption-responsive md:flex">
-                <div className="flex items-center gap-1 text-muted-foreground">
-                  <span>Hệ thống quản lý thiết bị y tế CVMEMS</span>
-                  <Copyright className="size-3" />
-                </div>
-              </footer>
+              </SheetContent>
+            </Sheet>
+            <Button
+              variant="outline"
+              size="icon"
+              className="hidden shrink-0 touch-target lg:flex"
+              onClick={() => dispatchUi({ type: "toggleSidebar" })}
+              data-tour="sidebar-toggle"
+            >
+              <Menu className="size-5" />
+              <span className="sr-only">Toggle sidebar</span>
+            </Button>
+            <div className="flex w-full flex-1 items-center">
+              <div className="flex items-center gap-3">
+                {branding.isLoading ? (
+                  <Skeleton className="size-7 rounded-full" />
+                ) : (
+                  <TenantLogo
+                    src={branding.data?.logo_url ?? null}
+                    name={branding.data?.name ?? null}
+                    size={28}
+                  />
+                )}
+                {branding.isLoading ? (
+                  <Skeleton className="h-5 w-48" />
+                ) : (
+                  <TenantName
+                    name={branding.data?.name ?? null}
+                    className="max-w-[calc(100vw-120px)] truncate text-sm sm:max-w-[400px] sm:text-base lg:max-w-none lg:text-lg"
+                  />
+                )}
+              </div>
             </div>
-          </div>
+
+            <HeaderEquipmentSearchEntry role={user.role} />
+
+            <RealtimeStatus variant="icon" className="hidden md:flex" />
+            <HelpButton className="hidden md:flex" />
+
+            <NotificationBellDialog
+              repairCount={notificationCounts.repair}
+              transferCount={notificationCounts.transfer}
+              maintenanceCount={notificationCounts.maintenance}
+            />
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  className="rounded-full touch-target"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <User className="size-5" />
+                  <span className="sr-only">Toggle user menu</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel className="pb-2">
+                  <div className="flex flex-col gap-y-1">
+                    <p className="text-sm font-medium leading-none">
+                      {user.full_name || user.username}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline" className="text-xs">
+                        {USER_ROLES[user.role as keyof typeof USER_ROLES]}
+                      </Badge>
+                    </div>
+                    {user.khoa_phong ? (
+                      <p className="text-xs leading-none text-muted-foreground">
+                        {user.khoa_phong}
+                      </p>
+                    ) : null}
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => dispatchUi({ type: "setChangePasswordOpen", isOpen: true })}
+                >
+                  <KeyRound className="mr-2 size-4" />
+                  Thay đổi mật khẩu
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleSignOut}>
+                  <LogOut className="mr-2 size-4" />
+                  Đăng xuất
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </header>
+          <main className="flex flex-1 flex-col gap-4 bg-background p-4 pb-24 lg:gap-8 lg:p-8 lg:pb-8">
+            <MainContentTransition>{children}</MainContentTransition>
+          </main>
+
+          <MobileFooterNav notificationCounts={notificationCounts} />
+
+          <AssistantTriggerButton
+            isOpen={isAssistantOpen}
+            onToggle={() => dispatchUi({ type: "toggleAssistant" })}
+          />
+          {isAssistantOpen ? (
+            <AssistantPanel
+              isOpen={isAssistantOpen}
+              onClose={() => dispatchUi({ type: "setAssistantOpen", isOpen: false })}
+            />
+          ) : null}
+
+          <footer className="hidden flex-col items-center gap-1 border-t border-border bg-muted p-4 text-center caption-responsive md:flex">
+            <div className="flex items-center gap-1 text-muted-foreground">
+              <span>Hệ thống quản lý thiết bị y tế CVMEMS</span>
+              <Copyright className="size-3" />
+            </div>
+          </footer>
+        </div>
+      </div>
     </>
   )
 }

--- a/src/app/(app)/_components/HeaderEquipmentSearchEntry.tsx
+++ b/src/app/(app)/_components/HeaderEquipmentSearchEntry.tsx
@@ -9,19 +9,25 @@ import { Button } from "@/components/ui/button"
 import { isPrivilegedRole } from "@/lib/rbac"
 
 type HeaderEquipmentSearchEntryProps = {
-  role?: string
+  userRole?: string
 }
 
 const SEARCH_LABEL = "Tìm kiếm thiết bị"
+const SEARCH_BUTTON_ADDON = (
+  <Button type="submit" variant="ghost" size="icon" className="h-7 w-7">
+    <Search className="size-4" />
+    <span className="sr-only">{SEARCH_LABEL}</span>
+  </Button>
+)
 
 /**
  * Header-only submit entry for the Reports equipment search tab.
  */
-export function HeaderEquipmentSearchEntry({ role }: HeaderEquipmentSearchEntryProps) {
+export function HeaderEquipmentSearchEntry({ userRole }: HeaderEquipmentSearchEntryProps) {
   const router = useRouter()
   const [keyword, setKeyword] = React.useState("")
 
-  if (!isPrivilegedRole(role)) {
+  if (!isPrivilegedRole(userRole)) {
     return null
   }
 
@@ -38,6 +44,7 @@ export function HeaderEquipmentSearchEntry({ role }: HeaderEquipmentSearchEntryP
       q: trimmedKeyword,
     })
     router.push(`/reports?${params.toString()}`)
+    setKeyword("")
   }
 
   return (
@@ -56,12 +63,7 @@ export function HeaderEquipmentSearchEntry({ role }: HeaderEquipmentSearchEntryP
         placeholder={SEARCH_LABEL}
         className="h-9 min-w-0"
         showClearButton={false}
-        endAddon={
-          <Button type="submit" variant="ghost" size="icon" className="h-7 w-7">
-            <Search className="size-4" />
-            <span className="sr-only">{SEARCH_LABEL}</span>
-          </Button>
-        }
+        endAddon={SEARCH_BUTTON_ADDON}
       />
     </form>
   )

--- a/src/app/(app)/_components/HeaderEquipmentSearchEntry.tsx
+++ b/src/app/(app)/_components/HeaderEquipmentSearchEntry.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { Search } from "lucide-react"
+
+import { SearchInput } from "@/components/shared/SearchInput"
+import { Button } from "@/components/ui/button"
+import { isPrivilegedRole } from "@/lib/rbac"
+
+type HeaderEquipmentSearchEntryProps = {
+  role?: string
+}
+
+const SEARCH_LABEL = "Tìm kiếm thiết bị"
+
+/**
+ * Header-only submit entry for the Reports equipment search tab.
+ */
+export function HeaderEquipmentSearchEntry({ role }: HeaderEquipmentSearchEntryProps) {
+  const router = useRouter()
+  const [keyword, setKeyword] = React.useState("")
+
+  if (!isPrivilegedRole(role)) {
+    return null
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmedKeyword = keyword.trim()
+
+    if (!trimmedKeyword) {
+      return
+    }
+
+    const params = new URLSearchParams({
+      tab: "equipment-search",
+      q: trimmedKeyword,
+    })
+    router.push(`/reports?${params.toString()}`)
+  }
+
+  return (
+    <form
+      role="search"
+      aria-label={SEARCH_LABEL}
+      className="hidden w-full max-w-xs items-center gap-2 md:flex lg:max-w-sm"
+      onSubmit={handleSubmit}
+    >
+      <SearchInput
+        id="header-equipment-search"
+        value={keyword}
+        onChange={setKeyword}
+        aria-label={SEARCH_LABEL}
+        autoComplete="off"
+        placeholder={SEARCH_LABEL}
+        className="h-9 min-w-0"
+        showClearButton={false}
+        endAddon={
+          <Button type="submit" variant="ghost" size="icon" className="h-7 w-7">
+            <Search className="size-4" />
+            <span className="sr-only">{SEARCH_LABEL}</span>
+          </Button>
+        }
+      />
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a compact Reports-owned header equipment search entry for admin/global and regional leader roles.
- Navigate only on Enter or the search button to `/reports?tab=equipment-search&q=<encodedKeyword>`.
- Keep v1 autocomplete-free and do not render results or Reports tab UI.
- Mark Phase 4 OpenSpec tasks complete.

## Verification
- npx openspec validate add-equipment-aggregate-global-search --strict
- npx prettier --check --ignore-unknown <touched files>
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js exec vitest --run `src/app/(app)/__tests__/HeaderEquipmentSearchEntry.test.tsx` `src/app/(app)/__tests__/AppLayoutShell.test.tsx` `src/app/(app)/__tests__/AppLayoutShell.logout-stale.test.tsx` --reporter=verbose
- node scripts/npm-run.js run react-doctor

Closes #629
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact equipment search input in the header for privileged users. Submits to Reports equipment-search with a URL-encoded query and clears after submit; no autocomplete or inline results. Meets #629 Phase 4 requirements.

- **New Features**
  - Added header `HeaderEquipmentSearchEntry` for `admin`, `global`, and `regional_leader`, integrated into `AppLayoutShell`.
  - Submits only on Enter or the search button; hidden for other roles; encodes `q` and clears on submit.

- **Bug Fixes**
  - Restored the mobile navigation trigger in the header; added a stricter regression test to ensure it remains visible.

<sup>Written for commit 261f9ee117279cd7f9e669d80af698fbfe4c96d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a header-only equipment search entry for privileged roles.
  * Submit via **Enter** or the search button to navigate to the Reports equipment search view, including properly encoded query text.
* **UI/UX Improvements**
  * Improved the mobile header navigation trigger to rely on responsive styling (so it’s shown on smaller screens rather than being forcibly hidden).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->