### PR TITLE
Technical configuration comparison P1: dossier foundation

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/contracts.md
+++ b/openspec/changes/add-technical-configuration-comparison/contracts.md
@@ -56,6 +56,46 @@ All tables include UUID primary keys and the audit columns required by `design.m
 - Archive is one-way in MVP; no restore RPC exists.
 - `technical_configuration_dossiers_archive` increments dossier revision atomically.
 
+P1 creates `technical_configuration_dossiers` with:
+
+- `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`
+- required trimmed non-empty `device_type_name TEXT`
+- required trimmed non-empty `name TEXT`
+- optional `description TEXT`
+- `revision BIGINT NOT NULL DEFAULT 1`
+- nullable `archived_at TIMESTAMPTZ` and `archived_by BIGINT`
+- `created_at`, `created_by`, `updated_at` and `updated_by` audit columns
+
+P1 RPC signatures are frozen as:
+
+```text
+technical_configuration_dossiers_list(
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 20,
+  p_include_archived BOOLEAN DEFAULT false
+)
+technical_configuration_dossiers_get(p_id UUID)
+technical_configuration_dossiers_create(
+  p_device_type_name TEXT,
+  p_name TEXT,
+  p_description TEXT,
+  p_expected_revision BIGINT
+)
+technical_configuration_dossiers_update(
+  p_id UUID,
+  p_device_type_name TEXT,
+  p_name TEXT,
+  p_description TEXT,
+  p_expected_revision BIGINT
+)
+technical_configuration_dossiers_archive(
+  p_id UUID,
+  p_expected_revision BIGINT
+)
+```
+
+Create requires `p_expected_revision=0` and returns revision `1`. Update and archive require the current dossier revision and increment it atomically. P1 adds no hard-delete or restore RPC.
+
 ### Baseline Version
 
 - States: `draft`, `locked`.
@@ -113,7 +153,7 @@ Outside the RPC proxy, raw `admin` handling uses `isGlobalRole()`. SQL tests may
 ### Common SQL Guards
 
 - `_technical_configuration_require_global_user()` validates role and non-empty user ID claims, normalizes `admin` to global semantics and returns the actor ID.
-- `_technical_configuration_require_editable_dossier(p_dossier_id uuid)` calls the role guard, verifies existence and raises `archived_dossier` when archived.
+- `_technical_configuration_require_editable_dossier(p_dossier_id uuid, p_expected_revision bigint)` calls the role guard, locks the dossier, verifies existence, archive state and revision, then returns the actor ID.
 - P4 owns `_technical_configuration_require_editable_baseline_version(p_baseline_version_id uuid)`, which calls the dossier guard and raises `locked_version` when needed.
 
 Every descendant mutation leaf must call the most specific applicable guard. A leaf may not duplicate or weaken these checks.
@@ -180,7 +220,7 @@ RPCs raise the SQLSTATE and machine message below. The proxy's `{ error: payload
 | `PT409`  | `archived_dossier`     | P1           | Mutation targets an archived dossier or descendant                  |
 | `PT409`  | `locked_version`       | P4           | Mutation targets locked baseline-owned data                         |
 | `PT409`  | `draft_already_exists` | P2           | Dossier already has an editable draft                               |
-| `PT422`  | `validation_error`     | P2           | Field, relationship, order, code or request-bound validation failed |
+| `PT422`  | `validation_error`     | P1           | Field, relationship, order, code or request-bound validation failed |
 | `PT422`  | `template_mismatch`    | P5           | Workbook kind/version/metadata/shape does not match the contract    |
 
 Errors must not include dossier data when authorization or ownership fails.

--- a/openspec/changes/add-technical-configuration-comparison/design.md
+++ b/openspec/changes/add-technical-configuration-comparison/design.md
@@ -44,7 +44,7 @@ Module phục vụ nhà tư vấn cấu hình có cái nhìn tổng quát giữa
 
 ### 1. Hồ sơ độc lập và một loại thiết bị
 
-Mỗi hồ sơ phân tích chứa đúng một cấu hình cơ sở cho một loại thiết bị. Bản thân hồ sơ là root của lineage cấu hình; không tạo bảng lineage riêng. Một hồ sơ có thể có nhiều phiên bản nối tiếp nhưng hệ thống không cho tạo hai lineage cấu hình song song trong cùng hồ sơ. Hồ sơ có ID ổn định, tên thiết bị, tên hồ sơ, mô tả tùy chọn và metadata tạo/cập nhật.
+Mỗi hồ sơ phân tích chứa đúng một cấu hình cơ sở cho một loại thiết bị. Bản thân hồ sơ là root của lineage cấu hình; không tạo bảng lineage riêng. Một hồ sơ có thể có nhiều phiên bản nối tiếp nhưng hệ thống không cho tạo hai lineage cấu hình song song trong cùng hồ sơ. Hồ sơ có `id` UUID ổn định, `device_type_name` và `name` bắt buộc sau khi trim, `description` tùy chọn, `revision BIGINT`, metadata archive một chiều và các trường audit tạo/cập nhật.
 
 Không thêm foreign key tới `thiet_bi`. Việc độc lập giúp cấu hình được xây dựng trước khi tồn tại thiết bị thực tế và tránh trộn dữ liệu tư vấn với dữ liệu quản lý tài sản.
 

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -266,6 +266,7 @@ P1 may start only after table/RPC contracts, migration split and authorization m
 - Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
 - Create: `src/app/(app)/technical-configurations/types.ts`
 - Create: `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+- Create: `src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts`
 - Modify after generation only when required: `src/types/database.ts`
 
 ### Tasks

--- a/openspec/changes/add-technical-configuration-comparison/p1-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p1-tdd-plan.md
@@ -22,7 +22,7 @@
 
 - [x] Record the approved dossier columns, required trimmed fields and five exact RPC signatures.
 - [x] Run `openspec validate add-technical-configuration-comparison --strict`.
-- [ ] Commit the contract backfill with the implementation after RED-GREEN verification.
+- [x] Commit the contract backfill with the implementation after RED-GREEN verification.
 
 ### Task 2: Add failing RPC whitelist coverage
 
@@ -107,4 +107,4 @@ node scripts/npm-run.js run test:run -- \
 
 - [x] Confirm `src/types/database.ts` remains unchanged because live types were not generated.
 - [x] Self-review migration ordering, grants, RLS, claim guards, selected columns, pagination, locking and absence of N+1 paths.
-- [ ] Commit, push, open a PR linked to issue `#742`, and leave live apply explicitly pending user permission.
+- [x] Commit, push, open a PR linked to issue `#742`, and leave live apply explicitly pending user permission.

--- a/openspec/changes/add-technical-configuration-comparison/p1-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p1-tdd-plan.md
@@ -1,0 +1,110 @@
+# P1 Dossier Foundation And Authorization TDD Plan
+
+> **Execution:** implement in the current session without subagents. Preserve RED-GREEN evidence for every production change.
+
+**Goal:** Add the backend-only dossier foundation for TC-01, TC-02, TC-19 and TC-20 without applying a live database migration.
+
+**Architecture:** One deny-by-default UUID dossier table is the configuration lineage root. Five `SECURITY DEFINER` RPCs provide bounded reads and revision-guarded writes; internal helpers centralize global-role authorization and the reusable archived-dossier guard. The RPC proxy receives only the five P1 names, and TypeScript types document snake_case wire contracts separately from future adapter/domain mapping.
+
+**Tech stack:** PostgreSQL/Supabase migration SQL, Next.js RPC allowlist, TypeScript and Vitest.
+
+---
+
+## Chunk 1: Contract Backfill And RED Tests
+
+### Task 1: Freeze exact P1 schema and RPC signatures
+
+**Files:**
+
+- Modify: `openspec/changes/add-technical-configuration-comparison/contracts.md`
+- Modify: `openspec/changes/add-technical-configuration-comparison/design.md`
+- Modify: `openspec/changes/add-technical-configuration-comparison/implementation-plan.md`
+
+- [x] Record the approved dossier columns, required trimmed fields and five exact RPC signatures.
+- [x] Run `openspec validate add-technical-configuration-comparison --strict`.
+- [ ] Commit the contract backfill with the implementation after RED-GREEN verification.
+
+### Task 2: Add failing RPC whitelist coverage
+
+**Files:**
+
+- Create: `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+
+- [x] Assert all five dossier RPC names exist in `ALLOWED_FUNCTIONS`.
+- [x] Assert each name reaches the proxy guard after the whitelist instead of returning `403`.
+- [x] Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+```
+
+- [x] Verify RED because the five names are not allowlisted.
+
+### Task 3: Add failing migration contract coverage
+
+**Files:**
+
+- Create: `src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts`
+
+- [x] Assert exactly one P1 migration exists.
+- [x] Assert the dossier schema, UUID identity, audit/archive columns, non-empty checks and no `thiet_bi` or lineage dependency.
+- [x] Assert five exact RPC signatures, JSON wire shapes, bounded pagination and default archived filtering.
+- [x] Assert global/admin authorization, missing-claim denial, `SECURITY DEFINER`, pinned `search_path`, RLS, explicit grants and no direct Data API access.
+- [x] Assert create revision `0`, update/archive revision checks, `FOR UPDATE`, atomic increments and frozen errors.
+- [x] Assert the reusable archive guard rejects archived dossier and descendant mutations.
+- [x] Run:
+
+```bash
+node scripts/npm-run.js run test:run -- src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts
+```
+
+- [x] Verify RED because the migration does not exist.
+
+## Chunk 2: GREEN Implementation
+
+### Task 4: Add the minimal migration
+
+**Files:**
+
+- Create: `supabase/migrations/20260712112500_technical_configuration_dossier_foundation.sql`
+
+- [x] Create `technical_configuration_dossiers` and only list-path indexes.
+- [x] Enable RLS, add deny policies and revoke direct client table privileges.
+- [x] Add internal global-role and editable-dossier helpers with client execution revoked.
+- [x] Add list/get/create/update/archive RPCs with explicit selected columns and JSON envelopes.
+- [x] Grant only the five public module RPCs to `authenticated`.
+- [x] Rerun the migration contract test until GREEN.
+
+### Task 5: Add allowlist entries and wire types
+
+**Files:**
+
+- Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
+- Create: `src/app/(app)/technical-configurations/types.ts`
+
+- [x] Add only the five P1 RPC names to `ALLOWED_FUNCTIONS`.
+- [x] Add dossier wire, list response and RPC argument types without adding an adapter or UI.
+- [x] Rerun whitelist and migration tests until GREEN.
+
+## Chunk 3: Verification And Delivery
+
+### Task 6: Run focused and repository gates
+
+- [x] Run:
+
+```bash
+openspec validate add-technical-configuration-comparison --strict
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run test:run -- \
+  src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts \
+  src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts \
+  src/app/api/rpc/__tests__/rpc-whitelist.unit.test.ts \
+  src/lib/__tests__/rbac.test.ts
+```
+
+- [x] Confirm `src/types/database.ts` remains unchanged because live types were not generated.
+- [x] Self-review migration ordering, grants, RLS, claim guards, selected columns, pagination, locking and absence of N+1 paths.
+- [ ] Commit, push, open a PR linked to issue `#742`, and leave live apply explicitly pending user permission.

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -54,11 +54,11 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 
 ## Phase P1 - Dossier Foundation And Authorization
 
-- [ ] P1.1 Thêm schema/RPC tối thiểu cho hồ sơ độc lập và một configuration lineage.
-- [ ] P1.2 Thêm deny-by-default authorization cho `global`, raw `admin` và role bị từ chối.
-- [ ] P1.3 Thêm revision guard cho update/archive ngay từ foundation.
+- [x] P1.1 Thêm schema/RPC tối thiểu cho hồ sơ độc lập và một configuration lineage.
+- [x] P1.2 Thêm deny-by-default authorization cho `global`, raw `admin` và role bị từ chối.
+- [x] P1.3 Thêm revision guard cho update/archive ngay từ foundation.
 - [ ] P1.4 Chạy DB phase gate, migration verification và advisors sau live apply được phê duyệt.
-- [ ] P1.5 Thêm TypeScript contracts, RPC allowlist và focused tests.
+- [x] P1.5 Thêm TypeScript contracts, RPC allowlist và focused tests.
 
 ## Phase P2 - Baseline Draft Data Contracts
 

--- a/src/app/(app)/technical-configurations/types.ts
+++ b/src/app/(app)/technical-configurations/types.ts
@@ -1,0 +1,54 @@
+export interface TechnicalConfigurationDossierWire {
+  id: string
+  device_type_name: string
+  name: string
+  description: string | null
+  revision: number
+  archived_at: string | null
+  archived_by: number | null
+  created_at: string
+  created_by: number
+  updated_at: string
+  updated_by: number
+}
+
+export interface TechnicalConfigurationDossierListWireResponse {
+  data: TechnicalConfigurationDossierWire[]
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface TechnicalConfigurationDossierWireResponse {
+  data: TechnicalConfigurationDossierWire
+}
+
+export interface TechnicalConfigurationDossierListRpcArgs {
+  p_page?: number
+  p_page_size?: number
+  p_include_archived?: boolean
+}
+
+export interface TechnicalConfigurationDossierGetRpcArgs {
+  p_id: string
+}
+
+export interface TechnicalConfigurationDossierCreateRpcArgs {
+  p_device_type_name: string
+  p_name: string
+  p_description: string | null
+  p_expected_revision: 0
+}
+
+export interface TechnicalConfigurationDossierUpdateRpcArgs {
+  p_id: string
+  p_device_type_name: string
+  p_name: string
+  p_description: string | null
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationDossierArchiveRpcArgs {
+  p_id: string
+  p_expected_revision: number
+}

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -85,6 +85,12 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   "get_maintenance_report_data",
   "maintenance_plan_status_counts",
   "dashboard_kpi_summary",
+  // Technical configuration comparison
+  "technical_configuration_dossiers_list",
+  "technical_configuration_dossiers_get",
+  "technical_configuration_dossiers_create",
+  "technical_configuration_dossiers_update",
+  "technical_configuration_dossiers_archive",
   // AI Assistant (read-only)
   "ai_equipment_lookup",
   "ai_maintenance_plan_lookup",

--- a/src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts
@@ -92,15 +92,21 @@ describe("technical configuration dossier foundation migration", () => {
 
     for (const signature of PUBLIC_RPC_SIGNATURES) {
       expect(migrationSource).toContain(
-        `REVOKE ALL ON FUNCTION public.${signature} FROM PUBLIC, anon, authenticated;`
+        `REVOKE ALL ON FUNCTION public.${signature} FROM PUBLIC, anon, authenticated, service_role;`
       )
       expect(migrationSource).toContain(
         `GRANT EXECUTE ON FUNCTION public.${signature} TO authenticated;`
       )
     }
-    expect(migrationSource).not.toMatch(
-      /GRANT EXECUTE ON FUNCTION public\.technical_configuration_dossiers_[^(]+\([^;]+ TO authenticated, service_role;/
-    )
+
+    const dossierRpcGrantStatements =
+      migrationSource.match(
+        /GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+public\.technical_configuration_dossiers_[\s\S]*?;/gi
+      ) ?? []
+    expect(dossierRpcGrantStatements).toHaveLength(PUBLIC_RPC_SIGNATURES.length)
+    for (const grantStatement of dossierRpcGrantStatements) {
+      expect(grantStatement).not.toMatch(/\bservice_role\b/i)
+    }
 
     expect(migrationSource).not.toMatch(
       /GRANT\s+(SELECT|INSERT|UPDATE|DELETE|ALL)[^;]*technical_configuration_dossiers[^;]*authenticated/i

--- a/src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts
@@ -1,0 +1,259 @@
+import { readdirSync, readFileSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const MIGRATION_MARKER = "technical_configuration_dossier_foundation"
+
+const PUBLIC_RPC_SIGNATURES = [
+  "technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN)",
+  "technical_configuration_dossiers_get(UUID)",
+  "technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT)",
+  "technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT)",
+  "technical_configuration_dossiers_archive(UUID, BIGINT)",
+] as const
+
+function getMigrationSource() {
+  const migrationsDir = path.resolve(process.cwd(), "supabase/migrations")
+  const migrationFiles = readdirSync(migrationsDir)
+    .filter((file) => file.includes(MIGRATION_MARKER) && file.endsWith(".sql"))
+    .sort()
+
+  expect(migrationFiles).toEqual(["20260712112500_technical_configuration_dossier_foundation.sql"])
+
+  const migrationFile = migrationFiles[0]
+  return migrationFile ? readFileSync(path.join(migrationsDir, migrationFile), "utf8") : ""
+}
+
+function getFunctionBlock(migrationSource: string, functionName: string) {
+  const marker = `CREATE OR REPLACE FUNCTION public.${functionName}`
+  const start = migrationSource.indexOf(marker)
+  expect(start, `Missing ${functionName}`).toBeGreaterThanOrEqual(0)
+
+  const next = migrationSource.indexOf(
+    "\nCREATE OR REPLACE FUNCTION public.",
+    start + marker.length
+  )
+  return migrationSource.slice(start, next === -1 ? migrationSource.length : next)
+}
+
+describe("technical configuration dossier foundation migration", () => {
+  it("creates one standalone dossier lineage root with the frozen columns", () => {
+    const migrationSource = getMigrationSource()
+
+    expect(migrationSource).toContain("CREATE TABLE public.technical_configuration_dossiers")
+    expect(migrationSource).toMatch(/id UUID PRIMARY KEY DEFAULT gen_random_uuid\(\)/)
+    expect(migrationSource).toMatch(/device_type_name TEXT NOT NULL/)
+    expect(migrationSource).toMatch(/name TEXT NOT NULL/)
+    expect(migrationSource).toMatch(/description TEXT/)
+    expect(migrationSource).toMatch(/revision BIGINT NOT NULL DEFAULT 1/)
+    expect(migrationSource).toMatch(/archived_at TIMESTAMPTZ/)
+    expect(migrationSource).toMatch(/archived_by BIGINT/)
+    expect(migrationSource).toMatch(/created_at TIMESTAMPTZ NOT NULL DEFAULT now\(\)/)
+    expect(migrationSource).toMatch(/created_by BIGINT NOT NULL/)
+    expect(migrationSource).toMatch(/updated_at TIMESTAMPTZ NOT NULL DEFAULT now\(\)/)
+    expect(migrationSource).toMatch(/updated_by BIGINT NOT NULL/)
+    expect(migrationSource).toContain("CHECK (btrim(device_type_name) <> '')")
+    expect(migrationSource).toContain("CHECK (btrim(name) <> '')")
+    expect(migrationSource).toContain("CHECK (revision > 0)")
+    expect(migrationSource).not.toMatch(/technical_configuration_lineages?/i)
+    expect(migrationSource).not.toMatch(/REFERENCES public\.thiet_bi/i)
+    expect(migrationSource).not.toMatch(/CREATE TABLE[^;]*\bai_/i)
+  })
+
+  it("uses only indexes justified by active and inclusive dossier lists", () => {
+    const migrationSource = getMigrationSource()
+
+    expect(migrationSource).toContain("technical_configuration_dossiers_active_list_idx")
+    expect(migrationSource).toContain(
+      "ON public.technical_configuration_dossiers (updated_at DESC, id)"
+    )
+    expect(migrationSource).toContain("WHERE archived_at IS NULL")
+    expect(migrationSource).toContain("technical_configuration_dossiers_all_list_idx")
+  })
+
+  it("denies direct Data API access and exposes only guarded authenticated RPCs", () => {
+    const migrationSource = getMigrationSource()
+
+    expect(migrationSource).toContain(
+      "ALTER TABLE public.technical_configuration_dossiers ENABLE ROW LEVEL SECURITY;"
+    )
+    expect(migrationSource).toContain(
+      "CREATE POLICY technical_configuration_dossiers_no_client_access"
+    )
+    expect(migrationSource).toContain("USING (false)")
+    expect(migrationSource).toContain("WITH CHECK (false)")
+    expect(migrationSource).toContain(
+      "REVOKE ALL ON TABLE public.technical_configuration_dossiers FROM PUBLIC, anon, authenticated;"
+    )
+    expect(migrationSource).toContain(
+      "GRANT ALL ON TABLE public.technical_configuration_dossiers TO service_role;"
+    )
+
+    for (const signature of PUBLIC_RPC_SIGNATURES) {
+      expect(migrationSource).toContain(
+        `REVOKE ALL ON FUNCTION public.${signature} FROM PUBLIC, anon, authenticated;`
+      )
+      expect(migrationSource).toContain(
+        `GRANT EXECUTE ON FUNCTION public.${signature} TO authenticated, service_role;`
+      )
+    }
+
+    expect(migrationSource).not.toMatch(
+      /GRANT\s+(SELECT|INSERT|UPDATE|DELETE|ALL)[^;]*technical_configuration_dossiers[^;]*authenticated/i
+    )
+  })
+
+  it("pins SECURITY DEFINER search paths and fail-closes global authorization", () => {
+    const migrationSource = getMigrationSource()
+    const guardedFunctions = [
+      "_technical_configuration_require_global_user",
+      "_technical_configuration_require_editable_dossier",
+      "technical_configuration_dossiers_list",
+      "technical_configuration_dossiers_get",
+      "technical_configuration_dossiers_create",
+      "technical_configuration_dossiers_update",
+      "technical_configuration_dossiers_archive",
+    ]
+
+    for (const functionName of guardedFunctions) {
+      const functionBlock = getFunctionBlock(migrationSource, functionName)
+      expect(functionBlock).toContain("SECURITY DEFINER")
+      expect(functionBlock).toContain("SET search_path = public, pg_temp")
+    }
+
+    const authBlock = getFunctionBlock(
+      migrationSource,
+      "_technical_configuration_require_global_user"
+    )
+    expect(authBlock).toContain("current_setting('request.jwt.claims', true)")
+    expect(authBlock).toContain("NULLIF(v_claims->>'user_id', '')::BIGINT")
+    expect(authBlock).toContain("v_role IN ('global', 'admin')")
+    expect(authBlock).toContain("RAISE EXCEPTION 'permission_denied'")
+    expect(authBlock).toContain("USING ERRCODE = '42501'")
+
+    expect(migrationSource).toMatch(
+      /REVOKE ALL ON FUNCTION public\._technical_configuration_require_global_user\(\)\s+FROM PUBLIC, anon, authenticated;/
+    )
+    expect(migrationSource).toMatch(
+      /REVOKE ALL ON FUNCTION public\._technical_configuration_require_editable_dossier\(UUID, BIGINT\)\s+FROM PUBLIC, anon, authenticated;/
+    )
+  })
+
+  it("returns bounded snake_case list responses and hides archived dossiers by default", () => {
+    const migrationSource = getMigrationSource()
+    const listBlock = getFunctionBlock(migrationSource, "technical_configuration_dossiers_list")
+
+    expect(listBlock).toContain("p_page INTEGER DEFAULT 1")
+    expect(listBlock).toContain("p_page_size INTEGER DEFAULT 20")
+    expect(listBlock).toContain("p_include_archived BOOLEAN DEFAULT false")
+    expect(listBlock).toContain("p_page IS NULL")
+    expect(listBlock).toContain("p_page_size IS NULL")
+    expect(listBlock).toContain("p_page < 1")
+    expect(listBlock).toContain("p_page_size < 1")
+    expect(listBlock).toContain("p_page_size > 100")
+    expect(listBlock).toContain("p_include_archived OR d.archived_at IS NULL")
+    expect(listBlock).toContain("ORDER BY f.updated_at DESC, f.id")
+    expect(listBlock).toContain("LIMIT p_page_size")
+    expect(listBlock).toContain("OFFSET (p_page - 1)::BIGINT * p_page_size")
+    expect(listBlock).toMatch(/'page_size',\s+p_page_size/)
+    expect(listBlock).toContain("'total'")
+    expect(listBlock).toContain("'data'")
+    expect(listBlock).not.toMatch(/SELECT\s+\*/i)
+  })
+
+  it("uses the frozen validation error for invalid pagination and required text fields", () => {
+    const migrationSource = getMigrationSource()
+    const listBlock = getFunctionBlock(migrationSource, "technical_configuration_dossiers_list")
+    const createBlock = getFunctionBlock(migrationSource, "technical_configuration_dossiers_create")
+    const updateBlock = getFunctionBlock(migrationSource, "technical_configuration_dossiers_update")
+
+    expect(listBlock).toContain("RAISE EXCEPTION 'validation_error'")
+    expect(listBlock).toContain("USING ERRCODE = 'PT422'")
+
+    for (const functionBlock of [createBlock, updateBlock]) {
+      expect(functionBlock).toContain("p_device_type_name IS NULL")
+      expect(functionBlock).toContain("btrim(p_device_type_name) = ''")
+      expect(functionBlock).toContain("p_name IS NULL")
+      expect(functionBlock).toContain("btrim(p_name) = ''")
+      expect(functionBlock).toContain("RAISE EXCEPTION 'validation_error'")
+      expect(functionBlock).toContain("USING ERRCODE = 'PT422'")
+    }
+  })
+
+  it("keeps archived dossiers readable through get without exposing unauthorized data", () => {
+    const migrationSource = getMigrationSource()
+    const getBlock = getFunctionBlock(migrationSource, "technical_configuration_dossiers_get")
+
+    expect(getBlock).toContain("PERFORM public._technical_configuration_require_global_user()")
+    expect(getBlock).toContain("WHERE d.id = p_id")
+    expect(getBlock).not.toContain("archived_at IS NULL")
+    expect(getBlock).toContain("RAISE EXCEPTION 'not_found'")
+    expect(getBlock).toContain("USING ERRCODE = 'PT404'")
+    expect(getBlock).not.toMatch(/SELECT\s+\*/i)
+  })
+
+  it("requires create revision zero and returns the first persisted revision", () => {
+    const migrationSource = getMigrationSource()
+    const createBlock = getFunctionBlock(migrationSource, "technical_configuration_dossiers_create")
+
+    expect(createBlock).toContain("p_expected_revision BIGINT")
+    expect(createBlock).toContain("p_expected_revision IS DISTINCT FROM 0")
+    expect(createBlock).toContain("RAISE EXCEPTION 'stale_revision'")
+    expect(createBlock).toContain("USING ERRCODE = 'PT409'")
+    expect(createBlock).toContain("btrim(p_device_type_name)")
+    expect(createBlock).toContain("btrim(p_name)")
+    expect(createBlock).toContain("NULLIF(btrim(p_description), '')")
+    expect(createBlock).toContain("revision")
+    expect(createBlock).toContain("1")
+    expect(createBlock).toContain("'data'")
+  })
+
+  it("centralizes archived and stale revision rejection for all descendant mutations", () => {
+    const migrationSource = getMigrationSource()
+    const guardBlock = getFunctionBlock(
+      migrationSource,
+      "_technical_configuration_require_editable_dossier"
+    )
+
+    expect(guardBlock).toContain("p_expected_revision BIGINT")
+    expect(guardBlock).toContain("RETURNS BIGINT")
+    expect(guardBlock).toContain(
+      "v_user_id := public._technical_configuration_require_global_user()"
+    )
+    expect(guardBlock).toContain("FOR UPDATE")
+    expect(guardBlock).toContain("RAISE EXCEPTION 'not_found'")
+    expect(guardBlock).toContain("USING ERRCODE = 'PT404'")
+    expect(guardBlock).toContain("v_archived_at IS NOT NULL")
+    expect(guardBlock).toContain("RAISE EXCEPTION 'archived_dossier'")
+    expect(guardBlock).toContain("USING ERRCODE = 'PT409'")
+    expect(guardBlock).toContain("v_revision IS DISTINCT FROM p_expected_revision")
+    expect(guardBlock).toContain("RAISE EXCEPTION 'stale_revision'")
+  })
+
+  it("updates and archives under row lock with atomic revision increments", () => {
+    const migrationSource = getMigrationSource()
+    const updateBlock = getFunctionBlock(migrationSource, "technical_configuration_dossiers_update")
+    const archiveBlock = getFunctionBlock(
+      migrationSource,
+      "technical_configuration_dossiers_archive"
+    )
+
+    for (const functionBlock of [updateBlock, archiveBlock]) {
+      expect(functionBlock).toContain(
+        "v_user_id := public._technical_configuration_require_editable_dossier"
+      )
+      expect(functionBlock).toContain("revision = revision + 1")
+      expect(functionBlock).toContain("'data'")
+    }
+
+    expect(updateBlock).toContain("device_type_name = btrim(p_device_type_name)")
+    expect(updateBlock).toContain("name = btrim(p_name)")
+    expect(updateBlock).toContain("description = NULLIF(btrim(p_description), '')")
+    expect(archiveBlock).toContain("archived_at = now()")
+    expect(archiveBlock).toContain("archived_by = v_user_id")
+    expect(migrationSource).not.toMatch(
+      /CREATE OR REPLACE FUNCTION public\.technical_configuration_dossiers_(restore|delete)/i
+    )
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-dossier-migration.test.ts
@@ -95,9 +95,12 @@ describe("technical configuration dossier foundation migration", () => {
         `REVOKE ALL ON FUNCTION public.${signature} FROM PUBLIC, anon, authenticated;`
       )
       expect(migrationSource).toContain(
-        `GRANT EXECUTE ON FUNCTION public.${signature} TO authenticated, service_role;`
+        `GRANT EXECUTE ON FUNCTION public.${signature} TO authenticated;`
       )
     }
+    expect(migrationSource).not.toMatch(
+      /GRANT EXECUTE ON FUNCTION public\.technical_configuration_dossiers_[^(]+\([^;]+ TO authenticated, service_role;/
+    )
 
     expect(migrationSource).not.toMatch(
       /GRANT\s+(SELECT|INSERT|UPDATE|DELETE|ALL)[^;]*technical_configuration_dossiers[^;]*authenticated/i
@@ -153,9 +156,13 @@ describe("technical configuration dossier foundation migration", () => {
     expect(listBlock).toContain("p_page_size < 1")
     expect(listBlock).toContain("p_page_size > 100")
     expect(listBlock).toContain("p_include_archived OR d.archived_at IS NULL")
-    expect(listBlock).toContain("ORDER BY f.updated_at DESC, f.id")
+    expect(listBlock).not.toContain("filtered AS MATERIALIZED")
+    expect(listBlock).toContain("ORDER BY d.updated_at DESC, d.id")
     expect(listBlock).toContain("LIMIT p_page_size")
     expect(listBlock).toContain("OFFSET (p_page - 1)::BIGINT * p_page_size")
+    expect(listBlock).toMatch(
+      /'total',\s+\(\s*SELECT count\(\*\)\s+FROM public\.technical_configuration_dossiers d\s+WHERE p_include_archived OR d\.archived_at IS NULL\s*\)/
+    )
     expect(listBlock).toMatch(/'page_size',\s+p_page_size/)
     expect(listBlock).toContain("'total'")
     expect(listBlock).toContain("'data'")

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("server-only", () => ({}))
+
+import { ALLOWED_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
+import { POST } from "@/app/api/rpc/[fn]/route"
+
+const DOSSIER_RPC_FUNCTIONS = [
+  "technical_configuration_dossiers_list",
+  "technical_configuration_dossiers_get",
+  "technical_configuration_dossiers_create",
+  "technical_configuration_dossiers_update",
+  "technical_configuration_dossiers_archive",
+] as const
+
+async function invokeRpcProxy(fn: string) {
+  const request = new Request(`http://localhost/api/rpc/${fn}`, { method: "POST" })
+  return POST(request as never, { params: Promise.resolve({ fn }) })
+}
+
+describe("technical configuration dossier RPC whitelist", () => {
+  it("allowlists exactly the five P1 dossier RPCs", () => {
+    expect(
+      [...ALLOWED_FUNCTIONS].filter((fn) => fn.startsWith("technical_configuration_dossiers_"))
+    ).toEqual(DOSSIER_RPC_FUNCTIONS)
+  })
+
+  it.each(DOSSIER_RPC_FUNCTIONS)('allows P1 RPC "%s" through the whitelist', async (fn) => {
+    const response = await invokeRpcProxy(fn)
+
+    expect(response.status).toBe(411)
+    await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
+  })
+})

--- a/supabase/migrations/20260712112500_technical_configuration_dossier_foundation.sql
+++ b/supabase/migrations/20260712112500_technical_configuration_dossier_foundation.sql
@@ -1,0 +1,444 @@
+-- Issue #742, Phase P1: technical configuration dossier foundation.
+-- Backend-only additive scope: one dossier root, five guarded RPCs and no live UI.
+
+BEGIN;
+
+CREATE TABLE public.technical_configuration_dossiers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  device_type_name TEXT NOT NULL CHECK (btrim(device_type_name) <> ''),
+  name TEXT NOT NULL CHECK (btrim(name) <> ''),
+  description TEXT,
+  revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0),
+  archived_at TIMESTAMPTZ,
+  archived_by BIGINT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by BIGINT NOT NULL
+);
+
+CREATE INDEX technical_configuration_dossiers_active_list_idx
+  ON public.technical_configuration_dossiers (updated_at DESC, id)
+  WHERE archived_at IS NULL;
+
+CREATE INDEX technical_configuration_dossiers_all_list_idx
+  ON public.technical_configuration_dossiers (updated_at DESC, id);
+
+ALTER TABLE public.technical_configuration_dossiers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY technical_configuration_dossiers_no_client_access
+  ON public.technical_configuration_dossiers
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+REVOKE ALL ON TABLE public.technical_configuration_dossiers FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.technical_configuration_dossiers TO service_role;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_require_global_user()
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claims JSONB;
+  v_role TEXT;
+  v_user_id BIGINT;
+BEGIN
+  BEGIN
+    v_claims := COALESCE(
+      NULLIF(current_setting('request.jwt.claims', true), ''),
+      '{}'
+    )::JSONB;
+    v_role := lower(
+      COALESCE(
+        NULLIF(v_claims->>'app_role', ''),
+        NULLIF(v_claims->>'role', '')
+      )
+    );
+    v_user_id := NULLIF(v_claims->>'user_id', '')::BIGINT;
+  EXCEPTION
+    WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'permission_denied' USING ERRCODE = '42501';
+  END;
+
+  IF v_role IS NULL
+     OR v_user_id IS NULL
+     OR NOT (v_role IN ('global', 'admin'))
+     OR NOT EXISTS (
+       SELECT 1
+       FROM public.nhan_vien nv
+       WHERE nv.id = v_user_id
+     ) THEN
+    RAISE EXCEPTION 'permission_denied' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN v_user_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_require_editable_dossier(
+  p_dossier_id UUID,
+  p_expected_revision BIGINT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_revision BIGINT;
+  v_archived_at TIMESTAMPTZ;
+BEGIN
+  v_user_id := public._technical_configuration_require_global_user();
+
+  SELECT
+    d.revision,
+    d.archived_at
+  INTO
+    v_revision,
+    v_archived_at
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = p_dossier_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  IF v_archived_at IS NOT NULL THEN
+    RAISE EXCEPTION 'archived_dossier' USING ERRCODE = 'PT409';
+  END IF;
+
+  IF v_revision IS DISTINCT FROM p_expected_revision THEN
+    RAISE EXCEPTION 'stale_revision' USING ERRCODE = 'PT409';
+  END IF;
+
+  RETURN v_user_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_list(
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 20,
+  p_include_archived BOOLEAN DEFAULT false
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_page IS NULL
+     OR p_page_size IS NULL
+     OR p_page < 1
+     OR p_page_size < 1
+     OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  WITH filtered AS MATERIALIZED (
+    SELECT
+      d.id,
+      d.device_type_name,
+      d.name,
+      d.description,
+      d.revision,
+      d.archived_at,
+      d.archived_by,
+      d.created_at,
+      d.created_by,
+      d.updated_at,
+      d.updated_by
+    FROM public.technical_configuration_dossiers d
+    WHERE p_include_archived OR d.archived_at IS NULL
+  ),
+  paged AS (
+    SELECT
+      f.id,
+      f.device_type_name,
+      f.name,
+      f.description,
+      f.revision,
+      f.archived_at,
+      f.archived_by,
+      f.created_at,
+      f.created_by,
+      f.updated_at,
+      f.updated_by
+    FROM filtered f
+    ORDER BY f.updated_at DESC, f.id
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  )
+  SELECT jsonb_build_object(
+    'data',
+    COALESCE(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', p.id,
+            'device_type_name', p.device_type_name,
+            'name', p.name,
+            'description', p.description,
+            'revision', p.revision,
+            'archived_at', p.archived_at,
+            'archived_by', p.archived_by,
+            'created_at', p.created_at,
+            'created_by', p.created_by,
+            'updated_at', p.updated_at,
+            'updated_by', p.updated_by
+          )
+          ORDER BY p.updated_at DESC, p.id
+        )
+        FROM paged p
+      ),
+      '[]'::JSONB
+    ),
+    'total',
+    (SELECT count(*) FROM filtered),
+    'page',
+    p_page,
+    'page_size',
+    p_page_size
+  )
+  INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_get(
+  p_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_data JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT jsonb_build_object(
+    'id', d.id,
+    'device_type_name', d.device_type_name,
+    'name', d.name,
+    'description', d.description,
+    'revision', d.revision,
+    'archived_at', d.archived_at,
+    'archived_by', d.archived_by,
+    'created_at', d.created_at,
+    'created_by', d.created_by,
+    'updated_at', d.updated_at,
+    'updated_by', d.updated_by
+  )
+  INTO v_data
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = p_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  RETURN jsonb_build_object('data', v_data);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_create(
+  p_device_type_name TEXT,
+  p_name TEXT,
+  p_description TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_data JSONB;
+BEGIN
+  v_user_id := public._technical_configuration_require_global_user();
+
+  IF p_expected_revision IS DISTINCT FROM 0 THEN
+    RAISE EXCEPTION 'stale_revision' USING ERRCODE = 'PT409';
+  END IF;
+
+  IF p_device_type_name IS NULL
+     OR btrim(p_device_type_name) = ''
+     OR p_name IS NULL
+     OR btrim(p_name) = '' THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name,
+    name,
+    description,
+    revision,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    btrim(p_device_type_name),
+    btrim(p_name),
+    NULLIF(btrim(p_description), ''),
+    1,
+    v_user_id,
+    v_user_id
+  )
+  RETURNING jsonb_build_object(
+    'id', id,
+    'device_type_name', device_type_name,
+    'name', name,
+    'description', description,
+    'revision', revision,
+    'archived_at', archived_at,
+    'archived_by', archived_by,
+    'created_at', created_at,
+    'created_by', created_by,
+    'updated_at', updated_at,
+    'updated_by', updated_by
+  )
+  INTO v_data;
+
+  RETURN jsonb_build_object('data', v_data);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_update(
+  p_id UUID,
+  p_device_type_name TEXT,
+  p_name TEXT,
+  p_description TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_data JSONB;
+BEGIN
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    p_id,
+    p_expected_revision
+  );
+
+  IF p_device_type_name IS NULL
+     OR btrim(p_device_type_name) = ''
+     OR p_name IS NULL
+     OR btrim(p_name) = '' THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  UPDATE public.technical_configuration_dossiers
+  SET device_type_name = btrim(p_device_type_name),
+      name = btrim(p_name),
+      description = NULLIF(btrim(p_description), ''),
+      revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = p_id
+  RETURNING jsonb_build_object(
+    'id', id,
+    'device_type_name', device_type_name,
+    'name', name,
+    'description', description,
+    'revision', revision,
+    'archived_at', archived_at,
+    'archived_by', archived_by,
+    'created_at', created_at,
+    'created_by', created_by,
+    'updated_at', updated_at,
+    'updated_by', updated_by
+  )
+  INTO v_data;
+
+  RETURN jsonb_build_object('data', v_data);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_dossiers_archive(
+  p_id UUID,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_data JSONB;
+BEGIN
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    p_id,
+    p_expected_revision
+  );
+
+  UPDATE public.technical_configuration_dossiers
+  SET archived_at = now(),
+      archived_by = v_user_id,
+      revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = p_id
+  RETURNING jsonb_build_object(
+    'id', id,
+    'device_type_name', device_type_name,
+    'name', name,
+    'description', description,
+    'revision', revision,
+    'archived_at', archived_at,
+    'archived_by', archived_by,
+    'created_at', created_at,
+    'created_by', created_by,
+    'updated_at', updated_at,
+    'updated_by', updated_by
+  )
+  INTO v_data;
+
+  RETURN jsonb_build_object('data', v_data);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._technical_configuration_require_global_user()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public._technical_configuration_require_editable_dossier(UUID, BIGINT)
+  FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_get(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_get(UUID) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_archive(UUID, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_archive(UUID, BIGINT) TO authenticated, service_role;
+
+COMMENT ON TABLE public.technical_configuration_dossiers IS
+  'Independent technical configuration dossier and single configuration lineage root.';
+
+COMMENT ON FUNCTION public._technical_configuration_require_editable_dossier(UUID, BIGINT) IS
+  'Common row-locking archive and revision guard for dossier and descendant mutations.';
+
+COMMIT;

--- a/supabase/migrations/20260712112500_technical_configuration_dossier_foundation.sql
+++ b/supabase/migrations/20260712112500_technical_configuration_dossier_foundation.sql
@@ -144,7 +144,7 @@ BEGIN
     RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
   END IF;
 
-  WITH filtered AS MATERIALIZED (
+  WITH paged AS (
     SELECT
       d.id,
       d.device_type_name,
@@ -159,22 +159,7 @@ BEGIN
       d.updated_by
     FROM public.technical_configuration_dossiers d
     WHERE p_include_archived OR d.archived_at IS NULL
-  ),
-  paged AS (
-    SELECT
-      f.id,
-      f.device_type_name,
-      f.name,
-      f.description,
-      f.revision,
-      f.archived_at,
-      f.archived_by,
-      f.created_at,
-      f.created_by,
-      f.updated_at,
-      f.updated_by
-    FROM filtered f
-    ORDER BY f.updated_at DESC, f.id
+    ORDER BY d.updated_at DESC, d.id
     LIMIT p_page_size
     OFFSET (p_page - 1)::BIGINT * p_page_size
   )
@@ -203,7 +188,11 @@ BEGIN
       '[]'::JSONB
     ),
     'total',
-    (SELECT count(*) FROM filtered),
+    (
+      SELECT count(*)
+      FROM public.technical_configuration_dossiers d
+      WHERE p_include_archived OR d.archived_at IS NULL
+    ),
     'page',
     p_page,
     'page_size',
@@ -421,19 +410,19 @@ REVOKE ALL ON FUNCTION public._technical_configuration_require_editable_dossier(
   FROM PUBLIC, anon, authenticated;
 
 REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN) TO authenticated;
 
 REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_get(UUID) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_get(UUID) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_get(UUID) TO authenticated;
 
 REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT) TO authenticated;
 
 REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT) TO authenticated;
 
 REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_archive(UUID, BIGINT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_archive(UUID, BIGINT) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_archive(UUID, BIGINT) TO authenticated;
 
 COMMENT ON TABLE public.technical_configuration_dossiers IS
   'Independent technical configuration dossier and single configuration lineage root.';

--- a/supabase/migrations/20260712112500_technical_configuration_dossier_foundation.sql
+++ b/supabase/migrations/20260712112500_technical_configuration_dossier_foundation.sql
@@ -409,19 +409,19 @@ REVOKE ALL ON FUNCTION public._technical_configuration_require_global_user()
 REVOKE ALL ON FUNCTION public._technical_configuration_require_editable_dossier(UUID, BIGINT)
   FROM PUBLIC, anon, authenticated;
 
-REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN) FROM PUBLIC, anon, authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_list(INTEGER, INTEGER, BOOLEAN) TO authenticated;
 
-REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_get(UUID) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_get(UUID) FROM PUBLIC, anon, authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_get(UUID) TO authenticated;
 
-REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_create(TEXT, TEXT, TEXT, BIGINT) TO authenticated;
 
-REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_update(UUID, TEXT, TEXT, TEXT, BIGINT) TO authenticated;
 
-REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_archive(UUID, BIGINT) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.technical_configuration_dossiers_archive(UUID, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
 GRANT EXECUTE ON FUNCTION public.technical_configuration_dossiers_archive(UUID, BIGINT) TO authenticated;
 
 COMMENT ON TABLE public.technical_configuration_dossiers IS


### PR DESCRIPTION
## Summary
- backfill the P0 dossier schema, RPC signatures, helper guard, and validation taxonomy contracts
- add the deny-by-default dossier table plus guarded list/get/create/update/archive RPCs
- add RPC allowlist entries, snake_case wire types, and TDD contract coverage

## TDD evidence
- RED: whitelist tests failed for all five missing RPC names
- RED: migration tests failed while the P1 migration and validation/guard behavior were absent
- GREEN: 4 focused test files, 75 tests passed

## Validation
- OpenSpec strict validation
- formatting, no-explicit-any, diff-only dedupe, and typecheck
- React Doctor 100/100
- migration ordering and static scope audit

## Deferred
- P1.4 live Supabase apply, runtime role/revision/archive checks, and advisors remain pending separate explicit permission
- no live database write was performed

Refs #742

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the P1 dossier foundation: a secure `technical_configuration_dossiers` table with strict RLS and five hardened, revision‑guarded RPCs, plus RPC allowlist, OpenSpec contract, and TypeScript wire types. Implements the backend scope for #742; no UI changes.

- **New Features**
  - Added `technical_configuration_dossiers` with trimmed required `device_type_name`/`name`, optional `description`, `revision`, archive metadata, audit columns, and RLS deny-by-default with active/all list indexes; client table privileges revoked.
  - Introduced `_technical_configuration_require_global_user()` and `_technical_configuration_require_editable_dossier(p_id, p_expected_revision)` guards (`SECURITY DEFINER`, pinned `search_path`) for global/admin-only access, row locks, archive checks, and stale revision checks.
  - Exposed authenticated RPCs: `technical_configuration_dossiers_list(p_page, p_page_size, p_include_archived)`, `technical_configuration_dossiers_get(p_id)`, `technical_configuration_dossiers_create(...)`, `technical_configuration_dossiers_update(...)`, `technical_configuration_dossiers_archive(...)` with bounded pagination, default archived filtering, atomic revision bumps, snake_case JSON (`data`, `total`, `page`, `page_size`), frozen errors (`PT404`, `PT409`, `PT422`), and create requiring `p_expected_revision=0` returning revision `1`.
  - Hardened ACLs: revoked EXECUTE on internal guards from all clients; revoked EXECUTE on public dossier RPCs from `service_role`, granting only to `authenticated`; no direct Data API grants to clients; RPC allowlist and TS wire types added; OpenSpec updated and tests cover contracts.

- **Migration**
  - Apply `supabase/migrations/20260712112500_technical_configuration_dossier_foundation.sql` when approved.
  - Ensure JWT claims include `user_id` and `app_role`/`role` for global/admin; archived dossiers remain readable via get; no restore/delete RPCs.

<sup>Written for commit a7def0868c05409265b9baf4a135217f7c2d750b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added technical configuration dossier management with listing, viewing, creating, updating, and archiving.
  * Added pagination, archived-item filtering, audit details, and revision tracking to prevent stale updates.
  * Added support for dossier metadata, including device type, name, and description.

* **Bug Fixes**
  * Improved validation error classification for invalid requests.

* **Tests**
  * Added coverage for dossier permissions, migration structure, RPC access, validation, revision handling, and archive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->