### PR TITLE
Add ZBS repair notification outbox contract

### DIFF
--- a/scripts/verify-zbs-repair-outbox.sql
+++ b/scripts/verify-zbs-repair-outbox.sql
@@ -1,0 +1,202 @@
+begin;
+
+do $$
+declare
+  v_fac_a bigint := -618101;
+  v_fac_b bigint := -618102;
+  v_fac_c bigint := -618103;
+  v_tb_a bigint := -618201;
+  v_tb_b bigint := -618202;
+  v_tb_c bigint := -618203;
+  v_req_a bigint;
+  v_req_b bigint;
+  v_req_c bigint;
+  v_count int;
+  v_phones text[];
+  v_duplicate record;
+begin
+  if to_regclass('public.zbs_recipient_configs') is null then
+    raise exception 'missing public.zbs_recipient_configs';
+  end if;
+
+  if to_regclass('public.zbs_notification_outbox') is null then
+    raise exception 'missing public.zbs_notification_outbox';
+  end if;
+
+  insert into public.don_vi (id, code, name, active)
+  values
+    (v_fac_a, 'ZBS-FAC-A-618', 'ZBS Facility A 618', true),
+    (v_fac_b, 'ZBS-FAC-B-618', 'ZBS Facility B 618', true),
+    (v_fac_c, 'ZBS-FAC-C-618', 'ZBS Facility C 618', true);
+
+  insert into public.nhan_vien
+    (id, username, password, full_name, role, don_vi, current_don_vi, is_active)
+  values
+    (618001, 'zbs-user-a-618', 'test-password', 'ZBS User A 618', 'to_qltb', v_fac_a, v_fac_a, true),
+    (618002, 'zbs-user-b-618', 'test-password', 'ZBS User B 618', 'to_qltb', v_fac_b, v_fac_b, true),
+    (618003, 'zbs-user-c-618', 'test-password', 'ZBS User C 618', 'to_qltb', v_fac_c, v_fac_c, true);
+
+  insert into public.thiet_bi
+    (id, ma_thiet_bi, ten_thiet_bi, don_vi, khoa_phong_quan_ly, tinh_trang_hien_tai, is_deleted)
+  values
+    (v_tb_a, 'ZBS-TB-A-618', 'ZBS Device A 618', v_fac_a, 'ICU', 'Hoat dong', false),
+    (v_tb_b, 'ZBS-TB-B-618', 'ZBS Device B 618', v_fac_b, 'ER', 'Hoat dong', false),
+    (v_tb_c, 'ZBS-TB-C-618', 'ZBS Device C 618', v_fac_c, 'LAB', 'Hoat dong', false);
+
+  insert into public.zbs_recipient_configs (don_vi_id, event_type, recipient_phone, active)
+  values
+    (v_fac_a, 'repair_request_created', '84901111111', true),
+    (v_fac_a, 'repair_request_created', '84902222222', true),
+    (v_fac_a, 'repair_request_created', '84903333333', false),
+    (v_fac_a, 'transfer_request_created', '84905555555', true),
+    (v_fac_b, 'repair_request_created', '84904444444', true),
+    (v_fac_c, 'repair_request_created', '84906666666', false);
+
+  perform set_config('request.jwt.claims', jsonb_build_object(
+    'app_role', 'to_qltb',
+    'user_id', '618001',
+    'don_vi', v_fac_a::text
+  )::text, true);
+
+  v_req_a := public.repair_request_create(
+    v_tb_a::integer,
+    'A needs repair',
+    'Check A',
+    current_date + 3,
+    'Tester A',
+    'noi_bo',
+    null
+  );
+
+  select count(*), array_agg(recipient_phone order by recipient_phone)
+  into v_count, v_phones
+  from public.zbs_notification_outbox
+  where event_type = 'repair_request_created'
+    and source_type = 'repair_request'
+    and source_id = v_req_a;
+
+  if v_count <> 2 or v_phones <> array['84901111111', '84902222222']::text[] then
+    raise exception 'tenant A expected two active recipients only, got count %, phones %', v_count, v_phones;
+  end if;
+
+  if exists (
+    select 1
+    from public.zbs_notification_outbox
+    where source_id = v_req_a
+      and (don_vi_id <> v_fac_a or recipient_phone in ('84903333333', '84904444444', '84905555555'))
+  ) then
+    raise exception 'tenant A outbox leaked inactive, other-event, or other-tenant recipients';
+  end if;
+
+  if exists (
+    select 1
+    from public.zbs_notification_outbox
+    where source_id = v_req_a
+      and (
+        template_data ->> 'equipment_code' <> 'ZBS-TB-A-618'
+        or template_data ->> 'equipment_name' <> 'ZBS Device A 618'
+        or template_data ->> 'issue_description' <> 'A needs repair'
+      )
+  ) then
+    raise exception 'tenant A outbox template_data did not snapshot repair request details';
+  end if;
+
+  perform set_config('request.jwt.claims', jsonb_build_object(
+    'app_role', 'to_qltb',
+    'user_id', '618002',
+    'don_vi', v_fac_b::text
+  )::text, true);
+
+  v_req_b := public.repair_request_create(
+    v_tb_b::integer,
+    'B needs repair',
+    'Check B',
+    current_date + 4,
+    'Tester B',
+    'noi_bo',
+    null
+  );
+
+  select count(*), array_agg(recipient_phone order by recipient_phone)
+  into v_count, v_phones
+  from public.zbs_notification_outbox
+  where event_type = 'repair_request_created'
+    and source_type = 'repair_request'
+    and source_id = v_req_b;
+
+  if v_count <> 1 or v_phones <> array['84904444444']::text[] then
+    raise exception 'tenant B expected only tenant B recipient, got count %, phones %', v_count, v_phones;
+  end if;
+
+  if exists (
+    select 1
+    from public.zbs_notification_outbox
+    where source_id = v_req_b
+      and recipient_phone in ('84901111111', '84902222222')
+  ) then
+    raise exception 'tenant B request enqueued tenant A recipients';
+  end if;
+
+  perform set_config('request.jwt.claims', jsonb_build_object(
+    'app_role', 'to_qltb',
+    'user_id', '618003',
+    'don_vi', v_fac_c::text
+  )::text, true);
+
+  v_req_c := public.repair_request_create(
+    v_tb_c::integer,
+    'C needs repair',
+    'Check C',
+    current_date + 5,
+    'Tester C',
+    'noi_bo',
+    null
+  );
+
+  select count(*)
+  into v_count
+  from public.zbs_notification_outbox
+  where event_type = 'repair_request_created'
+    and source_type = 'repair_request'
+    and source_id = v_req_c;
+
+  if v_count <> 0 then
+    raise exception 'tenant C with no active recipients expected no fallback outbox rows, got %', v_count;
+  end if;
+
+  select *
+  into v_duplicate
+  from public.zbs_notification_outbox
+  where source_id = v_req_a
+  order by recipient_phone
+  limit 1;
+
+  begin
+    insert into public.zbs_notification_outbox (
+      event_type,
+      source_type,
+      source_id,
+      don_vi_id,
+      recipient_config_id,
+      recipient_phone,
+      template_data
+    )
+    values (
+      v_duplicate.event_type,
+      v_duplicate.source_type,
+      v_duplicate.source_id,
+      v_duplicate.don_vi_id,
+      v_duplicate.recipient_config_id,
+      v_duplicate.recipient_phone,
+      v_duplicate.template_data
+    );
+
+    raise exception 'duplicate logical outbox key was accepted';
+  exception
+    when unique_violation then
+      null;
+  end;
+end;
+$$;
+
+rollback;

