### PR TITLE
Fix HeroUI overlay action transitions

### DIFF
--- a/src/components/equipment/heroui-pilot/__tests__/controls.test.tsx
+++ b/src/components/equipment/heroui-pilot/__tests__/controls.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { use } from "react"
 import "@testing-library/jest-dom"
 import { act, fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
@@ -14,7 +15,7 @@ vi.mock("@heroui/react", () => {
   const DropdownContext = React.createContext<DropdownState | null>(null)
 
   function useDropdownState() {
-    const state = React.useContext(DropdownContext)
+    const state = use(DropdownContext)
 
     if (!state) {
       throw new Error("HeroUI dropdown mock used outside Dropdown")

--- a/src/components/equipment/heroui-pilot/__tests__/controls.test.tsx
+++ b/src/components/equipment/heroui-pilot/__tests__/controls.test.tsx
@@ -1,0 +1,181 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { EquipmentHeroDropdown } from "../controls"
+
+vi.mock("@heroui/react", () => {
+  interface DropdownState {
+    isOpen: boolean
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>
+  }
+
+  const DropdownContext = React.createContext<DropdownState | null>(null)
+
+  function useDropdownState() {
+    const state = React.useContext(DropdownContext)
+
+    if (!state) {
+      throw new Error("HeroUI dropdown mock used outside Dropdown")
+    }
+
+    return state
+  }
+
+  return {
+    Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+    Dropdown: ({ children }: { children: React.ReactNode }) => {
+      const [isOpen, setOpen] = React.useState(false)
+
+      return (
+        <DropdownContext.Provider value={{ isOpen, setOpen }}>
+          <div data-testid="heroui-dropdown">{children}</div>
+        </DropdownContext.Provider>
+      )
+    },
+    DropdownTrigger: ({
+      children,
+      className,
+    }: {
+      children: React.ReactNode
+      className?: string
+    }) => {
+      const { setOpen } = useDropdownState()
+
+      return (
+        <button className={className} type="button" onClick={() => setOpen(true)}>
+          {children}
+        </button>
+      )
+    },
+    DropdownPopover: ({
+      children,
+      className,
+    }: {
+      children: React.ReactNode
+      className?: string
+    }) => {
+      const { isOpen } = useDropdownState()
+
+      return isOpen ? (
+        <div className={className} data-testid="source-menu">
+          {children}
+        </div>
+      ) : null
+    },
+    DropdownMenu: ({
+      children,
+      "aria-label": ariaLabel,
+    }: {
+      children: React.ReactNode
+      "aria-label"?: string
+    }) => (
+      <div aria-label={ariaLabel} role="menu">
+        {children}
+      </div>
+    ),
+    DropdownItem: ({
+      children,
+      isDisabled,
+      onAction,
+      textValue,
+    }: {
+      children: React.ReactNode
+      isDisabled?: boolean
+      onAction?: () => void
+      textValue?: string
+    }) => {
+      const { setOpen } = useDropdownState()
+
+      return (
+        <button
+          aria-label={textValue}
+          disabled={isDisabled}
+          role="menuitem"
+          type="button"
+          onClick={() => {
+            document.body.style.pointerEvents = "none"
+            onAction?.()
+            setOpen(false)
+            document.body.style.pointerEvents = ""
+          }}
+        >
+          {children}
+        </button>
+      )
+    },
+  }
+})
+
+describe("EquipmentHeroDropdown", () => {
+  it("defers item actions until after the HeroUI source menu closes", async () => {
+    vi.useFakeTimers()
+    document.body.style.pointerEvents = ""
+
+    const onAction = vi.fn(() => document.body.style.pointerEvents)
+
+    try {
+      render(
+        <EquipmentHeroDropdown
+          ariaLabel="Tác vụ kiểm thử"
+          items={[
+            {
+              id: "open-dialog",
+              label: "Mở hộp thoại",
+              textValue: "Mở hộp thoại",
+              onAction,
+            },
+          ]}
+          trigger="Tác vụ kiểm thử"
+        />
+      )
+
+      fireEvent.click(screen.getByRole("button", { name: "Tác vụ kiểm thử" }))
+      fireEvent.click(screen.getByRole("menuitem", { name: "Mở hộp thoại" }))
+
+      expect(screen.queryByTestId("source-menu")).not.toBeInTheDocument()
+      expect(onAction).not.toHaveBeenCalled()
+      expect(document.body.style.pointerEvents).not.toBe("none")
+
+      act(() => {
+        vi.advanceTimersByTime(0)
+      })
+
+      expect(onAction).toHaveReturnedWith("")
+    } finally {
+      vi.runOnlyPendingTimers()
+      vi.useRealTimers()
+      document.body.style.pointerEvents = ""
+    }
+  })
+
+  it("keeps disabled menu items from dispatching actions", async () => {
+    const onAction = vi.fn()
+
+    render(
+      <EquipmentHeroDropdown
+        ariaLabel="Tác vụ kiểm thử"
+        items={[
+          {
+            id: "export",
+            label: "Đang tải...",
+            textValue: "Đang tải...",
+            isDisabled: true,
+            onAction,
+          },
+        ]}
+        trigger="Tác vụ kiểm thử"
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Tác vụ kiểm thử" }))
+
+    expect(await screen.findByRole("menuitem", { name: "Đang tải..." })).toBeDisabled()
+    expect(onAction).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/equipment/heroui-pilot/controls.tsx
+++ b/src/components/equipment/heroui-pilot/controls.tsx
@@ -17,6 +17,7 @@ import {
   DropdownTrigger,
 } from "@heroui/react"
 
+import { useOverlayActionTransition } from "@/components/ui/use-deferred-dropdown-action"
 import { cn } from "@/lib/utils"
 
 export interface EquipmentHeroDropdownItem {
@@ -49,6 +50,8 @@ export function EquipmentHeroDropdown({
   menuClassName,
   placement = "bottom end",
 }: EquipmentHeroDropdownProps) {
+  const runOverlayAction = useOverlayActionTransition()
+
   return (
     <Dropdown>
       <DropdownTrigger
@@ -66,7 +69,7 @@ export function EquipmentHeroDropdown({
               key={item.id}
               id={item.id}
               isDisabled={item.isDisabled}
-              onAction={item.onAction}
+              onAction={() => runOverlayAction(item.onAction)}
               textValue={item.textValue}
             >
               {item.label}

--- a/src/components/shared/floating-actions/MobileFloatingActionMenu.tsx
+++ b/src/components/shared/floating-actions/MobileFloatingActionMenu.tsx
@@ -14,6 +14,7 @@ import {
   floatingActionButtonClassName,
   type FloatingActionButtonProps,
 } from "@/components/shared/FloatingActionButton"
+import { useOverlayActionTransition } from "@/components/ui/use-deferred-dropdown-action"
 import type { MobileFloatingActionDescriptor } from "./MobileFloatingActionsContext"
 
 interface MobileFloatingActionMenuProps {
@@ -30,14 +31,22 @@ export function MobileFloatingActionMenu({
   triggerLabel = "Mở tác vụ nhanh",
   className,
 }: MobileFloatingActionMenuProps) {
+  const runOverlayAction = useOverlayActionTransition()
+  const handleAction = React.useCallback(
+    (key: React.Key) => {
+      const targetAction = actions.find((action) => action.id === key)
+
+      if (!targetAction) {
+        return
+      }
+
+      runOverlayAction(targetAction.onSelect)
+    },
+    [actions, runOverlayAction]
+  )
+
   if (actions.length === 0) {
     return null
-  }
-
-  const handleAction = (key: React.Key) => {
-    const targetAction = actions.find((action) => action.id === key)
-
-    targetAction?.onSelect()
   }
 
   return (

--- a/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
+++ b/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { PlusCircle, Sparkles } from "lucide-react"
 import { describe, expect, it, vi } from "vitest"
@@ -127,9 +127,11 @@ vi.mock("@heroui/react", () => ({
         }
 
         document.body.style.pointerEvents = "none"
+        setTimeout(() => {
+          closeSourceMenu?.()
+          document.body.style.pointerEvents = ""
+        }, 0)
         onSelectKey?.(id)
-        closeSourceMenu?.()
-        document.body.style.pointerEvents = ""
       }}
     >
       {children}
@@ -189,11 +191,12 @@ describe("MobileFloatingActionMenu", () => {
     )
 
     await user.click(screen.getByRole("menuitem", { name: "Trợ lý AI" }))
+    await waitFor(() => expect(openAssistant).toHaveBeenCalledTimes(1))
+
     await user.click(screen.getByRole("button", { name: "Mở tác vụ nhanh" }))
     await user.click(screen.getByRole("menuitem", { name: "Tạo yêu cầu" }))
 
-    expect(openAssistant).toHaveBeenCalledTimes(1)
-    expect(openCreate).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(openCreate).toHaveBeenCalledTimes(1))
   })
 
   it("defers selected actions until after the HeroUI source menu closes", async () => {
@@ -218,14 +221,16 @@ describe("MobileFloatingActionMenu", () => {
 
       fireEvent.click(screen.getByRole("menuitem", { name: "Trợ lý AI" }))
 
-      expect(screen.queryByRole("menu", { name: "Tác vụ nhanh" })).not.toBeInTheDocument()
+      expect(screen.getByRole("menu", { name: "Tác vụ nhanh" })).toBeInTheDocument()
       expect(openAssistant).not.toHaveBeenCalled()
-      expect(document.body.style.pointerEvents).not.toBe("none")
+      expect(document.body.style.pointerEvents).toBe("none")
 
       act(() => {
         vi.advanceTimersByTime(0)
       })
 
+      expect(screen.queryByRole("menu", { name: "Tác vụ nhanh" })).not.toBeInTheDocument()
+      expect(document.body.style.pointerEvents).not.toBe("none")
       expect(openAssistant).toHaveReturnedWith("")
     } finally {
       vi.runOnlyPendingTimers()

--- a/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
+++ b/src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
-import { render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { PlusCircle, Sparkles } from "lucide-react"
 import { describe, expect, it, vi } from "vitest"
@@ -8,57 +8,130 @@ import { describe, expect, it, vi } from "vitest"
 import { MobileFloatingActionMenu } from "../MobileFloatingActionMenu"
 
 vi.mock("@heroui/react", () => ({
-  Dropdown: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="heroui-dropdown">{children}</div>
-  ),
+  Dropdown: ({ children }: { children: React.ReactNode }) => {
+    const [isOpen, setOpen] = React.useState(true)
+
+    return (
+      <div data-testid="heroui-dropdown">
+        {React.Children.map(children, (child) => {
+          if (!React.isValidElement(child)) {
+            return child
+          }
+
+          return React.cloneElement(child, {
+            isOpen,
+            setOpen,
+          } as Partial<{
+            isOpen: boolean
+            setOpen: React.Dispatch<React.SetStateAction<boolean>>
+          }>)
+        })}
+      </div>
+    )
+  },
   DropdownTrigger: ({
     children,
     className,
+    isOpen: _isOpen,
+    setOpen,
     ...props
   }: {
     children: React.ReactNode
     className?: string
+    isOpen?: boolean
+    setOpen?: React.Dispatch<React.SetStateAction<boolean>>
   } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" className={className} {...props}>
+    <button type="button" className={className} onClick={() => setOpen?.(true)} {...props}>
       {children}
     </button>
   ),
-  DropdownPopover: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  DropdownPopover: ({
+    children,
+    className,
+    isOpen,
+    setOpen,
+  }: {
+    children: React.ReactNode
+    className?: string
+    isOpen?: boolean
+    setOpen?: React.Dispatch<React.SetStateAction<boolean>>
+  }) => (
     <div className={className} data-testid="heroui-popover">
-      {children}
+      {React.Children.map(children, (child) => {
+        if (!React.isValidElement(child)) {
+          return child
+        }
+
+        return React.cloneElement(child, {
+          isOpen,
+          setOpen,
+        } as Partial<{
+          isOpen: boolean
+          setOpen: React.Dispatch<React.SetStateAction<boolean>>
+        }>)
+      })}
     </div>
   ),
   DropdownMenu: ({
     children,
     "aria-label": ariaLabel,
+    isOpen,
     onAction,
+    setOpen,
   }: {
     children: React.ReactNode
     "aria-label"?: string
+    isOpen?: boolean
     onAction?: (key: React.Key) => void
-  }) => (
-    <div aria-label={ariaLabel} role="menu">
-      {React.Children.map(children, (child) => {
-        if (!React.isValidElement<{ id?: string }>(child)) {
-          return child
-        }
+    setOpen?: React.Dispatch<React.SetStateAction<boolean>>
+  }) => {
+    if (!isOpen) {
+      return null
+    }
 
-        return React.cloneElement(child, {
-          onSelectKey: onAction,
-        } as Partial<{ onSelectKey: (key: React.Key) => void }>)
-      })}
-    </div>
-  ),
+    return (
+      <div aria-label={ariaLabel} role="menu">
+        {React.Children.map(children, (child) => {
+          if (!React.isValidElement<{ id?: string }>(child)) {
+            return child
+          }
+
+          return React.cloneElement(child, {
+            onSelectKey: onAction,
+            closeSourceMenu: () => setOpen?.(false),
+          } as Partial<{
+            closeSourceMenu: () => void
+            onSelectKey: (key: React.Key) => void
+          }>)
+        })}
+      </div>
+    )
+  },
   DropdownItem: ({
     children,
+    closeSourceMenu,
     id,
     onSelectKey,
   }: {
     children: React.ReactNode
+    closeSourceMenu?: () => void
     id?: string
     onSelectKey?: (key: React.Key) => void
   }) => (
-    <button type="button" role="menuitem" onClick={() => id && onSelectKey?.(id)}>
+    <button
+      type="button"
+      role="menuitem"
+      onClick={() => {
+        if (!id) {
+          return
+        }
+
+        document.body.style.pointerEvents = "none"
+        onSelectKey?.(id)
+        closeSourceMenu?.()
+        document.body.style.pointerEvents = ""
+      }}
+    >
       {children}
     </button>
   ),
@@ -116,9 +189,48 @@ describe("MobileFloatingActionMenu", () => {
     )
 
     await user.click(screen.getByRole("menuitem", { name: "Trợ lý AI" }))
+    await user.click(screen.getByRole("button", { name: "Mở tác vụ nhanh" }))
     await user.click(screen.getByRole("menuitem", { name: "Tạo yêu cầu" }))
 
     expect(openAssistant).toHaveBeenCalledTimes(1)
     expect(openCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it("defers selected actions until after the HeroUI source menu closes", async () => {
+    vi.useFakeTimers()
+    document.body.style.pointerEvents = ""
+
+    const openAssistant = vi.fn(() => document.body.style.pointerEvents)
+
+    try {
+      render(
+        <MobileFloatingActionMenu
+          actions={[
+            {
+              id: "assistant",
+              label: "Trợ lý AI",
+              icon: <Sparkles />,
+              onSelect: openAssistant,
+            },
+          ]}
+        />
+      )
+
+      fireEvent.click(screen.getByRole("menuitem", { name: "Trợ lý AI" }))
+
+      expect(screen.queryByRole("menu", { name: "Tác vụ nhanh" })).not.toBeInTheDocument()
+      expect(openAssistant).not.toHaveBeenCalled()
+      expect(document.body.style.pointerEvents).not.toBe("none")
+
+      act(() => {
+        vi.advanceTimersByTime(0)
+      })
+
+      expect(openAssistant).toHaveReturnedWith("")
+    } finally {
+      vi.runOnlyPendingTimers()
+      vi.useRealTimers()
+      document.body.style.pointerEvents = ""
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Move `EquipmentHeroDropdown` and `MobileFloatingActionMenu` action dispatch onto `useOverlayActionTransition`.
- Add consumer regressions for deferred action dispatch after source menu close and pointer-events restoration.
- Preserve existing labels, disabled behavior, action ids, and HeroUI import boundaries.

Closes #726

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/equipment/heroui-pilot/__tests__/controls.test.tsx src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx src/components/ui/__tests__/use-overlay-action-transition.test.tsx`
- `node scripts/npm-run.js run react-doctor`
- Lefthook pre-commit and pre-push hooks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers HeroUI menu actions until after the source menu closes to fix blocked interactions and stuck pointer-events. Updates `EquipmentHeroDropdown` and `MobileFloatingActionMenu` without changing ids, labels, or disabled behavior (closes #726).

- **Bug Fixes**
  - Route actions through `useOverlayActionTransition` (`@/components/ui/use-deferred-dropdown-action`) to run post-close and restore `pointer-events`.
  - Strengthen tests to verify deferred dispatch, disabled-item behavior, and mobile pointer-events toggle with menu close before action runs.
  - No API changes; `@heroui/react` usage and action ids/labels unchanged.

<sup>Written for commit a3f2285db5bd348e96ab5ad50841a69f73f85970. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown and mobile action menus so selected actions run only after the menu closes, improving interaction reliability.
  * Disabled menu items now stay inactive and no longer trigger actions.
  * Improved menu behavior to avoid stray pointer interaction issues during selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->