### PR TITLE
Fix cascading equipment filter buckets

### DIFF
--- a/src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx
+++ b/src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx
@@ -1,0 +1,170 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest"
+
+import { useActiveUsageLogs } from "@/hooks/use-usage-logs"
+import { callRpc, type RpcOptions } from "@/lib/rpc-client"
+
+import { useEquipmentData, type UseEquipmentDataParams } from "../useEquipmentData"
+
+vi.mock("@/hooks/use-usage-logs", () => ({
+  useActiveUsageLogs: vi.fn(),
+}))
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: vi.fn(),
+}))
+
+type RpcClientMock = MockedFunction<
+  (options: RpcOptions<Record<string, unknown>>) => Promise<unknown>
+>
+
+const callRpcMock = callRpc as unknown as RpcClientMock
+const useActiveUsageLogsMock = useActiveUsageLogs as unknown as MockedFunction<
+  typeof useActiveUsageLogs
+>
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+const baseParams: UseEquipmentDataParams = {
+  isGlobal: false,
+  isRegionalLeader: false,
+  userRole: "to_qltb",
+  userDiaBanId: null,
+  shouldFetchEquipment: true,
+  effectiveTenantKey: "tenant-42",
+  selectedDonVi: 42,
+  currentTenantId: 42,
+  debouncedSearch: "monitor",
+  sortParam: "id.asc",
+  pagination: { pageIndex: 0, pageSize: 20 },
+  selectedDepartments: ["ICU"],
+  selectedUsers: ["Dr A"],
+  selectedLocations: ["Room 1"],
+  selectedStatuses: ["Hoat dong"],
+  selectedClassifications: ["Class A"],
+  selectedFundingSources: ["Fund A"],
+  selectedFacilityId: null,
+  showSelector: false,
+  facilities: [],
+  isFacilitiesLoading: false,
+}
+
+function getBucketCalls() {
+  return callRpcMock.mock.calls
+    .map(([options]) => options)
+    .filter((options) => options.fn === "equipment_filter_buckets")
+}
+
+describe("useEquipmentData filter bucket query", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    useActiveUsageLogsMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as ReturnType<typeof useActiveUsageLogs>)
+
+    callRpcMock.mockImplementation(async ({ fn }) => {
+      if (fn === "equipment_list_enhanced") {
+        return { data: [], total: 0 }
+      }
+      if (fn === "equipment_department_distribution") {
+        return []
+      }
+      if (fn === "equipment_filter_buckets") {
+        return {
+          department: [],
+          user: [],
+          location: [],
+          status: [],
+          classification: [],
+          fundingSource: [],
+        }
+      }
+      return []
+    })
+  })
+
+  it("passes active search and filters to equipment_filter_buckets", async () => {
+    const queryClient = createQueryClient()
+
+    renderHook(() => useEquipmentData(baseParams), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
+
+    expect(getBucketCalls()[0]?.args).toMatchObject({
+      p_q: "monitor",
+      p_don_vi: 42,
+      p_khoa_phong_array: ["ICU"],
+      p_nguoi_su_dung_array: ["Dr A"],
+      p_vi_tri_lap_dat_array: ["Room 1"],
+      p_tinh_trang_array: ["Hoat dong"],
+      p_phan_loai_array: ["Class A"],
+      p_nguon_kinh_phi_array: ["Fund A"],
+    })
+  })
+
+  it("keys bucket data by active filters but not pagination", async () => {
+    const queryClient = createQueryClient()
+    const { rerender } = renderHook((params: UseEquipmentDataParams) => useEquipmentData(params), {
+      initialProps: baseParams,
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
+
+    const initialBucketQueries = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_filter_buckets"] })
+    const initialBucketKeyParams = initialBucketQueries[0]?.queryKey[1] as
+      Record<string, unknown> | undefined
+
+    expect(initialBucketKeyParams).toMatchObject({
+      q: "monitor",
+      khoa_phong_array: ["ICU"],
+      tinh_trang_array: ["Hoat dong"],
+    })
+    expect(initialBucketKeyParams).not.toHaveProperty("page")
+    expect(initialBucketKeyParams).not.toHaveProperty("size")
+
+    rerender({
+      ...baseParams,
+      debouncedSearch: "pump",
+      selectedStatuses: ["Bao tri"],
+    })
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(2))
+
+    expect(getBucketCalls()[1]?.args).toMatchObject({
+      p_q: "pump",
+      p_tinh_trang_array: ["Bao tri"],
+    })
+
+    rerender({
+      ...baseParams,
+      debouncedSearch: "pump",
+      selectedStatuses: ["Bao tri"],
+      pagination: { pageIndex: 3, pageSize: 20 },
+    })
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(2))
+  })
+})

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -298,12 +298,28 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
         role: userRole,
         diaBan: userDiaBanId,
         donVi: effectiveSelectedDonVi,
