### PR TITLE
feat: cascade mobile equipment filters

### DIFF
--- a/scripts/check-heroui-import-boundary.js
+++ b/scripts/check-heroui-import-boundary.js
@@ -14,6 +14,7 @@ const ALLOWED_BOUNDARY_FILES = [
   "src/components/shared/SearchInput.tsx",
   "src/components/shared/ListFilterSearchCard.tsx",
   "src/components/shared/table-filters/FacetedMultiSelectFilter.tsx",
+  "src/components/equipment/filter-bottom-sheet.tsx",
 ]
 
 function normalizePath(filePath) {

--- a/src/app/(app)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx
+++ b/src/app/(app)/equipment/__tests__/EquipmentPageClient.department-summary.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   openColumnsDialog: vi.fn(),
   openDetailDialog: vi.fn(),
   tenantSelector: vi.fn(),
+  equipmentToolbar: vi.fn(),
 }))
 
 vi.mock("../use-equipment-page", () => ({
@@ -59,9 +60,10 @@ vi.mock("../_components/EquipmentBulkDeleteBar", () => ({
 }))
 
 vi.mock("@/components/equipment/equipment-toolbar", () => ({
-  EquipmentToolbar: ({ tenantControl }: { tenantControl?: React.ReactNode }) => (
-    <section aria-label="equipment toolbar">{tenantControl}</section>
-  ),
+  EquipmentToolbar: (props: { tenantControl?: React.ReactNode; description?: React.ReactNode }) => {
+    mocks.equipmentToolbar(props)
+    return <section aria-label="equipment toolbar">{props.tenantControl}</section>
+  },
 }))
 
 vi.mock("@/components/equipment/filter-bottom-sheet", () => ({
@@ -212,6 +214,26 @@ describe("EquipmentPageClient department summary", () => {
     expect(within(summary).queryByText("Chưa cập nhật")).not.toBeInTheDocument()
     expect(screen.getByRole("region", { name: "equipment toolbar" })).toBeInTheDocument()
     expect(screen.getByRole("region", { name: "equipment table" })).toBeInTheDocument()
+  })
+
+  it("does not pass the equipment subtitle into desktop or compact toolbar layouts", () => {
+    render(<EquipmentPageClient />)
+
+    expect(mocks.equipmentToolbar).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        description: "Quản lý danh sách các trang thiết bị y tế.",
+      })
+    )
+
+    vi.clearAllMocks()
+    state.pageState = createPageState({ isMobile: true, isCardView: true })
+    render(<EquipmentPageClient />)
+
+    expect(mocks.equipmentToolbar).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        description: "Quản lý danh sách các trang thiết bị y tế.",
+      })
+    )
   })
 
   it("hides the department summary when compact filters are active", () => {

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -137,6 +137,9 @@ function EquipmentPageContent({ pageState }: { pageState: ReturnType<typeof useE
     // Filter sheet
     isFilterSheetOpen,
     setIsFilterSheetOpen,
+    onFilterSheetDraftChange,
+    onApplyFilterSheetFilters,
+    onClearFilterSheetFilters,
 
     // Handlers
     handleExportData,
@@ -331,8 +334,9 @@ function EquipmentPageContent({ pageState }: { pageState: ReturnType<typeof useE
         onOpenChange={setIsFilterSheetOpen}
         data={filterData}
         columnFilters={columnFilters}
-        onApply={setColumnFilters}
-        onClearAll={() => setColumnFilters([])}
+        onDraftFiltersChange={onFilterSheetDraftChange}
+        onApply={onApplyFilterSheetFilters}
+        onClearAll={onClearFilterSheetFilters}
       />
     </>
   )

--- a/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentPageClient.tsx
@@ -243,7 +243,6 @@ function EquipmentPageContent({ pageState }: { pageState: ReturnType<typeof useE
         <EquipmentToolbar
           table={table}
           title="Danh mục thiết bị"
-          description="Quản lý danh sách các trang thiết bị y tế."
           tenantControl={tenantControl}
           searchTerm={searchTerm}
           onSearchChange={setSearchTerm}

--- a/src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterBuckets.test.tsx
+++ b/src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterBuckets.test.tsx
@@ -1,0 +1,142 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest"
+
+import { callRpc, type RpcOptions } from "@/lib/rpc-client"
+
+import {
+  useEquipmentFilterBuckets,
+  type UseEquipmentFilterBucketsParams,
+} from "../useEquipmentFilterBuckets"
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: vi.fn(),
+}))
+
+type RpcClientMock = MockedFunction<
+  (options: RpcOptions<Record<string, unknown>>) => Promise<unknown>
+>
+
+const callRpcMock = callRpc as unknown as RpcClientMock
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+const baseParams: UseEquipmentFilterBucketsParams = {
+  shouldFetchData: true,
+  effectiveTenantKey: "tenant-42",
+  userRole: "to_qltb",
+  userDiaBanId: null,
+  effectiveSelectedDonVi: 42,
+  debouncedSearch: "monitor",
+  selectedDepartments: ["ICU"],
+  selectedUsers: ["Dr A"],
+  selectedLocations: ["Room 1"],
+  selectedStatuses: ["Hoat dong"],
+  selectedClassifications: ["Class A"],
+  selectedFundingSources: ["Fund A"],
+}
+
+function getBucketCalls() {
+  return callRpcMock.mock.calls
+    .map(([options]) => options)
+    .filter((options) => options.fn === "equipment_filter_buckets")
+}
+
+describe("useEquipmentFilterBuckets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    callRpcMock.mockResolvedValue({
+      department: [{ name: "ICU", count: 3 }],
+      user: [{ name: "Dr A", count: 2 }],
+      location: [{ name: "Room 1", count: 1 }],
+      status: [{ name: "Hoat dong", count: 4 }],
+      classification: [{ name: "Class A", count: 5 }],
+      fundingSource: [{ name: "Fund A", count: 6 }],
+    })
+  })
+
+  it("passes selected filters to the shared equipment_filter_buckets RPC", async () => {
+    const queryClient = createQueryClient()
+
+    renderHook(() => useEquipmentFilterBuckets(baseParams), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
+
+    expect(getBucketCalls()[0]?.args).toMatchObject({
+      p_q: "monitor",
+      p_don_vi: 42,
+      p_khoa_phong_array: ["ICU"],
+      p_nguoi_su_dung_array: ["Dr A"],
+      p_vi_tri_lap_dat_array: ["Room 1"],
+      p_tinh_trang_array: ["Hoat dong"],
+      p_phan_loai_array: ["Class A"],
+      p_nguon_kinh_phi_array: ["Fund A"],
+    })
+  })
+
+  it("maps bucket rows once for desktop strings and mobile sheet options", async () => {
+    const queryClient = createQueryClient()
+    const { result } = renderHook(() => useEquipmentFilterBuckets(baseParams), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.filterData.department).toHaveLength(1))
+
+    expect(result.current.departments).toEqual(["ICU"])
+    expect(result.current.filterData.department).toEqual([{ id: "ICU", label: "ICU", count: 3 }])
+    expect(result.current.filterData.status).toEqual([
+      { id: "Hoat dong", label: "Hoat dong", count: 4 },
+    ])
+  })
+
+  it("keys bucket data by draft filters without pagination inputs", async () => {
+    const queryClient = createQueryClient()
+    const { rerender } = renderHook(
+      (params: UseEquipmentFilterBucketsParams) => useEquipmentFilterBuckets(params),
+      {
+        initialProps: baseParams,
+        wrapper: createWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
+
+    rerender({
+      ...baseParams,
+      selectedStatuses: ["Bao tri"],
+    })
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(2))
+
+    const bucketQueries = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_filter_buckets"] })
+    const latestBucketKeyParams = bucketQueries.at(-1)?.queryKey[1] as
+      Record<string, unknown> | undefined
+
+    expect(latestBucketKeyParams).toMatchObject({
+      q: "monitor",
+      tinh_trang_array: ["Bao tri"],
+    })
+    expect(latestBucketKeyParams).not.toHaveProperty("page")
+    expect(latestBucketKeyParams).not.toHaveProperty("size")
+  })
+})

