### PR TITLE
feat: migrate shared SearchInput to HeroUI

### DIFF
--- a/scripts/__tests__/check-heroui-import-boundary.test.ts
+++ b/scripts/__tests__/check-heroui-import-boundary.test.ts
@@ -14,6 +14,10 @@ describe("check-heroui-import-boundary", () => {
         content: 'import { Dropdown } from "@heroui/react"\n',
       },
       {
+        path: "src/components/shared/SearchInput.tsx",
+        content: 'import { Input } from "@heroui/react/input"\n',
+      },
+      {
         path: "src/components/equipment/equipment-toolbar.tsx",
         content: 'import { Button } from "@heroui/react"\n',
       },

--- a/scripts/check-heroui-import-boundary.js
+++ b/scripts/check-heroui-import-boundary.js
@@ -10,6 +10,7 @@ const ALLOWED_BOUNDARY_PREFIXES = [
   "src/components/equipment/heroui-pilot/",
   "src/components/shared/floating-actions/",
 ]
+const ALLOWED_BOUNDARY_FILES = ["src/components/shared/SearchInput.tsx"]
 
 function normalizePath(filePath) {
   return filePath.split(path.sep).join("/")
@@ -22,7 +23,10 @@ function isScannableSourceFile(filePath) {
 
 function isAllowedBoundaryFile(filePath) {
   const normalizedPath = normalizePath(filePath)
-  return ALLOWED_BOUNDARY_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix))
+  return (
+    ALLOWED_BOUNDARY_FILES.includes(normalizedPath) ||
+    ALLOWED_BOUNDARY_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix))
+  )
 }
 
 function getHeroUIImportPath(line) {
@@ -113,7 +117,7 @@ function scanFiles(filePaths) {
 }
 
 function formatViolations(violations) {
-  const allowedBoundaryList = ALLOWED_BOUNDARY_PREFIXES.join(", ")
+  const allowedBoundaryList = [...ALLOWED_BOUNDARY_PREFIXES, ...ALLOWED_BOUNDARY_FILES].join(", ")
 
   return violations
     .map(
@@ -146,6 +150,7 @@ function main() {
 }
 
 module.exports = {
+  ALLOWED_BOUNDARY_FILES,
   ALLOWED_BOUNDARY_PREFIXES,
   collectChangedSourceFiles,
   findHeroUIImportViolations,

--- a/src/components/shared/SearchInput.tsx
+++ b/src/components/shared/SearchInput.tsx
@@ -16,8 +16,8 @@
 "use client"
 
 import * as React from "react"
+import { Input as HeroInput } from "@heroui/react/input"
 import { Search, X } from "lucide-react"
-import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
 export interface SearchInputProps extends Omit<React.ComponentProps<"input">, "onChange" | "type"> {
@@ -29,6 +29,7 @@ export interface SearchInputProps extends Omit<React.ComponentProps<"input">, "o
   endAddon?: React.ReactNode
 }
 
+/** Shared controlled search input with optional search icon, clear action, and end addon. */
 export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
   (
     {
@@ -97,7 +98,7 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
         ) : null}
 
         {/* Input field */}
-        <Input
+        <HeroInput
           ref={inputRef}
           type="search"
           value={value}

--- a/src/components/shared/__tests__/SearchInput.test.tsx
+++ b/src/components/shared/__tests__/SearchInput.test.tsx
@@ -1,0 +1,115 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { SearchInput } from "../SearchInput"
+
+describe("SearchInput", () => {
+  it("preserves the controlled search input contract", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <SearchInput
+        aria-label="Tìm kiếm thiết bị"
+        value=""
+        onChange={onChange}
+        placeholder="Nhập từ khóa"
+      />
+    )
+
+    const input = screen.getByRole("searchbox", { name: "Tìm kiếm thiết bị" })
+
+    expect(input).toHaveAttribute("type", "search")
+    expect(input).toHaveAttribute("placeholder", "Nhập từ khóa")
+
+    await user.type(input, "abc")
+
+    expect(onChange).toHaveBeenCalledWith("a")
+    expect(onChange).toHaveBeenCalledWith("b")
+    expect(onChange).toHaveBeenCalledWith("c")
+  })
+
+  it("forwards refs and disabled state to the input element", () => {
+    const ref = React.createRef<HTMLInputElement>()
+
+    render(<SearchInput ref={ref} aria-label="Tìm kiếm" value="" onChange={vi.fn()} disabled />)
+
+    const input = screen.getByRole("searchbox", { name: "Tìm kiếm" })
+
+    expect(ref.current).toBe(input)
+    expect(input).toBeDisabled()
+  })
+
+  it("clears with the clear button, calls onClear, and refocuses the input", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const onClear = vi.fn()
+
+    render(<SearchInput aria-label="Tìm kiếm" value="abc" onChange={onChange} onClear={onClear} />)
+
+    const input = screen.getByRole("searchbox", { name: "Tìm kiếm" })
+    await user.click(screen.getByRole("button", { name: "Xóa tìm kiếm" }))
+
+    expect(onChange).toHaveBeenCalledWith("")
+    expect(onClear).toHaveBeenCalledTimes(1)
+    expect(input).toHaveFocus()
+  })
+
+  it("clears with Escape only when a value exists", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const onClear = vi.fn()
+
+    const { rerender } = render(
+      <SearchInput aria-label="Tìm kiếm" value="abc" onChange={onChange} onClear={onClear} />
+    )
+
+    await user.click(screen.getByRole("searchbox", { name: "Tìm kiếm" }))
+    await user.keyboard("{Escape}")
+
+    expect(onChange).toHaveBeenCalledWith("")
+    expect(onClear).toHaveBeenCalledTimes(1)
+
+    onChange.mockClear()
+    onClear.mockClear()
+
+    rerender(<SearchInput aria-label="Tìm kiếm" value="" onChange={onChange} onClear={onClear} />)
+
+    await user.click(screen.getByRole("searchbox", { name: "Tìm kiếm" }))
+    await user.keyboard("{Escape}")
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onClear).not.toHaveBeenCalled()
+  })
+
+  it("supports icon, clear button, and end addon visibility controls", () => {
+    render(
+      <SearchInput
+        aria-label="Tìm kiếm"
+        value="abc"
+        onChange={vi.fn()}
+        showSearchIcon={false}
+        showClearButton={false}
+        endAddon={<span data-testid="search-addon">A</span>}
+      />
+    )
+
+    expect(screen.getByTestId("search-addon")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Xóa tìm kiếm" })).not.toBeInTheDocument()
+  })
+
+  it("uses HeroUI instead of the shadcn input backing", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/components/shared/SearchInput.tsx"),
+      "utf8"
+    )
+
+    expect(source).toContain("@heroui/react")
+    expect(source).not.toContain("@/components/ui/input")
+  })
+})


