### PR TITLE
[#690] Roll out shared mobile FAB actions to Equipments

### DIFF
--- a/src/app/(app)/__tests__/AppMobileFloatingActions.test.tsx
+++ b/src/app/(app)/__tests__/AppMobileFloatingActions.test.tsx
@@ -54,6 +54,36 @@ function RegisteredPageAction({ onSelect }: { onSelect: () => void }) {
   return null
 }
 
+function RegisteredPageActions({
+  onManualAdd,
+  onExcelImport,
+}: {
+  onManualAdd: () => void
+  onExcelImport: () => void
+}) {
+  const actions = React.useMemo(
+    () => [
+      {
+        id: "create-equipment-manual",
+        label: "Thêm thủ công",
+        icon: <PlusCircle />,
+        onSelect: onManualAdd,
+      },
+      {
+        id: "import-equipment-excel",
+        label: "Thêm bằng Excel",
+        icon: <PlusCircle />,
+        onSelect: onExcelImport,
+      },
+    ],
+    [onExcelImport, onManualAdd]
+  )
+
+  usePageFloatingAction(actions)
+
+  return null
+}
+
 describe("AppMobileFloatingActions", () => {
   it("keeps the standalone assistant trigger when no page action is registered", () => {
     render(
@@ -86,5 +116,27 @@ describe("AppMobileFloatingActions", () => {
 
     expect(toggleAssistant).toHaveBeenCalledTimes(1)
     expect(openCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it("combines assistant and multiple registered page actions into one mobile floating menu", async () => {
+    const user = userEvent.setup()
+    const toggleAssistant = vi.fn()
+    const openManualAdd = vi.fn()
+    const openExcelImport = vi.fn()
+
+    render(
+      <MobileFloatingActionsProvider>
+        <RegisteredPageActions onManualAdd={openManualAdd} onExcelImport={openExcelImport} />
+        <AppMobileFloatingActions isAssistantOpen={false} onAssistantToggle={toggleAssistant} />
+      </MobileFloatingActionsProvider>
+    )
+
+    await user.click(screen.getByRole("button", { name: "Trợ lý AI" }))
+    await user.click(screen.getByRole("button", { name: "Thêm thủ công" }))
+    await user.click(screen.getByRole("button", { name: "Thêm bằng Excel" }))
+
+    expect(toggleAssistant).toHaveBeenCalledTimes(1)
+    expect(openManualAdd).toHaveBeenCalledTimes(1)
+    expect(openExcelImport).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/(app)/_components/AppMobileFloatingActions.tsx
+++ b/src/app/(app)/_components/AppMobileFloatingActions.tsx
@@ -20,7 +20,7 @@ export function AppMobileFloatingActions({
   isAssistantOpen,
   onAssistantToggle,
 }: AppMobileFloatingActionsProps) {
-  const { pageAction } = useMobileFloatingActions()
+  const { pageActions } = useMobileFloatingActions()
 
   const assistantAction = React.useMemo<MobileFloatingActionDescriptor>(
     () => ({
@@ -32,9 +32,9 @@ export function AppMobileFloatingActions({
     [isAssistantOpen, onAssistantToggle]
   )
 
-  if (!pageAction) {
+  if (pageActions.length === 0) {
     return <AssistantTriggerButton isOpen={isAssistantOpen} onToggle={onAssistantToggle} />
   }
 
-  return <MobileFloatingActionMenu actions={[assistantAction, pageAction]} />
+  return <MobileFloatingActionMenu actions={[assistantAction, ...pageActions]} />
 }

--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import type { MobileFloatingActionDescriptor } from "@/components/shared/floating-actions"
 import type { useEquipmentPage } from "../use-equipment-page"
 
 type EquipmentPageState = ReturnType<typeof useEquipmentPage>
@@ -27,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   openColumnsDialog: vi.fn(),
   openDetailDialog: vi.fn(),
   openEditDialog: vi.fn(),
+  usePageFloatingAction: vi.fn(),
 }))
 
 vi.mock("../use-equipment-page", () => ({
@@ -84,6 +86,10 @@ vi.mock("@/components/shared/DataTablePagination", () => ({
 
 vi.mock("@/components/shared/TenantSelector", () => ({
   TenantSelector: () => null,
+}))
+
+vi.mock("@/components/shared/floating-actions", () => ({
+  usePageFloatingAction: mocks.usePageFloatingAction,
 }))
 
 import { EquipmentPageClient } from "../_components/EquipmentPageClient"
@@ -188,14 +194,29 @@ describe("EquipmentPageClient selection render boundary", () => {
     expect(screen.getByLabelText("selected count")).toHaveTextContent("1")
   })
 
-  it("renders the mobile create FAB with the shared floating action contract", () => {
+  it("registers the mobile create action with the app floating actions foundation", async () => {
     state.pageState = createPageState(createTable())
+    state.pageState.isMobile = true
 
     render(<EquipmentPageClient />)
 
-    const button = screen.getByRole("button", { name: "Thêm thiết bị" })
-    expect(button.className).toContain("bottom-[calc(env(safe-area-inset-bottom,0px)+5rem)]")
-    expect(button.className).toContain("size-14")
-    expect(button.className).toContain("shadow-[0_18px_34px_rgba(15,23,42,0.24)]")
+    expect(mocks.usePageFloatingAction).toHaveBeenCalled()
+    const registeredActions = mocks.usePageFloatingAction.mock
+      .calls[0][0] as MobileFloatingActionDescriptor[]
+
+    expect(registeredActions).toHaveLength(2)
+    expect(registeredActions[0]).toMatchObject({
+      id: "create-equipment-manual",
+      label: "Thêm thủ công",
+    })
+    expect(registeredActions[1]).toMatchObject({
+      id: "import-equipment-excel",
+      label: "Thêm bằng Excel",
+    })
+    registeredActions[0].onSelect()
+    registeredActions[1].onSelect()
+
+    expect(mocks.openAddDialog).toHaveBeenCalledTimes(1)
+    expect(mocks.openImportDialog).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/(app)/equipment/_components/EquipmentMobileFloatingActions.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentMobileFloatingActions.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import * as React from "react"
+import { FileUp, PlusCircle } from "lucide-react"
+
+import { usePageFloatingAction } from "@/components/shared/floating-actions"
+
+interface EquipmentMobileFloatingActionsProps {
+  canCreateEquipment: boolean
+  isMobile: boolean
+  onAddEquipment: () => void
+  onImportEquipment: () => void
+}
+
+/** Registers Equipments mobile actions for the shared app-shell floating menu. */
+export function EquipmentMobileFloatingActions({
+  canCreateEquipment,
+  isMobile,
+  onAddEquipment,
+  onImportEquipment,
+}: EquipmentMobileFloatingActionsProps) {
+  const actions = React.useMemo(
+    () =>
+      canCreateEquipment && isMobile
+        ? [
+            {
+              id: "create-equipment-manual",
+              label: "Thêm thủ công",
+              icon: <PlusCircle aria-hidden="true" />,
+              onSelect: onAddEquipment,
+            },
+            {
+              id: "import-equipment-excel",
+              label: "Thêm bằng Excel",
+              icon: <FileUp aria-hidden="true" />,
+              onSelect: onImportEquipment,
+            },
+          ]
+        : null,
+    [canCreateEquipment, isMobile, onAddEquipment, onImportEquipment]
+  )
+
+  usePageFloatingAction(actions)
+
+  return null
+}

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -2,22 +2,13 @@
 
 import * as React from "react"
 import type { ColumnFiltersState } from "@tanstack/react-table"
-import { Plus } from "lucide-react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { Skeleton } from "@/components/ui/skeleton"
 import { FilterBottomSheet } from "@/components/equipment/filter-bottom-sheet"
 import { LinkedRequestProvider } from "@/components/equipment-linked-request"
 import { DataTablePagination } from "@/components/shared/DataTablePagination"
 import type { DisplayContext } from "@/components/shared/DataTablePagination/types"
-import { floatingActionButtonClassName } from "@/components/shared/FloatingActionButton"
 import { EquipmentToolbar } from "@/components/equipment/equipment-toolbar"
 import { TenantSelector } from "@/components/shared/TenantSelector"
 import { applyAttentionStatusPresetFilters } from "@/lib/equipment-attention-preset"
@@ -31,6 +22,7 @@ import { EquipmentDialogProvider } from "./EquipmentDialogContext"
 import { EquipmentColumnsDialog } from "./EquipmentColumnsDialog"
 import { EquipmentBulkDeleteBar } from "./EquipmentBulkDeleteBar"
 import { EquipmentDepartmentSummary } from "./EquipmentDepartmentSummary"
+import { EquipmentMobileFloatingActions } from "./EquipmentMobileFloatingActions"
 import { useEquipmentContext } from "../_hooks/useEquipmentContext"
 
 const EQUIPMENT_ENTITY = { singular: "thiết bị" } as const
@@ -231,6 +223,13 @@ function EquipmentPageContent({ pageState }: { pageState: ReturnType<typeof useE
 
   return (
     <>
+      <EquipmentMobileFloatingActions
+        canCreateEquipment={canCreateEquipment}
+        isMobile={isMobile}
+        onAddEquipment={openAddDialog}
+        onImportEquipment={openImportDialog}
+      />
+
       <EquipmentDialogs
         onGenerateProfileSheet={handleGenerateProfileSheet}
         onGenerateDeviceLabel={handleGenerateDeviceLabel}
@@ -326,25 +325,6 @@ function EquipmentPageContent({ pageState }: { pageState: ReturnType<typeof useE
           </CardFooter>
         </Card>
       </div>
-
-      {/* Floating Add Button - Mobile only */}
-      {canCreateEquipment ? (
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            className={floatingActionButtonClassName()}
-            aria-label="Thêm thiết bị"
-          >
-            <Plus />
-            <span className="sr-only">Them thiet bi</span>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" side="top" className="mb-2">
-            <DropdownMenuItem onSelect={openAddDialog}>Thêm từng thiết bị</DropdownMenuItem>
-            <DropdownMenuItem onSelect={openImportDialog}>
-              Thêm hàng loạt bằng Excel
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ) : null}
 
       <FilterBottomSheet
         open={isFilterSheetOpen}

--- a/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
@@ -38,14 +38,21 @@ function areSameMobileFloatingActions(
     previousActions.length === nextActions.length &&
     previousActions.every((previousAction, index) => {
       const nextAction = nextActions[index]
-      return (
-        previousAction.id === nextAction.id &&
-        previousAction.label === nextAction.label &&
-        previousAction.icon === nextAction.icon &&
-        previousAction.onSelect === nextAction.onSelect
-      )
+      return previousAction.id === nextAction.id && previousAction.label === nextAction.label
     })
   )
+}
+
+function createStableMobileFloatingActions(
+  actions: readonly MobileFloatingActionDescriptor[],
+  latestActionsRef: React.RefObject<readonly MobileFloatingActionDescriptor[]>
+) {
+  return actions.map((action, index) => ({
+    id: action.id,
+    label: action.label,
+    icon: action.icon,
+    onSelect: () => latestActionsRef.current[index]?.onSelect(),
+  }))
 }
 
 /** Provides the app-shell-local mobile page action registration state. */
@@ -81,27 +88,38 @@ export function useMobileFloatingActions() {
 /** Registers or clears the current page's mobile floating action. */
 export function usePageFloatingAction(action: MobileFloatingActionRegistration) {
   const setPageActions = React.use(MobileFloatingActionsSetterContext)
+  const latestActionsRef = React.useRef<readonly MobileFloatingActionDescriptor[]>([])
+  const registeredActionIdsRef = React.useRef<readonly string[]>([])
 
   React.useEffect(() => {
     const nextActions = normalizeMobileFloatingActions(action)
+    latestActionsRef.current = nextActions
+    registeredActionIdsRef.current = nextActions.map((nextAction) => nextAction.id)
 
     setPageActions((currentActions) =>
-      areSameMobileFloatingActions(currentActions, nextActions) ? currentActions : nextActions
+      areSameMobileFloatingActions(currentActions, nextActions)
+        ? currentActions
+        : createStableMobileFloatingActions(nextActions, latestActionsRef)
     )
+  }, [action, setPageActions])
 
+  React.useEffect(() => {
     return () => {
       setPageActions((currentActions) => {
-        if (nextActions.length === 0) {
+        const registeredActionIds = registeredActionIdsRef.current
+
+        if (registeredActionIds.length === 0) {
           return currentActions
         }
 
-        const nextActionIds = new Set(nextActions.map((nextAction) => nextAction.id))
         const ownsCurrentActions =
-          currentActions.length === nextActions.length &&
-          currentActions.every((currentAction) => nextActionIds.has(currentAction.id))
+          currentActions.length === registeredActionIds.length &&
+          currentActions.every(
+            (currentAction, index) => currentAction.id === registeredActionIds[index]
+          )
 
         return ownsCurrentActions ? [] : currentActions
       })
     }
-  }, [action, setPageActions])
+  }, [setPageActions])
 }

--- a/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
@@ -9,37 +9,54 @@ export interface MobileFloatingActionDescriptor {
   onSelect: () => void
 }
 
+type MobileFloatingActionRegistration =
+  MobileFloatingActionDescriptor | readonly MobileFloatingActionDescriptor[] | null
+
 interface MobileFloatingActionsContextValue {
-  pageAction: MobileFloatingActionDescriptor | null
-  setPageAction: React.Dispatch<React.SetStateAction<MobileFloatingActionDescriptor | null>>
+  pageActions: readonly MobileFloatingActionDescriptor[]
+  setPageActions: React.Dispatch<React.SetStateAction<readonly MobileFloatingActionDescriptor[]>>
 }
 
-const MobileFloatingActionsStateContext =
-  React.createContext<MobileFloatingActionDescriptor | null>(null)
+const MobileFloatingActionsStateContext = React.createContext<
+  readonly MobileFloatingActionDescriptor[]
+>([])
 
 const MobileFloatingActionsSetterContext = React.createContext<
-  React.Dispatch<React.SetStateAction<MobileFloatingActionDescriptor | null>>
+  React.Dispatch<React.SetStateAction<readonly MobileFloatingActionDescriptor[]>>
 >(() => undefined)
 
-function isSameMobileFloatingAction(
-  previousAction: MobileFloatingActionDescriptor | null,
-  nextAction: MobileFloatingActionDescriptor | null
+function normalizeMobileFloatingActions(action: MobileFloatingActionRegistration) {
+  if (!action) return []
+  return Array.isArray(action) ? action : [action]
+}
+
+function areSameMobileFloatingActions(
+  previousActions: readonly MobileFloatingActionDescriptor[],
+  nextActions: readonly MobileFloatingActionDescriptor[]
 ) {
   return (
-    previousAction?.id === nextAction?.id &&
-    previousAction?.label === nextAction?.label &&
-    previousAction?.icon === nextAction?.icon &&
-    previousAction?.onSelect === nextAction?.onSelect
+    previousActions.length === nextActions.length &&
+    previousActions.every((previousAction, index) => {
+      const nextAction = nextActions[index]
+      return (
+        previousAction.id === nextAction.id &&
+        previousAction.label === nextAction.label &&
+        previousAction.icon === nextAction.icon &&
+        previousAction.onSelect === nextAction.onSelect
+      )
+    })
   )
 }
 
 /** Provides the app-shell-local mobile page action registration state. */
 export function MobileFloatingActionsProvider({ children }: { children: React.ReactNode }) {
-  const [pageAction, setPageAction] = React.useState<MobileFloatingActionDescriptor | null>(null)
+  const [pageActions, setPageActions] = React.useState<readonly MobileFloatingActionDescriptor[]>(
+    []
+  )
 
   return (
-    <MobileFloatingActionsSetterContext.Provider value={setPageAction}>
-      <MobileFloatingActionsStateContext.Provider value={pageAction}>
+    <MobileFloatingActionsSetterContext.Provider value={setPageActions}>
+      <MobileFloatingActionsStateContext.Provider value={pageActions}>
         {children}
       </MobileFloatingActionsStateContext.Provider>
     </MobileFloatingActionsSetterContext.Provider>
@@ -48,35 +65,43 @@ export function MobileFloatingActionsProvider({ children }: { children: React.Re
 
 /** Reads the currently registered mobile page action for layout composition. */
 export function useMobileFloatingActions() {
-  const pageAction = React.use(MobileFloatingActionsStateContext)
-  const setPageAction = React.use(MobileFloatingActionsSetterContext)
+  const pageActions = React.use(MobileFloatingActionsStateContext)
+  const setPageActions = React.use(MobileFloatingActionsSetterContext)
 
   return React.useMemo(
     () => ({
-      pageAction,
-      setPageAction,
+      pageAction: pageActions[0] ?? null,
+      pageActions,
+      setPageActions,
     }),
-    [pageAction, setPageAction]
+    [pageActions, setPageActions]
   )
 }
 
 /** Registers or clears the current page's mobile floating action. */
-export function usePageFloatingAction(action: MobileFloatingActionDescriptor | null) {
-  const setPageAction = React.use(MobileFloatingActionsSetterContext)
+export function usePageFloatingAction(action: MobileFloatingActionRegistration) {
+  const setPageActions = React.use(MobileFloatingActionsSetterContext)
 
   React.useEffect(() => {
-    setPageAction((currentAction) =>
-      isSameMobileFloatingAction(currentAction, action) ? currentAction : action
+    const nextActions = normalizeMobileFloatingActions(action)
+
+    setPageActions((currentActions) =>
+      areSameMobileFloatingActions(currentActions, nextActions) ? currentActions : nextActions
     )
 
     return () => {
-      setPageAction((currentAction) => {
-        if (!action || currentAction?.id !== action.id) {
-          return currentAction
+      setPageActions((currentActions) => {
+        if (nextActions.length === 0) {
+          return currentActions
         }
 
-        return null
+        const nextActionIds = new Set(nextActions.map((nextAction) => nextAction.id))
+        const ownsCurrentActions =
+          currentActions.length === nextActions.length &&
+          currentActions.every((currentAction) => nextActionIds.has(currentAction.id))
+
+        return ownsCurrentActions ? [] : currentActions
       })
     }
-  }, [action, setPageAction])
+  }, [action, setPageActions])
 }

--- a/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionsContext.tsx
@@ -55,6 +55,16 @@ function createStableMobileFloatingActions(
   }))
 }
 
+function ownsCurrentMobileFloatingActions(
+  currentActions: readonly MobileFloatingActionDescriptor[],
+  registeredActionIds: readonly string[]
+) {
+  return (
+    currentActions.length === registeredActionIds.length &&
+    currentActions.every((currentAction, index) => currentAction.id === registeredActionIds[index])
+  )
+}
+
 /** Provides the app-shell-local mobile page action registration state. */
 export function MobileFloatingActionsProvider({ children }: { children: React.ReactNode }) {
   const [pageActions, setPageActions] = React.useState<readonly MobileFloatingActionDescriptor[]>(
@@ -112,13 +122,9 @@ export function usePageFloatingAction(action: MobileFloatingActionRegistration) 
           return currentActions
         }
 
-        const ownsCurrentActions =
-          currentActions.length === registeredActionIds.length &&
-          currentActions.every(
-            (currentAction, index) => currentAction.id === registeredActionIds[index]
-          )
-
-        return ownsCurrentActions ? [] : currentActions
+        return ownsCurrentMobileFloatingActions(currentActions, registeredActionIds)
+          ? []
+          : currentActions
       })
     }
   }, [setPageActions])

--- a/src/components/shared/floating-actions/__tests__/MobileFloatingActionsContext.test.tsx
+++ b/src/components/shared/floating-actions/__tests__/MobileFloatingActionsContext.test.tsx
@@ -47,6 +47,24 @@ function InlinePageActionProbe() {
   return null
 }
 
+let inlineConsumerRenderCount = 0
+
+function InlineArrayConsumerProbe() {
+  inlineConsumerRenderCount += 1
+  useMobileFloatingActions()
+
+  usePageFloatingAction([
+    {
+      id: "inline-array-action",
+      label: "Tạo yêu cầu",
+      icon: <PlusCircle />,
+      onSelect: () => undefined,
+    },
+  ])
+
+  return null
+}
+
 function RegisteredActionLabel() {
   const { pageAction } = useMobileFloatingActions()
 
@@ -125,5 +143,19 @@ describe("MobileFloatingActionsContext", () => {
 
     expect(screen.getByTestId("registered-action")).toHaveTextContent("Tạo yêu cầu")
     expect(inlineProbeRenderCount).toBe(1)
+  })
+
+  it("does not loop when a context consumer registers an inline action array", () => {
+    inlineConsumerRenderCount = 0
+
+    render(
+      <MobileFloatingActionsProvider>
+        <InlineArrayConsumerProbe />
+        <RegisteredActionLabel />
+      </MobileFloatingActionsProvider>
+    )
+
+    expect(screen.getByTestId("registered-action")).toHaveTextContent("Tạo yêu cầu")
+    expect(inlineConsumerRenderCount).toBeLessThanOrEqual(2)
   })
 })


### PR DESCRIPTION
## Summary

- Extend the shared mobile floating actions foundation so pages can register one or more page actions while keeping the existing single-action API compatible.
- Move Equipments mobile actions into the shared app-shell FAB menu: `Trợ lý AI`, `Thêm thủ công`, and `Thêm bằng Excel`.
- Remove the page-local Equipments mobile FAB/dropdown and extract the registration into `EquipmentMobileFloatingActions` so `EquipmentPageClient.tsx` stays below the 350-line threshold.

Closes #697
Refs #690

Note: #698 was closed as superseded because this PR keeps the Excel import action in the shared menu.

## Verification

- `node scripts/npm-run.js npx prettier --check ...changed files...`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:heroui-boundary`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/app/(app)/equipment/__tests__/EquipmentPageClient.selection-render-boundary.test.tsx src/app/(app)/__tests__/AppMobileFloatingActions.test.tsx src/components/shared/floating-actions/__tests__/MobileFloatingActionsContext.test.tsx src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx`
- `node scripts/npm-run.js run react-doctor`
- pre-commit Lefthook
- pre-push Lefthook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Roll out the shared mobile floating action menu to Equipments, adding support for multiple page actions and merging `Trợ lý AI`, `Thêm thủ công`, and `Thêm bằng Excel` into one menu. Aligns with #690 and keeps the single-action API compatible.

- **New Features**
  - Shared floating actions now accept multiple actions via `usePageFloatingAction([...])`; `AppMobileFloatingActions` shows them with the assistant in one menu.
  - Equipments registers `Thêm thủ công` and `Thêm bằng Excel` on mobile when allowed via `EquipmentMobileFloatingActions`.

- **Bug Fixes**
  - Stabilized registration to avoid re-render loops with inline arrays and keep `onSelect` handlers fresh.
  - Cleanup only clears actions owned by the current page, preventing unintended unregistration.

<sup>Written for commit b751dbefd2eea994baedaedf562797e1da331667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile floating actions now support multiple page actions in the same menu, shown together with the assistant button.
  * Equipment pages on mobile provide two quick actions: manual add and Excel import.

* **Bug Fixes**
  * Fixed mobile menu composition and selection behavior so all registered options appear together and each selection reliably triggers the correct action.
  * Improved stability to prevent repeated/infinite re-rendering when registering multiple actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->