### PR TITLE
Add overlay action transition adapter

### DIFF
--- a/src/components/ui/__tests__/use-overlay-action-transition.test.tsx
+++ b/src/components/ui/__tests__/use-overlay-action-transition.test.tsx
@@ -32,8 +32,11 @@ describe("useOverlayActionTransition", () => {
             <button
               type="button"
               onClick={() => {
-                document.body.style.pointerEvents = "auto"
-                runOverlayAction(() => onAction(document.body.style.pointerEvents))
+                document.body.style.pointerEvents = "none"
+                runOverlayAction(() => {
+                  document.body.style.pointerEvents = ""
+                  onAction(document.body.style.pointerEvents)
+                })
                 setSourceMenuOpen(false)
               }}
             >
@@ -51,12 +54,13 @@ describe("useOverlayActionTransition", () => {
 
     expect(screen.getByTestId("source-state")).toHaveTextContent("closed")
     expect(onAction).not.toHaveBeenCalled()
+    expect(document.body.style.pointerEvents).toBe("none")
 
     act(() => {
       vi.advanceTimersByTime(0)
     })
 
-    expect(onAction).toHaveBeenCalledWith("auto")
+    expect(onAction).toHaveBeenCalledWith("")
     expect(document.body.style.pointerEvents).not.toBe("none")
   })
 

--- a/src/components/ui/__tests__/use-overlay-action-transition.test.tsx
+++ b/src/components/ui/__tests__/use-overlay-action-transition.test.tsx
@@ -1,0 +1,85 @@
+import * as React from "react"
+import { act, fireEvent, render, renderHook, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  useDeferredDropdownAction,
+  useOverlayActionTransition,
+} from "@/components/ui/use-deferred-dropdown-action"
+
+describe("useOverlayActionTransition", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    document.body.style.pointerEvents = ""
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    document.body.style.pointerEvents = ""
+  })
+
+  it("defers actions until after the source menu closes", () => {
+    const onAction = vi.fn()
+
+    function Harness() {
+      const runOverlayAction = useOverlayActionTransition()
+      const [sourceMenuOpen, setSourceMenuOpen] = React.useState(true)
+
+      return (
+        <div>
+          {sourceMenuOpen ? (
+            <button
+              type="button"
+              onClick={() => {
+                document.body.style.pointerEvents = "auto"
+                runOverlayAction(() => onAction(document.body.style.pointerEvents))
+                setSourceMenuOpen(false)
+              }}
+            >
+              Open follow-up overlay
+            </button>
+          ) : null}
+          <span data-testid="source-state">{sourceMenuOpen ? "open" : "closed"}</span>
+        </div>
+      )
+    }
+
+    render(<Harness />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Open follow-up overlay" }))
+
+    expect(screen.getByTestId("source-state")).toHaveTextContent("closed")
+    expect(onAction).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(onAction).toHaveBeenCalledWith("auto")
+    expect(document.body.style.pointerEvents).not.toBe("none")
+  })
+
+  it("cleans up pending action timers when the hook owner unmounts", () => {
+    const onAction = vi.fn()
+    const { result, unmount } = renderHook(() => useOverlayActionTransition())
+
+    act(() => {
+      result.current(onAction)
+    })
+
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(onAction).not.toHaveBeenCalled()
+  })
+
+  it("keeps useDeferredDropdownAction as a compatibility export", () => {
+    const { result } = renderHook(() => useDeferredDropdownAction())
+
+    expect(result.current).toEqual(expect.any(Function))
+  })
+})

--- a/src/components/ui/use-deferred-dropdown-action.ts
+++ b/src/components/ui/use-deferred-dropdown-action.ts
@@ -3,10 +3,10 @@
 import * as React from "react"
 
 /**
- * Defers opening a follow-up overlay until the source dropdown has finished
- * its close/focus lifecycle.
+ * Defers a follow-up overlay action until the source menu/dropdown has
+ * finished its close/focus lifecycle.
  */
-export function useDeferredDropdownAction() {
+export function useOverlayActionTransition() {
   const timeoutIdsRef = React.useRef<ReturnType<typeof setTimeout>[]>([])
 
   React.useEffect(() => {
@@ -25,3 +25,8 @@ export function useDeferredDropdownAction() {
     timeoutIdsRef.current.push(timeoutId)
   }, [])
 }
+
+/**
+ * Compatibility export for dropdown callers that still use the original name.
+ */
+export const useDeferredDropdownAction = useOverlayActionTransition


### PR DESCRIPTION
## Summary
- Promote the existing dropdown deferral helper to `useOverlayActionTransition`.
- Keep `useDeferredDropdownAction` as a compatibility export.
- Add focused contract tests for deferred dispatch, source menu close, pointer-events safety, cleanup on unmount, and compat export.

Closes #724

## Verification
- RED: `node scripts/npm-run.js run test:run -- src/components/ui/__tests__/use-overlay-action-transition.test.tsx --reporter=verbose` failed with `useOverlayActionTransition is not a function`.
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/ui/__tests__/use-overlay-action-transition.test.tsx --reporter=verbose`
- `node scripts/npm-run.js run react-doctor`
- pre-commit Lefthook: prettier, dedupe, no-explicit-any, Python docstrings, TS docstrings
- pre-push Lefthook: typecheck, dedupe, no-explicit-any, Python docstrings, TS docstrings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `useOverlayActionTransition` to defer follow-up overlay actions until the source menu/dropdown fully closes. Keeps `useDeferredDropdownAction` as a compatibility alias and strengthens tests for deferral timing, pointer-events restoration (no stuck pointer-events), unmount cleanup, and the alias; closes #724.

<sup>Written for commit 54f0522a13d7221b3d7c941e3444efec44d66dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the deferred dropdown/overlay action hook to `useOverlayActionTransition` for clearer naming.
  * Kept backward compatibility by continuing to export `useDeferredDropdownAction` as an alias.

* **Tests**
  * Added a React Testing Library + Vitest suite validating that overlay-triggered actions are deferred until after the source menu closes.
  * Verifies temporary interaction blocking is applied and then restored, and that pending deferred actions are cleaned up on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->