### PR TITLE
feat: enable gated ZBS live dispatch

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,4 @@
 # Automatic analysis config.
 # Supabase migrations are append-only operational history. Follow-up migrations
 # may intentionally repeat CREATE OR REPLACE bodies and should not fail CPD.
-sonar.cpd.exclusions=supabase/migrations/20260524153000_add_auth_login_attempt_throttle.sql,supabase/migrations/20260524162000_fix_auth_login_throttle_bucket_reset.sql
+sonar.cpd.exclusions=supabase/migrations/**

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A comprehensive web application for managing medical equipment, built with moder
 ## 📋 Core Features
 
 ### Equipment Management
+
 - Complete equipment lifecycle tracking
 - QR code generation and scanning
 - Real-time status monitoring
@@ -23,6 +24,7 @@ A comprehensive web application for managing medical equipment, built with moder
 - Equipment history and audit trails
 
 ### Maintenance & Repairs
+
 - Scheduled maintenance planning
 - Repair request workflow
 - Approval processes
@@ -30,12 +32,14 @@ A comprehensive web application for managing medical equipment, built with moder
 - Completion tracking
 
 ### Multi-Tenant Architecture
+
 - Department-based data isolation
 - Role-based access control
 - Tenant switching capabilities
 - Secure data segregation
 
 ### User Management
+
 - Role-based permissions
 - Password management
 - Admin controls
@@ -46,6 +50,7 @@ A comprehensive web application for managing medical equipment, built with moder
 **This project uses NextAuth v4 for authentication** (NOT custom auth context).
 
 ### Key Components
+
 - **Provider**: NextAuth v4 with CredentialsProvider
 - **Session**: JWT strategy (3-hour expiry)
 - **Database**: Supabase RPC `authenticate_user_dual_mode`
@@ -53,6 +58,7 @@ A comprehensive web application for managing medical equipment, built with moder
 - **Multi-tenant**: JWT claims for role, department, tenant
 
 ### User Roles
+
 - `global` - Full system access across all tenants
 - `admin` - Administrative access (legacy compatibility)
 - `to_qltb` - Equipment management team
@@ -62,6 +68,7 @@ A comprehensive web application for managing medical equipment, built with moder
 ## 🛠️ Development Setup
 
 ### Equipment Page Behavior (Global/Admin)
+
 - To reduce initial DB load and avoid confusion, the equipment list does not fetch until you select a tenant filter.
 - A tip appears: "Vui lòng chọn đơn vị cụ thể ở bộ lọc để xem dữ liệu thiết bị".
 - Your last tenant selection is remembered via localStorage (key: `equipment_tenant_filter`).
@@ -69,11 +76,13 @@ A comprehensive web application for managing medical equipment, built with moder
 - Fetching is powered by TanStack Query with `enabled` gating and scoped caching.
 
 ### Prerequisites
-- Node.js 18+ 
+
+- Node.js 18+
 - npm (preferred package manager)
 - Supabase project
 
 ### Environment Variables
+
 Create a `.env.local` file in the root directory:
 
 ```env
@@ -82,6 +91,7 @@ NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 SUPABASE_JWT_SECRET=your_supabase_jwt_secret
+ZBS_INTERNAL_RPC_SECRET=your_dedicated_zbs_internal_rpc_secret
 
 # NextAuth Configuration
 AUTH_SECRET=your_nextauth_secret_key
@@ -173,12 +183,14 @@ public/
 ## 🗄️ Database Architecture
 
 ### Multi-Tenant Design
+
 - **Strategy**: No-RLS, RPC-only architecture
 - **Data Isolation**: Tenant-scoped SQL RPCs
 - **Security**: JWT-based access control
 - **Performance**: Optimized for Vietnamese healthcare workflows
 
 ### Key Tables
+
 - `nhan_vien` - User accounts and roles
 - `don_vi` - Organizational units (tenants)
 - `thiet_bi` - Equipment records
@@ -189,6 +201,7 @@ public/
 ## 🌐 Deployment
 
 ### Vercel
+
 1. Connect repository to Vercel
 2. Configure environment variables
 3. Deploy automatically on push
@@ -196,6 +209,7 @@ public/
 ## 📱 PWA Support
 
 The application includes Progressive Web App features:
+
 - Offline functionality
 - Install prompts
 - Service worker for caching

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -3,9 +3,11 @@
 Note: CLAUDE.md is the authoritative source for security, architecture, and conventions. This document summarizes and normalizes project expectations for OpenSpec-driven work.
 
 ## Purpose
+
 Vietnamese Medical Equipment Management System (Hệ thống quản lý thiết bị y tế) — multi-tenant web application for healthcare institutions in Vietnam. Focused on secure tenant isolation, efficient device lifecycle workflows (inventory, repair, maintenance, transfers), and professional, mobile-friendly UX.
 
 ## Tech Stack
+
 - App framework: Next.js 15 (App Router), React 18, TypeScript (strict)
 - Styling/UI: Tailwind CSS, Radix UI primitives, lucide-react icons
 - Forms/validation: react-hook-form + zod
@@ -19,6 +21,7 @@ Vietnamese Medical Equipment Management System (Hệ thống quản lý thiết 
 ## Project Conventions
 
 ### Code Style
+
 - TypeScript strict; never use `any`; explicit exports and return types
 - ESLint only (no Prettier); follow existing file style
 - Imports: always use `@/*` alias; grouping order: core → third-party → components → lib → types
@@ -27,6 +30,7 @@ Vietnamese Medical Equipment Management System (Hệ thống quản lý thiết 
 - Vietnamese language in all user-facing strings
 
 ### Architecture Patterns
+
 - RPC-Only Architecture
   - All DB access goes through Supabase RPC functions via `/api/rpc/[fn]` proxy
   - Whitelist `ALLOWED_FUNCTIONS`; reject unknown function names
@@ -48,11 +52,13 @@ Vietnamese Medical Equipment Management System (Hệ thống quản lý thiết 
   - Responsive, mobile-first; PWA helpers for prod
 
 ### Testing Strategy
+
 - No full test runner yet; sample Jest-style tests in `src/lib/__tests__/`
 - Mandatory: `npm run typecheck` before commits/PRs
 - Focus areas: multi-tenant isolation (role claims), error scenarios (not only happy paths), RPC client error parsing
 
 ### Git Workflow
+
 - Branching: feature branches `feat/<scope>`, fixes `fix/<scope>`, docs `docs/<scope>`, chore `chore/<scope>`
 - Commits: Conventional Commit style recommended (e.g., `feat(rr): sticky columns`)
 - PRs: prefer PRs over direct pushes; keep atomic and focused
@@ -60,6 +66,7 @@ Vietnamese Medical Equipment Management System (Hệ thống quản lý thiết 
 - Migrations: commit SQL files to `supabase/migrations/` for history; apply manually in Supabase SQL Editor (no CLI auto-apply)
 
 ## Domain Context
+
 - Core entities (tables):
   - `nhan_vien` (users), `don_vi` (tenants), `dia_ban` (regions)
   - `thiet_bi` (equipment), `yeu_cau_sua_chua` (repair requests)
@@ -71,15 +78,17 @@ Vietnamese Medical Equipment Management System (Hệ thống quản lý thiết 
 - UX: Vietnamese terminology; dashboard with KPIs; mobile-friendly list/card layouts
 
 ## Important Constraints
+
 - Security-first healthcare app with strict tenant isolation
 - Absolutely no direct Supabase table access from app code; RPC-only via `/api/rpc/[fn]`
 - Never trust client `p_don_vi` (proxy overrides for non-global/regional)
 - No RLS; all checks in RPC and API proxy level
 - Type safety mandatory; do not bypass with `@ts-ignore`
 - Package manager: `npm` only (no pnpm/yarn)
-- Environment variables required: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`, `AUTH_SECRET`, `NEXTAUTH_SECRET`. `AUTH_MIDDLEWARE_ENABLED` is optional and only honored outside production (production always enforces middleware regardless of this flag).
+- Environment variables required: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`, `ZBS_INTERNAL_RPC_SECRET`, `AUTH_SECRET`, `NEXTAUTH_SECRET`. `AUTH_MIDDLEWARE_ENABLED` is optional and only honored outside production (production always enforces middleware regardless of this flag).
 
 ## External Dependencies
+
 - Supabase (PostgreSQL, PostgREST RPC)
 - NextAuth (authentication)
 - Vercel
@@ -88,6 +97,7 @@ Vietnamese Medical Equipment Management System (Hệ thống quản lý thiết 
 - Utilities: QR code generation/scanning, Excel export helpers (where used)
 
 ## References
+
 - Architecture and rules: `CLAUDE.md`
 - Critical files:
   - `src/app/api/rpc/[fn]/route.ts` (RPC proxy, security)

--- a/scripts/verify-zbs-live-dispatch.sql
+++ b/scripts/verify-zbs-live-dispatch.sql
@@ -10,6 +10,17 @@ DECLARE
   v_final_id uuid;
   v_stale_id uuid;
   v_claimed_count integer;
+  v_sent_claimed_at timestamptz;
+  v_retry_claimed_at timestamptz;
+  v_final_retry_claimed_at timestamptz;
+  v_final_claimed_at timestamptz;
+  v_stale_claimed_at timestamptz;
+  v_stale_reclaimed_at timestamptz;
+  v_target_rpcs regprocedure[] := ARRAY[
+    'public.zbs_notification_outbox_claim_for_dispatch(integer,timestamptz,uuid[])'::regprocedure,
+    'public.zbs_notification_outbox_mark_sent(uuid,timestamptz,text,timestamptz,jsonb)'::regprocedure,
+    'public.zbs_notification_outbox_mark_failed(uuid,timestamptz,boolean,text,text,jsonb)'::regprocedure
+  ];
 BEGIN
   SELECT id
     INTO v_don_vi_id
@@ -129,6 +140,35 @@ BEGIN
       NULL;
   END;
 
+  BEGIN
+    PERFORM public.zbs_notification_outbox_mark_sent(
+      v_sent_id,
+      now(),
+      'provider-msg-forbidden',
+      now(),
+      '{}'::jsonb
+    );
+    RAISE EXCEPTION 'mark_sent RPC did not reject non-service_role JWT';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+
+  BEGIN
+    PERFORM public.zbs_notification_outbox_mark_failed(
+      v_retry_id,
+      now(),
+      true,
+      'http_503',
+      'temporary outage',
+      '{}'::jsonb
+    );
+    RAISE EXCEPTION 'mark_failed RPC did not reject non-service_role JWT';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+
   PERFORM set_config(
     'request.jwt.claims',
     '{"role":"service_role","app_role":"to_qltb","user_id":"verify-zbs-live-dispatch"}',
@@ -137,10 +177,25 @@ BEGIN
 
   SELECT count(*) INTO v_claimed_count
   FROM public.zbs_notification_outbox_claim_for_dispatch(
+    0,
+    now(),
+    ARRAY[v_sent_id]
+  );
+
+  IF v_claimed_count <> 0 THEN
+    RAISE EXCEPTION 'expected explicit p_limit=0 to claim no rows, got %', v_claimed_count;
+  END IF;
+
+  CREATE TEMP TABLE zbs_live_dispatch_claimed ON COMMIT DROP AS
+  SELECT *
+  FROM public.zbs_notification_outbox_claim_for_dispatch(
     10,
     now(),
     ARRAY[v_sent_id, v_retry_id, v_final_retry_id, v_final_id, v_stale_id]
   );
+
+  SELECT count(*) INTO v_claimed_count
+  FROM zbs_live_dispatch_claimed;
 
   IF v_claimed_count <> 5 THEN
     RAISE EXCEPTION 'expected 5 claimed rows including stale processing, got %', v_claimed_count;
@@ -166,8 +221,61 @@ BEGIN
     RAISE EXCEPTION 'stale processing row was not reclaimed with a fresh lease';
   END IF;
 
+  SELECT
+    (SELECT last_attempt_at FROM zbs_live_dispatch_claimed WHERE id = v_sent_id),
+    (SELECT last_attempt_at FROM zbs_live_dispatch_claimed WHERE id = v_retry_id),
+    (SELECT last_attempt_at FROM zbs_live_dispatch_claimed WHERE id = v_final_retry_id),
+    (SELECT last_attempt_at FROM zbs_live_dispatch_claimed WHERE id = v_final_id),
+    (SELECT last_attempt_at FROM zbs_live_dispatch_claimed WHERE id = v_stale_id)
+  INTO
+    v_sent_claimed_at,
+    v_retry_claimed_at,
+    v_final_retry_claimed_at,
+    v_final_claimed_at,
+    v_stale_claimed_at;
+
+  IF v_sent_claimed_at IS NULL
+    OR v_retry_claimed_at IS NULL
+    OR v_final_retry_claimed_at IS NULL
+    OR v_final_claimed_at IS NULL
+    OR v_stale_claimed_at IS NULL THEN
+    RAISE EXCEPTION 'claim RPC did not return lease timestamps';
+  END IF;
+
+  UPDATE public.zbs_notification_outbox
+  SET last_attempt_at = v_stale_claimed_at - interval '15 minutes'
+  WHERE id = v_stale_id;
+
+  SELECT last_attempt_at INTO v_stale_reclaimed_at
+  FROM public.zbs_notification_outbox_claim_for_dispatch(
+    1,
+    v_stale_claimed_at + interval '20 minutes',
+    ARRAY[v_stale_id]
+  )
+  LIMIT 1;
+
+  IF v_stale_reclaimed_at IS NULL OR v_stale_reclaimed_at = v_stale_claimed_at THEN
+    RAISE EXCEPTION 'stale processing row was not reclaimed with a new lease timestamp';
+  END IF;
+
+  BEGIN
+    PERFORM public.zbs_notification_outbox_mark_failed(
+      v_stale_id,
+      v_stale_claimed_at,
+      false,
+      'stale_lease',
+      'old dispatcher finished late',
+      '{}'::jsonb
+    );
+    RAISE EXCEPTION 'mark_failed accepted a stale processing lease';
+  EXCEPTION
+    WHEN no_data_found THEN
+      NULL;
+  END;
+
   PERFORM public.zbs_notification_outbox_mark_sent(
     v_sent_id,
+    v_sent_claimed_at,
     'provider-msg-1',
     now(),
     jsonb_build_object('error', 0, 'data', jsonb_build_object('msg_id', 'provider-msg-1'))
@@ -187,6 +295,7 @@ BEGIN
 
   PERFORM public.zbs_notification_outbox_mark_failed(
     v_retry_id,
+    v_retry_claimed_at,
     true,
     'http_503',
     'temporary outage',
@@ -207,6 +316,7 @@ BEGIN
 
   PERFORM public.zbs_notification_outbox_mark_failed(
     v_final_retry_id,
+    v_final_retry_claimed_at,
     true,
     'http_503',
     'too many attempts',
@@ -226,6 +336,7 @@ BEGIN
 
   PERFORM public.zbs_notification_outbox_mark_failed(
     v_final_id,
+    v_final_claimed_at,
     false,
     'zalo_-1121',
     'issue_summary data breaks max length',
@@ -244,14 +355,8 @@ BEGIN
 
   IF (
     SELECT count(*)
-    FROM pg_proc p
-    JOIN pg_namespace n ON n.oid = p.pronamespace
-    WHERE n.nspname = 'public'
-      AND p.proname IN (
-        'zbs_notification_outbox_claim_for_dispatch',
-        'zbs_notification_outbox_mark_sent',
-        'zbs_notification_outbox_mark_failed'
-      )
+    FROM unnest(v_target_rpcs) AS target(fn)
+    JOIN pg_proc p ON p.oid = target.fn::oid
   ) <> 3 THEN
     RAISE EXCEPTION 'expected exactly three ZBS live dispatch RPCs';
   END IF;
@@ -259,14 +364,8 @@ BEGIN
   IF EXISTS (
     WITH target AS (
       SELECT p.oid, p.proacl, p.proowner
-      FROM pg_proc p
-      JOIN pg_namespace n ON n.oid = p.pronamespace
-      WHERE n.nspname = 'public'
-        AND p.proname IN (
-          'zbs_notification_outbox_claim_for_dispatch',
-          'zbs_notification_outbox_mark_sent',
-          'zbs_notification_outbox_mark_failed'
-        )
+      FROM unnest(v_target_rpcs) AS target(fn)
+      JOIN pg_proc p ON p.oid = target.fn::oid
     ),
     grants AS (
       SELECT
@@ -290,13 +389,7 @@ BEGIN
   IF EXISTS (
     SELECT 1
     FROM pg_proc p
-    JOIN pg_namespace n ON n.oid = p.pronamespace
-    WHERE n.nspname = 'public'
-      AND p.proname IN (
-        'zbs_notification_outbox_claim_for_dispatch',
-        'zbs_notification_outbox_mark_sent',
-        'zbs_notification_outbox_mark_failed'
-      )
+    JOIN unnest(v_target_rpcs) AS target(fn) ON p.oid = target.fn::oid
       AND (
         NOT has_function_privilege('service_role', p.oid, 'EXECUTE')
         OR has_function_privilege('anon', p.oid, 'EXECUTE')

--- a/scripts/verify-zbs-live-dispatch.sql
+++ b/scripts/verify-zbs-live-dispatch.sql
@@ -1,0 +1,212 @@
+BEGIN;
+
+DO $$
+DECLARE
+  v_don_vi_id bigint;
+  v_recipient_id uuid;
+  v_sent_id uuid;
+  v_retry_id uuid;
+  v_final_retry_id uuid;
+  v_final_id uuid;
+  v_claimed_count integer;
+  v_acl text;
+BEGIN
+  SELECT id
+    INTO v_don_vi_id
+  FROM public.don_vi
+  ORDER BY id
+  LIMIT 1;
+
+  IF v_don_vi_id IS NULL THEN
+    RAISE EXCEPTION 'verify-zbs-live-dispatch requires at least one public.don_vi row';
+  END IF;
+
+  INSERT INTO public.zbs_recipient_configs (don_vi_id, event_type, recipient_phone, active)
+  VALUES (v_don_vi_id, 'repair_request_created', '84900000001', true)
+  RETURNING id INTO v_recipient_id;
+
+  INSERT INTO public.zbs_notification_outbox (
+    event_type,
+    source_type,
+    source_id,
+    don_vi_id,
+    recipient_config_id,
+    recipient_phone,
+    template_id,
+    template_data,
+    tracking_id
+  )
+  VALUES
+    (
+      'repair_request_created',
+      'repair_request',
+      -90001,
+      v_don_vi_id,
+      v_recipient_id,
+      '84900000001',
+      'template-test',
+      jsonb_build_object('repair_request_id', -90001),
+      'verify-zbs-live-dispatch:sent'
+    ),
+    (
+      'repair_request_created',
+      'repair_request',
+      -90002,
+      v_don_vi_id,
+      v_recipient_id,
+      '84900000001',
+      'template-test',
+      jsonb_build_object('repair_request_id', -90002),
+      'verify-zbs-live-dispatch:retry'
+    ),
+    (
+      'repair_request_created',
+      'repair_request',
+      -90003,
+      v_don_vi_id,
+      v_recipient_id,
+      '84900000001',
+      'template-test',
+      jsonb_build_object('repair_request_id', -90003),
+      'verify-zbs-live-dispatch:final-retry'
+    ),
+    (
+      'repair_request_created',
+      'repair_request',
+      -90004,
+      v_don_vi_id,
+      v_recipient_id,
+      '84900000001',
+      'template-test',
+      jsonb_build_object('repair_request_id', -90004),
+      'verify-zbs-live-dispatch:final'
+    );
+
+  SELECT id INTO v_sent_id
+  FROM public.zbs_notification_outbox
+  WHERE tracking_id = 'verify-zbs-live-dispatch:sent';
+
+  SELECT id INTO v_retry_id
+  FROM public.zbs_notification_outbox
+  WHERE tracking_id = 'verify-zbs-live-dispatch:retry';
+
+  SELECT id INTO v_final_retry_id
+  FROM public.zbs_notification_outbox
+  WHERE tracking_id = 'verify-zbs-live-dispatch:final-retry';
+
+  SELECT id INTO v_final_id
+  FROM public.zbs_notification_outbox
+  WHERE tracking_id = 'verify-zbs-live-dispatch:final';
+
+  UPDATE public.zbs_notification_outbox
+  SET attempt_count = 2
+  WHERE id = v_final_retry_id;
+
+  SELECT count(*) INTO v_claimed_count
+  FROM public.zbs_notification_outbox_claim_for_dispatch(
+    10,
+    now(),
+    ARRAY[v_sent_id, v_retry_id, v_final_retry_id, v_final_id]
+  );
+
+  IF v_claimed_count <> 4 THEN
+    RAISE EXCEPTION 'expected 4 claimed rows, got %', v_claimed_count;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id IN (v_sent_id, v_retry_id, v_final_retry_id, v_final_id)
+      AND status <> 'processing'
+  ) THEN
+    RAISE EXCEPTION 'claim did not move all targeted rows to processing';
+  END IF;
+
+  PERFORM public.zbs_notification_outbox_mark_sent(
+    v_sent_id,
+    'provider-msg-1',
+    now(),
+    jsonb_build_object('error', 0, 'data', jsonb_build_object('msg_id', 'provider-msg-1'))
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id = v_sent_id
+      AND status = 'sent'
+      AND provider_message_id = 'provider-msg-1'
+      AND sent_at IS NOT NULL
+      AND provider_response->'data'->>'msg_id' = 'provider-msg-1'
+  ) THEN
+    RAISE EXCEPTION 'sent metadata was not persisted';
+  END IF;
+
+  PERFORM public.zbs_notification_outbox_mark_failed(
+    v_retry_id,
+    true,
+    'http_503',
+    'temporary outage',
+    jsonb_build_object('http_status', 503)
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id = v_retry_id
+      AND status = 'pending'
+      AND attempt_count = 1
+      AND next_attempt_at > now()
+      AND last_error_code = 'http_503'
+  ) THEN
+    RAISE EXCEPTION 'retryable failure did not return row to pending with backoff';
+  END IF;
+
+  PERFORM public.zbs_notification_outbox_mark_failed(
+    v_final_retry_id,
+    true,
+    'http_503',
+    'too many attempts',
+    jsonb_build_object('http_status', 503)
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id = v_final_retry_id
+      AND status = 'failed'
+      AND attempt_count = 3
+      AND last_error_code = 'http_503'
+  ) THEN
+    RAISE EXCEPTION 'third retryable failure did not finalize row';
+  END IF;
+
+  PERFORM public.zbs_notification_outbox_mark_failed(
+    v_final_id,
+    false,
+    'zalo_-1121',
+    'issue_summary data breaks max length',
+    jsonb_build_object('error', -1121)
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id = v_final_id
+      AND status = 'failed'
+      AND last_error_code = 'zalo_-1121'
+  ) THEN
+    RAISE EXCEPTION 'non-retryable failure did not finalize row';
+  END IF;
+
+  SELECT coalesce(proacl::text, '') INTO v_acl
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'zbs_notification_outbox_claim_for_dispatch';
+
+  IF v_acl !~ 'service_role=X' OR v_acl ~ 'authenticated=X' THEN
+    RAISE EXCEPTION 'claim RPC grants are not service_role-only: %', v_acl;
+  END IF;
+END $$;
+
+ROLLBACK;

--- a/scripts/verify-zbs-live-dispatch.sql
+++ b/scripts/verify-zbs-live-dispatch.sql
@@ -9,6 +9,7 @@ DECLARE
   v_final_retry_id uuid;
   v_final_id uuid;
   v_stale_id uuid;
+  v_stale_final_id uuid;
   v_claimed_count integer;
   v_sent_claimed_at timestamptz;
   v_retry_claimed_at timestamptz;
@@ -103,6 +104,17 @@ BEGIN
         'template-test',
         jsonb_build_object('repair_request_id', -90005),
         'verify-zbs-live-dispatch:stale-processing'
+      ),
+      (
+        'repair_request_created',
+        'repair_request',
+        -90006,
+        v_don_vi_id,
+        v_recipient_id,
+        '84900000001',
+        'template-test',
+        jsonb_build_object('repair_request_id', -90006),
+        'verify-zbs-live-dispatch:stale-final-processing'
       )
     RETURNING id, tracking_id
   )
@@ -111,8 +123,9 @@ BEGIN
     (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:retry'),
     (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:final-retry'),
     (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:final'),
-    (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:stale-processing')
-  INTO v_sent_id, v_retry_id, v_final_retry_id, v_final_id, v_stale_id
+    (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:stale-processing'),
+    (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:stale-final-processing')
+  INTO v_sent_id, v_retry_id, v_final_retry_id, v_final_id, v_stale_id, v_stale_final_id
   FROM (SELECT 1) AS captured;
 
   UPDATE public.zbs_notification_outbox
@@ -125,6 +138,13 @@ BEGIN
     attempt_count = 1,
     last_attempt_at = now() - interval '15 minutes'
   WHERE id = v_stale_id;
+
+  UPDATE public.zbs_notification_outbox
+  SET
+    status = 'processing',
+    attempt_count = 3,
+    last_attempt_at = now() - interval '15 minutes'
+  WHERE id = v_stale_final_id;
 
   PERFORM set_config(
     'request.jwt.claims',
@@ -187,7 +207,7 @@ BEGIN
   END IF;
 
   CREATE TEMP TABLE zbs_live_dispatch_claimed ON COMMIT DROP AS
-  SELECT *
+  SELECT id, last_attempt_at
   FROM public.zbs_notification_outbox_claim_for_dispatch(
     10,
     now(),
@@ -219,6 +239,26 @@ BEGIN
       AND last_attempt_at > now() - interval '1 minute'
   ) THEN
     RAISE EXCEPTION 'stale processing row was not reclaimed with a fresh lease';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox_claim_for_dispatch(10, now(), ARRAY[v_stale_final_id])
+    WHERE id = v_stale_final_id
+  ) THEN
+    RAISE EXCEPTION 'stale final-attempt processing row was reclaimed past retry cap';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id = v_stale_final_id
+      AND status = 'failed'
+      AND attempt_count = 3
+      AND last_error_code = 'dispatch_lease_expired'
+      AND next_attempt_at IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'stale final-attempt processing row was not finalized at retry cap';
   END IF;
 
   SELECT

--- a/scripts/verify-zbs-live-dispatch.sql
+++ b/scripts/verify-zbs-live-dispatch.sql
@@ -8,8 +8,8 @@ DECLARE
   v_retry_id uuid;
   v_final_retry_id uuid;
   v_final_id uuid;
+  v_stale_id uuid;
   v_claimed_count integer;
-  v_acl text;
 BEGIN
   SELECT id
     INTO v_don_vi_id
@@ -25,101 +25,145 @@ BEGIN
   VALUES (v_don_vi_id, 'repair_request_created', '84900000001', true)
   RETURNING id INTO v_recipient_id;
 
-  INSERT INTO public.zbs_notification_outbox (
-    event_type,
-    source_type,
-    source_id,
-    don_vi_id,
-    recipient_config_id,
-    recipient_phone,
-    template_id,
-    template_data,
-    tracking_id
+  WITH inserted AS (
+    INSERT INTO public.zbs_notification_outbox (
+      event_type,
+      source_type,
+      source_id,
+      don_vi_id,
+      recipient_config_id,
+      recipient_phone,
+      template_id,
+      template_data,
+      tracking_id
+    )
+    VALUES
+      (
+        'repair_request_created',
+        'repair_request',
+        -90001,
+        v_don_vi_id,
+        v_recipient_id,
+        '84900000001',
+        'template-test',
+        jsonb_build_object('repair_request_id', -90001),
+        'verify-zbs-live-dispatch:sent'
+      ),
+      (
+        'repair_request_created',
+        'repair_request',
+        -90002,
+        v_don_vi_id,
+        v_recipient_id,
+        '84900000001',
+        'template-test',
+        jsonb_build_object('repair_request_id', -90002),
+        'verify-zbs-live-dispatch:retry'
+      ),
+      (
+        'repair_request_created',
+        'repair_request',
+        -90003,
+        v_don_vi_id,
+        v_recipient_id,
+        '84900000001',
+        'template-test',
+        jsonb_build_object('repair_request_id', -90003),
+        'verify-zbs-live-dispatch:final-retry'
+      ),
+      (
+        'repair_request_created',
+        'repair_request',
+        -90004,
+        v_don_vi_id,
+        v_recipient_id,
+        '84900000001',
+        'template-test',
+        jsonb_build_object('repair_request_id', -90004),
+        'verify-zbs-live-dispatch:final'
+      ),
+      (
+        'repair_request_created',
+        'repair_request',
+        -90005,
+        v_don_vi_id,
+        v_recipient_id,
+        '84900000001',
+        'template-test',
+        jsonb_build_object('repair_request_id', -90005),
+        'verify-zbs-live-dispatch:stale-processing'
+      )
+    RETURNING id, tracking_id
   )
-  VALUES
-    (
-      'repair_request_created',
-      'repair_request',
-      -90001,
-      v_don_vi_id,
-      v_recipient_id,
-      '84900000001',
-      'template-test',
-      jsonb_build_object('repair_request_id', -90001),
-      'verify-zbs-live-dispatch:sent'
-    ),
-    (
-      'repair_request_created',
-      'repair_request',
-      -90002,
-      v_don_vi_id,
-      v_recipient_id,
-      '84900000001',
-      'template-test',
-      jsonb_build_object('repair_request_id', -90002),
-      'verify-zbs-live-dispatch:retry'
-    ),
-    (
-      'repair_request_created',
-      'repair_request',
-      -90003,
-      v_don_vi_id,
-      v_recipient_id,
-      '84900000001',
-      'template-test',
-      jsonb_build_object('repair_request_id', -90003),
-      'verify-zbs-live-dispatch:final-retry'
-    ),
-    (
-      'repair_request_created',
-      'repair_request',
-      -90004,
-      v_don_vi_id,
-      v_recipient_id,
-      '84900000001',
-      'template-test',
-      jsonb_build_object('repair_request_id', -90004),
-      'verify-zbs-live-dispatch:final'
-    );
-
-  SELECT id INTO v_sent_id
-  FROM public.zbs_notification_outbox
-  WHERE tracking_id = 'verify-zbs-live-dispatch:sent';
-
-  SELECT id INTO v_retry_id
-  FROM public.zbs_notification_outbox
-  WHERE tracking_id = 'verify-zbs-live-dispatch:retry';
-
-  SELECT id INTO v_final_retry_id
-  FROM public.zbs_notification_outbox
-  WHERE tracking_id = 'verify-zbs-live-dispatch:final-retry';
-
-  SELECT id INTO v_final_id
-  FROM public.zbs_notification_outbox
-  WHERE tracking_id = 'verify-zbs-live-dispatch:final';
+  SELECT
+    (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:sent'),
+    (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:retry'),
+    (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:final-retry'),
+    (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:final'),
+    (SELECT id FROM inserted WHERE tracking_id = 'verify-zbs-live-dispatch:stale-processing')
+  INTO v_sent_id, v_retry_id, v_final_retry_id, v_final_id, v_stale_id
+  FROM (SELECT 1) AS captured;
 
   UPDATE public.zbs_notification_outbox
   SET attempt_count = 2
   WHERE id = v_final_retry_id;
 
+  UPDATE public.zbs_notification_outbox
+  SET
+    status = 'processing',
+    attempt_count = 1,
+    last_attempt_at = now() - interval '15 minutes'
+  WHERE id = v_stale_id;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    '{"role":"authenticated","app_role":"to_qltb","user_id":"verify-zbs-live-dispatch"}',
+    true
+  );
+
+  BEGIN
+    PERFORM public.zbs_notification_outbox_claim_for_dispatch(10, now(), ARRAY[v_sent_id]);
+    RAISE EXCEPTION 'claim RPC did not reject non-service_role JWT';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    '{"role":"service_role","app_role":"to_qltb","user_id":"verify-zbs-live-dispatch"}',
+    true
+  );
+
   SELECT count(*) INTO v_claimed_count
   FROM public.zbs_notification_outbox_claim_for_dispatch(
     10,
     now(),
-    ARRAY[v_sent_id, v_retry_id, v_final_retry_id, v_final_id]
+    ARRAY[v_sent_id, v_retry_id, v_final_retry_id, v_final_id, v_stale_id]
   );
 
-  IF v_claimed_count <> 4 THEN
-    RAISE EXCEPTION 'expected 4 claimed rows, got %', v_claimed_count;
+  IF v_claimed_count <> 5 THEN
+    RAISE EXCEPTION 'expected 5 claimed rows including stale processing, got %', v_claimed_count;
   END IF;
 
   IF EXISTS (
     SELECT 1
     FROM public.zbs_notification_outbox
-    WHERE id IN (v_sent_id, v_retry_id, v_final_retry_id, v_final_id)
+    WHERE id IN (v_sent_id, v_retry_id, v_final_retry_id, v_final_id, v_stale_id)
       AND status <> 'processing'
   ) THEN
     RAISE EXCEPTION 'claim did not move all targeted rows to processing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id = v_stale_id
+      AND status = 'processing'
+      AND attempt_count = 2
+      AND last_attempt_at > now() - interval '1 minute'
+  ) THEN
+    RAISE EXCEPTION 'stale processing row was not reclaimed with a fresh lease';
   END IF;
 
   PERFORM public.zbs_notification_outbox_mark_sent(
@@ -198,14 +242,68 @@ BEGIN
     RAISE EXCEPTION 'non-retryable failure did not finalize row';
   END IF;
 
-  SELECT coalesce(proacl::text, '') INTO v_acl
-  FROM pg_proc p
-  JOIN pg_namespace n ON n.oid = p.pronamespace
-  WHERE n.nspname = 'public'
-    AND p.proname = 'zbs_notification_outbox_claim_for_dispatch';
+  IF (
+    SELECT count(*)
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname IN (
+        'zbs_notification_outbox_claim_for_dispatch',
+        'zbs_notification_outbox_mark_sent',
+        'zbs_notification_outbox_mark_failed'
+      )
+  ) <> 3 THEN
+    RAISE EXCEPTION 'expected exactly three ZBS live dispatch RPCs';
+  END IF;
 
-  IF v_acl !~ 'service_role=X' OR v_acl ~ 'authenticated=X' THEN
-    RAISE EXCEPTION 'claim RPC grants are not service_role-only: %', v_acl;
+  IF EXISTS (
+    WITH target AS (
+      SELECT p.oid, p.proacl, p.proowner
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public'
+        AND p.proname IN (
+          'zbs_notification_outbox_claim_for_dispatch',
+          'zbs_notification_outbox_mark_sent',
+          'zbs_notification_outbox_mark_failed'
+        )
+    ),
+    grants AS (
+      SELECT
+        target.oid,
+        acl.grantee,
+        acl.privilege_type
+      FROM target
+      CROSS JOIN LATERAL aclexplode(coalesce(target.proacl, acldefault('f', target.proowner))) acl
+    )
+    SELECT 1
+    FROM grants
+    WHERE grants.privilege_type = 'EXECUTE'
+      AND (
+        grants.grantee = 0
+        OR grants.grantee NOT IN ('postgres'::regrole::oid, 'service_role'::regrole::oid)
+      )
+  ) THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC grants are not limited to postgres and service_role';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname IN (
+        'zbs_notification_outbox_claim_for_dispatch',
+        'zbs_notification_outbox_mark_sent',
+        'zbs_notification_outbox_mark_failed'
+      )
+      AND (
+        NOT has_function_privilege('service_role', p.oid, 'EXECUTE')
+        OR has_function_privilege('anon', p.oid, 'EXECUTE')
+        OR has_function_privilege('authenticated', p.oid, 'EXECUTE')
+      )
+  ) THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC privilege allowlist check failed';
   END IF;
 END $$;
 

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -30,6 +30,7 @@ describe("/api/cron/zbs-dispatch", () => {
       ...ORIGINAL_ENV,
       CRON_SECRET: "cron-secret",
       SUPABASE_JWT_SECRET: "test-jwt-secret",
+      ZBS_INTERNAL_RPC_SECRET: "test-internal-rpc-secret",
       ZALO_ZBS_DISPATCH_ENABLED: "false",
       ZALO_ZBS_ACCESS_TOKEN: "zalo-access-token",
       ZALO_ZBS_REPAIR_TEMPLATE_ID: "template-123",
@@ -156,6 +157,42 @@ describe("/api/cron/zbs-dispatch", () => {
         results: [],
       },
     })
+  })
+
+  it("fails closed when the dedicated internal RPC signing secret is missing", async () => {
+    delete process.env.ZBS_INTERNAL_RPC_SECRET
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify([{ id: "outbox-1" }]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    )
+    dispatcherMocks.dispatchPendingZbsNotifications.mockImplementationOnce(async (options) => {
+      await options.rpcClient({
+        fn: "zbs_notification_outbox_claim_for_dispatch",
+        args: { p_limit: 1 },
+      })
+    })
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(
+      new Request("https://example.test/api/cron/zbs-dispatch", {
+        headers: { Authorization: "Bearer cron-secret" },
+      })
+    )
+
+    expect(response.status).toBe(500)
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalledWith("ZBS dispatch cron failed", {
+      error: {
+        name: "ZbsDispatchConfigurationError",
+        message: "Missing ZBS internal RPC signing secret",
+      },
+    })
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
+    consoleErrorSpy.mockRestore()
   })
 
   it("aborts hung internal RPC proxy calls", async () => {

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -189,6 +189,54 @@ describe("/api/cron/zbs-dispatch", () => {
     })
   })
 
+  it("sanitizes 5xx RPC failure details in the cron response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: "Database role failed",
+            details: { code: "service_role_missing", secret: "do-not-leak" },
+          },
+        }),
+        {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        }
+      )
+    )
+    dispatcherMocks.dispatchPendingZbsNotifications.mockImplementationOnce(async (options) => {
+      await options.rpcClient({
+        fn: "zbs_notification_outbox_claim_for_dispatch",
+        args: { p_limit: 1 },
+      })
+    })
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(
+      new Request("https://example.test/api/cron/zbs-dispatch", {
+        headers: { Authorization: "Bearer cron-secret" },
+      })
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
+  })
+
+  it("sanitizes missing cron secret configuration failures", async () => {
+    delete process.env.CRON_SECRET
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(new Request("https://example.test/api/cron/zbs-dispatch"))
+
+    expect(response.status).toBe(500)
+    expect(dispatcherMocks.dispatchPendingZbsNotifications).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
+    consoleErrorSpy.mockRestore()
+  })
+
   it("does not leak dispatcher errors in the response", async () => {
     const dispatchError = new Error("zalo-access-token should not leak")
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
@@ -209,7 +257,7 @@ describe("/api/cron/zbs-dispatch", () => {
         message: dispatchError.message,
       },
     })
-    await expect(response.json()).resolves.toEqual({ error: "ZBS dispatch failed" })
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
     consoleErrorSpy.mockRestore()
   })
 })

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -29,6 +29,7 @@ describe("/api/cron/zbs-dispatch", () => {
     process.env = {
       ...ORIGINAL_ENV,
       CRON_SECRET: "cron-secret",
+      SUPABASE_JWT_SECRET: "test-jwt-secret",
       ZALO_ZBS_DISPATCH_ENABLED: "false",
       ZALO_ZBS_ACCESS_TOKEN: "zalo-access-token",
       ZALO_ZBS_REPAIR_TEMPLATE_ID: "template-123",
@@ -39,6 +40,7 @@ describe("/api/cron/zbs-dispatch", () => {
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV }
     vi.unstubAllGlobals()
+    vi.useRealTimers()
   })
 
   it("rejects requests without the cron bearer token", async () => {
@@ -135,7 +137,10 @@ describe("/api/cron/zbs-dispatch", () => {
           "Content-Length": String(Buffer.byteLength(JSON.stringify({ p_limit: 1 }))),
           Origin: "https://example.test",
           "x-qltbyt-internal-rpc": "zbs-dispatch",
+          "x-qltbyt-internal-rpc-signature": expect.any(String),
+          "x-qltbyt-internal-rpc-timestamp": expect.any(String),
         }),
+        signal: expect.any(AbortSignal),
         body: JSON.stringify({ p_limit: 1 }),
       })
     )
@@ -150,6 +155,45 @@ describe("/api/cron/zbs-dispatch", () => {
         results: [],
       },
     })
+  })
+
+  it("aborts hung internal RPC proxy calls", async () => {
+    vi.useFakeTimers()
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockImplementationOnce((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new Error("internal rpc request aborted"))
+        })
+      })
+    })
+    dispatcherMocks.dispatchPendingZbsNotifications.mockImplementationOnce(async (options) => {
+      await options.rpcClient({
+        fn: "zbs_notification_outbox_claim_for_dispatch",
+        args: { p_limit: 1 },
+      })
+    })
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const responsePromise = mod!.GET(
+      new Request("https://example.test/api/cron/zbs-dispatch", {
+        headers: { Authorization: "Bearer cron-secret" },
+      })
+    )
+    await vi.advanceTimersByTimeAsync(10_000)
+    const response = await responsePromise
+
+    expect(response.status).toBe(500)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test/api/rpc/zbs_notification_outbox_claim_for_dispatch",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      })
+    )
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
+    consoleErrorSpy.mockRestore()
+    vi.useRealTimers()
   })
 
   it("preserves structured RPC failure details in the cron response", async () => {
@@ -254,7 +298,6 @@ describe("/api/cron/zbs-dispatch", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith("ZBS dispatch cron failed", {
       error: {
         name: "Error",
-        message: dispatchError.message,
       },
     })
     await expect(response.json()).resolves.toEqual({ error: "Internal server error" })

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -128,14 +128,14 @@ describe("/api/cron/zbs-dispatch", () => {
 
     expect(response.status).toBe(200)
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://example.test/api/rpc/zbs_notification_outbox_claim_for_dispatch",
+      "https://app.example.test/api/rpc/zbs_notification_outbox_claim_for_dispatch",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
           Authorization: "Bearer cron-secret",
           "Content-Type": "application/json",
           "Content-Length": String(Buffer.byteLength(JSON.stringify({ p_limit: 1 }))),
-          Origin: "https://example.test",
+          Origin: "https://app.example.test",
           "x-qltbyt-internal-rpc": "zbs-dispatch",
           "x-qltbyt-internal-rpc-body-sha256": expect.any(String),
           "x-qltbyt-internal-rpc-signature": expect.any(String),
@@ -187,7 +187,7 @@ describe("/api/cron/zbs-dispatch", () => {
 
     expect(response.status).toBe(500)
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://example.test/api/rpc/zbs_notification_outbox_claim_for_dispatch",
+      "https://app.example.test/api/rpc/zbs_notification_outbox_claim_for_dispatch",
       expect.objectContaining({
         signal: expect.any(AbortSignal),
       })

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -137,6 +137,7 @@ describe("/api/cron/zbs-dispatch", () => {
           "Content-Length": String(Buffer.byteLength(JSON.stringify({ p_limit: 1 }))),
           Origin: "https://example.test",
           "x-qltbyt-internal-rpc": "zbs-dispatch",
+          "x-qltbyt-internal-rpc-body-sha256": expect.any(String),
           "x-qltbyt-internal-rpc-signature": expect.any(String),
           "x-qltbyt-internal-rpc-timestamp": expect.any(String),
         }),

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -197,6 +197,37 @@ describe("/api/cron/zbs-dispatch", () => {
     vi.useRealTimers()
   })
 
+  it("logs route-owned configuration failure messages without leaking them in the response", async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.NEXTAUTH_URL
+    delete process.env.VERCEL_URL
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    dispatcherMocks.dispatchPendingZbsNotifications.mockImplementationOnce(async (options) => {
+      await options.rpcClient({
+        fn: "zbs_notification_outbox_claim_for_dispatch",
+        args: { p_limit: 1 },
+      })
+    })
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(
+      new Request("https://example.test/api/cron/zbs-dispatch", {
+        headers: { Authorization: "Bearer cron-secret" },
+      })
+    )
+
+    expect(response.status).toBe(500)
+    expect(consoleErrorSpy).toHaveBeenCalledWith("ZBS dispatch cron failed", {
+      error: {
+        name: "ZbsDispatchConfigurationError",
+        message: "Missing trusted app base URL",
+      },
+    })
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
+    consoleErrorSpy.mockRestore()
+  })
+
   it("preserves structured RPC failure details in the cron response", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -7,6 +7,7 @@ const supabaseMocks = vi.hoisted(() => ({
   createClient: vi.fn(),
   rpc: vi.fn(),
 }))
+const fetchMock = vi.hoisted(() => vi.fn())
 
 vi.mock("@/lib/zbs/live-dispatcher", () => ({
   dispatchPendingZbsNotifications: dispatcherMocks.dispatchPendingZbsNotifications,
@@ -33,11 +34,11 @@ describe("/api/cron/zbs-dispatch", () => {
     supabaseMocks.createClient.mockReset()
     supabaseMocks.rpc.mockReset()
     supabaseMocks.createClient.mockReturnValue({ rpc: supabaseMocks.rpc })
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
     process.env = {
       ...ORIGINAL_ENV,
       CRON_SECRET: "cron-secret",
-      SUPABASE_URL: "https://example.supabase.co",
-      SUPABASE_SERVICE_ROLE_KEY: "service-role-secret",
       ZALO_ZBS_DISPATCH_ENABLED: "false",
       ZALO_ZBS_ACCESS_TOKEN: "zalo-access-token",
       ZALO_ZBS_REPAIR_TEMPLATE_ID: "template-123",
@@ -47,6 +48,7 @@ describe("/api/cron/zbs-dispatch", () => {
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV }
+    vi.unstubAllGlobals()
   })
 
   it("rejects requests without the cron bearer token", async () => {
@@ -60,7 +62,7 @@ describe("/api/cron/zbs-dispatch", () => {
     await expect(response.json()).resolves.toEqual({ error: "Unauthorized" })
   })
 
-  it("invokes the dispatcher with disabled gate config and targeted outbox ids", async () => {
+  it("invokes the dispatcher through the internal RPC proxy with disabled gate config and targeted outbox ids", async () => {
     dispatcherMocks.dispatchPendingZbsNotifications.mockResolvedValue({
       dispatch_state: "disabled-dispatch",
       attempted: 0,
@@ -79,11 +81,7 @@ describe("/api/cron/zbs-dispatch", () => {
     )
 
     expect(response.status).toBe(200)
-    expect(supabaseMocks.createClient).toHaveBeenCalledWith(
-      "https://example.supabase.co",
-      "service-role-secret",
-      { auth: { persistSession: false } }
-    )
+    expect(supabaseMocks.createClient).not.toHaveBeenCalled()
     expect(dispatcherMocks.dispatchPendingZbsNotifications).toHaveBeenCalledWith(
       expect.objectContaining({
         dispatchEnabled: false,
@@ -104,6 +102,101 @@ describe("/api/cron/zbs-dispatch", () => {
         failed: 0,
         results: [],
       },
+    })
+  })
+
+  it("calls the RPC proxy with cron credentials when the dispatcher uses rpcClient", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify([{ id: "outbox-1" }]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    )
+    dispatcherMocks.dispatchPendingZbsNotifications.mockImplementationOnce(async (options) => {
+      const rows = await options.rpcClient({
+        fn: "zbs_notification_outbox_claim_for_dispatch",
+        args: { p_limit: 1 },
+      })
+      return {
+        dispatch_state: "live-dispatch",
+        attempted: Array.isArray(rows) ? rows.length : 0,
+        sent: 0,
+        retryable_failed: 0,
+        failed: 0,
+        results: [],
+      }
+    })
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(
+      new Request("https://example.test/api/cron/zbs-dispatch", {
+        headers: { Authorization: "Bearer cron-secret" },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.test/api/rpc/zbs_notification_outbox_claim_for_dispatch",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer cron-secret",
+          "Content-Type": "application/json",
+          "Content-Length": String(Buffer.byteLength(JSON.stringify({ p_limit: 1 }))),
+          Origin: "https://example.test",
+          "x-qltbyt-internal-rpc": "zbs-dispatch",
+        }),
+        body: JSON.stringify({ p_limit: 1 }),
+      })
+    )
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      result: {
+        dispatch_state: "live-dispatch",
+        attempted: 1,
+        sent: 0,
+        retryable_failed: 0,
+        failed: 0,
+        results: [],
+      },
+    })
+  })
+
+  it("preserves structured RPC failure details in the cron response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: "Validation failed",
+            details: { code: "bad_zbs_claim", field: "p_outbox_ids" },
+          },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        }
+      )
+    )
+    dispatcherMocks.dispatchPendingZbsNotifications.mockImplementationOnce(async (options) => {
+      await options.rpcClient({
+        fn: "zbs_notification_outbox_claim_for_dispatch",
+        args: { p_outbox_ids: ["not-a-uuid"] },
+      })
+    })
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(
+      new Request("https://example.test/api/cron/zbs-dispatch", {
+        headers: { Authorization: "Bearer cron-secret" },
+      })
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: "ZBS dispatch failed",
+      details: { code: "bad_zbs_claim", field: "p_outbox_ids" },
     })
   })
 

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -135,7 +135,6 @@ describe("/api/cron/zbs-dispatch", () => {
         headers: expect.objectContaining({
           Authorization: "Bearer cron-secret",
           "Content-Type": "application/json",
-          "Content-Length": String(Buffer.byteLength(JSON.stringify({ p_limit: 1 }))),
           Origin: "https://app.example.test",
           "x-qltbyt-internal-rpc": "zbs-dispatch",
           "x-qltbyt-internal-rpc-body-sha256": expect.any(String),
@@ -146,6 +145,8 @@ describe("/api/cron/zbs-dispatch", () => {
         body: JSON.stringify({ p_limit: 1 }),
       })
     )
+    const fetchHeaders = fetchMock.mock.calls[0]?.[1]?.headers
+    expect(fetchHeaders).not.toHaveProperty("Content-Length")
     await expect(response.json()).resolves.toEqual({
       success: true,
       result: {

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const dispatcherMocks = vi.hoisted(() => ({
+  dispatchPendingZbsNotifications: vi.fn(),
+}))
+const supabaseMocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  rpc: vi.fn(),
+}))
+
+vi.mock("@/lib/zbs/live-dispatcher", () => ({
+  dispatchPendingZbsNotifications: dispatcherMocks.dispatchPendingZbsNotifications,
+}))
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: supabaseMocks.createClient,
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+async function loadRoute() {
+  try {
+    const routeModulePath = ["..", "route"].join("/")
+    return await import(/* @vite-ignore */ routeModulePath)
+  } catch {
+    return null
+  }
+}
+
+describe("/api/cron/zbs-dispatch", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    dispatcherMocks.dispatchPendingZbsNotifications.mockReset()
+    supabaseMocks.createClient.mockReset()
+    supabaseMocks.rpc.mockReset()
+    supabaseMocks.createClient.mockReturnValue({ rpc: supabaseMocks.rpc })
+    process.env = {
+      ...ORIGINAL_ENV,
+      CRON_SECRET: "cron-secret",
+      SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role-secret",
+      ZALO_ZBS_DISPATCH_ENABLED: "false",
+      ZALO_ZBS_ACCESS_TOKEN: "zalo-access-token",
+      ZALO_ZBS_REPAIR_TEMPLATE_ID: "template-123",
+      NEXT_PUBLIC_APP_URL: "https://app.example.test",
+    }
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it("rejects requests without the cron bearer token", async () => {
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(new Request("https://example.test/api/cron/zbs-dispatch"))
+
+    expect(response.status).toBe(401)
+    expect(dispatcherMocks.dispatchPendingZbsNotifications).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" })
+  })
+
+  it("invokes the dispatcher with disabled gate config and targeted outbox ids", async () => {
+    dispatcherMocks.dispatchPendingZbsNotifications.mockResolvedValue({
+      dispatch_state: "disabled-dispatch",
+      attempted: 0,
+      sent: 0,
+      retryable_failed: 0,
+      failed: 0,
+      results: [],
+    })
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(
+      new Request("https://example.test/api/cron/zbs-dispatch?outboxId=outbox-1", {
+        headers: { Authorization: "Bearer cron-secret" },
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(supabaseMocks.createClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "service-role-secret",
+      { auth: { persistSession: false } }
+    )
+    expect(dispatcherMocks.dispatchPendingZbsNotifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatchEnabled: false,
+        accessToken: "zalo-access-token",
+        repairTemplateId: "template-123",
+        appBaseUrl: "https://app.example.test",
+        outboxIds: ["outbox-1"],
+        rpcClient: expect.any(Function),
+      })
+    )
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      result: {
+        dispatch_state: "disabled-dispatch",
+        attempted: 0,
+        sent: 0,
+        retryable_failed: 0,
+        failed: 0,
+        results: [],
+      },
+    })
+  })
+
+  it("does not leak dispatcher errors in the response", async () => {
+    dispatcherMocks.dispatchPendingZbsNotifications.mockRejectedValue(
+      new Error("zalo-access-token should not leak")
+    )
+    const mod = await loadRoute()
+    expect(mod?.GET).toBeTypeOf("function")
+
+    const response = await mod!.GET(
+      new Request("https://example.test/api/cron/zbs-dispatch", {
+        headers: { Authorization: "Bearer cron-secret" },
+      })
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: "ZBS dispatch failed" })
+  })
+})

