### PR TITLE
React Doctor Rank 2 mechanical cleanup

### DIFF
--- a/docs/review/2026-07-06-react-doctor-full-scan-triage.md
+++ b/docs/review/2026-07-06-react-doctor-full-scan-triage.md
@@ -94,13 +94,14 @@ React Doctor full JSON summaries for the four target rules:
 | Rule                                                            | Baseline | After compact batch | Delta |
 | --------------------------------------------------------------- | -------: | ------------------: | ----: |
 | `Maintainability / prefer-module-scope-pure-function / warning` |       19 |                  15 |    -4 |
-| `Maintainability / prefer-module-scope-static-value / warning`  |        6 |                   2 |    -4 |
+| `Maintainability / prefer-module-scope-static-value / warning`  |        6 |                   0 |    -6 |
 | `Performance / rerender-lazy-ref-init / warning`                |        2 |                   0 |    -2 |
 | `Performance / js-hoist-intl / warning`                         |        1 |                   0 |    -1 |
 
 Fixed scope:
 
 - Hoisted static nav/status/chart values in app layout, device quota status badges, and login template.
+- Hoisted form branding static size/alignment maps and replaced the local explicit `any` with a narrow session-user role type.
 - Converted both `useRef(new Map())` sites to lazy null-ref initialization.
 - Hoisted the static Vietnamese currency `Intl.NumberFormat`.
 - Hoisted the pure equipment distribution helper cluster.
@@ -112,7 +113,6 @@ Verification note:
 
 Skipped scope:
 
-- `src/components/form-branding-header.tsx` still has 2 static-value findings. It already contains an unrelated explicit `any`, so touching it would require a separate type-safety cleanup to keep the diff-aware `verify:no-explicit-any` gate green.
 - The remaining 15 pure-function findings are spread across page/demo/form/template modules and should be handled only when the relevant file is already in scope or with focused tests.
 
 ## Priority Triage
@@ -173,7 +173,7 @@ ROI ranking uses four criteria: likely issue-count reduction, low blast radius, 
 | Rank | Batch                                                                                                                                   | Issues | Risk        | Why this is high ROI                                                                                                                                | Verification                                                                       |
 | ---: | --------------------------------------------------------------------------------------------------------------------------------------- | -----: | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 |    1 | React correctness quick fixes: `jsx-key`, `query-destructure-result` - completed                                                        |      0 | Low         | Completed in `cfe75fdc`; removed 5 non-DB Bug errors.                                                                                               | Focused component tests, `typecheck`, React Doctor diff scan.                      |
-|    2 | Module-scope hoists: `prefer-module-scope-pure-function`, `prefer-module-scope-static-value`, `rerender-lazy-ref-init`, `js-hoist-intl` |     17 | Low         | Compact batch reduced 11 warnings. Remaining findings are intentionally deferred where they touch broader modules or require unrelated cleanup.     | `typecheck`, focused tests for touched components, React Doctor diff/full scan.    |
+|    2 | Module-scope hoists: `prefer-module-scope-pure-function`, `prefer-module-scope-static-value`, `rerender-lazy-ref-init`, `js-hoist-intl` |     15 | Low         | Compact batch reduced 13 warnings. Remaining findings are intentionally deferred where they touch broader modules or require unrelated cleanup.     | `typecheck`, focused tests for touched components, React Doctor diff/full scan.    |
 |    3 | Dependency hygiene: remaining `unused-dev-dependency` and verified `unused-dependency`                                                  |      8 | Low-Medium  | Low-supply findings are cleared; remaining package cleanup still needs import/runtime checks, especially for dynamic or service-worker usage.       | Import search, build/typecheck, dependency install sanity, React Doctor diff scan. |
 |    4 | Print/template HTML review: `dangerous-html-sink`                                                                                       |      6 | Medium      | Security ROI is high, count is modest. Requires source-by-source check to avoid breaking print/export flows.                                        | Targeted escaping/sanitization tests, manual print/export smoke checks.            |
 |    5 | Hook behavior cleanup: `exhaustive-deps`, `prefer-use-effect-event`, selected `no-event-handler`                                        |     24 | Medium      | Good correctness value, but render timing/subscription changes can regress UI behavior. Start with repeated patterns, not a sweeping rewrite.       | Focused page tests, interaction smoke tests, React Doctor diff scan.               |
@@ -191,7 +191,7 @@ ROI ranking uses four criteria: likely issue-count reduction, low blast radius, 
 
 2. **PR 2: Mechanical render-cost cleanup**
    - Scope: module-scope pure functions/static values, lazy ref initialization, `Intl.NumberFormat` hoist.
-   - Result: compact branch reduced target warnings from 28 to 17.
+   - Result: compact branch reduced target warnings from 28 to 15.
    - Reason: best warning-count reduction with low behavior risk if each hoist is verified as state-independent.
 
 3. **PR 3: Dependency/security noise cleanup - partially completed**

--- a/docs/review/2026-07-06-react-doctor-full-scan-triage.md
+++ b/docs/review/2026-07-06-react-doctor-full-scan-triage.md
@@ -85,6 +85,36 @@ Current category breakdown:
 
 Current remaining error-level findings are all `supabase-table-missing-rls` and must stay on the separate Supabase MCP audit track.
 
+## Rank 2 Mechanical Cleanup Update - 2026-07-06
+
+Branch `react-doctor-rank2-mechanical-cleanup` applied the compact Rank 2 cleanup scope after `main` was synced to `origin/main`.
+
+React Doctor full JSON summaries for the four target rules:
+
+| Rule                                                            | Baseline | After compact batch | Delta |
+| --------------------------------------------------------------- | -------: | ------------------: | ----: |
+| `Maintainability / prefer-module-scope-pure-function / warning` |       19 |                  15 |    -4 |
+| `Maintainability / prefer-module-scope-static-value / warning`  |        6 |                   2 |    -4 |
+| `Performance / rerender-lazy-ref-init / warning`                |        2 |                   0 |    -2 |
+| `Performance / js-hoist-intl / warning`                         |        1 |                   0 |    -1 |
+
+Fixed scope:
+
+- Hoisted static nav/status/chart values in app layout, device quota status badges, and login template.
+- Converted both `useRef(new Map())` sites to lazy null-ref initialization.
+- Hoisted the static Vietnamese currency `Intl.NumberFormat`.
+- Hoisted the pure equipment distribution helper cluster.
+
+Verification note:
+
+- Changed-scope React Doctor no longer reports the four Rank 2 target rules.
+- Changed-scope React Doctor still reports 2 out-of-scope warnings in touched files: `prefer-dynamic-import` for the existing Recharts login template import and `no-react19-deprecated-apis` for the existing realtime context API. Both are explicitly outside this compact batch.
+
+Skipped scope:
+
+- `src/components/form-branding-header.tsx` still has 2 static-value findings. It already contains an unrelated explicit `any`, so touching it would require a separate type-safety cleanup to keep the diff-aware `verify:no-explicit-any` gate green.
+- The remaining 15 pure-function findings are spread across page/demo/form/template modules and should be handled only when the relevant file is already in scope or with focused tests.
+
 ## Priority Triage
 
 ### P0 - Verify Before Fixing
@@ -143,7 +173,7 @@ ROI ranking uses four criteria: likely issue-count reduction, low blast radius, 
 | Rank | Batch                                                                                                                                   | Issues | Risk        | Why this is high ROI                                                                                                                                | Verification                                                                       |
 | ---: | --------------------------------------------------------------------------------------------------------------------------------------- | -----: | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 |    1 | React correctness quick fixes: `jsx-key`, `query-destructure-result` - completed                                                        |      0 | Low         | Completed in `cfe75fdc`; removed 5 non-DB Bug errors.                                                                                               | Focused component tests, `typecheck`, React Doctor diff scan.                      |
-|    2 | Module-scope hoists: `prefer-module-scope-pure-function`, `prefer-module-scope-static-value`, `rerender-lazy-ref-init`, `js-hoist-intl` |     28 | Low         | Mostly mechanical moves of pure helpers/static values. Good issue reduction with small runtime risk when values are truly local-state independent.  | `typecheck`, focused tests for touched components, React Doctor diff scan.         |
+|    2 | Module-scope hoists: `prefer-module-scope-pure-function`, `prefer-module-scope-static-value`, `rerender-lazy-ref-init`, `js-hoist-intl` |     17 | Low         | Compact batch reduced 11 warnings. Remaining findings are intentionally deferred where they touch broader modules or require unrelated cleanup.     | `typecheck`, focused tests for touched components, React Doctor diff/full scan.    |
 |    3 | Dependency hygiene: remaining `unused-dev-dependency` and verified `unused-dependency`                                                  |      8 | Low-Medium  | Low-supply findings are cleared; remaining package cleanup still needs import/runtime checks, especially for dynamic or service-worker usage.       | Import search, build/typecheck, dependency install sanity, React Doctor diff scan. |
 |    4 | Print/template HTML review: `dangerous-html-sink`                                                                                       |      6 | Medium      | Security ROI is high, count is modest. Requires source-by-source check to avoid breaking print/export flows.                                        | Targeted escaping/sanitization tests, manual print/export smoke checks.            |
 |    5 | Hook behavior cleanup: `exhaustive-deps`, `prefer-use-effect-event`, selected `no-event-handler`                                        |     24 | Medium      | Good correctness value, but render timing/subscription changes can regress UI behavior. Start with repeated patterns, not a sweeping rewrite.       | Focused page tests, interaction smoke tests, React Doctor diff scan.               |
@@ -161,7 +191,7 @@ ROI ranking uses four criteria: likely issue-count reduction, low blast radius, 
 
 2. **PR 2: Mechanical render-cost cleanup**
    - Scope: module-scope pure functions/static values, lazy ref initialization, `Intl.NumberFormat` hoist.
-   - Expected reduction: up to 28 warnings.
+   - Result: compact branch reduced target warnings from 28 to 17.
    - Reason: best warning-count reduction with low behavior risk if each hoist is verified as state-independent.
 
 3. **PR 3: Dependency/security noise cleanup - partially completed**

--- a/src/app/(app)/_components/AppLayoutShell.tsx
+++ b/src/app/(app)/_components/AppLayoutShell.tsx
@@ -61,6 +61,17 @@ type AppLayoutShellProps = {
   user: AppLayoutUser
 }
 
+const TOUR_ATTRIBUTES: Record<string, string> = {
+  "/dashboard": "sidebar-nav-dashboard",
+  "/equipment": "sidebar-nav-equipment",
+  "/repair-requests": "sidebar-nav-repairs",
+  "/maintenance": "sidebar-nav-maintenance",
+  "/transfers": "sidebar-nav-transfers",
+  "/device-quota": "sidebar-nav-device-quota",
+  "/reports": "sidebar-nav-reports",
+  "/qr-scanner": "sidebar-nav-qr",
+}
+
 /**
  * Wraps authenticated app pages with shared navigation, header actions, and mobile footer state.
  */
@@ -88,17 +99,6 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
     enabled: status === "authenticated" && shouldFetchData,
     facilityId: selectedFacilityId,
   })