--- a/supabase/migrations/20260630100000_add_zbs_recipient_config_and_outbox.sql
+++ b/supabase/migrations/20260630100000_add_zbs_recipient_config_and_outbox.sql
@@ -1,0 +1,330 @@
+-- Issue #618 Phase 1: SQL data contract for ZBS repair-request notifications.
+-- Scope:
+-- - Tenant-scoped recipient config.
+-- - Generic notification outbox.
+-- - repair_request_create enqueue for repair_request_created only.
+-- - No dispatcher, outbound Zalo call, webhook handling, feature gate, or transfer events.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.zbs_recipient_configs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  don_vi_id BIGINT NOT NULL REFERENCES public.don_vi(id) ON DELETE RESTRICT,
+  event_type TEXT NOT NULL CHECK (btrim(event_type) <> ''),
+  recipient_phone TEXT NOT NULL CHECK (recipient_phone ~ '^[0-9]{8,15}$'),
+  active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (don_vi_id, event_type, recipient_phone)
+);
+
+CREATE TABLE IF NOT EXISTS public.zbs_notification_outbox (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type TEXT NOT NULL CHECK (btrim(event_type) <> ''),
+  source_type TEXT NOT NULL CHECK (btrim(source_type) <> ''),
+  source_id BIGINT NOT NULL,
+  don_vi_id BIGINT NOT NULL REFERENCES public.don_vi(id) ON DELETE RESTRICT,
+  recipient_config_id UUID NOT NULL REFERENCES public.zbs_recipient_configs(id) ON DELETE RESTRICT,
+  recipient_phone TEXT NOT NULL CHECK (recipient_phone ~ '^[0-9]{8,15}$'),
+  template_id TEXT,
+  template_data JSONB NOT NULL DEFAULT '{}'::jsonb
+    CHECK (jsonb_typeof(template_data) = 'object'),
+  tracking_id TEXT NOT NULL DEFAULT gen_random_uuid()::text,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'sent', 'delivered', 'failed', 'cancelled')),
+  attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_attempt_at TIMESTAMPTZ,
+  provider TEXT NOT NULL DEFAULT 'zalo_zbs' CHECK (provider = 'zalo_zbs'),
+  provider_message_id TEXT,
+  provider_response JSONB,
+  last_error_code TEXT,
+  last_error_message TEXT,
+  sent_at TIMESTAMPTZ,
+  delivered_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (event_type, source_type, source_id, recipient_config_id)
+);
+
+CREATE INDEX IF NOT EXISTS zbs_recipient_configs_active_lookup_idx
+  ON public.zbs_recipient_configs (don_vi_id, event_type)
+  WHERE active;
+
+CREATE INDEX IF NOT EXISTS zbs_notification_outbox_pending_dispatch_idx
+  ON public.zbs_notification_outbox (status, next_attempt_at, created_at)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS zbs_notification_outbox_don_vi_idx
+  ON public.zbs_notification_outbox (don_vi_id);
+
+CREATE INDEX IF NOT EXISTS zbs_notification_outbox_recipient_config_idx
+  ON public.zbs_notification_outbox (recipient_config_id);
+
+CREATE INDEX IF NOT EXISTS zbs_notification_outbox_source_idx
+  ON public.zbs_notification_outbox (source_type, source_id);
+
+CREATE OR REPLACE FUNCTION public.touch_zbs_notification_contract_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_zbs_recipient_configs_updated_at
+  ON public.zbs_recipient_configs;
+CREATE TRIGGER trg_zbs_recipient_configs_updated_at
+BEFORE UPDATE ON public.zbs_recipient_configs
+FOR EACH ROW
+EXECUTE FUNCTION public.touch_zbs_notification_contract_updated_at();
+
+DROP TRIGGER IF EXISTS trg_zbs_notification_outbox_updated_at
+  ON public.zbs_notification_outbox;
+CREATE TRIGGER trg_zbs_notification_outbox_updated_at
+BEFORE UPDATE ON public.zbs_notification_outbox
+FOR EACH ROW
+EXECUTE FUNCTION public.touch_zbs_notification_contract_updated_at();
+
+ALTER TABLE public.zbs_recipient_configs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.zbs_notification_outbox ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS zbs_recipient_configs_no_client_access
+  ON public.zbs_recipient_configs;
+CREATE POLICY zbs_recipient_configs_no_client_access
+  ON public.zbs_recipient_configs
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+DROP POLICY IF EXISTS zbs_notification_outbox_no_client_access
+  ON public.zbs_notification_outbox;
+CREATE POLICY zbs_notification_outbox_no_client_access
+  ON public.zbs_notification_outbox
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+REVOKE ALL ON public.zbs_recipient_configs FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON public.zbs_notification_outbox FROM PUBLIC, anon, authenticated;
+GRANT ALL ON public.zbs_recipient_configs TO service_role;
+GRANT ALL ON public.zbs_notification_outbox TO service_role;
+REVOKE ALL ON FUNCTION public.touch_zbs_notification_contract_updated_at()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.touch_zbs_notification_contract_updated_at()
+  TO service_role;
+
+COMMENT ON TABLE public.zbs_recipient_configs IS
+  'Server-only tenant-scoped ZBS recipient configuration. Client roles have no direct table access.';
+
+COMMENT ON TABLE public.zbs_notification_outbox IS
+  'Server-only generic notification outbox for Zalo ZBS delivery. Phase 1 only enqueues repair request notifications.';
+
+COMMENT ON COLUMN public.zbs_notification_outbox.template_data IS
+  'Internal semantic snapshot for dispatcher mapping to provider-approved ZBS template fields.';
+
+CREATE OR REPLACE FUNCTION public.repair_request_create(
+  p_thiet_bi_id integer,
+  p_mo_ta_su_co text,
+  p_hang_muc_sua_chua text,
+  p_ngay_mong_muon_hoan_thanh date,
+  p_nguoi_yeu_cau text,
+  p_don_vi_thuc_hien text,
+  p_ten_don_vi_thue text
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_id integer;
+  v_claims jsonb;
+  v_role text;
+  v_is_global boolean := false;
+  v_user_id bigint;
+  v_don_vi bigint;
+  v_department_scope text;
+  v_tb record;
+  v_snapshot_status text;
+BEGIN
+  v_claims := coalesce(current_setting('request.jwt.claims', true), '{}'::text)::jsonb;
+  v_role := lower(coalesce(nullif(v_claims->>'app_role', ''), nullif(v_claims->>'role', '')));
+  v_is_global := v_role in ('global', 'admin');
+  v_user_id := nullif(v_claims->>'user_id', '')::bigint;
+  v_don_vi := nullif(v_claims->>'don_vi', '')::bigint;
+
+  IF v_role IS NULL OR v_role = '' THEN
+    RAISE EXCEPTION 'Missing role claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing user_id claim in JWT' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'regional_leader' THEN
+    RAISE EXCEPTION 'Permission denied' USING errcode = '42501';
+  END IF;
+
+  IF NOT v_is_global AND v_don_vi IS NULL THEN
+    RAISE EXCEPTION 'Missing don_vi claim for non-global role %', v_role USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_claims->>'khoa_phong');
+  END IF;
+
+  SELECT
+    tb.id,
+    tb.don_vi,
+    tb.khoa_phong_quan_ly,
+    tb.tinh_trang_hien_tai,
+    tb.ma_thiet_bi,
+    tb.ten_thiet_bi
+  INTO v_tb
+  FROM public.thiet_bi tb
+  WHERE tb.id = p_thiet_bi_id
+    AND tb.is_deleted = false
+  FOR UPDATE OF tb;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Thiết bị không tồn tại' USING errcode = 'P0002';
+  END IF;
+
+  IF NOT v_is_global AND v_tb.don_vi IS DISTINCT FROM v_don_vi THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc đơn vị khác' USING errcode = '42501';
+  END IF;
+
+  IF v_role = 'user'
+     AND (
+       v_department_scope IS NULL
+       OR public._normalize_department_scope(v_tb.khoa_phong_quan_ly) IS DISTINCT FROM v_department_scope
+     ) THEN
+    RAISE EXCEPTION 'Không có quyền trên thiết bị thuộc khoa/phòng khác' USING errcode = '42501';
+  END IF;
+
+  v_snapshot_status := v_tb.tinh_trang_hien_tai;
+
+  IF v_tb.tinh_trang_hien_tai = 'Chờ sửa chữa' THEN
+    SELECT ycss.tinh_trang_thiet_bi_truoc_yeu_cau
+    INTO v_snapshot_status
+    FROM public.yeu_cau_sua_chua ycss
+    WHERE ycss.thiet_bi_id = p_thiet_bi_id
+      AND ycss.trang_thai IN ('Chờ xử lý', 'Đã duyệt', 'Không HT')
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau IS NOT NULL
+      AND ycss.tinh_trang_thiet_bi_truoc_yeu_cau <> 'Chờ sửa chữa'
+    ORDER BY ycss.id DESC
+    LIMIT 1;
+
+    v_snapshot_status := coalesce(
+      v_snapshot_status,
+      nullif(v_tb.tinh_trang_hien_tai, 'Chờ sửa chữa'),
+      'Hoạt động'
+    );
+  END IF;
+
+  INSERT INTO public.yeu_cau_sua_chua(
+    thiet_bi_id,
+    mo_ta_su_co,
+    hang_muc_sua_chua,
+    ngay_mong_muon_hoan_thanh,
+    nguoi_yeu_cau,
+    trang_thai,
+    don_vi_thuc_hien,
+    ten_don_vi_thue,
+    tinh_trang_thiet_bi_truoc_yeu_cau
+  )
+  VALUES (
+    p_thiet_bi_id,
+    p_mo_ta_su_co,
+    p_hang_muc_sua_chua,
+    p_ngay_mong_muon_hoan_thanh,
+    p_nguoi_yeu_cau,
+    'Chờ xử lý',
+    p_don_vi_thuc_hien,
+    p_ten_don_vi_thue,
+    v_snapshot_status
+  )
+  RETURNING id INTO v_id;
+
+  PERFORM public.repair_request_sync_equipment_status(p_thiet_bi_id::bigint);
+
+  INSERT INTO public.lich_su_thiet_bi(thiet_bi_id, loai_su_kien, mo_ta, chi_tiet, yeu_cau_id)
+  VALUES (
+    p_thiet_bi_id,
+    'Sửa chữa',
+    'Tạo yêu cầu sửa chữa',
+    jsonb_build_object(
+      'mo_ta_su_co', p_mo_ta_su_co,
+      'hang_muc', p_hang_muc_sua_chua,
+      'ngay_mong_muon_hoan_thanh', p_ngay_mong_muon_hoan_thanh,
+      'don_vi_thuc_hien', p_don_vi_thuc_hien,
+      'ten_don_vi_thue', p_ten_don_vi_thue
+    ),
+    v_id
+  );
+
+  IF NOT public.audit_log(
+    'repair_request_create',
+    'repair_request',
+    v_id,
+    NULL,
+    jsonb_build_object(
+      'thiet_bi_id', p_thiet_bi_id,
+      'mo_ta_su_co', p_mo_ta_su_co
+    )
+  ) THEN
+    RAISE EXCEPTION 'audit_log failed for repair_request %', v_id;
+  END IF;
+
+  INSERT INTO public.zbs_notification_outbox (
+    event_type,
+    source_type,
+    source_id,
+    don_vi_id,
+    recipient_config_id,
+    recipient_phone,
+    template_data,
+    tracking_id
+  )
+  SELECT
+    'repair_request_created',
+    'repair_request',
+    v_id,
+    v_tb.don_vi,
+    cfg.id,
+    cfg.recipient_phone,
+    jsonb_build_object(
+      'repair_request_id', v_id,
+      'equipment_id', v_tb.id,
+      'equipment_code', v_tb.ma_thiet_bi,
+      'equipment_name', v_tb.ten_thiet_bi,
+      'department', v_tb.khoa_phong_quan_ly,
+      'issue_description', p_mo_ta_su_co,
+      'repair_scope', p_hang_muc_sua_chua,
+      'requested_completion_date', p_ngay_mong_muon_hoan_thanh,
+      'requester', p_nguoi_yeu_cau,
+      'don_vi_id', v_tb.don_vi,
+      'don_vi_thuc_hien', p_don_vi_thuc_hien,
+      'ten_don_vi_thue', p_ten_don_vi_thue
+    ),
+    format('repair_request:%s:%s', v_id, cfg.id)
+  FROM public.zbs_recipient_configs cfg
+  WHERE cfg.don_vi_id = v_tb.don_vi
+    AND cfg.event_type = 'repair_request_created'
+    AND cfg.active = true
+  ON CONFLICT (event_type, source_type, source_id, recipient_config_id) DO NOTHING;
+
+  RETURN v_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.repair_request_create(integer, text, text, date, text, text, text) FROM PUBLIC;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add tenant-scoped ZBS recipient config table and generic notification outbox
- enqueue repair_request_created rows from repair_request_create for active same-tenant recipients only
- add rollback-only SQL smoke covering tenant isolation, inactive recipients, no fallback, multiple recipients, and idempotency

