### PR TITLE
fix: cap ZBS requester template field

### DIFF
--- a/src/lib/zbs/__tests__/dispatcher.test.ts
+++ b/src/lib/zbs/__tests__/dispatcher.test.ts
@@ -89,6 +89,48 @@ describe("mapRepairRequestTemplateData", () => {
     expect(new TextEncoder().encode(templateData.issue_summary).length).toBeLessThanOrEqual(32)
   })
 
+  it("normalizes and truncates requester to the provider character limit", () => {
+    const templateData = mapRepairRequestTemplateData({
+      ...baseOutboxRow,
+      template_data: {
+        ...baseOutboxRow.template_data,
+        requester: "Khoa Hồi Sức Tích Cực - Chống Độc",
+      },
+    })
+
+    expect(templateData.requester).toBe("Khoa Hồi Sức Tích Cực - Chố...")
+    expect([...templateData.requester]).toHaveLength(30)
+  })
+
+  it.each([
+    {
+      name: "keeps an exact 30-character requester unchanged",
+      requester: "Đ".repeat(30),
+      expected: "Đ".repeat(30),
+    },
+    {
+      name: "normalizes a short requester to NFC",
+      requester: "  Khoa Hồi Sức  ",
+      expected: "Khoa Hồi Sức",
+    },
+    {
+      name: "does not split a four-byte Unicode code point",
+      requester: "12345678901234567890123456😀abcdef",
+      expected: "12345678901234567890123456😀...",
+    },
+  ])("$name", ({ requester, expected }) => {
+    const templateData = mapRepairRequestTemplateData({
+      ...baseOutboxRow,
+      template_data: {
+        ...baseOutboxRow.template_data,
+        requester,
+      },
+    })
+
+    expect(templateData.requester).toBe(expected)
+    expect([...templateData.requester].length).toBeLessThanOrEqual(30)
+  })
+
   it("uses documented fallbacks and fixed issue_summary before request construction", () => {
     const longIssueSummary = "Loi ".repeat(80)
 

--- a/src/lib/zbs/dispatcher.ts
+++ b/src/lib/zbs/dispatcher.ts
@@ -9,10 +9,14 @@ export const ZALO_ZBS_ACCESS_TOKEN_HEADER_PLACEHOLDER = "<ZALO_ZBS_ACCESS_TOKEN>
 export const ZALO_ZBS_REPAIR_TEMPLATE_ID_PLACEHOLDER = "<ZALO_ZBS_REPAIR_TEMPLATE_ID>"
 /** Fixed provider-safe text for the constrained `issue_summary` ZBS template field. */
 export const ZBS_REPAIR_ISSUE_SUMMARY = "Lỗi thiết bị"
+/** Maximum character length accepted by the approved `requester` template field. */
+const ZBS_REQUESTER_MAX_CHARACTERS = 30
 /** RPC boundary for reading pending ZBS outbox rows through the app proxy. */
 export const ZBS_PENDING_DISPATCH_RPC = "zbs_notification_outbox_pending_for_dispatch"
 
 type JsonObject = Record<string, unknown>
+
+const ZBS_TRUNCATION_SUFFIX = "..."
 
 export interface ZbsNotificationOutboxRow {
   id: string
@@ -133,6 +137,21 @@ function firstPresent(...values: string[]): string {
   return values.find((value) => value.length > 0) ?? "Khong ro"
 }
 
+function providerSafeRequester(value: unknown): string {
+  const requester = firstPresent(stringValue(value)).normalize("NFC")
+  const characters = [...requester]
+
+  if (characters.length <= ZBS_REQUESTER_MAX_CHARACTERS) {
+    return requester
+  }
+
+  const suffixLength = [...ZBS_TRUNCATION_SUFFIX].length
+  const contentLimit = ZBS_REQUESTER_MAX_CHARACTERS - suffixLength
+  const truncated = characters.slice(0, contentLimit).join("")
+
+  return `${truncated}${ZBS_TRUNCATION_SUFFIX}`
+}
+
 function equipmentLabel(templateData: JsonObject): string {
   const equipmentName = stringValue(templateData.equipment_name)
   const equipmentCode = stringValue(templateData.equipment_code)
@@ -171,7 +190,7 @@ export function mapRepairRequestTemplateData(
       stringValue(templateData.ten_don_vi_thue),
       stringValue(templateData.don_vi_thuc_hien)
     ),
-    requester: firstPresent(stringValue(templateData.requester)),
+    requester: providerSafeRequester(templateData.requester),
     issue_summary: ZBS_REPAIR_ISSUE_SUMMARY,
     detail_url: buildDetailUrl(row, options.appBaseUrl),
   }


### PR DESCRIPTION
## Summary
- normalize ZBS requester values to NFC
- keep requester values at or below the approved 30-character limit unchanged
- truncate longer values to 27 Unicode code points plus `...`
- add regression coverage for the live request #492 value, multibyte text, and astral characters

## Root cause
The dispatcher passed `requester` through without enforcing the approved template parameter limit. The two failed outbox rows for repair request #492 carried the same 37-character decomposed requester value.

## Verification
- RED: production requester regression failed before implementation
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test -- src/lib/zbs/__tests__/dispatcher.test.ts src/lib/zbs/__tests__/live-dispatcher.test.ts` (24 tests)
- `node scripts/npm-run.js run react-doctor` (100/100)
- independent code review: no findings

## Operations
After production deploy is Ready, requeue only the two failed outbox rows with `source_id = 492` after explicit live-DB approval.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the ZBS `requester` field 30-character limit and NFC normalization to prevent provider rejections. Truncates overlong values safely with `...` and adds regression tests, including for live request #492.

- **Bug Fixes**
  - Normalize `requester` to NFC.
  - Cap at 30 characters; truncate to 27 + `...` when longer.
  - Handle multibyte and astral characters without splitting.
  - Updated dispatcher to apply the cap; added focused tests.

- **Migration**
  - After deploy, requeue only the two failed outbox rows with `source_id = 492` (after live DB approval).

<sup>Written for commit 9d2c47722af9a150e8b970138683e0150a75f517. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved requester name formatting for ZBS requests.
  * Normalized special characters and whitespace.
  * Limited requester values to 30 characters without splitting emoji or other Unicode characters.
  * Added an ellipsis when names are truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->