### PR TITLE
Implement #684 Equipments HeroUI top controls pilot

### DIFF
--- a/src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx
@@ -71,6 +71,25 @@ describe("EquipmentToolbar HeroUI top controls", () => {
     expect(shell).toContainElement(searchControl)
     expect(searchControl).toContainElement(search)
     expect(search).toHaveAttribute("type", "search")
+    expect(screen.getByTitle("Quét mã QR")).toContainElement(
+      screen.getByRole("button", { name: "Quét mã QR" })
+    )
+  })
+
+  it("keeps the desktop search clear affordance wired", () => {
+    const onSearchChange = vi.fn()
+
+    render(
+      <EquipmentToolbar
+        {...createBaseProps()}
+        searchTerm="máy thở"
+        onSearchChange={onSearchChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Xóa tìm kiếm" }))
+
+    expect(onSearchChange).toHaveBeenCalledWith("")
   })
 
   it("keeps desktop options actions wired through the HeroUI dropdown", async () => {

--- a/src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx
@@ -88,6 +88,7 @@ describe("EquipmentToolbar HeroUI top controls", () => {
     )
 
     fireEvent.click(screen.getByRole("button", { name: /Tùy chọn/i }))
+    expect(await screen.findByRole("menu", { name: "Tùy chọn" })).toBeInTheDocument()
     fireEvent.click(await screen.findByText("Hiện/ẩn cột"))
     fireEvent.click(screen.getByRole("button", { name: /Tùy chọn/i }))
     fireEvent.click(await screen.findByText("Tải Excel mẫu"))
@@ -112,6 +113,7 @@ describe("EquipmentToolbar HeroUI top controls", () => {
     )
 
     fireEvent.click(screen.getByRole("button", { name: /Thêm thiết bị/i }))
+    expect(await screen.findByRole("menu", { name: "Thêm thiết bị" })).toBeInTheDocument()
     fireEvent.click(await screen.findByText("Thêm thủ công"))
     fireEvent.click(screen.getByRole("button", { name: /Thêm thiết bị/i }))
     fireEvent.click(await screen.findByText("Nhập từ Excel"))

--- a/src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx
@@ -1,0 +1,122 @@
+import * as React from "react"
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom"
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { Table } from "@tanstack/react-table"
+
+import type { Equipment } from "@/types/database"
+import { EquipmentToolbar } from "../equipment-toolbar"
+
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}))
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}))
+
+function createMockTable() {
+  const table = {
+    getColumn: vi.fn(() => ({
+      getFilterValue: vi.fn(),
+      setFilterValue: vi.fn(),
+    })),
+    resetColumnFilters: vi.fn(),
+    getHeaderGroups: () => [],
+    getRowModel: () => ({ rows: [] }),
+    getAllColumns: () => [],
+    getState: () => ({ columnFilters: [] }),
+  }
+
+  return table as unknown as Table<Equipment>
+}
+
+function createBaseProps() {
+  return {
+    table: createMockTable(),
+    searchTerm: "",
+    onSearchChange: vi.fn(),
+    columnFilters: [],
+    statuses: ["Hoạt động", "Hỏng"],
+    departments: ["ICU", "Surgery"],
+    users: ["User A"],
+    classifications: ["Loại A"],
+    fundingSources: ["Ngân sách"],
+    filterMode: "faceted" as const,
+    filterState: {
+      isFiltered: false,
+      hasFacilityFilter: false,
+    },
+    actionState: {
+      canCreateEquipment: true,
+      isExporting: false,
+    },
+    onOpenFilterSheet: vi.fn(),
+    onOpenColumnsDialog: vi.fn(),
+    onDownloadTemplate: vi.fn(),
+    onExportData: vi.fn(),
+    onAddEquipment: vi.fn(),
+    onImportEquipment: vi.fn(),
+  }
+}
+
+describe("EquipmentToolbar HeroUI top controls", () => {
+  it("renders the desktop shell and search through the Equipments HeroUI pilot", () => {
+    render(<EquipmentToolbar {...createBaseProps()} />)
+
+    const shell = screen.getByTestId("equipment-heroui-top-controls-shell")
+    const searchControl = screen.getByTestId("equipment-heroui-search-control")
+    const search = screen.getByRole("searchbox", { name: "Tìm kiếm chung..." })
+
+    expect(shell).toContainElement(searchControl)
+    expect(searchControl).toContainElement(search)
+    expect(search).toHaveAttribute("type", "search")
+  })
+
+  it("keeps desktop options actions wired through the HeroUI dropdown", async () => {
+    const onOpenColumnsDialog = vi.fn()
+    const onDownloadTemplate = vi.fn()
+    const onExportData = vi.fn()
+
+    render(
+      <EquipmentToolbar
+        {...createBaseProps()}
+        onOpenColumnsDialog={onOpenColumnsDialog}
+        onDownloadTemplate={onDownloadTemplate}
+        onExportData={onExportData}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Tùy chọn/i }))
+    fireEvent.click(await screen.findByText("Hiện/ẩn cột"))
+    fireEvent.click(screen.getByRole("button", { name: /Tùy chọn/i }))
+    fireEvent.click(await screen.findByText("Tải Excel mẫu"))
+    fireEvent.click(screen.getByRole("button", { name: /Tùy chọn/i }))
+    fireEvent.click(await screen.findByText("Tải về dữ liệu"))
+
+    expect(onOpenColumnsDialog).toHaveBeenCalledTimes(1)
+    expect(onDownloadTemplate).toHaveBeenCalledTimes(1)
+    expect(onExportData).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps desktop add actions wired through the HeroUI dropdown", async () => {
+    const onAddEquipment = vi.fn()
+    const onImportEquipment = vi.fn()
+
+    render(
+      <EquipmentToolbar
+        {...createBaseProps()}
+        onAddEquipment={onAddEquipment}
+        onImportEquipment={onImportEquipment}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Thêm thiết bị/i }))
+    fireEvent.click(await screen.findByText("Thêm thủ công"))
+    fireEvent.click(screen.getByRole("button", { name: /Thêm thiết bị/i }))
+    fireEvent.click(await screen.findByText("Nhập từ Excel"))
+
+    expect(onAddEquipment).toHaveBeenCalledTimes(1)
+    expect(onImportEquipment).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/equipment/equipment-toolbar-layout.tsx
+++ b/src/components/equipment/equipment-toolbar-layout.tsx
@@ -5,10 +5,16 @@ import type { Table } from "@tanstack/react-table"
 import { Building2, Filter, Tags, UserRound, WalletCards, X } from "lucide-react"
 
 import type { Equipment } from "@/types/database"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { SearchInput } from "@/components/shared/SearchInput"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
