### PR TITLE
feat(transfers): polish toolbar and mobile layout

### DIFF
--- a/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
+++ b/src/app/(app)/transfers/_components/TransfersPagePanel.tsx
@@ -1,28 +1,18 @@
 "use client"
 
 import * as React from "react"
-import type {
-  ColumnDef,
-  PaginationState,
-  Table as ReactTable,
-} from "@tanstack/react-table"
-import { Filter, Loader2, PlusCircle } from "lucide-react"
+import type { ColumnDef, PaginationState, Table as ReactTable } from "@tanstack/react-table"
+import { Loader2 } from "lucide-react"
 
 import { DataTablePagination } from "@/components/shared/DataTablePagination"
-import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
-import { TenantSelector } from "@/components/shared/TenantSelector"
-import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { TransferCard } from "@/components/transfers/TransferCard"
-import { FilterChips, type FilterChipsValue } from "@/components/transfers/FilterChips"
+import type { FilterChipsValue } from "@/components/transfers/FilterChips"
 import type { FilterModalValue } from "@/components/transfers/FilterModal"
 import { TransferTypeTabs } from "@/components/transfers/TransferTypeTabs"
 import { TransfersKanbanView } from "@/components/transfers/TransfersKanbanView"
 import { TransfersSearchParamsBoundary } from "@/components/transfers/TransfersSearchParamsBoundary"
 import { TransfersTableView } from "@/components/transfers/TransfersTableView"
 import { TransfersTenantSelectionPlaceholder } from "@/components/transfers/TransfersTenantSelectionPlaceholder"
