### PR TITLE
feat(equipment): modernize filter command tokens

### DIFF
--- a/docs/superpowers/plans/2026-07-03-equipment-command-filter-toolbar.md
+++ b/docs/superpowers/plans/2026-07-03-equipment-command-filter-toolbar.md
@@ -1,0 +1,300 @@
+# Equipment Command Filter Toolbar Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the Equipments filter/search toolbar to use the Stitch-approved Command Token overflow layout without changing data contracts, API behavior, filter ids, query keys, or backend code.
+
+**Architecture:** Keep existing shared primitives and add presentation-only variants. Extend `FacetedMultiSelectFilter` with a command-token trigger style, then update `EquipmentToolbar` to show three primary command filters plus a compact `Bộ lọc` overflow command on desktop, while preserving the existing sheet mode for tablet/mobile.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, TanStack Table, Vitest, Testing Library, existing shadcn-style UI primitives, lucide icons already used by this repo.
+
+---
+
+## Reference Inputs
+
+- Stitch project: `7945259677379130435`
+- Selected mockup: `Danh mục thiết bị - Overflow Command Layout`
+- Stitch screen id: `0229a443d63c42a3a8bbf336d4bdf0e6`
+- Indexed reference source: `Stitch HTML: Equipments Overflow Command Layout`
+- Current toolbar: `src/components/equipment/equipment-toolbar.tsx`
+- Shared layout: `src/components/shared/ListFilterSearchCard.tsx`
+- Shared filter primitive: `src/components/shared/table-filters/FacetedMultiSelectFilter.tsx`
+- Current tests:
+  - `src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx`
+  - `src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx`
+
+## Non-Goals
+
+- Do not change filter ids, TanStack column filter values, table callbacks, route sync, API calls, RPCs, database code, or export behavior.
+- Do not replace `FilterBottomSheet`; keep `filterMode="sheet"` behavior intact.
+- Do not roll the new layout into all pages in this pass. Build it safely for Equipments first, using shared components so later rollout is small.
+- Do not copy Stitch HTML into production. Use it only as visual reference.
+
+## File Map
+
+- Modify: `src/components/shared/table-filters/FacetedMultiSelectFilter.tsx`
+  - Add presentation-only trigger variant support for command tokens.
+  - Preserve existing default outline trigger for all current callers.
+- Modify: `src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx`
+  - Add tests for command-token rendering and selected-count badge.
+- Modify: `src/components/equipment/equipment-toolbar.tsx`
+  - Use command-token filters for Equipments faceted desktop mode.
+  - Add progressive overflow: direct tokens for `Tình trạng`, `Khoa/Phòng`, `Phân loại`; overflow token `Bộ lọc` for `Người sử dụng`, `Nguồn kinh phí`.
+  - Keep full mobile/tablet sheet mode unchanged.
+- Modify: `src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx`
+  - Add regression tests for command token labels, overflow trigger, clear behavior, and sheet mode.
+
+## Chunk 1: Shared Command Token Trigger
+
+### Task 1: Add failing tests for command-token trigger
+
+**Files:**
+
+- Test: `src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx`
+
+- [ ] **Step 1: Write failing test for command token variant**
+
+Add tests that render `FacetedMultiSelectFilter` in controlled mode with:
+
+```tsx
+<FacetedMultiSelectFilter
+  title="Khoa/Phòng"
+  options={[{ label: "Khoa A", value: "khoa-a" }]}
+  value={[]}
+  onChange={vi.fn()}
+  triggerVariant="command"
+/>
+```
+
+Assert:
+
+- Button exists with accessible name including `Khoa/Phòng`.
+- Button has command-token classes or a stable attribute such as `data-trigger-variant="command"`.
+- It still opens the popover when clicked.
+
+- [ ] **Step 2: Run focused test and verify RED**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test -- src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx -t "command token"
+```
+
+Expected: FAIL because `triggerVariant` does not exist.
+
+- [ ] **Step 3: Implement minimal shared prop**
+
+Modify `FacetedMultiSelectFilterProps`:
+
+```ts
+triggerVariant?: "outline" | "command"
+triggerIcon?: React.ReactNode
+```
+
+Default to `"outline"`.
+
+For `triggerVariant === "command"`:
+
+- Use 38px-ish height (`h-9` is acceptable if repo uses 36px controls).
+- Use 8px radius.
+- Use tactile slate surface.
+- Render optional leading icon zone.
+- Render selected count badge when `selectedValues.size > 0`.
+- Preserve `PopoverTrigger`, selected state, keyboard accessibility, and existing option list.
+
+- [ ] **Step 4: Run focused test and verify GREEN**
+
+Run the same focused test.
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full shared filter tests**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test -- src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
+```
+
+Expected: PASS. Existing outline behavior remains unchanged.
+
+## Chunk 2: Equipment Overflow Command Layout
+
+### Task 2: Add failing toolbar tests
+
+**Files:**
+
+- Test: `src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx`
+- Modify: `src/components/equipment/equipment-toolbar.tsx`
+
+- [ ] **Step 1: Write failing test for visible command tokens and overflow token**
+
+In desktop faceted mode, assert visible:
+
+- `Tình trạng`
+- `Khoa/Phòng`
+- `Phân loại`
+- `Bộ lọc`
+- `Xóa` only when filters are active
+
+Assert `Người sử dụng` and `Nguồn kinh phí` are not direct top-level tokens in the default desktop overflow layout. They should be available through `Bộ lọc`.
+
+- [ ] **Step 2: Write failing test that callbacks are preserved**
+
+Assert:
+
+- Clicking direct token still opens the existing faceted popover.
+- Clicking `Xóa` calls `table.resetColumnFilters()`.
+- Facility clear remains separate and still calls `onClearFacilityFilter` when facility filter state is active.
+
+- [ ] **Step 3: Run focused toolbar tests and verify RED**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test -- src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx -t "command"
+```
+
+Expected: FAIL because Equipments still renders all filters as outline buttons and has no `Bộ lọc` overflow token.
+
+- [ ] **Step 4: Implement minimal command layout in `EquipmentToolbar`**
+
+Implementation shape:
+
+- Keep `mobileFilterControl` unchanged for `filterMode === "sheet"`.
+- Split desktop filters into:
+  - primary command filters: status, department, classification
+  - overflow command filters: user, funding source
+- Use `FacetedMultiSelectFilter triggerVariant="command"` for all visible direct filters.
+- Add a compact `Popover`/`DropdownMenu` trigger labeled `Bộ lọc` with count badge for selected overflow filters.
+- Inside overflow content, render the two existing `FacetedMultiSelectFilter` controls or equivalent controlled UI without changing their column filter ids.
+- Render compact clear token `Xóa` only when `isFiltered` is true.
+
+- [ ] **Step 5: Run focused toolbar tests and verify GREEN**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test -- src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+```
+
+Expected: PASS.
+
+## Chunk 3: Responsive Guardrails
+
+### Task 3: Lock small desktop behavior
+
+**Files:**
+
+- Modify: `src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx`
+- Modify: `src/components/equipment/equipment-toolbar.tsx`
+- Optional modify: `src/components/shared/ListFilterSearchCard.tsx`
+
+- [ ] **Step 1: Write failing layout contract test**
+
+Use DOM assertions rather than pixel assertions:
+
+- The filter group has a stable wrapper class or `data-testid="equipment-command-filter-row"`.
+- The wrapper allows wrapping or overflow-safe layout (`flex-wrap`, two-line safe layout, or progressive overflow).
+- Search container keeps `min-w-0` so it can shrink without pushing actions off-screen.
+
+- [ ] **Step 2: Run focused test and verify RED if missing**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test -- src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx -t "responsive"
+```
+
+Expected: FAIL if wrappers/classes are not yet present.
+
+- [ ] **Step 3: Implement responsive classes only**
+
+Preferred layout:
+
+- Search and facility remain visible.
+- Command filters use progressive overflow on standard desktop.
+- Wide screens may show all filters only if there is enough room, but do not require that in this pass.
+- Avoid fixed widths that make the search field unusable.
+
+- [ ] **Step 4: Run focused test and verify GREEN**
+
+Run the same responsive test.
+
+Expected: PASS.
+
+## Chunk 4: Visual Verification
+
+### Task 4: Browser check against Stitch intent
+
+**Files:**
+
+- No source changes unless a visual issue is found.
+
+- [ ] **Step 1: Run verification chain for TS/TSX changes**
+
+Run through context-mode as one batch:
+
+```bash
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run test -- src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+node scripts/npm-run.js run react-doctor
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Start dev server**
+
+Run the repo's normal dev command, then open `/equipment`.
+
+- [ ] **Step 3: Verify desktop widths**
+
+Check:
+
+- 1440px: command tokens look like Stitch `Overflow Command Layout`.
+- 1280px: row does not overlap or compress search to unusable width.
+- 1024px: overflow token keeps the toolbar usable.
+- Tablet/mobile: existing filter sheet mode still appears.
+
+- [ ] **Step 4: Capture screenshots**
+
+Save screenshots only if needed for review handoff. Do not commit generated screenshots unless the repo already tracks UI snapshots.
+
+## Chunk 5: Final Checks and Handoff
+
+- [ ] **Step 1: Run Code Review Graph changed-file context**
+
+Use Code Review Graph `detect_changes` or review context with minimal detail before final review.
+
+- [ ] **Step 2: Inspect git diff**
+
+Route `git diff` through context-mode and verify:
+
+- No API/backend/query contract changes.
+- No route sync changes.
+- No unrelated UI refactors.
+
+- [ ] **Step 3: Commit**
+
+Commit after all tests pass:
+
+```bash
+git add src/components/shared/table-filters/FacetedMultiSelectFilter.tsx \
+  src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx \
+  src/components/equipment/equipment-toolbar.tsx \
+  src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+git commit -m "feat(equipment): modernize filter command tokens"
+```
+
+- [ ] **Step 4: Push**
+
+```bash
+git pull --rebase
+git push
+git status
+```
+
+Expected: branch is up to date with remote.

