### PR TITLE
feat(reports): add equipment deep links

### DIFF
--- a/src/app/(app)/equipment/__tests__/useEquipmentData.cacheInvalidation.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentData.cacheInvalidation.test.ts
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockCallRpc = vi.hoisted(() => vi.fn())
@@ -19,31 +19,24 @@ vi.mock("@/hooks/use-usage-logs", () => ({
 import { useEquipmentData } from "../_hooks/useEquipmentData"
 import type { UseEquipmentDataParams } from "../_hooks/useEquipmentData"
 
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
+type QueryPredicate = (query: { readonly queryKey: readonly unknown[] }) => boolean
 
+function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { readonly children: React.ReactNode }) {
     return React.createElement(QueryClientProvider, { client: queryClient }, children)
   }
 }
 
-function createRegionalLeaderParams(
-  overrides?: Partial<UseEquipmentDataParams>
-): UseEquipmentDataParams {
+function createParams(overrides?: Partial<UseEquipmentDataParams>): UseEquipmentDataParams {
   return {
     isGlobal: false,
-    isRegionalLeader: true,
-    userRole: "regional_leader",
-    userDiaBanId: 10,
+    isRegionalLeader: false,
+    userRole: "user",
+    userDiaBanId: undefined,
     shouldFetchEquipment: true,
-    effectiveTenantKey: "regional-10",
-    selectedDonVi: null,
-    currentTenantId: null,
+    effectiveTenantKey: "5",
+    selectedDonVi: 5,
+    currentTenantId: 5,
     debouncedSearch: "",
     sortParam: "id.asc",
     pagination: { pageIndex: 0, pageSize: 20 },
@@ -53,15 +46,15 @@ function createRegionalLeaderParams(
     selectedStatuses: [],
     selectedClassifications: [],
     selectedFundingSources: [],
-    selectedFacilityId: null,
-    showSelector: true,
+    selectedFacilityId: undefined,
+    showSelector: false,
     facilities: [],
     isFacilitiesLoading: false,
     ...overrides,
   }
 }
 
-describe("useEquipmentData regional leader facility scope", () => {
+describe("useEquipmentData cache invalidation", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
@@ -78,35 +71,38 @@ describe("useEquipmentData regional leader facility scope", () => {
     })
   })
 
-  it("fetches all allowed facilities when selected facility is null", async () => {
-    renderHook(() => useEquipmentData(createRegionalLeaderParams()), {
-      wrapper: createWrapper(),
+  it("invalidates tenant-scoped filter bucket caches with equipment data caches", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0 },
+        mutations: { retry: false },
+      },
+    })
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderHook(() => useEquipmentData(createParams()), {
+      wrapper: createWrapper(queryClient),
     })
 
-    await waitFor(() => {
-      expect(mockCallRpc).toHaveBeenCalledWith(
-        expect.objectContaining({
-          fn: "equipment_list_enhanced",
-          args: expect.objectContaining({
-            p_don_vi: null,
-          }),
-        })
-      )
-    })
-  })
-
-  it("waits for facility context while selected facility is undefined", async () => {
-    const { result } = renderHook(
-      () => useEquipmentData(createRegionalLeaderParams({ selectedFacilityId: undefined })),
-      { wrapper: createWrapper() }
-    )
-
-    await waitFor(() => {
-      expect(result.current.shouldFetchData).toBe(false)
+    act(() => {
+      result.current.invalidateEquipmentForCurrentTenant()
     })
 
-    expect(mockCallRpc).not.toHaveBeenCalledWith(
-      expect.objectContaining({ fn: "equipment_list_enhanced" })
-    )
+    const filters = invalidateQueries.mock.calls.at(-1)?.[0] as
+      { readonly predicate?: QueryPredicate } | undefined
+    expect(filters?.predicate).toBeDefined()
+
+    const matchesFilterBuckets = filters?.predicate?.({
+      queryKey: [
+        "equipment_filter_buckets",
+        {
+          tenant: "5",
+          role: "user",
+          diaBan: undefined,
+          donVi: 5,
+        },
+      ],
+    })
+
+    expect(matchesFilterBuckets).toBe(true)
   })
 })

--- a/src/app/(app)/equipment/__tests__/useEquipmentData.regionalScope.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentData.regionalScope.test.ts
@@ -1,0 +1,110 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockCallRpc = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: (args: unknown) => mockCallRpc(args),
+}))
+
+vi.mock("@/hooks/use-usage-logs", () => ({
+  useActiveUsageLogs: () => ({
+    data: [],
+    isLoading: false,
+  }),
+}))
+
+import { useEquipmentData } from "../_hooks/useEquipmentData"
+import type { UseEquipmentDataParams } from "../_hooks/useEquipmentData"
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+
+  return function Wrapper({ children }: { readonly children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function createRegionalLeaderParams(
+  overrides?: Partial<UseEquipmentDataParams>
+): UseEquipmentDataParams {
+  return {
+    isGlobal: false,
+    isRegionalLeader: true,
+    userRole: "regional_leader",
+    userDiaBanId: 10,
+    shouldFetchEquipment: true,
+    effectiveTenantKey: "regional-10",
+    selectedDonVi: null,
+    currentTenantId: null,
+    debouncedSearch: "",
+    sortParam: "id.asc",
+    pagination: { pageIndex: 0, pageSize: 20 },
+    selectedDepartments: [],
+    selectedUsers: [],
+    selectedLocations: [],
+    selectedStatuses: [],
+    selectedClassifications: [],
+    selectedFundingSources: [],
+    selectedFacilityId: null,
+    showSelector: true,
+    facilities: [],
+    isFacilitiesLoading: false,
+    ...overrides,
+  }
+}
+
+describe("useEquipmentData regional leader facility scope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
+      switch (fn) {
+        case "equipment_list_enhanced":
+          return Promise.resolve({ data: [], total: 0 })
+        case "equipment_filter_buckets":
+          return Promise.resolve({})
+        case "equipment_department_distribution":
+          return Promise.resolve([])
+        default:
+          return Promise.resolve([])
+      }
+    })
+  })
+
+  it("fetches all allowed facilities when selected facility is null", async () => {
+    renderHook(() => useEquipmentData(createRegionalLeaderParams()), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(mockCallRpc).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fn: "equipment_list_enhanced",
+          args: expect.objectContaining({
+            p_don_vi: null,
+          }),
+        })
+      )
+    })
+  })
+
+  it("waits for facility context while selected facility is undefined", async () => {
+    renderHook(
+      () => useEquipmentData(createRegionalLeaderParams({ selectedFacilityId: undefined })),
+      { wrapper: createWrapper() }
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(mockCallRpc).not.toHaveBeenCalledWith(
+      expect.objectContaining({ fn: "equipment_list_enhanced" })
+    )
+  })
+})