+        q: debouncedSearch || null,
+        khoa_phong_array: selectedDepartments,
+        nguoi_su_dung_array: selectedUsers,
+        vi_tri_lap_dat_array: selectedLocations,
+        tinh_trang_array: selectedStatuses,
+        phan_loai_array: selectedClassifications,
+        nguon_kinh_phi_array: selectedFundingSources,
       },
     ],
     queryFn: async ({ signal }) => {
       const result = await callRpc<EquipmentFilterBucketsResponse>({
         fn: "equipment_filter_buckets",
-        args: { p_don_vi: effectiveSelectedDonVi },
+        args: {
+          p_q: debouncedSearch || null,
+          p_don_vi: effectiveSelectedDonVi,
+          p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
+          p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
+          p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
+          p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
+          p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
+          p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
+        },
         signal,
       })
       return result ?? {}

--- a/supabase/migrations/20260704070000_cascade_equipment_filter_buckets.sql
+++ b/supabase/migrations/20260704070000_cascade_equipment_filter_buckets.sql
@@ -1,0 +1,274 @@
+-- Cascade Equipment page filter buckets from active server-side filters.
+--
+-- The RPC keeps the bundled JSON response introduced in
+-- 20260501090000_add_equipment_dashboard_perf_rpcs.sql, but mirrors the
+-- current Equipment list/distribution filter contract so option buckets follow
+-- the full server result set instead of remaining tenant-global.
+--
+-- Role user scope is enforced in the base relation before bucket-specific
+-- filter exclusion, so excluding the department bucket's own filter can never
+-- escape the JWT khoa_phong boundary.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.equipment_filter_buckets(bigint);
+
+CREATE OR REPLACE FUNCTION public.equipment_filter_buckets(
+  p_q text DEFAULT NULL::text,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_allowed bigint[];
+  v_effective bigint[];
+  v_department_scope text;
+  v_jwt_claims jsonb;
+  v_sanitized_q text;
+  v_result jsonb;
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN jsonb_build_object(
+        'department', '[]'::jsonb,
+        'user', '[]'::jsonb,
+        'location', '[]'::jsonb,
+        'status', '[]'::jsonb,
+        'classification', '[]'::jsonb,
+        'fundingSource', '[]'::jsonb
+      );
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN jsonb_build_object(
+        'department', '[]'::jsonb,
+        'user', '[]'::jsonb,
+        'location', '[]'::jsonb,
+        'status', '[]'::jsonb,
+        'classification', '[]'::jsonb,
+        'fundingSource', '[]'::jsonb
+      );
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  WITH base_equipment AS MATERIALIZED (
+    SELECT
+      tb.khoa_phong_quan_ly AS department_raw,
+      tb.nguoi_dang_truc_tiep_quan_ly AS user_raw,
+      tb.vi_tri_lap_dat AS location_raw,
+      tb.tinh_trang_hien_tai AS status_raw,
+      tb.phan_loai_theo_nd98 AS classification_raw,
+      COALESCE(NULLIF(TRIM(tb.khoa_phong_quan_ly), ''), 'Chưa phân loại') AS department_name,
+      COALESCE(NULLIF(TRIM(tb.nguoi_dang_truc_tiep_quan_ly), ''), 'Chưa có người sử dụng') AS user_name,
+      COALESCE(NULLIF(TRIM(tb.vi_tri_lap_dat), ''), 'Chưa có vị trí') AS location_name,
+      COALESCE(NULLIF(TRIM(tb.tinh_trang_hien_tai), ''), 'Chưa phân loại') AS status_name,
+      COALESCE(NULLIF(TRIM(tb.phan_loai_theo_nd98), ''), 'Chưa phân loại') AS classification_name,
+      COALESCE(NULLIF(TRIM(tb.nguon_kinh_phi), ''), 'Chưa có') AS funding_source_name
+    FROM public.thiet_bi tb
+    WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+      AND tb.is_deleted = false
+      AND (
+        v_role <> 'user'
+        OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+      )
+      AND (
+        v_sanitized_q IS NULL
+        OR tb.ten_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+        OR tb.ma_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+        OR tb.serial ILIKE '%' || v_sanitized_q || '%'
+        OR tb.so_luu_hanh ILIKE '%' || v_sanitized_q || '%'
+        OR tb.model ILIKE '%' || v_sanitized_q || '%'
+      )
+  )
+  SELECT jsonb_build_object(
+    'department', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT department_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_raw = ANY(p_nguoi_su_dung_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_raw = ANY(p_vi_tri_lap_dat_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_raw = ANY(p_tinh_trang_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_raw = ANY(p_phan_loai_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY department_name
+      ) bucket
+    ), '[]'::jsonb),
+    'user', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT user_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_raw = ANY(p_khoa_phong_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_raw = ANY(p_vi_tri_lap_dat_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_raw = ANY(p_tinh_trang_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_raw = ANY(p_phan_loai_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY user_name
+      ) bucket
+    ), '[]'::jsonb),
+    'location', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT location_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_raw = ANY(p_khoa_phong_array))
+          AND (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_raw = ANY(p_nguoi_su_dung_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_raw = ANY(p_tinh_trang_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_raw = ANY(p_phan_loai_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY location_name
+      ) bucket
+    ), '[]'::jsonb),
+    'status', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT status_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_raw = ANY(p_khoa_phong_array))
+          AND (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_raw = ANY(p_nguoi_su_dung_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_raw = ANY(p_vi_tri_lap_dat_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_raw = ANY(p_phan_loai_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY status_name
+      ) bucket
+    ), '[]'::jsonb),
+    'classification', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT classification_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_raw = ANY(p_khoa_phong_array))
+          AND (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_raw = ANY(p_nguoi_su_dung_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_raw = ANY(p_vi_tri_lap_dat_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_raw = ANY(p_tinh_trang_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY classification_name
+      ) bucket
+    ), '[]'::jsonb),
+    'fundingSource', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT funding_source_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_raw = ANY(p_khoa_phong_array))
+          AND (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_raw = ANY(p_nguoi_su_dung_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_raw = ANY(p_vi_tri_lap_dat_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_raw = ANY(p_tinh_trang_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_raw = ANY(p_phan_loai_array))
+        GROUP BY funding_source_name
+      ) bucket
+    ), '[]'::jsonb)
+  )
+  INTO v_result;
+
+  RETURN COALESCE(v_result, jsonb_build_object(
+    'department', '[]'::jsonb,
+    'user', '[]'::jsonb,
+    'location', '[]'::jsonb,
+    'status', '[]'::jsonb,
+    'classification', '[]'::jsonb,
+    'fundingSource', '[]'::jsonb
+  ));
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.equipment_filter_buckets(
+  text,
+  bigint,
+  text[],
+  text[],
+  text[],
+  text[],
+  text[],
+  text[]
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.equipment_filter_buckets(
+  text,
+  bigint,
+  text[],
+  text[],
+  text[],
+  text[],
+  text[],
+  text[]
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.equipment_filter_buckets(
+  text,
+  bigint,
+  text[],
+  text[],
+  text[],
+  text[],
+  text[],
+  text[]
+) TO service_role;
+
+COMMENT ON FUNCTION public.equipment_filter_buckets(
+  text,
+  bigint,
+  text[],
+  text[],
+  text[],
+  text[],
+  text[],
+  text[]
+) IS 'Returns cascading equipment filter option buckets for the scoped Equipment result set.';
+
+COMMIT;

--- a/supabase/migrations/20260704073000_fix_equipment_filter_buckets_review_feedback.sql
+++ b/supabase/migrations/20260704073000_fix_equipment_filter_buckets_review_feedback.sql
@@ -1,0 +1,259 @@
+-- Fix Equipment filter bucket cascade predicates after PR review.
+--
+-- 20260704070000_cascade_equipment_filter_buckets.sql was applied before
+-- review feedback. Keep that applied migration immutable and supersede the RPC
+-- in this later migration instead.
+--
+-- Forward-only rollback: add a later migration that restores the
+-- equipment_filter_buckets body/signature from
+-- 20260704070000_cascade_equipment_filter_buckets.sql, or from
+-- 20260501090000_add_equipment_dashboard_perf_rpcs.sql to fully revert the
+-- cascade behavior.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.equipment_filter_buckets(
+  p_q text DEFAULT NULL::text,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role text;
+  v_user_id text;
+  v_allowed bigint[];
+  v_effective bigint[];
+  v_department_scope text;
+  v_jwt_claims jsonb;
+  v_sanitized_q text;
+  v_result jsonb;
+  v_unclassified_label CONSTANT text := 'Chưa phân loại';
+  v_empty_user_label CONSTANT text := 'Chưa có người sử dụng';
+  v_empty_location_label CONSTANT text := 'Chưa có vị trí';
+  v_empty_funding_label CONSTANT text := 'Chưa có';
+  v_empty_result CONSTANT jsonb := jsonb_build_object(
+    'department', '[]'::jsonb,
+    'user', '[]'::jsonb,
+    'location', '[]'::jsonb,
+    'status', '[]'::jsonb,
+    'classification', '[]'::jsonb,
+    'fundingSource', '[]'::jsonb
+  );
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := lower(COALESCE(
+    v_jwt_claims ->> 'app_role',
+    v_jwt_claims ->> 'role',
+    ''
+  ));
+  v_user_id := NULLIF(v_jwt_claims ->> 'user_id', '');
+
+  IF v_role = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  v_allowed := public.allowed_don_vi_for_session_safe();
+
+  IF v_role = 'global' THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := NULL;
+    END IF;
+  ELSE
+    IF v_allowed IS NULL OR array_length(v_allowed, 1) IS NULL THEN
+      RETURN v_empty_result;
+    END IF;
+
+    IF p_don_vi IS NOT NULL THEN
+      IF NOT (p_don_vi = ANY(v_allowed)) THEN
+        RAISE EXCEPTION 'Access denied for tenant %', p_don_vi USING ERRCODE = '42501';
+      END IF;
+      v_effective := ARRAY[p_don_vi];
+    ELSE
+      v_effective := v_allowed;
+    END IF;
+  END IF;
+
+  IF v_role = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->> 'khoa_phong');
+    IF v_department_scope IS NULL THEN
+      RETURN v_empty_result;
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  WITH base_equipment AS MATERIALIZED (
+    SELECT
+      COALESCE(NULLIF(TRIM(tb.khoa_phong_quan_ly), ''), v_unclassified_label) AS department_name,
+      COALESCE(NULLIF(TRIM(tb.nguoi_dang_truc_tiep_quan_ly), ''), v_empty_user_label) AS user_name,
+      COALESCE(NULLIF(TRIM(tb.vi_tri_lap_dat), ''), v_empty_location_label) AS location_name,
+      COALESCE(NULLIF(TRIM(tb.tinh_trang_hien_tai), ''), v_unclassified_label) AS status_name,
+      COALESCE(NULLIF(TRIM(tb.phan_loai_theo_nd98), ''), v_unclassified_label) AS classification_name,
+      COALESCE(NULLIF(TRIM(tb.nguon_kinh_phi), ''), v_empty_funding_label) AS funding_source_name
+    FROM public.thiet_bi tb
+    WHERE (v_effective IS NULL OR tb.don_vi = ANY(v_effective))
+      AND tb.is_deleted = false
+      AND (
+        v_role <> 'user'
+        OR public._normalize_department_scope(tb.khoa_phong_quan_ly) = v_department_scope
+      )
+      AND (
+        v_sanitized_q IS NULL
+        OR tb.ten_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+        OR tb.ma_thiet_bi ILIKE '%' || v_sanitized_q || '%'
+        OR tb.serial ILIKE '%' || v_sanitized_q || '%'
+        OR tb.so_luu_hanh ILIKE '%' || v_sanitized_q || '%'
+        OR tb.model ILIKE '%' || v_sanitized_q || '%'
+      )
+  )
+  SELECT jsonb_build_object(
+    'department', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT department_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_name = ANY(p_nguoi_su_dung_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_name = ANY(p_vi_tri_lap_dat_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_name = ANY(p_tinh_trang_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_name = ANY(p_phan_loai_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY department_name
+      ) bucket
+    ), '[]'::jsonb),
+    'user', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT user_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_name = ANY(p_khoa_phong_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_name = ANY(p_vi_tri_lap_dat_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_name = ANY(p_tinh_trang_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_name = ANY(p_phan_loai_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY user_name
+      ) bucket
+    ), '[]'::jsonb),
+    'location', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT location_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_name = ANY(p_khoa_phong_array))
+          AND (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_name = ANY(p_nguoi_su_dung_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_name = ANY(p_tinh_trang_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_name = ANY(p_phan_loai_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY location_name
+      ) bucket
+    ), '[]'::jsonb),
+    'status', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT status_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_name = ANY(p_khoa_phong_array))
+          AND (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_name = ANY(p_nguoi_su_dung_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_name = ANY(p_vi_tri_lap_dat_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_name = ANY(p_phan_loai_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY status_name
+      ) bucket
+    ), '[]'::jsonb),
+    'classification', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT classification_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_name = ANY(p_khoa_phong_array))
+          AND (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_name = ANY(p_nguoi_su_dung_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_name = ANY(p_vi_tri_lap_dat_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_name = ANY(p_tinh_trang_array))
+          AND (p_nguon_kinh_phi_array IS NULL OR array_length(p_nguon_kinh_phi_array, 1) IS NULL OR funding_source_name = ANY(p_nguon_kinh_phi_array))
+        GROUP BY classification_name
+      ) bucket
+    ), '[]'::jsonb),
+    'fundingSource', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', bucket.name, 'count', bucket.count) ORDER BY bucket.count DESC, bucket.name)
+      FROM (
+        SELECT funding_source_name AS name, COUNT(*)::integer AS count
+        FROM base_equipment
+        WHERE (p_khoa_phong_array IS NULL OR array_length(p_khoa_phong_array, 1) IS NULL OR department_name = ANY(p_khoa_phong_array))
+          AND (p_nguoi_su_dung_array IS NULL OR array_length(p_nguoi_su_dung_array, 1) IS NULL OR user_name = ANY(p_nguoi_su_dung_array))
+          AND (p_vi_tri_lap_dat_array IS NULL OR array_length(p_vi_tri_lap_dat_array, 1) IS NULL OR location_name = ANY(p_vi_tri_lap_dat_array))
+          AND (p_tinh_trang_array IS NULL OR array_length(p_tinh_trang_array, 1) IS NULL OR status_name = ANY(p_tinh_trang_array))
+          AND (p_phan_loai_array IS NULL OR array_length(p_phan_loai_array, 1) IS NULL OR classification_name = ANY(p_phan_loai_array))
+        GROUP BY funding_source_name
+      ) bucket
+    ), '[]'::jsonb)
+  )
+  INTO v_result;
+
+  RETURN COALESCE(v_result, v_empty_result);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.equipment_filter_buckets(
+  text,
+  bigint,
+  text[],
+  text[],
+  text[],
+  text[],
+  text[],
+  text[]
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.equipment_filter_buckets(
+  text,
+  bigint,
+  text[],
+  text[],
+  text[],
+  text[],
+  text[],
+  text[]
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.equipment_filter_buckets(
+  text,
+  bigint,
+  text[],
+  text[],
+  text[],
+  text[],
+  text[],
+  text[]
+) TO service_role;
+
+COMMENT ON FUNCTION public.equipment_filter_buckets(
+  text,
+  bigint,
+  text[],
+  text[],
+  text[],
+  text[],
+  text[],
+  text[]
+) IS 'Returns cascading equipment filter option buckets for the scoped Equipment result set.';
+
+COMMIT;

--- a/supabase/migrations/20260704074500_align_equipment_list_filters_with_bucket_labels.sql
+++ b/supabase/migrations/20260704074500_align_equipment_list_filters_with_bucket_labels.sql
@@ -1,0 +1,322 @@
+-- Align Equipment list filters with normalized filter bucket labels.
+--
+-- 20260704073000_fix_equipment_filter_buckets_review_feedback.sql made the
+-- bucket RPC accept the normalized labels it emits, including fallback labels
+-- for blank values. Keep the table RPC on the same filter contract so selecting
+-- a bucket option cannot produce matching bucket counts with an empty table.
+--
+-- Forward-only rollback: add a later migration that restores the
+-- equipment_list_enhanced body from
+-- 20260623090000_add_model_to_equipment_list_search.sql.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.equipment_list_enhanced(
+  p_q text DEFAULT NULL::text,
+  p_sort text DEFAULT 'id.asc'::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung text DEFAULT NULL::text,
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat text DEFAULT NULL::text,
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang text DEFAULT NULL::text,
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai text DEFAULT NULL::text,
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi text DEFAULT NULL::text,
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := '';
+  v_user_id TEXT := NULL;
+  v_claim_donvi BIGINT := NULL;
+  v_allowed_don_vi BIGINT[];
+  v_effective_donvi BIGINT := NULL;
+  v_department_scope TEXT;
+  v_sort_col TEXT := 'id';
+  v_sort_dir TEXT := 'ASC';
+  v_limit INT := GREATEST(p_page_size, 1);
+  v_offset INT := GREATEST(p_page - 1, 0) * GREATEST(p_page_size, 1);
+  v_where TEXT := '1=1 AND is_deleted = false';
+  v_total BIGINT := 0;
+  v_data JSONB := '[]'::jsonb;
+  v_jwt_claims JSONB;
+  v_sanitized_q TEXT;
+  v_unclassified_label CONSTANT TEXT := 'Chưa phân loại';
+  v_empty_user_label CONSTANT TEXT := 'Chưa có người sử dụng';
+  v_empty_location_label CONSTANT TEXT := 'Chưa có vị trí';
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := COALESCE(
+    v_jwt_claims ->>'app_role',
+    v_jwt_claims ->>'role',
+    ''
+  );
+  v_user_id := NULLIF(v_jwt_claims ->>'user_id', '');
+  v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
+  END IF;
+
+  IF p_sort IS NOT NULL AND p_sort != '' THEN
+    v_sort_col := split_part(p_sort, '.', 1);
+    v_sort_dir := UPPER(COALESCE(NULLIF(split_part(p_sort, '.', 2), ''), 'ASC'));
+    IF v_sort_dir NOT IN ('ASC', 'DESC') THEN
+      v_sort_dir := 'ASC';
+    END IF;
+    IF v_sort_col NOT IN (
+      'id', 'ma_thiet_bi', 'ten_thiet_bi', 'model', 'serial',
+      'khoa_phong_quan_ly', 'tinh_trang_hien_tai', 'vi_tri_lap_dat',
+      'nguoi_dang_truc_tiep_quan_ly', 'phan_loai_theo_nd98', 'nguon_kinh_phi', 'don_vi',
+      'gia_goc', 'ngay_nhap', 'ngay_dua_vao_su_dung', 'ngay_bt_tiep_theo',
+      'so_luu_hanh'
+    ) THEN
+      v_sort_col := 'id';
+    END IF;
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF lower(v_role) IN ('global', 'admin') THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective_donvi := p_don_vi;
+    ELSE
+      v_effective_donvi := NULL;
+    END IF;
+  ELSE
+    IF v_allowed_don_vi IS NOT NULL AND array_length(v_allowed_don_vi, 1) > 0 THEN
+      IF p_don_vi IS NOT NULL THEN
+        IF p_don_vi = ANY(v_allowed_don_vi) THEN
+          v_effective_donvi := p_don_vi;
+        ELSE
+          RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'Access denied for tenant');
+        END IF;
+      ELSE
+        v_effective_donvi := NULL;
+      END IF;
+    ELSE
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'No tenant access');
+    END IF;
+  END IF;
+
+  IF lower(v_role) = 'user' AND v_department_scope IS NULL THEN
+    RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+  END IF;
+
+  IF v_effective_donvi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ' || v_effective_donvi;
+  END IF;
+
+  IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin') AND v_allowed_don_vi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = '
+      || quote_literal(v_department_scope);
+  END IF;
+
+  IF p_khoa_phong_array IS NOT NULL AND array_length(p_khoa_phong_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_khoa_phong_array) AS x), ',') || '])';
+  ELSIF p_khoa_phong IS NOT NULL AND trim(p_khoa_phong) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_khoa_phong);
+  END IF;
+
+  IF p_nguoi_su_dung_array IS NOT NULL AND array_length(p_nguoi_su_dung_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''''), ' || quote_literal(v_empty_user_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguoi_su_dung_array) AS x), ',') || '])';
+  ELSIF p_nguoi_su_dung IS NOT NULL AND trim(p_nguoi_su_dung) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''''), ' || quote_literal(v_empty_user_label) || ') = ' || quote_literal(p_nguoi_su_dung);
+  END IF;
+
+  IF p_vi_tri_lap_dat_array IS NOT NULL AND array_length(p_vi_tri_lap_dat_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''''), ' || quote_literal(v_empty_location_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_vi_tri_lap_dat_array) AS x), ',') || '])';
+  ELSIF p_vi_tri_lap_dat IS NOT NULL AND trim(p_vi_tri_lap_dat) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''''), ' || quote_literal(v_empty_location_label) || ') = ' || quote_literal(p_vi_tri_lap_dat);
+  END IF;
+
+  IF p_tinh_trang_array IS NOT NULL AND array_length(p_tinh_trang_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_tinh_trang_array) AS x), ',') || '])';
+  ELSIF p_tinh_trang IS NOT NULL AND trim(p_tinh_trang) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_tinh_trang);
+  END IF;
+
+  IF p_phan_loai_array IS NOT NULL AND array_length(p_phan_loai_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_phan_loai_array) AS x), ',') || '])';
+  ELSIF p_phan_loai IS NOT NULL AND trim(p_phan_loai) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_phan_loai);
+  END IF;
+
+  IF p_nguon_kinh_phi_array IS NOT NULL AND array_length(p_nguon_kinh_phi_array, 1) > 0 THEN
+    IF 'Chưa có' = ANY(p_nguon_kinh_phi_array) THEN
+      DECLARE v_non_empty_sources TEXT[];
+      BEGIN
+        SELECT ARRAY(SELECT x FROM unnest(p_nguon_kinh_phi_array) AS x WHERE x != 'Chưa có') INTO v_non_empty_sources;
+        IF v_non_empty_sources IS NOT NULL AND array_length(v_non_empty_sources, 1) > 0 THEN
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''' OR TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+            array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(v_non_empty_sources) AS x), ',') || ']))';
+        ELSE
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+        END IF;
+      END;
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+        array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguon_kinh_phi_array) AS x), ',') || '])';
+    END IF;
+  ELSIF p_nguon_kinh_phi IS NOT NULL AND trim(p_nguon_kinh_phi) != '' THEN
+    IF p_nguon_kinh_phi = 'Chưa có' THEN
+      v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ' || quote_literal(p_nguon_kinh_phi);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_where := v_where || ' AND (ten_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR ma_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR serial ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR so_luu_hanh ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR model ILIKE ' || quote_literal('%' || v_sanitized_q || '%') || ')';
+  END IF;
+
+  EXECUTE format('SELECT count(*) FROM public.thiet_bi WHERE %s', v_where) INTO v_total;
+
+  EXECUTE format(
+    'SELECT COALESCE(jsonb_agg(t), ''[]''::jsonb) FROM (
+       SELECT (jsonb_build_object(
+         ''ma_thiet_bi'', tb.ma_thiet_bi,
+         ''ten_thiet_bi'', tb.ten_thiet_bi,
+         ''model'', tb.model,
+         ''serial'', tb.serial,
+         ''cau_hinh_thiet_bi'', tb.cau_hinh_thiet_bi,
+         ''phu_kien_kem_theo'', tb.phu_kien_kem_theo,
+         ''hang_san_xuat'', tb.hang_san_xuat,
+         ''noi_san_xuat'', tb.noi_san_xuat,
+         ''nam_san_xuat'', tb.nam_san_xuat,
+         ''ngay_nhap'', tb.ngay_nhap,
+         ''ngay_dua_vao_su_dung'', tb.ngay_dua_vao_su_dung,
+         ''nguon_kinh_phi'', tb.nguon_kinh_phi,
+         ''gia_goc'', tb.gia_goc,
+         ''nam_tinh_hao_mon'', tb.nam_tinh_hao_mon,
+         ''ty_le_hao_mon'', tb.ty_le_hao_mon,
+         ''han_bao_hanh'', tb.han_bao_hanh,
+         ''vi_tri_lap_dat'', tb.vi_tri_lap_dat,
+         ''nguoi_dang_truc_tiep_quan_ly'', tb.nguoi_dang_truc_tiep_quan_ly,
+         ''khoa_phong_quan_ly'', tb.khoa_phong_quan_ly,
+         ''tinh_trang_hien_tai'', tb.tinh_trang_hien_tai,
+         ''ghi_chu'', tb.ghi_chu,
+         ''chu_ky_bt_dinh_ky'', tb.chu_ky_bt_dinh_ky,
+         ''ngay_bt_tiep_theo'', tb.ngay_bt_tiep_theo,
+         ''chu_ky_hc_dinh_ky'', tb.chu_ky_hc_dinh_ky,
+         ''ngay_hc_tiep_theo'', tb.ngay_hc_tiep_theo,
+         ''chu_ky_kd_dinh_ky'', tb.chu_ky_kd_dinh_ky,
+         ''ngay_kd_tiep_theo'', tb.ngay_kd_tiep_theo,
+         ''phan_loai_theo_nd98'', tb.phan_loai_theo_nd98,
+         ''id'', tb.id,
+         ''created_at'', tb.created_at,
+         ''don_vi'', tb.don_vi,
+         ''nguon_nhap'', tb.nguon_nhap,
+         ''so_luu_hanh'', tb.so_luu_hanh,
+         ''nhom_thiet_bi_id'', tb.nhom_thiet_bi_id,
+         ''is_deleted'', tb.is_deleted,
+         ''ngay_ngung_su_dung'', tb.ngay_ngung_su_dung,
+         ''google_drive_folder_url'', dv.google_drive_folder_url,
+         ''don_vi_name'', dv.name,
+         ''active_repair_request_id'', ar.active_id
+       )) AS t
+       FROM public.thiet_bi tb
+       LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+       LEFT JOIN LATERAL (
+         SELECT r.id AS active_id
+         FROM public.yeu_cau_sua_chua r
+         WHERE r.thiet_bi_id = tb.id
+           AND r.trang_thai IN (''Chờ xử lý'', ''Đã duyệt'')
+         ORDER BY r.ngay_yeu_cau DESC, r.id DESC
+         LIMIT 1
+       ) ar ON TRUE
+       WHERE %s
+       ORDER BY tb.%I %s
+       OFFSET %s LIMIT %s
+     ) sub',
+    v_where, v_sort_col, v_sort_dir, v_offset, v_limit
+  ) INTO v_data;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'total', v_total,
+    'page', p_page,
+    'pageSize', p_page_size
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260704075000_align_equipment_distribution_filters_with_bucket_labels.sql
+++ b/supabase/migrations/20260704075000_align_equipment_distribution_filters_with_bucket_labels.sql
@@ -1,0 +1,268 @@
+-- Align Equipment department distribution filters with normalized bucket labels.
+--
+-- The distribution RPC receives the same active filters as the Equipment list
+-- and filter bucket RPCs. Keep its selected-filter semantics aligned with the
+-- normalized labels emitted by equipment_filter_buckets.
+--
+-- Forward-only rollback: add a later migration that restores the
+-- equipment_department_distribution body from
+-- 20260624131500_add_equipment_department_distribution.sql.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.equipment_department_distribution(
+  p_q text DEFAULT NULL::text,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung text DEFAULT NULL::text,
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat text DEFAULT NULL::text,
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang text DEFAULT NULL::text,
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai text DEFAULT NULL::text,
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi text DEFAULT NULL::text,
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]
+)
+RETURNS TABLE(department text, label text, "count" integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_role TEXT := '';
+  v_user_id TEXT := NULL;
+  v_claim_donvi BIGINT := NULL;
+  v_allowed_don_vi BIGINT[];
+  v_effective_donvi BIGINT := NULL;
+  v_department_scope TEXT;
+  v_where TEXT := '1=1 AND is_deleted = false';
+  v_jwt_claims JSONB;
+  v_sanitized_q TEXT;
+  v_unclassified_label CONSTANT TEXT := 'Chưa phân loại';
+  v_empty_user_label CONSTANT TEXT := 'Chưa có người sử dụng';
+  v_empty_location_label CONSTANT TEXT := 'Chưa có vị trí';
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := COALESCE(
+    v_jwt_claims ->>'app_role',
+    v_jwt_claims ->>'role',
+    ''
+  );
+  v_user_id := NULLIF(v_jwt_claims ->>'user_id', '');
+  v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF lower(v_role) IN ('global', 'admin') THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective_donvi := p_don_vi;
+    ELSE
+      v_effective_donvi := NULL;
+    END IF;
+  ELSE
+    IF v_allowed_don_vi IS NOT NULL AND array_length(v_allowed_don_vi, 1) > 0 THEN
+      IF p_don_vi IS NOT NULL THEN
+        IF p_don_vi = ANY(v_allowed_don_vi) THEN
+          v_effective_donvi := p_don_vi;
+        ELSE
+          RETURN;
+        END IF;
+      ELSE
+        v_effective_donvi := NULL;
+      END IF;
+    ELSE
+      RETURN;
+    END IF;
+  END IF;
+
+  IF lower(v_role) = 'user' AND v_department_scope IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF v_effective_donvi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ' || v_effective_donvi;
+  END IF;
+
+  IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin') AND v_allowed_don_vi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = '
+      || quote_literal(v_department_scope);
+  END IF;
+
+  IF p_khoa_phong_array IS NOT NULL AND array_length(p_khoa_phong_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_khoa_phong_array) AS x), ',') || '])';
+  ELSIF p_khoa_phong IS NOT NULL AND trim(p_khoa_phong) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_khoa_phong);
+  END IF;
+
+  IF p_nguoi_su_dung_array IS NOT NULL AND array_length(p_nguoi_su_dung_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''''), ' || quote_literal(v_empty_user_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguoi_su_dung_array) AS x), ',') || '])';
+  ELSIF p_nguoi_su_dung IS NOT NULL AND trim(p_nguoi_su_dung) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''''), ' || quote_literal(v_empty_user_label) || ') = ' || quote_literal(p_nguoi_su_dung);
+  END IF;
+
+  IF p_vi_tri_lap_dat_array IS NOT NULL AND array_length(p_vi_tri_lap_dat_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''''), ' || quote_literal(v_empty_location_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_vi_tri_lap_dat_array) AS x), ',') || '])';
+  ELSIF p_vi_tri_lap_dat IS NOT NULL AND trim(p_vi_tri_lap_dat) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''''), ' || quote_literal(v_empty_location_label) || ') = ' || quote_literal(p_vi_tri_lap_dat);
+  END IF;
+
+  IF p_tinh_trang_array IS NOT NULL AND array_length(p_tinh_trang_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_tinh_trang_array) AS x), ',') || '])';
+  ELSIF p_tinh_trang IS NOT NULL AND trim(p_tinh_trang) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_tinh_trang);
+  END IF;
+
+  IF p_phan_loai_array IS NOT NULL AND array_length(p_phan_loai_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_phan_loai_array) AS x), ',') || '])';
+  ELSIF p_phan_loai IS NOT NULL AND trim(p_phan_loai) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_phan_loai);
+  END IF;
+
+  IF p_nguon_kinh_phi_array IS NOT NULL AND array_length(p_nguon_kinh_phi_array, 1) > 0 THEN
+    IF 'Chưa có' = ANY(p_nguon_kinh_phi_array) THEN
+      DECLARE v_non_empty_sources TEXT[];
+      BEGIN
+        SELECT ARRAY(SELECT x FROM unnest(p_nguon_kinh_phi_array) AS x WHERE x != 'Chưa có') INTO v_non_empty_sources;
+        IF v_non_empty_sources IS NOT NULL AND array_length(v_non_empty_sources, 1) > 0 THEN
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''' OR TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+            array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(v_non_empty_sources) AS x), ',') || ']))';
+        ELSE
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+        END IF;
+      END;
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+        array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguon_kinh_phi_array) AS x), ',') || '])';
+    END IF;
+  ELSIF p_nguon_kinh_phi IS NOT NULL AND trim(p_nguon_kinh_phi) != '' THEN
+    IF p_nguon_kinh_phi = 'Chưa có' THEN
+      v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ' || quote_literal(p_nguon_kinh_phi);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_where := v_where || ' AND (ten_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR ma_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR serial ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR so_luu_hanh ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR model ILIKE ' || quote_literal('%' || v_sanitized_q || '%') || ')';
+  END IF;
+
+  RETURN QUERY EXECUTE format(
+    'SELECT department,
+            COALESCE(department, ''Chưa cập nhật'') AS label,
+            COUNT(*)::integer AS "count"
+       FROM (
+         SELECT NULLIF(BTRIM(khoa_phong_quan_ly), '''') AS department
+         FROM public.thiet_bi
+         WHERE %s
+       ) scoped
+       GROUP BY department
+       ORDER BY COUNT(*) DESC, label ASC',
+    v_where
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.equipment_department_distribution(
+  text,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.equipment_department_distribution(
+  text,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.equipment_department_distribution(
+  text,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) TO service_role;
+
+COMMENT ON FUNCTION public.equipment_department_distribution(
+  text,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+) IS 'Returns department distribution counts for the filtered Equipment result set.';
+
+COMMIT;

--- a/supabase/tests/equipment_filter_buckets_smoke.sql
+++ b/supabase/tests/equipment_filter_buckets_smoke.sql
@@ -97,6 +97,21 @@ BEGIN
       false
     ),
     (
+      'SMK-BUCKET-FALLBACK-' || v_suffix,
+      'Smoke Cascade Fallback Labels ' || v_suffix,
+      'Model Fallback ' || v_suffix,
+      'Serial Fallback ' || v_suffix,
+      'Reg Fallback ' || v_suffix,
+      v_tenant,
+      'Khoa ICU ' || v_suffix,
+      ' ',
+      ' ',
+      ' ',
+      ' ',
+      ' ',
+      false
+    ),
+    (
       'SMK-BUCKET-DELETED-' || v_suffix,
       'Smoke Cascade Deleted ' || v_suffix,
       'Model Deleted ' || v_suffix,
@@ -194,6 +209,24 @@ BEGIN
   END IF;
 
   v_payload := public.equipment_filter_buckets(
+    p_don_vi => v_tenant,
+    p_nguoi_su_dung_array => ARRAY['Chưa có người sử dụng'],
+    p_vi_tri_lap_dat_array => ARRAY['Chưa có vị trí'],
+    p_tinh_trang_array => ARRAY['Chưa phân loại'],
+    p_phan_loai_array => ARRAY['Chưa phân loại'],
+    p_nguon_kinh_phi_array => ARRAY['Chưa có']
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'department') entry
+    WHERE entry->>'name' = 'Khoa ICU ' || v_suffix
+      AND (entry->>'count')::integer = 1
+  ) THEN
+    RAISE EXCEPTION 'selected fallback labels should cascade against normalized bucket names: %', v_payload;
+  END IF;
+
+  v_payload := public.equipment_filter_buckets(
     p_q => 'Smoke Cascade Alpha',
     p_don_vi => v_tenant
   );
@@ -260,8 +293,11 @@ BEGIN
 
   v_payload := public.equipment_filter_buckets(p_don_vi => v_tenant);
 
-  IF COALESCE(jsonb_array_length(v_payload->'department'), 0) <> 0
-     OR COALESCE(jsonb_array_length(v_payload->'status'), 0) <> 0 THEN
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_each(v_payload) bucket(key, value)
+    WHERE COALESCE(jsonb_array_length(value), 0) <> 0
+  ) THEN
     RAISE EXCEPTION 'role=user with blank khoa_phong must fail closed to empty buckets: %', v_payload;
   END IF;
 

--- a/supabase/tests/equipment_filter_buckets_smoke.sql
+++ b/supabase/tests/equipment_filter_buckets_smoke.sql
@@ -11,6 +11,7 @@ DECLARE
   v_other_tenant bigint;
   v_payload jsonb;
   v_count integer;
+  v_distribution_count integer;
 BEGIN
   INSERT INTO public.don_vi(name, active)
   VALUES ('Smoke Filter Buckets Tenant ' || v_suffix, true)
@@ -224,6 +225,35 @@ BEGIN
       AND (entry->>'count')::integer = 1
   ) THEN
     RAISE EXCEPTION 'selected fallback labels should cascade against normalized bucket names: %', v_payload;
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_don_vi => v_tenant,
+    p_nguoi_su_dung_array => ARRAY['Chưa có người sử dụng'],
+    p_vi_tri_lap_dat_array => ARRAY['Chưa có vị trí'],
+    p_tinh_trang_array => ARRAY['Chưa phân loại'],
+    p_phan_loai_array => ARRAY['Chưa phân loại'],
+    p_nguon_kinh_phi_array => ARRAY['Chưa có']
+  );
+
+  IF (v_payload->>'total')::integer <> 1
+     OR COALESCE(jsonb_array_length(v_payload->'data'), 0) <> 1 THEN
+    RAISE EXCEPTION 'equipment_list_enhanced should match selected fallback bucket labels: %', v_payload;
+  END IF;
+
+  SELECT COALESCE(SUM(distribution."count"), 0)::integer
+  INTO v_distribution_count
+  FROM public.equipment_department_distribution(
+    p_don_vi => v_tenant,
+    p_nguoi_su_dung_array => ARRAY['Chưa có người sử dụng'],
+    p_vi_tri_lap_dat_array => ARRAY['Chưa có vị trí'],
+    p_tinh_trang_array => ARRAY['Chưa phân loại'],
+    p_phan_loai_array => ARRAY['Chưa phân loại'],
+    p_nguon_kinh_phi_array => ARRAY['Chưa có']
+  ) distribution;
+
+  IF v_distribution_count <> 1 THEN
+    RAISE EXCEPTION 'equipment_department_distribution should match selected fallback bucket labels: count=%', v_distribution_count;
   END IF;
 
   v_payload := public.equipment_filter_buckets(

--- a/supabase/tests/equipment_filter_buckets_smoke.sql
+++ b/supabase/tests/equipment_filter_buckets_smoke.sql
@@ -12,6 +12,11 @@ DECLARE
   v_payload jsonb;
   v_count integer;
   v_distribution_count integer;
+  v_fallback_users text[] := ARRAY['Chưa có người sử dụng'];
+  v_fallback_locations text[] := ARRAY['Chưa có vị trí'];
+  v_fallback_statuses text[] := ARRAY['Chưa phân loại'];
+  v_fallback_classifications text[] := ARRAY['Chưa phân loại'];
+  v_fallback_funding_sources text[] := ARRAY['Chưa có'];
 BEGIN
   INSERT INTO public.don_vi(name, active)
   VALUES ('Smoke Filter Buckets Tenant ' || v_suffix, true)
@@ -211,11 +216,11 @@ BEGIN
 
   v_payload := public.equipment_filter_buckets(
     p_don_vi => v_tenant,
-    p_nguoi_su_dung_array => ARRAY['Chưa có người sử dụng'],
-    p_vi_tri_lap_dat_array => ARRAY['Chưa có vị trí'],
-    p_tinh_trang_array => ARRAY['Chưa phân loại'],
-    p_phan_loai_array => ARRAY['Chưa phân loại'],
-    p_nguon_kinh_phi_array => ARRAY['Chưa có']
+    p_nguoi_su_dung_array => v_fallback_users,
+    p_vi_tri_lap_dat_array => v_fallback_locations,
+    p_tinh_trang_array => v_fallback_statuses,
+    p_phan_loai_array => v_fallback_classifications,
+    p_nguon_kinh_phi_array => v_fallback_funding_sources
   );
 
   IF NOT EXISTS (
@@ -229,11 +234,11 @@ BEGIN
 
   v_payload := public.equipment_list_enhanced(
     p_don_vi => v_tenant,
-    p_nguoi_su_dung_array => ARRAY['Chưa có người sử dụng'],
-    p_vi_tri_lap_dat_array => ARRAY['Chưa có vị trí'],
-    p_tinh_trang_array => ARRAY['Chưa phân loại'],
-    p_phan_loai_array => ARRAY['Chưa phân loại'],
-    p_nguon_kinh_phi_array => ARRAY['Chưa có']
+    p_nguoi_su_dung_array => v_fallback_users,
+    p_vi_tri_lap_dat_array => v_fallback_locations,
+    p_tinh_trang_array => v_fallback_statuses,
+    p_phan_loai_array => v_fallback_classifications,
+    p_nguon_kinh_phi_array => v_fallback_funding_sources
   );
 
   IF (v_payload->>'total')::integer <> 1
@@ -245,11 +250,11 @@ BEGIN
   INTO v_distribution_count
   FROM public.equipment_department_distribution(
     p_don_vi => v_tenant,
-    p_nguoi_su_dung_array => ARRAY['Chưa có người sử dụng'],
-    p_vi_tri_lap_dat_array => ARRAY['Chưa có vị trí'],
-    p_tinh_trang_array => ARRAY['Chưa phân loại'],
-    p_phan_loai_array => ARRAY['Chưa phân loại'],
-    p_nguon_kinh_phi_array => ARRAY['Chưa có']
+    p_nguoi_su_dung_array => v_fallback_users,
+    p_vi_tri_lap_dat_array => v_fallback_locations,
+    p_tinh_trang_array => v_fallback_statuses,
+    p_phan_loai_array => v_fallback_classifications,
+    p_nguon_kinh_phi_array => v_fallback_funding_sources
   ) distribution;
 
   IF v_distribution_count <> 1 THEN

--- a/supabase/tests/equipment_filter_buckets_smoke.sql
+++ b/supabase/tests/equipment_filter_buckets_smoke.sql
@@ -1,5 +1,5 @@
 -- supabase/tests/equipment_filter_buckets_smoke.sql
--- Purpose: smoke-test equipment_filter_buckets after the migration is applied.
+-- Purpose: smoke-test cascading equipment_filter_buckets after the migration is applied.
 -- Non-destructive: wrapped in transaction and rolled back.
 
 BEGIN;
@@ -10,6 +10,7 @@ DECLARE
   v_tenant bigint;
   v_other_tenant bigint;
   v_payload jsonb;
+  v_count integer;
 BEGIN
   INSERT INTO public.don_vi(name, active)
   VALUES ('Smoke Filter Buckets Tenant ' || v_suffix, true)
@@ -22,6 +23,9 @@ BEGIN
   INSERT INTO public.thiet_bi(
     ma_thiet_bi,
     ten_thiet_bi,
+    model,
+    serial,
+    so_luu_hanh,
     don_vi,
     khoa_phong_quan_ly,
     tinh_trang_hien_tai,
@@ -33,27 +37,93 @@ BEGIN
   )
   VALUES
     (
-      'SMK-BUCKET-ALLOW-' || v_suffix,
-      'Smoke Bucket Allowed ' || v_suffix,
+      'SMK-BUCKET-A-' || v_suffix,
+      'Smoke Cascade Alpha ' || v_suffix,
+      'Model Alpha ' || v_suffix,
+      'Serial Alpha ' || v_suffix,
+      'Reg Alpha ' || v_suffix,
       v_tenant,
-      'Khoa Bucket ' || v_suffix,
+      'Khoa ICU ' || v_suffix,
       'Hoat dong',
-      'User Bucket ' || v_suffix,
-      'Room Bucket ' || v_suffix,
-      'Class Bucket ' || v_suffix,
-      'Fund Bucket ' || v_suffix,
+      'User A ' || v_suffix,
+      'Room A ' || v_suffix,
+      'Class A ' || v_suffix,
+      'Fund A ' || v_suffix,
       false
     ),
     (
-      'SMK-BUCKET-OTHER-' || v_suffix,
-      'Smoke Bucket Other ' || v_suffix,
-      v_other_tenant,
-      'Khoa Other ' || v_suffix,
+      'SMK-BUCKET-B-' || v_suffix,
+      'Smoke Cascade Beta ' || v_suffix,
+      'Model Beta ' || v_suffix,
+      'Serial Beta ' || v_suffix,
+      'Reg Beta ' || v_suffix,
+      v_tenant,
+      'Khoa ICU ' || v_suffix,
+      'Bao tri',
+      'User B ' || v_suffix,
+      'Room B ' || v_suffix,
+      'Class B ' || v_suffix,
+      'Fund B ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-BUCKET-C-' || v_suffix,
+      'Smoke Cascade Alpha Other Dept ' || v_suffix,
+      'Model Gamma ' || v_suffix,
+      'Serial Gamma ' || v_suffix,
+      'Reg Gamma ' || v_suffix,
+      v_tenant,
+      'Khoa Surgery ' || v_suffix,
       'Hoat dong',
-      'User Other ' || v_suffix,
-      'Room Other ' || v_suffix,
-      'Class Other ' || v_suffix,
-      'Fund Other ' || v_suffix,
+      'User C ' || v_suffix,
+      'Room C ' || v_suffix,
+      'Class C ' || v_suffix,
+      'Fund C ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-BUCKET-D-' || v_suffix,
+      'Smoke Cascade Delta ' || v_suffix,
+      'Model Delta ' || v_suffix,
+      'Serial Delta ' || v_suffix,
+      'Reg Delta ' || v_suffix,
+      v_tenant,
+      'Khoa Surgery ' || v_suffix,
+      'Bao tri',
+      'User D ' || v_suffix,
+      'Room D ' || v_suffix,
+      'Class D ' || v_suffix,
+      'Fund D ' || v_suffix,
+      false
+    ),
+    (
+      'SMK-BUCKET-DELETED-' || v_suffix,
+      'Smoke Cascade Deleted ' || v_suffix,
+      'Model Deleted ' || v_suffix,
+      'Serial Deleted ' || v_suffix,
+      'Reg Deleted ' || v_suffix,
+      v_tenant,
+      'Khoa Deleted ' || v_suffix,
+      'Hoat dong',
+      'User Deleted ' || v_suffix,
+      'Room Deleted ' || v_suffix,
+      'Class Deleted ' || v_suffix,
+      'Fund Deleted ' || v_suffix,
+      true
+    ),
+    (
+      'SMK-BUCKET-OTHER-' || v_suffix,
+      'Smoke Cascade Other Tenant ' || v_suffix,
+      'Model Other ' || v_suffix,
+      'Serial Other ' || v_suffix,
+      'Reg Other ' || v_suffix,
+      v_other_tenant,
+      'Khoa Other Tenant ' || v_suffix,
+      'Hoat dong',
+      'User Other Tenant ' || v_suffix,
+      'Room Other Tenant ' || v_suffix,
+      'Class Other Tenant ' || v_suffix,
+      'Fund Other Tenant ' || v_suffix,
       false
     );
 
@@ -67,36 +137,132 @@ BEGIN
     true
   );
 
-  v_payload := public.equipment_filter_buckets(v_tenant);
+  v_payload := public.equipment_filter_buckets(
+    p_don_vi => v_tenant,
+    p_tinh_trang_array => ARRAY['Hoat dong']
+  );
 
   IF jsonb_typeof(v_payload->'department') IS DISTINCT FROM 'array' THEN
     RAISE EXCEPTION 'equipment_filter_buckets.department must be an array: %', v_payload;
   END IF;
 
-  IF NOT EXISTS (
-    SELECT 1
-    FROM jsonb_array_elements(v_payload->'department') entry
-    WHERE entry->>'name' = 'Khoa Bucket ' || v_suffix
-      AND (entry->>'count')::integer = 1
-  ) THEN
-    RAISE EXCEPTION 'equipment_filter_buckets missing scoped department bucket: %', v_payload;
+  SELECT COUNT(*)
+  INTO v_count
+  FROM jsonb_array_elements(v_payload->'department') entry
+  WHERE entry->>'name' IN ('Khoa ICU ' || v_suffix, 'Khoa Surgery ' || v_suffix)
+    AND (entry->>'count')::integer = 1;
+
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'status filter should narrow department buckets across full tenant scope: %', v_payload;
   END IF;
 
   IF EXISTS (
     SELECT 1
     FROM jsonb_array_elements(v_payload->'department') entry
-    WHERE entry->>'name' = 'Khoa Other ' || v_suffix
+    WHERE entry->>'name' IN ('Khoa Deleted ' || v_suffix, 'Khoa Other Tenant ' || v_suffix)
   ) THEN
-    RAISE EXCEPTION 'equipment_filter_buckets leaked cross-tenant department bucket: %', v_payload;
+    RAISE EXCEPTION 'equipment_filter_buckets leaked deleted or cross-tenant department bucket: %', v_payload;
   END IF;
 
   IF NOT EXISTS (
     SELECT 1
-    FROM jsonb_array_elements(v_payload->'fundingSource') entry
-    WHERE entry->>'name' = 'Fund Bucket ' || v_suffix
+    FROM jsonb_array_elements(v_payload->'status') entry
+    WHERE entry->>'name' = 'Hoat dong'
+      AND (entry->>'count')::integer = 2
+  ) OR NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'status') entry
+    WHERE entry->>'name' = 'Bao tri'
+      AND (entry->>'count')::integer = 2
+  ) THEN
+    RAISE EXCEPTION 'status bucket should exclude its own selected status filter: %', v_payload;
+  END IF;
+
+  v_payload := public.equipment_filter_buckets(
+    p_don_vi => v_tenant,
+    p_khoa_phong_array => ARRAY['Khoa ICU ' || v_suffix],
+    p_tinh_trang_array => ARRAY['Hoat dong']
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'status') entry
+    WHERE entry->>'name' = 'Bao tri'
       AND (entry->>'count')::integer = 1
   ) THEN
-    RAISE EXCEPTION 'equipment_filter_buckets missing fundingSource bucket: %', v_payload;
+    RAISE EXCEPTION 'status bucket should keep same-department unselected statuses visible: %', v_payload;
+  END IF;
+
+  v_payload := public.equipment_filter_buckets(
+    p_q => 'Smoke Cascade Alpha',
+    p_don_vi => v_tenant
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'status') entry
+    WHERE entry->>'name' = 'Hoat dong'
+      AND (entry->>'count')::integer = 2
+  ) OR EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'status') entry
+    WHERE entry->>'name' = 'Bao tri'
+  ) THEN
+    RAISE EXCEPTION 'search text should narrow every bucket to matching server rows: %', v_payload;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', '900002',
+      'don_vi', v_tenant,
+      'khoa_phong', 'Khoa ICU ' || v_suffix
+    )::text,
+    true
+  );
+
+  v_payload := public.equipment_filter_buckets(
+    p_don_vi => v_tenant,
+    p_khoa_phong_array => ARRAY['Khoa Surgery ' || v_suffix],
+    p_tinh_trang_array => ARRAY['Hoat dong']
+  );
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'department') entry
+    WHERE entry->>'name' = 'Khoa ICU ' || v_suffix
+      AND (entry->>'count')::integer = 1
+  ) THEN
+    RAISE EXCEPTION 'role=user department bucket must keep JWT department scope even when own filter is excluded: %', v_payload;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_payload->'department') entry
+    WHERE entry->>'name' = 'Khoa Surgery ' || v_suffix
+  ) THEN
+    RAISE EXCEPTION 'role=user department bucket leaked cross-department data: %', v_payload;
+  END IF;
+
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'user',
+      'role', 'authenticated',
+      'user_id', '900003',
+      'don_vi', v_tenant,
+      'khoa_phong', ' '
+    )::text,
+    true
+  );
+
+  v_payload := public.equipment_filter_buckets(p_don_vi => v_tenant);
+
+  IF COALESCE(jsonb_array_length(v_payload->'department'), 0) <> 0
+     OR COALESCE(jsonb_array_length(v_payload->'status'), 0) <> 0 THEN
+    RAISE EXCEPTION 'role=user with blank khoa_phong must fail closed to empty buckets: %', v_payload;
   END IF;
 
   RAISE NOTICE 'equipment_filter_buckets smoke: PASSED';


### PR DESCRIPTION
## Summary
- extend equipment_filter_buckets to accept active Equipment search/filter args and compute cascading bucket counts server-side
- keep role=user JWT department scope enforced before bucket-specific own-filter exclusion
- key useEquipmentData bucket query by search/filter state, not pagination

## Verification
- Supabase MCP apply_migration: cascade_equipment_filter_buckets
- Supabase MCP SQL smoke: supabase/tests/equipment_filter_buckets_smoke.sql passed inside rollback
- Supabase MCP security advisor run after DDL; only existing baseline lint classes observed
- ./node_modules/.bin/prettier --check --ignore-unknown changed files
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx'
- node scripts/npm-run.js run react-doctor

Closes #670

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Equipment filter buckets cascade with the active search and filters. Align the Equipment list and department distribution with the same normalized labels and predicates so counts and selections stay in sync.

- **Bug Fixes**
  - Update bucket RPC to accept search text and filter arrays; compute per-bucket counts while excluding its own filter and using normalized fallback labels.
  - Enforce JWT department scope before bucket-specific exclusion (covers role=user).
  - Align `equipment_list_enhanced` and `equipment_department_distribution` filters with bucket labels (e.g., “Chưa có”, “Chưa phân loại”) to prevent mismatches.
  - Update hook to pass active search/filters and key the bucket query by filters only (not pagination). Add unit and smoke tests for search narrowing, fallback labels, deletions/cross-tenant, role=user fail-closed; dedupe fallback inputs in smoke tests.

- **Migration**
  - Apply Supabase migrations:
    - `20260704070000_cascade_equipment_filter_buckets.sql`
    - `20260704073000_fix_equipment_filter_buckets_review_feedback.sql`
    - `20260704074500_align_equipment_list_filters_with_bucket_labels.sql`
    - `20260704075000_align_equipment_distribution_filters_with_bucket_labels.sql`

<sup>Written for commit 218aa977b92f598c6b65288e34e8c9a01ea8a015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Equipment filter options now update reliably as search text and all selected filters change.
  * Filter bucket counts cascade more accurately across department, user, location, status, classification, and funding source.

* **Bug Fixes**
  * Fixed stale or mismatched bucket data when pagination changes or when filters/search are adjusted.
  * Improved access-aware scoping and “fail closed” behavior for missing/blank department scope.

* **Tests**
  * Added/expanded automated coverage for cascading bucket behavior and query caching identity.
  * Updated smoke tests and fixtures to validate bucket-label alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->