### PR TITLE
feat: add ZBS delivery webhook

### DIFF
--- a/docs/runbooks/zbs-delivery-webhook.md
+++ b/docs/runbooks/zbs-delivery-webhook.md
@@ -1,0 +1,133 @@
+# Runbook: ZBS delivery webhook
+
+Ap dung cho inbound Zalo ZBS delivery callback vao:
+
+```text
+https://www.cvmems.vn/api/webhooks/zalo/zbs
+```
+
+Webhook nay chi cap nhat delivery status cho outbox da gui. No khong enqueue va
+khong gui thong bao moi.
+
+## Required env
+
+Production can co cac bien da dung cho ZBS dispatch:
+
+```text
+ZALO_ZBS_APP_ID
+ZALO_ZBS_APP_SECRET
+SUPABASE_URL
+SUPABASE_SERVICE_ROLE_KEY
+```
+
+`ZALO_ZBS_APP_SECRET` la secret dung de validate `X-ZEvent-Signature`. Khong tao
+secret rieng neu Zalo console dang ky callback bang cung OA/app secret.
+
+## Zalo console setup
+
+Trong Zalo/ZNS webhook configuration:
+
+1. Dat callback URL thanh `https://www.cvmems.vn/api/webhooks/zalo/zbs`.
+2. Bat event `user_received_message`.
+3. Luu cau hinh va dung chinh `ZALO_ZBS_APP_ID` / `ZALO_ZBS_APP_SECRET` cua
+   production.
+4. Neu rotate app secret, cap nhat Vercel Production env truoc, redeploy, roi
+   rotate trong Zalo console de tranh callback bi `401`.
+
+Route validate raw body theo header `X-ZEvent-Signature` dang `mac=<sha256>`.
+Signature hop le moi duoc parse thanh delivery mutation.
+
+## Expected DB effect
+
+Trusted event `event_name=user_received_message` phai co `message.tracking_id`.
+Route goi service-role RPC:
+
+```sql
+public.zbs_notification_outbox_mark_delivered(
+  p_tracking_id,
+  p_provider_message_id,
+  p_recipient_phone,
+  p_delivered_at,
+  p_delivery_webhook_received_at,
+  p_delivery_webhook_payload
+)
+```
+
+RPC chi match `public.zbs_notification_outbox` rows:
+
+- `provider = 'zalo_zbs'`
+- `tracking_id = p_tracking_id`
+- `status in ('sent', 'delivered')`
+
+Lan dau match row `sent` se chuyen sang `delivered`, set `delivered_at`, set
+`delivery_webhook_received_at`, va luu metadata o
+`provider_response.delivery_webhook`. Neu row da `delivered`, RPC tra row theo
+tracking id nhung giu gia tri delivery hien co de duplicate callback idempotent.
+
+## Monitoring
+
+Theo doi sent vs delivered:
+
+```sql
+select
+  status,
+  count(*) as total,
+  min(created_at) as oldest_created_at,
+  max(updated_at) as newest_updated_at
+from public.zbs_notification_outbox
+where provider = 'zalo_zbs'
+group by status
+order by status;
+```
+
+Kiem tra delivery webhook gan day:
+
+```sql
+select
+  id,
+  source_type,
+  source_id,
+  recipient_phone,
+  tracking_id,
+  provider_message_id,
+  sent_at,
+  delivered_at,
+  delivery_webhook_received_at,
+  provider_response->'delivery_webhook' as delivery_webhook
+from public.zbs_notification_outbox
+where provider = 'zalo_zbs'
+  and delivery_webhook_received_at is not null
+order by delivery_webhook_received_at desc
+limit 20;
+```
+
+Kiem tra rows da sent nhung chua co delivery callback:
+
+```sql
+select
+  id,
+  source_type,
+  source_id,
+  recipient_phone,
+  tracking_id,
+  provider_message_id,
+  sent_at,
+  now() - sent_at as sent_age
+from public.zbs_notification_outbox
+where provider = 'zalo_zbs'
+  and status = 'sent'
+order by sent_at asc
+limit 50;
+```
+
+## Troubleshooting
+
+- `401`: signature sai, sai app id/secret, body bi proxy rewrite, hoac header
+  `X-ZEvent-Signature` thieu.
+- `202`: event signed hop le nhung khong phai `user_received_message`; khong co
+  DB mutation.
+- `400`: delivery event trusted nhung payload thieu `message.tracking_id`.
+- `500`: route config thieu hoac RPC loi. Kiem tra Vercel logs, khong expose DB
+  error cho caller.
+
+Dung Supabase MCP de inspect DB/RPC. Khong dung Supabase CLI cho live DB.