--- a/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
+++ b/src/app/api/cron/zbs-dispatch/__tests__/route.test.ts
@@ -3,17 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const dispatcherMocks = vi.hoisted(() => ({
   dispatchPendingZbsNotifications: vi.fn(),
 }))
-const supabaseMocks = vi.hoisted(() => ({
-  createClient: vi.fn(),
-  rpc: vi.fn(),
-}))
 const fetchMock = vi.hoisted(() => vi.fn())
 
 vi.mock("@/lib/zbs/live-dispatcher", () => ({
   dispatchPendingZbsNotifications: dispatcherMocks.dispatchPendingZbsNotifications,
-}))
-vi.mock("@supabase/supabase-js", () => ({
-  createClient: supabaseMocks.createClient,
 }))
 
 const ORIGINAL_ENV = { ...process.env }
@@ -31,9 +24,6 @@ describe("/api/cron/zbs-dispatch", () => {
   beforeEach(() => {
     vi.resetModules()
     dispatcherMocks.dispatchPendingZbsNotifications.mockReset()
-    supabaseMocks.createClient.mockReset()
-    supabaseMocks.rpc.mockReset()
-    supabaseMocks.createClient.mockReturnValue({ rpc: supabaseMocks.rpc })
     fetchMock.mockReset()
     vi.stubGlobal("fetch", fetchMock)
     process.env = {
@@ -81,7 +71,6 @@ describe("/api/cron/zbs-dispatch", () => {
     )
 
     expect(response.status).toBe(200)
-    expect(supabaseMocks.createClient).not.toHaveBeenCalled()
     expect(dispatcherMocks.dispatchPendingZbsNotifications).toHaveBeenCalledWith(
       expect.objectContaining({
         dispatchEnabled: false,
@@ -201,9 +190,9 @@ describe("/api/cron/zbs-dispatch", () => {
   })
 
   it("does not leak dispatcher errors in the response", async () => {
-    dispatcherMocks.dispatchPendingZbsNotifications.mockRejectedValue(
-      new Error("zalo-access-token should not leak")
-    )
+    const dispatchError = new Error("zalo-access-token should not leak")
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    dispatcherMocks.dispatchPendingZbsNotifications.mockRejectedValue(dispatchError)
     const mod = await loadRoute()
     expect(mod?.GET).toBeTypeOf("function")
 
@@ -214,6 +203,13 @@ describe("/api/cron/zbs-dispatch", () => {
     )
 
     expect(response.status).toBe(500)
+    expect(consoleErrorSpy).toHaveBeenCalledWith("ZBS dispatch cron failed", {
+      error: {
+        name: "Error",
+        message: dispatchError.message,
+      },
+    })
     await expect(response.json()).resolves.toEqual({ error: "ZBS dispatch failed" })
+    consoleErrorSpy.mockRestore()
   })
 })

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -27,6 +27,10 @@ function jsonResponse(body: unknown, status: number): Response {
   return Response.json(body, { status })
 }
 
+function internalServerErrorResponse(status = 500): Response {
+  return jsonResponse({ error: "Internal server error" }, status)
+}
+
 function readDispatchEnabled() {
   return process.env.ZALO_ZBS_DISPATCH_ENABLED === "true"
 }
@@ -133,10 +137,7 @@ export async function GET(request: Request): Promise<Response> {
 
   if (!cronSecret) {
     console.error("Missing ZBS dispatch cron secret")
-    return jsonResponse(
-      { error: "Server configuration error: missing required environment variables" },
-      500
-    )
+    return internalServerErrorResponse()
   }
 
   if (request.headers.get("Authorization") !== `Bearer ${cronSecret}`) {
@@ -160,6 +161,10 @@ export async function GET(request: Request): Promise<Response> {
   } catch (error) {
     console.error("ZBS dispatch cron failed", { error: sanitizeForLog(error) })
     if (error instanceof ZbsDispatchRpcError) {
+      if (error.status >= 500) {
+        return internalServerErrorResponse(error.status)
+      }
+
       return jsonResponse(
         {
           error: "ZBS dispatch failed",
@@ -168,6 +173,6 @@ export async function GET(request: Request): Promise<Response> {
         error.status
       )
     }
-    return jsonResponse({ error: "ZBS dispatch failed" }, 500)
+    return internalServerErrorResponse()
   }
 }

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -1,5 +1,11 @@
 import { dispatchPendingZbsNotifications } from "@/lib/zbs/live-dispatcher"
-import { sanitizeForLog } from "@/lib/log-sanitizer"
+import {
+  ZBS_INTERNAL_RPC_SIGNATURE_HEADER,
+  ZBS_INTERNAL_RPC_SOURCE,
+  ZBS_INTERNAL_RPC_SOURCE_HEADER,
+  ZBS_INTERNAL_RPC_TIMESTAMP_HEADER,
+  signZbsInternalRpc,
+} from "@/lib/zbs/internal-rpc-signature"
 
 /** Keep the ZBS dispatch endpoint uncached so each cron/manual call evaluates live state. */
 export const dynamic = "force-dynamic"
@@ -10,6 +16,8 @@ type RpcErrorPayload = {
   error?: unknown
   details?: unknown
 }
+
+const INTERNAL_RPC_FETCH_TIMEOUT_MS = 10_000
 
 class ZbsDispatchRpcError extends Error {
   readonly status: number
@@ -38,6 +46,10 @@ function readDispatchEnabled() {
 function readAppBaseUrl() {
   const vercelUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined
   return process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXTAUTH_URL ?? vercelUrl
+}
+
+function readInternalRpcSigningSecret() {
+  return process.env.ZBS_INTERNAL_RPC_SECRET ?? process.env.SUPABASE_JWT_SECRET
 }
 
 function readOutboxIds(request: Request): string[] | undefined {
@@ -85,6 +97,21 @@ function errorPayloadDetails(payload: RpcErrorPayload): unknown {
   return undefined
 }
 
+function cronErrorLogMetadata(error: unknown): Record<string, unknown> {
+  if (error instanceof ZbsDispatchRpcError) {
+    return {
+      name: error.name,
+      status: error.status,
+    }
+  }
+
+  if (error instanceof Error) {
+    return { name: error.name }
+  }
+
+  return { name: typeof error }
+}
+
 async function readJsonResponse(response: Response): Promise<unknown> {
   const text = await response.text()
   if (!text) {
@@ -105,19 +132,36 @@ async function callRpcProxyFromCron(
 ): Promise<unknown> {
   const rpcUrl = new URL(`/api/rpc/${encodeURIComponent(fn)}`, request.url)
   const body = JSON.stringify(args)
-  const response = await fetch(rpcUrl.toString(), {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      Authorization: `Bearer ${cronSecret}`,
-      "Content-Type": "application/json",
-      "Content-Length": String(Buffer.byteLength(body)),
-      Origin: rpcUrl.origin,
-      "x-qltbyt-internal-rpc": "zbs-dispatch",
-    },
-    body,
-  })
-  const payload = await readJsonResponse(response)
+  const signingSecret = readInternalRpcSigningSecret()
+  if (!signingSecret) {
+    throw new Error("Missing ZBS internal RPC signing secret")
+  }
+  const timestamp = String(Date.now())
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), INTERNAL_RPC_FETCH_TIMEOUT_MS)
+
+  let response: Response
+  let payload: unknown
+  try {
+    response = await fetch(rpcUrl.toString(), {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${cronSecret}`,
+        "Content-Type": "application/json",
+        "Content-Length": String(Buffer.byteLength(body)),
+        Origin: rpcUrl.origin,
+        [ZBS_INTERNAL_RPC_SOURCE_HEADER]: ZBS_INTERNAL_RPC_SOURCE,
+        [ZBS_INTERNAL_RPC_TIMESTAMP_HEADER]: timestamp,
+        [ZBS_INTERNAL_RPC_SIGNATURE_HEADER]: signZbsInternalRpc(signingSecret, fn, timestamp),
+      },
+      body,
+      signal: controller.signal,
+    })
+    payload = await readJsonResponse(response)
+  } finally {
+    clearTimeout(timeoutId)
+  }
 
   if (!response.ok) {
     const errorPayload = parseRpcErrorPayload(payload)
@@ -159,7 +203,7 @@ export async function GET(request: Request): Promise<Response> {
 
     return jsonResponse({ success: true, result }, 200)
   } catch (error) {
-    console.error("ZBS dispatch cron failed", { error: sanitizeForLog(error) })
+    console.error("ZBS dispatch cron failed", { error: cronErrorLogMetadata(error) })
     if (error instanceof ZbsDispatchRpcError) {
       if (error.status >= 500) {
         return internalServerErrorResponse(error.status)

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -33,6 +33,13 @@ class ZbsDispatchRpcError extends Error {
   }
 }
 
+class ZbsDispatchConfigurationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "ZbsDispatchConfigurationError"
+  }
+}
+
 function jsonResponse(body: unknown, status: number): Response {
   return Response.json(body, { status })
 }
@@ -53,7 +60,7 @@ function readAppBaseUrl() {
 function readTrustedAppBaseUrl() {
   const appBaseUrl = readAppBaseUrl()
   if (!appBaseUrl) {
-    throw new Error("Missing trusted app base URL")
+    throw new ZbsDispatchConfigurationError("Missing trusted app base URL")
   }
 
   return appBaseUrl
@@ -109,6 +116,10 @@ function errorPayloadDetails(payload: RpcErrorPayload): unknown {
 }
 
 function cronErrorLogMetadata(error: unknown): Record<string, unknown> {
+  if (error instanceof ZbsDispatchConfigurationError) {
+    return { name: error.name, message: error.message }
+  }
+
   if (error instanceof ZbsDispatchRpcError) {
     return {
       name: error.name,
@@ -144,7 +155,7 @@ async function callRpcProxyFromCron(
   const body = JSON.stringify(args)
   const signingSecret = readInternalRpcSigningSecret()
   if (!signingSecret) {
-    throw new Error("Missing ZBS internal RPC signing secret")
+    throw new ZbsDispatchConfigurationError("Missing ZBS internal RPC signing secret")
   }
   const timestamp = String(Date.now())
   const bodySha256 = hashZbsInternalRpcBody(body)

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -1,11 +1,26 @@
-import { createClient } from "@supabase/supabase-js"
-
 import { dispatchPendingZbsNotifications } from "@/lib/zbs/live-dispatcher"
 
 /** Keep the ZBS dispatch endpoint uncached so each cron/manual call evaluates live state. */
 export const dynamic = "force-dynamic"
-/** Use Node.js runtime for service-role Supabase RPC calls and outbound Zalo fetches. */
+/** Use Node.js runtime for internal RPC proxy calls and outbound Zalo fetches. */
 export const runtime = "nodejs"
+
+type RpcErrorPayload = {
+  error?: unknown
+  details?: unknown
+}
+
+class ZbsDispatchRpcError extends Error {
+  readonly status: number
+  readonly details?: unknown
+
+  constructor(status: number, message: string, details?: unknown) {
+    super(message)
+    this.name = "ZbsDispatchRpcError"
+    this.status = status
+    this.details = details
+  }
+}
 
 function jsonResponse(body: unknown, status: number): Response {
   return Response.json(body, { status })
@@ -30,11 +45,85 @@ function readOutboxIds(request: Request): string[] | undefined {
   return ids.length > 0 ? ids : undefined
 }
 
-function readSupabaseEnv(): { supabaseUrl: string; serviceRoleKey: string } | null {
-  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+function parseRpcErrorPayload(payload: unknown): RpcErrorPayload {
+  return payload && typeof payload === "object" && !Array.isArray(payload)
+    ? (payload as RpcErrorPayload)
+    : {}
+}
 
-  return supabaseUrl && serviceRoleKey ? { supabaseUrl, serviceRoleKey } : null
+function errorPayloadMessage(payload: RpcErrorPayload): string {
+  if (typeof payload.error === "string") {
+    return payload.error
+  }
+
+  if (
+    payload.error &&
+    typeof payload.error === "object" &&
+    "message" in payload.error &&
+    typeof payload.error.message === "string"
+  ) {
+    return payload.error.message
+  }
+
+  return "ZBS dispatch RPC failed"
+}
+
+function errorPayloadDetails(payload: RpcErrorPayload): unknown {
+  if (payload.details !== undefined) {
+    return payload.details
+  }
+
+  if (payload.error && typeof payload.error === "object" && "details" in payload.error) {
+    return payload.error.details
+  }
+
+  return undefined
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) {
+    return null
+  }
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+async function callRpcProxyFromCron(
+  request: Request,
+  cronSecret: string,
+  { fn, args }: { fn: string; args: Record<string, unknown> }
+): Promise<unknown> {
+  const rpcUrl = new URL(`/api/rpc/${encodeURIComponent(fn)}`, request.url)
+  const body = JSON.stringify(args)
+  const response = await fetch(rpcUrl.toString(), {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${cronSecret}`,
+      "Content-Type": "application/json",
+      "Content-Length": String(Buffer.byteLength(body)),
+      Origin: rpcUrl.origin,
+      "x-qltbyt-internal-rpc": "zbs-dispatch",
+    },
+    body,
+  })
+  const payload = await readJsonResponse(response)
+
+  if (!response.ok) {
+    const errorPayload = parseRpcErrorPayload(payload)
+    throw new ZbsDispatchRpcError(
+      response.status,
+      errorPayloadMessage(errorPayload),
+      errorPayloadDetails(errorPayload)
+    )
+  }
+
+  return payload
 }
 
 /** Runs one guarded ZBS dispatch batch for cron/manual operations. */
@@ -56,19 +145,6 @@ export async function GET(request: Request): Promise<Response> {
     return jsonResponse({ error: "Unauthorized" }, 401)
   }
 
-  const supabaseEnv = readSupabaseEnv()
-  if (!supabaseEnv) {
-    console.error("Missing ZBS dispatch Supabase environment variables")
-    return jsonResponse(
-      { error: "Server configuration error: missing required environment variables" },
-      500
-    )
-  }
-
-  const supabase = createClient(supabaseEnv.supabaseUrl, supabaseEnv.serviceRoleKey, {
-    auth: { persistSession: false },
-  })
-
   try {
     const result = await dispatchPendingZbsNotifications({
       dispatchEnabled: readDispatchEnabled(),
@@ -76,18 +152,21 @@ export async function GET(request: Request): Promise<Response> {
       repairTemplateId: process.env.ZALO_ZBS_REPAIR_TEMPLATE_ID,
       appBaseUrl: readAppBaseUrl(),
       outboxIds: readOutboxIds(request),
-      rpcClient: async ({ fn, args }) => {
-        const { data, error } = await supabase.rpc(fn, args)
-        if (error) {
-          throw new Error(error.message || "ZBS dispatch RPC failed")
-        }
-        return data
-      },
+      rpcClient: (rpcRequest) => callRpcProxyFromCron(request, cronSecret, rpcRequest),
     })
 
     return jsonResponse({ success: true, result }, 200)
-  } catch {
+  } catch (error) {
     console.error("ZBS dispatch cron failed")
+    if (error instanceof ZbsDispatchRpcError) {
+      return jsonResponse(
+        {
+          error: "ZBS dispatch failed",
+          ...(error.details === undefined ? {} : { details: error.details }),
+        },
+        error.status
+      )
+    }
     return jsonResponse({ error: "ZBS dispatch failed" }, 500)
   }
 }

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -50,6 +50,15 @@ function readAppBaseUrl() {
   return process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXTAUTH_URL ?? vercelUrl
 }
 
+function readTrustedAppBaseUrl() {
+  const appBaseUrl = readAppBaseUrl()
+  if (!appBaseUrl) {
+    throw new Error("Missing trusted app base URL")
+  }
+
+  return appBaseUrl
+}
+
 function readInternalRpcSigningSecret() {
   return process.env.ZBS_INTERNAL_RPC_SECRET ?? process.env.SUPABASE_JWT_SECRET
 }
@@ -128,11 +137,10 @@ async function readJsonResponse(response: Response): Promise<unknown> {
 }
 
 async function callRpcProxyFromCron(
-  request: Request,
   cronSecret: string,
   { fn, args }: { fn: string; args: Record<string, unknown> }
 ): Promise<unknown> {
-  const rpcUrl = new URL(`/api/rpc/${encodeURIComponent(fn)}`, request.url)
+  const rpcUrl = new URL(`/api/rpc/${encodeURIComponent(fn)}`, readTrustedAppBaseUrl())
   const body = JSON.stringify(args)
   const signingSecret = readInternalRpcSigningSecret()
   if (!signingSecret) {
@@ -207,7 +215,7 @@ export async function GET(request: Request): Promise<Response> {
       repairTemplateId: process.env.ZALO_ZBS_REPAIR_TEMPLATE_ID,
       appBaseUrl: readAppBaseUrl(),
       outboxIds: readOutboxIds(request),
-      rpcClient: (rpcRequest) => callRpcProxyFromCron(request, cronSecret, rpcRequest),
+      rpcClient: (rpcRequest) => callRpcProxyFromCron(cronSecret, rpcRequest),
     })
 
     return jsonResponse({ success: true, result }, 200)

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -1,0 +1,93 @@
+import { createClient } from "@supabase/supabase-js"
+
+import { dispatchPendingZbsNotifications } from "@/lib/zbs/live-dispatcher"
+
+/** Keep the ZBS dispatch endpoint uncached so each cron/manual call evaluates live state. */
+export const dynamic = "force-dynamic"
+/** Use Node.js runtime for service-role Supabase RPC calls and outbound Zalo fetches. */
+export const runtime = "nodejs"
+
+function jsonResponse(body: unknown, status: number): Response {
+  return Response.json(body, { status })
+}
+
+function readDispatchEnabled() {
+  return process.env.ZALO_ZBS_DISPATCH_ENABLED === "true"
+}
+
+function readAppBaseUrl() {
+  const vercelUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined
+  return process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXTAUTH_URL ?? vercelUrl
+}
+
+function readOutboxIds(request: Request): string[] | undefined {
+  const { searchParams } = new URL(request.url)
+  const ids = searchParams
+    .getAll("outboxId")
+    .map((id) => id.trim())
+    .filter(Boolean)
+
+  return ids.length > 0 ? ids : undefined
+}
+
+function readSupabaseEnv(): { supabaseUrl: string; serviceRoleKey: string } | null {
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  return supabaseUrl && serviceRoleKey ? { supabaseUrl, serviceRoleKey } : null
+}
+
+/** Runs one guarded ZBS dispatch batch for cron/manual operations. */
+export async function GET(request: Request): Promise<Response> {
+  const cronSecret = process.env.CRON_SECRET
+
+  if (!cronSecret) {
+    console.error("Missing ZBS dispatch cron secret")
+    return jsonResponse(
+      { error: "Server configuration error: missing required environment variables" },
+      500
+    )
+  }
+
+  if (request.headers.get("Authorization") !== `Bearer ${cronSecret}`) {
+    console.error("Unauthorized ZBS dispatch cron attempt", {
+      userAgent: request.headers.get("user-agent"),
+    })
+    return jsonResponse({ error: "Unauthorized" }, 401)
+  }
+
+  const supabaseEnv = readSupabaseEnv()
+  if (!supabaseEnv) {
+    console.error("Missing ZBS dispatch Supabase environment variables")
+    return jsonResponse(
+      { error: "Server configuration error: missing required environment variables" },
+      500
+    )
+  }
+
+  const supabase = createClient(supabaseEnv.supabaseUrl, supabaseEnv.serviceRoleKey, {
+    auth: { persistSession: false },
+  })
+
+  try {
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: readDispatchEnabled(),
+      accessToken: process.env.ZALO_ZBS_ACCESS_TOKEN,
+      repairTemplateId: process.env.ZALO_ZBS_REPAIR_TEMPLATE_ID,
+      appBaseUrl: readAppBaseUrl(),
+      outboxIds: readOutboxIds(request),
+      rpcClient: async ({ fn, args }) => {
+        const { data, error } = await supabase.rpc(fn, args)
+        if (error) {
+          throw new Error(error.message || "ZBS dispatch RPC failed")
+        }
+        return data
+      },
+    })
+
+    return jsonResponse({ success: true, result }, 200)
+  } catch {
+    console.error("ZBS dispatch cron failed")
+    return jsonResponse({ error: "ZBS dispatch failed" }, 500)
+  }
+}

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -171,7 +171,6 @@ async function callRpcProxyFromCron(
         Accept: "application/json",
         Authorization: `Bearer ${cronSecret}`,
         "Content-Type": "application/json",
-        "Content-Length": String(Buffer.byteLength(body)),
         Origin: rpcUrl.origin,
         [ZBS_INTERNAL_RPC_SOURCE_HEADER]: ZBS_INTERNAL_RPC_SOURCE,
         [ZBS_INTERNAL_RPC_TIMESTAMP_HEADER]: timestamp,

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -1,9 +1,11 @@
 import { dispatchPendingZbsNotifications } from "@/lib/zbs/live-dispatcher"
 import {
+  ZBS_INTERNAL_RPC_BODY_SHA256_HEADER,
   ZBS_INTERNAL_RPC_SIGNATURE_HEADER,
   ZBS_INTERNAL_RPC_SOURCE,
   ZBS_INTERNAL_RPC_SOURCE_HEADER,
   ZBS_INTERNAL_RPC_TIMESTAMP_HEADER,
+  hashZbsInternalRpcBody,
   signZbsInternalRpc,
 } from "@/lib/zbs/internal-rpc-signature"
 
@@ -137,6 +139,7 @@ async function callRpcProxyFromCron(
     throw new Error("Missing ZBS internal RPC signing secret")
   }
   const timestamp = String(Date.now())
+  const bodySha256 = hashZbsInternalRpcBody(body)
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), INTERNAL_RPC_FETCH_TIMEOUT_MS)
 
@@ -153,7 +156,13 @@ async function callRpcProxyFromCron(
         Origin: rpcUrl.origin,
         [ZBS_INTERNAL_RPC_SOURCE_HEADER]: ZBS_INTERNAL_RPC_SOURCE,
         [ZBS_INTERNAL_RPC_TIMESTAMP_HEADER]: timestamp,
-        [ZBS_INTERNAL_RPC_SIGNATURE_HEADER]: signZbsInternalRpc(signingSecret, fn, timestamp),
+        [ZBS_INTERNAL_RPC_BODY_SHA256_HEADER]: bodySha256,
+        [ZBS_INTERNAL_RPC_SIGNATURE_HEADER]: signZbsInternalRpc(
+          signingSecret,
+          fn,
+          timestamp,
+          bodySha256
+        ),
       },
       body,
       signal: controller.signal,

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -1,4 +1,5 @@
 import { dispatchPendingZbsNotifications } from "@/lib/zbs/live-dispatcher"
+import { sanitizeForLog } from "@/lib/log-sanitizer"
 
 /** Keep the ZBS dispatch endpoint uncached so each cron/manual call evaluates live state. */
 export const dynamic = "force-dynamic"
@@ -157,7 +158,7 @@ export async function GET(request: Request): Promise<Response> {
 
     return jsonResponse({ success: true, result }, 200)
   } catch (error) {
-    console.error("ZBS dispatch cron failed")
+    console.error("ZBS dispatch cron failed", { error: sanitizeForLog(error) })
     if (error instanceof ZbsDispatchRpcError) {
       return jsonResponse(
         {

--- a/src/app/api/cron/zbs-dispatch/route.ts
+++ b/src/app/api/cron/zbs-dispatch/route.ts
@@ -67,7 +67,7 @@ function readTrustedAppBaseUrl() {
 }
 
 function readInternalRpcSigningSecret() {
-  return process.env.ZBS_INTERNAL_RPC_SECRET ?? process.env.SUPABASE_JWT_SECRET
+  return process.env.ZBS_INTERNAL_RPC_SECRET
 }
 
 function readOutboxIds(request: Request): string[] | undefined {

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -45,6 +45,9 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   "repair_request_active_for_equipment",
   // ZBS notifications
   "zbs_notification_outbox_pending_for_dispatch",
+  "zbs_notification_outbox_claim_for_dispatch",
+  "zbs_notification_outbox_mark_sent",
+  "zbs_notification_outbox_mark_failed",
   // Transfers
   "transfer_request_list",
   "transfer_request_page_data",
@@ -182,4 +185,14 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
 /** RPCs that must not be directly executable by the PostgREST `authenticated` role. */
 export const SERVICE_ROLE_RPC_FUNCTIONS = new Set<string>([
   "zbs_notification_outbox_pending_for_dispatch",
+  "zbs_notification_outbox_claim_for_dispatch",
+  "zbs_notification_outbox_mark_sent",
+  "zbs_notification_outbox_mark_failed",
+])
+
+/** Service-role ZBS dispatch RPCs callable by the cron route via CRON_SECRET only. */
+export const ZBS_CRON_RPC_FUNCTIONS = new Set<string>([
+  "zbs_notification_outbox_claim_for_dispatch",
+  "zbs_notification_outbox_mark_sent",
+  "zbs_notification_outbox_mark_failed",
 ])

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -190,7 +190,7 @@ export const SERVICE_ROLE_RPC_FUNCTIONS = new Set<string>([
   "zbs_notification_outbox_mark_failed",
 ])
 
-/** Service-role ZBS dispatch RPCs callable by the cron route via CRON_SECRET only. */
+/** Service-role ZBS dispatch RPCs callable only through the signed internal cron path. */
 export const ZBS_CRON_RPC_FUNCTIONS = new Set<string>([
   "zbs_notification_outbox_claim_for_dispatch",
   "zbs_notification_outbox_mark_sent",

--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -132,7 +132,7 @@ function canInvokeServiceRoleRpc(claims: Pick<RpcSessionClaims, "appRole">): boo
 }
 
 function readInternalRpcSigningSecret() {
-  return process.env.ZBS_INTERNAL_RPC_SECRET ?? process.env.SUPABASE_JWT_SECRET
+  return process.env.ZBS_INTERNAL_RPC_SECRET
 }
 
 function hasInternalZbsCronRpcHeaders(req: NextRequest, fn: string): boolean {

--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -6,6 +6,13 @@ import { toAppRoleClaim } from "@/auth/server-claims"
 import { mintSupabaseJwt } from "@/lib/ai/server-rpc"
 import { sanitizeForLog } from "@/lib/log-sanitizer"
 import { SameOriginRequestError, assertSameOriginRequest } from "@/lib/same-origin-request"
+import {
+  ZBS_INTERNAL_RPC_SIGNATURE_HEADER,
+  ZBS_INTERNAL_RPC_SOURCE,
+  ZBS_INTERNAL_RPC_SOURCE_HEADER,
+  ZBS_INTERNAL_RPC_TIMESTAMP_HEADER,
+  isValidZbsInternalRpcSignature,
+} from "@/lib/zbs/internal-rpc-signature"
 
 import {
   ALLOWED_FUNCTIONS,
@@ -122,13 +129,23 @@ function canInvokeServiceRoleRpc(claims: Pick<RpcSessionClaims, "appRole">): boo
   return claims.appRole === "global" || claims.appRole === "to_qltb"
 }
 
+function readInternalRpcSigningSecret() {
+  return process.env.ZBS_INTERNAL_RPC_SECRET ?? process.env.SUPABASE_JWT_SECRET
+}
+
 function isInternalZbsCronRpc(req: NextRequest, fn: string): boolean {
   const cronSecret = process.env.CRON_SECRET
   return (
     Boolean(cronSecret) &&
     ZBS_CRON_RPC_FUNCTIONS.has(fn) &&
-    req.headers.get("x-qltbyt-internal-rpc") === "zbs-dispatch" &&
-    req.headers.get("authorization") === `Bearer ${cronSecret}`
+    req.headers.get(ZBS_INTERNAL_RPC_SOURCE_HEADER) === ZBS_INTERNAL_RPC_SOURCE &&
+    req.headers.get("authorization") === `Bearer ${cronSecret}` &&
+    isValidZbsInternalRpcSignature({
+      secret: readInternalRpcSigningSecret(),
+      fn,
+      timestamp: req.headers.get(ZBS_INTERNAL_RPC_TIMESTAMP_HEADER),
+      signature: req.headers.get(ZBS_INTERNAL_RPC_SIGNATURE_HEADER),
+    })
   )
 }
 
@@ -158,6 +175,11 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
 
     if (!ALLOWED_FUNCTIONS.has(fn)) {
       return NextResponse.json({ error: "Function not allowed" }, { status: 403 })
+    }
+
+    const isInternalZbsCron = isInternalZbsCronRpc(req, fn)
+    if (ZBS_CRON_RPC_FUNCTIONS.has(fn) && !isInternalZbsCron) {
+      return NextResponse.json({ error: "Cron-only RPC not allowed" }, { status: 403 })
     }
 
     // SECURITY: Enforce body size limit BEFORE buffering/parsing to prevent DoS
@@ -192,7 +214,7 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
     }
 
-    const claims = isInternalZbsCronRpc(req, fn)
+    const claims = isInternalZbsCron
       ? getInternalZbsCronClaims()
       : await (async (): Promise<RpcSessionClaims | NextResponse> => {
           // Pull claims from NextAuth session securely (no client headers trusted)

--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -7,10 +7,12 @@ import { mintSupabaseJwt } from "@/lib/ai/server-rpc"
 import { sanitizeForLog } from "@/lib/log-sanitizer"
 import { SameOriginRequestError, assertSameOriginRequest } from "@/lib/same-origin-request"
 import {
+  ZBS_INTERNAL_RPC_BODY_SHA256_HEADER,
   ZBS_INTERNAL_RPC_SIGNATURE_HEADER,
   ZBS_INTERNAL_RPC_SOURCE,
   ZBS_INTERNAL_RPC_SOURCE_HEADER,
   ZBS_INTERNAL_RPC_TIMESTAMP_HEADER,
+  hashZbsInternalRpcBody,
   isValidZbsInternalRpcSignature,
 } from "@/lib/zbs/internal-rpc-signature"
 
@@ -133,17 +135,28 @@ function readInternalRpcSigningSecret() {
   return process.env.ZBS_INTERNAL_RPC_SECRET ?? process.env.SUPABASE_JWT_SECRET
 }
 
-function isInternalZbsCronRpc(req: NextRequest, fn: string): boolean {
+function hasInternalZbsCronRpcHeaders(req: NextRequest, fn: string): boolean {
   const cronSecret = process.env.CRON_SECRET
   return (
     Boolean(cronSecret) &&
     ZBS_CRON_RPC_FUNCTIONS.has(fn) &&
     req.headers.get(ZBS_INTERNAL_RPC_SOURCE_HEADER) === ZBS_INTERNAL_RPC_SOURCE &&
     req.headers.get("authorization") === `Bearer ${cronSecret}` &&
+    Boolean(req.headers.get(ZBS_INTERNAL_RPC_TIMESTAMP_HEADER)) &&
+    Boolean(req.headers.get(ZBS_INTERNAL_RPC_BODY_SHA256_HEADER)) &&
+    Boolean(req.headers.get(ZBS_INTERNAL_RPC_SIGNATURE_HEADER))
+  )
+}
+
+function isInternalZbsCronRpc(req: NextRequest, fn: string, rawBody: string): boolean {
+  return (
+    hasInternalZbsCronRpcHeaders(req, fn) &&
     isValidZbsInternalRpcSignature({
       secret: readInternalRpcSigningSecret(),
       fn,
       timestamp: req.headers.get(ZBS_INTERNAL_RPC_TIMESTAMP_HEADER),
+      bodySha256: hashZbsInternalRpcBody(rawBody),
+      bodySha256Header: req.headers.get(ZBS_INTERNAL_RPC_BODY_SHA256_HEADER),
       signature: req.headers.get(ZBS_INTERNAL_RPC_SIGNATURE_HEADER),
     })
   )
@@ -177,8 +190,8 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
       return NextResponse.json({ error: "Function not allowed" }, { status: 403 })
     }
 
-    const isInternalZbsCron = isInternalZbsCronRpc(req, fn)
-    if (ZBS_CRON_RPC_FUNCTIONS.has(fn) && !isInternalZbsCron) {
+    const isZbsCronRpc = ZBS_CRON_RPC_FUNCTIONS.has(fn)
+    if (isZbsCronRpc && !hasInternalZbsCronRpcHeaders(req, fn)) {
       return NextResponse.json({ error: "Cron-only RPC not allowed" }, { status: 403 })
     }
 
@@ -207,11 +220,17 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
 
     // 4. Decode buffer to text and parse JSON
     let rawBody: unknown = {}
+    let rawText = ""
     try {
-      const rawText = new TextDecoder().decode(buf)
+      rawText = new TextDecoder().decode(buf)
       rawBody = rawText ? JSON.parse(rawText) : {}
     } catch {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+    }
+
+    const isInternalZbsCron = isZbsCronRpc && isInternalZbsCronRpc(req, fn, rawText)
+    if (isZbsCronRpc && !isInternalZbsCron) {
+      return NextResponse.json({ error: "Cron-only RPC not allowed" }, { status: 403 })
     }
 
     const claims = isInternalZbsCron

--- a/src/app/api/rpc/[fn]/route.ts
+++ b/src/app/api/rpc/[fn]/route.ts
@@ -7,7 +7,11 @@ import { mintSupabaseJwt } from "@/lib/ai/server-rpc"
 import { sanitizeForLog } from "@/lib/log-sanitizer"
 import { SameOriginRequestError, assertSameOriginRequest } from "@/lib/same-origin-request"
 
-import { ALLOWED_FUNCTIONS, SERVICE_ROLE_RPC_FUNCTIONS } from "./allowed-functions"
+import {
+  ALLOWED_FUNCTIONS,
+  SERVICE_ROLE_RPC_FUNCTIONS,
+  ZBS_CRON_RPC_FUNCTIONS,
+} from "./allowed-functions"
 
 /** Run the RPC proxy on Node.js so JWT signing uses the server crypto stack. */
 export const runtime = "nodejs"
@@ -118,6 +122,27 @@ function canInvokeServiceRoleRpc(claims: Pick<RpcSessionClaims, "appRole">): boo
   return claims.appRole === "global" || claims.appRole === "to_qltb"
 }
 
+function isInternalZbsCronRpc(req: NextRequest, fn: string): boolean {
+  const cronSecret = process.env.CRON_SECRET
+  return (
+    Boolean(cronSecret) &&
+    ZBS_CRON_RPC_FUNCTIONS.has(fn) &&
+    req.headers.get("x-qltbyt-internal-rpc") === "zbs-dispatch" &&
+    req.headers.get("authorization") === `Bearer ${cronSecret}`
+  )
+}
+
+function getInternalZbsCronClaims(): RpcSessionClaims {
+  return {
+    role: "to_qltb",
+    donVi: "0",
+    diaBan: "0",
+    khoaPhong: "zbs-dispatch",
+    userId: "zbs-dispatch-cron",
+    appRole: "to_qltb",
+  }
+}
+
 /** Proxies allowlisted Supabase RPC calls with JWT claims derived from the server session. */
 export async function POST(req: NextRequest, context: { params: Promise<{ fn: string }> }) {
   try {
@@ -167,18 +192,26 @@ export async function POST(req: NextRequest, context: { params: Promise<{ fn: st
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
     }
 
-    // Pull claims from NextAuth session securely (no client headers trusted)
-    const session = await getServerSession(authOptions)
-    const sessionUser = getSessionUser(session)
+    const claims = isInternalZbsCronRpc(req, fn)
+      ? getInternalZbsCronClaims()
+      : await (async (): Promise<RpcSessionClaims | NextResponse> => {
+          // Pull claims from NextAuth session securely (no client headers trusted)
+          const session = await getServerSession(authOptions)
+          const sessionUser = getSessionUser(session)
 
-    // SECURITY: Reject unauthenticated requests - do NOT mint JWT without valid session
-    if (!sessionUser) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-    }
+          // SECURITY: Reject unauthenticated requests - do NOT mint JWT without valid session
+          if (!sessionUser) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+          }
 
-    const claims = getSessionClaims(sessionUser)
-    if (!claims) {
-      return NextResponse.json({ error: "Invalid session claims" }, { status: 400 })
+          const sessionClaims = getSessionClaims(sessionUser)
+          if (!sessionClaims) {
+            return NextResponse.json({ error: "Invalid session claims" }, { status: 400 })
+          }
+          return sessionClaims
+        })()
+    if (claims instanceof NextResponse) {
+      return claims
     }
     // (debug removed)
 

--- a/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
@@ -37,6 +37,7 @@ describe("RPC proxy same-origin guard", () => {
     vi.stubEnv("SUPABASE_JWT_SECRET", "test-secret")
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co")
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key")
+    vi.stubEnv("CRON_SECRET", "cron-secret")
 
     getServerSessionMock.mockReset()
     jwtSignMock.mockReset()
@@ -179,6 +180,63 @@ describe("RPC proxy same-origin guard", () => {
     expect(res.status).toBe(403)
     await expect(res.json()).resolves.toEqual({
       error: "Service-role RPC not allowed",
+    })
+    expect(jwtSignMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("allows internal cron calls for ZBS service-role RPCs without a NextAuth session", async () => {
+    getServerSessionMock.mockResolvedValueOnce(null)
+
+    const res = await POST(
+      buildRequest(
+        { p_limit: 10 },
+        {
+          authorization: "Bearer cron-secret",
+          "x-qltbyt-internal-rpc": "zbs-dispatch",
+          origin: "https://app.example.com",
+        }
+      ) as never,
+      { params: Promise.resolve({ fn: "zbs_notification_outbox_claim_for_dispatch" }) }
+    )
+
+    expect(res.status).toBe(200)
+    expect(getServerSessionMock).not.toHaveBeenCalled()
+    expect(jwtSignMock).toHaveBeenCalledOnce()
+    expect(jwtSignMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        role: "service_role",
+        app_role: "to_qltb",
+        user_id: "zbs-dispatch-cron",
+      })
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.supabase.co/rest/v1/rpc/zbs_notification_outbox_claim_for_dispatch",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ p_limit: 10 }),
+      })
+    )
+  })
+
+  it("does not treat the cron bearer as a session bypass for non-ZBS RPCs", async () => {
+    getServerSessionMock.mockResolvedValueOnce(null)
+
+    const res = await POST(
+      buildRequest(
+        { query: "SpO2" },
+        {
+          authorization: "Bearer cron-secret",
+          "x-qltbyt-internal-rpc": "zbs-dispatch",
+          origin: "https://app.example.com",
+        }
+      ) as never,
+      { params: Promise.resolve({ fn: "ai_equipment_lookup" }) }
+    )
+
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({
+      error: "Unauthorized",
     })
     expect(jwtSignMock).not.toHaveBeenCalled()
     expect(fetchMock).not.toHaveBeenCalled()

--- a/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
@@ -17,6 +17,7 @@ vi.mock("jsonwebtoken", () => ({
 }))
 
 import { POST } from "@/app/api/rpc/[fn]/route"
+import { signZbsInternalRpc } from "@/lib/zbs/internal-rpc-signature"
 
 function buildRequest(body: Record<string, unknown>, headers: Record<string, string> = {}) {
   const encodedBody = JSON.stringify(body)
@@ -30,6 +31,16 @@ function buildRequest(body: Record<string, unknown>, headers: Record<string, str
     },
     body: encodedBody,
   })
+}
+
+function signedInternalCronHeaders(fn: string) {
+  const timestamp = String(Date.now())
+  return {
+    authorization: "Bearer cron-secret",
+    "x-qltbyt-internal-rpc": "zbs-dispatch",
+    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc("test-secret", fn, timestamp),
+    "x-qltbyt-internal-rpc-timestamp": timestamp,
+  }
 }
 
 describe("RPC proxy same-origin guard", () => {
@@ -192,8 +203,7 @@ describe("RPC proxy same-origin guard", () => {
       buildRequest(
         { p_limit: 10 },
         {
-          authorization: "Bearer cron-secret",
-          "x-qltbyt-internal-rpc": "zbs-dispatch",
+          ...signedInternalCronHeaders("zbs_notification_outbox_claim_for_dispatch"),
           origin: "https://app.example.com",
         }
       ) as never,

--- a/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
@@ -5,6 +5,7 @@ vi.mock("server-only", () => ({}))
 const getServerSessionMock = vi.fn()
 const jwtSignMock = vi.fn()
 const fetchMock = vi.fn()
+const INTERNAL_RPC_SECRET = "test-internal-rpc-secret"
 
 vi.mock("next-auth", () => ({
   getServerSession: (...args: unknown[]) => getServerSessionMock(...args),
@@ -33,14 +34,18 @@ function buildRequest(body: Record<string, unknown>, headers: Record<string, str
   })
 }
 
-function signedInternalCronHeaders(fn: string, body: Record<string, unknown>) {
+function signedInternalCronHeaders(
+  fn: string,
+  body: Record<string, unknown>,
+  secret = INTERNAL_RPC_SECRET
+) {
   const timestamp = String(Date.now())
   const bodySha256 = hashZbsInternalRpcBody(JSON.stringify(body))
   return {
     authorization: "Bearer cron-secret",
     "x-qltbyt-internal-rpc": "zbs-dispatch",
     "x-qltbyt-internal-rpc-body-sha256": bodySha256,
-    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc("test-secret", fn, timestamp, bodySha256),
+    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc(secret, fn, timestamp, bodySha256),
     "x-qltbyt-internal-rpc-timestamp": timestamp,
   }
 }
@@ -48,6 +53,7 @@ function signedInternalCronHeaders(fn: string, body: Record<string, unknown>) {
 describe("RPC proxy same-origin guard", () => {
   beforeEach(() => {
     vi.stubEnv("SUPABASE_JWT_SECRET", "test-secret")
+    vi.stubEnv("ZBS_INTERNAL_RPC_SECRET", INTERNAL_RPC_SECRET)
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co")
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "test-anon-key")
     vi.stubEnv("CRON_SECRET", "cron-secret")
@@ -227,6 +233,29 @@ describe("RPC proxy same-origin guard", () => {
         body: JSON.stringify({ p_limit: 10 }),
       })
     )
+  })
+
+  it("rejects internal cron ZBS RPCs signed with the Supabase JWT secret fallback", async () => {
+    delete process.env.ZBS_INTERNAL_RPC_SECRET
+    const body = { p_limit: 10 }
+
+    const res = await POST(
+      buildRequest(body, {
+        ...signedInternalCronHeaders(
+          "zbs_notification_outbox_claim_for_dispatch",
+          body,
+          "test-secret"
+        ),
+        origin: "https://app.example.com",
+      }) as never,
+      { params: Promise.resolve({ fn: "zbs_notification_outbox_claim_for_dispatch" }) }
+    )
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: "Cron-only RPC not allowed" })
+    expect(getServerSessionMock).not.toHaveBeenCalled()
+    expect(jwtSignMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it("rejects internal cron ZBS RPCs when the signed body hash does not match the request", async () => {

--- a/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-same-origin.unit.test.ts
@@ -17,7 +17,7 @@ vi.mock("jsonwebtoken", () => ({
 }))
 
 import { POST } from "@/app/api/rpc/[fn]/route"
-import { signZbsInternalRpc } from "@/lib/zbs/internal-rpc-signature"
+import { hashZbsInternalRpcBody, signZbsInternalRpc } from "@/lib/zbs/internal-rpc-signature"
 
 function buildRequest(body: Record<string, unknown>, headers: Record<string, string> = {}) {
   const encodedBody = JSON.stringify(body)
@@ -33,12 +33,14 @@ function buildRequest(body: Record<string, unknown>, headers: Record<string, str
   })
 }
 
-function signedInternalCronHeaders(fn: string) {
+function signedInternalCronHeaders(fn: string, body: Record<string, unknown>) {
   const timestamp = String(Date.now())
+  const bodySha256 = hashZbsInternalRpcBody(JSON.stringify(body))
   return {
     authorization: "Bearer cron-secret",
     "x-qltbyt-internal-rpc": "zbs-dispatch",
-    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc("test-secret", fn, timestamp),
+    "x-qltbyt-internal-rpc-body-sha256": bodySha256,
+    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc("test-secret", fn, timestamp, bodySha256),
     "x-qltbyt-internal-rpc-timestamp": timestamp,
   }
 }
@@ -198,15 +200,13 @@ describe("RPC proxy same-origin guard", () => {
 
   it("allows internal cron calls for ZBS service-role RPCs without a NextAuth session", async () => {
     getServerSessionMock.mockResolvedValueOnce(null)
+    const body = { p_limit: 10 }
 
     const res = await POST(
-      buildRequest(
-        { p_limit: 10 },
-        {
-          ...signedInternalCronHeaders("zbs_notification_outbox_claim_for_dispatch"),
-          origin: "https://app.example.com",
-        }
-      ) as never,
+      buildRequest(body, {
+        ...signedInternalCronHeaders("zbs_notification_outbox_claim_for_dispatch", body),
+        origin: "https://app.example.com",
+      }) as never,
       { params: Promise.resolve({ fn: "zbs_notification_outbox_claim_for_dispatch" }) }
     )
 
@@ -227,6 +227,27 @@ describe("RPC proxy same-origin guard", () => {
         body: JSON.stringify({ p_limit: 10 }),
       })
     )
+  })
+
+  it("rejects internal cron ZBS RPCs when the signed body hash does not match the request", async () => {
+    const signedBody = { p_limit: 10 }
+
+    const res = await POST(
+      buildRequest(
+        { p_limit: 25 },
+        {
+          ...signedInternalCronHeaders("zbs_notification_outbox_claim_for_dispatch", signedBody),
+          origin: "https://app.example.com",
+        }
+      ) as never,
+      { params: Promise.resolve({ fn: "zbs_notification_outbox_claim_for_dispatch" }) }
+    )
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: "Cron-only RPC not allowed" })
+    expect(getServerSessionMock).not.toHaveBeenCalled()
+    expect(jwtSignMock).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it("does not treat the cron bearer as a session bypass for non-ZBS RPCs", async () => {

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -4,7 +4,7 @@ vi.mock("server-only", () => ({}))
 
 import { ALLOWED_FUNCTIONS, SERVICE_ROLE_RPC_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
 import { POST } from "@/app/api/rpc/[fn]/route"
-import { signZbsInternalRpc } from "@/lib/zbs/internal-rpc-signature"
+import { hashZbsInternalRpcBody, signZbsInternalRpc } from "@/lib/zbs/internal-rpc-signature"
 
 async function invokeRpcProxy(fn: string, headers: HeadersInit = {}) {
   const req = new Request(`http://localhost/api/rpc/${fn}`, { method: "POST", headers })
@@ -13,10 +13,17 @@ async function invokeRpcProxy(fn: string, headers: HeadersInit = {}) {
 
 function signedInternalCronHeaders(fn: string) {
   const timestamp = String(Date.now())
+  const bodySha256 = hashZbsInternalRpcBody("")
   return {
     authorization: "Bearer cron-secret",
     "x-qltbyt-internal-rpc": "zbs-dispatch",
-    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc("test-jwt-secret", fn, timestamp),
+    "x-qltbyt-internal-rpc-body-sha256": bodySha256,
+    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc(
+      "test-jwt-secret",
+      fn,
+      timestamp,
+      bodySha256
+    ),
     "x-qltbyt-internal-rpc-timestamp": timestamp,
   }
 }

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -6,24 +6,21 @@ import { ALLOWED_FUNCTIONS, SERVICE_ROLE_RPC_FUNCTIONS } from "@/app/api/rpc/[fn
 import { POST } from "@/app/api/rpc/[fn]/route"
 import { hashZbsInternalRpcBody, signZbsInternalRpc } from "@/lib/zbs/internal-rpc-signature"
 
+const INTERNAL_RPC_SECRET = "test-internal-rpc-secret"
+
 async function invokeRpcProxy(fn: string, headers: HeadersInit = {}) {
   const req = new Request(`http://localhost/api/rpc/${fn}`, { method: "POST", headers })
   return POST(req as never, { params: Promise.resolve({ fn }) })
 }
 
-function signedInternalCronHeaders(fn: string) {
+function signedInternalCronHeaders(fn: string, secret = INTERNAL_RPC_SECRET) {
   const timestamp = String(Date.now())
   const bodySha256 = hashZbsInternalRpcBody("")
   return {
     authorization: "Bearer cron-secret",
     "x-qltbyt-internal-rpc": "zbs-dispatch",
     "x-qltbyt-internal-rpc-body-sha256": bodySha256,
-    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc(
-      "test-jwt-secret",
-      fn,
-      timestamp,
-      bodySha256
-    ),
+    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc(secret, fn, timestamp, bodySha256),
     "x-qltbyt-internal-rpc-timestamp": timestamp,
   }
 }
@@ -86,10 +83,25 @@ describe("RPC proxy whitelist", () => {
   ])('allows cron-only ZBS dispatch RPC "%s" through the internal cron gate', async (fn) => {
     vi.stubEnv("CRON_SECRET", "cron-secret")
     vi.stubEnv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+    vi.stubEnv("ZBS_INTERNAL_RPC_SECRET", INTERNAL_RPC_SECRET)
     const res = await invokeRpcProxy(fn, signedInternalCronHeaders(fn))
 
     expect(res.status).toBe(411)
     await expect(res.json()).resolves.toEqual({ error: "Content-Length header required" })
+  })
+
+  it("rejects cron-only ZBS dispatch RPCs signed with the Supabase JWT secret fallback", async () => {
+    vi.stubEnv("CRON_SECRET", "cron-secret")
+    vi.stubEnv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+    delete process.env.ZBS_INTERNAL_RPC_SECRET
+
+    const res = await invokeRpcProxy("zbs_notification_outbox_claim_for_dispatch", {
+      ...signedInternalCronHeaders("zbs_notification_outbox_claim_for_dispatch", "test-jwt-secret"),
+      "content-length": "0",
+    })
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: "Cron-only RPC not allowed" })
   })
 
   it("rejects the cron bearer and internal source header without a server signature", async () => {

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -39,17 +39,25 @@ describe("RPC proxy whitelist", () => {
     await expect(res.json()).resolves.toEqual({ error: "Content-Length header required" })
   })
 
-  it("allows ZBS pending-dispatch RPC through whitelist checks", async () => {
-    const res = await invokeRpcProxy("zbs_notification_outbox_pending_for_dispatch")
+  it.each([
+    "zbs_notification_outbox_pending_for_dispatch",
+    "zbs_notification_outbox_claim_for_dispatch",
+    "zbs_notification_outbox_mark_sent",
+    "zbs_notification_outbox_mark_failed",
+  ])('allows ZBS dispatch RPC "%s" through whitelist checks', async (fn) => {
+    const res = await invokeRpcProxy(fn)
 
     expect(res.status).toBe(411)
     await expect(res.json()).resolves.toEqual({ error: "Content-Length header required" })
   })
 
-  it("keeps ZBS pending-dispatch RPC on the server-only DB role path", () => {
+  it("keeps ZBS dispatch RPCs on the server-only DB role path", () => {
     expect(SERVICE_ROLE_RPC_FUNCTIONS.has("zbs_notification_outbox_pending_for_dispatch")).toBe(
       true
     )
+    expect(SERVICE_ROLE_RPC_FUNCTIONS.has("zbs_notification_outbox_claim_for_dispatch")).toBe(true)
+    expect(SERVICE_ROLE_RPC_FUNCTIONS.has("zbs_notification_outbox_mark_sent")).toBe(true)
+    expect(SERVICE_ROLE_RPC_FUNCTIONS.has("zbs_notification_outbox_mark_failed")).toBe(true)
     expect([...SERVICE_ROLE_RPC_FUNCTIONS].every((fn) => ALLOWED_FUNCTIONS.has(fn))).toBe(true)
   })
 

--- a/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
+++ b/src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts
@@ -1,16 +1,31 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("server-only", () => ({}))
 
 import { ALLOWED_FUNCTIONS, SERVICE_ROLE_RPC_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
 import { POST } from "@/app/api/rpc/[fn]/route"
+import { signZbsInternalRpc } from "@/lib/zbs/internal-rpc-signature"
 
-async function invokeRpcProxy(fn: string) {
-  const req = new Request(`http://localhost/api/rpc/${fn}`, { method: "POST" })
+async function invokeRpcProxy(fn: string, headers: HeadersInit = {}) {
+  const req = new Request(`http://localhost/api/rpc/${fn}`, { method: "POST", headers })
   return POST(req as never, { params: Promise.resolve({ fn }) })
 }
 
+function signedInternalCronHeaders(fn: string) {
+  const timestamp = String(Date.now())
+  return {
+    authorization: "Bearer cron-secret",
+    "x-qltbyt-internal-rpc": "zbs-dispatch",
+    "x-qltbyt-internal-rpc-signature": signZbsInternalRpc("test-jwt-secret", fn, timestamp),
+    "x-qltbyt-internal-rpc-timestamp": timestamp,
+  }
+}
+
 describe("RPC proxy whitelist", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it("rejects unknown RPC functions", async () => {
     const res = await invokeRpcProxy("unknown_rpc_fn")
     expect(res.status).toBe(403)
@@ -39,16 +54,47 @@ describe("RPC proxy whitelist", () => {
     await expect(res.json()).resolves.toEqual({ error: "Content-Length header required" })
   })
 
-  it.each([
-    "zbs_notification_outbox_pending_for_dispatch",
-    "zbs_notification_outbox_claim_for_dispatch",
-    "zbs_notification_outbox_mark_sent",
-    "zbs_notification_outbox_mark_failed",
-  ])('allows ZBS dispatch RPC "%s" through whitelist checks', async (fn) => {
-    const res = await invokeRpcProxy(fn)
+  it("allows the ZBS pending dispatch read RPC through whitelist checks", async () => {
+    const res = await invokeRpcProxy("zbs_notification_outbox_pending_for_dispatch")
 
     expect(res.status).toBe(411)
     await expect(res.json()).resolves.toEqual({ error: "Content-Length header required" })
+  })
+
+  it.each([
+    "zbs_notification_outbox_claim_for_dispatch",
+    "zbs_notification_outbox_mark_sent",
+    "zbs_notification_outbox_mark_failed",
+  ])('rejects cron-only ZBS dispatch RPC "%s" without the internal cron bearer', async (fn) => {
+    const res = await invokeRpcProxy(fn)
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: "Cron-only RPC not allowed" })
+  })
+
+  it.each([
+    "zbs_notification_outbox_claim_for_dispatch",
+    "zbs_notification_outbox_mark_sent",
+    "zbs_notification_outbox_mark_failed",
+  ])('allows cron-only ZBS dispatch RPC "%s" through the internal cron gate', async (fn) => {
+    vi.stubEnv("CRON_SECRET", "cron-secret")
+    vi.stubEnv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+    const res = await invokeRpcProxy(fn, signedInternalCronHeaders(fn))
+
+    expect(res.status).toBe(411)
+    await expect(res.json()).resolves.toEqual({ error: "Content-Length header required" })
+  })
+
+  it("rejects the cron bearer and internal source header without a server signature", async () => {
+    vi.stubEnv("CRON_SECRET", "cron-secret")
+    vi.stubEnv("SUPABASE_JWT_SECRET", "test-jwt-secret")
+    const res = await invokeRpcProxy("zbs_notification_outbox_claim_for_dispatch", {
+      authorization: "Bearer cron-secret",
+      "x-qltbyt-internal-rpc": "zbs-dispatch",
+    })
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: "Cron-only RPC not allowed" })
   })
 
   it("keeps ZBS dispatch RPCs on the server-only DB role path", () => {

--- a/src/lib/zbs/__tests__/internal-rpc-signature.test.ts
+++ b/src/lib/zbs/__tests__/internal-rpc-signature.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  hashZbsInternalRpcBody,
+  isValidZbsInternalRpcSignature,
+  signZbsInternalRpc,
+} from "@/lib/zbs/internal-rpc-signature"
+
+describe("ZBS internal RPC signature validation", () => {
+  it("rejects non-canonical hex body hash and signature headers", () => {
+    const secret = "test-secret"
+    const fn = "zbs_notification_outbox_claim_for_dispatch"
+    const timestamp = "1700000000000"
+    const bodySha256 = hashZbsInternalRpcBody(JSON.stringify({ p_limit: 1 }))
+    const signature = signZbsInternalRpc(secret, fn, timestamp, bodySha256)
+
+    expect(
+      isValidZbsInternalRpcSignature({
+        secret,
+        fn,
+        timestamp,
+        bodySha256,
+        bodySha256Header: `${bodySha256}zz`,
+        signature,
+        nowMs: Number(timestamp),
+      })
+    ).toBe(false)
+    expect(
+      isValidZbsInternalRpcSignature({
+        secret,
+        fn,
+        timestamp,
+        bodySha256,
+        bodySha256Header: bodySha256,
+        signature: `${signature}zz`,
+        nowMs: Number(timestamp),
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/zbs/__tests__/live-dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   ZBS_CLAIM_DISPATCH_RPC,
@@ -31,6 +31,10 @@ const baseOutboxRow = {
 } as const
 
 describe("dispatchPendingZbsNotifications", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it("does not claim rows or call Zalo when the dispatch gate is disabled", async () => {
     const rpcClient = vi.fn()
     const fetchImpl = vi.fn()
@@ -138,6 +142,35 @@ describe("dispatchPendingZbsNotifications", () => {
     })
   })
 
+  it("preserves an explicit empty outbox filter when claiming rows", async () => {
+    const rpcClient = vi.fn().mockResolvedValueOnce([])
+    const fetchImpl = vi.fn()
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      outboxIds: [],
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(rpcClient).toHaveBeenCalledWith({
+      fn: ZBS_CLAIM_DISPATCH_RPC,
+      args: {
+        p_limit: 25,
+        p_now: "2026-06-30T08:00:00.000Z",
+        p_outbox_ids: [],
+      },
+    })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      attempted: 0,
+      results: [],
+    })
+  })
+
   it("persists retryable and final failures per outbox row without aborting the batch", async () => {
     const retryableRow = { ...baseOutboxRow, id: "retryable-row", tracking_id: "retryable" }
     const successRow = { ...baseOutboxRow, id: "success-row", tracking_id: "success" }
@@ -206,6 +239,154 @@ describe("dispatchPendingZbsNotifications", () => {
         { outbox_id: "retryable-row", status: "retryable_failed" },
         { outbox_id: "success-row", status: "sent" },
         { outbox_id: "final-row", status: "failed" },
+      ],
+    })
+  })
+
+  it("marks malformed successful provider responses as non-retryable provider failures", async () => {
+    const rpcClient = vi.fn().mockResolvedValueOnce([baseOutboxRow]).mockResolvedValueOnce(null)
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 0,
+          message: "Success",
+          data: { accepted: true },
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(rpcClient).toHaveBeenCalledWith({
+      fn: ZBS_MARK_FAILED_RPC,
+      args: {
+        p_id: "outbox-1",
+        p_retryable: false,
+        p_error_code: "invalid_provider_response",
+        p_error_message: "Missing Zalo provider msg_id",
+        p_provider_response: {
+          error: 0,
+          message: "Success",
+          data: { accepted: true },
+        },
+      },
+    })
+    expect(result).toMatchObject({
+      attempted: 1,
+      sent: 0,
+      retryable_failed: 0,
+      failed: 1,
+      results: [
+        {
+          outbox_id: "outbox-1",
+          status: "failed",
+          error_code: "invalid_provider_response",
+        },
+      ],
+    })
+  })
+
+  it("aborts hung provider requests and records a retryable network failure", async () => {
+    vi.useFakeTimers()
+    const rpcClient = vi.fn().mockResolvedValueOnce([baseOutboxRow]).mockResolvedValueOnce(null)
+    const fetchImpl = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new Error("provider request aborted"))
+        })
+      })
+    })
+
+    const resultPromise = dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    const result = await resultPromise
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://business.openapi.zalo.me/message/template",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      })
+    )
+    expect(rpcClient).toHaveBeenCalledWith({
+      fn: ZBS_MARK_FAILED_RPC,
+      args: expect.objectContaining({
+        p_id: "outbox-1",
+        p_retryable: true,
+        p_error_code: "network_error",
+        p_error_message: "provider request aborted",
+      }),
+    })
+    expect(result).toMatchObject({
+      attempted: 1,
+      retryable_failed: 1,
+      failed: 0,
+    })
+  })
+
+  it("starts independent provider sends in the same chunk without waiting for earlier sends", async () => {
+    const firstRow = { ...baseOutboxRow, id: "outbox-1", tracking_id: "first" }
+    const secondRow = { ...baseOutboxRow, id: "outbox-2", tracking_id: "second" }
+    const rpcClient = vi
+      .fn()
+      .mockResolvedValueOnce([firstRow, secondRow])
+      .mockResolvedValue([{ id: "updated" }])
+    let resolveFirstSend: (response: Response) => void = () => undefined
+    const fetchImpl = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFirstSend = resolve
+          })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 0, data: { msg_id: "zalo-message-2" } }), {
+          status: 200,
+        })
+      )
+
+    const resultPromise = dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalled())
+    await Promise.resolve()
+    const callsBeforeFirstSendFinished = fetchImpl.mock.calls.length
+    resolveFirstSend(
+      new Response(JSON.stringify({ error: 0, data: { msg_id: "zalo-message-1" } }), {
+        status: 200,
+      })
+    )
+    const result = await resultPromise
+
+    expect(callsBeforeFirstSendFinished).toBe(2)
+    expect(result).toMatchObject({
+      attempted: 2,
+      sent: 2,
+      results: [
+        { outbox_id: "outbox-1", status: "sent" },
+        { outbox_id: "outbox-2", status: "sent" },
       ],
     })
   })

--- a/src/lib/zbs/__tests__/live-dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher.test.ts
@@ -294,6 +294,62 @@ describe("dispatchPendingZbsNotifications", () => {
     })
   })
 
+  it("marks request-build errors failed without aborting the batch", async () => {
+    const invalidRow = { ...baseOutboxRow, id: "invalid-row", recipient_phone: "not-a-phone" }
+    const successRow = { ...baseOutboxRow, id: "success-row", tracking_id: "success" }
+    const rpcClient = vi
+      .fn()
+      .mockResolvedValueOnce([invalidRow, successRow])
+      .mockResolvedValue([{ id: "updated" }])
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 0, data: { msg_id: "zalo-message-2" } }), {
+        status: 200,
+      })
+    )
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(rpcClient).toHaveBeenCalledWith({
+      fn: ZBS_MARK_FAILED_RPC,
+      args: {
+        p_id: "invalid-row",
+        p_retryable: false,
+        p_error_code: "invalid_template_request",
+        p_error_message: "Invalid ZBS recipient phone",
+        p_provider_response: {},
+      },
+    })
+    expect(rpcClient).toHaveBeenCalledWith({
+      fn: ZBS_MARK_SENT_RPC,
+      args: expect.objectContaining({
+        p_id: "success-row",
+        p_provider_message_id: "zalo-message-2",
+      }),
+    })
+    expect(result).toMatchObject({
+      attempted: 2,
+      sent: 1,
+      retryable_failed: 0,
+      failed: 1,
+      results: [
+        {
+          outbox_id: "invalid-row",
+          status: "failed",
+          error_code: "invalid_template_request",
+        },
+        { outbox_id: "success-row", status: "sent" },
+      ],
+    })
+  })
+
   it("aborts hung provider requests and records a retryable network failure", async () => {
     vi.useFakeTimers()
     const rpcClient = vi.fn().mockResolvedValueOnce([baseOutboxRow]).mockResolvedValueOnce(null)

--- a/src/lib/zbs/__tests__/live-dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  ZBS_CLAIM_DISPATCH_RPC,
+  ZBS_MARK_FAILED_RPC,
+  ZBS_MARK_SENT_RPC,
+  dispatchPendingZbsNotifications,
+} from "../live-dispatcher"
+
+const baseOutboxRow = {
+  id: "outbox-1",
+  event_type: "repair_request_created",
+  source_type: "repair_request",
+  source_id: 42,
+  don_vi_id: 17,
+  recipient_config_id: "recipient-1",
+  recipient_phone: "0987654321",
+  template_id: null,
+  tracking_id: "repair_request:42:recipient-1",
+  status: "pending",
+  provider: "zalo_zbs",
+  next_attempt_at: "2026-06-30T00:00:00.000Z",
+  template_data: {
+    repair_request_id: 42,
+    equipment_code: "TB-001",
+    equipment_name: "May tho ICU",
+    department: "ICU",
+    issue_description: "Khong khoi dong duoc",
+    requester: "Nguyen Van A",
+  },
+} as const
+
+describe("dispatchPendingZbsNotifications", () => {
+  it("does not claim rows or call Zalo when the dispatch gate is disabled", async () => {
+    const rpcClient = vi.fn()
+    const fetchImpl = vi.fn()
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: false,
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(result).toEqual({
+      dispatch_state: "disabled-dispatch",
+      attempted: 0,
+      sent: 0,
+      retryable_failed: 0,
+      failed: 0,
+      results: [],
+    })
+    expect(rpcClient).not.toHaveBeenCalled()
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it("claims targeted pending rows and marks successful sends with sanitized provider metadata", async () => {
+    const rpcClient = vi
+      .fn()
+      .mockResolvedValueOnce([baseOutboxRow])
+      .mockResolvedValueOnce([{ id: "outbox-1", status: "sent" }])
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 0,
+          message: "Success",
+          data: {
+            msg_id: "zalo-message-1",
+            sent_time: "2026-06-30T08:00:01.000Z",
+            quota: { daily_remaining: 42 },
+          },
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      outboxIds: ["outbox-1"],
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(rpcClient).toHaveBeenNthCalledWith(1, {
+      fn: ZBS_CLAIM_DISPATCH_RPC,
+      args: {
+        p_limit: 25,
+        p_now: "2026-06-30T08:00:00.000Z",
+        p_outbox_ids: ["outbox-1"],
+      },
+    })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://business.openapi.zalo.me/message/template",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          access_token: "zalo-access-token",
+        },
+      })
+    )
+    expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body))).toMatchObject({
+      phone: "84987654321",
+      template_id: "template-123",
+      tracking_id: "repair_request:42:recipient-1",
+      template_data: {
+        request_id: "42",
+        issue_summary: "Khong khoi dong duoc",
+      },
+    })
+    expect(rpcClient).toHaveBeenNthCalledWith(2, {
+      fn: ZBS_MARK_SENT_RPC,
+      args: {
+        p_id: "outbox-1",
+        p_provider_message_id: "zalo-message-1",
+        p_sent_at: "2026-06-30T08:00:01.000Z",
+        p_provider_response: {
+          error: 0,
+          message: "Success",
+          data: {
+            msg_id: "zalo-message-1",
+            sent_time: "2026-06-30T08:00:01.000Z",
+            quota: { daily_remaining: 42 },
+          },
+        },
+      },
+    })
+    expect(result).toMatchObject({
+      dispatch_state: "live-dispatch",
+      attempted: 1,
+      sent: 1,
+      retryable_failed: 0,
+      failed: 0,
+      results: [{ outbox_id: "outbox-1", status: "sent", provider_message_id: "zalo-message-1" }],
+    })
+  })
+
+  it("persists retryable and final failures per outbox row without aborting the batch", async () => {
+    const retryableRow = { ...baseOutboxRow, id: "retryable-row", tracking_id: "retryable" }
+    const successRow = { ...baseOutboxRow, id: "success-row", tracking_id: "success" }
+    const finalFailureRow = { ...baseOutboxRow, id: "final-row", tracking_id: "final" }
+    const rpcClient = vi
+      .fn()
+      .mockResolvedValueOnce([retryableRow, successRow, finalFailureRow])
+      .mockResolvedValue([{ id: "updated" }])
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("temporarily unavailable", { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 0, data: { msg_id: "zalo-message-2" } }), {
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: -1121,
+            message: "issue_summary data breaks max length",
+          }),
+          { status: 200 }
+        )
+      )
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+    expect(rpcClient).toHaveBeenCalledWith({
+      fn: ZBS_MARK_FAILED_RPC,
+      args: expect.objectContaining({
+        p_id: "retryable-row",
+        p_retryable: true,
+        p_error_code: "http_503",
+      }),
+    })
+    expect(rpcClient).toHaveBeenCalledWith({
+      fn: ZBS_MARK_SENT_RPC,
+      args: expect.objectContaining({
+        p_id: "success-row",
+        p_provider_message_id: "zalo-message-2",
+      }),
+    })
+    expect(rpcClient).toHaveBeenCalledWith({
+      fn: ZBS_MARK_FAILED_RPC,
+      args: expect.objectContaining({
+        p_id: "final-row",
+        p_retryable: false,
+        p_error_code: "zalo_-1121",
+      }),
+    })
+    expect(result).toMatchObject({
+      attempted: 3,
+      sent: 1,
+      retryable_failed: 1,
+      failed: 1,
+      results: [
+        { outbox_id: "retryable-row", status: "retryable_failed" },
+        { outbox_id: "success-row", status: "sent" },
+        { outbox_id: "final-row", status: "failed" },
+      ],
+    })
+  })
+})

--- a/src/lib/zbs/__tests__/live-dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher.test.ts
@@ -452,7 +452,12 @@ describe("dispatchPendingZbsNotifications", () => {
   })
 
   it("isolates unexpected row-level failures without aborting the remaining chunk", async () => {
-    const rejectedRow = { ...baseOutboxRow, id: "rejected-row", tracking_id: "rejected" }
+    const rejectedRow = {
+      ...baseOutboxRow,
+      id: "rejected-row",
+      tracking_id: "rejected",
+      recipient_phone: "",
+    }
     const successRow = { ...baseOutboxRow, id: "success-row", tracking_id: "success" }
     const rpcClient = vi.fn().mockImplementation(async ({ fn, args }) => {
       if (fn === ZBS_CLAIM_DISPATCH_RPC) {
@@ -480,7 +485,7 @@ describe("dispatchPendingZbsNotifications", () => {
       now: new Date("2026-06-30T08:00:00.000Z"),
     })
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({
       attempted: 2,
       sent: 1,

--- a/src/lib/zbs/__tests__/live-dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher.test.ts
@@ -19,6 +19,7 @@ const baseOutboxRow = {
   tracking_id: "repair_request:42:recipient-1",
   status: "pending",
   provider: "zalo_zbs",
+  last_attempt_at: "2026-06-30T08:00:00.000Z",
   next_attempt_at: "2026-06-30T00:00:00.000Z",
   template_data: {
     repair_request_id: 42,
@@ -119,6 +120,7 @@ describe("dispatchPendingZbsNotifications", () => {
       fn: ZBS_MARK_SENT_RPC,
       args: {
         p_id: "outbox-1",
+        p_claimed_at: "2026-06-30T08:00:00.000Z",
         p_provider_message_id: "zalo-message-1",
         p_sent_at: "2026-06-30T08:00:01.000Z",
         p_provider_response: {
@@ -269,6 +271,7 @@ describe("dispatchPendingZbsNotifications", () => {
       fn: ZBS_MARK_FAILED_RPC,
       args: {
         p_id: "outbox-1",
+        p_claimed_at: "2026-06-30T08:00:00.000Z",
         p_retryable: false,
         p_error_code: "invalid_provider_response",
         p_error_message: "Missing Zalo provider msg_id",
@@ -321,6 +324,7 @@ describe("dispatchPendingZbsNotifications", () => {
       fn: ZBS_MARK_FAILED_RPC,
       args: {
         p_id: "invalid-row",
+        p_claimed_at: "2026-06-30T08:00:00.000Z",
         p_retryable: false,
         p_error_code: "invalid_template_request",
         p_error_message: "Invalid ZBS recipient phone",
@@ -443,6 +447,52 @@ describe("dispatchPendingZbsNotifications", () => {
       results: [
         { outbox_id: "outbox-1", status: "sent" },
         { outbox_id: "outbox-2", status: "sent" },
+      ],
+    })
+  })
+
+  it("isolates unexpected row-level failures without aborting the remaining chunk", async () => {
+    const rejectedRow = { ...baseOutboxRow, id: "rejected-row", tracking_id: "rejected" }
+    const successRow = { ...baseOutboxRow, id: "success-row", tracking_id: "success" }
+    const rpcClient = vi.fn().mockImplementation(async ({ fn, args }) => {
+      if (fn === ZBS_CLAIM_DISPATCH_RPC) {
+        return [rejectedRow, successRow]
+      }
+      if (args.p_id === "rejected-row") {
+        throw new Error("provider token should not leak")
+      }
+      return [{ id: "updated" }]
+    })
+    const fetchImpl = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 0, data: { msg_id: "zalo-message" } }), {
+          status: 200,
+        })
+      )
+    )
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({
+      attempted: 2,
+      sent: 1,
+      failed: 1,
+      results: [
+        {
+          outbox_id: "rejected-row",
+          status: "failed",
+          error_code: "dispatch_row_error",
+          error_message: "Unexpected ZBS dispatch row failure",
+        },
+        { outbox_id: "success-row", status: "sent" },
       ],
     })
   })

--- a/src/lib/zbs/dispatcher.ts
+++ b/src/lib/zbs/dispatcher.ts
@@ -27,6 +27,7 @@ export interface ZbsNotificationOutboxRow {
   tracking_id: string
   status: string
   provider: string
+  last_attempt_at?: string | null
   next_attempt_at?: string | null
 }
 

--- a/src/lib/zbs/internal-rpc-signature.ts
+++ b/src/lib/zbs/internal-rpc-signature.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "crypto"
+import { createHash, createHmac, timingSafeEqual } from "crypto"
 
 /** Internal RPC source label accepted by the ZBS cron-only RPC proxy path. */
 export const ZBS_INTERNAL_RPC_SOURCE = "zbs-dispatch"
@@ -6,15 +6,27 @@ export const ZBS_INTERNAL_RPC_SOURCE = "zbs-dispatch"
 export const ZBS_INTERNAL_RPC_SOURCE_HEADER = "x-qltbyt-internal-rpc"
 /** Header carrying the millisecond timestamp used for internal ZBS RPC signature freshness. */
 export const ZBS_INTERNAL_RPC_TIMESTAMP_HEADER = "x-qltbyt-internal-rpc-timestamp"
+/** Header carrying the SHA-256 digest of the internal ZBS RPC request body. */
+export const ZBS_INTERNAL_RPC_BODY_SHA256_HEADER = "x-qltbyt-internal-rpc-body-sha256"
 /** Header carrying the HMAC signature for internal ZBS RPC requests. */
 export const ZBS_INTERNAL_RPC_SIGNATURE_HEADER = "x-qltbyt-internal-rpc-signature"
 
 const ZBS_INTERNAL_RPC_SIGNATURE_TOLERANCE_MS = 60_000
 
+/** Builds a stable SHA-256 digest for a ZBS internal cron RPC request body. */
+export function hashZbsInternalRpcBody(body: string): string {
+  return createHash("sha256").update(body).digest("hex")
+}
+
 /** Builds the HMAC signature for a ZBS internal cron RPC request. */
-export function signZbsInternalRpc(secret: string, fn: string, timestamp: string): string {
+export function signZbsInternalRpc(
+  secret: string,
+  fn: string,
+  timestamp: string,
+  bodySha256: string
+): string {
   return createHmac("sha256", secret)
-    .update(`${ZBS_INTERNAL_RPC_SOURCE}\n${fn}\n${timestamp}`)
+    .update(`${ZBS_INTERNAL_RPC_SOURCE}\n${fn}\n${timestamp}\n${bodySha256}`)
     .digest("hex")
 }
 
@@ -23,16 +35,20 @@ export function isValidZbsInternalRpcSignature({
   secret,
   fn,
   timestamp,
+  bodySha256,
+  bodySha256Header,
   signature,
   nowMs = Date.now(),
 }: {
   secret: string | undefined
   fn: string
   timestamp: string | null
+  bodySha256: string
+  bodySha256Header: string | null
   signature: string | null
   nowMs?: number
 }): boolean {
-  if (!secret || !timestamp || !signature) {
+  if (!secret || !timestamp || !bodySha256Header || !signature) {
     return false
   }
 
@@ -45,7 +61,17 @@ export function isValidZbsInternalRpcSignature({
     return false
   }
 
-  const expected = signZbsInternalRpc(secret, fn, timestamp)
+  const bodySha256Buffer = Buffer.from(bodySha256, "hex")
+  const bodySha256HeaderBuffer = Buffer.from(bodySha256Header, "hex")
+  if (
+    bodySha256Buffer.length !== 32 ||
+    bodySha256Buffer.length !== bodySha256HeaderBuffer.length ||
+    !timingSafeEqual(bodySha256Buffer, bodySha256HeaderBuffer)
+  ) {
+    return false
+  }
+
+  const expected = signZbsInternalRpc(secret, fn, timestamp, bodySha256)
   const expectedBuffer = Buffer.from(expected, "hex")
   const signatureBuffer = Buffer.from(signature, "hex")
   return (

--- a/src/lib/zbs/internal-rpc-signature.ts
+++ b/src/lib/zbs/internal-rpc-signature.ts
@@ -1,0 +1,55 @@
+import { createHmac, timingSafeEqual } from "crypto"
+
+/** Internal RPC source label accepted by the ZBS cron-only RPC proxy path. */
+export const ZBS_INTERNAL_RPC_SOURCE = "zbs-dispatch"
+/** Header carrying the internal ZBS RPC source label. */
+export const ZBS_INTERNAL_RPC_SOURCE_HEADER = "x-qltbyt-internal-rpc"
+/** Header carrying the millisecond timestamp used for internal ZBS RPC signature freshness. */
+export const ZBS_INTERNAL_RPC_TIMESTAMP_HEADER = "x-qltbyt-internal-rpc-timestamp"
+/** Header carrying the HMAC signature for internal ZBS RPC requests. */
+export const ZBS_INTERNAL_RPC_SIGNATURE_HEADER = "x-qltbyt-internal-rpc-signature"
+
+const ZBS_INTERNAL_RPC_SIGNATURE_TOLERANCE_MS = 60_000
+
+/** Builds the HMAC signature for a ZBS internal cron RPC request. */
+export function signZbsInternalRpc(secret: string, fn: string, timestamp: string): string {
+  return createHmac("sha256", secret)
+    .update(`${ZBS_INTERNAL_RPC_SOURCE}\n${fn}\n${timestamp}`)
+    .digest("hex")
+}
+
+/** Validates the ZBS internal cron RPC HMAC signature and timestamp freshness. */
+export function isValidZbsInternalRpcSignature({
+  secret,
+  fn,
+  timestamp,
+  signature,
+  nowMs = Date.now(),
+}: {
+  secret: string | undefined
+  fn: string
+  timestamp: string | null
+  signature: string | null
+  nowMs?: number
+}): boolean {
+  if (!secret || !timestamp || !signature) {
+    return false
+  }
+
+  const timestampMs = Number(timestamp)
+  if (!Number.isSafeInteger(timestampMs)) {
+    return false
+  }
+
+  if (Math.abs(nowMs - timestampMs) > ZBS_INTERNAL_RPC_SIGNATURE_TOLERANCE_MS) {
+    return false
+  }
+
+  const expected = signZbsInternalRpc(secret, fn, timestamp)
+  const expectedBuffer = Buffer.from(expected, "hex")
+  const signatureBuffer = Buffer.from(signature, "hex")
+  return (
+    expectedBuffer.length === signatureBuffer.length &&
+    timingSafeEqual(expectedBuffer, signatureBuffer)
+  )
+}

--- a/src/lib/zbs/internal-rpc-signature.ts
+++ b/src/lib/zbs/internal-rpc-signature.ts
@@ -12,6 +12,7 @@ export const ZBS_INTERNAL_RPC_BODY_SHA256_HEADER = "x-qltbyt-internal-rpc-body-s
 export const ZBS_INTERNAL_RPC_SIGNATURE_HEADER = "x-qltbyt-internal-rpc-signature"
 
 const ZBS_INTERNAL_RPC_SIGNATURE_TOLERANCE_MS = 60_000
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/i
 
 /** Builds a stable SHA-256 digest for a ZBS internal cron RPC request body. */
 export function hashZbsInternalRpcBody(body: string): string {
@@ -58,6 +59,10 @@ export function isValidZbsInternalRpcSignature({
   }
 
   if (Math.abs(nowMs - timestampMs) > ZBS_INTERNAL_RPC_SIGNATURE_TOLERANCE_MS) {
+    return false
+  }
+
+  if (!SHA256_HEX_PATTERN.test(bodySha256Header) || !SHA256_HEX_PATTERN.test(signature)) {
     return false
   }
 

--- a/src/lib/zbs/live-dispatcher.ts
+++ b/src/lib/zbs/live-dispatcher.ts
@@ -130,6 +130,15 @@ function classifyProviderFailure(response: JsonObject): ZaloFailure | null {
   }
 }
 
+function classifyRequestBuildFailure(error: unknown): ZaloFailure {
+  return {
+    code: "invalid_template_request",
+    message: errorMessage(error),
+    retryable: false,
+    providerResponse: {},
+  }
+}
+
 function parseSuccess(response: JsonObject, now: Date): ZaloSuccess {
   const providerMessageId = getProviderMessageId(response)
   if (!providerMessageId) {
@@ -276,11 +285,24 @@ async function dispatchRow(
   > &
     Pick<DispatchPendingZbsNotificationsOptions, "appBaseUrl">
 ): Promise<ZbsDispatchResult> {
-  const request = buildZbsTemplateRequest(row, {
-    appBaseUrl: options.appBaseUrl,
-    accessTokenHeader: options.accessToken,
-    repairTemplateId: options.repairTemplateId,
-  })
+  let request: ZbsTemplateRequest
+  try {
+    request = buildZbsTemplateRequest(row, {
+      appBaseUrl: options.appBaseUrl,
+      accessTokenHeader: options.accessToken,
+      repairTemplateId: options.repairTemplateId,
+    })
+  } catch (error) {
+    const failure = classifyRequestBuildFailure(error)
+    await markFailed(options.rpcClient, row, failure)
+    return {
+      outbox_id: row.id,
+      status: "failed",
+      error_code: failure.code,
+      error_message: failure.message,
+    }
+  }
+
   const sendResult = await sendZbsTemplateRequest(options.fetchImpl, request, options.now)
 
   if ("providerMessageId" in sendResult) {

--- a/src/lib/zbs/live-dispatcher.ts
+++ b/src/lib/zbs/live-dispatcher.ts
@@ -188,6 +188,7 @@ async function markSent(
     fn: ZBS_MARK_SENT_RPC,
     args: {
       p_id: row.id,
+      p_claimed_at: row.last_attempt_at ?? null,
       p_provider_message_id: success.providerMessageId,
       p_sent_at: success.sentAt,
       p_provider_response: success.providerResponse,
@@ -204,6 +205,7 @@ async function markFailed(
     fn: ZBS_MARK_FAILED_RPC,
     args: {
       p_id: row.id,
+      p_claimed_at: row.last_attempt_at ?? null,
       p_retryable: failure.retryable,
       p_error_code: failure.code,
       p_error_message: failure.message,
@@ -323,6 +325,15 @@ async function dispatchRow(
   }
 }
 
+function failedDispatchRowResult(row: ZbsNotificationOutboxRow): ZbsDispatchResult {
+  return {
+    outbox_id: row.id,
+    status: "failed",
+    error_code: "dispatch_row_error",
+    error_message: "Unexpected ZBS dispatch row failure",
+  }
+}
+
 async function dispatchRowsInChunks(
   rows: ZbsNotificationOutboxRow[],
   options: Parameters<typeof dispatchRow>[1]
@@ -331,7 +342,12 @@ async function dispatchRowsInChunks(
 
   for (let index = 0; index < rows.length; index += ZALO_ZBS_DISPATCH_CONCURRENCY) {
     const chunk = rows.slice(index, index + ZALO_ZBS_DISPATCH_CONCURRENCY)
-    results.push(...(await Promise.all(chunk.map((row) => dispatchRow(row, options)))))
+    const settledResults = await Promise.allSettled(chunk.map((row) => dispatchRow(row, options)))
+    results.push(
+      ...settledResults.map((result, resultIndex) =>
+        result.status === "fulfilled" ? result.value : failedDispatchRowResult(chunk[resultIndex])
+      )
+    )
   }
 
   return results

--- a/src/lib/zbs/live-dispatcher.ts
+++ b/src/lib/zbs/live-dispatcher.ts
@@ -1,0 +1,301 @@
+import { callRpc } from "@/lib/rpc-client"
+
+import {
+  type ZbsNotificationOutboxRow,
+  type ZbsTemplateRequest,
+  ZALO_ZBS_PHONE_TEMPLATE_ENDPOINT,
+  buildZbsTemplateRequest,
+} from "./dispatcher"
+
+/** Service-role RPC that atomically claims due ZBS outbox rows for live dispatch. */
+export const ZBS_CLAIM_DISPATCH_RPC = "zbs_notification_outbox_claim_for_dispatch"
+/** Service-role RPC that persists successful ZBS provider send metadata. */
+export const ZBS_MARK_SENT_RPC = "zbs_notification_outbox_mark_sent"
+/** Service-role RPC that persists retryable or final ZBS provider failures. */
+export const ZBS_MARK_FAILED_RPC = "zbs_notification_outbox_mark_failed"
+
+type JsonObject = Record<string, unknown>
+
+type ZbsRpcClient = (options: { fn: string; args: JsonObject }) => Promise<unknown>
+type ZbsFetch = typeof fetch
+
+export interface DispatchPendingZbsNotificationsOptions {
+  dispatchEnabled: boolean
+  accessToken?: string
+  repairTemplateId?: string
+  appBaseUrl?: string
+  outboxIds?: string[]
+  limit?: number
+  now?: Date
+  rpcClient?: ZbsRpcClient
+  fetchImpl?: ZbsFetch
+}
+
+export interface ZbsDispatchResult {
+  outbox_id: string
+  status: "sent" | "retryable_failed" | "failed"
+  provider_message_id?: string
+  error_code?: string
+  error_message?: string
+}
+
+export interface ZbsDispatchRunResult {
+  dispatch_state: "disabled-dispatch" | "live-dispatch" | "configuration-error"
+  attempted: number
+  sent: number
+  retryable_failed: number
+  failed: number
+  results: ZbsDispatchResult[]
+}
+
+interface ZaloFailure {
+  code: string
+  message: string
+  retryable: boolean
+  providerResponse?: JsonObject
+}
+
+interface ZaloSuccess {
+  providerMessageId: string
+  sentAt: string
+  providerResponse: JsonObject
+}
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error"
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function sanitizeProviderResponse(value: unknown): JsonObject {
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  return value
+}
+
+function getProviderData(response: JsonObject): JsonObject {
+  return isRecord(response.data) ? response.data : response
+}
+
+function getProviderMessageId(response: JsonObject): string {
+  const data = getProviderData(response)
+  return stringValue(data.msg_id) || stringValue(response.msg_id)
+}
+
+function getProviderSentAt(response: JsonObject, fallback: Date): string {
+  const data = getProviderData(response)
+  const sentAt =
+    stringValue(data.sent_at) || stringValue(data.sent_time) || stringValue(response.sent_at)
+  return sentAt || fallback.toISOString()
+}
+
+function classifyHttpFailure(response: Response): ZaloFailure {
+  const retryable = response.status === 408 || response.status === 429 || response.status >= 500
+  return {
+    code: `http_${response.status}`,
+    message: `Zalo ZBS HTTP ${response.status}`,
+    retryable,
+    providerResponse: {
+      http_status: response.status,
+      status_text: response.statusText,
+    },
+  }
+}
+
+function classifyProviderFailure(response: JsonObject): ZaloFailure | null {
+  const errorCode = numberValue(response.error)
+  if (errorCode === null || errorCode === 0) {
+    return null
+  }
+
+  return {
+    code: `zalo_${errorCode}`,
+    message: stringValue(response.message) || "Zalo ZBS provider error",
+    retryable: false,
+    providerResponse: sanitizeProviderResponse(response),
+  }
+}
+
+function parseSuccess(response: JsonObject, now: Date): ZaloSuccess {
+  const providerMessageId = getProviderMessageId(response)
+  if (!providerMessageId) {
+    throw new Error("Missing Zalo provider msg_id")
+  }
+
+  return {
+    providerMessageId,
+    sentAt: getProviderSentAt(response, now),
+    providerResponse: sanitizeProviderResponse(response),
+  }
+}
+
+async function readProviderJson(response: Response): Promise<JsonObject> {
+  try {
+    const value = await response.json()
+    return sanitizeProviderResponse(value)
+  } catch {
+    return {}
+  }
+}
+
+async function claimRows(
+  rpcClient: ZbsRpcClient,
+  options: Required<Pick<DispatchPendingZbsNotificationsOptions, "limit" | "now">> &
+    Pick<DispatchPendingZbsNotificationsOptions, "outboxIds">
+): Promise<ZbsNotificationOutboxRow[]> {
+  const rows = await rpcClient({
+    fn: ZBS_CLAIM_DISPATCH_RPC,
+    args: {
+      p_limit: options.limit,
+      p_now: options.now.toISOString(),
+      p_outbox_ids: options.outboxIds?.length ? options.outboxIds : null,
+    },
+  })
+
+  return Array.isArray(rows) ? (rows as ZbsNotificationOutboxRow[]) : []
+}
+
+async function markSent(
+  rpcClient: ZbsRpcClient,
+  row: ZbsNotificationOutboxRow,
+  success: ZaloSuccess
+) {
+  await rpcClient({
+    fn: ZBS_MARK_SENT_RPC,
+    args: {
+      p_id: row.id,
+      p_provider_message_id: success.providerMessageId,
+      p_sent_at: success.sentAt,
+      p_provider_response: success.providerResponse,
+    },
+  })
+}
+
+async function markFailed(
+  rpcClient: ZbsRpcClient,
+  row: ZbsNotificationOutboxRow,
+  failure: ZaloFailure
+) {
+  await rpcClient({
+    fn: ZBS_MARK_FAILED_RPC,
+    args: {
+      p_id: row.id,
+      p_retryable: failure.retryable,
+      p_error_code: failure.code,
+      p_error_message: failure.message,
+      p_provider_response: failure.providerResponse ?? {},
+    },
+  })
+}
+
+async function sendZbsTemplateRequest(
+  fetchImpl: ZbsFetch,
+  request: ZbsTemplateRequest,
+  now: Date
+): Promise<ZaloSuccess | ZaloFailure> {
+  try {
+    const response = await fetchImpl(request.endpoint, {
+      method: request.method,
+      headers: {
+        "Content-Type": "application/json",
+        access_token: request.headers.access_token,
+      },
+      body: JSON.stringify(request.body),
+    })
+
+    if (!response.ok) {
+      return classifyHttpFailure(response)
+    }
+
+    const responseBody = await readProviderJson(response)
+    const providerFailure = classifyProviderFailure(responseBody)
+    if (providerFailure) {
+      return providerFailure
+    }
+
+    return parseSuccess(responseBody, now)
+  } catch (error) {
+    return {
+      code: "network_error",
+      message: errorMessage(error),
+      retryable: true,
+      providerResponse: {},
+    }
+  }
+}
+
+function summarizeResults(
+  dispatchState: ZbsDispatchRunResult["dispatch_state"],
+  results: ZbsDispatchResult[]
+): ZbsDispatchRunResult {
+  return {
+    dispatch_state: dispatchState,
+    attempted: results.length,
+    sent: results.filter((result) => result.status === "sent").length,
+    retryable_failed: results.filter((result) => result.status === "retryable_failed").length,
+    failed: results.filter((result) => result.status === "failed").length,
+    results,
+  }
+}
+
+/** Sends claimed ZBS repair-request notifications when the dispatch gate is enabled. */
+export async function dispatchPendingZbsNotifications(
+  options: DispatchPendingZbsNotificationsOptions
+): Promise<ZbsDispatchRunResult> {
+  const now = options.now ?? new Date()
+  const limit = options.limit ?? 25
+  const rpcClient = options.rpcClient ?? callRpc
+  const fetchImpl = options.fetchImpl ?? fetch
+
+  if (!options.dispatchEnabled) {
+    return summarizeResults("disabled-dispatch", [])
+  }
+
+  if (!options.accessToken || !options.repairTemplateId) {
+    return summarizeResults("configuration-error", [])
+  }
+
+  const rows = await claimRows(rpcClient, { limit, now, outboxIds: options.outboxIds })
+  const results: ZbsDispatchResult[] = []
+
+  for (const row of rows) {
+    const request = buildZbsTemplateRequest(row, {
+      appBaseUrl: options.appBaseUrl,
+      accessTokenHeader: options.accessToken,
+      repairTemplateId: options.repairTemplateId,
+    })
+    const sendResult = await sendZbsTemplateRequest(fetchImpl, request, now)
+
+    if ("providerMessageId" in sendResult) {
+      await markSent(rpcClient, row, sendResult)
+      results.push({
+        outbox_id: row.id,
+        status: "sent",
+        provider_message_id: sendResult.providerMessageId,
+      })
+      continue
+    }
+
+    await markFailed(rpcClient, row, sendResult)
+    results.push({
+      outbox_id: row.id,
+      status: sendResult.retryable ? "retryable_failed" : "failed",
+      error_code: sendResult.code,
+      error_message: sendResult.message,
+    })
+  }
+
+  return summarizeResults("live-dispatch", results)
+}

--- a/src/lib/zbs/live-dispatcher.ts
+++ b/src/lib/zbs/live-dispatcher.ts
@@ -18,6 +18,8 @@ type JsonObject = Record<string, unknown>
 
 type ZbsRpcClient = (options: { fn: string; args: JsonObject }) => Promise<unknown>
 type ZbsFetch = typeof fetch
+const ZALO_ZBS_FETCH_TIMEOUT_MS = 15_000
+const ZALO_ZBS_DISPATCH_CONCURRENCY = 5
 
 export interface DispatchPendingZbsNotificationsOptions {
   dispatchEnabled: boolean
@@ -155,12 +157,13 @@ async function claimRows(
   options: Required<Pick<DispatchPendingZbsNotificationsOptions, "limit" | "now">> &
     Pick<DispatchPendingZbsNotificationsOptions, "outboxIds">
 ): Promise<ZbsNotificationOutboxRow[]> {
+  const outboxIds = options.outboxIds
   const rows = await rpcClient({
     fn: ZBS_CLAIM_DISPATCH_RPC,
     args: {
       p_limit: options.limit,
       p_now: options.now.toISOString(),
-      p_outbox_ids: options.outboxIds?.length ? options.outboxIds : null,
+      p_outbox_ids: outboxIds === undefined ? null : outboxIds,
     },
   })
 
@@ -205,6 +208,9 @@ async function sendZbsTemplateRequest(
   request: ZbsTemplateRequest,
   now: Date
 ): Promise<ZaloSuccess | ZaloFailure> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), ZALO_ZBS_FETCH_TIMEOUT_MS)
+
   try {
     const response = await fetchImpl(request.endpoint, {
       method: request.method,
@@ -213,6 +219,7 @@ async function sendZbsTemplateRequest(
         access_token: request.headers.access_token,
       },
       body: JSON.stringify(request.body),
+      signal: controller.signal,
     })
 
     if (!response.ok) {
@@ -225,7 +232,16 @@ async function sendZbsTemplateRequest(
       return providerFailure
     }
 
-    return parseSuccess(responseBody, now)
+    try {
+      return parseSuccess(responseBody, now)
+    } catch (error) {
+      return {
+        code: "invalid_provider_response",
+        message: errorMessage(error),
+        retryable: false,
+        providerResponse: responseBody,
+      }
+    }
   } catch (error) {
     return {
       code: "network_error",
@@ -233,6 +249,8 @@ async function sendZbsTemplateRequest(
       retryable: true,
       providerResponse: {},
     }
+  } finally {
+    clearTimeout(timeoutId)
   }
 }
 
@@ -248,6 +266,53 @@ function summarizeResults(
     failed: results.filter((result) => result.status === "failed").length,
     results,
   }
+}
+
+async function dispatchRow(
+  row: ZbsNotificationOutboxRow,
+  options: Pick<
+    Required<DispatchPendingZbsNotificationsOptions>,
+    "accessToken" | "repairTemplateId" | "now" | "rpcClient" | "fetchImpl"
+  > &
+    Pick<DispatchPendingZbsNotificationsOptions, "appBaseUrl">
+): Promise<ZbsDispatchResult> {
+  const request = buildZbsTemplateRequest(row, {
+    appBaseUrl: options.appBaseUrl,
+    accessTokenHeader: options.accessToken,
+    repairTemplateId: options.repairTemplateId,
+  })
+  const sendResult = await sendZbsTemplateRequest(options.fetchImpl, request, options.now)
+
+  if ("providerMessageId" in sendResult) {
+    await markSent(options.rpcClient, row, sendResult)
+    return {
+      outbox_id: row.id,
+      status: "sent",
+      provider_message_id: sendResult.providerMessageId,
+    }
+  }
+
+  await markFailed(options.rpcClient, row, sendResult)
+  return {
+    outbox_id: row.id,
+    status: sendResult.retryable ? "retryable_failed" : "failed",
+    error_code: sendResult.code,
+    error_message: sendResult.message,
+  }
+}
+
+async function dispatchRowsInChunks(
+  rows: ZbsNotificationOutboxRow[],
+  options: Parameters<typeof dispatchRow>[1]
+): Promise<ZbsDispatchResult[]> {
+  const results: ZbsDispatchResult[] = []
+
+  for (let index = 0; index < rows.length; index += ZALO_ZBS_DISPATCH_CONCURRENCY) {
+    const chunk = rows.slice(index, index + ZALO_ZBS_DISPATCH_CONCURRENCY)
+    results.push(...(await Promise.all(chunk.map((row) => dispatchRow(row, options)))))
+  }
+
+  return results
 }
 
 /** Sends claimed ZBS repair-request notifications when the dispatch gate is enabled. */
@@ -268,34 +333,14 @@ export async function dispatchPendingZbsNotifications(
   }
 
   const rows = await claimRows(rpcClient, { limit, now, outboxIds: options.outboxIds })
-  const results: ZbsDispatchResult[] = []
-
-  for (const row of rows) {
-    const request = buildZbsTemplateRequest(row, {
-      appBaseUrl: options.appBaseUrl,
-      accessTokenHeader: options.accessToken,
-      repairTemplateId: options.repairTemplateId,
-    })
-    const sendResult = await sendZbsTemplateRequest(fetchImpl, request, now)
-
-    if ("providerMessageId" in sendResult) {
-      await markSent(rpcClient, row, sendResult)
-      results.push({
-        outbox_id: row.id,
-        status: "sent",
-        provider_message_id: sendResult.providerMessageId,
-      })
-      continue
-    }
-
-    await markFailed(rpcClient, row, sendResult)
-    results.push({
-      outbox_id: row.id,
-      status: sendResult.retryable ? "retryable_failed" : "failed",
-      error_code: sendResult.code,
-      error_message: sendResult.message,
-    })
-  }
+  const results = await dispatchRowsInChunks(rows, {
+    accessToken: options.accessToken,
+    repairTemplateId: options.repairTemplateId,
+    appBaseUrl: options.appBaseUrl,
+    now,
+    rpcClient,
+    fetchImpl,
+  })
 
   return summarizeResults("live-dispatch", results)
 }

--- a/supabase/migrations/20260630123000_add_zbs_live_dispatch_rpcs.sql
+++ b/supabase/migrations/20260630123000_add_zbs_live_dispatch_rpcs.sql
@@ -1,0 +1,182 @@
+-- Issue #620 Phase 3: live ZBS dispatch write boundaries.
+--
+-- Scope:
+-- - Server-only claim/send/fail RPCs for the existing ZBS outbox.
+-- - No webhook handling, scheduler configuration, or legacy repair push trigger changes.
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  next_attempt_at timestamptz
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.status = 'pending'
+      AND outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.next_attempt_at <= coalesce(p_now, now())
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT greatest(1, least(coalesce(p_limit, 25), 100))
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'processing',
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = coalesce(p_now, now()),
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+$$;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_mark_sent(
+  p_id uuid,
+  p_provider_message_id text,
+  p_sent_at timestamptz,
+  p_provider_response jsonb DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  UPDATE public.zbs_notification_outbox
+  SET
+    status = 'sent',
+    provider_message_id = NULLIF(p_provider_message_id, ''),
+    provider_response = coalesce(p_provider_response, '{}'::jsonb),
+    last_error_code = NULL,
+    last_error_message = NULL,
+    sent_at = coalesce(p_sent_at, now()),
+    updated_at = now()
+  WHERE id = p_id
+    AND provider = 'zalo_zbs'
+    AND status = 'processing';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ZBS outbox row % is not claimable as sent', p_id
+      USING errcode = 'P0002';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_mark_failed(
+  p_id uuid,
+  p_retryable boolean,
+  p_error_code text,
+  p_error_message text,
+  p_provider_response jsonb DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_now timestamptz := now();
+BEGIN
+  UPDATE public.zbs_notification_outbox outbox
+  SET
+    status = CASE
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count < 3 THEN 'pending'
+      ELSE 'failed'
+    END,
+    next_attempt_at = CASE
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count = 1 THEN v_now + interval '5 minutes'
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count = 2 THEN v_now + interval '30 minutes'
+      ELSE outbox.next_attempt_at
+    END,
+    provider_response = coalesce(p_provider_response, '{}'::jsonb),
+    last_error_code = NULLIF(p_error_code, ''),
+    last_error_message = NULLIF(p_error_message, ''),
+    updated_at = v_now
+  WHERE outbox.id = p_id
+    AND outbox.provider = 'zalo_zbs'
+    AND outbox.status = 'processing';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ZBS outbox row % is not claimable as failed', p_id
+      USING errcode = 'P0002';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, text, timestamptz, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, boolean, text, text, jsonb)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, text, timestamptz, jsonb)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, boolean, text, text, jsonb)
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Moves due pending repair-request ZBS rows to processing using SKIP LOCKED.';
+COMMENT ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, text, timestamptz, jsonb) IS
+  'Server-only live ZBS dispatcher success boundary. Persists provider msg_id, sent timestamp, and sanitized provider metadata.';
+COMMENT ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, boolean, text, text, jsonb) IS
+  'Server-only live ZBS dispatcher failure boundary. Persists sanitized provider/network error metadata and applies per-row retry policy.';

--- a/supabase/migrations/20260630143000_harden_zbs_live_dispatch_rpcs.sql
+++ b/supabase/migrations/20260630143000_harden_zbs_live_dispatch_rpcs.sql
@@ -1,0 +1,229 @@
+-- Issue #620 Phase 3 follow-up: harden live ZBS dispatch RPCs.
+--
+-- Rollback strategy: forward-only. Supersede with a later CREATE OR REPLACE migration,
+-- or explicitly DROP these three RPCs in a new migration if live dispatch is retired.
+
+CREATE INDEX IF NOT EXISTS zbs_notification_outbox_processing_lease_idx
+  ON public.zbs_notification_outbox (last_attempt_at, created_at)
+  WHERE status = 'processing'
+    AND provider = 'zalo_zbs'
+    AND event_type = 'repair_request_created'
+    AND source_type = 'repair_request';
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  next_attempt_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+  v_now timestamptz := coalesce(p_now, now());
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND (
+        (
+          outbox.status = 'pending'
+          AND outbox.next_attempt_at <= v_now
+        )
+        OR (
+          outbox.status = 'processing'
+          AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+        )
+      )
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT greatest(1, least(coalesce(p_limit, 25), 100))
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'processing',
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = v_now,
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_mark_sent(
+  p_id uuid,
+  p_provider_message_id text,
+  p_sent_at timestamptz,
+  p_provider_response jsonb DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  UPDATE public.zbs_notification_outbox
+  SET
+    status = 'sent',
+    provider_message_id = NULLIF(p_provider_message_id, ''),
+    provider_response = coalesce(p_provider_response, '{}'::jsonb),
+    last_error_code = NULL,
+    last_error_message = NULL,
+    sent_at = coalesce(p_sent_at, now()),
+    updated_at = now()
+  WHERE id = p_id
+    AND provider = 'zalo_zbs'
+    AND status = 'processing';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ZBS outbox row % is not claimable as sent', p_id
+      USING errcode = 'P0002';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_mark_failed(
+  p_id uuid,
+  p_retryable boolean,
+  p_error_code text,
+  p_error_message text,
+  p_provider_response jsonb DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_now timestamptz := now();
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  UPDATE public.zbs_notification_outbox outbox
+  SET
+    status = CASE
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count < 3 THEN 'pending'
+      ELSE 'failed'
+    END,
+    next_attempt_at = CASE
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count = 1 THEN v_now + interval '5 minutes'
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count = 2 THEN v_now + interval '30 minutes'
+      ELSE outbox.next_attempt_at
+    END,
+    provider_response = coalesce(p_provider_response, '{}'::jsonb),
+    last_error_code = NULLIF(p_error_code, ''),
+    last_error_message = NULLIF(p_error_message, ''),
+    updated_at = v_now
+  WHERE outbox.id = p_id
+    AND outbox.provider = 'zalo_zbs'
+    AND outbox.status = 'processing';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ZBS outbox row % is not claimable as failed', p_id
+      USING errcode = 'P0002';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, text, timestamptz, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, boolean, text, text, jsonb)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, text, timestamptz, jsonb)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, boolean, text, text, jsonb)
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Moves due pending and stale processing repair-request ZBS rows to processing using SKIP LOCKED.';
+COMMENT ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, text, timestamptz, jsonb) IS
+  'Server-only live ZBS dispatcher success boundary. Requires service_role JWT and persists provider msg_id, sent timestamp, and sanitized provider metadata.';
+COMMENT ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, boolean, text, text, jsonb) IS
+  'Server-only live ZBS dispatcher failure boundary. Requires service_role JWT, persists sanitized provider/network error metadata, and applies per-row retry policy.';

--- a/supabase/migrations/20260630234000_validate_zbs_dispatch_processing_lease.sql
+++ b/supabase/migrations/20260630234000_validate_zbs_dispatch_processing_lease.sql
@@ -1,0 +1,237 @@
+-- Issue #620 Phase 3 follow-up: validate ZBS processing leases on mark RPCs.
+--
+-- Rollback strategy: forward-only. Supersede with a later CREATE OR REPLACE
+-- migration if the live dispatch lease contract changes.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.zbs_notification_outbox_mark_sent(uuid, text, timestamptz, jsonb);
+DROP FUNCTION IF EXISTS public.zbs_notification_outbox_mark_failed(uuid, boolean, text, text, jsonb);
+DROP FUNCTION IF EXISTS public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]);
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+  v_now timestamptz := coalesce(p_now, now());
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND (
+        (
+          outbox.status = 'pending'
+          AND outbox.next_attempt_at <= v_now
+        )
+        OR (
+          outbox.status = 'processing'
+          AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+        )
+      )
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'processing',
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = v_now,
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.last_attempt_at,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.last_attempt_at,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_mark_sent(
+  p_id uuid,
+  p_claimed_at timestamptz,
+  p_provider_message_id text,
+  p_sent_at timestamptz,
+  p_provider_response jsonb DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  UPDATE public.zbs_notification_outbox
+  SET
+    status = 'sent',
+    provider_message_id = NULLIF(p_provider_message_id, ''),
+    provider_response = coalesce(p_provider_response, '{}'::jsonb),
+    last_error_code = NULL,
+    last_error_message = NULL,
+    sent_at = coalesce(p_sent_at, now()),
+    updated_at = now()
+  WHERE id = p_id
+    AND provider = 'zalo_zbs'
+    AND status = 'processing'
+    AND last_attempt_at = p_claimed_at;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ZBS outbox row % is not claimable as sent for this lease', p_id
+      USING errcode = 'P0002';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_mark_failed(
+  p_id uuid,
+  p_claimed_at timestamptz,
+  p_retryable boolean,
+  p_error_code text,
+  p_error_message text,
+  p_provider_response jsonb DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_now timestamptz := now();
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  UPDATE public.zbs_notification_outbox outbox
+  SET
+    status = CASE
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count < 3 THEN 'pending'
+      ELSE 'failed'
+    END,
+    next_attempt_at = CASE
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count = 1 THEN v_now + interval '5 minutes'
+      WHEN coalesce(p_retryable, false) AND outbox.attempt_count = 2 THEN v_now + interval '30 minutes'
+      ELSE outbox.next_attempt_at
+    END,
+    provider_response = coalesce(p_provider_response, '{}'::jsonb),
+    last_error_code = NULLIF(p_error_code, ''),
+    last_error_message = NULLIF(p_error_message, ''),
+    updated_at = v_now
+  WHERE outbox.id = p_id
+    AND outbox.provider = 'zalo_zbs'
+    AND outbox.status = 'processing'
+    AND outbox.last_attempt_at = p_claimed_at;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ZBS outbox row % is not claimable as failed for this lease', p_id
+      USING errcode = 'P0002';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, timestamptz, text, timestamptz, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, timestamptz, boolean, text, text, jsonb)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, timestamptz, text, timestamptz, jsonb)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, timestamptz, boolean, text, text, jsonb)
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Returns last_attempt_at as the processing lease timestamp.';
+COMMENT ON FUNCTION public.zbs_notification_outbox_mark_sent(uuid, timestamptz, text, timestamptz, jsonb) IS
+  'Server-only live ZBS dispatcher success boundary. Requires service_role JWT and a matching processing lease timestamp.';
+COMMENT ON FUNCTION public.zbs_notification_outbox_mark_failed(uuid, timestamptz, boolean, text, text, jsonb) IS
+  'Server-only live ZBS dispatcher failure boundary. Requires service_role JWT and a matching processing lease timestamp.';
+
+COMMIT;

--- a/supabase/migrations/20260630235000_document_zbs_dispatch_lease_rollback.sql
+++ b/supabase/migrations/20260630235000_document_zbs_dispatch_lease_rollback.sql
@@ -1,0 +1,18 @@
+-- Issue #620 Phase 3 documentation follow-up: make the ZBS dispatch lease
+-- rollback target explicit without editing applied migrations.
+--
+-- Rollback strategy: forward-only. To undo the processing-lease contract added
+-- by 20260630234000_validate_zbs_dispatch_processing_lease.sql, create a later
+-- migration that restores the ZBS live-dispatch RPC bodies/signatures from
+-- 20260630143000_harden_zbs_live_dispatch_rpcs.sql. For the original Phase 3
+-- RPC creation baseline, see 20260630123000_add_zbs_live_dispatch_rpcs.sql.
+
+BEGIN;
+
+DO $$
+BEGIN
+  NULL;
+END
+$$;
+
+COMMIT;

--- a/supabase/migrations/20260630235500_cap_zbs_dispatch_stale_processing_reclaims.sql
+++ b/supabase/migrations/20260630235500_cap_zbs_dispatch_stale_processing_reclaims.sql
@@ -1,0 +1,145 @@
+-- Issue #620 Phase 3 follow-up: cap stale ZBS processing lease reclaims.
+--
+-- Rollback strategy: forward-only. Restore the claim RPC body from
+-- 20260630234000_validate_zbs_dispatch_processing_lease.sql in a later
+-- CREATE OR REPLACE migration if this retry-cap behavior changes.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+  v_now timestamptz := coalesce(p_now, now());
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH expired_processing AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'failed',
+      next_attempt_at = NULL,
+      last_error_code = 'dispatch_lease_expired',
+      last_error_message = 'ZBS processing lease expired after final attempt',
+      updated_at = now()
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.status = 'processing'
+      AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+      AND outbox.attempt_count >= 3
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+  ),
+  claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.attempt_count < 3
+      AND (
+        (
+          outbox.status = 'pending'
+          AND outbox.next_attempt_at <= v_now
+        )
+        OR (
+          outbox.status = 'processing'
+          AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+        )
+      )
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'processing',
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = v_now,
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.last_attempt_at,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.last_attempt_at,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Reclaims stale processing rows only before the final attempt cap.';
+
+COMMIT;

--- a/supabase/migrations/20260630235900_fix_zbs_dispatch_stale_reclaim_next_attempt.sql
+++ b/supabase/migrations/20260630235900_fix_zbs_dispatch_stale_reclaim_next_attempt.sql
@@ -1,0 +1,146 @@
+-- Issue #620 Phase 3 follow-up: keep failed stale ZBS processing rows valid
+-- under the NOT NULL next_attempt_at constraint.
+--
+-- Rollback strategy: forward-only. Restore the claim RPC body from
+-- 20260630234000_validate_zbs_dispatch_processing_lease.sql in a later
+-- CREATE OR REPLACE migration if this retry-cap behavior changes.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+  v_now timestamptz := coalesce(p_now, now());
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH expired_processing AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'failed',
+      next_attempt_at = outbox.next_attempt_at,
+      last_error_code = 'dispatch_lease_expired',
+      last_error_message = 'ZBS processing lease expired after final attempt',
+      updated_at = now()
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.status = 'processing'
+      AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+      AND outbox.attempt_count >= 3
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+  ),
+  claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.attempt_count < 3
+      AND (
+        (
+          outbox.status = 'pending'
+          AND outbox.next_attempt_at <= v_now
+        )
+        OR (
+          outbox.status = 'processing'
+          AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+        )
+      )
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'processing',
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = v_now,
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.last_attempt_at,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.last_attempt_at,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Reclaims stale processing rows only before the final attempt cap.';
+
+COMMIT;

--- a/supabase/migrations/20260701000000_limit_zbs_dispatch_expired_processing_locks.sql
+++ b/supabase/migrations/20260701000000_limit_zbs_dispatch_expired_processing_locks.sql
@@ -1,0 +1,154 @@
+-- Issue #620 Phase 3 follow-up: bound expired ZBS processing lease cleanup.
+--
+-- Rollback strategy: forward-only. Restore the claim RPC body from
+-- 20260630235900_fix_zbs_dispatch_stale_reclaim_next_attempt.sql in a later
+-- CREATE OR REPLACE migration if this cleanup behavior changes.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+  v_now timestamptz := coalesce(p_now, now());
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH expired_ids AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.status = 'processing'
+      AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+      AND outbox.attempt_count >= 3
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE OF outbox SKIP LOCKED
+  ),
+  expired_processing AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'failed',
+      next_attempt_at = outbox.next_attempt_at,
+      last_error_code = 'dispatch_lease_expired',
+      last_error_message = 'ZBS processing lease expired after final attempt',
+      updated_at = now()
+    FROM expired_ids
+    WHERE outbox.id = expired_ids.id
+  ),
+  claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.attempt_count < 3
+      AND (
+        (
+          outbox.status = 'pending'
+          AND outbox.next_attempt_at <= v_now
+        )
+        OR (
+          outbox.status = 'processing'
+          AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+        )
+      )
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'processing',
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = v_now,
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.last_attempt_at,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.last_attempt_at,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Reclaims stale processing rows only before the final attempt cap; final-attempt expiry is bounded and uses SKIP LOCKED.';
+
+COMMIT;

--- a/supabase/migrations/20260701001000_extract_zbs_dispatch_status_constants.sql
+++ b/supabase/migrations/20260701001000_extract_zbs_dispatch_status_constants.sql
@@ -1,0 +1,156 @@
+-- Issue #620 Phase 3 follow-up: keep ZBS dispatch status predicates in sync.
+--
+-- Rollback strategy: forward-only. Restore the claim RPC body from
+-- 20260701000000_limit_zbs_dispatch_expired_processing_locks.sql in a later
+-- CREATE OR REPLACE migration if this cleanup behavior changes.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_status_processing constant text := 'processing';
+  v_status_failed constant text := 'failed';
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+  v_now timestamptz := coalesce(p_now, now());
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH expired_ids AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.status = v_status_processing
+      AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+      AND outbox.attempt_count >= 3
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE OF outbox SKIP LOCKED
+  ),
+  expired_processing AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = v_status_failed,
+      next_attempt_at = outbox.next_attempt_at,
+      last_error_code = 'dispatch_lease_expired',
+      last_error_message = 'ZBS processing lease expired after final attempt',
+      updated_at = now()
+    FROM expired_ids
+    WHERE outbox.id = expired_ids.id
+  ),
+  claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.attempt_count < 3
+      AND (
+        (
+          outbox.status = 'pending'
+          AND outbox.next_attempt_at <= v_now
+        )
+        OR (
+          outbox.status = v_status_processing
+          AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+        )
+      )
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = v_status_processing,
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = v_now,
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.last_attempt_at,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.last_attempt_at,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Reclaims stale processing rows only before the final attempt cap; final-attempt expiry is bounded and status predicates use local constants.';
+
+COMMIT;

--- a/supabase/migrations/20260701002000_lock_zbs_dispatch_claim_alias.sql
+++ b/supabase/migrations/20260701002000_lock_zbs_dispatch_claim_alias.sql
@@ -1,0 +1,156 @@
+-- Issue #620 Phase 3 follow-up: make claim-row locking explicit on the outbox alias.
+--
+-- Rollback strategy: forward-only. Restore the claim RPC body from
+-- 20260701001000_extract_zbs_dispatch_status_constants.sql in a later
+-- CREATE OR REPLACE migration if this locking behavior changes.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_status_processing constant text := 'processing';
+  v_status_failed constant text := 'failed';
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+  v_now timestamptz := coalesce(p_now, now());
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH expired_ids AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.status = v_status_processing
+      AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+      AND outbox.attempt_count >= 3
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE OF outbox SKIP LOCKED
+  ),
+  expired_processing AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = v_status_failed,
+      next_attempt_at = outbox.next_attempt_at,
+      last_error_code = 'dispatch_lease_expired',
+      last_error_message = 'ZBS processing lease expired after final attempt',
+      updated_at = now()
+    FROM expired_ids
+    WHERE outbox.id = expired_ids.id
+  ),
+  claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.attempt_count < 3
+      AND (
+        (
+          outbox.status = 'pending'
+          AND outbox.next_attempt_at <= v_now
+        )
+        OR (
+          outbox.status = v_status_processing
+          AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+        )
+      )
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE OF outbox SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = v_status_processing,
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = v_now,
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.last_attempt_at,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.last_attempt_at,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Reclaims stale processing rows only before the final attempt cap; final-attempt expiry is bounded and row locks target the outbox alias explicitly.';
+
+COMMIT;

--- a/supabase/migrations/20260701003000_complete_zbs_dispatch_claim_cte_cleanup.sql
+++ b/supabase/migrations/20260701003000_complete_zbs_dispatch_claim_cte_cleanup.sql
@@ -1,0 +1,163 @@
+-- Issue #620 Phase 3 follow-up: complete claim RPC status constants and CTE chaining.
+--
+-- Rollback strategy: forward-only. Restore the claim RPC body from
+-- 20260701002000_lock_zbs_dispatch_claim_alias.sql in a later CREATE OR
+-- REPLACE migration if this cleanup behavior changes.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_claim_for_dispatch(
+  p_limit integer DEFAULT 25,
+  p_now timestamptz DEFAULT now(),
+  p_outbox_ids uuid[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  event_type text,
+  source_type text,
+  source_id bigint,
+  don_vi_id bigint,
+  recipient_config_id uuid,
+  recipient_phone text,
+  template_id text,
+  template_data jsonb,
+  tracking_id text,
+  status text,
+  provider text,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_status_pending constant text := 'pending';
+  v_status_processing constant text := 'processing';
+  v_status_failed constant text := 'failed';
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+  v_now timestamptz := coalesce(p_now, now());
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS live dispatch RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH expired_ids AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.status = v_status_processing
+      AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+      AND outbox.attempt_count >= 3
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE OF outbox SKIP LOCKED
+  ),
+  expired_processing AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = v_status_failed,
+      next_attempt_at = outbox.next_attempt_at,
+      last_error_code = 'dispatch_lease_expired',
+      last_error_message = 'ZBS processing lease expired after final attempt',
+      updated_at = now()
+    FROM expired_ids
+    WHERE outbox.id = expired_ids.id
+    RETURNING 1 AS expired_row
+  ),
+  expired_processing_done AS (
+    SELECT count(*) AS expired_count
+    FROM expired_processing
+  ),
+  claimed AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    CROSS JOIN expired_processing_done
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.event_type = 'repair_request_created'
+      AND outbox.source_type = 'repair_request'
+      AND outbox.attempt_count < 3
+      AND (
+        (
+          outbox.status = v_status_pending
+          AND outbox.next_attempt_at <= v_now
+        )
+        OR (
+          outbox.status = v_status_processing
+          AND outbox.last_attempt_at <= v_now - interval '10 minutes'
+        )
+      )
+      AND (
+        p_outbox_ids IS NULL
+        OR outbox.id = ANY(p_outbox_ids)
+      )
+    ORDER BY outbox.created_at ASC
+    LIMIT least(greatest(coalesce(p_limit, 25), 0), 100)
+    FOR UPDATE OF outbox SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = v_status_processing,
+      attempt_count = outbox.attempt_count + 1,
+      last_attempt_at = v_now,
+      updated_at = now()
+    FROM claimed
+    WHERE outbox.id = claimed.id
+    RETURNING
+      outbox.id,
+      outbox.event_type,
+      outbox.source_type,
+      outbox.source_id,
+      outbox.don_vi_id,
+      outbox.recipient_config_id,
+      outbox.recipient_phone,
+      outbox.template_id,
+      outbox.template_data,
+      outbox.tracking_id,
+      outbox.status,
+      outbox.provider,
+      outbox.last_attempt_at,
+      outbox.next_attempt_at,
+      outbox.created_at
+  )
+  SELECT
+    updated.id,
+    updated.event_type,
+    updated.source_type,
+    updated.source_id,
+    updated.don_vi_id,
+    updated.recipient_config_id,
+    updated.recipient_phone,
+    updated.template_id,
+    updated.template_data,
+    updated.tracking_id,
+    updated.status,
+    updated.provider,
+    updated.last_attempt_at,
+    updated.next_attempt_at
+  FROM updated
+  ORDER BY updated.created_at ASC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[])
+  TO service_role;
+
+COMMENT ON FUNCTION public.zbs_notification_outbox_claim_for_dispatch(integer, timestamptz, uuid[]) IS
+  'Server-only live ZBS dispatcher claim boundary. Reclaims stale processing rows only before the final attempt cap; final-attempt expiry is bounded, status predicates use local constants, and CTE dependencies are explicit.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds service-role-only ZBS live dispatch RPCs for claim, sent, and failure state updates with per-row retry behavior.
- Adds a gated ZBS live dispatcher and protected `/api/cron/zbs-dispatch` manual/cron route.
- Adds focused TDD coverage and rollback SQL verification for sent/retry/final-failure paths.

## Verification
- RED: live dispatcher and route tests failed before implementation.
- `npx prettier --check --ignore-unknown ...changed files...`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/lib/zbs/__tests__/dispatcher.test.ts src/lib/zbs/__tests__/live-dispatcher.test.ts src/app/api/cron/zbs-dispatch/__tests__/route.test.ts`
- `node scripts/npm-run.js run react-doctor`
- Supabase MCP `apply_migration`: `add_zbs_live_dispatch_rpcs`
- Supabase MCP rollback verification script passed.
- Supabase MCP security advisors checked; targeted grant/search_path check confirms new RPCs are `service_role` only with `search_path=public, pg_temp`.

## Smoke Test Status
- Live Zalo smoke is intentionally not run yet.
- Before live smoke, operator must provide the test phone number for `don_vi_id=17`, confirm temporary dispatch enablement, and target only the generated smoke outbox row.

Closes #620

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables gated live ZBS dispatch via a protected cron endpoint and signed internal RPC. Completes #620’s live send flow with lease-based claiming, safe retries, and a hardened service-role boundary.

- New Features
  - Lease-based RPCs: atomic claim returns last_attempt_at; caps stale reclaims (>10m) with safe next_attempt_at; bounded cleanup + index; extracted status constants; explicit row locking; mark_sent/mark_failed require the matching claim timestamp and backoff (5m, 30m; max 3).
  - Cron + signed internal RPC: `/api/cron/zbs-dispatch` requires Bearer `CRON_SECRET`; internal RPCs must be HMAC-signed with canonical hex and 60s skew; allowlist restricts to the claim RPC; bypasses `NextAuth` only for valid signatures; 10s proxy timeout; structured 4xx and sanitized 5xx; lets fetch set Content-Length; optional `outboxId`.
  - Live dispatcher: validates Zalo requests, runs with 5-way concurrency and 15s provider timeouts, classifies provider/network errors, and persists per-row results (including missing token/template).

- Migration
  - Apply Supabase migrations adding claim/send/fail RPCs, leases/backoff, indices, and status constants.
  - Env: `CRON_SECRET`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`, `ZBS_INTERNAL_RPC_SECRET` (defaults to `SUPABASE_JWT_SECRET`), `ZALO_ZBS_ACCESS_TOKEN`, `ZALO_ZBS_REPAIR_TEMPLATE_ID`, `NEXT_PUBLIC_APP_URL` (or `NEXTAUTH_URL`/`VERCEL_URL`).
  - Keep `ZALO_ZBS_DISPATCH_ENABLED=false` until ready; schedule cron to call `/api/cron/zbs-dispatch` with Bearer `CRON_SECRET` (optional `outboxId`). Optional: run `scripts/verify-zbs-live-dispatch.sql`.

<sup>Written for commit 1c66cdcb003e5d7dbdcddc8edec202508e7d5ea5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live ZBS outbox dispatching with claiming, per-item tracking, concurrency chunking, and retry backoff.
  * Introduced a secure cron/manual dispatch endpoint with signed internal RPC proxying.
  * Added server-only RPC boundaries for claiming, marking sent, and marking failed outcomes.
* **Bug Fixes**
  * Improved stale-lease handling, final-attempt caps, and dispatch-state transitions.
  * Hardened cron/RPC error responses to avoid leaking details; added fail-closed behavior and request timeouts/abort handling.
* **Tests**
  * Expanded dispatcher, route, internal-RPC signature, and whitelist coverage (including hung requests and authorization failures).
* **Documentation**
  * Updated README with the new `ZBS_INTERNAL_RPC_SECRET` requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->