--- a/src/components/equipment/EquipmentOverflowFilters.tsx
+++ b/src/components/equipment/EquipmentOverflowFilters.tsx
@@ -1,0 +1,141 @@
+/**
+ * EquipmentOverflowFilters.tsx
+ *
+ * Inline overflow filter controls for secondary equipment filters.
+ */
+
+"use client"
+
+import * as React from "react"
+import type { ColumnFiltersState, Table } from "@tanstack/react-table"
+import type { LucideIcon } from "lucide-react"
+import { Check, UserRound, WalletCards } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Badge } from "@/components/ui/badge"
+import type { Equipment } from "@/types/database"
+
+const EQUIPMENT_OVERFLOW_FILTERS = [
+  {
+    id: "nguoi_dang_truc_tiep_quan_ly",
+    title: "Người sử dụng",
+    Icon: UserRound,
+  },
+  {
+    id: "nguon_kinh_phi",
+    title: "Nguồn kinh phí",
+    Icon: WalletCards,
+  },
+] as const satisfies readonly {
+  id: string
+  title: string
+  Icon: LucideIcon
+}[]
+
+type EquipmentOverflowFilterId = (typeof EQUIPMENT_OVERFLOW_FILTERS)[number]["id"]
+
+const EQUIPMENT_OVERFLOW_FILTER_IDS = new Set<string>(
+  EQUIPMENT_OVERFLOW_FILTERS.map((filter) => filter.id)
+)
+
+type EquipmentOverflowFiltersProps = {
+  table: Table<Equipment>
+  users: string[]
+  fundingSources: string[]
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string")
+}
+
+function toggleSelection(currentValues: string[], optionValue: string): string[] {
+  if (currentValues.includes(optionValue)) {
+    return currentValues.filter((value) => value !== optionValue)
+  }
+  return [...currentValues, optionValue]
+}
+
+/** Counts selected values owned by the equipment overflow filter group. */
+export function getEquipmentOverflowFilterCount(columnFilters: ColumnFiltersState): number {
+  return columnFilters.reduce((count, filter) => {
+    if (!EQUIPMENT_OVERFLOW_FILTER_IDS.has(filter.id)) return count
+    return count + toStringArray(filter.value).length
+  }, 0)
+}
+
+/** Renders secondary equipment filters as inline controls inside a single popover. */
+export function EquipmentOverflowFilters({
+  table,
+  users,
+  fundingSources,
+}: EquipmentOverflowFiltersProps) {
+  const optionsByFilterId: Record<EquipmentOverflowFilterId, string[]> = {
+    nguoi_dang_truc_tiep_quan_ly: users,
+    nguon_kinh_phi: fundingSources,
+  }
+
+  return (
+    <div className="space-y-3">
+      {EQUIPMENT_OVERFLOW_FILTERS.map(({ id, title, Icon }) => {
+        const column = table.getColumn(id)
+        const selectedValues = toStringArray(column?.getFilterValue())
+        const options = optionsByFilterId[id]
+
+        return (
+          <section key={id} aria-label={title} className="space-y-1.5">
+            <div className="flex items-center gap-2 px-1 text-sm font-semibold text-slate-900">
+              <Icon className="size-3.5 text-muted-foreground" aria-hidden="true" />
+              <span className="min-w-0 flex-1 truncate">{title}</span>
+              {selectedValues.length > 0 ? (
+                <Badge
+                  variant="secondary"
+                  className="h-5 min-w-[20px] rounded-full bg-primary px-1.5 text-xs font-semibold text-white"
+                >
+                  {selectedValues.length}
+                </Badge>
+              ) : null}
+            </div>
+            <div className="space-y-1">
+              {options.length > 0 ? (
+                options.map((option) => {
+                  const isSelected = selectedValues.includes(option)
+                  return (
+                    <button
+                      key={option}
+                      type="button"
+                      aria-label={`${title} ${option}`}
+                      aria-pressed={isSelected}
+                      onClick={() => {
+                        const nextValues = toggleSelection(selectedValues, option)
+                        column?.setFilterValue(nextValues.length ? nextValues : undefined)
+                      }}
+                      className={cn(
+                        "flex min-h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm transition-colors",
+                        "hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                        isSelected ? "bg-primary/10 text-slate-950" : "text-slate-600"
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "flex size-4 shrink-0 items-center justify-center rounded border",
+                          isSelected
+                            ? "border-primary bg-primary text-white"
+                            : "border-slate-300 bg-white"
+                        )}
+                      >
+                        {isSelected ? <Check className="size-3" strokeWidth={3} /> : null}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">{option}</span>
+                    </button>
+                  )
+                })
+              ) : (
+                <p className="px-2 py-1 text-sm text-muted-foreground">Chưa có lựa chọn</p>
+              )}
+            </div>
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/equipment/EquipmentOverflowFilters.tsx
+++ b/src/components/equipment/EquipmentOverflowFilters.tsx
@@ -7,60 +7,22 @@
 "use client"
 
 import * as React from "react"
-import type { ColumnFiltersState, Table } from "@tanstack/react-table"
-import type { LucideIcon } from "lucide-react"
-import { Check, UserRound, WalletCards } from "lucide-react"
+import type { Table } from "@tanstack/react-table"
+import { Check } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import type { Equipment } from "@/types/database"
-
-const EQUIPMENT_OVERFLOW_FILTERS = [
-  {
-    id: "nguoi_dang_truc_tiep_quan_ly",
-    title: "Người sử dụng",
-    Icon: UserRound,
-  },
-  {
-    id: "nguon_kinh_phi",
-    title: "Nguồn kinh phí",
-    Icon: WalletCards,
-  },
-] as const satisfies readonly {
-  id: string
-  title: string
-  Icon: LucideIcon
-}[]
-
-type EquipmentOverflowFilterId = (typeof EQUIPMENT_OVERFLOW_FILTERS)[number]["id"]
-
-const EQUIPMENT_OVERFLOW_FILTER_IDS = new Set<string>(
-  EQUIPMENT_OVERFLOW_FILTERS.map((filter) => filter.id)
-)
+import {
+  EQUIPMENT_OVERFLOW_FILTERS,
+  type EquipmentOverflowFilterId,
+  toStringArray,
+  toggleSelection,
+} from "./EquipmentOverflowFiltersUtils"
 
 type EquipmentOverflowFiltersProps = {
   table: Table<Equipment>
   users: string[]
   fundingSources: string[]
-}
-
-function toStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) return []
-  return value.filter((item): item is string => typeof item === "string")
-}
-
-function toggleSelection(currentValues: string[], optionValue: string): string[] {
-  if (currentValues.includes(optionValue)) {
-    return currentValues.filter((value) => value !== optionValue)
-  }
-  return [...currentValues, optionValue]
-}
-
-/** Counts selected values owned by the equipment overflow filter group. */
-export function getEquipmentOverflowFilterCount(columnFilters: ColumnFiltersState): number {
-  return columnFilters.reduce((count, filter) => {
-    if (!EQUIPMENT_OVERFLOW_FILTER_IDS.has(filter.id)) return count
-    return count + toStringArray(filter.value).length
-  }, 0)
 }
 
 /** Renders secondary equipment filters as inline controls inside a single popover. */
@@ -103,8 +65,9 @@ export function EquipmentOverflowFilters({
                     <button
                       key={option}
                       type="button"
+                      role="checkbox"
                       aria-label={`${title} ${option}`}
-                      aria-pressed={isSelected}
+                      aria-checked={isSelected}
                       onClick={() => {
                         const nextValues = toggleSelection(selectedValues, option)
                         column?.setFilterValue(nextValues.length ? nextValues : undefined)

--- a/src/components/equipment/EquipmentOverflowFilters.tsx
+++ b/src/components/equipment/EquipmentOverflowFilters.tsx
@@ -41,7 +41,7 @@ export function EquipmentOverflowFilters({
       {EQUIPMENT_OVERFLOW_FILTERS.map(({ id, title, Icon }) => {
         const column = table.getColumn(id)
         const selectedValues = toStringArray(column?.getFilterValue())
-        const options = optionsByFilterId[id]
+        const options = optionsByFilterId[id] ?? []
 
         return (
           <section key={id} aria-label={title} className="space-y-1.5">

--- a/src/components/equipment/EquipmentOverflowFiltersUtils.ts
+++ b/src/components/equipment/EquipmentOverflowFiltersUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * EquipmentOverflowFiltersUtils.ts
+ *
+ * Shared constants and value helpers for equipment overflow filters.
+ */
+
+import type { ColumnFiltersState } from "@tanstack/react-table"
+import type { LucideIcon } from "lucide-react"
+import { UserRound, WalletCards } from "lucide-react"
+
+/** Secondary equipment filters grouped behind the desktop overflow trigger. */
+export const EQUIPMENT_OVERFLOW_FILTERS = [
+  {
+    id: "nguoi_dang_truc_tiep_quan_ly",
+    title: "Người sử dụng",
+    Icon: UserRound,
+  },
+  {
+    id: "nguon_kinh_phi",
+    title: "Nguồn kinh phí",
+    Icon: WalletCards,
+  },
+] as const satisfies readonly {
+  id: string
+  title: string
+  Icon: LucideIcon
+}[]
+
+/** Column ids owned by the equipment overflow filter group. */
+export const EQUIPMENT_OVERFLOW_FILTER_IDS = new Set<string>(
+  EQUIPMENT_OVERFLOW_FILTERS.map((filter) => filter.id)
+)
+
+export type EquipmentOverflowFilterId = (typeof EQUIPMENT_OVERFLOW_FILTERS)[number]["id"]
+
+/** Converts unknown TanStack filter values into a stable string array. */
+export function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === "string")
+}
+
+/** Toggles one option in a multi-select filter value array. */
+export function toggleSelection(currentValues: string[], optionValue: string): string[] {
+  if (currentValues.includes(optionValue)) {
+    return currentValues.filter((value) => value !== optionValue)
+  }
+  return [...currentValues, optionValue]
+}
+
+/** Counts selected values owned by the equipment overflow filter group. */
+export function getEquipmentOverflowFilterCount(columnFilters: ColumnFiltersState): number {
+  return columnFilters.reduce((count, filter) => {
+    if (!EQUIPMENT_OVERFLOW_FILTER_IDS.has(filter.id)) return count
+    return count + toStringArray(filter.value).length
+  }, 0)
+}

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -180,11 +180,23 @@ vi.mock("@/hooks/use-toast", () => ({
 
 import { EquipmentToolbar } from "../equipment-toolbar"
 
-function createMockTable() {
+function createMockTable(initialFilterValues: Record<string, string[] | undefined> = {}) {
+  const columns = new Map<
+    string,
+    {
+      getFilterValue: ReturnType<typeof vi.fn>
+      setFilterValue: ReturnType<typeof vi.fn>
+    }
+  >()
   const table = {
-    getColumn: vi.fn().mockReturnValue({
-      getFilterValue: () => undefined,
-      setFilterValue: vi.fn(),
+    getColumn: vi.fn((id: string) => {
+      if (!columns.has(id)) {
+        columns.set(id, {
+          getFilterValue: vi.fn(() => initialFilterValues[id]),
+          setFilterValue: vi.fn(),
+        })
+      }
+      return columns.get(id)
     }),
     resetColumnFilters: vi.fn(),
     getHeaderGroups: () => [],
@@ -192,12 +204,15 @@ function createMockTable() {
     getAllColumns: () => [],
     getState: () => ({ columnFilters: [] }),
   }
-  return table as unknown as Table<Equipment>
+  return {
+    table: table as unknown as Table<Equipment>,
+    columns,
+  }
 }
 
 describe("EquipmentToolbar with shared filters", () => {
   const baseProps = {
-    table: createMockTable(),
+    table: createMockTable().table,
     searchTerm: "",
     onSearchChange: vi.fn(),
     columnFilters: [],
@@ -237,6 +252,20 @@ describe("EquipmentToolbar with shared filters", () => {
 
     expect(screen.getByText("Người sử dụng")).toBeInTheDocument()
     expect(screen.getByText("Nguồn kinh phí")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Người sử dụng User A/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Nguồn kinh phí Ngân sách/i })).toBeInTheDocument()
+  })
+
+  it("applies desktop overflow filter selections inline without nested filter popovers", () => {
+    const { table, columns } = createMockTable()
+    render(<EquipmentToolbar {...baseProps} table={table} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Bộ lọc/i }))
+    fireEvent.click(screen.getByRole("button", { name: /Người sử dụng User A/i }))
+
+    expect(columns.get("nguoi_dang_truc_tiep_quan_ly")?.setFilterValue).toHaveBeenCalledWith([
+      "User A",
+    ])
   })
 
   it("renders desktop filters as command tokens with progressive overflow", () => {
@@ -287,15 +316,10 @@ describe("EquipmentToolbar with shared filters", () => {
     expect(onOpenFilterSheet).toHaveBeenCalled()
   })
 
-  it("shows compact clear command when filters are active", () => {
-    render(
-      <EquipmentToolbar
-        {...baseProps}
-        filterState={{ ...baseProps.filterState, isFiltered: true }}
-      />
-    )
+  it("hides compact clear command when filters are inactive", () => {
+    render(<EquipmentToolbar {...baseProps} />)
 
-    expect(screen.getByRole("button", { name: /^Xóa$/i })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^Xóa$/i })).not.toBeInTheDocument()
   })
 
   it("shows a compact clear command when desktop filters are active", () => {

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -5,185 +5,338 @@
  * after migration, and that mobile/tablet filter sheet still triggers correctly.
  */
 
-import * as React from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import * as React from "react"
+import { describe, it, expect, vi } from "vitest"
 import "@testing-library/jest-dom"
-import { render, screen, fireEvent } from '@testing-library/react'
-import type { Table } from '@tanstack/react-table'
-import type { Equipment } from '@/types/database'
+import { render, screen, fireEvent } from "@testing-library/react"
+import type { Table } from "@tanstack/react-table"
+import type { Equipment } from "@/types/database"
 
 type DropdownStateProps = {
-    open?: boolean
-    setOpen?: React.Dispatch<React.SetStateAction<boolean>>
+  open?: boolean
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 type DropdownChildProps = DropdownStateProps & Record<string, unknown>
 
 type DropdownWithChildrenProps = DropdownStateProps & {
-    children: React.ReactNode
+  children: React.ReactNode
+}
+
+type PopoverStateProps = {
+  open?: boolean
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+type PopoverChildProps = PopoverStateProps & Record<string, unknown>
+
+type PopoverWithChildrenProps = PopoverStateProps & {
+  children: React.ReactNode
 }
 
 /**
  * Mock dynamic imports (QR scanner components) to avoid SSR issues in tests
  */
-vi.mock('next/dynamic', () => ({
-    default: () => () => null,
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
 }))
 
 /**
  * Mock radix DropdownMenu to render inline (no portal in jsdom)
  */
-vi.mock('@/components/ui/dropdown-menu', () => {
-    return {
-        DropdownMenu: ({ children }: { children: React.ReactNode }) => {
-            const [open, setOpen] = React.useState(false)
-            return (
-                <div data-testid="dropdown-menu">
-                    {React.Children.map(children, (child) =>
-                        React.isValidElement(child)
-                            ? React.cloneElement(child as React.ReactElement<DropdownChildProps>, { open, setOpen })
-                            : child
-                    )}
-                </div>
-            )
-        },
-        DropdownMenuTrigger: ({ children, asChild, open, setOpen, ...rest }: DropdownWithChildrenProps & { asChild?: boolean }) => {
-            const toggleDropdownMenu = () => setOpen?.(!open)
-            if (asChild && React.isValidElement(children)) {
-                const childElement = children as React.ReactElement<{ onClick?: (...args: unknown[]) => void }>
-                return React.cloneElement(childElement, {
-                    ...rest,
-                    onClick: (...args: unknown[]) => {
-                        toggleDropdownMenu()
-                            ; childElement.props.onClick?.(...args)
-                    },
+vi.mock("@/components/ui/dropdown-menu", () => {
+  return {
+    DropdownMenu: ({ children }: { children: React.ReactNode }) => {
+      const [open, setOpen] = React.useState(false)
+      return (
+        <div data-testid="dropdown-menu">
+          {React.Children.map(children, (child) =>
+            React.isValidElement(child)
+              ? React.cloneElement(child as React.ReactElement<DropdownChildProps>, {
+                  open,
+                  setOpen,
                 })
-            }
-            return <button {...rest} onClick={toggleDropdownMenu}>{children}</button>
-        },
-        DropdownMenuContent: ({ children, open, ...rest }: DropdownWithChildrenProps) => {
-            if (!open) return null
-            return <div data-testid="dropdown-content" {...rest}>{children}</div>
-        },
-        DropdownMenuItem: ({ children, onSelect, ...rest }: { children: React.ReactNode; onSelect?: () => void } & Record<string, unknown>) => (
-            <button {...rest} onClick={onSelect}>{children}</button>
-        ),
-    }
+              : child
+          )}
+        </div>
+      )
+    },
+    DropdownMenuTrigger: ({
+      children,
+      asChild,
+      open,
+      setOpen,
+      ...rest
+    }: DropdownWithChildrenProps & { asChild?: boolean }) => {
+      const toggleDropdownMenu = () => setOpen?.(!open)
+      if (asChild && React.isValidElement(children)) {
+        const childElement = children as React.ReactElement<{
+          onClick?: (...args: unknown[]) => void
+        }>
+        return React.cloneElement(childElement, {
+          ...rest,
+          onClick: (...args: unknown[]) => {
+            toggleDropdownMenu()
+            childElement.props.onClick?.(...args)
+          },
+        })
+      }
+      return (
+        <button {...rest} onClick={toggleDropdownMenu}>
+          {children}
+        </button>
+      )
+    },
+    DropdownMenuContent: ({
+      children,
+      open,
+      setOpen: _setOpen,
+      ...rest
+    }: DropdownWithChildrenProps) => {
+      if (!open) return null
+      return (
+        <div data-testid="dropdown-content" {...rest}>
+          {children}
+        </div>
+      )
+    },
+    DropdownMenuItem: ({
+      children,
+      onSelect,
+      ...rest
+    }: { children: React.ReactNode; onSelect?: () => void } & Record<string, unknown>) => (
+      <button {...rest} onClick={onSelect}>
+        {children}
+      </button>
+    ),
+  }
 })
 
-vi.mock('@/hooks/use-toast', () => ({
-    useToast: () => ({ toast: vi.fn() }),
+/**
+ * Mock radix Popover so overflow filter content renders inline in jsdom.
+ */
+vi.mock("@/components/ui/popover", () => {
+  return {
+    Popover: ({ children }: { children: React.ReactNode }) => {
+      const [open, setOpen] = React.useState(false)
+      return (
+        <div data-testid="popover">
+          {React.Children.map(children, (child) =>
+            React.isValidElement(child)
+              ? React.cloneElement(child as React.ReactElement<PopoverChildProps>, {
+                  open,
+                  setOpen,
+                })
+              : child
+          )}
+        </div>
+      )
+    },
+    PopoverTrigger: ({
+      children,
+      asChild,
+      open,
+      setOpen,
+      ...rest
+    }: PopoverWithChildrenProps & { asChild?: boolean }) => {
+      const togglePopover = () => setOpen?.(!open)
+      if (asChild && React.isValidElement(children)) {
+        const childElement = children as React.ReactElement<{
+          onClick?: (...args: unknown[]) => void
+        }>
+        return React.cloneElement(childElement, {
+          ...rest,
+          onClick: (...args: unknown[]) => {
+            togglePopover()
+            childElement.props.onClick?.(...args)
+          },
+        })
+      }
+      return (
+        <button {...rest} onClick={togglePopover}>
+          {children}
+        </button>
+      )
+    },
+    PopoverContent: ({
+      children,
+      open,
+      setOpen: _setOpen,
+      ...rest
+    }: PopoverWithChildrenProps & React.HTMLAttributes<HTMLDivElement>) => {
+      if (!open) return null
+      return (
+        <div data-testid="popover-content" {...rest}>
+          {children}
+        </div>
+      )
+    },
+  }
+})
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
 }))
 
-
-import { EquipmentToolbar } from '../equipment-toolbar'
+import { EquipmentToolbar } from "../equipment-toolbar"
 
 function createMockTable() {
-    const table = {
-        getColumn: vi.fn().mockReturnValue({
-            getFilterValue: () => undefined,
-            setFilterValue: vi.fn(),
-        }),
-        resetColumnFilters: vi.fn(),
-        getHeaderGroups: () => [],
-        getRowModel: () => ({ rows: [] }),
-        getAllColumns: () => [],
-        getState: () => ({ columnFilters: [] }),
-    }
-    return table as unknown as Table<Equipment>
+  const table = {
+    getColumn: vi.fn().mockReturnValue({
+      getFilterValue: () => undefined,
+      setFilterValue: vi.fn(),
+    }),
+    resetColumnFilters: vi.fn(),
+    getHeaderGroups: () => [],
+    getRowModel: () => ({ rows: [] }),
+    getAllColumns: () => [],
+    getState: () => ({ columnFilters: [] }),
+  }
+  return table as unknown as Table<Equipment>
 }
 
-describe('EquipmentToolbar with shared filters', () => {
-    const baseProps = {
-        table: createMockTable(),
-        searchTerm: '',
-        onSearchChange: vi.fn(),
-        columnFilters: [],
-        statuses: ['Hoạt động', 'Hỏng'],
-        departments: ['ICU', 'Surgery'],
-        users: ['User A'],
-        classifications: ['Loại A'],
-        fundingSources: ['Ngân sách'],
-        filterMode: 'faceted' as const,
-        filterState: {
-            isFiltered: false,
-            hasFacilityFilter: false,
-        },
-        actionState: {
-            canCreateEquipment: true,
-            isExporting: false,
-        },
-        onOpenFilterSheet: vi.fn(),
-        onOpenColumnsDialog: vi.fn(),
-        onDownloadTemplate: vi.fn(),
-        onExportData: vi.fn(),
-        onAddEquipment: vi.fn(),
-        onImportEquipment: vi.fn(),
-        onClearFacilityFilter: vi.fn(),
-    }
+describe("EquipmentToolbar with shared filters", () => {
+  const baseProps = {
+    table: createMockTable(),
+    searchTerm: "",
+    onSearchChange: vi.fn(),
+    columnFilters: [],
+    statuses: ["Hoạt động", "Hỏng"],
+    departments: ["ICU", "Surgery"],
+    users: ["User A"],
+    classifications: ["Loại A"],
+    fundingSources: ["Ngân sách"],
+    filterMode: "faceted" as const,
+    filterState: {
+      isFiltered: false,
+      hasFacilityFilter: false,
+    },
+    actionState: {
+      canCreateEquipment: true,
+      isExporting: false,
+    },
+    onOpenFilterSheet: vi.fn(),
+    onOpenColumnsDialog: vi.fn(),
+    onDownloadTemplate: vi.fn(),
+    onExportData: vi.fn(),
+    onAddEquipment: vi.fn(),
+    onImportEquipment: vi.fn(),
+    onClearFacilityFilter: vi.fn(),
+  }
 
-    it('renders shared FacetedMultiSelectFilter titles in desktop mode', () => {
-        render(<EquipmentToolbar {...baseProps} />)
+  it("keeps secondary faceted filters available through desktop overflow", () => {
+    render(<EquipmentToolbar {...baseProps} />)
 
-        expect(screen.getByText('Tình trạng')).toBeInTheDocument()
-        expect(screen.getByText('Khoa/Phòng')).toBeInTheDocument()
-        expect(screen.getByText('Người sử dụng')).toBeInTheDocument()
-        expect(screen.getByText('Phân loại')).toBeInTheDocument()
-        expect(screen.getByText('Nguồn kinh phí')).toBeInTheDocument()
-    })
+    expect(screen.getByText("Tình trạng")).toBeInTheDocument()
+    expect(screen.getByText("Khoa/Phòng")).toBeInTheDocument()
+    expect(screen.getByText("Phân loại")).toBeInTheDocument()
+    expect(screen.queryByText("Người sử dụng")).not.toBeInTheDocument()
+    expect(screen.queryByText("Nguồn kinh phí")).not.toBeInTheDocument()
 
-    it('renders mobile filter sheet trigger instead of faceted filters on mobile', () => {
-        render(<EquipmentToolbar {...baseProps} filterMode="sheet" />)
+    fireEvent.click(screen.getByRole("button", { name: /Bộ lọc/i }))
 
-        expect(screen.getByText('Lọc')).toBeInTheDocument()
-        expect(screen.queryByText('Tình trạng')).not.toBeInTheDocument()
-        expect(screen.queryByText('Khoa/Phòng')).not.toBeInTheDocument()
-    })
+    expect(screen.getByText("Người sử dụng")).toBeInTheDocument()
+    expect(screen.getByText("Nguồn kinh phí")).toBeInTheDocument()
+  })
 
-    it('calls onOpenFilterSheet when mobile filter button is clicked', () => {
-        const onOpenFilterSheet = vi.fn()
-        render(<EquipmentToolbar {...baseProps} filterMode="sheet" onOpenFilterSheet={onOpenFilterSheet} />)
+  it("renders desktop filters as command tokens with progressive overflow", () => {
+    render(<EquipmentToolbar {...baseProps} />)
 
-        fireEvent.click(screen.getByText('Lọc'))
-        expect(onOpenFilterSheet).toHaveBeenCalled()
-    })
+    expect(screen.getByRole("button", { name: /Tình trạng/i })).toHaveAttribute(
+      "data-trigger-variant",
+      "command"
+    )
+    expect(screen.getByRole("button", { name: /Khoa\/Phòng/i })).toHaveAttribute(
+      "data-trigger-variant",
+      "command"
+    )
+    expect(screen.getByRole("button", { name: /Phân loại/i })).toHaveAttribute(
+      "data-trigger-variant",
+      "command"
+    )
+    expect(screen.getByRole("button", { name: /Bộ lọc/i })).toBeInTheDocument()
 
-    it('shows clear all button when filters are active', () => {
-        render(
-            <EquipmentToolbar
-                {...baseProps}
-                filterState={{ ...baseProps.filterState, isFiltered: true }}
-            />
-        )
+    expect(screen.queryByRole("button", { name: /Người sử dụng/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Nguồn kinh phí/i })).not.toBeInTheDocument()
+  })
 
-        expect(screen.getByText('Xóa tất cả')).toBeInTheDocument()
-    })
+  it("marks the command filter row as an overflow-safe responsive layout", () => {
+    render(<EquipmentToolbar {...baseProps} />)
 
-    it('hides add actions when create permission is disabled', () => {
-        render(
-            <EquipmentToolbar
-                {...baseProps}
-                actionState={{ ...baseProps.actionState, canCreateEquipment: false }}
-            />
-        )
+    const row = screen.getByTestId("equipment-command-filter-row")
+    expect(row).toHaveAttribute("data-layout", "command-overflow")
+    expect(row.className).toContain("flex-wrap")
+    expect(row.className).toContain("min-w-0")
+  })
 
-        expect(screen.queryByText('Thêm thiết bị')).not.toBeInTheDocument()
-    })
+  it("renders mobile filter sheet trigger instead of faceted filters on mobile", () => {
+    render(<EquipmentToolbar {...baseProps} filterMode="sheet" />)
 
-    it('places selection actions immediately before the add equipment button', () => {
-        render(
-            <EquipmentToolbar
-                {...baseProps}
-                selectionActions={<div data-testid="toolbar-selection-actions">Đã chọn 1 thiết bị</div>}
-            />
-        )
+    expect(screen.getByText("Lọc")).toBeInTheDocument()
+    expect(screen.queryByText("Tình trạng")).not.toBeInTheDocument()
+    expect(screen.queryByText("Khoa/Phòng")).not.toBeInTheDocument()
+  })
 
-        const selectionActions = screen.getByTestId('toolbar-selection-actions')
-        const addButton = screen.getByRole('button', { name: /Thêm thiết bị/i })
+  it("calls onOpenFilterSheet when mobile filter button is clicked", () => {
+    const onOpenFilterSheet = vi.fn()
+    render(
+      <EquipmentToolbar {...baseProps} filterMode="sheet" onOpenFilterSheet={onOpenFilterSheet} />
+    )
 
-        expect(selectionActions.compareDocumentPosition(addButton)).toBe(
-            Node.DOCUMENT_POSITION_FOLLOWING
-        )
-    })
+    fireEvent.click(screen.getByText("Lọc"))
+    expect(onOpenFilterSheet).toHaveBeenCalled()
+  })
 
+  it("shows compact clear command when filters are active", () => {
+    render(
+      <EquipmentToolbar
+        {...baseProps}
+        filterState={{ ...baseProps.filterState, isFiltered: true }}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /^Xóa$/i })).toBeInTheDocument()
+  })
+
+  it("shows a compact clear command when desktop filters are active", () => {
+    render(
+      <EquipmentToolbar
+        {...baseProps}
+        filterState={{ ...baseProps.filterState, isFiltered: true }}
+      />
+    )
+
+    const clearButton = screen.getByRole("button", { name: /^Xóa$/i })
+    expect(clearButton).toBeInTheDocument()
+
+    fireEvent.click(clearButton)
+    expect(baseProps.table.resetColumnFilters).toHaveBeenCalled()
+  })
+
+  it("hides add actions when create permission is disabled", () => {
+    render(
+      <EquipmentToolbar
+        {...baseProps}
+        actionState={{ ...baseProps.actionState, canCreateEquipment: false }}
+      />
+    )
+
+    expect(screen.queryByText("Thêm thiết bị")).not.toBeInTheDocument()
+  })
+
+  it("places selection actions immediately before the add equipment button", () => {
+    render(
+      <EquipmentToolbar
+        {...baseProps}
+        selectionActions={<div data-testid="toolbar-selection-actions">Đã chọn 1 thiết bị</div>}
+      />
+    )
+
+    const selectionActions = screen.getByTestId("toolbar-selection-actions")
+    const addButton = screen.getByRole("button", { name: /Thêm thiết bị/i })
+
+    expect(selectionActions.compareDocumentPosition(addButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  })
 })

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -252,8 +252,8 @@ describe("EquipmentToolbar with shared filters", () => {
 
     expect(screen.getByText("Người sử dụng")).toBeInTheDocument()
     expect(screen.getByText("Nguồn kinh phí")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /Người sử dụng User A/i })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /Nguồn kinh phí Ngân sách/i })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: /Người sử dụng User A/i })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: /Nguồn kinh phí Ngân sách/i })).toBeInTheDocument()
   })
 
   it("applies desktop overflow filter selections inline without nested filter popovers", () => {
@@ -261,7 +261,7 @@ describe("EquipmentToolbar with shared filters", () => {
     render(<EquipmentToolbar {...baseProps} table={table} />)
 
     fireEvent.click(screen.getByRole("button", { name: /Bộ lọc/i }))
-    fireEvent.click(screen.getByRole("button", { name: /Người sử dụng User A/i }))
+    fireEvent.click(screen.getByRole("checkbox", { name: /Người sử dụng User A/i }))
 
     expect(columns.get("nguoi_dang_truc_tiep_quan_ly")?.setFilterValue).toHaveBeenCalledWith([
       "User A",

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -337,6 +337,24 @@ describe("EquipmentToolbar with shared filters", () => {
     expect(baseProps.table.resetColumnFilters).toHaveBeenCalled()
   })
 
+  it("renders facility clear command consistently with desktop clear controls", () => {
+    const onClearFacilityFilter = vi.fn()
+    render(
+      <EquipmentToolbar
+        {...baseProps}
+        filterState={{ ...baseProps.filterState, hasFacilityFilter: true }}
+        onClearFacilityFilter={onClearFacilityFilter}
+      />
+    )
+
+    const facilityClearButton = screen.getByRole("button", { name: /Xóa lọc cơ sở/i })
+    expect(facilityClearButton.className).toContain("h-9")
+    expect(facilityClearButton.className).toContain("rounded-lg")
+
+    fireEvent.click(facilityClearButton)
+    expect(onClearFacilityFilter).toHaveBeenCalled()
+  })
+
   it("hides add actions when create permission is disabled", () => {
     render(
       <EquipmentToolbar

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -32,10 +32,8 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
-import {
-  EquipmentOverflowFilters,
-  getEquipmentOverflowFilterCount,
-} from "./EquipmentOverflowFilters"
+import { EquipmentOverflowFilters } from "./EquipmentOverflowFilters"
+import { getEquipmentOverflowFilterCount } from "./EquipmentOverflowFiltersUtils"
 import { useQRScanner } from "./useEquipmentQRScanner"
 import type { Equipment } from "@/types/database"
 

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -240,9 +240,13 @@ export function EquipmentToolbar({
         </Button>
       )}
       {hasFacilityFilter && (
-        <Button variant="ghost" onClick={onClearFacilityFilter} className="h-8 px-2 lg:px-3">
-          <span className="hidden sm:inline">Xóa lọc cơ sở</span>
-          <FilterX className="size-4 sm:ml-2" />
+        <Button
+          variant="ghost"
+          onClick={onClearFacilityFilter}
+          className="h-9 rounded-lg px-2 text-muted-foreground hover:bg-slate-100 hover:text-foreground lg:px-3"
+        >
+          <FilterX className="size-4" aria-hidden="true" />
+          <span className="ml-1.5 hidden text-sm font-medium sm:inline">Xóa lọc cơ sở</span>
         </Button>
       )}
     </div>

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -19,8 +19,6 @@ import {
   Settings,
   ScanLine,
   Tags,
-  UserRound,
-  WalletCards,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
@@ -34,6 +32,10 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
+import {
+  EquipmentOverflowFilters,
+  getEquipmentOverflowFilterCount,
+} from "./EquipmentOverflowFilters"
 import { useQRScanner } from "./useEquipmentQRScanner"
 import type { Equipment } from "@/types/database"
 
@@ -115,13 +117,7 @@ export function EquipmentToolbar({
     const vals = filter.value as string[] | undefined
     return acc + (vals?.length || 0)
   }, 0)
-  const overflowFilterCount = columnFilters.reduce((acc, filter) => {
-    if (filter.id !== "nguoi_dang_truc_tiep_quan_ly" && filter.id !== "nguon_kinh_phi") {
-      return acc
-    }
-    const vals = filter.value as string[] | undefined
-    return acc + (vals?.length || 0)
-  }, 0)
+  const overflowFilterCount = getEquipmentOverflowFilterCount(columnFilters)
 
   const searchEndAddon = (
     <Button
@@ -231,21 +227,8 @@ export function EquipmentToolbar({
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-64 space-y-2 p-2">
-          <FacetedMultiSelectFilter
-            column={table.getColumn("nguoi_dang_truc_tiep_quan_ly")}
-            title="Người sử dụng"
-            options={users.map((d) => ({ label: d, value: d }))}
-            triggerVariant="command"
-            triggerIcon={<UserRound className="size-3.5" aria-hidden="true" />}
-          />
-          <FacetedMultiSelectFilter
-            column={table.getColumn("nguon_kinh_phi")}
-            title="Nguồn kinh phí"
-            options={fundingSources.map((f) => ({ label: f, value: f }))}
-            triggerVariant="command"
-            triggerIcon={<WalletCards className="size-3.5" aria-hidden="true" />}
-          />
+        <PopoverContent align="start" className="w-72 p-3">
+          <EquipmentOverflowFilters table={table} users={users} fundingSources={fundingSources} />
         </PopoverContent>
       </Popover>
       {isFiltered && (

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -10,7 +10,18 @@
 import * as React from "react"
 import type { Table, ColumnFiltersState } from "@tanstack/react-table"
 import dynamic from "next/dynamic"
-import { Filter, FilterX, PlusCircle, Settings, ScanLine } from "lucide-react"
+import {
+  Building2,
+  Filter,
+  FilterX,
+  ListFilter,
+  PlusCircle,
+  Settings,
+  ScanLine,
+  Tags,
+  UserRound,
+  WalletCards,
+} from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -20,18 +31,19 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { useQRScanner } from "./useEquipmentQRScanner"
 import type { Equipment } from "@/types/database"
 
 const QRScannerCamera = dynamic(
-  () => import("@/components/qr-scanner-camera").then(mod => ({ default: mod.QRScannerCamera })),
+  () => import("@/components/qr-scanner-camera").then((mod) => ({ default: mod.QRScannerCamera })),
   { ssr: false, loading: () => null }
 )
 
 const QRActionSheet = dynamic(
-  () => import("@/components/qr-action-sheet").then(mod => ({ default: mod.QRActionSheet })),
+  () => import("@/components/qr-action-sheet").then((mod) => ({ default: mod.QRActionSheet })),
   { ssr: false, loading: () => null }
 )
 
@@ -68,6 +80,7 @@ export interface EquipmentToolbarProps {
   onShowEquipmentDetails?: (equipment: Equipment) => void
 }
 
+/** Renders the equipment page search, command filters, actions, and QR scanner controls. */
 export function EquipmentToolbar({
   table,
   title,
@@ -99,6 +112,13 @@ export function EquipmentToolbar({
   const { isFiltered, hasFacilityFilter } = filterState
   const { canCreateEquipment, isExporting = false } = actionState
   const activeFilterCount = columnFilters.reduce((acc, filter) => {
+    const vals = filter.value as string[] | undefined
+    return acc + (vals?.length || 0)
+  }, 0)
+  const overflowFilterCount = columnFilters.reduce((acc, filter) => {
+    if (filter.id !== "nguoi_dang_truc_tiep_quan_ly" && filter.id !== "nguon_kinh_phi") {
+      return acc
+    }
     const vals = filter.value as string[] | undefined
     return acc + (vals?.length || 0)
   }, 0)
@@ -150,12 +170,8 @@ export function EquipmentToolbar({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-56">
-          <DropdownMenuItem onSelect={onOpenColumnsDialog}>
-            Hiện/ẩn cột
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={onDownloadTemplate}>
-            Tải Excel mẫu
-          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onOpenColumnsDialog}>Hiện/ẩn cột</DropdownMenuItem>
+          <DropdownMenuItem onSelect={onDownloadTemplate}>Tải Excel mẫu</DropdownMenuItem>
           <DropdownMenuItem onSelect={onExportData} disabled={isExporting}>
             {isExporting ? "Đang tải..." : "Tải về dữ liệu"}
           </DropdownMenuItem>
@@ -165,53 +181,90 @@ export function EquipmentToolbar({
   )
 
   const filterControls = (
-    <>
+    <div
+      data-testid="equipment-command-filter-row"
+      data-layout="command-overflow"
+      className="flex min-w-0 flex-wrap items-center gap-2"
+    >
       <FacetedMultiSelectFilter
         column={table.getColumn("tinh_trang_hien_tai")}
         title="Tình trạng"
-        options={statuses.map(s => ({ label: s, value: s }))}
+        options={statuses.map((s) => ({ label: s, value: s }))}
+        triggerVariant="command"
+        triggerIcon={<Filter className="size-3.5" aria-hidden="true" />}
       />
       <FacetedMultiSelectFilter
         column={table.getColumn("khoa_phong_quan_ly")}
         title="Khoa/Phòng"
-        options={departments.map(d => ({ label: d, value: d }))}
-      />
-      <FacetedMultiSelectFilter
-        column={table.getColumn("nguoi_dang_truc_tiep_quan_ly")}
-        title="Người sử dụng"
-        options={users.map(d => ({ label: d, value: d }))}
+        options={departments.map((d) => ({ label: d, value: d }))}
+        triggerVariant="command"
+        triggerIcon={<Building2 className="size-3.5" aria-hidden="true" />}
       />
       <FacetedMultiSelectFilter
         column={table.getColumn("phan_loai_theo_nd98")}
         title="Phân loại"
-        options={classifications.map(c => ({ label: c, value: c }))}
+        options={classifications.map((c) => ({ label: c, value: c }))}
+        triggerVariant="command"
+        triggerIcon={<Tags className="size-3.5" aria-hidden="true" />}
       />
-      <FacetedMultiSelectFilter
-        column={table.getColumn("nguon_kinh_phi")}
-        title="Nguồn kinh phí"
-        options={fundingSources.map(f => ({ label: f, value: f }))}
-      />
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-9 min-w-[112px] justify-between rounded-lg border-slate-200 bg-slate-100/80 px-3 shadow-none transition-all hover:border-primary/30 hover:bg-slate-100"
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
+                <ListFilter className="size-3.5" aria-hidden="true" />
+              </span>
+              <span className="truncate font-medium">Bộ lọc</span>
+            </span>
+            {overflowFilterCount > 0 && (
+              <Badge
+                variant="secondary"
+                className="ml-2 h-5 min-w-[20px] rounded-full bg-primary px-1.5 text-xs font-semibold text-white"
+              >
+                {overflowFilterCount}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-64 space-y-2 p-2">
+          <FacetedMultiSelectFilter
+            column={table.getColumn("nguoi_dang_truc_tiep_quan_ly")}
+            title="Người sử dụng"
+            options={users.map((d) => ({ label: d, value: d }))}
+            triggerVariant="command"
+            triggerIcon={<UserRound className="size-3.5" aria-hidden="true" />}
+          />
+          <FacetedMultiSelectFilter
+            column={table.getColumn("nguon_kinh_phi")}
+            title="Nguồn kinh phí"
+            options={fundingSources.map((f) => ({ label: f, value: f }))}
+            triggerVariant="command"
+            triggerIcon={<WalletCards className="size-3.5" aria-hidden="true" />}
+          />
+        </PopoverContent>
+      </Popover>
       {isFiltered && (
         <Button
           variant="ghost"
           onClick={() => table.resetColumnFilters()}
-          className="h-8 px-2 lg:px-3"
+          className="h-9 rounded-lg px-2 text-muted-foreground hover:bg-slate-100 hover:text-foreground lg:px-3"
         >
-          <span className="hidden sm:inline">Xóa tất cả</span>
-          <FilterX className="size-4 sm:ml-2" />
+          <FilterX className="size-4" aria-hidden="true" />
+          <span className="ml-1.5 text-sm font-medium">Xóa</span>
         </Button>
       )}
       {hasFacilityFilter && (
-        <Button
-          variant="ghost"
-          onClick={onClearFacilityFilter}
-          className="h-8 px-2 lg:px-3"
-        >
+        <Button variant="ghost" onClick={onClearFacilityFilter} className="h-8 px-2 lg:px-3">
           <span className="hidden sm:inline">Xóa lọc cơ sở</span>
           <FilterX className="size-4 sm:ml-2" />
         </Button>
       )}
-    </>
+    </div>
   )
 
   const actions = (
@@ -221,18 +274,12 @@ export function EquipmentToolbar({
           <DropdownMenuTrigger asChild>
             <Button size="sm" className="hidden md:flex h-8 gap-1 touch-target-sm md:h-8">
               <PlusCircle className="size-3.5" />
-              <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
-                Thêm thiết bị
-              </span>
+              <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">Thêm thiết bị</span>
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onSelect={onAddEquipment}>
-              Thêm thủ công
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={onImportEquipment}>
-              Nhập từ Excel
-            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onAddEquipment}>Thêm thủ công</DropdownMenuItem>
+            <DropdownMenuItem onSelect={onImportEquipment}>Nhập từ Excel</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       )}
@@ -245,12 +292,8 @@ export function EquipmentToolbar({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
-          <DropdownMenuItem onSelect={onOpenColumnsDialog}>
-            Hiện/ẩn cột
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={onDownloadTemplate}>
-            Tải Excel mẫu
-          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onOpenColumnsDialog}>Hiện/ẩn cột</DropdownMenuItem>
+          <DropdownMenuItem onSelect={onDownloadTemplate}>Tải Excel mẫu</DropdownMenuItem>
           <DropdownMenuItem onSelect={onExportData} disabled={isExporting}>
             {isExporting ? "Đang tải..." : "Tải về dữ liệu"}
           </DropdownMenuItem>

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -157,6 +157,17 @@ export function FacetedMultiSelectFilter<TData, TValue>({
     []
   )
 
+  const triggerVariantClassName =
+    triggerVariant === "command"
+      ? "justify-between rounded-lg bg-slate-100/80 px-3 shadow-none hover:border-primary/30 hover:bg-slate-100"
+      : "justify-start shadow-sm"
+  const triggerSelectionClassName =
+    selectedValues.size > 0
+      ? triggerVariant === "command"
+        ? "border-primary/50 bg-primary/10 hover:bg-primary/15"
+        : "border-primary/50 bg-primary/5 hover:bg-primary/10"
+      : "hover:border-primary/30"
+
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
@@ -168,14 +179,8 @@ export function FacetedMultiSelectFilter<TData, TValue>({
           data-trigger-variant={triggerVariant}
           className={cn(
             "h-9 min-w-[132px] border-slate-200 transition-all",
-            triggerVariant === "command"
-              ? "justify-between rounded-lg bg-slate-100/80 px-3 shadow-none hover:border-primary/30 hover:bg-slate-100"
-              : "justify-start shadow-sm",
-            selectedValues?.size > 0
-              ? triggerVariant === "command"
-                ? "border-primary/50 bg-primary/10 hover:bg-primary/15"
-                : "border-primary/50 bg-primary/5 hover:bg-primary/10"
-              : "hover:border-primary/30"
+            triggerVariantClassName,
+            triggerSelectionClassName
           )}
         >
           <div className="flex min-w-0 items-center gap-2">
@@ -185,7 +190,7 @@ export function FacetedMultiSelectFilter<TData, TValue>({
               </span>
             ) : null}
             <span className="truncate font-medium">{title}</span>
-            {selectedValues?.size > 0 && (
+            {selectedValues.size > 0 && (
               <Badge
                 variant="secondary"
                 className="h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -159,7 +159,7 @@ export function FacetedMultiSelectFilter<TData, TValue>({
 
   const triggerVariantClassName =
     triggerVariant === "command"
-      ? "justify-between rounded-lg bg-slate-100/80 px-3 shadow-none hover:border-primary/30 hover:bg-slate-100"
+      ? "justify-between rounded-lg bg-muted/80 px-3 shadow-none hover:border-primary/30 hover:bg-muted"
       : "justify-start shadow-sm"
   const triggerSelectionClassName =
     selectedValues.size > 0

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -26,243 +26,272 @@ const DEFAULT_SEARCH_PLACEHOLDER = "Tìm lựa chọn..."
 const DEFAULT_EMPTY_SEARCH_MESSAGE = "Không tìm thấy lựa chọn phù hợp"
 
 function useDebouncedValue(value: string, delay: number): string {
-    const [debouncedValue, setDebouncedValue] = React.useState(value)
+  const [debouncedValue, setDebouncedValue] = React.useState(value)
 
-    React.useEffect(() => {
-        const timer = window.setTimeout(() => {
-            setDebouncedValue(value)
-        }, delay)
+  React.useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
 
-        return () => window.clearTimeout(timer)
-    }, [delay, value])
+    return () => window.clearTimeout(timer)
+  }, [delay, value])
 
-    return debouncedValue
+  return debouncedValue
 }
 
 export interface FacetedMultiSelectFilterProps<TData, TValue> {
-    column?: Column<TData, TValue>
-    title?: string
-    options: {
-        label: string
-        value: string
-    }[]
-    /** Controlled mode: current selected values (no column needed) */
-    value?: string[]
-    /** Controlled mode: callback when selection changes */
-    onChange?: (values: string[]) => void
-    searchable?: boolean
-    searchPlaceholder?: string
-    searchDebounceMs?: number
-    emptySearchMessage?: string
-    contentClassName?: string
+  column?: Column<TData, TValue>
+  title?: string
+  options: {
+    label: string
+    value: string
+  }[]
+  /** Controlled mode: current selected values (no column needed) */
+  value?: string[]
+  /** Controlled mode: callback when selection changes */
+  onChange?: (values: string[]) => void
+  searchable?: boolean
+  searchPlaceholder?: string
+  searchDebounceMs?: number
+  emptySearchMessage?: string
+  contentClassName?: string
+  triggerVariant?: "outline" | "command"
+  triggerIcon?: React.ReactNode
 }
 
 /** Renders a searchable faceted multi-select filter in column or controlled mode. */
 export function FacetedMultiSelectFilter<TData, TValue>({
-    column,
-    title,
-    options,
-    value: controlledValue,
-    onChange,
-    searchable = true,
-    searchPlaceholder = DEFAULT_SEARCH_PLACEHOLDER,
-    searchDebounceMs = DEFAULT_SEARCH_DEBOUNCE_MS,
-    emptySearchMessage = DEFAULT_EMPTY_SEARCH_MESSAGE,
-    contentClassName,
+  column,
+  title,
+  options,
+  value: controlledValue,
+  onChange,
+  searchable = true,
+  searchPlaceholder = DEFAULT_SEARCH_PLACEHOLDER,
+  searchDebounceMs = DEFAULT_SEARCH_DEBOUNCE_MS,
+  emptySearchMessage = DEFAULT_EMPTY_SEARCH_MESSAGE,
+  contentClassName,
+  triggerVariant = "outline",
+  triggerIcon,
 }: FacetedMultiSelectFilterProps<TData, TValue>) {
-    const [open, setOpen] = React.useState(false)
-    const [optionSearch, setOptionSearch] = React.useState("")
-    const searchInputRef = React.useRef<HTMLInputElement>(null)
-    const firstOptionRef = React.useRef<HTMLButtonElement>(null)
-    const debouncedOptionSearch = useDebouncedValue(optionSearch, searchDebounceMs)
+  const [open, setOpen] = React.useState(false)
+  const [optionSearch, setOptionSearch] = React.useState("")
+  const searchInputRef = React.useRef<HTMLInputElement>(null)
+  const firstOptionRef = React.useRef<HTMLButtonElement>(null)
+  const debouncedOptionSearch = useDebouncedValue(optionSearch, searchDebounceMs)
 
-    // Resolve selected values from either column mode or controlled mode
-    const isControlled = controlledValue !== undefined
-    const selectedFilterValue = isControlled
-        ? controlledValue
-        : (column?.getFilterValue() as string[] | undefined)
-    const selectedValues = React.useMemo(
-        () => new Set(selectedFilterValue || []),
-        [selectedFilterValue]
+  // Resolve selected values from either column mode or controlled mode
+  const isControlled = controlledValue !== undefined
+  const selectedFilterValue = isControlled
+    ? controlledValue
+    : (column?.getFilterValue() as string[] | undefined)
+  const selectedValues = React.useMemo(
+    () => new Set(selectedFilterValue || []),
+    [selectedFilterValue]
+  )
+
+  const visibleOptions = React.useMemo(() => {
+    const normalizedSearch = normalizeSearchText(debouncedOptionSearch)
+    if (!normalizedSearch) return options
+    return options.filter(
+      (option) =>
+        includesNormalizedSearch(option.label, normalizedSearch) ||
+        includesNormalizedSearch(option.value, normalizedSearch)
     )
+  }, [debouncedOptionSearch, options])
 
-    const visibleOptions = React.useMemo(() => {
-        const normalizedSearch = normalizeSearchText(debouncedOptionSearch)
-        if (!normalizedSearch) return options
-        return options.filter((option) =>
-            includesNormalizedSearch(option.label, normalizedSearch) ||
-            includesNormalizedSearch(option.value, normalizedSearch)
-        )
-    }, [debouncedOptionSearch, options])
+  const handleOpenChange = React.useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      setOptionSearch("")
+    }
+    setOpen(nextOpen)
+  }, [])
 
-    const handleOpenChange = React.useCallback((nextOpen: boolean) => {
-        if (!nextOpen) {
-            setOptionSearch("")
-        }
-        setOpen(nextOpen)
-    }, [])
+  React.useEffect(() => {
+    if (!open) return
+    if (!searchable) return
 
-    React.useEffect(() => {
-        if (!open) return
-        if (!searchable) return
+    const timer = window.setTimeout(() => {
+      searchInputRef.current?.focus()
+    }, 0)
 
-        const timer = window.setTimeout(() => {
-            searchInputRef.current?.focus()
-        }, 0)
+    return () => window.clearTimeout(timer)
+  }, [open, searchable])
 
-        return () => window.clearTimeout(timer)
-    }, [open, searchable])
+  const updateSelectedValues = React.useCallback(
+    (filterValues: string[]) => {
+      if (isControlled) {
+        onChange?.(filterValues)
+        return
+      }
 
-    const updateSelectedValues = React.useCallback((filterValues: string[]) => {
-        if (isControlled) {
-            onChange?.(filterValues)
-            return
-        }
+      column?.setFilterValue(filterValues.length ? filterValues : undefined)
+    },
+    [column, isControlled, onChange]
+  )
 
-        column?.setFilterValue(filterValues.length ? filterValues : undefined)
-    }, [column, isControlled, onChange])
+  const handleOptionToggle = React.useCallback(
+    (optionValue: string) => {
+      const nextValues = new Set(selectedValues)
+      if (nextValues.has(optionValue)) {
+        nextValues.delete(optionValue)
+      } else {
+        nextValues.add(optionValue)
+      }
+      updateSelectedValues(Array.from(nextValues))
+    },
+    [selectedValues, updateSelectedValues]
+  )
 
-    const handleOptionToggle = React.useCallback((optionValue: string) => {
-        const nextValues = new Set(selectedValues)
-        if (nextValues.has(optionValue)) {
-            nextValues.delete(optionValue)
-        } else {
-            nextValues.add(optionValue)
-        }
-        updateSelectedValues(Array.from(nextValues))
-    }, [selectedValues, updateSelectedValues])
+  const handleClear = React.useCallback(() => {
+    updateSelectedValues([])
+  }, [updateSelectedValues])
 
-    const handleClear = React.useCallback(() => {
-        updateSelectedValues([])
-    }, [updateSelectedValues])
+  const handleOptionSearchKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault()
+        firstOptionRef.current?.focus()
+      }
+    },
+    []
+  )
 
-    const handleOptionSearchKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.key === "ArrowDown") {
-            event.preventDefault()
-            firstOptionRef.current?.focus()
-        }
-    }, [])
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-haspopup="dialog"
+          data-trigger-variant={triggerVariant}
+          className={cn(
+            "h-9 min-w-[132px] border-slate-200 transition-all",
+            triggerVariant === "command"
+              ? "justify-between rounded-lg bg-slate-100/80 px-3 shadow-none hover:border-primary/30 hover:bg-slate-100"
+              : "justify-start shadow-sm",
+            selectedValues?.size > 0
+              ? triggerVariant === "command"
+                ? "border-primary/50 bg-primary/10 hover:bg-primary/15"
+                : "border-primary/50 bg-primary/5 hover:bg-primary/10"
+              : "hover:border-primary/30"
+          )}
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            {triggerIcon ? (
+              <span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
+                {triggerIcon}
+              </span>
+            ) : null}
+            <span className="truncate font-medium">{title}</span>
+            {selectedValues?.size > 0 && (
+              <Badge
+                variant="secondary"
+                className="h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"
+              >
+                {selectedValues.size}
+              </Badge>
+            )}
+          </div>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className={cn(
+          "w-[min(420px,calc(100vw-2rem))] max-h-[440px] overflow-hidden rounded-xl border border-slate-200 p-0 shadow-lg",
+          contentClassName
+        )}
+        align="start"
+      >
+        {/* Header */}
+        <div className="px-3 py-2.5 border-b border-slate-100 bg-slate-50/50">
+          <div className="flex items-center gap-2">
+            <Filter className="size-4 text-primary" />
+            <span className="font-semibold text-sm text-slate-900">{title}</span>
+          </div>
+        </div>
 
-    return (
-        <Popover open={open} onOpenChange={handleOpenChange}>
-            <PopoverTrigger asChild>
-                <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    aria-haspopup="dialog"
-                    className={cn(
-                        "h-9 min-w-[132px] justify-start border-slate-200 shadow-sm transition-all",
-                        selectedValues?.size > 0
-                            ? "border-primary/50 bg-primary/5 hover:bg-primary/10"
-                            : "hover:border-primary/30"
-                    )}
-                >
-                    <div className="flex items-center gap-2">
-                        <span className="font-medium">{title}</span>
-                        {selectedValues?.size > 0 && (
-                            <Badge
-                                variant="secondary"
-                                className="h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"
-                            >
-                                {selectedValues.size}
-                            </Badge>
-                        )}
-                    </div>
-                </Button>
-            </PopoverTrigger>
-            <PopoverContent
+        {searchable ? (
+          <div className="border-b border-slate-100 p-2">
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                ref={searchInputRef}
+                type="search"
+                value={optionSearch}
+                onChange={(event) => setOptionSearch(event.target.value)}
+                onKeyDown={handleOptionSearchKeyDown}
+                aria-label={`Tìm lựa chọn ${title ?? "bộ lọc"}`}
+                placeholder={searchPlaceholder}
+                className="h-9 pl-9"
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {/* Options List */}
+        <div className="max-h-[300px] overflow-y-auto py-1">
+          {visibleOptions.length === 0 ? (
+            <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+              {emptySearchMessage}
+            </div>
+          ) : null}
+          {visibleOptions.map((option, index) => {
+            const isSelected = selectedValues.has(option.value)
+            return (
+              <button
+                ref={index === 0 ? firstOptionRef : undefined}
+                type="button"
+                key={option.value}
+                onClick={() => handleOptionToggle(option.value)}
+                aria-pressed={isSelected}
                 className={cn(
-                    "w-[min(420px,calc(100vw-2rem))] max-h-[440px] overflow-hidden rounded-xl border border-slate-200 p-0 shadow-lg",
-                    contentClassName
+                  "w-full flex items-center gap-3 px-3 py-2.5 text-sm transition-colors",
+                  "hover:bg-slate-50 active:bg-slate-100",
+                  isSelected && "bg-primary/5 hover:bg-primary/10"
                 )}
-                align="start"
+              >
+                <div
+                  className={cn(
+                    "flex items-center justify-center size-5 rounded border-2 transition-all shrink-0",
+                    isSelected
+                      ? "bg-primary border-primary"
+                      : "border-slate-300 hover:border-primary/50"
+                  )}
+                >
+                  {isSelected && <Check className="size-3.5 text-white" strokeWidth={3} />}
+                </div>
+                <span
+                  className={cn(
+                    "truncate text-left flex-1",
+                    isSelected ? "font-medium text-slate-900" : "text-slate-600"
+                  )}
+                >
+                  {option.label}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+
+        {/* Footer — Clear button */}
+        {selectedValues.size > 0 && (
+          <div className="border-t border-slate-100 p-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleClear}
+              className="w-full h-8 text-xs font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100"
             >
-                {/* Header */}
-                <div className="px-3 py-2.5 border-b border-slate-100 bg-slate-50/50">
-                    <div className="flex items-center gap-2">
-                        <Filter className="size-4 text-primary" />
-                        <span className="font-semibold text-sm text-slate-900">{title}</span>
-                    </div>
-                </div>
-
-                {searchable ? (
-                    <div className="border-b border-slate-100 p-2">
-                        <div className="relative">
-                            <Search
-                                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-                                aria-hidden="true"
-                            />
-                            <Input
-                                ref={searchInputRef}
-                                type="search"
-                                value={optionSearch}
-                                onChange={(event) => setOptionSearch(event.target.value)}
-                                onKeyDown={handleOptionSearchKeyDown}
-                                aria-label={`Tìm lựa chọn ${title ?? "bộ lọc"}`}
-                                placeholder={searchPlaceholder}
-                                className="h-9 pl-9"
-                            />
-                        </div>
-                    </div>
-                ) : null}
-
-                {/* Options List */}
-                <div className="max-h-[300px] overflow-y-auto py-1">
-                    {visibleOptions.length === 0 ? (
-                        <div className="px-3 py-6 text-center text-sm text-muted-foreground">
-                            {emptySearchMessage}
-                        </div>
-                    ) : null}
-                    {visibleOptions.map((option, index) => {
-                        const isSelected = selectedValues.has(option.value)
-                        return (
-                            <button
-                                ref={index === 0 ? firstOptionRef : undefined}
-                                type="button"
-                                key={option.value}
-                                onClick={() => handleOptionToggle(option.value)}
-                                aria-pressed={isSelected}
-                                className={cn(
-                                    "w-full flex items-center gap-3 px-3 py-2.5 text-sm transition-colors",
-                                    "hover:bg-slate-50 active:bg-slate-100",
-                                    isSelected && "bg-primary/5 hover:bg-primary/10"
-                                )}
-                            >
-                                <div className={cn(
-                                    "flex items-center justify-center size-5 rounded border-2 transition-all shrink-0",
-                                    isSelected
-                                        ? "bg-primary border-primary"
-                                        : "border-slate-300 hover:border-primary/50"
-                                )}>
-                                    {isSelected && <Check className="size-3.5 text-white" strokeWidth={3} />}
-                                </div>
-                                <span className={cn(
-                                    "truncate text-left flex-1",
-                                    isSelected ? "font-medium text-slate-900" : "text-slate-600"
-                                )}>
-                                    {option.label}
-                                </span>
-                            </button>
-                        )
-                    })}
-                </div>
-
-                {/* Footer — Clear button */}
-                {selectedValues.size > 0 && (
-                    <div className="border-t border-slate-100 p-2">
-                        <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleClear}
-                            className="w-full h-8 text-xs font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100"
-                        >
-                            Xóa bộ lọc
-                        </Button>
-                    </div>
-                )}
-            </PopoverContent>
-        </Popover>
-    )
+              Xóa bộ lọc
+            </Button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
 }

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
@@ -1,312 +1,325 @@
-import * as React from 'react'
-import { afterEach, describe, it, expect, vi } from 'vitest'
+import * as React from "react"
+import { afterEach, describe, it, expect, vi } from "vitest"
 import "@testing-library/jest-dom"
-import { act, render, screen, fireEvent } from '@testing-library/react'
+import { act, render, screen, fireEvent } from "@testing-library/react"
 import {
-    getCoreRowModel,
-    getFacetedRowModel,
-    getFacetedUniqueValues,
-    getFilteredRowModel,
-    useReactTable,
-    type ColumnFiltersState,
-    type ColumnDef,
-} from '@tanstack/react-table'
+  getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  getFilteredRowModel,
+  useReactTable,
+  type ColumnFiltersState,
+  type ColumnDef,
+} from "@tanstack/react-table"
 
 type PopoverStateProps = {
-    open?: boolean
-    setOpen?: React.Dispatch<React.SetStateAction<boolean>>
+  open?: boolean
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 type PopoverTriggerProps = PopoverStateProps & {
-    asChild?: boolean
-    children: React.ReactNode
-    onClick?: (...args: unknown[]) => void
+  asChild?: boolean
+  children: React.ReactNode
+  onClick?: (...args: unknown[]) => void
 } & Record<string, unknown>
 
 type PopoverContentProps = PopoverStateProps & {
-    children: React.ReactNode
+  children: React.ReactNode
 } & React.HTMLAttributes<HTMLDivElement>
 
 /**
  * Mock radix Popover so content renders inline (no portal / no jsdom issues).
  */
-vi.mock('@/components/ui/popover', () => {
-    const Trigger = ({ children, asChild, open, setOpen, ...rest }: PopoverTriggerProps) => {
-        const togglePopover = () => setOpen?.(!open)
-        if (asChild && React.isValidElement(children)) {
-            const childElement = children as React.ReactElement<{ onClick?: (...args: unknown[]) => void }>
-            return React.cloneElement(childElement, {
-                ...rest,
-                onClick: (...args: unknown[]) => {
-                    togglePopover()
-                    childElement.props.onClick?.(...args)
-                },
-            })
-        }
-        return <button {...rest} onClick={togglePopover}>{children}</button>
+vi.mock("@/components/ui/popover", () => {
+  const Trigger = ({ children, asChild, open, setOpen, ...rest }: PopoverTriggerProps) => {
+    const togglePopover = () => setOpen?.(!open)
+    if (asChild && React.isValidElement(children)) {
+      const childElement = children as React.ReactElement<{
+        onClick?: (...args: unknown[]) => void
+      }>
+      return React.cloneElement(childElement, {
+        ...rest,
+        onClick: (...args: unknown[]) => {
+          togglePopover()
+          childElement.props.onClick?.(...args)
+        },
+      })
     }
+    return (
+      <button {...rest} onClick={togglePopover}>
+        {children}
+      </button>
+    )
+  }
 
-    return {
-        Popover: ({ children }: { children: React.ReactNode }) => {
-            const [open, setOpen] = React.useState(false)
-            return (
-                <div data-testid="popover">
-                    {React.Children.map(children, (child) =>
-                        React.isValidElement(child)
-                            ? React.cloneElement(child as React.ReactElement<PopoverStateProps>, { open, setOpen })
-                            : child
-                    )}
-                </div>
-            )
-        },
-        PopoverTrigger: Trigger,
-        PopoverContent: ({ children, open, setOpen: _setOpen, ...rest }: PopoverContentProps) => {
-            if (!open) return null
-            return <dialog data-testid="popover-content" open {...rest}>{children}</dialog>
-        },
-    }
+  return {
+    Popover: ({ children }: { children: React.ReactNode }) => {
+      const [open, setOpen] = React.useState(false)
+      return (
+        <div data-testid="popover">
+          {React.Children.map(children, (child) =>
+            React.isValidElement(child)
+              ? React.cloneElement(child as React.ReactElement<PopoverStateProps>, {
+                  open,
+                  setOpen,
+                })
+              : child
+          )}
+        </div>
+      )
+    },
+    PopoverTrigger: Trigger,
+    PopoverContent: ({ children, open, setOpen: _setOpen, ...rest }: PopoverContentProps) => {
+      if (!open) return null
+      return (
+        <dialog data-testid="popover-content" open {...rest}>
+          {children}
+        </dialog>
+      )
+    },
+  }
 })
 
-import { FacetedMultiSelectFilter } from '../FacetedMultiSelectFilter'
+import { FacetedMultiSelectFilter } from "../FacetedMultiSelectFilter"
 
 type Row = { id: number; department: string }
 
 const DATA: Row[] = [
-    { id: 1, department: 'ICU' },
-    { id: 2, department: 'Surgery' },
-    { id: 3, department: 'Radiology' },
-    { id: 4, department: 'ICU' },
+  { id: 1, department: "ICU" },
+  { id: 2, department: "Surgery" },
+  { id: 3, department: "Radiology" },
+  { id: 4, department: "ICU" },
 ]
 
 const COLUMNS: ColumnDef<Row>[] = [
-    {
-        accessorKey: 'department',
-        header: 'Department',
-        filterFn: (row, id, value: string[]) => {
-            return value.includes(row.getValue(id) as string)
-        },
+  {
+    accessorKey: "department",
+    header: "Department",
+    filterFn: (row, id, value: string[]) => {
+      return value.includes(row.getValue(id) as string)
     },
+  },
 ]
 
 const OPTIONS = [
-    { label: 'ICU', value: 'ICU' },
-    { label: 'Surgery', value: 'Surgery' },
-    { label: 'Radiology', value: 'Radiology' },
+  { label: "ICU", value: "ICU" },
+  { label: "Surgery", value: "Surgery" },
+  { label: "Radiology", value: "Radiology" },
 ]
 
 const FACILITY_OPTIONS = [
-    { label: 'Bệnh viện Đa khoa Cần Thơ', value: 'can-tho' },
-    { label: 'Bệnh viện Đa khoa An Giang', value: 'an-giang' },
+  { label: "Bệnh viện Đa khoa Cần Thơ", value: "can-tho" },
+  { label: "Bệnh viện Đa khoa An Giang", value: "an-giang" },
 ]
 
 const EMPTY_CONTROLLED_VALUE: string[] = []
 
 afterEach(() => {
-    vi.useRealTimers()
+  vi.useRealTimers()
 })
 
 /**
  * Test wrapper with real TanStack Table for integration testing.
  */
 function Wrapper({ onFilterChange }: { onFilterChange?: (values: string[] | undefined) => void }) {
-    const [columnFilters, setColumnFilters] = React.useReducer(
-        (_state: ColumnFiltersState, next: ColumnFiltersState) => next,
-        [] as ColumnFiltersState
-    )
-    const table = useReactTable({
-        data: DATA,
-        columns: COLUMNS,
-        state: { columnFilters },
-        onColumnFiltersChange: (updater) => {
-            const next = typeof updater === 'function' ? updater(columnFilters) : updater
-            setColumnFilters(next)
-            const deptFilter = next.find((f) => f.id === 'department')
-            onFilterChange?.(deptFilter?.value as string[] | undefined)
-        },
-        getCoreRowModel: getCoreRowModel(),
-        getFilteredRowModel: getFilteredRowModel(),
-        getFacetedRowModel: getFacetedRowModel(),
-        getFacetedUniqueValues: getFacetedUniqueValues(),
-    })
+  const [columnFilters, setColumnFilters] = React.useReducer(
+    (_state: ColumnFiltersState, next: ColumnFiltersState) => next,
+    [] as ColumnFiltersState
+  )
+  const table = useReactTable({
+    data: DATA,
+    columns: COLUMNS,
+    state: { columnFilters },
+    onColumnFiltersChange: (updater) => {
+      const next = typeof updater === "function" ? updater(columnFilters) : updater
+      setColumnFilters(next)
+      const deptFilter = next.find((f) => f.id === "department")
+      onFilterChange?.(deptFilter?.value as string[] | undefined)
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+  })
 
-    return (
-        <FacetedMultiSelectFilter
-            column={table.getColumn('department')}
-            title="Khoa/Phòng"
-            options={OPTIONS}
-        />
-    )
+  return (
+    <FacetedMultiSelectFilter
+      column={table.getColumn("department")}
+      title="Khoa/Phòng"
+      options={OPTIONS}
+    />
+  )
 }
 
 function NoColumnWrapper() {
-    return <FacetedMultiSelectFilter title="Empty" options={OPTIONS} />
+  return <FacetedMultiSelectFilter title="Empty" options={OPTIONS} />
 }
 
-describe('FacetedMultiSelectFilter', () => {
-    it('renders title on the trigger button', () => {
-        render(<Wrapper />)
-        expect(screen.getByText('Khoa/Phòng')).toBeInTheDocument()
+describe("FacetedMultiSelectFilter", () => {
+  it("renders title on the trigger button", () => {
+    render(<Wrapper />)
+    expect(screen.getByText("Khoa/Phòng")).toBeInTheDocument()
+  })
+
+  it("shows all options when dropdown is opened", () => {
+    render(<Wrapper />)
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+
+    expect(screen.getByRole("button", { name: "ICU" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Surgery" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Radiology" })).toBeInTheDocument()
+  })
+
+  it("debounces internal option search before filtering visible options", async () => {
+    vi.useFakeTimers()
+    render(<Wrapper />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+    const optionSearch = screen.getByRole("searchbox", { name: "Tìm lựa chọn Khoa/Phòng" })
+
+    fireEvent.change(optionSearch, { target: { value: "radio" } })
+
+    expect(screen.getByRole("button", { name: "ICU" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Surgery" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Radiology" })).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
+    expect(screen.getByRole("button", { name: "ICU" })).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
     })
 
-    it('shows all options when dropdown is opened', () => {
-        render(<Wrapper />)
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
+    expect(screen.queryByRole("button", { name: "ICU" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Surgery" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Radiology" })).toBeInTheDocument()
+  })
 
-        expect(screen.getByRole('button', { name: 'ICU' })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Surgery' })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Radiology' })).toBeInTheDocument()
+  it("matches option search without accents or case sensitivity", async () => {
+    vi.useFakeTimers()
+    render(<FacetedMultiSelectFilter title="Cơ sở" options={FACILITY_OPTIONS} />)
+    fireEvent.click(screen.getByText("Cơ sở"))
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Tìm lựa chọn Cơ sở" }), {
+      target: { value: "can tho" },
     })
 
-    it('debounces internal option search before filtering visible options', async () => {
-        vi.useFakeTimers()
-        render(<Wrapper />)
-
-        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
-        const optionSearch = screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' })
-
-        fireEvent.change(optionSearch, { target: { value: 'radio' } })
-
-        expect(screen.getByRole('button', { name: 'ICU' })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Surgery' })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Radiology' })).toBeInTheDocument()
-
-        act(() => {
-            vi.advanceTimersByTime(299)
-        })
-        expect(screen.getByRole('button', { name: 'ICU' })).toBeInTheDocument()
-
-        act(() => {
-            vi.advanceTimersByTime(1)
-        })
-
-        expect(screen.queryByRole('button', { name: 'ICU' })).not.toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Surgery' })).not.toBeInTheDocument()
-        expect(screen.getByRole('button', { name: 'Radiology' })).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(300)
     })
 
-    it('matches option search without accents or case sensitivity', async () => {
-        vi.useFakeTimers()
-        render(<FacetedMultiSelectFilter title="Cơ sở" options={FACILITY_OPTIONS} />)
-        fireEvent.click(screen.getByText('Cơ sở'))
+    expect(screen.getByRole("button", { name: "Bệnh viện Đa khoa Cần Thơ" })).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Bệnh viện Đa khoa An Giang" })
+    ).not.toBeInTheDocument()
+  })
 
-        fireEvent.change(screen.getByRole('searchbox', { name: 'Tìm lựa chọn Cơ sở' }), {
-            target: { value: 'can tho' },
-        })
+  it("does not change filter selection while typing internal option search", async () => {
+    vi.useFakeTimers()
+    const onFilterChange = vi.fn()
+    render(<Wrapper onFilterChange={onFilterChange} />)
 
-        act(() => {
-            vi.advanceTimersByTime(300)
-        })
-
-        expect(screen.getByRole('button', { name: 'Bệnh viện Đa khoa Cần Thơ' })).toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Bệnh viện Đa khoa An Giang' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+    fireEvent.change(screen.getByRole("searchbox", { name: "Tìm lựa chọn Khoa/Phòng" }), {
+      target: { value: "icu" },
     })
 
-    it('does not change filter selection while typing internal option search', async () => {
-        vi.useFakeTimers()
-        const onFilterChange = vi.fn()
-        render(<Wrapper onFilterChange={onFilterChange} />)
-
-        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
-        fireEvent.change(screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' }), {
-            target: { value: 'icu' },
-        })
-
-        act(() => {
-            vi.advanceTimersByTime(300)
-        })
-
-        expect(onFilterChange).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(300)
     })
 
-    it('shows empty state when internal option search has no match', async () => {
-        vi.useFakeTimers()
-        render(<Wrapper />)
+    expect(onFilterChange).not.toHaveBeenCalled()
+  })
 
-        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
-        fireEvent.change(screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' }), {
-            target: { value: 'zzz' },
-        })
+  it("shows empty state when internal option search has no match", async () => {
+    vi.useFakeTimers()
+    render(<Wrapper />)
 
-        act(() => {
-            vi.advanceTimersByTime(300)
-        })
-
-        expect(screen.getByText('Không tìm thấy lựa chọn phù hợp')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+    fireEvent.change(screen.getByRole("searchbox", { name: "Tìm lựa chọn Khoa/Phòng" }), {
+      target: { value: "zzz" },
     })
 
-    it('moves focus from option search to first visible option on ArrowDown', async () => {
-        vi.useFakeTimers()
-        render(<Wrapper />)
-
-        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
-        const optionSearch = screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' })
-        optionSearch.focus()
-
-        fireEvent.keyDown(optionSearch, { key: 'ArrowDown' })
-
-        expect(screen.getByRole('button', { name: 'ICU' })).toHaveFocus()
+    act(() => {
+      vi.advanceTimersByTime(300)
     })
 
-    it('selects an option and calls column.setFilterValue', () => {
-        const onFilterChange = vi.fn()
-        render(<Wrapper onFilterChange={onFilterChange} />)
+    expect(screen.getByText("Không tìm thấy lựa chọn phù hợp")).toBeInTheDocument()
+  })
 
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
+  it("moves focus from option search to first visible option on ArrowDown", async () => {
+    vi.useFakeTimers()
+    render(<Wrapper />)
 
-        expect(onFilterChange).toHaveBeenCalledWith(['ICU'])
-    })
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+    const optionSearch = screen.getByRole("searchbox", { name: "Tìm lựa chọn Khoa/Phòng" })
+    optionSearch.focus()
 
-    it('supports multi-select toggle', () => {
-        const onFilterChange = vi.fn()
-        render(<Wrapper onFilterChange={onFilterChange} />)
+    fireEvent.keyDown(optionSearch, { key: "ArrowDown" })
 
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
-        fireEvent.click(screen.getByRole('button', { name: 'Surgery' }))
+    expect(screen.getByRole("button", { name: "ICU" })).toHaveFocus()
+  })
 
-        expect(onFilterChange).toHaveBeenLastCalledWith(
-            expect.arrayContaining(['ICU', 'Surgery'])
-        )
-    })
+  it("selects an option and calls column.setFilterValue", () => {
+    const onFilterChange = vi.fn()
+    render(<Wrapper onFilterChange={onFilterChange} />)
 
-    it('deselects an option when clicked again', () => {
-        const onFilterChange = vi.fn()
-        render(<Wrapper onFilterChange={onFilterChange} />)
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
 
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
+    expect(onFilterChange).toHaveBeenCalledWith(["ICU"])
+  })
 
-        expect(onFilterChange).toHaveBeenLastCalledWith(undefined)
-    })
+  it("supports multi-select toggle", () => {
+    const onFilterChange = vi.fn()
+    render(<Wrapper onFilterChange={onFilterChange} />)
 
-    it('shows selected count badge when options are selected', () => {
-        render(<Wrapper />)
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
+    fireEvent.click(screen.getByRole("button", { name: "Surgery" }))
 
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
-        fireEvent.click(screen.getByRole('button', { name: 'Surgery' }))
+    expect(onFilterChange).toHaveBeenLastCalledWith(expect.arrayContaining(["ICU", "Surgery"]))
+  })
 
-        expect(screen.getByText('2')).toBeInTheDocument()
-    })
+  it("deselects an option when clicked again", () => {
+    const onFilterChange = vi.fn()
+    render(<Wrapper onFilterChange={onFilterChange} />)
 
-    it('clears all selections when clear button is clicked', () => {
-        const onFilterChange = vi.fn()
-        render(<Wrapper onFilterChange={onFilterChange} />)
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
 
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
-        fireEvent.click(screen.getByRole('button', { name: 'Surgery' }))
-        fireEvent.click(screen.getByText('Xóa bộ lọc'))
+    expect(onFilterChange).toHaveBeenLastCalledWith(undefined)
+  })
 
-        expect(onFilterChange).toHaveBeenLastCalledWith(undefined)
-    })
+  it("shows selected count badge when options are selected", () => {
+    render(<Wrapper />)
 
-    it('handles undefined column gracefully without crashing', () => {
-        expect(() => render(<NoColumnWrapper />)).not.toThrow()
-        expect(screen.getByText('Empty')).toBeInTheDocument()
-    })
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
+    fireEvent.click(screen.getByRole("button", { name: "Surgery" }))
+
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("clears all selections when clear button is clicked", () => {
+    const onFilterChange = vi.fn()
+    render(<Wrapper onFilterChange={onFilterChange} />)
+
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
+    fireEvent.click(screen.getByRole("button", { name: "Surgery" }))
+    fireEvent.click(screen.getByText("Xóa bộ lọc"))
+
+    expect(onFilterChange).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it("handles undefined column gracefully without crashing", () => {
+    expect(() => render(<NoColumnWrapper />)).not.toThrow()
+    expect(screen.getByText("Empty")).toBeInTheDocument()
+  })
 })
 
 // ============================================
@@ -314,99 +327,117 @@ describe('FacetedMultiSelectFilter', () => {
 // ============================================
 
 function ControlledWrapper({
-    initialValue = EMPTY_CONTROLLED_VALUE,
-    onChange,
+  initialValue = EMPTY_CONTROLLED_VALUE,
+  onChange,
 }: {
-    initialValue?: string[]
-    onChange?: (values: string[]) => void
+  initialValue?: string[]
+  onChange?: (values: string[]) => void
 }) {
-    const [value, setValue] = React.useReducer(
-        (_state: string[], next: string[]) => next,
-        initialValue
-    )
-    const syncSelectedValues = (newValues: string[]) => {
-        setValue(newValues)
-        onChange?.(newValues)
-    }
-    return (
-        <FacetedMultiSelectFilter
-            title="Khoa/Phòng"
-            options={OPTIONS}
-            value={value}
-            onChange={syncSelectedValues}
-        />
-    )
+  const [value, setValue] = React.useReducer(
+    (_state: string[], next: string[]) => next,
+    initialValue
+  )
+  const syncSelectedValues = (newValues: string[]) => {
+    setValue(newValues)
+    onChange?.(newValues)
+  }
+  return (
+    <FacetedMultiSelectFilter
+      title="Khoa/Phòng"
+      options={OPTIONS}
+      value={value}
+      onChange={syncSelectedValues}
+    />
+  )
 }
 
-describe('FacetedMultiSelectFilter — controlled mode', () => {
-    it('renders pre-selected values from controlled value prop', () => {
-        render(<ControlledWrapper initialValue={['ICU']} />)
+describe("FacetedMultiSelectFilter — controlled mode", () => {
+  it("renders command trigger variant without changing dropdown behavior", () => {
+    const onChange = vi.fn()
+    render(
+      <FacetedMultiSelectFilter
+        title="Khoa/Phòng"
+        options={OPTIONS}
+        value={[]}
+        onChange={onChange}
+        triggerVariant="command"
+      />
+    )
 
-        // Badge should show "1" for the pre-selected item
-        expect(screen.getByText('1')).toBeInTheDocument()
+    const trigger = screen.getByRole("button", { name: /Khoa\/Phòng/i })
+    expect(trigger).toHaveAttribute("data-trigger-variant", "command")
+
+    fireEvent.click(trigger)
+
+    expect(screen.getByRole("button", { name: "ICU" })).toBeInTheDocument()
+  })
+
+  it("renders pre-selected values from controlled value prop", () => {
+    render(<ControlledWrapper initialValue={["ICU"]} />)
+
+    // Badge should show "1" for the pre-selected item
+    expect(screen.getByText("1")).toBeInTheDocument()
+  })
+
+  it("calls onChange when an option is toggled on", () => {
+    const onChange = vi.fn()
+    render(<ControlledWrapper onChange={onChange} />)
+
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
+
+    expect(onChange).toHaveBeenCalledWith(["ICU"])
+  })
+
+  it("calls onChange when an option is toggled off", () => {
+    const onChange = vi.fn()
+    render(<ControlledWrapper initialValue={["ICU"]} onChange={onChange} />)
+
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it("supports multi-select in controlled mode", () => {
+    const onChange = vi.fn()
+    render(<ControlledWrapper onChange={onChange} />)
+
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByRole("button", { name: "ICU" }))
+    fireEvent.click(screen.getByRole("button", { name: "Surgery" }))
+
+    expect(onChange).toHaveBeenLastCalledWith(expect.arrayContaining(["ICU", "Surgery"]))
+  })
+
+  it("clears all selections via clear button in controlled mode", () => {
+    const onChange = vi.fn()
+    render(<ControlledWrapper initialValue={["ICU", "Surgery"]} onChange={onChange} />)
+
+    fireEvent.click(screen.getByText("Khoa/Phòng"))
+    fireEvent.click(screen.getByText("Xóa bộ lọc"))
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it("shows badge count matching controlled value length", () => {
+    render(<ControlledWrapper initialValue={["ICU", "Surgery"]} />)
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("preserves selected value when option search hides that option", async () => {
+    vi.useFakeTimers()
+    render(<ControlledWrapper initialValue={["ICU"]} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+    fireEvent.change(screen.getByRole("searchbox", { name: "Tìm lựa chọn Khoa/Phòng" }), {
+      target: { value: "surgery" },
+    })
+    act(() => {
+      vi.advanceTimersByTime(300)
     })
 
-    it('calls onChange when an option is toggled on', () => {
-        const onChange = vi.fn()
-        render(<ControlledWrapper onChange={onChange} />)
-
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
-
-        expect(onChange).toHaveBeenCalledWith(['ICU'])
-    })
-
-    it('calls onChange when an option is toggled off', () => {
-        const onChange = vi.fn()
-        render(<ControlledWrapper initialValue={['ICU']} onChange={onChange} />)
-
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
-
-        expect(onChange).toHaveBeenCalledWith([])
-    })
-
-    it('supports multi-select in controlled mode', () => {
-        const onChange = vi.fn()
-        render(<ControlledWrapper onChange={onChange} />)
-
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByRole('button', { name: 'ICU' }))
-        fireEvent.click(screen.getByRole('button', { name: 'Surgery' }))
-
-        expect(onChange).toHaveBeenLastCalledWith(
-            expect.arrayContaining(['ICU', 'Surgery'])
-        )
-    })
-
-    it('clears all selections via clear button in controlled mode', () => {
-        const onChange = vi.fn()
-        render(<ControlledWrapper initialValue={['ICU', 'Surgery']} onChange={onChange} />)
-
-        fireEvent.click(screen.getByText('Khoa/Phòng'))
-        fireEvent.click(screen.getByText('Xóa bộ lọc'))
-
-        expect(onChange).toHaveBeenCalledWith([])
-    })
-
-    it('shows badge count matching controlled value length', () => {
-        render(<ControlledWrapper initialValue={['ICU', 'Surgery']} />)
-        expect(screen.getByText('2')).toBeInTheDocument()
-    })
-
-    it('preserves selected value when option search hides that option', async () => {
-        vi.useFakeTimers()
-        render(<ControlledWrapper initialValue={['ICU']} />)
-
-        fireEvent.click(screen.getByRole('button', { name: /Khoa\/Phòng/i }))
-        fireEvent.change(screen.getByRole('searchbox', { name: 'Tìm lựa chọn Khoa/Phòng' }), {
-            target: { value: 'surgery' },
-        })
-        act(() => {
-            vi.advanceTimersByTime(300)
-        })
-
-        expect(screen.queryByRole('button', { name: 'ICU' })).not.toBeInTheDocument()
-        expect(screen.getByRole('button', { name: /Khoa\/Phòng/i })).toHaveTextContent('1')
-    })
+    expect(screen.queryByRole("button", { name: "ICU" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Khoa\/Phòng/i })).toHaveTextContent("1")
+  })
 })


### PR DESCRIPTION
## Summary
- Add a backward-compatible `command` trigger variant for shared faceted filters.
- Update Equipments desktop toolbar to use command-token filters with progressive overflow (`Bộ lọc`) and compact clear action.
- Add TDD coverage for command trigger rendering, overflow behavior, responsive guardrail, and unchanged sheet-mode behavior.

Closes #659
Part of #658

## Test Plan
- `node scripts/npm-run.js npx prettier --check docs/superpowers/plans/2026-07-03-equipment-command-filter-toolbar.md src/components/shared/table-filters/FacetedMultiSelectFilter.tsx src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx src/components/equipment/equipment-toolbar.tsx src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test -- src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx`
- `node scripts/npm-run.js run react-doctor`

## Notes
- Full repo `format:check` still reports unrelated baseline formatting noise across existing files, so this PR verifies Prettier on the changed files directly.
- Dev server visual check was intentionally skipped per user request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernizes the Equipments toolbar with command-token filters and a compact “Bộ lọc” overflow on desktop while keeping filter IDs, data flow, and mobile sheet mode unchanged. Closes #659 and supports #658; also aligns the facility clear-filter action with the new command style.

- **New Features**
  - `FacetedMultiSelectFilter`: added `triggerVariant: "outline" | "command"` and `triggerIcon`; command triggers show a selected-count badge; column and controlled modes unchanged.
  - Desktop toolbar: command tokens (with icons) for “Tình trạng”, “Khoa/Phòng”, “Phân loại”; “Bộ lọc” popover uses `EquipmentOverflowFilters` to show “Người sử dụng” and “Nguồn kinh phí” as inline checkbox options with a combined count via `getEquipmentOverflowFilterCount`; compact clear action “Xóa”; responsive guardrails (`data-testid="equipment-command-filter-row"`, `data-layout="command-overflow"`, `flex-wrap`, `min-w-0`).

- **Bug Fixes**
  - Polished overflow behavior and accessibility; added stable attributes for testing (`data-trigger-variant`, `data-layout`).
  - Matched facility clear-filter button size and style with the desktop clear control.

<sup>Written for commit f4c8d2133a980af8f106c66d3b656ccd5026e38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the equipment toolbar filters to a command-style row on larger screens, with a compact **“Bộ lọc”** overflow control for additional filters.
  * Added command presentation support for multi-select filters, including optional icons and active-count badges.
  * Improved **“Tùy chọn”** dropdown formatting for clearer actions.
* **Bug Fixes**
  * Refined clear/reset behavior so **“Xóa”** only appears when desktop filters are active, while keeping sheet-style filtering on mobile/tablet.
  * Ensured selecting overflow filters updates the correct table filters inline.
* **Tests**
  * Expanded and stabilized toolbar and multi-select filter regression coverage.
* **Documentation**
  * Added a documentation plan for the staged toolbar redesign.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->