--- a/scripts/verify-zbs-delivery-webhook.sql
+++ b/scripts/verify-zbs-delivery-webhook.sql
@@ -25,6 +25,7 @@ BEGIN
   RETURNING id INTO v_recipient_id;
 
   INSERT INTO public.zbs_notification_outbox (
+    provider,
     event_type,
     source_type,
     source_id,
@@ -40,6 +41,7 @@ BEGIN
     sent_at
   )
   VALUES (
+    'zalo_zbs',
     'repair_request_created',
     'repair_request',
     -62101,
@@ -57,6 +59,7 @@ BEGIN
   RETURNING id INTO v_sent_id;
 
   INSERT INTO public.zbs_notification_outbox (
+    provider,
     event_type,
     source_type,
     source_id,
@@ -74,6 +77,7 @@ BEGIN
     delivery_webhook_received_at
   )
   VALUES (
+    'zalo_zbs',
     'repair_request_created',
     'repair_request',
     -62102,

--- a/scripts/verify-zbs-delivery-webhook.sql
+++ b/scripts/verify-zbs-delivery-webhook.sql
@@ -1,0 +1,193 @@
+BEGIN;
+
+DO $$
+DECLARE
+  v_don_vi_id bigint;
+  v_recipient_id uuid;
+  v_sent_id uuid;
+  v_delivered_id uuid;
+  v_unmatched_count integer;
+  v_duplicate_received_at timestamptz;
+  v_result record;
+BEGIN
+  SELECT id
+    INTO v_don_vi_id
+  FROM public.don_vi
+  ORDER BY id
+  LIMIT 1;
+
+  IF v_don_vi_id IS NULL THEN
+    RAISE EXCEPTION 'verify-zbs-delivery-webhook requires at least one public.don_vi row';
+  END IF;
+
+  INSERT INTO public.zbs_recipient_configs (don_vi_id, event_type, recipient_phone, active)
+  VALUES (v_don_vi_id, 'repair_request_created', '84900000002', true)
+  RETURNING id INTO v_recipient_id;
+
+  INSERT INTO public.zbs_notification_outbox (
+    event_type,
+    source_type,
+    source_id,
+    don_vi_id,
+    recipient_config_id,
+    recipient_phone,
+    template_id,
+    template_data,
+    tracking_id,
+    status,
+    provider_message_id,
+    provider_response,
+    sent_at
+  )
+  VALUES (
+    'repair_request_created',
+    'repair_request',
+    -62101,
+    v_don_vi_id,
+    v_recipient_id,
+    '84900000002',
+    'template-test',
+    jsonb_build_object('repair_request_id', -62101),
+    'verify-zbs-delivery-webhook:sent',
+    'sent',
+    'existing-provider-message',
+    jsonb_build_object('send', 'ok'),
+    now() - interval '5 minutes'
+  )
+  RETURNING id INTO v_sent_id;
+
+  INSERT INTO public.zbs_notification_outbox (
+    event_type,
+    source_type,
+    source_id,
+    don_vi_id,
+    recipient_config_id,
+    recipient_phone,
+    template_id,
+    template_data,
+    tracking_id,
+    status,
+    provider_message_id,
+    provider_response,
+    sent_at,
+    delivered_at,
+    delivery_webhook_received_at
+  )
+  VALUES (
+    'repair_request_created',
+    'repair_request',
+    -62102,
+    v_don_vi_id,
+    v_recipient_id,
+    '84900000002',
+    'template-test',
+    jsonb_build_object('repair_request_id', -62102),
+    'verify-zbs-delivery-webhook:delivered',
+    'delivered',
+    'existing-delivered-message',
+    jsonb_build_object('delivery_webhook', jsonb_build_object('tracking_id', 'verify-zbs-delivery-webhook:delivered')),
+    now() - interval '10 minutes',
+    now() - interval '9 minutes',
+    now() - interval '8 minutes'
+  )
+  RETURNING id INTO v_delivered_id;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    '{"role":"authenticated","app_role":"to_qltb","user_id":"verify-zbs-delivery-webhook"}',
+    true
+  );
+
+  BEGIN
+    PERFORM public.zbs_notification_outbox_mark_delivered(
+      'verify-zbs-delivery-webhook:sent',
+      'forbidden-provider-message',
+      '84900000002',
+      now(),
+      now(),
+      '{}'::jsonb
+    );
+    RAISE EXCEPTION 'mark_delivered RPC did not reject non-service_role JWT';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    '{"role":"service_role","app_role":"to_qltb","user_id":"verify-zbs-delivery-webhook"}',
+    true
+  );
+
+  SELECT *
+    INTO v_result
+  FROM public.zbs_notification_outbox_mark_delivered(
+    'verify-zbs-delivery-webhook:sent',
+    'new-provider-message',
+    '84900000002',
+    '2026-07-02T08:30:00Z'::timestamptz,
+    '2026-07-02T08:31:00Z'::timestamptz,
+    jsonb_build_object('message_tracking_id', 'verify-zbs-delivery-webhook:sent', 'message_msg_id', 'new-provider-message')
+  );
+
+  IF v_result.id IS DISTINCT FROM v_sent_id OR v_result.status <> 'delivered' THEN
+    RAISE EXCEPTION 'mark_delivered returned unexpected row: %, %', v_result.id, v_result.status;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id = v_sent_id
+      AND status = 'delivered'
+      AND tracking_id = 'verify-zbs-delivery-webhook:sent'
+      AND provider_message_id = 'existing-provider-message'
+      AND delivered_at = '2026-07-02T08:30:00Z'::timestamptz
+      AND delivery_webhook_received_at = '2026-07-02T08:31:00Z'::timestamptz
+      AND provider_response->'delivery_webhook'->>'message_tracking_id' = 'verify-zbs-delivery-webhook:sent'
+  ) THEN
+    RAISE EXCEPTION 'sent row was not marked delivered by tracking_id with preserved provider_message_id';
+  END IF;
+
+  SELECT count(*)
+    INTO v_unmatched_count
+  FROM public.zbs_notification_outbox_mark_delivered(
+    'verify-zbs-delivery-webhook:missing',
+    'missing-message',
+    NULL,
+    now(),
+    now(),
+    '{}'::jsonb
+  );
+
+  IF v_unmatched_count <> 0 THEN
+    RAISE EXCEPTION 'unmatched tracking id returned rows: %', v_unmatched_count;
+  END IF;
+
+  SELECT delivery_webhook_received_at
+    INTO v_duplicate_received_at
+  FROM public.zbs_notification_outbox
+  WHERE id = v_delivered_id;
+
+  PERFORM public.zbs_notification_outbox_mark_delivered(
+    'verify-zbs-delivery-webhook:delivered',
+    'duplicate-provider-message',
+    '84900000002',
+    '2026-07-02T08:40:00Z'::timestamptz,
+    '2026-07-02T08:41:00Z'::timestamptz,
+    jsonb_build_object('message_tracking_id', 'verify-zbs-delivery-webhook:delivered')
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.zbs_notification_outbox
+    WHERE id = v_delivered_id
+      AND status = 'delivered'
+      AND provider_message_id = 'existing-delivered-message'
+      AND delivery_webhook_received_at = v_duplicate_received_at
+  ) THEN
+    RAISE EXCEPTION 'duplicate delivery event was not idempotent';
+  END IF;
+END;
+$$;
+
+ROLLBACK;

--- a/scripts/verify-zbs-delivery-webhook.sql
+++ b/scripts/verify-zbs-delivery-webhook.sql
@@ -130,6 +130,10 @@ BEGIN
     jsonb_build_object('message_tracking_id', 'verify-zbs-delivery-webhook:sent', 'message_msg_id', 'new-provider-message')
   );
 
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'mark_delivered returned no rows for sent tracking id';
+  END IF;
+
   IF v_result.id IS DISTINCT FROM v_sent_id OR v_result.status <> 'delivered' THEN
     RAISE EXCEPTION 'mark_delivered returned unexpected row: %, %', v_result.id, v_result.status;
   END IF;

