### PR TITLE
feat(reports): add equipment search tab

### DIFF
--- a/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
+++ b/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const state = vi.hoisted(() => ({
@@ -192,7 +192,19 @@ describe("ReportsPage auth gate", () => {
     expect(screen.getByTestId("reports-tabs-list")).toHaveClass("w-max", "min-w-max")
   })
 
-  it("activates the equipment search tab and hydrates the query from the Reports URL", () => {
+  it("shows the Reports tab skeleton while the equipment search tab loads", () => {
+    state.sessionData = {
+      user: { role: "admin", don_vi: null, dia_ban_id: null },
+    }
+    state.shouldFetchData = true
+    state.searchParams = new URLSearchParams("tab=equipment-search&q=monitor")
+
+    render(<ReportsPage />)
+
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0)
+  })
+
+  it("activates the equipment search tab and hydrates the query from the Reports URL", async () => {
     state.sessionData = {
       user: { role: "admin", don_vi: null, dia_ban_id: null },
     }
@@ -205,10 +217,10 @@ describe("ReportsPage auth gate", () => {
       "data-state",
       "active"
     )
-    expect(screen.getByTestId("equipment-search-report-tab")).toHaveTextContent("monitor")
+    expect(await screen.findByTestId("equipment-search-report-tab")).toHaveTextContent("monitor")
   })
 
-  it("updates equipment search query props without remounting the tab component", () => {
+  it("updates equipment search query props without remounting the tab component", async () => {
     state.sessionData = {
       user: { role: "admin", don_vi: null, dia_ban_id: null },
     }
@@ -217,14 +229,16 @@ describe("ReportsPage auth gate", () => {
 
     const { rerender } = render(<ReportsPage />)
 
-    const instanceId = screen
-      .getByTestId("equipment-search-report-tab")
-      .getAttribute("data-instance-id")
+    const instanceId = (await screen.findByTestId("equipment-search-report-tab")).getAttribute(
+      "data-instance-id"
+    )
 
     state.searchParams = new URLSearchParams("tab=equipment-search&q=máy thở")
     rerender(<ReportsPage />)
 
-    expect(screen.getByTestId("equipment-search-report-tab")).toHaveTextContent("máy thở")
+    await waitFor(() =>
+      expect(screen.getByTestId("equipment-search-report-tab")).toHaveTextContent("máy thở")
+    )
     expect(screen.getByTestId("equipment-search-report-tab")).toHaveAttribute(
       "data-instance-id",
       instanceId

--- a/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
+++ b/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
@@ -220,6 +220,20 @@ describe("ReportsPage auth gate", () => {
     expect(await screen.findByTestId("equipment-search-report-tab")).toHaveTextContent("monitor")
   })
 
+  it("renders equipment search without requiring tenant selection", async () => {
+    state.sessionData = {
+      user: { role: "admin", don_vi: null, dia_ban_id: null },
+    }
+    state.showSelector = true
+    state.shouldFetchData = false
+    state.searchParams = new URLSearchParams("tab=equipment-search&q=monitor")
+
+    render(<ReportsPage />)
+
+    expect(screen.queryByTestId("tenant-selection-tip")).not.toBeInTheDocument()
+    expect(await screen.findByTestId("equipment-search-report-tab")).toHaveTextContent("monitor")
+  })
+
   it("updates equipment search query props without remounting the tab component", async () => {
     state.sessionData = {
       user: { role: "admin", don_vi: null, dia_ban_id: null },

--- a/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
+++ b/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
   pathname: "/reports",
   tabsValue: "inventory",
   tabsOnValueChange: undefined as ((value: string) => void) | undefined,
+  equipmentSearchInstanceCount: 0,
 }))
 
 const mocks = vi.hoisted(() => ({
@@ -62,9 +63,18 @@ vi.mock("@/app/(app)/reports/components/tenant-selection-tip", () => ({
 }))
 
 vi.mock("../components/equipment-search-report-tab", () => ({
-  EquipmentSearchReportTab: ({ initialQuery }: { initialQuery: string }) => (
-    <div data-testid="equipment-search-report-tab">{initialQuery}</div>
-  ),
+  EquipmentSearchReportTab: ({ initialQuery }: { initialQuery: string }) => {
+    const [instanceId] = React.useState(() => {
+      state.equipmentSearchInstanceCount += 1
+      return state.equipmentSearchInstanceCount
+    })
+
+    return (
+      <div data-instance-id={instanceId} data-testid="equipment-search-report-tab">
+        {initialQuery}
+      </div>
+    )
+  },
 }))
 
 vi.mock("@/components/ui/card", () => ({
@@ -145,6 +155,7 @@ describe("ReportsPage auth gate", () => {
     state.pathname = "/reports"
     state.tabsValue = "inventory"
     state.tabsOnValueChange = undefined
+    state.equipmentSearchInstanceCount = 0
   })
 
   it("shows the loading skeleton without redirecting unauthenticated users", () => {
@@ -195,6 +206,29 @@ describe("ReportsPage auth gate", () => {
       "active"
     )
     expect(screen.getByTestId("equipment-search-report-tab")).toHaveTextContent("monitor")
+  })
+
+  it("updates equipment search query props without remounting the tab component", () => {
+    state.sessionData = {
+      user: { role: "admin", don_vi: null, dia_ban_id: null },
+    }
+    state.shouldFetchData = true
+    state.searchParams = new URLSearchParams("tab=equipment-search&q=monitor")
+
+    const { rerender } = render(<ReportsPage />)
+
+    const instanceId = screen
+      .getByTestId("equipment-search-report-tab")
+      .getAttribute("data-instance-id")
+
+    state.searchParams = new URLSearchParams("tab=equipment-search&q=máy thở")
+    rerender(<ReportsPage />)
+
+    expect(screen.getByTestId("equipment-search-report-tab")).toHaveTextContent("máy thở")
+    expect(screen.getByTestId("equipment-search-report-tab")).toHaveAttribute(
+      "data-instance-id",
+      instanceId
+    )
   })
 
   it("does not render inactive tab content in the Reports tab mock", () => {

--- a/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
+++ b/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const state = vi.hoisted(() => ({
@@ -8,10 +8,18 @@ const state = vi.hoisted(() => ({
   selectedFacilityId: undefined as number | null | undefined,
   showSelector: false,
   shouldFetchData: false,
+  searchParams: new URLSearchParams(),
+  pathname: "/reports",
+  tabsValue: "inventory",
+  tabsOnValueChange: undefined as ((value: string) => void) | undefined,
 }))
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
+  replace: vi.fn((url: string) => {
+    const query = url.split("?")[1] ?? ""
+    state.searchParams = new URLSearchParams(query)
+  }),
   useTenantSelection: vi.fn(() => ({
     selectedFacilityId: state.selectedFacilityId,
     showSelector: state.showSelector,
@@ -29,7 +37,10 @@ vi.mock("next-auth/react", () => ({
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mocks.push,
+    replace: mocks.replace,
   }),
+  usePathname: () => state.pathname,
+  useSearchParams: () => state.searchParams,
 }))
 
 vi.mock("@/contexts/TenantSelectionContext", () => ({
@@ -50,6 +61,12 @@ vi.mock("@/app/(app)/reports/components/tenant-selection-tip", () => ({
   TenantSelectionTip: () => <div data-testid="tenant-selection-tip" />,
 }))
 
+vi.mock("../components/equipment-search-report-tab", () => ({
+  EquipmentSearchReportTab: ({ initialQuery }: { initialQuery: string }) => (
+    <div data-testid="equipment-search-report-tab">{initialQuery}</div>
+  ),
+}))
+
 vi.mock("@/components/ui/card", () => ({
   Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -59,29 +76,58 @@ vi.mock("@/components/ui/card", () => ({
 }))
 
 vi.mock("@/components/ui/tabs", () => ({
-  Tabs: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-    <div className={className}>{children}</div>
-  ),
+  Tabs: ({
+    children,
+    className,
+    value,
+    onValueChange,
+  }: {
+    children: React.ReactNode
+    className?: string
+    value: string
+    onValueChange: (value: string) => void
+  }) => {
+    state.tabsValue = value
+    state.tabsOnValueChange = onValueChange
+    return <div className={className}>{children}</div>
+  },
   TabsList: ({ children, className }: { children: React.ReactNode; className?: string }) => (
-    <div data-testid="reports-tabs-list" className={className}>{children}</div>
+    <div data-testid="reports-tabs-list" className={className}>
+      {children}
+    </div>
   ),
   TabsTrigger: ({
+    children,
+    className,
+    value,
+  }: {
+    children: React.ReactNode
+    value: string
+    className?: string
+  }) => (
+    <button
+      type="button"
+      data-state={state.tabsValue === value ? "active" : "inactive"}
+      className={className}
+      onClick={() => state.tabsOnValueChange?.(value)}
+    >
+      {children}
+    </button>
+  ),
+  TabsContent: ({
     children,
     className,
   }: {
     children: React.ReactNode
     value: string
     className?: string
-  }) => (
-    <button type="button" className={className}>{children}</button>
-  ),
-  TabsContent: ({ children, className }: { children: React.ReactNode; value: string; className?: string }) => (
-    <div className={className}>{children}</div>
-  ),
+  }) => <div className={className}>{children}</div>,
 }))
 
 vi.mock("@/components/ui/skeleton", () => ({
-  Skeleton: (props: React.HTMLAttributes<HTMLDivElement>) => <div data-testid="skeleton" {...props} />,
+  Skeleton: (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="skeleton" {...props} />
+  ),
 }))
 
 import ReportsPage from "../page"
@@ -94,6 +140,10 @@ describe("ReportsPage auth gate", () => {
     state.selectedFacilityId = undefined
     state.showSelector = false
     state.shouldFetchData = false
+    state.searchParams = new URLSearchParams()
+    state.pathname = "/reports"
+    state.tabsValue = "inventory"
+    state.tabsOnValueChange = undefined
   })
 
   it("shows the loading skeleton without redirecting unauthenticated users", () => {
@@ -128,5 +178,36 @@ describe("ReportsPage auth gate", () => {
     expect(screen.getByTestId("reports-page-content").className).not.toContain("md:p-8")
     expect(screen.getByTestId("reports-tabs-scroll-container")).toHaveClass("overflow-x-auto")
     expect(screen.getByTestId("reports-tabs-list")).toHaveClass("w-max", "min-w-max")
+  })
+
+  it("activates the equipment search tab and hydrates the query from the Reports URL", () => {
+    state.sessionData = {
+      user: { role: "admin", don_vi: null, dia_ban_id: null },
+    }
+    state.shouldFetchData = true
+    state.searchParams = new URLSearchParams("tab=equipment-search&q=monitor")
+
+    render(<ReportsPage />)
+
+    expect(screen.getByRole("button", { name: "Tìm kiếm thiết bị" })).toHaveAttribute(
+      "data-state",
+      "active"
+    )
+    expect(screen.getByTestId("equipment-search-report-tab")).toHaveTextContent("monitor")
+  })
+
+  it("keeps Reports tab changes in URL query state", () => {
+    state.sessionData = {
+      user: { role: "admin", don_vi: null, dia_ban_id: null },
+    }
+    state.shouldFetchData = true
+
+    render(<ReportsPage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Tìm kiếm thiết bị" }))
+
+    expect(mocks.replace).toHaveBeenCalledWith("/reports?tab=equipment-search", {
+      scroll: false,
+    })
   })
 })

--- a/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
+++ b/src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx
@@ -117,11 +117,12 @@ vi.mock("@/components/ui/tabs", () => ({
   TabsContent: ({
     children,
     className,
+    value,
   }: {
     children: React.ReactNode
     value: string
     className?: string
-  }) => <div className={className}>{children}</div>,
+  }) => (state.tabsValue === value ? <div className={className}>{children}</div> : null),
 }))
 
 vi.mock("@/components/ui/skeleton", () => ({
@@ -194,6 +195,21 @@ describe("ReportsPage auth gate", () => {
       "active"
     )
     expect(screen.getByTestId("equipment-search-report-tab")).toHaveTextContent("monitor")
+  })
+
+  it("does not render inactive tab content in the Reports tab mock", () => {
+    state.sessionData = {
+      user: { role: "admin", don_vi: null, dia_ban_id: null },
+    }
+    state.shouldFetchData = true
+
+    render(<ReportsPage />)
+
+    expect(screen.getByRole("button", { name: "Xuất-Nhập-Tồn" })).toHaveAttribute(
+      "data-state",
+      "active"
+    )
+    expect(screen.queryByTestId("equipment-search-report-tab")).not.toBeInTheDocument()
   })
 
   it("keeps Reports tab changes in URL query state", () => {

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
@@ -211,4 +211,94 @@ describe("EquipmentSearchReportTab", () => {
 
     expect(mocks.onQueryCommit).toHaveBeenCalledWith("máy thở")
   })
+
+  it("resets the submitted query and drill-down scope when the URL-backed query changes", () => {
+    const { rerender } = render(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Xem cơ sở Miền Bắc" }))
+
+    rerender(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="máy thở"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    expect(screen.getByRole("searchbox", { name: "Từ khóa thiết bị" })).toHaveValue("máy thở")
+    expect(mocks.useEquipmentAggregateSearch).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: "máy thở",
+        groupBy: "region",
+        regionId: null,
+        role: "admin",
+      })
+    )
+  })
+
+  it("shows the loading state instead of stale placeholder rows during a new fetch", () => {
+    mocks.useEquipmentAggregateSearch.mockReturnValue({
+      data: createRegionData(),
+      isLoading: false,
+      isFetching: true,
+      isPlaceholderData: true,
+      isError: false,
+      error: null,
+    })
+
+    render(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    expect(screen.queryByText("36 thiết bị phù hợp")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("table", { name: "Bảng kết quả tìm kiếm thiết bị" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("suppresses the empty state while the current search is still fetching", () => {
+    mocks.useEquipmentAggregateSearch.mockReturnValue({
+      data: {
+        rows: [],
+        summary: {
+          totalEquipmentCount: 0,
+          regionCount: 0,
+          facilityCount: 0,
+          query: "monitor",
+          scopeLabel: "Toàn hệ thống",
+        },
+      },
+      isLoading: false,
+      isFetching: true,
+      isPlaceholderData: true,
+      isError: false,
+      error: null,
+    })
+
+    render(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    expect(
+      screen.queryByText("Không tìm thấy thiết bị phù hợp trong phạm vi hiện tại.")
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
@@ -244,6 +244,32 @@ describe("EquipmentSearchReportTab", () => {
     )
   })
 
+  it("keeps the search input mounted when the URL-backed query changes", () => {
+    const { rerender } = render(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+    const searchbox = screen.getByRole("searchbox", { name: "Từ khóa thiết bị" })
+    searchbox.focus()
+
+    rerender(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="máy thở"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    const updatedSearchbox = screen.getByRole("searchbox", { name: "Từ khóa thiết bị" })
+    expect(updatedSearchbox).toHaveValue("máy thở")
+    expect(document.activeElement).toBe(updatedSearchbox)
+  })
+
   it("shows the loading state instead of stale placeholder rows during a new fetch", () => {
     mocks.useEquipmentAggregateSearch.mockReturnValue({
       data: createRegionData(),

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
@@ -1,0 +1,214 @@
+import * as React from "react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  EquipmentAggregateSearchData,
+  EquipmentAggregateSearchGroupBy,
+} from "../../hooks/use-equipment-aggregate-search.types"
+
+const mocks = vi.hoisted(() => ({
+  useEquipmentAggregateSearch: vi.fn(),
+  onQueryCommit: vi.fn(),
+}))
+
+vi.mock("../../hooks/use-equipment-aggregate-search", () => ({
+  canUseEquipmentAggregateSearch: (role: string | null | undefined) =>
+    role === "admin" || role === "global" || role === "regional_leader",
+  normalizeEquipmentAggregateSearchError: () => "Không thể tải kết quả tìm kiếm thiết bị",
+  useEquipmentAggregateSearch: mocks.useEquipmentAggregateSearch,
+}))
+
+import { EquipmentSearchReportTab } from "../equipment-search-report-tab"
+
+interface HookParams {
+  query: string
+  groupBy: EquipmentAggregateSearchGroupBy
+  regionId?: number | null
+  role: string | null | undefined
+}
+
+function createRegionData(): EquipmentAggregateSearchData {
+  return {
+    rows: [
+      {
+        groupType: "region",
+        groupId: 10,
+        groupName: "Miền Bắc",
+        parentRegionId: null,
+        parentRegionName: null,
+        equipmentCount: 27,
+        facilityCount: 4,
+        quotaCurrentCount: null,
+        quotaMinCount: null,
+        quotaMaxCount: null,
+        quotaStatus: null,
+      },
+      {
+        groupType: "region",
+        groupId: 20,
+        groupName: "Miền Nam",
+        parentRegionId: null,
+        parentRegionName: null,
+        equipmentCount: 9,
+        facilityCount: 2,
+        quotaCurrentCount: null,
+        quotaMinCount: null,
+        quotaMaxCount: null,
+        quotaStatus: null,
+      },
+    ],
+    summary: {
+      totalEquipmentCount: 36,
+      regionCount: 2,
+      facilityCount: 6,
+      query: "monitor",
+      scopeLabel: "Toàn hệ thống",
+    },
+  }
+}
+
+function createFacilityData(): EquipmentAggregateSearchData {
+  return {
+    rows: [
+      {
+        groupType: "facility",
+        groupId: 101,
+        groupName: "Bệnh viện A",
+        parentRegionId: 10,
+        parentRegionName: "Miền Bắc",
+        equipmentCount: 12,
+        facilityCount: null,
+        quotaCurrentCount: 12,
+        quotaMinCount: 4,
+        quotaMaxCount: 20,
+        quotaStatus: "within_limit",
+      },
+      {
+        groupType: "facility",
+        groupId: 102,
+        groupName: "Trung tâm Y tế B",
+        parentRegionId: 10,
+        parentRegionName: "Miền Bắc",
+        equipmentCount: 5,
+        facilityCount: null,
+        quotaCurrentCount: 5,
+        quotaMinCount: null,
+        quotaMaxCount: null,
+        quotaStatus: "no_active_quota",
+      },
+    ],
+    summary: {
+      totalEquipmentCount: 17,
+      regionCount: 1,
+      facilityCount: 2,
+      query: "monitor",
+      scopeLabel: "Miền Bắc",
+    },
+  }
+}
+
+function mockAggregateData() {
+  mocks.useEquipmentAggregateSearch.mockImplementation((params: HookParams) => ({
+    data: params.groupBy === "facility" ? createFacilityData() : createRegionData(),
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    error: null,
+  }))
+}
+
+describe("EquipmentSearchReportTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAggregateData()
+  })
+
+  it("renders admin region-first chart and table from the same count-first aggregate rows", () => {
+    render(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    expect(screen.getByRole("searchbox", { name: "Từ khóa thiết bị" })).toHaveValue("monitor")
+    expect(screen.getByText("Toàn hệ thống")).toBeInTheDocument()
+    expect(screen.getByText("36 thiết bị phù hợp")).toBeInTheDocument()
+
+    const chart = screen.getByTestId("equipment-search-chart")
+    const table = screen.getByRole("table", { name: "Bảng kết quả tìm kiếm thiết bị" })
+
+    expect(within(chart).getByText("Miền Bắc")).toBeInTheDocument()
+    expect(within(chart).getByText("27")).toBeInTheDocument()
+    expect(
+      within(table).getByRole("row", { name: /Miền Bắc.*27 thiết bị.*4 cơ sở/ })
+    ).toBeInTheDocument()
+  })
+
+  it("drills from a region row into facility grouping", () => {
+    render(
+      <EquipmentSearchReportTab
+        userRole="global"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Xem cơ sở Miền Bắc" }))
+
+    expect(mocks.useEquipmentAggregateSearch).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: "monitor",
+        groupBy: "facility",
+        regionId: 10,
+        role: "global",
+      })
+    )
+    expect(screen.getAllByText("Miền Bắc").length).toBeGreaterThan(0)
+    expect(screen.getByRole("row", { name: /Bệnh viện A.*12 thiết bị/ })).toBeInTheDocument()
+  })
+
+  it("starts a single-region regional leader at facility grouping", () => {
+    render(
+      <EquipmentSearchReportTab
+        userRole="regional_leader"
+        userRegionId={10}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    expect(mocks.useEquipmentAggregateSearch).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: "monitor",
+        groupBy: "facility",
+        regionId: 10,
+        role: "regional_leader",
+      })
+    )
+    expect(screen.getAllByText("Cơ sở trong vùng phụ trách").length).toBeGreaterThan(0)
+    expect(screen.getByRole("row", { name: /Bệnh viện A.*12 thiết bị/ })).toBeInTheDocument()
+  })
+
+  it("submits repeated searches through the Reports-owned query callback", () => {
+    render(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Từ khóa thiết bị" }), {
+      target: { value: "máy thở" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Tìm kiếm" }))
+
+    expect(mocks.onQueryCommit).toHaveBeenCalledWith("máy thở")
+  })
+})

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
@@ -270,6 +270,41 @@ describe("EquipmentSearchReportTab", () => {
     expect(document.activeElement).toBe(updatedSearchbox)
   })
 
+  it("does not clobber in-progress draft input when the URL catches up after submit", () => {
+    const { rerender } = render(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+    const searchbox = screen.getByRole("searchbox", { name: "Từ khóa thiết bị" })
+
+    fireEvent.change(searchbox, { target: { value: "máy thở" } })
+    fireEvent.click(screen.getByRole("button", { name: "Tìm kiếm" }))
+    fireEvent.change(searchbox, { target: { value: "máy thở ICU" } })
+
+    rerender(
+      <EquipmentSearchReportTab
+        userRole="admin"
+        userRegionId={null}
+        initialQuery="máy thở"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    expect(screen.getByRole("searchbox", { name: "Từ khóa thiết bị" })).toHaveValue("máy thở ICU")
+    expect(mocks.useEquipmentAggregateSearch).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: "máy thở",
+        groupBy: "region",
+        regionId: null,
+        role: "admin",
+      })
+    )
+  })
+
   it("shows the loading state instead of stale placeholder rows during a new fetch", () => {
     mocks.useEquipmentAggregateSearch.mockReturnValue({
       data: createRegionData(),

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import type { EquipmentAggregateSearchRow } from "../../hooks/use-equipment-aggregate-search.types"
+import { getEquipmentSearchMaxCount } from "../equipment-search-report-tab.utils"
+
+function createRow(equipmentCount: number): EquipmentAggregateSearchRow {
+  return {
+    groupType: "region",
+    groupId: equipmentCount,
+    groupName: `Khu vực ${equipmentCount}`,
+    parentRegionId: null,
+    parentRegionName: null,
+    equipmentCount,
+    facilityCount: 1,
+    quotaCurrentCount: null,
+    quotaMinCount: null,
+    quotaMaxCount: null,
+    quotaStatus: null,
+  }
+}
+
+describe("equipment-search-report-tab.utils", () => {
+  it("computes the max equipment count without spreading rows onto the call stack", () => {
+    const rows = Array.from({ length: 150_000 }, (_, index) => createRow(index + 1))
+
+    expect(getEquipmentSearchMaxCount(rows)).toBe(150_000)
+  })
+
+  it("uses one as the minimum chart scale for empty rows", () => {
+    expect(getEquipmentSearchMaxCount([])).toBe(1)
+  })
+})

--- a/src/app/(app)/reports/components/equipment-search-report-tab-skeleton.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab-skeleton.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+
+/** Renders skeleton placeholders for the equipment search chart and table. */
+export function EquipmentSearchSkeleton() {
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(420px,0.9fr)]">
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-8 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-32" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Skeleton key={index} className="h-9 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(app)/reports/components/equipment-search-report-tab-skeleton.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab-skeleton.tsx
@@ -1,3 +1,5 @@
+import * as React from "react"
+
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 

--- a/src/app/(app)/reports/components/equipment-search-report-tab.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.tsx
@@ -1,0 +1,304 @@
+"use client"
+
+import * as React from "react"
+import { ChevronRight, Search } from "lucide-react"
+
+import { SearchInput } from "@/components/shared/SearchInput"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { isRegionalLeaderRole } from "@/lib/rbac"
+import {
+  canUseEquipmentAggregateSearch,
+  normalizeEquipmentAggregateSearchError,
+  useEquipmentAggregateSearch,
+} from "../hooks/use-equipment-aggregate-search"
+import { EquipmentSearchSkeleton } from "./equipment-search-report-tab-skeleton"
+import {
+  formatEquipmentSearchCount,
+  getEquipmentSearchFacilityText,
+  getEquipmentSearchQuotaContext,
+  normalizeEquipmentSearchRegionId,
+  sortEquipmentSearchRows,
+} from "./equipment-search-report-tab.utils"
+
+interface EquipmentSearchReportTabProps {
+  initialQuery: string
+  onQueryCommit: (query: string) => void
+  userRegionId?: number | string | null
+  userRole: string | null | undefined
+}
+
+interface SelectedRegion {
+  id: number
+  name: string
+}
+
+/** Renders the Reports-owned aggregate equipment search workspace. */
+export function EquipmentSearchReportTab({
+  initialQuery,
+  onQueryCommit,
+  userRegionId,
+  userRole,
+}: EquipmentSearchReportTabProps) {
+  const normalizedUserRegionId = normalizeEquipmentSearchRegionId(userRegionId)
+  const startsAtFacility = isRegionalLeaderRole(userRole) && normalizedUserRegionId !== null
+  const [draftQuery, setDraftQuery] = React.useState(initialQuery)
+  const [submittedQuery, setSubmittedQuery] = React.useState(() => initialQuery.trim())
+  const [selectedRegion, setSelectedRegion] = React.useState<SelectedRegion | null>(
+    startsAtFacility ? { id: normalizedUserRegionId, name: "Cơ sở trong vùng phụ trách" } : null
+  )
+
+  const groupBy = selectedRegion ? "facility" : "region"
+  const searchQuery = useEquipmentAggregateSearch({
+    query: submittedQuery,
+    groupBy,
+    regionId: selectedRegion?.id ?? null,
+    role: userRole,
+    limit: 50,
+  })
+
+  const rows = React.useMemo(
+    () => sortEquipmentSearchRows(searchQuery.data?.rows ?? []),
+    [searchQuery.data?.rows]
+  )
+  const maxCount = Math.max(1, ...rows.map((row) => row.equipmentCount))
+  const summary = searchQuery.data?.summary
+  const trimmedDraft = draftQuery.trim()
+  const isInitialEmpty = submittedQuery.length === 0
+
+  const handleSubmit = React.useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      setSubmittedQuery(trimmedDraft)
+      setSelectedRegion(
+        startsAtFacility && normalizedUserRegionId !== null
+          ? { id: normalizedUserRegionId, name: "Cơ sở trong vùng phụ trách" }
+          : null
+      )
+      onQueryCommit(trimmedDraft)
+    },
+    [normalizedUserRegionId, onQueryCommit, startsAtFacility, trimmedDraft]
+  )
+
+  if (!canUseEquipmentAggregateSearch(userRole)) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-sm text-muted-foreground">
+          Bạn không có quyền sử dụng tìm kiếm tổng hợp thiết bị.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div data-testid="equipment-search-report-tab" className="space-y-4">
+      <Card>
+        <CardHeader className="space-y-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <CardTitle className="text-lg">Tìm kiếm thiết bị</CardTitle>
+            <Badge variant="outline">
+              {selectedRegion?.name ?? summary?.scopeLabel ?? "Toàn hệ thống"}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <form
+            role="search"
+            className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]"
+            onSubmit={handleSubmit}
+          >
+            <label htmlFor="reports-equipment-search-query" className="space-y-1.5">
+              <span className="text-sm font-medium">Từ khóa thiết bị</span>
+              <SearchInput
+                id="reports-equipment-search-query"
+                aria-label="Từ khóa thiết bị"
+                value={draftQuery}
+                onChange={setDraftQuery}
+                placeholder="Tên thiết bị, model, serial hoặc nhóm thiết bị"
+              />
+            </label>
+            <Button type="submit" className="self-end">
+              <Search aria-hidden="true" />
+              Tìm kiếm
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {isInitialEmpty ? (
+        <Card>
+          <CardContent className="py-10 text-sm text-muted-foreground">
+            Nhập từ khóa để xem thiết bị phù hợp theo khu vực hoặc cơ sở.
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {searchQuery.isError ? (
+        <Card className="border-destructive/40">
+          <CardContent className="py-6 text-sm text-destructive">
+            {normalizeEquipmentAggregateSearchError(searchQuery.error)}
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {!isInitialEmpty &&
+      (searchQuery.isLoading || (searchQuery.isFetching && rows.length === 0)) ? (
+        <EquipmentSearchSkeleton />
+      ) : null}
+
+      {!isInitialEmpty && !searchQuery.isError && rows.length > 0 ? (
+        <>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <Card>
+              <CardContent className="py-4">
+                <div className="text-2xl font-semibold tabular-nums">
+                  {formatEquipmentSearchCount(summary?.totalEquipmentCount ?? 0)} phù hợp
+                </div>
+                <p className="text-sm text-muted-foreground">với từ khóa</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="py-4">
+                <div className="text-2xl font-semibold tabular-nums">
+                  {(summary?.regionCount ?? 0).toLocaleString("vi-VN")}
+                </div>
+                <p className="text-sm text-muted-foreground">khu vực có kết quả</p>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="py-4">
+                <div className="text-2xl font-semibold tabular-nums">
+                  {(summary?.facilityCount ?? 0).toLocaleString("vi-VN")}
+                </div>
+                <p className="text-sm text-muted-foreground">cơ sở có kết quả</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <button
+              type="button"
+              className="font-medium text-foreground hover:underline disabled:pointer-events-none disabled:text-muted-foreground"
+              disabled={!selectedRegion || startsAtFacility}
+              onClick={() => setSelectedRegion(null)}
+            >
+              Tất cả khu vực
+            </button>
+            {selectedRegion ? (
+              <>
+                <ChevronRight className="size-4" aria-hidden="true" />
+                <span>{selectedRegion.name}</span>
+              </>
+            ) : null}
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(420px,0.9fr)]">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Phân bố theo số thiết bị</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul
+                  data-testid="equipment-search-chart"
+                  aria-label="Biểu đồ kết quả tìm kiếm thiết bị"
+                  className="space-y-3"
+                >
+                  {rows.map((row) => {
+                    const width = `${Math.max(8, (row.equipmentCount / maxCount) * 100)}%`
+                    return (
+                      <li
+                        key={`${row.groupType}-${row.groupId ?? row.groupName}`}
+                        className="space-y-1.5"
+                      >
+                        <div className="flex items-center justify-between gap-3 text-sm">
+                          <span className="truncate font-medium">{row.groupName}</span>
+                          <span className="font-semibold tabular-nums">{row.equipmentCount}</span>
+                        </div>
+                        <div className="h-2.5 overflow-hidden rounded bg-muted">
+                          <div className="h-full rounded bg-primary" style={{ width }} />
+                        </div>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Bảng kết quả tìm kiếm</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Table aria-label="Bảng kết quả tìm kiếm thiết bị">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Nhóm</TableHead>
+                      <TableHead className="text-right">Số thiết bị</TableHead>
+                      <TableHead>Ngữ cảnh</TableHead>
+                      <TableHead className="text-right">Thao tác</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {rows.map((row) => {
+                      const facilityText = getEquipmentSearchFacilityText(row)
+                      const canDrillDown = row.groupType === "region" && row.groupId !== null
+                      return (
+                        <TableRow
+                          key={`${row.groupType}-${row.groupId ?? row.groupName}`}
+                          aria-label={`${row.groupName} ${formatEquipmentSearchCount(row.equipmentCount)} ${facilityText}`}
+                        >
+                          <TableCell className="font-medium">{row.groupName}</TableCell>
+                          <TableCell className="text-right font-semibold tabular-nums">
+                            {formatEquipmentSearchCount(row.equipmentCount)}
+                          </TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {row.groupType === "region"
+                              ? facilityText
+                              : getEquipmentSearchQuotaContext(row)}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            {canDrillDown ? (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() =>
+                                  setSelectedRegion({ id: row.groupId!, name: row.groupName })
+                                }
+                              >
+                                Xem cơ sở {row.groupName}
+                              </Button>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">Tổng hợp</span>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </div>
+        </>
+      ) : null}
+
+      {!isInitialEmpty && !searchQuery.isError && !searchQuery.isLoading && rows.length === 0 ? (
+        <Card>
+          <CardContent className="py-10 text-sm text-muted-foreground">
+            Không tìm thấy thiết bị phù hợp trong phạm vi hiện tại.
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/(app)/reports/components/equipment-search-report-tab.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.tsx
@@ -42,6 +42,67 @@ interface SelectedRegion {
   name: string
 }
 
+interface EquipmentSearchState {
+  draftQuery: string
+  selectedRegion: SelectedRegion | null
+  submittedQuery: string
+}
+
+type EquipmentSearchAction =
+  | { type: "draft"; query: string }
+  | { type: "select-region"; region: SelectedRegion | null }
+  | { type: "submit"; query: string; selectedRegion: SelectedRegion | null }
+  | { type: "sync-url"; state: EquipmentSearchState }
+
+function createEquipmentSearchState(
+  initialQuery: string,
+  selectedRegion: SelectedRegion | null
+): EquipmentSearchState {
+  return {
+    draftQuery: initialQuery,
+    selectedRegion,
+    submittedQuery: initialQuery.trim(),
+  }
+}
+
+function equipmentSearchReducer(
+  state: EquipmentSearchState,
+  action: EquipmentSearchAction
+): EquipmentSearchState {
+  switch (action.type) {
+    case "draft":
+      return { ...state, draftQuery: action.query }
+    case "select-region":
+      return { ...state, selectedRegion: action.region }
+    case "submit":
+      return {
+        draftQuery: action.query,
+        selectedRegion: action.selectedRegion,
+        submittedQuery: action.query,
+      }
+    case "sync-url":
+      if (
+        state.draftQuery === action.state.draftQuery &&
+        state.submittedQuery === action.state.submittedQuery &&
+        state.selectedRegion?.id === action.state.selectedRegion?.id &&
+        state.selectedRegion?.name === action.state.selectedRegion?.name
+      ) {
+        return state
+      }
+
+      return action.state
+  }
+}
+
+function getDefaultSelectedRegion(
+  startsAtFacility: boolean,
+  normalizedUserRegionId: number | null
+): SelectedRegion | null {
+  return startsAtFacility && normalizedUserRegionId !== null
+    ? { id: normalizedUserRegionId, name: "Cơ sở trong vùng phụ trách" }
+    : null
+}
+
 /** Renders the Reports-owned aggregate equipment search workspace. */
 export function EquipmentSearchReportTab({
   initialQuery,
@@ -64,7 +125,6 @@ export function EquipmentSearchReportTab({
 
   return (
     <EquipmentSearchReportTabContent
-      key={`${initialQuery}:${startsAtFacility}:${normalizedUserRegionId ?? ""}`}
       initialQuery={initialQuery}
       normalizedUserRegionId={normalizedUserRegionId}
       onQueryCommit={onQueryCommit}
@@ -89,13 +149,24 @@ function EquipmentSearchReportTabContent({
   startsAtFacility,
   userRole,
 }: EquipmentSearchReportTabContentProps) {
-  const [draftQuery, setDraftQuery] = React.useState(initialQuery)
-  const [submittedQuery, setSubmittedQuery] = React.useState(() => initialQuery.trim())
-  const [selectedRegion, setSelectedRegion] = React.useState<SelectedRegion | null>(
-    startsAtFacility && normalizedUserRegionId !== null
-      ? { id: normalizedUserRegionId, name: "Cơ sở trong vùng phụ trách" }
-      : null
+  const defaultSelectedRegion = React.useMemo(
+    () => getDefaultSelectedRegion(startsAtFacility, normalizedUserRegionId),
+    [normalizedUserRegionId, startsAtFacility]
   )
+  const [state, dispatch] = React.useReducer(
+    equipmentSearchReducer,
+    { initialQuery, selectedRegion: defaultSelectedRegion },
+    ({ initialQuery: query, selectedRegion }) => createEquipmentSearchState(query, selectedRegion)
+  )
+
+  React.useEffect(() => {
+    dispatch({
+      type: "sync-url",
+      state: createEquipmentSearchState(initialQuery, defaultSelectedRegion),
+    })
+  }, [defaultSelectedRegion, initialQuery])
+
+  const { draftQuery, selectedRegion, submittedQuery } = state
 
   const groupBy = selectedRegion ? "facility" : "region"
   const searchQuery = useEquipmentAggregateSearch({
@@ -122,15 +193,14 @@ function EquipmentSearchReportTabContent({
   const handleSubmit = React.useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault()
-      setSubmittedQuery(trimmedDraft)
-      setSelectedRegion(
-        startsAtFacility && normalizedUserRegionId !== null
-          ? { id: normalizedUserRegionId, name: "Cơ sở trong vùng phụ trách" }
-          : null
-      )
+      dispatch({
+        type: "submit",
+        query: trimmedDraft,
+        selectedRegion: defaultSelectedRegion,
+      })
       onQueryCommit(trimmedDraft)
     },
-    [normalizedUserRegionId, onQueryCommit, startsAtFacility, trimmedDraft]
+    [defaultSelectedRegion, onQueryCommit, trimmedDraft]
   )
 
   return (
@@ -156,7 +226,7 @@ function EquipmentSearchReportTabContent({
                 id="reports-equipment-search-query"
                 aria-label="Từ khóa thiết bị"
                 value={draftQuery}
-                onChange={setDraftQuery}
+                onChange={(query) => dispatch({ type: "draft", query })}
                 placeholder="Tên thiết bị, model, serial hoặc nhóm thiết bị"
               />
             </label>
@@ -222,7 +292,7 @@ function EquipmentSearchReportTabContent({
               type="button"
               className="font-medium text-foreground hover:underline disabled:pointer-events-none disabled:text-muted-foreground"
               disabled={!selectedRegion || startsAtFacility}
-              onClick={() => setSelectedRegion(null)}
+              onClick={() => dispatch({ type: "select-region", region: null })}
             >
               Tất cả khu vực
             </button>
@@ -305,7 +375,10 @@ function EquipmentSearchReportTabContent({
                                 variant="ghost"
                                 size="sm"
                                 onClick={() =>
-                                  setSelectedRegion({ id: row.groupId!, name: row.groupName })
+                                  dispatch({
+                                    type: "select-region",
+                                    region: { id: row.groupId!, name: row.groupName },
+                                  })
                                 }
                               >
                                 Xem cơ sở {row.groupName}

--- a/src/app/(app)/reports/components/equipment-search-report-tab.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.tsx
@@ -83,7 +83,6 @@ function equipmentSearchReducer(
       }
     case "sync-url":
       if (
-        state.draftQuery === action.state.draftQuery &&
         state.submittedQuery === action.state.submittedQuery &&
         state.selectedRegion?.id === action.state.selectedRegion?.id &&
         state.selectedRegion?.name === action.state.selectedRegion?.name

--- a/src/app/(app)/reports/components/equipment-search-report-tab.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.tsx
@@ -51,10 +51,50 @@ export function EquipmentSearchReportTab({
 }: EquipmentSearchReportTabProps) {
   const normalizedUserRegionId = normalizeEquipmentSearchRegionId(userRegionId)
   const startsAtFacility = isRegionalLeaderRole(userRole) && normalizedUserRegionId !== null
+
+  if (!canUseEquipmentAggregateSearch(userRole)) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-sm text-muted-foreground">
+          Bạn không có quyền sử dụng tìm kiếm tổng hợp thiết bị.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <EquipmentSearchReportTabContent
+      key={`${initialQuery}:${startsAtFacility}:${normalizedUserRegionId ?? ""}`}
+      initialQuery={initialQuery}
+      normalizedUserRegionId={normalizedUserRegionId}
+      onQueryCommit={onQueryCommit}
+      startsAtFacility={startsAtFacility}
+      userRole={userRole}
+    />
+  )
+}
+
+interface EquipmentSearchReportTabContentProps {
+  initialQuery: string
+  normalizedUserRegionId: number | null
+  onQueryCommit: (query: string) => void
+  startsAtFacility: boolean
+  userRole: string | null | undefined
+}
+
+function EquipmentSearchReportTabContent({
+  initialQuery,
+  normalizedUserRegionId,
+  onQueryCommit,
+  startsAtFacility,
+  userRole,
+}: EquipmentSearchReportTabContentProps) {
   const [draftQuery, setDraftQuery] = React.useState(initialQuery)
   const [submittedQuery, setSubmittedQuery] = React.useState(() => initialQuery.trim())
   const [selectedRegion, setSelectedRegion] = React.useState<SelectedRegion | null>(
-    startsAtFacility ? { id: normalizedUserRegionId, name: "Cơ sở trong vùng phụ trách" } : null
+    startsAtFacility && normalizedUserRegionId !== null
+      ? { id: normalizedUserRegionId, name: "Cơ sở trong vùng phụ trách" }
+      : null
   )
 
   const groupBy = selectedRegion ? "facility" : "region"
@@ -74,6 +114,10 @@ export function EquipmentSearchReportTab({
   const summary = searchQuery.data?.summary
   const trimmedDraft = draftQuery.trim()
   const isInitialEmpty = submittedQuery.length === 0
+  const isWaitingForCurrentResult =
+    searchQuery.isLoading ||
+    searchQuery.isPlaceholderData === true ||
+    (searchQuery.isFetching && rows.length === 0)
 
   const handleSubmit = React.useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
@@ -88,16 +132,6 @@ export function EquipmentSearchReportTab({
     },
     [normalizedUserRegionId, onQueryCommit, startsAtFacility, trimmedDraft]
   )
-
-  if (!canUseEquipmentAggregateSearch(userRole)) {
-    return (
-      <Card>
-        <CardContent className="py-8 text-sm text-muted-foreground">
-          Bạn không có quyền sử dụng tìm kiếm tổng hợp thiết bị.
-        </CardContent>
-      </Card>
-    )
-  }
 
   return (
     <div data-testid="equipment-search-report-tab" className="space-y-4">
@@ -150,12 +184,11 @@ export function EquipmentSearchReportTab({
         </Card>
       ) : null}
 
-      {!isInitialEmpty &&
-      (searchQuery.isLoading || (searchQuery.isFetching && rows.length === 0)) ? (
+      {!isInitialEmpty && !searchQuery.isError && isWaitingForCurrentResult ? (
         <EquipmentSearchSkeleton />
       ) : null}
 
-      {!isInitialEmpty && !searchQuery.isError && rows.length > 0 ? (
+      {!isInitialEmpty && !searchQuery.isError && !isWaitingForCurrentResult && rows.length > 0 ? (
         <>
           <div className="grid gap-3 sm:grid-cols-3">
             <Card>
@@ -292,7 +325,10 @@ export function EquipmentSearchReportTab({
         </>
       ) : null}
 
-      {!isInitialEmpty && !searchQuery.isError && !searchQuery.isLoading && rows.length === 0 ? (
+      {!isInitialEmpty &&
+      !searchQuery.isError &&
+      !isWaitingForCurrentResult &&
+      rows.length === 0 ? (
         <Card>
           <CardContent className="py-10 text-sm text-muted-foreground">
             Không tìm thấy thiết bị phù hợp trong phạm vi hiện tại.

--- a/src/app/(app)/reports/components/equipment-search-report-tab.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.tsx
@@ -24,6 +24,7 @@ import {
 import { EquipmentSearchSkeleton } from "./equipment-search-report-tab-skeleton"
 import {
   formatEquipmentSearchCount,
+  getEquipmentSearchMaxCount,
   getEquipmentSearchFacilityText,
   getEquipmentSearchQuotaContext,
   normalizeEquipmentSearchRegionId,
@@ -181,7 +182,7 @@ function EquipmentSearchReportTabContent({
     () => sortEquipmentSearchRows(searchQuery.data?.rows ?? []),
     [searchQuery.data?.rows]
   )
-  const maxCount = Math.max(1, ...rows.map((row) => row.equipmentCount))
+  const maxCount = getEquipmentSearchMaxCount(rows)
   const summary = searchQuery.data?.summary
   const trimmedDraft = draftQuery.trim()
   const isInitialEmpty = submittedQuery.length === 0

--- a/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
@@ -1,0 +1,57 @@
+import type { EquipmentAggregateSearchRow } from "../hooks/use-equipment-aggregate-search.types"
+
+/** Normalizes session region identifiers before passing them to the search RPC hook. */
+export function normalizeEquipmentSearchRegionId(
+  value: number | string | null | undefined
+): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+/** Formats the primary equipment count label for chart and table rows. */
+export function formatEquipmentSearchCount(count: number): string {
+  return `${count.toLocaleString("vi-VN")} thiết bị`
+}
+
+/** Builds the secondary facility or parent-region text for an aggregate row. */
+export function getEquipmentSearchFacilityText(row: EquipmentAggregateSearchRow): string {
+  if (row.groupType === "facility") {
+    return row.parentRegionName ?? "Cơ sở"
+  }
+
+  const count = row.facilityCount ?? 0
+  return `${count.toLocaleString("vi-VN")} cơ sở`
+}
+
+/** Builds the Phase 5 quota placeholder context without rendering detailed status labels. */
+export function getEquipmentSearchQuotaContext(row: EquipmentAggregateSearchRow): string {
+  if (row.groupType !== "facility") {
+    return "Đếm theo khu vực"
+  }
+
+  if (row.quotaCurrentCount === null) {
+    return "Chờ ngữ cảnh định mức"
+  }
+
+  const limits = [row.quotaMinCount, row.quotaMaxCount]
+    .filter((value): value is number => typeof value === "number")
+    .map((value) => value.toLocaleString("vi-VN"))
+    .join(" - ")
+
+  return limits ? `Định mức: ${limits}` : "Có dữ liệu định mức"
+}
+
+/** Sorts aggregate rows by matching equipment count for count-first rendering. */
+export function sortEquipmentSearchRows(
+  rows: EquipmentAggregateSearchRow[]
+): EquipmentAggregateSearchRow[] {
+  return [...rows].sort((left, right) => right.equipmentCount - left.equipmentCount)
+}

--- a/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
@@ -49,6 +49,11 @@ export function getEquipmentSearchQuotaContext(row: EquipmentAggregateSearchRow)
   return limits ? `Định mức: ${limits}` : "Có dữ liệu định mức"
 }
 
+/** Computes the chart scale without spreading arbitrary row counts onto the call stack. */
+export function getEquipmentSearchMaxCount(rows: EquipmentAggregateSearchRow[]): number {
+  return rows.reduce((maxCount, row) => Math.max(maxCount, row.equipmentCount), 1)
+}
+
 /** Sorts aggregate rows by matching equipment count for count-first rendering. */
 export function sortEquipmentSearchRows(
   rows: EquipmentAggregateSearchRow[]

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -11,7 +11,6 @@ import { AuthenticatedPageBoundary } from "@/app/(app)/_components/Authenticated
 import { AuthenticatedPageSkeletonFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { TenantSelectionTip } from "./components/tenant-selection-tip"
 import { useTenantSelection } from "@/contexts/TenantSelectionContext"
-import { EquipmentSearchReportTab } from "./components/equipment-search-report-tab"
 import { canUseEquipmentAggregateSearch } from "./hooks/use-equipment-aggregate-search"
 
 // Lazy load components to improve initial load time
@@ -28,6 +27,11 @@ const MaintenanceReportTab = React.lazy(() =>
 const UsageAnalyticsDashboard = React.lazy(() =>
   import("@/components/usage-analytics-dashboard").then((module) => ({
     default: module.UsageAnalyticsDashboard,
+  }))
+)
+const EquipmentSearchReportTab = React.lazy(() =>
+  import("./components/equipment-search-report-tab").then((module) => ({
+    default: module.EquipmentSearchReportTab,
   }))
 )
 
@@ -250,13 +254,15 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
             </TabsContent>
             {canUseEquipmentSearch ? (
               <TabsContent value="equipment-search" className="min-w-0 space-y-4">
-                <EquipmentSearchReportTab
-                  key={`${userRole}:${user.dia_ban_id ?? ""}`}
-                  initialQuery={urlQuery}
-                  onQueryCommit={handleEquipmentQueryCommit}
-                  userRegionId={normalizeUserRegionId(user.dia_ban_id)}
-                  userRole={userRole}
-                />
+                <React.Suspense fallback={<TabSkeleton />}>
+                  <EquipmentSearchReportTab
+                    key={`${userRole}:${user.dia_ban_id ?? ""}`}
+                    initialQuery={urlQuery}
+                    onQueryCommit={handleEquipmentQueryCommit}
+                    userRegionId={normalizeUserRegionId(user.dia_ban_id)}
+                    userRole={userRole}
+                  />
+                </React.Suspense>
               </TabsContent>
             ) : null}
           </>

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -133,6 +133,8 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
   const urlTab = searchParams.get("tab")
   const urlQuery = searchParams.get("q") ?? ""
   const activeTab = isReportsTab(urlTab, canUseEquipmentSearch) ? urlTab! : "inventory"
+  const shouldShowTenantSelectionTip =
+    showSelector && !shouldFetchData && activeTab !== "equipment-search"
 
   const updateReportsQuery = React.useCallback(
     (updates: Record<string, string | null>) => {
@@ -204,7 +206,7 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
       </div>
 
       {/* Show tip when no tenant selected (same pattern as Equipment page) */}
-      {showSelector && !shouldFetchData && <TenantSelectionTip />}
+      {shouldShowTenantSelectionTip && <TenantSelectionTip />}
 
       {/* Report tabs - only render when should fetch */}
       <Tabs value={activeTab} onValueChange={handleTabChange} className="min-w-0 space-y-4">
@@ -219,7 +221,7 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
           </TabsList>
         </div>
 
-        {/* Only show content when shouldFetchData is true */}
+        {/* Only tenant-scoped report tabs wait for tenant selection. */}
         {shouldFetchData ? (
           <>
             <TabsContent value="inventory" className="min-w-0 space-y-4">
@@ -252,20 +254,21 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
                 />
               </React.Suspense>
             </TabsContent>
-            {canUseEquipmentSearch ? (
-              <TabsContent value="equipment-search" className="min-w-0 space-y-4">
-                <React.Suspense fallback={<TabSkeleton />}>
-                  <EquipmentSearchReportTab
-                    key={`${userRole}:${user.dia_ban_id ?? ""}`}
-                    initialQuery={urlQuery}
-                    onQueryCommit={handleEquipmentQueryCommit}
-                    userRegionId={normalizeUserRegionId(user.dia_ban_id)}
-                    userRole={userRole}
-                  />
-                </React.Suspense>
-              </TabsContent>
-            ) : null}
           </>
+        ) : null}
+
+        {canUseEquipmentSearch ? (
+          <TabsContent value="equipment-search" className="min-w-0 space-y-4">
+            <React.Suspense fallback={<TabSkeleton />}>
+              <EquipmentSearchReportTab
+                key={`${userRole}:${user.dia_ban_id ?? ""}`}
+                initialQuery={urlQuery}
+                onQueryCommit={handleEquipmentQueryCommit}
+                userRegionId={normalizeUserRegionId(user.dia_ban_id)}
+                userRole={userRole}
+              />
+            </React.Suspense>
+          </TabsContent>
         ) : null}
       </Tabs>
     </div>

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -251,7 +251,7 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
             {canUseEquipmentSearch ? (
               <TabsContent value="equipment-search" className="min-w-0 space-y-4">
                 <EquipmentSearchReportTab
-                  key={`${userRole}:${user.dia_ban_id ?? ""}:${urlQuery}`}
+                  key={`${userRole}:${user.dia_ban_id ?? ""}`}
                   initialQuery={urlQuery}
                   onQueryCommit={handleEquipmentQueryCommit}
                   userRegionId={normalizeUserRegionId(user.dia_ban_id)}

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import type { Session } from "next-auth"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -10,11 +11,43 @@ import { AuthenticatedPageBoundary } from "@/app/(app)/_components/Authenticated
 import { AuthenticatedPageSkeletonFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
 import { TenantSelectionTip } from "./components/tenant-selection-tip"
 import { useTenantSelection } from "@/contexts/TenantSelectionContext"
+import { EquipmentSearchReportTab } from "./components/equipment-search-report-tab"
+import { canUseEquipmentAggregateSearch } from "./hooks/use-equipment-aggregate-search"
 
 // Lazy load components to improve initial load time
-const InventoryReportTab = React.lazy(() => import("./components/inventory-report-tab").then(module => ({ default: module.InventoryReportTab })))
-const MaintenanceReportTab = React.lazy(() => import("./components/maintenance-report-tab").then(module => ({ default: module.MaintenanceReportTab })))
-const UsageAnalyticsDashboard = React.lazy(() => import("@/components/usage-analytics-dashboard").then(module => ({ default: module.UsageAnalyticsDashboard })))
+const InventoryReportTab = React.lazy(() =>
+  import("./components/inventory-report-tab").then((module) => ({
+    default: module.InventoryReportTab,
+  }))
+)
+const MaintenanceReportTab = React.lazy(() =>
+  import("./components/maintenance-report-tab").then((module) => ({
+    default: module.MaintenanceReportTab,
+  }))
+)
+const UsageAnalyticsDashboard = React.lazy(() =>
+  import("@/components/usage-analytics-dashboard").then((module) => ({
+    default: module.UsageAnalyticsDashboard,
+  }))
+)
+
+function normalizeUserRegionId(value: Session["user"]["dia_ban_id"]): number | string | null {
+  return value ?? null
+}
+
+function buildReportsUrl(pathname: string, params: URLSearchParams): string {
+  const query = params.toString()
+  return query ? `${pathname}?${query}` : pathname
+}
+
+function isReportsTab(value: string | null, canUseEquipmentSearch: boolean): boolean {
+  return (
+    value === "inventory" ||
+    value === "maintenance" ||
+    value === "utilization" ||
+    (canUseEquipmentSearch && value === "equipment-search")
+  )
+}
 
 // Loading skeleton for tabs
 function TabSkeleton() {
@@ -31,7 +64,7 @@ function TabSkeleton() {
           </div>
         </CardContent>
       </Card>
-      
+
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
           <Card key={i}>
@@ -46,7 +79,7 @@ function TabSkeleton() {
           </Card>
         ))}
       </div>
-      
+
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
         <Card className="col-span-4">
           <CardHeader>
@@ -71,6 +104,7 @@ function TabSkeleton() {
   )
 }
 
+/** Renders the authenticated Reports workspace. */
 export default function ReportsPage() {
   return (
     <AuthenticatedPageBoundary fallback={<AuthenticatedPageSkeletonFallback />}>
@@ -84,15 +118,57 @@ interface ReportsPageContentProps {
 }
 
 function ReportsPageContent({ user }: ReportsPageContentProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
   // Get facility selection from shared context
-  const {
-    selectedFacilityId,
-    showSelector,
-    shouldFetchData,
-  } = useTenantSelection()
+  const { selectedFacilityId, showSelector, shouldFetchData } = useTenantSelection()
 
-  // State
-  const [activeTab, setActiveTab] = React.useState("inventory")
+  const userRole = user.role
+  const canUseEquipmentSearch = canUseEquipmentAggregateSearch(userRole)
+  const urlTab = searchParams.get("tab")
+  const urlQuery = searchParams.get("q") ?? ""
+  const activeTab = isReportsTab(urlTab, canUseEquipmentSearch) ? urlTab! : "inventory"
+
+  const updateReportsQuery = React.useCallback(
+    (updates: Record<string, string | null>) => {
+      const nextParams = new URLSearchParams(searchParams.toString())
+
+      for (const [key, value] of Object.entries(updates)) {
+        if (value === null || value === "") {
+          nextParams.delete(key)
+        } else {
+          nextParams.set(key, value)
+        }
+      }
+
+      router.replace(buildReportsUrl(pathname, nextParams), { scroll: false })
+    },
+    [pathname, router, searchParams]
+  )
+
+  const handleTabChange = React.useCallback(
+    (value: string) => {
+      if (value === "inventory") {
+        updateReportsQuery({ tab: null })
+      } else if (value === "equipment-search") {
+        updateReportsQuery({ tab: "equipment-search" })
+      } else {
+        updateReportsQuery({ tab: value })
+      }
+    },
+    [updateReportsQuery]
+  )
+
+  const handleEquipmentQueryCommit = React.useCallback(
+    (query: string) => {
+      updateReportsQuery({
+        tab: "equipment-search",
+        q: query.trim(),
+      })
+    },
+    [updateReportsQuery]
+  )
 
   // Map selectedFacilityId to legacy string-based tenantFilter for child components
   // undefined = 'unset', null = 'all', number = String(number)
@@ -120,27 +196,22 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
         <h2 className="text-3xl font-semibold tracking-tight">Báo cáo</h2>
 
         {/* Tenant selector for global/regional_leader users */}
-        {showSelector && (
-          <TenantSelector className="min-w-[280px] sm:min-w-[360px]" />
-        )}
+        {showSelector && <TenantSelector className="min-w-[280px] sm:min-w-[360px]" />}
       </div>
 
       {/* Show tip when no tenant selected (same pattern as Equipment page) */}
-      {showSelector && !shouldFetchData && (
-        <TenantSelectionTip />
-      )}
+      {showSelector && !shouldFetchData && <TenantSelectionTip />}
 
       {/* Report tabs - only render when should fetch */}
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="min-w-0 space-y-4">
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="min-w-0 space-y-4">
         <div data-testid="reports-tabs-scroll-container" className="overflow-x-auto pb-1">
           <TabsList className="w-max min-w-max">
             <TabsTrigger value="inventory">Xuất-Nhập-Tồn</TabsTrigger>
-            <TabsTrigger value="maintenance">
-              Bảo trì / Sửa chữa
-            </TabsTrigger>
-            <TabsTrigger value="utilization">
-              Sử dụng thiết bị
-            </TabsTrigger>
+            <TabsTrigger value="maintenance">Bảo trì / Sửa chữa</TabsTrigger>
+            <TabsTrigger value="utilization">Sử dụng thiết bị</TabsTrigger>
+            {canUseEquipmentSearch ? (
+              <TabsTrigger value="equipment-search">Tìm kiếm thiết bị</TabsTrigger>
+            ) : null}
           </TabsList>
         </div>
 
@@ -177,6 +248,17 @@ function ReportsPageContent({ user }: ReportsPageContentProps) {
                 />
               </React.Suspense>
             </TabsContent>
+            {canUseEquipmentSearch ? (
+              <TabsContent value="equipment-search" className="min-w-0 space-y-4">
+                <EquipmentSearchReportTab
+                  key={`${userRole}:${user.dia_ban_id ?? ""}:${urlQuery}`}
+                  initialQuery={urlQuery}
+                  onQueryCommit={handleEquipmentQueryCommit}
+                  userRegionId={normalizeUserRegionId(user.dia_ban_id)}
+                  userRole={userRole}
+                />
+              </TabsContent>
+            ) : null}
           </>
         ) : null}
       </Tabs>


### PR DESCRIPTION
## Summary
- Adds the Reports-owned `Tìm kiếm thiết bị` tab at `/reports?tab=equipment-search&q=<keyword>`.
- Reuses the Phase 3 aggregate search hook/data layer for region/facility grouped results.
- Renders submit-only search, scope badge, summary, breadcrumb, count-first chart/table, drill-down, and empty/loading/error states.
- Keeps authorization at API/RPC/SQL boundaries; UI role checks remain UX-only.

## Scope notes
- No `/global-search` page.
- No backend migrations or Supabase CLI usage.
- No device-level rows and no `ma_thiet_bi` matching changes.
- Detailed quota labels remain Phase 6 scope.

## Verification
- `npx openspec validate add-equipment-aggregate-global-search --strict`
- `node scripts/npm-run.js run test -- 'src/app/(app)/reports/__tests__/ReportsPage.auth-and-hooks.test.tsx' 'src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx' --run`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run react-doctor`
- Lefthook pre-commit: Prettier, no-explicit-any, dedupe, Python/TS docstring gates
- Lefthook pre-push: typecheck, no-explicit-any, dedupe, Python/TS docstring gates

Closes #630

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Tìm kiếm thiết bị” tab in Reports for cross‑region equipment search with drill‑down, URL‑driven tab/query state, and stable in‑place updates. The tab is lazy‑loaded with skeletons, works without tenant selection, and improves accessibility and large‑data handling per #630.

- **New Features**
  - New tab at `/reports?tab=equipment-search&q=<keyword>`; reads and trims `q`, keeps state in the URL via `router.replace(..., { scroll: false })`, and omits the `tab` param for the default `inventory` view.
  - Region‑first view with drill‑down to facilities; regional leaders start at facility scope with breadcrumb/back. Submit‑only search using the existing aggregate hook; scope badge, summary cards, and quota context placeholders.
  - Bypasses tenant selection; `TenantSelectionTip` is not shown for this tab. Lazy‑loaded and shows skeletons while the tab or results load. Handles very large result sets safely and includes clear ARIA labels for the chart, table, and search input.

- **Bug Fixes**
  - Tabs stay in sync with the URL (unknown values default to `inventory`) and only render active tab content.
  - Query updates no longer remount the equipment tab; props update in place, input focus is preserved, and URL hydration won’t overwrite an in‑progress draft.
  - Avoids flicker with skeletons during placeholder fetches and suppresses the empty state while fetching.

<sup>Written for commit 4c027fb86588c264b98c7078a5412607d9ad8816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an equipment search tab in Reports, including a loading skeleton, region/facility results view, and drill-down controls.
  * Reports tabs are now URL-driven, with search terms persisted for sharing and restoration.
* **Bug Fixes**
  * Improved URL hydration for authenticated flows so the correct tab and query load reliably from saved links.
  * Refined empty, loading, error, and not-found states for equipment search results, suppressing stale/empty UI during active fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->