### PR TITLE
fix: refine equipment compact filters

### DIFF
--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   openImportDialog: vi.fn(),
   openColumnsDialog: vi.fn(),
   openDetailDialog: vi.fn(),
+  tenantSelector: vi.fn(),
 }))
 
 vi.mock("../use-equipment-page", () => ({
@@ -58,7 +59,9 @@ vi.mock("../_components/EquipmentBulkDeleteBar", () => ({
 }))
 
 vi.mock("@/components/equipment/equipment-toolbar", () => ({
-  EquipmentToolbar: () => <section aria-label="equipment toolbar" />,
+  EquipmentToolbar: ({ tenantControl }: { tenantControl?: React.ReactNode }) => (
+    <section aria-label="equipment toolbar">{tenantControl}</section>
+  ),
 }))
 
 vi.mock("@/components/equipment/filter-bottom-sheet", () => ({
@@ -70,7 +73,10 @@ vi.mock("@/components/shared/DataTablePagination", () => ({
 }))
 
 vi.mock("@/components/shared/TenantSelector", () => ({
-  TenantSelector: () => null,
+  TenantSelector: (props: { variant?: "default" | "command"; className?: string }) => {
+    mocks.tenantSelector(props)
+    return <button type="button">Cơ sở</button>
+  },
 }))
 
 vi.mock("@/components/ui/popover", () => ({
@@ -206,6 +212,32 @@ describe("EquipmentPageClient department summary", () => {
     expect(within(summary).queryByText("Chưa cập nhật")).not.toBeInTheDocument()
     expect(screen.getByRole("region", { name: "equipment toolbar" })).toBeInTheDocument()
     expect(screen.getByRole("region", { name: "equipment table" })).toBeInTheDocument()
+  })
+
+  it("hides the department summary when compact filters are active", () => {
+    state.pageState = createPageState({ isMobile: true, isCardView: true })
+
+    render(<EquipmentPageClient />)
+
+    expect(
+      screen.queryByRole("region", { name: "Phân bố theo khoa/phòng" })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("region", { name: "equipment toolbar" })).toBeInTheDocument()
+    expect(screen.getByRole("region", { name: "equipment table" })).toBeInTheDocument()
+  })
+
+  it("uses the command tenant selector variant in compact filter mode", () => {
+    state.pageState = createPageState({
+      isMobile: true,
+      isCardView: true,
+      showFacilityFilter: true,
+    })
+
+    render(<EquipmentPageClient />)
+
+    expect(mocks.tenantSelector).toHaveBeenCalledWith(
+      expect.objectContaining({ className: "w-full md:w-auto", variant: "command" })
+    )
   })
 
   it("shows the remaining departments in a searchable popover list", async () => {

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -179,13 +179,8 @@ function EquipmentPageContent({ pageState }: { pageState: ReturnType<typeof useE
   const tenantControl = React.useMemo(() => {
     if (!showFacilityFilter) return null
 
-    return (
-      <TenantSelector
-        className="w-full md:w-auto"
-        variant={useCompactFilters ? "default" : "command"}
-      />
-    )
-  }, [showFacilityFilter, useCompactFilters])
+    return <TenantSelector className="w-full md:w-auto" variant="command" />
+  }, [showFacilityFilter])
   const selectedDepartments = React.useMemo(() => {
     const value = columnFilters.find((filter) => filter.id === "khoa_phong_quan_ly")?.value
     return Array.isArray(value)
@@ -275,11 +270,13 @@ function EquipmentPageContent({ pageState }: { pageState: ReturnType<typeof useE
           onShowEquipmentDetails={(eq) => openDetailDialog(eq)}
         />
 
-        <EquipmentDepartmentSummary
-          items={departmentDistribution}
-          selectedDepartments={selectedDepartments}
-          onSelectDepartment={handleSelectDepartmentSummary}
-        />
+        {!useCompactFilters ? (
+          <EquipmentDepartmentSummary
+            items={departmentDistribution}
+            selectedDepartments={selectedDepartments}
+            onSelectDepartment={handleSelectDepartmentSummary}
+          />
+        ) : null}
 
         <Card>
           <CardContent className="space-y-4 px-4 pt-4 md:px-6">

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -8,7 +8,7 @@
 import * as React from "react"
 import { describe, it, expect, vi } from "vitest"
 import "@testing-library/jest-dom"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
 import type { Table } from "@tanstack/react-table"
 import type { Equipment } from "@/types/database"
 
@@ -335,6 +335,11 @@ describe("EquipmentToolbar with shared filters", () => {
     render(<EquipmentToolbar {...baseProps} filterMode="sheet" />)
 
     expect(screen.getByText("Lọc")).toBeInTheDocument()
+    const compactActions = screen.getByTestId("equipment-compact-filter-actions")
+
+    expect(compactActions).toHaveClass("grid", "w-full", "grid-cols-2", "gap-2")
+    expect(within(compactActions).getByRole("button", { name: /Lọc/i })).toHaveClass("w-full")
+    expect(within(compactActions).getByRole("button", { name: /Tùy chọn/i })).toHaveClass("w-full")
     expect(screen.queryByText("Tình trạng")).not.toBeInTheDocument()
     expect(screen.queryByText("Khoa/Phòng")).not.toBeInTheDocument()
   })

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -125,13 +125,13 @@ export function EquipmentToolbar({
 
   const mobileFilterControl = React.useMemo(
     () => (
-      <>
+      <div data-testid="equipment-compact-filter-actions" className="grid w-full grid-cols-2 gap-2">
         <Button
           variant="outline"
           size="sm"
           onClick={onOpenFilterSheet}
           className={cn(
-            "h-9 border-slate-200 shadow-sm transition-all",
+            "h-9 w-full justify-center border-slate-200 shadow-sm transition-all",
             isFiltered
               ? "border-primary/50 bg-primary/5 hover:bg-primary/10"
               : "hover:border-primary/30"
@@ -151,7 +151,7 @@ export function EquipmentToolbar({
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="h-9">
+            <Button variant="outline" size="sm" className="h-9 w-full justify-center">
               <Settings className="size-4 mr-2" />
               Tùy chọn
             </Button>
@@ -164,7 +164,7 @@ export function EquipmentToolbar({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-      </>
+      </div>
     ),
     [
       activeFilterCount,


### PR DESCRIPTION
## Summary
- Reuse the command-style tenant selector on Equipments across desktop and compact viewports.
- Hide the department summary chip row when compact filters are active.
- Balance the compact `Lọc` and `Tùy chọn` controls in a two-column row.

## Test Plan
- `npx prettier --check 'src/components/equipment/equipment-toolbar.tsx' 'src/app/(app)/equipment/_components/EquipmentPageClient.tsx' 'src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx' 'src/app/(app)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx'`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx src/app/\(app\)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx`
- `node scripts/npm-run.js run react-doctor`

## Notes
- Browser visual check was not completed because local auth redirected `/equipment` to `/api/auth/error?error=Configuration` due missing NextAuth dev env (`NEXTAUTH_SECRET`/`NEXTAUTH_URL`). No dev server is running now.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined compact filters on the Equipment page for a cleaner mobile experience. Always use the command-style `TenantSelector`, hide the department summary in compact mode, and make the `Lọc` and `Tùy chọn` buttons full-width in a balanced two-column row.

<sup>Written for commit c0a3a1981f86165b98cbde6313ca75bf8fff2e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the mobile and compact filter experience with a clearer two-column layout for filter and options actions.
  * Facility selection now uses a consistent command-style control when the facility filter is enabled.

* **Bug Fixes**
  * Hid the department summary section in compact, tablet, and mobile filter modes to better match the available screen space.
  * Updated mobile buttons so “Lọc” and “Tùy chọn” display full-width and align more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->