### PR TITLE
Refactor repair request edit flow to side sheet

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestRowActions.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestRowActions.test.tsx
@@ -81,12 +81,37 @@ describe("RepairRequestRowActions", () => {
     expect(options.setEditingRequest).toHaveBeenCalledWith(request)
   })
 
+  it("labels the approve action as confirmation and shows an icon for every visible action", async () => {
+    const user = userEvent.setup()
+    const request = makeRepairRequest()
+    const options = makeColumnOptions()
+
+    render(<RepairRequestRowActions request={request} options={options} />)
+
+    await user.click(screen.getByRole("button", { name: "Mở menu" }))
+
+    const visibleActions = [
+      screen.getByRole("menuitem", { name: "Xem phiếu yêu cầu" }),
+      screen.getByRole("menuitem", { name: "Sửa" }),
+      screen.getByRole("menuitem", { name: "Xoá" }),
+      screen.getByRole("menuitem", { name: "Xác nhận" }),
+    ]
+
+    expect(screen.queryByRole("menuitem", { name: "Duyệt" })).not.toBeInTheDocument()
+    visibleActions.forEach((action) => {
+      expect(action.querySelector("svg")).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole("menuitem", { name: "Xác nhận" }))
+    expect(options.handleApproveRequest).toHaveBeenCalledWith(request)
+  })
+
   it("hides actions for read-only regional leaders", () => {
     render(
       <RepairRequestRowActions
         request={makeRepairRequest()}
         options={{ ...makeColumnOptions(), isRegionalLeader: true }}
-      />,
+      />
     )
 
     expect(screen.queryByRole("button", { name: "Mở menu" })).not.toBeInTheDocument()

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsEditSheet.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsEditSheet.test.tsx
@@ -64,6 +64,7 @@ vi.mock("@/components/shared/SideSheetShell", () => ({
     contentClassName,
     description,
     onOpenChange,
+    open,
     title,
   }: {
     bodyClassName?: string
@@ -71,32 +72,24 @@ vi.mock("@/components/shared/SideSheetShell", () => ({
     contentClassName?: string
     description?: React.ReactNode
     onOpenChange: (open: boolean) => void
+    open: boolean
     title: React.ReactNode
-  }) => (
-    <section
-      data-testid="edit-side-sheet"
-      data-body-class={bodyClassName}
-      data-content-class={contentClassName}
-    >
-      <h2>{title}</h2>
-      <p>{description}</p>
-      <button type="button" onClick={() => onOpenChange(false)}>
-        close edit sheet
-      </button>
-      {children}
-    </section>
-  ),
-}))
-
-vi.mock("@/components/ui/dialog", () => ({
-  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="legacy-dialog-content">{children}</div>
-  ),
-  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
-  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  }) =>
+    open ? (
+      <section
+        data-testid="edit-side-sheet"
+        data-body-class={bodyClassName}
+        data-content-class={contentClassName}
+        data-open={open}
+      >
+        <h2>{title}</h2>
+        <p>{description}</p>
+        <button type="button" onClick={() => onOpenChange(false)}>
+          close edit sheet
+        </button>
+        {children}
+      </section>
+    ) : null,
 }))
 
 vi.mock("@/components/ui/button", () => ({
@@ -156,9 +149,9 @@ describe("RepairRequestsEditDialog side sheet", () => {
     render(<RepairRequestsEditDialog />)
 
     const sheet = screen.getByTestId("edit-side-sheet")
+    expect(sheet).toHaveAttribute("data-open", "true")
     expect(sheet).toHaveAttribute("data-content-class", "sm:max-w-lg")
     expect(sheet).toHaveAttribute("data-body-class", "mt-4 overflow-y-auto px-4 pb-4")
-    expect(screen.queryByTestId("legacy-dialog-content")).not.toBeInTheDocument()
     expect(screen.getByText("Sửa yêu cầu sửa chữa")).toBeInTheDocument()
     expect(screen.getByText(/Máy siêu âm/)).toBeInTheDocument()
 

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsEditSheet.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsEditSheet.test.tsx
@@ -1,0 +1,190 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { RepairRequestWithEquipment } from "../types"
+
+const mocks = vi.hoisted(() => ({
+  closeAllDialogs: vi.fn(),
+  updateMutate: vi.fn(),
+}))
+
+function makeRepairRequest(): RepairRequestWithEquipment {
+  return {
+    id: 42,
+    thiet_bi_id: 7,
+    ngay_yeu_cau: "2026-05-01T00:00:00.000Z",
+    trang_thai: "Chờ xử lý",
+    mo_ta_su_co: "Máy không hoạt động",
+    hang_muc_sua_chua: "Kiểm tra nguồn",
+    ngay_mong_muon_hoan_thanh: "2026-05-03",
+    nguoi_yeu_cau: "Nguyễn Văn A",
+    ngay_duyet: null,
+    ngay_hoan_thanh: null,
+    nguoi_duyet: null,
+    nguoi_xac_nhan: null,
+    chi_phi_sua_chua: null,
+    don_vi_thuc_hien: "noi_bo",
+    ten_don_vi_thue: null,
+    ket_qua_sua_chua: null,
+    ly_do_khong_hoan_thanh: null,
+    thiet_bi: {
+      ten_thiet_bi: "Máy siêu âm",
+      ma_thiet_bi: "TB-EDIT",
+      model: null,
+      serial: null,
+      khoa_phong_quan_ly: "Khoa Khám bệnh",
+      facility_name: "Bệnh viện A",
+      facility_id: 1,
+    },
+  }
+}
+
+const contextValue = {
+  dialogState: {
+    requestToEdit: makeRepairRequest(),
+  },
+  closeAllDialogs: mocks.closeAllDialogs,
+  updateMutation: {
+    mutate: mocks.updateMutate,
+    isPending: false,
+  },
+  canSetRepairUnit: true,
+}
+
+vi.mock("../_hooks/useRepairRequestsContext", () => ({
+  useRepairRequestsContext: () => contextValue,
+}))
+
+vi.mock("@/components/shared/SideSheetShell", () => ({
+  SideSheetShell: ({
+    bodyClassName,
+    children,
+    contentClassName,
+    description,
+    onOpenChange,
+    title,
+  }: {
+    bodyClassName?: string
+    children: React.ReactNode
+    contentClassName?: string
+    description?: React.ReactNode
+    onOpenChange: (open: boolean) => void
+    title: React.ReactNode
+  }) => (
+    <section
+      data-testid="edit-side-sheet"
+      data-body-class={bodyClassName}
+      data-content-class={contentClassName}
+    >
+      <h2>{title}</h2>
+      <p>{description}</p>
+      <button type="button" onClick={() => onOpenChange(false)}>
+        close edit sheet
+      </button>
+      {children}
+    </section>
+  ),
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="legacy-dialog-content">{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    type = "button",
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type={type} {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+}))
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}))
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock("@/components/ui/calendar", () => ({
+  Calendar: () => <div>calendar</div>,
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+
+import { RepairRequestsEditDialog } from "../_components/RepairRequestsEditDialog"
+
+describe("RepairRequestsEditDialog side sheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the edit form in the shared side-sheet shell", async () => {
+    const user = userEvent.setup()
+
+    render(<RepairRequestsEditDialog />)
+
+    const sheet = screen.getByTestId("edit-side-sheet")
+    expect(sheet).toHaveAttribute("data-content-class", "sm:max-w-lg")
+    expect(sheet).toHaveAttribute("data-body-class", "mt-4 overflow-y-auto px-4 pb-4")
+    expect(screen.queryByTestId("legacy-dialog-content")).not.toBeInTheDocument()
+    expect(screen.getByText("Sửa yêu cầu sửa chữa")).toBeInTheDocument()
+    expect(screen.getByText(/Máy siêu âm/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "close edit sheet" }))
+    expect(mocks.closeAllDialogs).toHaveBeenCalledTimes(1)
+  })
+
+  it("submits the current edit payload through the existing update mutation", async () => {
+    const user = userEvent.setup()
+
+    render(<RepairRequestsEditDialog />)
+
+    await user.clear(screen.getByLabelText("Mô tả sự cố"))
+    await user.type(screen.getByLabelText("Mô tả sự cố"), "Mô tả đã cập nhật")
+    await user.clear(screen.getByLabelText("Các hạng mục yêu cầu sửa chữa"))
+    await user.type(screen.getByLabelText("Các hạng mục yêu cầu sửa chữa"), "Thay nguồn")
+    await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+    expect(mocks.updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 42,
+        hang_muc_sua_chua: "Thay nguồn",
+        mo_ta_su_co: "Mô tả đã cập nhật",
+        ngay_mong_muon_hoan_thanh: "2026-05-03",
+      }),
+      { onSuccess: mocks.closeAllDialogs }
+    )
+  })
+})

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsFormFields.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsFormFields.test.tsx
@@ -1,0 +1,130 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { RepairRequestsFormFields } from "../_components/RepairRequestsFormFields"
+import type { RepairUnit } from "../types"
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    type = "button",
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type={type} {...props}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock("@/components/ui/textarea", () => ({
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => <textarea {...props} />,
+}))
+
+vi.mock("@/components/ui/label", () => ({
+  Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}))
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("@/components/ui/calendar", () => ({
+  Calendar: () => <div>calendar</div>,
+}))
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    children,
+    onValueChange,
+  }: {
+    children: React.ReactNode
+    onValueChange?: (value: string) => void
+  }) => (
+    <div>
+      {children}
+      <button type="button" onClick={() => onValueChange?.("thue_ngoai")}>
+        chọn thuê ngoài
+      </button>
+    </div>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children, id }: { children: React.ReactNode; id?: string }) => (
+    <button type="button" id={id}>
+      {children}
+    </button>
+  ),
+  SelectValue: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+
+type RepairRequestsFormFieldsProps = React.ComponentProps<typeof RepairRequestsFormFields>
+
+function renderForm(overrides: Partial<RepairRequestsFormFieldsProps> = {}) {
+  const props: RepairRequestsFormFieldsProps = {
+    canSetRepairUnit: true,
+    desiredDate: undefined,
+    externalCompanyName: "",
+    fieldIdPrefix: "test-repair-request",
+    isDateDisabled: () => false,
+    issueDescription: "",
+    onDesiredDateChange: vi.fn(),
+    onExternalCompanyNameChange: vi.fn(),
+    onIssueDescriptionChange: vi.fn(),
+    onRepairItemsChange: vi.fn(),
+    onRepairUnitChange: vi.fn(),
+    repairItems: "",
+    repairItemsLabel: "Các hạng mục yêu cầu sửa chữa",
+    repairItemsRequired: false,
+    repairUnit: "noi_bo",
+    ...overrides,
+  }
+
+  render(<RepairRequestsFormFields {...props} />)
+
+  return props
+}
+
+describe("RepairRequestsFormFields", () => {
+  it("wires labels to visible controls and exposes repair-unit selection", async () => {
+    const user = userEvent.setup()
+    const props = renderForm()
+
+    expect(screen.getByLabelText("Mô tả sự cố")).toBeInTheDocument()
+    expect(screen.getByLabelText("Các hạng mục yêu cầu sửa chữa")).not.toBeRequired()
+    expect(screen.getByLabelText("Ngày mong muốn hoàn thành (nếu có)")).toHaveAttribute(
+      "id",
+      "test-repair-request-desired-date"
+    )
+    expect(screen.getByLabelText("Đơn vị thực hiện")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "chọn thuê ngoài" }))
+
+    expect(props.onRepairUnitChange).toHaveBeenCalledWith("thue_ngoai" satisfies RepairUnit)
+  })
+
+  it("renders the external company input when repair unit is external", () => {
+    renderForm({
+      externalCompanyName: "Công ty ABC",
+      repairUnit: "thue_ngoai",
+    })
+
+    expect(screen.getByLabelText("Tên đơn vị được thuê")).toHaveValue("Công ty ABC")
+    expect(screen.getByLabelText("Tên đơn vị được thuê")).toBeRequired()
+  })
+
+  it("toggles repair-items required state from props", () => {
+    renderForm({ repairItemsRequired: true })
+
+    expect(screen.getByLabelText("Các hạng mục yêu cầu sửa chữa")).toBeRequired()
+  })
+})

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsFormFields.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsFormFields.test.tsx
@@ -100,6 +100,7 @@ describe("RepairRequestsFormFields", () => {
     const props = renderForm()
 
     expect(screen.getByLabelText("Mô tả sự cố")).toBeInTheDocument()
+    expect(screen.getByLabelText("Mô tả sự cố")).toBeRequired()
     expect(screen.getByLabelText("Các hạng mục yêu cầu sửa chữa")).not.toBeRequired()
     expect(screen.getByLabelText("Ngày mong muốn hoàn thành (nếu có)")).toHaveAttribute(
       "id",
@@ -110,6 +111,16 @@ describe("RepairRequestsFormFields", () => {
     await user.click(screen.getByRole("button", { name: "chọn thuê ngoài" }))
 
     expect(props.onRepairUnitChange).toHaveBeenCalledWith("thue_ngoai" satisfies RepairUnit)
+  })
+
+  it("hides repair-unit fields when the user cannot set the repair unit", () => {
+    renderForm({
+      canSetRepairUnit: false,
+      repairUnit: "thue_ngoai",
+    })
+
+    expect(screen.queryByLabelText("Đơn vị thực hiện")).toBeNull()
+    expect(screen.queryByLabelText("Tên đơn vị được thuê")).toBeNull()
   })
 
   it("renders the external company input when repair unit is external", () => {

--- a/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
@@ -55,6 +55,18 @@ interface RepairRequestRowActionsProps {
   readonly options: RepairRequestColumnOptions
 }
 
+type DaysStatus = NonNullable<ReturnType<typeof calculateDaysRemaining>>["status"]
+
+const daysStatusTextClassByStatus: Record<DaysStatus, string> = {
+  success: "text-emerald-600",
+  warning: "text-amber-600",
+  danger: "text-rose-600",
+}
+
+function getDaysStatusTextClass(status: DaysStatus) {
+  return daysStatusTextClassByStatus[status]
+}
+
 /**
  * Renders the actions dropdown menu for a repair request row.
  * Actions vary based on request status and user permissions.
@@ -260,7 +272,7 @@ export function useRepairRequestColumns(
           // Chỉ hiển thị progress bar cho yêu cầu chưa hoàn thành
           const isCompleted =
             request.trang_thai === "Hoàn thành" || request.trang_thai === "Không HT"
-          const daysInfo = !isCompleted ? calculateDaysRemaining(ngayMongMuon) : null
+          const daysInfo = isCompleted ? null : calculateDaysRemaining(ngayMongMuon)
 
           return (
             <div className="space-y-1.5 w-[180px]">
@@ -270,13 +282,7 @@ export function useRepairRequestColumns(
                 </span>
                 {daysInfo && (
                   <span
-                    className={`text-[10px] uppercase font-bold tracking-tight whitespace-nowrap ${
-                      daysInfo.status === "success"
-                        ? "text-emerald-600"
-                        : daysInfo.status === "warning"
-                          ? "text-amber-600"
-                          : "text-rose-600"
-                    }`}
+                    className={`text-[10px] uppercase font-bold tracking-tight whitespace-nowrap ${getDaysStatusTextClass(daysInfo.status)}`}
                   >
                     {daysInfo.text}
                   </span>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsColumns.tsx
@@ -2,10 +2,26 @@ import type { ColumnDef } from "@tanstack/react-table"
 import * as React from "react"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
-import { ArrowUpDown, MoreHorizontal, Edit, Trash2 } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  ArrowUpDown,
+  BadgeCheck,
+  CircleCheck,
+  CircleX,
+  MoreHorizontal,
+  Edit,
+  FileText,
+  Trash2,
+} from "lucide-react"
 import { format, parseISO } from "date-fns"
-import { vi } from 'date-fns/locale'
+import { vi } from "date-fns/locale"
 import type { RepairRequestWithEquipment, AuthUser } from "../types"
 import { calculateDaysRemaining, getStatusVariant } from "../utils"
 import { cn } from "@/lib/utils"
@@ -25,7 +41,7 @@ export interface RepairRequestColumnOptions {
   /** Handle approval workflow */
   handleApproveRequest: (req: RepairRequestWithEquipment) => void
   /** Handle completion workflow */
-  handleCompletion: (req: RepairRequestWithEquipment, type: 'Hoàn thành' | 'Không HT') => void
+  handleCompletion: (req: RepairRequestWithEquipment, type: "Hoàn thành" | "Không HT") => void
   /** Set request for detail view */
   setRequestToView: (req: RepairRequestWithEquipment | null) => void
   /** Current user from session (typed, not 'any') */
@@ -43,10 +59,7 @@ interface RepairRequestRowActionsProps {
  * Renders the actions dropdown menu for a repair request row.
  * Actions vary based on request status and user permissions.
  */
-export function RepairRequestRowActions({
-  request,
-  options,
-}: RepairRequestRowActionsProps) {
+export function RepairRequestRowActions({ request, options }: RepairRequestRowActionsProps) {
   const {
     onGenerateSheet,
     setEditingRequest,
@@ -54,7 +67,7 @@ export function RepairRequestRowActions({
     handleApproveRequest,
     handleCompletion,
     user,
-    isRegionalLeader
+    isRegionalLeader,
   } = options
 
   if (!user) return null
@@ -73,17 +86,21 @@ export function RepairRequestRowActions({
       <DropdownMenuContent align="end">
         <DropdownMenuLabel>Hành động</DropdownMenuLabel>
         <DropdownMenuItem onClick={() => onGenerateSheet(request)}>
+          <FileText className="mr-2 size-4" />
           Xem phiếu yêu cầu
         </DropdownMenuItem>
 
-        {request.trang_thai === 'Chờ xử lý' && (
+        {request.trang_thai === "Chờ xử lý" && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuItem onSelect={() => setEditingRequest(request)}>
               <Edit className="mr-2 size-4" />
               Sửa
             </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => setRequestToDelete(request)} className="text-destructive focus:text-destructive">
+            <DropdownMenuItem
+              onSelect={() => setRequestToDelete(request)}
+              className="text-destructive focus:text-destructive"
+            >
               <Trash2 className="mr-2 size-4" />
               Xoá
             </DropdownMenuItem>
@@ -93,17 +110,20 @@ export function RepairRequestRowActions({
         {canManage && (
           <>
             <DropdownMenuSeparator />
-            {request.trang_thai === 'Chờ xử lý' && (
+            {request.trang_thai === "Chờ xử lý" && (
               <DropdownMenuItem onClick={() => handleApproveRequest(request)}>
-                Duyệt
+                <BadgeCheck className="mr-2 size-4" />
+                Xác nhận
               </DropdownMenuItem>
             )}
-            {request.trang_thai === 'Đã duyệt' && (
+            {request.trang_thai === "Đã duyệt" && (
               <>
-                <DropdownMenuItem onClick={() => handleCompletion(request, 'Hoàn thành')}>
+                <DropdownMenuItem onClick={() => handleCompletion(request, "Hoàn thành")}>
+                  <CircleCheck className="mr-2 size-4" />
                   Hoàn thành
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => handleCompletion(request, 'Không HT')}>
+                <DropdownMenuItem onClick={() => handleCompletion(request, "Không HT")}>
+                  <CircleX className="mr-2 size-4" />
                   Không hoàn thành
                 </DropdownMenuItem>
               </>
@@ -112,197 +132,250 @@ export function RepairRequestRowActions({
         )}
       </DropdownMenuContent>
     </DropdownMenu>
-  );
+  )
 }
 
 /**
  * Creates memoized column definitions for repair requests table.
  * Uses useMemo to prevent unnecessary re-renders.
  */
-export function useRepairRequestColumns(options: RepairRequestColumnOptions): ColumnDef<RepairRequestWithEquipment>[] {
-  const columns = React.useMemo<ColumnDef<RepairRequestWithEquipment>[]>(() => [
-    // 1. Thiết bị (với mô tả sự cố)
-    {
-      accessorFn: (row) => {
-        // Safe null-checking to prevent "undefined undefined" in sorting/filtering
-        const parts: string[] = [];
-        if (row.thiet_bi?.ten_thiet_bi) {
-          parts.push(String(row.thiet_bi.ten_thiet_bi));
-        }
-        if (row.mo_ta_su_co) {
-          parts.push(String(row.mo_ta_su_co));
-        }
-        return parts.join(' ').trim() || 'N/A';
-      },
-      id: 'thiet_bi_va_mo_ta',
-      header: ({ column }) => (
-        <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-          Thiết bị
-          <ArrowUpDown className="ml-2 size-4" />
-        </Button>
-      ),
-      cell: ({ row }) => {
-        const request = row.original
-        return (
-          <div className="space-y-0.5">
-            <div className="font-medium text-base text-foreground/90">{request.thiet_bi?.ten_thiet_bi || 'N/A'}</div>
-            {request.thiet_bi?.ma_thiet_bi && (
-              <div className="text-xs text-muted-foreground/70 font-mono">{request.thiet_bi.ma_thiet_bi}</div>
-            )}
-            <div className="text-sm text-muted-foreground truncate max-w-[16rem]">{request.mo_ta_su_co}</div>
-          </div>
-        )
-      },
-      sortingFn: (rowA, rowB) => {
-        const nameA = rowA.original.thiet_bi?.ten_thiet_bi || '';
-        const nameB = rowB.original.thiet_bi?.ten_thiet_bi || '';
-        return nameA.localeCompare(nameB);
-      }
-    },
-    // 2. Người yêu cầu
-    {
-      accessorKey: "nguoi_yeu_cau",
-      header: ({ column }) => (
-        <Button variant="ghost" className="hover:bg-transparent px-0 font-semibold text-muted-foreground" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-          Người yêu cầu
-          <ArrowUpDown className="ml-2 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => {
-        const nguoiYeuCau = row.getValue("nguoi_yeu_cau") as string | null;
-        return (
-          <div className="text-sm font-medium text-foreground/80">
-            {nguoiYeuCau || <span className="text-muted-foreground italic font-normal">N/A</span>}
-          </div>
-        );
-      },
-    },
-    // 3. Ngày yêu cầu
-    {
-      accessorKey: "ngay_yeu_cau",
-      header: ({ column }) => (
-        <Button variant="ghost" className="hover:bg-transparent px-0 font-semibold text-muted-foreground" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-          Ngày yêu cầu
-          <ArrowUpDown className="ml-2 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => <div className="text-sm text-foreground/80">{format(parseISO(row.getValue("ngay_yeu_cau")), 'dd/MM/yyyy HH:mm', { locale: vi })}</div>,
-    },
-    // 4. Ngày mong muốn hoàn thành
-    {
-      accessorKey: "ngay_mong_muon_hoan_thanh",
-      header: ({ column }) => (
-        <Button variant="ghost" className="hover:bg-transparent px-0 font-semibold text-muted-foreground" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-          Hạn hoàn thành
-          <ArrowUpDown className="ml-2 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => {
-        const ngayMongMuon = row.getValue("ngay_mong_muon_hoan_thanh") as string | null;
-        const request = row.original;
-
-        if (!ngayMongMuon) {
+export function useRepairRequestColumns(
+  options: RepairRequestColumnOptions
+): ColumnDef<RepairRequestWithEquipment>[] {
+  const columns = React.useMemo<ColumnDef<RepairRequestWithEquipment>[]>(
+    () => [
+      // 1. Thiết bị (với mô tả sự cố)
+      {
+        accessorFn: (row) => {
+          // Safe null-checking to prevent "undefined undefined" in sorting/filtering
+          const parts: string[] = []
+          if (row.thiet_bi?.ten_thiet_bi) {
+            parts.push(String(row.thiet_bi.ten_thiet_bi))
+          }
+          if (row.mo_ta_su_co) {
+            parts.push(String(row.mo_ta_su_co))
+          }
+          return parts.join(" ").trim() || "N/A"
+        },
+        id: "thiet_bi_va_mo_ta",
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Thiết bị
+            <ArrowUpDown className="ml-2 size-4" />
+          </Button>
+        ),
+        cell: ({ row }) => {
+          const request = row.original
           return (
-            <div className="text-sm">
-              <span className="text-muted-foreground italic">Không có</span>
+            <div className="space-y-0.5">
+              <div className="font-medium text-base text-foreground/90">
+                {request.thiet_bi?.ten_thiet_bi || "N/A"}
+              </div>
+              {request.thiet_bi?.ma_thiet_bi && (
+                <div className="text-xs text-muted-foreground/70 font-mono">
+                  {request.thiet_bi.ma_thiet_bi}
+                </div>
+              )}
+              <div className="text-sm text-muted-foreground truncate max-w-[16rem]">
+                {request.mo_ta_su_co}
+              </div>
             </div>
-          );
-        }
+          )
+        },
+        sortingFn: (rowA, rowB) => {
+          const nameA = rowA.original.thiet_bi?.ten_thiet_bi || ""
+          const nameB = rowB.original.thiet_bi?.ten_thiet_bi || ""
+          return nameA.localeCompare(nameB)
+        },
+      },
+      // 2. Người yêu cầu
+      {
+        accessorKey: "nguoi_yeu_cau",
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            className="hover:bg-transparent px-0 font-semibold text-muted-foreground"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Người yêu cầu
+            <ArrowUpDown className="ml-2 size-3.5" />
+          </Button>
+        ),
+        cell: ({ row }) => {
+          const nguoiYeuCau = row.getValue("nguoi_yeu_cau") as string | null
+          return (
+            <div className="text-sm font-medium text-foreground/80">
+              {nguoiYeuCau || <span className="text-muted-foreground italic font-normal">N/A</span>}
+            </div>
+          )
+        },
+      },
+      // 3. Ngày yêu cầu
+      {
+        accessorKey: "ngay_yeu_cau",
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            className="hover:bg-transparent px-0 font-semibold text-muted-foreground"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Ngày yêu cầu
+            <ArrowUpDown className="ml-2 size-3.5" />
+          </Button>
+        ),
+        cell: ({ row }) => (
+          <div className="text-sm text-foreground/80">
+            {format(parseISO(row.getValue("ngay_yeu_cau")), "dd/MM/yyyy HH:mm", { locale: vi })}
+          </div>
+        ),
+      },
+      // 4. Ngày mong muốn hoàn thành
+      {
+        accessorKey: "ngay_mong_muon_hoan_thanh",
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            className="hover:bg-transparent px-0 font-semibold text-muted-foreground"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Hạn hoàn thành
+            <ArrowUpDown className="ml-2 size-3.5" />
+          </Button>
+        ),
+        cell: ({ row }) => {
+          const ngayMongMuon = row.getValue("ngay_mong_muon_hoan_thanh") as string | null
+          const request = row.original
 
-        // Chỉ hiển thị progress bar cho yêu cầu chưa hoàn thành
-        const isCompleted = request.trang_thai === 'Hoàn thành' || request.trang_thai === 'Không HT';
-        const daysInfo = !isCompleted ? calculateDaysRemaining(ngayMongMuon) : null;
+          if (!ngayMongMuon) {
+            return (
+              <div className="text-sm">
+                <span className="text-muted-foreground italic">Không có</span>
+              </div>
+            )
+          }
 
-        return (
-          <div className="space-y-1.5 w-[180px]">
-            <div className="flex items-center justify-between gap-2">
-              <span className="text-sm font-medium text-foreground/90 whitespace-nowrap">
-                {format(parseISO(ngayMongMuon), 'dd/MM/yyyy', { locale: vi })}
-              </span>
-              {daysInfo && (
-                <span className={`text-[10px] uppercase font-bold tracking-tight whitespace-nowrap ${daysInfo.status === 'success' ? 'text-emerald-600' :
-                  daysInfo.status === 'warning' ? 'text-amber-600' : 'text-rose-600'
-                  }`}>
-                  {daysInfo.text}
+          // Chỉ hiển thị progress bar cho yêu cầu chưa hoàn thành
+          const isCompleted =
+            request.trang_thai === "Hoàn thành" || request.trang_thai === "Không HT"
+          const daysInfo = !isCompleted ? calculateDaysRemaining(ngayMongMuon) : null
+
+          return (
+            <div className="space-y-1.5 w-[180px]">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium text-foreground/90 whitespace-nowrap">
+                  {format(parseISO(ngayMongMuon), "dd/MM/yyyy", { locale: vi })}
                 </span>
+                {daysInfo && (
+                  <span
+                    className={`text-[10px] uppercase font-bold tracking-tight whitespace-nowrap ${
+                      daysInfo.status === "success"
+                        ? "text-emerald-600"
+                        : daysInfo.status === "warning"
+                          ? "text-amber-600"
+                          : "text-rose-600"
+                    }`}
+                  >
+                    {daysInfo.text}
+                  </span>
+                )}
+              </div>
+
+              {daysInfo && (
+                <div className="h-1.5 w-full bg-muted/50 rounded-full overflow-hidden">
+                  <div
+                    className={`h-full rounded-full ${daysInfo.color} transition-all duration-500 ease-out`}
+                    style={{
+                      width:
+                        daysInfo.days > 0
+                          ? `${Math.min(100, Math.max(5, (daysInfo.days / 14) * 100))}%`
+                          : "100%",
+                    }}
+                  />
+                </div>
               )}
             </div>
-
-            {daysInfo && (
-              <div className="h-1.5 w-full bg-muted/50 rounded-full overflow-hidden">
-                <div
-                  className={`h-full rounded-full ${daysInfo.color} transition-all duration-500 ease-out`}
-                  style={{
-                    width: daysInfo.days > 0
-                      ? `${Math.min(100, Math.max(5, (daysInfo.days / 14) * 100))}%`
-                      : '100%'
-                  }}
-                />
-              </div>
-            )}
-          </div>
-        );
+          )
+        },
       },
-    },
-    // 5. Trạng thái
-    {
-      accessorKey: "trang_thai",
-      header: ({ column }) => (
-        <Button variant="ghost" className="hover:bg-transparent px-0 font-semibold text-muted-foreground" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-          Trạng thái
-          <ArrowUpDown className="ml-2 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => {
-        const request = row.original
-        return (
-          <div className="flex flex-col gap-1.5 item-start">
-            <Badge
-              variant="secondary"
-              className={cn(
-                "w-fit whitespace-nowrap px-2.5 py-0.5 text-xs font-semibold rounded-md border-0 ring-0 shadow-none",
-                request.trang_thai === 'Chờ xử lý' && "bg-orange-50 text-orange-700 hover:bg-orange-100",
-                request.trang_thai === 'Đã duyệt' && "bg-blue-50 text-blue-700 hover:bg-blue-100",
-                request.trang_thai === 'Hoàn thành' && "bg-emerald-50 text-emerald-700 hover:bg-emerald-100",
-                request.trang_thai === 'Không HT' && "bg-rose-50 text-rose-700 hover:bg-rose-100",
+      // 5. Trạng thái
+      {
+        accessorKey: "trang_thai",
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            className="hover:bg-transparent px-0 font-semibold text-muted-foreground"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Trạng thái
+            <ArrowUpDown className="ml-2 size-3.5" />
+          </Button>
+        ),
+        cell: ({ row }) => {
+          const request = row.original
+          return (
+            <div className="flex flex-col gap-1.5 item-start">
+              <Badge
+                variant="secondary"
+                className={cn(
+                  "w-fit whitespace-nowrap px-2.5 py-0.5 text-xs font-semibold rounded-md border-0 ring-0 shadow-none",
+                  request.trang_thai === "Chờ xử lý" &&
+                    "bg-orange-50 text-orange-700 hover:bg-orange-100",
+                  request.trang_thai === "Đã duyệt" && "bg-blue-50 text-blue-700 hover:bg-blue-100",
+                  request.trang_thai === "Hoàn thành" &&
+                    "bg-emerald-50 text-emerald-700 hover:bg-emerald-100",
+                  request.trang_thai === "Không HT" && "bg-rose-50 text-rose-700 hover:bg-rose-100"
+                )}
+              >
+                {request.trang_thai}
+              </Badge>
+              {request.trang_thai === "Đã duyệt" && request.ngay_duyet && (
+                <div className="flex flex-col gap-0.5 text-xs text-muted-foreground/80">
+                  <span>
+                    {format(parseISO(request.ngay_duyet), "dd/MM/yyyy HH:mm", { locale: vi })}
+                  </span>
+                  {request.nguoi_duyet && (
+                    <span className="text-blue-600/90 font-medium">Bởi: {request.nguoi_duyet}</span>
+                  )}
+                </div>
               )}
-            >
-              {request.trang_thai}
-            </Badge>
-            {request.trang_thai === 'Đã duyệt' && request.ngay_duyet && (
-              <div className="flex flex-col gap-0.5 text-xs text-muted-foreground/80">
-                <span>{format(parseISO(request.ngay_duyet), 'dd/MM/yyyy HH:mm', { locale: vi })}</span>
-                {request.nguoi_duyet && (
-                  <span className="text-blue-600/90 font-medium">Bởi: {request.nguoi_duyet}</span>
+              {(request.trang_thai === "Hoàn thành" || request.trang_thai === "Không HT") &&
+                request.ngay_hoan_thanh && (
+                  <div className="flex flex-col gap-0.5 text-xs text-muted-foreground/80">
+                    <span>
+                      {format(parseISO(request.ngay_hoan_thanh), "dd/MM/yyyy HH:mm", {
+                        locale: vi,
+                      })}
+                    </span>
+                    {request.nguoi_xac_nhan && (
+                      <span className="text-emerald-600/90 font-medium">
+                        Bởi: {request.nguoi_xac_nhan}
+                      </span>
+                    )}
+                  </div>
                 )}
-              </div>
-            )}
-            {(request.trang_thai === 'Hoàn thành' || request.trang_thai === 'Không HT') && request.ngay_hoan_thanh && (
-              <div className="flex flex-col gap-0.5 text-xs text-muted-foreground/80">
-                <span>{format(parseISO(request.ngay_hoan_thanh), 'dd/MM/yyyy HH:mm', { locale: vi })}</span>
-                {request.nguoi_xac_nhan && (
-                  <span className="text-emerald-600/90 font-medium">Bởi: {request.nguoi_xac_nhan}</span>
-                )}
-              </div>
-            )}
-          </div>
-        )
+            </div>
+          )
+        },
+        filterFn: (row, id, value) => value.includes(row.getValue(id)),
       },
-      filterFn: (row, id, value) => value.includes(row.getValue(id)),
-    },
-    {
-      id: "actions",
-      cell: ({ row }) => (
-        <div
-          onClick={(event) => event.stopPropagation()}
-          onKeyDown={(event) => event.stopPropagation()}
-          role="presentation"
-        >
-          <RepairRequestRowActions request={row.original} options={options} />
-        </div>
-      ),
-    },
-  ], [options]) // Only recreate when options change
+      {
+        id: "actions",
+        cell: ({ row }) => (
+          <div
+            onClick={(event) => event.stopPropagation()}
+            onKeyDown={(event) => event.stopPropagation()}
+            role="presentation"
+          >
+            <RepairRequestRowActions request={row.original} options={options} />
+          </div>
+        ),
+      },
+    ],
+    [options]
+  ) // Only recreate when options change
 
   return columns
 }

--- a/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx
@@ -1,27 +1,11 @@
 "use client"
 
 import * as React from "react"
-import { format } from "date-fns"
-import { Calendar as CalendarIcon } from "lucide-react"
-
-import { Button } from "@/components/ui/button"
-import { Calendar } from "@/components/ui/calendar"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { Textarea } from "@/components/ui/textarea"
-import { cn } from "@/lib/utils"
 
 import type { EquipmentSelectItem, RepairUnit } from "../types"
-import { RepairRequestsCreateSheetActions } from "./RepairRequestsCreateSheetActions"
+import { RepairRequestsFormFields } from "./RepairRequestsFormFields"
 import { RepairRequestsEquipmentSearchField } from "./RepairRequestsEquipmentSearchField"
+import { RepairRequestsSheetActions } from "./RepairRequestsSheetActions"
 
 function getTodayStart(): Date {
   const today = new Date()
@@ -79,7 +63,7 @@ export function RepairRequestsCreateSheetForm({
 
   const isDateDisabled = React.useCallback(
     (date: Date) => date < minimumSelectableDate,
-    [minimumSelectableDate],
+    [minimumSelectableDate]
   )
 
   return (
@@ -92,87 +76,27 @@ export function RepairRequestsCreateSheetForm({
         onSearchChange={handleSearchChange}
         onSelectEquipment={handleSelectEquipment}
       />
-      <div className="space-y-2">
-        <Label htmlFor="issue">Mô tả sự cố</Label>
-        <Textarea
-          id="issue"
-          placeholder="Mô tả chi tiết vấn đề gặp phải…"
-          rows={4}
-          value={issueDescription}
-          onChange={(e) => onIssueDescriptionChange(e.target.value)}
-          required
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="repair-items">Các hạng mục yêu cầu sửa chữa (nếu có)</Label>
-        <Textarea
-          id="repair-items"
-          placeholder="VD: Thay màn hình, sửa nguồn…"
-          rows={3}
-          value={repairItems}
-          onChange={(e) => onRepairItemsChange(e.target.value)}
-        />
-      </div>
-      <div className="space-y-2">
-        <Label>Ngày mong muốn hoàn thành (nếu có)</Label>
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              className={cn(
-                "w-full justify-start text-left font-normal touch-target",
-                !desiredDate && "text-muted-foreground",
-              )}
-            >
-              <CalendarIcon className="mr-2 size-4" />
-              {desiredDate ? format(desiredDate, "dd/MM/yyyy") : <span>Chọn ngày</span>}
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-0">
-                <Calendar
-                  mode="single"
-                  selected={desiredDate}
-                  onSelect={onDesiredDateChange}
-                  initialFocus
-                  disabled={isDateDisabled}
-                />
-          </PopoverContent>
-        </Popover>
-      </div>
-
-      {canSetRepairUnit && (
-        <div className="space-y-2">
-          <Label htmlFor="repair-unit">Đơn vị thực hiện</Label>
-          <Select value={repairUnit} onValueChange={(value) => onRepairUnitChange(value as RepairUnit)}>
-            <SelectTrigger className="touch-target">
-              <SelectValue placeholder="Chọn đơn vị thực hiện" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="noi_bo">Nội bộ</SelectItem>
-              <SelectItem value="thue_ngoai">Thuê ngoài</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      )}
-
-      {canSetRepairUnit && repairUnit === "thue_ngoai" && (
-        <div className="space-y-2">
-          <Label htmlFor="external-company">Tên đơn vị được thuê</Label>
-          <Input
-            id="external-company"
-            placeholder="Nhập tên đơn vị được thuê sửa chữa…"
-            value={externalCompanyName}
-            onChange={(e) => onExternalCompanyNameChange(e.target.value)}
-            required
-            className="touch-target"
-          />
-        </div>
-      )}
-
-      <RepairRequestsCreateSheetActions
+      <RepairRequestsFormFields
+        canSetRepairUnit={canSetRepairUnit}
+        desiredDate={desiredDate}
+        externalCompanyName={externalCompanyName}
+        fieldIdPrefix="create-repair-request"
+        isDateDisabled={isDateDisabled}
+        issueDescription={issueDescription}
+        onDesiredDateChange={onDesiredDateChange}
+        onExternalCompanyNameChange={onExternalCompanyNameChange}
+        onIssueDescriptionChange={onIssueDescriptionChange}
+        onRepairItemsChange={onRepairItemsChange}
+        onRepairUnitChange={onRepairUnitChange}
+        repairItems={repairItems}
+        repairItemsLabel="Các hạng mục yêu cầu sửa chữa (nếu có)"
+        repairUnit={repairUnit}
+      />
+      <RepairRequestsSheetActions
         isSubmitting={isSubmitting}
         onCancel={onCancel}
+        submitLabel="Gửi yêu cầu"
+        submittingLabel="Đang gửi..."
       />
     </form>
   )

--- a/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
@@ -2,31 +2,11 @@
 
 import * as React from "react"
 import { parseISO, format, startOfDay } from "date-fns"
-import { Button } from "@/components/ui/button"
-import { Calendar } from "@/components/ui/calendar"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { Textarea } from "@/components/ui/textarea"
-import { cn } from "@/lib/utils"
-import { Calendar as CalendarIcon, Loader2 } from "lucide-react"
+import { SideSheetShell } from "@/components/shared/SideSheetShell"
 import { useRepairRequestsContext } from "../_hooks/useRepairRequestsContext"
 import type { RepairUnit } from "../types"
+import { RepairRequestsFormFields } from "./RepairRequestsFormFields"
+import { RepairRequestsSheetActions } from "./RepairRequestsSheetActions"
 
 interface RepairRequestsEditFormState {
   desiredDate: Date | undefined
@@ -36,20 +16,11 @@ interface RepairRequestsEditFormState {
   repairUnit: RepairUnit
 }
 
-type RepairRequestsEditFormAction =
-  | { type: "patch"; updates: Partial<RepairRequestsEditFormState> }
-
-const initialEditFormState: RepairRequestsEditFormState = {
-  desiredDate: undefined,
-  externalCompanyName: "",
-  issueDescription: "",
-  repairItems: "",
-  repairUnit: "noi_bo",
-}
+type RepairRequestsEditFormAction = { type: "patch"; updates: Partial<RepairRequestsEditFormState> }
 
 function repairRequestsEditFormReducer(
   state: RepairRequestsEditFormState,
-  action: RepairRequestsEditFormAction,
+  action: RepairRequestsEditFormAction
 ): RepairRequestsEditFormState {
   switch (action.type) {
     case "patch":
@@ -73,6 +44,7 @@ function createEditFormState(requestToEdit: RepairRequestToEdit): RepairRequests
   }
 }
 
+/** Renders the repair-request edit workflow inside the page-owned side sheet. */
 export function RepairRequestsEditDialog() {
   const {
     dialogState: { requestToEdit },
@@ -108,11 +80,11 @@ function RepairRequestsEditDialogContent({
   const [formState, dispatchForm] = React.useReducer(
     repairRequestsEditFormReducer,
     requestToEdit,
-    createEditFormState,
+    createEditFormState
   )
 
-  const handleSubmit = () => {
-    if (!requestToEdit) return
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
 
     updateMutation.mutate(
       {
@@ -123,144 +95,78 @@ function RepairRequestsEditDialogContent({
           ? format(formState.desiredDate, "yyyy-MM-dd")
           : null,
         don_vi_thuc_hien: canSetRepairUnit ? formState.repairUnit : undefined,
-        ten_don_vi_thue: canSetRepairUnit && formState.repairUnit === "thue_ngoai"
-          ? formState.externalCompanyName.trim()
-          : null,
+        ten_don_vi_thue:
+          canSetRepairUnit && formState.repairUnit === "thue_ngoai"
+            ? formState.externalCompanyName.trim()
+            : null,
       },
       { onSuccess: closeAllDialogs }
     )
   }
 
   return (
-    <Dialog open={!!requestToEdit} onOpenChange={(open) => !open && closeAllDialogs()}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Sửa yêu cầu sửa chữa</DialogTitle>
-          <DialogDescription>
-            Cập nhật thông tin cho yêu cầu của thiết bị: {requestToEdit.thiet_bi?.ten_thiet_bi}
-          </DialogDescription>
-        </DialogHeader>
-        <div className="space-y-4 py-4 mobile-card-spacing">
-          <div className="space-y-2">
-            <Label htmlFor="edit-issue">Mô tả sự cố</Label>
-            <Textarea
-              id="edit-issue"
-              placeholder="Mô tả chi tiết vấn đề gặp phải…"
-              rows={4}
-              value={formState.issueDescription}
-              onChange={(e) => dispatchForm({
-                type: "patch",
-                updates: { issueDescription: e.target.value },
-              })}
-              required
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="edit-repair-items">Các hạng mục yêu cầu sửa chữa</Label>
-            <Textarea
-              id="edit-repair-items"
-              placeholder="VD: Thay màn hình, sửa nguồn…"
-              rows={3}
-              value={formState.repairItems}
-              onChange={(e) => dispatchForm({
-                type: "patch",
-                updates: { repairItems: e.target.value },
-              })}
-              required
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Ngày mong muốn hoàn thành (nếu có)</Label>
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  className={cn(
-                    "w-full justify-start text-left font-normal touch-target",
-                    !formState.desiredDate && "text-muted-foreground"
-                  )}
-                >
-                  <CalendarIcon className="mr-2 size-4" />
-                  {formState.desiredDate ? format(formState.desiredDate, "dd/MM/yyyy") : <span>Chọn ngày</span>}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-auto p-0">
-                <Calendar
-                  mode="single"
-                  selected={formState.desiredDate}
-                  onSelect={(desiredDate) => dispatchForm({
-                    type: "patch",
-                    updates: { desiredDate },
-                  })}
-                  initialFocus
-                  disabled={(date) => {
-                    const requestTimestamp = Date.parse(requestToEdit.ngay_yeu_cau)
-                    return Number.isFinite(requestTimestamp)
-                      ? date.getTime() < startOfDay(requestTimestamp).getTime()
-                      : false
-                  }}
-                />
-              </PopoverContent>
-            </Popover>
-          </div>
-
-          {canSetRepairUnit && (
-            <div className="space-y-2">
-              <Label htmlFor="edit-repair-unit">Đơn vị thực hiện</Label>
-              <Select
-                value={formState.repairUnit}
-                onValueChange={(value) => dispatchForm({
-                  type: "patch",
-                  updates: { repairUnit: value as RepairUnit },
-                })}
-              >
-                <SelectTrigger className="touch-target">
-                  <SelectValue placeholder="Chọn đơn vị thực hiện" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="noi_bo">Nội bộ</SelectItem>
-                  <SelectItem value="thue_ngoai">Thuê ngoài</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          {canSetRepairUnit && formState.repairUnit === "thue_ngoai" && (
-            <div className="space-y-2">
-              <Label htmlFor="edit-external-company">Tên đơn vị được thuê</Label>
-              <Input
-                id="edit-external-company"
-                placeholder="Nhập tên đơn vị được thuê sửa chữa…"
-                value={formState.externalCompanyName}
-                onChange={(e) => dispatchForm({
-                  type: "patch",
-                  updates: { externalCompanyName: e.target.value },
-                })}
-                required
-                className="touch-target"
-              />
-            </div>
-          )}
-        </div>
-        <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={closeAllDialogs}
-            disabled={updateMutation.isPending}
-            className="touch-target"
-          >
-            Hủy
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={updateMutation.isPending}
-            className="touch-target"
-          >
-            {updateMutation.isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
-            Lưu thay đổi
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <SideSheetShell
+      open={!!requestToEdit}
+      onOpenChange={(open) => !open && closeAllDialogs()}
+      title="Sửa yêu cầu sửa chữa"
+      description={`Cập nhật thông tin cho yêu cầu của thiết bị: ${requestToEdit.thiet_bi?.ten_thiet_bi ?? ""}`}
+      contentClassName="sm:max-w-lg"
+      bodyClassName="mt-4 overflow-y-auto px-4 pb-4"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <RepairRequestsFormFields
+          canSetRepairUnit={canSetRepairUnit}
+          desiredDate={formState.desiredDate}
+          externalCompanyName={formState.externalCompanyName}
+          fieldIdPrefix="edit-repair-request"
+          isDateDisabled={(date) => {
+            const requestTimestamp = Date.parse(requestToEdit.ngay_yeu_cau)
+            return Number.isFinite(requestTimestamp)
+              ? date.getTime() < startOfDay(requestTimestamp).getTime()
+              : false
+          }}
+          issueDescription={formState.issueDescription}
+          onDesiredDateChange={(desiredDate) =>
+            dispatchForm({
+              type: "patch",
+              updates: { desiredDate },
+            })
+          }
+          onExternalCompanyNameChange={(externalCompanyName) =>
+            dispatchForm({
+              type: "patch",
+              updates: { externalCompanyName },
+            })
+          }
+          onIssueDescriptionChange={(issueDescription) =>
+            dispatchForm({
+              type: "patch",
+              updates: { issueDescription },
+            })
+          }
+          onRepairItemsChange={(repairItems) =>
+            dispatchForm({
+              type: "patch",
+              updates: { repairItems },
+            })
+          }
+          onRepairUnitChange={(repairUnit) =>
+            dispatchForm({
+              type: "patch",
+              updates: { repairUnit },
+            })
+          }
+          repairItems={formState.repairItems}
+          repairItemsLabel="Các hạng mục yêu cầu sửa chữa"
+          repairItemsRequired
+          repairUnit={formState.repairUnit}
+        />
+        <RepairRequestsSheetActions
+          isSubmitting={updateMutation.isPending}
+          onCancel={closeAllDialogs}
+          submitLabel="Lưu thay đổi"
+        />
+      </form>
+    </SideSheetShell>
   )
 }

--- a/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsEditDialog.tsx
@@ -83,6 +83,16 @@ function RepairRequestsEditDialogContent({
     createEditFormState
   )
 
+  const isDesiredDateDisabled = React.useCallback(
+    (date: Date) => {
+      const requestTimestamp = Date.parse(requestToEdit.ngay_yeu_cau)
+      return Number.isFinite(requestTimestamp)
+        ? date.getTime() < startOfDay(requestTimestamp).getTime()
+        : false
+    },
+    [requestToEdit.ngay_yeu_cau]
+  )
+
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault()
 
@@ -119,12 +129,7 @@ function RepairRequestsEditDialogContent({
           desiredDate={formState.desiredDate}
           externalCompanyName={formState.externalCompanyName}
           fieldIdPrefix="edit-repair-request"
-          isDateDisabled={(date) => {
-            const requestTimestamp = Date.parse(requestToEdit.ngay_yeu_cau)
-            return Number.isFinite(requestTimestamp)
-              ? date.getTime() < startOfDay(requestTimestamp).getTime()
-              : false
-          }}
+          isDateDisabled={isDesiredDateDisabled}
           issueDescription={formState.issueDescription}
           onDesiredDateChange={(desiredDate) =>
             dispatchForm({

--- a/src/app/(app)/repair-requests/_components/RepairRequestsFormFields.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsFormFields.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import * as React from "react"
+import { format } from "date-fns"
+import { Calendar as CalendarIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+import type { RepairUnit } from "../types"
+
+interface RepairRequestsFormFieldsProps {
+  readonly canSetRepairUnit: boolean
+  readonly desiredDate: Date | undefined
+  readonly externalCompanyName: string
+  readonly fieldIdPrefix: string
+  readonly isDateDisabled: (date: Date) => boolean
+  readonly issueDescription: string
+  readonly onDesiredDateChange: (value: Date | undefined) => void
+  readonly onExternalCompanyNameChange: (value: string) => void
+  readonly onIssueDescriptionChange: (value: string) => void
+  readonly onRepairItemsChange: (value: string) => void
+  readonly onRepairUnitChange: (value: RepairUnit) => void
+  readonly repairItems: string
+  readonly repairItemsLabel: string
+  readonly repairItemsRequired?: boolean
+  readonly repairUnit: RepairUnit
+}
+
+/** Renders the repair-request fields shared by create and edit sheets. */
+export function RepairRequestsFormFields({
+  canSetRepairUnit,
+  desiredDate,
+  externalCompanyName,
+  fieldIdPrefix,
+  isDateDisabled,
+  issueDescription,
+  onDesiredDateChange,
+  onExternalCompanyNameChange,
+  onIssueDescriptionChange,
+  onRepairItemsChange,
+  onRepairUnitChange,
+  repairItems,
+  repairItemsLabel,
+  repairItemsRequired = false,
+  repairUnit,
+}: RepairRequestsFormFieldsProps) {
+  const issueId = `${fieldIdPrefix}-issue`
+  const repairItemsId = `${fieldIdPrefix}-repair-items`
+  const repairUnitId = `${fieldIdPrefix}-repair-unit`
+  const externalCompanyId = `${fieldIdPrefix}-external-company`
+
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor={issueId}>Mô tả sự cố</Label>
+        <Textarea
+          id={issueId}
+          placeholder="Mô tả chi tiết vấn đề gặp phải…"
+          rows={4}
+          value={issueDescription}
+          onChange={(event) => onIssueDescriptionChange(event.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={repairItemsId}>{repairItemsLabel}</Label>
+        <Textarea
+          id={repairItemsId}
+          placeholder="VD: Thay màn hình, sửa nguồn…"
+          rows={3}
+          value={repairItems}
+          onChange={(event) => onRepairItemsChange(event.target.value)}
+          required={repairItemsRequired}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>Ngày mong muốn hoàn thành (nếu có)</Label>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              className={cn(
+                "w-full justify-start text-left font-normal touch-target",
+                !desiredDate && "text-muted-foreground"
+              )}
+            >
+              <CalendarIcon className="mr-2 size-4" />
+              {desiredDate ? format(desiredDate, "dd/MM/yyyy") : <span>Chọn ngày</span>}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0">
+            <Calendar
+              mode="single"
+              selected={desiredDate}
+              onSelect={onDesiredDateChange}
+              initialFocus
+              disabled={isDateDisabled}
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      {canSetRepairUnit && (
+        <div className="space-y-2">
+          <Label htmlFor={repairUnitId}>Đơn vị thực hiện</Label>
+          <Select
+            value={repairUnit}
+            onValueChange={(value) => onRepairUnitChange(value as RepairUnit)}
+          >
+            <SelectTrigger id={repairUnitId} className="touch-target">
+              <SelectValue placeholder="Chọn đơn vị thực hiện" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="noi_bo">Nội bộ</SelectItem>
+              <SelectItem value="thue_ngoai">Thuê ngoài</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {canSetRepairUnit && repairUnit === "thue_ngoai" && (
+        <div className="space-y-2">
+          <Label htmlFor={externalCompanyId}>Tên đơn vị được thuê</Label>
+          <Input
+            id={externalCompanyId}
+            placeholder="Nhập tên đơn vị được thuê sửa chữa…"
+            value={externalCompanyName}
+            onChange={(event) => onExternalCompanyNameChange(event.target.value)}
+            required
+            className="touch-target"
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsFormFields.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsFormFields.tsx
@@ -61,6 +61,7 @@ export function RepairRequestsFormFields({
   const repairItemsId = `${fieldIdPrefix}-repair-items`
   const repairUnitId = `${fieldIdPrefix}-repair-unit`
   const externalCompanyId = `${fieldIdPrefix}-external-company`
+  const desiredDateId = `${fieldIdPrefix}-desired-date`
 
   return (
     <>
@@ -87,10 +88,11 @@ export function RepairRequestsFormFields({
         />
       </div>
       <div className="space-y-2">
-        <Label>Ngày mong muốn hoàn thành (nếu có)</Label>
+        <Label htmlFor={desiredDateId}>Ngày mong muốn hoàn thành (nếu có)</Label>
         <Popover>
           <PopoverTrigger asChild>
             <Button
+              id={desiredDateId}
               type="button"
               variant="outline"
               className={cn(

--- a/src/app/(app)/repair-requests/_components/RepairRequestsSheetActions.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsSheetActions.tsx
@@ -2,17 +2,23 @@
 
 import * as React from "react"
 import { Loader2 } from "lucide-react"
+
 import { Button } from "@/components/ui/button"
 
-interface RepairRequestsCreateSheetActionsProps {
-  isSubmitting: boolean
-  onCancel: () => void
+interface RepairRequestsSheetActionsProps {
+  readonly isSubmitting: boolean
+  readonly onCancel: () => void
+  readonly submitLabel: string
+  readonly submittingLabel?: string
 }
 
-export function RepairRequestsCreateSheetActions({
+/** Renders shared submit and cancel actions for repair-request sheets. */
+export function RepairRequestsSheetActions({
   isSubmitting,
   onCancel,
-}: RepairRequestsCreateSheetActionsProps) {
+  submitLabel,
+  submittingLabel,
+}: RepairRequestsSheetActionsProps) {
   return (
     <div className="flex gap-3 pt-2">
       <Button
@@ -20,12 +26,13 @@ export function RepairRequestsCreateSheetActions({
         variant="outline"
         className="flex-1 touch-target"
         onClick={onCancel}
+        disabled={isSubmitting}
       >
         Hủy
       </Button>
       <Button type="submit" className="flex-1 touch-target" disabled={isSubmitting}>
         {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
-        {isSubmitting ? "Đang gửi..." : "Gửi yêu cầu"}
+        {isSubmitting && submittingLabel ? submittingLabel : submitLabel}
       </Button>
     </div>
   )

--- a/src/app/(app)/repair-requests/_components/RepairRequestsSheetActions.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsSheetActions.tsx
@@ -30,7 +30,12 @@ export function RepairRequestsSheetActions({
       >
         Hủy
       </Button>
-      <Button type="submit" className="flex-1 touch-target" disabled={isSubmitting}>
+      <Button
+        type="submit"
+        className="flex-1 touch-target"
+        disabled={isSubmitting}
+        aria-busy={isSubmitting}
+      >
         {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
         {isSubmitting && submittingLabel ? submittingLabel : submitLabel}
       </Button>


### PR DESCRIPTION
## Summary
- Refactor repair request edit UI from centered dialog to shared side-sheet shell.
- Extract shared repair request form fields/actions for create and edit flows.
- Rename row approve action to Xác nhận and add lucide icons to row action menu items.

## Test Plan
- ./node_modules/.bin/prettier --check --ignore-unknown changed repair-request files
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- focused repair-request tests
- node scripts/npm-run.js run react-doctor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the repair request edit flow into the shared side sheet and unified create/edit with shared fields and actions. Clarified row action labels with icons and tightened desired-date validation; expanded tests to cover field edge cases.

- **Refactors**
  - Edit now uses `SideSheetShell`; submits via the existing update mutation and closes with the sheet.
  - Added `RepairRequestsFormFields` and `RepairRequestsSheetActions`; `RepairRequestsCreateSheetForm` now reuses them and removed `RepairRequestsCreateSheetActions`.
  - Row menu in `RepairRequestsColumns`: renamed "Duyệt" to "Xác nhận" and added icons for view, edit, delete, approve, and completion actions.
  - Edit desired date is now constrained to be on/after the request date.
  - Tests: added `RepairRequestsEditSheet.test.tsx` and expanded `RepairRequestsFormFields.test.tsx` for labels, permissions, and required-field edge cases; updated `RepairRequestRowActions.test.tsx` to assert the new label and icons.

<sup>Written for commit 7c7129a9dc68f3601b209792b92e9cefe07165cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repair request forms now share a consistent layout, including optional desired completion date and repair unit/external company fields when applicable.
  * Repair request editing is now presented in a side sheet with clearer submit/cancel behavior.
  * Repair request row actions now use improved confirmation/approval wording and status icons.

* **Bug Fixes**
  * Improved form submission reliability and automatic closing after saving changes.
  * Enhanced table rendering for device/date/status details to make review and completion states easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->