### PR TITLE
refactor(equipment): centralize query parameters

### DIFF
--- a/src/app/(app)/equipment/_hooks/EquipmentDataQueryParams.ts
+++ b/src/app/(app)/equipment/_hooks/EquipmentDataQueryParams.ts
@@ -1,0 +1,56 @@
+export interface EquipmentDataQueryParamsInput {
+  effectiveTenantKey: string
+  userRole: string
+  userDiaBanId?: number | null
+  effectiveSelectedDonVi: number | null
+  debouncedSearch: string
+  selectedDepartments: string[]
+  selectedUsers: string[]
+  selectedLocations: string[]
+  selectedStatuses: string[]
+  selectedClassifications: string[]
+  selectedFundingSources: string[]
+}
+
+/** Builds the shared equipment query-key parameters and RPC arguments. */
+export function buildEquipmentDataQueryParams(params: EquipmentDataQueryParamsInput) {
+  const {
+    effectiveTenantKey,
+    userRole,
+    userDiaBanId,
+    effectiveSelectedDonVi,
+    debouncedSearch,
+    selectedDepartments,
+    selectedUsers,
+    selectedLocations,
+    selectedStatuses,
+    selectedClassifications,
+    selectedFundingSources,
+  } = params
+
+  return {
+    queryKeyParams: {
+      tenant: effectiveTenantKey,
+      role: userRole,
+      diaBan: userDiaBanId,
+      donVi: effectiveSelectedDonVi,
+      q: debouncedSearch || null,
+      khoa_phong_array: selectedDepartments,
+      nguoi_su_dung_array: selectedUsers,
+      vi_tri_lap_dat_array: selectedLocations,
+      tinh_trang_array: selectedStatuses,
+      phan_loai_array: selectedClassifications,
+      nguon_kinh_phi_array: selectedFundingSources,
+    },
+    rpcArgs: {
+      p_q: debouncedSearch || null,
+      p_don_vi: effectiveSelectedDonVi,
+      p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
+      p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
+      p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
+      p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
+      p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
+      p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
+    },
+  }
+}

--- a/src/app/(app)/equipment/_hooks/EquipmentDataQueryParams.ts
+++ b/src/app/(app)/equipment/_hooks/EquipmentDataQueryParams.ts
@@ -28,29 +28,37 @@ export function buildEquipmentDataQueryParams(params: EquipmentDataQueryParamsIn
     selectedFundingSources,
   } = params
 
+  const q = debouncedSearch || null
+  const departmentFilters = selectedDepartments.length > 0 ? selectedDepartments : null
+  const userFilters = selectedUsers.length > 0 ? selectedUsers : null
+  const locationFilters = selectedLocations.length > 0 ? selectedLocations : null
+  const statusFilters = selectedStatuses.length > 0 ? selectedStatuses : null
+  const classificationFilters = selectedClassifications.length > 0 ? selectedClassifications : null
+  const fundingSourceFilters = selectedFundingSources.length > 0 ? selectedFundingSources : null
+
   return {
     queryKeyParams: {
       tenant: effectiveTenantKey,
       role: userRole,
       diaBan: userDiaBanId,
       donVi: effectiveSelectedDonVi,
-      q: debouncedSearch || null,
-      khoa_phong_array: selectedDepartments,
-      nguoi_su_dung_array: selectedUsers,
-      vi_tri_lap_dat_array: selectedLocations,
-      tinh_trang_array: selectedStatuses,
-      phan_loai_array: selectedClassifications,
-      nguon_kinh_phi_array: selectedFundingSources,
+      q,
+      khoa_phong_array: departmentFilters,
+      nguoi_su_dung_array: userFilters,
+      vi_tri_lap_dat_array: locationFilters,
+      tinh_trang_array: statusFilters,
+      phan_loai_array: classificationFilters,
+      nguon_kinh_phi_array: fundingSourceFilters,
     },
     rpcArgs: {
-      p_q: debouncedSearch || null,
+      p_q: q,
       p_don_vi: effectiveSelectedDonVi,
-      p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
-      p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
-      p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
-      p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
-      p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
-      p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
+      p_khoa_phong_array: departmentFilters,
+      p_nguoi_su_dung_array: userFilters,
+      p_vi_tri_lap_dat_array: locationFilters,
+      p_tinh_trang_array: statusFilters,
+      p_phan_loai_array: classificationFilters,
+      p_nguon_kinh_phi_array: fundingSourceFilters,
     },
   }
 }

