### PR TITLE
Fix ZBS successful send persistence

### DIFF
--- a/src/lib/zbs/__tests__/live-dispatcher-success-persistence.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher-success-persistence.test.ts
@@ -4,7 +4,7 @@ import {
   ZBS_CLAIM_DISPATCH_RPC,
   ZBS_MARK_SENT_RPC,
   dispatchPendingZbsNotifications,
-} from "../live-dispatcher"
+} from "@/lib/zbs/live-dispatcher"
 
 const baseOutboxRow = {
   id: "outbox-1",

--- a/src/lib/zbs/__tests__/live-dispatcher-success-persistence.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher-success-persistence.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  ZBS_CLAIM_DISPATCH_RPC,
+  ZBS_MARK_SENT_RPC,
+  dispatchPendingZbsNotifications,
+} from "../live-dispatcher"
+
+const baseOutboxRow = {
+  id: "outbox-1",
+  event_type: "repair_request_created",
+  source_type: "repair_request",
+  source_id: 42,
+  don_vi_id: 17,
+  recipient_config_id: "recipient-1",
+  recipient_phone: "0987654321",
+  template_id: null,
+  tracking_id: "repair_request:42:recipient-1",
+  status: "pending",
+  provider: "zalo_zbs",
+  last_attempt_at: "2026-06-30T08:00:00.000Z",
+  next_attempt_at: "2026-06-30T00:00:00.000Z",
+  template_data: {
+    repair_request_id: 42,
+    equipment_code: "TB-001",
+    equipment_name: "May tho ICU",
+    department: "ICU",
+    issue_description: "Khong khoi dong duoc",
+    requester: "Nguyen Van A",
+  },
+} as const
+
+describe("dispatchPendingZbsNotifications success persistence", () => {
+  it("normalizes epoch-millisecond provider sent_time before marking successful sends", async () => {
+    const rpcClient = vi
+      .fn()
+      .mockResolvedValueOnce([baseOutboxRow])
+      .mockResolvedValueOnce([{ id: "outbox-1", status: "sent" }])
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: 0,
+          message: "Success",
+          data: {
+            msg_id: "zalo-message-1",
+            sent_time: "1719734401000",
+          },
+        }),
+        { status: 200 }
+      )
+    )
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(rpcClient).toHaveBeenNthCalledWith(2, {
+      fn: ZBS_MARK_SENT_RPC,
+      args: expect.objectContaining({
+        p_id: "outbox-1",
+        p_claimed_at: "2026-06-30T08:00:00.000Z",
+        p_provider_message_id: "zalo-message-1",
+        p_sent_at: "2024-06-30T08:00:01.000Z",
+      }),
+    })
+    expect(result).toMatchObject({
+      attempted: 1,
+      sent: 1,
+      failed: 0,
+      results: [{ outbox_id: "outbox-1", status: "sent", provider_message_id: "zalo-message-1" }],
+    })
+  })
+
+  it("surfaces safe mark-sent RPC failures without aborting the remaining chunk", async () => {
+    const rejectedRow = { ...baseOutboxRow, id: "rejected-row", tracking_id: "rejected" }
+    const successRow = { ...baseOutboxRow, id: "success-row", tracking_id: "success" }
+    const rpcClient = vi.fn().mockImplementation(async ({ fn, args }) => {
+      if (fn === ZBS_CLAIM_DISPATCH_RPC) {
+        return [rejectedRow, successRow]
+      }
+      if (args.p_id === "rejected-row") {
+        throw new Error("ZBS outbox row rejected-row is not claimable as sent for this lease")
+      }
+      return [{ id: "updated" }]
+    })
+    const fetchImpl = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 0, data: { msg_id: "zalo-message" } }), {
+          status: 200,
+        })
+      )
+    )
+
+    const result = await dispatchPendingZbsNotifications({
+      dispatchEnabled: true,
+      accessToken: "zalo-access-token",
+      repairTemplateId: "template-123",
+      rpcClient,
+      fetchImpl,
+      now: new Date("2026-06-30T08:00:00.000Z"),
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({
+      attempted: 2,
+      sent: 1,
+      failed: 1,
+      results: [
+        {
+          outbox_id: "rejected-row",
+          status: "failed",
+          error_code: "dispatch_row_error",
+          error_message: "ZBS outbox row rejected-row is not claimable as sent for this lease",
+        },
+        { outbox_id: "success-row", status: "sent" },
+      ],
+    })
+  })
+})

