### PR TITLE
Fix Radix row action overlay transitions

### DIFF
--- a/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/DeviceQuotaDecisionsTable.tsx
@@ -31,6 +31,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useOverlayActionTransition } from "@/components/ui/use-deferred-dropdown-action"
 import { useDeviceQuotaDecisionsContext } from "../_hooks/useDeviceQuotaDecisionsContext"
 import type { Decision } from "./DeviceQuotaDecisionsContext"
 
@@ -200,6 +201,7 @@ interface ActionsDropdownProps {
 
 function ActionsDropdown({ decision, onView, onEdit, onActivate, onDelete }: ActionsDropdownProps) {
   const isDraft = decision.trang_thai === "draft"
+  const runOverlayAction = useOverlayActionTransition()
 
   return (
     <DropdownMenu>
@@ -210,7 +212,7 @@ function ActionsDropdown({ decision, onView, onEdit, onActivate, onDelete }: Act
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={onView}>
+        <DropdownMenuItem onClick={() => runOverlayAction(onView)}>
           <Eye className="mr-2 size-4" />
           Xem chi tiết
         </DropdownMenuItem>
@@ -218,18 +220,18 @@ function ActionsDropdown({ decision, onView, onEdit, onActivate, onDelete }: Act
         {isDraft && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onEdit}>
+            <DropdownMenuItem onClick={() => runOverlayAction(onEdit)}>
               <Edit className="mr-2 size-4" />
               Chỉnh sửa
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onActivate}>
+            <DropdownMenuItem onClick={() => runOverlayAction(onActivate)}>
               <CheckCircle className="mr-2 size-4" />
               Kích hoạt
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              onClick={onDelete}
+              onClick={() => runOverlayAction(onDelete)}
               className="text-destructive focus:text-destructive"
             >
               <Trash2 className="mr-2 size-4" />

--- a/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionsTable.actions.test.tsx
+++ b/src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionsTable.actions.test.tsx
@@ -1,0 +1,112 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const routerMocks = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: routerMocks.push,
+  }),
+}))
+
+import { DeviceQuotaDecisionsContext, type Decision } from "../DeviceQuotaDecisionsContext"
+import { DeviceQuotaDecisionsTable } from "../DeviceQuotaDecisionsTable"
+
+type DecisionsContextValue = NonNullable<
+  React.ComponentProps<typeof DeviceQuotaDecisionsContext.Provider>["value"]
+>
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    id: 101,
+    don_vi_id: 1,
+    so_quyet_dinh: "QD-101",
+    ngay_ban_hanh: "2026-01-01",
+    ngay_hieu_luc: "2026-02-01",
+    ngay_het_hieu_luc: null,
+    nguoi_ky: "Nguyen Van A",
+    chuc_vu_nguoi_ky: "Giam doc",
+    trang_thai: "draft",
+    ghi_chu: null,
+    thay_the_cho_id: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    total_categories: 0,
+    total_equipment_mapped: 0,
+    ...overrides,
+  }
+}
+
+function makeMutation(): DecisionsContextValue["activateMutation"] {
+  return {
+    mutate: vi.fn(),
+    isPending: false,
+  } as DecisionsContextValue["activateMutation"]
+}
+
+function renderTable(contextOverrides: Partial<DecisionsContextValue> = {}) {
+  const value: DecisionsContextValue = {
+    user: null,
+    donViId: 1,
+    decisions: [makeDecision()],
+    statusFilter: "all",
+    setStatusFilter: vi.fn(),
+    dialogState: {
+      isCreateOpen: false,
+      isEditOpen: false,
+      selectedDecision: null,
+    },
+    isCreateDialogOpen: false,
+    isEditDialogOpen: false,
+    selectedDecision: null,
+    openCreateDialog: vi.fn(),
+    openEditDialog: vi.fn(),
+    closeDialogs: vi.fn(),
+    createMutation: makeMutation(),
+    updateMutation: makeMutation(),
+    activateMutation: makeMutation(),
+    deleteMutation: makeMutation(),
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    invalidateAndRefetch: vi.fn(),
+    ...contextOverrides,
+  }
+
+  return render(
+    <DeviceQuotaDecisionsContext.Provider value={value}>
+      <DeviceQuotaDecisionsTable />
+    </DeviceQuotaDecisionsContext.Provider>
+  )
+}
+
+describe("DeviceQuotaDecisionsTable row action menu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.style.pointerEvents = ""
+  })
+
+  it("opens the edit dialog only after the row action menu has closed", async () => {
+    const user = userEvent.setup()
+    const callbackMenuState: boolean[] = []
+    const openEditDialog = vi.fn(() => {
+      callbackMenuState.push(screen.queryByRole("menuitem", { name: "Chỉnh sửa" }) !== null)
+    })
+
+    renderTable({ openEditDialog })
+
+    await user.click(screen.getByRole("button", { name: "Mở menu hành động" }))
+    await user.click(screen.getByRole("menuitem", { name: "Chỉnh sửa" }))
+
+    await waitFor(() =>
+      expect(openEditDialog).toHaveBeenCalledWith(expect.objectContaining({ id: 101 }))
+    )
+    expect(callbackMenuState).toEqual([false])
+    expect(document.body.style.pointerEvents).not.toBe("none")
+  })
+})