--- a/src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterSheetCascade.test.tsx
+++ b/src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterSheetCascade.test.tsx
@@ -1,0 +1,101 @@
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest"
+
+import { callRpc, type RpcOptions } from "@/lib/rpc-client"
+
+import { useEquipmentFilterSheetCascade } from "../useEquipmentFilterSheetCascade"
+import type { FilterBottomSheetData } from "../../types"
+
+vi.mock("@/lib/rpc-client", () => ({
+  callRpc: vi.fn(),
+}))
+
+type RpcClientMock = MockedFunction<
+  (options: RpcOptions<Record<string, unknown>>) => Promise<unknown>
+>
+
+const callRpcMock = callRpc as unknown as RpcClientMock
+
+const committedFilterData: FilterBottomSheetData = {
+  status: [{ id: "Hoat dong", label: "Hoat dong", count: 10 }],
+  department: [],
+  location: [],
+  user: [],
+  classification: [],
+  fundingSource: [],
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function getBucketCalls() {
+  return callRpcMock.mock.calls
+    .map(([options]) => options)
+    .filter((options) => options.fn === "equipment_filter_buckets")
+}
+
+describe("useEquipmentFilterSheetCascade", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    callRpcMock.mockResolvedValue({
+      status: [{ name: "Hoat dong", count: 3 }],
+      department: [{ name: "ICU", count: 2 }],
+      location: [],
+      user: [],
+      classification: [],
+      fundingSource: [],
+    })
+  })
+
+  it("refreshes sheet bucket options from draft filters without applying them", async () => {
+    const onApply = vi.fn()
+    const queryClient = createQueryClient()
+    const { result } = renderHook(
+      () =>
+        useEquipmentFilterSheetCascade({
+          shouldFetchData: true,
+          committedColumnFilters: [],
+          committedFilterData,
+          effectiveTenantKey: "tenant-42",
+          userRole: "to_qltb",
+          userDiaBanId: null,
+          effectiveSelectedDonVi: 42,
+          debouncedSearch: "monitor",
+          onApply,
+          onClearAll: vi.fn(),
+        }),
+      { wrapper: createWrapper(queryClient) }
+    )
+
+    act(() => result.current.setIsFilterSheetOpen(true))
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
+
+    act(() =>
+      result.current.onDraftFiltersChange([{ id: "tinh_trang_hien_tai", value: ["Hoat dong"] }])
+    )
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(2))
+
+    expect(getBucketCalls()[1]?.args).toMatchObject({
+      p_tinh_trang_array: ["Hoat dong"],
+    })
+    expect(onApply).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -4,6 +4,7 @@ import * as React from "react"
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { callRpc } from "@/lib/rpc-client"
 import { useActiveUsageLogs } from "@/hooks/use-usage-logs"
+import { useEquipmentFilterBuckets } from "./useEquipmentFilterBuckets"
 import type { Equipment } from "../types"
 import type {
   EquipmentDepartmentDistributionItem,
@@ -74,26 +75,6 @@ export interface UseEquipmentDataReturn {
 
   // Cache invalidation
   invalidateEquipmentForCurrentTenant: () => void
-}
-
-type FilterBucketItem = { name: string; count: number }
-
-type EquipmentFilterBucketsResponse = Partial<{
-  department: FilterBucketItem[]
-  user: FilterBucketItem[]
-  location: FilterBucketItem[]
-  status: FilterBucketItem[]
-  classification: FilterBucketItem[]
-  fundingSource: FilterBucketItem[]
-}>
-
-const EMPTY_FILTER_BUCKET: FilterBucketItem[] = []
-
-function normalizeBucket(
-  data: EquipmentFilterBucketsResponse | undefined,
-  key: keyof EquipmentFilterBucketsResponse
-) {
-  return data?.[key] ?? EMPTY_FILTER_BUCKET
 }
 
 /** Loads equipment table data, filter buckets, and department distribution for the current scope. */
@@ -289,107 +270,21 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
 
   const isFetching = isEqFetching
 
-  // Filter buckets are bundled into one RPC to avoid six parallel cold-start calls.
-  const { data: filterBucketsData } = useQuery<EquipmentFilterBucketsResponse>({
-    queryKey: [
-      "equipment_filter_buckets",
-      {
-        tenant: effectiveTenantKey,
-        role: userRole,
-        diaBan: userDiaBanId,
-        donVi: effectiveSelectedDonVi,
-        q: debouncedSearch || null,
-        khoa_phong_array: selectedDepartments,
-        nguoi_su_dung_array: selectedUsers,
-        vi_tri_lap_dat_array: selectedLocations,
-        tinh_trang_array: selectedStatuses,
-        phan_loai_array: selectedClassifications,
-        nguon_kinh_phi_array: selectedFundingSources,
-      },
-    ],
-    queryFn: async ({ signal }) => {
-      const result = await callRpc<EquipmentFilterBucketsResponse>({
-        fn: "equipment_filter_buckets",
-        args: {
-          p_q: debouncedSearch || null,
-          p_don_vi: effectiveSelectedDonVi,
-          p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
-          p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
-          p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
-          p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
-          p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
-          p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
-        },
-        signal,
-      })
-      return result ?? {}
-    },
-    enabled: shouldFetchData,
-    staleTime: 300_000,
-    gcTime: 10 * 60_000,
-    refetchOnWindowFocus: false,
-  })
-
-  const departmentsData = normalizeBucket(filterBucketsData, "department")
-  const usersData = normalizeBucket(filterBucketsData, "user")
-  const locationsData = normalizeBucket(filterBucketsData, "location")
-  const classificationsData = normalizeBucket(filterBucketsData, "classification")
-  const statusesData = normalizeBucket(filterBucketsData, "status")
-  const fundingSourcesData = normalizeBucket(filterBucketsData, "fundingSource")
-
-  const departments = React.useMemo(
-    () => departmentsData.map((x) => x.name).filter(Boolean),
-    [departmentsData]
-  )
-  const users = React.useMemo(() => usersData.map((x) => x.name).filter(Boolean), [usersData])
-  const locations = React.useMemo(
-    () => locationsData.map((x) => x.name).filter(Boolean),
-    [locationsData]
-  )
-  const classifications = React.useMemo(
-    () => classificationsData.map((x) => x.name).filter(Boolean),
-    [classificationsData]
-  )
-  const statuses = React.useMemo(
-    () => statusesData.map((x) => x.name).filter(Boolean),
-    [statusesData]
-  )
-  const fundingSources = React.useMemo(
-    () => fundingSourcesData.map((x) => x.name).filter(Boolean),
-    [fundingSourcesData]
-  )
-
-  // Filter data for bottom sheet
-  const filterData: FilterBottomSheetData = React.useMemo(
-    () => ({
-      status: (statusesData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
-      department: (departmentsData || []).map((x) => ({
-        id: x.name,
-        label: x.name,
-        count: x.count,
-      })),
-      location: (locationsData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
-      user: (usersData || []).map((x) => ({ id: x.name, label: x.name, count: x.count })),
-      classification: (classificationsData || []).map((x) => ({
-        id: x.name,
-        label: x.name,
-        count: x.count,
-      })),
-      fundingSource: (fundingSourcesData || []).map((x) => ({
-        id: x.name,
-        label: x.name,
-        count: x.count,
-      })),
-    }),
-    [
-      statusesData,
-      departmentsData,
-      locationsData,
-      usersData,
-      classificationsData,
-      fundingSourcesData,
-    ]
-  )
+  const { departments, users, locations, statuses, classifications, fundingSources, filterData } =
+    useEquipmentFilterBuckets({
+      shouldFetchData,
+      effectiveTenantKey,
+      userRole,
+      userDiaBanId,
+      effectiveSelectedDonVi,
+      debouncedSearch,
+      selectedDepartments,
+      selectedUsers,
+      selectedLocations,
+      selectedStatuses,
+      selectedClassifications,
+      selectedFundingSources,
+    })
 
   // Cache invalidation - check all cache isolation fields
   const invalidateEquipmentForCurrentTenant = React.useCallback(() => {

--- a/src/app/(app)/equipment/_hooks/useEquipmentFilterBuckets.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentFilterBuckets.ts
@@ -1,0 +1,194 @@
+"use client"
+
+import * as React from "react"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import type { ColumnFiltersState } from "@tanstack/react-table"
+
+import { callRpc } from "@/lib/rpc-client"
+import type { FilterBottomSheetData } from "../types"
+
+export interface UseEquipmentFilterBucketsParams {
+  shouldFetchData: boolean
+  effectiveTenantKey: string
+  userRole: string
+  userDiaBanId?: number | null
+  effectiveSelectedDonVi: number | null
+  debouncedSearch: string
+  selectedDepartments: string[]
+  selectedUsers: string[]
+  selectedLocations: string[]
+  selectedStatuses: string[]
+  selectedClassifications: string[]
+  selectedFundingSources: string[]
+}
+
+export interface EquipmentSelectedFilters {
+  selectedDepartments: string[]
+  selectedUsers: string[]
+  selectedLocations: string[]
+  selectedStatuses: string[]
+  selectedClassifications: string[]
+  selectedFundingSources: string[]
+}
+
+export interface UseEquipmentFilterBucketsReturn {
+  departments: string[]
+  users: string[]
+  locations: string[]
+  statuses: string[]
+  classifications: string[]
+  fundingSources: string[]
+  filterData: FilterBottomSheetData
+}
+
+type FilterBucketItem = { name: string; count: number }
+
+type EquipmentFilterBucketsResponse = Partial<{
+  department: FilterBucketItem[]
+  user: FilterBucketItem[]
+  location: FilterBucketItem[]
+  status: FilterBucketItem[]
+  classification: FilterBucketItem[]
+  fundingSource: FilterBucketItem[]
+}>
+
+const EMPTY_FILTER_BUCKET: FilterBucketItem[] = []
+
+const EMPTY_FILTER_DATA: FilterBottomSheetData = {
+  status: [],
+  department: [],
+  location: [],
+  user: [],
+  classification: [],
+  fundingSource: [],
+}
+
+function normalizeBucket(
+  data: EquipmentFilterBucketsResponse | undefined,
+  key: keyof EquipmentFilterBucketsResponse
+) {
+  return data?.[key] ?? EMPTY_FILTER_BUCKET
+}
+
+function getArrayFilter(columnFilters: ColumnFiltersState, id: string): string[] {
+  const entry = columnFilters.find((filter) => filter.id === id)
+  if (!Array.isArray(entry?.value)) return []
+  return entry.value.filter((value): value is string => typeof value === "string")
+}
+
+/** Extracts equipment filter arrays from TanStack column filter state. */
+export function getEquipmentSelectedFilters(
+  columnFilters: ColumnFiltersState
+): EquipmentSelectedFilters {
+  return {
+    selectedDepartments: getArrayFilter(columnFilters, "khoa_phong_quan_ly"),
+    selectedUsers: getArrayFilter(columnFilters, "nguoi_dang_truc_tiep_quan_ly"),
+    selectedLocations: getArrayFilter(columnFilters, "vi_tri_lap_dat"),
+    selectedStatuses: getArrayFilter(columnFilters, "tinh_trang_hien_tai"),
+    selectedClassifications: getArrayFilter(columnFilters, "phan_loai_theo_nd98"),
+    selectedFundingSources: getArrayFilter(columnFilters, "nguon_kinh_phi"),
+  }
+}
+
+/** Loads cascaded equipment filter buckets and maps them for desktop and mobile filters. */
+export function useEquipmentFilterBuckets(
+  params: UseEquipmentFilterBucketsParams
+): UseEquipmentFilterBucketsReturn {
+  const {
+    shouldFetchData,
+    effectiveTenantKey,
+    userRole,
+    userDiaBanId,
+    effectiveSelectedDonVi,
+    debouncedSearch,
+    selectedDepartments,
+    selectedUsers,
+    selectedLocations,
+    selectedStatuses,
+    selectedClassifications,
+    selectedFundingSources,
+  } = params
+
+  const { data: filterBucketsData } = useQuery<EquipmentFilterBucketsResponse>({
+    queryKey: [
+      "equipment_filter_buckets",
+      {
+        tenant: effectiveTenantKey,
+        role: userRole,
+        diaBan: userDiaBanId,
+        donVi: effectiveSelectedDonVi,
+        q: debouncedSearch || null,
+        khoa_phong_array: selectedDepartments,
+        nguoi_su_dung_array: selectedUsers,
+        vi_tri_lap_dat_array: selectedLocations,
+        tinh_trang_array: selectedStatuses,
+        phan_loai_array: selectedClassifications,
+        nguon_kinh_phi_array: selectedFundingSources,
+      },
+    ],
+    queryFn: async ({ signal }) => {
+      const result = await callRpc<EquipmentFilterBucketsResponse>({
+        fn: "equipment_filter_buckets",
+        args: {
+          p_q: debouncedSearch || null,
+          p_don_vi: effectiveSelectedDonVi,
+          p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
+          p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
+          p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
+          p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
+          p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
+          p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
+        },
+        signal,
+      })
+      return result ?? {}
+    },
+    enabled: shouldFetchData,
+    placeholderData: keepPreviousData,
+    staleTime: 300_000,
+    gcTime: 10 * 60_000,
+    refetchOnWindowFocus: false,
+  })
+
+  const departmentsData = normalizeBucket(filterBucketsData, "department")
+  const usersData = normalizeBucket(filterBucketsData, "user")
+  const locationsData = normalizeBucket(filterBucketsData, "location")
+  const classificationsData = normalizeBucket(filterBucketsData, "classification")
+  const statusesData = normalizeBucket(filterBucketsData, "status")
+  const fundingSourcesData = normalizeBucket(filterBucketsData, "fundingSource")
+
+  const selectedFilterOptions = React.useMemo<UseEquipmentFilterBucketsReturn>(() => {
+    const mapNames = (items: FilterBucketItem[]) => items.map((x) => x.name).filter(Boolean)
+    const mapOptions = (items: FilterBucketItem[]) =>
+      items.map((x) => ({ id: x.name, label: x.name, count: x.count }))
+
+    return {
+      departments: mapNames(departmentsData),
+      users: mapNames(usersData),
+      locations: mapNames(locationsData),
+      statuses: mapNames(statusesData),
+      classifications: mapNames(classificationsData),
+      fundingSources: mapNames(fundingSourcesData),
+      filterData: filterBucketsData
+        ? {
+            status: mapOptions(statusesData),
+            department: mapOptions(departmentsData),
+            location: mapOptions(locationsData),
+            user: mapOptions(usersData),
+            classification: mapOptions(classificationsData),
+            fundingSource: mapOptions(fundingSourcesData),
+          }
+        : EMPTY_FILTER_DATA,
+    }
+  }, [
+    departmentsData,
+    usersData,
+    locationsData,
+    statusesData,
+    classificationsData,
+    fundingSourcesData,
+    filterBucketsData,
+  ])
+
+  return selectedFilterOptions
+}

--- a/src/app/(app)/equipment/_hooks/useEquipmentFilterBuckets.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentFilterBuckets.ts
@@ -66,7 +66,7 @@ const EMPTY_FILTER_DATA: FilterBottomSheetData = {
 function normalizeBucket(
   data: EquipmentFilterBucketsResponse | undefined,
   key: keyof EquipmentFilterBucketsResponse
-) {
+): FilterBucketItem[] {
   return data?.[key] ?? EMPTY_FILTER_BUCKET
 }
 

--- a/src/app/(app)/equipment/_hooks/useEquipmentFilterSheetCascade.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentFilterSheetCascade.ts
@@ -1,0 +1,112 @@
+"use client"
+
+import * as React from "react"
+import type { ColumnFiltersState } from "@tanstack/react-table"
+
+import type { FilterBottomSheetData } from "../types"
+import { getEquipmentSelectedFilters, useEquipmentFilterBuckets } from "./useEquipmentFilterBuckets"
+
+interface UseEquipmentFilterSheetCascadeParams {
+  shouldFetchData: boolean
+  committedColumnFilters: ColumnFiltersState
+  committedFilterData: FilterBottomSheetData
+  effectiveTenantKey: string
+  userRole: string
+  userDiaBanId?: number | null
+  effectiveSelectedDonVi: number | null
+  debouncedSearch: string
+  onApply: (next: ColumnFiltersState) => void
+  onClearAll: () => void
+}
+
+export interface UseEquipmentFilterSheetCascadeReturn {
+  filterData: FilterBottomSheetData
+  isFilterSheetOpen: boolean
+  setIsFilterSheetOpen: React.Dispatch<React.SetStateAction<boolean>>
+  onDraftFiltersChange: (next: ColumnFiltersState) => void
+  onApply: (next: ColumnFiltersState) => void
+  onClearAll: () => void
+}
+
+/** Coordinates mobile filter-sheet draft state with the shared cascaded bucket query. */
+export function useEquipmentFilterSheetCascade({
+  shouldFetchData,
+  committedColumnFilters,
+  committedFilterData,
+  effectiveTenantKey,
+  userRole,
+  userDiaBanId,
+  effectiveSelectedDonVi,
+  debouncedSearch,
+  onApply,
+  onClearAll,
+}: UseEquipmentFilterSheetCascadeParams): UseEquipmentFilterSheetCascadeReturn {
+  const [isFilterSheetOpen, setFilterSheetOpen] = React.useState(false)
+  const [draftColumnFilters, setDraftColumnFilters] = React.useState<ColumnFiltersState | null>(
+    null
+  )
+
+  const sheetColumnFilters = draftColumnFilters ?? committedColumnFilters
+  const sheetSelectedFilters = React.useMemo(
+    () => getEquipmentSelectedFilters(sheetColumnFilters),
+    [sheetColumnFilters]
+  )
+
+  const sheetBuckets = useEquipmentFilterBuckets({
+    shouldFetchData: shouldFetchData && isFilterSheetOpen,
+    effectiveTenantKey,
+    userRole,
+    userDiaBanId,
+    effectiveSelectedDonVi,
+    debouncedSearch,
+    ...sheetSelectedFilters,
+  })
+
+  const setIsFilterSheetOpen = React.useCallback<React.Dispatch<React.SetStateAction<boolean>>>(
+    (value) => {
+      setFilterSheetOpen((current) => {
+        const nextOpen = typeof value === "function" ? value(current) : value
+        setDraftColumnFilters(nextOpen ? committedColumnFilters : null)
+        return nextOpen
+      })
+    },
+    [committedColumnFilters]
+  )
+
+  const handleDraftFiltersChange = React.useCallback((next: ColumnFiltersState) => {
+    setDraftColumnFilters(next)
+  }, [])
+
+  const handleApply = React.useCallback(
+    (next: ColumnFiltersState) => {
+      setDraftColumnFilters(null)
+      onApply(next)
+    },
+    [onApply]
+  )
+
+  const handleClearAll = React.useCallback(() => {
+    setDraftColumnFilters(null)
+    onClearAll()
+  }, [onClearAll])
+
+  return React.useMemo(
+    () => ({
+      filterData: isFilterSheetOpen ? sheetBuckets.filterData : committedFilterData,
+      isFilterSheetOpen,
+      setIsFilterSheetOpen,
+      onDraftFiltersChange: handleDraftFiltersChange,
+      onApply: handleApply,
+      onClearAll: handleClearAll,
+    }),
+    [
+      isFilterSheetOpen,
+      sheetBuckets.filterData,
+      committedFilterData,
+      setIsFilterSheetOpen,
+      handleDraftFiltersChange,
+      handleApply,
+      handleClearAll,
+    ]
+  )
+}

--- a/src/app/(app)/equipment/types.ts
+++ b/src/app/(app)/equipment/types.ts
@@ -167,6 +167,9 @@ export interface UseEquipmentPageReturn {
   // Filter sheet
   isFilterSheetOpen: boolean
   setIsFilterSheetOpen: React.Dispatch<React.SetStateAction<boolean>>
+  onFilterSheetDraftChange: (next: ColumnFiltersState) => void
+  onApplyFilterSheetFilters: (next: ColumnFiltersState) => void
+  onClearFilterSheetFilters: () => void
 
   // Handlers
   handleDownloadTemplate: () => Promise<void>

--- a/src/app/(app)/equipment/use-equipment-page.tsx
+++ b/src/app/(app)/equipment/use-equipment-page.tsx
@@ -11,6 +11,7 @@ import { isEquipmentManagerRole } from "@/lib/rbac"
 import { useEquipmentAuth } from "./_hooks/useEquipmentAuth"
 import { useEquipmentFilters } from "./_hooks/useEquipmentFilters"
 import { useEquipmentData } from "./_hooks/useEquipmentData"
+import { useEquipmentFilterSheetCascade } from "./_hooks/useEquipmentFilterSheetCascade"
 import { useEquipmentTable } from "./_hooks/useEquipmentTable"
 import { useEquipmentExport } from "./_hooks/useEquipmentExport"
 import { useEquipmentRouteSync } from "./_hooks/useEquipmentRouteSync"
@@ -219,8 +220,18 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
   // NOTE: Legacy dialog state removed - now managed by EquipmentDialogContext
   // Route sync pending actions are exposed for handling in page.tsx with context
 
-  // Filter sheet state (not a dialog - stays here)
-  const [isFilterSheetOpen, setIsFilterSheetOpen] = React.useState(false)
+  const filterSheet = useEquipmentFilterSheetCascade({
+    shouldFetchData: data.shouldFetchData,
+    committedColumnFilters: filters.columnFilters,
+    committedFilterData: data.filterData,
+    effectiveTenantKey: auth.effectiveTenantKey,
+    userRole: auth.user?.role || "user",
+    userDiaBanId: auth.user?.dia_ban_id,
+    effectiveSelectedDonVi,
+    debouncedSearch: filters.debouncedSearch,
+    onApply: setColumnFiltersAndReset,
+    onClearAll: () => setColumnFiltersAndReset([]),
+  })
 
   // Tenant change effect: keep tenant-scoped filter state and show toast
   // Track by effectiveTenantKey which now uses context's selectedFacilityId
@@ -310,7 +321,7 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
       statuses: data.statuses,
       classifications: data.classifications,
       fundingSources: data.fundingSources,
-      filterData: data.filterData,
+      filterData: filterSheet.filterData,
 
       // Facility filter - now from context via auth/data hooks
       showFacilityFilter: data.showFacilityFilter,
@@ -322,8 +333,11 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
       isFacilitiesLoading: data.isFacilitiesLoading,
 
       // Filter sheet
-      isFilterSheetOpen,
-      setIsFilterSheetOpen,
+      isFilterSheetOpen: filterSheet.isFilterSheetOpen,
+      setIsFilterSheetOpen: filterSheet.setIsFilterSheetOpen,
+      onFilterSheetDraftChange: filterSheet.onDraftFiltersChange,
+      onApplyFilterSheetFilters: filterSheet.onApply,
+      onClearFilterSheetFilters: filterSheet.onClearAll,
 
       // Handlers
       handleDownloadTemplate: exports.handleDownloadTemplate,
@@ -356,7 +370,7 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
       setSearchTermAndReset,
       setColumnFiltersAndReset,
       hasFacilityFilter,
-      isFilterSheetOpen,
+      filterSheet,
       exports,
       onDataMutationSuccess,
       onDataMutationSuccessWithStatePreservation,

--- a/src/app/(app)/equipment/use-equipment-page.tsx
+++ b/src/app/(app)/equipment/use-equipment-page.tsx
@@ -220,6 +220,10 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
   // NOTE: Legacy dialog state removed - now managed by EquipmentDialogContext
   // Route sync pending actions are exposed for handling in page.tsx with context
 
+  const handleClearAllColumnFilters = React.useCallback(() => {
+    setColumnFiltersAndReset([])
+  }, [setColumnFiltersAndReset])
+
   const filterSheet = useEquipmentFilterSheetCascade({
     shouldFetchData: data.shouldFetchData,
     committedColumnFilters: filters.columnFilters,
@@ -230,7 +234,7 @@ export function useEquipmentPage(): UseEquipmentPageReturn {
     effectiveSelectedDonVi,
     debouncedSearch: filters.debouncedSearch,
     onApply: setColumnFiltersAndReset,
-    onClearAll: () => setColumnFiltersAndReset([]),
+    onClearAll: handleClearAllColumnFilters,
   })
 
   // Tenant change effect: keep tenant-scoped filter state and show toast

--- a/src/components/equipment/filter-bottom-sheet.tsx
+++ b/src/components/equipment/filter-bottom-sheet.tsx
@@ -85,15 +85,12 @@ export function FilterBottomSheet({
   )
 
   const toggleFilter = (category: string, value: string) => {
-    setLocalFilters((prev) => {
-      const current = prev[category] || []
-      const next = current.includes(value)
-        ? current.filter((v) => v !== value)
-        : [...current, value]
-      const nextFilters = { ...prev, [category]: next }
-      onDraftFiltersChange?.(toColumnFilters(nextFilters))
-      return nextFilters
-    })
+    const current = localFilters[category] || []
+    const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value]
+    const nextFilters = { ...localFilters, [category]: next }
+
+    setLocalFilters(nextFilters)
+    onDraftFiltersChange?.(toColumnFilters(nextFilters))
   }
 
   const isSelected = (category: string, value: string) => {

--- a/src/components/equipment/filter-bottom-sheet.tsx
+++ b/src/components/equipment/filter-bottom-sheet.tsx
@@ -3,9 +3,9 @@
 import * as React from "react"
 import { X, Check } from "lucide-react"
 import type { ColumnFiltersState } from "@tanstack/react-table"
+import { Badge as HeroBadge } from "@heroui/react/badge"
+import { Button as HeroButton } from "@heroui/react/button"
 
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import { MobileBottomSheet } from "@/components/shared/mobile-bottom-sheet"
 
@@ -25,6 +25,7 @@ interface FilterBottomSheetProps {
   onOpenChange: (open: boolean) => void
   data: EquipmentFilterData
   columnFilters: ColumnFiltersState
+  onDraftFiltersChange?: (next: ColumnFiltersState) => void
   onApply: (next: ColumnFiltersState) => void
   onClearAll: () => void
 }
@@ -39,12 +40,23 @@ function getLocalFilters(columnFilters: ColumnFiltersState): Record<string, stri
   return initial
 }
 
+function toColumnFilters(localFilters: Record<string, string[]>): ColumnFiltersState {
+  const next: ColumnFiltersState = []
+  for (const [id, value] of Object.entries(localFilters)) {
+    if (value.length > 0) {
+      next.push({ id, value })
+    }
+  }
+  return next
+}
+
 /** Renders the mobile equipment filter sheet with an apply-only local draft. */
 export function FilterBottomSheet({
   open,
   onOpenChange,
   data,
   columnFilters,
+  onDraftFiltersChange,
   onApply,
   onClearAll,
 }: FilterBottomSheetProps) {
@@ -78,7 +90,9 @@ export function FilterBottomSheet({
       const next = current.includes(value)
         ? current.filter((v) => v !== value)
         : [...current, value]
-      return { ...prev, [category]: next }
+      const nextFilters = { ...prev, [category]: next }
+      onDraftFiltersChange?.(toColumnFilters(nextFilters))
+      return nextFilters
     })
   }
 
@@ -91,13 +105,7 @@ export function FilterBottomSheet({
   }, [localFilters])
 
   const handleApply = () => {
-    const next: ColumnFiltersState = []
-    for (const [id, value] of Object.entries(localFilters)) {
-      if (value.length > 0) {
-        next.push({ id, value })
-      }
-    }
-    onApply(next)
+    onApply(toColumnFilters(localFilters))
     handleOpenChange(false)
   }
 
@@ -119,39 +127,41 @@ export function FilterBottomSheet({
     <MobileBottomSheet open={open} onOpenChange={handleOpenChange} ariaLabel="Bộ lọc thiết bị">
       {/* Header */}
       <div className="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
-        <h2 className="text-lg font-semibold text-foreground">
-          Bộ lọc thiết bị
-        </h2>
-        <Button
+        <h2 className="text-lg font-semibold text-foreground">Bộ lọc thiết bị</h2>
+        <HeroButton
           variant="ghost"
-          size="icon"
-          onClick={() => handleOpenChange(false)}
+          size="sm"
+          isIconOnly
+          onPress={() => handleOpenChange(false)}
           className="size-10 rounded-full"
           aria-label="Đóng bộ lọc"
         >
           <X className="size-5" />
-        </Button>
+        </HeroButton>
       </div>
 
       {/* Scrollable Content */}
-      <div className="flex-1 overflow-y-auto overscroll-contain px-6 py-4 space-y-6" style={{
-        maxHeight: 'calc(100vh - 20rem)',
-        WebkitOverflowScrolling: 'touch'
-      }}>
+      <div
+        className="flex-1 overflow-y-auto overscroll-contain px-6 py-4 space-y-6"
+        style={{
+          maxHeight: "calc(100vh - 20rem)",
+          WebkitOverflowScrolling: "touch",
+        }}
+      >
         {filterSections.map((section) =>
           section.options.length > 0 ? (
             <div key={section.key}>
-              <h3 className="text-sm font-semibold text-foreground mb-3">
-                {section.label}
-              </h3>
+              <h3 className="text-sm font-semibold text-foreground mb-3">{section.label}</h3>
               <div className="space-y-2">
                 {section.options.map((option) => {
                   const selected = isSelected(section.key, option.id)
                   return (
-                    <button
+                    <HeroButton
                       key={option.id}
                       type="button"
-                      onClick={() => toggleFilter(section.key, option.id)}
+                      variant="outline"
+                      onPress={() => toggleFilter(section.key, option.id)}
+                      aria-pressed={selected}
                       className={cn(
                         "w-full flex items-center justify-between p-3.5 rounded-xl border-2 transition-all touch-target-sm",
                         selected
@@ -169,7 +179,10 @@ export function FilterBottomSheet({
                           )}
                         >
                           {selected && (
-                            <Check className="size-3.5 text-[hsl(var(--primary-foreground))]" strokeWidth={3} />
+                            <Check
+                              className="size-3.5 text-[hsl(var(--primary-foreground))]"
+                              strokeWidth={3}
+                            />
                           )}
                         </div>
                         <span
@@ -181,13 +194,14 @@ export function FilterBottomSheet({
                           {option.label}
                         </span>
                       </div>
-                      <Badge
+                      <HeroBadge
                         variant="secondary"
+                        size="sm"
                         className="text-xs font-semibold shrink-0"
                       >
                         {option.count}
-                      </Badge>
-                    </button>
+                      </HeroBadge>
+                    </HeroButton>
                   )
                 })}
               </div>
@@ -199,19 +213,19 @@ export function FilterBottomSheet({
       {/* Footer - Extra padding to clear bottom navigation */}
       <div className="shrink-0 px-6 pt-4 pb-24 border-t border-border bg-muted/30">
         <div className="grid grid-cols-2 gap-3">
-          <Button
+          <HeroButton
             variant="outline"
-            onClick={handleClearAll}
+            onPress={handleClearAll}
             className="h-12 text-sm font-semibold rounded-xl"
           >
             Xóa tất cả
-          </Button>
-          <Button
-            onClick={handleApply}
+          </HeroButton>
+          <HeroButton
+            onPress={handleApply}
             className="h-12 text-sm font-semibold rounded-xl bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] hover:bg-[hsl(var(--primary))]/90"
           >
             Áp dụng {activeCount > 0 && `(${activeCount})`}
-          </Button>
+          </HeroButton>
         </div>
       </div>
     </MobileBottomSheet>

--- a/src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
+++ b/src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
@@ -89,6 +89,7 @@ describe("FilterBottomSheet (regression)", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Đang sử dụng/ }))
 
+    expect(onDraftFiltersChange).toHaveBeenCalledTimes(1)
     expect(onDraftFiltersChange).toHaveBeenCalledWith([
       { id: "tinh_trang_hien_tai", value: ["active"] },
     ])

--- a/src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
+++ b/src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
@@ -1,77 +1,97 @@
-import * as React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import * as React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
 
-import { FilterBottomSheet, type EquipmentFilterData } from '../../equipment/filter-bottom-sheet'
+import { FilterBottomSheet, type EquipmentFilterData } from "../../equipment/filter-bottom-sheet"
 
 const emptyFilterData: EquipmentFilterData = {
-    status: [{ id: 'active', label: 'Đang sử dụng', count: 10 }],
-    department: [],
-    location: [],
-    user: [],
-    classification: [],
-    fundingSource: [],
+  status: [{ id: "active", label: "Đang sử dụng", count: 10 }],
+  department: [],
+  location: [],
+  user: [],
+  classification: [],
+  fundingSource: [],
 }
 
-describe('FilterBottomSheet (regression)', () => {
-    const defaultProps = {
-        open: true,
-        onOpenChange: vi.fn(),
-        data: emptyFilterData,
-        columnFilters: [],
-        onApply: vi.fn(),
-        onClearAll: vi.fn(),
-    }
+describe("FilterBottomSheet (regression)", () => {
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    data: emptyFilterData,
+    columnFilters: [],
+    onApply: vi.fn(),
+    onClearAll: vi.fn(),
+  }
 
-    it('renders filter section labels when open', () => {
-        render(<FilterBottomSheet {...defaultProps} />)
+  it("renders filter section labels when open", () => {
+    render(<FilterBottomSheet {...defaultProps} />)
 
-        expect(screen.getByText('Trạng thái')).toBeInTheDocument()
-        expect(screen.getByText('Đang sử dụng')).toBeInTheDocument()
-    })
+    expect(screen.getByText("Trạng thái")).toBeInTheDocument()
+    expect(screen.getByText("Đang sử dụng")).toBeInTheDocument()
+  })
 
-    it('calls onOpenChange(false) when close button is clicked', () => {
-        const onOpenChange = vi.fn()
-        render(<FilterBottomSheet {...defaultProps} onOpenChange={onOpenChange} />)
+  it("calls onOpenChange(false) when close button is clicked", () => {
+    const onOpenChange = vi.fn()
+    render(<FilterBottomSheet {...defaultProps} onOpenChange={onOpenChange} />)
 
-        const closeButton = screen.getByLabelText('Đóng bộ lọc')
-        fireEvent.click(closeButton)
-        expect(onOpenChange).toHaveBeenCalledWith(false)
-    })
+    const closeButton = screen.getByLabelText("Đóng bộ lọc")
+    fireEvent.click(closeButton)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
 
-    it('calls onOpenChange(false) on backdrop click', () => {
-        const onOpenChange = vi.fn()
-        render(<FilterBottomSheet {...defaultProps} onOpenChange={onOpenChange} />)
+  it("calls onOpenChange(false) on backdrop click", () => {
+    const onOpenChange = vi.fn()
+    render(<FilterBottomSheet {...defaultProps} onOpenChange={onOpenChange} />)
 
-        const backdrop = screen.getByTestId('mobile-bottom-sheet-backdrop')
-        fireEvent.click(backdrop)
-        expect(onOpenChange).toHaveBeenCalledWith(false)
-    })
+    const backdrop = screen.getByTestId("mobile-bottom-sheet-backdrop")
+    fireEvent.click(backdrop)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
 
-    it('does not render when closed', () => {
-        render(<FilterBottomSheet {...defaultProps} open={false} />)
+  it("does not render when closed", () => {
+    render(<FilterBottomSheet {...defaultProps} open={false} />)
 
-        expect(screen.queryByText('Trạng thái')).not.toBeInTheDocument()
-    })
+    expect(screen.queryByText("Trạng thái")).not.toBeInTheDocument()
+  })
 
-    it('keeps the local draft when parent filters refresh while open', () => {
-        const { rerender } = render(
-            <FilterBottomSheet
-                {...defaultProps}
-                columnFilters={[{ id: 'tinh_trang_hien_tai', value: ['active'] }]}
-            />
-        )
+  it("keeps the local draft when parent filters refresh while open", () => {
+    const { rerender } = render(
+      <FilterBottomSheet
+        {...defaultProps}
+        columnFilters={[{ id: "tinh_trang_hien_tai", value: ["active"] }]}
+      />
+    )
 
-        fireEvent.click(screen.getByRole('button', { name: /Đang sử dụng/ }))
+    fireEvent.click(screen.getByRole("button", { name: /Đang sử dụng/ }))
 
-        rerender(
-            <FilterBottomSheet
-                {...defaultProps}
-                columnFilters={[{ id: 'tinh_trang_hien_tai', value: ['active'] }]}
-            />
-        )
-        fireEvent.click(screen.getByRole('button', { name: /Áp dụng/ }))
+    rerender(
+      <FilterBottomSheet
+        {...defaultProps}
+        columnFilters={[{ id: "tinh_trang_hien_tai", value: ["active"] }]}
+      />
+    )
+    fireEvent.click(screen.getByRole("button", { name: /Áp dụng/ }))
 
-        expect(defaultProps.onApply).toHaveBeenCalledWith([])
-    })
+    expect(defaultProps.onApply).toHaveBeenCalledWith([])
+  })
+
+  it("reports local draft changes so parent can refresh cascade buckets before apply", () => {
+    const onApply = vi.fn()
+    const onDraftFiltersChange = vi.fn()
+
+    render(
+      <FilterBottomSheet
+        {...defaultProps}
+        onApply={onApply}
+        onDraftFiltersChange={onDraftFiltersChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Đang sử dụng/ }))
+
+    expect(onDraftFiltersChange).toHaveBeenCalledWith([
+      { id: "tinh_trang_hien_tai", value: ["active"] },
+    ])
+    expect(onApply).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- migrate Equipments mobile filter sheet internals to the approved HeroUI boundary
- reuse the shared equipment_filter_buckets pattern for desktop and mobile filter options
- add draft-mode mobile cascade so option groups refresh inside the sheet before Apply commits filters

Closes #710

## Verification
- npx prettier --check --ignore-unknown <changed files>
- node scripts/npm-run.js run verify:heroui-boundary
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
- node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterBuckets.test.tsx'
- node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterSheetCascade.test.tsx'
- node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx'
- node scripts/npm-run.js run react-doctor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cascaded mobile equipment filters with a draft mode so options refresh inside the sheet before Apply, and completes the migration to the approved HeroUI boundary. Implements the mobile filter-sheet cascade and HeroUI boundary requirements from #710.

- New Features
  - Mobile filter sheet cascades: selecting options refreshes other groups in-sheet; changes apply only on Apply.
  - Added `useEquipmentFilterSheetCascade` to manage draft state and handlers (`onDraftFiltersChange`, `onApply`, `onClearAll`), integrated via `useEquipmentPage`, `EquipmentPageClient`, and `FilterBottomSheet`.
  - Migrated sheet UI to `@heroui/react` (`button`, `badge`) and updated the HeroUI import boundary to allow `src/components/equipment/filter-bottom-sheet.tsx`.

- Refactors
  - Extracted bucket fetching to `useEquipmentFilterBuckets` (shared by desktop and mobile) using `equipment_filter_buckets`; `useEquipmentData` now uses this hook.
  - Unified mapping for desktop strings and mobile sheet options; query keys scope to draft filters and keep previous data to avoid flicker.
  - Removed equipment toolbar subtitle from desktop and compact layouts per review.
  - Added tests for `useEquipmentFilterBuckets` and `useEquipmentFilterSheetCascade`, and extended the filter sheet regression test to validate draft-change emissions.

<sup>Written for commit c771b635fed124b45516375ba67503c10b199c2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved equipment filtering with live draft updates in the bottom sheet, plus separate **Apply** and **Clear all** actions.
  * Cascading filter counts now refresh based on the current sheet draft/selection for more accurate options.

* **Bug Fixes**
  * Corrected filter state behavior so changes are reflected during drafting but only committed when you apply.
  * Enhanced mobile filter sheet interaction consistency (open, update, close, and re-sync).

* **Tests**
  * Added/expanded regression coverage for the bottom sheet and filter cascade logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->