### PR TITLE
feat(reports): render quota context in equipment search

### DIFF
--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
@@ -249,6 +249,35 @@ describe("EquipmentSearchReportTab", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("keeps facility-mode rows aligned with the quota table columns when row context is missing", () => {
+    const mismatchedFacilityData = {
+      ...createFacilityData(),
+      rows: [{ ...createRegionData().rows[0]!, groupName: "Dữ liệu chưa khớp", equipmentCount: 3 }],
+    }
+
+    mocks.useEquipmentAggregateSearch.mockImplementation((params: HookParams) => ({
+      data: params.groupBy === "facility" ? mismatchedFacilityData : createRegionData(),
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+    }))
+
+    render(
+      <EquipmentSearchReportTab
+        userRole="regional_leader"
+        userRegionId={10}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    const table = screen.getByRole("table", { name: "Bảng kết quả tìm kiếm thiết bị" })
+    const row = within(table).getByRole("row", { name: /Dữ liệu chưa khớp.*3 thiết bị/ })
+
+    expect(within(row).getAllByRole("cell")).toHaveLength(5)
+  })
+
   it("submits repeated searches through the Reports-owned query callback", () => {
     render(
       <EquipmentSearchReportTab

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
@@ -83,6 +83,7 @@ function createFacilityData(): EquipmentAggregateSearchData {
         quotaMinCount: 4,
         quotaMaxCount: 20,
         quotaStatus: "within_limit",
+        quotaNotes: ["within_limit"],
       },
       {
         groupType: "facility",
@@ -96,6 +97,7 @@ function createFacilityData(): EquipmentAggregateSearchData {
         quotaMinCount: null,
         quotaMaxCount: null,
         quotaStatus: "no_active_quota",
+        quotaNotes: [],
       },
     ],
     summary: {
@@ -172,6 +174,23 @@ describe("EquipmentSearchReportTab", () => {
     expect(screen.getByRole("row", { name: /Bệnh viện A.*12 thiết bị/ })).toBeInTheDocument()
   })
 
+  it("keeps the region grouping drill-down action column", () => {
+    render(
+      <EquipmentSearchReportTab
+        userRole="global"
+        userRegionId={null}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    const table = screen.getByRole("table", { name: "Bảng kết quả tìm kiếm thiết bị" })
+
+    expect(within(table).getByRole("columnheader", { name: "Nhóm" })).toBeInTheDocument()
+    expect(within(table).getByRole("columnheader", { name: "Thao tác" })).toBeInTheDocument()
+    expect(within(table).getByRole("button", { name: "Xem cơ sở Miền Bắc" })).toBeInTheDocument()
+  })
+
   it("starts a single-region regional leader at facility grouping", () => {
     render(
       <EquipmentSearchReportTab
@@ -192,6 +211,42 @@ describe("EquipmentSearchReportTab", () => {
     )
     expect(screen.getAllByText("Cơ sở trong vùng phụ trách").length).toBeGreaterThan(0)
     expect(screen.getByRole("row", { name: /Bệnh viện A.*12 thiết bị/ })).toBeInTheDocument()
+  })
+
+  it("renders read-only quota context in facility grouping without quota action CTAs", () => {
+    render(
+      <EquipmentSearchReportTab
+        userRole="regional_leader"
+        userRegionId={10}
+        initialQuery="monitor"
+        onQueryCommit={mocks.onQueryCommit}
+      />
+    )
+
+    const table = screen.getByRole("table", { name: "Bảng kết quả tìm kiếm thiết bị" })
+
+    expect(
+      within(table).getByRole("columnheader", { name: "Số lượng hiện có" })
+    ).toBeInTheDocument()
+    expect(within(table).getByRole("columnheader", { name: "Định mức" })).toBeInTheDocument()
+    expect(within(table).getByRole("columnheader", { name: "Trạng thái" })).toBeInTheDocument()
+    expect(within(table).getByRole("columnheader", { name: "Ghi chú" })).toBeInTheDocument()
+    expect(within(table).queryByRole("columnheader", { name: "Thao tác" })).not.toBeInTheDocument()
+
+    expect(
+      within(table).getByRole("row", {
+        name: /Bệnh viện A.*12 thiết bị.*12\/4-20.*Trong giới hạn định mức.*Trong giới hạn định mức/,
+      })
+    ).toBeInTheDocument()
+    expect(
+      within(table).getByRole("row", { name: /Trung tâm Y tế B.*5 thiết bị.*-.*Chưa có định mức/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("link", { name: /định mức|gán|sửa|khắc phục/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /định mức|gán|sửa|khắc phục/i })
+    ).not.toBeInTheDocument()
   })
 
   it("submits repeated searches through the Reports-owned query callback", () => {

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
@@ -105,4 +105,17 @@ describe("equipment-search-report-tab.utils", () => {
         "Gồm nhiều nhóm định mức; Trong giới hạn định mức; Vượt giới hạn định mức; Chưa gán danh mục định mức",
     })
   })
+
+  it("leaves inherited object keys as neutral quota notes", () => {
+    expect(
+      getEquipmentSearchQuotaContext(
+        createFacilityRow("mixed", {
+          quotaNotes: ["toString"],
+        })
+      )
+    ).toMatchObject({
+      statusLabel: "-",
+      notesText: "Gồm nhiều nhóm định mức; toString",
+    })
+  })
 })

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest"
 
-import type { EquipmentAggregateSearchRow } from "../../hooks/use-equipment-aggregate-search.types"
-import { getEquipmentSearchMaxCount } from "../equipment-search-report-tab.utils"
+import type {
+  EquipmentAggregateSearchQuotaStatus,
+  EquipmentAggregateSearchRow,
+} from "../../hooks/use-equipment-aggregate-search.types"
+import {
+  getEquipmentSearchMaxCount,
+  getEquipmentSearchQuotaContext,
+} from "../equipment-search-report-tab.utils"
 
 function createRow(equipmentCount: number): EquipmentAggregateSearchRow {
   return {
@@ -19,6 +25,26 @@ function createRow(equipmentCount: number): EquipmentAggregateSearchRow {
   }
 }
 
+function createFacilityRow(
+  quotaStatus: EquipmentAggregateSearchQuotaStatus | null,
+  overrides: Partial<EquipmentAggregateSearchRow> = {}
+): EquipmentAggregateSearchRow {
+  return {
+    groupType: "facility",
+    groupId: 100,
+    groupName: "Bệnh viện kiểm thử",
+    parentRegionId: 10,
+    parentRegionName: "Miền Bắc",
+    equipmentCount: 100,
+    facilityCount: null,
+    quotaCurrentCount: 100,
+    quotaMinCount: null,
+    quotaMaxCount: 150,
+    quotaStatus,
+    ...overrides,
+  }
+}
+
 describe("equipment-search-report-tab.utils", () => {
   it("computes the max equipment count without spreading rows onto the call stack", () => {
     const rows = Array.from({ length: 150_000 }, (_, index) => createRow(index + 1))
@@ -28,5 +54,55 @@ describe("equipment-search-report-tab.utils", () => {
 
   it("uses one as the minimum chart scale for empty rows", () => {
     expect(getEquipmentSearchMaxCount([])).toBe(1)
+  })
+
+  it("formats quota ratios from available current, minimum, and maximum counts", () => {
+    expect(getEquipmentSearchQuotaContext(createFacilityRow("within_limit")).quotaDisplay).toBe(
+      "100/150"
+    )
+    expect(
+      getEquipmentSearchQuotaContext(
+        createFacilityRow("within_limit", { quotaCurrentCount: 5, quotaMinCount: 10 })
+      ).quotaDisplay
+    ).toBe("5/10-150")
+  })
+
+  it("uses a dash when quota ratio counts are not available", () => {
+    expect(
+      getEquipmentSearchQuotaContext(
+        createFacilityRow("no_active_quota", {
+          quotaCurrentCount: null,
+          quotaMinCount: null,
+          quotaMaxCount: null,
+        })
+      ).quotaDisplay
+    ).toBe("-")
+  })
+
+  it.each([
+    ["within_limit", "Trong giới hạn định mức"],
+    ["below_minimum", "Dưới mức tối thiểu"],
+    ["over_limit", "Vượt giới hạn định mức"],
+    ["no_active_quota", "Chưa có định mức"],
+    ["unassigned_category", "Chưa gán danh mục định mức"],
+    ["not_in_unit_quota", "Chưa được gán vào định mức của đơn vị"],
+  ] as const)("maps %s to the exact quota status label", (quotaStatus, statusLabel) => {
+    expect(getEquipmentSearchQuotaContext(createFacilityRow(quotaStatus)).statusLabel).toBe(
+      statusLabel
+    )
+  })
+
+  it("prepends the mixed quota-group note and chooses a primary translated status", () => {
+    expect(
+      getEquipmentSearchQuotaContext(
+        createFacilityRow("mixed", {
+          quotaNotes: ["within_limit", "over_limit", "unassigned_category"],
+        })
+      )
+    ).toMatchObject({
+      statusLabel: "Chưa gán danh mục định mức",
+      notesText:
+        "Gồm nhiều nhóm định mức; Trong giới hạn định mức; Vượt giới hạn định mức; Chưa gán danh mục định mức",
+    })
   })
 })

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
@@ -65,6 +65,15 @@ describe("equipment-search-report-tab.utils", () => {
         createFacilityRow("within_limit", { quotaCurrentCount: 5, quotaMinCount: 10 })
       ).quotaDisplay
     ).toBe("5/10-150")
+    expect(
+      getEquipmentSearchQuotaContext(
+        createFacilityRow("below_minimum", {
+          quotaCurrentCount: 3,
+          quotaMinCount: 5,
+          quotaMaxCount: null,
+        })
+      ).quotaDisplay
+    ).toBe("3/5")
   })
 
   it("uses a dash when quota ratio counts are not available", () => {

--- a/src/app/(app)/reports/components/equipment-search-report-tab.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.tsx
@@ -26,7 +26,7 @@ import {
   formatEquipmentSearchCount,
   getEquipmentSearchMaxCount,
   getEquipmentSearchFacilityText,
-  getEquipmentSearchQuotaContext,
+  getEquipmentSearchTableQuotaContext,
   normalizeEquipmentSearchRegionId,
   sortEquipmentSearchRows,
 } from "./equipment-search-report-tab.utils"
@@ -365,7 +365,7 @@ function EquipmentSearchReportTabContent({
                       const facilityText = getEquipmentSearchFacilityText(row)
                       const canDrillDown = row.groupType === "region" && row.groupId !== null
                       const quotaContext =
-                        row.groupType === "facility" ? getEquipmentSearchQuotaContext(row) : null
+                        groupBy === "facility" ? getEquipmentSearchTableQuotaContext(row) : null
 
                       if (quotaContext) {
                         return (

--- a/src/app/(app)/reports/components/equipment-search-report-tab.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.tsx
@@ -343,17 +343,51 @@ function EquipmentSearchReportTabContent({
               <CardContent>
                 <Table aria-label="Bảng kết quả tìm kiếm thiết bị">
                   <TableHeader>
-                    <TableRow>
-                      <TableHead>Nhóm</TableHead>
-                      <TableHead className="text-right">Số thiết bị</TableHead>
-                      <TableHead>Ngữ cảnh</TableHead>
-                      <TableHead className="text-right">Thao tác</TableHead>
-                    </TableRow>
+                    {groupBy === "facility" ? (
+                      <TableRow>
+                        <TableHead>Cơ sở</TableHead>
+                        <TableHead className="text-right">Số lượng hiện có</TableHead>
+                        <TableHead>Định mức</TableHead>
+                        <TableHead>Trạng thái</TableHead>
+                        <TableHead>Ghi chú</TableHead>
+                      </TableRow>
+                    ) : (
+                      <TableRow>
+                        <TableHead>Nhóm</TableHead>
+                        <TableHead className="text-right">Số thiết bị</TableHead>
+                        <TableHead>Ngữ cảnh</TableHead>
+                        <TableHead className="text-right">Thao tác</TableHead>
+                      </TableRow>
+                    )}
                   </TableHeader>
                   <TableBody>
                     {rows.map((row) => {
                       const facilityText = getEquipmentSearchFacilityText(row)
                       const canDrillDown = row.groupType === "region" && row.groupId !== null
+                      const quotaContext =
+                        row.groupType === "facility" ? getEquipmentSearchQuotaContext(row) : null
+
+                      if (quotaContext) {
+                        return (
+                          <TableRow
+                            key={`${row.groupType}-${row.groupId ?? row.groupName}`}
+                            aria-label={`${row.groupName} ${formatEquipmentSearchCount(row.equipmentCount)} ${quotaContext.quotaDisplay} ${quotaContext.statusLabel} ${quotaContext.notesText}`}
+                          >
+                            <TableCell className="font-medium">{row.groupName}</TableCell>
+                            <TableCell className="text-right font-semibold tabular-nums">
+                              {formatEquipmentSearchCount(row.equipmentCount)}
+                            </TableCell>
+                            <TableCell className="tabular-nums">
+                              {quotaContext.quotaDisplay}
+                            </TableCell>
+                            <TableCell>{quotaContext.statusLabel}</TableCell>
+                            <TableCell className="text-muted-foreground">
+                              {quotaContext.notesText}
+                            </TableCell>
+                          </TableRow>
+                        )
+                      }
+
                       return (
                         <TableRow
                           key={`${row.groupType}-${row.groupId ?? row.groupName}`}
@@ -363,11 +397,7 @@ function EquipmentSearchReportTabContent({
                           <TableCell className="text-right font-semibold tabular-nums">
                             {formatEquipmentSearchCount(row.equipmentCount)}
                           </TableCell>
-                          <TableCell className="text-muted-foreground">
-                            {row.groupType === "region"
-                              ? facilityText
-                              : getEquipmentSearchQuotaContext(row)}
-                          </TableCell>
+                          <TableCell className="text-muted-foreground">{facilityText}</TableCell>
                           <TableCell className="text-right">
                             {canDrillDown ? (
                               <Button

--- a/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
@@ -1,4 +1,31 @@
 import type { EquipmentAggregateSearchRow } from "../hooks/use-equipment-aggregate-search.types"
+import type { EquipmentAggregateSearchQuotaStatus } from "../hooks/use-equipment-aggregate-search.types"
+
+export interface EquipmentSearchQuotaContext {
+  quotaDisplay: string
+  statusLabel: string
+  notesText: string
+}
+
+const QUOTA_STATUS_LABELS: Record<Exclude<EquipmentAggregateSearchQuotaStatus, "mixed">, string> = {
+  within_limit: "Trong giới hạn định mức",
+  below_minimum: "Dưới mức tối thiểu",
+  over_limit: "Vượt giới hạn định mức",
+  no_active_quota: "Chưa có định mức",
+  unassigned_category: "Chưa gán danh mục định mức",
+  not_in_unit_quota: "Chưa được gán vào định mức của đơn vị",
+}
+
+const MIXED_QUOTA_STATUS_PRIORITY: Exclude<EquipmentAggregateSearchQuotaStatus, "mixed">[] = [
+  "unassigned_category",
+  "not_in_unit_quota",
+  "no_active_quota",
+  "over_limit",
+  "below_minimum",
+  "within_limit",
+]
+
+const MIXED_QUOTA_NOTE = "Gồm nhiều nhóm định mức"
 
 /** Normalizes session region identifiers before passing them to the search RPC hook. */
 export function normalizeEquipmentSearchRegionId(
@@ -31,22 +58,83 @@ export function getEquipmentSearchFacilityText(row: EquipmentAggregateSearchRow)
   return `${count.toLocaleString("vi-VN")} cơ sở`
 }
 
-/** Builds the Phase 5 quota placeholder context without rendering detailed status labels. */
-export function getEquipmentSearchQuotaContext(row: EquipmentAggregateSearchRow): string {
+function formatQuotaNumber(value: number): string {
+  return value.toLocaleString("vi-VN")
+}
+
+function getQuotaDisplay(row: EquipmentAggregateSearchRow): string {
+  if (typeof row.quotaCurrentCount !== "number") {
+    return "-"
+  }
+
+  if (typeof row.quotaMinCount === "number" && typeof row.quotaMaxCount === "number") {
+    return `${formatQuotaNumber(row.quotaCurrentCount)}/${formatQuotaNumber(
+      row.quotaMinCount
+    )}-${formatQuotaNumber(row.quotaMaxCount)}`
+  }
+
+  if (typeof row.quotaMaxCount === "number") {
+    return `${formatQuotaNumber(row.quotaCurrentCount)}/${formatQuotaNumber(row.quotaMaxCount)}`
+  }
+
+  return "-"
+}
+
+function isQuotaStatus(
+  value: string
+): value is Exclude<EquipmentAggregateSearchQuotaStatus, "mixed"> {
+  return value in QUOTA_STATUS_LABELS
+}
+
+function translateQuotaNote(note: string): string {
+  return isQuotaStatus(note) ? QUOTA_STATUS_LABELS[note] : note
+}
+
+function getStatusLabel(row: EquipmentAggregateSearchRow): string {
+  if (row.quotaStatus && row.quotaStatus !== "mixed") {
+    return QUOTA_STATUS_LABELS[row.quotaStatus]
+  }
+
+  const notes = row.quotaNotes ?? []
+  const primaryStatus = MIXED_QUOTA_STATUS_PRIORITY.find((status) =>
+    notes.some((note) => note === status || note === QUOTA_STATUS_LABELS[status])
+  )
+
+  return primaryStatus ? QUOTA_STATUS_LABELS[primaryStatus] : "-"
+}
+
+function getNotesText(row: EquipmentAggregateSearchRow): string {
+  const translatedNotes = (row.quotaNotes ?? [])
+    .map(translateQuotaNote)
+    .filter((note) => note.trim().length > 0)
+  const shouldPrependMixedNote =
+    row.quotaStatus === "mixed" ||
+    translatedNotes.filter((note) => note !== MIXED_QUOTA_NOTE).length > 1
+
+  const notes = shouldPrependMixedNote
+    ? [MIXED_QUOTA_NOTE, ...translatedNotes.filter((note) => note !== MIXED_QUOTA_NOTE)]
+    : translatedNotes
+
+  return notes.length > 0 ? notes.join("; ") : "-"
+}
+
+/** Builds read-only quota context for a facility aggregate row. */
+export function getEquipmentSearchQuotaContext(
+  row: EquipmentAggregateSearchRow
+): EquipmentSearchQuotaContext {
   if (row.groupType !== "facility") {
-    return "Đếm theo khu vực"
+    return {
+      quotaDisplay: "-",
+      statusLabel: "Đếm theo khu vực",
+      notesText: "-",
+    }
   }
 
-  if (row.quotaCurrentCount === null) {
-    return "Chờ ngữ cảnh định mức"
+  return {
+    quotaDisplay: getQuotaDisplay(row),
+    statusLabel: getStatusLabel(row),
+    notesText: getNotesText(row),
   }
-
-  const limits = [row.quotaMinCount, row.quotaMaxCount]
-    .filter((value): value is number => typeof value === "number")
-    .map((value) => value.toLocaleString("vi-VN"))
-    .join(" - ")
-
-  return limits ? `Định mức: ${limits}` : "Có dữ liệu định mức"
 }
 
 /** Computes the chart scale without spreading arbitrary row counts onto the call stack. */

--- a/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
@@ -83,7 +83,7 @@ function getQuotaDisplay(row: EquipmentAggregateSearchRow): string {
 function isQuotaStatus(
   value: string
 ): value is Exclude<EquipmentAggregateSearchQuotaStatus, "mixed"> {
-  return value in QUOTA_STATUS_LABELS
+  return Object.prototype.hasOwnProperty.call(QUOTA_STATUS_LABELS, value)
 }
 
 function translateQuotaNote(note: string): string {
@@ -135,6 +135,15 @@ export function getEquipmentSearchQuotaContext(
     statusLabel: getStatusLabel(row),
     notesText: getNotesText(row),
   }
+}
+
+/** Returns quota cells for facility-mode tables, including safe placeholders for unexpected row types. */
+export function getEquipmentSearchTableQuotaContext(
+  row: EquipmentAggregateSearchRow
+): EquipmentSearchQuotaContext {
+  return row.groupType === "facility"
+    ? getEquipmentSearchQuotaContext(row)
+    : { quotaDisplay: "-", statusLabel: "-", notesText: "-" }
 }
 
 /** Computes the chart scale without spreading arbitrary row counts onto the call stack. */

--- a/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
@@ -77,6 +77,10 @@ function getQuotaDisplay(row: EquipmentAggregateSearchRow): string {
     return `${formatQuotaNumber(row.quotaCurrentCount)}/${formatQuotaNumber(row.quotaMaxCount)}`
   }
 
+  if (typeof row.quotaMinCount === "number") {
+    return `${formatQuotaNumber(row.quotaCurrentCount)}/${formatQuotaNumber(row.quotaMinCount)}`
+  }
+
   return "-"
 }
 

--- a/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
@@ -111,13 +111,10 @@ function getNotesText(row: EquipmentAggregateSearchRow): string {
   const translatedNotes = (row.quotaNotes ?? [])
     .map(translateQuotaNote)
     .filter((note) => note.trim().length > 0)
-  const shouldPrependMixedNote =
-    row.quotaStatus === "mixed" ||
-    translatedNotes.filter((note) => note !== MIXED_QUOTA_NOTE).length > 1
+  const filteredNotes = translatedNotes.filter((note) => note !== MIXED_QUOTA_NOTE)
+  const shouldPrependMixedNote = row.quotaStatus === "mixed" || filteredNotes.length > 1
 
-  const notes = shouldPrependMixedNote
-    ? [MIXED_QUOTA_NOTE, ...translatedNotes.filter((note) => note !== MIXED_QUOTA_NOTE)]
-    : translatedNotes
+  const notes = shouldPrependMixedNote ? [MIXED_QUOTA_NOTE, ...filteredNotes] : translatedNotes
 
   return notes.length > 0 ? notes.join("; ") : "-"
 }


### PR DESCRIPTION
## Summary
- Render read-only quota context in the Reports equipment search facility table.
- Keep region grouping on the Phase 5 columns and drill-down action.
- Add focused utility/component coverage for quota ratio formatting, exact status labels, mixed notes, and read-only facility rows.

## Scope Notes
- Closes #631.
- No `/global-search` page.
- No route-specific data layer.
- No `ma_thiet_bi` search.
- No quota assignment/edit/fix CTAs.
- No migration and no Supabase CLI usage.
- Backend auth/RPC/SQL boundary unchanged.

## Verification
- `npx openspec validate add-equipment-aggregate-global-search --strict`
- `node scripts/npm-run.js run test -- 'src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts' 'src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx' --run`
- `npx prettier --check 'src/app/(app)/reports/components/equipment-search-report-tab.tsx' 'src/app/(app)/reports/components/equipment-search-report-tab.utils.ts' 'src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx' 'src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts'`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run react-doctor`

## Visual Check
- Skipped per maintainer request after confirming this was not needed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders read-only quota context in the Reports equipment search when grouping by facility, with dedicated columns for current count, quota, status, and notes. Keeps region grouping and drill-down unchanged. Closes #631.

- **New Features**
  - Facility grouping shows: current count, quota range, status, and notes (read-only; no quota CTAs).
  - Adds `getEquipmentSearchQuotaContext` and `getEquipmentSearchTableQuotaContext` to format ratios (e.g., 5/10-150) and build safe placeholders.

- **Bug Fixes**
  - Correctly shows min-only quota ratios (current/min) and uses "-" when counts/notes are missing.
  - Mixed-note rows pick a primary status, de-duplicate mixed-note labels, and ignore inherited keys; facility rows stay 5-column aligned; region mode keeps the "Thao tác" column and drill-down.

<sup>Written for commit b6fdb9530695ceb4fa6f9f3b7d80e227a8df14aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Equipment search reports now provide more informative quota details when grouped by facility (quota amounts/limits, quota status, and notes).
  * Results tables dynamically adjust columns for region vs. facility grouping.
* **Bug Fixes**
  * Drill-down now consistently preserves the facility “action” column when navigating from region-level results.
  * Regional-leader quota views render quota context read-only (hiding quota “action” links/buttons).
  * Improved quota text formatting and alignment, including correct placeholders when quota data is missing.
* **Tests**
  * Expanded UI coverage for quota rendering, drill-down behavior, and edge-row alignment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->