### PR TITLE
Roll out Transfers mobile floating actions

### DIFF
--- a/src/app/(app)/transfers/__tests__/TransfersToolbar.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersToolbar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
-import { AppMobileFloatingActions } from "../../_components/AppMobileFloatingActions"
+import { AppMobileFloatingActions } from "@/app/(app)/_components/AppMobileFloatingActions"
 import { MobileFloatingActionsProvider } from "@/components/shared/floating-actions"
 import { TransfersToolbar } from "../_components/TransfersToolbar"
 

--- a/src/app/(app)/transfers/__tests__/TransfersToolbar.test.tsx
+++ b/src/app/(app)/transfers/__tests__/TransfersToolbar.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
+import { AppMobileFloatingActions } from "../../_components/AppMobileFloatingActions"
+import { MobileFloatingActionsProvider } from "@/components/shared/floating-actions"
 import { TransfersToolbar } from "../_components/TransfersToolbar"
 
 vi.mock("@/components/shared/TenantSelector", () => ({
@@ -30,6 +32,33 @@ vi.mock("@/components/transfers/FilterChips", () => ({
 
 vi.mock("@/components/transfers/TransfersViewToggle", () => ({
   TransfersViewToggle: () => <div data-testid="view-toggle" />,
+}))
+
+vi.mock("@/components/assistant/AssistantTriggerButton", () => ({
+  AssistantTriggerButton: ({ isOpen, onToggle }: { isOpen: boolean; onToggle: () => void }) => (
+    <button
+      type="button"
+      aria-label={isOpen ? "Đóng trợ lý" : "Trợ lý AI"}
+      data-testid="assistant-trigger-button"
+      onClick={onToggle}
+    />
+  ),
+}))
+
+vi.mock("@/components/shared/floating-actions/MobileFloatingActionMenu", () => ({
+  MobileFloatingActionMenu: ({
+    actions,
+  }: {
+    actions: Array<{ id: string; label: string; onSelect: () => void }>
+  }) => (
+    <div data-testid="mobile-floating-action-menu">
+      {actions.map((action) => (
+        <button type="button" key={action.id} onClick={action.onSelect}>
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
 }))
 
 type TransfersToolbarProps = React.ComponentProps<typeof TransfersToolbar>
@@ -61,6 +90,22 @@ function renderToolbar(overrides: Partial<TransfersToolbarProps> = {}) {
   }
 }
 
+function renderToolbarWithMobileActions(overrides: Partial<TransfersToolbarProps> = {}) {
+  const props = buildProps(overrides)
+  const onAssistantToggle = vi.fn()
+
+  return {
+    props,
+    onAssistantToggle,
+    ...render(
+      <MobileFloatingActionsProvider>
+        <TransfersToolbar {...props} />
+        <AppMobileFloatingActions isAssistantOpen={false} onAssistantToggle={onAssistantToggle} />
+      </MobileFloatingActionsProvider>
+    ),
+  }
+}
+
 describe("TransfersToolbar", () => {
   it("matches the Repair compact toolbar without the desktop title above the grid", () => {
     renderToolbar()
@@ -87,22 +132,23 @@ describe("TransfersToolbar", () => {
     )
   })
 
-  it("uses the shared mobile FAB contract for creating a transfer in compact mode", async () => {
+  it("registers the compact create action in the shared mobile floating menu", async () => {
     const onOpenAddDialog = vi.fn()
-    renderToolbar({ onOpenAddDialog })
+    renderToolbarWithMobileActions({ onOpenAddDialog })
 
-    const createButton = screen.getByRole("button", { name: "Tạo yêu cầu mới" })
-    expect(createButton.className).toContain("fixed")
-    expect(createButton.className).toContain("rounded-full")
-    expect(createButton.className).toContain("md:hidden")
+    expect(screen.getByTestId("mobile-floating-action-menu")).toBeInTheDocument()
+    expect(screen.queryByTestId("assistant-trigger-button")).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Trợ lý AI" })).toBeInTheDocument()
 
-    await userEvent.setup().click(createButton)
+    await userEvent.setup().click(screen.getByRole("button", { name: "Tạo yêu cầu mới" }))
     expect(onOpenAddDialog).toHaveBeenCalledTimes(1)
   })
 
-  it("hides the compact create FAB for regional leaders", () => {
-    renderToolbar({ isRegionalLeader: true })
+  it("does not register the compact create action for regional leaders", () => {
+    renderToolbarWithMobileActions({ isRegionalLeader: true })
 
+    expect(screen.getByTestId("assistant-trigger-button")).toBeInTheDocument()
+    expect(screen.queryByTestId("mobile-floating-action-menu")).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Tạo yêu cầu mới" })).not.toBeInTheDocument()
   })
 
@@ -112,5 +158,13 @@ describe("TransfersToolbar", () => {
     expect(
       screen.queryByText("Theo dõi và xử lý yêu cầu luân chuyển theo từng loại hình")
     ).not.toBeInTheDocument()
+  })
+
+  it("keeps the desktop create button wired outside compact mode", async () => {
+    const onOpenAddDialog = vi.fn()
+    renderToolbar({ compactFilters: false, onOpenAddDialog })
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Tạo yêu cầu mới" }))
+    expect(onOpenAddDialog).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/(app)/transfers/_components/TransfersToolbar.tsx
+++ b/src/app/(app)/transfers/_components/TransfersToolbar.tsx
@@ -3,10 +3,10 @@
 import * as React from "react"
 import { PlusCircle } from "lucide-react"
 
-import { FloatingActionButton } from "@/components/shared/FloatingActionButton"
 import { ListFilterSearchCard } from "@/components/shared/ListFilterSearchCard"
 import { SearchInput } from "@/components/shared/SearchInput"
 import { TenantSelector } from "@/components/shared/TenantSelector"
+import { usePageFloatingAction } from "@/components/shared/floating-actions"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { FilterChips, type FilterChipsValue } from "@/components/transfers/FilterChips"
 import type { FilterModalValue } from "@/components/transfers/FilterModal"
@@ -126,6 +126,21 @@ export function TransfersToolbar({
     [filterValue, onFilterChange, setDateRangePart, statusOptions]
   )
 
+  const mobileCreateAction = React.useMemo(
+    () =>
+      compactFilters && !isRegionalLeader
+        ? {
+            id: "create-transfer-request",
+            label: "Tạo yêu cầu mới",
+            icon: <PlusCircle />,
+            onSelect: onOpenAddDialog,
+          }
+        : null,
+    [compactFilters, isRegionalLeader, onOpenAddDialog]
+  )
+
+  usePageFloatingAction(mobileCreateAction)
+
   const actions = React.useMemo(
     () => (
       <>
@@ -179,12 +194,6 @@ export function TransfersToolbar({
         </div>
 
         <div data-testid="transfers-toolbar-filter-chips">{chips}</div>
-
-        {!isRegionalLeader ? (
-          <FloatingActionButton onClick={onOpenAddDialog} aria-label="Tạo yêu cầu mới">
-            <PlusCircle />
-          </FloatingActionButton>
-        ) : null}
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Register the Transfers compact create action through the shared mobile floating-actions seam from #693.
- Remove the Transfers local compact FloatingActionButton so the app shell can combine `Trợ lý AI` and `Tạo yêu cầu mới` in one mobile menu.
- Keep desktop Transfers toolbar create behavior unchanged.

Closes #694
Umbrella: #690

## TDD / code-dedupe notes
- RED: the new Transfers toolbar integration test failed because `mobile-floating-action-menu` was not registered.
- GREEN: `TransfersToolbar` now reuses `usePageFloatingAction`; no new shared helper/component was added.
- Code-dedupe check: followed the existing Repair Requests registration pattern and reused the shared floating-actions foundation.

## Tests
- node scripts/npm-run.js run format:check
- node scripts/npm-run.js run verify:no-explicit-any
- node scripts/npm-run.js run verify:dedupe
- node scripts/npm-run.js run typecheck
- node scripts/npm-run.js run test:run -- 'src/app/(app)/transfers/__tests__/TransfersToolbar.test.tsx'
- node scripts/npm-run.js run react-doctor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates Transfers with the shared mobile floating actions so the app shows one mobile menu with `Trợ lý AI` and `Tạo yêu cầu mới`. Desktop behavior is unchanged. Closes #694.

- **New Features**
  - Registers the compact create action via `usePageFloatingAction` (id: `create-transfer-request`); hidden for regional leaders.
  - Removes the local `FloatingActionButton`; mobile create is now provided by `AppMobileFloatingActions`.
  - Updates tests to verify shared menu registration, assistant visibility for leaders, and desktop create button wiring.

<sup>Written for commit 5100bdc67b5435ce8d5f7c8eeae5a7c43ab769c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared mobile floating action for creating transfer requests in compact mode.
  * Regional leaders continue to see the assistant action instead of the transfer-request action.
  * Preserved the desktop create-request button in standard mode.

* **Bug Fixes**
  * Improved mobile action behavior and ensured the create-request action opens the correct dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->