### PR TITLE
feat(technical-config): add P7A2 reference product workspace

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/reference-products-comparison-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-comparison-cases.tsx
@@ -32,8 +32,13 @@ export function registerReferenceProductComparisonTests() {
         const draft = toTechnicalConfigurationReferenceProductDraft(
           product(`product-${index + 1}`, model)
         )
-        draft.responses["criterion-1"] = index === 0 ? longResponse : `Phản hồi dài của ${model}`
-        return draft
+        return {
+          ...draft,
+          responses: {
+            ...draft.responses,
+            "criterion-1": index === 0 ? longResponse : `Phản hồi dài của ${model}`,
+          },
+        }
       })
 
       const { rerender } = renderWithQueryClient(

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-comparison-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-comparison-cases.tsx
@@ -1,3 +1,4 @@
+import * as React from "react"
 import { screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
@@ -5,6 +6,39 @@ import { describe, expect, it, vi } from "vitest"
 import { TechnicalConfigurationReferenceComparison } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison"
 import { toTechnicalConfigurationReferenceProductDraft } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
 import { baselineVersion, product, renderWithQueryClient } from "./reference-products-fixtures"
+
+type ReferenceProductDraft = React.ComponentProps<
+  typeof TechnicalConfigurationReferenceComparison
+>["products"][number]
+
+function ReferenceComparisonHarness({
+  initialProducts,
+}: Readonly<{ initialProducts: ReferenceProductDraft[] }>) {
+  const [products, setProducts] = React.useState(initialProducts)
+
+  return (
+    <TechnicalConfigurationReferenceComparison
+      baselineVersion={baselineVersion}
+      products={products}
+      readOnly={false}
+      onResponseChange={(productId, criterionId, responseText) =>
+        setProducts((current) =>
+          current.map((draft) =>
+            draft.id === productId
+              ? {
+                  ...draft,
+                  responses: {
+                    ...draft.responses,
+                    [criterionId]: responseText,
+                  },
+                }
+              : draft
+          )
+        )
+      }
+    />
+  )
+}
 
 export function registerReferenceProductComparisonTests() {
   describe("technical configuration reference-product comparison", () => {
@@ -110,6 +144,93 @@ export function registerReferenceProductComparisonTests() {
       expect(screen.getByRole("columnheader", { name: "Model D" })).toBeInTheDocument()
       expect(screen.getByRole("columnheader", { name: "Model E" })).toBeInTheDocument()
       expect(screen.queryByText(/xếp hạng|tài liệu|trích dẫn/i)).not.toBeInTheDocument()
+    })
+
+    it("paginates visible products in groups of five and preserves drafts between pages", async () => {
+      const user = userEvent.setup()
+      const products = Array.from({ length: 12 }, (_, index) =>
+        toTechnicalConfigurationReferenceProductDraft(
+          product(`product-${index + 1}`, `Model ${index + 1}`)
+        )
+      )
+
+      renderWithQueryClient(<ReferenceComparisonHarness initialProducts={products} />)
+
+      expect(screen.getByText("Trang 1 / 3")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Trước" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Sau" })).toBeEnabled()
+      expect(screen.getByRole("columnheader", { name: "Model 1" })).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model 5" })).toBeInTheDocument()
+      expect(screen.queryByRole("columnheader", { name: "Model 6" })).not.toBeInTheDocument()
+
+      const firstPageResponse = screen.getByLabelText("Phản hồi Model 1 cho TC-0001")
+      await user.clear(firstPageResponse)
+      await user.type(firstPageResponse, "Bản nháp trang 1")
+      await user.click(screen.getByRole("button", { name: "Sau" }))
+
+      expect(screen.getByText("Trang 2 / 3")).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model 6" })).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model 10" })).toBeInTheDocument()
+      expect(screen.queryByRole("columnheader", { name: "Model 11" })).not.toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Sau" }))
+      expect(screen.getByText("Trang 3 / 3")).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model 11" })).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model 12" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Sau" })).toBeDisabled()
+
+      await user.click(screen.getByRole("button", { name: "Trước" }))
+      await user.click(screen.getByRole("button", { name: "Trước" }))
+      expect(screen.getByLabelText("Phản hồi Model 1 cho TC-0001")).toHaveValue("Bản nháp trang 1")
+
+      await user.click(screen.getByRole("checkbox", { name: "Hiển thị Model 5" }))
+      expect(screen.queryByRole("columnheader", { name: "Model 5" })).not.toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model 6" })).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Sau" }))
+      await user.click(screen.getByRole("button", { name: "Sau" }))
+      expect(screen.getByText("Trang 3 / 3")).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model 12" })).toBeInTheDocument()
+
+      await user.click(screen.getByRole("checkbox", { name: "Hiển thị Model 12" }))
+      expect(screen.getByText("Trang 2 / 2")).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model 11" })).toBeInTheDocument()
+    })
+
+    it("disambiguates duplicate product names across comparison controls", () => {
+      const products = [1, 2].map((number) => {
+        const draft = toTechnicalConfigurationReferenceProductDraft(
+          product(`product-${number}`, "Model A")
+        )
+        return {
+          ...draft,
+          responses: {
+            ...draft.responses,
+            "criterion-1": `Phản hồi ${number}`,
+          },
+        }
+      })
+
+      renderWithQueryClient(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={baselineVersion}
+          products={products}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+        />
+      )
+
+      for (const number of [1, 2]) {
+        const name = `Model A (Sản phẩm ${number})`
+        expect(screen.getByRole("columnheader", { name })).toBeInTheDocument()
+        expect(screen.getByRole("checkbox", { name: `Hiển thị ${name}` })).toBeInTheDocument()
+        expect(screen.getByLabelText(`Phản hồi ${name} cho TC-0001`)).toBeInTheDocument()
+        expect(
+          screen.getByRole("button", {
+            name: `Xem đầy đủ phản hồi ${name} cho TC-0001`,
+          })
+        ).toBeInTheDocument()
+      }
     })
   })
 }

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-comparison-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-comparison-cases.tsx
@@ -1,0 +1,110 @@
+import { screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationReferenceComparison } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison"
+import { toTechnicalConfigurationReferenceProductDraft } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+import { baselineVersion, product, renderWithQueryClient } from "./reference-products-fixtures"
+
+export function registerReferenceProductComparisonTests() {
+  describe("technical configuration reference-product comparison", () => {
+    it("keeps hidden columns by product identity and resets them for another baseline", async () => {
+      const user = userEvent.setup()
+      const longRequirement =
+        "Hệ thống phải duy trì nguồn điện ổn định trong suốt quá trình vận hành liên tục tại khoa điều trị."
+      const longResponse =
+        "Phản hồi chi tiết cho Model A được giữ nguyên đầy đủ để người dùng kiểm tra thông số tham chiếu."
+      const version = {
+        ...baselineVersion,
+        groups: [
+          {
+            ...baselineVersion.groups[0],
+            criteria: [
+              {
+                ...baselineVersion.groups[0]!.criteria[0],
+                requirement_text: longRequirement,
+              },
+            ],
+          },
+        ],
+      }
+      const products = ["Model A", "Model B", "Model C"].map((model, index) => {
+        const draft = toTechnicalConfigurationReferenceProductDraft(
+          product(`product-${index + 1}`, model)
+        )
+        draft.responses["criterion-1"] = index === 0 ? longResponse : `Phản hồi dài của ${model}`
+        return draft
+      })
+
+      const { rerender } = renderWithQueryClient(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={version}
+          products={products}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+        />
+      )
+
+      expect(screen.getByTestId("reference-comparison-scroll")).toHaveClass("overflow-x-auto")
+      expect(screen.getByRole("columnheader", { name: "Yêu cầu cơ sở" })).toHaveClass("sticky")
+      expect(screen.getByRole("columnheader", { name: "Model A" })).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model B" })).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model C" })).toBeInTheDocument()
+
+      await user.click(screen.getByRole("checkbox", { name: "Hiển thị Model B" }))
+      expect(screen.queryByRole("columnheader", { name: "Model B" })).not.toBeInTheDocument()
+
+      const editedProducts = products.map((draft, index) =>
+        index === 0 ? { ...draft, model: "Model A cập nhật" } : draft
+      )
+      rerender(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={version}
+          products={editedProducts}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+        />
+      )
+      expect(screen.getByRole("columnheader", { name: "Model A cập nhật" })).toBeInTheDocument()
+      expect(screen.queryByRole("columnheader", { name: "Model B" })).not.toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Xem đầy đủ yêu cầu TC-0001" }))
+      expect(within(screen.getByRole("dialog")).getByText(longRequirement)).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Đóng" }))
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Xem đầy đủ phản hồi Model A cập nhật cho TC-0001",
+        })
+      )
+      expect(within(screen.getByRole("dialog")).getByText(longResponse)).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Đóng" }))
+
+      rerender(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={version}
+          products={editedProducts.slice(1)}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+        />
+      )
+      expect(screen.queryByRole("columnheader", { name: "Model B" })).not.toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model C" })).toBeInTheDocument()
+
+      const nextProducts = ["Model D", "Model E"].map((model, index) =>
+        toTechnicalConfigurationReferenceProductDraft(product(`next-${index + 1}`, model))
+      )
+      rerender(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={{ ...version, id: "version-2" }}
+          products={nextProducts}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+        />
+      )
+      expect(screen.getByRole("columnheader", { name: "Model D" })).toBeInTheDocument()
+      expect(screen.getByRole("columnheader", { name: "Model E" })).toBeInTheDocument()
+      expect(screen.queryByText(/xếp hạng|tài liệu|trích dẫn/i)).not.toBeInTheDocument()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-conflict-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-conflict-cases.tsx
@@ -1,0 +1,113 @@
+import { act, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { TechnicalConfigurationRpcError } from "@/app/(app)/technical-configurations/technical-configuration-rpc"
+import {
+  baselineVersion,
+  listResponse,
+  product,
+  renderReferenceProductsHook,
+  type ReferenceProductRpcMocks,
+} from "./reference-products-fixtures"
+
+export function registerReferenceProductConflictTests(referenceRpc: ReferenceProductRpcMocks) {
+  describe("technical configuration reference-product conflict recovery", () => {
+    beforeEach(() => {
+      Object.values(referenceRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("preserves the local response draft when a stale revision interrupts save", async () => {
+      const first = product("product-1", "Model A")
+      referenceRpc.listProducts.mockResolvedValue(listResponse([first]))
+      referenceRpc.upsertResponse.mockRejectedValue(
+        new TechnicalConfigurationRpcError(409, { message: "stale_revision" })
+      )
+
+      const { result } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      act(() => {
+        result.current.updateResponse(first.id, "criterion-1", "Phản hồi giữ lại")
+      })
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(result.current.isConflict).toBe(true)
+      expect(result.current.isDirty).toBe(true)
+      expect(result.current.products[0]?.responses["criterion-1"]).toBe("Phản hồi giữ lại")
+      expect(result.current.saveError).toMatch(/được giữ lại/i)
+      expect(referenceRpc.listProducts).toHaveBeenCalledTimes(1)
+    })
+
+    it("preserves the conflicted draft when reload fails", async () => {
+      const first = product("product-1", "Model A")
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([first]))
+        .mockRejectedValueOnce(new Error("network unavailable"))
+      referenceRpc.updateProduct.mockRejectedValue(
+        new TechnicalConfigurationRpcError(409, { message: "stale_revision" })
+      )
+
+      const { result } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      act(() => {
+        result.current.updateProduct(first.id, { model: "Model giữ lại" })
+      })
+      await act(async () => {
+        await result.current.save()
+        await result.current.reload()
+      })
+
+      expect(result.current.isConflict).toBe(true)
+      expect(result.current.isDirty).toBe(true)
+      expect(result.current.products[0]?.model).toBe("Model giữ lại")
+      expect(result.current.saveError).toBe("Không thể tải lại sản phẩm tham chiếu.")
+    })
+
+    it("replaces a conflicted response draft after a successful reload", async () => {
+      const first = product("product-1", "Model A")
+      const refreshed = product("product-1", "Model A", 6)
+      refreshed.responses = [
+        {
+          id: "response-1",
+          baseline_version_id: baselineVersion.id,
+          reference_product_id: first.id,
+          criterion_id: "criterion-1",
+          response_text: "Phản hồi máy chủ",
+          created_at: "2026-07-17T00:00:00.000Z",
+          created_by: 1,
+          updated_at: "2026-07-17T00:00:00.000Z",
+          updated_by: 1,
+          revision: 6,
+        },
+      ]
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([first]))
+        .mockResolvedValueOnce(listResponse([refreshed]))
+      referenceRpc.upsertResponse.mockRejectedValue(
+        new TechnicalConfigurationRpcError(409, { message: "stale_revision" })
+      )
+
+      const { result } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      act(() => {
+        result.current.updateResponse(first.id, "criterion-1", "Phản hồi giữ lại")
+      })
+      await act(async () => {
+        await result.current.save()
+      })
+      expect(result.current.isConflict).toBe(true)
+      expect(result.current.products[0]?.responses["criterion-1"]).toBe("Phản hồi giữ lại")
+
+      await act(async () => {
+        await result.current.reload()
+      })
+      expect(result.current.isConflict).toBe(false)
+      expect(result.current.isDirty).toBe(false)
+      expect(result.current.products[0]?.responses["criterion-1"]).toBe("Phản hồi máy chủ")
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-fixtures.tsx
@@ -104,10 +104,12 @@ export function product(
 }
 
 export function listResponse(
-  data: TechnicalConfigurationReferenceProductWire[]
+  data: TechnicalConfigurationReferenceProductWire[],
+  revision = data[0]?.revision ?? baselineVersion.revision
 ): TechnicalConfigurationReferenceProductsListWireResponse {
   return {
     data,
+    revision,
     total: data.length,
     page: 1,
     page_size: 100,

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-fixtures.tsx
@@ -1,0 +1,148 @@
+import type { ReactNode } from "react"
+import { render, renderHook } from "@testing-library/react"
+import { vi, type Mock } from "vitest"
+
+import { useTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type {
+  TechnicalConfigurationReferenceProductWire,
+  TechnicalConfigurationReferenceProductsListWireResponse,
+} from "@/app/(app)/technical-configurations/reference-product-types"
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+
+export type ReferenceProductRpcMocks = {
+  listProducts: Mock
+  createProduct: Mock
+  updateProduct: Mock
+  deleteProduct: Mock
+  upsertResponse: Mock
+}
+
+export type BaselineVersionRpcMocks = {
+  listVersions: Mock
+}
+
+export const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy lọc thận",
+  name: "Cấu hình máy lọc thận",
+  description: null,
+  revision: 3,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-17T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-17T00:00:00.000Z",
+  updated_by: 1,
+}
+
+export const baselineVersion: TechnicalConfigurationBaselineDraftWire = {
+  id: "version-1",
+  dossier_id: dossier.id,
+  version_number: 1,
+  status: "draft",
+  source_baseline_version_id: null,
+  source_version_number: null,
+  next_criterion_number: 2,
+  revision: 5,
+  locked_at: null,
+  locked_by: null,
+  created_at: "2026-07-17T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-17T00:00:00.000Z",
+  updated_by: 1,
+  groups: [
+    {
+      id: "group-1",
+      baseline_version_id: "version-1",
+      name: "Yêu cầu chung",
+      sort_order: 1,
+      created_at: "2026-07-17T00:00:00.000Z",
+      created_by: 1,
+      updated_at: "2026-07-17T00:00:00.000Z",
+      updated_by: 1,
+      criteria: [
+        {
+          id: "criterion-1",
+          baseline_version_id: "version-1",
+          group_id: "group-1",
+          criterion_code: "TC-0001",
+          title: "Nguồn điện",
+          requirement_text: "Nguồn điện ổn định",
+          sort_order: 1,
+          source_criterion_id: null,
+          created_at: "2026-07-17T00:00:00.000Z",
+          created_by: 1,
+          updated_at: "2026-07-17T00:00:00.000Z",
+          updated_by: 1,
+        },
+      ],
+    },
+  ],
+}
+
+export function product(
+  id: string,
+  model: string,
+  revision = baselineVersion.revision
+): TechnicalConfigurationReferenceProductWire {
+  return {
+    id,
+    baseline_version_id: baselineVersion.id,
+    model,
+    manufacturer: "Hãng A",
+    description: null,
+    notes: null,
+    created_at: "2026-07-17T00:00:00.000Z",
+    created_by: 1,
+    updated_at: "2026-07-17T00:00:00.000Z",
+    updated_by: 1,
+    revision,
+    responses: [],
+  }
+}
+
+export function listResponse(
+  data: TechnicalConfigurationReferenceProductWire[]
+): TechnicalConfigurationReferenceProductsListWireResponse {
+  return {
+    data,
+    total: data.length,
+    page: 1,
+    page_size: 100,
+  }
+}
+
+export function renderReferenceProductsHook({
+  onRevisionChange = vi.fn(),
+  onNavigationBlockedChange = vi.fn(),
+  isArchived = false,
+}: {
+  onRevisionChange?: (revision: number) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+  isArchived?: boolean
+} = {}) {
+  const queryClient = createTestQueryClient()
+  const rendered = renderHook(
+    () =>
+      useTechnicalConfigurationReferenceProducts({
+        baselineVersion,
+        isArchived,
+        onRevisionChange,
+        onNavigationBlockedChange,
+      }),
+    {
+      wrapper: createReactQueryWrapper(queryClient),
+    }
+  )
+  return { ...rendered, queryClient, onRevisionChange, onNavigationBlockedChange }
+}
+
+export function renderWithQueryClient(node: ReactNode) {
+  const queryClient = createTestQueryClient()
+  return {
+    ...render(node, { wrapper: createReactQueryWrapper(queryClient) }),
+    queryClient,
+  }
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-hook-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-hook-cases.tsx
@@ -1,6 +1,7 @@
 import { act, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { listAllTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-operations"
 import {
   baselineVersion,
   listResponse,
@@ -42,12 +43,14 @@ export function registerReferenceProductHookTests(referenceRpc: ReferenceProduct
       referenceRpc.listProducts
         .mockResolvedValueOnce({
           data: firstPage,
+          revision: baselineVersion.revision,
           total: 101,
           page: 1,
           page_size: 100,
         })
         .mockResolvedValueOnce({
           data: [lastProduct],
+          revision: baselineVersion.revision,
           total: 101,
           page: 2,
           page_size: 100,
@@ -66,7 +69,54 @@ export function registerReferenceProductHookTests(referenceRpc: ReferenceProduct
         expect.any(AbortSignal)
       )
       expect(result.current.products.at(-1)?.model).toBe("Model 101")
+      expect(result.current.productsQuery.data).toEqual({
+        products: [...firstPage, lastProduct],
+        revision: baselineVersion.revision,
+      })
     })
+
+    it.each([
+      {
+        changedField: "revision",
+        secondRevision: baselineVersion.revision + 1,
+        secondTotal: 2,
+      },
+      {
+        changedField: "total",
+        secondRevision: baselineVersion.revision,
+        secondTotal: 3,
+      },
+    ])(
+      "rejects the aggregate when paginated snapshot $changedField changes",
+      async ({ secondRevision, secondTotal }) => {
+        referenceRpc.listProducts
+          .mockResolvedValueOnce({
+            data: [product("product-1", "Model 1")],
+            revision: baselineVersion.revision,
+            total: 2,
+            page: 1,
+            page_size: 100,
+          })
+          .mockResolvedValueOnce({
+            data: [product("product-2", "Model 2", secondRevision)],
+            revision: secondRevision,
+            total: secondTotal,
+            page: 2,
+            page_size: 100,
+          })
+          .mockResolvedValueOnce({
+            data: [],
+            revision: secondRevision,
+            total: secondTotal,
+            page: 3,
+            page_size: 100,
+          })
+
+        await expect(
+          listAllTechnicalConfigurationReferenceProducts(baselineVersion.id)
+        ).rejects.toThrow("Reference-product pagination snapshot changed during load.")
+      }
+    )
 
     it("reports navigation blocking while reload is in flight", async () => {
       let resolveReload: ((value: ReturnType<typeof listResponse>) => void) | undefined

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-hook-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-hook-cases.tsx
@@ -1,0 +1,275 @@
+import { act, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  baselineVersion,
+  listResponse,
+  product,
+  renderReferenceProductsHook,
+  type ReferenceProductRpcMocks,
+} from "./reference-products-fixtures"
+
+export function registerReferenceProductHookTests(referenceRpc: ReferenceProductRpcMocks) {
+  describe("useTechnicalConfigurationReferenceProducts", () => {
+    beforeEach(() => {
+      Object.values(referenceRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("loads the exact baseline-version aggregate through the P7A1 list wrapper", async () => {
+      referenceRpc.listProducts.mockResolvedValue(listResponse([product("product-1", "Model A")]))
+
+      const { result } = renderReferenceProductsHook()
+
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      expect(referenceRpc.listProducts).toHaveBeenCalledWith(
+        {
+          p_baseline_version_id: baselineVersion.id,
+          p_page: 1,
+          p_page_size: 100,
+        },
+        expect.any(AbortSignal)
+      )
+      expect(result.current.products[0]?.model).toBe("Model A")
+      expect(result.current.isDirty).toBe(false)
+    })
+
+    it("loads every reference-product page for the selected baseline version", async () => {
+      const firstPage = Array.from({ length: 100 }, (_, index) =>
+        product(`product-${index + 1}`, `Model ${index + 1}`)
+      )
+      const lastProduct = product("product-101", "Model 101")
+      referenceRpc.listProducts
+        .mockResolvedValueOnce({
+          data: firstPage,
+          total: 101,
+          page: 1,
+          page_size: 100,
+        })
+        .mockResolvedValueOnce({
+          data: [lastProduct],
+          total: 101,
+          page: 2,
+          page_size: 100,
+        })
+
+      const { result } = renderReferenceProductsHook()
+
+      await waitFor(() => expect(result.current.products).toHaveLength(101))
+      expect(referenceRpc.listProducts).toHaveBeenNthCalledWith(
+        2,
+        {
+          p_baseline_version_id: baselineVersion.id,
+          p_page: 2,
+          p_page_size: 100,
+        },
+        expect.any(AbortSignal)
+      )
+      expect(result.current.products.at(-1)?.model).toBe("Model 101")
+    })
+
+    it("reports navigation blocking while reload is in flight", async () => {
+      let resolveReload: ((value: ReturnType<typeof listResponse>) => void) | undefined
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([product("product-1", "Model A")]))
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveReload = resolve
+            })
+        )
+
+      const { result, onNavigationBlockedChange } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      let reloadPromise: Promise<void> | undefined
+      act(() => {
+        reloadPromise = result.current.reload()
+      })
+      expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(true)
+
+      await act(async () => {
+        resolveReload?.(listResponse([product("product-1", "Model A")]))
+        await reloadPromise
+      })
+      expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(false)
+    })
+
+    it("defers create, update, delete, and response mutations until explicit save", async () => {
+      const first = product("product-1", "Model A")
+      const removed = product("product-2", "Model B")
+      const refreshed = product("product-1", "Model A2", 10)
+      refreshed.responses = [
+        {
+          id: "response-1",
+          baseline_version_id: baselineVersion.id,
+          reference_product_id: first.id,
+          criterion_id: "criterion-1",
+          response_text: "Đáp ứng ổn định",
+          created_at: "2026-07-17T00:00:00.000Z",
+          created_by: 1,
+          updated_at: "2026-07-17T00:00:00.000Z",
+          updated_by: 1,
+          revision: 7,
+        },
+      ]
+      const created = product("product-3", "Model C", 8)
+      const finalResponse = listResponse([refreshed, created])
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([first, removed]))
+        .mockResolvedValueOnce(finalResponse)
+      referenceRpc.updateProduct.mockResolvedValueOnce({
+        data: { ...first, model: "Model A2", revision: 6 },
+      })
+      referenceRpc.upsertResponse
+        .mockResolvedValueOnce({ data: refreshed.responses[0] })
+        .mockResolvedValueOnce({
+          data: {
+            ...refreshed.responses[0],
+            id: "response-2",
+            reference_product_id: created.id,
+            response_text: "Thông số tham chiếu C",
+            revision: 9,
+          },
+        })
+      referenceRpc.createProduct.mockResolvedValueOnce({ data: created })
+      referenceRpc.deleteProduct.mockResolvedValueOnce({
+        data: { id: removed.id, revision: 10 },
+      })
+
+      const { result, onRevisionChange } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.products).toHaveLength(2))
+
+      let newProductId = ""
+      act(() => {
+        result.current.updateProduct(first.id, { model: "Model A2" })
+        result.current.updateResponse(first.id, "criterion-1", "Đáp ứng ổn định")
+        result.current.removeProduct(removed.id)
+        newProductId = result.current.addProduct()
+        result.current.updateProduct(newProductId, { model: "Model C" })
+        result.current.updateResponse(newProductId, "criterion-1", "Thông số tham chiếu C")
+      })
+
+      expect(result.current.isDirty).toBe(true)
+      expect(referenceRpc.createProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.updateProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.deleteProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.upsertResponse).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(referenceRpc.updateProduct).toHaveBeenCalledWith({
+        p_reference_product_id: first.id,
+        p_model: "Model A2",
+        p_manufacturer: "Hãng A",
+        p_description: null,
+        p_notes: null,
+        p_expected_revision: 5,
+      })
+      expect(referenceRpc.upsertResponse).toHaveBeenNthCalledWith(1, {
+        p_reference_product_id: first.id,
+        p_criterion_id: "criterion-1",
+        p_response_text: "Đáp ứng ổn định",
+        p_expected_revision: 6,
+      })
+      expect(referenceRpc.createProduct).toHaveBeenCalledWith({
+        p_baseline_version_id: baselineVersion.id,
+        p_model: "Model C",
+        p_manufacturer: null,
+        p_description: null,
+        p_notes: null,
+        p_expected_revision: 7,
+      })
+      expect(referenceRpc.upsertResponse).toHaveBeenNthCalledWith(2, {
+        p_reference_product_id: created.id,
+        p_criterion_id: "criterion-1",
+        p_response_text: "Thông số tham chiếu C",
+        p_expected_revision: 8,
+      })
+      expect(referenceRpc.deleteProduct).toHaveBeenCalledWith({
+        p_reference_product_id: removed.id,
+        p_expected_revision: 9,
+      })
+      expect(onRevisionChange).toHaveBeenLastCalledWith(10)
+      await waitFor(() => expect(result.current.isDirty).toBe(false))
+    })
+
+    it("does not replay completed writes when cache refresh fails", async () => {
+      const created = product("product-1", "Model A", 6)
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+      referenceRpc.createProduct.mockResolvedValue({ data: created })
+      referenceRpc.updateProduct.mockResolvedValue({
+        data: { ...created, model: "Model B", revision: 7 },
+      })
+
+      const { result, queryClient } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.productsQuery.isSuccess).toBe(true))
+      const invalidateQueries = vi
+        .spyOn(queryClient, "invalidateQueries")
+        .mockRejectedValue(new Error("cache unavailable"))
+
+      let localId = ""
+      act(() => {
+        localId = result.current.addProduct()
+        result.current.updateProduct(localId, { model: "Model A" })
+      })
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(referenceRpc.createProduct).toHaveBeenCalledTimes(1)
+      expect(result.current.products[0]).toMatchObject({
+        id: created.id,
+        persistedId: created.id,
+        model: "Model A",
+      })
+      expect(result.current.isDirty).toBe(false)
+      expect(result.current.saveStatus).toBe("saved")
+      expect(result.current.saveError).toBeNull()
+      expect(result.current.refreshWarning).toBe(
+        "Đã lưu thay đổi nhưng không thể làm mới dữ liệu từ máy chủ."
+      )
+
+      act(() => {
+        result.current.updateProduct(created.id, { model: "Model B" })
+      })
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(referenceRpc.createProduct).toHaveBeenCalledTimes(1)
+      expect(referenceRpc.updateProduct).toHaveBeenCalledWith({
+        p_reference_product_id: created.id,
+        p_model: "Model B",
+        p_manufacturer: "Hãng A",
+        p_description: null,
+        p_notes: null,
+        p_expected_revision: 6,
+      })
+      invalidateQueries.mockRestore()
+    })
+
+    it("blocks archived-dossier product and criterion-response authoring", async () => {
+      const first = product("product-1", "Model A")
+      referenceRpc.listProducts.mockResolvedValue(listResponse([first]))
+
+      const { result } = renderReferenceProductsHook({ isArchived: true })
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      act(() => {
+        result.current.updateProduct(first.id, { model: "Không được lưu" })
+        result.current.updateResponse(first.id, "criterion-1", "Không được lưu")
+      })
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(result.current.isReadOnly).toBe(true)
+      expect(result.current.products[0]?.model).toBe("Model A")
+      expect(referenceRpc.updateProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.upsertResponse).not.toHaveBeenCalled()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-operation-lock-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-operation-lock-cases.tsx
@@ -1,0 +1,140 @@
+import { act, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  listResponse,
+  product,
+  renderReferenceProductsHook,
+  type ReferenceProductRpcMocks,
+} from "./reference-products-fixtures"
+
+export function registerReferenceProductOperationLockTests(referenceRpc: ReferenceProductRpcMocks) {
+  describe("technical configuration reference-product operation locking", () => {
+    beforeEach(() => {
+      Object.values(referenceRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("blocks overlapping reloads, saves, and draft edits while reload is active", async () => {
+      const initialProduct = product("product-1", "Model A")
+      const refreshedProduct = product("product-1", "Model máy chủ", 6)
+      let resolveReload: ((value: ReturnType<typeof listResponse>) => void) | undefined
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([initialProduct]))
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveReload = resolve
+            })
+        )
+
+      const { result, onNavigationBlockedChange } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      act(() => {
+        result.current.updateProduct(initialProduct.id, { model: "Model chưa lưu" })
+      })
+
+      let firstReload: Promise<void> | undefined
+      let secondReload: Promise<void> | undefined
+      let saveDuringReload: Promise<void> | undefined
+      let addedProductId: string | undefined
+      act(() => {
+        firstReload = result.current.reload()
+        secondReload = result.current.reload()
+        saveDuringReload = result.current.save()
+        result.current.updateProduct(initialProduct.id, { model: "Model ghi đè" })
+        result.current.updateResponse(initialProduct.id, "criterion-1", "Phản hồi ghi đè")
+        result.current.removeProduct(initialProduct.id)
+        addedProductId = result.current.addProduct()
+      })
+
+      expect(referenceRpc.listProducts).toHaveBeenCalledTimes(2)
+      expect(referenceRpc.updateProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.upsertResponse).not.toHaveBeenCalled()
+      expect(referenceRpc.deleteProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.createProduct).not.toHaveBeenCalled()
+      expect(addedProductId).toBe("")
+      expect(result.current.products).toEqual([
+        expect.objectContaining({
+          id: initialProduct.id,
+          model: "Model chưa lưu",
+          responses: {},
+        }),
+      ])
+
+      await act(async () => {
+        resolveReload?.(listResponse([refreshedProduct]))
+        await Promise.all([firstReload, secondReload, saveDuringReload])
+      })
+
+      expect(result.current.products).toEqual([
+        expect.objectContaining({
+          id: refreshedProduct.id,
+          model: "Model máy chủ",
+        }),
+      ])
+      expect(onNavigationBlockedChange.mock.calls).toEqual([[true], [false]])
+    })
+
+    it("blocks reloads and draft edits while save is active", async () => {
+      const initialProduct = product("product-1", "Model A")
+      const savedProduct = product("product-1", "Model đã lưu", 6)
+      let resolveSave: ((value: { data: typeof savedProduct }) => void) | undefined
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([initialProduct]))
+        .mockResolvedValueOnce(listResponse([savedProduct]))
+      referenceRpc.updateProduct.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSave = resolve
+          })
+      )
+
+      const { result, onNavigationBlockedChange } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      act(() => {
+        result.current.updateProduct(initialProduct.id, { model: "Model đã lưu" })
+      })
+
+      let savePromise: Promise<void> | undefined
+      let reloadDuringSave: Promise<void> | undefined
+      let addedProductId: string | undefined
+      act(() => {
+        savePromise = result.current.save()
+        reloadDuringSave = result.current.reload()
+        result.current.updateProduct(initialProduct.id, { model: "Model ghi đè" })
+        result.current.updateResponse(initialProduct.id, "criterion-1", "Phản hồi ghi đè")
+        result.current.removeProduct(initialProduct.id)
+        addedProductId = result.current.addProduct()
+      })
+
+      expect(referenceRpc.listProducts).toHaveBeenCalledTimes(1)
+      expect(addedProductId).toBe("")
+      expect(result.current.products).toEqual([
+        expect.objectContaining({
+          id: initialProduct.id,
+          model: "Model đã lưu",
+          responses: {},
+        }),
+      ])
+
+      await act(async () => {
+        resolveSave?.({ data: savedProduct })
+        await Promise.all([savePromise, reloadDuringSave])
+      })
+
+      expect(referenceRpc.updateProduct).toHaveBeenCalledTimes(1)
+      expect(referenceRpc.upsertResponse).not.toHaveBeenCalled()
+      expect(referenceRpc.deleteProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.createProduct).not.toHaveBeenCalled()
+      expect(result.current.products).toEqual([
+        expect.objectContaining({
+          id: savedProduct.id,
+          model: "Model đã lưu",
+        }),
+      ])
+      expect(onNavigationBlockedChange.mock.calls).toEqual([[true], [false]])
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
@@ -46,6 +46,9 @@ export function registerReferenceProductResilienceTests({
       renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
 
       expect(await screen.findByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeDisabled()
+      expect(
+        screen.queryByRole("region", { name: "Ma trận đối chiếu sản phẩm tham chiếu" })
+      ).not.toBeInTheDocument()
 
       resolveProducts?.(listResponse([]))
       await waitFor(() =>
@@ -62,6 +65,11 @@ export function registerReferenceProductResilienceTests({
       renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
 
       expect(await screen.findByText("Không thể tải sản phẩm tham chiếu")).toBeInTheDocument()
+      expect(screen.getByText("Vui lòng thử lại.")).toBeInTheDocument()
+      expect(screen.queryByText("products unavailable")).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole("region", { name: "Ma trận đối chiếu sản phẩm tham chiếu" })
+      ).not.toBeInTheDocument()
       expect(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeDisabled()
       await user.click(screen.getByRole("button", { name: "Thử lại" }))
 

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
@@ -81,6 +81,7 @@ export function registerReferenceProductResilienceTests({
     it("keeps saved products visible when background cache refresh fails", async () => {
       const user = userEvent.setup()
       const created = product("product-1", "Model đã lưu", 6)
+      const refreshed = product("product-1", "Model từ máy chủ", 6)
       baselineRpc.listVersions
         .mockResolvedValueOnce({
           data: [baselineVersion],
@@ -89,9 +90,16 @@ export function registerReferenceProductResilienceTests({
           page_size: 20,
         })
         .mockRejectedValueOnce(new Error("versions unavailable"))
+        .mockResolvedValueOnce({
+          data: [baselineVersion],
+          total: 1,
+          page: 1,
+          page_size: 20,
+        })
       referenceRpc.listProducts
         .mockResolvedValueOnce(listResponse([]))
         .mockRejectedValueOnce(new Error("products unavailable"))
+        .mockResolvedValueOnce(listResponse([refreshed]))
       referenceRpc.createProduct.mockResolvedValueOnce({ data: created })
 
       renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
@@ -107,6 +115,14 @@ export function registerReferenceProductResilienceTests({
       ).toBeInTheDocument()
       expect(screen.getByDisplayValue("Model đã lưu")).toBeInTheDocument()
       expect(screen.queryByRole("button", { name: "Thử lại" })).not.toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+
+      expect(await screen.findByDisplayValue("Model từ máy chủ")).toBeInTheDocument()
+      expect(screen.queryByDisplayValue("Model đã lưu")).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Đã lưu thay đổi nhưng không thể làm mới dữ liệu từ máy chủ.")
+      ).not.toBeInTheDocument()
     })
 
     it("blocks version and product navigation while version refresh is pending", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
@@ -1,0 +1,197 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts"
+import {
+  baselineVersion,
+  dossier,
+  listResponse,
+  product,
+  renderWithQueryClient,
+  type BaselineVersionRpcMocks,
+  type ReferenceProductRpcMocks,
+} from "./reference-products-fixtures"
+
+type RegisterReferenceProductResilienceTestsArgs = {
+  baselineRpc: BaselineVersionRpcMocks
+  referenceRpc: ReferenceProductRpcMocks
+}
+
+export function registerReferenceProductResilienceTests({
+  baselineRpc,
+  referenceRpc,
+}: RegisterReferenceProductResilienceTestsArgs) {
+  describe("technical configuration reference-product resilience", () => {
+    beforeEach(() => {
+      baselineRpc.listVersions.mockReset()
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baselineVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      Object.values(referenceRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("disables authoring while the initial product load is pending", async () => {
+      let resolveProducts: ((value: ReturnType<typeof listResponse>) => void) | undefined
+      referenceRpc.listProducts.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveProducts = resolve
+          })
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      expect(await screen.findByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeDisabled()
+
+      resolveProducts?.(listResponse([]))
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeEnabled()
+      )
+    })
+
+    it("offers retry after the initial product load fails", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts
+        .mockRejectedValueOnce(new Error("products unavailable"))
+        .mockResolvedValueOnce(listResponse([]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      expect(await screen.findByText("Không thể tải sản phẩm tham chiếu")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeDisabled()
+      await user.click(screen.getByRole("button", { name: "Thử lại" }))
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeEnabled()
+      )
+    })
+
+    it("keeps saved products visible when background cache refresh fails", async () => {
+      const user = userEvent.setup()
+      const created = product("product-1", "Model đã lưu", 6)
+      baselineRpc.listVersions
+        .mockResolvedValueOnce({
+          data: [baselineVersion],
+          total: 1,
+          page: 1,
+          page_size: 20,
+        })
+        .mockRejectedValueOnce(new Error("versions unavailable"))
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([]))
+        .mockRejectedValueOnce(new Error("products unavailable"))
+      referenceRpc.createProduct.mockResolvedValueOnce({ data: created })
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model đã lưu")
+      await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+      expect(await screen.findByText("Đã lưu sản phẩm tham chiếu.")).toBeInTheDocument()
+      expect(
+        screen.getByText("Đã lưu thay đổi nhưng không thể làm mới dữ liệu từ máy chủ.")
+      ).toBeInTheDocument()
+      expect(screen.getByDisplayValue("Model đã lưu")).toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: "Thử lại" })).not.toBeInTheDocument()
+    })
+
+    it("blocks version and product navigation while version refresh is pending", async () => {
+      const user = userEvent.setup()
+      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
+      let resolveVersions:
+        | ((value: {
+            data: Array<typeof baselineVersion>
+            total: number
+            page: number
+            page_size: number
+          }) => void)
+        | undefined
+      baselineRpc.listVersions
+        .mockResolvedValueOnce({
+          data: [baselineVersion],
+          total: 1,
+          page: 1,
+          page_size: 20,
+        })
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveVersions = resolve
+            })
+        )
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
+      await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+
+      expect(screen.getByRole("combobox", { name: "Phiên bản cấu hình cơ sở" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeDisabled()
+
+      resolveVersions?.({
+        data: [baselineVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      await waitFor(() =>
+        expect(screen.getByRole("combobox", { name: "Phiên bản cấu hình cơ sở" })).toBeEnabled()
+      )
+      confirm.mockRestore()
+    })
+
+    it("wires visible product update, response upsert, and delete through explicit save", async () => {
+      const user = userEvent.setup()
+      const first = product("product-1", "Model A")
+      const removed = product("product-2", "Model B")
+      const updated = { ...first, model: "Model A2", revision: 6 }
+      const response = {
+        id: "response-1",
+        baseline_version_id: baselineVersion.id,
+        reference_product_id: first.id,
+        criterion_id: "criterion-1",
+        response_text: "Phản hồi cập nhật",
+        created_at: "2026-07-17T00:00:00.000Z",
+        created_by: 1,
+        updated_at: "2026-07-17T00:00:00.000Z",
+        updated_by: 1,
+        revision: 7,
+      }
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([first, removed]))
+        .mockResolvedValueOnce(listResponse([{ ...updated, responses: [response] }]))
+      referenceRpc.updateProduct.mockResolvedValueOnce({ data: updated })
+      referenceRpc.upsertResponse.mockResolvedValueOnce({ data: response })
+      referenceRpc.deleteProduct.mockResolvedValueOnce({
+        data: { id: removed.id, revision: 8 },
+      })
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+      const modelInputs = await screen.findAllByLabelText("Model")
+      await user.clear(modelInputs[0]!)
+      await user.type(modelInputs[0]!, "Model A2")
+      await user.type(screen.getByLabelText("Phản hồi Model A2 cho TC-0001"), "Phản hồi cập nhật")
+      await user.click(screen.getByRole("button", { name: "Xóa Model B" }))
+
+      expect(referenceRpc.updateProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.upsertResponse).not.toHaveBeenCalled()
+      expect(referenceRpc.deleteProduct).not.toHaveBeenCalled()
+
+      await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+      await waitFor(() => expect(referenceRpc.updateProduct).toHaveBeenCalledTimes(1))
+      expect(referenceRpc.upsertResponse).toHaveBeenCalledTimes(1)
+      expect(referenceRpc.deleteProduct).toHaveBeenCalledTimes(1)
+      expect(screen.getByDisplayValue("Model A2")).toBeInTheDocument()
+      expect(screen.getByDisplayValue("Phản hồi cập nhật")).toBeInTheDocument()
+      expect(screen.queryByDisplayValue("Model B")).not.toBeInTheDocument()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-save-resume-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-save-resume-cases.tsx
@@ -132,5 +132,26 @@ export function registerReferenceProductSaveResumeTests(referenceRpc: ReferenceP
       expect(onRevisionChange).toHaveBeenLastCalledWith(7)
       await waitFor(() => expect(result.current.isDirty).toBe(false))
     })
+
+    it("does not expose raw non-conflict save errors", async () => {
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+      referenceRpc.createProduct.mockRejectedValue(
+        new Error("rpc_internal: relation details must stay private")
+      )
+
+      const { result } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.productsQuery.isSuccess).toBe(true))
+
+      act(() => {
+        const localId = result.current.addProduct()
+        result.current.updateProduct(localId, { model: "Model A" })
+      })
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(result.current.saveError).toBe("Không thể lưu sản phẩm tham chiếu.")
+      expect(result.current.saveError).not.toMatch(/relation details/i)
+    })
   })
 }

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-save-resume-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-save-resume-cases.tsx
@@ -1,0 +1,136 @@
+import { act, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  baselineVersion,
+  listResponse,
+  product,
+  renderReferenceProductsHook,
+  type ReferenceProductRpcMocks,
+} from "./reference-products-fixtures"
+
+export function registerReferenceProductSaveResumeTests(referenceRpc: ReferenceProductRpcMocks) {
+  describe("technical configuration reference-product partial-save recovery", () => {
+    beforeEach(() => {
+      Object.values(referenceRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("resumes a partial update save without replaying completed writes", async () => {
+      const first = product("product-1", "Model A")
+      const updated = product(first.id, "Model A2", 6)
+      const savedResponse = {
+        id: "response-1",
+        baseline_version_id: baselineVersion.id,
+        reference_product_id: first.id,
+        criterion_id: "criterion-1",
+        response_text: "Phản hồi cập nhật",
+        created_at: "2026-07-17T00:00:00.000Z",
+        created_by: 1,
+        updated_at: "2026-07-17T00:00:00.000Z",
+        updated_by: 1,
+        revision: 7,
+      }
+      const refreshed = product(first.id, "Model A2", 7)
+      refreshed.responses = [savedResponse]
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([first]))
+        .mockResolvedValueOnce(listResponse([refreshed]))
+      referenceRpc.updateProduct.mockResolvedValue({ data: updated })
+      referenceRpc.upsertResponse
+        .mockRejectedValueOnce(new Error("response write failed"))
+        .mockResolvedValueOnce({ data: savedResponse })
+
+      const { result, onRevisionChange } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.products).toHaveLength(1))
+
+      act(() => {
+        result.current.updateProduct(first.id, { model: "Model A2" })
+        result.current.updateResponse(first.id, "criterion-1", "Phản hồi cập nhật")
+      })
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(onRevisionChange).toHaveBeenLastCalledWith(6)
+      expect(result.current.products[0]).toMatchObject({
+        model: "Model A2",
+        responses: { "criterion-1": "Phản hồi cập nhật" },
+      })
+      expect(result.current.isDirty).toBe(true)
+
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(referenceRpc.updateProduct).toHaveBeenCalledTimes(1)
+      expect(referenceRpc.upsertResponse).toHaveBeenNthCalledWith(2, {
+        p_reference_product_id: first.id,
+        p_criterion_id: "criterion-1",
+        p_response_text: "Phản hồi cập nhật",
+        p_expected_revision: 6,
+      })
+      expect(onRevisionChange).toHaveBeenLastCalledWith(7)
+      await waitFor(() => expect(result.current.isDirty).toBe(false))
+    })
+
+    it("resumes a partial create save with the persisted product id", async () => {
+      const created = product("product-1", "Model A", 6)
+      const savedResponse = {
+        id: "response-1",
+        baseline_version_id: baselineVersion.id,
+        reference_product_id: created.id,
+        criterion_id: "criterion-1",
+        response_text: "Phản hồi sản phẩm mới",
+        created_at: "2026-07-17T00:00:00.000Z",
+        created_by: 1,
+        updated_at: "2026-07-17T00:00:00.000Z",
+        updated_by: 1,
+        revision: 7,
+      }
+      const refreshed = product(created.id, created.model ?? "", 7)
+      refreshed.responses = [savedResponse]
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([]))
+        .mockResolvedValueOnce(listResponse([refreshed]))
+      referenceRpc.createProduct.mockResolvedValue({ data: created })
+      referenceRpc.upsertResponse
+        .mockRejectedValueOnce(new Error("response write failed"))
+        .mockResolvedValueOnce({ data: savedResponse })
+
+      const { result, onRevisionChange } = renderReferenceProductsHook()
+      await waitFor(() => expect(result.current.productsQuery.isSuccess).toBe(true))
+
+      let localId = ""
+      act(() => {
+        localId = result.current.addProduct()
+        result.current.updateProduct(localId, { model: "Model A" })
+        result.current.updateResponse(localId, "criterion-1", "Phản hồi sản phẩm mới")
+      })
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(onRevisionChange).toHaveBeenLastCalledWith(6)
+      expect(result.current.products[0]).toMatchObject({
+        id: created.id,
+        persistedId: created.id,
+        responses: { "criterion-1": "Phản hồi sản phẩm mới" },
+      })
+      expect(result.current.isDirty).toBe(true)
+
+      await act(async () => {
+        await result.current.save()
+      })
+
+      expect(referenceRpc.createProduct).toHaveBeenCalledTimes(1)
+      expect(referenceRpc.upsertResponse).toHaveBeenNthCalledWith(2, {
+        p_reference_product_id: created.id,
+        p_criterion_id: "criterion-1",
+        p_response_text: "Phản hồi sản phẩm mới",
+        p_expected_revision: 6,
+      })
+      expect(onRevisionChange).toHaveBeenLastCalledWith(7)
+      await waitFor(() => expect(result.current.isDirty).toBe(false))
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
@@ -232,13 +232,21 @@ export function registerReferenceProductWorkspaceTests({
 
       renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
 
-      expect(await screen.findByDisplayValue("Model A")).toBeDisabled()
+      const modelInput = await screen.findByDisplayValue("Model A")
+      expect(modelInput).toHaveAttribute("readonly")
+      expect(modelInput).not.toBeDisabled()
+      modelInput.focus()
+      expect(modelInput).toHaveFocus()
       expect(
         screen.queryByRole("button", { name: "Thêm sản phẩm tham chiếu" })
       ).not.toBeInTheDocument()
       expect(screen.queryByRole("button", { name: "Lưu thay đổi" })).not.toBeInTheDocument()
       expect(screen.queryByRole("button", { name: "Xóa Model A" })).not.toBeInTheDocument()
-      expect(screen.getByLabelText("Phản hồi Model A cho TC-0001")).toBeDisabled()
+      const response = screen.getByLabelText("Phản hồi Model A cho TC-0001")
+      expect(response).toHaveAttribute("readonly")
+      expect(response).not.toBeDisabled()
+      response.focus()
+      expect(response).toHaveFocus()
     })
 
     it("preserves a dirty reference draft when dossier-back navigation is rejected", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts"
 import { TechnicalConfigurationWorkspaceShell } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell"
+import { technicalConfigurationBaselineVersionsQueryKey } from "@/app/(app)/technical-configurations/technical-configuration-query-keys"
 import {
   baselineVersion,
   dossier,
@@ -64,6 +65,21 @@ export function registerReferenceProductWorkspaceTests({
         name: "Phiên bản cấu hình cơ sở",
       })
       expect(versionPicker.tagName).toBe("BUTTON")
+    })
+
+    it("reloads a clean reference-product workspace on demand", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([]))
+        .mockResolvedValueOnce(listResponse([product("product-1", "Model mới")]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+
+      expect(await screen.findByRole("columnheader", { name: "Model mới" })).toBeInTheDocument()
+      expect(referenceRpc.listProducts).toHaveBeenCalledTimes(2)
     })
 
     it("loads later baseline-version pages from the shadcn select", async () => {
@@ -173,6 +189,84 @@ export function registerReferenceProductWorkspaceTests({
       confirm.mockRestore()
     })
 
+    it("preserves a dirty draft when the versions query selects a newer draft", async () => {
+      const user = userEvent.setup()
+      const newerVersion = {
+        ...baselineVersion,
+        id: "version-2",
+        version_number: 2,
+        revision: baselineVersion.revision + 1,
+      }
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+      const { queryClient } = renderWithQueryClient(
+        <TechnicalConfigurationReferenceProducts dossier={dossier} />
+      )
+      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
+      baselineRpc.listVersions.mockResolvedValueOnce({
+        data: [newerVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+
+      await act(async () => {
+        await queryClient.invalidateQueries({
+          queryKey: technicalConfigurationBaselineVersionsQueryKey(dossier.id),
+          exact: true,
+        })
+      })
+
+      await waitFor(() => expect(baselineRpc.listVersions).toHaveBeenCalledTimes(2))
+      expect(screen.getByDisplayValue("Model chưa lưu")).toBeInTheDocument()
+      expect(screen.getByRole("combobox", { name: "Phiên bản cấu hình cơ sở" })).toHaveTextContent(
+        "Phiên bản 1"
+      )
+    })
+
+    it("keeps the product snapshot revision when baseline history refreshes independently", async () => {
+      const user = userEvent.setup()
+      const refreshedVersion = {
+        ...baselineVersion,
+        revision: baselineVersion.revision + 4,
+      }
+      const created = product("product-1", "Model lưu", baselineVersion.revision + 1)
+      referenceRpc.listProducts.mockResolvedValue(listResponse([], baselineVersion.revision))
+      referenceRpc.createProduct.mockResolvedValueOnce({ data: created })
+      const { queryClient } = renderWithQueryClient(
+        <TechnicalConfigurationReferenceProducts dossier={dossier} />
+      )
+      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+
+      baselineRpc.listVersions.mockResolvedValueOnce({
+        data: [refreshedVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      await act(async () => {
+        await queryClient.invalidateQueries({
+          queryKey: technicalConfigurationBaselineVersionsQueryKey(dossier.id),
+          exact: true,
+        })
+      })
+      await waitFor(() => expect(baselineRpc.listVersions).toHaveBeenCalledTimes(2))
+
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model lưu")
+      await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+      await waitFor(() =>
+        expect(referenceRpc.createProduct).toHaveBeenCalledWith(
+          expect.objectContaining({
+            p_expected_revision: baselineVersion.revision,
+          })
+        )
+      )
+    })
+
     it("preserves a dirty draft when reload confirmation is rejected", async () => {
       const user = userEvent.setup()
       const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
@@ -242,6 +336,8 @@ export function registerReferenceProductWorkspaceTests({
       ).not.toBeInTheDocument()
       expect(screen.queryByRole("button", { name: "Lưu thay đổi" })).not.toBeInTheDocument()
       expect(screen.queryByRole("button", { name: "Xóa Model A" })).not.toBeInTheDocument()
+      await userEvent.setup().click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+      await waitFor(() => expect(referenceRpc.listProducts).toHaveBeenCalledTimes(2))
       const response = screen.getByLabelText("Phản hồi Model A cho TC-0001")
       expect(response).toHaveAttribute("readonly")
       expect(response).not.toBeDisabled()

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
@@ -1,0 +1,266 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts"
+import { TechnicalConfigurationWorkspaceShell } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell"
+import {
+  baselineVersion,
+  dossier,
+  listResponse,
+  product,
+  renderWithQueryClient,
+  type BaselineVersionRpcMocks,
+  type ReferenceProductRpcMocks,
+} from "./reference-products-fixtures"
+
+type RegisterReferenceProductWorkspaceTestsArgs = {
+  baselineRpc: BaselineVersionRpcMocks
+  referenceRpc: ReferenceProductRpcMocks
+}
+
+export function registerReferenceProductWorkspaceTests({
+  baselineRpc,
+  referenceRpc,
+}: RegisterReferenceProductWorkspaceTestsArgs) {
+  const originalScrollIntoView = Element.prototype.scrollIntoView
+
+  beforeAll(() => {
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    })
+  })
+
+  afterAll(() => {
+    if (originalScrollIntoView) {
+      Object.defineProperty(Element.prototype, "scrollIntoView", {
+        configurable: true,
+        value: originalScrollIntoView,
+      })
+      return
+    }
+    Reflect.deleteProperty(Element.prototype, "scrollIntoView")
+  })
+
+  describe("technical configuration reference-product workspace", () => {
+    beforeEach(() => {
+      baselineRpc.listVersions.mockReset()
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baselineVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      Object.values(referenceRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("renders the baseline-version picker with the shared shadcn select", async () => {
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const versionPicker = await screen.findByRole("combobox", {
+        name: "Phiên bản cấu hình cơ sở",
+      })
+      expect(versionPicker.tagName).toBe("BUTTON")
+    })
+
+    it("loads later baseline-version pages from the shadcn select", async () => {
+      const currentVersion = {
+        ...baselineVersion,
+        version_number: 101,
+      }
+      const firstPageVersions = Array.from({ length: 100 }, (_, index) =>
+        index === 0
+          ? currentVersion
+          : {
+              ...baselineVersion,
+              id: `version-${101 - index}`,
+              version_number: 101 - index,
+              status: "locked" as const,
+              locked_at: "2026-07-17T01:00:00.000Z",
+              locked_by: 1,
+            }
+      )
+      const olderVersion = {
+        ...baselineVersion,
+        id: "version-older",
+        version_number: 1,
+        status: "locked" as const,
+        locked_at: "2026-07-17T01:00:00.000Z",
+        locked_by: 1,
+      }
+      baselineRpc.listVersions
+        .mockResolvedValueOnce({
+          data: firstPageVersions,
+          total: 101,
+          page: 1,
+          page_size: 100,
+        })
+        .mockResolvedValueOnce({
+          data: [olderVersion],
+          total: 101,
+          page: 2,
+          page_size: 100,
+        })
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const versionPicker = await screen.findByRole("combobox", {
+        name: "Phiên bản cấu hình cơ sở",
+      })
+      versionPicker.focus()
+      fireEvent.keyDown(versionPicker, { key: "ArrowDown" })
+      fireEvent.click(await screen.findByRole("option", { name: "Tải thêm phiên bản" }))
+
+      await waitFor(() =>
+        expect(baselineRpc.listVersions).toHaveBeenLastCalledWith({
+          p_dossier_id: dossier.id,
+          p_page: 2,
+          p_page_size: 100,
+        })
+      )
+      if (!screen.queryByRole("listbox")) {
+        fireEvent.keyDown(versionPicker, { key: "ArrowDown" })
+      }
+      expect(
+        await screen.findByRole("option", { name: "Phiên bản 1 · Đã khóa" })
+      ).toBeInTheDocument()
+    })
+
+    it("supports zero products, reload, and explicit save without premature mutations", async () => {
+      const user = userEvent.setup()
+      const onDirtyChange = vi.fn()
+      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
+      const created = product("product-1", "Model lưu", 6)
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([]))
+        .mockResolvedValueOnce(listResponse([]))
+        .mockResolvedValueOnce(listResponse([created]))
+      referenceRpc.createProduct.mockResolvedValueOnce({ data: created })
+
+      renderWithQueryClient(
+        <TechnicalConfigurationReferenceProducts dossier={dossier} onDirtyChange={onDirtyChange} />
+      )
+      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model tạm")
+      expect(referenceRpc.createProduct).not.toHaveBeenCalled()
+      await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(true))
+
+      await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+      await waitFor(() => expect(screen.queryByDisplayValue("Model tạm")).not.toBeInTheDocument())
+
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model lưu")
+      expect(referenceRpc.createProduct).not.toHaveBeenCalled()
+      await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+      await waitFor(() =>
+        expect(referenceRpc.createProduct).toHaveBeenCalledWith({
+          p_baseline_version_id: baselineVersion.id,
+          p_model: "Model lưu",
+          p_manufacturer: null,
+          p_description: null,
+          p_notes: null,
+          p_expected_revision: baselineVersion.revision,
+        })
+      )
+      expect(await screen.findByRole("columnheader", { name: "Model lưu" })).toBeInTheDocument()
+      confirm.mockRestore()
+    })
+
+    it("preserves a dirty draft when reload confirmation is rejected", async () => {
+      const user = userEvent.setup()
+      const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
+      await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+
+      expect(confirm).toHaveBeenCalledWith(
+        "Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?"
+      )
+      expect(referenceRpc.listProducts).toHaveBeenCalledTimes(1)
+      expect(screen.getByDisplayValue("Model chưa lưu")).toBeInTheDocument()
+      confirm.mockRestore()
+    })
+
+    it("registers beforeunload protection while the reference draft is dirty", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+
+      const cleanEvent = new Event("beforeunload", { cancelable: true })
+      window.dispatchEvent(cleanEvent)
+      expect(cleanEvent.defaultPrevented).toBe(false)
+
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
+
+      const dirtyEvent = new Event("beforeunload", { cancelable: true })
+      window.dispatchEvent(dirtyEvent)
+      expect(dirtyEvent.defaultPrevented).toBe(true)
+    })
+
+    it("renders locked reference products read-only without mutation affordances", async () => {
+      const lockedVersion = {
+        ...baselineVersion,
+        status: "locked" as const,
+        revision: 6,
+        locked_at: "2026-07-17T01:00:00.000Z",
+        locked_by: 1,
+      }
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [lockedVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([product("product-1", "Model A", 6)])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      expect(await screen.findByDisplayValue("Model A")).toBeDisabled()
+      expect(
+        screen.queryByRole("button", { name: "Thêm sản phẩm tham chiếu" })
+      ).not.toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: "Lưu thay đổi" })).not.toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: "Xóa Model A" })).not.toBeInTheDocument()
+      expect(screen.getByLabelText("Phản hồi Model A cho TC-0001")).toBeDisabled()
+    })
+
+    it("preserves a dirty reference draft when dossier-back navigation is rejected", async () => {
+      const user = userEvent.setup()
+      const onBack = vi.fn()
+      const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+
+      renderWithQueryClient(
+        <TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />
+      )
+      await user.click(screen.getByRole("tab", { name: "Sản phẩm tham chiếu" }))
+      await user.click(await screen.findByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
+      await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
+
+      expect(confirm).toHaveBeenCalledWith(
+        "Bạn có thay đổi chưa lưu. Rời hồ sơ và bỏ các thay đổi?"
+      )
+      expect(onBack).not.toHaveBeenCalled()
+      expect(screen.getByDisplayValue("Model chưa lưu")).toBeInTheDocument()
+      confirm.mockRestore()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
@@ -1,0 +1,61 @@
+import { vi } from "vitest"
+
+import { registerReferenceProductComparisonTests } from "./reference-products-comparison-cases"
+import { registerReferenceProductConflictTests } from "./reference-products-conflict-cases"
+import { registerReferenceProductHookTests } from "./reference-products-hook-cases"
+import { registerReferenceProductResilienceTests } from "./reference-products-resilience-cases"
+import { registerReferenceProductSaveResumeTests } from "./reference-products-save-resume-cases"
+import { registerReferenceProductWorkspaceTests } from "./reference-products-workspace-cases"
+
+const baselineRpc = vi.hoisted(() => ({
+  listVersions: vi.fn(),
+}))
+
+const referenceRpc = vi.hoisted(() => ({
+  listProducts: vi.fn(),
+  createProduct: vi.fn(),
+  updateProduct: vi.fn(),
+  deleteProduct: vi.fn(),
+  upsertResponse: vi.fn(),
+}))
+
+vi.mock("@/app/(app)/technical-configurations/technical-configuration-reference-rpc", () => ({
+  listTechnicalConfigurationReferenceProducts: referenceRpc.listProducts,
+  createTechnicalConfigurationReferenceProduct: referenceRpc.createProduct,
+  updateTechnicalConfigurationReferenceProduct: referenceRpc.updateProduct,
+  deleteTechnicalConfigurationReferenceProduct: referenceRpc.deleteProduct,
+  upsertTechnicalConfigurationReferenceResponse: referenceRpc.upsertResponse,
+}))
+
+vi.mock("@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline", () => ({
+  useTechnicalConfigurationBaseline: () => baselineRpc,
+}))
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab",
+  async () => {
+    const ReactModule = await import("react")
+    return {
+      TechnicalConfigurationBaselineTab: ({
+        onDirtyChange,
+        onNavigationBlockedChange,
+      }: {
+        onDirtyChange: (dirty: boolean) => void
+        onNavigationBlockedChange?: (blocked: boolean) => void
+      }) => {
+        ReactModule.useEffect(() => {
+          onDirtyChange(false)
+          onNavigationBlockedChange?.(false)
+        }, [onDirtyChange, onNavigationBlockedChange])
+        return <div>Baseline editor</div>
+      },
+    }
+  }
+)
+
+registerReferenceProductHookTests(referenceRpc)
+registerReferenceProductSaveResumeTests(referenceRpc)
+registerReferenceProductConflictTests(referenceRpc)
+registerReferenceProductComparisonTests()
+registerReferenceProductWorkspaceTests({ baselineRpc, referenceRpc })
+registerReferenceProductResilienceTests({ baselineRpc, referenceRpc })

--- a/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
@@ -3,6 +3,7 @@ import { vi } from "vitest"
 import { registerReferenceProductComparisonTests } from "./reference-products-comparison-cases"
 import { registerReferenceProductConflictTests } from "./reference-products-conflict-cases"
 import { registerReferenceProductHookTests } from "./reference-products-hook-cases"
+import { registerReferenceProductOperationLockTests } from "./reference-products-operation-lock-cases"
 import { registerReferenceProductResilienceTests } from "./reference-products-resilience-cases"
 import { registerReferenceProductSaveResumeTests } from "./reference-products-save-resume-cases"
 import { registerReferenceProductWorkspaceTests } from "./reference-products-workspace-cases"
@@ -54,6 +55,7 @@ vi.mock(
 )
 
 registerReferenceProductHookTests(referenceRpc)
+registerReferenceProductOperationLockTests(referenceRpc)
 registerReferenceProductSaveResumeTests(referenceRpc)
 registerReferenceProductConflictTests(referenceRpc)
 registerReferenceProductComparisonTests()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -126,5 +126,13 @@ describe("technical configuration baseline workspace integration", () => {
     expect(shellSource).toContain("TechnicalConfigurationBaselineTab")
     expect(shellSource).not.toContain("useQuery")
     expect(shellSource).not.toContain("useMutation")
+
+    for (const file of [
+      "_components/TechnicalConfigurationBaselineTab.tsx",
+      "_hooks/useTechnicalConfigurationBaselineEditor.ts",
+    ]) {
+      const source = fs.readFileSync(path.join(moduleRoot, file), "utf8")
+      expect(source).not.toMatch(/ReferenceProduct|reference-product/)
+    }
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -132,7 +132,7 @@ describe("technical configuration baseline workspace integration", () => {
       "_hooks/useTechnicalConfigurationBaselineEditor.ts",
     ]) {
       const source = fs.readFileSync(path.join(moduleRoot, file), "utf8")
-      expect(source).not.toMatch(/ReferenceProduct|reference-product/)
+      expect(source).not.toMatch(/reference[-_ ]?product/i)
     }
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -193,6 +193,7 @@ describe("technical configuration dossier shell", () => {
     expect(await screen.findByRole("heading", { name: dossier.name })).toBeInTheDocument()
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent?.trim())).toEqual([
       "Cấu hình cơ sở",
+      "Sản phẩm tham chiếu",
       "Phương án",
       "So sánh & đánh giá",
     ])

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-reference-rpc.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-reference-rpc.test.ts
@@ -73,6 +73,7 @@ describe("technical configuration reference-product RPC adapter", () => {
           ],
         },
       ],
+      revision: 3,
       total: 1,
       page: 2,
       page_size: 25,

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison.tsx
@@ -1,0 +1,288 @@
+import * as React from "react"
+import { Maximize2 } from "lucide-react"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import {
+  getTechnicalConfigurationReferenceProductName,
+  type TechnicalConfigurationReferenceProductDraft,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+type TechnicalConfigurationReferenceComparisonProps = {
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  products: TechnicalConfigurationReferenceProductDraft[]
+  readOnly: boolean
+  onResponseChange: (productId: string, criterionId: string, responseText: string) => void
+}
+
+type FullTextDetail = {
+  title: string
+  text: string
+}
+
+type ReferenceColumnState = {
+  baselineVersionId: string
+  productIds: string[]
+  hiddenProductIds: string[]
+}
+
+const NEW_REFERENCE_PRODUCT_PREFIX = "new-reference-product-"
+
+function haveSameProductIds(left: string[], right: string[]) {
+  return (
+    left.length === right.length && left.every((productId, index) => productId === right[index])
+  )
+}
+
+function reconcileReferenceColumnState(
+  current: ReferenceColumnState,
+  baselineVersionId: string,
+  productIds: string[]
+): ReferenceColumnState | null {
+  if (current.baselineVersionId !== baselineVersionId) {
+    return {
+      baselineVersionId,
+      productIds,
+      hiddenProductIds: [],
+    }
+  }
+  if (haveSameProductIds(current.productIds, productIds)) return null
+
+  const priorProductIdSet = new Set(current.productIds)
+  const hiddenProductIdSet = new Set(current.hiddenProductIds)
+  productIds.forEach((productId, index) => {
+    if (priorProductIdSet.has(productId)) return
+    const priorProductId = current.productIds[index]
+    if (
+      priorProductId?.startsWith(NEW_REFERENCE_PRODUCT_PREFIX) &&
+      hiddenProductIdSet.has(priorProductId)
+    ) {
+      hiddenProductIdSet.add(productId)
+    }
+  })
+
+  return {
+    baselineVersionId,
+    productIds,
+    hiddenProductIds: [...hiddenProductIdSet],
+  }
+}
+
+/** Renders the baseline-first comparison matrix with user-selectable product columns. */
+export function TechnicalConfigurationReferenceComparison({
+  baselineVersion,
+  products,
+  readOnly,
+  onResponseChange,
+}: Readonly<TechnicalConfigurationReferenceComparisonProps>) {
+  const productIds = products.map((product) => product.id)
+  const [columnState, setColumnState] = React.useState<ReferenceColumnState>(() => ({
+    baselineVersionId: baselineVersion.id,
+    productIds,
+    hiddenProductIds: [],
+  }))
+  const [fullTextDetail, setFullTextDetail] = React.useState<FullTextDetail | null>(null)
+  const reconciledColumnState = reconcileReferenceColumnState(
+    columnState,
+    baselineVersion.id,
+    productIds
+  )
+  if (reconciledColumnState) {
+    setColumnState(reconciledColumnState)
+  }
+
+  const hiddenProductIdSet = React.useMemo(
+    () => new Set(columnState.hiddenProductIds),
+    [columnState.hiddenProductIds]
+  )
+  const productIndexById = React.useMemo(
+    () => new Map(products.map((product, index) => [product.id, index])),
+    [products]
+  )
+  const selectedProducts = products.filter((product) => !hiddenProductIdSet.has(product.id))
+
+  if (products.length === 0) {
+    return (
+      <section className="border-t pt-5" aria-label="Ma trận đối chiếu sản phẩm tham chiếu">
+        <h3 className="text-base font-semibold">Đối chiếu theo tiêu chí</h3>
+        <p className="mt-2 text-sm text-muted-foreground">Chưa có sản phẩm tham chiếu.</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="space-y-4 border-t pt-5" aria-label="Ma trận đối chiếu sản phẩm tham chiếu">
+      <div>
+        <h3 className="text-base font-semibold">Đối chiếu theo tiêu chí</h3>
+        <div className="mt-3 flex flex-wrap gap-x-5 gap-y-3">
+          {products.map((product, index) => {
+            const name = getTechnicalConfigurationReferenceProductName(product, index)
+            const checkboxId = `reference-product-column-${product.id}`
+            return (
+              <div key={product.id} className="flex items-center gap-2">
+                <Checkbox
+                  id={checkboxId}
+                  checked={!hiddenProductIdSet.has(product.id)}
+                  aria-label={`Hiển thị ${name}`}
+                  onCheckedChange={(checked) => {
+                    setColumnState((current) => {
+                      const hiddenProductIds = new Set(current.hiddenProductIds)
+                      if (checked) {
+                        hiddenProductIds.delete(product.id)
+                      } else {
+                        hiddenProductIds.add(product.id)
+                      }
+                      return {
+                        ...current,
+                        hiddenProductIds: [...hiddenProductIds],
+                      }
+                    })
+                  }}
+                />
+                <Label htmlFor={checkboxId}>{name}</Label>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div
+        data-testid="reference-comparison-scroll"
+        className="w-full overflow-x-auto rounded-md border"
+      >
+        <table className="min-w-max border-separate border-spacing-0 text-left text-sm">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-30 w-[220px] min-w-[220px] border-b border-r bg-muted px-3 py-3 font-semibold">
+                Tiêu chí
+              </th>
+              <th className="sticky left-[220px] z-30 w-[360px] min-w-[360px] border-b border-r bg-muted px-3 py-3 font-semibold">
+                Yêu cầu cơ sở
+              </th>
+              {selectedProducts.map((product) => {
+                const productIndex = productIndexById.get(product.id) ?? 0
+                return (
+                  <th
+                    key={product.id}
+                    className="w-[320px] min-w-[320px] border-b border-r bg-muted px-3 py-3 font-semibold last:border-r-0"
+                  >
+                    {getTechnicalConfigurationReferenceProductName(product, productIndex)}
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {baselineVersion.groups.map((group) => (
+              <React.Fragment key={group.id}>
+                <tr>
+                  <th
+                    colSpan={selectedProducts.length + 2}
+                    className="border-b bg-muted/40 px-3 py-2 font-semibold"
+                  >
+                    {group.name}
+                  </th>
+                </tr>
+                {group.criteria.map((criterion) => (
+                  <tr key={criterion.id} className="align-top">
+                    <th className="sticky left-0 z-20 border-b border-r bg-background px-3 py-3 font-medium">
+                      <span className="block text-xs text-muted-foreground">
+                        {criterion.criterion_code}
+                      </span>
+                      <span className="mt-1 block break-words">
+                        {criterion.title ?? "Chưa có tiêu đề"}
+                      </span>
+                    </th>
+                    <td className="sticky left-[220px] z-20 border-b border-r bg-background px-3 py-3">
+                      <p className="line-clamp-4 whitespace-pre-wrap break-words">
+                        {criterion.requirement_text}
+                      </p>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="mt-2 h-8 px-2"
+                        aria-label={`Xem đầy đủ yêu cầu ${criterion.criterion_code}`}
+                        onClick={() =>
+                          setFullTextDetail({
+                            title: `Yêu cầu ${criterion.criterion_code}`,
+                            text: criterion.requirement_text,
+                          })
+                        }
+                      >
+                        <Maximize2 className="size-4" aria-hidden="true" />
+                        Xem đầy đủ
+                      </Button>
+                    </td>
+                    {selectedProducts.map((product) => {
+                      const productIndex = productIndexById.get(product.id) ?? 0
+                      const productName = getTechnicalConfigurationReferenceProductName(
+                        product,
+                        productIndex
+                      )
+                      return (
+                        <td key={product.id} className="border-b border-r p-3 last:border-r-0">
+                          <Textarea
+                            value={product.responses[criterion.id] ?? ""}
+                            disabled={readOnly}
+                            aria-label={`Phản hồi ${productName} cho ${criterion.criterion_code}`}
+                            className="min-h-[120px] resize-y whitespace-pre-wrap"
+                            onChange={(event) =>
+                              onResponseChange(product.id, criterion.id, event.target.value)
+                            }
+                          />
+                          {product.responses[criterion.id] ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="mt-2 h-8 px-2"
+                              aria-label={`Xem đầy đủ phản hồi ${productName} cho ${criterion.criterion_code}`}
+                              onClick={() =>
+                                setFullTextDetail({
+                                  title: `${productName} · ${criterion.criterion_code}`,
+                                  text: product.responses[criterion.id] ?? "",
+                                })
+                              }
+                            >
+                              <Maximize2 className="size-4" aria-hidden="true" />
+                              Xem đầy đủ
+                            </Button>
+                          ) : null}
+                        </td>
+                      )
+                    })}
+                  </tr>
+                ))}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <Dialog
+        open={Boolean(fullTextDetail)}
+        onOpenChange={(open) => !open && setFullTextDetail(null)}
+      >
+        <DialogContent closeLabel="Đóng">
+          <DialogHeader>
+            <DialogTitle>{fullTextDetail?.title}</DialogTitle>
+            <DialogDescription className="max-h-[60vh] overflow-y-auto whitespace-pre-wrap break-words pt-2 text-foreground">
+              {fullTextDetail?.text}
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison.tsx
@@ -1,7 +1,14 @@
 import * as React from "react"
-import { Maximize2 } from "lucide-react"
+import { ChevronLeft, ChevronRight, Maximize2 } from "lucide-react"
 
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import {
+  clampReferenceProductPageIndex,
+  getReferenceProductDisplayLabels,
+  reconcileReferenceColumnState,
+  REFERENCE_PRODUCT_PAGE_SIZE,
+  type ReferenceColumnState,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonUtils"
 import {
   getTechnicalConfigurationReferenceProductName,
   type TechnicalConfigurationReferenceProductDraft,
@@ -30,54 +37,6 @@ type FullTextDetail = {
   text: string
 }
 
-type ReferenceColumnState = {
-  baselineVersionId: string
-  productIds: string[]
-  hiddenProductIds: string[]
-}
-
-const NEW_REFERENCE_PRODUCT_PREFIX = "new-reference-product-"
-
-function haveSameProductIds(left: string[], right: string[]) {
-  return (
-    left.length === right.length && left.every((productId, index) => productId === right[index])
-  )
-}
-
-function reconcileReferenceColumnState(
-  current: ReferenceColumnState,
-  baselineVersionId: string,
-  productIds: string[]
-): ReferenceColumnState | null {
-  if (current.baselineVersionId !== baselineVersionId) {
-    return {
-      baselineVersionId,
-      productIds,
-      hiddenProductIds: [],
-    }
-  }
-  if (haveSameProductIds(current.productIds, productIds)) return null
-
-  const priorProductIdSet = new Set(current.productIds)
-  const hiddenProductIdSet = new Set(current.hiddenProductIds)
-  productIds.forEach((productId, index) => {
-    if (priorProductIdSet.has(productId)) return
-    const priorProductId = current.productIds[index]
-    if (
-      priorProductId?.startsWith(NEW_REFERENCE_PRODUCT_PREFIX) &&
-      hiddenProductIdSet.has(priorProductId)
-    ) {
-      hiddenProductIdSet.add(productId)
-    }
-  })
-
-  return {
-    baselineVersionId,
-    productIds,
-    hiddenProductIds: [...hiddenProductIdSet],
-  }
-}
-
 /** Renders the baseline-first comparison matrix with user-selectable product columns. */
 export function TechnicalConfigurationReferenceComparison({
   baselineVersion,
@@ -90,6 +49,7 @@ export function TechnicalConfigurationReferenceComparison({
     baselineVersionId: baselineVersion.id,
     productIds,
     hiddenProductIds: [],
+    pageIndex: 0,
   }))
   const [fullTextDetail, setFullTextDetail] = React.useState<FullTextDetail | null>(null)
   const reconciledColumnState = reconcileReferenceColumnState(
@@ -101,15 +61,26 @@ export function TechnicalConfigurationReferenceComparison({
     setColumnState(reconciledColumnState)
   }
 
+  const activeColumnState = reconciledColumnState ?? columnState
   const hiddenProductIdSet = React.useMemo(
-    () => new Set(columnState.hiddenProductIds),
-    [columnState.hiddenProductIds]
+    () => new Set(activeColumnState.hiddenProductIds),
+    [activeColumnState.hiddenProductIds]
   )
   const productIndexById = React.useMemo(
     () => new Map(products.map((product, index) => [product.id, index])),
     [products]
   )
+  const productLabelById = React.useMemo(
+    () => getReferenceProductDisplayLabels(products),
+    [products]
+  )
   const selectedProducts = products.filter((product) => !hiddenProductIdSet.has(product.id))
+  const pageCount = Math.max(1, Math.ceil(selectedProducts.length / REFERENCE_PRODUCT_PAGE_SIZE))
+  const pageIndex = Math.min(activeColumnState.pageIndex, pageCount - 1)
+  const visibleProducts = selectedProducts.slice(
+    pageIndex * REFERENCE_PRODUCT_PAGE_SIZE,
+    (pageIndex + 1) * REFERENCE_PRODUCT_PAGE_SIZE
+  )
 
   if (products.length === 0) {
     return (
@@ -126,7 +97,9 @@ export function TechnicalConfigurationReferenceComparison({
         <h3 className="text-base font-semibold">Đối chiếu theo tiêu chí</h3>
         <div className="mt-3 flex flex-wrap gap-x-5 gap-y-3">
           {products.map((product, index) => {
-            const name = getTechnicalConfigurationReferenceProductName(product, index)
+            const name =
+              productLabelById.get(product.id) ??
+              getTechnicalConfigurationReferenceProductName(product, index)
             const checkboxId = `reference-product-column-${product.id}`
             return (
               <div key={product.id} className="flex items-center gap-2">
@@ -142,9 +115,15 @@ export function TechnicalConfigurationReferenceComparison({
                       } else {
                         hiddenProductIds.add(product.id)
                       }
+                      const nextHiddenProductIds = [...hiddenProductIds]
                       return {
                         ...current,
-                        hiddenProductIds: [...hiddenProductIds],
+                        hiddenProductIds: nextHiddenProductIds,
+                        pageIndex: clampReferenceProductPageIndex(
+                          current.pageIndex,
+                          current.productIds,
+                          nextHiddenProductIds
+                        ),
                       }
                     })
                   }}
@@ -169,14 +148,15 @@ export function TechnicalConfigurationReferenceComparison({
               <th className="sticky left-[220px] z-30 w-[360px] min-w-[360px] border-b border-r bg-muted px-3 py-3 font-semibold">
                 Yêu cầu cơ sở
               </th>
-              {selectedProducts.map((product) => {
+              {visibleProducts.map((product) => {
                 const productIndex = productIndexById.get(product.id) ?? 0
                 return (
                   <th
                     key={product.id}
                     className="w-[320px] min-w-[320px] border-b border-r bg-muted px-3 py-3 font-semibold last:border-r-0"
                   >
-                    {getTechnicalConfigurationReferenceProductName(product, productIndex)}
+                    {productLabelById.get(product.id) ??
+                      getTechnicalConfigurationReferenceProductName(product, productIndex)}
                   </th>
                 )
               })}
@@ -187,7 +167,7 @@ export function TechnicalConfigurationReferenceComparison({
               <React.Fragment key={group.id}>
                 <tr>
                   <th
-                    colSpan={selectedProducts.length + 2}
+                    colSpan={visibleProducts.length + 2}
                     className="border-b bg-muted/40 px-3 py-2 font-semibold"
                   >
                     {group.name}
@@ -224,17 +204,16 @@ export function TechnicalConfigurationReferenceComparison({
                         Xem đầy đủ
                       </Button>
                     </td>
-                    {selectedProducts.map((product) => {
+                    {visibleProducts.map((product) => {
                       const productIndex = productIndexById.get(product.id) ?? 0
-                      const productName = getTechnicalConfigurationReferenceProductName(
-                        product,
-                        productIndex
-                      )
+                      const productName =
+                        productLabelById.get(product.id) ??
+                        getTechnicalConfigurationReferenceProductName(product, productIndex)
                       return (
                         <td key={product.id} className="border-b border-r p-3 last:border-r-0">
                           <Textarea
                             value={product.responses[criterion.id] ?? ""}
-                            disabled={readOnly}
+                            readOnly={readOnly}
                             aria-label={`Phản hồi ${productName} cho ${criterion.criterion_code}`}
                             className="min-h-[120px] resize-y whitespace-pre-wrap"
                             onChange={(event) =>
@@ -268,6 +247,42 @@ export function TechnicalConfigurationReferenceComparison({
             ))}
           </tbody>
         </table>
+      </div>
+
+      <div className="flex items-center justify-end gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={pageIndex === 0}
+          onClick={() =>
+            setColumnState((current) => ({
+              ...current,
+              pageIndex: Math.max(0, current.pageIndex - 1),
+            }))
+          }
+        >
+          <ChevronLeft className="size-4" aria-hidden="true" />
+          Trước
+        </Button>
+        <p className="min-w-24 text-center text-sm text-muted-foreground" aria-live="polite">
+          Trang {pageIndex + 1} / {pageCount}
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={pageIndex >= pageCount - 1}
+          onClick={() =>
+            setColumnState((current) => ({
+              ...current,
+              pageIndex: Math.min(pageCount - 1, current.pageIndex + 1),
+            }))
+          }
+        >
+          Sau
+          <ChevronRight className="size-4" aria-hidden="true" />
+        </Button>
       </div>
 
       <Dialog

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonUtils.ts
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonUtils.ts
@@ -1,0 +1,97 @@
+import {
+  getTechnicalConfigurationReferenceProductName,
+  type TechnicalConfigurationReferenceProductDraft,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+
+export type ReferenceColumnState = {
+  baselineVersionId: string
+  productIds: string[]
+  hiddenProductIds: string[]
+  pageIndex: number
+}
+
+/** Maximum number of visible reference-product columns rendered per page. */
+export const REFERENCE_PRODUCT_PAGE_SIZE = 5
+
+const NEW_REFERENCE_PRODUCT_PREFIX = "new-reference-product-"
+
+function haveSameProductIds(left: string[], right: string[]) {
+  return (
+    left.length === right.length && left.every((productId, index) => productId === right[index])
+  )
+}
+
+/** Clamps a page index after products are hidden, added, or removed. */
+export function clampReferenceProductPageIndex(
+  pageIndex: number,
+  productIds: string[],
+  hiddenProductIds: string[]
+) {
+  const hiddenProductIdSet = new Set(hiddenProductIds)
+  const visibleProductCount = productIds.filter(
+    (productId) => !hiddenProductIdSet.has(productId)
+  ).length
+  const lastPageIndex = Math.max(
+    0,
+    Math.ceil(visibleProductCount / REFERENCE_PRODUCT_PAGE_SIZE) - 1
+  )
+
+  return Math.min(pageIndex, lastPageIndex)
+}
+
+/** Reconciles column identity and pagination when the baseline or products change. */
+export function reconcileReferenceColumnState(
+  current: ReferenceColumnState,
+  baselineVersionId: string,
+  productIds: string[]
+): ReferenceColumnState | null {
+  if (current.baselineVersionId !== baselineVersionId) {
+    return {
+      baselineVersionId,
+      productIds,
+      hiddenProductIds: [],
+      pageIndex: 0,
+    }
+  }
+  if (haveSameProductIds(current.productIds, productIds)) return null
+
+  const priorProductIdSet = new Set(current.productIds)
+  const hiddenProductIdSet = new Set(current.hiddenProductIds)
+  productIds.forEach((productId, index) => {
+    if (priorProductIdSet.has(productId)) return
+    const priorProductId = current.productIds[index]
+    if (
+      priorProductId?.startsWith(NEW_REFERENCE_PRODUCT_PREFIX) &&
+      hiddenProductIdSet.has(priorProductId)
+    ) {
+      hiddenProductIdSet.add(productId)
+    }
+  })
+
+  const hiddenProductIds = [...hiddenProductIdSet]
+  return {
+    baselineVersionId,
+    productIds,
+    hiddenProductIds,
+    pageIndex: clampReferenceProductPageIndex(current.pageIndex, productIds, hiddenProductIds),
+  }
+}
+
+/** Returns unique labels for product columns and their accessible controls. */
+export function getReferenceProductDisplayLabels(
+  products: TechnicalConfigurationReferenceProductDraft[]
+) {
+  const entries = products.map((product, index) => ({
+    product,
+    name: getTechnicalConfigurationReferenceProductName(product, index),
+  }))
+  const nameCounts = new Map<string, number>()
+  entries.forEach(({ name }) => nameCounts.set(name, (nameCounts.get(name) ?? 0) + 1))
+
+  return new Map(
+    entries.map(({ product, name }, index) => [
+      product.id,
+      nameCounts.get(name) === 1 ? name : `${name} (Sản phẩm ${index + 1})`,
+    ])
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductEditor.tsx
@@ -32,7 +32,6 @@ export function TechnicalConfigurationReferenceProductEditor({
 }: Readonly<TechnicalConfigurationReferenceProductEditorProps>) {
   const productName = getTechnicalConfigurationReferenceProductName(product, index)
   const fieldPrefix = `reference-product-${product.id}`
-  const disabled = readOnly || navigationBlocked
 
   return (
     <section className="rounded-md border p-4">
@@ -65,7 +64,8 @@ export function TechnicalConfigurationReferenceProductEditor({
           <Input
             id={`${fieldPrefix}-model`}
             value={product.model}
-            disabled={disabled}
+            readOnly={readOnly}
+            disabled={navigationBlocked}
             onChange={(event) => onUpdate(product.id, { model: event.target.value })}
           />
         </div>
@@ -74,7 +74,8 @@ export function TechnicalConfigurationReferenceProductEditor({
           <Input
             id={`${fieldPrefix}-manufacturer`}
             value={product.manufacturer}
-            disabled={disabled}
+            readOnly={readOnly}
+            disabled={navigationBlocked}
             onChange={(event) => onUpdate(product.id, { manufacturer: event.target.value })}
           />
         </div>
@@ -83,7 +84,8 @@ export function TechnicalConfigurationReferenceProductEditor({
           <Textarea
             id={`${fieldPrefix}-description`}
             value={product.description}
-            disabled={disabled}
+            readOnly={readOnly}
+            disabled={navigationBlocked}
             onChange={(event) => onUpdate(product.id, { description: event.target.value })}
           />
         </div>
@@ -92,7 +94,8 @@ export function TechnicalConfigurationReferenceProductEditor({
           <Textarea
             id={`${fieldPrefix}-notes`}
             value={product.notes}
-            disabled={disabled}
+            readOnly={readOnly}
+            disabled={navigationBlocked}
             onChange={(event) => onUpdate(product.id, { notes: event.target.value })}
           />
         </div>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductEditor.tsx
@@ -1,0 +1,102 @@
+import { Trash2 } from "lucide-react"
+
+import {
+  getTechnicalConfigurationReferenceProductName,
+  type TechnicalConfigurationReferenceProductDraft,
+  type TechnicalConfigurationReferenceProductPatch,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+
+type TechnicalConfigurationReferenceProductEditorProps = {
+  product: TechnicalConfigurationReferenceProductDraft
+  index: number
+  invalid: boolean
+  readOnly: boolean
+  navigationBlocked: boolean
+  onUpdate: (productId: string, patch: TechnicalConfigurationReferenceProductPatch) => void
+  onRemove: (productId: string) => void
+}
+
+/** Renders editable metadata for one reference product. */
+export function TechnicalConfigurationReferenceProductEditor({
+  product,
+  index,
+  invalid,
+  readOnly,
+  navigationBlocked,
+  onUpdate,
+  onRemove,
+}: Readonly<TechnicalConfigurationReferenceProductEditorProps>) {
+  const productName = getTechnicalConfigurationReferenceProductName(product, index)
+  const fieldPrefix = `reference-product-${product.id}`
+  const disabled = readOnly || navigationBlocked
+
+  return (
+    <section className="rounded-md border p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="break-words text-sm font-semibold">{productName}</h3>
+          {invalid ? (
+            <p className="mt-1 text-sm text-destructive">
+              Nhập ít nhất model, hãng sản xuất hoặc mô tả.
+            </p>
+          ) : null}
+        </div>
+        {!readOnly ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Xóa ${productName}`}
+            disabled={navigationBlocked}
+            onClick={() => onRemove(product.id)}
+          >
+            <Trash2 className="size-4" aria-hidden="true" />
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor={`${fieldPrefix}-model`}>Model</Label>
+          <Input
+            id={`${fieldPrefix}-model`}
+            value={product.model}
+            disabled={disabled}
+            onChange={(event) => onUpdate(product.id, { model: event.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={`${fieldPrefix}-manufacturer`}>Hãng sản xuất</Label>
+          <Input
+            id={`${fieldPrefix}-manufacturer`}
+            value={product.manufacturer}
+            disabled={disabled}
+            onChange={(event) => onUpdate(product.id, { manufacturer: event.target.value })}
+          />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <Label htmlFor={`${fieldPrefix}-description`}>Mô tả</Label>
+          <Textarea
+            id={`${fieldPrefix}-description`}
+            value={product.description}
+            disabled={disabled}
+            onChange={(event) => onUpdate(product.id, { description: event.target.value })}
+          />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <Label htmlFor={`${fieldPrefix}-notes`}>Ghi chú</Label>
+          <Textarea
+            id={`${fieldPrefix}-notes`}
+            value={product.notes}
+            disabled={disabled}
+            onChange={(event) => onUpdate(product.id, { notes: event.target.value })}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
@@ -5,6 +5,7 @@ import { TechnicalConfigurationReferenceProductsBody } from "@/app/(app)/technic
 import { useTechnicalConfigurationBaseline } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline"
 import { useTechnicalConfigurationBaselineVersions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersions"
 import { useTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
 import { selectTechnicalConfigurationBaselineVersion } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -38,16 +39,21 @@ export function TechnicalConfigurationReferenceProducts({
     listVersions: baselineRpc.listVersions,
   })
   const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null)
-  const selectedVersion = selectTechnicalConfigurationBaselineVersion(
-    versionState.versions,
-    selectedVersionId,
-    null,
-    Boolean(versionState.versionsQuery.hasNextPage)
+  const [selectedVersion, setSelectedVersion] =
+    React.useState<TechnicalConfigurationBaselineDraftWire | null>(null)
+  const adoptVersion = React.useCallback(
+    (version: TechnicalConfigurationBaselineDraftWire | null) => {
+      setSelectedVersionId(version?.id ?? null)
+      setSelectedVersion(version)
+    },
+    []
   )
   const handleRevisionChange = React.useCallback(
     (revision: number) => {
       if (!selectedVersion) return
-      versionState.cacheVersion({ ...selectedVersion, revision })
+      const nextVersion = { ...selectedVersion, revision }
+      setSelectedVersion(nextVersion)
+      versionState.cacheVersion(nextVersion)
     },
     [selectedVersion, versionState]
   )
@@ -61,6 +67,39 @@ export function TechnicalConfigurationReferenceProducts({
   const hasInitialProductsError =
     referenceState.productsQuery.isError && referenceState.productsQuery.data === undefined
   const isProductDataUnavailable = referenceState.productsQuery.isLoading || hasInitialProductsError
+  const versionOptions = React.useMemo(
+    () =>
+      selectedVersion && !versionState.versions.some((version) => version.id === selectedVersion.id)
+        ? [selectedVersion, ...versionState.versions]
+        : versionState.versions,
+    [selectedVersion, versionState.versions]
+  )
+
+  React.useEffect(() => {
+    if (!versionState.versionsQuery.data || referenceState.isDirty) return
+    const nextVersion = selectTechnicalConfigurationBaselineVersion(
+      versionState.versions,
+      selectedVersionId,
+      selectedVersion,
+      Boolean(versionState.versionsQuery.hasNextPage)
+    )
+    if (
+      selectedVersion?.id === nextVersion?.id &&
+      selectedVersion?.revision === nextVersion?.revision &&
+      selectedVersion?.status === nextVersion?.status
+    ) {
+      return
+    }
+    adoptVersion(nextVersion)
+  }, [
+    adoptVersion,
+    referenceState.isDirty,
+    selectedVersion,
+    selectedVersionId,
+    versionState.versions,
+    versionState.versionsQuery.data,
+    versionState.versionsQuery.hasNextPage,
+  ])
 
   React.useEffect(() => {
     onDirtyChange?.(referenceState.isDirty)
@@ -85,9 +124,10 @@ export function TechnicalConfigurationReferenceProducts({
       ) {
         return
       }
-      setSelectedVersionId(nextVersionId)
+      const nextVersion = versionOptions.find((version) => version.id === nextVersionId)
+      if (nextVersion) adoptVersion(nextVersion)
     },
-    [referenceState.isDirty]
+    [adoptVersion, referenceState.isDirty, versionOptions]
   )
 
   const handleVersionSelect = React.useCallback(
@@ -173,7 +213,7 @@ export function TechnicalConfigurationReferenceProducts({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {versionState.versions
+              {versionOptions
                 .toSorted((left, right) => right.version_number - left.version_number)
                 .map((version) => (
                   <SelectItem key={version.id} value={version.id}>
@@ -197,52 +237,50 @@ export function TechnicalConfigurationReferenceProducts({
           </Select>
         </div>
 
-        {!referenceState.isReadOnly ? (
-          <div className="flex flex-wrap gap-2">
-            {referenceState.isDirty ||
-            referenceState.isConflict ||
-            referenceState.refreshWarning ? (
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isNavigationBlocked || isProductDataUnavailable}
+            onClick={handleReload}
+          >
+            <RefreshCw
+              className={`size-4 ${referenceState.isReloading ? "animate-spin" : ""}`}
+              aria-hidden="true"
+            />
+            Tải lại dữ liệu
+          </Button>
+          {!referenceState.isReadOnly ? (
+            <>
               <Button
                 type="button"
                 variant="outline"
                 disabled={isNavigationBlocked || isProductDataUnavailable}
-                onClick={handleReload}
+                onClick={referenceState.addProduct}
               >
-                <RefreshCw
-                  className={`size-4 ${referenceState.isReloading ? "animate-spin" : ""}`}
-                  aria-hidden="true"
-                />
-                Tải lại dữ liệu
+                <Plus className="size-4" aria-hidden="true" />
+                Thêm sản phẩm tham chiếu
               </Button>
-            ) : null}
-            <Button
-              type="button"
-              variant="outline"
-              disabled={isNavigationBlocked || isProductDataUnavailable}
-              onClick={referenceState.addProduct}
-            >
-              <Plus className="size-4" aria-hidden="true" />
-              Thêm sản phẩm tham chiếu
-            </Button>
-            <Button
-              type="button"
-              disabled={
-                !referenceState.isDirty ||
-                referenceState.invalidProductIds.length > 0 ||
-                isNavigationBlocked ||
-                isProductDataUnavailable
-              }
-              onClick={referenceState.save}
-            >
-              {referenceState.isSaving ? (
-                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-              ) : (
-                <Save className="size-4" aria-hidden="true" />
-              )}
-              Lưu thay đổi
-            </Button>
-          </div>
-        ) : null}
+              <Button
+                type="button"
+                disabled={
+                  !referenceState.isDirty ||
+                  referenceState.invalidProductIds.length > 0 ||
+                  isNavigationBlocked ||
+                  isProductDataUnavailable
+                }
+                onClick={referenceState.save}
+              >
+                {referenceState.isSaving ? (
+                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Save className="size-4" aria-hidden="true" />
+                )}
+                Lưu thay đổi
+              </Button>
+            </>
+          ) : null}
+        </div>
       </section>
 
       {readOnlyMessage ? (

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
@@ -1,0 +1,289 @@
+import * as React from "react"
+import { AlertCircle, Archive, Loader2, LockKeyhole, Plus, RefreshCw, Save } from "lucide-react"
+
+import { TechnicalConfigurationReferenceProductsBody } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody"
+import { useTechnicalConfigurationBaseline } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline"
+import { useTechnicalConfigurationBaselineVersions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersions"
+import { useTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts"
+import { selectTechnicalConfigurationBaselineVersion } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+type TechnicalConfigurationReferenceProductsProps = {
+  dossier: TechnicalConfigurationDossierWire
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+const LOAD_MORE_BASELINE_VERSIONS_VALUE = "__load-more-baseline-versions__"
+
+/** Renders reference-product management and its baseline-first comparison surface. */
+export function TechnicalConfigurationReferenceProducts({
+  dossier,
+  onDirtyChange,
+  onNavigationBlockedChange,
+}: Readonly<TechnicalConfigurationReferenceProductsProps>) {
+  const baselineRpc = useTechnicalConfigurationBaseline()
+  const versionState = useTechnicalConfigurationBaselineVersions({
+    dossierId: dossier.id,
+    listVersions: baselineRpc.listVersions,
+  })
+  const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null)
+  const selectedVersion = selectTechnicalConfigurationBaselineVersion(
+    versionState.versions,
+    selectedVersionId,
+    null,
+    Boolean(versionState.versionsQuery.hasNextPage)
+  )
+  const handleRevisionChange = React.useCallback(
+    (revision: number) => {
+      if (!selectedVersion) return
+      versionState.cacheVersion({ ...selectedVersion, revision })
+    },
+    [selectedVersion, versionState]
+  )
+  const referenceState = useTechnicalConfigurationReferenceProducts({
+    baselineVersion: selectedVersion,
+    isArchived: Boolean(dossier.archived_at),
+    onRevisionChange: handleRevisionChange,
+    onNavigationBlockedChange,
+  })
+  const isNavigationBlocked = referenceState.isSaving || referenceState.isReloading
+  const hasInitialProductsError =
+    referenceState.productsQuery.isError && referenceState.productsQuery.data === undefined
+  const isProductDataUnavailable = referenceState.productsQuery.isLoading || hasInitialProductsError
+
+  React.useEffect(() => {
+    onDirtyChange?.(referenceState.isDirty)
+    return () => onDirtyChange?.(false)
+  }, [onDirtyChange, referenceState.isDirty])
+
+  React.useEffect(() => {
+    if (!referenceState.isDirty) return
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ""
+    }
+    window.addEventListener("beforeunload", handleBeforeUnload)
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload)
+  }, [referenceState.isDirty])
+
+  const handleVersionChange = React.useCallback(
+    (nextVersionId: string) => {
+      if (
+        referenceState.isDirty &&
+        !window.confirm("Bạn có thay đổi chưa lưu. Chuyển phiên bản và bỏ các thay đổi?")
+      ) {
+        return
+      }
+      setSelectedVersionId(nextVersionId)
+    },
+    [referenceState.isDirty]
+  )
+
+  const handleVersionSelect = React.useCallback(
+    (nextValue: string) => {
+      if (nextValue === LOAD_MORE_BASELINE_VERSIONS_VALUE) {
+        void versionState.loadMoreVersions()
+        return
+      }
+      handleVersionChange(nextValue)
+    },
+    [handleVersionChange, versionState.loadMoreVersions]
+  )
+
+  const handleReload = React.useCallback(async () => {
+    if (!selectedVersion) return
+    if (
+      referenceState.isDirty &&
+      !window.confirm("Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?")
+    ) {
+      return
+    }
+    await referenceState.reload(async () => {
+      const refreshedVersion = await versionState.refreshVersions(selectedVersion.id)
+      if (refreshedVersion) {
+        versionState.cacheVersion(refreshedVersion)
+      }
+    })
+  }, [referenceState, selectedVersion, versionState])
+
+  if (versionState.versionsQuery.isLoading) {
+    return (
+      <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        Đang tải phiên bản cấu hình...
+      </div>
+    )
+  }
+
+  if (versionState.versionsQuery.isError && versionState.versions.length === 0) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="size-4" aria-hidden="true" />
+        <AlertTitle>Không thể tải phiên bản cấu hình</AlertTitle>
+        <AlertDescription>
+          <Button type="button" variant="outline" size="sm" onClick={versionState.retryVersions}>
+            <RefreshCw className="size-4" aria-hidden="true" />
+            Thử lại
+          </Button>
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (!selectedVersion) {
+    return (
+      <Alert>
+        <AlertTitle>Chưa có phiên bản cấu hình cơ sở</AlertTitle>
+        <AlertDescription>
+          Tạo bản nháp cấu hình cơ sở trước khi thêm sản phẩm tham chiếu.
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  const isArchived = Boolean(dossier.archived_at)
+  const readOnlyMessage = isArchived
+    ? "Hồ sơ đã lưu trữ. Sản phẩm tham chiếu chỉ được xem."
+    : selectedVersion.status === "locked"
+      ? "Phiên bản đã khóa. Sản phẩm tham chiếu chỉ được xem."
+      : null
+
+  return (
+    <div className="space-y-6">
+      <section className="flex flex-col gap-4 border-y py-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0">
+          <Label htmlFor="reference-baseline-version">Phiên bản cấu hình cơ sở</Label>
+          <Select
+            value={selectedVersion.id}
+            disabled={isNavigationBlocked}
+            onValueChange={handleVersionSelect}
+          >
+            <SelectTrigger id="reference-baseline-version" className="mt-2 w-full sm:w-[300px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {versionState.versions
+                .toSorted((left, right) => right.version_number - left.version_number)
+                .map((version) => (
+                  <SelectItem key={version.id} value={version.id}>
+                    Phiên bản {version.version_number} ·{" "}
+                    {version.status === "locked" ? "Đã khóa" : "Bản nháp"}
+                  </SelectItem>
+                ))}
+              {versionState.versionsQuery.hasNextPage || versionState.hasHistoryRecoveryError ? (
+                <SelectItem
+                  value={LOAD_MORE_BASELINE_VERSIONS_VALUE}
+                  disabled={versionState.versionsQuery.isFetchingNextPage}
+                >
+                  {versionState.versionsQuery.isFetchingNextPage
+                    ? "Đang tải phiên bản..."
+                    : versionState.hasHistoryRecoveryError
+                      ? "Thử tải lại lịch sử phiên bản"
+                      : "Tải thêm phiên bản"}
+                </SelectItem>
+              ) : null}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {!referenceState.isReadOnly ? (
+          <div className="flex flex-wrap gap-2">
+            {referenceState.isDirty || referenceState.isConflict ? (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isNavigationBlocked || isProductDataUnavailable}
+                onClick={handleReload}
+              >
+                <RefreshCw
+                  className={`size-4 ${referenceState.isReloading ? "animate-spin" : ""}`}
+                  aria-hidden="true"
+                />
+                Tải lại dữ liệu
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isNavigationBlocked || isProductDataUnavailable}
+              onClick={referenceState.addProduct}
+            >
+              <Plus className="size-4" aria-hidden="true" />
+              Thêm sản phẩm tham chiếu
+            </Button>
+            <Button
+              type="button"
+              disabled={
+                !referenceState.isDirty ||
+                referenceState.invalidProductIds.length > 0 ||
+                isNavigationBlocked ||
+                isProductDataUnavailable
+              }
+              onClick={referenceState.save}
+            >
+              {referenceState.isSaving ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Save className="size-4" aria-hidden="true" />
+              )}
+              Lưu thay đổi
+            </Button>
+          </div>
+        ) : null}
+      </section>
+
+      {readOnlyMessage ? (
+        <Alert>
+          {isArchived ? (
+            <Archive className="size-4" aria-hidden="true" />
+          ) : (
+            <LockKeyhole className="size-4" aria-hidden="true" />
+          )}
+          <AlertTitle>Chế độ chỉ đọc</AlertTitle>
+          <AlertDescription>{readOnlyMessage}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {referenceState.saveError ? (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          <AlertTitle>
+            {referenceState.isConflict ? "Dữ liệu đã thay đổi" : "Không thể lưu"}
+          </AlertTitle>
+          <AlertDescription>{referenceState.saveError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {referenceState.saveStatus === "saved" ? (
+        <p role="status" className="text-sm text-emerald-700">
+          Đã lưu sản phẩm tham chiếu.
+        </p>
+      ) : null}
+
+      {referenceState.refreshWarning ? (
+        <Alert>
+          <RefreshCw className="size-4" aria-hidden="true" />
+          <AlertTitle>Đã lưu nhưng chưa làm mới dữ liệu</AlertTitle>
+          <AlertDescription>{referenceState.refreshWarning}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <TechnicalConfigurationReferenceProductsBody
+        baselineVersion={selectedVersion}
+        referenceState={referenceState}
+        navigationBlocked={isNavigationBlocked}
+      />
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
@@ -199,7 +199,9 @@ export function TechnicalConfigurationReferenceProducts({
 
         {!referenceState.isReadOnly ? (
           <div className="flex flex-wrap gap-2">
-            {referenceState.isDirty || referenceState.isConflict ? (
+            {referenceState.isDirty ||
+            referenceState.isConflict ||
+            referenceState.refreshWarning ? (
               <Button
                 type="button"
                 variant="outline"

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+import { AlertCircle, Loader2 } from "lucide-react"
+
+import { TechnicalConfigurationReferenceComparison } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison"
+import { TechnicalConfigurationReferenceProductEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductEditor"
+import type { useTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+
+type TechnicalConfigurationReferenceProductsBodyProps = {
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  referenceState: ReturnType<typeof useTechnicalConfigurationReferenceProducts>
+  navigationBlocked: boolean
+}
+
+/** Renders reference-product query states, metadata editors, and comparison matrix. */
+export function TechnicalConfigurationReferenceProductsBody({
+  baselineVersion,
+  referenceState,
+  navigationBlocked,
+}: Readonly<TechnicalConfigurationReferenceProductsBodyProps>) {
+  const invalidProductIdSet = React.useMemo(
+    () => new Set(referenceState.invalidProductIds),
+    [referenceState.invalidProductIds]
+  )
+  const hasInitialQueryError =
+    referenceState.productsQuery.isError && referenceState.productsQuery.data === undefined
+
+  return (
+    <>
+      {referenceState.productsQuery.isLoading ? (
+        <div className="flex min-h-28 items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          Đang tải sản phẩm tham chiếu...
+        </div>
+      ) : null}
+
+      {hasInitialQueryError ? (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          <AlertTitle>Không thể tải sản phẩm tham chiếu</AlertTitle>
+          <AlertDescription className="flex flex-col items-start gap-3">
+            <span>
+              {referenceState.productsQuery.error instanceof Error
+                ? referenceState.productsQuery.error.message
+                : "Vui lòng thử lại."}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                void referenceState.productsQuery.refetch()
+              }}
+            >
+              Thử lại
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {!referenceState.productsQuery.isLoading && !hasInitialQueryError ? (
+        <div className="space-y-4">
+          {referenceState.products.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Chưa có sản phẩm tham chiếu.</p>
+          ) : null}
+
+          {referenceState.products.map((product, index) => (
+            <TechnicalConfigurationReferenceProductEditor
+              key={product.id}
+              product={product}
+              index={index}
+              invalid={invalidProductIdSet.has(product.id)}
+              readOnly={referenceState.isReadOnly}
+              navigationBlocked={navigationBlocked}
+              onUpdate={referenceState.updateProduct}
+              onRemove={referenceState.removeProduct}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <TechnicalConfigurationReferenceComparison
+        baselineVersion={baselineVersion}
+        products={referenceState.products}
+        readOnly={referenceState.isReadOnly || navigationBlocked}
+        onResponseChange={referenceState.updateResponse}
+      />
+    </>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
@@ -26,6 +26,7 @@ export function TechnicalConfigurationReferenceProductsBody({
   )
   const hasInitialQueryError =
     referenceState.productsQuery.isError && referenceState.productsQuery.data === undefined
+  const canRenderProducts = !referenceState.productsQuery.isLoading && !hasInitialQueryError
 
   return (
     <>
@@ -41,11 +42,7 @@ export function TechnicalConfigurationReferenceProductsBody({
           <AlertCircle className="size-4" aria-hidden="true" />
           <AlertTitle>Không thể tải sản phẩm tham chiếu</AlertTitle>
           <AlertDescription className="flex flex-col items-start gap-3">
-            <span>
-              {referenceState.productsQuery.error instanceof Error
-                ? referenceState.productsQuery.error.message
-                : "Vui lòng thử lại."}
-            </span>
+            <span>Vui lòng thử lại.</span>
             <Button
               type="button"
               variant="outline"
@@ -60,12 +57,8 @@ export function TechnicalConfigurationReferenceProductsBody({
         </Alert>
       ) : null}
 
-      {!referenceState.productsQuery.isLoading && !hasInitialQueryError ? (
+      {canRenderProducts ? (
         <div className="space-y-4">
-          {referenceState.products.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Chưa có sản phẩm tham chiếu.</p>
-          ) : null}
-
           {referenceState.products.map((product, index) => (
             <TechnicalConfigurationReferenceProductEditor
               key={product.id}
@@ -81,12 +74,14 @@ export function TechnicalConfigurationReferenceProductsBody({
         </div>
       ) : null}
 
-      <TechnicalConfigurationReferenceComparison
-        baselineVersion={baselineVersion}
-        products={referenceState.products}
-        readOnly={referenceState.isReadOnly || navigationBlocked}
-        onResponseChange={referenceState.updateResponse}
-      />
+      {canRenderProducts ? (
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={baselineVersion}
+          products={referenceState.products}
+          readOnly={referenceState.isReadOnly || navigationBlocked}
+          onResponseChange={referenceState.updateResponse}
+        />
+      ) : null}
     </>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -1,11 +1,19 @@
 import * as React from "react"
-import { ArrowLeft, ClipboardList, GitCompareArrows, ListChecks, PackageSearch } from "lucide-react"
+import {
+  ArrowLeft,
+  ClipboardList,
+  GitCompareArrows,
+  LibraryBig,
+  ListChecks,
+  PackageSearch,
+} from "lucide-react"
 
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import { TechnicalConfigurationBaselineTab } from "./TechnicalConfigurationBaselineTab"
+import { TechnicalConfigurationReferenceProducts } from "./TechnicalConfigurationReferenceProducts"
 
 type TechnicalConfigurationWorkspaceShellProps = {
   dossier: TechnicalConfigurationDossierWire
@@ -17,19 +25,47 @@ export function TechnicalConfigurationWorkspaceShell({
   dossier,
   onBack,
 }: Readonly<TechnicalConfigurationWorkspaceShellProps>) {
+  const [activeTab, setActiveTab] = React.useState("baseline")
   const [isBaselineDirty, setIsBaselineDirty] = React.useState(false)
   const [isBaselineNavigationBlocked, setIsBaselineNavigationBlocked] = React.useState(false)
+  const [isReferenceDirty, setIsReferenceDirty] = React.useState(false)
+  const [isReferenceNavigationBlocked, setIsReferenceNavigationBlocked] = React.useState(false)
+  const isDirty = isBaselineDirty || isReferenceDirty
+  const isNavigationBlocked = isBaselineNavigationBlocked || isReferenceNavigationBlocked
 
   const handleBack = React.useCallback(() => {
-    if (isBaselineNavigationBlocked) return
-    if (
-      isBaselineDirty &&
-      !window.confirm("Bạn có thay đổi chưa lưu. Rời hồ sơ và bỏ các thay đổi?")
-    ) {
+    if (isNavigationBlocked) return
+    if (isDirty && !window.confirm("Bạn có thay đổi chưa lưu. Rời hồ sơ và bỏ các thay đổi?")) {
       return
     }
     onBack()
-  }, [isBaselineDirty, isBaselineNavigationBlocked, onBack])
+  }, [isDirty, isNavigationBlocked, onBack])
+
+  const handleTabChange = React.useCallback(
+    (nextTab: string) => {
+      const isCurrentTabDirty =
+        (activeTab === "baseline" && isBaselineDirty) ||
+        (activeTab === "references" && isReferenceDirty)
+      const isCurrentTabBlocked =
+        (activeTab === "baseline" && isBaselineNavigationBlocked) ||
+        (activeTab === "references" && isReferenceNavigationBlocked)
+      if (isCurrentTabBlocked) return
+      if (
+        isCurrentTabDirty &&
+        !window.confirm("Bạn có thay đổi chưa lưu. Chuyển khu vực và bỏ các thay đổi?")
+      ) {
+        return
+      }
+      setActiveTab(nextTab)
+    },
+    [
+      activeTab,
+      isBaselineDirty,
+      isBaselineNavigationBlocked,
+      isReferenceDirty,
+      isReferenceNavigationBlocked,
+    ]
+  )
 
   return (
     <div className="w-full">
@@ -38,7 +74,7 @@ export function TechnicalConfigurationWorkspaceShell({
           type="button"
           variant="ghost"
           className="-ml-3"
-          disabled={isBaselineNavigationBlocked}
+          disabled={isNavigationBlocked}
           onClick={handleBack}
         >
           <ArrowLeft className="size-4" aria-hidden="true" />
@@ -59,11 +95,15 @@ export function TechnicalConfigurationWorkspaceShell({
         </div>
       </header>
 
-      <Tabs defaultValue="baseline" className="mt-6">
-        <TabsList className="grid h-auto w-full grid-cols-1 gap-1 sm:grid-cols-3">
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="mt-6">
+        <TabsList className="grid h-auto w-full grid-cols-1 gap-1 sm:grid-cols-4">
           <TabsTrigger value="baseline" className="min-h-10 gap-2">
             <ListChecks className="size-4" aria-hidden="true" />
             Cấu hình cơ sở
+          </TabsTrigger>
+          <TabsTrigger value="references" className="min-h-10 gap-2">
+            <LibraryBig className="size-4" aria-hidden="true" />
+            Sản phẩm tham chiếu
           </TabsTrigger>
           <TabsTrigger value="options" className="min-h-10 gap-2" disabled>
             <PackageSearch className="size-4" aria-hidden="true" />
@@ -80,6 +120,13 @@ export function TechnicalConfigurationWorkspaceShell({
             dossier={dossier}
             onDirtyChange={setIsBaselineDirty}
             onNavigationBlockedChange={setIsBaselineNavigationBlocked}
+          />
+        </TabsContent>
+        <TabsContent value="references" className="mt-6">
+          <TechnicalConfigurationReferenceProducts
+            dossier={dossier}
+            onDirtyChange={setIsReferenceDirty}
+            onNavigationBlockedChange={setIsReferenceNavigationBlocked}
           />
         </TabsContent>
       </Tabs>

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts.ts
@@ -30,7 +30,6 @@ export type {
   TechnicalConfigurationReferenceProductDraft,
   TechnicalConfigurationReferenceProductPatch,
 } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
-
 type UseTechnicalConfigurationReferenceProductsArgs = {
   baselineVersion: TechnicalConfigurationBaselineDraftWire | null
   isArchived?: boolean
@@ -55,7 +54,7 @@ export function useTechnicalConfigurationReferenceProducts({
     createTechnicalConfigurationReferenceProductsState(baselineVersion)
   )
   const nextLocalId = React.useRef(0)
-
+  const activeOperationRef = React.useRef<"save" | "reload" | null>(null)
   const productsQuery = useQuery({
     queryKey,
     queryFn: ({ signal }) =>
@@ -98,7 +97,7 @@ export function useTechnicalConfigurationReferenceProducts({
   }
 
   const addProduct = React.useCallback(() => {
-    if (isReadOnly) return ""
+    if (isReadOnly || activeOperationRef.current) return ""
     nextLocalId.current += 1
     const id = `new-reference-product-${nextLocalId.current}`
     setState((current) => ({
@@ -123,7 +122,7 @@ export function useTechnicalConfigurationReferenceProducts({
 
   const updateProduct = React.useCallback(
     (productId: string, patch: TechnicalConfigurationReferenceProductPatch) => {
-      if (isReadOnly) return
+      if (isReadOnly || activeOperationRef.current) return
       setState((current) => ({
         ...current,
         products: current.products.map((product) =>
@@ -138,7 +137,7 @@ export function useTechnicalConfigurationReferenceProducts({
 
   const removeProduct = React.useCallback(
     (productId: string) => {
-      if (isReadOnly) return
+      if (isReadOnly || activeOperationRef.current) return
       setState((current) => ({
         ...current,
         products: current.products.filter((product) => product.id !== productId),
@@ -151,7 +150,7 @@ export function useTechnicalConfigurationReferenceProducts({
 
   const updateResponse = React.useCallback(
     (productId: string, criterionId: string, responseText: string) => {
-      if (isReadOnly) return
+      if (isReadOnly || activeOperationRef.current) return
       setState((current) => ({
         ...current,
         products: current.products.map((product) =>
@@ -178,11 +177,12 @@ export function useTechnicalConfigurationReferenceProducts({
       isReadOnly ||
       !isDirty ||
       invalidProductIds.length > 0 ||
-      state.isSaving
+      activeOperationRef.current
     ) {
       return
     }
 
+    activeOperationRef.current = "save"
     onNavigationBlockedChange?.(true)
     setState((current) => ({
       ...current,
@@ -259,6 +259,7 @@ export function useTechnicalConfigurationReferenceProducts({
         applyTechnicalConfigurationReferenceProductSaveErrorState(current, error)
       )
     } finally {
+      activeOperationRef.current = null
       setState((current) => ({ ...current, isSaving: false }))
       onNavigationBlockedChange?.(false)
     }
@@ -272,14 +273,14 @@ export function useTechnicalConfigurationReferenceProducts({
     queryClient,
     queryKey,
     state.baseProducts,
-    state.isSaving,
     state.products,
     state.revision,
   ])
 
   const reload = React.useCallback(
     async (beforeProductsReload?: () => Promise<void>) => {
-      if (!baselineVersionId || state.isSaving) return
+      if (!baselineVersionId || activeOperationRef.current) return
+      activeOperationRef.current = "reload"
       onNavigationBlockedChange?.(true)
       setState((current) => ({
         ...current,
@@ -316,11 +317,12 @@ export function useTechnicalConfigurationReferenceProducts({
           saveError: "Không thể tải lại sản phẩm tham chiếu.",
         }))
       } finally {
+        activeOperationRef.current = null
         setState((current) => ({ ...current, isReloading: false }))
         onNavigationBlockedChange?.(false)
       }
     },
-    [baselineVersionId, onNavigationBlockedChange, productsQuery, state.isSaving]
+    [baselineVersionId, onNavigationBlockedChange, productsQuery]
   )
 
   return {

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts.ts
@@ -1,8 +1,7 @@
 import * as React from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 
-import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
-import type { TechnicalConfigurationReferenceProductWire } from "@/app/(app)/technical-configurations/reference-product-types"
+import type { TechnicalConfigurationReferenceProductsSnapshot } from "@/app/(app)/technical-configurations/reference-product-types"
 import {
   applyTechnicalConfigurationReferenceProductSaveErrorState,
   applyTechnicalConfigurationReferenceProductSaveFailureState,
@@ -14,6 +13,7 @@ import {
   toTechnicalConfigurationReferenceProductDraft,
   type TechnicalConfigurationReferenceProductDraft,
   type TechnicalConfigurationReferenceProductPatch,
+  type TechnicalConfigurationReferenceProductsHookArgs,
   type TechnicalConfigurationReferenceProductsState,
 } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
 import {
@@ -30,12 +30,6 @@ export type {
   TechnicalConfigurationReferenceProductDraft,
   TechnicalConfigurationReferenceProductPatch,
 } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
-type UseTechnicalConfigurationReferenceProductsArgs = {
-  baselineVersion: TechnicalConfigurationBaselineDraftWire | null
-  isArchived?: boolean
-  onRevisionChange?: (revision: number) => void
-  onNavigationBlockedChange?: (blocked: boolean) => void
-}
 
 /** Owns reference-product retrieval, local drafts, explicit save, and conflict preservation. */
 export function useTechnicalConfigurationReferenceProducts({
@@ -43,7 +37,7 @@ export function useTechnicalConfigurationReferenceProducts({
   isArchived = false,
   onRevisionChange,
   onNavigationBlockedChange,
-}: UseTechnicalConfigurationReferenceProductsArgs) {
+}: TechnicalConfigurationReferenceProductsHookArgs) {
   const queryClient = useQueryClient()
   const baselineVersionId = baselineVersion?.id ?? ""
   const queryKey = React.useMemo(
@@ -222,11 +216,15 @@ export function useTechnicalConfigurationReferenceProducts({
       ])
       if (productsRefresh.status === "fulfilled") {
         const refreshedProducts =
-          queryClient.getQueryData<TechnicalConfigurationReferenceProductWire[]>(queryKey)
+          queryClient.getQueryData<TechnicalConfigurationReferenceProductsSnapshot>(queryKey)
         if (refreshedProducts) {
-          const nextProducts = refreshedProducts.map(toTechnicalConfigurationReferenceProductDraft)
+          const nextProducts = refreshedProducts.products.map(
+            toTechnicalConfigurationReferenceProductDraft
+          )
+          onRevisionChange?.(refreshedProducts.revision)
           setState((current) => ({
             ...current,
+            revision: refreshedProducts.revision,
             baseProducts: nextProducts,
             products: cloneTechnicalConfigurationReferenceProductDrafts(nextProducts),
             ignoreProductsQueryData: false,
@@ -294,9 +292,13 @@ export function useTechnicalConfigurationReferenceProducts({
         }
         const refreshed = await productsQuery.refetch({ throwOnError: true })
         if (refreshed.data) {
-          const nextProducts = refreshed.data.map(toTechnicalConfigurationReferenceProductDraft)
+          const nextProducts = refreshed.data.products.map(
+            toTechnicalConfigurationReferenceProductDraft
+          )
+          onRevisionChange?.(refreshed.data.revision)
           setState((current) => ({
             ...current,
+            revision: refreshed.data.revision,
             baseProducts: nextProducts,
             products: cloneTechnicalConfigurationReferenceProductDrafts(nextProducts),
             isConflict: false,
@@ -322,7 +324,7 @@ export function useTechnicalConfigurationReferenceProducts({
         onNavigationBlockedChange?.(false)
       }
     },
-    [baselineVersionId, onNavigationBlockedChange, productsQuery]
+    [baselineVersionId, onNavigationBlockedChange, onRevisionChange, productsQuery]
   )
 
   return {

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts.ts
@@ -1,0 +1,346 @@
+import * as React from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationReferenceProductWire } from "@/app/(app)/technical-configurations/reference-product-types"
+import {
+  applyTechnicalConfigurationReferenceProductSaveErrorState,
+  applyTechnicalConfigurationReferenceProductSaveFailureState,
+  canonicalizeTechnicalConfigurationReferenceProductDrafts,
+  cloneTechnicalConfigurationReferenceProductDrafts,
+  createTechnicalConfigurationReferenceProductsState,
+  reconcileTechnicalConfigurationReferenceProductsState,
+  toNullableReferenceProductText,
+  toTechnicalConfigurationReferenceProductDraft,
+  type TechnicalConfigurationReferenceProductDraft,
+  type TechnicalConfigurationReferenceProductPatch,
+  type TechnicalConfigurationReferenceProductsState,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+import {
+  listAllTechnicalConfigurationReferenceProducts,
+  ReferenceProductSaveFailure,
+  saveTechnicalConfigurationReferenceProducts,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-operations"
+import {
+  technicalConfigurationBaselineVersionsQueryKey,
+  technicalConfigurationReferenceProductsQueryKey,
+} from "@/app/(app)/technical-configurations/technical-configuration-query-keys"
+
+export type {
+  TechnicalConfigurationReferenceProductDraft,
+  TechnicalConfigurationReferenceProductPatch,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+
+type UseTechnicalConfigurationReferenceProductsArgs = {
+  baselineVersion: TechnicalConfigurationBaselineDraftWire | null
+  isArchived?: boolean
+  onRevisionChange?: (revision: number) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+/** Owns reference-product retrieval, local drafts, explicit save, and conflict preservation. */
+export function useTechnicalConfigurationReferenceProducts({
+  baselineVersion,
+  isArchived = false,
+  onRevisionChange,
+  onNavigationBlockedChange,
+}: UseTechnicalConfigurationReferenceProductsArgs) {
+  const queryClient = useQueryClient()
+  const baselineVersionId = baselineVersion?.id ?? ""
+  const queryKey = React.useMemo(
+    () => technicalConfigurationReferenceProductsQueryKey(baselineVersionId),
+    [baselineVersionId]
+  )
+  const [state, setState] = React.useState<TechnicalConfigurationReferenceProductsState>(() =>
+    createTechnicalConfigurationReferenceProductsState(baselineVersion)
+  )
+  const nextLocalId = React.useRef(0)
+
+  const productsQuery = useQuery({
+    queryKey,
+    queryFn: ({ signal }) =>
+      listAllTechnicalConfigurationReferenceProducts(baselineVersionId, signal),
+    enabled: Boolean(baselineVersionId),
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+  const isDirty = React.useMemo(
+    () =>
+      JSON.stringify(
+        canonicalizeTechnicalConfigurationReferenceProductDrafts(state.baseProducts)
+      ) !==
+      JSON.stringify(canonicalizeTechnicalConfigurationReferenceProductDrafts(state.products)),
+    [state.baseProducts, state.products]
+  )
+  const invalidProductIds = React.useMemo(
+    () =>
+      state.products.flatMap((product) =>
+        !toNullableReferenceProductText(product.model) &&
+        !toNullableReferenceProductText(product.manufacturer) &&
+        !toNullableReferenceProductText(product.description)
+          ? [product.id]
+          : []
+      ),
+    [state.products]
+  )
+  const isLocked = baselineVersion?.status === "locked"
+  const isReadOnly = isLocked || isArchived
+
+  const reconciledState = reconcileTechnicalConfigurationReferenceProductsState({
+    state,
+    baselineVersion,
+    productsQueryData: productsQuery.data,
+    isDirty,
+  })
+  if (reconciledState) {
+    setState(reconciledState)
+  }
+
+  const addProduct = React.useCallback(() => {
+    if (isReadOnly) return ""
+    nextLocalId.current += 1
+    const id = `new-reference-product-${nextLocalId.current}`
+    setState((current) => ({
+      ...current,
+      products: [
+        ...current.products,
+        {
+          id,
+          persistedId: null,
+          model: "",
+          manufacturer: "",
+          description: "",
+          notes: "",
+          responses: {},
+        },
+      ],
+      saveStatus: "idle",
+      refreshWarning: null,
+    }))
+    return id
+  }, [isReadOnly])
+
+  const updateProduct = React.useCallback(
+    (productId: string, patch: TechnicalConfigurationReferenceProductPatch) => {
+      if (isReadOnly) return
+      setState((current) => ({
+        ...current,
+        products: current.products.map((product) =>
+          product.id === productId ? { ...product, ...patch } : product
+        ),
+        saveStatus: "idle",
+        refreshWarning: null,
+      }))
+    },
+    [isReadOnly]
+  )
+
+  const removeProduct = React.useCallback(
+    (productId: string) => {
+      if (isReadOnly) return
+      setState((current) => ({
+        ...current,
+        products: current.products.filter((product) => product.id !== productId),
+        saveStatus: "idle",
+        refreshWarning: null,
+      }))
+    },
+    [isReadOnly]
+  )
+
+  const updateResponse = React.useCallback(
+    (productId: string, criterionId: string, responseText: string) => {
+      if (isReadOnly) return
+      setState((current) => ({
+        ...current,
+        products: current.products.map((product) =>
+          product.id === productId
+            ? {
+                ...product,
+                responses: {
+                  ...product.responses,
+                  [criterionId]: responseText,
+                },
+              }
+            : product
+        ),
+        saveStatus: "idle",
+        refreshWarning: null,
+      }))
+    },
+    [isReadOnly]
+  )
+
+  const save = React.useCallback(async () => {
+    if (
+      !baselineVersion ||
+      isReadOnly ||
+      !isDirty ||
+      invalidProductIds.length > 0 ||
+      state.isSaving
+    ) {
+      return
+    }
+
+    onNavigationBlockedChange?.(true)
+    setState((current) => ({
+      ...current,
+      isSaving: true,
+      isConflict: false,
+      saveError: null,
+      refreshWarning: null,
+      saveStatus: "idle",
+    }))
+
+    try {
+      const saved = await saveTechnicalConfigurationReferenceProducts({
+        baselineVersion,
+        baseProducts: state.baseProducts,
+        products: state.products,
+        revision: state.revision,
+      })
+      onRevisionChange?.(saved.revision)
+      setState((current) => ({
+        ...current,
+        revision: saved.revision,
+        baseProducts: saved.products,
+        products: cloneTechnicalConfigurationReferenceProductDrafts(saved.products),
+        saveStatus: "saved",
+        ignoreProductsQueryData: true,
+      }))
+
+      const [productsRefresh, versionsRefresh] = await Promise.allSettled([
+        queryClient.invalidateQueries({ queryKey, exact: true }, { throwOnError: true }),
+        queryClient.invalidateQueries(
+          {
+            queryKey: technicalConfigurationBaselineVersionsQueryKey(baselineVersion.dossier_id),
+            exact: true,
+          },
+          { throwOnError: true }
+        ),
+      ])
+      if (productsRefresh.status === "fulfilled") {
+        const refreshedProducts =
+          queryClient.getQueryData<TechnicalConfigurationReferenceProductWire[]>(queryKey)
+        if (refreshedProducts) {
+          const nextProducts = refreshedProducts.map(toTechnicalConfigurationReferenceProductDraft)
+          setState((current) => ({
+            ...current,
+            baseProducts: nextProducts,
+            products: cloneTechnicalConfigurationReferenceProductDrafts(nextProducts),
+            ignoreProductsQueryData: false,
+            syncedProductsQueryData: refreshedProducts,
+          }))
+        }
+      }
+      if (productsRefresh.status === "rejected" || versionsRefresh.status === "rejected") {
+        setState((current) => ({
+          ...current,
+          refreshWarning: "Đã lưu thay đổi nhưng không thể làm mới dữ liệu từ máy chủ.",
+        }))
+      }
+    } catch (error) {
+      if (error instanceof ReferenceProductSaveFailure) {
+        if (error.progress.revision !== state.revision) {
+          onRevisionChange?.(error.progress.revision)
+        }
+        setState((current) =>
+          applyTechnicalConfigurationReferenceProductSaveFailureState({
+            state: current,
+            progress: error.progress,
+            isConflict: error.isConflict,
+            originalError: error.originalError,
+          })
+        )
+        return
+      }
+      setState((current) =>
+        applyTechnicalConfigurationReferenceProductSaveErrorState(current, error)
+      )
+    } finally {
+      setState((current) => ({ ...current, isSaving: false }))
+      onNavigationBlockedChange?.(false)
+    }
+  }, [
+    baselineVersion,
+    invalidProductIds.length,
+    isDirty,
+    isReadOnly,
+    onNavigationBlockedChange,
+    onRevisionChange,
+    queryClient,
+    queryKey,
+    state.baseProducts,
+    state.isSaving,
+    state.products,
+    state.revision,
+  ])
+
+  const reload = React.useCallback(
+    async (beforeProductsReload?: () => Promise<void>) => {
+      if (!baselineVersionId || state.isSaving) return
+      onNavigationBlockedChange?.(true)
+      setState((current) => ({
+        ...current,
+        isReloading: true,
+        saveError: null,
+        refreshWarning: null,
+      }))
+      try {
+        if (beforeProductsReload) {
+          await beforeProductsReload()
+        }
+        const refreshed = await productsQuery.refetch({ throwOnError: true })
+        if (refreshed.data) {
+          const nextProducts = refreshed.data.map(toTechnicalConfigurationReferenceProductDraft)
+          setState((current) => ({
+            ...current,
+            baseProducts: nextProducts,
+            products: cloneTechnicalConfigurationReferenceProductDrafts(nextProducts),
+            isConflict: false,
+            saveStatus: "idle",
+            ignoreProductsQueryData: false,
+            syncedProductsQueryData: refreshed.data ?? null,
+          }))
+        } else {
+          setState((current) => ({
+            ...current,
+            isConflict: false,
+            saveStatus: "idle",
+          }))
+        }
+      } catch {
+        setState((current) => ({
+          ...current,
+          saveError: "Không thể tải lại sản phẩm tham chiếu.",
+        }))
+      } finally {
+        setState((current) => ({ ...current, isReloading: false }))
+        onNavigationBlockedChange?.(false)
+      }
+    },
+    [baselineVersionId, onNavigationBlockedChange, productsQuery, state.isSaving]
+  )
+
+  return {
+    productsQuery,
+    products: state.products,
+    isDirty,
+    isConflict: state.isConflict,
+    isLocked,
+    isReadOnly,
+    isSaving: state.isSaving,
+    isReloading: state.isReloading,
+    saveStatus: state.saveStatus,
+    saveError: state.saveError,
+    refreshWarning: state.refreshWarning,
+    invalidProductIds,
+    addProduct,
+    updateProduct,
+    removeProduct,
+    updateResponse,
+    save,
+    reload,
+  }
+}

--- a/src/app/(app)/technical-configurations/reference-product-types.ts
+++ b/src/app/(app)/technical-configurations/reference-product-types.ts
@@ -28,9 +28,15 @@ export interface TechnicalConfigurationReferenceProductWire {
 
 export interface TechnicalConfigurationReferenceProductsListWireResponse {
   data: TechnicalConfigurationReferenceProductWire[]
+  revision: number
   total: number
   page: number
   page_size: number
+}
+
+export type TechnicalConfigurationReferenceProductsSnapshot = {
+  products: TechnicalConfigurationReferenceProductWire[]
+  revision: number
 }
 
 export interface TechnicalConfigurationReferenceProductMutationWireResponse {

--- a/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
@@ -13,3 +13,8 @@ export function technicalConfigurationDossierDetailQueryKey(dossierId: string) {
 export function technicalConfigurationBaselineVersionsQueryKey(dossierId: string) {
   return ["technical-configurations", "baseline-versions", dossierId] as const
 }
+
+/** Builds the cache key for reference products under one exact baseline version. */
+export function technicalConfigurationReferenceProductsQueryKey(baselineVersionId: string) {
+  return ["technical-configurations", "reference-products", baselineVersionId] as const
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-reference-product-operations.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-reference-product-operations.ts
@@ -1,0 +1,271 @@
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationReferenceProductWire } from "@/app/(app)/technical-configurations/reference-product-types"
+import { isTechnicalConfigurationBaselineConflict } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
+import {
+  cloneTechnicalConfigurationReferenceProductDrafts,
+  getChangedTechnicalConfigurationReferenceResponses,
+  haveSameTechnicalConfigurationReferenceProductFields,
+  toNullableReferenceProductText,
+  toTechnicalConfigurationReferenceProductDraft,
+  type TechnicalConfigurationReferenceProductDraft,
+  type TechnicalConfigurationReferenceProductSaveProgress,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+import {
+  createTechnicalConfigurationReferenceProduct,
+  deleteTechnicalConfigurationReferenceProduct,
+  listTechnicalConfigurationReferenceProducts,
+  updateTechnicalConfigurationReferenceProduct,
+  upsertTechnicalConfigurationReferenceResponse,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-rpc"
+
+const REFERENCE_PRODUCT_PAGE_SIZE = 100
+
+type TechnicalConfigurationReferenceProductSaveResult = {
+  revision: number
+  products: TechnicalConfigurationReferenceProductDraft[]
+}
+
+/** Carries resumable progress when a multi-RPC reference-product save fails. */
+export class ReferenceProductSaveFailure extends Error {
+  readonly isConflict: boolean
+  readonly progress: TechnicalConfigurationReferenceProductSaveProgress
+  readonly originalError: unknown
+
+  constructor(error: unknown, progress: TechnicalConfigurationReferenceProductSaveProgress) {
+    super(error instanceof Error && error.message ? error.message : "reference_product_save_failed")
+    this.name = "ReferenceProductSaveFailure"
+    this.isConflict = isTechnicalConfigurationBaselineConflict(error)
+    this.progress = cloneReferenceProductSaveProgress(progress)
+    this.originalError = error
+  }
+}
+
+/** Loads every paginated reference product for a baseline version. */
+export async function listAllTechnicalConfigurationReferenceProducts(
+  baselineVersionId: string,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationReferenceProductWire[]> {
+  const products: TechnicalConfigurationReferenceProductWire[] = []
+  let page = 1
+  let total = Number.POSITIVE_INFINITY
+
+  while (products.length < total) {
+    const response = await listTechnicalConfigurationReferenceProducts(
+      {
+        p_baseline_version_id: baselineVersionId,
+        p_page: page,
+        p_page_size: REFERENCE_PRODUCT_PAGE_SIZE,
+      },
+      signal
+    )
+    products.push(...response.data)
+    total = response.total
+    if (response.data.length === 0) break
+    page += 1
+  }
+
+  return products
+}
+
+/** Persists reference-product drafts with resumable optimistic-concurrency progress. */
+export async function saveTechnicalConfigurationReferenceProducts({
+  baselineVersion,
+  baseProducts,
+  products,
+  revision,
+}: {
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  baseProducts: TechnicalConfigurationReferenceProductDraft[]
+  products: TechnicalConfigurationReferenceProductDraft[]
+  revision: number
+}): Promise<TechnicalConfigurationReferenceProductSaveResult> {
+  const progress = cloneReferenceProductSaveProgress({
+    revision,
+    baseProducts,
+    products,
+  })
+  const desiredPersistedIds = new Set(
+    products.flatMap((product) => (product.persistedId ? [product.persistedId] : []))
+  )
+  const deletedProducts = baseProducts.filter(
+    (product) => product.persistedId && !desiredPersistedIds.has(product.persistedId)
+  )
+  const run = async <T>(request: () => Promise<T>): Promise<T> => {
+    try {
+      return await request()
+    } catch (error) {
+      throw new ReferenceProductSaveFailure(error, progress)
+    }
+  }
+
+  for (const draft of progress.products.filter((product) => product.persistedId)) {
+    const base = progress.baseProducts.find((product) => product.id === draft.id)
+    if (base && !haveSameTechnicalConfigurationReferenceProductFields(base, draft)) {
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Expected revisions serialize these writes.
+      const response = await run(() =>
+        updateTechnicalConfigurationReferenceProduct({
+          p_reference_product_id: draft.id,
+          p_model: toNullableReferenceProductText(draft.model),
+          p_manufacturer: toNullableReferenceProductText(draft.manufacturer),
+          p_description: toNullableReferenceProductText(draft.description),
+          p_notes: toNullableReferenceProductText(draft.notes),
+          p_expected_revision: progress.revision,
+        })
+      )
+      progress.revision = response.data.revision
+      const confirmed = {
+        ...toTechnicalConfigurationReferenceProductDraft(response.data),
+        responses: { ...base.responses },
+      }
+      progress.baseProducts = replaceReferenceProductDraft(
+        progress.baseProducts,
+        draft.id,
+        confirmed
+      )
+      progress.products = replaceReferenceProductDraft(progress.products, draft.id, {
+        ...confirmed,
+        responses: { ...draft.responses },
+      })
+    }
+    for (const [criterionId, responseText] of getChangedTechnicalConfigurationReferenceResponses(
+      base,
+      draft
+    )) {
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Expected revisions serialize these writes.
+      const response = await run(() =>
+        upsertTechnicalConfigurationReferenceResponse({
+          p_reference_product_id: draft.id,
+          p_criterion_id: criterionId,
+          p_response_text: responseText,
+          p_expected_revision: progress.revision,
+        })
+      )
+      progress.revision = response.data.revision
+      progress.baseProducts = replaceReferenceProductResponse(
+        progress.baseProducts,
+        draft.id,
+        criterionId,
+        response.data.response_text
+      )
+      progress.products = replaceReferenceProductResponse(
+        progress.products,
+        draft.id,
+        criterionId,
+        response.data.response_text
+      )
+    }
+  }
+
+  for (const draft of progress.products.filter((product) => !product.persistedId)) {
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Expected revisions serialize these writes.
+    const created = await run(() =>
+      createTechnicalConfigurationReferenceProduct({
+        p_baseline_version_id: baselineVersion.id,
+        p_model: toNullableReferenceProductText(draft.model),
+        p_manufacturer: toNullableReferenceProductText(draft.manufacturer),
+        p_description: toNullableReferenceProductText(draft.description),
+        p_notes: toNullableReferenceProductText(draft.notes),
+        p_expected_revision: progress.revision,
+      })
+    )
+    progress.revision = created.data.revision
+    const persistedDraft = toTechnicalConfigurationReferenceProductDraft(created.data)
+    const createdProductId = created.data.id
+    progress.baseProducts = [...progress.baseProducts, persistedDraft]
+    progress.products = replaceReferenceProductDraft(progress.products, draft.id, {
+      ...persistedDraft,
+      responses: { ...draft.responses },
+    })
+
+    for (const [criterionId, responseText] of getChangedTechnicalConfigurationReferenceResponses(
+      undefined,
+      draft
+    )) {
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Expected revisions serialize these writes.
+      const response = await run(() =>
+        upsertTechnicalConfigurationReferenceResponse({
+          p_reference_product_id: createdProductId,
+          p_criterion_id: criterionId,
+          p_response_text: responseText,
+          p_expected_revision: progress.revision,
+        })
+      )
+      progress.revision = response.data.revision
+      progress.baseProducts = replaceReferenceProductResponse(
+        progress.baseProducts,
+        createdProductId,
+        criterionId,
+        response.data.response_text
+      )
+      progress.products = replaceReferenceProductResponse(
+        progress.products,
+        createdProductId,
+        criterionId,
+        response.data.response_text
+      )
+    }
+  }
+
+  for (const deletedProduct of deletedProducts) {
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Expected revisions serialize these writes.
+    const response = await run(() =>
+      deleteTechnicalConfigurationReferenceProduct({
+        p_reference_product_id: deletedProduct.id,
+        p_expected_revision: progress.revision,
+      })
+    )
+    progress.revision = response.data.revision
+    progress.baseProducts = progress.baseProducts.filter(
+      (product) => product.id !== deletedProduct.id
+    )
+  }
+
+  return {
+    revision: progress.revision,
+    products: cloneTechnicalConfigurationReferenceProductDrafts(progress.baseProducts),
+  }
+}
+
+function cloneReferenceProductSaveProgress(
+  progress: TechnicalConfigurationReferenceProductSaveProgress
+): TechnicalConfigurationReferenceProductSaveProgress {
+  return {
+    revision: progress.revision,
+    baseProducts: cloneTechnicalConfigurationReferenceProductDrafts(progress.baseProducts),
+    products: cloneTechnicalConfigurationReferenceProductDrafts(progress.products),
+  }
+}
+
+function replaceReferenceProductDraft(
+  products: TechnicalConfigurationReferenceProductDraft[],
+  productId: string,
+  replacement: TechnicalConfigurationReferenceProductDraft
+) {
+  return products.map((product) =>
+    product.id === productId
+      ? {
+          ...replacement,
+          responses: { ...replacement.responses },
+        }
+      : product
+  )
+}
+
+function replaceReferenceProductResponse(
+  products: TechnicalConfigurationReferenceProductDraft[],
+  productId: string,
+  criterionId: string,
+  responseText: string
+) {
+  return products.map((product) =>
+    product.id === productId
+      ? {
+          ...product,
+          responses: {
+            ...product.responses,
+            [criterionId]: responseText,
+          },
+        }
+      : product
+  )
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-reference-product-operations.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-reference-product-operations.ts
@@ -1,5 +1,8 @@
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
-import type { TechnicalConfigurationReferenceProductWire } from "@/app/(app)/technical-configurations/reference-product-types"
+import type {
+  TechnicalConfigurationReferenceProductWire,
+  TechnicalConfigurationReferenceProductsSnapshot,
+} from "@/app/(app)/technical-configurations/reference-product-types"
 import { isTechnicalConfigurationBaselineConflict } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
 import {
   cloneTechnicalConfigurationReferenceProductDrafts,
@@ -44,10 +47,11 @@ export class ReferenceProductSaveFailure extends Error {
 export async function listAllTechnicalConfigurationReferenceProducts(
   baselineVersionId: string,
   signal?: AbortSignal
-): Promise<TechnicalConfigurationReferenceProductWire[]> {
+): Promise<TechnicalConfigurationReferenceProductsSnapshot> {
   const products: TechnicalConfigurationReferenceProductWire[] = []
   let page = 1
   let total = Number.POSITIVE_INFINITY
+  let revision: number | null = null
 
   while (products.length < total) {
     const response = await listTechnicalConfigurationReferenceProducts(
@@ -58,13 +62,20 @@ export async function listAllTechnicalConfigurationReferenceProducts(
       },
       signal
     )
+    if (
+      (revision !== null && response.revision !== revision) ||
+      (Number.isFinite(total) && response.total !== total)
+    ) {
+      throw new Error("Reference-product pagination snapshot changed during load.")
+    }
+    revision ??= response.revision
     products.push(...response.data)
     total = response.total
     if (response.data.length === 0) break
     page += 1
   }
 
-  return products
+  return { products, revision: revision ?? 0 }
 }
 
 /** Persists reference-product drafts with resumable optimistic-concurrency progress. */

--- a/src/app/(app)/technical-configurations/technical-configuration-reference-product-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-reference-product-state.ts
@@ -1,0 +1,233 @@
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationReferenceProductWire } from "@/app/(app)/technical-configurations/reference-product-types"
+import { isTechnicalConfigurationBaselineConflict } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
+
+export type TechnicalConfigurationReferenceProductDraft = {
+  id: string
+  persistedId: string | null
+  model: string
+  manufacturer: string
+  description: string
+  notes: string
+  responses: Record<string, string>
+}
+
+export type TechnicalConfigurationReferenceProductPatch = Partial<
+  Pick<
+    TechnicalConfigurationReferenceProductDraft,
+    "model" | "manufacturer" | "description" | "notes"
+  >
+>
+
+export type TechnicalConfigurationReferenceProductSaveProgress = {
+  revision: number
+  baseProducts: TechnicalConfigurationReferenceProductDraft[]
+  products: TechnicalConfigurationReferenceProductDraft[]
+}
+
+export type TechnicalConfigurationReferenceProductsState = {
+  loadedVersionId: string
+  baseProducts: TechnicalConfigurationReferenceProductDraft[]
+  products: TechnicalConfigurationReferenceProductDraft[]
+  revision: number
+  isConflict: boolean
+  isSaving: boolean
+  isReloading: boolean
+  saveStatus: "idle" | "saved"
+  saveError: string | null
+  refreshWarning: string | null
+  ignoreProductsQueryData: boolean
+  syncedProductsQueryData: TechnicalConfigurationReferenceProductWire[] | null
+}
+
+/** Creates reference-product editor state for the selected baseline version. */
+export function createTechnicalConfigurationReferenceProductsState(
+  baselineVersion: TechnicalConfigurationBaselineDraftWire | null
+): TechnicalConfigurationReferenceProductsState {
+  return {
+    loadedVersionId: baselineVersion?.id ?? "",
+    baseProducts: [],
+    products: [],
+    revision: baselineVersion?.revision ?? 0,
+    isConflict: false,
+    isSaving: false,
+    isReloading: false,
+    saveStatus: "idle",
+    saveError: null,
+    refreshWarning: null,
+    ignoreProductsQueryData: false,
+    syncedProductsQueryData: null,
+  }
+}
+
+/** Applies resumable progress captured from a partially completed save. */
+export function applyTechnicalConfigurationReferenceProductSaveFailureState({
+  state,
+  progress,
+  isConflict,
+  originalError,
+}: {
+  state: TechnicalConfigurationReferenceProductsState
+  progress: TechnicalConfigurationReferenceProductSaveProgress
+  isConflict: boolean
+  originalError: unknown
+}): TechnicalConfigurationReferenceProductsState {
+  return {
+    ...state,
+    revision: progress.revision,
+    baseProducts: progress.baseProducts,
+    products: progress.products,
+    isConflict,
+    saveError: getTechnicalConfigurationReferenceProductSaveError(originalError),
+  }
+}
+
+/** Records a non-resumable save error while preserving the current drafts. */
+export function applyTechnicalConfigurationReferenceProductSaveErrorState(
+  state: TechnicalConfigurationReferenceProductsState,
+  error: unknown
+): TechnicalConfigurationReferenceProductsState {
+  return {
+    ...state,
+    isConflict: isTechnicalConfigurationBaselineConflict(error),
+    saveError: getTechnicalConfigurationReferenceProductSaveError(error),
+  }
+}
+
+/** Returns the best available display name for a reference-product draft. */
+export function getTechnicalConfigurationReferenceProductName(
+  product: TechnicalConfigurationReferenceProductDraft,
+  index: number
+) {
+  return (
+    product.model.trim() ||
+    product.manufacturer.trim() ||
+    product.description.trim() ||
+    `Sản phẩm ${index + 1}`
+  )
+}
+
+/** Normalizes optional reference-product text for RPC parameters. */
+export function toNullableReferenceProductText(value: string): string | null {
+  const normalized = value.trim()
+  return normalized ? normalized : null
+}
+
+/** Converts a persisted reference product into an editable draft. */
+export function toTechnicalConfigurationReferenceProductDraft(
+  product: TechnicalConfigurationReferenceProductWire
+): TechnicalConfigurationReferenceProductDraft {
+  return {
+    id: product.id,
+    persistedId: product.id,
+    model: product.model ?? "",
+    manufacturer: product.manufacturer ?? "",
+    description: product.description ?? "",
+    notes: product.notes ?? "",
+    responses: Object.fromEntries(
+      product.responses.map((response) => [response.criterion_id, response.response_text])
+    ),
+  }
+}
+
+/** Deep-clones drafts and their criterion-response maps. */
+export function cloneTechnicalConfigurationReferenceProductDrafts(
+  products: TechnicalConfigurationReferenceProductDraft[]
+): TechnicalConfigurationReferenceProductDraft[] {
+  return products.map((product) => ({
+    ...product,
+    responses: { ...product.responses },
+  }))
+}
+
+/** Reconciles server data without overwriting dirty or conflicting drafts. */
+export function reconcileTechnicalConfigurationReferenceProductsState({
+  state,
+  baselineVersion,
+  productsQueryData,
+  isDirty,
+}: {
+  state: TechnicalConfigurationReferenceProductsState
+  baselineVersion: TechnicalConfigurationBaselineDraftWire | null
+  productsQueryData: TechnicalConfigurationReferenceProductWire[] | undefined
+  isDirty: boolean
+}): TechnicalConfigurationReferenceProductsState | null {
+  if ((baselineVersion?.id ?? "") !== state.loadedVersionId) {
+    return createTechnicalConfigurationReferenceProductsState(baselineVersion)
+  }
+
+  const canSyncProducts =
+    Boolean(productsQueryData) &&
+    productsQueryData !== state.syncedProductsQueryData &&
+    !state.ignoreProductsQueryData &&
+    !isDirty &&
+    !state.isConflict &&
+    !state.isSaving
+  const nextRevision =
+    !isDirty && baselineVersion?.revision !== undefined
+      ? Math.max(state.revision, baselineVersion.revision)
+      : state.revision
+  if (!canSyncProducts && nextRevision === state.revision) return null
+
+  const nextProducts = canSyncProducts
+    ? productsQueryData?.map(toTechnicalConfigurationReferenceProductDraft)
+    : null
+  return {
+    ...state,
+    ...(nextProducts
+      ? {
+          baseProducts: nextProducts,
+          products: cloneTechnicalConfigurationReferenceProductDrafts(nextProducts),
+          syncedProductsQueryData: productsQueryData ?? null,
+        }
+      : {}),
+    revision: nextRevision,
+  }
+}
+
+/** Produces a stable representation for reference-product dirty checks. */
+export function canonicalizeTechnicalConfigurationReferenceProductDrafts(
+  products: TechnicalConfigurationReferenceProductDraft[]
+) {
+  return products.map((product) => ({
+    persistedId: product.persistedId,
+    model: product.model,
+    manufacturer: product.manufacturer,
+    description: product.description,
+    notes: product.notes,
+    responses: Object.entries(product.responses).toSorted(([left], [right]) =>
+      left.localeCompare(right)
+    ),
+  }))
+}
+
+/** Compares the editable metadata fields of two reference-product drafts. */
+export function haveSameTechnicalConfigurationReferenceProductFields(
+  left: TechnicalConfigurationReferenceProductDraft,
+  right: TechnicalConfigurationReferenceProductDraft
+) {
+  return (
+    left.model === right.model &&
+    left.manufacturer === right.manufacturer &&
+    left.description === right.description &&
+    left.notes === right.notes
+  )
+}
+
+/** Returns criterion responses that differ from the persisted base draft. */
+export function getChangedTechnicalConfigurationReferenceResponses(
+  base: TechnicalConfigurationReferenceProductDraft | undefined,
+  draft: TechnicalConfigurationReferenceProductDraft
+) {
+  return Object.entries(draft.responses).filter(
+    ([criterionId, responseText]) => base?.responses[criterionId] !== responseText
+  )
+}
+
+/** Converts reference-product save failures into user-facing messages. */
+export function getTechnicalConfigurationReferenceProductSaveError(error: unknown) {
+  if (isTechnicalConfigurationBaselineConflict(error)) {
+    return "Dữ liệu sản phẩm tham chiếu đã thay đổi. Các chỉnh sửa chưa lưu được giữ lại; hãy tải lại dữ liệu máy chủ."
+  }
+  return error instanceof Error ? error.message : "Không thể lưu sản phẩm tham chiếu."
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-reference-product-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-reference-product-state.ts
@@ -1,5 +1,8 @@
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
-import type { TechnicalConfigurationReferenceProductWire } from "@/app/(app)/technical-configurations/reference-product-types"
+import type {
+  TechnicalConfigurationReferenceProductWire,
+  TechnicalConfigurationReferenceProductsSnapshot,
+} from "@/app/(app)/technical-configurations/reference-product-types"
 import { isTechnicalConfigurationBaselineConflict } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
 
 export type TechnicalConfigurationReferenceProductDraft = {
@@ -25,6 +28,13 @@ export type TechnicalConfigurationReferenceProductSaveProgress = {
   products: TechnicalConfigurationReferenceProductDraft[]
 }
 
+export type TechnicalConfigurationReferenceProductsHookArgs = {
+  baselineVersion: TechnicalConfigurationBaselineDraftWire | null
+  isArchived?: boolean
+  onRevisionChange?: (revision: number) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
 export type TechnicalConfigurationReferenceProductsState = {
   loadedVersionId: string
   baseProducts: TechnicalConfigurationReferenceProductDraft[]
@@ -37,7 +47,7 @@ export type TechnicalConfigurationReferenceProductsState = {
   saveError: string | null
   refreshWarning: string | null
   ignoreProductsQueryData: boolean
-  syncedProductsQueryData: TechnicalConfigurationReferenceProductWire[] | null
+  syncedProductsQueryData: TechnicalConfigurationReferenceProductsSnapshot | null
 }
 
 /** Creates reference-product editor state for the selected baseline version. */
@@ -149,7 +159,7 @@ export function reconcileTechnicalConfigurationReferenceProductsState({
 }: {
   state: TechnicalConfigurationReferenceProductsState
   baselineVersion: TechnicalConfigurationBaselineDraftWire | null
-  productsQueryData: TechnicalConfigurationReferenceProductWire[] | undefined
+  productsQueryData: TechnicalConfigurationReferenceProductsSnapshot | undefined
   isDirty: boolean
 }): TechnicalConfigurationReferenceProductsState | null {
   if ((baselineVersion?.id ?? "") !== state.loadedVersionId) {
@@ -163,14 +173,10 @@ export function reconcileTechnicalConfigurationReferenceProductsState({
     !isDirty &&
     !state.isConflict &&
     !state.isSaving
-  const nextRevision =
-    !isDirty && baselineVersion?.revision !== undefined
-      ? Math.max(state.revision, baselineVersion.revision)
-      : state.revision
-  if (!canSyncProducts && nextRevision === state.revision) return null
+  if (!canSyncProducts) return null
 
   const nextProducts = canSyncProducts
-    ? productsQueryData?.map(toTechnicalConfigurationReferenceProductDraft)
+    ? productsQueryData?.products.map(toTechnicalConfigurationReferenceProductDraft)
     : null
   return {
     ...state,
@@ -181,7 +187,7 @@ export function reconcileTechnicalConfigurationReferenceProductsState({
           syncedProductsQueryData: productsQueryData ?? null,
         }
       : {}),
-    revision: nextRevision,
+    revision: productsQueryData?.revision ?? state.revision,
   }
 }
 

--- a/src/app/(app)/technical-configurations/technical-configuration-reference-product-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-reference-product-state.ts
@@ -229,5 +229,5 @@ export function getTechnicalConfigurationReferenceProductSaveError(error: unknow
   if (isTechnicalConfigurationBaselineConflict(error)) {
     return "Dữ liệu sản phẩm tham chiếu đã thay đổi. Các chỉnh sửa chưa lưu được giữ lại; hãy tải lại dữ liệu máy chủ."
   }
-  return error instanceof Error ? error.message : "Không thể lưu sản phẩm tham chiếu."
+  return "Không thể lưu sản phẩm tham chiếu."
 }

--- a/src/app/api/rpc/__tests__/technical-configuration-reference-products-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-reference-products-migration.test.ts
@@ -8,6 +8,8 @@ const MIGRATION_SUFFIX = "_technical_configuration_reference_products.sql"
 const PERFORMANCE_MIGRATION_SUFFIX = "_technical_configuration_reference_response_fk_indexes.sql"
 const LIST_PERFORMANCE_MIGRATION_SUFFIX =
   "_technical_configuration_reference_products_list_set_based.sql"
+const SNAPSHOT_REVISION_MIGRATION_SUFFIX =
+  "_technical_configuration_reference_products_snapshot_revision.sql"
 const PHASE_GATE_PATH = path.resolve(
   REPO_ROOT,
   "supabase/tests/technical_configuration_reference_products_phase_gate.sql"
@@ -67,6 +69,13 @@ const listPerformanceMigrationFiles = readdirSync(MIGRATIONS_DIR)
 const listPerformanceMigrationFile = listPerformanceMigrationFiles[0] ?? ""
 const listPerformanceMigrationSource = listPerformanceMigrationFile
   ? readFileSync(path.resolve(MIGRATIONS_DIR, listPerformanceMigrationFile), "utf8")
+  : ""
+const snapshotRevisionMigrationFiles = readdirSync(MIGRATIONS_DIR)
+  .filter((file) => file.endsWith(SNAPSHOT_REVISION_MIGRATION_SUFFIX))
+  .sort()
+const snapshotRevisionMigrationFile = snapshotRevisionMigrationFiles[0] ?? ""
+const snapshotRevisionMigrationSource = snapshotRevisionMigrationFile
+  ? readFileSync(path.resolve(MIGRATIONS_DIR, snapshotRevisionMigrationFile), "utf8")
   : ""
 const phaseGateSource = readIfExists(PHASE_GATE_PATH)
 const rpcNamesSource = readIfExists(RPC_NAMES_PATH)
@@ -170,6 +179,28 @@ describe("technical configuration P7A1 reference product contracts", () => {
       "REVOKE ALL ON FUNCTION public.technical_configuration_reference_products_list"
     )
     expect(listPerformanceMigrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public.technical_configuration_reference_products_list"
+    )
+  })
+
+  it("returns the product data and revision from one later statement snapshot", () => {
+    expect(snapshotRevisionMigrationFiles).toHaveLength(1)
+    expect(snapshotRevisionMigrationFile > listPerformanceMigrationFile).toBe(true)
+
+    const listBlock = getFunctionBlock(
+      snapshotRevisionMigrationSource,
+      "technical_configuration_reference_products_list"
+    )
+    expect(listBlock).not.toBe("")
+    expect(listBlock).toContain("WITH baseline AS MATERIALIZED")
+    expect(listBlock).toContain("snapshot AS MATERIALIZED")
+    expect(listBlock).toContain("'revision', snapshot.revision")
+    expect(listBlock).toContain("'data', data.products")
+    expect(listBlock).not.toContain("SELECT v.revision INTO")
+    expect(snapshotRevisionMigrationSource).toContain(
+      "REVOKE ALL ON FUNCTION public.technical_configuration_reference_products_list"
+    )
+    expect(snapshotRevisionMigrationSource).toContain(
       "GRANT EXECUTE ON FUNCTION public.technical_configuration_reference_products_list"
     )
   })
@@ -332,6 +363,16 @@ describe("technical configuration P7A1 reference product contracts", () => {
       .filter((file) => /\.(?:ts|tsx)$/.test(file))
       .filter((file) => /reference/i.test(file))
       .filter((file) => /(?:_components|_hooks|\.tsx$)/.test(file))
+      .filter((file) => {
+        const source = readFileSync(
+          path.resolve(REPO_ROOT, "src/app/(app)/technical-configurations", file),
+          "utf8"
+        )
+        return (
+          source.includes("callTechnicalConfigurationRpc") ||
+          source.includes("REFERENCE_PRODUCT_RPC_FUNCTIONS")
+        )
+      })
 
     expect(forbiddenRuntimeFiles).toEqual([])
   })

--- a/supabase/migrations/20260717143556_technical_configuration_reference_products_snapshot_revision.sql
+++ b/supabase/migrations/20260717143556_technical_configuration_reference_products_snapshot_revision.sql
@@ -1,0 +1,138 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_reference_products_list(
+  p_baseline_version_id UUID,
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_page IS NULL OR p_page < 1
+     OR p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  WITH baseline AS MATERIALIZED (
+    SELECT v.revision
+    FROM public.technical_configuration_baseline_versions v
+    WHERE v.id = p_baseline_version_id
+  ),
+  snapshot AS MATERIALIZED (
+    SELECT
+      baseline.revision,
+      (
+        SELECT count(*)
+        FROM public.technical_configuration_reference_products product_count
+        WHERE product_count.baseline_version_id = p_baseline_version_id
+      ) AS total
+    FROM baseline
+  ),
+  page AS MATERIALIZED (
+    SELECT
+      product.id,
+      product.baseline_version_id,
+      product.model,
+      product.manufacturer,
+      product.description,
+      product.notes,
+      product.created_at,
+      product.created_by,
+      product.updated_at,
+      product.updated_by,
+      snapshot.revision
+    FROM public.technical_configuration_reference_products product
+    CROSS JOIN snapshot
+    WHERE product.baseline_version_id = p_baseline_version_id
+    ORDER BY product.created_at, product.id
+    LIMIT p_page_size
+    OFFSET (p_page - 1) * p_page_size
+  ),
+  responses_by_product AS (
+    SELECT
+      response.reference_product_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'id', response.id,
+          'baseline_version_id', response.baseline_version_id,
+          'reference_product_id', response.reference_product_id,
+          'criterion_id', response.criterion_id,
+          'response_text', response.response_text,
+          'created_at', response.created_at,
+          'created_by', response.created_by,
+          'updated_at', response.updated_at,
+          'updated_by', response.updated_by,
+          'revision', page_product.revision
+        )
+        ORDER BY criterion.sort_order, criterion.id
+      ) AS responses
+    FROM public.technical_configuration_reference_responses response
+    JOIN public.technical_configuration_baseline_criteria criterion
+      ON criterion.id = response.criterion_id
+     AND criterion.baseline_version_id = response.baseline_version_id
+    JOIN page page_product
+      ON page_product.id = response.reference_product_id
+    GROUP BY response.reference_product_id
+  ),
+  data AS (
+    SELECT COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id', page.id,
+          'baseline_version_id', page.baseline_version_id,
+          'model', page.model,
+          'manufacturer', page.manufacturer,
+          'description', page.description,
+          'notes', page.notes,
+          'created_at', page.created_at,
+          'created_by', page.created_by,
+          'updated_at', page.updated_at,
+          'updated_by', page.updated_by,
+          'revision', page.revision,
+          'responses', COALESCE(responses.responses, '[]'::JSONB)
+        )
+        ORDER BY page.created_at, page.id
+      ),
+      '[]'::JSONB
+    ) AS products
+    FROM page
+    LEFT JOIN responses_by_product responses
+      ON responses.reference_product_id = page.id
+  )
+  SELECT jsonb_build_object(
+    'data', data.products,
+    'revision', snapshot.revision,
+    'total', snapshot.total,
+    'page', p_page,
+    'page_size', p_page_size
+  )
+  INTO v_result
+  FROM snapshot
+  CROSS JOIN data;
+
+  IF v_result IS NULL THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_reference_products_list(
+  UUID,
+  INTEGER,
+  INTEGER
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_reference_products_list(
+  UUID,
+  INTEGER,
+  INTEGER
+) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add the P7A2 reference-product management and comparison workspace over the applied P7A1 RPC contracts
- add a leaf-local React Query workflow with pagination, explicit save/reload, dirty-state protection, stale-revision conflict handling, locked read-only behavior, and resumable partial saves
- use a shadcn baseline picker in the new workspace; track the pre-existing `TechnicalConfigurationVersionBar` native select separately in #766

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- focused Vitest: 3 files, 42 tests passed
- React Doctor changed scope: 100/100, no issues
- browser automation skipped per request

## Database
- no migration changes
- no live DB writes

Closes #765

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the P7A2 reference‑product workspace with product CRUD, per‑criterion responses, and a paginated comparison view. Integrates as a new tab in the dossier shell with scoped caching, manual save/reload, and consistent snapshot/conflict handling.

- **New Features**
  - New “Reference products” tab: create, update, delete products and record criterion responses; comparison supports paging (5 columns per page), column visibility, and full‑text dialogs.
  - Local `@tanstack/react-query` workflow with manual save/reload, dirty‑state protection, read‑only mode for archived/locked configs, and resumable saves; caching via `technicalConfigurationReferenceProductsQueryKey`. Baseline selection via a `shadcn` picker; tests cover hooks, workspace, comparison, conflicts, resilience, and save‑resume.

- **Bug Fixes**
  - Added operation locking to block overlapping reloads, saves, and edits; paging now clamps after add/delete/hide.
  - Column visibility now keys to product identity and resets on baseline change.
  - Reference‑product list now includes a snapshot `revision` and a DB migration ensures consistent paging and save/resume; improves conflict recovery and prevents partial lists.

<sup>Written for commit cd5ca9d0fc5e1d88249597af9a1e57e7bbbc6ce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Reference Products” tab to manage reference products for a technical configuration, including baseline selection, product editing, criterion responses, a comparison matrix (column show/hide, pagination), and full-text detail dialogs.
* **Improvements**
  * Enhanced save/reload workflows with stronger navigation protection, operation locking, retry/error states, conflict recovery, and partial-save resume with draft preservation.
* **Bug Fixes**
  * Prevented exposure of raw internal error details and improved handling of duplicate product names via clearer disambiguation.
* **Tests**
  * Expanded automated UI and hook coverage for resilience, conflicts, and comparison behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->