### PR TITLE
feat: add mobile floating actions foundation

### DIFF
--- a/scripts/__tests__/check-heroui-import-boundary.test.ts
+++ b/scripts/__tests__/check-heroui-import-boundary.test.ts
@@ -3,15 +3,23 @@ import { describe, expect, it } from "vitest"
 import { findHeroUIImportViolations } from "../check-heroui-import-boundary"
 
 describe("check-heroui-import-boundary", () => {
-  it("allows HeroUI imports only inside the Equipments pilot boundary", () => {
+  it("allows HeroUI imports only inside approved boundary folders", () => {
     const violations = findHeroUIImportViolations([
       {
         path: "src/components/equipment/heroui-pilot/controls.tsx",
         content: 'import { Button } from "@heroui/react"\n',
       },
       {
+        path: "src/components/shared/floating-actions/MobileFloatingActionMenu.tsx",
+        content: 'import { Dropdown } from "@heroui/react"\n',
+      },
+      {
         path: "src/components/equipment/equipment-toolbar.tsx",
         content: 'import { Button } from "@heroui/react"\n',
+      },
+      {
+        path: "src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx",
+        content: 'import { Dropdown } from "@heroui/react"\n',
       },
       {
         path: "src/components/ui/button.tsx",
@@ -34,6 +42,11 @@ describe("check-heroui-import-boundary", () => {
     expect(violations).toEqual([
       {
         path: "src/components/equipment/equipment-toolbar.tsx",
+        line: 1,
+        importPath: "@heroui/react",
+      },
+      {
+        path: "src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx",
         line: 1,
         importPath: "@heroui/react",
       },

--- a/scripts/check-heroui-import-boundary.js
+++ b/scripts/check-heroui-import-boundary.js
@@ -6,7 +6,10 @@ const DEFAULT_BASE_REF = process.env.HEROUI_BOUNDARY_BASE || "main"
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"])
 const HEROUI_IMPORT_RE =
   /\b(?:from\s+["'](@heroui\/[^"']+)["']|import\s*\(\s*["'](@heroui\/[^"']+)["']\s*\)|export\s+.*?\s+from\s+["'](@heroui\/[^"']+)["']|require\s*\(\s*["'](@heroui\/[^"']+)["']\s*\)|import\s+["'](@heroui\/[^"']+)["'])/
-const ALLOWED_BOUNDARY_PREFIX = "src/components/equipment/heroui-pilot/"
+const ALLOWED_BOUNDARY_PREFIXES = [
+  "src/components/equipment/heroui-pilot/",
+  "src/components/shared/floating-actions/",
+]
 
 function normalizePath(filePath) {
   return filePath.split(path.sep).join("/")
@@ -18,7 +21,8 @@ function isScannableSourceFile(filePath) {
 }
 
 function isAllowedBoundaryFile(filePath) {
-  return normalizePath(filePath).startsWith(ALLOWED_BOUNDARY_PREFIX)
+  const normalizedPath = normalizePath(filePath)
+  return ALLOWED_BOUNDARY_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix))
 }
 
 function getHeroUIImportPath(line) {
@@ -109,10 +113,12 @@ function scanFiles(filePaths) {
 }
 
 function formatViolations(violations) {
+  const allowedBoundaryList = ALLOWED_BOUNDARY_PREFIXES.join(", ")
+
   return violations
     .map(
       (violation) =>
-        `${violation.path}:${violation.line} imports ${violation.importPath} outside ${ALLOWED_BOUNDARY_PREFIX}`
+        `${violation.path}:${violation.line} imports ${violation.importPath} outside ${allowedBoundaryList}`
     )
     .join("\n")
 }
@@ -128,7 +134,7 @@ function main() {
   const violations = scanFiles(filePaths)
 
   if (violations.length === 0) {
-    console.log("No HeroUI imports found outside the approved Equipments pilot boundary.")
+    console.log("No HeroUI imports found outside approved HeroUI boundary folders.")
     return
   }
 
@@ -140,7 +146,7 @@ function main() {
 }
 
 module.exports = {
-  ALLOWED_BOUNDARY_PREFIX,
+  ALLOWED_BOUNDARY_PREFIXES,
   collectChangedSourceFiles,
   findHeroUIImportViolations,
   formatViolations,

--- a/src/app/(app)/__tests__/AppMobileFloatingActions.test.tsx
+++ b/src/app/(app)/__tests__/AppMobileFloatingActions.test.tsx
@@ -1,0 +1,90 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PlusCircle } from "lucide-react"
+import { describe, expect, it, vi } from "vitest"
+
+import { AppMobileFloatingActions } from "../_components/AppMobileFloatingActions"
+import {
+  MobileFloatingActionsProvider,
+  usePageFloatingAction,
+} from "@/components/shared/floating-actions"
+
+vi.mock("@/components/assistant/AssistantTriggerButton", () => ({
+  AssistantTriggerButton: ({ isOpen, onToggle }: { isOpen: boolean; onToggle: () => void }) => (
+    <button
+      type="button"
+      aria-label={isOpen ? "Đóng trợ lý" : "Trợ lý AI"}
+      data-testid="assistant-trigger-button"
+      onClick={onToggle}
+    />
+  ),
+}))
+
+vi.mock("@/components/shared/floating-actions/MobileFloatingActionMenu", () => ({
+  MobileFloatingActionMenu: ({
+    actions,
+  }: {
+    actions: Array<{ id: string; label: string; onSelect: () => void }>
+  }) => (
+    <div data-testid="mobile-floating-action-menu">
+      {actions.map((action) => (
+        <button type="button" key={action.id} onClick={action.onSelect}>
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+function RegisteredPageAction({ onSelect }: { onSelect: () => void }) {
+  const action = React.useMemo(
+    () => ({
+      id: "create-repair-request",
+      label: "Tạo yêu cầu",
+      icon: <PlusCircle />,
+      onSelect,
+    }),
+    [onSelect]
+  )
+
+  usePageFloatingAction(action)
+
+  return null
+}
+
+describe("AppMobileFloatingActions", () => {
+  it("keeps the standalone assistant trigger when no page action is registered", () => {
+    render(
+      <MobileFloatingActionsProvider>
+        <AppMobileFloatingActions isAssistantOpen={false} onAssistantToggle={vi.fn()} />
+      </MobileFloatingActionsProvider>
+    )
+
+    expect(screen.getByTestId("assistant-trigger-button")).toBeInTheDocument()
+    expect(screen.queryByTestId("mobile-floating-action-menu")).not.toBeInTheDocument()
+  })
+
+  it("combines assistant and registered page action into one mobile floating menu", async () => {
+    const user = userEvent.setup()
+    const toggleAssistant = vi.fn()
+    const openCreate = vi.fn()
+
+    render(
+      <MobileFloatingActionsProvider>
+        <RegisteredPageAction onSelect={openCreate} />
+        <AppMobileFloatingActions isAssistantOpen={false} onAssistantToggle={toggleAssistant} />
+      </MobileFloatingActionsProvider>
+    )
+
+    expect(screen.queryByTestId("assistant-trigger-button")).not.toBeInTheDocument()
+    expect(screen.getByTestId("mobile-floating-action-menu")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Trợ lý AI" }))
+    await user.click(screen.getByRole("button", { name: "Tạo yêu cầu" }))
+
+    expect(toggleAssistant).toHaveBeenCalledTimes(1)
+    expect(openCreate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -39,14 +39,11 @@ import { AppSidebarNav } from "@/components/app-sidebar-nav"
 import { getAppNavigationItems } from "@/components/app-navigation"
 import { useAppNotificationCounts } from "@/hooks/useAppNotificationCounts"
 import { signOutWithReason } from "@/lib/auth-signout"
+import { MobileFloatingActionsProvider } from "@/components/shared/floating-actions"
 import { appLayoutUiReducer, initialAppLayoutUiState } from "./AppLayoutShellState"
+import { AppMobileFloatingActions } from "./AppMobileFloatingActions"
 import { HeaderEquipmentSearchEntry } from "./HeaderEquipmentSearchEntry"
 
-const AssistantTriggerButton = dynamic(
-  () =>
-    import("@/components/assistant/AssistantTriggerButton").then((m) => m.AssistantTriggerButton),
-  { ssr: false }
-)
 const AssistantPanel = dynamic(
   () => import("@/components/assistant/AssistantPanel").then((m) => m.AssistantPanel),
   { ssr: false }
@@ -71,7 +68,9 @@ export function AppLayoutShell({ children, user }: AppLayoutShellProps) {
   return (
     <TenantSelectionProvider>
       <EquipmentFilterProvider>
-        <AppLayoutShellContent user={user}>{children}</AppLayoutShellContent>
+        <MobileFloatingActionsProvider>
+          <AppLayoutShellContent user={user}>{children}</AppLayoutShellContent>
+        </MobileFloatingActionsProvider>
       </EquipmentFilterProvider>
     </TenantSelectionProvider>
   )
@@ -294,9 +293,9 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
 
           <MobileFooterNav notificationCounts={notificationCounts} />
 
-          <AssistantTriggerButton
-            isOpen={isAssistantOpen}
-            onToggle={() => dispatchUi({ type: "toggleAssistant" })}
+          <AppMobileFloatingActions
+            isAssistantOpen={isAssistantOpen}
+            onAssistantToggle={() => dispatchUi({ type: "toggleAssistant" })}
           />
           {isAssistantOpen ? (
             <AssistantPanel

--- a/src/app/(app)/_components/AppMobileFloatingActions.tsx
+++ b/src/app/(app)/_components/AppMobileFloatingActions.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import * as React from "react"
+import { Sparkles } from "lucide-react"
+
+import { AssistantTriggerButton } from "@/components/assistant/AssistantTriggerButton"
+import {
+  MobileFloatingActionMenu,
+  useMobileFloatingActions,
+  type MobileFloatingActionDescriptor,
+} from "@/components/shared/floating-actions"
+
+interface AppMobileFloatingActionsProps {
+  isAssistantOpen: boolean
+  onAssistantToggle: () => void
+}
+
+/** Renders the assistant FAB alone or combines it with the current page mobile action. */
+export function AppMobileFloatingActions({
+  isAssistantOpen,
+  onAssistantToggle,
+}: AppMobileFloatingActionsProps) {
+  const { pageAction } = useMobileFloatingActions()
+
+  const assistantAction = React.useMemo<MobileFloatingActionDescriptor>(
+    () => ({
+      id: "assistant",
+      label: isAssistantOpen ? "Đóng trợ lý" : "Trợ lý AI",
+      icon: <Sparkles aria-hidden="true" />,
+      onSelect: onAssistantToggle,
+    }),
+    [isAssistantOpen, onAssistantToggle]
+  )
+
+  if (!pageAction) {
+    return <AssistantTriggerButton isOpen={isAssistantOpen} onToggle={onAssistantToggle} />
+  }
+
+  return <MobileFloatingActionMenu actions={[assistantAction, pageAction]} />
+}

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx
@@ -13,6 +13,10 @@ import type { RepairStatus } from "@/components/kpi"
 import { RepairRequestsPageLayout } from "../_components/RepairRequestsPageLayout"
 import type { RepairRequestWithEquipment } from "../types"
 import type { RepairRequestColumnOptions } from "../_components/RepairRequestsColumns"
+import {
+  MobileFloatingActionsProvider,
+  useMobileFloatingActions,
+} from "@/components/shared/floating-actions"
 
 // ── Mock child components ──────────────────────────────────────────────
 vi.mock("@/components/repair-request-alert", () => ({
@@ -175,6 +179,20 @@ const withAccessState = (overrides: Partial<typeof defaultProps.accessState>) =>
   },
 })
 
+function RegisteredFloatingActionProbe() {
+  const { pageAction } = useMobileFloatingActions()
+
+  if (!pageAction) {
+    return <div data-testid="registered-page-action">none</div>
+  }
+
+  return (
+    <button type="button" data-testid="registered-page-action" onClick={pageAction.onSelect}>
+      {pageAction.label}
+    </button>
+  )
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────
 describe("RepairRequestsPageLayout", () => {
   it('renders header with title "Yêu cầu sửa chữa"', () => {
@@ -259,6 +277,28 @@ describe("RepairRequestsPageLayout", () => {
     const mobileList = screen.getByTestId("repair-mobile-list")
     expect(mobileList).toContainElement(screen.getByTestId("mobile-list"))
     expect(mobileList.closest("[data-testid='repair-requests-desktop-card']")).toBeNull()
+  })
+
+  it("registers mobile create as a shared page floating action without rendering a local FAB", async () => {
+    const openCreateSheet = vi.fn()
+
+    render(
+      <MobileFloatingActionsProvider>
+        <RepairRequestsPageLayout
+          {...withAccessState({ isRegionalLeader: false })}
+          listState={{ ...defaultProps.listState, isMobile: true }}
+          openCreateSheet={openCreateSheet}
+        />
+        <RegisteredFloatingActionProbe />
+      </MobileFloatingActionsProvider>
+    )
+
+    expect(screen.getByTestId("registered-page-action")).toHaveTextContent("Tạo yêu cầu")
+    expect(screen.getAllByRole("button", { name: "Tạo yêu cầu" })).toHaveLength(1)
+
+    screen.getByTestId("registered-page-action").click()
+
+    expect(openCreateSheet).toHaveBeenCalledTimes(1)
   })
 
   it("passes facility selector visibility to the toolbar like Equipment", () => {

--- a/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
+++ b/src/app/(app)/repair-requests/_components/RepairRequestsPageLayout.tsx
@@ -8,7 +8,7 @@ import { KpiStatusBar, REPAIR_STATUS_CONFIGS } from "@/components/kpi"
 import type { RepairStatus } from "@/components/kpi"
 import { RepairRequestAlert } from "@/components/repair-request-alert"
 import { DataTablePagination } from "@/components/shared/DataTablePagination"
-import { FloatingActionButton } from "@/components/shared/FloatingActionButton"
+import { usePageFloatingAction } from "@/components/shared/floating-actions"
 import { RepairRequestsFilterModal, type FilterModalValue } from "./RepairRequestsFilterModal"
 import { RepairRequestsCreateSheet } from "./RepairRequestsCreateSheet"
 import { RepairRequestsToolbar } from "./RepairRequestsToolbar"
@@ -120,6 +120,20 @@ export function RepairRequestsPageLayout({
   const { isMobile, isLoading, isFetching } = listState
   const isCompactLayout = listState.isCompactLayout ?? isMobile
   const tableRows = table.getRowModel().rows.map((row) => row.original)
+  const mobileCreateAction = React.useMemo(
+    () =>
+      !isRegionalLeader && isMobile
+        ? {
+            id: "create-repair-request",
+            label: "Tạo yêu cầu",
+            icon: <PlusCircle />,
+            onSelect: openCreateSheet,
+          }
+        : null,
+    [isMobile, isRegionalLeader, openCreateSheet]
+  )
+
+  usePageFloatingAction(mobileCreateAction)
 
   const toolbar = (
     <RepairRequestsToolbar
@@ -209,13 +223,6 @@ export function RepairRequestsPageLayout({
 
         {/* Create Sheet */}
         {!isRegionalLeader ? <RepairRequestsCreateSheet /> : null}
-
-        {/* Mobile FAB for quick create */}
-        {!isRegionalLeader && isMobile ? (
-          <FloatingActionButton onClick={() => openCreateSheet()} aria-label="Tạo yêu cầu">
-            <PlusCircle />
-          </FloatingActionButton>
-        ) : null}
 
         {isCompactLayout ? (
           <div className="space-y-4" data-testid="repair-requests-mobile-content">

--- a/src/components/shared/floating-actions/MobileFloatingActionMenu.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionMenu.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import * as React from "react"
+import { MoreHorizontal } from "lucide-react"
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownMenu,
+  DropdownPopover,
+  DropdownTrigger,
+} from "@heroui/react"
+
+import {
+  floatingActionButtonClassName,
+  type FloatingActionButtonProps,
+} from "@/components/shared/FloatingActionButton"
+import type { MobileFloatingActionDescriptor } from "./MobileFloatingActionsContext"
+
+interface MobileFloatingActionMenuProps {
+  actions: readonly MobileFloatingActionDescriptor[]
+  ariaLabel?: string
+  triggerLabel?: string
+  className?: string
+}
+
+/** Renders a HeroUI-backed mobile floating menu for one or more quick actions. */
+export function MobileFloatingActionMenu({
+  actions,
+  ariaLabel = "Tác vụ nhanh",
+  triggerLabel = "Mở tác vụ nhanh",
+  className,
+}: MobileFloatingActionMenuProps) {
+  if (actions.length === 0) {
+    return null
+  }
+
+  return (
+    <Dropdown>
+      <DropdownTrigger
+        aria-label={triggerLabel}
+        className={floatingActionButtonClassName({
+          className,
+          placement: "page",
+          tone: "primary",
+        } satisfies Pick<FloatingActionButtonProps, "className" | "placement" | "tone">)}
+      >
+        <MoreHorizontal aria-hidden="true" />
+      </DropdownTrigger>
+      <DropdownPopover className="z-[998] min-w-56" placement="top end">
+        <DropdownMenu aria-label={ariaLabel}>
+          {actions.map((action) => (
+            <DropdownItem
+              key={action.id}
+              id={action.id}
+              onAction={action.onSelect}
+              textValue={action.label}
+            >
+              <span className="flex items-center gap-2">
+                <span className="flex size-5 items-center justify-center [&_svg]:size-4">
+                  {action.icon}
+                </span>
+                <span>{action.label}</span>
+              </span>
+            </DropdownItem>
+          ))}
+        </DropdownMenu>
+      </DropdownPopover>
+    </Dropdown>
+  )
+}

--- a/src/components/shared/floating-actions/MobileFloatingActionMenu.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionMenu.tsx
@@ -46,7 +46,7 @@ export function MobileFloatingActionMenu({
       >
         <MoreHorizontal aria-hidden="true" />
       </DropdownTrigger>
-      <DropdownPopover className="z-[998] min-w-56" placement="top end">
+      <DropdownPopover className="z-[1001] min-w-56" placement="top end">
         <DropdownMenu aria-label={ariaLabel}>
           {actions.map((action) => (
             <DropdownItem

--- a/src/components/shared/floating-actions/MobileFloatingActionMenu.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionMenu.tsx
@@ -34,6 +34,12 @@ export function MobileFloatingActionMenu({
     return null
   }
 
+  const handleAction = (key: React.Key) => {
+    const targetAction = actions.find((action) => action.id === key)
+
+    targetAction?.onSelect()
+  }
+
   return (
     <Dropdown>
       <DropdownTrigger
@@ -47,14 +53,9 @@ export function MobileFloatingActionMenu({
         <MoreHorizontal aria-hidden="true" />
       </DropdownTrigger>
       <DropdownPopover className="z-[1001] min-w-56" placement="top end">
-        <DropdownMenu aria-label={ariaLabel}>
+        <DropdownMenu aria-label={ariaLabel} onAction={handleAction}>
           {actions.map((action) => (
-            <DropdownItem
-              key={action.id}
-              id={action.id}
-              onAction={action.onSelect}
-              textValue={action.label}
-            >
+            <DropdownItem key={action.id} id={action.id} textValue={action.label}>
               <span className="flex items-center gap-2">
                 <span className="flex size-5 items-center justify-center [&_svg]:size-4">
                   {action.icon}

--- a/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
@@ -14,45 +14,60 @@ interface MobileFloatingActionsContextValue {
   setPageAction: React.Dispatch<React.SetStateAction<MobileFloatingActionDescriptor | null>>
 }
 
-const MobileFloatingActionsContext = React.createContext<MobileFloatingActionsContextValue | null>(
-  null
-)
+const MobileFloatingActionsStateContext =
+  React.createContext<MobileFloatingActionDescriptor | null>(null)
 
-const fallbackContextValue: MobileFloatingActionsContextValue = {
-  pageAction: null,
-  setPageAction: () => undefined,
+const MobileFloatingActionsSetterContext = React.createContext<
+  React.Dispatch<React.SetStateAction<MobileFloatingActionDescriptor | null>>
+>(() => undefined)
+
+function isSameMobileFloatingAction(
+  previousAction: MobileFloatingActionDescriptor | null,
+  nextAction: MobileFloatingActionDescriptor | null
+) {
+  return (
+    previousAction?.id === nextAction?.id &&
+    previousAction?.label === nextAction?.label &&
+    previousAction?.icon === nextAction?.icon &&
+    previousAction?.onSelect === nextAction?.onSelect
+  )
 }
 
 /** Provides the app-shell-local mobile page action registration state. */
 export function MobileFloatingActionsProvider({ children }: { children: React.ReactNode }) {
   const [pageAction, setPageAction] = React.useState<MobileFloatingActionDescriptor | null>(null)
 
-  const value = React.useMemo(
-    () => ({
-      pageAction,
-      setPageAction,
-    }),
-    [pageAction]
-  )
-
   return (
-    <MobileFloatingActionsContext.Provider value={value}>
-      {children}
-    </MobileFloatingActionsContext.Provider>
+    <MobileFloatingActionsSetterContext.Provider value={setPageAction}>
+      <MobileFloatingActionsStateContext.Provider value={pageAction}>
+        {children}
+      </MobileFloatingActionsStateContext.Provider>
+    </MobileFloatingActionsSetterContext.Provider>
   )
 }
 
 /** Reads the currently registered mobile page action for layout composition. */
 export function useMobileFloatingActions() {
-  return React.useContext(MobileFloatingActionsContext) ?? fallbackContextValue
+  const pageAction = React.use(MobileFloatingActionsStateContext)
+  const setPageAction = React.use(MobileFloatingActionsSetterContext)
+
+  return React.useMemo(
+    () => ({
+      pageAction,
+      setPageAction,
+    }),
+    [pageAction, setPageAction]
+  )
 }
 
 /** Registers or clears the current page's mobile floating action. */
 export function usePageFloatingAction(action: MobileFloatingActionDescriptor | null) {
-  const { setPageAction } = useMobileFloatingActions()
+  const setPageAction = React.use(MobileFloatingActionsSetterContext)
 
   React.useEffect(() => {
-    setPageAction(action)
+    setPageAction((currentAction) =>
+      isSameMobileFloatingAction(currentAction, action) ? currentAction : action
+    )
 
     return () => {
       setPageAction((currentAction) => {

--- a/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import * as React from "react"
+
+export interface MobileFloatingActionDescriptor {
+  id: string
+  label: string
+  icon: React.ReactNode
+  onSelect: () => void
+}
+
+interface MobileFloatingActionsContextValue {
+  pageAction: MobileFloatingActionDescriptor | null
+  setPageAction: React.Dispatch<React.SetStateAction<MobileFloatingActionDescriptor | null>>
+}
+
+const MobileFloatingActionsContext = React.createContext<MobileFloatingActionsContextValue | null>(
+  null
+)
+
+const fallbackContextValue: MobileFloatingActionsContextValue = {
+  pageAction: null,
+  setPageAction: () => undefined,
+}
+
+/** Provides the app-shell-local mobile page action registration state. */
+export function MobileFloatingActionsProvider({ children }: { children: React.ReactNode }) {
+  const [pageAction, setPageAction] = React.useState<MobileFloatingActionDescriptor | null>(null)
+
+  const value = React.useMemo(
+    () => ({
+      pageAction,
+      setPageAction,
+    }),
+    [pageAction]
+  )
+
+  return (
+    <MobileFloatingActionsContext.Provider value={value}>
+      {children}
+    </MobileFloatingActionsContext.Provider>
+  )
+}
+
+/** Reads the currently registered mobile page action for layout composition. */
+export function useMobileFloatingActions() {
+  return React.useContext(MobileFloatingActionsContext) ?? fallbackContextValue
+}
+
+/** Registers or clears the current page's mobile floating action. */
+export function usePageFloatingAction(action: MobileFloatingActionDescriptor | null) {
+  const { setPageAction } = useMobileFloatingActions()
+
+  React.useEffect(() => {
+    setPageAction(action)
+
+    return () => {
+      setPageAction((currentAction) => {
+        if (!action || currentAction?.id !== action.id) {
+          return currentAction
+        }
+
+        return null
+      })
+    }
+  }, [action, setPageAction])
+}

--- a/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
+++ b/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
@@ -31,16 +31,34 @@ vi.mock("@heroui/react", () => ({
   DropdownMenu: ({
     children,
     "aria-label": ariaLabel,
+    onAction,
   }: {
     children: React.ReactNode
     "aria-label"?: string
+    onAction?: (key: React.Key) => void
   }) => (
     <div aria-label={ariaLabel} role="menu">
-      {children}
+      {React.Children.map(children, (child) => {
+        if (!React.isValidElement<{ id?: string }>(child)) {
+          return child
+        }
+
+        return React.cloneElement(child, {
+          onSelectKey: onAction,
+        } as Partial<{ onSelectKey: (key: React.Key) => void }>)
+      })}
     </div>
   ),
-  DropdownItem: ({ children, onAction }: { children: React.ReactNode; onAction?: () => void }) => (
-    <button type="button" role="menuitem" onClick={onAction}>
+  DropdownItem: ({
+    children,
+    id,
+    onSelectKey,
+  }: {
+    children: React.ReactNode
+    id?: string
+    onSelectKey?: (key: React.Key) => void
+  }) => (
+    <button type="button" role="menuitem" onClick={() => id && onSelectKey?.(id)}>
       {children}
     </button>
   ),

--- a/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
+++ b/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
@@ -70,6 +70,7 @@ describe("MobileFloatingActionMenu", () => {
     expect(trigger).toHaveClass("md:hidden")
     expect(trigger).toHaveClass("size-14")
     expect(trigger).toHaveClass("rounded-full")
+    expect(screen.getByTestId("heroui-popover")).toHaveClass("z-[1001]")
   })
 
   it("renders accessible assistant and page actions and calls their callbacks", async () => {

--- a/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
+++ b/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
@@ -1,0 +1,105 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PlusCircle, Sparkles } from "lucide-react"
+import { describe, expect, it, vi } from "vitest"
+
+import { MobileFloatingActionMenu } from "../MobileFloatingActionMenu"
+
+vi.mock("@heroui/react", () => ({
+  Dropdown: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="heroui-dropdown">{children}</div>
+  ),
+  DropdownTrigger: ({
+    children,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode
+    className?: string
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" className={className} {...props}>
+      {children}
+    </button>
+  ),
+  DropdownPopover: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className} data-testid="heroui-popover">
+      {children}
+    </div>
+  ),
+  DropdownMenu: ({
+    children,
+    "aria-label": ariaLabel,
+  }: {
+    children: React.ReactNode
+    "aria-label"?: string
+  }) => (
+    <div aria-label={ariaLabel} role="menu">
+      {children}
+    </div>
+  ),
+  DropdownItem: ({ children, onAction }: { children: React.ReactNode; onAction?: () => void }) => (
+    <button type="button" role="menuitem" onClick={onAction}>
+      {children}
+    </button>
+  ),
+}))
+
+describe("MobileFloatingActionMenu", () => {
+  it("renders a single fixed mobile trigger using the floating action class contract", () => {
+    render(
+      <MobileFloatingActionMenu
+        actions={[
+          {
+            id: "assistant",
+            label: "Trợ lý AI",
+            icon: <Sparkles />,
+            onSelect: vi.fn(),
+          },
+        ]}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: "Mở tác vụ nhanh" })
+
+    expect(trigger).toHaveClass("fixed")
+    expect(trigger).toHaveClass("right-6")
+    expect(trigger.className).toContain("bottom-[calc(env(safe-area-inset-bottom,0px)+5rem)]")
+    expect(trigger).toHaveClass("z-[100]")
+    expect(trigger).toHaveClass("md:hidden")
+    expect(trigger).toHaveClass("size-14")
+    expect(trigger).toHaveClass("rounded-full")
+  })
+
+  it("renders accessible assistant and page actions and calls their callbacks", async () => {
+    const user = userEvent.setup()
+    const openAssistant = vi.fn()
+    const openCreate = vi.fn()
+
+    render(
+      <MobileFloatingActionMenu
+        actions={[
+          {
+            id: "assistant",
+            label: "Trợ lý AI",
+            icon: <Sparkles />,
+            onSelect: openAssistant,
+          },
+          {
+            id: "create-repair-request",
+            label: "Tạo yêu cầu",
+            icon: <PlusCircle />,
+            onSelect: openCreate,
+          },
+        ]}
+      />
+    )
+
+    await user.click(screen.getByRole("menuitem", { name: "Trợ lý AI" }))
+    await user.click(screen.getByRole("menuitem", { name: "Tạo yêu cầu" }))
+
+    expect(openAssistant).toHaveBeenCalledTimes(1)
+    expect(openCreate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/shared/floating-actions/__tests__/MobileFloatingActionsContext.test.tsx
+++ b/src/components/shared/floating-actions/__tests__/MobileFloatingActionsContext.test.tsx
@@ -30,6 +30,23 @@ function PageActionProbe({ label }: { label: string | null }) {
   return null
 }
 
+let inlineProbeRenderCount = 0
+const inlineProbeIcon = <PlusCircle />
+const inlineProbeSelect = () => undefined
+
+function InlinePageActionProbe() {
+  inlineProbeRenderCount += 1
+
+  usePageFloatingAction({
+    id: "inline-page-action",
+    label: "Tạo yêu cầu",
+    icon: inlineProbeIcon,
+    onSelect: inlineProbeSelect,
+  })
+
+  return null
+}
+
 function RegisteredActionLabel() {
   const { pageAction } = useMobileFloatingActions()
 
@@ -94,5 +111,19 @@ describe("MobileFloatingActionsContext", () => {
     await user.click(screen.getByRole("button", { name: "Rename action" }))
 
     expect(screen.getByTestId("registered-action")).toHaveTextContent("Tạo phiếu sửa chữa")
+  })
+
+  it("does not rerender the registering page from its own inline action registration", () => {
+    inlineProbeRenderCount = 0
+
+    render(
+      <MobileFloatingActionsProvider>
+        <InlinePageActionProbe />
+        <RegisteredActionLabel />
+      </MobileFloatingActionsProvider>
+    )
+
+    expect(screen.getByTestId("registered-action")).toHaveTextContent("Tạo yêu cầu")
+    expect(inlineProbeRenderCount).toBe(1)
   })
 })

--- a/src/components/shared/floating-actions/__tests__/MobileFloatingActionsContext.test.tsx
+++ b/src/components/shared/floating-actions/__tests__/MobileFloatingActionsContext.test.tsx
@@ -1,0 +1,98 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PlusCircle } from "lucide-react"
+import { describe, expect, it } from "vitest"
+
+import {
+  MobileFloatingActionsProvider,
+  useMobileFloatingActions,
+  usePageFloatingAction,
+} from "../MobileFloatingActionsContext"
+
+function PageActionProbe({ label }: { label: string | null }) {
+  const action = React.useMemo(
+    () =>
+      label
+        ? {
+            id: "page-action",
+            label,
+            icon: <PlusCircle />,
+            onSelect: () => undefined,
+          }
+        : null,
+    [label]
+  )
+
+  usePageFloatingAction(action)
+
+  return null
+}
+
+function RegisteredActionLabel() {
+  const { pageAction } = useMobileFloatingActions()
+
+  return <div data-testid="registered-action">{pageAction?.label ?? "none"}</div>
+}
+
+describe("MobileFloatingActionsContext", () => {
+  it("lets a page register one floating action for the layout to read", () => {
+    render(
+      <MobileFloatingActionsProvider>
+        <PageActionProbe label="Tạo yêu cầu" />
+        <RegisteredActionLabel />
+      </MobileFloatingActionsProvider>
+    )
+
+    expect(screen.getByTestId("registered-action")).toHaveTextContent("Tạo yêu cầu")
+  })
+
+  it("clears the registered action when the page unmounts", async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [showPage, setShowPage] = React.useState(true)
+
+      return (
+        <MobileFloatingActionsProvider>
+          {showPage ? <PageActionProbe label="Tạo yêu cầu" /> : null}
+          <RegisteredActionLabel />
+          <button type="button" onClick={() => setShowPage(false)}>
+            Unmount page
+          </button>
+        </MobileFloatingActionsProvider>
+      )
+    }
+
+    render(<Harness />)
+
+    await user.click(screen.getByRole("button", { name: "Unmount page" }))
+
+    expect(screen.getByTestId("registered-action")).toHaveTextContent("none")
+  })
+
+  it("replaces the previous descriptor when a page updates its action", async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [label, setLabel] = React.useState("Tạo yêu cầu")
+
+      return (
+        <MobileFloatingActionsProvider>
+          <PageActionProbe label={label} />
+          <RegisteredActionLabel />
+          <button type="button" onClick={() => setLabel("Tạo phiếu sửa chữa")}>
+            Rename action
+          </button>
+        </MobileFloatingActionsProvider>
+      )
+    }
+
+    render(<Harness />)
+
+    await user.click(screen.getByRole("button", { name: "Rename action" }))
+
+    expect(screen.getByTestId("registered-action")).toHaveTextContent("Tạo phiếu sửa chữa")
+  })
+})

--- a/src/components/shared/floating-actions/index.ts
+++ b/src/components/shared/floating-actions/index.ts
@@ -1,0 +1,7 @@
+export {
+  MobileFloatingActionsProvider,
+  useMobileFloatingActions,
+  usePageFloatingAction,
+  type MobileFloatingActionDescriptor,
+} from "./MobileFloatingActionsContext"
+export { MobileFloatingActionMenu } from "./MobileFloatingActionMenu"


### PR DESCRIPTION
## Summary
- Add shared mobile floating action primitives under src/components/shared/floating-actions using HeroUI only inside that boundary.
- Wire AppLayoutShell to combine assistant and registered page actions.
- Roll Repair Requests mobile create action onto the shared registration path and remove its local mobile FAB.

Refs #693
Umbrella: #690

## Tests
- node scripts/npm-run.js npx prettier --check <changed files>
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:heroui-boundary
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- scripts/__tests__/check-heroui-import-boundary.test.ts src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx src/components/shared/floating-actions/__tests__/MobileFloatingActionsContext.test.tsx "src/app/(app)/__tests__/AppMobileFloatingActions.test.tsx" "src/app/(app)/__tests__/AppLayoutShell.test.tsx" "src/app/(app)/repair-requests/__tests__/RepairRequestsPageLayout.test.tsx"
- node scripts/npm-run.js run react-doctor

Note: broad node scripts/npm-run.js run format:check still fails on existing baseline files outside this diff; changed files pass Prettier.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared mobile floating actions system and wires it into the app shell to merge the assistant and per‑page actions into one mobile menu. First integration is on Repair Requests, and action selection is now handled at the menu level so `@heroui/react` dropdown actions fire reliably, aligned with #693.

- **New Features**
  - Added provider, `usePageFloatingAction` (auto-clears on unmount), `MobileFloatingActionMenu`, and `AppMobileFloatingActions` using `@heroui/react` in the approved boundary; the app layout wraps the provider and shows the assistant FAB alone or a combined menu when a page action exists.
  - Repair Requests registers “Tạo yêu cầu” as its page action and removes the local FAB.

- **Migration**
  - To add a page action, call `usePageFloatingAction({ id, label, icon, onSelect })` and remove any local mobile FABs.

<sup>Written for commit 2339f5a7029a7f874430dd79c872ff4d6b81884b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared mobile quick-actions system with a combined menu that can show page actions alongside the assistant trigger.
  * Updated the app layout and Repair Requests “quick create” to use the new mobile quick-actions experience.
* **Bug Fixes**
  * Improved mobile action registration and cleanup so page-specific actions appear reliably and are cleared when no longer applicable.
* **Tests**
  * Added and expanded tests for the quick-actions menu, the mobile actions context, and the Repair Requests create action flow.
* **Chores**
  * Updated import-boundary checking to support multiple allowed source prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->