### PR TITLE
fix: use safe ZBS issue summary

### DIFF
--- a/src/lib/zbs/__tests__/dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/dispatcher.test.ts
@@ -5,7 +5,7 @@ import {
   ZALO_ZBS_ACCESS_TOKEN_HEADER_PLACEHOLDER,
   ZALO_ZBS_PHONE_TEMPLATE_ENDPOINT,
   ZBS_PENDING_DISPATCH_RPC,
-  ZBS_ISSUE_SUMMARY_MAX_LENGTH,
+  ZBS_REPAIR_ISSUE_SUMMARY,
   buildZbsDryRunDispatches,
   buildZbsTemplateRequest,
   mapRepairRequestTemplateData,
@@ -64,12 +64,32 @@ describe("mapRepairRequestTemplateData", () => {
       equipment: "May tho ICU (TB-001)",
       department: "ICU",
       requester: "Nguyen Van A",
-      issue_summary: "Khong khoi dong duoc",
+      issue_summary: ZBS_REPAIR_ISSUE_SUMMARY,
       detail_url: "https://app.example.test/repair-requests?action=view&requestId=42",
     })
   })
 
-  it("uses documented fallbacks and caps issue_summary before request construction", () => {
+  it("uses a fixed provider-safe issue summary instead of long user-entered details", () => {
+    const longIssueDescription = [
+      "Máy thở báo lỗi áp lực đường thở liên tục, màn hình hiển thị cảnh báo kéo dài.",
+      "Khoa đã thử khởi động lại nhiều lần nhưng thiết bị vẫn không hoạt động ổn định.",
+      "Cần kiểm tra gấp vì nội dung này dài hơn giới hạn trường Zalo template.",
+    ].join(" ")
+
+    const templateData = mapRepairRequestTemplateData({
+      ...baseOutboxRow,
+      template_data: {
+        ...baseOutboxRow.template_data,
+        issue_description: longIssueDescription,
+      },
+    })
+
+    expect(templateData.issue_summary).toBe(ZBS_REPAIR_ISSUE_SUMMARY)
+    expect(templateData.issue_summary).not.toContain("Máy thở báo lỗi")
+    expect(new TextEncoder().encode(templateData.issue_summary).length).toBeLessThanOrEqual(32)
+  })
+
+  it("uses documented fallbacks and fixed issue_summary before request construction", () => {
     const longIssueSummary = "Loi ".repeat(80)
 
     const templateData = mapRepairRequestTemplateData({
@@ -92,8 +112,7 @@ describe("mapRepairRequestTemplateData", () => {
       requester: "Khong ro",
       detail_url: "/repair-requests?action=view&requestId=99",
     })
-    expect(templateData.issue_summary.length).toBeLessThanOrEqual(ZBS_ISSUE_SUMMARY_MAX_LENGTH)
-    expect(templateData.issue_summary).toMatch(/\.\.\.$/)
+    expect(templateData.issue_summary).toBe(ZBS_REPAIR_ISSUE_SUMMARY)
   })
 })
 
@@ -117,7 +136,7 @@ describe("buildZbsTemplateRequest", () => {
           equipment: "May tho ICU (TB-001)",
           department: "ICU",
           requester: "Nguyen Van A",
-          issue_summary: "Khong khoi dong duoc",
+          issue_summary: ZBS_REPAIR_ISSUE_SUMMARY,
           detail_url: "https://app.example.test/repair-requests?action=view&requestId=42",
         },
         tracking_id: "repair_request:42:recipient-1",

--- a/src/lib/zbs/__tests__/live-dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher.test.ts
@@ -113,7 +113,7 @@ describe("dispatchPendingZbsNotifications", () => {
       tracking_id: "repair_request:42:recipient-1",
       template_data: {
         request_id: "42",
-        issue_summary: "Khong khoi dong duoc",
+        issue_summary: "Lỗi thiết bị",
       },
     })
     expect(rpcClient).toHaveBeenNthCalledWith(2, {

--- a/src/lib/zbs/__tests__/live-dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/live-dispatcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
+import { ZBS_REPAIR_ISSUE_SUMMARY } from "../dispatcher"
 import {
   ZBS_CLAIM_DISPATCH_RPC,
   ZBS_MARK_FAILED_RPC,
@@ -113,7 +114,7 @@ describe("dispatchPendingZbsNotifications", () => {
       tracking_id: "repair_request:42:recipient-1",
       template_data: {
         request_id: "42",
-        issue_summary: "Lỗi thiết bị",
+        issue_summary: ZBS_REPAIR_ISSUE_SUMMARY,
       },
     })
     expect(rpcClient).toHaveBeenNthCalledWith(2, {

--- a/src/lib/zbs/dispatcher.ts
+++ b/src/lib/zbs/dispatcher.ts
@@ -7,8 +7,8 @@ export const ZALO_ZBS_PHONE_TEMPLATE_ENDPOINT = "https://business.openapi.zalo.m
 export const ZALO_ZBS_ACCESS_TOKEN_HEADER_PLACEHOLDER = "<ZALO_ZBS_ACCESS_TOKEN>"
 /** Placeholder used until a pending outbox row carries the approved template id. */
 export const ZALO_ZBS_REPAIR_TEMPLATE_ID_PLACEHOLDER = "<ZALO_ZBS_REPAIR_TEMPLATE_ID>"
-/** Conservative cap for the approved `issue_summary` ZBS template field. */
-export const ZBS_ISSUE_SUMMARY_MAX_LENGTH = 120
+/** Fixed provider-safe text for the constrained `issue_summary` ZBS template field. */
+export const ZBS_REPAIR_ISSUE_SUMMARY = "Lỗi thiết bị"
 /** RPC boundary for reading pending ZBS outbox rows through the app proxy. */
 export const ZBS_PENDING_DISPATCH_RPC = "zbs_notification_outbox_pending_for_dispatch"
 
@@ -133,16 +133,6 @@ function firstPresent(...values: string[]): string {
   return values.find((value) => value.length > 0) ?? "Khong ro"
 }
 
-function truncateIssueSummary(value: string): string {
-  const summary = firstPresent(value, "Yeu cau sua chua thiet bi moi")
-
-  if (summary.length <= ZBS_ISSUE_SUMMARY_MAX_LENGTH) {
-    return summary
-  }
-
-  return `${summary.slice(0, ZBS_ISSUE_SUMMARY_MAX_LENGTH - 3).trimEnd()}...`
-}
-
 function equipmentLabel(templateData: JsonObject): string {
   const equipmentName = stringValue(templateData.equipment_name)
   const equipmentCode = stringValue(templateData.equipment_code)
@@ -182,7 +172,7 @@ export function mapRepairRequestTemplateData(
       stringValue(templateData.don_vi_thuc_hien)
     ),
     requester: firstPresent(stringValue(templateData.requester)),
-    issue_summary: truncateIssueSummary(stringValue(templateData.issue_description)),
+    issue_summary: ZBS_REPAIR_ISSUE_SUMMARY,
     detail_url: buildDetailUrl(row, options.appBaseUrl),
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #651 by sending the fixed Zalo-safe issue summary `Lỗi thiết bị` for repair notifications.
- Keeps the full user-entered repair description out of the constrained ZBS template field.
- Leaves scheduler cadence and mark_sent persistence unchanged.

## Test Plan
- [x] RED: focused dispatcher regression failed before implementation
- [x] node scripts/npm-run.js run test -- src/lib/zbs/__tests__/dispatcher.test.ts src/lib/zbs/__tests__/live-dispatcher.test.ts
- [x] node scripts/npm-run.js run verify:no-explicit-any
- [x] node scripts/npm-run.js run verify:dedupe
- [x] node scripts/npm-run.js run typecheck
- [x] node scripts/npm-run.js run react-doctor
- [x] ./node_modules/.bin/prettier --check src/lib/zbs/dispatcher.ts src/lib/zbs/__tests__/dispatcher.test.ts src/lib/zbs/__tests__/live-dispatcher.test.ts

Note: full `format:check` currently fails on unrelated baseline formatting noise outside this diff; changed files pass Prettier and pre-commit formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force ZBS repair notifications to use the fixed, provider-safe issue summary "Lỗi thiết bị" to avoid template rejections and keep user-entered details out of the constrained field. Fixes #651.

- **Bug Fixes**
  - Always set `issue_summary` to `ZBS_REPAIR_ISSUE_SUMMARY`; removed truncation and `ZBS_ISSUE_SUMMARY_MAX_LENGTH`. Tests now reuse the constant and verify provider-safe length.
  - No changes to scheduler cadence or `mark_sent` behavior.

<sup>Written for commit 5bb014892ad2880ec557935f5361161a72a10e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the ZBS issue summary text used in outgoing template requests.
  * Replaced variable, length-limited summary text with a fixed Vietnamese message to keep requests consistent and compatible.
  * Updated tests to match the new request payload and expected summary value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->