### PR TITLE
feat: add technical configuration P3A workspace

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -75,7 +75,7 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 - [x] P3A.2 Thêm dossier list/create/open workflow.
 - [x] P3A.3 Thêm workspace/tab shell làm integration surface cho các phase sau.
 - [x] P3A.4 Giữ shell mỏng và theo dõi extraction threshold.
-- [ ] P3A.5 Viết role visibility, list/create và browser tests.
+- [x] P3A.5 Viết role visibility, list/create và browser tests.
 
 ## Phase P3B - Manual Baseline Editor And Save Conflicts
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -71,10 +71,10 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 
 ## Phase P3A - Route, Workspace Shell And Dossier List
 
-- [ ] P3A.1 Thêm route và navigation boundary chỉ cho `admin/global`.
-- [ ] P3A.2 Thêm dossier list/create/open workflow.
-- [ ] P3A.3 Thêm workspace/tab shell làm integration surface cho các phase sau.
-- [ ] P3A.4 Giữ shell mỏng và theo dõi extraction threshold.
+- [x] P3A.1 Thêm route và navigation boundary chỉ cho `admin/global`.
+- [x] P3A.2 Thêm dossier list/create/open workflow.
+- [x] P3A.3 Thêm workspace/tab shell làm integration surface cho các phase sau.
+- [x] P3A.4 Giữ shell mỏng và theo dõi extraction threshold.
 - [ ] P3A.5 Viết role visibility, list/create và browser tests.
 
 ## Phase P3B - Manual Baseline Editor And Save Conflicts