--- a/src/app/(app)/maintenance/__tests__/maintenance-plan-actions-overlay.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/maintenance-plan-actions-overlay.test.tsx
@@ -1,0 +1,159 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { flexRender, type CellContext } from "@tanstack/react-table"
+import { render, renderHook, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { MaintenancePlan } from "@/hooks/use-cached-maintenance"
+import { usePlanColumns, type PlanColumnOptions } from "../_components/maintenance-columns"
+import { MaintenanceMobilePlanCards } from "../_components/maintenance-mobile-plan-cards"
+import { MaintenancePageLegacyMobileCards } from "../_components/maintenance-page-legacy-mobile-cards"
+
+function makePlan(overrides: Partial<MaintenancePlan> = {}): MaintenancePlan {
+  return {
+    id: 77,
+    ten_ke_hoach: "Kế hoạch bảo trì",
+    nam: 2026,
+    loai_cong_viec: "Bảo dưỡng",
+    khoa_phong: null,
+    nguoi_lap_ke_hoach: "Nguyễn Văn A",
+    trang_thai: "Bản nháp",
+    ngay_phe_duyet: null,
+    nguoi_duyet: null,
+    ly_do_khong_duyet: null,
+    created_at: "2026-01-01T00:00:00Z",
+    don_vi: 1,
+    facility_name: "Cơ sở 1",
+    ...overrides,
+  }
+}
+
+function makePlanColumnOptions(overrides: Partial<PlanColumnOptions> = {}): PlanColumnOptions {
+  return {
+    sorting: [],
+    setSorting: vi.fn(),
+    onRowClick: vi.fn(),
+    openApproveDialog: vi.fn(),
+    openRejectDialog: vi.fn(),
+    openDeleteDialog: vi.fn(),
+    setEditingPlan: vi.fn(),
+    canManagePlans: true,
+    isRegionalLeader: false,
+    ...overrides,
+  }
+}
+
+function renderPlanActionsCell(options: PlanColumnOptions, plan = makePlan()) {
+  const { result } = renderHook(() => usePlanColumns(options))
+  const actionsColumn = result.current.find((column) => column.id === "actions")
+
+  if (!actionsColumn?.cell) {
+    throw new Error("Missing plan actions column cell")
+  }
+
+  return render(
+    <>
+      {flexRender(actionsColumn.cell, {
+        row: { original: plan },
+      } as CellContext<MaintenancePlan, unknown>)}
+    </>
+  )
+}
+
+function renderMobilePlanCards(
+  actions: Partial<React.ComponentProps<typeof MaintenanceMobilePlanCards>["actions"]> = {}
+) {
+  return render(
+    <MaintenanceMobilePlanCards
+      plans={[makePlan()]}
+      planState={{ isLoadingPlans: false, showFacilityFilter: false }}
+      access={{ canManagePlans: true, canCreatePlans: true }}
+      actions={{
+        onOpenAddPlanDialog: vi.fn(),
+        onSelectPlan: vi.fn(),
+        onSetTasksTab: vi.fn(),
+        onEditPlan: vi.fn(),
+        onOpenApproveDialog: vi.fn(),
+        onOpenRejectDialog: vi.fn(),
+        onOpenDeleteDialog: vi.fn(),
+        ...actions,
+      }}
+    />
+  )
+}
+
+describe("Maintenance plan action menus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.style.pointerEvents = ""
+  })
+
+  it("opens the desktop edit dialog only after the plan action menu has closed", async () => {
+    const user = userEvent.setup()
+    const callbackMenuState: boolean[] = []
+    const setEditingPlan = vi.fn(() => {
+      callbackMenuState.push(screen.queryByRole("menuitem", { name: "Sửa" }) !== null)
+    })
+
+    renderPlanActionsCell(makePlanColumnOptions({ setEditingPlan }))
+
+    await user.click(screen.getByRole("button", { name: "Mở menu" }))
+    await user.click(screen.getByRole("menuitem", { name: "Sửa" }))
+
+    await waitFor(() =>
+      expect(setEditingPlan).toHaveBeenCalledWith(expect.objectContaining({ id: 77 }))
+    )
+    expect(callbackMenuState).toEqual([false])
+    expect(document.body.style.pointerEvents).not.toBe("none")
+  })
+
+  it("opens the mobile delete dialog only after the plan action menu has closed", async () => {
+    const user = userEvent.setup()
+    const callbackMenuState: boolean[] = []
+    const onOpenDeleteDialog = vi.fn(() => {
+      callbackMenuState.push(screen.queryByRole("menuitem", { name: "Xóa kế hoạch" }) !== null)
+    })
+
+    renderMobilePlanCards({ onOpenDeleteDialog })
+
+    await user.click(screen.getAllByRole("button")[1])
+    await user.click(screen.getByRole("menuitem", { name: "Xóa kế hoạch" }))
+
+    await waitFor(() =>
+      expect(onOpenDeleteDialog).toHaveBeenCalledWith(expect.objectContaining({ id: 77 }))
+    )
+    expect(callbackMenuState).toEqual([false])
+    expect(document.body.style.pointerEvents).not.toBe("none")
+  })
+
+  it("opens the legacy mobile approve dialog only after the plan action menu has closed", async () => {
+    const user = userEvent.setup()
+    const callbackMenuState: boolean[] = []
+    const onOpenApproveDialog = vi.fn(() => {
+      callbackMenuState.push(screen.queryByRole("menuitem", { name: "Duyệt" }) !== null)
+    })
+
+    render(
+      <MaintenancePageLegacyMobileCards
+        isLoading={false}
+        plans={[makePlan()]}
+        canManagePlans
+        onSelectPlan={vi.fn()}
+        onOpenApproveDialog={onOpenApproveDialog}
+        onOpenRejectDialog={vi.fn()}
+        onOpenDeleteDialog={vi.fn()}
+        onEditPlan={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mở menu" }))
+    await user.click(screen.getByRole("menuitem", { name: "Duyệt" }))
+
+    await waitFor(() =>
+      expect(onOpenApproveDialog).toHaveBeenCalledWith(expect.objectContaining({ id: 77 }))
+    )
+    expect(callbackMenuState).toEqual([false])
+    expect(document.body.style.pointerEvents).not.toBe("none")
+  })
+})