--- a/src/app/(app)/equipment/_hooks/__tests__/EquipmentDataQueryParams.test.ts
+++ b/src/app/(app)/equipment/_hooks/__tests__/EquipmentDataQueryParams.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+
+import { buildEquipmentDataQueryParams } from "../EquipmentDataQueryParams"
+
+const baseInput = {
+  effectiveTenantKey: "tenant-42",
+  userRole: "to_qltb",
+  userDiaBanId: 7,
+  effectiveSelectedDonVi: 42,
+  debouncedSearch: "monitor",
+}
+
+describe("buildEquipmentDataQueryParams", () => {
+  it("preserves non-empty filter array references across query keys and RPC args", () => {
+    const selectedDepartments = ["ICU"]
+    const selectedUsers = ["Dr A"]
+    const selectedLocations = ["Room 1"]
+    const selectedStatuses = ["Hoat dong"]
+    const selectedClassifications = ["Class A"]
+    const selectedFundingSources = ["Fund A"]
+
+    const { queryKeyParams, rpcArgs } = buildEquipmentDataQueryParams({
+      ...baseInput,
+      selectedDepartments,
+      selectedUsers,
+      selectedLocations,
+      selectedStatuses,
+      selectedClassifications,
+      selectedFundingSources,
+    })
+
+    expect(queryKeyParams.khoa_phong_array).toBe(selectedDepartments)
+    expect(rpcArgs.p_khoa_phong_array).toBe(selectedDepartments)
+    expect(queryKeyParams.nguoi_su_dung_array).toBe(selectedUsers)
+    expect(rpcArgs.p_nguoi_su_dung_array).toBe(selectedUsers)
+    expect(queryKeyParams.vi_tri_lap_dat_array).toBe(selectedLocations)
+    expect(rpcArgs.p_vi_tri_lap_dat_array).toBe(selectedLocations)
+    expect(queryKeyParams.tinh_trang_array).toBe(selectedStatuses)
+    expect(rpcArgs.p_tinh_trang_array).toBe(selectedStatuses)
+    expect(queryKeyParams.phan_loai_array).toBe(selectedClassifications)
+    expect(rpcArgs.p_phan_loai_array).toBe(selectedClassifications)
+    expect(queryKeyParams.nguon_kinh_phi_array).toBe(selectedFundingSources)
+    expect(rpcArgs.p_nguon_kinh_phi_array).toBe(selectedFundingSources)
+  })
+
+  it("normalizes empty filter arrays and an empty search to null in both outputs", () => {
+    const { queryKeyParams, rpcArgs } = buildEquipmentDataQueryParams({
+      ...baseInput,
+      debouncedSearch: "",
+      selectedDepartments: [],
+      selectedUsers: [],
+      selectedLocations: [],
+      selectedStatuses: [],
+      selectedClassifications: [],
+      selectedFundingSources: [],
+    })
+
+    expect(queryKeyParams).toMatchObject({
+      q: null,
+      khoa_phong_array: null,
+      nguoi_su_dung_array: null,
+      vi_tri_lap_dat_array: null,
+      tinh_trang_array: null,
+      phan_loai_array: null,
+      nguon_kinh_phi_array: null,
+    })
+    expect(rpcArgs).toMatchObject({
+      p_q: null,
+      p_khoa_phong_array: null,
+      p_nguoi_su_dung_array: null,
+      p_vi_tri_lap_dat_array: null,
+      p_tinh_trang_array: null,
+      p_phan_loai_array: null,
+      p_nguon_kinh_phi_array: null,
+    })
+  })
+
+  it("keeps cache-isolation fields query-only while aligning donVi and q", () => {
+    const { queryKeyParams, rpcArgs } = buildEquipmentDataQueryParams({
+      ...baseInput,
+      selectedDepartments: [],
+      selectedUsers: [],
+      selectedLocations: [],
+      selectedStatuses: [],
+      selectedClassifications: [],
+      selectedFundingSources: [],
+    })
+
+    expect(queryKeyParams).toMatchObject({
+      tenant: "tenant-42",
+      role: "to_qltb",
+      diaBan: 7,
+      donVi: 42,
+      q: "monitor",
+    })
+    expect(rpcArgs).toMatchObject({
+      p_don_vi: queryKeyParams.donVi,
+      p_q: queryKeyParams.q,
+    })
+    expect(rpcArgs).not.toHaveProperty("tenant")
+    expect(rpcArgs).not.toHaveProperty("role")
+    expect(rpcArgs).not.toHaveProperty("diaBan")
+  })
+})

