### PR TITLE
feat(technical-configurations): add baseline lifecycle RPCs (P4A)

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/baseline-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-contract.test.ts
@@ -46,9 +46,18 @@ describe("technical configuration baseline RPC contract", () => {
       p_requirement_text: "Dòng 1\nDòng 2",
       p_expected_revision: 4,
     })
+    await technicalConfigurationBaselineRpc.listVersions({
+      p_dossier_id: "dossier-1",
+      p_page: 2,
+      p_page_size: 25,
+    })
     await technicalConfigurationBaselineRpc.lockVersion({
       p_baseline_version_id: "draft-1",
       p_expected_revision: 5,
+    })
+    await technicalConfigurationBaselineRpc.copyVersion({
+      p_source_baseline_version_id: "draft-1",
+      p_expected_revision: 6,
     })
 
     expect(callTechnicalConfigurationRpc).toHaveBeenNthCalledWith(
@@ -71,10 +80,27 @@ describe("technical configuration baseline RPC contract", () => {
     )
     expect(callTechnicalConfigurationRpc).toHaveBeenNthCalledWith(
       3,
+      "technical_configuration_baseline_versions_list",
+      {
+        p_dossier_id: "dossier-1",
+        p_page: 2,
+        p_page_size: 25,
+      }
+    )
+    expect(callTechnicalConfigurationRpc).toHaveBeenNthCalledWith(
+      4,
       "technical_configuration_baseline_lock",
       {
         p_baseline_version_id: "draft-1",
         p_expected_revision: 5,
+      }
+    )
+    expect(callTechnicalConfigurationRpc).toHaveBeenNthCalledWith(
+      5,
+      "technical_configuration_baseline_copy",
+      {
+        p_source_baseline_version_id: "draft-1",
+        p_expected_revision: 6,
       }
     )
   })

--- a/src/app/(app)/technical-configurations/__tests__/baseline-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-contract.test.ts
@@ -14,10 +14,13 @@ describe("technical configuration baseline RPC contract", () => {
     vi.clearAllMocks()
   })
 