--- a/src/app/(app)/maintenance/_components/maintenance-columns.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-columns.tsx
@@ -2,9 +2,19 @@
 
 import * as React from "react"
 import type { ColumnDef, Row, Table } from "@tanstack/react-table"
-import { ArrowUpDown, MoreHorizontal, Check, X, Edit, Trash2, Save, CheckCircle2, Loader2 } from "lucide-react"
-import { format, parseISO } from 'date-fns'
-import { vi } from 'date-fns/locale'
+import {
+  ArrowUpDown,
+  MoreHorizontal,
+  Check,
+  X,
+  Edit,
+  Trash2,
+  Save,
+  CheckCircle2,
+  Loader2,
+} from "lucide-react"
+import { format, parseISO } from "date-fns"
+import { vi } from "date-fns/locale"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Badge } from "@/components/ui/badge"
@@ -17,7 +27,14 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useOverlayActionTransition } from "@/components/ui/use-deferred-dropdown-action"
 import type { MaintenancePlan } from "@/hooks/use-cached-maintenance"
 import type { MaintenanceTask } from "@/lib/data"
 import { NotesInput } from "./notes-input"
@@ -49,375 +66,432 @@ export function usePlanColumns(options: PlanColumnOptions): ColumnDef<Maintenanc
     setEditingPlan,
     canManagePlans,
   } = options
