### PR TITLE
Redesign Repair Requests mobile layout

### DIFF
--- a/docs/superpowers/plans/2026-07-04-repair-requests-clean-mobile-redesign.md
+++ b/docs/superpowers/plans/2026-07-04-repair-requests-clean-mobile-redesign.md
@@ -1,0 +1,505 @@
+# Repair Requests Clean Mobile Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the Repair Requests mobile/tablet layout so it is clean, spacious, and balanced while preserving the existing fixed global header, tenant display, data flow, and desktop table experience.
+
+**Architecture:** Keep the existing route and data hooks unchanged. Add a local mobile KPI presentation for the five repair status cards, tighten the existing compact toolbar for mobile, and simplify mobile request cards through progressive disclosure: list cards show only decision-critical information; detail/menu flows keep secondary information available. Desktop continues to use the existing shared `KpiStatusBar`, toolbar, table, and pagination patterns.
+
+**Tech Stack:** Next.js App Router, React, TypeScript, Tailwind/shadcn components, Vitest, Testing Library, existing `scripts/npm-run.js` verification wrapper.
+
+---
+
+## Design Constraints
+
+- Preserve the current fixed global app header and tenant name. Do not copy the Stitch mockup header into the page body.
+- Do not repeat tenant/facility text under the page title when the fixed header already displays it.
+- Mobile and tablet use the card layout until desktop/laptop width. Table layout is desktop-only.
+- Five KPI cards must be visually balanced:
+  - `Tổng` is a full-width summary card.
+  - `Chờ xử lý`, `Đã duyệt`, `Hoàn thành`, `Không HT` form a 2x2 grid below.
+- Keep mobile list cards clean:
+  - Show equipment name, equipment code, status, requester department, request date, short problem description, and one primary action.
+  - Move secondary actions into the existing menu/action zone.
+  - Avoid nesting the list inside a large desktop-style card container on mobile.
+- Treat spacing as part of the design contract, not final polish:
+  - Page body horizontal padding: `px-4` on mobile, `md:px-6` on tablet.
+  - Main vertical rhythm: `gap-5` to `gap-6` between title, KPI, toolbar, and list.
+  - KPI grid gap: `gap-3` on mobile, `md:gap-4` on tablet.
+  - KPI card padding: `p-4`; total card can use `py-4 px-5`.
+  - Request card padding: `p-4`; internal sections use `gap-3` or `space-y-3`.
+  - Metadata rows must have enough column gap to avoid label/value collisions: at least `gap-x-4`.
+  - Action row gap: `gap-3`; primary button height 48px.
+  - Bottom padding must account for bottom nav/FAB: at least `pb-28` on mobile list/page content.
+- Maintain accessibility:
+  - Tap targets at least 44px, preferably 48px for primary actions.
+  - Card activation must remain separate from action controls.
+  - Searchbox and filter controls keep accessible labels.
+- Avoid broad shared component changes unless the local page cannot meet the design without them.
+
+## File Structure
+
+- Create: `src/app/(app)/repair-requests/_components/RepairRequestsMobileKpi.tsx`
+  - Local mobile/tablet KPI renderer for the five-card balanced layout.
+- Create: `src/app/(app)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx`
+  - Focused tests for total-card-first layout, 2x2 status grid, counts, loading/undefined behavior.
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx`
+  - Use `RepairRequestsMobileKpi` for mobile/tablet and keep `KpiStatusBar` for desktop.
+  - Remove/avoid the desktop-style list wrapper from mobile rendering.
+  - Keep access-gate empty state behavior unchanged.
+- Modify: `src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx`
+  - Assert mobile KPI is rendered with counts and desktop KPI remains available.
+  - Assert mobile list is not nested inside the desktop summary card container.
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx`
+  - Refine `compactFilters` layout only: search + `Bộ lọc` same row, chips below.
+- Modify: `src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx`
+  - Assert compact toolbar ordering and callbacks remain intact.
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx`
+  - Simplify the card visual hierarchy and action area while preserving keyboard/card/action behavior.
+- Modify: `src/app/(app)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx`
+  - Extend current accessibility tests for the cleaner card structure.
+
+## Chunk 1: Balanced Mobile KPI
+
+### Task 1: Add failing tests for five-card mobile KPI layout
+
+**Files:**
+
+- Create: `src/app/(app)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx`
+- Create later: `src/app/(app)/repair-requests/_components/RepairRequestsMobileKpi.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen, within } from "@testing-library/react"
+
+import { RepairRequestsMobileKpi } from "../_components/RepairRequestsMobileKpi"
+import type { RepairStatus } from "@/components/kpi"
+
+const counts: Record<RepairStatus, number> = {
+  "Chờ xử lý": 34,
+  "Đã duyệt": 3,
+  "Hoàn thành": 30,
+  "Không HT": 2,
+}
+
+describe("RepairRequestsMobileKpi", () => {
+  it("renders total as a full-width summary before a balanced 2x2 status grid", () => {
+    render(<RepairRequestsMobileKpi counts={counts} loading={false} />)
+
+    const region = screen.getByTestId("repair-mobile-kpi")
+    const total = screen.getByTestId("repair-mobile-kpi-total")
+    const statusGrid = screen.getByTestId("repair-mobile-kpi-status-grid")
+
+    expect(total).toHaveTextContent("Tổng")
+    expect(total).toHaveTextContent("69")
+    expect(total).toHaveClass("col-span-2")
+    expect(region.compareDocumentPosition(statusGrid)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+
+    expect(within(statusGrid).getAllByTestId(/^repair-mobile-kpi-status-/)).toHaveLength(4)
+    expect(screen.getByTestId("repair-mobile-kpi-status-Chờ xử lý")).toHaveTextContent("34")
+    expect(screen.getByTestId("repair-mobile-kpi-status-Đã duyệt")).toHaveTextContent("3")
+    expect(screen.getByTestId("repair-mobile-kpi-status-Hoàn thành")).toHaveTextContent("30")
+    expect(screen.getByTestId("repair-mobile-kpi-status-Không HT")).toHaveTextContent("2")
+  })
+
+  it("uses zero counts while status counts are unavailable", () => {
+    render(<RepairRequestsMobileKpi counts={undefined} loading={false} />)
+
+    expect(screen.getByTestId("repair-mobile-kpi-total")).toHaveTextContent("0")
+    expect(screen.getByTestId("repair-mobile-kpi-status-Chờ xử lý")).toHaveTextContent("0")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run through context-mode:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx
+```
+
+Expected: FAIL because `RepairRequestsMobileKpi` does not exist.
+
+- [ ] **Step 3: Implement minimal mobile KPI component**
+
+Create `src/app/(app)/repair-requests/_components/RepairRequestsMobileKpi.tsx`.
+
+Implementation notes:
+
+- Import `REPAIR_STATUS_CONFIGS` and `type RepairStatus` from `@/components/kpi`.
+- Render a wrapper with `data-testid="repair-mobile-kpi"` and `className="grid grid-cols-2 gap-3 md:max-w-3xl"`.
+- Render total first with `data-testid="repair-mobile-kpi-total"` and `className` including `col-span-2`.
+- Render status cards inside `data-testid="repair-mobile-kpi-status-grid"` with `className="col-span-2 grid grid-cols-2 gap-3"`.
+- Use consistent card padding (`p-4`, total `px-5 py-4`) and avoid cramped icon/value stacks.
+- Use the existing status config order. Do not introduce a new status order unless product asks for it.
+- Use existing icon/color config where practical, but keep styling local and restrained.
+- Loading may use muted placeholders, but do not add spinner-only UI.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/\(app\)/repair-requests/_components/RepairRequestsMobileKpi.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx
+git commit -m "test: add repair request mobile KPI layout"
+```
+
+## Chunk 2: Page Layout Integration
+
+### Task 2: Use mobile KPI and remove mobile desktop-style container
+
+**Files:**
+
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx`
+- Modify: `src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Add tests to `RepairRequestsPageLayout.test.tsx`.
+
+Test intent:
+
+- The layout passes `statusCounts` to the mobile KPI.
+- The mobile/tablet branch renders a card list without forcing it inside the desktop summary `Card`.
+- Desktop table/pagination behavior remains unchanged.
+
+Suggested test shape:
+
+```tsx
+vi.mock("../_components/RepairRequestsMobileKpi", () => ({
+  RepairRequestsMobileKpi: ({
+    counts,
+  }: {
+    counts: Record<string, number> | undefined
+    loading: boolean
+  }) => (
+    <div
+      data-testid="repair-mobile-kpi"
+      data-total={counts ? Object.values(counts).reduce((sum, value) => sum + value, 0) : 0}
+    />
+  ),
+}))
+
+it("renders the balanced mobile KPI with status counts", () => {
+  render(<RepairRequestsPageLayout {...defaultProps} />)
+
+  expect(screen.getByTestId("repair-mobile-kpi")).toHaveAttribute("data-total", "10")
+})
+
+it("keeps mobile cards outside the desktop summary card shell", () => {
+  render(<RepairRequestsPageLayout {...defaultProps} />)
+
+  const mobileList = screen.getByTestId("repair-mobile-list")
+  expect(mobileList.closest("[data-testid='repair-requests-desktop-card']")).toBeNull()
+})
+```
+
+If current tests do not expose stable container test ids, add semantic/test ids only where they document a real layout boundary.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
+```
+
+Expected: FAIL because the page does not yet render the local mobile KPI or the new mobile layout boundary.
+
+- [ ] **Step 3: Implement minimal layout integration**
+
+In `RepairRequestsPageLayout.tsx`:
+
+- Import `RepairRequestsMobileKpi`.
+- Render mobile KPI in the mobile/tablet content section with `className` visibility equivalent to `lg:hidden` or the repo's current breakpoint convention.
+- Keep shared `KpiStatusBar` in the desktop section only.
+- Add a stable `data-testid="repair-requests-desktop-card"` to the desktop summary card if needed by the test.
+- Add or preserve `data-testid="repair-mobile-list"` around the mobile list wrapper.
+- Keep the access-gate empty state unchanged; do not show mobile list when `shouldFetchData=false`.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/\(app\)/repair-requests/_components/RepairRequestsPageLayout.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
+git commit -m "feat: balance repair request mobile KPI layout"
+```
+
+## Chunk 3: Compact Toolbar
+
+### Task 3: Make mobile search/filter airy and single-purpose
+
+**Files:**
+
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx`
+- Modify: `src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx`
+
+- [ ] **Step 1: Write failing toolbar test**
+
+Extend compact filter tests:
+
+```tsx
+it("places compact search and filter trigger in one row with chips below", () => {
+  render(<RepairRequestsToolbar {...baseProps} compactFilters showFacilityFilter />)
+
+  const search = screen.getByRole("searchbox", { name: "Tìm thiết bị, mô tả..." })
+  const filter = screen.getByRole("button", { name: "Bộ lọc" })
+  const row = screen.getByTestId("repair-toolbar-compact-row")
+
+  expect(row).toContainElement(search)
+  expect(row).toContainElement(filter)
+  expect(row).toHaveClass("grid")
+  expect(screen.getByTestId("repair-toolbar-filter-chips")).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
+```
+
+Expected: FAIL because compact row/chips boundary test ids/classes do not exist yet.
+
+- [ ] **Step 3: Implement compact toolbar refinement**
+
+In `RepairRequestsToolbar.tsx`:
+
+- For `compactFilters=true`, render:
+  - One row: search input flexes, `Bộ lọc` button stays 48px height.
+  - Chips below the row with clear wrapping.
+- Use `gap-3` between search and filter, and `mt-3` or `gap-3` before filter chips so the toolbar breathes without wasting vertical space.
+- Preserve all current callbacks: `onSearchChange`, `onOpenFilterModal`, `onClearFilters`, `onRemoveFilter`.
+- Keep desktop inline controls unchanged.
+- Do not add explanatory visible text.
+
+- [ ] **Step 4: Run toolbar tests**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/\(app\)/repair-requests/_components/RepairRequestsToolbar.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
+git commit -m "feat: refine repair request mobile filters"
+```
+
+## Chunk 4: Clean Mobile Request Cards
+
+### Task 4: Simplify mobile request card hierarchy
+
+**Files:**
+
+- Modify: `src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx`
+- Modify: `src/app/(app)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx`
+
+- [ ] **Step 1: Write failing card layout tests**
+
+Add tests that protect the clean structure without over-specifying CSS:
+
+```tsx
+it("renders decision-critical fields without turning the whole content block into the activation button", () => {
+  render(
+    <RepairRequestsMobileList
+      requests={[request]}
+      isLoading={false}
+      setRequestToView={setRequestToView}
+      columnOptions={columnOptions}
+    />
+  )
+
+  const card = screen.getByTestId(`repair-mobile-card-${request.id}`)
+  expect(card).toHaveTextContent("Máy siêu âm")
+  expect(card).toHaveTextContent(request.ma_thiet_bi)
+  expect(card).toHaveTextContent("Người yêu cầu")
+  expect(card).toHaveTextContent("Ngày yêu cầu")
+  expect(card).toHaveTextContent("Mô tả sự cố")
+
+  const activationButton = screen.getByRole("button", { name: /Máy siêu âm/ })
+  expect(within(activationButton).queryByText("Mô tả sự cố")).not.toBeInTheDocument()
+})
+
+it("keeps one primary action and moves secondary actions into the action zone", () => {
+  render(
+    <RepairRequestsMobileList
+      requests={[request]}
+      isLoading={false}
+      setRequestToView={setRequestToView}
+      columnOptions={columnOptions}
+    />
+  )
+
+  const card = screen.getByTestId(`repair-mobile-card-${request.id}`)
+  expect(
+    within(card).getByRole("button", { name: /Hoàn thành|Duyệt|Xem chi tiết/ })
+  ).toBeInTheDocument()
+  expect(within(card).getByRole("button", { name: "Mở menu" })).toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
+```
+
+Expected: FAIL because the card boundary/test id and simplified hierarchy do not exist yet.
+
+- [ ] **Step 3: Implement card refinement**
+
+In `RepairRequestsMobileList.tsx`:
+
+- Keep `MobileCompactCard` if it supports the desired interaction boundary.
+- Add stable card test id.
+- Use a cleaner internal structure:
+  - Header row: equipment name/code left, status badge right.
+  - Metadata grid: requester department and request date.
+  - Problem description inset box with a short label.
+  - Action row: one primary action + compact menu/action control.
+- Use stable spacing: outer `p-4`, header `gap-3`, metadata `gap-y-3 gap-x-4`, description `p-3`, action row `gap-3 pt-1`.
+- Avoid adding all table columns to the card.
+- Keep existing `DaysRemainingBar` only if it is visually lightweight. If it makes the card busy, keep it for detail view or menu follow-up instead; document that choice in the handoff.
+- Preserve current keyboard activation and action-zone behavior.
+
+- [ ] **Step 4: Run mobile list tests**
+
+Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/\(app\)/repair-requests/_components/RepairRequestsMobileList.tsx src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
+git commit -m "feat: simplify repair request mobile cards"
+```
+
+## Chunk 5: Visual and Regression Verification
+
+### Task 5: Run focused and repo-required gates
+
+**Files:**
+
+- No new edits unless verification exposes issues.
+
+- [ ] **Step 1: Run focused tests**
+
+Run through context-mode:
+
+```bash
+node scripts/npm-run.js run test:run -- \
+  src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx \
+  src/app/\(app\)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx \
+  src/app/\(app\)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx \
+  src/app/\(app\)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run TypeScript/React repo gates in required order**
+
+Use one `ctx_batch_execute` call for these commands:
+
+```bash
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run react-doctor
+```
+
+Expected: all PASS. If `format:check` fails only on changed files, run Prettier or rely on Lefthook staged formatting before commit, then re-run.
+
+- [ ] **Step 3: Run browser visual check**
+
+Start the local dev server if needed and inspect Repair Requests at:
+
+- Mobile: 390x844
+- Tablet: 768x1024
+- Desktop: 1280x900
+
+Acceptance:
+
+- Fixed header remains the source of tenant display.
+- Page body does not duplicate tenant name.
+- KPI layout is balanced: total full-width, four statuses 2x2.
+- Spacing is intentional: no cramped card content, no oversized dead zones, consistent page padding/gaps across mobile and tablet.
+- Search/filter row does not wrap awkwardly.
+- Request cards do not feel dense; description and actions are readable.
+- Bottom nav/FAB do not cover final card actions.
+- Desktop table remains unchanged.
+
+- [ ] **Step 4: Commit verification fixes if any**
+
+```bash
+git add <changed files>
+git commit -m "fix: polish repair request mobile layout"
+```
+
+Only commit if verification required changes.
+
+## Chunk 6: Landing
+
+### Task 6: Push and hand off
+
+- [ ] **Step 1: Pull/rebase**
+
+```bash
+git pull --rebase
+```
+
+- [ ] **Step 2: Push**
+
+```bash
+git push
+```
+
+- [ ] **Step 3: Confirm clean/up-to-date status**
+
+```bash
+git status
+```
+
+Expected: working tree clean and branch up to date with origin.
+
+- [ ] **Step 4: Handoff summary**
+
+Include:
+
+- Files changed.
+- Tests/gates run.
+- Visual viewport checks.
+- Any explicit non-scope choices, especially if secondary fields were intentionally left for detail view to keep the mobile card clean.

--- a/docs/superpowers/plans/2026-07-04-repair-requests-clean-mobile-redesign.md
+++ b/docs/superpowers/plans/2026-07-04-repair-requests-clean-mobile-redesign.md
@@ -19,7 +19,7 @@
   - `Tổng` is a full-width summary card.
   - `Chờ xử lý`, `Đã duyệt`, `Hoàn thành`, `Không HT` form a 2x2 grid below.
 - Keep mobile list cards clean:
-  - Show equipment name, equipment code, status, requester department, request date, short problem description, and one primary action.
+  - Show equipment name, equipment code, status, requester name with department fallback, request date, short problem description, and one primary action.
   - Move secondary actions into the existing menu/action zone.
   - Avoid nesting the list inside a large desktop-style card container on mobile.
 - Treat spacing as part of the design contract, not final polish:
@@ -94,7 +94,7 @@ describe("RepairRequestsMobileKpi", () => {
     expect(total).toHaveTextContent("Tổng")
     expect(total).toHaveTextContent("69")
     expect(total).toHaveClass("col-span-2")
-    expect(region.compareDocumentPosition(statusGrid)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(total.compareDocumentPosition(statusGrid)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
 
     expect(within(statusGrid).getAllByTestId(/^repair-mobile-kpi-status-/)).toHaveLength(4)
     expect(screen.getByTestId("repair-mobile-kpi-status-Chờ xử lý")).toHaveTextContent("34")

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+import { render, screen, within } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { RepairRequestsMobileKpi } from "../_components/RepairRequestsMobileKpi"
+import type { RepairStatus } from "@/components/kpi"
+
+const counts: Record<RepairStatus, number> = {
+  "Chờ xử lý": 34,
+  "Đã duyệt": 3,
+  "Hoàn thành": 30,
+  "Không HT": 2,
+}
+
+describe("RepairRequestsMobileKpi", () => {
+  it("renders total as a full-width summary before a balanced 2x2 status grid", () => {
+    render(<RepairRequestsMobileKpi counts={counts} loading={false} />)
+
+    const total = screen.getByTestId("repair-mobile-kpi-total")
+    const statusGrid = screen.getByTestId("repair-mobile-kpi-status-grid")
+
+    expect(total).toHaveTextContent("Tổng")
+    expect(total).toHaveTextContent("69")
+    expect(total).toHaveClass("col-span-2")
+    expect(total.compareDocumentPosition(statusGrid)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+
+    expect(within(statusGrid).getAllByTestId(/^repair-mobile-kpi-status-/)).toHaveLength(4)
+    expect(screen.getByTestId("repair-mobile-kpi-status-Chờ xử lý")).toHaveTextContent("34")
+    expect(screen.getByTestId("repair-mobile-kpi-status-Đã duyệt")).toHaveTextContent("3")
+    expect(screen.getByTestId("repair-mobile-kpi-status-Hoàn thành")).toHaveTextContent("30")
+    expect(screen.getByTestId("repair-mobile-kpi-status-Không HT")).toHaveTextContent("2")
+  })
+
+  it("uses zero counts while status counts are unavailable", () => {
+    render(<RepairRequestsMobileKpi counts={undefined} loading={false} />)
+
+    expect(screen.getByTestId("repair-mobile-kpi-total")).toHaveTextContent("0")
+    expect(screen.getByTestId("repair-mobile-kpi-status-Chờ xử lý")).toHaveTextContent("0")
+  })
+})

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileKpi.test.tsx
@@ -37,4 +37,21 @@ describe("RepairRequestsMobileKpi", () => {
     expect(screen.getByTestId("repair-mobile-kpi-total")).toHaveTextContent("0")
     expect(screen.getByTestId("repair-mobile-kpi-status-Chờ xử lý")).toHaveTextContent("0")
   })
+
+  it("keeps status values readable in dark theme", () => {
+    render(<RepairRequestsMobileKpi counts={counts} loading={false} />)
+
+    expect(
+      within(screen.getByTestId("repair-mobile-kpi-status-Chờ xử lý")).getByText("34")
+    ).toHaveClass("dark:text-orange-300")
+    expect(
+      within(screen.getByTestId("repair-mobile-kpi-status-Đã duyệt")).getByText("3")
+    ).toHaveClass("dark:text-blue-300")
+    expect(
+      within(screen.getByTestId("repair-mobile-kpi-status-Hoàn thành")).getByText("30")
+    ).toHaveClass("dark:text-emerald-300")
+    expect(
+      within(screen.getByTestId("repair-mobile-kpi-status-Không HT")).getByText("2")
+    ).toHaveClass("dark:text-red-300")
+  })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
@@ -74,7 +74,7 @@ describe("RepairRequestsMobileList accessibility", () => {
         isLoading={false}
         setRequestToView={setRequestToView}
         columnOptions={makeColumnOptions()}
-      />,
+      />
     )
 
     const card = screen.getByRole("button", { name: /Máy siêu âm/ })
@@ -99,7 +99,7 @@ describe("RepairRequestsMobileList accessibility", () => {
         isLoading={false}
         setRequestToView={setRequestToView}
         columnOptions={columnOptions}
-      />,
+      />
     )
 
     await user.click(screen.getByRole("button", { name: "Mở menu" }))
@@ -121,7 +121,7 @@ describe("RepairRequestsMobileList accessibility", () => {
         isLoading={false}
         setRequestToView={setRequestToView}
         columnOptions={columnOptions}
-      />,
+      />
     )
 
     await user.click(screen.getByRole("button", { name: "Duyệt" }))
@@ -144,7 +144,7 @@ describe("RepairRequestsMobileList accessibility", () => {
         isLoading={false}
         setRequestToView={vi.fn()}
         columnOptions={columnOptions}
-      />,
+      />
     )
 
     await user.click(screen.getByRole("button", { name: "Hoàn thành" }))
@@ -165,7 +165,7 @@ describe("RepairRequestsMobileList accessibility", () => {
         isLoading={false}
         setRequestToView={vi.fn()}
         columnOptions={columnOptions}
-      />,
+      />
     )
 
     expect(screen.queryByRole("button", { name: "Duyệt" })).not.toBeInTheDocument()
@@ -186,7 +186,7 @@ describe("RepairRequestsMobileList accessibility", () => {
         isLoading={false}
         setRequestToView={vi.fn()}
         columnOptions={columnOptions}
-      />,
+      />
     )
 
     expect(screen.queryByRole("button", { name: "Duyệt" })).not.toBeInTheDocument()
@@ -203,12 +203,73 @@ describe("RepairRequestsMobileList accessibility", () => {
         isLoading={false}
         setRequestToView={vi.fn()}
         columnOptions={makeColumnOptions()}
-      />,
+      />
     )
 
     const activationButton = screen.getByRole("button", { name: /Máy siêu âm/ })
 
     expect(within(activationButton).queryByText("Người yêu cầu")).not.toBeInTheDocument()
     expect(screen.getByText("Người yêu cầu").closest("button")).not.toBe(activationButton)
+  })
+
+  it("renders a clean card with only decision-critical fields", () => {
+    const request = {
+      ...makeRepairRequest(),
+      hang_muc_sua_chua: "Thay toàn bộ cụm linh kiện phụ trợ",
+    }
+
+    render(
+      <RepairRequestsMobileList
+        requests={[request]}
+        isLoading={false}
+        setRequestToView={vi.fn()}
+        columnOptions={makeColumnOptions()}
+      />
+    )
+
+    const card = screen.getByTestId(`repair-mobile-card-${request.id}`)
+    expect(card).toHaveTextContent("Máy siêu âm")
+    expect(card).toHaveTextContent("TB-A11Y")
+    expect(card).toHaveTextContent("Chờ xử lý")
+    expect(card).toHaveTextContent("Người yêu cầu")
+    expect(card).toHaveTextContent("Khoa Khám bệnh")
+    expect(card).toHaveTextContent("Ngày yêu cầu")
+    expect(card).toHaveTextContent("Mô tả sự cố")
+    expect(card).not.toHaveTextContent("Hạng mục sửa chữa")
+    expect(card).not.toHaveTextContent("Thay toàn bộ cụm linh kiện phụ trợ")
+  })
+
+  it("keeps one 48px primary action and a compact secondary menu", () => {
+    const request = makeRepairRequest()
+
+    render(
+      <RepairRequestsMobileList
+        requests={[request]}
+        isLoading={false}
+        setRequestToView={vi.fn()}
+        columnOptions={makeColumnOptions()}
+      />
+    )
+
+    const card = screen.getByTestId(`repair-mobile-card-${request.id}`)
+    expect(within(card).getByRole("button", { name: "Duyệt" })).toHaveClass("h-12")
+    expect(within(card).getByRole("button", { name: "Mở menu" })).toBeInTheDocument()
+  })
+
+  it("uses spacious card padding and action gaps on mobile", () => {
+    const request = makeRepairRequest()
+
+    render(
+      <RepairRequestsMobileList
+        requests={[request]}
+        isLoading={false}
+        setRequestToView={vi.fn()}
+        columnOptions={makeColumnOptions()}
+      />
+    )
+
+    const card = screen.getByTestId(`repair-mobile-card-${request.id}`)
+    expect(card.querySelector(".p-4.space-y-3")).toBeInTheDocument()
+    expect(card.querySelector(".gap-3.px-4.pb-4")).toBeInTheDocument()
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsMobileList.a11y.test.tsx
@@ -232,11 +232,30 @@ describe("RepairRequestsMobileList accessibility", () => {
     expect(card).toHaveTextContent("TB-A11Y")
     expect(card).toHaveTextContent("Chờ xử lý")
     expect(card).toHaveTextContent("Người yêu cầu")
-    expect(card).toHaveTextContent("Khoa Khám bệnh")
+    expect(card).toHaveTextContent("Nguyễn Văn A")
     expect(card).toHaveTextContent("Ngày yêu cầu")
     expect(card).toHaveTextContent("Mô tả sự cố")
     expect(card).not.toHaveTextContent("Hạng mục sửa chữa")
     expect(card).not.toHaveTextContent("Thay toàn bộ cụm linh kiện phụ trợ")
+  })
+
+  it("falls back to department when requester name is missing", () => {
+    const request = {
+      ...makeRepairRequest(),
+      nguoi_yeu_cau: "",
+    }
+
+    render(
+      <RepairRequestsMobileList
+        requests={[request]}
+        isLoading={false}
+        setRequestToView={vi.fn()}
+        columnOptions={makeColumnOptions()}
+      />
+    )
+
+    const card = screen.getByTestId(`repair-mobile-card-${request.id}`)
+    expect(card).toHaveTextContent("Khoa Khám bệnh")
   })
 
   it("keeps one 48px primary action and a compact secondary menu", () => {

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
@@ -190,10 +190,22 @@ describe("RepairRequestsPageLayout", () => {
     expect(screen.getByText("Tạo yêu cầu")).toBeInTheDocument()
   })
 
+  it("shows create button for tablet compact layout when user can create requests", () => {
+    render(
+      <RepairRequestsPageLayout
+        {...withAccessState({ isRegionalLeader: false })}
+        listState={{ ...defaultProps.listState, isMobile: false, isCompactLayout: true }}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Tạo yêu cầu" })).toBeInTheDocument()
+  })
+
   it("shows tenant selection placeholder when shouldFetchData=false", () => {
     render(<RepairRequestsPageLayout {...withAccessState({ shouldFetchData: false })} />)
     expect(screen.getByText("Chọn cơ sở y tế")).toBeInTheDocument()
     expect(screen.getByText(/Vui lòng chọn một cơ sở y tế/)).toBeInTheDocument()
+    expect(screen.getByTestId("repair-requests-desktop-card")).not.toHaveClass("rounded-b-none")
   })
 
   it("shows table content when shouldFetchData=true", () => {

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
@@ -4,35 +4,41 @@
  * Verifies header, summary bar, create button visibility,
  * tenant placeholder, and table rendering.
  */
-import { describe, it, expect, vi } from 'vitest'
-import * as React from 'react'
+import { describe, it, expect, vi } from "vitest"
+import * as React from "react"
 import "@testing-library/jest-dom"
-import { render, screen } from '@testing-library/react'
-import type { Table } from '@tanstack/react-table'
-import type { RepairStatus } from '@/components/kpi'
-import { RepairRequestsPageLayout } from '../_components/RepairRequestsPageLayout'
-import type { RepairRequestWithEquipment } from '../types'
-import type { RepairRequestColumnOptions } from '../_components/RepairRequestsColumns'
+import { render, screen } from "@testing-library/react"
+import type { Table } from "@tanstack/react-table"
+import type { RepairStatus } from "@/components/kpi"
+import { RepairRequestsPageLayout } from "../_components/RepairRequestsPageLayout"
+import type { RepairRequestWithEquipment } from "../types"
+import type { RepairRequestColumnOptions } from "../_components/RepairRequestsColumns"
 
 // ── Mock child components ──────────────────────────────────────────────
-vi.mock('@/components/repair-request-alert', () => ({
+vi.mock("@/components/repair-request-alert", () => ({
   RepairRequestAlert: () => null,
 }))
 
-vi.mock('@/components/kpi', async () => {
-  const actual = await vi.importActual<typeof import('@/components/kpi')>('@/components/kpi')
+vi.mock("@/components/kpi", async () => {
+  const actual = await vi.importActual<typeof import("@/components/kpi")>("@/components/kpi")
 
   return {
     ...actual,
-    KpiStatusBar: ({ configs, counts, loading }: {
-      configs: Array<{ key: string; label: string }>;
-      counts: Record<string, number> | undefined;
-      loading: boolean;
+    KpiStatusBar: ({
+      configs,
+      counts,
+      loading,
+    }: {
+      configs: Array<{ key: string; label: string }>
+      counts: Record<string, number> | undefined
+      loading: boolean
     }) => {
       const total = counts ? Object.values(counts).reduce((s, v) => s + (v || 0), 0) : 0
       return (
         <div data-testid="kpi-status-bar">
-          <div data-testid="kpi-total" data-value={total}>Tổng: {total}</div>
+          <div data-testid="kpi-total" data-value={total}>
+            Tổng: {total}
+          </div>
           {configs.map((c: { key: string; label: string }) => (
             <div key={c.key} data-testid={`kpi-${c.key}`} data-value={counts?.[c.key] ?? 0}>
               {c.label}: {counts?.[c.key] ?? 0}
@@ -45,42 +51,56 @@ vi.mock('@/components/kpi', async () => {
   }
 })
 
-vi.mock('../_components/RepairRequestsCreateSheet', () => ({
+vi.mock("../_components/RepairRequestsCreateSheet", () => ({
   RepairRequestsCreateSheet: () => <div data-testid="create-sheet">create-sheet</div>,
 }))
 
-vi.mock('../_components/RepairRequestsToolbar', () => ({
+vi.mock("../_components/RepairRequestsMobileKpi", () => ({
+  RepairRequestsMobileKpi: ({
+    counts,
+    loading,
+  }: {
+    counts: Record<string, number> | undefined
+    loading: boolean
+  }) => {
+    const total = counts ? Object.values(counts).reduce((sum, value) => sum + value, 0) : 0
+    return (
+      <div data-testid="repair-mobile-kpi" data-loading={String(loading)} data-total={total}>
+        mobile-kpi
+      </div>
+    )
+  },
+}))
+
+vi.mock("../_components/RepairRequestsToolbar", () => ({
   RepairRequestsToolbar: ({ showFacilityFilter }: { showFacilityFilter: boolean }) => (
-    <div
-      data-testid="repair-toolbar"
-      data-show-facility-filter={String(showFacilityFilter)}
-    >
+    <div data-testid="repair-toolbar" data-show-facility-filter={String(showFacilityFilter)}>
       toolbar
     </div>
   ),
 }))
 
-vi.mock('../_components/RepairRequestsFilterModal', () => ({
+vi.mock("../_components/RepairRequestsFilterModal", () => ({
   RepairRequestsFilterModal: () => null,
 }))
 
-vi.mock('../_components/RepairRequestsTable', () => ({
+vi.mock("../_components/RepairRequestsTable", () => ({
   RepairRequestsTable: () => <div data-testid="repair-table">table</div>,
 }))
 
-vi.mock('../_components/RepairRequestsMobileList', () => ({
+vi.mock("../_components/RepairRequestsMobileList", () => ({
   RepairRequestsMobileList: () => <div data-testid="mobile-list">mobile</div>,
 }))
 
-vi.mock('../_components/RepairRequestsColumns', () => ({
+vi.mock("../_components/RepairRequestsColumns", () => ({
   renderActions: () => null,
 }))
 
-vi.mock('@/components/shared/DataTablePagination', () => ({
+vi.mock("@/components/shared/DataTablePagination", () => ({
   DataTablePagination: () => <div data-testid="pagination">pagination</div>,
 }))
 
-vi.mock('@/components/shared/TenantSelector', () => ({
+vi.mock("@/components/shared/TenantSelector", () => ({
   TenantSelector: () => <div data-testid="tenant-selector">selector</div>,
 }))
 
@@ -92,14 +112,15 @@ const defaultProps = {
     showFacilityFilter: false,
     shouldFetchData: true,
   },
-  statusCounts: { 'Chờ xử lý': 3, 'Đã duyệt': 2, 'Hoàn thành': 5, 'Không HT': 0 } as Record<RepairStatus, number> | undefined,
+  statusCounts: { "Chờ xử lý": 3, "Đã duyệt": 2, "Hoàn thành": 5, "Không HT": 0 } as
+    Record<RepairStatus, number> | undefined,
   overdueSummary: undefined,
   summaryState: {
     statusCountsLoading: false,
     overdueLoading: false,
   },
   requests: [],
-  searchTerm: '',
+  searchTerm: "",
   onSearchChange: vi.fn(),
   searchInputRef: { current: null },
   onClearFilters: vi.fn(),
@@ -118,7 +139,7 @@ const defaultProps = {
     getState: () => ({ columnFilters: [] }),
     resetColumnFilters: vi.fn(),
   } as unknown as Table<RepairRequestWithEquipment>,
-  tableKey: 'all_0',
+  tableKey: "all_0",
   listState: {
     isMobile: false,
     isLoading: false,
@@ -143,57 +164,85 @@ const withAccessState = (overrides: Partial<typeof defaultProps.accessState>) =>
 })
 
 // ── Tests ──────────────────────────────────────────────────────────────
-describe('RepairRequestsPageLayout', () => {
+describe("RepairRequestsPageLayout", () => {
   it('renders header with title "Yêu cầu sửa chữa"', () => {
     render(<RepairRequestsPageLayout {...defaultProps} />)
-    expect(screen.getByText('Yêu cầu sửa chữa')).toBeInTheDocument()
+    expect(screen.getByText("Yêu cầu sửa chữa")).toBeInTheDocument()
   })
 
-  it('renders facility name subtitle when provided', () => {
+  it("does not duplicate facility name below the fixed global header", () => {
     render(<RepairRequestsPageLayout {...defaultProps} selectedFacilityName="Hospital A" />)
-    expect(screen.getByText('Hospital A')).toBeInTheDocument()
+    expect(screen.queryByText("Hospital A")).not.toBeInTheDocument()
   })
 
-  it('hides create button when isRegionalLeader=true', () => {
+  it("hides create button when isRegionalLeader=true", () => {
     render(<RepairRequestsPageLayout {...withAccessState({ isRegionalLeader: true })} />)
-    expect(screen.queryByText('Tạo yêu cầu')).not.toBeInTheDocument()
+    expect(screen.queryByText("Tạo yêu cầu")).not.toBeInTheDocument()
   })
 
-  it('shows create button when isRegionalLeader=false', () => {
+  it("shows create button when isRegionalLeader=false", () => {
     render(
       <RepairRequestsPageLayout
         {...withAccessState({ isRegionalLeader: false })}
         listState={{ ...defaultProps.listState, isMobile: false }}
       />
     )
-    expect(screen.getByText('Tạo yêu cầu')).toBeInTheDocument()
+    expect(screen.getByText("Tạo yêu cầu")).toBeInTheDocument()
   })
 
-  it('shows tenant selection placeholder when shouldFetchData=false', () => {
+  it("shows tenant selection placeholder when shouldFetchData=false", () => {
     render(<RepairRequestsPageLayout {...withAccessState({ shouldFetchData: false })} />)
-    expect(screen.getByText('Chọn cơ sở y tế')).toBeInTheDocument()
+    expect(screen.getByText("Chọn cơ sở y tế")).toBeInTheDocument()
     expect(screen.getByText(/Vui lòng chọn một cơ sở y tế/)).toBeInTheDocument()
   })
 
-  it('shows table content when shouldFetchData=true', () => {
+  it("shows table content when shouldFetchData=true", () => {
     render(<RepairRequestsPageLayout {...withAccessState({ shouldFetchData: true })} />)
-    expect(screen.queryByText('Chọn cơ sở y tế')).not.toBeInTheDocument()
-    expect(screen.getByTestId('repair-table')).toBeInTheDocument()
-    expect(screen.getByTestId('pagination')).toBeInTheDocument()
+    expect(screen.queryByText("Chọn cơ sở y tế")).not.toBeInTheDocument()
+    expect(screen.getByTestId("repair-table")).toBeInTheDocument()
+    expect(screen.getByTestId("pagination")).toBeInTheDocument()
   })
 
-  it('renders KpiStatusBar with provided counts', () => {
-    const counts = { 'Chờ xử lý': 10, 'Đã duyệt': 5, 'Hoàn thành': 20, 'Không HT': 7 }
+  it("renders KpiStatusBar with provided counts", () => {
+    const counts = { "Chờ xử lý": 10, "Đã duyệt": 5, "Hoàn thành": 20, "Không HT": 7 }
     render(<RepairRequestsPageLayout {...defaultProps} statusCounts={counts} />)
-    expect(screen.getByTestId('kpi-total')).toHaveAttribute('data-value', '42')
+    expect(screen.getByTestId("kpi-total")).toHaveAttribute("data-value", "42")
   })
 
-  it('passes facility selector visibility to the toolbar like Equipment', () => {
+  it("renders the balanced mobile KPI with provided status counts", () => {
+    const counts = { "Chờ xử lý": 10, "Đã duyệt": 5, "Hoàn thành": 20, "Không HT": 7 }
+
+    render(
+      <RepairRequestsPageLayout
+        {...defaultProps}
+        statusCounts={counts}
+        listState={{ ...defaultProps.listState, isCompactLayout: true }}
+      />
+    )
+
+    expect(screen.getByTestId("repair-mobile-kpi")).toHaveAttribute("data-total", "42")
+    expect(screen.getByTestId("repair-mobile-kpi")).toHaveAttribute("data-loading", "false")
+  })
+
+  it("keeps mobile cards outside the desktop summary card shell", () => {
+    render(
+      <RepairRequestsPageLayout
+        {...defaultProps}
+        listState={{ ...defaultProps.listState, isMobile: true }}
+      />
+    )
+
+    const mobileList = screen.getByTestId("repair-mobile-list")
+    expect(mobileList).toContainElement(screen.getByTestId("mobile-list"))
+    expect(mobileList.closest("[data-testid='repair-requests-desktop-card']")).toBeNull()
+  })
+
+  it("passes facility selector visibility to the toolbar like Equipment", () => {
     render(<RepairRequestsPageLayout {...withAccessState({ showFacilityFilter: true })} />)
 
-    expect(screen.getByTestId('repair-toolbar')).toHaveAttribute(
-      'data-show-facility-filter',
-      'true'
+    expect(screen.getByTestId("repair-toolbar")).toHaveAttribute(
+      "data-show-facility-filter",
+      "true"
     )
   })
 })

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx
@@ -92,6 +92,27 @@ describe("RepairRequestsToolbar", () => {
     expect(screen.getByTestId("tenant-selector")).toHaveAttribute("data-trigger-variant", "default")
   })
 
+  it("places compact search and filter trigger in one row with chips below", () => {
+    render(
+      <RepairRequestsToolbar
+        {...baseProps}
+        compactFilters
+        isFiltered
+        uiFilters={{ status: ["Đã duyệt"], dateRange: null }}
+      />
+    )
+
+    const search = screen.getByRole("searchbox", { name: "Tìm thiết bị, mô tả..." })
+    const filter = screen.getByRole("button", { name: "Bộ lọc" })
+    const row = screen.getByTestId("repair-toolbar-compact-row")
+
+    expect(row).toContainElement(search)
+    expect(row).toContainElement(filter)
+    expect(row).toHaveClass("grid", "gap-3")
+    expect(screen.getByTestId("repair-toolbar-filter-chips")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Xóa trạng thái Đã duyệt" })).toBeInTheDocument()
+  })
+
   it("updates status filters from the inline status control", async () => {
     const user = userEvent.setup()
     const onFilterChange = vi.fn()

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMobileKpi.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMobileKpi.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import * as React from "react"
+import { Layers } from "lucide-react"
+
+import { REPAIR_STATUS_CONFIGS, type RepairStatus } from "@/components/kpi"
+import { cn } from "@/lib/utils"
+
+interface RepairRequestsMobileKpiProps {
+  counts: Partial<Record<RepairStatus, number>> | undefined
+  loading?: boolean
+}
+
+const toneStyles: Record<
+  "default" | "success" | "warning" | "danger" | "muted",
+  {
+    accent: string
+    icon: string
+    value: string
+  }
+> = {
+  default: {
+    accent: "bg-primary",
+    icon: "bg-primary/10 text-primary",
+    value: "text-foreground",
+  },
+  success: {
+    accent: "bg-emerald-500",
+    icon: "bg-emerald-100 text-emerald-700",
+    value: "text-emerald-700",
+  },
+  warning: {
+    accent: "bg-orange-500",
+    icon: "bg-orange-100 text-orange-700",
+    value: "text-orange-700",
+  },
+  danger: {
+    accent: "bg-red-500",
+    icon: "bg-red-100 text-red-700",
+    value: "text-red-700",
+  },
+  muted: {
+    accent: "bg-blue-500",
+    icon: "bg-blue-100 text-blue-700",
+    value: "text-blue-700",
+  },
+}
+
+function countTotal(counts: RepairRequestsMobileKpiProps["counts"]) {
+  if (!counts) return 0
+  return REPAIR_STATUS_CONFIGS.reduce((total, config) => total + (counts[config.key] ?? 0), 0)
+}
+
+function KpiValue({
+  value,
+  loading,
+  className,
+}: {
+  value: number
+  loading?: boolean
+  className?: string
+}) {
+  return (
+    <span className={cn("text-2xl font-semibold leading-none", className)}>
+      {loading ? "..." : value}
+    </span>
+  )
+}
+
+/** Renders the balanced mobile/tablet KPI grid for repair requests. */
+export function RepairRequestsMobileKpi({ counts, loading = false }: RepairRequestsMobileKpiProps) {
+  const total = countTotal(counts)
+
+  return (
+    <section
+      aria-label="Tổng quan yêu cầu sửa chữa"
+      className="grid grid-cols-2 gap-3 md:max-w-3xl md:gap-4"
+      data-testid="repair-mobile-kpi"
+    >
+      <div
+        className="col-span-2 overflow-hidden rounded-2xl border bg-card px-5 py-4 shadow-sm"
+        data-testid="repair-mobile-kpi-total"
+      >
+        <div className="flex items-center gap-4">
+          <div className="flex size-11 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Layers className="size-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 space-y-1">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Tổng yêu cầu
+            </p>
+            <KpiValue value={total} loading={loading} />
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="col-span-2 grid grid-cols-2 gap-3 md:gap-4"
+        data-testid="repair-mobile-kpi-status-grid"
+      >
+        {REPAIR_STATUS_CONFIGS.map((config) => {
+          const styles = toneStyles[config.tone]
+          return (
+            <div
+              key={config.key}
+              className="relative min-h-[132px] overflow-hidden rounded-2xl border bg-card p-4 shadow-sm"
+              data-testid={`repair-mobile-kpi-status-${config.key}`}
+            >
+              <div className={cn("absolute inset-y-0 left-0 w-1", styles.accent)} />
+              <div className="flex h-full flex-col justify-between gap-4 pl-1">
+                <div
+                  className={cn(
+                    "flex size-9 items-center justify-center rounded-full",
+                    styles.icon
+                  )}
+                >
+                  {config.icon}
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {config.label}
+                  </p>
+                  <KpiValue
+                    value={counts?.[config.key] ?? 0}
+                    loading={loading}
+                    className={styles.value}
+                  />
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMobileKpi.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMobileKpi.tsx
@@ -26,23 +26,23 @@ const toneStyles: Record<
   },
   success: {
     accent: "bg-emerald-500",
-    icon: "bg-emerald-100 text-emerald-700",
-    value: "text-emerald-700",
+    icon: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300",
+    value: "text-emerald-700 dark:text-emerald-300",
   },
   warning: {
     accent: "bg-orange-500",
-    icon: "bg-orange-100 text-orange-700",
-    value: "text-orange-700",
+    icon: "bg-orange-100 text-orange-700 dark:bg-orange-950/60 dark:text-orange-300",
+    value: "text-orange-700 dark:text-orange-300",
   },
   danger: {
     accent: "bg-red-500",
-    icon: "bg-red-100 text-red-700",
-    value: "text-red-700",
+    icon: "bg-red-100 text-red-700 dark:bg-red-950/60 dark:text-red-300",
+    value: "text-red-700 dark:text-red-300",
   },
   muted: {
     accent: "bg-blue-500",
-    icon: "bg-blue-100 text-blue-700",
-    value: "text-blue-700",
+    icon: "bg-blue-100 text-blue-700 dark:bg-blue-950/60 dark:text-blue-300",
+    value: "text-blue-700 dark:text-blue-300",
   },
 }
 

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { format, parseISO } from "date-fns"
-import { vi } from 'date-fns/locale'
+import { vi } from "date-fns/locale"
 import { Loader2 } from "lucide-react"
 
 import { MobileCompactCard } from "@/components/shared/MobileCompactCard"
@@ -10,11 +10,7 @@ import { isEquipmentManagerRole } from "@/lib/rbac"
 
 import type { RepairRequestWithEquipment } from "../types"
 import { getStatusVariant } from "../utils"
-import { DaysRemainingBar } from "./DaysRemainingBar"
-import {
-  RepairRequestRowActions,
-  type RepairRequestColumnOptions,
-} from "./RepairRequestsColumns"
+import { RepairRequestRowActions, type RepairRequestColumnOptions } from "./RepairRequestsColumns"
 
 /**
  * Props for the MobileRequestList component.
@@ -30,17 +26,11 @@ export interface MobileRequestListProps {
   columnOptions: RepairRequestColumnOptions
 }
 
-function RepairRequestCardField({
-  label,
-  value,
-}: {
-  label: string
-  value: React.ReactNode
-}) {
+function RepairRequestCardField({ label, value }: { label: string; value: React.ReactNode }) {
   return (
-    <div className="flex items-start justify-between gap-2">
-      <span className="shrink-0 text-xs text-muted-foreground">{label}</span>
-      <span className="text-right text-xs font-medium">{value}</span>
+    <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)] items-start gap-x-4 gap-y-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-right text-sm font-medium leading-snug">{value}</span>
     </div>
   )
 }
@@ -55,20 +45,15 @@ function RepairRequestStatusBadge({ status }: { status: string }) {
 
 function getRepairRequestPrimaryAction(
   request: RepairRequestWithEquipment,
-  columnOptions: RepairRequestColumnOptions,
+  columnOptions: RepairRequestColumnOptions
 ) {
-  const {
-    handleApproveRequest,
-    handleCompletion,
-    onGenerateSheet,
-    user,
-    isRegionalLeader,
-  } = columnOptions
+  const { handleApproveRequest, handleCompletion, onGenerateSheet, user, isRegionalLeader } =
+    columnOptions
 
   if (!user || isRegionalLeader) return null
 
   const canManage = isEquipmentManagerRole(user.role)
-  const buttonClassName = "h-8 flex-1 rounded-lg text-xs font-semibold"
+  const buttonClassName = "h-12 flex-1 rounded-lg text-sm font-semibold"
 
   if (canManage && request.trang_thai === "Chờ xử lý") {
     return (
@@ -131,70 +116,51 @@ export function RepairRequestsMobileList({
   }
 
   if (!requests.length) {
-    return (
-      <div className="text-center py-6 text-muted-foreground text-sm">
-        Không có kết quả.
-      </div>
-    )
+    return <div className="text-center py-6 text-muted-foreground text-sm">Không có kết quả.</div>
   }
 
   return (
-    <div className="space-y-3">
-      {requests.map((request) => (
-        <MobileCompactCard
-          key={request.id}
-          title={request.thiet_bi?.ten_thiet_bi || "N/A"}
-          subtitle={request.thiet_bi?.ma_thiet_bi || "N/A"}
-          TopRightComponent={RepairRequestStatusBadge}
-          topRightProps={{ status: request.trang_thai }}
-          activationLabel={`Xem yêu cầu sửa chữa ${request.thiet_bi?.ten_thiet_bi || "N/A"}`}
-          onActivate={() => setRequestToView(request)}
-          primaryAction={getRepairRequestPrimaryAction(request, columnOptions)}
-          actions={
-            shouldShowRowActions
-              ? <RepairRequestRowActions request={request} options={columnOptions} />
-              : undefined
-          }
-        >
-          {request.nguoi_yeu_cau && (
-            <RepairRequestCardField label="Người yêu cầu" value={request.nguoi_yeu_cau} />
-          )}
+    <div className="space-y-4">
+      {requests.map((request) => {
+        const requester = request.thiet_bi?.khoa_phong_quan_ly || request.nguoi_yeu_cau || "N/A"
 
-          <RepairRequestCardField
-            label="Ngày yêu cầu"
-            value={format(parseISO(request.ngay_yeu_cau), "dd/MM/yyyy", { locale: vi })}
-          />
+        return (
+          <div key={request.id} data-testid={`repair-mobile-card-${request.id}`}>
+            <MobileCompactCard
+              title={request.thiet_bi?.ten_thiet_bi || "N/A"}
+              subtitle={request.thiet_bi?.ma_thiet_bi || "N/A"}
+              TopRightComponent={RepairRequestStatusBadge}
+              topRightProps={{ status: request.trang_thai }}
+              activationLabel={`Xem yêu cầu sửa chữa ${request.thiet_bi?.ten_thiet_bi || "N/A"}`}
+              onActivate={() => setRequestToView(request)}
+              primaryAction={getRepairRequestPrimaryAction(request, columnOptions)}
+              actions={
+                shouldShowRowActions ? (
+                  <RepairRequestRowActions request={request} options={columnOptions} />
+                ) : undefined
+              }
+              className="rounded-2xl border bg-card shadow-sm hover:shadow-sm"
+            >
+              <div className="space-y-3">
+                <div className="grid gap-y-3">
+                  <RepairRequestCardField label="Người yêu cầu" value={requester} />
+                  <RepairRequestCardField
+                    label="Ngày yêu cầu"
+                    value={format(parseISO(request.ngay_yeu_cau), "dd/MM/yyyy", { locale: vi })}
+                  />
+                </div>
 
-          {request.ngay_mong_muon_hoan_thanh && (
-            <div className="space-y-2">
-              <RepairRequestCardField
-                label="Ngày mong muốn HT"
-                value={format(parseISO(request.ngay_mong_muon_hoan_thanh), "dd/MM/yyyy", { locale: vi })}
-              />
-              <DaysRemainingBar
-                deadline={request.ngay_mong_muon_hoan_thanh}
-                status={request.trang_thai}
-              />
-            </div>
-          )}
-
-          <div className="space-y-1">
-            <span className="text-xs text-muted-foreground">Mô tả sự cố:</span>
-            <p className="line-clamp-2 text-left text-xs font-medium leading-relaxed">
-              {request.mo_ta_su_co}
-            </p>
+                <div className="rounded-lg border bg-muted/40 p-3">
+                  <span className="text-xs text-muted-foreground">Mô tả sự cố:</span>
+                  <p className="mt-1 line-clamp-3 text-left text-sm font-medium leading-relaxed">
+                    {request.mo_ta_su_co}
+                  </p>
+                </div>
+              </div>
+            </MobileCompactCard>
           </div>
-
-          {request.hang_muc_sua_chua && (
-            <div className="space-y-1">
-              <span className="text-xs text-muted-foreground">Hạng mục sửa chữa:</span>
-              <p className="line-clamp-2 text-left text-xs font-medium leading-relaxed">
-                {request.hang_muc_sua_chua}
-              </p>
-            </div>
-          )}
-        </MobileCompactCard>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsMobileList.tsx
@@ -122,7 +122,7 @@ export function RepairRequestsMobileList({
   return (
     <div className="space-y-4">
       {requests.map((request) => {
-        const requester = request.thiet_bi?.khoa_phong_quan_ly || request.nguoi_yeu_cau || "N/A"
+        const requester = request.nguoi_yeu_cau || request.thiet_bi?.khoa_phong_quan_ly || "N/A"
 
         return (
           <div key={request.id} data-testid={`repair-mobile-card-${request.id}`}>

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageClient.tsx
@@ -314,7 +314,7 @@ function RepairRequestsPageClientInner() {
           filterState={{ isFiltered, isFilterModalOpen }}
           table={table}
           tableKey={tableKey}
-          listState={{ isMobile, isLoading, isFetching }}
+          listState={{ isMobile, isCompactLayout: isSheetMobile, isLoading, isFetching }}
           totalRequests={totalRequests}
           repairPagination={repairPagination}
           columnOptions={columnOptions}

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
@@ -1,14 +1,7 @@
 import * as React from "react"
 import type { Table } from "@tanstack/react-table"
 import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Building2, PlusCircle } from "lucide-react"
 import { parseISO } from "date-fns"
 import { KpiStatusBar, REPAIR_STATUS_CONFIGS } from "@/components/kpi"
@@ -21,14 +14,10 @@ import { RepairRequestsCreateSheet } from "./RepairRequestsCreateSheet"
 import { RepairRequestsToolbar } from "./RepairRequestsToolbar"
 import { RepairRequestsTable } from "./RepairRequestsTable"
 import { RepairRequestsMobileList } from "./RepairRequestsMobileList"
+import { RepairRequestsMobileKpi } from "./RepairRequestsMobileKpi"
 import type { RepairRequestColumnOptions } from "./RepairRequestsColumns"
-import type {
-  RepairRequestOverdueSummary,
-  RepairRequestWithEquipment,
-} from "../types"
-import type {
-  UiFilters as UiFiltersPrefs,
-} from "@/lib/rr-prefs"
+import type { RepairRequestOverdueSummary, RepairRequestWithEquipment } from "../types"
+import type { UiFilters as UiFiltersPrefs } from "@/lib/rr-prefs"
 
 const REPAIR_REQUEST_ENTITY = { singular: "yêu cầu" } as const
 
@@ -73,6 +62,7 @@ interface RepairRequestsPageLayoutProps {
   tableKey: string
   listState: {
     isMobile: boolean
+    isCompactLayout?: boolean
     isLoading: boolean
     isFetching: boolean
   }
@@ -128,50 +118,142 @@ export function RepairRequestsPageLayout({
   const { statusCountsLoading, overdueLoading } = summaryState
   const { isFiltered, isFilterModalOpen } = filterState
   const { isMobile, isLoading, isFetching } = listState
+  const isCompactLayout = listState.isCompactLayout ?? isMobile
+  const tableRows = table.getRowModel().rows.map((row) => row.original)
+
+  const toolbar = (
+    <RepairRequestsToolbar
+      searchTerm={searchTerm}
+      onSearchChange={onSearchChange}
+      searchInputRef={searchInputRef}
+      isFiltered={isFiltered}
+      onClearFilters={onClearFilters}
+      onOpenFilterModal={() => onFilterModalOpenChange(true)}
+      compactFilters={isCompactLayout}
+      uiFilters={uiFilters}
+      selectedFacilityId={selectedFacilityId}
+      selectedFacilityName={selectedFacilityName}
+      showFacilityFilter={showFacilityFilter}
+      onFilterChange={onFilterChange}
+      onRemoveFilter={onRemoveFilter}
+    />
+  )
+
+  const filterModal = (
+    <RepairRequestsFilterModal
+      open={isFilterModalOpen}
+      onOpenChange={onFilterModalOpenChange}
+      value={{
+        status: uiFilters.status,
+        facilityId: selectedFacilityId ?? null,
+        dateRange: uiFilters.dateRange
+          ? {
+              from: uiFilters.dateRange.from ? parseISO(uiFilters.dateRange.from) : null,
+              to: uiFilters.dateRange.to ? parseISO(uiFilters.dateRange.to) : null,
+            }
+          : { from: null, to: null },
+      }}
+      onChange={onFilterChange}
+      showFacility={showFacilityFilter}
+      facilities={facilityOptions.map((f) => ({ id: f.id, name: f.name }))}
+      variant={isCompactLayout ? "sheet" : "dialog"}
+    />
+  )
+
+  const pagination = shouldFetchData ? (
+    <div className={isCompactLayout ? "pt-1" : "rounded-b-xl border-x border-b bg-card px-6 py-4"}>
+      <DataTablePagination
+        table={table}
+        totalCount={totalRequests}
+        entity={REPAIR_REQUEST_ENTITY}
+        paginationMode={{
+          mode: "controlled",
+          pagination: repairPagination.pagination,
+          onPaginationChange: repairPagination.setPagination,
+        }}
+        displayFormat="range-total"
+        responsive={{ stackLayoutAt: "md", showFirstLastAt: "lg" }}
+        isLoading={isLoading || isFetching}
+      />
+    </div>
+  ) : null
 
   return (
     <>
       {/* Repair Request Alert */}
       <RepairRequestAlert summary={overdueSummary} isLoading={overdueLoading} />
 
-      <div className="space-y-6">
+      <div className="space-y-5 pb-28 md:space-y-6 lg:pb-0">
         {/* Header */}
         <div className="flex items-center justify-between gap-3">
           <div>
             <h1 className="text-xl md:text-2xl font-semibold">Yêu cầu sửa chữa</h1>
-            {selectedFacilityName ? (
-              <p className="text-sm text-muted-foreground">{selectedFacilityName}</p>
-            ) : null}
           </div>
         </div>
 
         {/* Summary */}
-        <KpiStatusBar
-          configs={REPAIR_STATUS_CONFIGS}
-          counts={statusCounts}
-          loading={statusCountsLoading}
-        />
+        {isCompactLayout ? (
+          <RepairRequestsMobileKpi counts={statusCounts} loading={statusCountsLoading} />
+        ) : (
+          <KpiStatusBar
+            configs={REPAIR_STATUS_CONFIGS}
+            counts={statusCounts}
+            loading={statusCountsLoading}
+          />
+        )}
 
         {/* Create Sheet */}
         {!isRegionalLeader ? <RepairRequestsCreateSheet /> : null}
 
         {/* Mobile FAB for quick create */}
         {!isRegionalLeader && isMobile ? (
-          <FloatingActionButton
-            onClick={() => openCreateSheet()}
-            aria-label="Tạo yêu cầu"
-          >
+          <FloatingActionButton onClick={() => openCreateSheet()} aria-label="Tạo yêu cầu">
             <PlusCircle />
           </FloatingActionButton>
         ) : null}
 
-        {/* Content area */}
-        <div className="grid grid-cols-1 gap-4">
-          <div className="w-full">
-            <Card className="overflow-hidden">
+        {isCompactLayout ? (
+          <div className="space-y-4" data-testid="repair-requests-mobile-content">
+            {toolbar}
+            {filterModal}
+
+            {shouldFetchData ? (
+              <div data-testid="repair-mobile-list">
+                <RepairRequestsMobileList
+                  requests={tableRows}
+                  isLoading={isLoading || isFetching}
+                  setRequestToView={setRequestToView}
+                  columnOptions={columnOptions}
+                />
+              </div>
+            ) : (
+              <div className="flex min-h-[360px] items-center justify-center rounded-2xl border bg-card p-6">
+                <div className="flex max-w-md flex-col items-center gap-4 text-center">
+                  <Building2 className="size-12 text-muted-foreground" />
+                  <div className="space-y-2">
+                    <h3 className="text-lg font-medium">Chọn cơ sở y tế</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Vui lòng chọn một cơ sở y tế từ bộ lọc phía trên để xem danh sách yêu cầu sửa
+                      chữa.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {pagination}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4">
+            <Card
+              className="overflow-hidden rounded-b-none"
+              data-testid="repair-requests-desktop-card"
+            >
               <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                 <div>
-                  <CardTitle className="heading-responsive-h2">Tổng hợp các yêu cầu sửa chữa thiết bị</CardTitle>
+                  <CardTitle className="heading-responsive-h2">
+                    Tổng hợp các yêu cầu sửa chữa thiết bị
+                  </CardTitle>
                   <CardDescription className="body-responsive-sm">
                     Tất cả các yêu cầu sửa chữa đã được ghi nhận.
                   </CardDescription>
@@ -179,69 +261,25 @@ export function RepairRequestsPageLayout({
 
                 {!isRegionalLeader ? (
                   <div className="flex items-center gap-2">
-                    <Button onClick={() => openCreateSheet()} className="hidden md:flex touch-target">
+                    <Button
+                      onClick={() => openCreateSheet()}
+                      className="hidden md:flex touch-target"
+                    >
                       <PlusCircle className="mr-2 size-4" /> Tạo yêu cầu
                     </Button>
                   </div>
                 ) : null}
               </CardHeader>
               <CardContent className="p-3 md:p-6 gap-3 md:gap-4">
-                <RepairRequestsToolbar
-                  searchTerm={searchTerm}
-                  onSearchChange={onSearchChange}
-                  searchInputRef={searchInputRef}
-                  isFiltered={isFiltered}
-                  onClearFilters={onClearFilters}
-                  onOpenFilterModal={() => onFilterModalOpenChange(true)}
-                  compactFilters={isMobile}
-                  uiFilters={uiFilters}
-                  selectedFacilityId={selectedFacilityId}
-                  selectedFacilityName={selectedFacilityName}
-                  showFacilityFilter={showFacilityFilter}
-                  onFilterChange={onFilterChange}
-                  onRemoveFilter={onRemoveFilter}
-                />
-
-                {/* Filter Modal */}
-                <RepairRequestsFilterModal
-                  open={isFilterModalOpen}
-                  onOpenChange={onFilterModalOpenChange}
-                  value={{
-                    status: uiFilters.status,
-                    facilityId: selectedFacilityId ?? null,
-                    dateRange: uiFilters.dateRange ? {
-                      from: uiFilters.dateRange.from ? parseISO(uiFilters.dateRange.from) : null,
-                      to: uiFilters.dateRange.to ? parseISO(uiFilters.dateRange.to) : null,
-                    } : { from: null, to: null },
-                  }}
-                  onChange={onFilterChange}
-                  showFacility={showFacilityFilter}
-                  facilities={facilityOptions.map(f => ({ id: f.id, name: f.name }))}
-                  variant={isMobile ? 'sheet' : 'dialog'}
-                />
+                {toolbar}
+                {filterModal}
 
                 {shouldFetchData ? (
-                  <>
-                    {/* Mobile Card View */}
-                    {isMobile ? (
-                      <RepairRequestsMobileList
-                        requests={table.getRowModel().rows.map((row) => row.original)}
-                        isLoading={isLoading || isFetching}
-                        setRequestToView={setRequestToView}
-                        columnOptions={columnOptions}
-                      />
-                    ) : (
-                      /* Desktop Table View */
-                      <div key={tableKey} className="rounded-md border overflow-x-auto">
-                        <div className="min-w-[1100px]">
-                          <RepairRequestsTable
-                            table={table}
-                            isLoading={isLoading || isFetching}
-                          />
-                        </div>
-                      </div>
-                    )}
-                  </>
+                  <div key={tableKey} className="rounded-md border overflow-x-auto">
+                    <div className="min-w-[1100px]">
+                      <RepairRequestsTable table={table} isLoading={isLoading || isFetching} />
+                    </div>
+                  </div>
                 ) : (
                   <div className="flex items-center justify-center min-h-[400px]">
                     <div className="flex max-w-md flex-col items-center gap-4 text-center">
@@ -249,33 +287,18 @@ export function RepairRequestsPageLayout({
                       <div className="space-y-2">
                         <h3 className="text-lg font-medium">Chọn cơ sở y tế</h3>
                         <p className="text-sm text-muted-foreground">
-                          Vui lòng chọn một cơ sở y tế từ bộ lọc phía trên để xem danh sách yêu cầu sửa chữa.
+                          Vui lòng chọn một cơ sở y tế từ bộ lọc phía trên để xem danh sách yêu cầu
+                          sửa chữa.
                         </p>
                       </div>
                     </div>
                   </div>
                 )}
               </CardContent>
-              {shouldFetchData ? (
-                <CardFooter className="py-4">
-                  <DataTablePagination
-                    table={table}
-                    totalCount={totalRequests}
-                    entity={REPAIR_REQUEST_ENTITY}
-                    paginationMode={{
-                      mode: "controlled",
-                      pagination: repairPagination.pagination,
-                      onPaginationChange: repairPagination.setPagination,
-                    }}
-                    displayFormat="range-total"
-                    responsive={{ stackLayoutAt: "md", showFirstLastAt: "lg" }}
-                    isLoading={isLoading || isFetching}
-                  />
-                </CardFooter>
-              ) : null}
             </Card>
+            {pagination}
           </div>
-        </div>
+        )}
       </div>
     </>
   )

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
@@ -189,6 +189,11 @@ export function RepairRequestsPageLayout({
           <div>
             <h1 className="text-xl md:text-2xl font-semibold">Yêu cầu sửa chữa</h1>
           </div>
+          {!isRegionalLeader && isCompactLayout && !isMobile ? (
+            <Button onClick={() => openCreateSheet()} className="h-11 shrink-0 rounded-lg">
+              <PlusCircle className="mr-2 size-4" /> Tạo yêu cầu
+            </Button>
+          ) : null}
         </div>
 
         {/* Summary */}
@@ -246,7 +251,7 @@ export function RepairRequestsPageLayout({
         ) : (
           <div className="grid grid-cols-1 gap-4">
             <Card
-              className="overflow-hidden rounded-b-none"
+              className={shouldFetchData ? "overflow-hidden rounded-b-none" : "overflow-hidden"}
               data-testid="repair-requests-desktop-card"
             >
               <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">

--- a/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsToolbar.tsx
@@ -7,6 +7,7 @@ import { Calendar as CalendarIcon, FilterX } from "lucide-react"
 import { Calendar } from "@/components/ui/calendar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
+import { SearchInput } from "@/components/shared/SearchInput"
 import { TenantSelector } from "@/components/shared/TenantSelector"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { cn } from "@/lib/utils"
@@ -125,45 +126,12 @@ export function RepairRequestsToolbar({
     [isFiltered, onClearFilters]
   )
 
-  const filterControls = React.useMemo(
-    () => (
-      <>
-        <FacetedMultiSelectFilter
-          title="Trạng thái"
-          options={statusOptions}
-          value={filterValue.status}
-          onChange={(values) => applyFilterChange({ status: values })}
-          triggerVariant="command"
-        />
-        <DateFilterButton
-          label="Từ ngày"
-          value={filterValue.dateRange?.from ?? null}
-          onChange={(date) => setDateRangePart("from", date)}
-        />
-        <DateFilterButton
-          label="Đến ngày"
-          value={filterValue.dateRange?.to ?? null}
-          onChange={(date) => setDateRangePart("to", date)}
-        />
-        {clearAction}
-      </>
-    ),
-    [
-      applyFilterChange,
-      clearAction,
-      filterValue.dateRange,
-      filterValue.status,
-      setDateRangePart,
-      statusOptions,
-    ]
-  )
-
   const mobileFilterControl = React.useMemo(
     () => (
       <Button
         variant="outline"
         size="sm"
-        className="h-9 touch-target-sm"
+        className="h-12 shrink-0 rounded-lg px-4 font-medium touch-target"
         onClick={onOpenFilterModal}
       >
         Bộ lọc
@@ -207,6 +175,59 @@ export function RepairRequestsToolbar({
       />
     ) : null
   }, [compactFilters, showFacilityFilter, tenantControl])
+
+  if (compactFilters) {
+    return (
+      <div className="space-y-3" data-testid="repair-toolbar-compact">
+        {resolvedTenantControl ? (
+          <div className="w-full" data-testid="repair-toolbar-compact-tenant">
+            {resolvedTenantControl}
+          </div>
+        ) : null}
+
+        <div
+          className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3"
+          data-testid="repair-toolbar-compact-row"
+        >
+          <SearchInput
+            ref={searchInputRef}
+            placeholder="Tìm thiết bị, mô tả..."
+            value={searchTerm}
+            onChange={onSearchChange}
+            showSearchIcon
+            className="h-12 rounded-lg bg-muted/70"
+            aria-label="Tìm thiết bị, mô tả..."
+          />
+          {mobileFilterControl}
+        </div>
+
+        <div data-testid="repair-toolbar-filter-chips">{chips}</div>
+      </div>
+    )
+  }
+
+  const filterControls = (
+    <>
+      <FacetedMultiSelectFilter
+        title="Trạng thái"
+        options={statusOptions}
+        value={filterValue.status}
+        onChange={(values) => applyFilterChange({ status: values })}
+        triggerVariant="command"
+      />
+      <DateFilterButton
+        label="Từ ngày"
+        value={filterValue.dateRange?.from ?? null}
+        onChange={(date) => setDateRangePart("from", date)}
+      />
+      <DateFilterButton
+        label="Đến ngày"
+        value={filterValue.dateRange?.to ?? null}
+        onChange={(date) => setDateRangePart("to", date)}
+      />
+      {clearAction}
+    </>
+  )
 
   return (
     <ListFilterSearchCard

--- a/src/components/shared/MobileCompactCard.tsx
+++ b/src/components/shared/MobileCompactCard.tsx
@@ -50,12 +50,9 @@ export function MobileCompactCard<
   disabled = false,
 }: MobileCompactCardProps<MetaProps, TopRightProps>) {
   const canActivate = Boolean(onActivate) && !disabled
-  const topRightContent = TopRightComponent && topRightProps ? (
-    <TopRightComponent {...topRightProps} />
-  ) : topRight
-  const metaContent = MetaComponent && metaProps ? (
-    <MetaComponent {...metaProps} />
-  ) : meta
+  const topRightContent =
+    TopRightComponent && topRightProps ? <TopRightComponent {...topRightProps} /> : topRight
+  const metaContent = MetaComponent && metaProps ? <MetaComponent {...metaProps} /> : meta
 
   return (
     <Card
@@ -63,7 +60,7 @@ export function MobileCompactCard<
         "relative overflow-hidden rounded-xl transition-all hover:shadow-md",
         disabled && "opacity-70",
         canActivate && "cursor-pointer",
-        className,
+        className
       )}
     >
       {canActivate && (
@@ -74,7 +71,7 @@ export function MobileCompactCard<
           onClick={onActivate}
         />
       )}
-      <div className="pointer-events-none relative z-10 p-3 space-y-2">
+      <div className="pointer-events-none relative z-10 p-4 space-y-3">
         {(eyebrow || topRightContent) && (
           <div className="flex items-center justify-between gap-3">
             <span className="min-w-0 truncate text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
@@ -89,31 +86,19 @@ export function MobileCompactCard<
         )}
 
         <div className="min-w-0">
-          <h3 className="text-[15px] font-semibold leading-tight text-foreground">
-            {title}
-          </h3>
+          <h3 className="text-[15px] font-semibold leading-tight text-foreground">{title}</h3>
           {subtitle && (
-            <div className="mt-0.5 truncate text-xs text-muted-foreground">
-              {subtitle}
-            </div>
+            <div className="mt-0.5 truncate text-xs text-muted-foreground">{subtitle}</div>
           )}
         </div>
 
-        {metaContent && (
-          <div className="text-xs text-muted-foreground">
-            {metaContent}
-          </div>
-        )}
+        {metaContent && <div className="text-xs text-muted-foreground">{metaContent}</div>}
 
-        {children && (
-          <div className="space-y-2">
-            {children}
-          </div>
-        )}
+        {children && <div className="space-y-3">{children}</div>}
       </div>
 
       {(primaryAction || actions) && (
-        <div className="relative z-20 flex min-w-0 gap-2 px-3 pb-3 pt-0.5">
+        <div className="relative z-20 flex min-w-0 gap-3 px-4 pb-4 pt-1">
           {primaryAction}
           {actions}
         </div>


### PR DESCRIPTION
## Summary
- Redesigns Repair Requests mobile/tablet content into a cleaner flow with balanced 5-card KPI layout.
- Keeps global fixed header/tenant display as the source of tenant context and removes duplicated facility subtitle from page body.
- Simplifies mobile repair request cards with critical fields, 48px primary actions, compact secondary menu, and improved spacing.

## Test Plan
- [x] Changed-file Prettier check
- [x] verify:no-explicit-any
- [x] verify:dedupe
- [x] typecheck
- [x] Focused Repair Requests mobile/layout/toolbar tests
- [x] react-doctor diff scan

## Notes
- Browser visual route check was attempted but local dev route was blocked by NextAuth dev configuration (NO_SECRET). Dev server and temporary Playwright artifacts were cleaned up afterward.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Repair Requests mobile/tablet layout with a balanced 5-card KPI, compact search/filter toolbar, and cleaner request cards, keeping the desktop table intact. Addressed review feedback for compact/tablet behavior, create action visibility, no duplicate facility subtitle, and consistent pagination.

- New Features
  - Added `RepairRequestsMobileKpi`: total card + 2x2 status grid using `REPAIR_STATUS_CONFIGS` (readable in dark theme).
  - Compact toolbar on mobile/tablet: search and “Bộ lọc” in one row; chips below; 48px controls; filter opens as a sheet on compact.
  - Compact flow via `isCompactLayout`: list renders outside the desktop shell; pagination shows below; FAB on mobile and create button on tablet compact layout.
  - Simplified mobile cards: essential fields only, requester falls back to department, 48px primary action, compact menu, better spacing.

- Refactors
  - Removed facility subtitle from the page body; rely on the fixed global header for tenant context.
  - Updated `MobileCompactCard` spacing/touch targets and tightened metadata/action gaps.
  - Split KPI rendering: mobile/tablet use `RepairRequestsMobileKpi`; desktop keeps `KpiStatusBar`.
  - Standardized pagination outside the desktop card and ensured the mobile list isn’t nested in the desktop container.

<sup>Written for commit 9497e8f5319f525edd8c1efab6cf0800af8d4676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cleaner mobile/tablet view for repair requests, including a summary KPI grid and a more compact filter/search toolbar.
  * Improved mobile request cards to show the most important details with a clearer action area.

* **Bug Fixes**
  * Fixed layout issues so the desktop header, table view, and pagination stay consistent across screen sizes.
  * Improved spacing and accessibility in compact/mobile views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->