### PR TITLE
feat: migrate ListFilterSearchCard to HeroUI

### DIFF
--- a/scripts/__tests__/check-heroui-import-boundary.test.ts
+++ b/scripts/__tests__/check-heroui-import-boundary.test.ts
@@ -18,6 +18,10 @@ describe("check-heroui-import-boundary", () => {
         content: 'import { Input } from "@heroui/react/input"\n',
       },
       {
+        path: "src/components/shared/ListFilterSearchCard.tsx",
+        content: 'import { Card } from "@heroui/react"\n',
+      },
+      {
         path: "src/components/equipment/equipment-toolbar.tsx",
         content: 'import { Button } from "@heroui/react"\n',
       },

--- a/scripts/check-heroui-import-boundary.js
+++ b/scripts/check-heroui-import-boundary.js
@@ -10,7 +10,10 @@ const ALLOWED_BOUNDARY_PREFIXES = [
   "src/components/equipment/heroui-pilot/",
   "src/components/shared/floating-actions/",
 ]
-const ALLOWED_BOUNDARY_FILES = ["src/components/shared/SearchInput.tsx"]
+const ALLOWED_BOUNDARY_FILES = [
+  "src/components/shared/SearchInput.tsx",
+  "src/components/shared/ListFilterSearchCard.tsx",
+]
 
 function normalizePath(filePath) {
   return filePath.split(path.sep).join("/")

--- a/src/components/shared/ListFilterSearchCard.tsx
+++ b/src/components/shared/ListFilterSearchCard.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import * as React from "react"
+import { Card as HeroCard } from "@heroui/react/card"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { SearchInput } from "@/components/shared/SearchInput"
 import { cn } from "@/lib/utils"
 
@@ -74,12 +74,12 @@ export function ListFilterSearchCard({
 
   const header =
     !title && !description ? null : surface === "card" ? (
-      <CardHeader className="gap-y-1 pb-3">
-        {title ? <CardTitle className="heading-responsive-h2">{title}</CardTitle> : null}
+      <HeroCard.Header className="gap-y-1 pb-3">
+        {title ? <HeroCard.Title className="heading-responsive-h2">{title}</HeroCard.Title> : null}
         {description ? (
-          <CardDescription className="body-responsive-sm">{description}</CardDescription>
+          <HeroCard.Description className="body-responsive-sm">{description}</HeroCard.Description>
         ) : null}
-      </CardHeader>
+      </HeroCard.Header>
     ) : (
       <div className="space-y-1 pb-3">
         {title ? <div className="heading-responsive-h2 font-semibold">{title}</div> : null}
@@ -150,9 +150,9 @@ export function ListFilterSearchCard({
   }
 
   return (
-    <Card className={className}>
+    <HeroCard className={className}>
       {header}
-      <CardContent className="px-4 pb-4 md:px-6">{content}</CardContent>
-    </Card>
+      <HeroCard.Content className="px-4 pb-4 md:px-6">{content}</HeroCard.Content>
+    </HeroCard>
   )
 }

--- a/src/components/shared/__tests__/ListFilterSearchCard.backing.test.tsx
+++ b/src/components/shared/__tests__/ListFilterSearchCard.backing.test.tsx
@@ -1,0 +1,60 @@
+import type { HTMLAttributes, ReactNode } from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+type MockElementProps = HTMLAttributes<HTMLElement> & {
+  children?: ReactNode
+}
+
+function createHeroCardMock(ReactRuntime: typeof import("react")) {
+  const createMockElement =
+    (tagName: "section" | "div" | "h3" | "p", testId: string) =>
+    ({ children, ...props }: MockElementProps) =>
+      ReactRuntime.createElement(tagName, { ...props, "data-testid": testId }, children)
+
+  return Object.assign(createMockElement("section", "heroui-card-root"), {
+    Header: createMockElement("div", "heroui-card-header"),
+    Title: createMockElement("h3", "heroui-card-title"),
+    Description: createMockElement("p", "heroui-card-description"),
+    Content: createMockElement("div", "heroui-card-content"),
+  })
+}
+
+vi.mock("@heroui/react/card", async () => {
+  const ReactRuntime = await import("react")
+
+  return { Card: createHeroCardMock(ReactRuntime) }
+})
+
+vi.mock("@heroui/react", async () => {
+  const ReactRuntime = await import("react")
+
+  return { Card: createHeroCardMock(ReactRuntime) }
+})
+
+import { ListFilterSearchCard } from "../ListFilterSearchCard"
+
+describe("ListFilterSearchCard HeroUI backing", () => {
+  it("renders the card surface through HeroUI card primitives", () => {
+    render(
+      <ListFilterSearchCard
+        title="Danh mục thiết bị"
+        description="Quản lý danh sách thiết bị."
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Tìm kiếm chung..."
+      />
+    )
+
+    expect(screen.getByTestId("heroui-card-root")).toBeInTheDocument()
+    expect(screen.getByTestId("heroui-card-header")).toHaveTextContent("Danh mục thiết bị")
+    expect(screen.getByTestId("heroui-card-title")).toHaveTextContent("Danh mục thiết bị")
+    expect(screen.getByTestId("heroui-card-description")).toHaveTextContent(
+      "Quản lý danh sách thiết bị."
+    )
+    expect(screen.getByTestId("heroui-card-content")).toContainElement(
+      screen.getByRole("searchbox", { name: "Tìm kiếm chung..." })
+    )
+  })
+})

--- a/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
+++ b/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs"
-import { join } from "node:path"
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { render, screen } from "@testing-library/react"
@@ -164,15 +162,5 @@ describe("ListFilterSearchCard", () => {
     )
 
     expect(screen.getByRole("searchbox", { name: "Chọn cơ sở để tìm kiếm..." })).toBeDisabled()
-  })
-
-  it("uses HeroUI instead of the shadcn card backing", () => {
-    const source = readFileSync(
-      join(process.cwd(), "src/components/shared/ListFilterSearchCard.tsx"),
-      "utf8"
-    )
-
-    expect(source).toContain("@heroui/react")
-    expect(source).not.toContain("@/components/ui/card")
   })
 })

--- a/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
+++ b/src/components/shared/__tests__/ListFilterSearchCard.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { render, screen } from "@testing-library/react"
@@ -70,6 +72,21 @@ describe("ListFilterSearchCard", () => {
 
     expect(screen.getByTestId("selection-actions")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Tùy chọn" })).toBeInTheDocument()
+  })
+
+  it("keeps optional addon and chip slots stable", () => {
+    render(
+      <ListFilterSearchCard
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Tìm kiếm chung..."
+        searchEndAddon={<button type="button">Quét mã</button>}
+        chips={<div data-testid="active-filter-chips">Đang lọc</div>}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Quét mã" })).toBeInTheDocument()
+    expect(screen.getByTestId("active-filter-chips")).toBeInTheDocument()
   })
 
   it("supports filter-only sections without rendering a search input", () => {
@@ -147,5 +164,15 @@ describe("ListFilterSearchCard", () => {
     )
 
     expect(screen.getByRole("searchbox", { name: "Chọn cơ sở để tìm kiếm..." })).toBeDisabled()
+  })
+
+  it("uses HeroUI instead of the shadcn card backing", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/components/shared/ListFilterSearchCard.tsx"),
+      "utf8"
+    )
+
+    expect(source).toContain("@heroui/react")
+    expect(source).not.toContain("@/components/ui/card")
   })
 })


### PR DESCRIPTION
Closes #703

## Summary
- Replace shared `ListFilterSearchCard` shadcn Card/CardHeader/CardTitle/CardDescription/CardContent backing with HeroUI v3 `Card` internals.
- Preserve the existing shared public API, slot contract, `surface="card"` / `surface="plain"`, and consumers.
- Extend focused contract tests for HeroUI backing plus stable addon/chip slots.
- Extend the HeroUI import boundary allowlist for this shared file only.

## TDD Evidence
- RED observed before implementation:
  - `ListFilterSearchCard.test.tsx` failed on missing HeroUI backing while preserved behavior tests passed.
  - `check-heroui-import-boundary.test.ts` failed because `ListFilterSearchCard.tsx` was not yet an approved HeroUI boundary file.
- GREEN after implementation:
  - `ListFilterSearchCard.test.tsx`: 11 passed.
  - `check-heroui-import-boundary.test.ts`: 4 passed.
  - `TransfersToolbar.test.tsx`: 4 passed with the real shared component.

## Verification
- Changed-files Prettier check: PASS
- `verify:no-explicit-any`: PASS
- `verify:dedupe`: PASS
- `typecheck`: PASS
- Focused tests: PASS, 3 files / 19 tests
- `verify:heroui-boundary`: PASS
- `react-doctor`: PASS, no issues found
- Pre-commit Lefthook: PASS
- Pre-push Lefthook: PASS

## Scope Held
- No consumer rewrites.
- No page-level HeroUI filter/search forks.
- No changes to `FacetedMultiSelectFilter` / #704.
- No revert of #702 to Radix/shadcn.

## Note
Full repo `format:check` still reports unrelated baseline Prettier warnings in docs/plans, so this PR uses changed-files Prettier verification plus Lefthook staged formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the shared `ListFilterSearchCard` to HeroUI v3 `Card`, preserving its API, slots, and visuals. Aligns with Linear #703 by standardizing on HeroUI and avoiding page-level forks.

- **Refactors**
  - Swapped shadcn `Card` internals for `@heroui/react/card` while keeping `surface="card" | "plain"` and slot contract intact.
  - Added resilient backing test that mocks `@heroui/react/card` and `@heroui/react` to verify HeroUI rendering; confirmed `searchEndAddon` and `chips` slots stay stable.
  - Updated the HeroUI import boundary allowlist to include `src/components/shared/ListFilterSearchCard.tsx` and adjusted the boundary test.

<sup>Written for commit eb9949975365e5d6fb83f0c7c742c525e14b5885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

