### PR TITLE
Disable legacy repair request push trigger

### DIFF
--- a/scripts/verify-zbs-repair-outbox.sql
+++ b/scripts/verify-zbs-repair-outbox.sql
@@ -23,6 +23,20 @@ begin
     raise exception 'missing public.zbs_notification_outbox';
   end if;
 
+  if exists (
+    select 1
+    from pg_trigger t
+    join pg_class c on c.oid = t.tgrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = 'yeu_cau_sua_chua'
+      and t.tgname = 'on_repair_request_created'
+      and t.tgenabled <> 'D'
+      and not t.tgisinternal
+  ) then
+    raise exception 'legacy repair request push trigger must be disabled before ZBS outbox dispatch';
+  end if;
+
   insert into public.don_vi (id, code, name, active)
   values
     (v_fac_a, 'ZBS-FAC-A-618', 'ZBS Facility A 618', true),

--- a/supabase/migrations/20260630103000_disable_legacy_repair_request_push_trigger.sql
+++ b/supabase/migrations/20260630103000_disable_legacy_repair_request_push_trigger.sql
@@ -1,0 +1,17 @@
+-- Issue #618 follow-up: prevent legacy push trigger from running beside ZBS outbox.
+--
+-- The new repair_request_create path enqueues repair_request_created rows into
+-- zbs_notification_outbox. The older AFTER INSERT trigger on yeu_cau_sua_chua
+-- calls send-push-notification through pg_net for the same repair-created
+-- event. Keep the legacy function available for audit/rollback context, but
+-- remove the automatic trigger path so future ZBS dispatch is the single
+-- repair-created outbound notification mechanism.
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS on_repair_request_created ON public.yeu_cau_sua_chua;
+
+COMMENT ON FUNCTION public.handle_new_repair_request_notification() IS
+  'Deprecated legacy repair-created push path. Automatic trigger disabled by migration 20260630103000; ZBS notifications use public.zbs_notification_outbox.';
+
+COMMIT;


### PR DESCRIPTION
## Triage
The review comment is valid. Live DB still had on_repair_request_created enabled on public.yeu_cau_sua_chua, calling handle_new_repair_request_notification() after every repair request insert. That legacy function uses pg_net to call send-push-notification, creating a second automatic notification path beside the new ZBS outbox contract.

## Summary
- add forward-only migration 20260630103000_disable_legacy_repair_request_push_trigger.sql
- drop only the legacy automatic trigger; leave the function in place with a deprecation comment for audit/rollback context
- extend scripts/verify-zbs-repair-outbox.sql to fail if the legacy trigger is enabled

## Verification
- RED: Supabase MCP execute_sql trigger assertion failed before migration with legacy repair request push trigger must be disabled before ZBS outbox dispatch
- Supabase MCP apply_migration: disable_legacy_repair_request_push_trigger
- GREEN: full scripts/verify-zbs-repair-outbox.sql passed in rollback transaction
- Supabase MCP trigger query returned no on_repair_request_created rows
- Supabase MCP get_advisors(security): reviewed; existing baseline advisories remain
- node scripts/npm-run.js npx prettier --check --ignore-unknown scripts/verify-zbs-repair-outbox.sql supabase/migrations/20260630103000_disable_legacy_repair_request_push_trigger.sql
- pre-push hook: typecheck, verify:dedupe, verify:no-explicit-any