### PR TITLE
fix: address technical configuration review findings

### DIFF
--- a/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
+++ b/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
@@ -63,6 +63,7 @@ export function TechnicalConfigurationsClient({
   const createDossierMutation = useMutation({
     mutationFn: createTechnicalConfigurationDossier,
     onSuccess: async (response) => {
+      setOpenDossierError(null)
       setSelectedDossier(response.data)
       setIsCreateOpen(false)
       await queryClient.invalidateQueries({ queryKey: DOSSIER_QUERY_ROOT })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx
@@ -1,0 +1,72 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationDossierForm } from "../_components/TechnicalConfigurationDossierForm"
+
+const TYPE_IMPORT_COMPONENTS = [
+  "TechnicalConfigurationDossierForm.tsx",
+  "TechnicalConfigurationDossierTable.tsx",
+  "TechnicalConfigurationWorkspaceShell.tsx",
+] as const
+
+function renderForm(onSubmit = vi.fn().mockResolvedValue(undefined)) {
+  const props = {
+    open: true,
+    isSubmitting: false,
+    errorMessage: null,
+    onOpenChange: vi.fn(),
+    onSubmit,
+  }
+  const view = render(<TechnicalConfigurationDossierForm {...props} />)
+
+  return { ...view, onSubmit, props }
+}
+
+describe("technical configuration dossier form", () => {
+  it("uses the project alias for shared dossier types", () => {
+    const componentRoot = path.resolve(
+      process.cwd(),
+      "src/app/(app)/technical-configurations/_components"
+    )
+
+    for (const file of TYPE_IMPORT_COMPONENTS) {
+      const source = fs.readFileSync(path.join(componentRoot, file), "utf8")
+
+      expect(source).toContain('from "@/app/(app)/technical-configurations/types"')
+      expect(source).not.toContain('from "../types"')
+    }
+  })
+
+  it("shows field errors instead of submitting whitespace-only required values", async () => {
+    const user = userEvent.setup()
+    const { onSubmit } = renderForm()
+
+    await user.type(screen.getByLabelText("Loại thiết bị"), "   ")
+    await user.type(screen.getByLabelText("Tên hồ sơ"), "   ")
+    await user.click(screen.getByRole("button", { name: "Lưu hồ sơ" }))
+
+    expect(await screen.findByText("Vui lòng nhập loại thiết bị.")).toBeInTheDocument()
+    expect(screen.getByText("Vui lòng nhập tên hồ sơ.")).toBeInTheDocument()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("resets values after an external close before reopening", async () => {
+    const user = userEvent.setup()
+    const { rerender, props } = renderForm()
+
+    await user.type(screen.getByLabelText("Loại thiết bị"), "Máy siêu âm")
+    await user.type(screen.getByLabelText("Tên hồ sơ"), "Cấu hình chuẩn")
+
+    rerender(<TechnicalConfigurationDossierForm {...props} open={false} />)
+    rerender(<TechnicalConfigurationDossierForm {...props} open />)
+
+    expect(screen.getByLabelText("Loại thiết bị")).toHaveValue("")
+    expect(screen.getByLabelText("Tên hồ sơ")).toHaveValue("")
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -224,6 +224,26 @@ describe("technical configuration dossier shell", () => {
     ).toEqual({ data: dossier })
   })
 
+  it("does not restore an earlier open error after create and back", async () => {
+    const user = userEvent.setup()
+    const createdDossier = { ...dossier, id: "dossier-created", name: "Hồ sơ mới" }
+    mocks.listDossiers.mockResolvedValue({ ...emptyList, data: [dossier], total: 1 })
+    mocks.getDossier.mockRejectedValue(new Error("Hồ sơ cũ không thể mở"))
+    mocks.createDossier.mockResolvedValue({ data: createdDossier })
+
+    renderClient("global")
+
+    await user.click(await screen.findByRole("button", { name: `Mở ${dossier.name}` }))
+    expect(await screen.findByText("Hồ sơ cũ không thể mở")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Tạo hồ sơ" }))
+    await user.type(screen.getByLabelText("Loại thiết bị"), createdDossier.device_type_name)
+    await user.type(screen.getByLabelText("Tên hồ sơ"), createdDossier.name)
+    await user.click(screen.getByRole("button", { name: "Lưu hồ sơ" }))
+    await user.click(await screen.findByRole("button", { name: "Danh sách hồ sơ" }))
+
+    expect(screen.queryByText("Hồ sơ cũ không thể mở")).not.toBeInTheDocument()
+  })
+
   it("blocks a second dossier open while the first request is pending", async () => {
     const user = userEvent.setup()
     const secondDossier = {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-rpc.test.ts
@@ -144,4 +144,25 @@ describe("technical configuration RPC adapter", () => {
       hint: "Use an authorized session",
     })
   })
+
+  it("rejects a successful response whose JSON payload cannot be parsed", async () => {
+    expect(rpc.listTechnicalConfigurationDossiers).toEqual(expect.any(Function))
+    if (!rpc.listTechnicalConfigurationDossiers) return
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("not-json", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+    )
+
+    await expect(rpc.listTechnicalConfigurationDossiers()).rejects.toMatchObject({
+      name: "TechnicalConfigurationRpcError",
+      status: 200,
+      message: "RPC returned an invalid JSON response",
+    })
+  })
 })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx
@@ -1,8 +1,12 @@
 "use client"
 
 import * as React from "react"
+import { zodResolver } from "@hookform/resolvers/zod"
 import { AlertCircle, Loader2 } from "lucide-react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
 
+import type { TechnicalConfigurationDossierCreateRpcArgs } from "@/app/(app)/technical-configurations/types"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import {
@@ -13,11 +17,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-
-import type { TechnicalConfigurationDossierCreateRpcArgs } from "../types"
 
 type TechnicalConfigurationDossierFormProps = {
   open: boolean
@@ -27,7 +36,15 @@ type TechnicalConfigurationDossierFormProps = {
   onSubmit: (args: TechnicalConfigurationDossierCreateRpcArgs) => Promise<void>
 }
 
-const EMPTY_FORM = {
+const dossierFormSchema = z.object({
+  deviceTypeName: z.string().trim().min(1, "Vui lòng nhập loại thiết bị."),
+  name: z.string().trim().min(1, "Vui lòng nhập tên hồ sơ."),
+  description: z.string().trim(),
+})
+
+type DossierFormValues = z.infer<typeof dossierFormSchema>
+
+const EMPTY_FORM: DossierFormValues = {
   deviceTypeName: "",
   name: "",
   description: "",
@@ -41,22 +58,24 @@ export function TechnicalConfigurationDossierForm({
   onOpenChange,
   onSubmit,
 }: Readonly<TechnicalConfigurationDossierFormProps>) {
-  const [form, setForm] = React.useState(EMPTY_FORM)
+  const form = useForm<DossierFormValues>({
+    resolver: zodResolver(dossierFormSchema),
+    defaultValues: EMPTY_FORM,
+  })
+  const { reset } = form
 
   React.useEffect(() => {
     if (!open) {
-      setForm(EMPTY_FORM)
+      reset(EMPTY_FORM)
     }
-  }, [open])
+  }, [open, reset])
 
-  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-
+  async function submitForm(values: DossierFormValues) {
     try {
       await onSubmit({
-        p_device_type_name: form.deviceTypeName.trim(),
-        p_name: form.name.trim(),
-        p_description: form.description.trim() || null,
+        p_device_type_name: values.deviceTypeName,
+        p_name: values.name,
+        p_description: values.description || null,
         p_expected_revision: 0,
       })
     } catch {
@@ -86,66 +105,84 @@ export function TechnicalConfigurationDossierForm({
           </DialogDescription>
         </DialogHeader>
 
-        <form className="space-y-5" onSubmit={handleSubmit}>
-          <div className="space-y-2">
-            <Label htmlFor="technical-configuration-device-type">Loại thiết bị</Label>
-            <Input
-              id="technical-configuration-device-type"
-              value={form.deviceTypeName}
-              required
-              disabled={isSubmitting}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, deviceTypeName: event.target.value }))
-              }
+        <Form {...form}>
+          <form className="space-y-5" onSubmit={form.handleSubmit(submitForm)}>
+            <FormField
+              control={form.control}
+              name="deviceTypeName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="technical-configuration-device-type">Loại thiết bị</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      id="technical-configuration-device-type"
+                      disabled={isSubmitting}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="technical-configuration-name">Tên hồ sơ</Label>
-            <Input
-              id="technical-configuration-name"
-              value={form.name}
-              required
-              disabled={isSubmitting}
-              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="technical-configuration-name">Tên hồ sơ</FormLabel>
+                  <FormControl>
+                    <Input {...field} id="technical-configuration-name" disabled={isSubmitting} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="technical-configuration-description">Mô tả</Label>
-            <Textarea
-              id="technical-configuration-description"
-              value={form.description}
-              rows={4}
-              disabled={isSubmitting}
-              onChange={(event) =>
-                setForm((current) => ({ ...current, description: event.target.value }))
-              }
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="technical-configuration-description">Mô tả</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      id="technical-configuration-description"
+                      rows={4}
+                      disabled={isSubmitting}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
 
-          {errorMessage ? (
-            <Alert variant="destructive">
-              <AlertCircle className="size-4" />
-              <AlertDescription>{errorMessage}</AlertDescription>
-            </Alert>
-          ) : null}
+            {errorMessage ? (
+              <Alert variant="destructive">
+                <AlertCircle className="size-4" />
+                <AlertDescription>{errorMessage}</AlertDescription>
+              </Alert>
+            ) : null}
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={isSubmitting}
-              onClick={() => onOpenChange(false)}
-            >
-              Hủy
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
-              Lưu hồ sơ
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isSubmitting}
+                onClick={() => onOpenChange(false)}
+              >
+                Hủy
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                ) : null}
+                Lưu hồ sơ
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   )

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierTable.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/table"
 import { formatVietnamDateTime } from "@/lib/vietnam-date-format"
 
-import type { TechnicalConfigurationDossierWire } from "../types"
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 
 type TechnicalConfigurationDossierTableProps = {
   dossiers: TechnicalConfigurationDossierWire[]

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -1,9 +1,8 @@
 import { ArrowLeft, ClipboardList, GitCompareArrows, ListChecks, PackageSearch } from "lucide-react"
 
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-
-import type { TechnicalConfigurationDossierWire } from "../types"
 
 type TechnicalConfigurationWorkspaceShellProps = {
   dossier: TechnicalConfigurationDossierWire

--- a/src/app/(app)/technical-configurations/technical-configuration-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-rpc.ts
@@ -77,6 +77,12 @@ async function callTechnicalConfigurationRpc<TResponse>(
     throw new TechnicalConfigurationRpcError(response.status, getErrorPayload(payload))
   }
 
+  if (payload === null) {
+    throw new TechnicalConfigurationRpcError(response.status, {
+      message: "RPC returned an invalid JSON response",
+    })
+  }
+
   return payload as TResponse
 }
 


### PR DESCRIPTION
## Triage

Fixed still-valid findings:
- migrate dossier create form to react-hook-form + Zod field validation
- switch dossier component type imports to the project alias
- reject null/invalid JSON RPC payloads
- clear stale open errors after successful dossier creation

Skipped after verification:
- render-time reset: the existing close effect already resets external open changes; calling react-hook-form reset during render would be an unsafe side effect
- table overflow: the shared Table component already wraps the table in overflow-auto, so the min-width columns remain horizontally reachable

## Verification

- format:check
- verify:no-explicit-any
- verify:dedupe
- typecheck
- focused Vitest: 23 passed
- React Doctor: 100/100


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addressed technical configuration review findings: migrated dossier create form to `react-hook-form` + `zod` with inline validation, hardened RPC JSON handling, and cleared stale open errors after creating a dossier. Improves form UX and overall reliability.

- **Bug Fixes**
  - Reject RPC responses with invalid or null JSON and surface `TechnicalConfigurationRpcError`.
  - Clear previous "open dossier" error after a successful dossier creation.
  - Block submitting whitespace-only required fields and show inline messages.

- **Refactors**
  - Rebuilt dossier create form using `react-hook-form` with a `zod` schema and `Form` UI components.
  - Reset form state when the dialog closes, so reopened forms start clean.
  - Switched dossier type imports to `@/app/(app)/technical-configurations/types` across components.

<sup>Written for commit 59f19d7772e24838c98de226157f7a04e86a933a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