-
-  const tourAttributes: Record<string, string> = {
-    "/dashboard": "sidebar-nav-dashboard",
-    "/equipment": "sidebar-nav-equipment",
-    "/repair-requests": "sidebar-nav-repairs",
-    "/maintenance": "sidebar-nav-maintenance",
-    "/transfers": "sidebar-nav-transfers",
-    "/device-quota": "sidebar-nav-device-quota",
-    "/reports": "sidebar-nav-reports",
-    "/qr-scanner": "sidebar-nav-qr",
-  }
 
   const navItems = React.useMemo(() => {
     return getAppNavigationItems(user.role)
@@ -186,7 +186,7 @@ function AppLayoutShellContent({ children, user }: AppLayoutShellProps) {
                 pathname={pathname}
                 isSidebarOpen={isSidebarOpen}
                 notificationCounts={notificationCounts}
-                tourAttributes={tourAttributes}
+                tourAttributes={TOUR_ATTRIBUTES}
                 className={cn("px-3", !isSidebarOpen && "justify-items-center px-0")}
               />
             </div>

--- a/src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietToolbar.tsx
+++ b/src/app/(app)/device-quota/decisions/[id]/_components/DeviceQuotaChiTietToolbar.tsx
@@ -25,17 +25,28 @@ function formatDate(dateStr: string | null | undefined): string {
   }
 }
 
+const STATUS_BADGE_VARIANTS: Record<
+  "draft" | "active" | "inactive",
+  { variant: "outline" | "default"; label: string; className: string }
+> = {
+  draft: { variant: "outline", label: "Bản nháp", className: "border-gray-400 text-gray-700" },
+  active: {
+    variant: "default",
+    label: "Đang hiệu lực",
+    className: "bg-green-600 hover:bg-green-700",
+  },
+  inactive: {
+    variant: "outline",
+    label: "Hết hiệu lực",
+    className: "border-gray-400 text-gray-600",
+  },
+}
+
 /**
  * Helper: Status Badge
  */
-function StatusBadge({ status }: { status: 'draft' | 'active' | 'inactive' }) {
-  const variants = {
-    draft: { variant: "outline" as const, label: "Bản nháp", className: "border-gray-400 text-gray-700" },
-    active: { variant: "default" as const, label: "Đang hiệu lực", className: "bg-green-600 hover:bg-green-700" },
-    inactive: { variant: "outline" as const, label: "Hết hiệu lực", className: "border-gray-400 text-gray-600" },
-  }
-
-  const config = variants[status] || variants.draft
+function StatusBadge({ status }: { status: "draft" | "active" | "inactive" }) {
+  const config = STATUS_BADGE_VARIANTS[status] ?? STATUS_BADGE_VARIANTS.draft
 
   return (
     <Badge variant={config.variant} className={config.className}>
@@ -55,17 +66,12 @@ function StatusBadge({ status }: { status: 'draft' | 'active' | 'inactive' }) {
 export function DeviceQuotaChiTietToolbar() {
   const { push } = useRouter()
   const { toast } = useToast()
-  const {
-    decision,
-    isDecisionLoading,
-    leafCategories,
-    isCategoriesLoading,
-    openImportDialog,
-  } = useDeviceQuotaChiTietContext()
+  const { decision, isDecisionLoading, leafCategories, isCategoriesLoading, openImportDialog } =
+    useDeviceQuotaChiTietContext()
 
   const [isDownloading, setIsDownloading] = React.useState(false)
 
-  const canEdit = decision?.trang_thai === 'draft' || decision?.trang_thai === 'active'
+  const canEdit = decision?.trang_thai === "draft" || decision?.trang_thai === "active"
 
   // Handle download template
   const handleDownloadTemplate = React.useCallback(async () => {
@@ -85,9 +91,9 @@ export function DeviceQuotaChiTietToolbar() {
 
       // Trigger download
       const url = URL.createObjectURL(blob)
-      const link = document.createElement('a')
+      const link = document.createElement("a")
       link.href = url
-      link.download = `Mau_Dinh_Muc_${decision?.so_quyet_dinh || 'Template'}_${new Date().getTime()}.xlsx`
+      link.download = `Mau_Dinh_Muc_${decision?.so_quyet_dinh || "Template"}_${new Date().getTime()}.xlsx`
       document.body.appendChild(link)
       link.click()
       document.body.removeChild(link)
@@ -98,7 +104,7 @@ export function DeviceQuotaChiTietToolbar() {
         description: "Đã tải xuống file mẫu định mức.",
       })
     } catch (error: unknown) {
-      const errorMessage = getUnknownErrorMessage(error, 'Lỗi không xác định')
+      const errorMessage = getUnknownErrorMessage(error, "Lỗi không xác định")
       toast({
         variant: "destructive",
         title: "Lỗi tải xuống",
@@ -118,7 +124,7 @@ export function DeviceQuotaChiTietToolbar() {
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => push('/device-quota/decisions')}
+            onClick={() => push("/device-quota/decisions")}
             aria-label="Quay lại danh sách quyết định"
             className="size-9"
           >
@@ -130,17 +136,15 @@ export function DeviceQuotaChiTietToolbar() {
             </h2>
             {decision && (
               <p className="text-sm text-muted-foreground">
-                Ngày ban hành: {formatDate(decision.ngay_ban_hanh)} |
-                Hiệu lực: {formatDate(decision.ngay_hieu_luc)}
+                Ngày ban hành: {formatDate(decision.ngay_ban_hanh)} | Hiệu lực:{" "}
+                {formatDate(decision.ngay_hieu_luc)}
               </p>
             )}
           </div>
         </div>
 
         {/* Right: Status badge */}
-        <div>
-          {decision && <StatusBadge status={decision.trang_thai} />}
-        </div>
+        <div>{decision && <StatusBadge status={decision.trang_thai} />}</div>
       </div>
 
       {/* Action Buttons (draft and active) */}
@@ -168,7 +172,12 @@ export function DeviceQuotaChiTietToolbar() {
               variant="outline"
               size="sm"
               onClick={handleDownloadTemplate}
-              disabled={isDownloading || isCategoriesLoading || !leafCategories || leafCategories.length === 0}
+              disabled={
+                isDownloading ||
+                isCategoriesLoading ||
+                !leafCategories ||
+                leafCategories.length === 0
+              }
               className="h-9 w-full sm:w-auto"
               aria-label="Tải xuống file mẫu Excel định mức"
             >

--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx
@@ -48,18 +48,29 @@ function formatDate(dateStr: string | null | undefined): string {
   }
 }
 
+const STATUS_BADGE_VARIANTS: Record<
+  Decision["trang_thai"],
+  { variant: "outline" | "default"; label: string; className: string }
+> = {
+  draft: { variant: "outline", label: "Nháp", className: "border-gray-400 text-gray-700" },
+  active: {
+    variant: "default",
+    label: "Đang áp dụng",
+    className: "bg-green-600 hover:bg-green-700",
+  },
+  inactive: {
+    variant: "outline",
+    label: "Không áp dụng",
+    className: "border-gray-400 text-gray-600",
+  },
+}
+
 // ============================================
 // Helper: Status Badge
 // ============================================
 
 function StatusBadge({ status }: { status: Decision["trang_thai"] }) {
-  const variants = {
-    draft: { variant: "outline" as const, label: "Nháp", className: "border-gray-400 text-gray-700" },
-    active: { variant: "default" as const, label: "Đang áp dụng", className: "bg-green-600 hover:bg-green-700" },
-    inactive: { variant: "outline" as const, label: "Không áp dụng", className: "border-gray-400 text-gray-600" },
-  }
-
-  const config = variants[status] || variants.draft
+  const config = STATUS_BADGE_VARIANTS[status] ?? STATUS_BADGE_VARIANTS.draft
 
   return (
     <Badge variant={config.variant} className={config.className}>
@@ -77,11 +88,21 @@ function TableLoadingSkeleton() {
     <>
       {Array.from({ length: 5 }).map((_, idx) => (
         <TableRow key={idx}>
-          <TableCell><Skeleton className="h-4 w-32" /></TableCell>
-          <TableCell><Skeleton className="h-4 w-24" /></TableCell>
-          <TableCell><Skeleton className="h-4 w-24" /></TableCell>
-          <TableCell><Skeleton className="h-6 w-28" /></TableCell>
-          <TableCell><Skeleton className="size-8 rounded" /></TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-32" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-24" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-24" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-6 w-28" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="size-8 rounded" />
+          </TableCell>
         </TableRow>
       ))}
     </>
@@ -117,7 +138,13 @@ interface MobileDecisionCardProps {
   onDelete: () => void
 }
 
-function MobileDecisionCard({ decision, onView, onEdit, onActivate, onDelete }: MobileDecisionCardProps) {
+function MobileDecisionCard({
+  decision,
+  onView,
+  onEdit,
+  onActivate,
+  onDelete,
+}: MobileDecisionCardProps) {
   return (
     <div className="border rounded-lg p-4 space-y-3 bg-card hover:shadow-md transition-shadow">
       <div className="flex items-start justify-between">
@@ -201,7 +228,10 @@ function ActionsDropdown({ decision, onView, onEdit, onActivate, onDelete }: Act
               Kích hoạt
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onDelete} className="text-destructive focus:text-destructive">
+            <DropdownMenuItem
+              onClick={onDelete}
+              className="text-destructive focus:text-destructive"
+            >
               <Trash2 className="mr-2 size-4" />
               Xóa
             </DropdownMenuItem>
@@ -219,22 +249,20 @@ function ActionsDropdown({ decision, onView, onEdit, onActivate, onDelete }: Act
 /** Renders quota decisions with row-level view, activate, and delete actions. */
 export function DeviceQuotaDecisionsTable() {
   const { push } = useRouter()
-  const {
-    decisions,
-    isLoading,
-    openEditDialog,
-    activateMutation,
-    deleteMutation,
-  } = useDeviceQuotaDecisionsContext()
+  const { decisions, isLoading, openEditDialog, activateMutation, deleteMutation } =
+    useDeviceQuotaDecisionsContext()
 
   // Confirmation dialogs state
   const [activateDialog, setActivateDialog] = React.useState<Decision | null>(null)
   const [deleteDialog, setDeleteDialog] = React.useState<Decision | null>(null)
 
   // Navigate to decision detail page
-  const handleViewDetails = React.useCallback((decisionId: number) => {
-    push(`/device-quota/decisions/${decisionId}`)
-  }, [push])
+  const handleViewDetails = React.useCallback(
+    (decisionId: number) => {
+      push(`/device-quota/decisions/${decisionId}`)
+    },
+    [push]
+  )
 
   const handleActivateConfirm = React.useCallback(() => {
     if (!activateDialog) return
@@ -330,15 +358,20 @@ export function DeviceQuotaDecisionsTable() {
       </div>
 
       {/* Activate Confirmation Dialog */}
-      <AlertDialog open={!!activateDialog} onOpenChange={(open) => !open && setActivateDialog(null)}>
+      <AlertDialog
+        open={!!activateDialog}
+        onOpenChange={(open) => !open && setActivateDialog(null)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Kích hoạt quyết định</AlertDialogTitle>
             <AlertDialogDescription>
-              Bạn có chắc chắn muốn kích hoạt quyết định <strong>{activateDialog?.so_quyet_dinh}</strong>?
+              Bạn có chắc chắn muốn kích hoạt quyết định{" "}
+              <strong>{activateDialog?.so_quyet_dinh}</strong>?
               <br />
               <br />
-              Khi kích hoạt, quyết định cũ sẽ tự động ngưng áp dụng và quyết định này sẽ có hiệu lực.
+              Khi kích hoạt, quyết định cũ sẽ tự động ngưng áp dụng và quyết định này sẽ có hiệu
+              lực.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -347,9 +380,7 @@ export function DeviceQuotaDecisionsTable() {
               onClick={handleActivateConfirm}
               disabled={activateMutation.isPending}
             >
-              {activateMutation.isPending && (
-                <Loader2 className="size-4 animate-spin" />
-              )}
+              {activateMutation.isPending && <Loader2 className="size-4 animate-spin" />}
               Kích hoạt
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -375,9 +406,7 @@ export function DeviceQuotaDecisionsTable() {
               disabled={deleteMutation.isPending}
               className="bg-destructive hover:bg-destructive/90"
             >
-              {deleteMutation.isPending && (
-                <Loader2 className="size-4 animate-spin" />
-              )}
+              {deleteMutation.isPending && <Loader2 className="size-4 animate-spin" />}
               Xóa
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingPreviewDialog.tsx
+++ b/src/app/(app)/device-quota/mapping/_components/DeviceQuotaMappingPreviewDialog.tsx
@@ -6,21 +6,21 @@ import { Folder, CheckCircle2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { callRpc } from "@/lib/rpc-client"
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import type { Category } from "./DeviceQuotaMappingContext"
 import {
-    MappingPreviewCountBadge,
-    MappingPreviewLoadingState,
-    MappingPreviewEquipmentItem,
-    type EquipmentPreviewItem,
+  MappingPreviewCountBadge,
+  MappingPreviewLoadingState,
+  MappingPreviewEquipmentItem,
+  type EquipmentPreviewItem,
 } from "./MappingPreviewPrimitives"
 
 // ============================================
@@ -30,22 +30,22 @@ import {
 const EMPTY_EQUIPMENT_LIST: EquipmentPreviewItem[] = []
 
 export interface DeviceQuotaMappingPreviewDialogProps {
-    open: boolean
-    onOpenChange: (open: boolean) => void
-    selectedIds: Set<number>
-    targetCategory: Category | null
-    onConfirm: (confirmedIds: number[]) => void
-    isLinking: boolean
-    donViId: number | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  selectedIds: Set<number>
+  targetCategory: Category | null
+  onConfirm: (confirmedIds: number[]) => void
+  isLinking: boolean
+  donViId: number | null
 }
 
 type DeviceQuotaMappingPreviewDialogContentProps = Readonly<{
-    selectedIds: Set<number>
-    targetCategory: Category
-    onConfirm: (confirmedIds: number[]) => void
-    isLinking: boolean
-    donViId: number | null
-    onCancel: () => void
+  selectedIds: Set<number>
+  targetCategory: Category
+  onConfirm: (confirmedIds: number[]) => void
+  isLinking: boolean
+  donViId: number | null
+  onCancel: () => void
 }>
 
 // ============================================
@@ -53,18 +53,18 @@ type DeviceQuotaMappingPreviewDialogContentProps = Readonly<{
 // ============================================
 
 function CategoryCard({ category }: { category: Category }) {
-    return (
-        <div
-            className="flex flex-col items-center justify-center gap-2 rounded-lg border bg-muted/50 p-4 text-center min-w-[160px] max-w-[200px]"
-            data-testid="category-card"
-        >
-            <Folder className="size-8 text-primary/70" />
-            <span className="text-xs text-muted-foreground">Gán vào danh mục:</span>
-            <span className="text-sm font-bold">{category.ma_nhom}</span>
-            <span className="text-sm">{category.ten_nhom}</span>
-            <Badge variant="secondary">Cấp {category.level}</Badge>
-        </div>
-    )
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 rounded-lg border bg-muted/50 p-4 text-center min-w-[160px] max-w-[200px]"
+      data-testid="category-card"
+    >
+      <Folder className="size-8 text-primary/70" />
+      <span className="text-xs text-muted-foreground">Gán vào danh mục:</span>
+      <span className="text-sm font-bold">{category.ma_nhom}</span>
+      <span className="text-sm">{category.ten_nhom}</span>
+      <Badge variant="secondary">Cấp {category.level}</Badge>
+    </div>
+  )
 }
 
 // EquipmentPreviewItem and EquipmentSkeletonList extracted to MappingPreviewPrimitives.tsx
@@ -74,87 +74,79 @@ function CategoryCard({ category }: { category: Category }) {
 // ============================================
 
 function SvgConnectors({
-    categoryRef,
-    itemRefs,
-    containerRef,
-    scrollRef,
-    excludedIds,
-    itemCount,
+  categoryRef,
+  itemRefs,
+  containerRef,
+  scrollRef,
+  excludedIds,
+  itemCount,
 }: {
-    categoryRef: React.RefObject<HTMLDivElement | null>
-    itemRefs: React.RefObject<Map<number, HTMLDivElement>>
-    containerRef: React.RefObject<HTMLDivElement | null>
-    scrollRef: React.RefObject<HTMLDivElement | null>
-    excludedIds: Set<number>
-    /** Drives effect re-run when equipment items finish loading */
-    itemCount: number
+  categoryRef: React.RefObject<HTMLDivElement | null>
+  itemRefs: React.RefObject<Map<number, HTMLDivElement> | null>
+  containerRef: React.RefObject<HTMLDivElement | null>
+  scrollRef: React.RefObject<HTMLDivElement | null>
+  excludedIds: Set<number>
+  /** Drives effect re-run when equipment items finish loading */
+  itemCount: number
 }) {
-    const [paths, setPaths] = React.useState<
-        { id: number; d: string; excluded: boolean }[]
-    >([])
+  const [paths, setPaths] = React.useState<{ id: number; d: string; excluded: boolean }[]>([])
 
-    React.useLayoutEffect(() => {
-        function recalculate() {
-            const container = containerRef.current
-            const catEl = categoryRef.current
-            const items = itemRefs.current
-            if (!container || !catEl || !items) return
+  React.useLayoutEffect(() => {
+    function recalculate() {
+      const container = containerRef.current
+      const catEl = categoryRef.current
+      const items = itemRefs.current
+      if (!container || !catEl || !items) return
 
-            const containerRect = container.getBoundingClientRect()
-            const catRect = catEl.getBoundingClientRect()
-            const startX = catRect.right - containerRect.left
-            const startY = catRect.top + catRect.height / 2 - containerRect.top
+      const containerRect = container.getBoundingClientRect()
+      const catRect = catEl.getBoundingClientRect()
+      const startX = catRect.right - containerRect.left
+      const startY = catRect.top + catRect.height / 2 - containerRect.top
 
-            const newPaths: typeof paths = []
-            items.forEach((el, id) => {
-                const elRect = el.getBoundingClientRect()
-                const endX = elRect.left - containerRect.left
-                const endY = elRect.top + elRect.height / 2 - containerRect.top
-                const cpOffset = Math.min(60, Math.abs(endX - startX) * 0.4)
-                const d = `M ${startX},${startY} C ${startX + cpOffset},${startY} ${endX - cpOffset},${endY} ${endX},${endY}`
-                newPaths.push({ id, d, excluded: excludedIds.has(id) })
-            })
-            setPaths(newPaths)
-        }
+      const newPaths: typeof paths = []
+      items.forEach((el, id) => {
+        const elRect = el.getBoundingClientRect()
+        const endX = elRect.left - containerRect.left
+        const endY = elRect.top + elRect.height / 2 - containerRect.top
+        const cpOffset = Math.min(60, Math.abs(endX - startX) * 0.4)
+        const d = `M ${startX},${startY} C ${startX + cpOffset},${startY} ${endX - cpOffset},${endY} ${endX},${endY}`
+        newPaths.push({ id, d, excluded: excludedIds.has(id) })
+      })
+      setPaths(newPaths)
+    }
 
-        recalculate()
+    recalculate()
 
-        const observer = new ResizeObserver(recalculate)
-        if (containerRef.current) observer.observe(containerRef.current)
+    const observer = new ResizeObserver(recalculate)
+    if (containerRef.current) observer.observe(containerRef.current)
 
-        // Recalculate on scroll so lines track equipment items
-        const scrollEl = scrollRef.current
-        scrollEl?.addEventListener('scroll', recalculate, { passive: true })
+    // Recalculate on scroll so lines track equipment items
+    const scrollEl = scrollRef.current
+    scrollEl?.addEventListener("scroll", recalculate, { passive: true })
 
-        return () => {
-            observer.disconnect()
-            scrollEl?.removeEventListener('scroll', recalculate)
-        }
-    }, [categoryRef, itemRefs, containerRef, scrollRef, excludedIds, itemCount])
+    return () => {
+      observer.disconnect()
+      scrollEl?.removeEventListener("scroll", recalculate)
+    }
+  }, [categoryRef, itemRefs, containerRef, scrollRef, excludedIds, itemCount])
 
-    if (paths.length === 0) return null
+  if (paths.length === 0) return null
 
-    return (
-        <svg
-            className="absolute inset-0 w-full h-full pointer-events-none"
-            aria-hidden="true"
-        >
-            {paths.map(({ id, d, excluded }) => (
-                <path
-                    key={id}
-                    d={d}
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth={1.5}
-                    className={cn(
-                        "text-primary/40 transition-opacity",
-                        excluded && "opacity-30"
-                    )}
-                    strokeDasharray={excluded ? "6 4" : undefined}
-                />
-            ))}
-        </svg>
-    )
+  return (
+    <svg className="absolute inset-0 w-full h-full pointer-events-none" aria-hidden="true">
+      {paths.map(({ id, d, excluded }) => (
+        <path
+          key={id}
+          d={d}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          className={cn("text-primary/40 transition-opacity", excluded && "opacity-30")}
+          strokeDasharray={excluded ? "6 4" : undefined}
+        />
+      ))}
+    </svg>
+  )
 }
 
 // ============================================
@@ -167,166 +159,159 @@ function SvgConnectors({
  * connected by SVG bezier curves. Users can exclude/restore individual items before confirming.
  */
 export function DeviceQuotaMappingPreviewDialog({
-    open,
-    onOpenChange,
-    selectedIds,
-    targetCategory,
-    onConfirm,
-    isLinking,
-    donViId,
+  open,
+  onOpenChange,
+  selectedIds,
+  targetCategory,
+  onConfirm,
+  isLinking,
+  donViId,
 }: DeviceQuotaMappingPreviewDialogProps) {
-    if (!open || !targetCategory) return null
+  if (!open || !targetCategory) return null
 
-    return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DeviceQuotaMappingPreviewDialogContent
-                selectedIds={selectedIds}
-                targetCategory={targetCategory}
-                onConfirm={onConfirm}
-                isLinking={isLinking}
-                donViId={donViId}
-                onCancel={() => onOpenChange(false)}
-            />
-        </Dialog>
-    )
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DeviceQuotaMappingPreviewDialogContent
+        selectedIds={selectedIds}
+        targetCategory={targetCategory}
+        onConfirm={onConfirm}
+        isLinking={isLinking}
+        donViId={donViId}
+        onCancel={() => onOpenChange(false)}
+      />
+    </Dialog>
+  )
 }
 
 function DeviceQuotaMappingPreviewDialogContent({
-    selectedIds,
-    targetCategory,
-    onConfirm,
-    isLinking,
-    donViId,
-    onCancel,
+  selectedIds,
+  targetCategory,
+  onConfirm,
+  isLinking,
+  donViId,
+  onCancel,
 }: DeviceQuotaMappingPreviewDialogContentProps) {
-    const [excludedIds, setExcludedIds] = React.useState<Set<number>>(new Set())
+  const [excludedIds, setExcludedIds] = React.useState<Set<number>>(new Set())
 
-    // Fetch full equipment details for selected IDs
-    const idsArray = React.useMemo(() => Array.from(selectedIds), [selectedIds])
+  // Fetch full equipment details for selected IDs
+  const idsArray = React.useMemo(() => Array.from(selectedIds), [selectedIds])
 
-    const { data: equipment, isLoading } = useQuery({
-        queryKey: ["dinh_muc_thiet_bi_by_ids", { ids: idsArray, donViId }],
-        queryFn: () =>
-            callRpc<EquipmentPreviewItem[]>({
-                fn: "dinh_muc_thiet_bi_by_ids",
-                args: { p_thiet_bi_ids: idsArray, p_don_vi: donViId },
-            }),
-        enabled: idsArray.length > 0 && donViId !== null,
+  const { data: equipment, isLoading } = useQuery({
+    queryKey: ["dinh_muc_thiet_bi_by_ids", { ids: idsArray, donViId }],
+    queryFn: () =>
+      callRpc<EquipmentPreviewItem[]>({
+        fn: "dinh_muc_thiet_bi_by_ids",
+        args: { p_thiet_bi_ids: idsArray, p_don_vi: donViId },
+      }),
+    enabled: idsArray.length > 0 && donViId !== null,
+  })
+
+  const equipmentList = equipment ?? EMPTY_EQUIPMENT_LIST
+  const activeCount = equipmentList.filter((eq) => !excludedIds.has(eq.id)).length
+
+  // Refs for SVG connectors
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const categoryRef = React.useRef<HTMLDivElement>(null)
+  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const itemRefsMap = React.useRef<Map<number, HTMLDivElement> | null>(null)
+  if (itemRefsMap.current === null) {
+    itemRefsMap.current = new Map()
+  }
+
+  const toggleExclude = React.useCallback((id: number) => {
+    setExcludedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
     })
+  }, [])
 
-    const equipmentList = equipment ?? EMPTY_EQUIPMENT_LIST
-    const activeCount = equipmentList.filter(
-        (eq) => !excludedIds.has(eq.id)
-    ).length
+  const handleConfirm = React.useCallback(() => {
+    const confirmedIds: number[] = []
+    for (const eq of equipmentList) {
+      if (!excludedIds.has(eq.id)) confirmedIds.push(eq.id)
+    }
+    onConfirm(confirmedIds)
+  }, [equipmentList, excludedIds, onConfirm])
 
-    // Refs for SVG connectors
-    const containerRef = React.useRef<HTMLDivElement>(null)
-    const categoryRef = React.useRef<HTMLDivElement>(null)
-    const scrollRef = React.useRef<HTMLDivElement>(null)
-    const itemRefsMap = React.useRef<Map<number, HTMLDivElement>>(new Map())
+  return (
+    <DialogContent className="max-w-2xl">
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2">
+          <CheckCircle2 className="size-5 text-primary" />
+          Xác nhận phân loại thiết bị
+        </DialogTitle>
+        <DialogDescription>Vui lòng kiểm tra lại trước khi lưu</DialogDescription>
+      </DialogHeader>
 
-    const toggleExclude = React.useCallback((id: number) => {
-        setExcludedIds((prev) => {
-            const next = new Set(prev)
-            if (next.has(id)) {
-                next.delete(id)
-            } else {
-                next.add(id)
-            }
-            return next
-        })
-    }, [])
+      {/* Active count badge */}
+      <MappingPreviewCountBadge count={activeCount} label="thiết bị đã chọn" />
 
-    const handleConfirm = React.useCallback(() => {
-        const confirmedIds: number[] = []
-        for (const eq of equipmentList) {
-            if (!excludedIds.has(eq.id)) confirmedIds.push(eq.id)
-        }
-        onConfirm(confirmedIds)
-    }, [equipmentList, excludedIds, onConfirm])
+      {/* Mapping diagram */}
+      <div ref={containerRef} className="relative flex flex-row items-start gap-6 min-h-[200px]">
+        {/* Category card (left) */}
+        <div ref={categoryRef} className="flex-shrink-0 self-center hidden md:block">
+          <CategoryCard category={targetCategory} />
+        </div>
 
-    return (
-        <DialogContent className="max-w-2xl">
-                <DialogHeader>
-                    <DialogTitle className="flex items-center gap-2">
-                        <CheckCircle2 className="size-5 text-primary" />
-                        Xác nhận phân loại thiết bị
-                    </DialogTitle>
-                    <DialogDescription>
-                        Vui lòng kiểm tra lại trước khi lưu
-                    </DialogDescription>
-                </DialogHeader>
+        {/* Mobile category card (stacked, no SVG) */}
+        <div className="md:hidden w-full mb-2">
+          <CategoryCard category={targetCategory} />
+        </div>
 
-                {/* Active count badge */}
-                <MappingPreviewCountBadge count={activeCount} label="thiết bị đã chọn" />
+        {/* SVG connectors (desktop only) */}
+        <SvgConnectors
+          categoryRef={categoryRef}
+          itemRefs={itemRefsMap}
+          containerRef={containerRef}
+          scrollRef={scrollRef}
+          excludedIds={excludedIds}
+          itemCount={equipmentList.length}
+        />
 
-                {/* Mapping diagram */}
-                <div
-                    ref={containerRef}
-                    className="relative flex flex-row items-start gap-6 min-h-[200px]"
-                >
-                    {/* Category card (left) */}
-                    <div
-                        ref={categoryRef}
-                        className="flex-shrink-0 self-center hidden md:block"
-                    >
-                        <CategoryCard category={targetCategory} />
-                    </div>
+        {/* Equipment list (right) */}
+        <div
+          ref={scrollRef}
+          className="flex-1 overflow-y-auto max-h-[350px] space-y-2 relative z-10"
+        >
+          {isLoading ? (
+            <MappingPreviewLoadingState />
+          ) : (
+            equipmentList.map((item) => (
+              <div
+                key={item.id}
+                ref={(el) => {
+                  if (el) {
+                    itemRefsMap.current?.set(item.id, el)
+                  } else {
+                    itemRefsMap.current?.delete(item.id)
+                  }
+                }}
+              >
+                <MappingPreviewEquipmentItem
+                  item={item}
+                  isExcluded={excludedIds.has(item.id)}
+                  onToggle={() => toggleExclude(item.id)}
+                />
+              </div>
+            ))
+          )}
+        </div>
+      </div>
 
-                    {/* Mobile category card (stacked, no SVG) */}
-                    <div className="md:hidden w-full mb-2">
-                        <CategoryCard category={targetCategory} />
-                    </div>
-
-                    {/* SVG connectors (desktop only) */}
-                    <SvgConnectors
-                        categoryRef={categoryRef}
-                        itemRefs={itemRefsMap}
-                        containerRef={containerRef}
-                        scrollRef={scrollRef}
-                        excludedIds={excludedIds}
-                        itemCount={equipmentList.length}
-                    />
-
-                    {/* Equipment list (right) */}
-                    <div ref={scrollRef} className="flex-1 overflow-y-auto max-h-[350px] space-y-2 relative z-10">
-                        {isLoading ? (
-                            <MappingPreviewLoadingState />
-                        ) : (
-                            equipmentList.map((item) => (
-                                <div
-                                    key={item.id}
-                                    ref={(el) => {
-                                        if (el) {
-                                            itemRefsMap.current.set(item.id, el)
-                                        } else {
-                                            itemRefsMap.current.delete(item.id)
-                                        }
-                                    }}
-                                >
-                                    <MappingPreviewEquipmentItem
-                                        item={item}
-                                        isExcluded={excludedIds.has(item.id)}
-                                        onToggle={() => toggleExclude(item.id)}
-                                    />
-                                </div>
-                            ))
-                        )}
-                    </div>
-                </div>
-
-                <DialogFooter>
-                    <Button variant="outline" onClick={onCancel}>
-                        Hủy
-                    </Button>
-                    <Button
-                        onClick={handleConfirm}
-                        disabled={activeCount === 0 || isLinking}
-                    >
-                        <CheckCircle2 className="size-4 mr-1" />
-                        {isLinking ? "Đang xử lý..." : "Xác nhận phân loại"}
-                    </Button>
-                </DialogFooter>
-        </DialogContent>
-    )
+      <DialogFooter>
+        <Button variant="outline" onClick={onCancel}>
+          Hủy
+        </Button>
+        <Button onClick={handleConfirm} disabled={activeCount === 0 || isLinking}>
+          <CheckCircle2 className="size-4 mr-1" />
+          {isLinking ? "Đang xử lý..." : "Xác nhận phân loại"}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  )
 }

--- a/src/components/equipment-distribution-summary.tsx
+++ b/src/components/equipment-distribution-summary.tsx
@@ -8,10 +8,10 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Progress } from "@/components/ui/progress"
 import { DynamicPieChart } from "@/components/dynamic-chart"
 import { buildStatusDonutData } from "@/components/equipment-distribution-summary.utils"
-import { 
-  useEquipmentDistribution, 
+import {
+  useEquipmentDistribution,
   STATUS_COLORS,
-  STATUS_LABELS
+  STATUS_LABELS,
 } from "@/hooks/use-equipment-distribution"
 
 interface EquipmentDistributionSummaryProps {
@@ -37,33 +37,87 @@ const STATUS_DISPLAY_ORDER = [
   "cho_hieu_chuan",
 ] as const
 
+function getStatusIcon(statusKey: string) {
+  const iconClassName = "size-5 text-white"
+
+  switch (statusKey) {
+    case "hoat_dong":
+      return <CheckCircle className={iconClassName} />
+    case "cho_sua_chua":
+      return <XCircle className={iconClassName} />
+    case "cho_bao_tri":
+      return <Clock className={iconClassName} />
+    case "cho_hieu_chuan":
+      return <AlertCircle className={iconClassName} />
+    case "ngung_su_dung":
+      return <Pause className={iconClassName} />
+    default:
+      return <Activity className={iconClassName} />
+  }
+}
+
+function getHealthScoreColor(score: number) {
+  if (score >= 80) return "text-green-600"
+  if (score >= 60) return "text-yellow-600"
+  return "text-red-600"
+}
+
+function getHealthScoreBadge(score: number) {
+  if (score >= 80) return "default"
+  if (score >= 60) return "secondary"
+  return "destructive"
+}
+
+function getStatusProgressStyle(
+  color: string
+): React.CSSProperties & Record<"--status-progress-color", string> {
+  return {
+    "--status-progress-color": color,
+    accentColor: color,
+  }
+}
+
 /** Renders equipment distribution totals and status breakdowns. */
-export function EquipmentDistributionSummary({ className, tenantFilter, selectedDonVi, effectiveTenantKey }: EquipmentDistributionSummaryProps) {
-  const { data, isLoading, error } = useEquipmentDistribution(undefined, undefined, tenantFilter, selectedDonVi, effectiveTenantKey)
+export function EquipmentDistributionSummary({
+  className,
+  tenantFilter,
+  selectedDonVi,
+  effectiveTenantKey,
+}: EquipmentDistributionSummaryProps) {
+  const { data, isLoading, error } = useEquipmentDistribution(
+    undefined,
+    undefined,
+    tenantFilter,
+    selectedDonVi,
+    effectiveTenantKey
+  )
 
   // Calculate overall statistics
   const overallStats = React.useMemo(() => {
     if (!data) return null
 
     const totalEquipment = data.totalEquipment
-    
+
     // Sum up all status counts from departments data
-    const statusCounts = data.byDepartment.reduce((acc, dept) => {
-      acc.hoat_dong += dept.hoat_dong
-      acc.cho_sua_chua += dept.cho_sua_chua
-      acc.cho_bao_tri += dept.cho_bao_tri
-      acc.cho_hieu_chuan += dept.cho_hieu_chuan
-      acc.ngung_su_dung += dept.ngung_su_dung
-      acc.chua_co_nhu_cau += dept.chua_co_nhu_cau
-      return acc
-    }, {
-      hoat_dong: 0,
-      cho_sua_chua: 0,
-      cho_bao_tri: 0,
-      cho_hieu_chuan: 0,
-      ngung_su_dung: 0,
-      chua_co_nhu_cau: 0
-    })
+    const statusCounts = data.byDepartment.reduce(
+      (acc, dept) => {
+        acc.hoat_dong += dept.hoat_dong
+        acc.cho_sua_chua += dept.cho_sua_chua
+        acc.cho_bao_tri += dept.cho_bao_tri
+        acc.cho_hieu_chuan += dept.cho_hieu_chuan
+        acc.ngung_su_dung += dept.ngung_su_dung
+        acc.chua_co_nhu_cau += dept.chua_co_nhu_cau
+        return acc
+      },
+      {
+        hoat_dong: 0,
+        cho_sua_chua: 0,
+        cho_bao_tri: 0,
+        cho_hieu_chuan: 0,
+        ngung_su_dung: 0,
+        chua_co_nhu_cau: 0,
+      }
+    )
 
     // Calculate percentages
     const statusPercentages = Object.entries(statusCounts).map(([key, count]) => ({
@@ -71,11 +125,12 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
       count,
       percentage: totalEquipment > 0 ? Math.round((count / totalEquipment) * 100) : 0,
       label: STATUS_LABELS[key as keyof typeof STATUS_LABELS],
-      color: STATUS_COLORS[key as keyof typeof STATUS_COLORS]
+      color: STATUS_COLORS[key as keyof typeof STATUS_COLORS],
     }))
 
     // Health score calculation (active equipment percentage)
-    const healthScore = totalEquipment > 0 ? Math.round((statusCounts.hoat_dong / totalEquipment) * 100) : 0
+    const healthScore =
+      totalEquipment > 0 ? Math.round((statusCounts.hoat_dong / totalEquipment) * 100) : 0
 
     return {
       totalEquipment,
@@ -83,7 +138,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
       statusPercentages,
       healthScore,
       departmentCount: data.departments.length,
-      locationCount: data.locations.length
+      locationCount: data.locations.length,
     }
   }, [data])
 
@@ -109,44 +164,6 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
   if (error || !overallStats) {
     return null
   }
-
-  const getStatusIcon = (statusKey: string) => {
-    const iconClassName = "size-5 text-white"
-
-    switch (statusKey) {
-      case 'hoat_dong':
-        return <CheckCircle className={iconClassName} />
-      case 'cho_sua_chua':
-        return <XCircle className={iconClassName} />
-      case 'cho_bao_tri':
-        return <Clock className={iconClassName} />
-      case 'cho_hieu_chuan':
-        return <AlertCircle className={iconClassName} />
-      case 'ngung_su_dung':
-        return <Pause className={iconClassName} />
-      default:
-        return <Activity className={iconClassName} />
-    }
-  }
-
-  const getHealthScoreColor = (score: number) => {
-    if (score >= 80) return "text-green-600"
-    if (score >= 60) return "text-yellow-600"
-    return "text-red-600"
-  }
-
-  const getHealthScoreBadge = (score: number) => {
-    if (score >= 80) return "default"
-    if (score >= 60) return "secondary"
-    return "destructive"
-  }
-
-  const getStatusProgressStyle = (
-    color: string
-  ): React.CSSProperties & Record<"--status-progress-color", string> => ({
-    "--status-progress-color": color,
-    accentColor: color,
-  })
 
   const donutData = buildStatusDonutData(overallStats.statusPercentages)
   const hasDonutData = donutData.length > 0
@@ -175,8 +192,11 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
             <div className="flex items-center gap-2 mt-1">
               <Progress value={overallStats.healthScore} className="flex-1" />
               <Badge variant={getHealthScoreBadge(overallStats.healthScore)}>
-                {overallStats.healthScore >= 80 ? 'Tốt' : 
-                 overallStats.healthScore >= 60 ? 'Trung bình' : 'Cần chú ý'}
+                {overallStats.healthScore >= 80
+                  ? "Tốt"
+                  : overallStats.healthScore >= 60
+                    ? "Trung bình"
+                    : "Cần chú ý"}
               </Badge>
             </div>
           </CardContent>
@@ -189,9 +209,7 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
             <CheckCircle className="size-4 text-green-600" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-blue-600">
-              {overallStats.totalEquipment}
-            </div>
+            <div className="text-2xl font-bold text-blue-600">{overallStats.totalEquipment}</div>
             <p className="text-xs text-muted-foreground">
               {overallStats.statusCounts.hoat_dong} đang hoạt động
             </p>
@@ -206,13 +224,11 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-purple-600">
-              {overallStats.departmentCount > 0 
+              {overallStats.departmentCount > 0
                 ? Math.round(overallStats.totalEquipment / overallStats.departmentCount)
                 : 0}
             </div>
-            <p className="text-xs text-muted-foreground">
-              TB trung bình/khoa
-            </p>
+            <p className="text-xs text-muted-foreground">TB trung bình/khoa</p>
           </CardContent>
         </Card>
 
@@ -224,13 +240,11 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-orange-600">
-              {overallStats.locationCount > 0 
+              {overallStats.locationCount > 0
                 ? Math.round(overallStats.totalEquipment / overallStats.locationCount)
                 : 0}
             </div>
-            <p className="text-xs text-muted-foreground">
-              TB trung bình/vị trí
-            </p>
+            <p className="text-xs text-muted-foreground">TB trung bình/vị trí</p>
           </CardContent>
         </Card>
       </div>
@@ -262,7 +276,10 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
                   />
                   <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
                     <div className="text-center">
-                      <div data-testid="status-donut-total" className="text-3xl font-bold tracking-normal">
+                      <div
+                        data-testid="status-donut-total"
+                        className="text-3xl font-bold tracking-normal"
+                      >
                         {overallStats.totalEquipment}
                       </div>
                       <div className="text-xs text-muted-foreground">thiết bị</div>
@@ -275,7 +292,10 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
                 </div>
               )}
               {hasDonutData && (
-                <div data-testid="status-donut-legend" className="mt-3 grid gap-x-5 gap-y-2 sm:grid-cols-2">
+                <div
+                  data-testid="status-donut-legend"
+                  className="mt-3 grid gap-x-5 gap-y-2 sm:grid-cols-2"
+                >
                   {donutData.map((item) => (
                     <div
                       key={item.key}
@@ -315,11 +335,13 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
                       <div className="min-w-0">
                         <div className="truncate text-sm font-medium">{status.label}</div>
                         <div className="text-xs text-muted-foreground">
-                          <span className="text-lg font-bold text-foreground">{status.count}</span> thiết bị
+                          <span className="text-lg font-bold text-foreground">{status.count}</span>{" "}
+                          thiết bị
                         </div>
                       </div>
                       <div className="shrink-0 text-right text-sm text-muted-foreground">
-                        <span className="font-medium text-foreground">{status.percentage}%</span> tổng số
+                        <span className="font-medium text-foreground">{status.percentage}%</span>{" "}
+                        tổng số
                       </div>
                     </div>
                     <progress
@@ -338,4 +360,4 @@ export function EquipmentDistributionSummary({ className, tenantFilter, selected
       </Card>
     </div>
   )
-} 
+}

--- a/src/components/form-branding-header.tsx
+++ b/src/components/form-branding-header.tsx
@@ -13,57 +13,67 @@ export interface FormBrandingHeaderProps {
   size?: "sm" | "md" | "lg"
   showDivider?: boolean
   className?: string
-  tenantId?: number | null  // New: Form owner's tenant ID for static branding
-  mode?: 'auto' | 'static' | 'dynamic'  // New: Override branding mode
+  tenantId?: number | null // New: Form owner's tenant ID for static branding
+  mode?: "auto" | "static" | "dynamic" // New: Override branding mode
 }
 
+type SessionUserWithRole = {
+  role?: string | null
+}
+
+const FORM_BRANDING_SIZE_CONFIG = {
+  sm: { logoSize: 24, textSize: "text-sm" },
+  md: { logoSize: 32, textSize: "text-base" },
+  lg: { logoSize: 40, textSize: "text-lg" },
+} satisfies Record<
+  NonNullable<FormBrandingHeaderProps["size"]>,
+  { logoSize: number; textSize: string }
+>
+
+const FORM_BRANDING_ALIGNMENT_CLASS = {
+  left: "justify-start",
+  center: "justify-center",
+  right: "justify-end",
+} satisfies Record<NonNullable<FormBrandingHeaderProps["align"]>, string>
+
+/** Renders tenant branding for forms with static or session-derived context. */
 export function FormBrandingHeader({
   align = "left",
   size = "md",
   showDivider = false,
   className = "",
   tenantId = null,
-  mode = 'auto'
+  mode = "auto",
 }: FormBrandingHeaderProps) {
   const { data: session } = useSession()
-  const user = session?.user as any
+  const user = session?.user as SessionUserWithRole | undefined
   const isPrivileged = isGlobalRole(user?.role)
-  
+
   // Determine branding mode
-  const shouldUseFormContext = mode === 'static' || 
-    (mode === 'auto' && isPrivileged && tenantId !== null)
-  
+  const shouldUseFormContext =
+    mode === "static" || (mode === "auto" && isPrivileged && tenantId !== null)
+
   const branding = useTenantBranding({
     formTenantId: tenantId,
-    useFormContext: shouldUseFormContext
+    useFormContext: shouldUseFormContext,
   })
-  
-  // Size configuration
-  const sizeConfig = {
-    sm: { logoSize: 24, textSize: "text-sm" },
-    md: { logoSize: 32, textSize: "text-base" },
-    lg: { logoSize: 40, textSize: "text-lg" }
-  }
-  
-  const config = sizeConfig[size]
-  
-  // Alignment classes
-  const alignmentClass = {
-    left: "justify-start",
-    center: "justify-center",
-    right: "justify-end"
-  }
-  
+
+  const config = FORM_BRANDING_SIZE_CONFIG[size]
+  const alignmentClass = FORM_BRANDING_ALIGNMENT_CLASS
+
   // Loading skeleton
   if (branding.isLoading) {
     return (
       <div className={`flex items-center ${alignmentClass[align]} ${className}`}>
-        <Skeleton className="rounded-full" style={{ width: config.logoSize, height: config.logoSize }} />
+        <Skeleton
+          className="rounded-full"
+          style={{ width: config.logoSize, height: config.logoSize }}
+        />
         <Skeleton className={`ml-3 h-5 ${config.textSize} w-32`} />
       </div>
     )
   }
-  
+
   // Error or no data
   if (branding.isError || !branding.data) {
     return (
@@ -76,19 +86,10 @@ export function FormBrandingHeader({
 
   return (
     <div className={`flex items-center ${alignmentClass[align]} ${className}`}>
-      <TenantLogo 
-        src={branding.data.logo_url} 
-        name={branding.data.name} 
-        size={config.logoSize} 
-      />
-      <TenantName 
-        name={branding.data.name} 
-        className={`ml-3 ${config.textSize}`} 
-      />
-      
-      {showDivider && (
-        <div className="ml-4 w-px h-8 bg-gray-300" />
-      )}
+      <TenantLogo src={branding.data.logo_url} name={branding.data.name} size={config.logoSize} />
+      <TenantName name={branding.data.name} className={`ml-3 ${config.textSize}`} />
+
+      {showDivider && <div className="ml-4 w-px h-8 bg-gray-300" />}
     </div>
   )
 }

--- a/src/components/login-template.tsx
+++ b/src/components/login-template.tsx
@@ -8,39 +8,36 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Info, User, Lock } from "lucide-react"
-import { PieChart, Pie, Cell, ResponsiveContainer, Legend as RechartsLegend } from 'recharts'
+import { PieChart, Pie, Cell, ResponsiveContainer, Legend as RechartsLegend } from "recharts"
 
+const LOGIN_TEMPLATE_CHART_DATA = [
+  { name: "Hoạt động", value: 120, color: "#0079FF" },
+  { name: "Chờ sửa chữa", value: 15, color: "#FFC107" },
+  { name: "Đang bảo trì", value: 8, color: "#FD7E14" },
+  { name: "Đã thanh lý", value: 5, color: "#6C757D" },
+]
+
+/** Renders the demo login template used for branded form previews. */
 export function LoginTemplate() {
-  const chartData = [
-    { name: 'Hoạt động', value: 120, color: '#0079FF' },
-    { name: 'Chờ sửa chữa', value: 15, color: '#FFC107' },
-    { name: 'Đang bảo trì', value: 8, color: '#FD7E14' },
-    { name: 'Đã thanh lý', value: 5, color: '#6C757D' }
-  ]
-
   const handleLogin = (e: React.FormEvent) => {
     e.preventDefault()
-    alert('Đây là template demo. Để đăng nhập thực tế, vui lòng sử dụng trang chính của ứng dụng.')
+    alert("Đây là template demo. Để đăng nhập thực tế, vui lòng sử dụng trang chính của ứng dụng.")
   }
 
   return (
     <div className="min-h-screen bg-sky-50">
       <div className="flex flex-col md:flex-row min-h-screen">
-        
         {/* Left Column: Infographic/Overview */}
         <div className="w-full md:w-1/2 lg:w-3/5 bg-white p-8 lg:p-12 flex flex-col justify-center">
           <div className="max-w-2xl mx-auto">
-            <FormBrandingHeader 
-              align="left" 
-              size="lg" 
-              className="mb-6" 
-            />
-            
+            <FormBrandingHeader align="left" size="lg" className="mb-6" />
+
             <h1 className="text-3xl md:text-4xl font-semibold text-[#004AAD] mb-4">
               Hệ Thống Quản Lý Thiết Bị Y Tế Toàn Diện
             </h1>
             <p className="text-gray-600 mb-8">
-              Nền tảng thông minh giúp tối ưu hóa hiệu suất, đảm bảo an toàn và kéo dài tuổi thọ cho các tài sản y tế quan trọng.
+              Nền tảng thông minh giúp tối ưu hóa hiệu suất, đảm bảo an toàn và kéo dài tuổi thọ cho
+              các tài sản y tế quan trọng.
             </p>
 
             <div className="grid grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
@@ -48,33 +45,38 @@ export function LoginTemplate() {
                 {
                   icon: "📊",
                   title: "Tổng quan Dashboard",
-                  description: "Số liệu, biểu đồ và các cảnh báo quan trọng được tổng hợp tại một nơi."
+                  description:
+                    "Số liệu, biểu đồ và các cảnh báo quan trọng được tổng hợp tại một nơi.",
                 },
                 {
                   icon: "🔬",
                   title: "Quản lý Thiết bị",
-                  description: "Danh mục chi tiết, tìm kiếm và lọc thông minh, quản lý toàn bộ vòng đời thiết bị."
+                  description:
+                    "Danh mục chi tiết, tìm kiếm và lọc thông minh, quản lý toàn bộ vòng đời thiết bị.",
                 },
                 {
                   icon: "🔧",
                   title: "Quản lý Sửa chữa",
-                  description: "Tạo, theo dõi và quản lý các yêu cầu sửa chữa một cách hiệu quả."
+                  description: "Tạo, theo dõi và quản lý các yêu cầu sửa chữa một cách hiệu quả.",
                 },
                 {
                   icon: "📅",
                   title: "Kế hoạch Bảo trì",
-                  description: "Chủ động lập lịch và giám sát công việc bảo trì, hiệu chuẩn, kiểm định."
+                  description:
+                    "Chủ động lập lịch và giám sát công việc bảo trì, hiệu chuẩn, kiểm định.",
                 },
                 {
                   icon: "📈",
                   title: "Báo cáo Trực quan",
-                  description: "Cung cấp biểu đồ và số liệu chi tiết giúp ra quyết định nhanh chóng."
+                  description:
+                    "Cung cấp biểu đồ và số liệu chi tiết giúp ra quyết định nhanh chóng.",
                 },
                 {
                   icon: "📱",
                   title: "Quét mã QR",
-                  description: "Truy xuất tức thì thông tin và lịch sử thiết bị chỉ với một lần quét."
-                }
+                  description:
+                    "Truy xuất tức thì thông tin và lịch sử thiết bị chỉ với một lần quét.",
+                },
               ].map((feature, index) => (
                 <Card key={feature.title} className="bg-blue-50 border-blue-100">
                   <CardContent className="p-4">
@@ -91,7 +93,7 @@ export function LoginTemplate() {
                 <ResponsiveContainer width="100%" height="100%">
                   <PieChart>
                     <Pie
-                      data={chartData}
+                      data={LOGIN_TEMPLATE_CHART_DATA}
                       cx="50%"
                       cy="50%"
                       innerRadius={60}
@@ -99,15 +101,11 @@ export function LoginTemplate() {
                       paddingAngle={5}
                       dataKey="value"
                     >
-                      {chartData.map((entry) => (
+                      {LOGIN_TEMPLATE_CHART_DATA.map((entry) => (
                         <Cell key={entry.name} fill={entry.color} />
                       ))}
                     </Pie>
-                    <RechartsLegend 
-                      verticalAlign="bottom" 
-                      height={36}
-                      iconType="circle"
-                    />
+                    <RechartsLegend verticalAlign="bottom" height={36} iconType="circle" />
                   </PieChart>
                 </ResponsiveContainer>
               </div>
@@ -121,23 +119,22 @@ export function LoginTemplate() {
             <Card className="shadow-2xl overflow-hidden">
               <CardHeader className="bg-[#4a7c82] text-center text-white">
                 <div className="mb-4">
-                  <FormBrandingHeader 
-                    align="center" 
-                    size="md" 
-                    className="text-white [&_*]:text-white" 
+                  <FormBrandingHeader
+                    align="center"
+                    size="md"
+                    className="text-white [&_*]:text-white"
                   />
                 </div>
                 <CardTitle className="text-2xl font-bold">QUẢN LÝ THIẾT BỊ Y TẾ</CardTitle>
-                <CardDescription className="text-white/80">
-                  Đăng nhập vào hệ thống
-                </CardDescription>
+                <CardDescription className="text-white/80">Đăng nhập vào hệ thống</CardDescription>
               </CardHeader>
-              
+
               <CardContent className="p-8">
                 <Alert className="mb-6 border-yellow-200 bg-yellow-50">
                   <Info className="size-4" />
                   <AlertDescription>
-                    <strong>Chú ý:</strong> Đây là template demo. Để đăng nhập thực tế, vui lòng sử dụng trang chính của ứng dụng.
+                    <strong>Chú ý:</strong> Đây là template demo. Để đăng nhập thực tế, vui lòng sử
+                    dụng trang chính của ứng dụng.
                   </AlertDescription>
                 </Alert>
 
@@ -158,7 +155,7 @@ export function LoginTemplate() {
                       />
                     </div>
                   </div>
-                  
+
                   <div>
                     <Label htmlFor="password" className="text-sm font-medium text-gray-600">
                       Mật khẩu
@@ -175,24 +172,25 @@ export function LoginTemplate() {
                       />
                     </div>
                   </div>
-                  
-                  <Button 
-                    type="submit" 
+
+                  <Button
+                    type="submit"
                     className="w-full bg-[#5d9a9f] hover:bg-[#4a7c82] py-3 font-bold transition-colors duration-300"
                   >
                     Đăng nhập (Demo)
                   </Button>
                 </form>
-                
+
                 <div className="text-center mt-6">
                   <span className="text-sm text-gray-500">English</span>
                 </div>
               </CardContent>
             </Card>
-            
+
             <div className="text-center mt-6">
               <p className="text-sm text-gray-500">
-                Cần hỗ trợ? <span className="font-medium text-[#0079FF]">Liên hệ quản trị viên</span>
+                Cần hỗ trợ?{" "}
+                <span className="font-medium text-[#0079FF]">Liên hệ quản trị viên</span>
               </p>
             </div>
           </div>

--- a/src/components/qr-action-sheet-config.tsx
+++ b/src/components/qr-action-sheet-config.tsx
@@ -2,14 +2,11 @@ import type { ComponentType } from "react"
 import { ClipboardList, Eye, History, Settings, Wrench } from "lucide-react"
 
 export type QRActionKey =
-  | "usage-log"
-  | "view-details"
-  | "view-history"
-  | "create-repair"
-  | "update-status"
+  "usage-log" | "view-details" | "view-history" | "create-repair" | "update-status"
 
 export type QRErrorType = "not_found" | "access_denied" | "network" | "server_error" | null
 
+/** QR action sheet options shown after scanning a device code. */
 export const QR_ACTION_ITEMS = [
   {
     action: "usage-log",
@@ -72,6 +69,12 @@ export const QR_ACTION_ITEMS = [
   descriptionClassName: string
 }>
 
+const VIETNAMESE_CURRENCY_FORMATTER = new Intl.NumberFormat("vi-VN", {
+  style: "currency",
+  currency: "VND",
+})
+
+/** Returns the status badge color classes for a device status label. */
 export function getStatusColor(status: string | null) {
   switch (status) {
     case "Hoạt động":
@@ -91,9 +94,7 @@ export function getStatusColor(status: string | null) {
   }
 }
 
+/** Formats a numeric amount as Vietnamese dong. */
 export function formatCurrency(amount: number) {
-  return new Intl.NumberFormat("vi-VN", {
-    style: "currency",
-    currency: "VND",
-  }).format(amount)
+  return VIETNAMESE_CURRENCY_FORMATTER.format(amount)
 }

--- a/src/contexts/__tests__/realtime-context.invalidation.test.tsx
+++ b/src/contexts/__tests__/realtime-context.invalidation.test.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import { act, render } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { repairKeys } from '@/hooks/use-cached-repair'
+import * as React from "react"
+import { act, render } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { repairKeys } from "@/hooks/use-cached-repair"
 
 type RealtimeCallback = (payload: {
   table: string
-  eventType: 'INSERT' | 'UPDATE' | 'DELETE'
+  eventType: "INSERT" | "UPDATE" | "DELETE"
   new: Record<string, unknown>
   old: Record<string, unknown>
 }) => void
@@ -17,21 +17,24 @@ const mockRealtime = vi.hoisted(() => {
   let subscribeCallback: ((status: string) => void) | undefined
   const channel = {
     on: vi.fn((event: string, filter: { table?: string }, callback: RealtimeCallback) => {
-      if (event === 'postgres_changes' && filter.table) {
+      if (event === "postgres_changes" && filter.table) {
         postgresCallbacks.set(filter.table, callback)
       }
-      if (event === 'system') {
-        systemCallback = callback as unknown as (payload: { extension?: string; status?: string }) => void
+      if (event === "system") {
+        systemCallback = callback as unknown as (payload: {
+          extension?: string
+          status?: string
+        }) => void
       }
       return channel
     }),
     subscribe: vi.fn((callback: (status: string) => void) => {
       subscribeCallback = callback
-      callback('SUBSCRIBED')
+      callback("SUBSCRIBED")
       return channel
     }),
   }
-  const removeChannel = vi.fn(() => Promise.resolve('ok'))
+  const removeChannel = vi.fn(() => Promise.resolve("ok"))
 
   return {
     postgresCallbacks,
@@ -42,18 +45,18 @@ const mockRealtime = vi.hoisted(() => {
   }
 })
 
-vi.mock('@/lib/supabase', () => ({
+vi.mock("@/lib/supabase", () => ({
   supabase: {
     channel: vi.fn(() => mockRealtime.channel),
     removeChannel: mockRealtime.removeChannel,
   },
 }))
 
-vi.mock('@/hooks/use-toast', () => ({
+vi.mock("@/hooks/use-toast", () => ({
   toast: vi.fn(),
 }))
 
-import { RealtimeProvider } from '../realtime-context'
+import { RealtimeProvider } from "../realtime-context"
 
 function renderWithQueryClient(queryClient: QueryClient) {
   return render(
@@ -65,7 +68,7 @@ function renderWithQueryClient(queryClient: QueryClient) {
   )
 }
 
-describe('RealtimeProvider invalidation', () => {
+describe("RealtimeProvider invalidation", () => {
   beforeEach(() => {
     vi.useFakeTimers()
     mockRealtime.postgresCallbacks.clear()
@@ -78,25 +81,25 @@ describe('RealtimeProvider invalidation', () => {
     vi.useRealTimers()
   })
 
-  it('invalidates repair and equipment-list queries when repair requests change', async () => {
+  it("invalidates repair and equipment-list queries when repair requests change", async () => {
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
         mutations: { retry: false },
       },
     })
-    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
-    const refetchSpy = vi.spyOn(queryClient, 'refetchQueries')
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    const refetchSpy = vi.spyOn(queryClient, "refetchQueries")
 
     const view = renderWithQueryClient(queryClient)
 
-    const callback = mockRealtime.postgresCallbacks.get('yeu_cau_sua_chua')
+    const callback = mockRealtime.postgresCallbacks.get("yeu_cau_sua_chua")
     expect(callback).toBeDefined()
 
     act(() => {
       callback?.({
-        table: 'yeu_cau_sua_chua',
-        eventType: 'UPDATE',
+        table: "yeu_cau_sua_chua",
+        eventType: "UPDATE",
         new: { id: 1 },
         old: { id: 1 },
       })
@@ -109,22 +112,63 @@ describe('RealtimeProvider invalidation', () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: repairKeys.all,
-      refetchType: 'active',
+      refetchType: "active",
     })
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: ['equipment_list_enhanced'],
-      refetchType: 'active',
+      queryKey: ["equipment_list_enhanced"],
+      refetchType: "active",
     })
 
     expect(refetchSpy).toHaveBeenCalledWith({
-      queryKey: ['equipment_list_enhanced'],
-      type: 'active',
+      queryKey: ["equipment_list_enhanced"],
+      type: "active",
     })
 
     view.unmount()
   })
 
-  it('deduplicates reconnect timers and clears them when the channel recovers', async () => {
+  it("handles refetch failures after invalidation", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    const refetchError = new Error("refetch failed")
+    vi.spyOn(queryClient, "invalidateQueries")
+    vi.spyOn(queryClient, "refetchQueries").mockRejectedValueOnce(refetchError)
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const view = renderWithQueryClient(queryClient)
+
+    const callback = mockRealtime.postgresCallbacks.get("nhat_ky_su_dung")
+    expect(callback).toBeDefined()
+
+    act(() => {
+      callback?.({
+        table: "nhat_ky_su_dung",
+        eventType: "UPDATE",
+        new: { id: 1 },
+        old: { id: 1 },
+      })
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(150)
+      await Promise.resolve()
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Realtime] Failed to invalidate and refetch queries for:",
+      ["usage-analytics"],
+      refetchError
+    )
+
+    warnSpy.mockRestore()
+    view.unmount()
+  })
+
+  it("deduplicates reconnect timers and clears them when the channel recovers", async () => {
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: { retry: false },
@@ -139,15 +183,15 @@ describe('RealtimeProvider invalidation', () => {
     expect(subscribeCallback).toBeDefined()
 
     act(() => {
-      systemCallback?.({ extension: 'postgres_changes', status: 'error' })
-      systemCallback?.({ extension: 'postgres_changes', status: 'error' })
-      subscribeCallback?.('CHANNEL_ERROR')
+      systemCallback?.({ extension: "postgres_changes", status: "error" })
+      systemCallback?.({ extension: "postgres_changes", status: "error" })
+      subscribeCallback?.("CHANNEL_ERROR")
     })
 
     expect(vi.getTimerCount()).toBe(1)
 
     act(() => {
-      systemCallback?.({ extension: 'postgres_changes', status: 'ok' })
+      systemCallback?.({ extension: "postgres_changes", status: "ok" })
     })
 
     expect(vi.getTimerCount()).toBe(0)

--- a/src/contexts/realtime-context.tsx
+++ b/src/contexts/realtime-context.tsx
@@ -98,21 +98,26 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
       const timeout = setTimeout(async () => {
         realtimeLog(`[Realtime] Invalidating and refetching queries for:`, queryKey)
 
-        // Invalidate and force refetch
-        await queryClient.invalidateQueries({
-          queryKey,
-          refetchType: "active", // Only refetch active queries
-        })
+        try {
+          // Invalidate and force refetch
+          await queryClient.invalidateQueries({
+            queryKey,
+            refetchType: "active", // Only refetch active queries
+          })
 
-        // Also trigger refetch for good measure
-        queryClient.refetchQueries({
-          queryKey,
-          type: "active",
-        })
+          // Also trigger refetch for good measure
+          await queryClient.refetchQueries({
+            queryKey,
+            type: "active",
+          })
 
-        invalidationTimeouts.delete(key)
-        setLastUpdate(new Date())
-        realtimeLog(`[Realtime] Cache invalidated and refetched successfully for:`, queryKey)
+          invalidationTimeouts.delete(key)
+          setLastUpdate(new Date())
+          realtimeLog(`[Realtime] Cache invalidated and refetched successfully for:`, queryKey)
+        } catch (error) {
+          invalidationTimeouts.delete(key)
+          realtimeWarn(`[Realtime] Failed to invalidate and refetch queries for:`, queryKey, error)
+        }
       }, delay)
 
       invalidationTimeouts.set(key, timeout)

--- a/src/contexts/realtime-context.tsx
+++ b/src/contexts/realtime-context.tsx
@@ -1,29 +1,35 @@
 "use client"
 
-import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
-import { supabase } from '@/lib/supabase'
-import { toast } from '@/hooks/use-toast'
-import { equipmentKeys } from '@/hooks/use-cached-equipment'
-import { repairKeys } from '@/hooks/use-cached-repair'
-import { maintenanceKeys } from '@/hooks/use-cached-maintenance'
-import { dashboardStatsKeys } from '@/hooks/use-dashboard-stats'
-import type { RealtimeChannel, RealtimePostgresChangesPayload } from '@supabase/supabase-js'
+import React, { createContext, useContext, useEffect, useRef, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { supabase } from "@/lib/supabase"
+import { toast } from "@/hooks/use-toast"
+import { equipmentKeys } from "@/hooks/use-cached-equipment"
+import { repairKeys } from "@/hooks/use-cached-repair"
+import { maintenanceKeys } from "@/hooks/use-cached-maintenance"
+import { dashboardStatsKeys } from "@/hooks/use-dashboard-stats"
+import type { RealtimeChannel, RealtimePostgresChangesPayload } from "@supabase/supabase-js"
 
 // Types for realtime events
-type DatabaseEvent = 'INSERT' | 'UPDATE' | 'DELETE'
-type TableName = 'thiet_bi' | 'yeu_cau_sua_chua' | 'ke_hoach_bao_tri' | 'nhat_ky_su_dung' | 'yeu_cau_luan_chuyen' | 'cong_viec_bao_tri'
+type DatabaseEvent = "INSERT" | "UPDATE" | "DELETE"
+type TableName =
+  | "thiet_bi"
+  | "yeu_cau_sua_chua"
+  | "ke_hoach_bao_tri"
+  | "nhat_ky_su_dung"
+  | "yeu_cau_luan_chuyen"
+  | "cong_viec_bao_tri"
 
 interface RealtimeContextType {
   isConnected: boolean
-  connectionStatus: 'connecting' | 'connected' | 'disconnected' | 'error'
+  connectionStatus: "connecting" | "connected" | "disconnected" | "error"
   lastUpdate: Date | null
   reconnect: () => void
 }
 
 const RealtimeContext = createContext<RealtimeContextType | undefined>(undefined)
 
-const isRealtimeDebugEnabled = process.env.NODE_ENV !== 'production'
+const isRealtimeDebugEnabled = process.env.NODE_ENV !== "production"
 
 function realtimeLog(...args: unknown[]) {
   if (isRealtimeDebugEnabled) {
@@ -48,7 +54,7 @@ function clearReconnectTimeout(reconnectTimeoutRef: React.MutableRefObject<NodeJ
 export function useRealtime() {
   const context = useContext(RealtimeContext)
   if (context === undefined) {
-    throw new Error('useRealtime must be used within a RealtimeProvider')
+    throw new Error("useRealtime must be used within a RealtimeProvider")
   }
   return context
 }
@@ -61,7 +67,9 @@ interface RealtimeProviderProps {
 export function RealtimeProvider({ children }: RealtimeProviderProps) {
   const queryClient = useQueryClient()
   const [isConnected, setIsConnected] = useState(false)
-  const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'disconnected' | 'error'>('disconnected')
+  const [connectionStatus, setConnectionStatus] = useState<
+    "connecting" | "connected" | "disconnected" | "error"
+  >("disconnected")
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
   const channelRef = useRef<RealtimeChannel | null>(null)
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
@@ -69,122 +77,132 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
   const maxReconnectAttempts = 5
 
   // Debounce cache invalidation to prevent excessive re-renders
-  const invalidationTimeouts = useRef<Map<string, NodeJS.Timeout>>(new Map())
+  const invalidationTimeoutsRef = useRef<Map<string, NodeJS.Timeout> | null>(null)
+  if (invalidationTimeoutsRef.current === null) {
+    invalidationTimeoutsRef.current = new Map()
+  }
+  const invalidationTimeouts = invalidationTimeoutsRef.current
   const scheduleReconnectRef = useRef<() => void>(() => {})
 
-  const debouncedInvalidate = React.useCallback((queryKey: readonly string[], delay = 100) => {
-    const key = queryKey.join('-')
-    
-    // Clear existing timeout for this query key
-    const existingTimeout = invalidationTimeouts.current.get(key)
-    if (existingTimeout) {
-      clearTimeout(existingTimeout)
-    }
+  const debouncedInvalidate = React.useCallback(
+    (queryKey: readonly string[], delay = 100) => {
+      const key = queryKey.join("-")
 
-    // Set new timeout
-    const timeout = setTimeout(async () => {
-      realtimeLog(`[Realtime] Invalidating and refetching queries for:`, queryKey)
+      // Clear existing timeout for this query key
+      const existingTimeout = invalidationTimeouts.get(key)
+      if (existingTimeout) {
+        clearTimeout(existingTimeout)
+      }
 
-      // Invalidate and force refetch
-      await queryClient.invalidateQueries({
-        queryKey,
-        refetchType: 'active' // Only refetch active queries
-      })
+      // Set new timeout
+      const timeout = setTimeout(async () => {
+        realtimeLog(`[Realtime] Invalidating and refetching queries for:`, queryKey)
 
-      // Also trigger refetch for good measure
-      queryClient.refetchQueries({
-        queryKey,
-        type: 'active'
-      })
+        // Invalidate and force refetch
+        await queryClient.invalidateQueries({
+          queryKey,
+          refetchType: "active", // Only refetch active queries
+        })
 
-      invalidationTimeouts.current.delete(key)
-      setLastUpdate(new Date())
-      realtimeLog(`[Realtime] Cache invalidated and refetched successfully for:`, queryKey)
-    }, delay)
+        // Also trigger refetch for good measure
+        queryClient.refetchQueries({
+          queryKey,
+          type: "active",
+        })
 
-    invalidationTimeouts.current.set(key, timeout)
-  }, [queryClient])
+        invalidationTimeouts.delete(key)
+        setLastUpdate(new Date())
+        realtimeLog(`[Realtime] Cache invalidated and refetched successfully for:`, queryKey)
+      }, delay)
+
+      invalidationTimeouts.set(key, timeout)
+    },
+    [invalidationTimeouts, queryClient]
+  )
 
   // Handle database changes
-  const handleDatabaseChange = React.useCallback((payload: RealtimePostgresChangesPayload<Record<string, unknown>>) => {
-    const { table, eventType } = payload
-    
-    realtimeLog(`[Realtime] ${eventType} on ${table}`)
+  const handleDatabaseChange = React.useCallback(
+    (payload: RealtimePostgresChangesPayload<Record<string, unknown>>) => {
+      const { table, eventType } = payload
 
-    // Invalidate relevant caches based on table and event type
-    switch (table as TableName) {
-      case 'thiet_bi':
-        // Equipment changes affect multiple areas
-        // Use proper query keys from hooks
-        debouncedInvalidate(['equipment']) // ['equipment'] - invalidates all equipment queries
-        debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats'] - invalidates dashboard
-        debouncedInvalidate(['reports'])
-        debouncedInvalidate(['equipment-distribution'])
-        break
+      realtimeLog(`[Realtime] ${eventType} on ${table}`)
 
-      case 'yeu_cau_sua_chua':
-        // Repair request changes also affect equipment_list_enhanced.active_repair_request_id.
-        debouncedInvalidate(repairKeys.all) // ['repair'] - invalidates all repair queries
-        debouncedInvalidate(['equipment_list_enhanced'])
-        debouncedInvalidate(['equipment'])
-        debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats']
-        debouncedInvalidate(['reports'])
-        break
+      // Invalidate relevant caches based on table and event type
+      switch (table as TableName) {
+        case "thiet_bi":
+          // Equipment changes affect multiple areas
+          // Use proper query keys from hooks
+          debouncedInvalidate(["equipment"]) // ['equipment'] - invalidates all equipment queries
+          debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats'] - invalidates dashboard
+          debouncedInvalidate(["reports"])
+          debouncedInvalidate(["equipment-distribution"])
+          break
 
-      case 'ke_hoach_bao_tri':
-        // Maintenance plan changes
-        debouncedInvalidate(maintenanceKeys.all) // ['maintenance'] - invalidates all maintenance queries
-        debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats']
-        debouncedInvalidate(['calendar-events'])
-        break
+        case "yeu_cau_sua_chua":
+          // Repair request changes also affect equipment_list_enhanced.active_repair_request_id.
+          debouncedInvalidate(repairKeys.all) // ['repair'] - invalidates all repair queries
+          debouncedInvalidate(["equipment_list_enhanced"])
+          debouncedInvalidate(["equipment"])
+          debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats']
+          debouncedInvalidate(["reports"])
+          break
 
-      case 'nhat_ky_su_dung':
-        // Usage log changes
-        debouncedInvalidate(['usage-analytics'])
-        debouncedInvalidate(['equipment'])
-        break
+        case "ke_hoach_bao_tri":
+          // Maintenance plan changes
+          debouncedInvalidate(maintenanceKeys.all) // ['maintenance'] - invalidates all maintenance queries
+          debouncedInvalidate(dashboardStatsKeys.all) // ['dashboard-stats']
+          debouncedInvalidate(["calendar-events"])
+          break
 
-      case 'yeu_cau_luan_chuyen':
-        // Transfer request changes - invalidate both Kanban and Table views
-        debouncedInvalidate(['transfers-kanban'])    // Kanban board view
-        debouncedInvalidate(['transfers-data-grid']) // Table/list view  
-        debouncedInvalidate(['transfers'])           // Legacy (useTransferRequestsRealtime)
-        debouncedInvalidate(['equipment'])
-        debouncedInvalidate(['reports'])
-        break
+        case "nhat_ky_su_dung":
+          // Usage log changes
+          debouncedInvalidate(["usage-analytics"])
+          debouncedInvalidate(["equipment"])
+          break
 
-      case 'cong_viec_bao_tri':
-        // Maintenance task changes
-        debouncedInvalidate(['maintenance']) // maintenance queries
-        debouncedInvalidate(['dashboard-stats'])
-        debouncedInvalidate(['calendar-events'])
-        break
+        case "yeu_cau_luan_chuyen":
+          // Transfer request changes - invalidate both Kanban and Table views
+          debouncedInvalidate(["transfers-kanban"]) // Kanban board view
+          debouncedInvalidate(["transfers-data-grid"]) // Table/list view
+          debouncedInvalidate(["transfers"]) // Legacy (useTransferRequestsRealtime)
+          debouncedInvalidate(["equipment"])
+          debouncedInvalidate(["reports"])
+          break
 
-      default:
-        realtimeWarn(`[Realtime] Unhandled table: ${table}`)
-    }
+        case "cong_viec_bao_tri":
+          // Maintenance task changes
+          debouncedInvalidate(["maintenance"]) // maintenance queries
+          debouncedInvalidate(["dashboard-stats"])
+          debouncedInvalidate(["calendar-events"])
+          break
 
-    // Show toast notification for important changes (optional)
-    if (eventType === 'INSERT') {
-      const messages = {
-        'thiet_bi': 'Thiết bị mới đã được thêm',
-        'yeu_cau_sua_chua': 'Yêu cầu sửa chữa mới',
-        'ke_hoach_bao_tri': 'Kế hoạch bảo trì mới',
-        'cong_viec_bao_tri': 'Công việc bảo trì mới',
-        'yeu_cau_luan_chuyen': 'Yêu cầu luân chuyển mới',
-        'nhat_ky_su_dung': 'Nhật ký sử dụng mới'
+        default:
+          realtimeWarn(`[Realtime] Unhandled table: ${table}`)
       }
-      
-      const message = messages[table as TableName]
-      if (message) {
-        toast({
-          title: "Cập nhật dữ liệu",
-          description: message,
-          duration: 3000,
-        })
+
+      // Show toast notification for important changes (optional)
+      if (eventType === "INSERT") {
+        const messages = {
+          thiet_bi: "Thiết bị mới đã được thêm",
+          yeu_cau_sua_chua: "Yêu cầu sửa chữa mới",
+          ke_hoach_bao_tri: "Kế hoạch bảo trì mới",
+          cong_viec_bao_tri: "Công việc bảo trì mới",
+          yeu_cau_luan_chuyen: "Yêu cầu luân chuyển mới",
+          nhat_ky_su_dung: "Nhật ký sử dụng mới",
+        }
+
+        const message = messages[table as TableName]
+        if (message) {
+          toast({
+            title: "Cập nhật dữ liệu",
+            description: message,
+            duration: 3000,
+          })
+        }
       }
-    }
-  }, [debouncedInvalidate])
+    },
+    [debouncedInvalidate]
+  )
 
   // Cleanup function
   const cleanup = React.useCallback(async () => {
@@ -194,72 +212,72 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
       try {
         await supabase?.removeChannel(channel)
       } catch (error) {
-        console.error('[Realtime] Failed to remove channel:', error)
+        console.error("[Realtime] Failed to remove channel:", error)
       }
     }
 
     clearReconnectTimeout(reconnectTimeoutRef)
 
     // Clear all pending invalidation timeouts
-    invalidationTimeouts.current.forEach(timeout => clearTimeout(timeout))
-    invalidationTimeouts.current.clear()
+    invalidationTimeouts.forEach((timeout) => clearTimeout(timeout))
+    invalidationTimeouts.clear()
 
     setIsConnected(false)
-    setConnectionStatus('disconnected')
-  }, [])
+    setConnectionStatus("disconnected")
+  }, [invalidationTimeouts])
 
   // Setup realtime subscription
   const setupRealtimeSubscription = React.useCallback(() => {
     if (!supabase) {
-      console.error('[Realtime] Supabase client not available')
-      setConnectionStatus('error')
+      console.error("[Realtime] Supabase client not available")
+      setConnectionStatus("error")
       return
     }
 
-    setConnectionStatus('connecting')
-    
+    setConnectionStatus("connecting")
+
     // Create a single channel for all table subscriptions
-    const channel = supabase.channel('app-realtime-sync')
+    const channel = supabase.channel("app-realtime-sync")
 
     // Subscribe to tables that have Publications enabled
     const tables: TableName[] = [
-      'thiet_bi',
-      'yeu_cau_sua_chua',
-      'ke_hoach_bao_tri',
-      'nhat_ky_su_dung',
-      'yeu_cau_luan_chuyen',
-      'cong_viec_bao_tri'
+      "thiet_bi",
+      "yeu_cau_sua_chua",
+      "ke_hoach_bao_tri",
+      "nhat_ky_su_dung",
+      "yeu_cau_luan_chuyen",
+      "cong_viec_bao_tri",
     ]
 
-    tables.forEach(table => {
+    tables.forEach((table) => {
       channel.on(
-        'postgres_changes',
+        "postgres_changes",
         {
-          event: '*', // Listen to all events (INSERT, UPDATE, DELETE)
-          schema: 'public',
-          table: table
+          event: "*", // Listen to all events (INSERT, UPDATE, DELETE)
+          schema: "public",
+          table: table,
         },
         handleDatabaseChange
       )
     })
 
     // Handle connection status
-    channel.on('system', {}, (payload) => {
-      realtimeLog('[Realtime] System event:', payload)
-      
-      if (payload.extension === 'postgres_changes') {
+    channel.on("system", {}, (payload) => {
+      realtimeLog("[Realtime] System event:", payload)
+
+      if (payload.extension === "postgres_changes") {
         switch (payload.status) {
-          case 'ok':
+          case "ok":
             clearReconnectTimeout(reconnectTimeoutRef)
             setIsConnected(true)
-            setConnectionStatus('connected')
+            setConnectionStatus("connected")
             reconnectAttemptsRef.current = 0
-            realtimeLog('[Realtime] Connected successfully')
+            realtimeLog("[Realtime] Connected successfully")
             break
-          case 'error':
+          case "error":
             setIsConnected(false)
-            setConnectionStatus('error')
-            console.error('[Realtime] Connection error:', payload)
+            setConnectionStatus("error")
+            console.error("[Realtime] Connection error:", payload)
             scheduleReconnectRef.current()
             break
         }
@@ -268,16 +286,16 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
 
     // Subscribe to the channel
     channel.subscribe((status) => {
-      realtimeLog('[Realtime] Subscription status:', status)
-      
-      if (status === 'SUBSCRIBED') {
+      realtimeLog("[Realtime] Subscription status:", status)
+
+      if (status === "SUBSCRIBED") {
         clearReconnectTimeout(reconnectTimeoutRef)
         setIsConnected(true)
-        setConnectionStatus('connected')
+        setConnectionStatus("connected")
         reconnectAttemptsRef.current = 0
-      } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+      } else if (status === "CHANNEL_ERROR" || status === "TIMED_OUT") {
         setIsConnected(false)
-        setConnectionStatus('error')
+        setConnectionStatus("error")
         scheduleReconnectRef.current()
       }
     })
@@ -292,19 +310,21 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
     }
 
     if (reconnectAttemptsRef.current >= maxReconnectAttempts) {
-      console.error('[Realtime] Max reconnection attempts reached')
-      setConnectionStatus('error')
+      console.error("[Realtime] Max reconnection attempts reached")
+      setConnectionStatus("error")
       return
     }
 
     const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 30000) // Max 30 seconds
     reconnectAttemptsRef.current++
 
-    realtimeLog(`[Realtime] Scheduling reconnect attempt ${reconnectAttemptsRef.current} in ${delay}ms`)
+    realtimeLog(
+      `[Realtime] Scheduling reconnect attempt ${reconnectAttemptsRef.current} in ${delay}ms`
+    )
 
     reconnectTimeoutRef.current = setTimeout(async () => {
       reconnectTimeoutRef.current = null
-      realtimeLog('[Realtime] Attempting to reconnect...')
+      realtimeLog("[Realtime] Attempting to reconnect...")
       await cleanup()
       setupRealtimeSubscription()
     }, delay)
@@ -312,7 +332,7 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
 
   // Manual reconnect function
   const reconnect = React.useCallback(() => {
-    realtimeLog('[Realtime] Manual reconnect triggered')
+    realtimeLog("[Realtime] Manual reconnect triggered")
     reconnectAttemptsRef.current = 0
     void (async () => {
       await cleanup()
@@ -330,33 +350,29 @@ export function RealtimeProvider({ children }: RealtimeProviderProps) {
 
     // Cleanup on unmount
     return () => {
-      cleanup().catch(error => realtimeWarn('[Realtime] Cleanup failed:', error))
+      cleanup().catch((error) => realtimeWarn("[Realtime] Cleanup failed:", error))
     }
   }, [cleanup, setupRealtimeSubscription])
 
   // Handle page visibility changes
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible' && !isConnected) {
-        realtimeLog('[Realtime] Page became visible, attempting to reconnect')
+      if (document.visibilityState === "visible" && !isConnected) {
+        realtimeLog("[Realtime] Page became visible, attempting to reconnect")
         reconnect()
       }
     }
 
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange)
   }, [isConnected, reconnect])
 
   const value: RealtimeContextType = {
     isConnected,
     connectionStatus,
     lastUpdate,
-    reconnect
+    reconnect,
   }
 
-  return (
-    <RealtimeContext.Provider value={value}>
-      {children}
-    </RealtimeContext.Provider>
-  )
+  return <RealtimeContext.Provider value={value}>{children}</RealtimeContext.Provider>
 }


### PR DESCRIPTION
## Summary
- Hoist low-risk module-scope constants/helpers for React Doctor Rank 2 target rules.
- Lazily initialize `Map` refs, hoist the static Vietnamese currency formatter, and clear the form-branding static-value findings.
- Update `docs/review/2026-07-06-react-doctor-full-scan-triage.md` with final compact-batch deltas and deferred pure-function findings.

## Target Rule Delta
- `prefer-module-scope-pure-function`: `19 -> 15`
- `prefer-module-scope-static-value`: `6 -> 0`
- `rerender-lazy-ref-init`: `2 -> 0`
- `js-hoist-intl`: `1 -> 0`

## Verification
- [x] Changed-file Prettier check
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run verify:ts-docstrings`
- [x] `node scripts/npm-run.js run typecheck`
- [x] Focused Vitest: 10 files, 71 tests passed before the form-branding follow-up
- [x] React Doctor full JSON summary for the four Rank 2 rules
- [x] Pre-push Lefthook: typecheck, dedupe, no-explicit-any, Python docstrings skipped, TS docstrings

## Notes
- React Doctor changed-scope still reports 2 out-of-scope warnings in touched files: existing Recharts eager import in `login-template` and existing React 19 API migration warning in `realtime-context`.
- Remaining target-rule findings are 15 `prefer-module-scope-pure-function` warnings deferred to future focused batches.
