### PR TITLE
feat: roll out maintenance mobile floating actions

### DIFF
--- a/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
+++ b/src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx
@@ -1,7 +1,11 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { AppMobileFloatingActions } from "@/app/(app)/_components/AppMobileFloatingActions"
+import { MobileFloatingActionsProvider } from "@/components/shared/floating-actions"
 
 const mocks = vi.hoisted(() => ({
   context: {
@@ -50,6 +54,33 @@ vi.mock("@/components/kpi", () => ({
   KpiStatusBar: () => <div data-testid="maintenance-kpi-bar" />,
 }))
 
+vi.mock("@/components/assistant/AssistantTriggerButton", () => ({
+  AssistantTriggerButton: ({ isOpen, onToggle }: { isOpen: boolean; onToggle: () => void }) => (
+    <button
+      type="button"
+      aria-label={isOpen ? "Đóng trợ lý" : "Trợ lý AI"}
+      data-testid="assistant-trigger-button"
+      onClick={onToggle}
+    />
+  ),
+}))
+
+vi.mock("@/components/shared/floating-actions/MobileFloatingActionMenu", () => ({
+  MobileFloatingActionMenu: ({
+    actions,
+  }: {
+    actions: Array<{ id: string; label: string; onSelect: () => void }>
+  }) => (
+    <div data-testid="mobile-floating-action-menu">
+      {actions.map((action) => (
+        <button type="button" key={action.id} onClick={action.onSelect}>
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
 vi.mock("../_hooks/useMaintenanceContext", () => ({
   useMaintenanceContext: () => mocks.context,
 }))
@@ -70,7 +101,7 @@ vi.mock("../_components/maintenance-mobile-tasks-panel", () => ({
 
 import { MobileMaintenanceLayout } from "../_components/mobile-maintenance-layout"
 
-function renderMobileLayout({
+function createMobileLayout({
   planSearchTerm = "",
   totalPages = 1,
   totalCount = 0,
@@ -81,7 +112,7 @@ function renderMobileLayout({
   totalCount?: number
   currentPage?: number
 } = {}) {
-  return render(
+  return (
     <MobileMaintenanceLayout
       countsState={{
         statusCounts: { "Bản nháp": 1 },
@@ -104,8 +135,28 @@ function renderMobileLayout({
       filterState={{ showFacilityFilter: false }}
       expandedTaskIds={{}}
       toggleTaskExpansion={vi.fn()}
-    />,
+    />
   )
+}
+
+function renderMobileLayout(options: Parameters<typeof createMobileLayout>[0] = {}) {
+  return render(createMobileLayout(options))
+}
+
+function renderMobileLayoutWithMobileActions(
+  options: Parameters<typeof createMobileLayout>[0] = {}
+) {
+  const onAssistantToggle = vi.fn()
+
+  return {
+    onAssistantToggle,
+    ...render(
+      <MobileFloatingActionsProvider>
+        {createMobileLayout(options)}
+        <AppMobileFloatingActions isAssistantOpen={false} onAssistantToggle={onAssistantToggle} />
+      </MobileFloatingActionsProvider>
+    ),
+  }
 }
 
 describe("MobileMaintenanceLayout create-plan entry points", () => {
@@ -124,20 +175,31 @@ describe("MobileMaintenanceLayout create-plan entry points", () => {
   it.each(["global", "admin"])("hides create-plan controls for %s users", (role) => {
     mocks.context.user.role = role
 
-    renderMobileLayout()
+    renderMobileLayoutWithMobileActions()
 
+    expect(screen.getByTestId("assistant-trigger-button")).toBeInTheDocument()
+    expect(screen.queryByTestId("mobile-floating-action-menu")).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Tạo kế hoạch mới" })).not.toBeInTheDocument()
     expect(mocks.lastPlanCardsProps?.access?.canCreatePlans).toBe(false)
   })
 
-  it("keeps create-plan controls available for non-global maintenance managers", () => {
+  it("registers create-plan controls in the shared mobile floating menu", async () => {
+    const user = userEvent.setup()
     mocks.context.user.role = "to_qltb"
     mocks.context.canCreatePlans = true
 
-    renderMobileLayout()
+    renderMobileLayoutWithMobileActions()
 
+    expect(screen.queryByTestId("assistant-trigger-button")).not.toBeInTheDocument()
+    expect(screen.getByTestId("mobile-floating-action-menu")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Trợ lý AI" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Tạo kế hoạch mới" })).toBeInTheDocument()
     expect(mocks.lastPlanCardsProps?.access?.canCreatePlans).toBe(true)
+
+    await user.click(screen.getByRole("button", { name: "Tạo kế hoạch mới" }))
+
+    expect(mocks.context.setIsAddPlanDialogOpen).toHaveBeenCalledWith(true)
+    expect(mocks.context.setIsAddPlanDialogOpen).toHaveBeenCalledTimes(1)
   })
 
   it("passes grouped task state to the mobile tasks panel", () => {

--- a/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
+++ b/src/app/(app)/maintenance/_components/mobile-maintenance-layout.tsx
@@ -12,8 +12,8 @@ import {
 } from "lucide-react"
 import { KpiStatusBar } from "@/components/kpi"
 import { MAINTENANCE_STATUS_CONFIGS } from "@/components/kpi/configs/maintenance"
-import { FloatingActionButton } from "@/components/shared/FloatingActionButton"
 import { TenantSelector } from "@/components/shared/TenantSelector"
+import { usePageFloatingAction } from "@/components/shared/floating-actions"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import type { MaintenancePlan } from "@/hooks/use-cached-maintenance"
@@ -56,6 +56,7 @@ export interface MobileMaintenanceLayoutProps {
   toggleTaskExpansion: (taskId: number) => void
 }
 
+/** Renders the compact Maintenance mobile layout and registers its create-plan action. */
 export function MobileMaintenanceLayout({
   countsState,
   plansState,
@@ -76,6 +77,20 @@ export function MobileMaintenanceLayout({
     () => ({ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 16px)" }),
     []
   )
+  const mobileCreatePlanAction = React.useMemo(
+    () =>
+      ctx.canCreatePlans
+        ? {
+            id: "create-maintenance-plan",
+            label: "Tạo kế hoạch mới",
+            icon: <PlusCircle />,
+            onSelect: () => ctx.setIsAddPlanDialogOpen(true),
+          }
+        : null,
+    [ctx.canCreatePlans, ctx.setIsAddPlanDialogOpen]
+  )
+
+  usePageFloatingAction(mobileCreatePlanAction)
 
   return (
     <div className="relative flex min-h-screen flex-col bg-muted/20">
@@ -199,20 +214,16 @@ export function MobileMaintenanceLayout({
         </div>
       </main>
 
-      {ctx.canCreatePlans && (
-        <FloatingActionButton
-          onClick={() => ctx.setIsAddPlanDialogOpen(true)}
-          aria-label="Tạo kế hoạch mới"
-        >
-          <PlusCircle />
-        </FloatingActionButton>
-      )}
-
       {planTabActive && (
-        <div className="fixed bottom-0 left-0 right-0 border-t border-border/60 bg-background/95 shadow-lg backdrop-blur" style={safeAreaFooterStyle}>
+        <div
+          className="fixed bottom-0 left-0 right-0 border-t border-border/60 bg-background/95 shadow-lg backdrop-blur"
+          style={safeAreaFooterStyle}
+        >
           <div className="px-4">
             <div className="flex items-center justify-between py-2 text-xs text-muted-foreground">
-              <span>Trang {currentPage}/{Math.max(totalPages, 1)}</span>
+              <span>
+                Trang {currentPage}/{Math.max(totalPages, 1)}
+              </span>
               <span>{totalCount} kế hoạch</span>
             </div>
             <div className="grid grid-cols-4 gap-2 pb-2">
@@ -256,7 +267,6 @@ export function MobileMaintenanceLayout({
           </div>
         </div>
       )}
-
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replaces the Maintenance local create-plan mobile FAB with shared page-action registration.
- Keeps `ctx.canCreatePlans` gating and the existing `ctx.setIsAddPlanDialogOpen(true)` flow.
- Adds focused integration coverage for the shared mobile menu containing `Trợ lý AI` and `Tạo kế hoạch mới`.

## Test Plan
- [x] `node scripts/npm-run.js run format:check`
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run verify:ts-docstrings`
- [x] `node scripts/npm-run.js run typecheck`
- [x] `node scripts/npm-run.js run test -- 'src/app/(app)/maintenance/__tests__/mobile-maintenance-layout.create-plan.test.tsx' 'src/app/(app)/transfers/__tests__/TransfersToolbar.test.tsx' 'src/app/(app)/__tests__/AppMobileFloatingActions.test.tsx' --reporter=verbose`
- [x] `node scripts/npm-run.js run react-doctor`

Closes #695


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Maintenance mobile FAB with the shared floating action system so create-plan shows in the global mobile menu next to "Trợ lý AI", while keeping permission gating and the existing dialog flow. Closes #695.

- **New Features**
  - Registered create-plan via `usePageFloatingAction`; removed local `FloatingActionButton`.
  - Action triggers `ctx.setIsAddPlanDialogOpen(true)`.
  - Added integration tests for the shared mobile menu and role-based visibility.

<sup>Written for commit 9f7da00ffef081fcfed65dc91a1fbe5363ac0447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile floating actions for creating maintenance plans when permitted.
  * Added assistant access through the shared mobile floating actions menu.

* **Bug Fixes**
  * Improved mobile footer positioning and safe-area handling.
  * Prevented create-plan actions from appearing when plan creation is unavailable.

* **Tests**
  * Expanded coverage for mobile floating action visibility and create-plan interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->