## Verification
- Supabase MCP apply_migration: add_zbs_recipient_config_and_outbox
- Supabase MCP execute_sql: scripts/verify-zbs-repair-outbox.sql passed inside rollback transaction
- Supabase MCP get_advisors(security): reviewed; no new ZBS-specific findings observed, existing baseline advisories remain
- node scripts/npm-run.js npx prettier --check --ignore-unknown scripts/verify-zbs-repair-outbox.sql supabase/migrations/20260630100000_add_zbs_recipient_config_and_outbox.sql
- pre-push hook: typecheck, verify:dedupe, verify:no-explicit-any

Closes #618
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/thienchi2109/qltbyt-nam-phong/pull/641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tenant-scoped ZBS recipient config and a generic notification outbox, and enqueues a repair-request notification when a repair request is created. Delivers Phase 1 of #618 with strict tenant isolation and idempotent inserts.

- **New Features**
  - `public.zbs_recipient_configs`: per-tenant recipients by event; active flag; unique (don_vi_id, event_type, recipient_phone); RLS denies client access.
  - `public.zbs_notification_outbox`: provider 'zalo_zbs', status/attempt fields, unique (event_type, source_type, source_id, recipient_config_id); indexes for dispatch/lookups; RLS denies client access.
  - `public.repair_request_create(...)` enqueues `repair_request_created` for active same-tenant configs only, with template_data snapshot; ON CONFLICT ensures idempotency.
  - Rollback-only SQL test validates tenant isolation, inactive recipients ignored, no fallback when none active, multi-recipient enqueue, and duplicate-key rejection.

- **Migration**
  - Run `20260630100000_add_zbs_recipient_config_and_outbox.sql`.
  - Optional: run `scripts/verify-zbs-repair-outbox.sql` to smoke-test inside a transaction.

<sup>Written for commit 7861aa675554adf2a189748aa567ccc19d43a659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automated repair-request notifications, including tenant-specific recipient settings and delivery tracking.
  * Repair request creation now records a snapshot of key equipment details and updates request history more consistently.

* **Bug Fixes**
  * Improved access checks so repair requests respect the current tenant and user scope.
  * Prevented duplicate notification entries and ensured notifications only go to active recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->