### PR DESCRIPTION
Closes #702

## Summary
- Replace shared `SearchInput` shadcn input backing with HeroUI v3 input primitive.
- Keep `@/components/shared/SearchInput` public API and behavior stable.
- Add focused SearchInput contract tests and a narrow HeroUI boundary allowlist for this shared component.

## TDD Evidence
- RED observed: `SearchInput.test.tsx` failed on missing `@heroui/react` backing while behavior tests passed.
- GREEN: focused `SearchInput` tests pass after implementation.

## Verification
- Changed-files Prettier check: PASS
- `verify:ts-docstrings`: PASS
- `verify:no-explicit-any`: PASS
- `verify:dedupe`: PASS
- `typecheck`: PASS
- Focused tests: PASS, 4 files / 30 tests
  - `src/components/shared/__tests__/SearchInput.test.tsx`
  - `src/components/shared/__tests__/ListFilterSearchCard.test.tsx`
  - `src/components/__tests__/add-tasks-dialog.filters-and-pagination.test.tsx`
  - `scripts/__tests__/check-heroui-import-boundary.test.ts`
- `verify:heroui-boundary`: PASS
- `react-doctor`: PASS, no issues found

## Note
Full repo `format:check` currently fails on unrelated baseline Prettier noise in many existing files, so this PR used changed-files Prettier verification and Lefthook staged formatting.

## Scope Held
- No page-level HeroUI filter/search forks.
- No debounce added to `SearchInput`.
- #703 and #704 remain separate child issues.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the shared SearchInput to HeroUI v3 while keeping its public API and behavior unchanged. Addresses #702 with a targeted allowlist entry for this file in the HeroUI import boundary.

- **Refactors**
  - Replaced shadcn `Input` with `HeroInput` from `@heroui/react/input` in `src/components/shared/SearchInput.tsx`.
  - Added contract tests to verify controlled input behavior, clear action, ref forwarding, and HeroUI backing.
  - Updated `check-heroui-import-boundary` to allow HeroUI imports only from this shared file.

<sup>Written for commit dd2be50e3ed1eb7b0487622ecf3ad74bae601761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared search input with improved clear, keyboard, and focus behavior.
  * Search input now supports optional search icon, clear button, and addon content.

* **Bug Fixes**
  * Updated the app to allow this search input to work within the approved UI boundary, preventing it from being flagged incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->