### PR TITLE
feat: migrate equipment compact controls to HeroUI

### DIFF
--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import * as React from "react"
-import { describe, it, expect, vi } from "vitest"
+import { beforeAll, describe, it, expect, vi } from "vitest"
 import "@testing-library/jest-dom"
 import { render, screen, fireEvent, within } from "@testing-library/react"
 import type { Table } from "@tanstack/react-table"
@@ -22,6 +22,43 @@ type PopoverChildProps = PopoverStateProps & Record<string, unknown>
 type PopoverWithChildrenProps = PopoverStateProps & {
   children: React.ReactNode
 }
+
+class ResizeObserverMock {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string): MediaQueryList => {
+      return {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(() => false),
+      }
+    }),
+  })
+
+  Object.defineProperty(window, "ResizeObserver", {
+    writable: true,
+    configurable: true,
+    value: ResizeObserverMock,
+  })
+
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    writable: true,
+    configurable: true,
+    value: ResizeObserverMock,
+  })
+})
 
 /**
  * Mock dynamic imports (QR scanner components) to avoid SSR issues in tests

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -12,17 +12,6 @@ import { render, screen, fireEvent, within } from "@testing-library/react"
 import type { Table } from "@tanstack/react-table"
 import type { Equipment } from "@/types/database"
 
-type DropdownStateProps = {
-  open?: boolean
-  setOpen?: React.Dispatch<React.SetStateAction<boolean>>
-}
-
-type DropdownChildProps = DropdownStateProps & Record<string, unknown>
-
-type DropdownWithChildrenProps = DropdownStateProps & {
-  children: React.ReactNode
-}
-
 type PopoverStateProps = {
   open?: boolean
   setOpen?: React.Dispatch<React.SetStateAction<boolean>>
@@ -40,77 +29,6 @@ type PopoverWithChildrenProps = PopoverStateProps & {
 vi.mock("next/dynamic", () => ({
   default: () => () => null,
 }))
-
-/**
- * Mock radix DropdownMenu to render inline (no portal in jsdom)
- */
-vi.mock("@/components/ui/dropdown-menu", () => {
-  return {
-    DropdownMenu: ({ children }: { children: React.ReactNode }) => {
-      const [open, setOpen] = React.useState(false)
-      return (
-        <div data-testid="dropdown-menu">
-          {React.Children.map(children, (child) =>
-            React.isValidElement(child)
-              ? React.cloneElement(child as React.ReactElement<DropdownChildProps>, {
-                  open,
-                  setOpen,
-                })
-              : child
-          )}
-        </div>
-      )
-    },
-    DropdownMenuTrigger: ({
-      children,
-      asChild,
-      open,
-      setOpen,
-      ...rest
-    }: DropdownWithChildrenProps & { asChild?: boolean }) => {
-      const toggleDropdownMenu = () => setOpen?.(!open)
-      if (asChild && React.isValidElement(children)) {
-        const childElement = children as React.ReactElement<{
-          onClick?: (...args: unknown[]) => void
-        }>
-        return React.cloneElement(childElement, {
-          ...rest,
-          onClick: (...args: unknown[]) => {
-            toggleDropdownMenu()
-            childElement.props.onClick?.(...args)
-          },
-        })
-      }
-      return (
-        <button {...rest} onClick={toggleDropdownMenu}>
-          {children}
-        </button>
-      )
-    },
-    DropdownMenuContent: ({
-      children,
-      open,
-      setOpen: _setOpen,
-      ...rest
-    }: DropdownWithChildrenProps) => {
-      if (!open) return null
-      return (
-        <div data-testid="dropdown-content" {...rest}>
-          {children}
-        </div>
-      )
-    },
-    DropdownMenuItem: ({
-      children,
-      onSelect,
-      ...rest
-    }: { children: React.ReactNode; onSelect?: () => void } & Record<string, unknown>) => (
-      <button {...rest} onClick={onSelect}>
-        {children}
-      </button>
-    ),
-  }
-})
 
 /**
  * Mock radix Popover so overflow filter content renders inline in jsdom.
@@ -331,13 +249,22 @@ describe("EquipmentToolbar with shared filters", () => {
   })
 
   it("renders mobile filter sheet trigger instead of faceted filters on mobile", () => {
-    render(<EquipmentToolbar {...baseProps} filterMode="sheet" />)
+    render(
+      <EquipmentToolbar
+        {...baseProps}
+        filterMode="sheet"
+        columnFilters={[{ id: "tinh_trang_hien_tai", value: ["Hoạt động", "Hỏng"] }]}
+        filterState={{ ...baseProps.filterState, isFiltered: true }}
+      />
+    )
 
-    expect(screen.getByText("Lọc")).toBeInTheDocument()
     const compactActions = screen.getByTestId("equipment-compact-filter-actions")
+    const filterTrigger = within(compactActions).getByRole("button", { name: /Lọc\s*2/i })
 
     expect(compactActions).toHaveClass("grid", "w-full", "grid-cols-2", "gap-2")
-    expect(within(compactActions).getByRole("button", { name: /Lọc/i })).toHaveClass("w-full")
+    expect(filterTrigger).toHaveAttribute("data-testid", "equipment-heroui-compact-filter-trigger")
+    expect(filterTrigger).toHaveClass("w-full")
+    expect(filterTrigger).toHaveTextContent("2")
     expect(within(compactActions).getByRole("button", { name: /Tùy chọn/i })).toHaveClass("w-full")
     expect(screen.queryByText("Tình trạng")).not.toBeInTheDocument()
     expect(screen.queryByText("Khoa/Phòng")).not.toBeInTheDocument()
@@ -363,6 +290,38 @@ describe("EquipmentToolbar with shared filters", () => {
 
     fireEvent.click(screen.getByText("Lọc"))
     expect(onOpenFilterSheet).toHaveBeenCalled()
+  })
+
+  it("keeps compact options actions wired through the HeroUI dropdown", async () => {
+    const onOpenColumnsDialog = vi.fn()
+    const onDownloadTemplate = vi.fn()
+    const onExportData = vi.fn()
+
+    render(
+      <EquipmentToolbar
+        {...baseProps}
+        filterMode="sheet"
+        onOpenColumnsDialog={onOpenColumnsDialog}
+        onDownloadTemplate={onDownloadTemplate}
+        onExportData={onExportData}
+      />
+    )
+
+    const compactActions = screen.getByTestId("equipment-compact-filter-actions")
+    const openCompactOptions = () =>
+      fireEvent.click(within(compactActions).getByRole("button", { name: /Tùy chọn/i }))
+
+    openCompactOptions()
+    expect(await screen.findByRole("menu", { name: "Tùy chọn" })).toBeInTheDocument()
+    fireEvent.click(await screen.findByText("Hiện/ẩn cột"))
+    openCompactOptions()
+    fireEvent.click(await screen.findByText("Tải Excel mẫu"))
+    openCompactOptions()
+    fireEvent.click(await screen.findByText("Tải về dữ liệu"))
+
+    expect(onOpenColumnsDialog).toHaveBeenCalledTimes(1)
+    expect(onDownloadTemplate).toHaveBeenCalledTimes(1)
+    expect(onExportData).toHaveBeenCalledTimes(1)
   })
 
   it("hides compact clear command when filters are inactive", () => {

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -12,20 +12,12 @@ import type { Table, ColumnFiltersState } from "@tanstack/react-table"
 import dynamic from "next/dynamic"
 import { Filter, PlusCircle, Settings, ScanLine } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import {
   EquipmentToolbarDesktopFilters,
   EquipmentToolbarDesktopLayout,
 } from "./equipment-toolbar-layout"
-import { EquipmentHeroButton, EquipmentHeroDropdown } from "./heroui-pilot"
+import { EquipmentHeroButton, EquipmentHeroDropdown } from "./heroui-pilot/controls"
 import { useQRScanner } from "./useEquipmentQRScanner"
 import type { Equipment } from "@/types/database"
 
@@ -129,10 +121,12 @@ export function EquipmentToolbar({
   const mobileFilterControl = React.useMemo(
     () => (
       <div data-testid="equipment-compact-filter-actions" className="grid w-full grid-cols-2 gap-2">
-        <Button
-          variant="outline"
+        <EquipmentHeroButton
+          type="button"
+          variant="ghost"
           size="sm"
-          onClick={onOpenFilterSheet}
+          onPress={onOpenFilterSheet}
+          data-testid="equipment-heroui-compact-filter-trigger"
           className={cn(
             "h-9 w-full justify-center border-slate-200 shadow-sm transition-all",
             isFiltered
@@ -143,30 +137,44 @@ export function EquipmentToolbar({
           <Filter className="size-4 mr-2" />
           <span className="font-medium">Lọc</span>
           {isFiltered && (
-            <Badge
-              variant="secondary"
-              className="ml-2 h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold"
-            >
+            <span className="ml-2 h-5 min-w-[20px] rounded-full bg-primary text-white px-1.5 text-xs font-semibold">
               {activeFilterCount}
-            </Badge>
+            </span>
           )}
-        </Button>
+        </EquipmentHeroButton>
 
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="h-9 w-full justify-center">
-              <Settings className="size-4 mr-2" />
+        <EquipmentHeroDropdown
+          ariaLabel="Tùy chọn"
+          placement="bottom start"
+          trigger={
+            <>
+              <Settings className="size-4" />
               Tùy chọn
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-56">
-            <DropdownMenuItem onSelect={onOpenColumnsDialog}>Hiện/ẩn cột</DropdownMenuItem>
-            <DropdownMenuItem onSelect={onDownloadTemplate}>Tải Excel mẫu</DropdownMenuItem>
-            <DropdownMenuItem onSelect={onExportData} disabled={isExporting}>
-              {isExporting ? "Đang tải..." : "Tải về dữ liệu"}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+            </>
+          }
+          triggerClassName="h-9 w-full justify-center gap-2"
+          items={[
+            {
+              id: "columns",
+              label: "Hiện/ẩn cột",
+              textValue: "Hiện/ẩn cột",
+              onAction: onOpenColumnsDialog,
+            },
+            {
+              id: "template",
+              label: "Tải Excel mẫu",
+              textValue: "Tải Excel mẫu",
+              onAction: onDownloadTemplate,
+            },
+            {
+              id: "export",
+              label: isExporting ? "Đang tải..." : "Tải về dữ liệu",
+              textValue: isExporting ? "Đang tải..." : "Tải về dữ liệu",
+              onAction: onExportData,
+              isDisabled: isExporting,
+            },
+          ]}
+        />
       </div>
     ),
     [

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -118,6 +118,31 @@ export function EquipmentToolbar({
     [qr.handleStartScanning]
   )
 
+  const optionsMenuItems = React.useMemo(
+    () => [
+      {
+        id: "columns",
+        label: "Hiện/ẩn cột",
+        textValue: "Hiện/ẩn cột",
+        onAction: onOpenColumnsDialog,
+      },
+      {
+        id: "template",
+        label: "Tải Excel mẫu",
+        textValue: "Tải Excel mẫu",
+        onAction: onDownloadTemplate,
+      },
+      {
+        id: "export",
+        label: isExporting ? "Đang tải..." : "Tải về dữ liệu",
+        textValue: isExporting ? "Đang tải..." : "Tải về dữ liệu",
+        onAction: onExportData,
+        isDisabled: isExporting,
+      },
+    ],
+    [isExporting, onDownloadTemplate, onExportData, onOpenColumnsDialog]
+  )
+
   const mobileFilterControl = React.useMemo(
     () => (
       <div data-testid="equipment-compact-filter-actions" className="grid w-full grid-cols-2 gap-2">
@@ -153,39 +178,11 @@ export function EquipmentToolbar({
             </>
           }
           triggerClassName="h-9 w-full justify-center gap-2"
-          items={[
-            {
-              id: "columns",
-              label: "Hiện/ẩn cột",
-              textValue: "Hiện/ẩn cột",
-              onAction: onOpenColumnsDialog,
-            },
-            {
-              id: "template",
-              label: "Tải Excel mẫu",
-              textValue: "Tải Excel mẫu",
-              onAction: onDownloadTemplate,
-            },
-            {
-              id: "export",
-              label: isExporting ? "Đang tải..." : "Tải về dữ liệu",
-              textValue: isExporting ? "Đang tải..." : "Tải về dữ liệu",
-              onAction: onExportData,
-              isDisabled: isExporting,
-            },
-          ]}
+          items={optionsMenuItems}
         />
       </div>
     ),
-    [
-      activeFilterCount,
-      isExporting,
-      isFiltered,
-      onDownloadTemplate,
-      onExportData,
-      onOpenColumnsDialog,
-      onOpenFilterSheet,
-    ]
+    [activeFilterCount, isFiltered, onOpenFilterSheet, optionsMenuItems]
   )
 
   const actions = React.useMemo(
@@ -227,39 +224,11 @@ export function EquipmentToolbar({
             </>
           }
           triggerClassName="hidden h-8 gap-1 lg:inline-flex touch-target-sm md:h-8"
-          items={[
-            {
-              id: "columns",
-              label: "Hiện/ẩn cột",
-              textValue: "Hiện/ẩn cột",
-              onAction: onOpenColumnsDialog,
-            },
-            {
-              id: "template",
-              label: "Tải Excel mẫu",
-              textValue: "Tải Excel mẫu",
-              onAction: onDownloadTemplate,
-            },
-            {
-              id: "export",
-              label: isExporting ? "Đang tải..." : "Tải về dữ liệu",
-              textValue: isExporting ? "Đang tải..." : "Tải về dữ liệu",
-              onAction: onExportData,
-              isDisabled: isExporting,
-            },
-          ]}
+          items={optionsMenuItems}
         />
       </>
     ),
-    [
-      canCreateEquipment,
-      isExporting,
-      onAddEquipment,
-      onDownloadTemplate,
-      onExportData,
-      onImportEquipment,
-      onOpenColumnsDialog,
-    ]
+    [canCreateEquipment, onAddEquipment, onImportEquipment, optionsMenuItems]
   )
 
   return (


### PR DESCRIPTION
## Summary
- Migrates Equipments compact/mobile filter trigger to the existing HeroUI adapter path.
- Migrates the compact/mobile options menu to `EquipmentHeroDropdown`.
- Removes obsolete Radix dropdown test mock and keeps `filter-bottom-sheet.tsx` untouched for #710.

## Test Plan
- [x] RED confirmed first with new compact HeroUI assertions.
- [x] `node scripts/npm-run.js npx prettier --check src/components/equipment/equipment-toolbar.tsx src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx`
- [x] `node scripts/npm-run.js run verify:heroui-boundary`
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test:run -- src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx`
- [x] `node scripts/npm-run.js run react-doctor`

Closes #691

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the equipment compact/mobile filter trigger and options menu to HeroUI for a consistent UI, better a11y, and shared logic across views. Addresses #691 via the existing HeroUI adapter.

- **Refactors**
  - Replaced Radix `Button`/`DropdownMenu`/`Badge` with `EquipmentHeroButton` and `EquipmentHeroDropdown` from `./heroui-pilot/controls` in `equipment-toolbar.tsx`; now uses `onPress`, ghost style, `ariaLabel="Tùy chọn"`, and a `data-testid` on the compact filter trigger.
  - Consolidated options into `optionsMenuItems` reused on mobile and desktop; export shows “Đang tải...” and is disabled while exporting.
  - Updated tests to assert the HeroUI trigger count and dropdown actions; added `matchMedia`/`ResizeObserver` mocks and removed the Radix dropdown mock. Left the filter bottom sheet as-is to avoid overlap with #710.

<sup>Written for commit cb69b0c91ca81f26513dd8e60a26454806d97410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the mobile equipment toolbar with a compact filter button that displays the active filter count.
  * Updated the “Tùy chọn” menu to streamline column visibility, template download, and data export.
* **Bug Fixes**
  * Improved compact (mobile) filter and options wiring for more reliable behavior.
  * Export action is now disabled while an export is in progress, and the options menu reflects the loading state.
* **Tests**
  * Updated toolbar tests and assertions to match the new compact filter trigger and options flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->