-import { TransfersViewToggle } from "@/components/transfers/TransfersViewToggle"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import type { DisplayContext } from "@/components/shared/DataTablePagination/types"
 import type {
@@ -30,12 +20,10 @@ import type {
   TransferKanbanResponse,
   TransferListFilters,
   TransferListItem,
-  TransferStatus,
   TransferType,
 } from "@/types/transfers-data-grid"
-import { TRANSFER_STATUS_LABELS } from "@/types/transfers-data-grid"
 
-import { TransfersDateFilterButton } from "./TransfersDateFilterButton"
+import { TransfersToolbar } from "./TransfersToolbar"
 import type { TransferUserRole } from "./TransfersTypes"
 
 type TransfersPagePanelPermissions = Readonly<{
@@ -78,7 +66,9 @@ type TransfersPagePanelProps = Readonly<{
   userRole?: TransferUserRole
   columns: ColumnDef<TransferListItem>[]
   pagination: PaginationState
-  onPaginationChange: (updater: PaginationState | ((old: PaginationState) => PaginationState)) => void
+  onPaginationChange: (
+    updater: PaginationState | ((old: PaginationState) => PaginationState)
+  ) => void
   pageCount: number
   table: ReactTable<TransferListItem>
   transferEntity: { singular: string }
@@ -88,7 +78,7 @@ type TransfersPagePanelProps = Readonly<{
 function getTransferTypeCounts(
   activeTab: TransferType,
   transferCounts: TransferCountsResponse | null | undefined,
-  totalCount: number,
+  totalCount: number
 ) {
   const activeCount = transferCounts?.totalCount ?? totalCount
 
@@ -99,6 +89,7 @@ function getTransferTypeCounts(
   }
 }
 
+/** Renders the Transfers page shell around toolbar, tabs, list, kanban, and pagination. */
 export function TransfersPagePanel({
   activeTab,
   onTabChange,
@@ -138,103 +129,24 @@ export function TransfersPagePanel({
   const { shouldFetch, isLoading: isListLoading, isFetching: isListFetching } = dataState
   const transferTypeCounts = getTransferTypeCounts(activeTab, transferCounts, totalCount)
   const compactFilters = filterVariant === "sheet"
-  const statusOptions = React.useMemo(
-    () =>
-      (Object.entries(TRANSFER_STATUS_LABELS) as [TransferStatus, string][]).map(
-        ([value, label]) => ({ value, label }),
-      ),
-    [],
-  )
-
-  const setDateRangePart = React.useCallback(
-    (key: "from" | "to", date: Date | null) => {
-      onFilterChange({
-        ...filterValue,
-        dateRange: {
-          from: key === "from" ? date : filterValue.dateRange?.from ?? null,
-          to: key === "to" ? date : filterValue.dateRange?.to ?? null,
-        },
-      })
-    },
-    [filterValue, onFilterChange],
-  )
-
-  const filterButton = (
-    <Button
-      variant="outline"
-      onClick={onOpenFilterModal}
-      className="h-11 gap-2 font-medium sm:h-9"
-    >
-      <Filter className="size-5 sm:size-4" />
-      <span className="hidden sm:inline">Bộ lọc</span>
-      {activeFilterCount > 0 && (
-        <Badge variant="secondary" className="h-5 px-1.5 text-xs sm:ml-1">
-          {activeFilterCount}
-        </Badge>
-      )}
-    </Button>
-  )
-
-  const filterControls = (
-    <>
-      <FacetedMultiSelectFilter
-        title="Trạng thái"
-        options={statusOptions}
-        value={filterValue.statuses}
-        onChange={(statuses) =>
-          onFilterChange({ ...filterValue, statuses: statuses as TransferStatus[] })
-        }
-      />
-      <TransfersDateFilterButton
-        label="Từ ngày"
-        value={filterValue.dateRange?.from ?? null}
-        onChange={(date) => setDateRangePart("from", date)}
-      />
-      <TransfersDateFilterButton
-        label="Đến ngày"
-        value={filterValue.dateRange?.to ?? null}
-        onChange={(date) => setDateRangePart("to", date)}
-      />
-    </>
-  )
 
   return (
     <Card>
-      <CardContent className="space-y-4">
-        <ListFilterSearchCard
-          title="Theo dõi và xử lý yêu cầu luân chuyển theo từng loại hình"
-          tenantControl={showFacilityFilter ? <TenantSelector /> : undefined}
-          surface="plain"
-          searchValue={searchTerm}
-          onSearchChange={onSearchTermChange}
-          searchPlaceholder="Tìm kiếm mã yêu cầu, thiết bị, lý do..."
-          showSearchIcon={true}
-          filterControls={filterControls}
-          mobileFilterControl={filterButton}
+      <CardContent className="space-y-4 px-4 pb-5 sm:px-6 sm:pb-6">
+        <TransfersToolbar
+          showFacilityFilter={showFacilityFilter}
+          isRegionalLeader={isRegionalLeader}
+          activeFilterCount={activeFilterCount}
+          onOpenFilterModal={onOpenFilterModal}
+          onOpenAddDialog={onOpenAddDialog}
+          filterChipsValue={filterChipsValue}
+          onRemoveFilter={onRemoveFilter}
+          onClearAllFilters={onClearAllFilters}
+          searchTerm={searchTerm}
+          onSearchTermChange={onSearchTermChange}
+          filterValue={filterValue}
+          onFilterChange={onFilterChange}
           compactFilters={compactFilters}
-          actions={(
-            <>
-              <div className="hidden sm:block">
-                <TransfersViewToggle />
-              </div>
-              {!isRegionalLeader && (
-                <Button
-                  onClick={onOpenAddDialog}
-                  className="h-11 gap-2 font-medium sm:h-9"
-                >
-                  <PlusCircle className="size-5 sm:size-4" />
-                  Tạo yêu cầu mới
-                </Button>
-              )}
-            </>
-          )}
-          chips={(
-            <FilterChips
-              value={filterChipsValue}
-              onRemove={onRemoveFilter}
-              onClearAll={onClearAllFilters}
-            />
-          )}
         />
 
         <TransfersSearchParamsBoundary>
@@ -259,7 +171,7 @@ export function TransfersPagePanel({
                 )
               ) : shouldFetch ? (
                 <>
-                  <div className="space-y-3 lg:hidden">
+                  <div className="space-y-3 pb-2 lg:hidden">
                     {isListLoading ? (
                       <div className="flex min-h-[200px] items-center justify-center rounded-lg border border-dashed">
                         <div className="flex flex-col items-center gap-2 text-sm text-muted-foreground">

--- a/src/app/(app)/transfers/_components/TransfersToolbar.tsx
+++ b/src/app/(app)/transfers/_components/TransfersToolbar.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import * as React from "react"
+import { Filter, PlusCircle } from "lucide-react"
+
+import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
+import { TenantSelector } from "@/components/shared/TenantSelector"
+import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
+import { FilterChips, type FilterChipsValue } from "@/components/transfers/FilterChips"
+import type { FilterModalValue } from "@/components/transfers/FilterModal"
+import { TransfersViewToggle } from "@/components/transfers/TransfersViewToggle"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import type { TransferStatus } from "@/types/transfers-data-grid"
+import { TRANSFER_STATUS_LABELS } from "@/types/transfers-data-grid"
+
+import { TransfersDateFilterButton } from "./TransfersDateFilterButton"
+
+type TransfersToolbarProps = Readonly<{
+  showFacilityFilter: boolean
+  isRegionalLeader: boolean
+  activeFilterCount: number
+  onOpenFilterModal: () => void
+  onOpenAddDialog: () => void
+  filterChipsValue: FilterChipsValue
+  onRemoveFilter: (key: keyof FilterChipsValue, subkey?: string) => void
+  onClearAllFilters: () => void
+  searchTerm: string
+  onSearchTermChange: (value: string) => void
+  filterValue: FilterModalValue
+  onFilterChange: (value: FilterModalValue) => void
+  compactFilters: boolean
+}>
+
+/** Renders the Transfers tenant, search, filter, chips, and page actions toolbar. */
+export function TransfersToolbar({
+  showFacilityFilter,
+  isRegionalLeader,
+  activeFilterCount,
+  onOpenFilterModal,
+  onOpenAddDialog,
+  filterChipsValue,
+  onRemoveFilter,
+  onClearAllFilters,
+  searchTerm,
+  onSearchTermChange,
+  filterValue,
+  onFilterChange,
+  compactFilters,
+}: TransfersToolbarProps) {
+  const statusOptions = React.useMemo(
+    () =>
+      (Object.entries(TRANSFER_STATUS_LABELS) as [TransferStatus, string][]).map(
+        ([value, label]) => ({ value, label })
+      ),
+    []
+  )
+
+  const setDateRangePart = React.useCallback(
+    (key: "from" | "to", date: Date | null) => {
+      onFilterChange({
+        ...filterValue,
+        dateRange: {
+          from: key === "from" ? date : (filterValue.dateRange?.from ?? null),
+          to: key === "to" ? date : (filterValue.dateRange?.to ?? null),
+        },
+      })
+    },
+    [filterValue, onFilterChange]
+  )
+
+  const tenantControl = React.useMemo(
+    () =>
+      showFacilityFilter ? (
+        <TenantSelector className="w-full md:w-auto" variant="command" />
+      ) : undefined,
+    [showFacilityFilter]
+  )
+
+  const filterButton = React.useMemo(
+    () => (
+      <Button
+        variant="outline"
+        onClick={onOpenFilterModal}
+        className="h-11 shrink-0 gap-2 rounded-lg px-4 font-medium sm:h-9"
+        aria-label="Bộ lọc"
+      >
+        <Filter className="size-5 sm:size-4" />
+        <span className="hidden sm:inline">Bộ lọc</span>
+        {activeFilterCount > 0 && (
+          <Badge variant="secondary" className="h-5 px-1.5 text-xs sm:ml-1">
+            {activeFilterCount}
+          </Badge>
+        )}
+      </Button>
+    ),
+    [activeFilterCount, onOpenFilterModal]
+  )
+
+  const filterControls = React.useMemo(
+    () => (
+      <>
+        <FacetedMultiSelectFilter
+          title="Trạng thái"
+          options={statusOptions}
+          value={filterValue.statuses}
+          onChange={(statuses) =>
+            onFilterChange({ ...filterValue, statuses: statuses as TransferStatus[] })
+          }
+          triggerVariant="command"
+        />
+        <TransfersDateFilterButton
+          label="Từ ngày"
+          value={filterValue.dateRange?.from ?? null}
+          onChange={(date) => setDateRangePart("from", date)}
+        />
+        <TransfersDateFilterButton
+          label="Đến ngày"
+          value={filterValue.dateRange?.to ?? null}
+          onChange={(date) => setDateRangePart("to", date)}
+        />
+      </>
+    ),
+    [filterValue, onFilterChange, setDateRangePart, statusOptions]
+  )
+
+  const actions = React.useMemo(
+    () => (
+      <>
+        <div className="hidden sm:block">
+          <TransfersViewToggle />
+        </div>
+        {!isRegionalLeader && (
+          <Button onClick={onOpenAddDialog} className="h-11 gap-2 font-medium sm:h-9">
+            <PlusCircle className="size-5 sm:size-4" />
+            Tạo yêu cầu mới
+          </Button>
+        )}
+      </>
+    ),
+    [isRegionalLeader, onOpenAddDialog]
+  )
+
+  const chips = React.useMemo(
+    () => (
+      <FilterChips
+        value={filterChipsValue}
+        onRemove={onRemoveFilter}
+        onClearAll={onClearAllFilters}
+      />
+    ),
+    [filterChipsValue, onClearAllFilters, onRemoveFilter]
+  )
+
+  return (
+    <ListFilterSearchCard
+      title="Theo dõi và xử lý yêu cầu luân chuyển theo từng loại hình"
+      tenantControl={tenantControl}
+      surface="plain"
+      searchValue={searchTerm}
+      onSearchChange={onSearchTermChange}
+      searchPlaceholder="Tìm kiếm mã yêu cầu, thiết bị, lý do..."
+      showSearchIcon={true}
+      tenantClassName="w-full md:w-auto"
+      searchClassName="md:min-w-[360px] md:max-w-none xl:min-w-[520px]"
+      filterControls={filterControls}
+      mobileFilterControl={filterButton}
+      compactFilters={compactFilters}
+      actions={actions}
+      chips={chips}
+    />
+  )
+}

--- a/src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx
+++ b/src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx
@@ -13,7 +13,22 @@ import type {
   TransferType,
 } from "@/types/transfers-data-grid"
 vi.mock("@/components/shared/TenantSelector", () => ({
-  TenantSelector: () => <div data-testid="tenant-selector" />,
+  TenantSelector: ({
+    className,
+    variant = "default",
+  }: {
+    className?: string
+    variant?: "default" | "command"
+  }) => (
+    <button
+      type="button"
+      data-testid="tenant-selector"
+      data-class-name={className}
+      data-trigger-variant={variant}
+    >
+      Cơ sở
+    </button>
+  ),
 }))
 vi.mock("@/components/shared/ListFilterSearchCard", () => ({
   ListFilterSearchCard: (props: {
@@ -37,31 +52,34 @@ vi.mock("@/components/shared/ListFilterSearchCard", () => ({
         data-placeholder={props.searchPlaceholder}
         data-has-mobile-filter={props.mobileFilterControl ? "true" : "false"}
       >
-      <div data-testid="tenant-control-slot">{props.tenantControl}</div>
-      <input
-        aria-label="shared-transfer-search"
-        value={props.searchValue}
-        onChange={(event) => props.onSearchChange(event.target.value)}
-      />
-      <button type="button" onClick={() => props.onSearchChange("")}>
-        shared-clear-search
-      </button>
-      <div data-testid="visible-filter-slot">{visibleFilters}</div>
-      <div data-testid="actions-slot">{props.actions}</div>
-      <div data-testid="chips-slot">{props.chips}</div>
-    </div>
-  )},
+        <div data-testid="tenant-control-slot">{props.tenantControl}</div>
+        <input
+          aria-label="shared-transfer-search"
+          value={props.searchValue}
+          onChange={(event) => props.onSearchChange(event.target.value)}
+        />
+        <button type="button" onClick={() => props.onSearchChange("")}>
+          shared-clear-search
+        </button>
+        <div data-testid="visible-filter-slot">{visibleFilters}</div>
+        <div data-testid="actions-slot">{props.actions}</div>
+        <div data-testid="chips-slot">{props.chips}</div>
+      </div>
+    )
+  },
 }))
 vi.mock("@/components/shared/table-filters/FacetedMultiSelectFilter", () => ({
   FacetedMultiSelectFilter: (props: {
     title?: string
     value?: string[]
     onChange?: (values: string[]) => void
+    triggerVariant?: "outline" | "command"
   }) => (
     <button
       type="button"
       data-testid="transfer-status-filter"
       data-value={(props.value ?? []).join(",")}
+      data-trigger-variant={props.triggerVariant ?? "outline"}
       onClick={() => props.onChange?.(["da_duyet"])}
     >
       {props.title}
@@ -187,9 +205,7 @@ describe("TransfersPagePanel grouped props", () => {
   it("invokes onOpenAddDialog when create button is clicked (non-regional leader)", async () => {
     const onOpenAddDialog = vi.fn()
     renderPanel({ onOpenAddDialog })
-    await userEvent.setup().click(
-      screen.getByRole("button", { name: /Tạo yêu cầu mới/ }),
-    )
+    await userEvent.setup().click(screen.getByRole("button", { name: /Tạo yêu cầu mới/ }))
     expect(onOpenAddDialog).toHaveBeenCalledTimes(1)
   })
 
@@ -228,10 +244,7 @@ describe("TransfersPagePanel grouped props", () => {
       dataState: { shouldFetch: true, isLoading: false, isFetching: false },
       kanbanData: { columns: {}, totalCount: 0 } as PanelProps["kanbanData"],
     })
-    expect(screen.getByTestId("transfers-kanban-view")).toHaveAttribute(
-      "data-initial",
-      "data",
-    )
+    expect(screen.getByTestId("transfers-kanban-view")).toHaveAttribute("data-initial", "data")
   })
 
   it("renders table view + footer pagination in table mode when shouldFetch=true", () => {
@@ -242,6 +255,32 @@ describe("TransfersPagePanel grouped props", () => {
     })
     expect(screen.getByTestId("transfers-table-view")).toBeInTheDocument()
     expect(screen.getByTestId("data-table-pagination")).toBeInTheDocument()
+  })
+
+  it("keeps the Transfers panel content padded for compact and tablet layouts", () => {
+    renderPanel()
+
+    expect(screen.getByTestId("list-filter-search-card").parentElement).toHaveClass(
+      "px-4",
+      "pb-5",
+      "sm:px-6",
+      "sm:pb-6"
+    )
+  })
+
+  it("keeps mobile transfer cards in a breathable stack below the toolbar", () => {
+    const transfer = makeTransferItem({ id: 99, ma_yeu_cau: "LC-099" })
+    renderPanel({
+      viewMode: "table",
+      dataState: { shouldFetch: true, isLoading: false, isFetching: false },
+      tableData: [transfer],
+    })
+
+    expect(screen.getByTestId("transfer-card-99").parentElement).toHaveClass(
+      "space-y-3",
+      "pb-2",
+      "lg:hidden"
+    )
   })
 
   it("shows mobile loading indicator when dataState.isLoading=true", () => {
@@ -275,36 +314,43 @@ describe("TransfersPagePanel grouped props", () => {
 
     const card = screen.getByTestId("list-filter-search-card")
     expect(card).toHaveAttribute("data-surface", "plain")
-    expect(card).toHaveAttribute(
-      "data-placeholder",
-      "Tìm kiếm mã yêu cầu, thiết bị, lý do...",
-    )
+    expect(card).toHaveAttribute("data-placeholder", "Tìm kiếm mã yêu cầu, thiết bị, lý do...")
     expect(screen.getByTestId("tenant-control-slot")).toContainElement(
-      screen.getByTestId("tenant-selector"),
+      screen.getByTestId("tenant-selector")
     )
     const statusFilter = within(screen.getByTestId("visible-filter-slot")).getByTestId(
-      "transfer-status-filter",
+      "transfer-status-filter"
     )
     expect(statusFilter).toHaveAttribute("data-value", "cho_duyet")
+    expect(statusFilter).toHaveAttribute("data-trigger-variant", "command")
     fireEvent.click(statusFilter)
     expect(onFilterChange).toHaveBeenCalledWith({
       statuses: ["da_duyet"],
       dateRange: null,
     })
-    expect(within(screen.getByTestId("visible-filter-slot")).getByRole(
-      "button",
-      { name: /Từ ngày/ },
-    )).toBeInTheDocument()
-    expect(within(screen.getByTestId("visible-filter-slot")).queryByRole(
-      "button",
-      { name: /Bộ lọc/ },
-    )).toBeNull()
+    expect(
+      within(screen.getByTestId("visible-filter-slot")).getByRole("button", { name: /Từ ngày/ })
+    ).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId("visible-filter-slot")).queryByRole("button", { name: /Bộ lọc/ })
+    ).toBeNull()
     expect(screen.getByTestId("actions-slot")).toContainElement(
-      screen.getByRole("button", { name: /Tạo yêu cầu mới/ }),
+      screen.getByRole("button", { name: /Tạo yêu cầu mới/ })
     )
-    expect(screen.getByTestId("chips-slot")).toContainElement(
-      screen.getByTestId("filter-chips"),
-    )
+    expect(screen.getByTestId("chips-slot")).toContainElement(screen.getByTestId("filter-chips"))
+  })
+
+  it("uses the Equipment-style command tenant selector before Transfers search", () => {
+    renderPanel({
+      permissions: { showFacilityFilter: true, isRegionalLeader: false },
+    })
+
+    const tenantSelector = screen.getByTestId("tenant-selector")
+    const search = screen.getByLabelText("shared-transfer-search")
+
+    expect(tenantSelector).toHaveAttribute("data-trigger-variant", "command")
+    expect(tenantSelector).toHaveAttribute("data-class-name", "w-full md:w-auto")
+    expect(tenantSelector.compareDocumentPosition(search)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
   it("uses the shared card mobile filter slot when Transfers filters render as a sheet", async () => {
@@ -319,12 +365,33 @@ describe("TransfersPagePanel grouped props", () => {
     expect(card).toHaveAttribute("data-compact-filters", "true")
     expect(card).toHaveAttribute("data-has-mobile-filter", "true")
     expect(screen.getByTestId("visible-filter-slot")).toContainElement(
-      screen.getByRole("button", { name: /Bộ lọc/ }),
+      screen.getByRole("button", { name: /Bộ lọc/ })
     )
     const filterButton = screen.getByRole("button", { name: /Bộ lọc/ })
+    expect(filterButton).toHaveAttribute("aria-label", "Bộ lọc")
     expect(within(filterButton).getByText("3")).toBeInTheDocument()
     await userEvent.setup().click(filterButton)
     expect(onOpenFilterModal).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps compact facility selection in the tenant slot instead of the filter sheet", () => {
+    renderPanel({
+      filterVariant: "sheet",
+      permissions: { showFacilityFilter: true, isRegionalLeader: false },
+    })
+
+    expect(screen.getByTestId("tenant-control-slot")).toContainElement(
+      screen.getByTestId("tenant-selector")
+    )
+    expect(screen.getByTestId("visible-filter-slot")).toContainElement(
+      screen.getByRole("button", { name: /Bộ lọc/ })
+    )
+    expect(
+      within(screen.getByTestId("visible-filter-slot")).queryByTestId("tenant-selector")
+    ).toBeNull()
+    expect(
+      within(screen.getByTestId("visible-filter-slot")).queryByTestId("transfer-status-filter")
+    ).toBeNull()
   })
 
   it("keeps shared card search interactions wired to Transfers search state", async () => {
@@ -337,12 +404,9 @@ describe("TransfersPagePanel grouped props", () => {
     fireEvent.change(screen.getByLabelText("shared-transfer-search"), {
       target: { value: "YC-413" },
     })
-    await userEvent.setup().click(
-      screen.getByRole("button", { name: "shared-clear-search" }),
-    )
+    await userEvent.setup().click(screen.getByRole("button", { name: "shared-clear-search" }))
 
     expect(onSearchTermChange).toHaveBeenCalledWith("YC-413")
     expect(onSearchTermChange).toHaveBeenLastCalledWith("")
   })
-
 })


### PR DESCRIPTION
## Summary
- Extract Transfers toolbar into a module-local component using the shared filter/search card pattern.
- Use the Equipment/Repair-style command tenant selector and command status filter trigger.
- Add compact/mobile layout regressions for tenant separation, panel padding, and card stack spacing.

## Test Plan
- [x] node scripts/npm-run.js npx prettier --check --ignore-unknown 'src/app/(app)/transfers/_components/TransfersPagePanel.tsx' 'src/app/(app)/transfers/_components/TransfersToolbar.tsx' 'src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx'
- [x] node scripts/npm-run.js run verify:no-explicit-any
- [x] node scripts/npm-run.js run verify:dedupe
- [x] node scripts/npm-run.js run verify:ts-docstrings
- [x] node scripts/npm-run.js run typecheck
- [x] node scripts/npm-run.js run test:run -- src/components/transfers/__tests__/TransfersPagePanel.render.test.tsx 'src/app/(app)/transfers/__tests__/TransfersKpi.test.tsx'
- [x] node scripts/npm-run.js run react-doctor

No dev server / visual browser check per request.

Closes #666
Closes #676

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Transfers toolbar and mobile layout to match Equipment/Repair patterns and improve small-screen spacing. Extracted the toolbar into `TransfersToolbar` and updated tenant/status filters and search to address #666 and #676.

- **Refactors**
  - Moved toolbar UI from `TransfersPagePanel` to `TransfersToolbar` using `ListFilterSearchCard`; switched `TenantSelector` to `variant="command"` and status filter to `triggerVariant="command"`, kept the view toggle and “Create request” in the toolbar, and rendered filter chips there.

- **Bug Fixes**
  - Fixed compact/tablet padding in the panel (`px-4 pb-5 sm:px-6 sm:pb-6`) and added `pb-2` for the mobile card stack; kept facility selection in the tenant slot when filters render as a sheet, and the mobile filter button shows the active count with an accessible label.

<sup>Written for commit 8104e6d66f15c54d2154df1b3dbfc8f88c7e3bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Transfers Page**
  * Consolidated the Transfers page controls into a more consistent toolbar layout with search, filters, view switching, and request actions.
  * Updated spacing and mobile layout for a cleaner, more usable experience.
* **Bug Fixes**
  * Refined filter and date-range behavior so selections update more reliably and preserve chosen values.
  * Improved button and panel interactions, including loading and modal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->