--- a/src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
+++ b/src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
@@ -177,6 +177,9 @@ describe("/api/webhooks/zalo/zbs", () => {
 
       expect(response.status).toBe(500)
       await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
+      expect(consoleErrorSpy).toHaveBeenCalledWith("ZBS delivery webhook update failed", {
+        message: "service-role secret leaked in DB detail",
+      })
     } finally {
       consoleErrorSpy.mockRestore()
     }

--- a/src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
+++ b/src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
@@ -86,6 +86,22 @@ describe("/api/webhooks/zalo/zbs", () => {
     await expect(response.json()).resolves.toEqual({ error: "Unauthorized" })
   })
 
+  it("returns the standard 500 body when webhook environment is incomplete", async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const mod = await loadRoute()
+
+    try {
+      const response = await mod.POST(signedRequest(deliveryPayload()))
+
+      expect(response.status).toBe(500)
+      expect(supabaseMocks.createClient).not.toHaveBeenCalled()
+      await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
   it("marks trusted user_received_message events as delivered by tracking id", async () => {
     supabaseMocks.rpc.mockResolvedValue({
       data: [{ id: "outbox-1", status: "delivered" }],
@@ -150,16 +166,19 @@ describe("/api/webhooks/zalo/zbs", () => {
 
   it("returns a sanitized 500 when the delivery RPC fails", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
-    supabaseMocks.rpc.mockResolvedValue({
-      data: null,
-      error: { message: "service-role secret leaked in DB detail" },
-    })
-    const mod = await loadRoute()
+    try {
+      supabaseMocks.rpc.mockResolvedValue({
+        data: null,
+        error: { message: "service-role secret leaked in DB detail" },
+      })
+      const mod = await loadRoute()
 
-    const response = await mod.POST(signedRequest(deliveryPayload()))
+      const response = await mod.POST(signedRequest(deliveryPayload()))
 
-    expect(response.status).toBe(500)
-    await expect(response.json()).resolves.toEqual({ error: "Delivery webhook update failed" })
-    consoleErrorSpy.mockRestore()
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({ error: "Internal server error" })
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
   })
 })

--- a/src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
+++ b/src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
@@ -14,6 +14,8 @@ vi.mock("@supabase/supabase-js", () => ({
 const ORIGINAL_ENV = { ...process.env }
 const APP_ID = "2074138120372622546"
 const SECRET = "zalo-webhook-secret"
+const WEBHOOK_NOW_MS = Date.parse("2026-07-02T09:00:00.000Z")
+const WEBHOOK_TIMESTAMP = String(WEBHOOK_NOW_MS)
 
 async function loadRoute() {
   const routeModulePath = ["..", "route"].join("/")
@@ -23,7 +25,7 @@ async function loadRoute() {
 function deliveryPayload(overrides: Record<string, unknown> = {}) {
   return {
     app_id: APP_ID,
-    timestamp: "1602560967477",
+    timestamp: WEBHOOK_TIMESTAMP,
     event_name: "user_received_message",
     sender: { id: "2893352839501541173" },
     recipient: { id: "1077170099018924429" },
@@ -60,6 +62,8 @@ function signedRequest(payload: unknown, signatureSecret = SECRET) {
 describe("/api/webhooks/zalo/zbs", () => {
   beforeEach(() => {
     vi.resetModules()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(WEBHOOK_NOW_MS))
     supabaseMocks.createClient.mockReset()
     supabaseMocks.rpc.mockReset()
     process.env = {
@@ -73,6 +77,7 @@ describe("/api/webhooks/zalo/zbs", () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     process.env = { ...ORIGINAL_ENV }
   })
 
@@ -141,7 +146,7 @@ describe("/api/webhooks/zalo/zbs", () => {
     const response = await mod.POST(
       signedRequest({
         app_id: APP_ID,
-        timestamp: "1602560967477",
+        timestamp: WEBHOOK_TIMESTAMP,
         event_name: "user_feedback",
         message: { tracking_id: "tracking-1" },
       })

--- a/src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
+++ b/src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { buildZbsDeliveryWebhookSignature } from "@/lib/zbs/delivery-webhook-signature"
+
+const supabaseMocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  rpc: vi.fn(),
+}))
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: supabaseMocks.createClient,
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+const APP_ID = "2074138120372622546"
+const SECRET = "zalo-webhook-secret"
+
+async function loadRoute() {
+  const routeModulePath = ["..", "route"].join("/")
+  return import(/* @vite-ignore */ routeModulePath)
+}
+
+function deliveryPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    app_id: APP_ID,
+    timestamp: "1602560967477",
+    event_name: "user_received_message",
+    sender: { id: "2893352839501541173" },
+    recipient: { id: "1077170099018924429" },
+    message: {
+      delivery_time: "1602960467432",
+      msg_id: "message-1",
+      tracking_id: "tracking-1",
+      phone: "84900000001",
+    },
+    ...overrides,
+  }
+}
+
+function signedRequest(payload: unknown, signatureSecret = SECRET) {
+  const body = JSON.stringify(payload)
+  const timestamp =
+    payload && typeof payload === "object" && "timestamp" in payload
+      ? String(payload.timestamp)
+      : ""
+  return new Request("https://example.test/api/webhooks/zalo/zbs", {
+    method: "POST",
+    headers: {
+      "X-ZEvent-Signature": buildZbsDeliveryWebhookSignature({
+        appId: APP_ID,
+        rawBody: body,
+        timestamp,
+        secret: signatureSecret,
+      }),
+    },
+    body,
+  })
+}
+
+describe("/api/webhooks/zalo/zbs", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    supabaseMocks.createClient.mockReset()
+    supabaseMocks.rpc.mockReset()
+    process.env = {
+      ...ORIGINAL_ENV,
+      ZALO_ZBS_APP_ID: APP_ID,
+      ZALO_ZBS_APP_SECRET: SECRET,
+      SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_SERVICE_ROLE_KEY: "service-role-secret",
+    }
+    supabaseMocks.createClient.mockReturnValue({ rpc: supabaseMocks.rpc })
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it("rejects invalid signatures without creating a Supabase client", async () => {
+    const mod = await loadRoute()
+
+    const response = await mod.POST(signedRequest(deliveryPayload(), "wrong-secret"))
+
+    expect(response.status).toBe(401)
+    expect(supabaseMocks.createClient).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" })
+  })
+
+  it("marks trusted user_received_message events as delivered by tracking id", async () => {
+    supabaseMocks.rpc.mockResolvedValue({
+      data: [{ id: "outbox-1", status: "delivered" }],
+      error: null,
+    })
+    const mod = await loadRoute()
+
+    const response = await mod.POST(signedRequest(deliveryPayload()))
+
+    expect(response.status).toBe(200)
+    expect(supabaseMocks.createClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "service-role-secret",
+      { auth: { persistSession: false } }
+    )
+    expect(supabaseMocks.rpc).toHaveBeenCalledWith("zbs_notification_outbox_mark_delivered", {
+      p_delivered_at: "2020-10-17T18:47:47.432Z",
+      p_delivery_webhook_payload: expect.objectContaining({
+        message_msg_id: "message-1",
+        message_tracking_id: "tracking-1",
+        recipient_phone: "84900000001",
+      }),
+      p_delivery_webhook_received_at: expect.any(String),
+      p_provider_message_id: "message-1",
+      p_recipient_phone: "84900000001",
+      p_tracking_id: "tracking-1",
+    })
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      result: [{ id: "outbox-1", status: "delivered" }],
+    })
+  })
+
+  it("accepts unsupported signed events without mutating the outbox", async () => {
+    const mod = await loadRoute()
+
+    const response = await mod.POST(
+      signedRequest({
+        app_id: APP_ID,
+        timestamp: "1602560967477",
+        event_name: "user_feedback",
+        message: { tracking_id: "tracking-1" },
+      })
+    )
+
+    expect(response.status).toBe(202)
+    expect(supabaseMocks.createClient).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({ success: true, ignored: true })
+  })
+
+  it("rejects malformed trusted delivery events without mutating the outbox", async () => {
+    const mod = await loadRoute()
+
+    const response = await mod.POST(
+      signedRequest(deliveryPayload({ message: { msg_id: "message-1" } }))
+    )
+
+    expect(response.status).toBe(400)
+    expect(supabaseMocks.createClient).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({ error: "Malformed delivery webhook" })
+  })
+
+  it("returns a sanitized 500 when the delivery RPC fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    supabaseMocks.rpc.mockResolvedValue({
+      data: null,
+      error: { message: "service-role secret leaked in DB detail" },
+    })
+    const mod = await loadRoute()
+
+    const response = await mod.POST(signedRequest(deliveryPayload()))
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: "Delivery webhook update failed" })
+    consoleErrorSpy.mockRestore()
+  })
+})

--- a/src/app/api/webhooks/zalo/zbs/route.ts
+++ b/src/app/api/webhooks/zalo/zbs/route.ts
@@ -1,0 +1,106 @@
+import { createClient } from "@supabase/supabase-js"
+
+import { isValidZbsDeliveryWebhookSignature } from "@/lib/zbs/delivery-webhook-signature"
+import { parseZbsDeliveryWebhookPayload } from "@/lib/zbs/delivery-webhook-payload"
+
+/** Keep Zalo delivery callbacks uncached so each signed event mutates live state. */
+export const dynamic = "force-dynamic"
+/** Use Node.js runtime for crypto signature validation and Supabase service-role RPCs. */
+export const runtime = "nodejs"
+
+const ZBS_MARK_DELIVERED_RPC = "zbs_notification_outbox_mark_delivered"
+
+function jsonResponse(body: unknown, status: number): Response {
+  return Response.json(body, { status })
+}
+
+function readRequiredEnv(): {
+  appId: string
+  appSecret: string
+  supabaseUrl: string
+  serviceRoleKey: string
+} | null {
+  const appId = process.env.ZALO_ZBS_APP_ID?.trim()
+  const appSecret = process.env.ZALO_ZBS_APP_SECRET?.trim()
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!appId || !appSecret || !supabaseUrl || !serviceRoleKey) {
+    return null
+  }
+
+  return { appId, appSecret, supabaseUrl, serviceRoleKey }
+}
+
+function stringField(payload: unknown, field: string): string {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return ""
+  }
+
+  const value = (payload as Record<string, unknown>)[field]
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function parseJsonBody(rawBody: string): unknown {
+  return JSON.parse(rawBody) as unknown
+}
+
+/** Handles trusted Zalo ZBS delivery callbacks and marks matched outbox rows delivered. */
+export async function POST(request: Request): Promise<Response> {
+  const env = readRequiredEnv()
+  if (!env) {
+    console.error("Missing ZBS delivery webhook environment variables")
+    return jsonResponse({ error: "Server configuration error" }, 500)
+  }
+
+  const rawBody = await request.text()
+  let payload: unknown
+  try {
+    payload = parseJsonBody(rawBody)
+  } catch {
+    return jsonResponse({ error: "Malformed JSON" }, 400)
+  }
+
+  const timestamp = stringField(payload, "timestamp")
+  const payloadAppId = stringField(payload, "app_id")
+  const isValidSignature = isValidZbsDeliveryWebhookSignature({
+    expectedAppId: env.appId,
+    payloadAppId,
+    rawBody,
+    timestamp,
+    secret: env.appSecret,
+    signatureHeader: request.headers.get("X-ZEvent-Signature"),
+  })
+
+  if (!isValidSignature) {
+    return jsonResponse({ error: "Unauthorized" }, 401)
+  }
+
+  const parsed = parseZbsDeliveryWebhookPayload(payload)
+  if (parsed.kind === "unsupported") {
+    return jsonResponse({ success: true, ignored: true }, 202)
+  }
+
+  if (parsed.kind === "malformed") {
+    return jsonResponse({ error: "Malformed delivery webhook" }, 400)
+  }
+
+  const supabase = createClient(env.supabaseUrl, env.serviceRoleKey, {
+    auth: { persistSession: false },
+  })
+  const { data, error } = await supabase.rpc(ZBS_MARK_DELIVERED_RPC, {
+    p_tracking_id: parsed.delivery.trackingId,
+    p_provider_message_id: parsed.delivery.providerMessageId,
+    p_recipient_phone: parsed.delivery.recipientPhone,
+    p_delivered_at: parsed.delivery.deliveredAt,
+    p_delivery_webhook_received_at: parsed.delivery.webhookReceivedAt,
+    p_delivery_webhook_payload: parsed.delivery.providerMetadata,
+  })
+
+  if (error) {
+    console.error("ZBS delivery webhook update failed")
+    return jsonResponse({ error: "Delivery webhook update failed" }, 500)
+  }
+
+  return jsonResponse({ success: true, result: data ?? [] }, 200)
+}

--- a/src/app/api/webhooks/zalo/zbs/route.ts
+++ b/src/app/api/webhooks/zalo/zbs/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: Request): Promise<Response> {
   const env = readRequiredEnv()
   if (!env) {
     console.error("Missing ZBS delivery webhook environment variables")
-    return jsonResponse({ error: "Server configuration error" }, 500)
+    return jsonResponse({ error: "Internal server error" }, 500)
   }
 
   const rawBody = await request.text()
@@ -99,7 +99,7 @@ export async function POST(request: Request): Promise<Response> {
 
   if (error) {
     console.error("ZBS delivery webhook update failed")
-    return jsonResponse({ error: "Delivery webhook update failed" }, 500)
+    return jsonResponse({ error: "Internal server error" }, 500)
   }
 
   return jsonResponse({ success: true, result: data ?? [] }, 200)

--- a/src/app/api/webhooks/zalo/zbs/route.ts
+++ b/src/app/api/webhooks/zalo/zbs/route.ts
@@ -98,7 +98,7 @@ export async function POST(request: Request): Promise<Response> {
   })
 
   if (error) {
-    console.error("ZBS delivery webhook update failed")
+    console.error("ZBS delivery webhook update failed", error)
     return jsonResponse({ error: "Internal server error" }, 500)
   }
 

--- a/src/lib/zbs/__tests__/delivery-webhook-payload.test.ts
+++ b/src/lib/zbs/__tests__/delivery-webhook-payload.test.ts
@@ -67,4 +67,27 @@ describe("ZBS delivery webhook payload parsing", () => {
       reason: expect.any(String),
     })
   })
+
+  it.each([0, -1])(
+    "falls back to webhook receipt time for invalid numeric delivery_time %s",
+    (deliveryTime) => {
+      const result = parseZbsDeliveryWebhookPayload(
+        {
+          event_name: "user_received_message",
+          message: {
+            delivery_time: deliveryTime,
+            tracking_id: "tracking-1",
+          },
+        },
+        new Date("2026-07-02T08:00:00.000Z")
+      )
+
+      expect(result).toMatchObject({
+        kind: "delivery",
+        delivery: {
+          deliveredAt: "2026-07-02T08:00:00.000Z",
+        },
+      })
+    }
+  )
 })

--- a/src/lib/zbs/__tests__/delivery-webhook-payload.test.ts
+++ b/src/lib/zbs/__tests__/delivery-webhook-payload.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+
+import { parseZbsDeliveryWebhookPayload } from "@/lib/zbs/delivery-webhook-payload"
+
+describe("ZBS delivery webhook payload parsing", () => {
+  it("extracts delivered-message fields from user_received_message", () => {
+    const result = parseZbsDeliveryWebhookPayload(
+      {
+        app_id: "2074138120372622546",
+        timestamp: "1602560967477",
+        event_name: "user_received_message",
+        sender: { id: "2893352839501541173" },
+        recipient: { id: "1077170099018924429" },
+        message: {
+          delivery_time: "1602960467432",
+          msg_id: "message-1",
+          tracking_id: "tracking-1",
+          phone: "84900000001",
+        },
+      },
+      new Date("2026-07-02T08:00:00.000Z")
+    )
+
+    expect(result).toEqual({
+      kind: "delivery",
+      delivery: {
+        eventName: "user_received_message",
+        trackingId: "tracking-1",
+        providerMessageId: "message-1",
+        recipientPhone: "84900000001",
+        deliveredAt: "2020-10-17T18:47:47.432Z",
+        webhookReceivedAt: "2026-07-02T08:00:00.000Z",
+        providerMetadata: {
+          app_id: "2074138120372622546",
+          event_name: "user_received_message",
+          message_delivery_time: "1602960467432",
+          message_msg_id: "message-1",
+          message_tracking_id: "tracking-1",
+          recipient_id: "1077170099018924429",
+          recipient_phone: "84900000001",
+          sender_id: "2893352839501541173",
+          timestamp: "1602560967477",
+        },
+      },
+    })
+  })
+
+  it("returns unsupported events without delivery extraction", () => {
+    expect(
+      parseZbsDeliveryWebhookPayload(
+        {
+          event_name: "user_feedback",
+          message: { tracking_id: "tracking-1" },
+        },
+        new Date("2026-07-02T08:00:00.000Z")
+      )
+    ).toEqual({ kind: "unsupported", eventName: "user_feedback" })
+  })
+
+  it.each([
+    ["missing tracking id", { event_name: "user_received_message", message: { msg_id: "m1" } }],
+    ["missing message", { event_name: "user_received_message" }],
+    ["non-object payload", null],
+  ])("rejects malformed trusted delivery payloads: %s", (_label, payload) => {
+    expect(parseZbsDeliveryWebhookPayload(payload, new Date("2026-07-02T08:00:00.000Z"))).toEqual({
+      kind: "malformed",
+      reason: expect.any(String),
+    })
+  })
+})

--- a/src/lib/zbs/__tests__/delivery-webhook-payload.test.ts
+++ b/src/lib/zbs/__tests__/delivery-webhook-payload.test.ts
@@ -90,4 +90,30 @@ describe("ZBS delivery webhook payload parsing", () => {
       })
     }
   )
+
+  it("preserves numeric delivery_time and timestamp in compact provider metadata", () => {
+    const result = parseZbsDeliveryWebhookPayload(
+      {
+        app_id: "2074138120372622546",
+        timestamp: 1782997200000,
+        event_name: "user_received_message",
+        message: {
+          delivery_time: 1602960467432,
+          tracking_id: "tracking-1",
+        },
+      },
+      new Date("2026-07-02T08:00:00.000Z")
+    )
+
+    expect(result).toMatchObject({
+      kind: "delivery",
+      delivery: {
+        deliveredAt: "2020-10-17T18:47:47.432Z",
+        providerMetadata: {
+          message_delivery_time: "1602960467432",
+          timestamp: "1782997200000",
+        },
+      },
+    })
+  })
 })

