### PR TITLE
Polish header equipment search placement

### DIFF
--- a/src/app/(app)/__tests__/AppLayoutShell.test.tsx
+++ b/src/app/(app)/__tests__/AppLayoutShell.test.tsx
@@ -468,4 +468,26 @@ describe("AppLayoutShell", () => {
     expect(mobileNavTrigger).not.toHaveClass("hidden")
     expect(mobileNavTrigger).not.toHaveStyle({ display: "none" })
   })
+
+  it("keeps the equipment search aligned inside the right header action cluster", () => {
+    render(
+      <AppLayoutShell
+        user={{
+          role: "global",
+          full_name: "Test User",
+          username: "tester",
+          khoa_phong: "IT",
+        }}
+      >
+        <div>Child Content</div>
+      </AppLayoutShell>
+    )
+
+    const headerActions = screen.getByTestId("app-header-actions")
+
+    expect(headerActions).toHaveClass("ml-auto", "shrink-0")
+    expect(headerActions).toContainElement(
+      screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i })
+    )
+  })
 })

--- a/src/app/(app)/__tests__/HeaderEquipmentSearchEntry.test.tsx
+++ b/src/app/(app)/__tests__/HeaderEquipmentSearchEntry.test.tsx
@@ -42,6 +42,18 @@ describe("HeaderEquipmentSearchEntry", () => {
     }
   })
 