--- a/src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx
+++ b/src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx
@@ -45,7 +45,7 @@ const baseParams: UseEquipmentDataParams = {
   isGlobal: false,
   isRegionalLeader: false,
   userRole: "to_qltb",
-  userDiaBanId: null,
+  userDiaBanId: 7,
   shouldFetchEquipment: true,
   effectiveTenantKey: "tenant-42",
   selectedDonVi: 42,
@@ -122,7 +122,7 @@ describe("useEquipmentData filter bucket query", () => {
     })
   })
 
-  it("keys bucket data by active filters but not pagination", async () => {
+  it("keys list, distribution, and bucket data by their current cache scopes", async () => {
     const queryClient = createQueryClient()
     const { rerender } = renderHook((params: UseEquipmentDataParams) => useEquipmentData(params), {
       initialProps: baseParams,
@@ -131,19 +131,40 @@ describe("useEquipmentData filter bucket query", () => {
 
     await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
 
-    const initialBucketQueries = queryClient
-      .getQueryCache()
-      .findAll({ queryKey: ["equipment_filter_buckets"] })
-    const initialBucketKeyParams = initialBucketQueries[0]?.queryKey[1] as
-      Record<string, unknown> | undefined
-
-    expect(initialBucketKeyParams).toMatchObject({
+    const sharedKeyParams = {
+      tenant: "tenant-42",
+      role: "to_qltb",
+      diaBan: 7,
+      donVi: 42,
       q: "monitor",
       khoa_phong_array: ["ICU"],
+      nguoi_su_dung_array: ["Dr A"],
+      vi_tri_lap_dat_array: ["Room 1"],
       tinh_trang_array: ["Hoat dong"],
+      phan_loai_array: ["Class A"],
+      nguon_kinh_phi_array: ["Fund A"],
+    }
+    const listKeyParams = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_list_enhanced"] })
+      .at(-1)?.queryKey[1]
+    const distributionKeyParams = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_department_distribution"] })
+      .at(-1)?.queryKey[1]
+    const bucketKeyParams = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_filter_buckets"] })
+      .at(-1)?.queryKey[1]
+
+    expect(listKeyParams).toEqual({
+      ...sharedKeyParams,
+      page: 0,
+      size: 20,
+      sort: "id.asc",
     })
-    expect(initialBucketKeyParams).not.toHaveProperty("page")
-    expect(initialBucketKeyParams).not.toHaveProperty("size")
+    expect(distributionKeyParams).toEqual(sharedKeyParams)
+    expect(bucketKeyParams).toEqual(sharedKeyParams)
 
     rerender({
       ...baseParams,

--- a/src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx
+++ b/src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx
@@ -210,7 +210,11 @@ describe("useEquipmentData filter bucket query", () => {
       wrapper: createWrapper(queryClient),
     })
 
-    await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
+    await waitFor(() => {
+      expect(getRpcCall("equipment_list_enhanced")).toBeDefined()
+      expect(getRpcCall("equipment_department_distribution")).toBeDefined()
+      expect(getRpcCall("equipment_filter_buckets")).toBeDefined()
+    })
 
     const sharedKeyParams = {
       tenant: "tenant-42",

--- a/src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx
+++ b/src/app/(app)/equipment/_hooks/__tests__/useEquipmentData.filter-buckets.test.tsx
@@ -71,6 +71,10 @@ function getBucketCalls() {
     .filter((options) => options.fn === "equipment_filter_buckets")
 }
 
+function getRpcCall(fn: string) {
+  return callRpcMock.mock.calls.map(([options]) => options).find((options) => options.fn === fn)
+}
+
 describe("useEquipmentData filter bucket query", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -187,5 +191,75 @@ describe("useEquipmentData filter bucket query", () => {
     })
 
     await waitFor(() => expect(getBucketCalls()).toHaveLength(2))
+  })
+
+  it("normalizes empty filters across list, distribution, and bucket query scopes", async () => {
+    const queryClient = createQueryClient()
+    const emptyFilterParams: UseEquipmentDataParams = {
+      ...baseParams,
+      debouncedSearch: "",
+      selectedDepartments: [],
+      selectedUsers: [],
+      selectedLocations: [],
+      selectedStatuses: [],
+      selectedClassifications: [],
+      selectedFundingSources: [],
+    }
+
+    renderHook(() => useEquipmentData(emptyFilterParams), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
+
+    const sharedKeyParams = {
+      tenant: "tenant-42",
+      role: "to_qltb",
+      diaBan: 7,
+      donVi: 42,
+      q: null,
+      khoa_phong_array: null,
+      nguoi_su_dung_array: null,
+      vi_tri_lap_dat_array: null,
+      tinh_trang_array: null,
+      phan_loai_array: null,
+      nguon_kinh_phi_array: null,
+    }
+    const listKeyParams = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_list_enhanced"] })
+      .at(-1)?.queryKey[1]
+    const distributionKeyParams = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_department_distribution"] })
+      .at(-1)?.queryKey[1]
+    const bucketKeyParams = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_filter_buckets"] })
+      .at(-1)?.queryKey[1]
+
+    expect(listKeyParams).toEqual({
+      ...sharedKeyParams,
+      page: 0,
+      size: 20,
+      sort: "id.asc",
+    })
+    expect(distributionKeyParams).toEqual(sharedKeyParams)
+    expect(bucketKeyParams).toEqual(sharedKeyParams)
+
+    const emptyRpcFilters = {
+      p_q: null,
+      p_don_vi: 42,
+      p_khoa_phong_array: null,
+      p_nguoi_su_dung_array: null,
+      p_vi_tri_lap_dat_array: null,
+      p_tinh_trang_array: null,
+      p_phan_loai_array: null,
+      p_nguon_kinh_phi_array: null,
+    }
+
+    expect(getRpcCall("equipment_list_enhanced")?.args).toMatchObject(emptyRpcFilters)
+    expect(getRpcCall("equipment_department_distribution")?.args).toMatchObject(emptyRpcFilters)
+    expect(getRpcCall("equipment_filter_buckets")?.args).toMatchObject(emptyRpcFilters)
   })
 })

--- a/src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterBuckets.test.tsx
+++ b/src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterBuckets.test.tsx
@@ -40,7 +40,7 @@ const baseParams: UseEquipmentFilterBucketsParams = {
   shouldFetchData: true,
   effectiveTenantKey: "tenant-42",
   userRole: "to_qltb",
-  userDiaBanId: null,
+  userDiaBanId: 7,
   effectiveSelectedDonVi: 42,
   debouncedSearch: "monitor",
   selectedDepartments: ["ICU"],
@@ -133,10 +133,20 @@ describe("useEquipmentFilterBuckets", () => {
       Record<string, unknown> | undefined
 
     expect(latestBucketKeyParams).toMatchObject({
+      tenant: "tenant-42",
+      role: "to_qltb",
+      diaBan: 7,
+      donVi: 42,
       q: "monitor",
+      khoa_phong_array: ["ICU"],
+      nguoi_su_dung_array: ["Dr A"],
+      vi_tri_lap_dat_array: ["Room 1"],
       tinh_trang_array: ["Bao tri"],
+      phan_loai_array: ["Class A"],
+      nguon_kinh_phi_array: ["Fund A"],
     })
     expect(latestBucketKeyParams).not.toHaveProperty("page")
     expect(latestBucketKeyParams).not.toHaveProperty("size")
+    expect(latestBucketKeyParams).not.toHaveProperty("sort")
   })
 })

--- a/src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterBuckets.test.tsx
+++ b/src/app/(app)/equipment/_hooks/__tests__/useEquipmentFilterBuckets.test.tsx
@@ -149,4 +149,59 @@ describe("useEquipmentFilterBuckets", () => {
     expect(latestBucketKeyParams).not.toHaveProperty("size")
     expect(latestBucketKeyParams).not.toHaveProperty("sort")
   })
+
+  it("normalizes empty filters in the bucket query key and RPC args", async () => {
+    const queryClient = createQueryClient()
+
+    renderHook(
+      () =>
+        useEquipmentFilterBuckets({
+          ...baseParams,
+          debouncedSearch: "",
+          selectedDepartments: [],
+          selectedUsers: [],
+          selectedLocations: [],
+          selectedStatuses: [],
+          selectedClassifications: [],
+          selectedFundingSources: [],
+        }),
+      {
+        wrapper: createWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(getBucketCalls()).toHaveLength(1))
+
+    const bucketKeyParams = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["equipment_filter_buckets"] })
+      .at(-1)?.queryKey[1]
+
+    expect(bucketKeyParams).toEqual({
+      tenant: "tenant-42",
+      role: "to_qltb",
+      diaBan: 7,
+      donVi: 42,
+      q: null,
+      khoa_phong_array: null,
+      nguoi_su_dung_array: null,
+      vi_tri_lap_dat_array: null,
+      tinh_trang_array: null,
+      phan_loai_array: null,
+      nguon_kinh_phi_array: null,
+    })
+    expect(bucketKeyParams).not.toHaveProperty("page")
+    expect(bucketKeyParams).not.toHaveProperty("size")
+    expect(bucketKeyParams).not.toHaveProperty("sort")
+    expect(getBucketCalls()[0]?.args).toMatchObject({
+      p_q: null,
+      p_don_vi: 42,
+      p_khoa_phong_array: null,
+      p_nguoi_su_dung_array: null,
+      p_vi_tri_lap_dat_array: null,
+      p_tinh_trang_array: null,
+      p_phan_loai_array: null,
+      p_nguon_kinh_phi_array: null,
+    })
+  })
 })

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -4,6 +4,7 @@ import * as React from "react"
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { callRpc } from "@/lib/rpc-client"
 import { useActiveUsageLogs } from "@/hooks/use-usage-logs"
+import { buildEquipmentDataQueryParams } from "./EquipmentDataQueryParams"
 import { useEquipmentFilterBuckets } from "./useEquipmentFilterBuckets"
 import type { Equipment } from "../types"
 import type {
@@ -126,6 +127,20 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
     return selectedDonVi
   }, [isRegionalLeader, selectedFacilityId, selectedDonVi])
 
+  const { queryKeyParams, rpcArgs } = buildEquipmentDataQueryParams({
+    effectiveTenantKey,
+    userRole,
+    userDiaBanId,
+    effectiveSelectedDonVi,
+    debouncedSearch,
+    selectedDepartments,
+    selectedUsers,
+    selectedLocations,
+    selectedStatuses,
+    selectedClassifications,
+    selectedFundingSources,
+  })
+
   // Active usage logs
   const { data: activeUsageLogs, isLoading: isLoadingActiveUsage } = useActiveUsageLogs({
     tenantId: currentTenantId,
@@ -164,19 +179,9 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
     queryKey: [
       "equipment_list_enhanced",
       {
-        tenant: effectiveTenantKey,
-        role: userRole, // Cache isolation by role
-        diaBan: userDiaBanId, // Cache isolation by region
-        donVi: effectiveSelectedDonVi,
+        ...queryKeyParams,
         page: pagination.pageIndex,
         size: pagination.pageSize,
-        q: debouncedSearch || null,
-        khoa_phong_array: selectedDepartments,
-        nguoi_su_dung_array: selectedUsers,
-        vi_tri_lap_dat_array: selectedLocations,
-        tinh_trang_array: selectedStatuses,
-        phan_loai_array: selectedClassifications,
-        nguon_kinh_phi_array: selectedFundingSources,
         sort: sortParam,
       },
     ],
@@ -185,17 +190,10 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
       const result = await callRpc<EquipmentListResponse>({
         fn: "equipment_list_enhanced",
         args: {
-          p_q: debouncedSearch || null,
+          ...rpcArgs,
           p_sort: sortParam,
           p_page: effectivePage,
           p_page_size: effectivePageSize,
-          p_don_vi: effectiveSelectedDonVi,
-          p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
-          p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
-          p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
-          p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
-          p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
-          p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
         },
         signal,
       })
@@ -215,31 +213,14 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
     queryKey: [
       "equipment_department_distribution",
       {
-        tenant: effectiveTenantKey,
-        role: userRole,
-        diaBan: userDiaBanId,
-        donVi: effectiveSelectedDonVi,
-        q: debouncedSearch || null,
-        khoa_phong_array: selectedDepartments,
-        nguoi_su_dung_array: selectedUsers,
-        vi_tri_lap_dat_array: selectedLocations,
-        tinh_trang_array: selectedStatuses,
-        phan_loai_array: selectedClassifications,
-        nguon_kinh_phi_array: selectedFundingSources,
+        ...queryKeyParams,
       },
     ],
     queryFn: async ({ signal }) => {
       const result = await callRpc<EquipmentDepartmentDistributionItem[]>({
         fn: "equipment_department_distribution",
         args: {
-          p_q: debouncedSearch || null,
-          p_don_vi: effectiveSelectedDonVi,
-          p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
-          p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
-          p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
-          p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
-          p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
-          p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
+          ...rpcArgs,
         },
         signal,
       })

--- a/src/app/(app)/equipment/_hooks/useEquipmentFilterBuckets.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentFilterBuckets.ts
@@ -6,6 +6,7 @@ import type { ColumnFiltersState } from "@tanstack/react-table"
 
 import { callRpc } from "@/lib/rpc-client"
 import type { FilterBottomSheetData } from "../types"
+import { buildEquipmentDataQueryParams } from "./EquipmentDataQueryParams"
 
 export interface UseEquipmentFilterBucketsParams {
   shouldFetchData: boolean
@@ -109,35 +110,32 @@ export function useEquipmentFilterBuckets(
     selectedFundingSources,
   } = params
 
+  const { queryKeyParams, rpcArgs } = buildEquipmentDataQueryParams({
+    effectiveTenantKey,
+    userRole,
+    userDiaBanId,
+    effectiveSelectedDonVi,
+    debouncedSearch,
+    selectedDepartments,
+    selectedUsers,
+    selectedLocations,
+    selectedStatuses,
+    selectedClassifications,
+    selectedFundingSources,
+  })
+
   const { data: filterBucketsData } = useQuery<EquipmentFilterBucketsResponse>({
     queryKey: [
       "equipment_filter_buckets",
       {
-        tenant: effectiveTenantKey,
-        role: userRole,
-        diaBan: userDiaBanId,
-        donVi: effectiveSelectedDonVi,
-        q: debouncedSearch || null,
-        khoa_phong_array: selectedDepartments,
-        nguoi_su_dung_array: selectedUsers,
-        vi_tri_lap_dat_array: selectedLocations,
-        tinh_trang_array: selectedStatuses,
-        phan_loai_array: selectedClassifications,
-        nguon_kinh_phi_array: selectedFundingSources,
+        ...queryKeyParams,
       },
     ],
     queryFn: async ({ signal }) => {
       const result = await callRpc<EquipmentFilterBucketsResponse>({
         fn: "equipment_filter_buckets",
         args: {
-          p_q: debouncedSearch || null,
-          p_don_vi: effectiveSelectedDonVi,
-          p_khoa_phong_array: selectedDepartments.length > 0 ? selectedDepartments : null,
-          p_nguoi_su_dung_array: selectedUsers.length > 0 ? selectedUsers : null,
-          p_vi_tri_lap_dat_array: selectedLocations.length > 0 ? selectedLocations : null,
-          p_tinh_trang_array: selectedStatuses.length > 0 ? selectedStatuses : null,
-          p_phan_loai_array: selectedClassifications.length > 0 ? selectedClassifications : null,
-          p_nguon_kinh_phi_array: selectedFundingSources.length > 0 ? selectedFundingSources : null,
+          ...rpcArgs,
         },
         signal,
       })


### PR DESCRIPTION
## Summary

- centralize common Equipment cache-scope, search, tenant, and filter parameter mapping for list, department distribution, and filter-bucket queries
- normalize empty filter arrays once at the shared helper boundary and reuse the same processed values for query keys and RPC arguments
- add characterization, helper, and integration coverage while reducing `useEquipmentData.ts` from 380 to 361 lines

## TDD Evidence

- RED: 3 focused failures with `Expected: null` / `Received: []` across the pure helper, combined Equipment hook, and direct filter-bucket hook
- GREEN: the same focused tests passed after centralizing normalization in `EquipmentDataQueryParams.ts`

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- focused Vitest suite: 7 files, 42 tests passed
- `node scripts/npm-run.js run react-doctor` — 100/100, no issues
- `git diff --check origin/main...HEAD`

Closes #672

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes equipment query parameter building in a shared helper to keep cache keys and RPC args consistent across list, distribution, and filter-bucket queries. Normalizes empty filters and search to null, fixing prior [] vs null mismatches and meeting Linear #672.

- **Refactors**
  - Added `EquipmentDataQueryParams.ts` with `buildEquipmentDataQueryParams` to output shared `queryKeyParams` and `rpcArgs`.
  - Updated `useEquipmentData` and `useEquipmentFilterBuckets` to use the helper; list keys include pagination/sort, distribution and buckets use the shared scope (tenant, role, diaBan, donVi, q, filters).
  - Tests: unit tests for the helper; integration asserts for shared scopes/RPC args and empty-value normalization; added waits for all equipment RPC calls; `useEquipmentData` reduced by 19 lines.

<sup>Written for commit df892aa8ba5a059a96b8dd843adc694e675ae5d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved equipment list, distribution, and filter bucket results when changing search terms or filters.
  - Empty selections and search values are now handled consistently, preventing unintended filtering.
  - Updated caching behavior so equipment data refreshes correctly for different filter combinations.
  - Filter bucket requests no longer include irrelevant pagination or sorting settings, improving result consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->