--- a/src/lib/zbs/__tests__/delivery-webhook-signature.test.ts
+++ b/src/lib/zbs/__tests__/delivery-webhook-signature.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   buildZbsDeliveryWebhookSignature,
@@ -7,7 +7,8 @@ import {
 
 const APP_ID = "2074138120372622546"
 const SECRET = "zalo-webhook-secret"
-const TIMESTAMP = "1602560967477"
+const NOW_MS = Date.parse("2026-07-02T09:00:00.000Z")
+const TIMESTAMP = String(NOW_MS)
 const RAW_BODY = JSON.stringify({
   app_id: APP_ID,
   timestamp: TIMESTAMP,
@@ -19,7 +20,29 @@ const RAW_BODY = JSON.stringify({
   },
 })
 
+function rawBodyWithTimestamp(timestamp: string): string {
+  return JSON.stringify({
+    app_id: APP_ID,
+    timestamp,
+    event_name: "user_received_message",
+    message: {
+      tracking_id: "tracking-1",
+      msg_id: "message-1",
+      delivery_time: "1602960467432",
+    },
+  })
+}
+
 describe("ZBS delivery webhook signature validation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(NOW_MS))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it("accepts a valid mac header built from app id, raw body, timestamp, and secret", () => {
     const signatureHeader = buildZbsDeliveryWebhookSignature({
       appId: APP_ID,
@@ -111,6 +134,50 @@ describe("ZBS delivery webhook signature validation", () => {
         payloadAppId: APP_ID,
         rawBody: RAW_BODY,
         timestamp: TIMESTAMP,
+        secret: SECRET,
+        signatureHeader,
+      })
+    ).toBe(false)
+  })
+
+  it("rejects a replayed signed payload with a stale timestamp", () => {
+    const staleTimestamp = String(NOW_MS - 5 * 60 * 1000 - 1)
+    const rawBody = rawBodyWithTimestamp(staleTimestamp)
+    const signatureHeader = buildZbsDeliveryWebhookSignature({
+      appId: APP_ID,
+      rawBody,
+      timestamp: staleTimestamp,
+      secret: SECRET,
+    })
+
+    expect(
+      isValidZbsDeliveryWebhookSignature({
+        expectedAppId: APP_ID,
+        payloadAppId: APP_ID,
+        rawBody,
+        timestamp: staleTimestamp,
+        secret: SECRET,
+        signatureHeader,
+      })
+    ).toBe(false)
+  })
+
+  it("rejects a signed payload with a timestamp too far in the future", () => {
+    const futureTimestamp = String(NOW_MS + 5 * 60 * 1000 + 1)
+    const rawBody = rawBodyWithTimestamp(futureTimestamp)
+    const signatureHeader = buildZbsDeliveryWebhookSignature({
+      appId: APP_ID,
+      rawBody,
+      timestamp: futureTimestamp,
+      secret: SECRET,
+    })
+
+    expect(
+      isValidZbsDeliveryWebhookSignature({
+        expectedAppId: APP_ID,
+        payloadAppId: APP_ID,
+        rawBody,
+        timestamp: futureTimestamp,
         secret: SECRET,
         signatureHeader,
       })

--- a/src/lib/zbs/__tests__/delivery-webhook-signature.test.ts
+++ b/src/lib/zbs/__tests__/delivery-webhook-signature.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildZbsDeliveryWebhookSignature,
+  isValidZbsDeliveryWebhookSignature,
+} from "@/lib/zbs/delivery-webhook-signature"
+
+const APP_ID = "2074138120372622546"
+const SECRET = "zalo-webhook-secret"
+const TIMESTAMP = "1602560967477"
+const RAW_BODY = JSON.stringify({
+  app_id: APP_ID,
+  timestamp: TIMESTAMP,
+  event_name: "user_received_message",
+  message: {
+    tracking_id: "tracking-1",
+    msg_id: "message-1",
+    delivery_time: "1602960467432",
+  },
+})
+
+describe("ZBS delivery webhook signature validation", () => {
+  it("accepts a valid mac header built from app id, raw body, timestamp, and secret", () => {
+    const signatureHeader = buildZbsDeliveryWebhookSignature({
+      appId: APP_ID,
+      rawBody: RAW_BODY,
+      timestamp: TIMESTAMP,
+      secret: SECRET,
+    })
+
+    expect(
+      isValidZbsDeliveryWebhookSignature({
+        expectedAppId: APP_ID,
+        payloadAppId: APP_ID,
+        rawBody: RAW_BODY,
+        timestamp: TIMESTAMP,
+        secret: SECRET,
+        signatureHeader,
+      })
+    ).toBe(true)
+  })
+
+  it.each([
+    ["missing header", null],
+    ["malformed header", "sha256=not-a-zalo-header"],
+    ["non-hex mac", "mac=not-hex"],
+  ])("rejects %s", (_label, signatureHeader) => {
+    expect(
+      isValidZbsDeliveryWebhookSignature({
+        expectedAppId: APP_ID,
+        payloadAppId: APP_ID,
+        rawBody: RAW_BODY,
+        timestamp: TIMESTAMP,
+        secret: SECRET,
+        signatureHeader,
+      })
+    ).toBe(false)
+  })
+
+  it("rejects a payload app id that does not match the configured app id", () => {
+    const signatureHeader = buildZbsDeliveryWebhookSignature({
+      appId: APP_ID,
+      rawBody: RAW_BODY,
+      timestamp: TIMESTAMP,
+      secret: SECRET,
+    })
+
+    expect(
+      isValidZbsDeliveryWebhookSignature({
+        expectedAppId: APP_ID,
+        payloadAppId: "wrong-app-id",
+        rawBody: RAW_BODY,
+        timestamp: TIMESTAMP,
+        secret: SECRET,
+        signatureHeader,
+      })
+    ).toBe(false)
+  })
+
+  it("rejects a signature when the raw body changes", () => {
+    const signatureHeader = buildZbsDeliveryWebhookSignature({
+      appId: APP_ID,
+      rawBody: RAW_BODY,
+      timestamp: TIMESTAMP,
+      secret: SECRET,
+    })
+
+    expect(
+      isValidZbsDeliveryWebhookSignature({
+        expectedAppId: APP_ID,
+        payloadAppId: APP_ID,
+        rawBody: RAW_BODY.replace("tracking-1", "tracking-2"),
+        timestamp: TIMESTAMP,
+        secret: SECRET,
+        signatureHeader,
+      })
+    ).toBe(false)
+  })
+
+  it("rejects a signature built with the wrong secret", () => {
+    const signatureHeader = buildZbsDeliveryWebhookSignature({
+      appId: APP_ID,
+      rawBody: RAW_BODY,
+      timestamp: TIMESTAMP,
+      secret: "wrong-secret",
+    })
+
+    expect(
+      isValidZbsDeliveryWebhookSignature({
+        expectedAppId: APP_ID,
+        payloadAppId: APP_ID,
+        rawBody: RAW_BODY,
+        timestamp: TIMESTAMP,
+        secret: SECRET,
+        signatureHeader,
+      })
+    ).toBe(false)
+  })
+})

--- a/src/lib/zbs/delivery-webhook-payload.ts
+++ b/src/lib/zbs/delivery-webhook-payload.ts
@@ -1,0 +1,110 @@
+type JsonObject = Record<string, unknown>
+
+export interface ZbsDeliveryWebhook {
+  eventName: "user_received_message"
+  trackingId: string
+  providerMessageId: string | null
+  recipientPhone: string | null
+  deliveredAt: string
+  webhookReceivedAt: string
+  providerMetadata: JsonObject
+}
+
+export type ZbsDeliveryWebhookParseResult =
+  | { kind: "delivery"; delivery: ZbsDeliveryWebhook }
+  | { kind: "unsupported"; eventName: string }
+  | { kind: "malformed"; reason: string }
+
+const USER_RECEIVED_MESSAGE_EVENT = "user_received_message"
+const MIN_REASONABLE_EPOCH_MILLISECONDS = 1_000_000_000_000
+
+function isRecord(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function parseProviderTimestamp(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const parsed = new Date(value < MIN_REASONABLE_EPOCH_MILLISECONDS ? value * 1000 : value)
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+  }
+
+  const text = stringValue(value)
+  if (!text) {
+    return null
+  }
+
+  if (/^\d+$/.test(text)) {
+    const epoch = Number(text)
+    if (!Number.isFinite(epoch) || epoch <= 0) {
+      return null
+    }
+    const parsed = new Date(epoch < MIN_REASONABLE_EPOCH_MILLISECONDS ? epoch * 1000 : epoch)
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+  }
+
+  const parsed = new Date(text)
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+}
+
+function compactProviderMetadata(payload: JsonObject, message: JsonObject): JsonObject {
+  const sender = isRecord(payload.sender) ? payload.sender : {}
+  const recipient = isRecord(payload.recipient) ? payload.recipient : {}
+  const metadata: JsonObject = {
+    app_id: stringValue(payload.app_id),
+    event_name: stringValue(payload.event_name),
+    message_delivery_time: stringValue(message.delivery_time),
+    message_msg_id: stringValue(message.msg_id),
+    message_tracking_id: stringValue(message.tracking_id),
+    recipient_id: stringValue(recipient.id),
+    recipient_phone: stringValue(message.phone) || stringValue(recipient.phone),
+    sender_id: stringValue(sender.id),
+    timestamp: stringValue(payload.timestamp),
+  }
+
+  return Object.fromEntries(Object.entries(metadata).filter(([, value]) => value !== ""))
+}
+
+/** Extracts the supported ZBS delivery event shape from a trusted parsed webhook payload. */
+export function parseZbsDeliveryWebhookPayload(
+  payload: unknown,
+  receivedAt: Date = new Date()
+): ZbsDeliveryWebhookParseResult {
+  if (!isRecord(payload)) {
+    return { kind: "malformed", reason: "Payload must be a JSON object" }
+  }
+
+  const eventName = stringValue(payload.event_name)
+  if (eventName !== USER_RECEIVED_MESSAGE_EVENT) {
+    return { kind: "unsupported", eventName }
+  }
+
+  const message = isRecord(payload.message) ? payload.message : null
+  if (!message) {
+    return { kind: "malformed", reason: "Missing message payload" }
+  }
+
+  const trackingId = stringValue(message.tracking_id)
+  if (!trackingId) {
+    return { kind: "malformed", reason: "Missing tracking_id" }
+  }
+
+  const recipient = isRecord(payload.recipient) ? payload.recipient : {}
+  const webhookReceivedAt = receivedAt.toISOString()
+
+  return {
+    kind: "delivery",
+    delivery: {
+      eventName: USER_RECEIVED_MESSAGE_EVENT,
+      trackingId,
+      providerMessageId: stringValue(message.msg_id) || null,
+      recipientPhone: stringValue(message.phone) || stringValue(recipient.phone) || null,
+      deliveredAt: parseProviderTimestamp(message.delivery_time) ?? webhookReceivedAt,
+      webhookReceivedAt,
+      providerMetadata: compactProviderMetadata(payload, message),
+    },
+  }
+}

--- a/src/lib/zbs/delivery-webhook-payload.ts
+++ b/src/lib/zbs/delivery-webhook-payload.ts
@@ -26,6 +26,22 @@ function stringValue(value: unknown): string {
   return typeof value === "string" ? value.trim() : ""
 }
 
+function metadataScalarValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim()
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value)
+  }
+
+  if (typeof value === "boolean") {
+    return String(value)
+  }
+
+  return ""
+}
+
 function parseProviderTimestamp(value: unknown): string | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     if (value <= 0) {
@@ -59,13 +75,13 @@ function compactProviderMetadata(payload: JsonObject, message: JsonObject): Json
   const metadata: JsonObject = {
     app_id: stringValue(payload.app_id),
     event_name: stringValue(payload.event_name),
-    message_delivery_time: stringValue(message.delivery_time),
+    message_delivery_time: metadataScalarValue(message.delivery_time),
     message_msg_id: stringValue(message.msg_id),
     message_tracking_id: stringValue(message.tracking_id),
     recipient_id: stringValue(recipient.id),
     recipient_phone: stringValue(message.phone) || stringValue(recipient.phone),
     sender_id: stringValue(sender.id),
-    timestamp: stringValue(payload.timestamp),
+    timestamp: metadataScalarValue(payload.timestamp),
   }
 
   return Object.fromEntries(Object.entries(metadata).filter(([, value]) => value !== ""))

--- a/src/lib/zbs/delivery-webhook-payload.ts
+++ b/src/lib/zbs/delivery-webhook-payload.ts
@@ -28,6 +28,9 @@ function stringValue(value: unknown): string {
 
 function parseProviderTimestamp(value: unknown): string | null {
   if (typeof value === "number" && Number.isFinite(value)) {
+    if (value <= 0) {
+      return null
+    }
     const parsed = new Date(value < MIN_REASONABLE_EPOCH_MILLISECONDS ? value * 1000 : value)
     return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
   }

--- a/src/lib/zbs/delivery-webhook-signature.ts
+++ b/src/lib/zbs/delivery-webhook-signature.ts
@@ -2,6 +2,7 @@ import { createHash, timingSafeEqual } from "crypto"
 
 const ZALO_DELIVERY_SIGNATURE_PREFIX = "mac="
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/i
+const ZALO_DELIVERY_SIGNATURE_TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000
 
 /** Builds the Zalo delivery webhook mac header from app id, raw body, timestamp, and secret. */
 export function buildZbsDeliveryWebhookSignature({
@@ -39,6 +40,15 @@ function timingSafeHexEqual(expected: string, actual: string): boolean {
   )
 }
 
+function isFreshSignatureTimestamp(timestamp: string): boolean {
+  const timestampMs = Number(timestamp)
+  if (!Number.isSafeInteger(timestampMs) || timestampMs <= 0) {
+    return false
+  }
+
+  return Math.abs(Date.now() - timestampMs) <= ZALO_DELIVERY_SIGNATURE_TIMESTAMP_TOLERANCE_MS
+}
+
 /** Validates the Zalo delivery webhook mac header without leaking timing differences. */
 export function isValidZbsDeliveryWebhookSignature({
   expectedAppId,
@@ -60,6 +70,10 @@ export function isValidZbsDeliveryWebhookSignature({
   }
 
   if (payloadAppId !== expectedAppId) {
+    return false
+  }
+
+  if (!isFreshSignatureTimestamp(timestamp)) {
     return false
   }
 

--- a/src/lib/zbs/delivery-webhook-signature.ts
+++ b/src/lib/zbs/delivery-webhook-signature.ts
@@ -1,0 +1,80 @@
+import { createHash, timingSafeEqual } from "crypto"
+
+const ZALO_DELIVERY_SIGNATURE_PREFIX = "mac="
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/i
+
+/** Builds the Zalo delivery webhook mac header from app id, raw body, timestamp, and secret. */
+export function buildZbsDeliveryWebhookSignature({
+  appId,
+  rawBody,
+  timestamp,
+  secret,
+}: {
+  appId: string
+  rawBody: string
+  timestamp: string
+  secret: string
+}): string {
+  const mac = createHash("sha256").update(`${appId}${rawBody}${timestamp}${secret}`).digest("hex")
+  return `${ZALO_DELIVERY_SIGNATURE_PREFIX}${mac}`
+}
+
+function parseMacHeader(signatureHeader: string | null): string | null {
+  if (!signatureHeader?.startsWith(ZALO_DELIVERY_SIGNATURE_PREFIX)) {
+    return null
+  }
+
+  const mac = signatureHeader.slice(ZALO_DELIVERY_SIGNATURE_PREFIX.length)
+  return SHA256_HEX_PATTERN.test(mac) ? mac : null
+}
+
+function timingSafeHexEqual(expected: string, actual: string): boolean {
+  const expectedBuffer = Buffer.from(expected, "hex")
+  const actualBuffer = Buffer.from(actual, "hex")
+
+  return (
+    expectedBuffer.length === 32 &&
+    expectedBuffer.length === actualBuffer.length &&
+    timingSafeEqual(expectedBuffer, actualBuffer)
+  )
+}
+
+/** Validates the Zalo delivery webhook mac header without leaking timing differences. */
+export function isValidZbsDeliveryWebhookSignature({
+  expectedAppId,
+  payloadAppId,
+  rawBody,
+  timestamp,
+  secret,
+  signatureHeader,
+}: {
+  expectedAppId: string | undefined
+  payloadAppId: string
+  rawBody: string
+  timestamp: string
+  secret: string | undefined
+  signatureHeader: string | null
+}): boolean {
+  if (!expectedAppId || !secret || !payloadAppId || !timestamp) {
+    return false
+  }
+
+  if (payloadAppId !== expectedAppId) {
+    return false
+  }
+
+  const receivedMac = parseMacHeader(signatureHeader)
+  if (!receivedMac) {
+    return false
+  }
+
+  const expectedHeader = buildZbsDeliveryWebhookSignature({
+    appId: expectedAppId,
+    rawBody,
+    timestamp,
+    secret,
+  })
+  const expectedMac = parseMacHeader(expectedHeader)
+
+  return expectedMac ? timingSafeHexEqual(expectedMac, receivedMac) : false
+}

--- a/supabase/migrations/20260702090000_add_zbs_delivery_webhook_rpc.sql
+++ b/supabase/migrations/20260702090000_add_zbs_delivery_webhook_rpc.sql
@@ -1,0 +1,137 @@
+-- Issue #621 Phase 4: inbound ZBS delivery webhook persistence.
+--
+-- Scope:
+-- - Add webhook receipt timestamp for delivery callbacks.
+-- - Add tracking_id lookup index for provider webhook matching.
+-- - Add service-role-only RPC to mark sent outbox rows delivered by tracking_id.
+-- - No client RPC proxy allowlist exposure.
+
+BEGIN;
+
+ALTER TABLE public.zbs_notification_outbox
+  ADD COLUMN IF NOT EXISTS delivery_webhook_received_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS zbs_notification_outbox_tracking_id_idx
+  ON public.zbs_notification_outbox (tracking_id)
+  WHERE provider = 'zalo_zbs';
+
+CREATE OR REPLACE FUNCTION public.zbs_notification_outbox_mark_delivered(
+  p_tracking_id text,
+  p_provider_message_id text,
+  p_recipient_phone text,
+  p_delivered_at timestamptz,
+  p_delivery_webhook_received_at timestamptz,
+  p_delivery_webhook_payload jsonb DEFAULT '{}'::jsonb
+)
+RETURNS TABLE (
+  id uuid,
+  status text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims jsonb := coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb,
+    '{}'::jsonb
+  );
+BEGIN
+  IF coalesce(v_claims->>'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'ZBS delivery webhook RPC requires service_role JWT'
+      USING errcode = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH matched AS (
+    SELECT outbox.id
+    FROM public.zbs_notification_outbox outbox
+    WHERE outbox.provider = 'zalo_zbs'
+      AND outbox.tracking_id = nullif(p_tracking_id, '')
+      AND outbox.status IN ('sent', 'delivered')
+    ORDER BY outbox.created_at ASC
+    LIMIT 1
+    FOR UPDATE
+  ),
+  updated AS (
+    UPDATE public.zbs_notification_outbox outbox
+    SET
+      status = 'delivered',
+      provider_message_id = coalesce(
+        nullif(outbox.provider_message_id, ''),
+        nullif(p_provider_message_id, '')
+      ),
+      provider_response = CASE
+        WHEN outbox.status = 'sent' THEN
+          coalesce(outbox.provider_response, '{}'::jsonb)
+            || jsonb_build_object(
+              'delivery_webhook',
+              coalesce(p_delivery_webhook_payload, '{}'::jsonb)
+                || jsonb_build_object(
+                  'tracking_id', nullif(p_tracking_id, ''),
+                  'provider_message_id', nullif(p_provider_message_id, ''),
+                  'recipient_phone', nullif(p_recipient_phone, '')
+                )
+            )
+        ELSE outbox.provider_response
+      END,
+      delivered_at = CASE
+        WHEN outbox.status = 'sent' THEN coalesce(p_delivered_at, now())
+        ELSE outbox.delivered_at
+      END,
+      delivery_webhook_received_at = CASE
+        WHEN outbox.status = 'sent' THEN coalesce(p_delivery_webhook_received_at, now())
+        ELSE outbox.delivery_webhook_received_at
+      END,
+      last_error_code = CASE
+        WHEN outbox.status = 'sent' THEN NULL
+        ELSE outbox.last_error_code
+      END,
+      last_error_message = CASE
+        WHEN outbox.status = 'sent' THEN NULL
+        ELSE outbox.last_error_message
+      END,
+      updated_at = CASE
+        WHEN outbox.status = 'sent' THEN now()
+        ELSE outbox.updated_at
+      END
+    FROM matched
+    WHERE outbox.id = matched.id
+    RETURNING outbox.id, outbox.status
+  )
+  SELECT updated.id, updated.status
+  FROM updated;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.zbs_notification_outbox_mark_delivered(
+  text,
+  text,
+  text,
+  timestamptz,
+  timestamptz,
+  jsonb
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.zbs_notification_outbox_mark_delivered(
+  text,
+  text,
+  text,
+  timestamptz,
+  timestamptz,
+  jsonb
+) TO service_role;
+
+COMMENT ON COLUMN public.zbs_notification_outbox.delivery_webhook_received_at IS
+  'Server receipt timestamp for trusted Zalo ZBS delivery webhooks.';
+COMMENT ON FUNCTION public.zbs_notification_outbox_mark_delivered(
+  text,
+  text,
+  text,
+  timestamptz,
+  timestamptz,
+  jsonb
+) IS
+  'Server-only ZBS delivery webhook boundary. Requires service_role JWT, matches by tracking_id, and marks sent Zalo ZBS rows delivered idempotently.';
+
+COMMIT;

--- a/supabase/migrations/20260702094000_enforce_zbs_delivery_tracking_id_unique.sql
+++ b/supabase/migrations/20260702094000_enforce_zbs_delivery_tracking_id_unique.sql
@@ -1,0 +1,17 @@
+-- Issue #621 review follow-up: enforce the tracking_id uniqueness assumed by
+-- ZBS delivery webhook matching. The initial Phase 4 migration added a
+-- non-unique lookup index; this superseding migration keeps fresh DB order
+-- deterministic and makes duplicate provider tracking ids fail closed.
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.zbs_notification_outbox_tracking_id_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS zbs_notification_outbox_tracking_id_idx
+  ON public.zbs_notification_outbox (tracking_id)
+  WHERE provider = 'zalo_zbs';
+
+COMMENT ON INDEX public.zbs_notification_outbox_tracking_id_idx IS
+  'Unique ZBS delivery webhook lookup key. Prevents ambiguous delivery callbacks for reused tracking_id values.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add signed POST /api/webhooks/zalo/zbs for ZBS delivery callbacks
- add signature and payload helpers with focused tests
- add service-role-only mark-delivered RPC, tracking_id index, and delivery runbook

## Verification
- Supabase MCP migration apply: add_zbs_delivery_webhook_rpc
- Supabase MCP SQL verification: non-service-role rejection, sent -> delivered, unmatched no-op, duplicate idempotency
- Supabase MCP security advisors after migration; remaining findings are existing unrelated baseline
- npx prettier --check changed TS/MD files
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/lib/zbs/__tests__/delivery-webhook-signature.test.ts src/lib/zbs/__tests__/delivery-webhook-payload.test.ts src/app/api/webhooks/zalo/zbs/__tests__/route.test.ts
- node scripts/npm-run.js run react-doctor

Closes #621

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a signed Zalo ZBS delivery webhook at POST /api/webhooks/zalo/zbs to mark matching `zbs_notification_outbox` rows delivered by `tracking_id` via a service‑role RPC, with replay‑safe signature checks and idempotent updates. Implements #621 and keeps 500s sanitized while logging full RPC errors; adds a unique `tracking_id` index and a delivery receipt timestamp, and preserves numeric provider timestamps in saved metadata.

- **New Features**
  - New uncached Node.js route `/api/webhooks/zalo/zbs` with `mac=<sha256>` signature validation that checks `app_id`, raw body, and a 5‑minute timestamp window; accepts only `user_received_message`; returns 200/202/400/401/500; uses `@supabase/supabase-js` service‑role client; 500 body is sanitized but full RPC errors are logged; payload parsing preserves numeric `delivery_time` and `timestamp` values in provider metadata.
  - Service‑role RPC `public.zbs_notification_outbox_mark_delivered` matches by `tracking_id`, sets `delivered_at` and `delivery_webhook_received_at`, preserves existing `provider_message_id`, and is idempotent; adds `delivery_webhook_received_at` column and a unique partial `tracking_id` index (provider `zalo_zbs`). Tests cover signatures, payload parsing, route behavior; includes a SQL verification script and a delivery runbook.

- **Migration**
  - Apply Supabase migrations: `20260702090000_add_zbs_delivery_webhook_rpc.sql` and `20260702094000_enforce_zbs_delivery_tracking_id_unique.sql`.
  - Set env vars: `ZALO_ZBS_APP_ID`, `ZALO_ZBS_APP_SECRET`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`.
  - In Zalo console, set callback to `/api/webhooks/zalo/zbs` and enable `user_received_message`; rotate the app secret only after deploying updated env.

<sup>Written for commit 563ac36af2f9d1e500b7ac04fcc734e100794693. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Zalo ZBS delivery webhooks, including signature validation, payload parsing, and updating delivery status.
  * Introduced a secure server-side path to mark matching outbox items as delivered.
  * Added a new database field and index to track delivery webhook timestamps and speed up lookups.

* **Tests**
  * Added coverage for signature checks, webhook parsing, route handling, and delivery update behavior.

* **Documentation**
  * Added a runbook with setup, monitoring, and troubleshooting guidance for webhook operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->