--- a/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
+++ b/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
@@ -1,0 +1,229 @@
+"use client"
+
+import * as React from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { AlertCircle, ListChecks, Plus, RefreshCw, ShieldAlert } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { isGlobalRole } from "@/lib/rbac"
+
+import { TechnicalConfigurationDossierForm } from "./_components/TechnicalConfigurationDossierForm"
+import { TechnicalConfigurationDossierTable } from "./_components/TechnicalConfigurationDossierTable"
+import { TechnicalConfigurationWorkspaceShell } from "./_components/TechnicalConfigurationWorkspaceShell"
+import {
+  createTechnicalConfigurationDossier,
+  getTechnicalConfigurationDossier,
+  listTechnicalConfigurationDossiers,
+} from "./technical-configuration-rpc"
+import type {
+  TechnicalConfigurationDossierCreateRpcArgs,
+  TechnicalConfigurationDossierWire,
+} from "./types"
+
+const DOSSIER_PAGE_SIZE = 20
+const DOSSIER_QUERY_ROOT = ["technical-configurations", "dossiers"] as const
+
+type TechnicalConfigurationsClientProps = {
+  role?: string | null
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback
+}
+
+/** Orchestrates dossier listing, creation, and workspace selection for global roles. */
+export function TechnicalConfigurationsClient({
+  role,
+}: Readonly<TechnicalConfigurationsClientProps>) {
+  const queryClient = useQueryClient()
+  const canAccess = isGlobalRole(role)
+  const [page, setPage] = React.useState(1)
+  const [isCreateOpen, setIsCreateOpen] = React.useState(false)
+  const [openingDossierId, setOpeningDossierId] = React.useState<string | null>(null)
+  const [openDossierError, setOpenDossierError] = React.useState<unknown>(null)
+  const [selectedDossier, setSelectedDossier] =
+    React.useState<TechnicalConfigurationDossierWire | null>(null)
+
+  const dossierListQuery = useQuery({
+    queryKey: [...DOSSIER_QUERY_ROOT, { page, pageSize: DOSSIER_PAGE_SIZE }],
+    queryFn: ({ signal }) =>
+      listTechnicalConfigurationDossiers(
+        {
+          p_page: page,
+          p_page_size: DOSSIER_PAGE_SIZE,
+          p_include_archived: false,
+        },
+        signal
+      ),
+    enabled: canAccess,
+    staleTime: 30_000,
+  })
+
+  const createDossierMutation = useMutation({
+    mutationFn: createTechnicalConfigurationDossier,
+    onSuccess: async (response) => {
+      setSelectedDossier(response.data)
+      setIsCreateOpen(false)
+      await queryClient.invalidateQueries({ queryKey: DOSSIER_QUERY_ROOT })
+    },
+  })
+
+  const handleCreateOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (open && openingDossierId) {
+        return
+      }
+
+      if (open) {
+        createDossierMutation.reset()
+      }
+      setIsCreateOpen(open)
+    },
+    [createDossierMutation, openingDossierId]
+  )
+
+  const handleCreate = React.useCallback(
+    async (args: TechnicalConfigurationDossierCreateRpcArgs) => {
+      await createDossierMutation.mutateAsync(args)
+    },
+    [createDossierMutation]
+  )
+
+  const handleOpen = React.useCallback(
+    async (id: string) => {
+      if (openingDossierId) {
+        return
+      }
+
+      setOpeningDossierId(id)
+      setOpenDossierError(null)
+
+      try {
+        const response = await queryClient.fetchQuery({
+          queryKey: [...DOSSIER_QUERY_ROOT, "detail", id],
+          queryFn: () => getTechnicalConfigurationDossier(id),
+          staleTime: 30_000,
+        })
+        setSelectedDossier(response.data)
+      } catch (error) {
+        setOpenDossierError(error)
+      } finally {
+        setOpeningDossierId(null)
+      }
+    },
+    [openingDossierId, queryClient]
+  )
+
+  if (!canAccess) {
+    return (
+      <main className="mx-auto flex min-h-[60vh] max-w-2xl items-center px-4 py-10 sm:px-6">
+        <section className="w-full border-y py-10 text-center">
+          <ShieldAlert className="mx-auto size-9 text-destructive" aria-hidden="true" />
+          <h1 className="mt-4 text-xl font-semibold">Truy cập bị hạn chế</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Khu vực cấu hình kỹ thuật chỉ dành cho quản trị viên hệ thống.
+          </p>
+        </section>
+      </main>
+    )
+  }
+
+  if (selectedDossier) {
+    return (
+      <TechnicalConfigurationWorkspaceShell
+        dossier={selectedDossier}
+        onBack={() => setSelectedDossier(null)}
+      />
+    )
+  }
+
+  const listError = dossierListQuery.isError
+    ? getErrorMessage(dossierListQuery.error, "Không thể tải danh sách hồ sơ.")
+    : null
+  const openError = openDossierError
+    ? getErrorMessage(openDossierError, "Không thể mở hồ sơ.")
+    : null
+
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <header className="flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-3">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-md border bg-muted">
+              <ListChecks className="size-5 text-foreground" aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold">Cấu hình kỹ thuật</h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Quản lý hồ sơ cấu hình độc lập theo từng loại thiết bị.
+              </p>
+            </div>
+          </div>
+        </div>
+        <Button
+          className="w-full sm:w-auto"
+          disabled={openingDossierId !== null}
+          onClick={() => handleCreateOpenChange(true)}
+        >
+          <Plus className="size-4" aria-hidden="true" />
+          Tạo hồ sơ
+        </Button>
+      </header>
+
+      <section className="mt-6 space-y-4" aria-label="Danh sách hồ sơ cấu hình">
+        {listError ? (
+          <Alert variant="destructive">
+            <AlertCircle className="size-4" />
+            <AlertTitle>Không thể tải dữ liệu</AlertTitle>
+            <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <span>{listError}</span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void dossierListQuery.refetch()}
+              >
+                <RefreshCw className="size-4" aria-hidden="true" />
+                Thử lại
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {openError ? (
+          <Alert variant="destructive">
+            <AlertCircle className="size-4" />
+            <AlertTitle>Không thể mở hồ sơ</AlertTitle>
+            <AlertDescription>{openError}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        {!listError ? (
+          <TechnicalConfigurationDossierTable
+            dossiers={dossierListQuery.data?.data ?? []}
+            isLoading={dossierListQuery.isLoading}
+            openingDossierId={openingDossierId}
+            page={dossierListQuery.data?.page ?? page}
+            pageSize={dossierListQuery.data?.page_size ?? DOSSIER_PAGE_SIZE}
+            total={dossierListQuery.data?.total ?? 0}
+            onOpen={(id) => void handleOpen(id)}
+            onPageChange={setPage}
+          />
+        ) : null}
+      </section>
+
+      <TechnicalConfigurationDossierForm
+        open={isCreateOpen}
+        isSubmitting={createDossierMutation.isPending}
+        errorMessage={
+          createDossierMutation.isError
+            ? getErrorMessage(createDossierMutation.error, "Không thể tạo hồ sơ.")
+            : null
+        }
+        onOpenChange={handleCreateOpenChange}
+        onSubmit={handleCreate}
+      />
+    </main>
+  )
+}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -1,0 +1,321 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  TechnicalConfigurationDossierListWireResponse,
+  TechnicalConfigurationDossierWire,
+  TechnicalConfigurationDossierWireResponse,
+} from "../types"
+import * as clientModule from "../TechnicalConfigurationsClient"
+import * as pageModule from "../page"
+import { TechnicalConfigurationDossierForm } from "../_components/TechnicalConfigurationDossierForm"
+import { TechnicalConfigurationDossierTable } from "../_components/TechnicalConfigurationDossierTable"
+
+const P3A_FILES = [
+  "page.tsx",
+  "TechnicalConfigurationsClient.tsx",
+  "_components/TechnicalConfigurationWorkspaceShell.tsx",
+  "_components/TechnicalConfigurationDossierTable.tsx",
+  "_components/TechnicalConfigurationDossierForm.tsx",
+] as const
+
+const mocks = vi.hoisted(() => ({
+  listDossiers: vi.fn(),
+  getDossier: vi.fn(),
+  createDossier: vi.fn(),
+  pageRole: "global",
+}))
+
+vi.mock("@/app/(app)/_components/AuthenticatedPageBoundary", () => ({
+  AuthenticatedPageBoundary: ({
+    children,
+  }: {
+    children: (user: { role: string }) => React.ReactNode
+  }) => <>{children({ role: mocks.pageRole })}</>,
+}))
+
+vi.mock("@/app/(app)/_components/AuthenticatedPageFallbacks", () => ({
+  AuthenticatedPageSkeletonFallback: () => <div>Loading auth</div>,
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  listTechnicalConfigurationDossiers: (...args: unknown[]) => mocks.listDossiers(...args),
+  getTechnicalConfigurationDossier: (...args: unknown[]) => mocks.getDossier(...args),
+  createTechnicalConfigurationDossier: (...args: unknown[]) => mocks.createDossier(...args),
+}))
+
+type TechnicalConfigurationsClientContract = React.ComponentType<{
+  role?: string | null
+}>
+
+const TechnicalConfigurationsClient = (
+  clientModule as { TechnicalConfigurationsClient?: TechnicalConfigurationsClientContract }
+).TechnicalConfigurationsClient
+
+const TechnicalConfigurationsPage = (pageModule as { default?: React.ComponentType }).default
+
+const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy siêu âm",
+  name: "Cấu hình máy siêu âm",
+  description: "Cấu hình chuẩn",
+  revision: 1,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-13T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-13T00:00:00.000Z",
+  updated_by: 1,
+}
+
+const emptyList: TechnicalConfigurationDossierListWireResponse = {
+  data: [],
+  total: 0,
+  page: 1,
+  page_size: 20,
+}
+
+function renderWithQueryClient(node: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  render(<QueryClientProvider client={queryClient}>{node}</QueryClientProvider>)
+
+  return queryClient
+}
+
+function renderClient(role: string) {
+  expect(TechnicalConfigurationsClient).toEqual(expect.any(Function))
+  if (!TechnicalConfigurationsClient) return
+
+  return renderWithQueryClient(<TechnicalConfigurationsClient role={role} />)
+}
+
+describe("technical configuration dossier shell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.pageRole = "global"
+    mocks.listDossiers.mockResolvedValue(emptyList)
+  })
+
+  it("keeps the P3A route, orchestrator and views in separate files", () => {
+    const moduleRoot = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
+
+    expect(P3A_FILES.map((file) => fs.existsSync(path.join(moduleRoot, file)))).toEqual(
+      P3A_FILES.map(() => true)
+    )
+  })
+
+  it("uses the shared auth boundary and isGlobalRole without a direct global comparison", () => {
+    const moduleRoot = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
+    const pageSource = fs.readFileSync(path.join(moduleRoot, "page.tsx"), "utf8")
+    const clientSource = fs.readFileSync(
+      path.join(moduleRoot, "TechnicalConfigurationsClient.tsx"),
+      "utf8"
+    )
+
+    expect(pageSource).toMatch(/^"use client"/)
+    expect(pageSource).toContain("AuthenticatedPageBoundary")
+    expect(clientSource).toContain("isGlobalRole")
+    expect(clientSource).not.toMatch(/role\s*===\s*["']global["']/)
+  })
+
+  it("forwards the authenticated route role into the module boundary", () => {
+    expect(TechnicalConfigurationsPage).toEqual(expect.any(Function))
+    if (!TechnicalConfigurationsPage) return
+
+    mocks.pageRole = "regional_leader"
+    renderWithQueryClient(<TechnicalConfigurationsPage />)
+
+    expect(screen.getByRole("heading", { name: "Truy cập bị hạn chế" })).toBeInTheDocument()
+    expect(mocks.listDossiers).not.toHaveBeenCalled()
+  })
+
+  it.each(["global", "admin"])("loads the dossier list for %s", async (role) => {
+    renderClient(role)
+
+    expect(await screen.findByRole("heading", { name: "Cấu hình kỹ thuật" })).toBeInTheDocument()
+    await waitFor(() => expect(mocks.listDossiers).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText("Chưa có hồ sơ cấu hình")).toBeInTheDocument()
+  })
+
+  it("shows an unauthorized state without loading data for a denied role", () => {
+    renderClient("regional_leader")
+
+    expect(screen.getByRole("heading", { name: "Truy cập bị hạn chế" })).toBeInTheDocument()
+    expect(mocks.listDossiers).not.toHaveBeenCalled()
+  })
+
+  it("shows a stable loading state while the dossier list is pending", () => {
+    mocks.listDossiers.mockReturnValue(new Promise(() => undefined))
+
+    renderClient("global")
+
+    expect(screen.getByLabelText("Đang tải hồ sơ cấu hình")).toBeInTheDocument()
+  })
+
+  it("creates only after explicit save and opens the created dossier shell", async () => {
+    const user = userEvent.setup()
+    const createResponse: TechnicalConfigurationDossierWireResponse = { data: dossier }
+    mocks.createDossier.mockResolvedValue(createResponse)
+
+    renderClient("global")
+
+    await user.click(await screen.findByRole("button", { name: "Tạo hồ sơ" }))
+    await user.type(screen.getByLabelText("Loại thiết bị"), dossier.device_type_name)
+    await user.type(screen.getByLabelText("Tên hồ sơ"), dossier.name)
+    await user.type(screen.getByLabelText("Mô tả"), dossier.description ?? "")
+
+    expect(mocks.createDossier).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Lưu hồ sơ" }))
+
+    await waitFor(() =>
+      expect(mocks.createDossier).toHaveBeenCalledWith({
+        p_device_type_name: dossier.device_type_name,
+        p_name: dossier.name,
+        p_description: dossier.description,
+        p_expected_revision: 0,
+      })
+    )
+
+    expect(await screen.findByRole("heading", { name: dossier.name })).toBeInTheDocument()
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent?.trim())).toEqual([
+      "Cấu hình cơ sở",
+      "Phương án",
+      "So sánh & đánh giá",
+    ])
+    expect(screen.getByRole("tab", { name: "Phương án" })).toBeDisabled()
+    expect(screen.getByRole("tab", { name: "So sánh & đánh giá" })).toBeDisabled()
+    expect(screen.queryByRole("button", { name: "Thêm nhóm" })).not.toBeInTheDocument()
+  })
+
+  it("gets the selected dossier before opening its workspace", async () => {
+    const user = userEvent.setup()
+    mocks.listDossiers.mockResolvedValue({
+      data: [dossier],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    } satisfies TechnicalConfigurationDossierListWireResponse)
+    mocks.getDossier.mockResolvedValue({
+      data: dossier,
+    } satisfies TechnicalConfigurationDossierWireResponse)
+
+    const queryClient = renderClient("admin")
+
+    await user.click(await screen.findByRole("button", { name: `Mở ${dossier.name}` }))
+
+    await waitFor(() => expect(mocks.getDossier).toHaveBeenCalledWith(dossier.id))
+    expect(await screen.findByRole("heading", { name: dossier.name })).toBeInTheDocument()
+    expect(
+      queryClient?.getQueryData(["technical-configurations", "dossiers", "detail", dossier.id])
+    ).toEqual({ data: dossier })
+  })
+
+  it("blocks a second dossier open while the first request is pending", async () => {
+    const user = userEvent.setup()
+    const secondDossier = {
+      ...dossier,
+      id: "dossier-2",
+      name: "Cấu hình máy X-quang",
+    }
+    mocks.listDossiers.mockResolvedValue({
+      data: [dossier, secondDossier],
+      total: 2,
+      page: 1,
+      page_size: 20,
+    } satisfies TechnicalConfigurationDossierListWireResponse)
+    mocks.getDossier.mockReturnValue(new Promise(() => undefined))
+
+    renderClient("global")
+
+    const firstOpenButton = await screen.findByRole("button", { name: `Mở ${dossier.name}` })
+    const secondOpenButton = screen.getByRole("button", { name: `Mở ${secondDossier.name}` })
+    await user.click(firstOpenButton)
+
+    expect(firstOpenButton).toBeDisabled()
+    expect(secondOpenButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Tạo hồ sơ" })).toBeDisabled()
+  })
+
+  it("keeps create form values visible when explicit save fails", async () => {
+    const user = userEvent.setup()
+    mocks.createDossier.mockRejectedValue(new Error("Tên hồ sơ đã tồn tại"))
+
+    renderClient("global")
+
+    await user.click(await screen.findByRole("button", { name: "Tạo hồ sơ" }))
+    await user.type(screen.getByLabelText("Loại thiết bị"), dossier.device_type_name)
+    await user.type(screen.getByLabelText("Tên hồ sơ"), dossier.name)
+    await user.click(screen.getByRole("button", { name: "Lưu hồ sơ" }))
+
+    expect(await screen.findByText("Tên hồ sơ đã tồn tại")).toBeInTheDocument()
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue(dossier.name)
+  })
+
+  it("keeps the create dialog open when dismiss is requested during save", async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <TechnicalConfigurationDossierForm
+        open
+        isSubmitting
+        errorMessage={null}
+        onOpenChange={onOpenChange}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    await user.keyboard("{Escape}")
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it("offers a way back when a now-empty later page is returned", async () => {
+    const user = userEvent.setup()
+    const onPageChange = vi.fn()
+
+    render(
+      <TechnicalConfigurationDossierTable
+        dossiers={[]}
+        isLoading={false}
+        openingDossierId={null}
+        page={2}
+        pageSize={20}
+        total={1}
+        onOpen={vi.fn()}
+        onPageChange={onPageChange}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Quay lại trang trước" }))
+
+    expect(onPageChange).toHaveBeenCalledWith(1)
+  })
+
+  it("keeps the route and client orchestrators below the extraction threshold", () => {
+    const moduleRoot = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
+
+    for (const file of [
+      "page.tsx",
+      "TechnicalConfigurationsClient.tsx",
+      "_components/TechnicalConfigurationWorkspaceShell.tsx",
+    ]) {
+      const lineCount = fs.readFileSync(path.join(moduleRoot, file), "utf8").split("\n").length
+      expect(lineCount).toBeLessThan(350)
+    }
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  TechnicalConfigurationDossierCreateRpcArgs,
+  TechnicalConfigurationDossierListWireResponse,
+} from "../types"
+import * as rpcModule from "../technical-configuration-rpc"
+
+type RpcModuleContract = {
+  listTechnicalConfigurationDossiers?: (
+    args?: {
+      p_page?: number
+      p_page_size?: number
+      p_include_archived?: boolean
+    },
+    signal?: AbortSignal
+  ) => Promise<TechnicalConfigurationDossierListWireResponse>
+  createTechnicalConfigurationDossier?: (
+    args: TechnicalConfigurationDossierCreateRpcArgs,
+    signal?: AbortSignal
+  ) => Promise<unknown>
+}
+
+const rpc = rpcModule as RpcModuleContract
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("technical configuration RPC adapter", () => {
+  it("has a module-local adapter instead of changing the shared RPC client", () => {
+    const adapterPath = path.resolve(
+      process.cwd(),
+      "src/app/(app)/technical-configurations/technical-configuration-rpc.ts"
+    )
+
+    expect(fs.existsSync(adapterPath)).toBe(true)
+  })
+
+  it("posts typed dossier list arguments through the RPC proxy", async () => {
+    expect(rpc.listTechnicalConfigurationDossiers).toEqual(expect.any(Function))
+    if (!rpc.listTechnicalConfigurationDossiers) return
+
+    const response: TechnicalConfigurationDossierListWireResponse = {
+      data: [],
+      total: 0,
+      page: 2,
+      page_size: 10,
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(
+      rpc.listTechnicalConfigurationDossiers({
+        p_page: 2,
+        p_page_size: 10,
+        p_include_archived: false,
+      })
+    ).resolves.toEqual(response)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/rpc/technical_configuration_dossiers_list",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          p_page: 2,
+          p_page_size: 10,
+          p_include_archived: false,
+        }),
+      })
+    )
+  })
+
+  it("forces dossier creation to use the frozen expected revision", async () => {
+    expect(rpc.createTechnicalConfigurationDossier).toEqual(expect.any(Function))
+    if (!rpc.createTechnicalConfigurationDossier) return
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { id: "dossier-1" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await rpc.createTechnicalConfigurationDossier({
+      p_device_type_name: "Máy siêu âm",
+      p_name: "Cấu hình máy siêu âm",
+      p_description: null,
+      p_expected_revision: 0,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/rpc/technical_configuration_dossiers_create",
+      expect.objectContaining({
+        body: JSON.stringify({
+          p_device_type_name: "Máy siêu âm",
+          p_name: "Cấu hình máy siêu âm",
+          p_description: null,
+          p_expected_revision: 0,
+        }),
+      })
+    )
+  })
+
+  it("preserves HTTP status and PostgREST error metadata", async () => {
+    expect(rpc.listTechnicalConfigurationDossiers).toEqual(expect.any(Function))
+    if (!rpc.listTechnicalConfigurationDossiers) return
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "42501",
+              message: "Access denied",
+              details: "global role required",
+              hint: "Use an authorized session",
+            },
+          }),
+          {
+            status: 403,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
+      )
+    )
+
+    await expect(rpc.listTechnicalConfigurationDossiers()).rejects.toMatchObject({
+      name: "TechnicalConfigurationRpcError",
+      status: 403,
+      code: "42501",
+      message: "Access denied",
+      details: "global role required",
+      hint: "Use an authorized session",
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import * as React from "react"
+import { AlertCircle, Loader2 } from "lucide-react"
+
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+import type { TechnicalConfigurationDossierCreateRpcArgs } from "../types"
+
+type TechnicalConfigurationDossierFormProps = {
+  open: boolean
+  isSubmitting: boolean
+  errorMessage: string | null
+  onOpenChange: (open: boolean) => void
+  onSubmit: (args: TechnicalConfigurationDossierCreateRpcArgs) => Promise<void>
+}
+
+const EMPTY_FORM = {
+  deviceTypeName: "",
+  name: "",
+  description: "",
+}
+
+/** Renders the explicit-save form for creating a configuration dossier. */
+export function TechnicalConfigurationDossierForm({
+  open,
+  isSubmitting,
+  errorMessage,
+  onOpenChange,
+  onSubmit,
+}: Readonly<TechnicalConfigurationDossierFormProps>) {
+  const [form, setForm] = React.useState(EMPTY_FORM)
+
+  React.useEffect(() => {
+    if (!open) {
+      setForm(EMPTY_FORM)
+    }
+  }, [open])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    try {
+      await onSubmit({
+        p_device_type_name: form.deviceTypeName.trim(),
+        p_name: form.name.trim(),
+        p_description: form.description.trim() || null,
+        p_expected_revision: 0,
+      })
+    } catch {
+      // The mutation error is rendered without clearing locally edited values.
+    }
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && isSubmitting) {
+      return
+    }
+
+    onOpenChange(nextOpen)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-h-[90dvh] overflow-y-auto sm:max-w-xl"
+        closeLabel="Đóng"
+        showCloseButton={!isSubmitting}
+      >
+        <DialogHeader>
+          <DialogTitle>Tạo hồ sơ cấu hình</DialogTitle>
+          <DialogDescription>
+            Hồ sơ là gốc độc lập cho một dòng cấu hình thiết bị.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="technical-configuration-device-type">Loại thiết bị</Label>
+            <Input
+              id="technical-configuration-device-type"
+              value={form.deviceTypeName}
+              required
+              disabled={isSubmitting}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, deviceTypeName: event.target.value }))
+              }
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="technical-configuration-name">Tên hồ sơ</Label>
+            <Input
+              id="technical-configuration-name"
+              value={form.name}
+              required
+              disabled={isSubmitting}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="technical-configuration-description">Mô tả</Label>
+            <Textarea
+              id="technical-configuration-description"
+              value={form.description}
+              rows={4}
+              disabled={isSubmitting}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, description: event.target.value }))
+              }
+            />
+          </div>
+
+          {errorMessage ? (
+            <Alert variant="destructive">
+              <AlertCircle className="size-4" />
+              <AlertDescription>{errorMessage}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isSubmitting}
+              onClick={() => onOpenChange(false)}
+            >
+              Hủy
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
+              Lưu hồ sơ
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx
@@ -1,0 +1,160 @@
+import { ArrowRight, ChevronLeft, ChevronRight, FileText, Loader2 } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { formatVietnamDateTime } from "@/lib/vietnam-date-format"
+
+import type { TechnicalConfigurationDossierWire } from "../types"
+
+type TechnicalConfigurationDossierTableProps = {
+  dossiers: TechnicalConfigurationDossierWire[]
+  isLoading: boolean
+  openingDossierId: string | null
+  page: number
+  pageSize: number
+  total: number
+  onOpen: (id: string) => void
+  onPageChange: (page: number) => void
+}
+
+/** Renders the paginated dossier list and open actions. */
+export function TechnicalConfigurationDossierTable({
+  dossiers,
+  isLoading,
+  openingDossierId,
+  page,
+  pageSize,
+  total,
+  onOpen,
+  onPageChange,
+}: Readonly<TechnicalConfigurationDossierTableProps>) {
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3" aria-label="Đang tải hồ sơ cấu hình">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    )
+  }
+
+  if (dossiers.length === 0) {
+    return (
+      <div className="border-y py-12 text-center">
+        <FileText className="mx-auto size-9 text-muted-foreground" aria-hidden="true" />
+        <h2 className="mt-4 text-base font-semibold">Chưa có hồ sơ cấu hình</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Tạo hồ sơ đầu tiên để bắt đầu không gian làm việc.
+        </p>
+        {page > 1 ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="mt-5"
+            onClick={() => onPageChange(page - 1)}
+          >
+            <ChevronLeft className="size-4" aria-hidden="true" />
+            Quay lại trang trước
+          </Button>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-hidden rounded-md border">
+        <Table className="min-w-[760px]">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Hồ sơ</TableHead>
+              <TableHead>Loại thiết bị</TableHead>
+              <TableHead>Cập nhật</TableHead>
+              <TableHead className="w-24 text-right">Thao tác</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {dossiers.map((dossier) => {
+              const isOpening = openingDossierId === dossier.id
+
+              return (
+                <TableRow key={dossier.id}>
+                  <TableCell className="max-w-[320px]">
+                    <div className="font-medium text-foreground">{dossier.name}</div>
+                    <div className="mt-1 truncate text-xs text-muted-foreground">
+                      {dossier.description || "Không có mô tả"}
+                    </div>
+                  </TableCell>
+                  <TableCell>{dossier.device_type_name}</TableCell>
+                  <TableCell className="whitespace-nowrap text-muted-foreground">
+                    {formatVietnamDateTime(dossier.updated_at)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={openingDossierId !== null}
+                      aria-label={`Mở ${dossier.name}`}
+                      onClick={() => onOpen(dossier.id)}
+                    >
+                      {isOpening ? (
+                        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                      ) : (
+                        <ArrowRight className="size-4" aria-hidden="true" />
+                      )}
+                      Mở
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {pageCount > 1 ? (
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            Trang {page} / {pageCount}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              aria-label="Trang trước"
+              title="Trang trước"
+              disabled={page <= 1}
+              onClick={() => onPageChange(page - 1)}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              aria-label="Trang sau"
+              title="Trang sau"
+              disabled={page >= pageCount}
+              onClick={() => onPageChange(page + 1)}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -1,0 +1,68 @@
+import { ArrowLeft, ClipboardList, GitCompareArrows, ListChecks, PackageSearch } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+import type { TechnicalConfigurationDossierWire } from "../types"
+
+type TechnicalConfigurationWorkspaceShellProps = {
+  dossier: TechnicalConfigurationDossierWire
+  onBack: () => void
+}
+
+/** Renders the dossier workspace tabs available in the current delivery phase. */
+export function TechnicalConfigurationWorkspaceShell({
+  dossier,
+  onBack,
+}: Readonly<TechnicalConfigurationWorkspaceShellProps>) {
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+      <header className="border-b pb-5">
+        <Button type="button" variant="ghost" className="-ml-3" onClick={onBack}>
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Danh sách hồ sơ
+        </Button>
+
+        <div className="mt-4 flex min-w-0 items-start gap-3">
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-md border bg-muted">
+            <ClipboardList className="size-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <h1 className="break-words text-2xl font-semibold">{dossier.name}</h1>
+            <p className="mt-1 break-words text-sm text-muted-foreground">
+              {dossier.device_type_name}
+              {dossier.description ? ` · ${dossier.description}` : ""}
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <Tabs defaultValue="baseline" className="mt-6">
+        <TabsList className="grid h-auto w-full grid-cols-1 gap-1 sm:grid-cols-3">
+          <TabsTrigger value="baseline" className="min-h-10 gap-2">
+            <ListChecks className="size-4" aria-hidden="true" />
+            Cấu hình cơ sở
+          </TabsTrigger>
+          <TabsTrigger value="options" className="min-h-10 gap-2" disabled>
+            <PackageSearch className="size-4" aria-hidden="true" />
+            Phương án
+          </TabsTrigger>
+          <TabsTrigger value="comparison" className="min-h-10 gap-2" disabled>
+            <GitCompareArrows className="size-4" aria-hidden="true" />
+            So sánh &amp; đánh giá
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="baseline" className="mt-6">
+          <section className="border-y py-12 text-center">
+            <ListChecks className="mx-auto size-9 text-muted-foreground" aria-hidden="true" />
+            <h2 className="mt-4 text-base font-semibold">Không gian cấu hình cơ sở</h2>
+            <p className="mx-auto mt-1 max-w-xl text-sm text-muted-foreground">
+              Trình soạn cấu hình cơ sở sẽ được tích hợp ở phase tiếp theo.
+            </p>
+          </section>
+        </TabsContent>
+      </Tabs>
+    </main>
+  )
+}

--- a/src/app/(app)/technical-configurations/page.tsx
+++ b/src/app/(app)/technical-configurations/page.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { AuthenticatedPageBoundary } from "@/app/(app)/_components/AuthenticatedPageBoundary"
+import { AuthenticatedPageSkeletonFallback } from "@/app/(app)/_components/AuthenticatedPageFallbacks"
+
+import { TechnicalConfigurationsClient } from "./TechnicalConfigurationsClient"
+
+/** Renders the authenticated technical configuration workspace route. */
+export default function TechnicalConfigurationsPage() {
+  return (
+    <AuthenticatedPageBoundary fallback={<AuthenticatedPageSkeletonFallback />}>
+      {(user) => <TechnicalConfigurationsClient role={user.role} />}
+    </AuthenticatedPageBoundary>
+  )
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-rpc.ts
@@ -1,0 +1,107 @@
+import type {
+  TechnicalConfigurationDossierCreateRpcArgs,
+  TechnicalConfigurationDossierGetRpcArgs,
+  TechnicalConfigurationDossierListRpcArgs,
+  TechnicalConfigurationDossierListWireResponse,
+  TechnicalConfigurationDossierWireResponse,
+} from "./types"
+
+type TechnicalConfigurationRpcErrorPayload = {
+  code?: string
+  message?: string
+  details?: string
+  hint?: string
+}
+
+type TechnicalConfigurationRpcRequestOptions = {
+  signal?: AbortSignal
+}
+
+/** Preserves HTTP and PostgREST metadata from technical configuration RPC failures. */
+export class TechnicalConfigurationRpcError extends Error {
+  readonly status: number
+  readonly code?: string
+  readonly details?: string
+  readonly hint?: string
+
+  constructor(status: number, payload: TechnicalConfigurationRpcErrorPayload) {
+    super(payload.message || `RPC failed (${status})`)
+    this.name = "TechnicalConfigurationRpcError"
+    this.status = status
+    this.code = payload.code
+    this.details = payload.details
+    this.hint = payload.hint
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function getErrorPayload(payload: unknown): TechnicalConfigurationRpcErrorPayload {
+  const errorPayload = isRecord(payload) ? (payload.error ?? payload) : payload
+
+  if (typeof errorPayload === "string") {
+    return { message: errorPayload }
+  }
+
+  if (!isRecord(errorPayload)) {
+    return {}
+  }
+
+  return {
+    code: typeof errorPayload.code === "string" ? errorPayload.code : undefined,
+    message: typeof errorPayload.message === "string" ? errorPayload.message : undefined,
+    details: typeof errorPayload.details === "string" ? errorPayload.details : undefined,
+    hint: typeof errorPayload.hint === "string" ? errorPayload.hint : undefined,
+  }
+}
+
+async function callTechnicalConfigurationRpc<TResponse>(
+  fn: string,
+  args: object,
+  options: TechnicalConfigurationRpcRequestOptions = {}
+): Promise<TResponse> {
+  const response = await fetch(`/api/rpc/${encodeURIComponent(fn)}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(args),
+    signal: options.signal,
+  })
+
+  const payload: unknown = await response.json().catch(() => null)
+
+  if (!response.ok) {
+    throw new TechnicalConfigurationRpcError(response.status, getErrorPayload(payload))
+  }
+
+  return payload as TResponse
+}
+
+/** Lists configuration dossiers visible to the authenticated global user. */
+export function listTechnicalConfigurationDossiers(
+  args: TechnicalConfigurationDossierListRpcArgs = {},
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationDossierListWireResponse> {
+  return callTechnicalConfigurationRpc("technical_configuration_dossiers_list", args, { signal })
+}
+
+/** Fetches one configuration dossier by identifier. */
+export function getTechnicalConfigurationDossier(
+  id: string,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationDossierWireResponse> {
+  const args: TechnicalConfigurationDossierGetRpcArgs = { p_id: id }
+
+  return callTechnicalConfigurationRpc("technical_configuration_dossiers_get", args, { signal })
+}
+
+/** Creates a configuration dossier only when the explicit save action is submitted. */
+export function createTechnicalConfigurationDossier(
+  args: TechnicalConfigurationDossierCreateRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationDossierWireResponse> {
+  return callTechnicalConfigurationRpc("technical_configuration_dossiers_create", args, { signal })
+}

--- a/src/components/__tests__/app-navigation.test.ts
+++ b/src/components/__tests__/app-navigation.test.ts
@@ -18,6 +18,15 @@ function getMoreHrefs(role: string): string[] {
 }
 
 describe("app-navigation role filtering", () => {
+  it("shows technical configurations only to global-equivalent roles", () => {
+    expect(getHrefs("global")).toContain("/technical-configurations")
+    expect(getHrefs("admin")).toContain("/technical-configurations")
+
+    for (const role of ["regional_leader", "to_qltb", ...restrictedRoles]) {
+      expect(getHrefs(role)).not.toContain("/technical-configurations")
+    }
+  })
+
   it("hides device quota from restricted roles in the main navigation", () => {
     for (const role of restrictedRoles) {
       expect(getHrefs(role)).not.toContain("/device-quota")

--- a/src/components/__tests__/app-sidebar-nav.test.tsx
+++ b/src/components/__tests__/app-sidebar-nav.test.tsx
@@ -1,12 +1,35 @@
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { render, screen, within } from "@testing-library/react"
-import { ArrowLeftRight, HardHat, Home, Wrench } from "lucide-react"
+import { ArrowLeftRight, HardHat, Home, ListChecks, Wrench } from "lucide-react"
 import { describe, expect, it } from "vitest"
 
 import { AppSidebarNav } from "../app-sidebar-nav"
 
 describe("AppSidebarNav", () => {
+  it("renders technical configurations as one direct sidebar link", () => {
+    render(
+      <AppSidebarNav
+        items={[
+          {
+            href: "/technical-configurations",
+            icon: ListChecks,
+            label: "Cấu hình kỹ thuật",
+            mobileSection: "more",
+          },
+        ]}
+        pathname="/technical-configurations"
+        isSidebarOpen
+        notificationCounts={{ repair: 0, transfer: 0, maintenance: 0 }}
+      />
+    )
+
+    const link = screen.getByRole("link", { name: "Cấu hình kỹ thuật" })
+    expect(link).toHaveAttribute("href", "/technical-configurations")
+    expect(link).toHaveAttribute("aria-current", "page")
+    expect(link).not.toHaveAttribute("aria-haspopup")
+  })
+
   it("renders per-type badges on matching navigation items only", () => {
     render(
       <AppSidebarNav

--- a/src/components/app-navigation.tsx
+++ b/src/components/app-navigation.tsx
@@ -5,6 +5,7 @@ import {
   Calculator,
   HardHat,
   Home,
+  ListChecks,
   Package,
   QrCode,
   Users,
@@ -68,6 +69,13 @@ const APP_NAV_ITEMS: AppNavItem[] = [
   },
   { href: "/reports", icon: BarChart3, label: "Báo cáo", mobileSection: "more" },
   { href: "/qr-scanner", icon: QrCode, label: "Quét QR", mobileSection: "more" },
+  {
+    href: "/technical-configurations",
+    icon: ListChecks,
+    label: "Cấu hình kỹ thuật",
+    mobileSection: "more",
+    requiresGlobal: true,
+  },
   { href: "/users", icon: Users, label: "Người dùng", mobileSection: "more", requiresGlobal: true },
   {
     href: "/activity-logs",


### PR DESCRIPTION
## Summary
- add the global/admin-only technical configuration route and direct sidebar entry via `isGlobalRole()`
- add dossier list, explicit-create, open, pagination, loading/error/unauthorized states
- add the three-tab workspace shell while keeping P3B and later workflows disabled
- preserve HTTP status and PostgREST error metadata in a module-local typed RPC adapter

## TDD and verification
- RED-to-GREEN focused tests for role visibility, route boundary, RPC errors, dossier list/create/open, races, pagination recovery, and workspace tabs
- `format:check`
- `verify:ts-docstrings`
- `verify:no-explicit-any`
- `verify:dedupe`
- `typecheck`
- focused Vitest: 7 files, 66 tests passed
- React Doctor: 100/100
- two independent subagent reviews: approved with no remaining findings

## Scope note
- no P3B baseline editor, supplier workflow, comparison workflow, DB change, or AI behavior
- no dev-server/browser verification was run, per explicit user instruction
- OpenSpec P3A.5 was marked complete by explicit user acceptance

Refs #748