### PR TITLE
Fix #721: replace native mobile bottom sheet dialog

### DIFF
--- a/src/__tests__/react-doctor-issue-571-markup-perf.source.test.ts
+++ b/src/__tests__/react-doctor-issue-571-markup-perf.source.test.ts
@@ -59,7 +59,7 @@ describe("React Doctor Issue #571 semantic markup and perf source guards", () =>
 
   it("does not initialize repair request date state from a mount-only effect", () => {
     const source = readSource(
-      "src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx",
+      "src/app/(app)/repair-requests/_components/RepairRequestsCreateSheetForm.tsx"
     )
 
     expect(source).not.toContain("setMinimumSelectableDate")
@@ -68,12 +68,14 @@ describe("React Doctor Issue #571 semantic markup and perf source guards", () =>
 
   it("schedules inventory report date refreshes without a mount-only initial set", () => {
     const source = readSource(
-      "src/app/(app)/reports/components/inventory-report-filter-section.tsx",
+      "src/app/(app)/reports/components/inventory-report-filter-section.tsx"
     )
 
     expect(source).not.toMatch(/React\.useEffect\([\s\S]*setMaxReportDate\(now\)[\s\S]*\}, \[\]\)/)
     expect(source).toContain("React.useSyncExternalStore")
-    expect(source).toMatch(/maxReportDateSnapshot\s*=\s*new Date\(\)[\s\S]*onStoreChange\(\)[\s\S]*scheduleNextReportDateRefresh\(\)/)
+    expect(source).toMatch(
+      /maxReportDateSnapshot\s*=\s*new Date\(\)[\s\S]*onStoreChange\(\)[\s\S]*scheduleNextReportDateRefresh\(\)/
+    )
   })
 
   it("uses an external-store snapshot for mobile breakpoint state", () => {
@@ -95,11 +97,13 @@ describe("React Doctor Issue #571 semantic markup and perf source guards", () =>
     expect(source).toContain("cachedLanguageSnapshot")
   })
 
-  it("opens the mobile bottom sheet as a modal dialog", () => {
+  it("opens the mobile bottom sheet without native dialog APIs", () => {
     const source = readSource("src/components/shared/mobile-bottom-sheet.tsx")
 
-    expect(source).toContain(".showModal()")
-    expect(source).not.toMatch(/<dialog[\s\S]{0,120}\sopen\b/)
+    expect(source).toContain("SheetContent")
+    expect(source).not.toContain(".showModal()")
+    expect(source).not.toContain("HTMLDialogElement")
+    expect(source).not.toMatch(/<dialog\b/)
   })
 
   it("keeps category select buttons free of block component children", () => {

--- a/src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
+++ b/src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { render, screen, fireEvent } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
 import { FilterBottomSheet, type EquipmentFilterData } from "../../equipment/filter-bottom-sheet"
@@ -11,6 +12,37 @@ const emptyFilterData: EquipmentFilterData = {
   user: [],
   classification: [],
   fundingSource: [],
+}
+
+function ControlledFilterBottomSheet({
+  onApply = vi.fn(),
+  onClearAll = vi.fn(),
+  onOutsideAction = vi.fn(),
+}: {
+  onApply?: React.ComponentProps<typeof FilterBottomSheet>["onApply"]
+  onClearAll?: React.ComponentProps<typeof FilterBottomSheet>["onClearAll"]
+  onOutsideAction?: () => void
+}) {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Mở bộ lọc
+      </button>
+      <button type="button" onClick={onOutsideAction}>
+        Tác vụ ngoài trang
+      </button>
+      <FilterBottomSheet
+        open={open}
+        onOpenChange={setOpen}
+        data={emptyFilterData}
+        columnFilters={[]}
+        onApply={onApply}
+        onClearAll={onClearAll}
+      />
+    </>
+  )
 }
 
 describe("FilterBottomSheet (regression)", () => {
@@ -39,12 +71,13 @@ describe("FilterBottomSheet (regression)", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
-  it("calls onOpenChange(false) on backdrop click", () => {
+  it("calls onOpenChange(false) on backdrop click", async () => {
+    const user = userEvent.setup()
     const onOpenChange = vi.fn()
     render(<FilterBottomSheet {...defaultProps} onOpenChange={onOpenChange} />)
 
     const backdrop = screen.getByTestId("mobile-bottom-sheet-backdrop")
-    fireEvent.click(backdrop)
+    await user.click(backdrop)
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
@@ -106,5 +139,47 @@ describe("FilterBottomSheet (regression)", () => {
     expect(footer).toHaveClass("pb-12")
     expect(clearButton).toHaveClass("w-full", "min-w-0")
     expect(applyButton).toHaveClass("w-full", "min-w-0")
+  })
+
+  it("supports apply, clear, Escape close, and page interaction after close", async () => {
+    const user = userEvent.setup()
+    const onApply = vi.fn()
+    const onClearAll = vi.fn()
+    const onOutsideAction = vi.fn()
+
+    render(
+      <ControlledFilterBottomSheet
+        onApply={onApply}
+        onClearAll={onClearAll}
+        onOutsideAction={onOutsideAction}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mở bộ lọc" }))
+    await user.click(screen.getByRole("button", { name: /Đang sử dụng/ }))
+    await user.click(screen.getByRole("button", { name: /Áp dụng/ }))
+
+    expect(onApply).toHaveBeenCalledWith([{ id: "tinh_trang_hien_tai", value: ["active"] }])
+    expect(screen.queryByRole("dialog", { name: "Bộ lọc thiết bị" })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Tác vụ ngoài trang" }))
+    expect(onOutsideAction).toHaveBeenCalledTimes(1)
+
+    await user.click(screen.getByRole("button", { name: "Mở bộ lọc" }))
+    await user.click(screen.getByRole("button", { name: "Xóa tất cả" }))
+
+    expect(onClearAll).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole("dialog", { name: "Bộ lọc thiết bị" })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Tác vụ ngoài trang" }))
+    expect(onOutsideAction).toHaveBeenCalledTimes(2)
+
+    await user.click(screen.getByRole("button", { name: "Mở bộ lọc" }))
+    await user.keyboard("{Escape}")
+
+    expect(screen.queryByRole("dialog", { name: "Bộ lọc thiết bị" })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Tác vụ ngoài trang" }))
+    expect(onOutsideAction).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/components/shared/__tests__/mobile-bottom-sheet.test.tsx
+++ b/src/components/shared/__tests__/mobile-bottom-sheet.test.tsx
@@ -1,45 +1,44 @@
 import * as React from "react"
-import { render, screen, fireEvent } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
 
 import { MobileBottomSheet } from "../mobile-bottom-sheet"
 
 describe("MobileBottomSheet", () => {
-  let showModal: ReturnType<typeof vi.fn>
-  let close: ReturnType<typeof vi.fn>
-
   const defaultProps = {
     open: true,
     onOpenChange: vi.fn(),
     ariaLabel: "Test bottom sheet",
   }
 
-  beforeEach(() => {
-    showModal = vi.fn(function (this: HTMLDialogElement) {
-      this.setAttribute("open", "")
-    })
-    close = vi.fn(function (this: HTMLDialogElement) {
-      this.removeAttribute("open")
-    })
-    Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
-      configurable: true,
-      value: showModal,
-    })
-    Object.defineProperty(HTMLDialogElement.prototype, "close", {
-      configurable: true,
-      value: close,
-    })
-  })
-
-  it("opens the native dialog modally when open", () => {
+  it("opens without rendering a native dialog element", () => {
     render(
       <MobileBottomSheet {...defaultProps}>
         <p>Sheet content</p>
       </MobileBottomSheet>
     )
 
-    expect(showModal).toHaveBeenCalledTimes(1)
-    expect(close).not.toHaveBeenCalled()
+    expect(document.querySelector("dialog")).not.toBeInTheDocument()
+    expect(screen.getByRole("dialog", { name: "Test bottom sheet" })).toBeInTheDocument()
+  })
+
+  it("does not call native showModal when opened", () => {
+    const showModal = vi.fn(() => {
+      throw new Error("native dialog API should not be used")
+    })
+    Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
+      configurable: true,
+      value: showModal,
+    })
+
+    render(
+      <MobileBottomSheet {...defaultProps}>
+        <p>Sheet content</p>
+      </MobileBottomSheet>
+    )
+
+    expect(showModal).not.toHaveBeenCalled()
   })
 
   it("renders children when open", () => {
@@ -62,7 +61,8 @@ describe("MobileBottomSheet", () => {
     expect(screen.queryByText("Sheet content")).not.toBeInTheDocument()
   })
 
-  it("calls onOpenChange(false) when the native dialog is cancelled", () => {
+  it("calls onOpenChange(false) when Escape is pressed", async () => {
+    const user = userEvent.setup()
     const onOpenChange = vi.fn()
 
     render(
@@ -71,11 +71,13 @@ describe("MobileBottomSheet", () => {
       </MobileBottomSheet>
     )
 
-    fireEvent(screen.getByRole("dialog"), new Event("cancel", { cancelable: true }))
+    await user.keyboard("{Escape}")
+
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
-  it("calls onOpenChange(false) on backdrop click", () => {
+  it("calls onOpenChange(false) on backdrop click", async () => {
+    const user = userEvent.setup()
     const onOpenChange = vi.fn()
 
     render(
@@ -85,7 +87,7 @@ describe("MobileBottomSheet", () => {
     )
 
     const backdrop = screen.getByTestId("mobile-bottom-sheet-backdrop")
-    fireEvent.click(backdrop)
+    await user.click(backdrop)
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
@@ -111,7 +113,7 @@ describe("MobileBottomSheet", () => {
     expect(dialog).toHaveAttribute("aria-label", "Filter sheet")
   })
 
-  it("locks the dialog container to the viewport so the backdrop and panel cannot shrink", () => {
+  it("keeps the bottom sheet panel locked to the viewport width", () => {
     render(
       <MobileBottomSheet {...defaultProps}>
         <p>Content</p>
@@ -119,7 +121,7 @@ describe("MobileBottomSheet", () => {
     )
 
     const dialog = screen.getByRole("dialog")
-    expect(dialog).toHaveClass("fixed", "inset-0", "w-screen", "h-screen", "max-w-none")
+    expect(dialog).toHaveClass("fixed", "inset-x-0", "bottom-0", "w-full", "max-w-none")
   })
 
   it("applies custom className to the sheet panel", () => {
@@ -130,8 +132,32 @@ describe("MobileBottomSheet", () => {
     )
 
     const dialog = screen.getByRole("dialog")
-    // The className should be on the inner panel, not the outer container
-    const panel = dialog.querySelector(".custom-class")
-    expect(panel).toBeInTheDocument()
+    expect(dialog).toHaveClass("custom-class")
+  })
+
+  it("restores focus to the opener when the sheet closes", async () => {
+    const user = userEvent.setup()
+
+    function ControlledSheet() {
+      const [open, setOpen] = React.useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open filters
+          </button>
+          <MobileBottomSheet open={open} onOpenChange={setOpen} ariaLabel="Test bottom sheet">
+            <button type="button">Inside</button>
+          </MobileBottomSheet>
+        </>
+      )
+    }
+
+    render(<ControlledSheet />)
+
+    const opener = screen.getByRole("button", { name: "Open filters" })
+    await user.click(opener)
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => expect(opener).toHaveFocus())
   })
 })

--- a/src/components/shared/__tests__/mobile-bottom-sheet.test.tsx
+++ b/src/components/shared/__tests__/mobile-bottom-sheet.test.tsx
@@ -123,6 +123,16 @@ describe("MobileBottomSheet", () => {
     expect(dialog).toHaveAttribute("aria-label", "Filter sheet")
   })
 
+  it("renders a hidden title for the Radix dialog content contract", () => {
+    render(
+      <MobileBottomSheet {...defaultProps} ariaLabel="Filter sheet">
+        <p>Content</p>
+      </MobileBottomSheet>
+    )
+
+    expect(screen.getByText("Filter sheet")).toHaveClass("sr-only")
+  })
+
   it("keeps the bottom sheet panel locked to the viewport width", () => {
     render(
       <MobileBottomSheet {...defaultProps}>

--- a/src/components/shared/__tests__/mobile-bottom-sheet.test.tsx
+++ b/src/components/shared/__tests__/mobile-bottom-sheet.test.tsx
@@ -1,9 +1,11 @@
 import * as React from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { MobileBottomSheet } from "../mobile-bottom-sheet"
+
+const originalShowModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, "showModal")
 
 describe("MobileBottomSheet", () => {
   const defaultProps = {
@@ -11,6 +13,14 @@ describe("MobileBottomSheet", () => {
     onOpenChange: vi.fn(),
     ariaLabel: "Test bottom sheet",
   }
+
+  afterEach(() => {
+    if (originalShowModal) {
+      Object.defineProperty(HTMLDialogElement.prototype, "showModal", originalShowModal)
+    } else {
+      Reflect.deleteProperty(HTMLDialogElement.prototype, "showModal")
+    }
+  })
 
   it("opens without rendering a native dialog element", () => {
     render(

--- a/src/components/shared/mobile-bottom-sheet.tsx
+++ b/src/components/shared/mobile-bottom-sheet.tsx
@@ -1,7 +1,9 @@
 "use client"
 
 import * as React from "react"
+
 import { cn } from "@/lib/utils"
+import { Sheet, SheetContent } from "@/components/ui/sheet"
 
 interface MobileBottomSheetProps {
   open: boolean
@@ -16,7 +18,7 @@ interface MobileBottomSheetProps {
  *
  * Extracted from FilterBottomSheet to provide a reusable presentation
  * pattern: backdrop overlay, rounded-top panel, drag handle, focus trap,
- * Escape key, and ARIA dialog semantics.
+ * Escape key, and ARIA dialog semantics through the shared Radix Sheet primitive.
  */
 export function MobileBottomSheet({
   open,
@@ -25,78 +27,56 @@ export function MobileBottomSheet({
   children,
   className,
 }: MobileBottomSheetProps) {
-  const dialogRef = React.useRef<HTMLDialogElement>(null)
-  const previousActiveElement = React.useRef<HTMLElement | null>(null)
+  const previouslyFocusedElement = React.useRef<HTMLElement | null>(null)
+  const restoreFocusTimer = React.useRef<number | null>(null)
+  const wasOpen = React.useRef(false)
 
-  // Focus management: open modally, move focus into dialog, and restore on close.
   React.useEffect(() => {
-    const dialog = dialogRef.current
-    if (!open || !dialog) return
-
-    previousActiveElement.current = document.activeElement as HTMLElement
-
-    if (typeof dialog.showModal === "function" && !dialog.open) {
-      dialog.showModal()
-    } else if (!dialog.hasAttribute("open")) {
-      dialog.setAttribute("open", "")
-    }
-
-    const timer = setTimeout(() => {
-      const firstFocusable = dialog.querySelector<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      )
-
-      if (firstFocusable) {
-        firstFocusable.focus()
-      } else {
-        dialog.focus()
-      }
-    }, 100)
-
     return () => {
-      clearTimeout(timer)
-
-      if (dialog.open && typeof dialog.close === "function") {
-        dialog.close()
-      } else {
-        dialog.removeAttribute("open")
-      }
-
-      if (previousActiveElement.current) {
-        previousActiveElement.current.focus()
-        previousActiveElement.current = null
+      if (restoreFocusTimer.current !== null) {
+        window.clearTimeout(restoreFocusTimer.current)
       }
     }
+  }, [])
+
+  React.useLayoutEffect(() => {
+    if (open && !wasOpen.current) {
+      if (restoreFocusTimer.current !== null) {
+        window.clearTimeout(restoreFocusTimer.current)
+        restoreFocusTimer.current = null
+      }
+      previouslyFocusedElement.current = document.activeElement as HTMLElement | null
+    }
+
+    if (!open && wasOpen.current) {
+      const elementToRestore = previouslyFocusedElement.current
+      previouslyFocusedElement.current = null
+
+      restoreFocusTimer.current = window.setTimeout(() => {
+        if (elementToRestore && document.contains(elementToRestore)) {
+          elementToRestore.focus()
+        }
+        restoreFocusTimer.current = null
+      }, 0)
+    }
+
+    wasOpen.current = open
   }, [open])
 
-  const handleCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
-    event.preventDefault()
-    onOpenChange(false)
-  }
-
-  if (!open) return null
-
   return (
-    <dialog
-      ref={dialogRef}
-      className="fixed inset-0 z-[1002] m-0 flex h-screen w-screen max-h-none max-w-none items-end border-0 bg-transparent p-0"
-      onCancel={handleCancel}
-      aria-modal="true"
-      aria-label={ariaLabel}
-      tabIndex={-1}
-    >
-      {/* Backdrop */}
-      <div
-        data-testid="mobile-bottom-sheet-backdrop"
-        className="absolute inset-0 bg-gray-950/40 backdrop-blur-sm animate-in fade-in duration-300"
-        onClick={() => onOpenChange(false)}
-        aria-hidden="true"
-      />
-
-      {/* Sheet panel */}
-      <div
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        hideCloseButton
+        overlayProps={{
+          "data-testid": "mobile-bottom-sheet-backdrop",
+          className: "bg-gray-950/40 backdrop-blur-sm",
+        }}
+        aria-label={ariaLabel}
+        aria-modal="true"
         className={cn(
-          "relative w-full bg-background rounded-t-2xl shadow-2xl",
+          "w-full max-w-none gap-0 border-0 bg-background p-0",
+          "rounded-t-2xl shadow-2xl",
           "animate-in slide-in-from-bottom duration-300",
           "flex flex-col",
           className
@@ -112,7 +92,7 @@ export function MobileBottomSheet({
         </div>
 
         {children}
-      </div>
-    </dialog>
+      </SheetContent>
+    </Sheet>
   )
 }

--- a/src/components/shared/mobile-bottom-sheet.tsx
+++ b/src/components/shared/mobile-bottom-sheet.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
-import { Sheet, SheetContent } from "@/components/ui/sheet"
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet"
 
 interface MobileBottomSheetProps {
   open: boolean
@@ -83,6 +83,8 @@ export function MobileBottomSheet({
         )}
         style={{ maxHeight: "calc(100vh - 4rem)" }}
       >
+        <SheetTitle className="sr-only">{ariaLabel}</SheetTitle>
+
         {/* Drag handle */}
         <div className="flex justify-center pt-3 pb-1 shrink-0">
           <div

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -7,8 +7,10 @@ import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+/** Root controller for shared Radix-backed sheet overlays. */
 const Sheet = SheetPrimitive.Root
 
+/** Trigger element for opening a shared sheet overlay. */
 const SheetTrigger = SheetPrimitive.Trigger
 
 const SheetClose = SheetPrimitive.Close
@@ -50,58 +52,59 @@ const sheetVariants = cva(
 )
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {
+  overlayProps?: React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay> & {
+    [key: `data-${string}`]: string | undefined
+  }
+  hideCloseButton?: boolean
+}
 
+/** Positioned sheet panel with overlay and optional built-in close control. */
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="size-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
+>(
+  (
+    { side = "right", className, children, overlayProps, hideCloseButton = false, ...props },
+    ref
+  ) => (
+    <SheetPortal>
+      <SheetOverlay {...overlayProps} />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+        {hideCloseButton ? null : (
+          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <X className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+)
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
-const SheetHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col gap-y-2 text-center sm:text-left",
-      className
-    )}
-    {...props}
-  />
+/** Header layout for shared sheet title and description content. */
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col gap-y-2 text-center sm:text-left", className)} {...props} />
 )
 SheetHeader.displayName = "SheetHeader"
 
-const SheetFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-x-2",
-      className
-    )}
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-x-2", className)}
     {...props}
   />
 )
 SheetFooter.displayName = "SheetFooter"
 
+/** Accessible title element for shared sheet overlays. */
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
@@ -114,6 +117,7 @@ const SheetTitle = React.forwardRef<
 ))
 SheetTitle.displayName = SheetPrimitive.Title.displayName
 
+/** Accessible description element for shared sheet overlays. */
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
@@ -126,11 +130,4 @@ const SheetDescription = React.forwardRef<
 ))
 SheetDescription.displayName = SheetPrimitive.Description.displayName
 
-export {
-  Sheet,
-  SheetTrigger,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription
-}
+export { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescription }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -96,6 +96,7 @@ const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
 )
 SheetHeader.displayName = "SheetHeader"
 
+/** Footer layout for shared sheet action rows. */
 const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:gap-x-2", className)}
@@ -130,4 +131,4 @@ const SheetDescription = React.forwardRef<
 ))
 SheetDescription.displayName = SheetPrimitive.Description.displayName
 
-export { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescription }
+export { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetFooter, SheetTitle, SheetDescription }


### PR DESCRIPTION
## Summary
- Replaces shared MobileBottomSheet native `<dialog>.showModal()` usage with the existing Radix/shadcn Sheet primitive.
- Preserves mobile bottom-sheet layout, backdrop/Escape close, aria dialog labeling, and focus restore for external toolbar triggers.
- Adds regression coverage for apply/clear/close flows and page interaction after close.

Closes #721

## Verification
- RED confirmed: focused tests failed against native `<dialog>` / `.showModal()` implementation before production changes.
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/shared/__tests__/mobile-bottom-sheet.test.tsx src/components/shared/__tests__/filter-bottom-sheet.regression.test.tsx src/__tests__/react-doctor-issue-571-markup-perf.source.test.ts`
- `node scripts/npm-run.js run test:run -- src/components/shared/__tests__/SideSheetShell.test.tsx src/components/transfers/__tests__/FilterModal.test.tsx`
- `node scripts/npm-run.js run react-doctor`
- pre-commit hook passed
- pre-push hook passed

## Follow-up
- Filed #730 for unrelated standalone `equipment-toolbar.filters.test.tsx` failure in the HeroUI compact dropdown test; kept out of #721 scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the mobile bottom sheet’s native <dialog>.showModal() with the shared Radix-backed `Sheet` for consistent UX and accessibility, including a hidden `SheetTitle` for a proper accessible name and reliable focus restore on close. Satisfies #721 by keeping the same layout and Escape/backdrop close, and verifying no native dialog APIs are used.

- **Refactors**
  - Rebuilt `MobileBottomSheet` with `Sheet`/`SheetContent`; added sr-only `SheetTitle`; removed `HTMLDialogElement` and `.showModal()`; bottom-side sheet with overlay and ARIA labeling.
  - Improved focus restore to return to the opener after close; added targeted tests.
  - Extended `SheetContent` with `overlayProps` and `hideCloseButton`; exported `SheetFooter`; refined panel classes for a full-width bottom panel.
  - Updated tests to use `userEvent`; added regression coverage for apply/clear/Escape, backdrop clicks, page interaction after close; React Doctor guard asserts `SheetContent` usage and no native dialog APIs.

<sup>Written for commit 6cc925153d8b55484f31a84f03c5c24ed7386811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the mobile bottom sheet to use a more consistent sheet experience, with improved overlay handling and optional close-button visibility.
  * Added better focus restoration when the sheet closes.

* **Bug Fixes**
  * Improved backdrop click and Escape-key behavior for bottom sheets.
  * Tightened regression coverage for filter and inventory flows to prevent reopening/close-state issues.

* **Tests**
  * Expanded end-to-end interaction tests for sheet behavior, including apply, clear, outside actions, and focus return.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->