+  it("uses compact header sizing instead of expanding as a full-width search block", () => {
+    render(<HeaderEquipmentSearchEntry userRole="global" />)
+
+    const searchForm = screen.getByRole("search", { name: /tìm kiếm thiết bị/i })
+    const searchbox = screen.getByRole("searchbox", { name: /tìm kiếm thiết bị/i })
+
+    expect(searchForm).toHaveClass("hidden", "shrink-0", "items-center", "md:flex")
+    expect(searchForm).toHaveClass("w-56", "xl:w-64", "2xl:w-72")
+    expect(searchForm).not.toHaveClass("w-full", "max-w-xs", "lg:max-w-sm")
+    expect(searchbox).toHaveClass("h-8", "rounded-lg", "border-transparent", "bg-muted/50")
+  })
+
   it("navigates to the Reports equipment-search tab with an encoded keyword on Enter submit", async () => {
     const user = userEvent.setup()
     render(<HeaderEquipmentSearchEntry userRole="global" />)

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -243,8 +243,8 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
               <Menu className="size-5" />
               <span className="sr-only">Toggle sidebar</span>
             </Button>
-            <div className="flex w-full flex-1 items-center">
-              <div className="flex items-center gap-3">
+            <div className="flex min-w-0 flex-1 items-center">
+              <div className="flex min-w-0 items-center gap-3">
                 {branding.isLoading ? (
                   <Skeleton className="size-7 rounded-full" />
                 ) : (
@@ -265,61 +265,66 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
               </div>
             </div>
 
-            <HeaderEquipmentSearchEntry userRole={user.role} />
+            <div
+              data-testid="app-header-actions"
+              className="ml-auto flex shrink-0 items-center gap-1.5 sm:gap-2"
+            >
+              <HeaderEquipmentSearchEntry userRole={user.role} />
 
-            <RealtimeStatus variant="icon" className="hidden md:flex" />
-            <HelpButton className="hidden md:flex" />
+              <RealtimeStatus variant="icon" className="hidden md:flex" />
+              <HelpButton className="hidden md:flex" />
 
-            <NotificationBellDialog
-              repairCount={notificationCounts.repair}
-              transferCount={notificationCounts.transfer}
-              maintenanceCount={notificationCounts.maintenance}
-            />
+              <NotificationBellDialog
+                repairCount={notificationCounts.repair}
+                transferCount={notificationCounts.transfer}
+                maintenanceCount={notificationCounts.maintenance}
+              />
 
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="secondary"
-                  size="icon"
-                  className="rounded-full touch-target"
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <User className="size-5" />
-                  <span className="sr-only">Toggle user menu</span>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuLabel className="pb-2">
-                  <div className="flex flex-col gap-y-1">
-                    <p className="text-sm font-medium leading-none">
-                      {user.full_name || user.username}
-                    </p>
-                    <div className="flex items-center gap-2">
-                      <Badge variant="outline" className="text-xs">
-                        {USER_ROLES[user.role as keyof typeof USER_ROLES]}
-                      </Badge>
-                    </div>
-                    {user.khoa_phong ? (
-                      <p className="text-xs leading-none text-muted-foreground">
-                        {user.khoa_phong}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="secondary"
+                    size="icon"
+                    className="rounded-full touch-target"
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    <User className="size-5" />
+                    <span className="sr-only">Toggle user menu</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuLabel className="pb-2">
+                    <div className="flex flex-col gap-y-1">
+                      <p className="text-sm font-medium leading-none">
+                        {user.full_name || user.username}
                       </p>
-                    ) : null}
-                  </div>
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={() => dispatchUi({ type: "setChangePasswordOpen", isOpen: true })}
-                >
-                  <KeyRound className="mr-2 size-4" />
-                  Thay đổi mật khẩu
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleSignOut}>
-                  <LogOut className="mr-2 size-4" />
-                  Đăng xuất
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline" className="text-xs">
+                          {USER_ROLES[user.role as keyof typeof USER_ROLES]}
+                        </Badge>
+                      </div>
+                      {user.khoa_phong ? (
+                        <p className="text-xs leading-none text-muted-foreground">
+                          {user.khoa_phong}
+                        </p>
+                      ) : null}
+                    </div>
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => dispatchUi({ type: "setChangePasswordOpen", isOpen: true })}
+                  >
+                    <KeyRound className="mr-2 size-4" />
+                    Thay đổi mật khẩu
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleSignOut}>
+                    <LogOut className="mr-2 size-4" />
+                    Đăng xuất
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </header>
           <main className="flex flex-1 flex-col gap-4 bg-background p-4 pb-24 lg:gap-8 lg:p-8 lg:pb-8">
             <MainContentTransition>{children}</MainContentTransition>

--- a/src/app/(app)/_components/HeaderEquipmentSearchEntry.tsx
+++ b/src/app/(app)/_components/HeaderEquipmentSearchEntry.tsx
@@ -14,7 +14,12 @@ type HeaderEquipmentSearchEntryProps = {
 
 const SEARCH_LABEL = "Tìm kiếm thiết bị"
 const SEARCH_BUTTON_ADDON = (
-  <Button type="submit" variant="ghost" size="icon" className="h-7 w-7">
+  <Button
+    type="submit"
+    variant="ghost"
+    size="icon"
+    className="h-6 w-6 rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+  >
     <Search className="size-4" />
     <span className="sr-only">{SEARCH_LABEL}</span>
   </Button>
@@ -51,7 +56,7 @@ export function HeaderEquipmentSearchEntry({ userRole }: HeaderEquipmentSearchEn
     <form
       role="search"
       aria-label={SEARCH_LABEL}
-      className="hidden w-full max-w-xs items-center gap-2 md:flex lg:max-w-sm"
+      className="hidden w-56 shrink-0 items-center md:flex xl:w-64 2xl:w-72"
       onSubmit={handleSubmit}
     >
       <SearchInput
@@ -61,7 +66,7 @@ export function HeaderEquipmentSearchEntry({ userRole }: HeaderEquipmentSearchEn
         aria-label={SEARCH_LABEL}
         autoComplete="off"
         placeholder={SEARCH_LABEL}
-        className="h-9 min-w-0"
+        className="h-8 min-w-0 rounded-lg border-transparent bg-muted/50 text-sm shadow-none transition-colors placeholder:text-muted-foreground/80 hover:bg-muted/70 focus-visible:border-primary/30 focus-visible:bg-background focus-visible:ring-1 focus-visible:ring-primary/20 focus-visible:ring-offset-0"
         showClearButton={false}
         endAddon={SEARCH_BUTTON_ADDON}
       />


### PR DESCRIPTION
## Summary
- Move the equipment search launcher into the right header action cluster so it no longer floats between branding and utility icons.
- Reduce the input visual weight with compact width, muted background, lighter border treatment, and smaller submit affordance.
- Add regression tests for compact header sizing and action-cluster placement.

## Test Plan
- [x] Red/green focused tests for HeaderEquipmentSearchEntry and AppLayoutShell layout contract
- [x] Prettier check on touched files
- [x] verify:no-explicit-any
- [x] verify:dedupe
- [x] typecheck
- [x] react-doctor

## Visual note
- Dev server ran at http://localhost:3000, but browser verification reached the login gate instead of an authenticated header view.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the equipment search into the right header action cluster and made it compact for a lighter look. This aligns the header and prevents the search from floating between branding and utility icons.

- **UI Improvements**
  - Grouped search with header actions; utility icons moved into the same cluster.
  - Compact styling: fixed widths (w-56, xl:w-64, 2xl:w-72), smaller input (h-8), muted background, lighter borders, smaller submit button (h-6 w-6).
  - Added tests to lock alignment inside the action cluster and ensure compact sizing.

<sup>Written for commit 7d32994b631761681ca2a26ffd0ef1548c827a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

