### PR TITLE
feat: migrate faceted filter to HeroUI

### DIFF
--- a/scripts/__tests__/check-heroui-import-boundary.test.ts
+++ b/scripts/__tests__/check-heroui-import-boundary.test.ts
@@ -22,6 +22,10 @@ describe("check-heroui-import-boundary", () => {
         content: 'import { Card } from "@heroui/react"\n',
       },
       {
+        path: "src/components/shared/table-filters/FacetedMultiSelectFilter.tsx",
+        content: 'import { Popover } from "@heroui/react/popover"\n',
+      },
+      {
         path: "src/components/equipment/equipment-toolbar.tsx",
         content: 'import { Button } from "@heroui/react"\n',
       },

--- a/scripts/check-heroui-import-boundary.js
+++ b/scripts/check-heroui-import-boundary.js
@@ -13,6 +13,7 @@ const ALLOWED_BOUNDARY_PREFIXES = [
 const ALLOWED_BOUNDARY_FILES = [
   "src/components/shared/SearchInput.tsx",
   "src/components/shared/ListFilterSearchCard.tsx",
+  "src/components/shared/table-filters/FacetedMultiSelectFilter.tsx",
 ]
 
 function normalizePath(filePath) {

--- a/src/components/shared/SearchInput.tsx
+++ b/src/components/shared/SearchInput.tsx
@@ -104,7 +104,12 @@ export const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
           value={value}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          className={cn(paddingLeft, paddingRight, className)}
+          className={cn(
+            "border border-slate-300 bg-white shadow-sm focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20",
+            paddingLeft,
+            paddingRight,
+            className
+          )}
           {...props}
         />
 

--- a/src/components/shared/__tests__/SearchInput.test.tsx
+++ b/src/components/shared/__tests__/SearchInput.test.tsx
@@ -103,6 +103,18 @@ describe("SearchInput", () => {
     expect(screen.queryByRole("button", { name: "Xóa tìm kiếm" })).not.toBeInTheDocument()
   })
 
+  it("keeps the outer search field visually separated from filter containers on focus", () => {
+    render(<SearchInput aria-label="Tìm kiếm" value="" onChange={vi.fn()} />)
+
+    const input = screen.getByRole("searchbox", { name: "Tìm kiếm" })
+
+    expect(input).toHaveClass("border-slate-300")
+    expect(input).toHaveClass("bg-white")
+    expect(input).toHaveClass("focus-visible:border-primary")
+    expect(input).toHaveClass("focus-visible:ring-2")
+    expect(input).toHaveClass("focus-visible:ring-primary/20")
+  })
+
   it("uses HeroUI instead of the shadcn input backing", () => {
     const source = readFileSync(
       join(process.cwd(), "src/components/shared/SearchInput.tsx"),

--- a/src/components/shared/__tests__/SearchInput.test.tsx
+++ b/src/components/shared/__tests__/SearchInput.test.tsx
@@ -103,7 +103,7 @@ describe("SearchInput", () => {
     expect(screen.queryByRole("button", { name: "Xóa tìm kiếm" })).not.toBeInTheDocument()
   })
 
-  it("keeps the outer search field visually separated from filter containers on focus", () => {
+  it("renders with expected default input styling", () => {
     render(<SearchInput aria-label="Tìm kiếm" value="" onChange={vi.fn()} />)
 
     const input = screen.getByRole("searchbox", { name: "Tìm kiếm" })

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -15,11 +15,11 @@ import * as React from "react"
 import type { Column } from "@tanstack/react-table"
 import { Badge as HeroBadge } from "@heroui/react/badge"
 import { Button as HeroButton } from "@heroui/react/button"
-import { Input as HeroInput } from "@heroui/react/input"
 import { Popover as HeroPopover } from "@heroui/react/popover"
-import { Check, Filter, Search } from "lucide-react"
+import { Check, Filter } from "lucide-react"
 import { includesNormalizedSearch, normalizeSearchText } from "@/lib/search-normalize"
 import { cn } from "@/lib/utils"
+import { SearchInput } from "@/components/shared/SearchInput"
 
 const DEFAULT_SEARCH_DEBOUNCE_MS = 300
 const DEFAULT_SEARCH_PLACEHOLDER = "Tìm lựa chọn..."
@@ -220,22 +220,16 @@ export function FacetedMultiSelectFilter<TData, TValue>({
 
           {searchable ? (
             <div className="border-b border-slate-100 p-2">
-              <div className="relative">
-                <Search
-                  className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-                  aria-hidden="true"
-                />
-                <HeroInput
-                  ref={searchInputRef}
-                  type="search"
-                  value={optionSearch}
-                  onChange={(event) => setOptionSearch(event.target.value)}
-                  onKeyDown={handleOptionSearchKeyDown}
-                  aria-label={`Tìm lựa chọn ${title ?? "bộ lọc"}`}
-                  placeholder={searchPlaceholder}
-                  className="h-9 border border-slate-300 bg-white pl-9 shadow-sm focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20"
-                />
-              </div>
+              <SearchInput
+                ref={searchInputRef}
+                value={optionSearch}
+                onChange={setOptionSearch}
+                onKeyDown={handleOptionSearchKeyDown}
+                aria-label={`Tìm lựa chọn ${title ?? "bộ lọc"}`}
+                placeholder={searchPlaceholder}
+                showClearButton={false}
+                className="h-9"
+              />
             </div>
           ) : null}
 

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -233,7 +233,7 @@ export function FacetedMultiSelectFilter<TData, TValue>({
                   onKeyDown={handleOptionSearchKeyDown}
                   aria-label={`Tìm lựa chọn ${title ?? "bộ lọc"}`}
                   placeholder={searchPlaceholder}
-                  className="h-9 pl-9"
+                  className="h-9 border border-slate-300 bg-white pl-9 shadow-sm focus-visible:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20"
                 />
               </div>
             </div>

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -170,38 +170,36 @@ export function FacetedMultiSelectFilter<TData, TValue>({
 
   return (
     <HeroPopover isOpen={open} onOpenChange={handleOpenChange}>
-      <HeroPopover.Trigger>
-        <HeroButton
-          type="button"
-          variant="outline"
-          size="sm"
-          aria-haspopup="dialog"
-          data-trigger-variant={triggerVariant}
-          className={cn(
-            "h-9 min-w-[132px] border-slate-200 transition-all",
-            triggerVariantClassName,
-            triggerSelectionClassName
+      <HeroButton
+        type="button"
+        variant="outline"
+        size="sm"
+        aria-haspopup="dialog"
+        data-trigger-variant={triggerVariant}
+        className={cn(
+          "h-9 min-w-[132px] border-slate-200 transition-all",
+          triggerVariantClassName,
+          triggerSelectionClassName
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {triggerIcon ? (
+            <span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
+              {triggerIcon}
+            </span>
+          ) : null}
+          <span className="truncate font-medium">{title}</span>
+          {selectedValues.size > 0 && (
+            <HeroBadge
+              variant="secondary"
+              size="sm"
+              className="h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"
+            >
+              {selectedValues.size}
+            </HeroBadge>
           )}
-        >
-          <div className="flex min-w-0 items-center gap-2">
-            {triggerIcon ? (
-              <span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
-                {triggerIcon}
-              </span>
-            ) : null}
-            <span className="truncate font-medium">{title}</span>
-            {selectedValues.size > 0 && (
-              <HeroBadge
-                variant="secondary"
-                size="sm"
-                className="h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"
-              >
-                {selectedValues.size}
-              </HeroBadge>
-            )}
-          </div>
-        </HeroButton>
-      </HeroPopover.Trigger>
+        </div>
+      </HeroButton>
       <HeroPopover.Content
         className={cn(
           "w-[min(420px,calc(100vw-2rem))] max-h-[440px] overflow-hidden rounded-xl border border-slate-200 p-0 shadow-lg",

--- a/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
+++ b/src/components/shared/table-filters/FacetedMultiSelectFilter.tsx
@@ -13,13 +13,13 @@
 
 import * as React from "react"
 import type { Column } from "@tanstack/react-table"
+import { Badge as HeroBadge } from "@heroui/react/badge"
+import { Button as HeroButton } from "@heroui/react/button"
+import { Input as HeroInput } from "@heroui/react/input"
+import { Popover as HeroPopover } from "@heroui/react/popover"
 import { Check, Filter, Search } from "lucide-react"
 import { includesNormalizedSearch, normalizeSearchText } from "@/lib/search-normalize"
 import { cn } from "@/lib/utils"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 
 const DEFAULT_SEARCH_DEBOUNCE_MS = 300
 const DEFAULT_SEARCH_PLACEHOLDER = "Tìm lựa chọn..."
@@ -169,9 +169,9 @@ export function FacetedMultiSelectFilter<TData, TValue>({
       : "hover:border-primary/30"
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
+    <HeroPopover isOpen={open} onOpenChange={handleOpenChange}>
+      <HeroPopover.Trigger>
+        <HeroButton
           type="button"
           variant="outline"
           size="sm"
@@ -191,112 +191,115 @@ export function FacetedMultiSelectFilter<TData, TValue>({
             ) : null}
             <span className="truncate font-medium">{title}</span>
             {selectedValues.size > 0 && (
-              <Badge
+              <HeroBadge
                 variant="secondary"
+                size="sm"
                 className="h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"
               >
                 {selectedValues.size}
-              </Badge>
+              </HeroBadge>
             )}
           </div>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
+        </HeroButton>
+      </HeroPopover.Trigger>
+      <HeroPopover.Content
         className={cn(
           "w-[min(420px,calc(100vw-2rem))] max-h-[440px] overflow-hidden rounded-xl border border-slate-200 p-0 shadow-lg",
           contentClassName
         )}
-        align="start"
+        placement="bottom start"
       >
-        {/* Header */}
-        <div className="px-3 py-2.5 border-b border-slate-100 bg-slate-50/50">
-          <div className="flex items-center gap-2">
-            <Filter className="size-4 text-primary" />
-            <span className="font-semibold text-sm text-slate-900">{title}</span>
-          </div>
-        </div>
-
-        {searchable ? (
-          <div className="border-b border-slate-100 p-2">
-            <div className="relative">
-              <Search
-                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-                aria-hidden="true"
-              />
-              <Input
-                ref={searchInputRef}
-                type="search"
-                value={optionSearch}
-                onChange={(event) => setOptionSearch(event.target.value)}
-                onKeyDown={handleOptionSearchKeyDown}
-                aria-label={`Tìm lựa chọn ${title ?? "bộ lọc"}`}
-                placeholder={searchPlaceholder}
-                className="h-9 pl-9"
-              />
+        <HeroPopover.Dialog className="outline-none">
+          {/* Header */}
+          <div className="px-3 py-2.5 border-b border-slate-100 bg-slate-50/50">
+            <div className="flex items-center gap-2">
+              <Filter className="size-4 text-primary" />
+              <span className="font-semibold text-sm text-slate-900">{title}</span>
             </div>
           </div>
-        ) : null}
 
-        {/* Options List */}
-        <div className="max-h-[300px] overflow-y-auto py-1">
-          {visibleOptions.length === 0 ? (
-            <div className="px-3 py-6 text-center text-sm text-muted-foreground">
-              {emptySearchMessage}
+          {searchable ? (
+            <div className="border-b border-slate-100 p-2">
+              <div className="relative">
+                <Search
+                  className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                  aria-hidden="true"
+                />
+                <HeroInput
+                  ref={searchInputRef}
+                  type="search"
+                  value={optionSearch}
+                  onChange={(event) => setOptionSearch(event.target.value)}
+                  onKeyDown={handleOptionSearchKeyDown}
+                  aria-label={`Tìm lựa chọn ${title ?? "bộ lọc"}`}
+                  placeholder={searchPlaceholder}
+                  className="h-9 pl-9"
+                />
+              </div>
             </div>
           ) : null}
-          {visibleOptions.map((option, index) => {
-            const isSelected = selectedValues.has(option.value)
-            return (
-              <button
-                ref={index === 0 ? firstOptionRef : undefined}
-                type="button"
-                key={option.value}
-                onClick={() => handleOptionToggle(option.value)}
-                aria-pressed={isSelected}
-                className={cn(
-                  "w-full flex items-center gap-3 px-3 py-2.5 text-sm transition-colors",
-                  "hover:bg-slate-50 active:bg-slate-100",
-                  isSelected && "bg-primary/5 hover:bg-primary/10"
-                )}
-              >
-                <div
-                  className={cn(
-                    "flex items-center justify-center size-5 rounded border-2 transition-all shrink-0",
-                    isSelected
-                      ? "bg-primary border-primary"
-                      : "border-slate-300 hover:border-primary/50"
-                  )}
-                >
-                  {isSelected && <Check className="size-3.5 text-white" strokeWidth={3} />}
-                </div>
-                <span
-                  className={cn(
-                    "truncate text-left flex-1",
-                    isSelected ? "font-medium text-slate-900" : "text-slate-600"
-                  )}
-                >
-                  {option.label}
-                </span>
-              </button>
-            )
-          })}
-        </div>
 
-        {/* Footer — Clear button */}
-        {selectedValues.size > 0 && (
-          <div className="border-t border-slate-100 p-2">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={handleClear}
-              className="w-full h-8 text-xs font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100"
-            >
-              Xóa bộ lọc
-            </Button>
+          {/* Options List */}
+          <div className="max-h-[300px] overflow-y-auto py-1">
+            {visibleOptions.length === 0 ? (
+              <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                {emptySearchMessage}
+              </div>
+            ) : null}
+            {visibleOptions.map((option, index) => {
+              const isSelected = selectedValues.has(option.value)
+              return (
+                <button
+                  ref={index === 0 ? firstOptionRef : undefined}
+                  type="button"
+                  key={option.value}
+                  onClick={() => handleOptionToggle(option.value)}
+                  aria-pressed={isSelected}
+                  className={cn(
+                    "w-full flex items-center gap-3 px-3 py-2.5 text-sm transition-colors",
+                    "hover:bg-slate-50 active:bg-slate-100",
+                    isSelected && "bg-primary/5 hover:bg-primary/10"
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "flex items-center justify-center size-5 rounded border-2 transition-all shrink-0",
+                      isSelected
+                        ? "bg-primary border-primary"
+                        : "border-slate-300 hover:border-primary/50"
+                    )}
+                  >
+                    {isSelected && <Check className="size-3.5 text-white" strokeWidth={3} />}
+                  </div>
+                  <span
+                    className={cn(
+                      "truncate text-left flex-1",
+                      isSelected ? "font-medium text-slate-900" : "text-slate-600"
+                    )}
+                  >
+                    {option.label}
+                  </span>
+                </button>
+              )
+            })}
           </div>
-        )}
-      </PopoverContent>
-    </Popover>
+
+          {/* Footer — Clear button */}
+          {selectedValues.size > 0 && (
+            <div className="border-t border-slate-100 p-2">
+              <HeroButton
+                type="button"
+                variant="ghost"
+                size="sm"
+                onPress={handleClear}
+                className="w-full h-8 text-xs font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-100"
+              >
+                Xóa bộ lọc
+              </HeroButton>
+            </div>
+          )}
+        </HeroPopover.Dialog>
+      </HeroPopover.Content>
+    </HeroPopover>
   )
 }

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.backing.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.backing.test.tsx
@@ -1,0 +1,164 @@
+import type { ButtonHTMLAttributes, HTMLAttributes, InputHTMLAttributes, ReactNode } from "react"
+import "@testing-library/jest-dom"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+type MockButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children?: ReactNode
+  onPress?: () => void
+}
+
+type MockInputProps = InputHTMLAttributes<HTMLInputElement>
+
+type MockElementProps = HTMLAttributes<HTMLElement> & {
+  children?: ReactNode
+}
+
+function createMockElement(
+  ReactRuntime: typeof import("react"),
+  tagName: "div" | "span",
+  testId: string
+) {
+  return ({ children, ...props }: MockElementProps) =>
+    ReactRuntime.createElement(tagName, { ...props, "data-testid": testId }, children)
+}
+
+vi.mock("@heroui/react/button", async () => {
+  const ReactRuntime = await import("react")
+
+  return {
+    Button: ({ children, onPress, onClick, ...props }: MockButtonProps) =>
+      ReactRuntime.createElement(
+        "button",
+        {
+          ...props,
+          "data-testid": "heroui-button",
+          onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+            onPress?.()
+            onClick?.(event)
+          },
+        },
+        children
+      ),
+  }
+})
+
+vi.mock("@heroui/react/input", async () => {
+  const ReactRuntime = await import("react")
+
+  return {
+    Input: ReactRuntime.forwardRef<HTMLInputElement, MockInputProps>((props, ref) =>
+      ReactRuntime.createElement("input", { ...props, ref, "data-testid": "heroui-input" })
+    ),
+  }
+})
+
+vi.mock("@heroui/react/badge", async () => {
+  const ReactRuntime = await import("react")
+
+  return { Badge: createMockElement(ReactRuntime, "span", "heroui-badge") }
+})
+
+vi.mock("@heroui/react/popover", async () => {
+  const ReactRuntime = await import("react")
+
+  type PopoverProps = {
+    children: ReactNode
+    isOpen?: boolean
+    onOpenChange?: (open: boolean) => void
+  }
+
+  type PopoverChildProps = {
+    children?: ReactNode
+    className?: string
+  } & Record<string, unknown>
+
+  const Trigger = ({ children, ...props }: PopoverChildProps) =>
+    ReactRuntime.createElement(
+      "div",
+      { ...props, "data-testid": "heroui-popover-trigger" },
+      children
+    )
+
+  const Content = ({ children, ...props }: PopoverChildProps) =>
+    ReactRuntime.createElement(
+      "dialog",
+      { ...props, open: true, "data-testid": "heroui-popover-content" },
+      children
+    )
+
+  const Dialog = ({ children, ...props }: PopoverChildProps) =>
+    ReactRuntime.createElement(
+      "div",
+      { ...props, "data-testid": "heroui-popover-dialog" },
+      children
+    )
+
+  const Popover = Object.assign(
+    ({ children, isOpen: controlledOpen, onOpenChange }: PopoverProps) => {
+      const [uncontrolledOpen, setUncontrolledOpen] = ReactRuntime.useState(false)
+      const open = controlledOpen ?? uncontrolledOpen
+      const setOpen = (nextOpen: boolean) => {
+        setUncontrolledOpen(nextOpen)
+        onOpenChange?.(nextOpen)
+      }
+
+      return ReactRuntime.createElement(
+        "div",
+        { "data-testid": "heroui-popover-root" },
+        ReactRuntime.Children.map(children, (child) => {
+          if (!ReactRuntime.isValidElement(child)) return child
+          if (child.type === Content && !open) return null
+          if (child.type === Trigger) {
+            return ReactRuntime.cloneElement(child, {
+              onClick: () => setOpen(!open),
+            } as Partial<PopoverChildProps>)
+          }
+          return child
+        })
+      )
+    },
+    {
+      Content,
+      Dialog,
+      Trigger,
+    }
+  )
+
+  return { Popover }
+})
+
+import { FacetedMultiSelectFilter } from "../FacetedMultiSelectFilter"
+
+const OPTIONS = [
+  { label: "ICU", value: "ICU" },
+  { label: "Surgery", value: "Surgery" },
+]
+
+describe("FacetedMultiSelectFilter HeroUI backing", () => {
+  it("renders trigger, popover, search input, and selected count through HeroUI primitives", () => {
+    render(
+      <FacetedMultiSelectFilter
+        title="Khoa/Phòng"
+        options={OPTIONS}
+        value={["ICU"]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId("heroui-popover-root")).toBeInTheDocument()
+    expect(screen.getByTestId("heroui-popover-trigger")).toContainElement(
+      screen.getByRole("button", { name: /Khoa\/Phòng/i })
+    )
+    expect(screen.getByTestId("heroui-button")).toHaveTextContent("Khoa/Phòng")
+    expect(screen.getByTestId("heroui-badge")).toHaveTextContent("1")
+
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+
+    expect(screen.getByTestId("heroui-popover-content")).toBeInTheDocument()
+    expect(screen.getByTestId("heroui-input")).toHaveAttribute(
+      "aria-label",
+      "Tìm lựa chọn Khoa/Phòng"
+    )
+  })
+})

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.backing.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.backing.test.tsx
@@ -53,8 +53,15 @@ vi.mock("@heroui/react/input", async () => {
   const ReactRuntime = await import("react")
 
   return {
-    Input: ReactRuntime.forwardRef<HTMLInputElement, MockInputProps>((props, ref) =>
-      ReactRuntime.createElement("input", { ...props, ref, "data-testid": "heroui-input" })
+    Input: Object.assign(
+      ReactRuntime.forwardRef<HTMLInputElement, MockInputProps>(function MockHeroInput(props, ref) {
+        return ReactRuntime.createElement("input", {
+          ...props,
+          ref,
+          "data-testid": "heroui-input",
+        })
+      }),
+      { displayName: "MockHeroInput" }
     ),
   }
 })
@@ -79,13 +86,6 @@ vi.mock("@heroui/react/popover", async () => {
     className?: string
   } & Record<string, unknown>
 
-  const Trigger = ({ children, ...props }: PopoverChildProps) =>
-    ReactRuntime.createElement(
-      "div",
-      { ...props, "data-testid": "heroui-popover-trigger" },
-      children
-    )
-
   const Content = ({ children, ...props }: PopoverChildProps) =>
     ReactRuntime.createElement(
       "dialog",
@@ -108,6 +108,7 @@ vi.mock("@heroui/react/popover", async () => {
         setUncontrolledOpen(nextOpen)
         onOpenChange?.(nextOpen)
       }
+      let triggerConnected = false
 
       return ReactRuntime.createElement(
         "div",
@@ -115,9 +116,14 @@ vi.mock("@heroui/react/popover", async () => {
         ReactRuntime.Children.map(children, (child) => {
           if (!ReactRuntime.isValidElement(child)) return child
           if (child.type === Content && !open) return null
-          if (child.type === Trigger) {
+          if (!triggerConnected && child.type !== Content) {
+            triggerConnected = true
+            const childProps = child.props as { onClick?: () => void }
             return ReactRuntime.cloneElement(child, {
-              onClick: () => setOpen(!open),
+              onClick: () => {
+                setOpen(!open)
+                childProps.onClick?.()
+              },
             } as Partial<PopoverChildProps>)
           }
           return child
@@ -127,7 +133,6 @@ vi.mock("@heroui/react/popover", async () => {
     {
       Content,
       Dialog,
-      Trigger,
     }
   )
 
@@ -153,10 +158,8 @@ describe("FacetedMultiSelectFilter HeroUI backing", () => {
     )
 
     expect(screen.getByTestId("heroui-popover-root")).toBeInTheDocument()
-    expect(screen.getByTestId("heroui-popover-trigger")).toContainElement(
-      screen.getByRole("button", { name: /Khoa\/Phòng/i })
-    )
     expect(screen.getByTestId("heroui-button")).toHaveTextContent("Khoa/Phòng")
+    expect(screen.queryByTestId("heroui-popover-trigger")).not.toBeInTheDocument()
     expect(screen.getByTestId("heroui-badge")).toHaveTextContent("1")
 
     fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.backing.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.backing.test.tsx
@@ -1,4 +1,10 @@
-import type { ButtonHTMLAttributes, HTMLAttributes, InputHTMLAttributes, ReactNode } from "react"
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+} from "react"
 import "@testing-library/jest-dom"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
@@ -33,7 +39,7 @@ vi.mock("@heroui/react/button", async () => {
         {
           ...props,
           "data-testid": "heroui-button",
-          onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+          onClick: (event: ReactMouseEvent<HTMLButtonElement>) => {
             onPress?.()
             onClick?.(event)
           },

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.search-input.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.search-input.test.tsx
@@ -1,0 +1,61 @@
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode, Ref } from "react"
+import "@testing-library/jest-dom"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import "./FacetedMultiSelectFilter.test-utils"
+
+type MockSearchInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> & {
+  ref?: Ref<HTMLInputElement>
+  showClearButton?: boolean
+  value: string
+  onChange: (value: string) => void
+}
+
+vi.mock("@/components/shared/SearchInput", async () => {
+  const ReactRuntime = await import("react")
+
+  return {
+    SearchInput: ({ ref, showClearButton, value, onChange, ...props }: MockSearchInputProps) =>
+      ReactRuntime.createElement("input", {
+        ...props,
+        ref,
+        value,
+        "data-show-clear-button": String(showClearButton),
+        "data-testid": "shared-search-input",
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+          onChange(event.currentTarget.value),
+      }),
+  }
+})
+
+vi.mock("@heroui/react/button", async () => {
+  const ReactRuntime = await import("react")
+
+  return {
+    Button: ({
+      children,
+      ...props
+    }: ButtonHTMLAttributes<HTMLButtonElement> & { children: ReactNode }) =>
+      ReactRuntime.createElement("button", props, children),
+  }
+})
+
+import { FacetedMultiSelectFilter } from "../FacetedMultiSelectFilter"
+
+const OPTIONS = [
+  { label: "ICU", value: "ICU" },
+  { label: "Surgery", value: "Surgery" },
+]
+
+describe("FacetedMultiSelectFilter shared SearchInput backing", () => {
+  it("renders option search through the shared SearchInput component", () => {
+    render(<FacetedMultiSelectFilter title="Khoa/Phòng" options={OPTIONS} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+
+    const optionSearch = screen.getByTestId("shared-search-input")
+    expect(optionSearch).toHaveAttribute("aria-label", "Tìm lựa chọn Khoa/Phòng")
+    expect(optionSearch).toHaveAttribute("placeholder", "Tìm lựa chọn...")
+    expect(optionSearch).toHaveAttribute("data-show-clear-button", "false")
+  })
+})

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test-utils.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test-utils.tsx
@@ -1,0 +1,96 @@
+import * as React from "react"
+import { vi } from "vitest"
+
+type PopoverStateProps = {
+  open?: boolean
+  setOpen?: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+type PopoverTriggerProps = PopoverStateProps & {
+  children: React.ReactNode
+  onClick?: (...args: unknown[]) => void
+} & Record<string, unknown>
+
+type PopoverContentProps = PopoverStateProps & {
+  children: React.ReactNode
+} & React.HTMLAttributes<HTMLDivElement>
+
+vi.mock("@heroui/react/input", () => ({
+  Input: React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+    (props, ref) => <input {...props} ref={ref} />
+  ),
+}))
+
+/**
+ * Mock HeroUI Popover so content renders inline (no portal / no jsdom issues).
+ */
+vi.mock("@heroui/react/popover", () => {
+  const Trigger = ({ children, open, setOpen, ...rest }: PopoverTriggerProps) => {
+    const togglePopover = () => setOpen?.(!open)
+    if (React.isValidElement(children)) {
+      const childElement = children as React.ReactElement<{
+        onClick?: (...args: unknown[]) => void
+      }>
+      return React.cloneElement(childElement, {
+        ...rest,
+        onClick: (...args: unknown[]) => {
+          togglePopover()
+          childElement.props.onClick?.(...args)
+        },
+      })
+    }
+    return (
+      <button {...rest} onClick={togglePopover}>
+        {children}
+      </button>
+    )
+  }
+
+  const Popover = Object.assign(
+    ({
+      children,
+      isOpen,
+      onOpenChange,
+    }: {
+      children: React.ReactNode
+      isOpen?: boolean
+      onOpenChange?: (open: boolean) => void
+    }) => {
+      const [open, setOpen] = React.useState(false)
+      const renderedOpen = isOpen ?? open
+      const setRenderedOpen = (nextOpen: boolean) => {
+        setOpen(nextOpen)
+        onOpenChange?.(nextOpen)
+      }
+
+      return (
+        <div data-testid="popover">
+          {React.Children.map(children, (child) =>
+            React.isValidElement(child)
+              ? React.cloneElement(child as React.ReactElement<PopoverStateProps>, {
+                  open: renderedOpen,
+                  setOpen: setRenderedOpen,
+                })
+              : child
+          )}
+        </div>
+      )
+    },
+    {
+      Trigger,
+      Content: ({ children, open, setOpen: _setOpen, ...rest }: PopoverContentProps) => {
+        if (!open) return null
+        return (
+          <dialog data-testid="popover-content" open {...rest}>
+            {children}
+          </dialog>
+        )
+      },
+      Dialog: ({ children, ...rest }: React.HTMLAttributes<HTMLDivElement>) => (
+        <div {...rest}>{children}</div>
+      ),
+    }
+  )
+
+  return { Popover }
+})

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test-utils.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test-utils.tsx
@@ -15,14 +15,19 @@ type PopoverContentProps = PopoverStateProps & {
   children: React.ReactNode
 } & React.HTMLAttributes<HTMLDivElement>
 
-vi.mock("@heroui/react/input", () => ({
-  Input: ({
+vi.mock("@heroui/react/input", () => {
+  function MockHeroInput({
     ref,
     ...props
   }: React.InputHTMLAttributes<HTMLInputElement> & {
     ref?: React.Ref<HTMLInputElement>
-  }) => <input {...props} ref={ref} />,
-}))
+  }) {
+    return <input {...props} ref={ref} />
+  }
+  MockHeroInput.displayName = "MockHeroInput"
+
+  return { Input: MockHeroInput }
+})
 
 /**
  * Mock HeroUI Popover so content renders inline (no portal / no jsdom issues).
@@ -66,16 +71,35 @@ vi.mock("@heroui/react/popover", () => {
         onOpenChange?.(nextOpen)
       }
 
+      let triggerConnected = false
+
       return (
         <div data-testid="popover">
-          {React.Children.map(children, (child) =>
-            React.isValidElement(child)
-              ? React.cloneElement(child as React.ReactElement<PopoverStateProps>, {
-                  open: renderedOpen,
-                  setOpen: setRenderedOpen,
-                })
-              : child
-          )}
+          {React.Children.map(children, (child) => {
+            if (!React.isValidElement(child)) return child
+
+            if (child.type === Popover.Content) {
+              return React.cloneElement(child as React.ReactElement<PopoverStateProps>, {
+                open: renderedOpen,
+                setOpen: setRenderedOpen,
+              })
+            }
+
+            if (!triggerConnected) {
+              triggerConnected = true
+              const triggerElement = child as React.ReactElement<{
+                onClick?: (...args: unknown[]) => void
+              }>
+              return React.cloneElement(triggerElement, {
+                onClick: (...args: unknown[]) => {
+                  setRenderedOpen(!renderedOpen)
+                  triggerElement.props.onClick?.(...args)
+                },
+              })
+            }
+
+            return child
+          })}
         </div>
       )
     },

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test-utils.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test-utils.tsx
@@ -16,9 +16,12 @@ type PopoverContentProps = PopoverStateProps & {
 } & React.HTMLAttributes<HTMLDivElement>
 
 vi.mock("@heroui/react/input", () => ({
-  Input: React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
-    (props, ref) => <input {...props} ref={ref} />
-  ),
+  Input: ({
+    ref,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement> & {
+    ref?: React.Ref<HTMLInputElement>
+  }) => <input {...props} ref={ref} />,
 }))
 
 /**

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
@@ -11,74 +11,7 @@ import {
   type ColumnFiltersState,
   type ColumnDef,
 } from "@tanstack/react-table"
-
-type PopoverStateProps = {
-  open?: boolean
-  setOpen?: React.Dispatch<React.SetStateAction<boolean>>
-}
-
-type PopoverTriggerProps = PopoverStateProps & {
-  asChild?: boolean
-  children: React.ReactNode
-  onClick?: (...args: unknown[]) => void
-} & Record<string, unknown>
-
-type PopoverContentProps = PopoverStateProps & {
-  children: React.ReactNode
-} & React.HTMLAttributes<HTMLDivElement>
-
-/**
- * Mock radix Popover so content renders inline (no portal / no jsdom issues).
- */
-vi.mock("@/components/ui/popover", () => {
-  const Trigger = ({ children, asChild, open, setOpen, ...rest }: PopoverTriggerProps) => {
-    const togglePopover = () => setOpen?.(!open)
-    if (asChild && React.isValidElement(children)) {
-      const childElement = children as React.ReactElement<{
-        onClick?: (...args: unknown[]) => void
-      }>
-      return React.cloneElement(childElement, {
-        ...rest,
-        onClick: (...args: unknown[]) => {
-          togglePopover()
-          childElement.props.onClick?.(...args)
-        },
-      })
-    }
-    return (
-      <button {...rest} onClick={togglePopover}>
-        {children}
-      </button>
-    )
-  }
-
-  return {
-    Popover: ({ children }: { children: React.ReactNode }) => {
-      const [open, setOpen] = React.useState(false)
-      return (
-        <div data-testid="popover">
-          {React.Children.map(children, (child) =>
-            React.isValidElement(child)
-              ? React.cloneElement(child as React.ReactElement<PopoverStateProps>, {
-                  open,
-                  setOpen,
-                })
-              : child
-          )}
-        </div>
-      )
-    },
-    PopoverTrigger: Trigger,
-    PopoverContent: ({ children, open, setOpen: _setOpen, ...rest }: PopoverContentProps) => {
-      if (!open) return null
-      return (
-        <dialog data-testid="popover-content" open {...rest}>
-          {children}
-        </dialog>
-      )
-    },
-  }
-})
+import "./FacetedMultiSelectFilter.test-utils"
 
 import { FacetedMultiSelectFilter } from "../FacetedMultiSelectFilter"
 

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
@@ -182,6 +182,19 @@ describe("FacetedMultiSelectFilter", () => {
     expect(screen.getByText("Không tìm thấy lựa chọn phù hợp")).toBeInTheDocument()
   })
 
+  it("keeps option search input visually separated from its container on focus", () => {
+    render(<Wrapper />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+    const optionSearch = screen.getByRole("searchbox", { name: "Tìm lựa chọn Khoa/Phòng" })
+
+    expect(optionSearch).toHaveClass("border-slate-300")
+    expect(optionSearch).toHaveClass("bg-white")
+    expect(optionSearch).toHaveClass("focus-visible:border-primary")
+    expect(optionSearch).toHaveClass("focus-visible:ring-2")
+    expect(optionSearch).toHaveClass("focus-visible:ring-primary/20")
+  })
+
   it("moves focus from option search to first visible option on ArrowDown", async () => {
     vi.useFakeTimers()
     render(<Wrapper />)

--- a/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
+++ b/src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx
@@ -103,6 +103,20 @@ describe("FacetedMultiSelectFilter", () => {
     expect(screen.getByRole("button", { name: "Radiology" })).toBeInTheDocument()
   })
 
+  it("focuses option search input when dropdown is opened", () => {
+    vi.useFakeTimers()
+    render(<Wrapper />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))
+    const optionSearch = screen.getByRole("searchbox", { name: "Tìm lựa chọn Khoa/Phòng" })
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(optionSearch).toHaveFocus()
+  })
+
   it("debounces internal option search before filtering visible options", async () => {
     vi.useFakeTimers()
     render(<Wrapper />)
@@ -182,7 +196,7 @@ describe("FacetedMultiSelectFilter", () => {
     expect(screen.getByText("Không tìm thấy lựa chọn phù hợp")).toBeInTheDocument()
   })
 
-  it("keeps option search input visually separated from its container on focus", () => {
+  it("renders option search input with intended focus-visible classes", () => {
     render(<Wrapper />)
 
     fireEvent.click(screen.getByRole("button", { name: /Khoa\/Phòng/i }))


### PR DESCRIPTION
## Summary
- Replace `FacetedMultiSelectFilter` shadcn `Button`/`Input`/`Badge`/`Popover` internals with HeroUI-backed primitives.
- Preserve the shared component public API and existing column/controlled-mode consumers.
- Allow the shared table-filter component in the HeroUI import boundary.

## TDD / Verification
- RED: `FacetedMultiSelectFilter.backing.test.tsx` failed because the component still rendered Radix/shadcn backing.
- RED: `check-heroui-import-boundary.test.ts` failed because the table-filter file was not allowlisted.
- GREEN: `node scripts/npm-run.js run test:run -- src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.backing.test.tsx src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx scripts/__tests__/check-heroui-import-boundary.test.ts`
- `node scripts/npm-run.js exec -- prettier --check scripts/__tests__/check-heroui-import-boundary.test.ts scripts/check-heroui-import-boundary.js src/components/shared/table-filters/FacetedMultiSelectFilter.tsx src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test.tsx src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.test-utils.tsx src/components/shared/table-filters/__tests__/FacetedMultiSelectFilter.backing.test.tsx`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run verify:heroui-boundary`
- `node scripts/npm-run.js run react-doctor`

Closes #704

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `FacetedMultiSelectFilter` to HeroUI and moved option search to the shared `SearchInput`, keeping the API and UX the same. Aligns with Linear #704 by keeping this shared filter inside the HeroUI import boundary.

- **Refactors**
  - Replaced shadcn/Radix with `@heroui/react/badge`, `@heroui/react/button`, and `@heroui/react/popover`; mapped Clear to `onPress`.
  - Switched option search to the shared `SearchInput` (no clear button). Allowlisted the filter file for HeroUI boundary checks and added tests to enforce HeroUI backing and shared `SearchInput` usage.

- **Bug Fixes**
  - Centralized focus-visible styles in `SearchInput` (border/bg/ring) with tests in both `SearchInput` and the filter.
  - Ensured the option search is focused when the popover opens; added tests.

<sup>Written for commit 98fceac61009c0f96873f55ae5d3e68bf0a0871a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the multi-select table filter to use the newer HeroUI-based dropdown, input, badge, and action controls.
  * Added stronger test coverage for the filter’s HeroUI-backed behavior.

* **Bug Fixes**
  * Adjusted import-boundary handling so the updated filter component is recognized as an approved location for HeroUI imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->