### PR TITLE
fix(technical-configurations): align sheet and page layout

### DIFF
--- a/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
+++ b/src/app/(app)/technical-configurations/TechnicalConfigurationsClient.tsx
@@ -147,7 +147,7 @@ export function TechnicalConfigurationsClient({
     : null
 
   return (
-    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    <div className="w-full">
       <header className="flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-3">
@@ -225,6 +225,6 @@ export function TechnicalConfigurationsClient({
         onOpenChange={handleCreateOpenChange}
         onSubmit={handleCreate}
       />
-    </main>
+    </div>
   )
 }

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-form.test.tsx
@@ -14,6 +14,10 @@ const TYPE_IMPORT_COMPONENTS = [
   "TechnicalConfigurationDossierTable.tsx",
   "TechnicalConfigurationWorkspaceShell.tsx",
 ] as const
+const TECHNICAL_CONFIGURATION_ROOT = path.resolve(
+  process.cwd(),
+  "src/app/(app)/technical-configurations"
+)
 
 function renderForm(onSubmit = vi.fn().mockResolvedValue(undefined)) {
   const props = {
@@ -30,10 +34,7 @@ function renderForm(onSubmit = vi.fn().mockResolvedValue(undefined)) {
 
 describe("technical configuration dossier form", () => {
   it("uses the project alias for shared dossier types", () => {
-    const componentRoot = path.resolve(
-      process.cwd(),
-      "src/app/(app)/technical-configurations/_components"
-    )
+    const componentRoot = path.join(TECHNICAL_CONFIGURATION_ROOT, "_components")
 
     for (const file of TYPE_IMPORT_COMPONENTS) {
       const source = fs.readFileSync(path.join(componentRoot, file), "utf8")
@@ -41,6 +42,49 @@ describe("technical configuration dossier form", () => {
       expect(source).toContain('from "@/app/(app)/technical-configurations/types"')
       expect(source).not.toContain('from "../types"')
     }
+  })
+
+  it("uses the shared side sheet with a scrollable body and linked footer submit", () => {
+    const source = fs.readFileSync(
+      path.join(TECHNICAL_CONFIGURATION_ROOT, "_components/TechnicalConfigurationDossierForm.tsx"),
+      "utf8"
+    )
+
+    renderForm()
+
+    const form = screen.getByLabelText("Loại thiết bị").closest("form")
+    const submitButton = screen.getByRole("button", { name: "Lưu hồ sơ" })
+
+    expect(source).toContain('from "@/components/shared/SideSheetShell"')
+    expect(source).not.toContain('from "@/components/ui/dialog"')
+    expect(screen.getByRole("dialog")).toHaveClass("sm:max-w-lg")
+    expect(form).toHaveAttribute("id", "technical-configuration-dossier-form")
+    expect(form?.parentElement).toHaveClass("overflow-y-auto", "p-4")
+    expect(submitButton).toHaveAttribute("form", "technical-configuration-dossier-form")
+  })
+
+  it("uses the AppLayoutShell content area without nested page constraints", () => {
+    for (const file of [
+      "TechnicalConfigurationsClient.tsx",
+      "_components/TechnicalConfigurationWorkspaceShell.tsx",
+    ]) {
+      const source = fs.readFileSync(path.join(TECHNICAL_CONFIGURATION_ROOT, file), "utf8")
+
+      expect(source).toContain('<div className="w-full">')
+      expect(source).not.toContain(
+        '<main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">'
+      )
+    }
+  })
+
+  it("localizes the close control and hides it while submitting", () => {
+    const { rerender, props } = renderForm()
+
+    expect(screen.getByRole("button", { name: "Đóng" })).toBeInTheDocument()
+
+    rerender(<TechnicalConfigurationDossierForm {...props} isSubmitting />)
+
+    expect(screen.queryByRole("button", { name: /^(?:Đóng|Close)$/ })).not.toBeInTheDocument()
   })
 
   it("shows field errors instead of submitting whitespace-only required values", async () => {

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDossierForm.tsx
@@ -7,16 +7,9 @@ import { useForm } from "react-hook-form"
 import { z } from "zod"
 
 import type { TechnicalConfigurationDossierCreateRpcArgs } from "@/app/(app)/technical-configurations/types"
+import { SideSheetShell } from "@/components/shared/SideSheetShell"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
 import {
   Form,
   FormControl,
@@ -49,6 +42,7 @@ const EMPTY_FORM: DossierFormValues = {
   name: "",
   description: "",
 }
+const DOSSIER_FORM_ID = "technical-configuration-dossier-form"
 
 /** Renders the explicit-save form for creating a configuration dossier. */
 export function TechnicalConfigurationDossierForm({
@@ -92,98 +86,93 @@ export function TechnicalConfigurationDossierForm({
   }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent
-        className="max-h-[90dvh] overflow-y-auto sm:max-w-xl"
-        closeLabel="Đóng"
-        showCloseButton={!isSubmitting}
-      >
-        <DialogHeader>
-          <DialogTitle>Tạo hồ sơ cấu hình</DialogTitle>
-          <DialogDescription>
-            Hồ sơ là gốc độc lập cho một dòng cấu hình thiết bị.
-          </DialogDescription>
-        </DialogHeader>
+    <SideSheetShell
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Tạo hồ sơ cấu hình"
+      description="Hồ sơ là gốc độc lập cho một dòng cấu hình thiết bị."
+      closeLabel="Đóng"
+      hideCloseButton={isSubmitting}
+      contentClassName="sm:max-w-lg"
+      bodyClassName="overflow-y-auto p-4"
+      footer={
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isSubmitting}
+            onClick={() => onOpenChange(false)}
+          >
+            Hủy
+          </Button>
+          <Button type="submit" form={DOSSIER_FORM_ID} disabled={isSubmitting}>
+            {isSubmitting ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
+            Lưu hồ sơ
+          </Button>
+        </div>
+      }
+    >
+      <Form {...form}>
+        <form id={DOSSIER_FORM_ID} className="space-y-5" onSubmit={form.handleSubmit(submitForm)}>
+          <FormField
+            control={form.control}
+            name="deviceTypeName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="technical-configuration-device-type">Loại thiết bị</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    id="technical-configuration-device-type"
+                    disabled={isSubmitting}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-        <Form {...form}>
-          <form className="space-y-5" onSubmit={form.handleSubmit(submitForm)}>
-            <FormField
-              control={form.control}
-              name="deviceTypeName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel htmlFor="technical-configuration-device-type">Loại thiết bị</FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      id="technical-configuration-device-type"
-                      disabled={isSubmitting}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="technical-configuration-name">Tên hồ sơ</FormLabel>
+                <FormControl>
+                  <Input {...field} id="technical-configuration-name" disabled={isSubmitting} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel htmlFor="technical-configuration-name">Tên hồ sơ</FormLabel>
-                  <FormControl>
-                    <Input {...field} id="technical-configuration-name" disabled={isSubmitting} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="technical-configuration-description">Mô tả</FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    id="technical-configuration-description"
+                    rows={4}
+                    disabled={isSubmitting}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel htmlFor="technical-configuration-description">Mô tả</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      id="technical-configuration-description"
-                      rows={4}
-                      disabled={isSubmitting}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {errorMessage ? (
-              <Alert variant="destructive">
-                <AlertCircle className="size-4" />
-                <AlertDescription>{errorMessage}</AlertDescription>
-              </Alert>
-            ) : null}
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={isSubmitting}
-                onClick={() => onOpenChange(false)}
-              >
-                Hủy
-              </Button>
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? (
-                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                ) : null}
-                Lưu hồ sơ
-              </Button>
-            </DialogFooter>
-          </form>
-        </Form>
-      </DialogContent>
-    </Dialog>
+          {errorMessage ? (
+            <Alert variant="destructive">
+              <AlertCircle className="size-4" />
+              <AlertDescription>{errorMessage}</AlertDescription>
+            </Alert>
+          ) : null}
+        </form>
+      </Form>
+    </SideSheetShell>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -15,7 +15,7 @@ export function TechnicalConfigurationWorkspaceShell({
   onBack,
 }: Readonly<TechnicalConfigurationWorkspaceShellProps>) {
   return (
-    <main className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+    <div className="w-full">
       <header className="border-b pb-5">
         <Button type="button" variant="ghost" className="-ml-3" onClick={onBack}>
           <ArrowLeft className="size-4" aria-hidden="true" />
@@ -62,6 +62,6 @@ export function TechnicalConfigurationWorkspaceShell({
           </section>
         </TabsContent>
       </Tabs>
-    </main>
+    </div>
   )
 }

--- a/src/components/shared/SideSheetShell.tsx
+++ b/src/components/shared/SideSheetShell.tsx
@@ -21,6 +21,8 @@ export interface SideSheetShellProps {
   readonly children: React.ReactNode
   readonly footer?: React.ReactNode
   readonly side?: SheetSide
+  readonly closeLabel?: string
+  readonly hideCloseButton?: boolean
   readonly contentClassName?: string
   readonly headerClassName?: string
   readonly bodyClassName?: string
@@ -38,6 +40,8 @@ export function SideSheetShell({
   children,
   footer,
   side = "right",
+  closeLabel,
+  hideCloseButton,
   contentClassName,
   headerClassName,
   bodyClassName,
@@ -47,7 +51,12 @@ export function SideSheetShell({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side={side} className={cn("w-full p-0", contentClassName)}>
+      <SheetContent
+        side={side}
+        closeLabel={closeLabel}
+        hideCloseButton={hideCloseButton}
+        className={cn("w-full p-0", contentClassName)}
+      >
         <div className="flex h-full flex-col">
           {hasHeader ? (
             <SheetHeader className={cn("border-b p-4", headerClassName)}>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -58,6 +58,7 @@ interface SheetContentProps
   overlayProps?: React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay> & {
     [key: `data-${string}`]: string | undefined
   }
+  closeLabel?: string
   hideCloseButton?: boolean
 }
 
@@ -67,7 +68,15 @@ const SheetContent = React.forwardRef<
   SheetContentProps
 >(
   (
-    { side = "right", className, children, overlayProps, hideCloseButton = false, ...props },
+    {
+      side = "right",
+      className,
+      children,
+      overlayProps,
+      closeLabel = "Close",
+      hideCloseButton = false,
+      ...props
+    },
     ref
   ) => (
     <SheetPortal>
@@ -81,7 +90,7 @@ const SheetContent = React.forwardRef<
         {hideCloseButton ? null : (
           <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
             <X className="size-4" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{closeLabel}</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Content>


### PR DESCRIPTION
## Summary

- replace the dossier create dialog with the shared `SideSheetShell`
- keep the form body scrollable and actions fixed in the sheet footer
- preserve submit-time close protection and the Vietnamese close label
- remove the redundant centered max-width/padding wrappers from the dossier list and workspace

## Validation

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused Vitest: 22 passed
- React Doctor: 100/100

## Follow-up

- #751 tracks evaluating a shared `AppLayoutShell` page container; intentionally excluded here to keep this fix narrow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the technical configurations sheet and page layout for consistency with the app shell. The dossier create flow now uses the shared side sheet with a scrollable body and pinned footer.

- **Refactors**
  - Replaced dialog with `SideSheetShell`; preserved Vietnamese close label and hid close while submitting.
  - Linked footer submit to `technical-configuration-dossier-form` via the `form` attribute.
  - Removed nested max-width/padding wrappers; use `<div className="w-full">` in client and workspace shells.
  - Added `closeLabel` and `hideCloseButton` to shared `SideSheetShell`/`SheetContent`; updated tests to cover layout and i18n.

<sup>Written for commit 3b2a112462a764df0163de93ebb0e5ddc53ca43d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Technical configuration forms now open in a side-sheet layout.
  * Added localized close-button labels and improved accessibility for form submission.
  * Close controls are hidden while forms are submitting.

* **Improvements**
  * Technical configuration pages now use the full available width for content.
  * Updated layouts provide clearer form structure and consistent sizing.

* **Tests**
  * Expanded coverage for side-sheet behavior, responsive layout, localization, and submission states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->