### PR TITLE
fix(equipment): use shared search input

### DIFF
--- a/src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx
@@ -61,7 +61,7 @@ function createBaseProps() {
 }
 
 describe("EquipmentToolbar HeroUI top controls", () => {
-  it("renders the desktop shell and search through the Equipments HeroUI pilot", () => {
+  it("renders desktop search through the shared SearchInput contract", () => {
     render(
       <EquipmentToolbar
         {...createBaseProps()}
@@ -70,15 +70,13 @@ describe("EquipmentToolbar HeroUI top controls", () => {
       />
     )
 
-    const shell = screen.getByTestId("equipment-heroui-top-controls-shell")
-    const searchControl = screen.getByTestId("equipment-heroui-search-control")
     const search = screen.getByRole("searchbox", { name: "Tìm kiếm chung..." })
 
-    expect(shell).toContainElement(searchControl)
-    expect(searchControl).toContainElement(search)
+    expect(screen.queryByTestId("equipment-heroui-search-control")).not.toBeInTheDocument()
     expect(search).toHaveAttribute("type", "search")
+    expect(search).toHaveClass("border", "border-slate-300", "bg-white", "shadow-sm")
     expect(screen.getByText("Quản lý danh sách các trang thiết bị y tế.")).toHaveClass(
-      "text-muted-foreground"
+      "body-responsive-sm"
     )
     expect(screen.getByTitle("Quét mã QR")).toContainElement(
       screen.getByRole("button", { name: "Quét mã QR" })
@@ -98,7 +96,7 @@ describe("EquipmentToolbar HeroUI top controls", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Xóa tìm kiếm" }))
 
-    expect(screen.getByRole("searchbox", { name: "Tìm kiếm chung..." })).toHaveClass("pr-20")
+    expect(screen.getByRole("searchbox", { name: "Tìm kiếm chung..." })).toHaveClass("pr-16")
     expect(onSearchChange).toHaveBeenCalledWith("")
   })
 

--- a/src/components/equipment/equipment-toolbar-layout.tsx
+++ b/src/components/equipment/equipment-toolbar-layout.tsx
@@ -6,15 +6,7 @@ import { Building2, Filter, Tags, UserRound, WalletCards, X } from "lucide-react
 
 import type { Equipment } from "@/types/database"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
-import {
-  EquipmentHeroButton,
-  EquipmentHeroCard,
-  EquipmentHeroCardContent,
-  EquipmentHeroCardDescription,
-  EquipmentHeroCardHeader,
-  EquipmentHeroCardTitle,
-  EquipmentHeroSearchInput,
-} from "./heroui-pilot"
+import { EquipmentHeroButton } from "./heroui-pilot/controls"
 
 interface EquipmentFilterFieldProps {
   label: string
@@ -30,18 +22,6 @@ interface EquipmentToolbarDesktopFiltersProps {
   classifications: string[]
   fundingSources: string[]
   isFiltered: boolean
-}
-
-interface EquipmentToolbarDesktopLayoutProps {
-  title?: React.ReactNode
-  description?: React.ReactNode
-  searchValue: string
-  onSearchChange: (value: string) => void
-  searchPlaceholder: string
-  searchEndAddon?: React.ReactNode
-  selectionActions?: React.ReactNode
-  actions?: React.ReactNode
-  children: React.ReactNode
 }
 
 /** Wraps an equipment toolbar filter with its desktop row label. */
@@ -133,62 +113,5 @@ export function EquipmentToolbarDesktopFilters({
         </EquipmentHeroButton>
       )}
     </div>
-  )
-}
-
-/** Renders the desktop equipment toolbar as separate search and filter rows. */
-export function EquipmentToolbarDesktopLayout({
-  title,
-  description,
-  searchValue,
-  onSearchChange,
-  searchPlaceholder,
-  searchEndAddon,
-  selectionActions,
-  actions,
-  children,
-}: EquipmentToolbarDesktopLayoutProps) {
-  return (
-    <EquipmentHeroCard data-testid="equipment-heroui-top-controls-shell">
-      {title || description ? (
-        <EquipmentHeroCardHeader className="gap-y-1 pb-3">
-          {title ? (
-            <EquipmentHeroCardTitle className="heading-responsive-h2">
-              {title}
-            </EquipmentHeroCardTitle>
-          ) : null}
-          {description ? (
-            <EquipmentHeroCardDescription className="body-responsive-sm text-muted-foreground">
-              {description}
-            </EquipmentHeroCardDescription>
-          ) : null}
-        </EquipmentHeroCardHeader>
-      ) : null}
-      <EquipmentHeroCardContent className="px-4 pb-4 md:px-6">
-        <div data-testid="equipment-reference-filter-layout" className="space-y-3">
-          <EquipmentHeroSearchInput
-            placeholder={searchPlaceholder}
-            value={searchValue}
-            onValueChange={onSearchChange}
-            className="h-9 w-full"
-            endAddon={searchEndAddon}
-            aria-label={searchPlaceholder}
-          />
-
-          <div className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
-            <div className="min-w-0 flex-1">{children}</div>
-
-            {selectionActions || actions ? (
-              <div className="flex w-full flex-wrap items-center justify-between gap-2 xl:w-auto xl:justify-end">
-                {selectionActions ? (
-                  <div className="min-w-0 shrink-0">{selectionActions}</div>
-                ) : null}
-                {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
-              </div>
-            ) : null}
-          </div>
-        </div>
-      </EquipmentHeroCardContent>
-    </EquipmentHeroCard>
   )
 }

--- a/src/components/equipment/equipment-toolbar-layout.tsx
+++ b/src/components/equipment/equipment-toolbar-layout.tsx
@@ -6,7 +6,7 @@ import { Building2, Filter, Tags, UserRound, WalletCards, X } from "lucide-react
 
 import type { Equipment } from "@/types/database"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
-import { EquipmentHeroButton } from "./heroui-pilot/controls"
+import { EquipmentHeroButton } from "@/components/equipment/heroui-pilot/controls"
 
 interface EquipmentFilterFieldProps {
   label: string

--- a/src/components/equipment/equipment-toolbar.tsx
+++ b/src/components/equipment/equipment-toolbar.tsx
@@ -13,10 +13,7 @@ import dynamic from "next/dynamic"
 import { Filter, PlusCircle, Settings, ScanLine } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
-import {
-  EquipmentToolbarDesktopFilters,
-  EquipmentToolbarDesktopLayout,
-} from "./equipment-toolbar-layout"
+import { EquipmentToolbarDesktopFilters } from "./equipment-toolbar-layout"
 import { EquipmentHeroButton, EquipmentHeroDropdown } from "./heroui-pilot/controls"
 import { useQRScanner } from "./useEquipmentQRScanner"
 import type { Equipment } from "@/types/database"
@@ -269,27 +266,31 @@ export function EquipmentToolbar({
           actions={actions}
         />
       ) : (
-        <EquipmentToolbarDesktopLayout
-          title={title}
-          description={description}
-          searchValue={searchTerm}
-          onSearchChange={onSearchChange}
-          searchPlaceholder={searchPlaceholder}
-          searchEndAddon={searchEndAddon}
-          selectionActions={selectionActions}
-          actions={actions}
-        >
-          <EquipmentToolbarDesktopFilters
-            table={table}
-            tenantControl={tenantControl}
-            statuses={statuses}
-            departments={departments}
-            users={users}
-            classifications={classifications}
-            fundingSources={fundingSources}
-            isFiltered={isFiltered}
+        <div data-testid="equipment-reference-filter-layout">
+          <ListFilterSearchCard
+            title={title}
+            description={description}
+            searchValue={searchTerm}
+            onSearchChange={onSearchChange}
+            searchPlaceholder={searchPlaceholder}
+            searchEndAddon={searchEndAddon}
+            showSearchIcon={false}
+            filterControls={
+              <EquipmentToolbarDesktopFilters
+                table={table}
+                tenantControl={tenantControl}
+                statuses={statuses}
+                departments={departments}
+                users={users}
+                classifications={classifications}
+                fundingSources={fundingSources}
+                isFiltered={isFiltered}
+              />
+            }
+            selectionActions={selectionActions}
+            actions={actions}
           />
-        </EquipmentToolbarDesktopLayout>
+        </div>
       )}
     </>
   )

--- a/src/components/equipment/heroui-pilot/controls.tsx
+++ b/src/components/equipment/heroui-pilot/controls.tsx
@@ -8,34 +8,16 @@
 "use client"
 
 import * as React from "react"
-import { X } from "lucide-react"
 import {
   Button,
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
   Dropdown,
   DropdownItem,
   DropdownMenu,
   DropdownPopover,
   DropdownTrigger,
-  Input,
 } from "@heroui/react"
 
 import { cn } from "@/lib/utils"
-
-type EquipmentHeroSearchInputProps = Omit<
-  React.ComponentProps<typeof Input>,
-  "onChange" | "type" | "value"
-> & {
-  value: string
-  onValueChange: (value: string) => void
-  onClear?: () => void
-  showClearButton?: boolean
-  endAddon?: React.ReactNode
-}
 
 export interface EquipmentHeroDropdownItem {
   id: string
@@ -55,69 +37,7 @@ interface EquipmentHeroDropdownProps {
   placement?: React.ComponentProps<typeof DropdownPopover>["placement"]
 }
 
-export {
-  Button as EquipmentHeroButton,
-  Card as EquipmentHeroCard,
-  CardContent as EquipmentHeroCardContent,
-  CardDescription as EquipmentHeroCardDescription,
-  CardHeader as EquipmentHeroCardHeader,
-  CardTitle as EquipmentHeroCardTitle,
-}
-
-/** Renders the Equipments pilot search input with the current toolbar end-addon contract. */
-export function EquipmentHeroSearchInput({
-  value,
-  onValueChange,
-  onClear,
-  showClearButton = true,
-  endAddon,
-  className,
-  fullWidth = true,
-  ...props
-}: EquipmentHeroSearchInputProps) {
-  const inputRef = React.useRef<HTMLInputElement>(null)
-  const hasClearButton = showClearButton && value.length > 0
-  const paddingRight =
-    hasClearButton && endAddon ? "pr-20" : hasClearButton || endAddon ? "pr-9" : null
-
-  const handleClear = React.useCallback(() => {
-    onValueChange("")
-    onClear?.()
-    inputRef.current?.focus()
-  }, [onClear, onValueChange])
-
-  return (
-    <div className="relative w-full" data-testid="equipment-heroui-search-control">
-      <Input
-        {...props}
-        ref={inputRef}
-        type="search"
-        value={value}
-        onChange={(event) => onValueChange(event.currentTarget.value)}
-        fullWidth={fullWidth}
-        className={cn("h-9 w-full pl-3", paddingRight, className)}
-      />
-      {hasClearButton || endAddon ? (
-        <div className="absolute inset-y-0 right-1 flex items-center gap-1">
-          {hasClearButton ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              isIconOnly
-              onPress={handleClear}
-              className="size-8 text-muted-foreground hover:text-foreground"
-              aria-label="Xóa tìm kiếm"
-            >
-              <X className="size-4" aria-hidden="true" />
-            </Button>
-          ) : null}
-          {endAddon}
-        </div>
-      ) : null}
-    </div>
-  )
-}
+export { Button as EquipmentHeroButton }
 
 /** Adapts HeroUI's React Aria dropdown API to the existing Equipments toolbar action model. */
 export function EquipmentHeroDropdown({


### PR DESCRIPTION
## Summary
- Consolidate Equipments desktop toolbar search onto the shared ListFilterSearchCard/SearchInput path.
- Remove the obsolete EquipmentHeroSearchInput pilot fork and keep toolbar actions/dropdowns on the existing HeroUI adapter.
- Add rendered-DOM coverage proving the shared SearchInput border/classes are applied and Repair Requests remains unchanged.

Closes #712

## Test Plan
- RED observed first: focused Equipments top-controls test failed on old pilot wrapper/shared-class expectations.
- npx prettier --check src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx src/components/equipment/equipment-toolbar.tsx src/components/equipment/equipment-toolbar-layout.tsx src/components/equipment/heroui-pilot/controls.tsx
- node scripts/npm-run.js run verify:heroui-boundary
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/components/equipment/__tests__/equipment-toolbar.heroui-top-controls.test.tsx src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx src/components/shared/__tests__/SearchInput.test.tsx src/components/shared/__tests__/ListFilterSearchCard.test.tsx src/components/shared/__tests__/ListFilterSearchCard.backing.test.tsx 'src/app/(app)/repair-requests/__tests__/RepairRequestsToolbar.test.tsx'
- node scripts/npm-run.js run react-doctor

Note: repo-wide format:check still reports unrelated baseline Prettier noise; changed files pass Prettier.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated Equipment desktop search onto the shared `ListFilterSearchCard`/`SearchInput`, removing the HeroUI pilot search fork. Aligns with Linear #712 and keeps existing HeroUI actions and dropdowns.

- **Refactors**
  - Switched to `ListFilterSearchCard` with shared `SearchInput` (no search icon); moved filters into `filterControls`.
  - Removed `EquipmentToolbarDesktopLayout` and `EquipmentHeroSearchInput`; kept `EquipmentHeroButton` and `EquipmentHeroDropdown`.
  - Updated tests for shared input border/classes and removed obsolete test IDs; padding `pr-16` and description text `body-responsive-sm`.
  - Switched to alias import for HeroUI controls.

<sup>Written for commit d25d9472a991f38b2238f856e7ce202f0cf816a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the desktop equipment toolbar to use a shared search/filter layout, improving consistency across the app.
  * Refined the search field’s appearance and spacing, including clearer search input styling and adjusted padding for the clear control.

* **Tests**
  * Aligned automated checks with the updated search field behavior and styling expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->