+import {
+  EquipmentHeroButton,
+  EquipmentHeroCard,
+  EquipmentHeroCardContent,
+  EquipmentHeroCardDescription,
+  EquipmentHeroCardHeader,
+  EquipmentHeroCardTitle,
+  EquipmentHeroSearchInput,
+} from "./heroui-pilot"
 
 interface EquipmentFilterFieldProps {
   label: string
@@ -114,16 +120,17 @@ export function EquipmentToolbarDesktopFilters({
         />
       </EquipmentFilterField>
       {isFiltered && (
-        <Button
+        <EquipmentHeroButton
           type="button"
           variant="ghost"
+          size="sm"
           data-testid="equipment-clear-filters-control"
-          onClick={() => table.resetColumnFilters()}
+          onPress={() => table.resetColumnFilters()}
           className="h-9 self-end justify-start gap-1.5 px-2 text-muted-foreground hover:bg-transparent hover:text-foreground"
         >
           <X className="size-4" aria-hidden="true" />
           <span className="text-sm font-medium">Xóa bộ lọc</span>
-        </Button>
+        </EquipmentHeroButton>
       )}
     </div>
   )
@@ -142,22 +149,27 @@ export function EquipmentToolbarDesktopLayout({
   children,
 }: EquipmentToolbarDesktopLayoutProps) {
   return (
-    <Card>
+    <EquipmentHeroCard data-testid="equipment-heroui-top-controls-shell">
       {title || description ? (
-        <CardHeader className="gap-y-1 pb-3">
-          {title ? <CardTitle className="heading-responsive-h2">{title}</CardTitle> : null}
-          {description ? (
-            <CardDescription className="body-responsive-sm">{description}</CardDescription>
+        <EquipmentHeroCardHeader className="gap-y-1 pb-3">
+          {title ? (
+            <EquipmentHeroCardTitle className="heading-responsive-h2">
+              {title}
+            </EquipmentHeroCardTitle>
           ) : null}
-        </CardHeader>
+          {description ? (
+            <EquipmentHeroCardDescription className="body-responsive-sm">
+              {description}
+            </EquipmentHeroCardDescription>
+          ) : null}
+        </EquipmentHeroCardHeader>
       ) : null}
-      <CardContent className="px-4 pb-4 md:px-6">
+      <EquipmentHeroCardContent className="px-4 pb-4 md:px-6">
         <div data-testid="equipment-reference-filter-layout" className="space-y-3">
-          <SearchInput
+          <EquipmentHeroSearchInput
             placeholder={searchPlaceholder}
             value={searchValue}
-            onChange={onSearchChange}
-            showSearchIcon={false}
+            onValueChange={onSearchChange}
             className="h-9 w-full"
             endAddon={searchEndAddon}
             aria-label={searchPlaceholder}
@@ -176,7 +188,7 @@ export function EquipmentToolbarDesktopLayout({
             ) : null}
           </div>
         </div>
-      </CardContent>
-    </Card>
+      </EquipmentHeroCardContent>
+    </EquipmentHeroCard>
   )
 }

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -109,17 +109,19 @@ export function EquipmentToolbar({
 
   const searchEndAddon = React.useMemo(
     () => (
-      <EquipmentHeroButton
-        type="button"
-        variant="ghost"
-        size="sm"
-        isIconOnly
-        onPress={qr.handleStartScanning}
-        className="size-8 hover:bg-primary/10"
-        aria-label="Quét mã QR"
-      >
-        <ScanLine className="size-4 text-muted-foreground hover:text-primary" />
-      </EquipmentHeroButton>
+      <span title="Quét mã QR" className="inline-flex">
+        <EquipmentHeroButton
+          type="button"
+          variant="ghost"
+          size="sm"
+          isIconOnly
+          onPress={qr.handleStartScanning}
+          className="size-8 hover:bg-primary/10"
+          aria-label="Quét mã QR"
+        >
+          <ScanLine className="size-4 text-muted-foreground hover:text-primary" />
+        </EquipmentHeroButton>
+      </span>
     ),
     [qr.handleStartScanning]
   )

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -25,6 +25,7 @@ import {
   EquipmentToolbarDesktopFilters,
   EquipmentToolbarDesktopLayout,
 } from "./equipment-toolbar-layout"
+import { EquipmentHeroButton, EquipmentHeroDropdown } from "./heroui-pilot"
 import { useQRScanner } from "./useEquipmentQRScanner"
 import type { Equipment } from "@/types/database"
 
@@ -108,17 +109,17 @@ export function EquipmentToolbar({
 
   const searchEndAddon = React.useMemo(
     () => (
-      <Button
+      <EquipmentHeroButton
         type="button"
         variant="ghost"
-        size="icon"
-        onClick={qr.handleStartScanning}
+        size="sm"
+        isIconOnly
+        onPress={qr.handleStartScanning}
         className="size-8 hover:bg-primary/10"
-        title="Quét mã QR"
         aria-label="Quét mã QR"
       >
         <ScanLine className="size-4 text-muted-foreground hover:text-primary" />
-      </Button>
+      </EquipmentHeroButton>
     ),
     [qr.handleStartScanning]
   )
@@ -181,35 +182,63 @@ export function EquipmentToolbar({
     () => (
       <>
         {canCreateEquipment && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button size="sm" className="hidden md:flex h-8 gap-1 touch-target-sm md:h-8">
+          <EquipmentHeroDropdown
+            ariaLabel="Thêm thiết bị"
+            trigger={
+              <>
                 <PlusCircle className="size-3.5" />
                 <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">Thêm thiết bị</span>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={onAddEquipment}>Thêm thủ công</DropdownMenuItem>
-              <DropdownMenuItem onSelect={onImportEquipment}>Nhập từ Excel</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+              </>
+            }
+            triggerClassName="hidden h-8 gap-1 border-transparent bg-primary text-primary-foreground hover:bg-primary/90 md:inline-flex touch-target-sm md:h-8"
+            items={[
+              {
+                id: "manual",
+                label: "Thêm thủ công",
+                textValue: "Thêm thủ công",
+                onAction: onAddEquipment,
+              },
+              {
+                id: "excel",
+                label: "Nhập từ Excel",
+                textValue: "Nhập từ Excel",
+                onAction: onImportEquipment,
+              },
+            ]}
+          />
         )}
 
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" className="hidden lg:flex h-8 gap-1 touch-target-sm md:h-8">
+        <EquipmentHeroDropdown
+          ariaLabel="Tùy chọn"
+          trigger={
+            <>
               <Settings className="size-3.5" />
               Tùy chọn
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuItem onSelect={onOpenColumnsDialog}>Hiện/ẩn cột</DropdownMenuItem>
-            <DropdownMenuItem onSelect={onDownloadTemplate}>Tải Excel mẫu</DropdownMenuItem>
-            <DropdownMenuItem onSelect={onExportData} disabled={isExporting}>
-              {isExporting ? "Đang tải..." : "Tải về dữ liệu"}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+            </>
+          }
+          triggerClassName="hidden h-8 gap-1 lg:inline-flex touch-target-sm md:h-8"
+          items={[
+            {
+              id: "columns",
+              label: "Hiện/ẩn cột",
+              textValue: "Hiện/ẩn cột",
+              onAction: onOpenColumnsDialog,
+            },
+            {
+              id: "template",
+              label: "Tải Excel mẫu",
+              textValue: "Tải Excel mẫu",
+              onAction: onDownloadTemplate,
+            },
+            {
+              id: "export",
+              label: isExporting ? "Đang tải..." : "Tải về dữ liệu",
+              textValue: isExporting ? "Đang tải..." : "Tải về dữ liệu",
+              onAction: onExportData,
+              isDisabled: isExporting,
+            },
+          ]}
+        />
       </>
     ),
     [

--- a/src/components/equipment/heroui-pilot/controls.tsx
+++ b/src/components/equipment/heroui-pilot/controls.tsx
@@ -8,6 +8,7 @@
 "use client"
 
 import * as React from "react"
+import { X } from "lucide-react"
 import {
   Button,
   Card,
@@ -31,6 +32,8 @@ type EquipmentHeroSearchInputProps = Omit<
 > & {
   value: string
   onValueChange: (value: string) => void
+  onClear?: () => void
+  showClearButton?: boolean
   endAddon?: React.ReactNode
 }
 
@@ -65,23 +68,52 @@ export {
 export function EquipmentHeroSearchInput({
   value,
   onValueChange,
+  onClear,
+  showClearButton = true,
   endAddon,
   className,
   fullWidth = true,
   ...props
 }: EquipmentHeroSearchInputProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const hasClearButton = showClearButton && value.length > 0
+  const paddingRight =
+    hasClearButton && endAddon ? "pr-16" : hasClearButton || endAddon ? "pr-9" : null
+
+  const handleClear = React.useCallback(() => {
+    onValueChange("")
+    onClear?.()
+    inputRef.current?.focus()
+  }, [onClear, onValueChange])
+
   return (
     <div className="relative w-full" data-testid="equipment-heroui-search-control">
       <Input
         {...props}
+        ref={inputRef}
         type="search"
         value={value}
         onChange={(event) => onValueChange(event.currentTarget.value)}
         fullWidth={fullWidth}
-        className={cn("h-9 w-full", endAddon ? "pr-10" : null, className)}
+        className={cn("h-9 w-full pl-3", paddingRight, className)}
       />
-      {endAddon ? (
-        <div className="absolute inset-y-0 right-1 flex items-center">{endAddon}</div>
+      {hasClearButton || endAddon ? (
+        <div className="absolute inset-y-0 right-1 flex items-center gap-1">
+          {hasClearButton ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              isIconOnly
+              onPress={handleClear}
+              className="size-8 text-muted-foreground hover:text-foreground"
+              aria-label="Xóa tìm kiếm"
+            >
+              <X className="size-4" aria-hidden="true" />
+            </Button>
+          ) : null}
+          {endAddon}
+        </div>
       ) : null}
     </div>
   )

--- a/src/components/equipment/heroui-pilot/controls.tsx
+++ b/src/components/equipment/heroui-pilot/controls.tsx
@@ -100,7 +100,6 @@ export function EquipmentHeroDropdown({
   return (
     <Dropdown>
       <DropdownTrigger
-        aria-label={ariaLabel}
         className={cn(
           "inline-flex h-8 items-center justify-center gap-1 rounded-md border border-slate-200 bg-background px-3 text-sm font-medium shadow-sm transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
           triggerClassName
@@ -109,7 +108,7 @@ export function EquipmentHeroDropdown({
         {trigger}
       </DropdownTrigger>
       <DropdownPopover className={cn("min-w-56", popoverClassName)} placement={placement}>
-        <DropdownMenu className={menuClassName}>
+        <DropdownMenu aria-label={ariaLabel} className={menuClassName}>
           {items.map((item) => (
             <DropdownItem
               key={item.id}

--- a/src/components/equipment/heroui-pilot/controls.tsx
+++ b/src/components/equipment/heroui-pilot/controls.tsx
@@ -1,0 +1,128 @@
+/**
+ * Pilot-only HeroUI import boundary for the Equipments toolbar slice.
+ *
+ * HeroUI must not be imported directly from feature files during the spike.
+ * #684 should import only the controls it needs from this module.
+ */
+
+"use client"
+
+import * as React from "react"
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownPopover,
+  DropdownTrigger,
+  Input,
+} from "@heroui/react"
+
+import { cn } from "@/lib/utils"
+
+type EquipmentHeroSearchInputProps = Omit<
+  React.ComponentProps<typeof Input>,
+  "onChange" | "type" | "value"
+> & {
+  value: string
+  onValueChange: (value: string) => void
+  endAddon?: React.ReactNode
+}
+
+export interface EquipmentHeroDropdownItem {
+  id: string
+  label: React.ReactNode
+  textValue: string
+  onAction: () => void
+  isDisabled?: boolean
+}
+
+interface EquipmentHeroDropdownProps {
+  ariaLabel: string
+  trigger: React.ReactNode
+  items: EquipmentHeroDropdownItem[]
+  triggerClassName?: string
+  popoverClassName?: string
+  menuClassName?: string
+  placement?: React.ComponentProps<typeof DropdownPopover>["placement"]
+}
+
+export {
+  Button as EquipmentHeroButton,
+  Card as EquipmentHeroCard,
+  CardContent as EquipmentHeroCardContent,
+  CardDescription as EquipmentHeroCardDescription,
+  CardHeader as EquipmentHeroCardHeader,
+  CardTitle as EquipmentHeroCardTitle,
+}
+
+/** Renders the Equipments pilot search input with the current toolbar end-addon contract. */
+export function EquipmentHeroSearchInput({
+  value,
+  onValueChange,
+  endAddon,
+  className,
+  fullWidth = true,
+  ...props
+}: EquipmentHeroSearchInputProps) {
+  return (
+    <div className="relative w-full" data-testid="equipment-heroui-search-control">
+      <Input
+        {...props}
+        type="search"
+        value={value}
+        onChange={(event) => onValueChange(event.currentTarget.value)}
+        fullWidth={fullWidth}
+        className={cn("h-9 w-full", endAddon ? "pr-10" : null, className)}
+      />
+      {endAddon ? (
+        <div className="absolute inset-y-0 right-1 flex items-center">{endAddon}</div>
+      ) : null}
+    </div>
+  )
+}
+
+/** Adapts HeroUI's React Aria dropdown API to the existing Equipments toolbar action model. */
+export function EquipmentHeroDropdown({
+  ariaLabel,
+  trigger,
+  items,
+  triggerClassName,
+  popoverClassName,
+  menuClassName,
+  placement = "bottom end",
+}: EquipmentHeroDropdownProps) {
+  return (
+    <Dropdown>
+      <DropdownTrigger
+        aria-label={ariaLabel}
+        className={cn(
+          "inline-flex h-8 items-center justify-center gap-1 rounded-md border border-slate-200 bg-background px-3 text-sm font-medium shadow-sm transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+          triggerClassName
+        )}
+      >
+        {trigger}
+      </DropdownTrigger>
+      <DropdownPopover className={cn("min-w-56", popoverClassName)} placement={placement}>
+        <DropdownMenu className={menuClassName}>
+          {items.map((item) => (
+            <DropdownItem
+              key={item.id}
+              id={item.id}
+              isDisabled={item.isDisabled}
+              onAction={item.onAction}
+              textValue={item.textValue}
+            >
+              {item.label}
+            </DropdownItem>
+          ))}
+        </DropdownMenu>
+      </DropdownPopover>
+    </Dropdown>
+  )
+}

--- a/src/components/equipment/heroui-pilot/index.ts
+++ b/src/components/equipment/heroui-pilot/index.ts
@@ -5,14 +5,4 @@
  * #684 should import only the controls it needs from this module.
  */
 
-export {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownTrigger,
-  Input,
-} from "@heroui/react"
+export * from "./controls"


### PR DESCRIPTION
## Summary
- Implements the #684 Equipments HeroUI pilot slice for the desktop top-controls shell/search/action area.
- Keeps HeroUI imports behind `src/components/equipment/heroui-pilot/`; feature files import only the Equipments pilot adapter/barrel and never `@heroui/react` directly.
- Leaves table selection, bulk delete, pagination, data hooks, detail/edit dialogs, and filter business controls wired as-is.

## Files touched
- `src/components/equipment/heroui-pilot/index.ts`
- `src/components/equipment/heroui-pilot/controls.tsx`
- `src/components/equipment/equipment-toolbar.tsx`
- `src/components/equipment/equipment-toolbar-layout.tsx`
- `src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx`

## Verification
- Targeted Prettier check for changed files: pass
- `node scripts/npm-run.js run verify:heroui-boundary`: pass
- `node scripts/npm-run.js run verify:no-explicit-any`: pass
- `node scripts/npm-run.js run verify:dedupe`: pass
- `node scripts/npm-run.js run typecheck`: pass
- `node scripts/npm-run.js run test:run -- src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx`: 17 tests pass
- `node scripts/npm-run.js run react-doctor`: completed with score 97/100 and 2 barrel-import warnings for `./heroui-pilot`; retained intentionally because #687 defines `index.ts` as the Equipments-scoped HeroUI adapter/barrel.
- Pre-commit Lefthook: pass
- Pre-push Lefthook: pass

## API mismatch notes
- `@heroui/react@3.2.1` exports `CardContent`; it does not export `CardBody`, so the pilot adapter uses `CardContent`.
- HeroUI dropdowns are React Aria based: item callbacks use `onAction`/`isDisabled`, not Radix `onSelect`/`disabled`. The adapter localizes that mismatch in `heroui-pilot/controls.tsx`.

## Remaining risk
- Visual behavior should be reviewed on the Equipments desktop toolbar because this intentionally changes the shell/search/action primitives, while preserving existing callbacks and data/table wiring.

Closes #684

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Piloted HeroUI in the Equipments desktop top-controls, replacing the shell, search, and action dropdowns while keeping filter and table wiring intact. Aligns with #684 by isolating all `@heroui/react` usage behind an Equipments-specific adapter.

- **Refactors**
  - Introduced `src/components/equipment/heroui-pilot/controls.tsx` and re-exported from `index.ts` to keep `@heroui/react` behind a local boundary.
  - Updated toolbar layout to use adapter Card, Button, and Search input; search now uses `onValueChange`, QR and clear-filters use `onPress`.
  - Replaced Radix dropdowns with `EquipmentHeroDropdown`, mapping to HeroUI’s `onAction` and `isDisabled`; existing callbacks and data wiring unchanged.
  - Added tests verifying the shell, search control, and action handlers.

- **Bug Fixes**
  - Fixed search affordances: added a clear button with proper aria label, kept `type="search"`, and ensured QR scan control remains accessible.
  - Corrected HeroUI dropdown menu and aria labels; export item shows a loading label and disables while exporting.

<sup>Written for commit d388c1a61be807fcebbae3f5b1a2b0dddbfb2d18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

