### PR TITLE
Modernize Repair Requests filter toolbar

### DIFF
--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
@@ -4,6 +4,25 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
+vi.mock("@/components/shared/TenantSelector", () => ({
+  TenantSelector: ({
+    className,
+    variant = "default",
+  }: {
+    className?: string
+    variant?: "default" | "command"
+  }) => (
+    <button
+      type="button"
+      data-testid="tenant-selector"
+      data-class-name={className}
+      data-trigger-variant={variant}
+    >
+      Cơ sở
+    </button>
+  ),
+}))
+
 import { RepairRequestsToolbar } from "../_components/RepairRequestsToolbar"
 
 const baseProps = {
@@ -36,18 +55,36 @@ describe("RepairRequestsToolbar", () => {
 
     expect(search).toBeInTheDocument()
     expect(tenant.compareDocumentPosition(search)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
-    expect(screen.getByRole("button", { name: "Trạng thái" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Trạng thái" })).toHaveAttribute(
+      "data-trigger-variant",
+      "command"
+    )
     expect(screen.queryByRole("button", { name: "Cơ sở" })).not.toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Từ ngày" })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Đến ngày" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Từ ngày" })).toHaveAttribute(
+      "data-trigger-variant",
+      "command"
+    )
+    expect(screen.getByRole("button", { name: "Đến ngày" })).toHaveAttribute(
+      "data-trigger-variant",
+      "command"
+    )
     expect(screen.queryByRole("button", { name: "Bộ lọc" })).not.toBeInTheDocument()
   })
 
+  it("uses the Equipment-style command tenant selector on desktop layouts", () => {
+    render(<RepairRequestsToolbar {...baseProps} showFacilityFilter />)
+
+    const tenantSelector = screen.getByTestId("tenant-selector")
+    expect(tenantSelector).toHaveAttribute("data-trigger-variant", "command")
+    expect(tenantSelector).toHaveAttribute("data-class-name", "w-full md:w-auto")
+  })
+
   it("keeps the compact filter trigger for mobile layouts", () => {
-    render(<RepairRequestsToolbar {...baseProps} compactFilters />)
+    render(<RepairRequestsToolbar {...baseProps} compactFilters showFacilityFilter />)
 
     expect(screen.getByRole("button", { name: "Bộ lọc" })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Trạng thái" })).not.toBeInTheDocument()
+    expect(screen.getByTestId("tenant-selector")).toHaveAttribute("data-trigger-variant", "default")
   })
 
   it("updates status filters from the inline status control", async () => {
@@ -94,13 +131,7 @@ describe("RepairRequestsToolbar", () => {
   })
 
   it("omits the Equipment-style tenant slot when no tenant control is provided", () => {
-    render(
-      <RepairRequestsToolbar
-        {...baseProps}
-        showFacilityFilter={false}
-        tenantControl={null}
-      />
-    )
+    render(<RepairRequestsToolbar {...baseProps} showFacilityFilter={false} tenantControl={null} />)
 
     expect(screen.queryByRole("button", { name: "Cơ sở" })).not.toBeInTheDocument()
   })

--- a/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
@@ -56,108 +56,149 @@ export function RepairRequestsToolbar({
   onRemoveFilter,
 }: RepairRequestsToolbarProps) {
   const dateRange = React.useMemo(
-    () => uiFilters.dateRange && (uiFilters.dateRange.from || uiFilters.dateRange.to)
-      ? {
-        from: parseFilterDate(uiFilters.dateRange.from),
-        to: parseFilterDate(uiFilters.dateRange.to),
-      }
-      : null,
+    () =>
+      uiFilters.dateRange && (uiFilters.dateRange.from || uiFilters.dateRange.to)
+        ? {
+            from: parseFilterDate(uiFilters.dateRange.from),
+            to: parseFilterDate(uiFilters.dateRange.to),
+          }
+        : null,
     [uiFilters.dateRange]
   )
 
-  const filterValue = React.useMemo<FilterModalValue>(() => ({
-    status: uiFilters.status,
-    facilityId: selectedFacilityId ?? null,
-    dateRange,
-  }), [dateRange, selectedFacilityId, uiFilters.status])
+  const filterValue = React.useMemo<FilterModalValue>(
+    () => ({
+      status: uiFilters.status,
+      facilityId: selectedFacilityId ?? null,
+      dateRange,
+    }),
+    [dateRange, selectedFacilityId, uiFilters.status]
+  )
 
-  const applyFilterChange = React.useCallback((patch: Partial<FilterModalValue>) => {
-    onFilterChange({
-      status: patch.status ?? filterValue.status,
-      facilityId: patch.facilityId === undefined ? filterValue.facilityId ?? null : patch.facilityId,
-      dateRange: patch.dateRange === undefined ? filterValue.dateRange ?? null : patch.dateRange,
-    })
-  }, [filterValue, onFilterChange])
+  const applyFilterChange = React.useCallback(
+    (patch: Partial<FilterModalValue>) => {
+      onFilterChange({
+        status: patch.status ?? filterValue.status,
+        facilityId:
+          patch.facilityId === undefined ? (filterValue.facilityId ?? null) : patch.facilityId,
+        dateRange:
+          patch.dateRange === undefined ? (filterValue.dateRange ?? null) : patch.dateRange,
+      })
+    },
+    [filterValue, onFilterChange]
+  )
 
-  const setDateRangePart = React.useCallback((key: "from" | "to", date: Date | null) => {
-    applyFilterChange({
-      dateRange: {
-        from: key === "from" ? date : filterValue.dateRange?.from ?? null,
-        to: key === "to" ? date : filterValue.dateRange?.to ?? null,
-      },
-    })
-  }, [applyFilterChange, filterValue.dateRange])
+  const setDateRangePart = React.useCallback(
+    (key: "from" | "to", date: Date | null) => {
+      applyFilterChange({
+        dateRange: {
+          from: key === "from" ? date : (filterValue.dateRange?.from ?? null),
+          to: key === "to" ? date : (filterValue.dateRange?.to ?? null),
+        },
+      })
+    },
+    [applyFilterChange, filterValue.dateRange]
+  )
 
-  const statusOptions = React.useMemo(() => REPAIR_REQUEST_STATUS_OPTIONS.map((status) => ({
-    label: status,
-    value: status,
-  })), [])
+  const statusOptions = React.useMemo(
+    () =>
+      REPAIR_REQUEST_STATUS_OPTIONS.map((status) => ({
+        label: status,
+        value: status,
+      })),
+    []
+  )
 
-  const filterControls = React.useMemo(() => (
-    <>
-      <FacetedMultiSelectFilter
-        title="Trạng thái"
-        options={statusOptions}
-        value={filterValue.status}
-        onChange={(values) => applyFilterChange({ status: values })}
+  const filterControls = React.useMemo(
+    () => (
+      <>
+        <FacetedMultiSelectFilter
+          title="Trạng thái"
+          options={statusOptions}
+          value={filterValue.status}
+          onChange={(values) => applyFilterChange({ status: values })}
+          triggerVariant="command"
+        />
+        <DateFilterButton
+          label="Từ ngày"
+          value={filterValue.dateRange?.from ?? null}
+          onChange={(date) => setDateRangePart("from", date)}
+        />
+        <DateFilterButton
+          label="Đến ngày"
+          value={filterValue.dateRange?.to ?? null}
+          onChange={(date) => setDateRangePart("to", date)}
+        />
+      </>
+    ),
+    [applyFilterChange, filterValue.dateRange, filterValue.status, setDateRangePart, statusOptions]
+  )
+
+  const mobileFilterControl = React.useMemo(
+    () => (
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-9 touch-target-sm"
+        onClick={onOpenFilterModal}
+      >
+        Bộ lọc
+      </Button>
+    ),
+    [onOpenFilterModal]
+  )
+
+  const clearAction = React.useMemo(
+    () =>
+      isFiltered ? (
+        <Button
+          variant="ghost"
+          onClick={onClearFilters}
+          className="h-9 px-2 lg:px-3 touch-target-sm"
+          aria-label="Xóa bộ lọc"
+        >
+          <span className="hidden sm:inline">Xóa</span>
+          <FilterX className="size-4 sm:ml-2" />
+        </Button>
+      ) : null,
+    [isFiltered, onClearFilters]
+  )
+
+  const chips = React.useMemo(
+    () => (
+      <RepairRequestsFilterChips
+        value={{
+          status: uiFilters.status,
+          facilityName: selectedFacilityName,
+          dateRange: uiFilters.dateRange
+            ? { from: uiFilters.dateRange.from ?? null, to: uiFilters.dateRange.to ?? null }
+            : null,
+        }}
+        showFacility={showFacilityFilter}
+        onRemove={onRemoveFilter}
       />
-      <DateFilterButton
-        label="Từ ngày"
-        value={filterValue.dateRange?.from ?? null}
-        onChange={(date) => setDateRangePart("from", date)}
-      />
-      <DateFilterButton
-        label="Đến ngày"
-        value={filterValue.dateRange?.to ?? null}
-        onChange={(date) => setDateRangePart("to", date)}
-      />
-    </>
-  ), [applyFilterChange, filterValue.dateRange, filterValue.status, setDateRangePart, statusOptions])
-
-  const mobileFilterControl = React.useMemo(() => (
-    <Button
-      variant="outline"
-      size="sm"
-      className="h-9 touch-target-sm"
-      onClick={onOpenFilterModal}
-    >
-      Bộ lọc
-    </Button>
-  ), [onOpenFilterModal])
-
-  const clearAction = React.useMemo(() => isFiltered ? (
-    <Button
-      variant="ghost"
-      onClick={onClearFilters}
-      className="h-9 px-2 lg:px-3 touch-target-sm"
-      aria-label="Xóa bộ lọc"
-    >
-      <span className="hidden sm:inline">Xóa</span>
-      <FilterX className="size-4 sm:ml-2" />
-    </Button>
-  ) : null, [isFiltered, onClearFilters])
-
-  const chips = React.useMemo(() => (
-    <RepairRequestsFilterChips
-      value={{
-        status: uiFilters.status,
-        facilityName: selectedFacilityName,
-        dateRange: uiFilters.dateRange
-          ? { from: uiFilters.dateRange.from ?? null, to: uiFilters.dateRange.to ?? null }
-          : null,
-      }}
-      showFacility={showFacilityFilter}
-      onRemove={onRemoveFilter}
-    />
-  ), [onRemoveFilter, selectedFacilityName, showFacilityFilter, uiFilters.dateRange, uiFilters.status])
+    ),
+    [
+      onRemoveFilter,
+      selectedFacilityName,
+      showFacilityFilter,
+      uiFilters.dateRange,
+      uiFilters.status,
+    ]
+  )
 
   const resolvedTenantControl = React.useMemo(() => {
     if (tenantControl !== undefined) {
       return tenantControl
     }
 
-    return showFacilityFilter ? <TenantSelector className="w-full" /> : null
-  }, [showFacilityFilter, tenantControl])
+    return showFacilityFilter ? (
+      <TenantSelector
+        className="w-full md:w-auto"
+        variant={compactFilters ? "default" : "command"}
+      />
+    ) : null
+  }, [compactFilters, showFacilityFilter, tenantControl])
 
   return (
     <ListFilterSearchCard
@@ -192,7 +233,11 @@ function DateFilterButton({ label, value, onChange }: DateFilterButtonProps) {
           type="button"
           variant="outline"
           size="sm"
-          className={cn("h-9 min-w-[116px] justify-start", !value && "text-muted-foreground")}
+          data-trigger-variant="command"
+          className={cn(
+            "h-9 min-w-[116px] justify-start rounded-lg border-slate-200 bg-muted/80 px-3 shadow-none transition-all hover:border-primary/30 hover:bg-muted",
+            value ? "border-primary/50 bg-primary/10 hover:bg-primary/15" : "text-muted-foreground"
+          )}
         >
           <CalendarIcon className="mr-2 size-4" />
           {value ? value.toLocaleDateString("vi-VN") : label}


### PR DESCRIPTION
## Summary
- Modernize Repair Requests desktop filters with command-token presentation for status and date controls.
- Sync the fallback tenant selector with Equipments: command variant on desktop, default variant on compact/mobile.
- Add focused regression coverage for command-token controls and tenant selector variant behavior.

Closes #664

## Test Plan
- [x] `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx'`
- [x] `node /root/qltbyt-nam-phong/node_modules/prettier/bin/prettier.cjs --check 'src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx' 'src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx'`
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run react-doctor`

Note: broad `node scripts/npm-run.js run format:check` currently fails on existing repository baseline formatting noise (1204 files), so this PR verified Prettier on the changed files and Lefthook `format:staged` during commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernizes the Repair Requests filter toolbar with command-style status/date controls and a responsive tenant selector to match the Equipments view. Improves clarity on desktop while keeping compact filters on mobile. Aligns with Linear #664.

- **New Features**
  - Status and date filters use command-token triggers on desktop; mobile keeps the "Bộ lọc" button.
  - `TenantSelector` switches to `variant="command"` on desktop and `variant="default"` on compact/mobile; layout set to `w-full md:w-auto`.
  - Added focused tests for command-token controls and tenant selector variant behavior.

<sup>Written for commit 28d46f538563f64c44aa8c176be1b2db4374a8a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the repair requests toolbar so tenant and filter controls now adapt more consistently between desktop and mobile views.
  * Fixed the date filter button’s active/inactive styling to better reflect whether a date range is selected.
  * Updated toolbar filter controls to keep the compact mobile experience while showing a fuller desktop layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->