### PR TITLE
test: add overlay workflow guardrails

### DIFF
--- a/src/app/(app)/equipment/__tests__/equipment-actions-overlay-workflow.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-actions-overlay-workflow.test.tsx
@@ -1,0 +1,125 @@
+import * as React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import type { Equipment, UsageLog } from "@/types/database"
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  openDetailDialog: vi.fn(),
+  openStartUsageDialog: vi.fn(),
+  openEndUsageDialog: vi.fn(),
+  openDeleteDialog: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mocks.push,
+  }),
+}))
+
+vi.mock("@/app/(app)/equipment/_hooks/useEquipmentContext", () => ({
+  useEquipmentContext: () => ({
+    user: {
+      id: 1,
+      role: "to_qltb",
+    },
+    isGlobal: false,
+    isRegionalLeader: false,
+    openDetailDialog: mocks.openDetailDialog,
+    openStartUsageDialog: mocks.openStartUsageDialog,
+    openEndUsageDialog: mocks.openEndUsageDialog,
+    openDeleteDialog: mocks.openDeleteDialog,
+  }),
+}))
+
+import { EquipmentActionsMenu } from "../../../../components/equipment/equipment-actions-menu"
+
+const equipment = {
+  id: 101,
+  ten_thiet_bi: "Máy thở test",
+} as unknown as Equipment
+
+const callbackMenuState: boolean[] = []
+
+function EquipmentDetailWorkflowHarness() {
+  const [detailEquipment, setDetailEquipment] = React.useState<Equipment | null>(null)
+  const [pageClicks, setPageClicks] = React.useState(0)
+
+  React.useEffect(() => {
+    mocks.openDetailDialog.mockImplementation((selectedEquipment: Equipment) => {
+      callbackMenuState.push(screen.queryByRole("menuitem", { name: "Xem chi tiết" }) !== null)
+      setDetailEquipment(selectedEquipment)
+    })
+  }, [])
+
+  return (
+    <div>
+      <EquipmentActionsMenu
+        equipment={equipment}
+        activeUsageLogs={[] as UsageLog[]}
+        isLoadingActiveUsage={false}
+      />
+      <Dialog
+        open={detailEquipment !== null}
+        onOpenChange={(open) => !open && setDetailEquipment(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Chi tiết thiết bị</DialogTitle>
+            <DialogDescription>{detailEquipment?.ten_thiet_bi}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" onClick={() => setDetailEquipment(null)}>
+              Lưu
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <button type="button" onClick={() => setPageClicks((count) => count + 1)}>
+        Nút nền {pageClicks}
+      </button>
+    </div>
+  )
+}
+
+describe("EquipmentActionsMenu overlay workflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    callbackMenuState.length = 0
+    document.body.style.pointerEvents = ""
+  })
+
+  it("opens details from the row menu, closes the dialog, and keeps the page interactive", async () => {
+    const user = userEvent.setup()
+    render(<EquipmentDetailWorkflowHarness />)
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }))
+    await user.click(screen.getByRole("menuitem", { name: "Xem chi tiết" }))
+
+    expect(await screen.findByRole("dialog", { name: "Chi tiết thiết bị" })).toBeInTheDocument()
+    expect(callbackMenuState).toEqual([false])
+    await waitFor(() => expect(screen.queryByRole("menuitem", { name: "Xem chi tiết" })).toBeNull())
+
+    await user.click(screen.getByRole("button", { name: "Lưu" }))
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Chi tiết thiết bị" })).not.toBeInTheDocument()
+    )
+    expect(document.body.style.pointerEvents).not.toBe("none")
+
+    await user.click(screen.getByRole("button", { name: "Nút nền 0" }))
+    expect(screen.getByRole("button", { name: "Nút nền 1" })).toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/repair-requests/__tests__/RepairRequestRowActionsOverlayWorkflow.test.tsx
+++ b/src/app/(app)/repair-requests/__tests__/RepairRequestRowActionsOverlayWorkflow.test.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom"
+
+import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import {
+  RepairRequestRowActions,
+  type RepairRequestColumnOptions,
+} from "../_components/RepairRequestsColumns"
+import type { AuthUser, RepairRequestWithEquipment } from "../types"
+
+function makeRepairRequest(): RepairRequestWithEquipment {
+  return {
+    id: 42,
+    thiet_bi_id: 7,
+    ngay_yeu_cau: "2026-05-01T00:00:00.000Z",
+    trang_thai: "Chờ xử lý",
+    mo_ta_su_co: "Máy không hoạt động",
+    hang_muc_sua_chua: null,
+    ngay_mong_muon_hoan_thanh: null,
+    nguoi_yeu_cau: "Nguyễn Văn A",
+    ngay_duyet: null,
+    ngay_hoan_thanh: null,
+    nguoi_duyet: null,
+    nguoi_xac_nhan: null,
+    chi_phi_sua_chua: null,
+    don_vi_thuc_hien: null,
+    ten_don_vi_thue: null,
+    ket_qua_sua_chua: null,
+    ly_do_khong_hoan_thanh: null,
+    thiet_bi: {
+      ten_thiet_bi: "Máy siêu âm",
+      ma_thiet_bi: "TB-A11Y",
+      model: null,
+      serial: null,
+      khoa_phong_quan_ly: "Khoa Khám bệnh",
+      facility_name: "Bệnh viện A",
+      facility_id: 1,
+    },
+  }
+}
+
+function makeUser(): AuthUser {
+  return {
+    id: "1",
+    username: "manager",
+    role: "to_qltb",
+    name: "Manager",
+    email: null,
+    image: null,
+  }
+}
+
+function RepairRequestEditWorkflowHarness() {
+  const request = React.useMemo(() => makeRepairRequest(), [])
+  const [editingRequest, setEditingRequest] = React.useState<RepairRequestWithEquipment | null>(
+    null
+  )
+  const [pageClicks, setPageClicks] = React.useState(0)
+  const callbackMenuState = React.useRef<boolean[]>([])
+
+  const options = React.useMemo<RepairRequestColumnOptions>(
+    () => ({
+      onGenerateSheet: vi.fn(),
+      setEditingRequest: (selectedRequest) => {
+        callbackMenuState.current.push(screen.queryByRole("menuitem", { name: "Sửa" }) !== null)
+        setEditingRequest(selectedRequest)
+      },
+      setRequestToDelete: vi.fn(),
+      handleApproveRequest: vi.fn(),
+      handleCompletion: vi.fn(),
+      setRequestToView: vi.fn(),
+      user: makeUser(),
+      isRegionalLeader: false,
+    }),
+    []
+  )
+
+  return (
+    <div>
+      <RepairRequestRowActions request={request} options={options} />
+      <Sheet
+        open={editingRequest !== null}
+        onOpenChange={(open) => !open && setEditingRequest(null)}
+      >
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Sửa yêu cầu sửa chữa</SheetTitle>
+            <SheetDescription>{editingRequest?.mo_ta_su_co}</SheetDescription>
+          </SheetHeader>
+          <SheetFooter>
+            <Button type="button" onClick={() => setEditingRequest(null)}>
+              Áp dụng
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+      <button type="button" onClick={() => setPageClicks((count) => count + 1)}>
+        Nút nền {pageClicks}
+      </button>
+      <output aria-label="Trạng thái menu callback">
+        {callbackMenuState.current.map(String).join(",")}
+      </output>
+    </div>
+  )
+}
+
+describe("RepairRequestRowActions overlay workflow", () => {
+  it("opens edit from the row menu, closes the sheet, and keeps the page interactive", async () => {
+    const user = userEvent.setup()
+    document.body.style.pointerEvents = ""
+    render(<RepairRequestEditWorkflowHarness />)
+
+    await user.click(screen.getByRole("button", { name: "Mở menu" }))
+    await user.click(screen.getByRole("menuitem", { name: "Sửa" }))
+
+    expect(await screen.findByRole("dialog", { name: "Sửa yêu cầu sửa chữa" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Trạng thái menu callback")).toHaveTextContent("false")
+    await waitFor(() => expect(screen.queryByRole("menuitem", { name: "Sửa" })).toBeNull())
+
+    await user.click(screen.getByRole("button", { name: "Áp dụng" }))
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Sửa yêu cầu sửa chữa" })).not.toBeInTheDocument()
+    )
+    expect(document.body.style.pointerEvents).not.toBe("none")
+
+    await user.click(screen.getByRole("button", { name: "Nút nền 0" }))
+    expect(screen.getByRole("button", { name: "Nút nền 1" })).toBeInTheDocument()
+  })
+})

--- a/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
+++ b/src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx
@@ -8,7 +8,7 @@
 import * as React from "react"
 import { beforeAll, describe, it, expect, vi } from "vitest"
 import "@testing-library/jest-dom"
-import { render, screen, fireEvent, within } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react"
 import type { Table } from "@tanstack/react-table"
 import type { Equipment } from "@/types/database"
 
@@ -345,20 +345,20 @@ describe("EquipmentToolbar with shared filters", () => {
     )
 
     const compactActions = screen.getByTestId("equipment-compact-filter-actions")
-    const openCompactOptions = () =>
+    const chooseCompactOption = async (name: string, assertion: () => void) => {
       fireEvent.click(within(compactActions).getByRole("button", { name: /Tùy chọn/i }))
+      expect(await screen.findByRole("menu", { name: "Tùy chọn" })).toBeInTheDocument()
+      fireEvent.click(await screen.findByText(name))
+      await waitFor(assertion)
+    }
 
-    openCompactOptions()
-    expect(await screen.findByRole("menu", { name: "Tùy chọn" })).toBeInTheDocument()
-    fireEvent.click(await screen.findByText("Hiện/ẩn cột"))
-    openCompactOptions()
-    fireEvent.click(await screen.findByText("Tải Excel mẫu"))
-    openCompactOptions()
-    fireEvent.click(await screen.findByText("Tải về dữ liệu"))
-
-    expect(onOpenColumnsDialog).toHaveBeenCalledTimes(1)
-    expect(onDownloadTemplate).toHaveBeenCalledTimes(1)
-    expect(onExportData).toHaveBeenCalledTimes(1)
+    await chooseCompactOption("Hiện/ẩn cột", () =>
+      expect(onOpenColumnsDialog).toHaveBeenCalledTimes(1)
+    )
+    await chooseCompactOption("Tải Excel mẫu", () =>
+      expect(onDownloadTemplate).toHaveBeenCalledTimes(1)
+    )
+    await chooseCompactOption("Tải về dữ liệu", () => expect(onExportData).toHaveBeenCalledTimes(1))
   })
 
   it("hides compact clear command when filters are inactive", () => {


### PR DESCRIPTION
## Summary
- Fix #730 test timing by awaiting each deferred HeroUI compact dropdown action before selecting the next action.
- Add #722 cross-route overlay workflow guardrails for Equipment row actions and Repair Requests row actions.
- Assert dropdown callback ownership yields before opening the next Dialog/Sheet, overlays close through save/apply, and the underlying page remains interactive.

## TDD / Regression Proof
- Reproduced #730 failure first: `equipment-toolbar.filters.test.tsx` failed because `onExportData` stayed at 0 calls.
- Temporarily mutated `useOverlayActionTransition` to run actions synchronously; the new workflow guardrail failed with Radix focus-stack recursion, then the mutation was reverted before commit.

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/components/equipment/__tests__/equipment-toolbar.filters.test.tsx`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/__tests__/equipment-actions-overlay-workflow.test.tsx'`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/RepairRequestRowActionsOverlayWorkflow.test.tsx'`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/equipment/__tests__/equipment-actions-menu.test.tsx'`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/repair-requests/__tests__/RepairRequestRowActions.test.tsx'`
- `node scripts/npm-run.js run test:run -- src/components/equipment/heroui-pilot/__tests__/controls.test.tsx`
- `node scripts/npm-run.js run test:run -- src/components/shared/floating-actions/__tests__/MobileFloatingActionMenu.test.tsx`
- `node scripts/npm-run.js run react-doctor`

Fixes #730
Closes #722


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds overlay workflow guardrail tests for Equipment and Repair Requests menus and fixes flaky timing in the equipment toolbar filters test. Closes #722 and fixes #730 by ensuring menus yield before overlays open and the page remains interactive after closing.

- **Bug Fixes**
  - Await each compact dropdown action in `equipment-toolbar.filters.test.tsx` so `onOpenColumnsDialog`, `onDownloadTemplate`, and `onExportData` fire reliably.

- **New Features**
  - Equipment: guardrail test ensures the row menu yields to the detail dialog, the dialog closes via "Lưu", and background clicks work after close.
  - Repair Requests: guardrail test ensures the row menu yields to the edit sheet, the sheet closes via "Áp dụng", and no global pointer-events lock persists.

<sup>Written for commit e2e1b2bd964363794ba110414d94adf6718498bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the equipment actions flow, including opening details, closing overlays, and returning to the page without blocking interaction.
  * Strengthened the repair request actions flow so edit dialogs close cleanly and the rest of the interface remains usable afterward.
  * Made toolbar action menu behavior more consistent for options like columns, templates, and data export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->