-  it("freezes the eleven named P2 RPC mappings", () => {
+  it("freezes the P2 and P4 baseline RPC mappings", () => {
     expect(BASELINE_RPC_FUNCTIONS).toEqual({
       createDraft: "technical_configuration_baseline_draft_create",
       getDraft: "technical_configuration_baseline_draft_get",
+      listVersions: "technical_configuration_baseline_versions_list",
+      lockVersion: "technical_configuration_baseline_lock",
+      copyVersion: "technical_configuration_baseline_copy",
       createGroup: "technical_configuration_baseline_group_create",
       updateGroup: "technical_configuration_baseline_group_update",
       deleteGroup: "technical_configuration_baseline_group_delete",
@@ -43,6 +46,10 @@ describe("technical configuration baseline RPC contract", () => {
       p_requirement_text: "Dòng 1\nDòng 2",
       p_expected_revision: 4,
     })
+    await technicalConfigurationBaselineRpc.lockVersion({
+      p_baseline_version_id: "draft-1",
+      p_expected_revision: 5,
+    })
 
     expect(callTechnicalConfigurationRpc).toHaveBeenNthCalledWith(
       1,
@@ -60,6 +67,14 @@ describe("technical configuration baseline RPC contract", () => {
         p_title: null,
         p_requirement_text: "Dòng 1\nDòng 2",
         p_expected_revision: 4,
+      }
+    )
+    expect(callTechnicalConfigurationRpc).toHaveBeenNthCalledWith(
+      3,
+      "technical_configuration_baseline_lock",
+      {
+        p_baseline_version_id: "draft-1",
+        p_expected_revision: 5,
       }
     )
   })

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline.ts
@@ -5,6 +5,7 @@ import type {
   TechnicalConfigurationBaselineBulkPreviewRpcArgs,
   TechnicalConfigurationBaselineBulkPreviewWireResponse,
   TechnicalConfigurationBaselineCriteriaReorderRpcArgs,
+  TechnicalConfigurationBaselineCopyRpcArgs,
   TechnicalConfigurationBaselineCriterionCreateRpcArgs,
   TechnicalConfigurationBaselineCriterionDeleteRpcArgs,
   TechnicalConfigurationBaselineCriterionUpdateRpcArgs,
@@ -19,9 +20,12 @@ import type {
   TechnicalConfigurationBaselineGroupsReorderRpcArgs,
   TechnicalConfigurationBaselineGroupUpdateRpcArgs,
   TechnicalConfigurationBaselineGroupWireResponse,
+  TechnicalConfigurationBaselineLockRpcArgs,
+  TechnicalConfigurationBaselineVersionsListRpcArgs,
+  TechnicalConfigurationBaselineVersionsListWireResponse,
 } from "../baseline-types"
 
-/** Typed client wrappers for the P2 baseline draft RPCs. */
+/** Typed client wrappers for baseline draft and lifecycle RPCs. */
 export const technicalConfigurationBaselineRpc = {
   createDraft(args: TechnicalConfigurationBaselineDraftCreateRpcArgs) {
     return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineDraftCreateWireResponse>(
@@ -32,6 +36,24 @@ export const technicalConfigurationBaselineRpc = {
   getDraft(args: TechnicalConfigurationBaselineDraftGetRpcArgs) {
     return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineDraftWireResponse>(
       BASELINE_RPC_FUNCTIONS.getDraft,
+      { ...args }
+    )
+  },
+  listVersions(args: TechnicalConfigurationBaselineVersionsListRpcArgs) {
+    return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineVersionsListWireResponse>(
+      BASELINE_RPC_FUNCTIONS.listVersions,
+      { ...args }
+    )
+  },
+  lockVersion(args: TechnicalConfigurationBaselineLockRpcArgs) {
+    return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineDraftWireResponse>(
+      BASELINE_RPC_FUNCTIONS.lockVersion,
+      { ...args }
+    )
+  },
+  copyVersion(args: TechnicalConfigurationBaselineCopyRpcArgs) {
+    return callTechnicalConfigurationRpc<TechnicalConfigurationBaselineDraftCreateWireResponse>(
+      BASELINE_RPC_FUNCTIONS.copyVersion,
       { ...args }
     )
   },
@@ -91,7 +113,7 @@ export const technicalConfigurationBaselineRpc = {
   },
 }
 
-/** Returns the typed P2 baseline draft RPC client. */
+/** Returns the typed baseline RPC client. */
 export function useTechnicalConfigurationBaseline() {
   return technicalConfigurationBaselineRpc
 }

--- a/src/app/(app)/technical-configurations/baseline-types.ts
+++ b/src/app/(app)/technical-configurations/baseline-types.ts
@@ -32,8 +32,12 @@ export interface TechnicalConfigurationBaselineDraftWire {
   dossier_id: string
   version_number: number
   status: TechnicalConfigurationBaselineStatus
+  source_baseline_version_id: string | null
+  source_version_number: number | null
   next_criterion_number: number
   revision: number
+  locked_at: string | null
+  locked_by: number | null
   created_at: string
   created_by: number
   updated_at: string
@@ -49,6 +53,13 @@ export interface TechnicalConfigurationBaselineDraftCreateWireResponse {
   data: TechnicalConfigurationBaselineDraftWire & {
     dossier_revision: number
   }
+}
+
+export interface TechnicalConfigurationBaselineVersionsListWireResponse {
+  data: TechnicalConfigurationBaselineDraftWire[]
+  total: number
+  page: number
+  page_size: number
 }
 
 export interface TechnicalConfigurationBaselineGroupMutationWire extends Omit<
@@ -105,6 +116,22 @@ export interface TechnicalConfigurationBaselineDraftCreateRpcArgs {
 
 export interface TechnicalConfigurationBaselineDraftGetRpcArgs {
   p_dossier_id: string
+}
+
+export interface TechnicalConfigurationBaselineVersionsListRpcArgs {
+  p_dossier_id: string
+  p_page?: number
+  p_page_size?: number
+}
+
+export interface TechnicalConfigurationBaselineLockRpcArgs {
+  p_baseline_version_id: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationBaselineCopyRpcArgs {
+  p_source_baseline_version_id: string
+  p_expected_revision: number
 }
 
 export interface TechnicalConfigurationBaselineGroupCreateRpcArgs {

--- a/src/app/api/rpc/__tests__/technical-configuration-baseline-locking-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-baseline-locking-migration.test.ts
@@ -1,0 +1,231 @@
+import { readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const MIGRATIONS_DIR = path.resolve(process.cwd(), "supabase/migrations")
+const PHASE_GATE_PATH = path.resolve(
+  process.cwd(),
+  "supabase/tests/technical_configuration_baseline_locking_phase_gate.sql"
+)
+const LOCKING_MIGRATION_SUFFIX = "_technical_configuration_baseline_locking.sql"
+const HISTORY_REVIEW_FIX_MIGRATION_SUFFIX =
+  "_technical_configuration_baseline_history_review_fixes.sql"
+const BASELINE_MUTATION_FUNCTIONS = [
+  "technical_configuration_baseline_group_create",
+  "technical_configuration_baseline_group_update",
+  "technical_configuration_baseline_group_delete",
+  "technical_configuration_baseline_groups_reorder",
+  "technical_configuration_baseline_criterion_create",
+  "technical_configuration_baseline_criterion_update",
+  "technical_configuration_baseline_criterion_delete",
+  "technical_configuration_baseline_criteria_reorder",
+  "technical_configuration_baseline_bulk_preview",
+] as const
+
+function getLockingMigrationSource(): string {
+  const migrationFiles = readdirSync(MIGRATIONS_DIR).filter((file) =>
+    file.endsWith(LOCKING_MIGRATION_SUFFIX)
+  )
+
+  expect(migrationFiles).toHaveLength(1)
+  return readFileSync(path.join(MIGRATIONS_DIR, migrationFiles[0] ?? ""), "utf8")
+}
+
+function getHistoryReviewFixMigrationSource(): string {
+  const migrationFiles = readdirSync(MIGRATIONS_DIR).filter((file) =>
+    file.endsWith(HISTORY_REVIEW_FIX_MIGRATION_SUFFIX)
+  )
+
+  expect(migrationFiles).toHaveLength(1)
+  return readFileSync(path.join(MIGRATIONS_DIR, migrationFiles[0] ?? ""), "utf8")
+}
+
+function getBaselineMigrationSource(): string {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.includes("technical_configuration_baseline_") && file.endsWith(".sql"))
+    .sort()
+    .map((file) => readFileSync(path.join(MIGRATIONS_DIR, file), "utf8"))
+    .join("\n")
+}
+
+function getFunctionBlock(migrationSource: string, functionName: string): string {
+  const start = migrationSource.indexOf(`CREATE OR REPLACE FUNCTION public.${functionName}`)
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  const end = migrationSource.indexOf("\n$$;", start)
+  expect(end).toBeGreaterThan(start)
+  return migrationSource.slice(start, end + 4)
+}
+
+describe("technical configuration baseline P4 locking migration", () => {
+  const migrationSource = getLockingMigrationSource()
+
+  it("adds immutable lifecycle metadata and indexed lineage", () => {
+    expect(migrationSource).toContain("source_baseline_version_id UUID")
+    expect(migrationSource).toContain("locked_at TIMESTAMPTZ")
+    expect(migrationSource).toContain("locked_by BIGINT")
+    expect(migrationSource).toContain("technical_configuration_baseline_versions_lock_state_check")
+    expect(migrationSource).toContain("technical_configuration_baseline_versions_source_idx")
+    expect(migrationSource).toContain("technical_configuration_baseline_criteria_source_idx")
+    expect(migrationSource).toMatch(
+      /FOREIGN KEY \(source_baseline_version_id, dossier_id\)[\s\S]*REFERENCES public\.technical_configuration_baseline_versions \(id, dossier_id\)/
+    )
+  })
+
+  it("extends snapshots with source and lock metadata", () => {
+    const block = getFunctionBlock(migrationSource, "_technical_configuration_baseline_snapshot")
+
+    expect(block).toContain("'source_baseline_version_id'")
+    expect(block).toContain("'locked_at'")
+    expect(block).toContain("'locked_by'")
+  })
+
+  it("allocates the next sequential blank draft version under the dossier lock", () => {
+    const block = getFunctionBlock(migrationSource, "technical_configuration_baseline_draft_create")
+
+    expect(block).toContain("_technical_configuration_require_editable_dossier")
+    expect(block).toMatch(/COALESCE\(MAX\(v\.version_number\), 0\) \+ 1/)
+    expect(block).toContain("draft_already_exists")
+    expect(block).toMatch(/revision = revision \+ 1/)
+  })
+
+  it("lists paginated complete version snapshots in newest-first order", () => {
+    const block = getFunctionBlock(
+      migrationSource,
+      "technical_configuration_baseline_versions_list"
+    )
+
+    expect(block).toContain("_technical_configuration_require_global_user")
+    expect(block).toContain("_technical_configuration_baseline_snapshot")
+    expect(block).toContain("p_page_size")
+    expect(block).toContain("BETWEEN 1 AND 100")
+    expect(block).toContain("ORDER BY v.version_number DESC")
+    expect(block).toContain("'total'")
+    expect(block).toContain("'page_size'")
+  })
+
+  it("locks only complete current drafts and records actor and time", () => {
+    const block = getFunctionBlock(migrationSource, "technical_configuration_baseline_lock")
+
+    expect(block).toContain("_technical_configuration_require_editable_baseline_version")
+    expect(block).toContain("p_expected_revision")
+    expect(block).toMatch(/COUNT\(\*\)[\s\S]*technical_configuration_baseline_groups/)
+    expect(block).toMatch(/COUNT\(\*\)[\s\S]*technical_configuration_baseline_criteria/)
+    expect(block).toContain("COUNT(DISTINCT c.criterion_code)")
+    expect(block).toContain("validation_error")
+    expect(block).toContain("status = 'locked'")
+    expect(block).toContain("locked_at = now()")
+    expect(block).toContain("locked_by = v_user_id")
+    expect(block).toMatch(/revision = revision \+ 1/)
+  })
+
+  it("copies one locked P4 aggregate atomically with fresh IDs and complete lineage", () => {
+    const block = getFunctionBlock(migrationSource, "technical_configuration_baseline_copy")
+    const insertedTables = [
+      ...block.matchAll(/INSERT INTO public\.(technical_configuration_[a-z0-9_]+)/g),
+    ].map((match) => match[1])
+
+    expect(block).toContain("_technical_configuration_require_global_user")
+    expect(block).toContain("p_expected_revision")
+    expect(block).toContain("draft_already_exists")
+    expect(block).toContain("source_baseline_version_id")
+    expect(block).toContain("source_criterion_id")
+    expect(block).toContain("gen_random_uuid()")
+    expect(block).toMatch(/COALESCE\(MAX\(v\.version_number\), 0\) \+ 1/)
+    expect(new Set(insertedTables)).toEqual(
+      new Set([
+        "technical_configuration_baseline_versions",
+        "technical_configuration_baseline_groups",
+        "technical_configuration_baseline_criteria",
+      ])
+    )
+  })
+
+  it("keeps every current baseline-owned mutation behind the editable-version guard", () => {
+    const baselineSource = getBaselineMigrationSource()
+
+    for (const functionName of BASELINE_MUTATION_FUNCTIONS) {
+      expect(getFunctionBlock(baselineSource, functionName)).toContain(
+        "_technical_configuration_require_editable_baseline_version"
+      )
+    }
+  })
+
+  it("exposes only the three P4 lifecycle RPCs to authenticated users", () => {
+    const signatures = [
+      "technical_configuration_baseline_versions_list(UUID, INTEGER, INTEGER)",
+      "technical_configuration_baseline_lock(UUID, BIGINT)",
+      "technical_configuration_baseline_copy(UUID, BIGINT)",
+    ]
+
+    for (const signature of signatures) {
+      expect(migrationSource).toContain(
+        `REVOKE ALL ON FUNCTION public.${signature} FROM PUBLIC, anon, authenticated, service_role;`
+      )
+      expect(migrationSource).toContain(
+        `GRANT EXECUTE ON FUNCTION public.${signature} TO authenticated;`
+      )
+    }
+  })
+
+  it("ships a rollback-safe phase gate for claims, locking, mutation, copy, and history", () => {
+    const phaseGateSource = readFileSync(PHASE_GATE_PATH, "utf8")
+
+    expect(phaseGateSource).toContain("BEGIN;")
+    expect(phaseGateSource).toContain("ROLLBACK;")
+    expect(phaseGateSource).toContain("pg_temp.set_claims('admin'")
+    expect(phaseGateSource).toContain("pg_temp.set_claims('global'")
+    expect(phaseGateSource).toContain("missing claims fail closed")
+    expect(phaseGateSource).toContain("non-global role denied")
+    expect(phaseGateSource).toContain("lock requires baseline content")
+    expect(phaseGateSource).toContain("lock rejects a stale revision")
+    expect(phaseGateSource).toContain("copy rejects a stale locked revision")
+    expect(phaseGateSource).toContain("blank creation rejects an existing draft")
+    expect(phaseGateSource).toContain("copy rejects an existing draft")
+    expect(phaseGateSource).toContain("historical read after newer version is locked")
+    expect(phaseGateSource).toContain("source_baseline_version_id")
+    expect(phaseGateSource).toContain("source_criterion_id")
+    expect(phaseGateSource).toContain("technical_configuration_baseline_versions_list")
+
+    for (const functionName of BASELINE_MUTATION_FUNCTIONS) {
+      expect(phaseGateSource).toContain(functionName)
+    }
+  })
+})
+
+describe("technical configuration baseline P4 history review fixes", () => {
+  it("uses set-based history snapshots and returns stable lineage metadata", () => {
+    const migrationSource = getHistoryReviewFixMigrationSource()
+    const snapshotBlock = getFunctionBlock(
+      migrationSource,
+      "_technical_configuration_baseline_snapshot"
+    )
+    const historyBlock = getFunctionBlock(
+      migrationSource,
+      "technical_configuration_baseline_versions_list"
+    )
+
+    expect(snapshotBlock).toContain("'source_version_number'")
+    expect(snapshotBlock).toContain("source_version.version_number")
+    expect(historyBlock).toContain("paged_versions")
+    expect(historyBlock).toContain("criteria_by_group")
+    expect(historyBlock).toContain("groups_by_version")
+    expect(historyBlock).toContain("'source_version_number'")
+    expect(historyBlock).not.toContain("_technical_configuration_baseline_snapshot(")
+    expect(historyBlock).toContain("SECURITY DEFINER")
+    expect(historyBlock).toContain("SET search_path = public, pg_temp")
+    expect(migrationSource).toContain(
+      "REVOKE ALL ON FUNCTION public._technical_configuration_baseline_snapshot(UUID) FROM PUBLIC, anon, authenticated, service_role;"
+    )
+    expect(migrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public._technical_configuration_baseline_snapshot(UUID) TO service_role;"
+    )
+    expect(migrationSource).toContain(
+      "REVOKE ALL ON FUNCTION public.technical_configuration_baseline_versions_list(UUID, INTEGER, INTEGER) FROM PUBLIC, anon, authenticated, service_role;"
+    )
+    expect(migrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_versions_list(UUID, INTEGER, INTEGER) TO authenticated;"
+    )
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-baseline-locking-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-baseline-locking-migration.test.ts
@@ -50,13 +50,35 @@ function getBaselineMigrationSource(): string {
 }
 
 function getFunctionBlock(migrationSource: string, functionName: string): string {
-  const start = migrationSource.indexOf(`CREATE OR REPLACE FUNCTION public.${functionName}`)
+  const start = migrationSource.lastIndexOf(`CREATE OR REPLACE FUNCTION public.${functionName}`)
   expect(start).toBeGreaterThanOrEqual(0)
 
   const end = migrationSource.indexOf("\n$$;", start)
   expect(end).toBeGreaterThan(start)
   return migrationSource.slice(start, end + 4)
 }
+
+describe("technical configuration migration test helpers", () => {
+  it("reads the final applied function definition from concatenated migrations", () => {
+    const migrationSource = `
+CREATE OR REPLACE FUNCTION public.example()
+RETURNS TEXT
+AS $$
+  SELECT 'stale';
+$$;
+CREATE OR REPLACE FUNCTION public.example()
+RETURNS TEXT
+AS $$
+  SELECT 'current';
+$$;
+`
+
+    const block = getFunctionBlock(migrationSource, "example")
+
+    expect(block).toContain("SELECT 'current';")
+    expect(block).not.toContain("SELECT 'stale';")
+  })
+})
 
 describe("technical configuration baseline P4 locking migration", () => {
   const migrationSource = getLockingMigrationSource()

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -35,16 +35,19 @@ describe("technical configuration dossier RPC whitelist", () => {
 })
 
 describe("technical configuration baseline RPC whitelist", () => {
-  it("allowlists exactly the eleven P2 baseline RPCs", () => {
+  it("allowlists exactly the P2 and P4 baseline RPCs", () => {
     expect(
       [...ALLOWED_FUNCTIONS].filter((fn) => fn.startsWith("technical_configuration_baseline_"))
     ).toEqual(BASELINE_RPC_FUNCTION_NAMES)
   })
 
-  it.each(BASELINE_RPC_FUNCTION_NAMES)('allows P2 RPC "%s" through the whitelist', async (fn) => {
-    const response = await invokeRpcProxy(fn)
+  it.each(BASELINE_RPC_FUNCTION_NAMES)(
+    'allows baseline RPC "%s" through the whitelist',
+    async (fn) => {
+      const response = await invokeRpcProxy(fn)
 
-    expect(response.status).toBe(411)
-    await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
-  })
+      expect(response.status).toBe(411)
+      await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
+    }
+  )
 })

--- a/src/lib/technical-configuration-baseline-rpcs.ts
+++ b/src/lib/technical-configuration-baseline-rpcs.ts
@@ -1,7 +1,10 @@
-/** Named P2 baseline RPC functions shared by client and server code. */
+/** Named baseline RPC functions shared by client and server code. */
 export const BASELINE_RPC_FUNCTIONS = {
   createDraft: "technical_configuration_baseline_draft_create",
   getDraft: "technical_configuration_baseline_draft_get",
+  listVersions: "technical_configuration_baseline_versions_list",
+  lockVersion: "technical_configuration_baseline_lock",
+  copyVersion: "technical_configuration_baseline_copy",
   createGroup: "technical_configuration_baseline_group_create",
   updateGroup: "technical_configuration_baseline_group_update",
   deleteGroup: "technical_configuration_baseline_group_delete",
@@ -13,5 +16,5 @@ export const BASELINE_RPC_FUNCTIONS = {
   previewBulk: "technical_configuration_baseline_bulk_preview",
 } as const
 
-/** Ordered P2 baseline RPC names for allowlists and contract iteration. */
+/** Ordered baseline RPC names for allowlists and contract iteration. */
 export const BASELINE_RPC_FUNCTION_NAMES = Object.values(BASELINE_RPC_FUNCTIONS)

--- a/supabase/migrations/20260714010000_technical_configuration_baseline_locking.sql
+++ b/supabase/migrations/20260714010000_technical_configuration_baseline_locking.sql
@@ -1,0 +1,445 @@
+-- OpenSpec Phase P4: baseline versioning, irreversible locking, history, and copy.
+BEGIN;
+ALTER TABLE public.technical_configuration_baseline_versions
+  ADD COLUMN source_baseline_version_id UUID,
+  ADD COLUMN locked_at TIMESTAMPTZ,
+  ADD COLUMN locked_by BIGINT;
+ALTER TABLE public.technical_configuration_baseline_versions
+  ADD CONSTRAINT technical_configuration_baseline_versions_id_dossier_key
+    UNIQUE (id, dossier_id),
+  ADD CONSTRAINT technical_configuration_baseline_versions_source_fkey
+    FOREIGN KEY (source_baseline_version_id, dossier_id)
+    REFERENCES public.technical_configuration_baseline_versions (id, dossier_id)
+    ON DELETE RESTRICT,
+  ADD CONSTRAINT technical_configuration_baseline_versions_source_not_self_check
+    CHECK (source_baseline_version_id IS NULL OR source_baseline_version_id <> id),
+  ADD CONSTRAINT technical_configuration_baseline_versions_lock_state_check
+    CHECK (
+      (
+        status = 'draft'
+        AND locked_at IS NULL
+        AND locked_by IS NULL
+      )
+      OR
+      (
+        status = 'locked'
+        AND locked_at IS NOT NULL
+        AND locked_by IS NOT NULL
+      )
+    );
+CREATE INDEX technical_configuration_baseline_versions_source_idx
+  ON public.technical_configuration_baseline_versions (source_baseline_version_id)
+  WHERE source_baseline_version_id IS NOT NULL;
+-- Issue #746: P4 starts populating source_criterion_id during baseline copy.
+CREATE INDEX technical_configuration_baseline_criteria_source_idx
+  ON public.technical_configuration_baseline_criteria (source_criterion_id)
+  WHERE source_criterion_id IS NOT NULL;
+CREATE OR REPLACE FUNCTION public._technical_configuration_baseline_snapshot(p_baseline_version_id UUID)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH criteria_by_group AS (
+    SELECT
+      c.group_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'id', c.id,
+          'baseline_version_id', c.baseline_version_id,
+          'group_id', c.group_id,
+          'criterion_code', c.criterion_code,
+          'title', c.title,
+          'requirement_text', c.requirement_text,
+          'sort_order', c.sort_order,
+          'source_criterion_id', c.source_criterion_id,
+          'created_at', c.created_at,
+          'created_by', c.created_by,
+          'updated_at', c.updated_at,
+          'updated_by', c.updated_by
+        )
+        ORDER BY c.sort_order, c.id
+      ) AS criteria
+    FROM public.technical_configuration_baseline_criteria c
+    WHERE c.baseline_version_id = p_baseline_version_id
+    GROUP BY c.group_id
+  ),
+  groups_by_version AS (
+    SELECT
+      g.baseline_version_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'id', g.id,
+          'baseline_version_id', g.baseline_version_id,
+          'name', g.name,
+          'sort_order', g.sort_order,
+          'created_at', g.created_at,
+          'created_by', g.created_by,
+          'updated_at', g.updated_at,
+          'updated_by', g.updated_by,
+          'criteria', COALESCE(cbg.criteria, '[]'::JSONB)
+        )
+        ORDER BY g.sort_order, g.id
+      ) AS groups
+    FROM public.technical_configuration_baseline_groups g
+    LEFT JOIN criteria_by_group cbg ON cbg.group_id = g.id
+    WHERE g.baseline_version_id = p_baseline_version_id
+    GROUP BY g.baseline_version_id
+  )
+  SELECT jsonb_build_object(
+    'id', v.id,
+    'dossier_id', v.dossier_id,
+    'version_number', v.version_number,
+    'status', v.status,
+    'source_baseline_version_id', v.source_baseline_version_id,
+    'next_criterion_number', v.next_criterion_number,
+    'revision', v.revision,
+    'locked_at', v.locked_at,
+    'locked_by', v.locked_by,
+    'created_at', v.created_at,
+    'created_by', v.created_by,
+    'updated_at', v.updated_at,
+    'updated_by', v.updated_by,
+    'groups', COALESCE(gbv.groups, '[]'::JSONB)
+  )
+  FROM public.technical_configuration_baseline_versions v
+  LEFT JOIN groups_by_version gbv ON gbv.baseline_version_id = v.id
+  WHERE v.id = p_baseline_version_id;
+$$;
+CREATE OR REPLACE FUNCTION public.technical_configuration_baseline_draft_create(
+  p_dossier_id UUID, p_expected_revision BIGINT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_revision BIGINT;
+  v_version_id UUID;
+  v_version_number BIGINT;
+BEGIN
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    p_dossier_id,
+    p_expected_revision
+  );
+  IF EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_versions
+    WHERE dossier_id = p_dossier_id AND status = 'draft'
+  ) THEN
+    RAISE EXCEPTION 'draft_already_exists' USING ERRCODE = 'PT409';
+  END IF;
+  SELECT COALESCE(MAX(v.version_number), 0) + 1
+  INTO v_version_number
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.dossier_id = p_dossier_id;
+  INSERT INTO public.technical_configuration_baseline_versions (
+    dossier_id,
+    version_number,
+    created_by,
+    updated_by
+  )
+  VALUES (p_dossier_id, v_version_number, v_user_id, v_user_id)
+  RETURNING id INTO v_version_id;
+  INSERT INTO public.technical_configuration_baseline_groups (
+    baseline_version_id,
+    name,
+    sort_order,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (v_version_id, 'Yêu cầu chung', 1, v_user_id, v_user_id),
+    (v_version_id, 'Yêu cầu cấu hình cung cấp', 2, v_user_id, v_user_id),
+    (v_version_id, 'Yêu cầu kỹ thuật', 3, v_user_id, v_user_id),
+    (v_version_id, 'Yêu cầu khác', 4, v_user_id, v_user_id);
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = p_dossier_id
+  RETURNING revision INTO v_dossier_revision;
+  RETURN jsonb_build_object(
+    'data',
+    public._technical_configuration_baseline_snapshot(v_version_id)
+      || jsonb_build_object('dossier_revision', v_dossier_revision)
+  );
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.technical_configuration_baseline_versions_list(
+  p_dossier_id UUID, p_page INTEGER DEFAULT 1, p_page_size INTEGER DEFAULT 20)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  IF p_page IS NULL
+     OR p_page < 1
+     OR p_page_size IS NULL
+     OR NOT (p_page_size BETWEEN 1 AND 100) THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  PERFORM 1
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = p_dossier_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  WITH paged AS (
+    SELECT v.id, v.version_number
+    FROM public.technical_configuration_baseline_versions v
+    WHERE v.dossier_id = p_dossier_id
+    ORDER BY v.version_number DESC, v.id
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  )
+  SELECT jsonb_build_object(
+    'data',
+    COALESCE(
+      (
+        SELECT jsonb_agg(
+          public._technical_configuration_baseline_snapshot(p.id)
+          ORDER BY p.version_number DESC, p.id
+        )
+        FROM paged p
+      ),
+      '[]'::JSONB
+    ),
+    'total',
+    (
+      SELECT count(*)
+      FROM public.technical_configuration_baseline_versions v
+      WHERE v.dossier_id = p_dossier_id
+    ),
+    'page',
+    p_page,
+    'page_size',
+    p_page_size
+  )
+  INTO v_result;
+  RETURN v_result;
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.technical_configuration_baseline_lock(
+  p_baseline_version_id UUID, p_expected_revision BIGINT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_group_count BIGINT;
+  v_criterion_count BIGINT;
+  v_distinct_code_count BIGINT;
+BEGIN
+  v_user_id := public._technical_configuration_require_editable_baseline_version(
+    p_baseline_version_id,
+    p_expected_revision
+  );
+  SELECT COUNT(*)
+  INTO v_group_count
+  FROM public.technical_configuration_baseline_groups g
+  WHERE g.baseline_version_id = p_baseline_version_id;
+  SELECT
+    COUNT(*),
+    COUNT(DISTINCT c.criterion_code)
+  INTO
+    v_criterion_count,
+    v_distinct_code_count
+  FROM public.technical_configuration_baseline_criteria c
+  WHERE c.baseline_version_id = p_baseline_version_id
+    AND btrim(c.requirement_text) <> '';
+  -- P5 must extend this function when persisted import-error state exists.
+  IF v_group_count < 1
+     OR v_criterion_count < 1
+     OR v_distinct_code_count <> v_criterion_count THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  UPDATE public.technical_configuration_baseline_versions
+  SET status = 'locked',
+      locked_at = now(),
+      locked_by = v_user_id,
+      revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = p_baseline_version_id;
+  RETURN jsonb_build_object(
+    'data',
+    public._technical_configuration_baseline_snapshot(p_baseline_version_id)
+  );
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.technical_configuration_baseline_copy(
+  p_source_baseline_version_id UUID, p_expected_revision BIGINT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_archived_at TIMESTAMPTZ;
+  v_source_status TEXT;
+  v_source_revision BIGINT;
+  v_next_criterion_number BIGINT;
+  v_version_number BIGINT;
+  v_new_version_id UUID;
+  v_new_group_id UUID;
+  v_dossier_revision BIGINT;
+  v_source_group RECORD;
+BEGIN
+  v_user_id := public._technical_configuration_require_global_user();
+  SELECT v.dossier_id
+  INTO v_dossier_id
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.id = p_source_baseline_version_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  SELECT d.archived_at
+  INTO v_archived_at
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = v_dossier_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  SELECT
+    v.status,
+    v.revision,
+    v.next_criterion_number
+  INTO
+    v_source_status,
+    v_source_revision,
+    v_next_criterion_number
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.id = p_source_baseline_version_id
+    AND v.dossier_id = v_dossier_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  IF v_archived_at IS NOT NULL THEN
+    RAISE EXCEPTION 'archived_dossier' USING ERRCODE = 'PT409';
+  END IF;
+  IF v_source_status <> 'locked' THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  IF v_source_revision IS DISTINCT FROM p_expected_revision THEN
+    RAISE EXCEPTION 'stale_revision' USING ERRCODE = 'PT409';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_versions v
+    WHERE v.dossier_id = v_dossier_id
+      AND v.status = 'draft'
+  ) THEN
+    RAISE EXCEPTION 'draft_already_exists' USING ERRCODE = 'PT409';
+  END IF;
+  SELECT COALESCE(MAX(v.version_number), 0) + 1
+  INTO v_version_number
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.dossier_id = v_dossier_id;
+  v_new_version_id := gen_random_uuid();
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id,
+    dossier_id,
+    version_number,
+    status,
+    source_baseline_version_id,
+    next_criterion_number,
+    revision,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    v_new_version_id,
+    v_dossier_id,
+    v_version_number,
+    'draft',
+    p_source_baseline_version_id,
+    v_next_criterion_number,
+    1,
+    v_user_id,
+    v_user_id
+  );
+  FOR v_source_group IN
+    SELECT g.id, g.name, g.sort_order
+    FROM public.technical_configuration_baseline_groups g
+    WHERE g.baseline_version_id = p_source_baseline_version_id
+    ORDER BY g.sort_order, g.id
+  LOOP
+    v_new_group_id := gen_random_uuid();
+    INSERT INTO public.technical_configuration_baseline_groups (
+      id,
+      baseline_version_id,
+      name,
+      sort_order,
+      created_by,
+      updated_by
+    )
+    VALUES (
+      v_new_group_id,
+      v_new_version_id,
+      v_source_group.name,
+      v_source_group.sort_order,
+      v_user_id,
+      v_user_id
+    );
+    INSERT INTO public.technical_configuration_baseline_criteria (
+      id,
+      baseline_version_id,
+      group_id,
+      criterion_code,
+      title,
+      requirement_text,
+      sort_order,
+      source_criterion_id,
+      created_by,
+      updated_by
+    )
+    SELECT
+      gen_random_uuid(),
+      v_new_version_id,
+      v_new_group_id,
+      c.criterion_code,
+      c.title,
+      c.requirement_text,
+      c.sort_order,
+      c.id,
+      v_user_id,
+      v_user_id
+    FROM public.technical_configuration_baseline_criteria c
+    WHERE c.baseline_version_id = p_source_baseline_version_id
+      AND c.group_id = v_source_group.id
+    ORDER BY c.sort_order, c.id;
+  END LOOP;
+  -- P7A/P7B extend this RPC after adding their baseline-owned leaf tables.
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_dossier_revision;
+  RETURN jsonb_build_object(
+    'data',
+    public._technical_configuration_baseline_snapshot(v_new_version_id)
+      || jsonb_build_object('dossier_revision', v_dossier_revision)
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_versions_list(UUID, INTEGER, INTEGER) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_versions_list(UUID, INTEGER, INTEGER) TO authenticated;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_lock(UUID, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_lock(UUID, BIGINT) TO authenticated;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_copy(UUID, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_copy(UUID, BIGINT) TO authenticated;
+COMMIT;

--- a/supabase/migrations/20260714030000_technical_configuration_baseline_history_review_fixes.sql
+++ b/supabase/migrations/20260714030000_technical_configuration_baseline_history_review_fixes.sql
@@ -1,0 +1,234 @@
+-- P4 review follow-up: set-based history snapshots and stable copy lineage metadata.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_baseline_snapshot(
+  p_baseline_version_id UUID
+)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  WITH criteria_by_group AS (
+    SELECT
+      c.group_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'id', c.id,
+          'baseline_version_id', c.baseline_version_id,
+          'group_id', c.group_id,
+          'criterion_code', c.criterion_code,
+          'title', c.title,
+          'requirement_text', c.requirement_text,
+          'sort_order', c.sort_order,
+          'source_criterion_id', c.source_criterion_id,
+          'created_at', c.created_at,
+          'created_by', c.created_by,
+          'updated_at', c.updated_at,
+          'updated_by', c.updated_by
+        )
+        ORDER BY c.sort_order, c.id
+      ) AS criteria
+    FROM public.technical_configuration_baseline_criteria c
+    WHERE c.baseline_version_id = p_baseline_version_id
+    GROUP BY c.group_id
+  ),
+  groups_by_version AS (
+    SELECT
+      g.baseline_version_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'id', g.id,
+          'baseline_version_id', g.baseline_version_id,
+          'name', g.name,
+          'sort_order', g.sort_order,
+          'created_at', g.created_at,
+          'created_by', g.created_by,
+          'updated_at', g.updated_at,
+          'updated_by', g.updated_by,
+          'criteria', COALESCE(cbg.criteria, '[]'::JSONB)
+        )
+        ORDER BY g.sort_order, g.id
+      ) AS groups
+    FROM public.technical_configuration_baseline_groups g
+    LEFT JOIN criteria_by_group cbg ON cbg.group_id = g.id
+    WHERE g.baseline_version_id = p_baseline_version_id
+    GROUP BY g.baseline_version_id
+  )
+  SELECT jsonb_build_object(
+    'id', v.id,
+    'dossier_id', v.dossier_id,
+    'version_number', v.version_number,
+    'status', v.status,
+    'source_baseline_version_id', v.source_baseline_version_id,
+    'source_version_number', source_version.version_number,
+    'next_criterion_number', v.next_criterion_number,
+    'revision', v.revision,
+    'locked_at', v.locked_at,
+    'locked_by', v.locked_by,
+    'created_at', v.created_at,
+    'created_by', v.created_by,
+    'updated_at', v.updated_at,
+    'updated_by', v.updated_by,
+    'groups', COALESCE(gbv.groups, '[]'::JSONB)
+  )
+  FROM public.technical_configuration_baseline_versions v
+  LEFT JOIN public.technical_configuration_baseline_versions source_version
+    ON source_version.id = v.source_baseline_version_id
+  LEFT JOIN groups_by_version gbv ON gbv.baseline_version_id = v.id
+  WHERE v.id = p_baseline_version_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_baseline_versions_list(
+  p_dossier_id UUID,
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 20
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_page IS NULL
+     OR p_page < 1
+     OR p_page_size IS NULL
+     OR NOT (p_page_size BETWEEN 1 AND 100) THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  PERFORM 1
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = p_dossier_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  WITH paged_versions AS (
+    SELECT
+      v.id,
+      v.dossier_id,
+      v.version_number,
+      v.status,
+      v.source_baseline_version_id,
+      source_version.version_number AS source_version_number,
+      v.next_criterion_number,
+      v.revision,
+      v.locked_at,
+      v.locked_by,
+      v.created_at,
+      v.created_by,
+      v.updated_at,
+      v.updated_by
+    FROM public.technical_configuration_baseline_versions v
+    LEFT JOIN public.technical_configuration_baseline_versions source_version
+      ON source_version.id = v.source_baseline_version_id
+    WHERE v.dossier_id = p_dossier_id
+    ORDER BY v.version_number DESC, v.id
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  ),
+  criteria_by_group AS (
+    SELECT
+      c.group_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'id', c.id,
+          'baseline_version_id', c.baseline_version_id,
+          'group_id', c.group_id,
+          'criterion_code', c.criterion_code,
+          'title', c.title,
+          'requirement_text', c.requirement_text,
+          'sort_order', c.sort_order,
+          'source_criterion_id', c.source_criterion_id,
+          'created_at', c.created_at,
+          'created_by', c.created_by,
+          'updated_at', c.updated_at,
+          'updated_by', c.updated_by
+        )
+        ORDER BY c.sort_order, c.id
+      ) AS criteria
+    FROM public.technical_configuration_baseline_criteria c
+    INNER JOIN paged_versions pv ON pv.id = c.baseline_version_id
+    GROUP BY c.group_id
+  ),
+  groups_by_version AS (
+    SELECT
+      g.baseline_version_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'id', g.id,
+          'baseline_version_id', g.baseline_version_id,
+          'name', g.name,
+          'sort_order', g.sort_order,
+          'created_at', g.created_at,
+          'created_by', g.created_by,
+          'updated_at', g.updated_at,
+          'updated_by', g.updated_by,
+          'criteria', COALESCE(cbg.criteria, '[]'::JSONB)
+        )
+        ORDER BY g.sort_order, g.id
+      ) AS groups
+    FROM public.technical_configuration_baseline_groups g
+    INNER JOIN paged_versions pv ON pv.id = g.baseline_version_id
+    LEFT JOIN criteria_by_group cbg ON cbg.group_id = g.id
+    GROUP BY g.baseline_version_id
+  )
+  SELECT jsonb_build_object(
+    'data',
+    COALESCE(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', pv.id,
+            'dossier_id', pv.dossier_id,
+            'version_number', pv.version_number,
+            'status', pv.status,
+            'source_baseline_version_id', pv.source_baseline_version_id,
+            'source_version_number', pv.source_version_number,
+            'next_criterion_number', pv.next_criterion_number,
+            'revision', pv.revision,
+            'locked_at', pv.locked_at,
+            'locked_by', pv.locked_by,
+            'created_at', pv.created_at,
+            'created_by', pv.created_by,
+            'updated_at', pv.updated_at,
+            'updated_by', pv.updated_by,
+            'groups', COALESCE(gbv.groups, '[]'::JSONB)
+          )
+          ORDER BY pv.version_number DESC, pv.id
+        )
+        FROM paged_versions pv
+        LEFT JOIN groups_by_version gbv ON gbv.baseline_version_id = pv.id
+      ),
+      '[]'::JSONB
+    ),
+    'total',
+    (
+      SELECT count(*)
+      FROM public.technical_configuration_baseline_versions v
+      WHERE v.dossier_id = p_dossier_id
+    ),
+    'page',
+    p_page,
+    'page_size',
+    p_page_size
+  )
+  INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public._technical_configuration_baseline_snapshot(UUID) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_baseline_snapshot(UUID) TO service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_baseline_versions_list(UUID, INTEGER, INTEGER) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_baseline_versions_list(UUID, INTEGER, INTEGER) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/technical_configuration_baseline_locking_phase_gate.sql
+++ b/supabase/tests/technical_configuration_baseline_locking_phase_gate.sql
@@ -1,0 +1,444 @@
+-- supabase/tests/technical_configuration_baseline_locking_phase_gate.sql
+-- Purpose: prove P4 role, lock, mutation, copy, and history invariants.
+-- Non-destructive: all fixture writes are wrapped in a transaction and rolled back.
+BEGIN;
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT,
+  p_statement TEXT,
+  p_expected_state TEXT,
+  p_expected_message TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION
+    WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+        v_state = RETURNED_SQLSTATE,
+        v_message = MESSAGE_TEXT;
+      IF v_state = p_expected_state AND v_message = p_expected_message THEN
+        RETURN;
+      END IF;
+      RAISE EXCEPTION '%: expected %/%, got %/%',
+        p_label,
+        p_expected_state,
+        p_expected_message,
+        v_state,
+        v_message;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::TEXT,
+      'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_version_id UUID;
+  v_copy_version_id UUID;
+  v_source_group_id UUID;
+  v_other_group_id UUID;
+  v_criterion_id UUID;
+  v_group_ids UUID[];
+  v_criterion_ids UUID[];
+  v_revision BIGINT;
+  v_locked_revision BIGINT;
+  v_response JSONB;
+  v_history JSONB;
+  v_count BIGINT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_baseline_locking_phase_gate')
+  );
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active = true
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Setup failed: no active nhan_vien row found';
+  END IF;
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name,
+    name,
+    description,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    'P4 phase gate device ' || v_suffix,
+    'P4 phase gate dossier ' || v_suffix,
+    'Rolled back after verification',
+    v_user_id,
+    v_user_id
+  )
+  RETURNING id INTO v_dossier_id;
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims fail closed',
+    format(
+      'SELECT public.technical_configuration_baseline_versions_list(%L::UUID, 1, 100)',
+      v_dossier_id
+    ),
+    '42501',
+    'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('to_qltb', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'non-global role denied',
+    format(
+      'SELECT public.technical_configuration_baseline_versions_list(%L::UUID, 1, 100)',
+      v_dossier_id
+    ),
+    '42501',
+    'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  SELECT public.technical_configuration_baseline_draft_create(v_dossier_id, 1)
+  INTO v_response;
+  v_version_id := (v_response->'data'->>'id')::UUID;
+  IF v_version_id IS NULL OR (v_response->'data'->>'version_number')::BIGINT <> 1 THEN
+    RAISE EXCEPTION 'Admin draft creation returned an invalid first version';
+  END IF;
+  PERFORM pg_temp.expect_error(
+    'blank creation rejects an existing draft',
+    format(
+      'SELECT public.technical_configuration_baseline_draft_create(%L::UUID, %s)',
+      v_dossier_id,
+      (v_response->'data'->>'dossier_revision')::BIGINT
+    ),
+    'PT409',
+    'draft_already_exists'
+  );
+  SELECT public.technical_configuration_baseline_versions_list(v_dossier_id, 1, 100)
+  INTO v_history;
+  IF (v_history->>'total')::BIGINT <> 1
+     OR v_history->'data'->0->>'status' <> 'draft' THEN
+    RAISE EXCEPTION 'Admin history read did not return the draft';
+  END IF;
+  SELECT revision
+  INTO v_revision
+  FROM public.technical_configuration_baseline_versions
+  WHERE id = v_version_id;
+  PERFORM pg_temp.expect_error(
+    'copy requires a locked source',
+    format(
+      'SELECT public.technical_configuration_baseline_copy(%L::UUID, %s)',
+      v_version_id,
+      v_revision
+    ),
+    'PT422',
+    'validation_error'
+  );
+  PERFORM pg_temp.expect_error(
+    'lock requires baseline content',
+    format(
+      'SELECT public.technical_configuration_baseline_lock(%L::UUID, %s)',
+      v_version_id,
+      v_revision
+    ),
+    'PT422',
+    'validation_error'
+  );
+  SELECT id
+  INTO v_source_group_id
+  FROM public.technical_configuration_baseline_groups
+  WHERE baseline_version_id = v_version_id
+  ORDER BY sort_order, id
+  LIMIT 1;
+  SELECT id
+  INTO v_other_group_id
+  FROM public.technical_configuration_baseline_groups
+  WHERE baseline_version_id = v_version_id
+    AND id <> v_source_group_id
+  ORDER BY sort_order, id
+  LIMIT 1;
+  PERFORM public.technical_configuration_baseline_criterion_create(
+    v_source_group_id,
+    'Nguồn điện',
+    '220V - 50Hz',
+    v_revision
+  );
+  SELECT revision
+  INTO v_revision
+  FROM public.technical_configuration_baseline_versions
+  WHERE id = v_version_id;
+  SELECT id
+  INTO v_criterion_id
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id
+  ORDER BY sort_order, id
+  LIMIT 1;
+  SELECT array_agg(id ORDER BY sort_order, id)
+  INTO v_group_ids
+  FROM public.technical_configuration_baseline_groups
+  WHERE baseline_version_id = v_version_id;
+  SELECT array_agg(id ORDER BY sort_order, id)
+  INTO v_criterion_ids
+  FROM public.technical_configuration_baseline_criteria
+  WHERE group_id = v_source_group_id;
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'lock rejects a stale revision',
+    format(
+      'SELECT public.technical_configuration_baseline_lock(%L::UUID, %s)',
+      v_version_id,
+      v_revision - 1
+    ),
+    'PT409',
+    'stale_revision'
+  );
+  SELECT public.technical_configuration_baseline_lock(v_version_id, v_revision)
+  INTO v_response;
+  v_locked_revision := (v_response->'data'->>'revision')::BIGINT;
+  IF v_response->'data'->>'status' <> 'locked'
+     OR (v_response->'data'->>'locked_by')::BIGINT <> v_user_id
+     OR v_response->'data'->>'locked_at' IS NULL THEN
+    RAISE EXCEPTION 'Global lock did not persist immutable lock metadata';
+  END IF;
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'locked version cannot be locked twice',
+    format(
+      'SELECT public.technical_configuration_baseline_lock(%L::UUID, %s)',
+      v_version_id,
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'group create blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_group_create(%L::UUID, %L, %s)',
+      v_version_id,
+      'Blocked group',
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'group update blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_group_update(%L::UUID, %L, %s)',
+      v_source_group_id,
+      'Blocked rename',
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'group delete blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_group_delete(%L::UUID, %s)',
+      v_other_group_id,
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'group reorder blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_groups_reorder(%L::UUID, %L::UUID[], %s)',
+      v_version_id,
+      v_group_ids::TEXT,
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'criterion create blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_criterion_create(%L::UUID, %L, %L, %s)',
+      v_source_group_id,
+      'Blocked criterion',
+      'Blocked requirement',
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'criterion update blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_criterion_update(%L::UUID, %L, %L, %s)',
+      v_criterion_id,
+      'Blocked update',
+      'Blocked requirement',
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'criterion delete blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_criterion_delete(%L::UUID, %s)',
+      v_criterion_id,
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'criterion reorder blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_criteria_reorder(%L::UUID, %L::UUID[], %s)',
+      v_source_group_id,
+      v_criterion_ids::TEXT,
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.expect_error(
+    'bulk preview blocked after lock',
+    format(
+      'SELECT public.technical_configuration_baseline_bulk_preview(%L::UUID, %L::JSONB, %s)',
+      v_source_group_id,
+      '[]',
+      v_locked_revision
+    ),
+    'PT409',
+    'locked_version'
+  );
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'copy rejects a stale locked revision',
+    format(
+      'SELECT public.technical_configuration_baseline_copy(%L::UUID, %s)',
+      v_version_id,
+      v_locked_revision - 1
+    ),
+    'PT409',
+    'stale_revision'
+  );
+  SELECT public.technical_configuration_baseline_copy(v_version_id, v_locked_revision)
+  INTO v_response;
+  v_copy_version_id := (v_response->'data'->>'id')::UUID;
+  IF v_copy_version_id IS NULL
+     OR v_copy_version_id = v_version_id
+     OR (v_response->'data'->>'version_number')::BIGINT <> 2
+     OR v_response->'data'->>'status' <> 'draft'
+     OR (v_response->'data'->>'source_baseline_version_id')::UUID <> v_version_id THEN
+    RAISE EXCEPTION 'Copy did not create the expected linked draft';
+  END IF;
+  PERFORM pg_temp.expect_error(
+    'copy rejects an existing draft',
+    format(
+      'SELECT public.technical_configuration_baseline_copy(%L::UUID, %s)',
+      v_version_id,
+      v_locked_revision
+    ),
+    'PT409',
+    'draft_already_exists'
+  );
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_versions source
+    JOIN public.technical_configuration_baseline_versions copied
+      ON copied.id = v_copy_version_id
+    WHERE source.id = v_version_id
+      AND copied.next_criterion_number = source.next_criterion_number
+  ) THEN
+    RAISE EXCEPTION 'Copy did not preserve the criterion counter';
+  END IF;
+  IF EXISTS (
+    SELECT g.name, g.sort_order
+    FROM public.technical_configuration_baseline_groups g
+    WHERE g.baseline_version_id = v_version_id
+    EXCEPT
+    SELECT g.name, g.sort_order
+    FROM public.technical_configuration_baseline_groups g
+    WHERE g.baseline_version_id = v_copy_version_id
+  ) OR EXISTS (
+    SELECT g.name, g.sort_order
+    FROM public.technical_configuration_baseline_groups g
+    WHERE g.baseline_version_id = v_copy_version_id
+    EXCEPT
+    SELECT g.name, g.sort_order
+    FROM public.technical_configuration_baseline_groups g
+    WHERE g.baseline_version_id = v_version_id
+  ) THEN
+    RAISE EXCEPTION 'Copy did not preserve the group snapshot';
+  END IF;
+  SELECT count(*)
+  INTO v_count
+  FROM public.technical_configuration_baseline_criteria
+  WHERE baseline_version_id = v_version_id;
+  IF v_count <> (
+    SELECT count(*)
+    FROM public.technical_configuration_baseline_criteria
+    WHERE baseline_version_id = v_copy_version_id
+  ) THEN
+    RAISE EXCEPTION 'Copy did not preserve the criterion count';
+  END IF;
+  SELECT count(*)
+  INTO v_count
+  FROM public.technical_configuration_baseline_criteria copied
+  JOIN public.technical_configuration_baseline_groups copied_group
+    ON copied_group.id = copied.group_id
+  LEFT JOIN public.technical_configuration_baseline_criteria source
+    ON source.id = copied.source_criterion_id
+  LEFT JOIN public.technical_configuration_baseline_groups source_group
+    ON source_group.id = source.group_id
+  WHERE copied.baseline_version_id = v_copy_version_id
+    AND (
+      source.id IS NULL
+      OR copied.id = source.id
+      OR source.baseline_version_id <> v_version_id
+      OR copied_group.name IS DISTINCT FROM source_group.name
+      OR copied_group.sort_order IS DISTINCT FROM source_group.sort_order
+      OR copied.criterion_code IS DISTINCT FROM source.criterion_code
+      OR copied.title IS DISTINCT FROM source.title
+      OR copied.requirement_text IS DISTINCT FROM source.requirement_text
+      OR copied.sort_order IS DISTINCT FROM source.sort_order
+    );
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'Copy criterion fidelity or lineage check failed';
+  END IF;
+  v_revision := (v_response->'data'->>'revision')::BIGINT;
+  SELECT public.technical_configuration_baseline_lock(v_copy_version_id, v_revision)
+  INTO v_response;
+  SELECT public.technical_configuration_baseline_versions_list(v_dossier_id, 1, 100)
+  INTO v_history;
+  IF (v_history->>'total')::BIGINT <> 2
+     OR (v_history->'data'->0->>'id')::UUID <> v_copy_version_id
+     OR v_history->'data'->0->>'status' <> 'locked'
+     OR (v_history->'data'->1->>'id')::UUID <> v_version_id
+     OR v_history->'data'->1->>'status' <> 'locked'
+     OR v_history->'data'->1->'groups'->0->'criteria'->0->>'criterion_code' <> 'TC-0001'
+     OR v_history->'data'->1->'groups'->0->'criteria'->0->>'requirement_text' <> '220V - 50Hz' THEN
+    RAISE EXCEPTION 'historical read after newer version is locked';
+  END IF;
+END;
+$gate$;
+ROLLBACK;


### PR DESCRIPTION
## Scope

P4A contains only the database and transport boundary for baseline version lifecycle:

- add version history, lock, and copy RPC migrations
- add the SQL phase gate and migration contract coverage
- allowlist the lifecycle RPCs through the existing proxy
- add typed wire fields, RPC arguments, and client transport wrappers

The client state/cache behavior and UI are intentionally excluded. P4B will open only after this PR merges; P4C will open only after P4B merges.

## Review context

This supersedes #760 after all nine Cubic findings were triaged. Valid findings were fixed in the stabilized snapshot; the HTTP 500 conflict-keyword finding was rejected because conflict classification intentionally requires both a 409/PT409 transport signal and a conflict marker.

## Live database state

Applied through Supabase MCP on July 14, 2026:

- local `20260714010000_technical_configuration_baseline_locking.sql` -> live version `20260714020812`
- local `20260714030000_technical_configuration_baseline_history_review_fixes.sql` -> live version `20260714030519`

Post-apply security and performance advisors were checked. No new security warning was attributed to these migrations; remaining notices are existing baseline/out-of-scope items.

## Verification

- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- `typecheck`
- 3 focused test files, 34/34 tests passed
- React Doctor: 100/100 for the P4A boundary
- `git diff --check`

Closes #746

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds baseline lifecycle RPCs to list versions, lock versions, and copy locked versions, plus typed client wrappers and wire fields for version history. Implements P4A of #746; UI and client state are deferred.

- New Features
  - New RPCs: `technical_configuration_baseline_versions_list`, `technical_configuration_baseline_lock`, `technical_configuration_baseline_copy`.
  - Typed client wrappers: `listVersions`, `lockVersion`, `copyVersion`; wire types include `source_baseline_version_id`, `source_version_number`, `locked_at`, `locked_by`.
  - RPC proxy allowlist includes the new lifecycle RPCs; mutation RPCs stay behind the editable-version guard.
  - Tests cover migration contracts, RPC allowlist, and client contract; client tests now cover lifecycle RPC argument pass-through. Migration tests select the final function definition when multiple migrations redefine it.

- Migration
  - Adds lifecycle/lineage columns and constraints; indexes for `source_baseline_version_id` and `source_criterion_id`; grants `authenticated` execute on lifecycle RPCs; restricts `_technical_configuration_baseline_snapshot` to `service_role`.
  - Implements locking with actor/time capture and atomic copy with fresh IDs, full lineage, and preserved criterion numbering.
  - Ships a rollback-safe phase gate SQL for roles, locking, mutation guards, copy, and history.
  - Switches history listing to set-based snapshots and adds `source_version_number`; enforces page bounds and newest-first ordering.

<sup>Written for commit 3466584964c3e4fdc56ddca367013fcc247757be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added baseline version history with pagination.
  * Added the ability to lock completed baseline versions permanently.
  * Added copying locked versions into new drafts while preserving lineage and content.
  * Added source and lock metadata to baseline versions.
* **Bug Fixes**
  * Improved history snapshots and version ordering.
  * Added validation to prevent incomplete, stale, or unauthorized baseline changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->