+  const runOverlayAction = useOverlayActionTransition()
 
   return React.useMemo(() => {
-
-  const planColumns: ColumnDef<MaintenancePlan>[] = [
-    {
-      accessorKey: "ten_ke_hoach",
-      header: "Tên kế hoạch",
-      cell: ({ row }) => <div className="font-medium">{row.getValue("ten_ke_hoach")}</div>,
-    },
-    {
-      accessorKey: "nguoi_lap_ke_hoach",
-      header: "Người lập",
-      cell: ({ row }) => {
-        const nguoiLap = row.getValue("nguoi_lap_ke_hoach") as string | null;
-        return nguoiLap ? (
-          <div className="text-sm">{nguoiLap}</div>
-        ) : (
-          <span className="text-muted-foreground italic text-xs">Chưa có</span>
-        );
+    const planColumns: ColumnDef<MaintenancePlan>[] = [
+      {
+        accessorKey: "ten_ke_hoach",
+        header: "Tên kế hoạch",
+        cell: ({ row }) => <div className="font-medium">{row.getValue("ten_ke_hoach")}</div>,
       },
-    },
-    {
-      accessorKey: "nam",
-      header: ({ column }) => (
-        <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-          Năm
-          <ArrowUpDown className="ml-2 size-4" />
-        </Button>
-      ),
-      cell: ({ row }) => <div className="text-center">{row.getValue("nam")}</div>
-    },
-    {
-      accessorKey: "khoa_phong",
-      header: "Khoa/Phòng",
-      cell: ({ row }) => row.getValue("khoa_phong") || <span className="text-muted-foreground italic">Tổng thể</span>,
-    },
-    {
-      accessorKey: "loai_cong_viec",
-      header: "Loại CV",
-      cell: ({ row }) => <Badge variant="outline">{row.getValue("loai_cong_viec")}</Badge>,
-    },
-    {
-      accessorKey: "trang_thai",
-      header: "Trạng thái",
-      cell: ({ row }) => {
-        const status = row.getValue("trang_thai") as MaintenancePlan["trang_thai"]
-        const plan = row.original
-        return (
-          <div className="space-y-1">
-            <Badge variant={getStatusVariant(status)}>{status}</Badge>
-            {status === "Không duyệt" && plan.ly_do_khong_duyet && (
-              <div className="text-xs text-muted-foreground italic max-w-[200px] break-words">
-                Lý do: {plan.ly_do_khong_duyet}
-              </div>
-            )}
-          </div>
-        )
+      {
+        accessorKey: "nguoi_lap_ke_hoach",
+        header: "Người lập",
+        cell: ({ row }) => {
+          const nguoiLap = row.getValue("nguoi_lap_ke_hoach") as string | null
+          return nguoiLap ? (
+            <div className="text-sm">{nguoiLap}</div>
+          ) : (
+            <span className="text-muted-foreground italic text-xs">Chưa có</span>
+          )
+        },
       },
-    },
-    {
-      accessorKey: "ngay_phe_duyet",
-      header: "Ngày phê duyệt",
-      cell: ({ row }) => {
-        const date = row.getValue("ngay_phe_duyet") as string | null
-        const plan = row.original
-        return date ? (
-          <div className="space-y-1">
-            <div>{format(parseISO(date), 'dd/MM/yyyy HH:mm', { locale: vi })}</div>
-            {plan.nguoi_duyet && (
-              <div className="text-xs text-blue-600 font-medium">
-                Duyệt: {plan.nguoi_duyet}
-              </div>
-            )}
-          </div>
-        ) : (
-          <span className="text-muted-foreground italic">Chưa duyệt</span>
-        )
+      {
+        accessorKey: "nam",
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Năm
+            <ArrowUpDown className="ml-2 size-4" />
+          </Button>
+        ),
+        cell: ({ row }) => <div className="text-center">{row.getValue("nam")}</div>,
       },
-    },
-    {
-      id: "actions",
-      cell: ({ row }) => {
-        const plan = row.original
-        const canManage = canManagePlans;
-
-        return (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                className="size-8 p-0"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <span className="sr-only">Mở menu</span>
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuLabel>Hành động</DropdownMenuLabel>
-              <DropdownMenuItem onSelect={() => onRowClick(plan)}>
-                Xem chi tiết công việc
-              </DropdownMenuItem>
-              {plan.trang_thai === 'Bản nháp' && (
-                <>
-                  <DropdownMenuSeparator />
-                  {canManage && (
-                    <>
-                      <DropdownMenuItem onSelect={() => openApproveDialog(plan)}>
-                        <Check className="mr-2 size-4" />
-                        Duyệt
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onSelect={() => openRejectDialog(plan)}>
-                        <X className="mr-2 size-4" />
-                        Không duyệt
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                  {canManage && (
-                    <>
-                      <DropdownMenuItem onSelect={() => setEditingPlan(plan)}>
-                        <Edit className="mr-2 size-4" />
-                        Sửa
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem onSelect={() => openDeleteDialog(plan)} className="text-destructive focus:text-destructive">
-                        <Trash2 className="mr-2 size-4" />
-                        Xoá
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                </>
+      {
+        accessorKey: "khoa_phong",
+        header: "Khoa/Phòng",
+        cell: ({ row }) =>
+          row.getValue("khoa_phong") || (
+            <span className="text-muted-foreground italic">Tổng thể</span>
+          ),
+      },
+      {
+        accessorKey: "loai_cong_viec",
+        header: "Loại CV",
+        cell: ({ row }) => <Badge variant="outline">{row.getValue("loai_cong_viec")}</Badge>,
+      },
+      {
+        accessorKey: "trang_thai",
+        header: "Trạng thái",
+        cell: ({ row }) => {
+          const status = row.getValue("trang_thai") as MaintenancePlan["trang_thai"]
+          const plan = row.original
+          return (
+            <div className="space-y-1">
+              <Badge variant={getStatusVariant(status)}>{status}</Badge>
+              {status === "Không duyệt" && plan.ly_do_khong_duyet && (
+                <div className="text-xs text-muted-foreground italic max-w-[200px] break-words">
+                  Lý do: {plan.ly_do_khong_duyet}
+                </div>
               )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )
+            </div>
+          )
+        },
       },
-    },
-  ]
+      {
+        accessorKey: "ngay_phe_duyet",
+        header: "Ngày phê duyệt",
+        cell: ({ row }) => {
+          const date = row.getValue("ngay_phe_duyet") as string | null
+          const plan = row.original
+          return date ? (
+            <div className="space-y-1">
+              <div>{format(parseISO(date), "dd/MM/yyyy HH:mm", { locale: vi })}</div>
+              {plan.nguoi_duyet && (
+                <div className="text-xs text-blue-600 font-medium">Duyệt: {plan.nguoi_duyet}</div>
+              )}
+            </div>
+          ) : (
+            <span className="text-muted-foreground italic">Chưa duyệt</span>
+          )
+        },
+      },
+      {
+        id: "actions",
+        cell: ({ row }) => {
+          const plan = row.original
+          const canManage = canManagePlans
 
-  return planColumns
-  }, [onRowClick, openApproveDialog, openRejectDialog, openDeleteDialog, setEditingPlan, canManagePlans])
+          return (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="size-8 p-0" onClick={(e) => e.stopPropagation()}>
+                  <span className="sr-only">Mở menu</span>
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Hành động</DropdownMenuLabel>
+                <DropdownMenuItem onSelect={() => runOverlayAction(() => onRowClick(plan))}>
+                  Xem chi tiết công việc
+                </DropdownMenuItem>
+                {plan.trang_thai === "Bản nháp" && (
+                  <>
+                    <DropdownMenuSeparator />
+                    {canManage && (
+                      <>
+                        <DropdownMenuItem
+                          onSelect={() => runOverlayAction(() => openApproveDialog(plan))}
+                        >
+                          <Check className="mr-2 size-4" />
+                          Duyệt
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={() => runOverlayAction(() => openRejectDialog(plan))}
+                        >
+                          <X className="mr-2 size-4" />
+                          Không duyệt
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                    {canManage && (
+                      <>
+                        <DropdownMenuItem
+                          onSelect={() => runOverlayAction(() => setEditingPlan(plan))}
+                        >
+                          <Edit className="mr-2 size-4" />
+                          Sửa
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onSelect={() => runOverlayAction(() => openDeleteDialog(plan))}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          <Trash2 className="mr-2 size-4" />
+                          Xoá
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )
+        },
+      },
+    ]
+
+    return planColumns
+  }, [
+    onRowClick,
+    openApproveDialog,
+    openRejectDialog,
+    openDeleteDialog,
+    setEditingPlan,
+    canManagePlans,
+    runOverlayAction,
+  ])
 }
 
 /** Builds the memoized column definitions for editable maintenance tasks. */
 export function useTaskColumns(options: TaskColumnOptions): ColumnDef<MaintenanceTask>[] {
-  const {
-    editingTaskId,
-    isPlanApproved,
-  } = options
+  const { editingTaskId, isPlanApproved } = options
 
   return React.useMemo(() => {
-
-  const taskColumns: ColumnDef<MaintenanceTask>[] = [
-    {
-      id: "select",
-      header: ({ table }) => (
-        <Checkbox
-          checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")}
-          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-          aria-label="Select all"
-          disabled={isPlanApproved || !!editingTaskId}
-        />
-      ),
-      cell: ({ row }) => (
-        <Checkbox
-          checked={row.getIsSelected()}
-          onCheckedChange={(value) => row.toggleSelected(!!value)}
-          aria-label="Select row"
-          disabled={isPlanApproved || !!editingTaskId}
-        />
-      ),
-      enableSorting: false,
-      enableHiding: false,
-      size: 40,
-    },
-    {
-      id: 'stt',
-      header: 'STT',
-      cell: ({ row, table }) => {
-        const { pageIndex, pageSize } = table.getState().pagination;
-        return pageIndex * pageSize + row.index + 1;
+    const taskColumns: ColumnDef<MaintenanceTask>[] = [
+      {
+        id: "select",
+        header: ({ table }) => (
+          <Checkbox
+            checked={
+              table.getIsAllPageRowsSelected() ||
+              (table.getIsSomePageRowsSelected() && "indeterminate")
+            }
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+            aria-label="Select all"
+            disabled={isPlanApproved || !!editingTaskId}
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(!!value)}
+            aria-label="Select row"
+            disabled={isPlanApproved || !!editingTaskId}
+          />
+        ),
+        enableSorting: false,
+        enableHiding: false,
+        size: 40,
       },
-      size: 50,
-    },
-    {
-      accessorKey: 'thiet_bi.ma_thiet_bi',
-      header: 'Mã TB',
-      cell: ({ row }) => row.original.thiet_bi?.ma_thiet_bi || '',
-      size: 120,
-    },
-    {
-      accessorKey: 'thiet_bi.ten_thiet_bi',
-      header: 'Tên thiết bị',
-      cell: ({ row }) => row.original.thiet_bi?.ten_thiet_bi || '',
-      size: 250,
-    },
-    {
-      accessorKey: 'loai_cong_viec',
-      header: 'Loại CV',
-      cell: ({ row }) => <Badge variant="outline">{row.getValue("loai_cong_viec")}</Badge>,
-      size: 140,
-    },
-    ...Array.from({ length: 12 }, (_, i) => i + 1).map((month) => ({
-      id: `thang_${month}`,
-      header: () => <div className="text-center">{month}</div>,
-      cell: ({ row, table }: { row: Row<MaintenanceTask>, table: Table<MaintenanceTask> }) => {
-        const meta = table.options.meta as TableMeta;
-        const {
-          editingTaskId, editingTaskData, handleTaskDataChange,
-          isPlanApproved, completionStatus, isLoadingCompletion,
-          handleMarkAsCompleted, isCompletingTask, canCompleteTask,
-        } = meta;
-        const fieldName = `thang_${month}` as keyof MaintenanceTask;
+      {
+        id: "stt",
+        header: "STT",
+        cell: ({ row, table }) => {
+          const { pageIndex, pageSize } = table.getState().pagination
+          return pageIndex * pageSize + row.index + 1
+        },
+        size: 50,
+      },
+      {
+        accessorKey: "thiet_bi.ma_thiet_bi",
+        header: "Mã TB",
+        cell: ({ row }) => row.original.thiet_bi?.ma_thiet_bi || "",
+        size: 120,
+      },
+      {
+        accessorKey: "thiet_bi.ten_thiet_bi",
+        header: "Tên thiết bị",
+        cell: ({ row }) => row.original.thiet_bi?.ten_thiet_bi || "",
+        size: 250,
+      },
+      {
+        accessorKey: "loai_cong_viec",
+        header: "Loại CV",
+        cell: ({ row }) => <Badge variant="outline">{row.getValue("loai_cong_viec")}</Badge>,
+        size: 140,
+      },
+      ...Array.from({ length: 12 }, (_, i) => i + 1).map((month) => ({
+        id: `thang_${month}`,
+        header: () => <div className="text-center">{month}</div>,
+        cell: ({ row, table }: { row: Row<MaintenanceTask>; table: Table<MaintenanceTask> }) => {
+          const meta = table.options.meta as TableMeta
+          const {
+            editingTaskId,
+            editingTaskData,
+            handleTaskDataChange,
+            isPlanApproved,
+            completionStatus,
+            isLoadingCompletion,
+            handleMarkAsCompleted,
+            isCompletingTask,
+            canCompleteTask,
+          } = meta
+          const fieldName = `thang_${month}` as keyof MaintenanceTask
 
-        if (isPlanApproved) {
-          const isScheduled = !!row.original[fieldName];
-          if (!isScheduled) return null;
+          if (isPlanApproved) {
+            const isScheduled = !!row.original[fieldName]
+            if (!isScheduled) return null
 
-          if (isLoadingCompletion) return <Skeleton className="size-4 mx-auto" />;
+            if (isLoadingCompletion) return <Skeleton className="size-4 mx-auto" />
 
-          // Check completion status from actual database field
-          const completionFieldName = `thang_${month}_hoan_thanh` as keyof MaintenanceTask;
-          const isCompletedFromDB = !!row.original[completionFieldName];
+            // Check completion status from actual database field
+            const completionFieldName = `thang_${month}_hoan_thanh` as keyof MaintenanceTask
+            const isCompletedFromDB = !!row.original[completionFieldName]
 
-          const completionKey = `${row.original.id}-${month}`;
-          const isUpdating = isCompletingTask.has(completionKey);
+            const completionKey = `${row.original.id}-${month}`
+            const isUpdating = isCompletingTask.has(completionKey)
 
-          if (isUpdating) {
-            return (
-              <div className="flex justify-center items-center h-full">
-                <Loader2 className="size-5 animate-spin text-primary" />
-              </div>
-            );
-          }
-
-          if (isCompletedFromDB) {
-            const completionDateField = `ngay_hoan_thanh_${month}` as keyof MaintenanceTask;
-            const completionDate = row.original[completionDateField] as string;
-            const formattedDate = completionDate ? new Date(completionDate).toLocaleDateString('vi-VN') : '';
-
-            return (
-              <div className="flex justify-center items-center h-full">
-                <div title={`Đã hoàn thành${formattedDate ? ` ngày ${formattedDate}` : ''}`}>
-                  <CheckCircle2 className="size-5 text-green-600" />
+            if (isUpdating) {
+              return (
+                <div className="flex justify-center items-center h-full">
+                  <Loader2 className="size-5 animate-spin text-primary" />
                 </div>
+              )
+            }
+
+            if (isCompletedFromDB) {
+              const completionDateField = `ngay_hoan_thanh_${month}` as keyof MaintenanceTask
+              const completionDate = row.original[completionDateField] as string
+              const formattedDate = completionDate
+                ? new Date(completionDate).toLocaleDateString("vi-VN")
+                : ""
+
+              return (
+                <div className="flex justify-center items-center h-full">
+                  <div title={`Đã hoàn thành${formattedDate ? ` ngày ${formattedDate}` : ""}`}>
+                    <CheckCircle2 className="size-5 text-green-600" />
+                  </div>
+                </div>
+              )
+            }
+
+            // Interactive checkbox for scheduled but not completed tasks
+            return (
+              <div className="flex justify-center items-center h-full">
+                <Checkbox
+                  onCheckedChange={(checked) => {
+                    if (checked) {
+                      handleMarkAsCompleted(row.original, month)
+                    }
+                  }}
+                  disabled={!canCompleteTask}
+                  title={
+                    canCompleteTask ? "Nhấp để ghi nhận hoàn thành" : "Bạn không có quyền thực hiện"
+                  }
+                />
               </div>
-            );
+            )
           }
 
-          // Interactive checkbox for scheduled but not completed tasks
+          // Draft mode logic
+          const isEditing = editingTaskId === row.original.id
+          const isChecked = isEditing ? editingTaskData?.[fieldName] : row.original[fieldName]
           return (
             <div className="flex justify-center items-center h-full">
               <Checkbox
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    handleMarkAsCompleted(row.original, month);
-                  }
-                }}
-                disabled={!canCompleteTask}
-                title={canCompleteTask ? "Nhấp để ghi nhận hoàn thành" : "Bạn không có quyền thực hiện"}
+                key={`checkbox-${row.original.id}-${fieldName}`}
+                checked={!!isChecked}
+                onCheckedChange={(value) => isEditing && handleTaskDataChange(fieldName, !!value)}
+                disabled={!isEditing}
               />
             </div>
-          );
-        }
+          )
+        },
+        size: 40,
+      })),
+      {
+        accessorKey: "don_vi_thuc_hien",
+        header: "Đơn vị TH",
+        cell: ({ row, table }) => {
+          const meta = table.options.meta as TableMeta
+          const { editingTaskId, editingTaskData, handleTaskDataChange } = meta
+          const isEditing = editingTaskId === row.original.id
+          return isEditing ? (
+            <Select
+              key={`select-don-vi-${row.original.id}`}
+              value={editingTaskData?.don_vi_thuc_hien || ""}
+              onValueChange={(value) =>
+                handleTaskDataChange("don_vi_thuc_hien", value === "none" ? null : value)
+              }
+            >
+              <SelectTrigger className="h-8">
+                <SelectValue placeholder="Chọn đơn vị" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Nội bộ">Nội bộ</SelectItem>
+                <SelectItem value="Thuê ngoài">Thuê ngoài</SelectItem>
+                <SelectItem value="none">Xóa</SelectItem>
+              </SelectContent>
+            </Select>
+          ) : (
+            row.original.don_vi_thuc_hien
+          )
+        },
+        size: 150,
+      },
+      {
+        accessorKey: "ghi_chu",
+        header: "Ghi chú",
+        cell: ({ row, table }) => {
+          const meta = table.options.meta as TableMeta
+          const { editingTaskId, editingTaskData, handleTaskDataChange } = meta
+          const isEditing = editingTaskId === row.original.id
 
-        // Draft mode logic
-        const isEditing = editingTaskId === row.original.id;
-        const isChecked = isEditing ? editingTaskData?.[fieldName] : row.original[fieldName];
-        return (
-          <div className="flex justify-center items-center h-full">
-            <Checkbox
-              key={`checkbox-${row.original.id}-${fieldName}`}
-              checked={!!isChecked}
-              onCheckedChange={(value) => isEditing && handleTaskDataChange(fieldName, !!value)}
-              disabled={!isEditing}
+          if (!isEditing) {
+            return row.original.ghi_chu
+          }
+
+          return (
+            <NotesInput
+              taskId={row.original.id}
+              value={editingTaskData?.ghi_chu || ""}
+              onChange={(value) => handleTaskDataChange("ghi_chu", value)}
             />
-          </div>
-        );
+          )
+        },
+        size: 200,
       },
-      size: 40,
-    })),
-    {
-      accessorKey: 'don_vi_thuc_hien',
-      header: 'Đơn vị TH',
-      cell: ({ row, table }) => {
-        const meta = table.options.meta as TableMeta;
-        const { editingTaskId, editingTaskData, handleTaskDataChange } = meta;
-        const isEditing = editingTaskId === row.original.id;
-        return isEditing ? (
-          <Select
-            key={`select-don-vi-${row.original.id}`}
-            value={editingTaskData?.don_vi_thuc_hien || ""}
-            onValueChange={(value) => handleTaskDataChange('don_vi_thuc_hien', value === 'none' ? null : value)}
-          >
-            <SelectTrigger className="h-8">
-              <SelectValue placeholder="Chọn đơn vị" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="Nội bộ">Nội bộ</SelectItem>
-              <SelectItem value="Thuê ngoài">Thuê ngoài</SelectItem>
-              <SelectItem value="none">Xóa</SelectItem>
-            </SelectContent>
-          </Select>
-        ) : (
-          row.original.don_vi_thuc_hien
-        )
-      },
-      size: 150,
-    },
-    {
-      accessorKey: 'ghi_chu',
-      header: 'Ghi chú',
-      cell: ({ row, table }) => {
-        const meta = table.options.meta as TableMeta;
-        const { editingTaskId, editingTaskData, handleTaskDataChange } = meta;
-        const isEditing = editingTaskId === row.original.id;
+      {
+        id: "actions",
+        cell: ({ row, table }) => {
+          const meta = table.options.meta as TableMeta
+          const {
+            editingTaskId,
+            handleSaveTask,
+            handleCancelEdit,
+            handleStartEdit,
+            isPlanApproved,
+            setTaskToDelete,
+          } = meta
+          const task = row.original
+          const isEditing = editingTaskId === task.id
 
-        if (!isEditing) {
-          return row.original.ghi_chu;
-        }
+          if (isPlanApproved) return null
 
-        return (
-          <NotesInput
-            taskId={row.original.id}
-            value={editingTaskData?.ghi_chu || ""}
-            onChange={(value) => handleTaskDataChange('ghi_chu', value)}
-          />
-        );
-      },
-      size: 200,
-    },
-    {
-      id: "actions",
-      cell: ({ row, table }) => {
-        const meta = table.options.meta as TableMeta;
-        const { editingTaskId, handleSaveTask, handleCancelEdit, handleStartEdit, isPlanApproved, setTaskToDelete } = meta;
-        const task = row.original;
-        const isEditing = editingTaskId === task.id;
+          if (isEditing) {
+            return (
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 text-green-600 hover:bg-green-100 hover:text-green-700"
+                  onClick={handleSaveTask}
+                >
+                  <Save className="size-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 text-gray-600 hover:bg-gray-100"
+                  onClick={handleCancelEdit}
+                >
+                  <X className="size-4" />
+                </Button>
+              </div>
+            )
+          }
 
-        if (isPlanApproved) return null;
-
-        if (isEditing) {
           return (
             <div className="flex items-center gap-1">
-              <Button variant="ghost" size="icon" className="size-8 text-green-600 hover:bg-green-100 hover:text-green-700" onClick={handleSaveTask}>
-                <Save className="size-4" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                onClick={() => handleStartEdit(task)}
+                disabled={!!editingTaskId}
+              >
+                <Edit className="size-4" />
               </Button>
-              <Button variant="ghost" size="icon" className="size-8 text-gray-600 hover:bg-gray-100" onClick={handleCancelEdit}>
-                <X className="size-4" />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 text-destructive hover:bg-destructive/10"
+                onClick={() => setTaskToDelete(task)}
+                disabled={!!editingTaskId}
+              >
+                <Trash2 className="size-4" />
               </Button>
             </div>
           )
-        }
-
-        return (
-          <div className="flex items-center gap-1">
-            <Button variant="ghost" size="icon" className="size-8" onClick={() => handleStartEdit(task)} disabled={!!editingTaskId}>
-              <Edit className="size-4" />
-            </Button>
-            <Button variant="ghost" size="icon" className="size-8 text-destructive hover:bg-destructive/10" onClick={() => setTaskToDelete(task)} disabled={!!editingTaskId}>
-              <Trash2 className="size-4" />
-            </Button>
-          </div>
-        )
+        },
+        size: 100,
       },
-      size: 100,
-    }
-  ]
+    ]
 
-  return taskColumns
+    return taskColumns
   }, [editingTaskId, isPlanApproved])
 }

--- a/src/app/(app)/maintenance/_components/maintenance-mobile-plan-cards.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-mobile-plan-cards.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useOverlayActionTransition } from "@/components/ui/use-deferred-dropdown-action"
 import { CalendarDays, MoreHorizontal, PlusCircle } from "lucide-react"
 import { getPlanStatusTone, resolveStatusBadgeVariant } from "./maintenance-mobile-status"
 
@@ -46,6 +47,7 @@ interface MaintenanceMobilePlanCardsProps {
   actions: MaintenanceMobilePlanCardsActions
 }
 
+/** Renders maintenance plan cards and row actions for the mobile plans view. */
 export function MaintenanceMobilePlanCards({
   plans,
   planState,
@@ -63,6 +65,7 @@ export function MaintenanceMobilePlanCards({
     onOpenRejectDialog,
     onOpenDeleteDialog,
   } = actions
+  const runOverlayAction = useOverlayActionTransition()
 
   if (isLoadingPlans) {
     return (
@@ -121,7 +124,9 @@ export function MaintenanceMobilePlanCards({
             <div className={`px-4 py-3 ${statusTone.header}`}>
               <div className="flex items-start justify-between gap-3">
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-base font-semibold leading-tight line-clamp-2">{plan.ten_ke_hoach}</h3>
+                  <h3 className="text-base font-semibold leading-tight line-clamp-2">
+                    {plan.ten_ke_hoach}
+                  </h3>
                   <p className="mt-1 text-xs text-muted-foreground line-clamp-1">
                     Năm {plan.nam} • {plan.khoa_phong || "Tổng thể"}
                   </p>
@@ -134,16 +139,22 @@ export function MaintenanceMobilePlanCards({
             <CardContent className="space-y-3 px-4 py-3 text-sm">
               <div className="flex items-start justify-between gap-3">
                 <span className="text-muted-foreground">Loại công việc</span>
-                <Badge variant="outline" className="shrink-0">{plan.loai_cong_viec}</Badge>
+                <Badge variant="outline" className="shrink-0">
+                  {plan.loai_cong_viec}
+                </Badge>
               </div>
               <div className="flex items-start justify-between gap-3">
                 <span className="text-muted-foreground">Người lập</span>
-                <span className="max-w-[55%] text-right font-medium">{plan.nguoi_lap_ke_hoach || "Chưa cập nhật"}</span>
+                <span className="max-w-[55%] text-right font-medium">
+                  {plan.nguoi_lap_ke_hoach || "Chưa cập nhật"}
+                </span>
               </div>
               {showFacilityFilter && (
                 <div className="flex items-start justify-between gap-3">
                   <span className="text-muted-foreground">Cơ sở</span>
-                  <span className="max-w-[55%] text-right font-medium">{plan.facility_name || "Tất cả"}</span>
+                  <span className="max-w-[55%] text-right font-medium">
+                    {plan.facility_name || "Tất cả"}
+                  </span>
                 </div>
               )}
               <div className="flex items-start justify-between gap-3">
@@ -177,15 +188,30 @@ export function MaintenanceMobilePlanCards({
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-48">
                     <DropdownMenuLabel>Hành động</DropdownMenuLabel>
-                    <DropdownMenuItem onSelect={() => onSelectPlan(plan)}>Xem chi tiết công việc</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => runOverlayAction(() => onSelectPlan(plan))}>
+                      Xem chi tiết công việc
+                    </DropdownMenuItem>
                     {plan.trang_thai === "Bản nháp" && canManagePlans && (
                       <>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem onSelect={() => onEditPlan(plan)}>Sửa kế hoạch</DropdownMenuItem>
-                        <DropdownMenuItem onSelect={() => onOpenApproveDialog(plan)}>Duyệt kế hoạch</DropdownMenuItem>
-                        <DropdownMenuItem onSelect={() => onOpenRejectDialog(plan)}>Không duyệt</DropdownMenuItem>
+                        <DropdownMenuItem onSelect={() => runOverlayAction(() => onEditPlan(plan))}>
+                          Sửa kế hoạch
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={() => runOverlayAction(() => onOpenApproveDialog(plan))}
+                        >
+                          Duyệt kế hoạch
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={() => runOverlayAction(() => onOpenRejectDialog(plan))}
+                        >
+                          Không duyệt
+                        </DropdownMenuItem>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem onSelect={() => onOpenDeleteDialog(plan)} className="text-destructive">
+                        <DropdownMenuItem
+                          onSelect={() => runOverlayAction(() => onOpenDeleteDialog(plan))}
+                          className="text-destructive"
+                        >
                           Xóa kế hoạch
                         </DropdownMenuItem>
                       </>

--- a/src/app/(app)/maintenance/_components/maintenance-page-legacy-mobile-cards.tsx
+++ b/src/app/(app)/maintenance/_components/maintenance-page-legacy-mobile-cards.tsx
@@ -4,13 +4,7 @@ import * as React from "react"
 import type { MaintenancePlan } from "@/hooks/use-cached-maintenance"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,6 +14,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useOverlayActionTransition } from "@/components/ui/use-deferred-dropdown-action"
 import { Check, Edit, MoreHorizontal, Trash2, X } from "lucide-react"
 
 interface MaintenancePageLegacyMobileCardsProps {
@@ -46,6 +41,7 @@ function getStatusVariant(status: MaintenancePlan["trang_thai"]) {
   }
 }
 
+/** Renders the legacy mobile maintenance plan cards and action menu. */
 export function MaintenancePageLegacyMobileCards({
   isLoading,
   plans,
@@ -56,6 +52,8 @@ export function MaintenancePageLegacyMobileCards({
   onOpenDeleteDialog,
   onEditPlan,
 }: MaintenancePageLegacyMobileCardsProps) {
+  const runOverlayAction = useOverlayActionTransition()
+
   if (isLoading) {
     return (
       <div className="space-y-4">
@@ -111,27 +109,31 @@ export function MaintenancePageLegacyMobileCards({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuLabel>Hành động</DropdownMenuLabel>
-                <DropdownMenuItem onSelect={() => onSelectPlan(plan)}>
+                <DropdownMenuItem onSelect={() => runOverlayAction(() => onSelectPlan(plan))}>
                   Xem chi tiết công việc
                 </DropdownMenuItem>
                 {plan.trang_thai === "Bản nháp" && canManagePlans && (
                   <>
                     <DropdownMenuSeparator />
-                    <DropdownMenuItem onSelect={() => onOpenApproveDialog(plan)}>
+                    <DropdownMenuItem
+                      onSelect={() => runOverlayAction(() => onOpenApproveDialog(plan))}
+                    >
                       <Check className="mr-2 size-4" />
                       Duyệt
                     </DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => onOpenRejectDialog(plan)}>
+                    <DropdownMenuItem
+                      onSelect={() => runOverlayAction(() => onOpenRejectDialog(plan))}
+                    >
                       <X className="mr-2 size-4" />
                       Không duyệt
                     </DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => onEditPlan(plan)}>
+                    <DropdownMenuItem onSelect={() => runOverlayAction(() => onEditPlan(plan))}>
                       <Edit className="mr-2 size-4" />
                       Sửa
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
-                      onSelect={() => onOpenDeleteDialog(plan)}
+                      onSelect={() => runOverlayAction(() => onOpenDeleteDialog(plan))}
                       className="text-destructive"
                     >
                       <Trash2 className="mr-2 size-4" />


### PR DESCRIPTION
## Summary
- Migrate DeviceQuota decision row dropdown actions to useOverlayActionTransition
- Migrate Maintenance desktop/mobile/legacy plan action dropdowns to the overlay adapter
- Add consumer regression tests proving callbacks run after the source menu closes and pointerEvents is not stuck

## Verification
- node scripts/npm-run.js run format:check
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run verify:ts-docstrings
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- src/app/(app)/device-quota/decisions/_components/__tests__/DeviceQuotaDecisionsTable.actions.test.tsx --reporter=verbose
- node scripts/npm-run.js run test:run -- src/app/(app)/maintenance/__tests__/maintenance-plan-actions-overlay.test.tsx --reporter=verbose
- node scripts/npm-run.js run react-doctor

Closes #725

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes row-action dropdown overlays so actions fire after the menu closes and pointer events don’t get stuck. Migrates DeviceQuota and Maintenance action menus to `useOverlayActionTransition`, addressing issue #725.

- **Bug Fixes**
  - Device Quota Decisions: wrap `onView`, `onEdit`, `onActivate`, `onDelete` with `useOverlayActionTransition`.
  - Maintenance (desktop, mobile, legacy): move plan action menus to the overlay adapter so dialogs open after the menu closes.
  - Add regression tests to ensure callbacks run post-close and `pointerEvents` reset correctly.

<sup>Written for commit 9d0da520c13ce311d634770e5dc27502a12d3c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