--- a/src/lib/zbs/__tests__/live-dispatcher-utils.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { getProviderSentAt } from "../live-dispatcher-utils"
+import { getProviderSentAt } from "@/lib/zbs/live-dispatcher-utils"
 
 describe("getProviderSentAt", () => {
   it("normalizes Unix-second sent_time values", () => {
@@ -10,6 +10,46 @@ describe("getProviderSentAt", () => {
           data: {
             sent_time: "1719734401",
           },
+        },
+        new Date("2026-06-30T08:00:00.000Z")
+      )
+    ).toBe("2024-06-30T08:00:01.000Z")
+  })
+
+  it("falls back to sent_time when sent_at is empty", () => {
+    expect(
+      getProviderSentAt(
+        {
+          data: {
+            sent_at: "",
+            sent_time: "1719734401000",
+          },
+        },
+        new Date("2026-06-30T08:00:00.000Z")
+      )
+    ).toBe("2024-06-30T08:00:01.000Z")
+  })
+
+  it("falls back to sent_time when sent_at is zero", () => {
+    expect(
+      getProviderSentAt(
+        {
+          data: {
+            sent_at: 0,
+            sent_time: "1719734401000",
+          },
+        },
+        new Date("2026-06-30T08:00:00.000Z")
+      )
+    ).toBe("2024-06-30T08:00:01.000Z")
+  })
+
+  it("falls back to top-level sent_time", () => {
+    expect(
+      getProviderSentAt(
+        {
+          data: {},
+          sent_time: "1719734401000",
         },
         new Date("2026-06-30T08:00:00.000Z")
       )

--- a/src/lib/zbs/__tests__/live-dispatcher-utils.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { getProviderSentAt } from "../live-dispatcher-utils"
+
+describe("getProviderSentAt", () => {
+  it("normalizes Unix-second sent_time values", () => {
+    expect(
+      getProviderSentAt(
+        {
+          data: {
+            sent_time: "1719734401",
+          },
+        },
+        new Date("2026-06-30T08:00:00.000Z")
+      )
+    ).toBe("2024-06-30T08:00:01.000Z")
+  })
+})

--- a/src/lib/zbs/live-dispatcher-utils.ts
+++ b/src/lib/zbs/live-dispatcher-utils.ts
@@ -77,24 +77,31 @@ export function getProviderMessageId(response: JsonObject): string {
   return stringValue(data.msg_id) || stringValue(response.msg_id)
 }
 
-function parseProviderTimestamp(value: unknown, fallback: Date): string {
+function parseProviderTimestamp(value: unknown): string | null {
   if (typeof value === "number" && Number.isFinite(value)) {
+    if (value <= 0) {
+      return null
+    }
     const parsed = new Date(normalizeEpochTimestamp(value))
-    return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
   }
 
   const text = stringValue(value)
   if (!text) {
-    return fallback.toISOString()
+    return null
   }
 
   if (/^\d+$/.test(text)) {
-    const parsed = new Date(normalizeEpochTimestamp(Number(text)))
-    return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
+    const epoch = Number(text)
+    if (epoch <= 0) {
+      return null
+    }
+    const parsed = new Date(normalizeEpochTimestamp(epoch))
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
   }
 
   const parsed = new Date(text)
-  return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
 }
 
 function normalizeEpochTimestamp(value: number): number {
@@ -104,5 +111,14 @@ function normalizeEpochTimestamp(value: number): number {
 /** Normalizes Zalo sent timestamps to ISO strings before RPC persistence. */
 export function getProviderSentAt(response: JsonObject, fallback: Date): string {
   const data = getProviderData(response)
-  return parseProviderTimestamp(data.sent_at ?? data.sent_time ?? response.sent_at, fallback)
+  const candidates = [data.sent_at, data.sent_time, response.sent_at, response.sent_time]
+
+  for (const candidate of candidates) {
+    const parsed = parseProviderTimestamp(candidate)
+    if (parsed) {
+      return parsed
+    }
+  }
+
+  return fallback.toISOString()
 }

--- a/src/lib/zbs/live-dispatcher-utils.ts
+++ b/src/lib/zbs/live-dispatcher-utils.ts
@@ -18,6 +18,7 @@ export interface ZaloSuccess {
 const DISPATCH_ROW_ERROR_MESSAGE = "Unexpected ZBS dispatch row failure"
 const SENSITIVE_ERROR_TEXT_PATTERN =
   /\b(token|secret|password|authorization|credential|api[_ -]?key|apikey)\b/i
+const MIN_REASONABLE_EPOCH_MILLISECONDS = 1_000_000_000_000
 
 /** Checks whether an unknown provider value is a non-array object. */
 export function isRecord(value: unknown): value is JsonObject {
@@ -78,7 +79,7 @@ export function getProviderMessageId(response: JsonObject): string {
 
 function parseProviderTimestamp(value: unknown, fallback: Date): string {
   if (typeof value === "number" && Number.isFinite(value)) {
-    const parsed = new Date(value)
+    const parsed = new Date(normalizeEpochTimestamp(value))
     return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
   }
 
@@ -88,12 +89,16 @@ function parseProviderTimestamp(value: unknown, fallback: Date): string {
   }
 
   if (/^\d+$/.test(text)) {
-    const parsed = new Date(Number(text))
+    const parsed = new Date(normalizeEpochTimestamp(Number(text)))
     return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
   }
 
   const parsed = new Date(text)
   return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
+}
+
+function normalizeEpochTimestamp(value: number): number {
+  return value < MIN_REASONABLE_EPOCH_MILLISECONDS ? value * 1000 : value
 }
 
 /** Normalizes Zalo sent timestamps to ISO strings before RPC persistence. */

--- a/src/lib/zbs/live-dispatcher-utils.ts
+++ b/src/lib/zbs/live-dispatcher-utils.ts
@@ -1,0 +1,103 @@
+import { sanitizeForLog } from "@/lib/log-sanitizer"
+
+export type JsonObject = Record<string, unknown>
+
+export interface ZaloFailure {
+  code: string
+  message: string
+  retryable: boolean
+  providerResponse?: JsonObject
+}
+
+export interface ZaloSuccess {
+  providerMessageId: string
+  sentAt: string
+  providerResponse: JsonObject
+}
+
+const DISPATCH_ROW_ERROR_MESSAGE = "Unexpected ZBS dispatch row failure"
+const SENSITIVE_ERROR_TEXT_PATTERN =
+  /\b(token|secret|password|authorization|credential|api[_ -]?key|apikey)\b/i
+
+/** Checks whether an unknown provider value is a non-array object. */
+export function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Returns a safe fallback message for unknown dispatcher errors. */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown error"
+}
+
+/** Trims string values while rejecting non-string provider fields. */
+export function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+/** Reads finite numeric provider fields without coercion. */
+export function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+/** Keeps provider JSON object metadata and drops non-object payloads. */
+export function sanitizeProviderResponse(value: unknown): JsonObject {
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  return value
+}
+
+/** Surfaces safe row-level dispatch errors while hiding sensitive-looking text. */
+export function safeDispatchRowErrorMessage(error: unknown): string {
+  const sanitized = sanitizeForLog(error)
+  let message = errorMessage(error)
+
+  if (typeof sanitized === "string") {
+    message = sanitized
+  } else if (isRecord(sanitized)) {
+    message = stringValue(sanitized.message)
+  }
+
+  if (!message || SENSITIVE_ERROR_TEXT_PATTERN.test(message)) {
+    return DISPATCH_ROW_ERROR_MESSAGE
+  }
+
+  return message
+}
+
+function getProviderData(response: JsonObject): JsonObject {
+  return isRecord(response.data) ? response.data : response
+}
+
+/** Extracts the Zalo provider message id from supported response shapes. */
+export function getProviderMessageId(response: JsonObject): string {
+  const data = getProviderData(response)
+  return stringValue(data.msg_id) || stringValue(response.msg_id)
+}
+
+function parseProviderTimestamp(value: unknown, fallback: Date): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const parsed = new Date(value)
+    return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
+  }
+
+  const text = stringValue(value)
+  if (!text) {
+    return fallback.toISOString()
+  }
+
+  if (/^\d+$/.test(text)) {
+    const parsed = new Date(Number(text))
+    return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
+  }
+
+  const parsed = new Date(text)
+  return Number.isNaN(parsed.getTime()) ? fallback.toISOString() : parsed.toISOString()
+}
+
+/** Normalizes Zalo sent timestamps to ISO strings before RPC persistence. */
+export function getProviderSentAt(response: JsonObject, fallback: Date): string {
+  const data = getProviderData(response)
+  return parseProviderTimestamp(data.sent_at ?? data.sent_time ?? response.sent_at, fallback)
+}

--- a/src/lib/zbs/live-dispatcher.ts
+++ b/src/lib/zbs/live-dispatcher.ts
@@ -7,6 +7,19 @@ import {
   ZALO_ZBS_PHONE_TEMPLATE_ENDPOINT,
   buildZbsTemplateRequest,
 } from "./dispatcher"
+import {
+  type JsonObject,
+  type ZaloFailure,
+  type ZaloSuccess,
+  errorMessage,
+  getProviderMessageId,
+  getProviderSentAt,
+  isRecord,
+  numberValue,
+  safeDispatchRowErrorMessage,
+  sanitizeProviderResponse,
+  stringValue,
+} from "./live-dispatcher-utils"
 
 /** Service-role RPC that atomically claims due ZBS outbox rows for live dispatch. */
 export const ZBS_CLAIM_DISPATCH_RPC = "zbs_notification_outbox_claim_for_dispatch"
@@ -14,8 +27,6 @@ export const ZBS_CLAIM_DISPATCH_RPC = "zbs_notification_outbox_claim_for_dispatc
 export const ZBS_MARK_SENT_RPC = "zbs_notification_outbox_mark_sent"
 /** Service-role RPC that persists retryable or final ZBS provider failures. */
 export const ZBS_MARK_FAILED_RPC = "zbs_notification_outbox_mark_failed"
-
-type JsonObject = Record<string, unknown>
 
 type ZbsRpcClient = (options: { fn: string; args: JsonObject }) => Promise<unknown>
 type ZbsFetch = typeof fetch
@@ -51,59 +62,6 @@ export interface ZbsDispatchRunResult {
   retryable_failed: number
   failed: number
   results: ZbsDispatchResult[]
-}
-
-interface ZaloFailure {
-  code: string
-  message: string
-  retryable: boolean
-  providerResponse?: JsonObject
-}
-
-interface ZaloSuccess {
-  providerMessageId: string
-  sentAt: string
-  providerResponse: JsonObject
-}
-
-function isRecord(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "unknown error"
-}
-
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value.trim() : ""
-}
-
-function numberValue(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null
-}
-
-function sanitizeProviderResponse(value: unknown): JsonObject {
-  if (!isRecord(value)) {
-    return {}
-  }
-
-  return value
-}
-
-function getProviderData(response: JsonObject): JsonObject {
-  return isRecord(response.data) ? response.data : response
-}
-
-function getProviderMessageId(response: JsonObject): string {
-  const data = getProviderData(response)
-  return stringValue(data.msg_id) || stringValue(response.msg_id)
-}
-
-function getProviderSentAt(response: JsonObject, fallback: Date): string {
-  const data = getProviderData(response)
-  const sentAt =
-    stringValue(data.sent_at) || stringValue(data.sent_time) || stringValue(response.sent_at)
-  return sentAt || fallback.toISOString()
 }
 
 function classifyHttpFailure(response: Response): ZaloFailure {
@@ -346,12 +304,12 @@ async function dispatchRow(
   }
 }
 
-function failedDispatchRowResult(row: ZbsNotificationOutboxRow): ZbsDispatchResult {
+function failedDispatchRowResult(row: ZbsNotificationOutboxRow, error: unknown): ZbsDispatchResult {
   return {
     outbox_id: row.id,
     status: "failed",
     error_code: "dispatch_row_error",
-    error_message: "Unexpected ZBS dispatch row failure",
+    error_message: safeDispatchRowErrorMessage(error),
   }
 }
 
@@ -366,7 +324,9 @@ async function dispatchRowsInChunks(
     const settledResults = await Promise.allSettled(chunk.map((row) => dispatchRow(row, options)))
     results.push(
       ...settledResults.map((result, resultIndex) =>
-        result.status === "fulfilled" ? result.value : failedDispatchRowResult(chunk[resultIndex])
+        result.status === "fulfilled"
+          ? result.value
+          : failedDispatchRowResult(chunk[resultIndex], result.reason)
       )
     )
   }

--- a/src/lib/zbs/live-dispatcher.ts
+++ b/src/lib/zbs/live-dispatcher.ts
@@ -14,7 +14,6 @@ import {
   errorMessage,
   getProviderMessageId,
   getProviderSentAt,
-  isRecord,
   numberValue,
   safeDispatchRowErrorMessage,
   sanitizeProviderResponse,


### PR DESCRIPTION
## Summary
- Fix ZBS successful provider-send persistence by normalizing epoch-millisecond `sent_time` before calling `zbs_notification_outbox_mark_sent`.
- Surface safe row-level mark-sent RPC errors in `dispatch_row_error` results while keeping sensitive-looking error text generic.
- Move provider parsing/safe row-error helpers into a focused ZBS utility module so `live-dispatcher.ts` stays below the repo file-size ceiling.

Refs #648

## Verification
- RED: `node scripts/npm-run.js run test:run -- src/lib/zbs/__tests__/live-dispatcher.test.ts -t "normalizes epoch-millisecond provider sent_time"` failed before the fix with raw `p_sent_at: "1719734401000"`.
- RED: `node scripts/npm-run.js run test:run -- src/lib/zbs/__tests__/live-dispatcher.test.ts -t "surfaces safe mark-sent RPC failures"` failed before the fix with generic `Unexpected ZBS dispatch row failure`.
- `node scripts/npm-run.js npx prettier --check --ignore-unknown src/lib/zbs/live-dispatcher.ts src/lib/zbs/live-dispatcher-utils.ts src/lib/zbs/__tests__/live-dispatcher-success-persistence.test.ts`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/lib/zbs/__tests__/live-dispatcher.test.ts src/lib/zbs/__tests__/live-dispatcher-success-persistence.test.ts`
- `node scripts/npm-run.js run react-doctor`
- Lefthook pre-commit passed.
- Lefthook pre-push passed.

## Notes
- No SQL migration.
- No scheduler cadence/realtime dispatch changes (#650 out of scope).
- No template text changes (#651 out of scope).
- Broad `format:check` still reports existing baseline repo formatting warnings, so changed-file Prettier check was used for this diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ZBS successful send persistence (addresses #648) by normalizing and falling back provider sent timestamps before marking rows as sent. Adds safe row-level error reporting and moves parsing/error helpers into a ZBS utility module.

- **Bug Fixes**
  - Normalize provider sent timestamps: accept seconds or milliseconds (string or number), read from `data.sent_at`, `data.sent_time`, top‑level `sent_at`/`sent_time`, and fallback to the lease time; store as ISO for mark‑sent RPC.
  - Surface sanitized mark‑sent RPC errors as `dispatch_row_error` without aborting the remaining chunk.

- **Refactors**
  - Extract parsing and error helpers into `src/lib/zbs/live-dispatcher-utils.ts` to keep `live-dispatcher.ts` focused and smaller.

<sup>Written for commit a9cf2611a1c906481a48565561a8ed333cb6517b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification dispatch reliability when some rows fail, allowing other items to continue processing.
  * Normalized provider timestamps more consistently, helping sent times appear correctly.
  * Replaced generic dispatch errors with clearer, more specific failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->