--- a/src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx
+++ b/src/app/(app)/equipment/__tests__/useEquipmentPage.test.tsx
@@ -1,5 +1,5 @@
-import { renderHook, waitFor, act } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor, act } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   toast: vi.fn(),
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
 
 type AuthState = {
   user: { role?: string; don_vi?: number | null; dia_ban_id?: number | null } | null
-  status: 'loading' | 'authenticated' | 'unauthenticated'
+  status: "loading" | "authenticated" | "unauthenticated"
   isGlobal: boolean
   isRegionalLeader: boolean
   tenantKey: string
@@ -179,14 +179,14 @@ import { useEquipmentPage } from "@/app/(app)/equipment/use-equipment-page"
 
 function createAuthState(overrides?: Partial<AuthState>): AuthState {
   return {
-    user: { role: 'global', don_vi: 42, dia_ban_id: 1 },
-    status: 'authenticated',
+    user: { role: "global", don_vi: 42, dia_ban_id: 1 },
+    status: "authenticated",
     isGlobal: true,
     isRegionalLeader: false,
-    tenantKey: '42',
+    tenantKey: "42",
     currentTenantId: 42,
     shouldFetchEquipment: true,
-    effectiveTenantKey: '42',
+    effectiveTenantKey: "42",
     selectedDonVi: 42,
     selectedFacilityId: 42,
     setSelectedFacilityId: mocks.setSelectedFacilityId,
@@ -200,12 +200,12 @@ function createAuthState(overrides?: Partial<AuthState>): AuthState {
 
 function createFiltersState(overrides?: Partial<FiltersState>): FiltersState {
   return {
-    searchTerm: '',
+    searchTerm: "",
     setSearchTerm: mocks.setSearchTerm,
-    debouncedSearch: '',
+    debouncedSearch: "",
     sorting: [],
     setSorting: mocks.setSorting,
-    sortParam: 'id.asc',
+    sortParam: "id.asc",
     columnFilters: [],
     setColumnFilters: mocks.setColumnFilters,
     resetFilters: mocks.resetFilters,
@@ -247,8 +247,8 @@ function createDataState(overrides?: Partial<DataState>): DataState {
     activeFacility: null,
     isFacilitiesLoading: false,
     tenantOptions: [
-      { id: 42, name: 'Đơn vị 42', code: '42' },
-      { id: 99, name: 'Đơn vị 99', code: '99' },
+      { id: 42, name: "Đơn vị 42", code: "42" },
+      { id: 99, name: "Đơn vị 99", code: "99" },
     ],
     isTenantsLoading: false,
     activeUsageLogs: undefined,
@@ -288,7 +288,7 @@ function createExportState(overrides?: Partial<ExportState>): ExportState {
   }
 }
 
-describe('useEquipmentPage tenant switching', () => {
+describe("useEquipmentPage tenant switching", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     state.auth = createAuthState()
@@ -298,15 +298,15 @@ describe('useEquipmentPage tenant switching', () => {
     state.exports = createExportState()
   })
 
-  it('does not reset filters when tenant changes because provider handles tenant-scoped state', async () => {
+  it("does not reset filters when tenant changes because provider handles tenant-scoped state", async () => {
     const { rerender } = renderHook(() => useEquipmentPage())
 
     act(() => {
       if (!state.auth || !state.data) {
-        throw new Error('Mock state not initialized')
+        throw new Error("Mock state not initialized")
       }
 
-      state.auth.effectiveTenantKey = '99'
+      state.auth.effectiveTenantKey = "99"
       state.auth.selectedDonVi = 99
       state.auth.selectedFacilityId = 99
       state.data.selectedFacilityId = 99
@@ -317,8 +317,8 @@ describe('useEquipmentPage tenant switching', () => {
     await waitFor(() => {
       expect(mocks.toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: 'Đã áp dụng bộ lọc đơn vị',
-          description: 'Hiển thị thiết bị thuộc Đơn vị 99',
+          title: "Đã áp dụng bộ lọc đơn vị",
+          description: "Hiển thị thiết bị thuộc Đơn vị 99",
         })
       )
     })
@@ -326,7 +326,7 @@ describe('useEquipmentPage tenant switching', () => {
     expect(mocks.resetFilters).not.toHaveBeenCalled()
   })
 
-  it('does not mark route sync data as ready when the equipment query is disabled', () => {
+  it("does not mark route sync data as ready when the equipment query is disabled", () => {
     state.data = createDataState({
       isLoading: false,
       shouldFetchData: false,
@@ -342,31 +342,56 @@ describe('useEquipmentPage tenant switching', () => {
     )
   })
 
-  it('resets pagination in the same action when filters change', () => {
+  it("resets pagination in the same action when filters change", () => {
     const { result } = renderHook(() => useEquipmentPage())
 
     act(() => {
-      result.current.setColumnFilters([{ id: 'tinh_trang_hien_tai', value: ['Chờ sửa chữa'] }])
+      result.current.setColumnFilters([{ id: "tinh_trang_hien_tai", value: ["Chờ sửa chữa"] }])
     })
 
     expect(mocks.setPagination).toHaveBeenCalledWith(expect.any(Function))
 
-    const resetUpdater = mocks.setPagination.mock.calls[0][0] as (
-      value: { pageIndex: number; pageSize: number }
-    ) => { pageIndex: number; pageSize: number }
+    const resetUpdater = mocks.setPagination.mock.calls[0][0] as (value: {
+      pageIndex: number
+      pageSize: number
+    }) => { pageIndex: number; pageSize: number }
     expect(resetUpdater({ pageIndex: 3, pageSize: 20 })).toEqual({
       pageIndex: 0,
       pageSize: 20,
     })
     expect(mocks.setColumnFilters).toHaveBeenCalledWith([
-      { id: 'tinh_trang_hien_tai', value: ['Chờ sửa chữa'] },
+      { id: "tinh_trang_hien_tai", value: ["Chờ sửa chữa"] },
     ])
   })
 
-  it('exposes department distribution from equipment data', () => {
+  it("resets pagination when route search params hydrate the search filter", () => {
+    renderHook(() => useEquipmentPage())
+
+    const routeSyncArgs = mocks.useEquipmentRouteSync.mock.calls[0][0] as {
+      onSearchParamHydrated: (value: string) => void
+    }
+
+    act(() => {
+      routeSyncArgs.onSearchParamHydrated("monitor")
+    })
+
+    expect(mocks.setPagination).toHaveBeenCalledWith(expect.any(Function))
+
+    const resetUpdater = mocks.setPagination.mock.calls[0][0] as (value: {
+      pageIndex: number
+      pageSize: number
+    }) => { pageIndex: number; pageSize: number }
+    expect(resetUpdater({ pageIndex: 3, pageSize: 20 })).toEqual({
+      pageIndex: 0,
+      pageSize: 20,
+    })
+    expect(mocks.setSearchTerm).toHaveBeenCalledWith("monitor")
+  })
+
+  it("exposes department distribution from equipment data", () => {
     const departmentDistribution = [
-      { department: 'Khoa Ngoai', label: 'Khoa Ngoai', count: 7 },
-      { department: null, label: 'Chưa cập nhật', count: 2 },
+      { department: "Khoa Ngoai", label: "Khoa Ngoai", count: 7 },
+      { department: null, label: "Chưa cập nhật", count: 2 },
     ]
     state.data = createDataState({ departmentDistribution })
 

--- a/src/app/(app)/equipment/__tests__/useEquipmentRouteSync.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentRouteSync.test.ts
@@ -139,6 +139,10 @@ describe("useEquipmentRouteSync", () => {
       expect(hydrateFacility).toHaveBeenCalledWith(101)
     })
     expect(hydrateSearch).not.toHaveBeenCalled()
+    expect(hydrateFacility).toHaveBeenCalledTimes(1)
+
+    rerender({ selectedFacilityId: undefined })
+    expect(hydrateFacility).toHaveBeenCalledTimes(1)
 
     hydrateFacility.mockClear()
 

--- a/src/app/(app)/equipment/__tests__/useEquipmentRouteSync.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentRouteSync.test.ts
@@ -56,9 +56,7 @@ describe("useEquipmentRouteSync", () => {
   it("creates pending preset action and cleans transient params for attention-status", async () => {
     nav.searchParams = new URLSearchParams(`action=${EQUIPMENT_ATTENTION_ACTION}&page=2&q=abc`)
 
-    const { result } = renderHook(() =>
-      useEquipmentRouteSync({ data: [], isDataReady: true })
-    )
+    const { result } = renderHook(() => useEquipmentRouteSync({ data: [], isDataReady: true }))
 
     await waitFor(() => {
       expect(result.current.pendingAction).toEqual({ type: "applyAttentionStatusPreset" })
@@ -70,15 +68,54 @@ describe("useEquipmentRouteSync", () => {
   it("keeps existing add action behavior", async () => {
     nav.searchParams = new URLSearchParams("action=add&tab=list")
 
-    const { result } = renderHook(() =>
-      useEquipmentRouteSync({ data: [], isDataReady: true })
-    )
+    const { result } = renderHook(() => useEquipmentRouteSync({ data: [], isDataReady: true }))
 
     await waitFor(() => {
       expect(result.current.pendingAction).toEqual({ type: "openAdd" })
     })
 
     expect(nav.replace).toHaveBeenCalledWith("/equipment?tab=list", { scroll: false })
+  })
+
+  it("hydrates search and facility query params for equipment deep-links", async () => {
+    const hydrateSearch = vi.fn()
+    const hydrateFacility = vi.fn()
+    nav.searchParams = new URLSearchParams("search=monitor&facility=101")
+
+    renderHook(() =>
+      useEquipmentRouteSync({
+        data: [],
+        isDataReady: true,
+        onSearchParamHydrated: hydrateSearch,
+        onFacilityParamHydrated: hydrateFacility,
+      })
+    )
+
+    await waitFor(() => {
+      expect(hydrateSearch).toHaveBeenCalledWith("monitor")
+      expect(hydrateFacility).toHaveBeenCalledWith(101)
+    })
+    expect(nav.replace).not.toHaveBeenCalled()
+  })
+
+  it("hydrates region query params to all-facility scope without overriding search", async () => {
+    const hydrateSearch = vi.fn()
+    const hydrateFacility = vi.fn()
+    nav.searchParams = new URLSearchParams("search=máy thở&region=10")
+
+    renderHook(() =>
+      useEquipmentRouteSync({
+        data: [],
+        isDataReady: true,
+        onSearchParamHydrated: hydrateSearch,
+        onFacilityParamHydrated: hydrateFacility,
+      })
+    )
+
+    await waitFor(() => {
+      expect(hydrateSearch).toHaveBeenCalledWith("máy thở")
+      expect(hydrateFacility).toHaveBeenCalledWith(null)
+    })
   })
 
   it("keeps highlight action behavior and preserves non-transient params", async () => {
@@ -136,9 +173,7 @@ describe("useEquipmentRouteSync", () => {
     mockCallRpc.mockResolvedValueOnce(fetchedEquipment)
     nav.searchParams = new URLSearchParams("highlight=42")
 
-    const { result } = renderHook(() =>
-      useEquipmentRouteSync({ data: [], isDataReady: true })
-    )
+    const { result } = renderHook(() => useEquipmentRouteSync({ data: [], isDataReady: true }))
 
     await waitFor(() => {
       expect(result.current.pendingAction?.type).toBe("openDetail")

--- a/src/app/(app)/equipment/__tests__/useEquipmentRouteSync.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentRouteSync.test.ts
@@ -132,15 +132,24 @@ describe("useEquipmentRouteSync", () => {
           onFacilityParamHydrated: hydrateFacility,
           selectedFacilityId,
         }),
-      { initialProps: { selectedFacilityId: 101 } }
+      { initialProps: { selectedFacilityId: undefined } }
     )
+
+    await waitFor(() => {
+      expect(hydrateFacility).toHaveBeenCalledWith(101)
+    })
+    expect(hydrateSearch).not.toHaveBeenCalled()
+
+    hydrateFacility.mockClear()
+
+    rerender({ selectedFacilityId: 101 })
 
     await waitFor(() => {
       expect(hydrateSearch).toHaveBeenCalledWith("monitor")
     })
+    expect(hydrateFacility).not.toHaveBeenCalled()
 
     hydrateSearch.mockClear()
-    hydrateFacility.mockClear()
 
     rerender({ selectedFacilityId: 202 })
 

--- a/src/app/(app)/equipment/__tests__/useEquipmentRouteSync.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentRouteSync.test.ts
@@ -118,6 +118,36 @@ describe("useEquipmentRouteSync", () => {
     })
   })
 
+  it("does not rehydrate facility params after a local facility selection change", async () => {
+    const hydrateSearch = vi.fn()
+    const hydrateFacility = vi.fn()
+    nav.searchParams = new URLSearchParams("search=monitor&facility=101")
+
+    const { rerender } = renderHook(
+      ({ selectedFacilityId }: { selectedFacilityId: number | null | undefined }) =>
+        useEquipmentRouteSync({
+          data: [],
+          isDataReady: true,
+          onSearchParamHydrated: hydrateSearch,
+          onFacilityParamHydrated: hydrateFacility,
+          selectedFacilityId,
+        }),
+      { initialProps: { selectedFacilityId: 101 } }
+    )
+
+    await waitFor(() => {
+      expect(hydrateSearch).toHaveBeenCalledWith("monitor")
+    })
+
+    hydrateSearch.mockClear()
+    hydrateFacility.mockClear()
+
+    rerender({ selectedFacilityId: 202 })
+
+    expect(hydrateSearch).not.toHaveBeenCalled()
+    expect(hydrateFacility).not.toHaveBeenCalled()
+  })
+
   it("keeps highlight action behavior and preserves non-transient params", async () => {
     const equipment = { id: 123, ten_thiet_bi: "X-quang" } as Equipment
     nav.searchParams = new URLSearchParams("highlight=123&view=card&page=4")

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -89,7 +89,10 @@ type EquipmentFilterBucketsResponse = Partial<{
 
 const EMPTY_FILTER_BUCKET: FilterBucketItem[] = []
 
-function normalizeBucket(data: EquipmentFilterBucketsResponse | undefined, key: keyof EquipmentFilterBucketsResponse) {
+function normalizeBucket(
+  data: EquipmentFilterBucketsResponse | undefined,
+  key: keyof EquipmentFilterBucketsResponse
+) {
   return data?.[key] ?? EMPTY_FILTER_BUCKET
 }
 
@@ -123,11 +126,11 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
   const queryClient = useQueryClient()
 
   // Computed: should we fetch data based on tenant/facility selection
-  // For regional_leader, require facility selection before fetching
+  // For regional_leader, undefined means facility context is still hydrating.
+  // Null is an explicit all-allowed-facilities scope for regional deep-links.
   const shouldFetchData = React.useMemo(() => {
     if (!shouldFetchEquipment) return false
-    // Regional leaders must select a specific facility
-    if (isRegionalLeader && (selectedFacilityId === null || selectedFacilityId === undefined)) return false
+    if (isRegionalLeader && selectedFacilityId === undefined) return false
     return true
   }, [shouldFetchEquipment, isRegionalLeader, selectedFacilityId])
 
@@ -135,7 +138,9 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
   const effectiveSelectedDonVi = React.useMemo(() => {
     if (isRegionalLeader) {
       // Regional leaders always use selectedFacilityId
-      return selectedFacilityId !== undefined && selectedFacilityId !== null ? selectedFacilityId : null
+      return selectedFacilityId !== undefined && selectedFacilityId !== null
+        ? selectedFacilityId
+        : null
     }
     return selectedDonVi
   }, [isRegionalLeader, selectedFacilityId, selectedDonVi])
@@ -170,13 +175,17 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
   const effectivePageSize = pagination.pageSize
   const effectivePage = pagination.pageIndex + 1
 
-  const { data: equipmentRes, isLoading: isEqLoading, isFetching: isEqFetching } = useQuery<EquipmentListResponse>({
+  const {
+    data: equipmentRes,
+    isLoading: isEqLoading,
+    isFetching: isEqFetching,
+  } = useQuery<EquipmentListResponse>({
     queryKey: [
       "equipment_list_enhanced",
       {
         tenant: effectiveTenantKey,
-        role: userRole,           // Cache isolation by role
-        diaBan: userDiaBanId,     // Cache isolation by region
+        role: userRole, // Cache isolation by role
+        diaBan: userDiaBanId, // Cache isolation by region
         donVi: effectiveSelectedDonVi,
         page: pagination.pageIndex,
         size: pagination.pageSize,
@@ -282,7 +291,15 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
 
   // Filter buckets are bundled into one RPC to avoid six parallel cold-start calls.
   const { data: filterBucketsData } = useQuery<EquipmentFilterBucketsResponse>({
-    queryKey: ["equipment_filter_buckets", { tenant: effectiveTenantKey, role: userRole, diaBan: userDiaBanId, donVi: effectiveSelectedDonVi }],
+    queryKey: [
+      "equipment_filter_buckets",
+      {
+        tenant: effectiveTenantKey,
+        role: userRole,
+        diaBan: userDiaBanId,
+        donVi: effectiveSelectedDonVi,
+      },
+    ],
     queryFn: async ({ signal }) => {
       const result = await callRpc<EquipmentFilterBucketsResponse>({
         fn: "equipment_filter_buckets",
@@ -304,24 +321,58 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
   const statusesData = normalizeBucket(filterBucketsData, "status")
   const fundingSourcesData = normalizeBucket(filterBucketsData, "fundingSource")
 
-  const departments = React.useMemo(() => departmentsData.map((x) => x.name).filter(Boolean), [departmentsData])
+  const departments = React.useMemo(
+    () => departmentsData.map((x) => x.name).filter(Boolean),
+    [departmentsData]
+  )
   const users = React.useMemo(() => usersData.map((x) => x.name).filter(Boolean), [usersData])
-  const locations = React.useMemo(() => locationsData.map((x) => x.name).filter(Boolean), [locationsData])
-  const classifications = React.useMemo(() => classificationsData.map((x) => x.name).filter(Boolean), [classificationsData])
-  const statuses = React.useMemo(() => statusesData.map((x) => x.name).filter(Boolean), [statusesData])
-  const fundingSources = React.useMemo(() => fundingSourcesData.map((x) => x.name).filter(Boolean), [fundingSourcesData])
+  const locations = React.useMemo(
+    () => locationsData.map((x) => x.name).filter(Boolean),
+    [locationsData]
+  )
+  const classifications = React.useMemo(
+    () => classificationsData.map((x) => x.name).filter(Boolean),
+    [classificationsData]
+  )
+  const statuses = React.useMemo(
+    () => statusesData.map((x) => x.name).filter(Boolean),
+    [statusesData]
+  )
+  const fundingSources = React.useMemo(
+    () => fundingSourcesData.map((x) => x.name).filter(Boolean),
+    [fundingSourcesData]
+  )
 
   // Filter data for bottom sheet
   const filterData: FilterBottomSheetData = React.useMemo(
     () => ({
       status: (statusesData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
-      department: (departmentsData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
+      department: (departmentsData || []).map((x) => ({
+        id: x.name,
+        label: x.name,
+        count: x.count,
+      })),
       location: (locationsData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
       user: (usersData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
-      classification: (classificationsData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
-      fundingSource: (fundingSourcesData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
+      classification: (classificationsData || []).map((x) => ({
+        id: x.name,
+        label: x.name,
+        count: x.count,
+      })),
+      fundingSource: (fundingSourcesData || []).map((x) => ({
+        id: x.name,
+        label: x.name,
+        count: x.count,
+      })),
     }),
-    [statusesData, departmentsData, locationsData, usersData, classificationsData, fundingSourcesData]
+    [
+      statusesData,
+      departmentsData,
+      locationsData,
+      usersData,
+      classificationsData,
+      fundingSourcesData,
+    ]
   )
 
   // Cache invalidation - check all cache isolation fields
@@ -331,7 +382,8 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
       predicate: (q) => {
         const key = q.queryKey
         if (!Array.isArray(key)) return false
-        if (key[0] !== "equipment_list_enhanced" && key[0] !== "equipment_department_distribution") return false
+        if (key[0] !== "equipment_list_enhanced" && key[0] !== "equipment_department_distribution")
+          return false
         const queryParams = key[1] as Record<string, unknown>
         return (
           queryParams?.tenant === effectiveTenantKey &&

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -382,7 +382,11 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
       predicate: (q) => {
         const key = q.queryKey
         if (!Array.isArray(key)) return false
-        if (key[0] !== "equipment_list_enhanced" && key[0] !== "equipment_department_distribution")
+        if (
+          key[0] !== "equipment_list_enhanced" &&
+          key[0] !== "equipment_department_distribution" &&
+          key[0] !== "equipment_filter_buckets"
+        )
           return false
         const queryParams = key[1] as Record<string, unknown>
         return (

--- a/src/app/(app)/equipment/_hooks/useEquipmentRouteSync.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentRouteSync.ts
@@ -76,6 +76,9 @@ export function useEquipmentRouteSync(
   // Track non-transient deep-link params independently from action/highlight params.
   const processedDeepLinkParamsRef = React.useRef<string | null>(null)
 
+  // Track facility hydration requests while waiting for parent scope state to catch up.
+  const requestedFacilityHydrationRef = React.useRef<string | null>(null)
+
   // Track in-flight highlight requests so stale responses cannot win races
   const highlightRequestRef = React.useRef(0)
 
@@ -116,8 +119,10 @@ export function useEquipmentRouteSync(
       if (
         routeFacilityScope !== undefined &&
         onFacilityParamHydrated &&
-        (!hasSelectedFacilityIdParam || selectedFacilityId !== routeFacilityScope)
+        (!hasSelectedFacilityIdParam || selectedFacilityId !== routeFacilityScope) &&
+        requestedFacilityHydrationRef.current !== deepLinkParamsKey
       ) {
+        requestedFacilityHydrationRef.current = deepLinkParamsKey
         onFacilityParamHydrated(routeFacilityScope)
       }
 
@@ -127,6 +132,7 @@ export function useEquipmentRouteSync(
 
       if (!shouldWaitForFacilityScope) {
         processedDeepLinkParamsRef.current = deepLinkParamsKey
+        requestedFacilityHydrationRef.current = null
       }
     }
 

--- a/src/app/(app)/equipment/_hooks/useEquipmentRouteSync.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentRouteSync.ts
@@ -10,6 +10,9 @@ import type { Equipment } from "../types"
 export interface UseEquipmentRouteSyncParams {
   data: Equipment[]
   isDataReady: boolean
+  onSearchParamHydrated?: (value: string) => void
+  onFacilityParamHydrated?: (value: number | null) => void
+  selectedFacilityId?: number | null
 }
 
 export interface RouteAction {
@@ -39,10 +42,22 @@ function buildCleanUrl(pathname: string, searchParams: URLSearchParams): string 
   return params.size > 0 ? `${pathname}?${params.toString()}` : pathname
 }
 
+function parseRouteId(value: string | null): number | null {
+  if (!value) return null
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+/** Synchronizes equipment page URL parameters with filters, facility scope, and route actions. */
 export function useEquipmentRouteSync(
   params: UseEquipmentRouteSyncParams
 ): UseEquipmentRouteSyncReturn {
-  const { data, isDataReady } = params
+  const { data, isDataReady, onFacilityParamHydrated, onSearchParamHydrated, selectedFacilityId } =
+    params
+  const hasSelectedFacilityIdParam = Object.prototype.hasOwnProperty.call(
+    params,
+    "selectedFacilityId"
+  )
 
   const router = useRouter()
   const pathname = usePathname()
@@ -57,6 +72,9 @@ export function useEquipmentRouteSync(
 
   // Track if we've processed the current URL params to prevent re-runs
   const processedParamsRef = React.useRef<string | null>(null)
+
+  // Track non-transient deep-link params independently from action/highlight params.
+  const processedDeepLinkParamsRef = React.useRef<string | null>(null)
 
   // Track in-flight highlight requests so stale responses cannot win races
   const highlightRequestRef = React.useRef(0)
@@ -80,8 +98,37 @@ export function useEquipmentRouteSync(
 
   // Handle URL parameters for dialog opening and equipment highlighting
   React.useEffect(() => {
+    const searchParam = searchParams.get("search")
+    const regionParam = searchParams.get("region")
+    const facilityParam = searchParams.get("facility")
     const actionParam = searchParams.get("action")
     const highlightParam = searchParams.get("highlight")
+    const facilityId = parseRouteId(facilityParam)
+    const regionId = parseRouteId(regionParam)
+    const routeFacilityScope = facilityId ?? (regionId ? null : undefined)
+    const shouldWaitForFacilityScope =
+      hasSelectedFacilityIdParam &&
+      routeFacilityScope !== undefined &&
+      selectedFacilityId !== routeFacilityScope
+    const deepLinkParamsKey = `${searchParam ?? ""}-${regionParam ?? ""}-${facilityParam ?? ""}-${selectedFacilityId ?? ""}`
+
+    if (processedDeepLinkParamsRef.current !== deepLinkParamsKey) {
+      if (
+        routeFacilityScope !== undefined &&
+        onFacilityParamHydrated &&
+        (!hasSelectedFacilityIdParam || selectedFacilityId !== routeFacilityScope)
+      ) {
+        onFacilityParamHydrated(routeFacilityScope)
+      }
+
+      if (!shouldWaitForFacilityScope && searchParam !== null && onSearchParamHydrated) {
+        onSearchParamHydrated(searchParam.trim())
+      }
+
+      if (!shouldWaitForFacilityScope) {
+        processedDeepLinkParamsRef.current = deepLinkParamsKey
+      }
+    }
 
     // Create a key to track if we've processed these params
     const paramsKey = `${actionParam || ""}-${highlightParam || ""}`
@@ -200,7 +247,19 @@ export function useEquipmentRouteSync(
         })()
       }
     }
-  }, [searchParams, router, pathname, data, toast, isDataReady, cancelInFlightHighlightRequest])
+  }, [
+    searchParams,
+    router,
+    pathname,
+    data,
+    toast,
+    isDataReady,
+    cancelInFlightHighlightRequest,
+    onFacilityParamHydrated,
+    onSearchParamHydrated,
+    hasSelectedFacilityIdParam,
+    selectedFacilityId,
+  ])
 
   const clearPendingAction = React.useCallback(() => {
     setPendingAction(null)

--- a/src/app/(app)/equipment/_hooks/useEquipmentRouteSync.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentRouteSync.ts
@@ -110,7 +110,7 @@ export function useEquipmentRouteSync(
       hasSelectedFacilityIdParam &&
       routeFacilityScope !== undefined &&
       selectedFacilityId !== routeFacilityScope
-    const deepLinkParamsKey = `${searchParam ?? ""}-${regionParam ?? ""}-${facilityParam ?? ""}-${selectedFacilityId ?? ""}`
+    const deepLinkParamsKey = `${searchParam ?? ""}-${regionParam ?? ""}-${facilityParam ?? ""}`
 
     if (processedDeepLinkParamsRef.current !== deepLinkParamsKey) {
       if (

--- a/src/app/(app)/equipment/use-equipment-page.tsx
+++ b/src/app/(app)/equipment/use-equipment-page.tsx
@@ -93,15 +93,6 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
     pagination,
   })
 
-  // Route sync hook - defined before renderActions which uses routeSync.router
-  const routeSync = useEquipmentRouteSync({
-    data: data.data,
-    isDataReady: data.shouldFetchData && !data.isLoading,
-    onFacilityParamHydrated: auth.setSelectedFacilityId,
-    onSearchParamHydrated: filters.setSearchTerm,
-    selectedFacilityId: auth.selectedFacilityId,
-  })
-
   // Render actions helper (needed for columns)
   // EquipmentActionsMenu now consumes dialog actions from context directly
   const renderActions = React.useCallback(
@@ -162,6 +153,14 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
     },
     [filters.setSearchTerm, resetPaginationForFilterChange]
   )
+
+  const routeSync = useEquipmentRouteSync({
+    data: data.data,
+    isDataReady: data.shouldFetchData && !data.isLoading,
+    onFacilityParamHydrated: auth.setSelectedFacilityId,
+    onSearchParamHydrated: setSearchTermAndReset,
+    selectedFacilityId: auth.selectedFacilityId,
+  })
 
   const setColumnFiltersAndReset = React.useCallback<
     React.Dispatch<React.SetStateAction<typeof filters.columnFilters>>

--- a/src/app/(app)/equipment/use-equipment-page.tsx
+++ b/src/app/(app)/equipment/use-equipment-page.tsx
@@ -97,6 +97,9 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
   const routeSync = useEquipmentRouteSync({
     data: data.data,
     isDataReady: data.shouldFetchData && !data.isLoading,
+    onFacilityParamHydrated: auth.setSelectedFacilityId,
+    onSearchParamHydrated: filters.setSearchTerm,
+    selectedFacilityId: auth.selectedFacilityId,
   })
 
   // Render actions helper (needed for columns)
@@ -160,7 +163,9 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
     [filters.setSearchTerm, resetPaginationForFilterChange]
   )
 
-  const setColumnFiltersAndReset = React.useCallback<React.Dispatch<React.SetStateAction<typeof filters.columnFilters>>>(
+  const setColumnFiltersAndReset = React.useCallback<
+    React.Dispatch<React.SetStateAction<typeof filters.columnFilters>>
+  >(
     (value) => {
       resetPaginationForFilterChange()
       filters.setColumnFilters(value)
@@ -179,27 +184,30 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
   }, [auth.isRegionalLeader, auth.selectedFacilityId, auth.selectedDonVi])
 
   // Memoize filter params to prevent unnecessary re-renders
-  const filterParams = React.useMemo(() => ({
-    debouncedSearch: filters.debouncedSearch,
-    sortParam: filters.sortParam,
-    effectiveSelectedDonVi,
-    selectedDepartments: filters.selectedDepartments,
-    selectedUsers: filters.selectedUsers,
-    selectedLocations: filters.selectedLocations,
-    selectedStatuses: filters.selectedStatuses,
-    selectedClassifications: filters.selectedClassifications,
-    selectedFundingSources: filters.selectedFundingSources,
-  }), [
-    filters.debouncedSearch,
-    filters.sortParam,
-    effectiveSelectedDonVi,
-    filters.selectedDepartments,
-    filters.selectedUsers,
-    filters.selectedLocations,
-    filters.selectedStatuses,
-    filters.selectedClassifications,
-    filters.selectedFundingSources,
-  ])
+  const filterParams = React.useMemo(
+    () => ({
+      debouncedSearch: filters.debouncedSearch,
+      sortParam: filters.sortParam,
+      effectiveSelectedDonVi,
+      selectedDepartments: filters.selectedDepartments,
+      selectedUsers: filters.selectedUsers,
+      selectedLocations: filters.selectedLocations,
+      selectedStatuses: filters.selectedStatuses,
+      selectedClassifications: filters.selectedClassifications,
+      selectedFundingSources: filters.selectedFundingSources,
+    }),
+    [
+      filters.debouncedSearch,
+      filters.sortParam,
+      effectiveSelectedDonVi,
+      filters.selectedDepartments,
+      filters.selectedUsers,
+      filters.selectedLocations,
+      filters.selectedStatuses,
+      filters.selectedClassifications,
+      filters.selectedFundingSources,
+    ]
+  )
 
   // Export hook - now with filter params for full data fetch
   const exports = useEquipmentExport({
@@ -227,9 +235,7 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
     // Show toast for tenant change
     if (auth.selectedDonVi !== null) {
       const selectedTenant = data.tenantOptions.find((t) => t.id === auth.selectedDonVi)
-      const tenantName = selectedTenant
-        ? selectedTenant.name
-        : `Đơn vị ${auth.selectedDonVi}`
+      const tenantName = selectedTenant ? selectedTenant.name : `Đơn vị ${auth.selectedDonVi}`
       toast({
         variant: "default",
         title: "Đã áp dụng bộ lọc đơn vị",
@@ -258,7 +264,10 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
   }, [table.table, table.setPreservePageState, onDataMutationSuccess])
 
   // Computed values
-  const hasFacilityFilter = data.showFacilityFilter && data.selectedFacilityId !== null && data.selectedFacilityId !== undefined
+  const hasFacilityFilter =
+    data.showFacilityFilter &&
+    data.selectedFacilityId !== null &&
+    data.selectedFacilityId !== undefined
 
   // Memoized return value for performance
   return React.useMemo<UseEquipmentPageReturn>(
@@ -312,7 +321,7 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
       // Facility filter - now from context via auth/data hooks
       showFacilityFilter: data.showFacilityFilter,
       facilities: data.facilities,
-      selectedFacilityId: data.selectedFacilityId ?? null,  // Convert undefined to null for return type
+      selectedFacilityId: data.selectedFacilityId ?? null, // Convert undefined to null for return type
       setSelectedFacilityId: auth.setSelectedFacilityId,
       activeFacility: data.activeFacility,
       hasFacilityFilter,

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.test.tsx
@@ -189,6 +189,10 @@ describe("EquipmentSearchReportTab", () => {
     expect(within(table).getByRole("columnheader", { name: "Nhóm" })).toBeInTheDocument()
     expect(within(table).getByRole("columnheader", { name: "Thao tác" })).toBeInTheDocument()
     expect(within(table).getByRole("button", { name: "Xem cơ sở Miền Bắc" })).toBeInTheDocument()
+    expect(within(table).getByRole("link", { name: "Xem thiết bị Miền Bắc" })).toHaveAttribute(
+      "href",
+      "/equipment?search=monitor&region=10"
+    )
   })
 
   it("starts a single-region regional leader at facility grouping", () => {
@@ -238,6 +242,10 @@ describe("EquipmentSearchReportTab", () => {
         name: /Bệnh viện A.*12 thiết bị.*12\/4-20.*Trong giới hạn định mức.*Trong giới hạn định mức/,
       })
     ).toBeInTheDocument()
+    expect(within(table).getByRole("link", { name: "Xem thiết bị Bệnh viện A" })).toHaveAttribute(
+      "href",
+      "/equipment?search=monitor&facility=101"
+    )
     expect(
       within(table).getByRole("row", { name: /Trung tâm Y tế B.*5 thiết bị.*-.*Chưa có định mức/ })
     ).toBeInTheDocument()

--- a/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
+++ b/src/app/(app)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts
@@ -5,6 +5,7 @@ import type {
   EquipmentAggregateSearchRow,
 } from "../../hooks/use-equipment-aggregate-search.types"
 import {
+  buildEquipmentSearchDetailHref,
   getEquipmentSearchMaxCount,
   getEquipmentSearchQuotaContext,
 } from "../equipment-search-report-tab.utils"
@@ -126,5 +127,14 @@ describe("equipment-search-report-tab.utils", () => {
       statusLabel: "-",
       notesText: "Gồm nhiều nhóm định mức; toString",
     })
+  })
+
+  it("builds encoded equipment detail links for region and facility aggregate rows", () => {
+    expect(buildEquipmentSearchDetailHref("Máy X-quang & CT", createRow(10))).toBe(
+      "/equipment?search=M%C3%A1y+X-quang+%26+CT&region=10"
+    )
+    expect(
+      buildEquipmentSearchDetailHref("monitor", createFacilityRow("within_limit", { groupId: 101 }))
+    ).toBe("/equipment?search=monitor&facility=101")
   })
 })

--- a/src/app/(app)/reports/components/equipment-search-report-tab.tsx
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import Link from "next/link"
 import { ChevronRight, Search } from "lucide-react"
 
 import { SearchInput } from "@/components/shared/SearchInput"
@@ -22,7 +23,9 @@ import {
   useEquipmentAggregateSearch,
 } from "../hooks/use-equipment-aggregate-search"
 import { EquipmentSearchSkeleton } from "./equipment-search-report-tab-skeleton"
+import { EquipmentSearchSummaryCards } from "./equipment-search-summary-cards"
 import {
+  buildEquipmentSearchDetailHref,
   formatEquipmentSearchCount,
   getEquipmentSearchMaxCount,
   getEquipmentSearchFacilityText,
@@ -260,32 +263,11 @@ function EquipmentSearchReportTabContent({
 
       {!isInitialEmpty && !searchQuery.isError && !isWaitingForCurrentResult && rows.length > 0 ? (
         <>
-          <div className="grid gap-3 sm:grid-cols-3">
-            <Card>
-              <CardContent className="py-4">
-                <div className="text-2xl font-semibold tabular-nums">
-                  {formatEquipmentSearchCount(summary?.totalEquipmentCount ?? 0)} phù hợp
-                </div>
-                <p className="text-sm text-muted-foreground">với từ khóa</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="py-4">
-                <div className="text-2xl font-semibold tabular-nums">
-                  {(summary?.regionCount ?? 0).toLocaleString("vi-VN")}
-                </div>
-                <p className="text-sm text-muted-foreground">khu vực có kết quả</p>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="py-4">
-                <div className="text-2xl font-semibold tabular-nums">
-                  {(summary?.facilityCount ?? 0).toLocaleString("vi-VN")}
-                </div>
-                <p className="text-sm text-muted-foreground">cơ sở có kết quả</p>
-              </CardContent>
-            </Card>
-          </div>
+          <EquipmentSearchSummaryCards
+            facilityCount={summary?.facilityCount ?? 0}
+            regionCount={summary?.regionCount ?? 0}
+            totalEquipmentCount={summary?.totalEquipmentCount ?? 0}
+          />
 
           <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
             <button
@@ -366,6 +348,7 @@ function EquipmentSearchReportTabContent({
                       const canDrillDown = row.groupType === "region" && row.groupId !== null
                       const quotaContext =
                         groupBy === "facility" ? getEquipmentSearchTableQuotaContext(row) : null
+                      const detailHref = buildEquipmentSearchDetailHref(submittedQuery, row)
 
                       if (quotaContext) {
                         return (
@@ -373,7 +356,15 @@ function EquipmentSearchReportTabContent({
                             key={`${row.groupType}-${row.groupId ?? row.groupName}`}
                             aria-label={`${row.groupName} ${formatEquipmentSearchCount(row.equipmentCount)} ${quotaContext.quotaDisplay} ${quotaContext.statusLabel} ${quotaContext.notesText}`}
                           >
-                            <TableCell className="font-medium">{row.groupName}</TableCell>
+                            <TableCell className="font-medium">
+                              <Link
+                                href={detailHref}
+                                aria-label={`Xem thiết bị ${row.groupName}`}
+                                className="hover:underline"
+                              >
+                                {row.groupName}
+                              </Link>
+                            </TableCell>
                             <TableCell className="text-right font-semibold tabular-nums">
                               {formatEquipmentSearchCount(row.equipmentCount)}
                             </TableCell>
@@ -400,19 +391,24 @@ function EquipmentSearchReportTabContent({
                           <TableCell className="text-muted-foreground">{facilityText}</TableCell>
                           <TableCell className="text-right">
                             {canDrillDown ? (
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="sm"
-                                onClick={() =>
-                                  dispatch({
-                                    type: "select-region",
-                                    region: { id: row.groupId!, name: row.groupName },
-                                  })
-                                }
-                              >
-                                Xem cơ sở {row.groupName}
-                              </Button>
+                              <div className="flex flex-wrap justify-end gap-1">
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() =>
+                                    dispatch({
+                                      type: "select-region",
+                                      region: { id: row.groupId!, name: row.groupName },
+                                    })
+                                  }
+                                >
+                                  Xem cơ sở {row.groupName}
+                                </Button>
+                                <Button asChild variant="ghost" size="sm">
+                                  <Link href={detailHref}>Xem thiết bị {row.groupName}</Link>
+                                </Button>
+                              </div>
                             ) : (
                               <span className="text-xs text-muted-foreground">Tổng hợp</span>
                             )}

--- a/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
+++ b/src/app/(app)/reports/components/equipment-search-report-tab.utils.ts
@@ -58,6 +58,26 @@ export function getEquipmentSearchFacilityText(row: EquipmentAggregateSearchRow)
   return `${count.toLocaleString("vi-VN")} cơ sở`
 }
 
+/** Builds the equipment page deep-link for read-only detail inspection. */
+export function buildEquipmentSearchDetailHref(
+  query: string,
+  row: EquipmentAggregateSearchRow
+): string {
+  const params = new URLSearchParams()
+  const trimmedQuery = query.trim()
+
+  if (trimmedQuery) {
+    params.set("search", trimmedQuery)
+  }
+
+  if (row.groupId !== null) {
+    params.set(row.groupType === "facility" ? "facility" : "region", String(row.groupId))
+  }
+
+  const search = params.toString()
+  return search ? `/equipment?${search}` : "/equipment"
+}
+
 function formatQuotaNumber(value: number): string {
   return value.toLocaleString("vi-VN")
 }

--- a/src/app/(app)/reports/components/equipment-search-summary-cards.tsx
+++ b/src/app/(app)/reports/components/equipment-search-summary-cards.tsx
@@ -4,10 +4,10 @@ import { Card, CardContent } from "@/components/ui/card"
 
 import { formatEquipmentSearchCount } from "./equipment-search-report-tab.utils"
 
-interface EquipmentSearchSummaryCardsProps {
-  facilityCount: number
-  regionCount: number
-  totalEquipmentCount: number
+export interface EquipmentSearchSummaryCardsProps {
+  readonly facilityCount: number
+  readonly regionCount: number
+  readonly totalEquipmentCount: number
 }
 
 /** Renders aggregate count summary cards for the Reports equipment search tab. */
@@ -15,7 +15,7 @@ export function EquipmentSearchSummaryCards({
   facilityCount,
   regionCount,
   totalEquipmentCount,
-}: EquipmentSearchSummaryCardsProps) {
+}: EquipmentSearchSummaryCardsProps): React.JSX.Element {
   return (
     <div className="grid gap-3 sm:grid-cols-3">
       <Card>

--- a/src/app/(app)/reports/components/equipment-search-summary-cards.tsx
+++ b/src/app/(app)/reports/components/equipment-search-summary-cards.tsx
@@ -1,0 +1,47 @@
+import * as React from "react"
+
+import { Card, CardContent } from "@/components/ui/card"
+
+import { formatEquipmentSearchCount } from "./equipment-search-report-tab.utils"
+
+interface EquipmentSearchSummaryCardsProps {
+  facilityCount: number
+  regionCount: number
+  totalEquipmentCount: number
+}
+
+/** Renders aggregate count summary cards for the Reports equipment search tab. */
+export function EquipmentSearchSummaryCards({
+  facilityCount,
+  regionCount,
+  totalEquipmentCount,
+}: EquipmentSearchSummaryCardsProps) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      <Card>
+        <CardContent className="py-4">
+          <div className="text-2xl font-semibold tabular-nums">
+            {formatEquipmentSearchCount(totalEquipmentCount)} phù hợp
+          </div>
+          <p className="text-sm text-muted-foreground">với từ khóa</p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="py-4">
+          <div className="text-2xl font-semibold tabular-nums">
+            {regionCount.toLocaleString("vi-VN")}
+          </div>
+          <p className="text-sm text-muted-foreground">khu vực có kết quả</p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="py-4">
+          <div className="text-2xl font-semibold tabular-nums">
+            {facilityCount.toLocaleString("vi-VN")}
+          </div>
+          <p className="text-sm text-muted-foreground">cơ sở có kết quả</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Hydrate `/equipment?search=...&facility=...` into existing equipment search and facility scope.
- Hydrate `/equipment?search=...&region=...` into search plus all-facility equipment scope without backend/migration changes.
- Add Reports aggregate links only to `/equipment`, while preserving region drill-down and read-only quota context.

## Verification
- `node scripts/npm-run.js exec -- prettier --check <touched files>`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test -- src/app/\(app\)/equipment/__tests__/useEquipmentRouteSync.test.ts src/app/\(app\)/reports/components/__tests__/equipment-search-report-tab.test.tsx src/app/\(app\)/reports/components/__tests__/equipment-search-report-tab.utils.test.ts`
- `node scripts/npm-run.js run react-doctor`

Browser verification skipped per maintainer request. Full repo `format:check` still fails on pre-existing baseline formatting noise; touched files pass Prettier.

Closes #632
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deep links from Reports to the Equipment page so users can open `/equipment` with prefilled `search` and facility or region. Also adds summary cards and improves hydration and cache behavior to keep filters, counts, and pagination accurate, aligning with #632.

- **New Features**
  - Hydrate `search`, `facility`, and `region` from `/equipment?search=...&(facility|region)=...`; `region` sets all-facility scope and keeps the search term; hydrated search resets pagination.
  - Add “Xem thiết bị …” deep links on report rows (region and facility); facility names are clickable links while keeping region drill-down and read-only quota context.
  - Add summary cards for total matches, regions, and facilities; extracted to `EquipmentSearchSummaryCards`.

- **Bug Fixes**
  - For regional leaders: wait when `selectedFacilityId` is `undefined`; allow `null` to fetch across allowed facilities for regional deep-links.
  - Prevent repeated deep-link facility hydration across renders and preserve URLs by not replacing the route; do not rehydrate after a local facility change.
  - Invalidate tenant-scoped caches for equipment list, department distribution, and filter buckets; query keys now isolate by tenant, role, region, and facility. Tests cover cache invalidation, regional all-facility scope, and deep-link hydration.

<sup>Written for commit 3ea8d5bd72dedbcd0e9a6f5347853dea605c358d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added equipment search summary cards to Reports (total matches, regions with results, facilities with results).
  - Updated equipment search results to use direct Next.js “view” links with correct URL query parameters.
- **Bug Fixes**
  - Improved deep-link URL syncing for equipment pages so `search` and location-related filters hydrate correctly without duplicate navigation.
  - Refined regional/facility data-fetch gating so fetching waits only when facility context is pending, not when it’s explicitly unset.
- **Tests**
  - Expanded coverage for route query hydration, pagination resets on hydrated filters, and cache invalidation for equipment data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->