### PR TITLE
fix(technical-config): widen reference product pagination offset

### DIFF
--- a/src/app/api/rpc/__tests__/technical-configuration-reference-products-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-reference-products-migration.test.ts
@@ -10,6 +10,8 @@ const LIST_PERFORMANCE_MIGRATION_SUFFIX =
   "_technical_configuration_reference_products_list_set_based.sql"
 const SNAPSHOT_REVISION_MIGRATION_SUFFIX =
   "_technical_configuration_reference_products_snapshot_revision.sql"
+const PAGINATION_BIGINT_OFFSET_MIGRATION_SUFFIX =
+  "_technical_configuration_reference_products_pagination_bigint_offset.sql"
 const PHASE_GATE_PATH = path.resolve(
   REPO_ROOT,
   "supabase/tests/technical_configuration_reference_products_phase_gate.sql"
@@ -76,6 +78,13 @@ const snapshotRevisionMigrationFiles = readdirSync(MIGRATIONS_DIR)
 const snapshotRevisionMigrationFile = snapshotRevisionMigrationFiles[0] ?? ""
 const snapshotRevisionMigrationSource = snapshotRevisionMigrationFile
   ? readFileSync(path.resolve(MIGRATIONS_DIR, snapshotRevisionMigrationFile), "utf8")
+  : ""
+const paginationBigintOffsetMigrationFiles = readdirSync(MIGRATIONS_DIR)
+  .filter((file) => file.endsWith(PAGINATION_BIGINT_OFFSET_MIGRATION_SUFFIX))
+  .sort()
+const paginationBigintOffsetMigrationFile = paginationBigintOffsetMigrationFiles[0] ?? ""
+const paginationBigintOffsetMigrationSource = paginationBigintOffsetMigrationFile
+  ? readFileSync(path.resolve(MIGRATIONS_DIR, paginationBigintOffsetMigrationFile), "utf8")
   : ""
 const phaseGateSource = readIfExists(PHASE_GATE_PATH)
 const rpcNamesSource = readIfExists(RPC_NAMES_PATH)
@@ -201,6 +210,33 @@ describe("technical configuration P7A1 reference product contracts", () => {
       "REVOKE ALL ON FUNCTION public.technical_configuration_reference_products_list"
     )
     expect(snapshotRevisionMigrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public.technical_configuration_reference_products_list"
+    )
+  })
+
+  it("widens list pagination arithmetic in a later superseding migration", () => {
+    expect(paginationBigintOffsetMigrationFiles).toHaveLength(1)
+    expect(paginationBigintOffsetMigrationFile > snapshotRevisionMigrationFile).toBe(true)
+
+    const listBlock = getFunctionBlock(
+      paginationBigintOffsetMigrationSource,
+      "technical_configuration_reference_products_list"
+    )
+    expect(listBlock).not.toBe("")
+    expect(listBlock).toContain(
+      "technical_configuration_reference_products_list(\n  p_baseline_version_id UUID,\n  p_page INTEGER DEFAULT 1,\n  p_page_size INTEGER DEFAULT 50"
+    )
+    expect(listBlock).toContain("LANGUAGE plpgsql SECURITY DEFINER")
+    expect(listBlock).toContain("SET search_path = public, pg_temp")
+    expect(listBlock).toContain("WITH baseline AS MATERIALIZED")
+    expect(listBlock).toContain("snapshot AS MATERIALIZED")
+    expect(listBlock).toContain("'revision', snapshot.revision")
+    expect(listBlock).toContain("OFFSET (p_page::BIGINT - 1) * p_page_size")
+    expect(listBlock).not.toContain("OFFSET (p_page - 1) * p_page_size")
+    expect(paginationBigintOffsetMigrationSource).toContain(
+      "REVOKE ALL ON FUNCTION public.technical_configuration_reference_products_list"
+    )
+    expect(paginationBigintOffsetMigrationSource).toContain(
       "GRANT EXECUTE ON FUNCTION public.technical_configuration_reference_products_list"
     )
   })

--- a/supabase/migrations/20260717151806_technical_configuration_reference_products_pagination_bigint_offset.sql
+++ b/supabase/migrations/20260717151806_technical_configuration_reference_products_pagination_bigint_offset.sql
@@ -1,0 +1,138 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_reference_products_list(
+  p_baseline_version_id UUID,
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_page IS NULL OR p_page < 1
+     OR p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  WITH baseline AS MATERIALIZED (
+    SELECT v.revision
+    FROM public.technical_configuration_baseline_versions v
+    WHERE v.id = p_baseline_version_id
+  ),
+  snapshot AS MATERIALIZED (
+    SELECT
+      baseline.revision,
+      (
+        SELECT count(*)
+        FROM public.technical_configuration_reference_products product_count
+        WHERE product_count.baseline_version_id = p_baseline_version_id
+      ) AS total
+    FROM baseline
+  ),
+  page AS MATERIALIZED (
+    SELECT
+      product.id,
+      product.baseline_version_id,
+      product.model,
+      product.manufacturer,
+      product.description,
+      product.notes,
+      product.created_at,
+      product.created_by,
+      product.updated_at,
+      product.updated_by,
+      snapshot.revision
+    FROM public.technical_configuration_reference_products product
+    CROSS JOIN snapshot
+    WHERE product.baseline_version_id = p_baseline_version_id
+    ORDER BY product.created_at, product.id
+    LIMIT p_page_size
+    OFFSET (p_page::BIGINT - 1) * p_page_size
+  ),
+  responses_by_product AS (
+    SELECT
+      response.reference_product_id,
+      jsonb_agg(
+        jsonb_build_object(
+          'id', response.id,
+          'baseline_version_id', response.baseline_version_id,
+          'reference_product_id', response.reference_product_id,
+          'criterion_id', response.criterion_id,
+          'response_text', response.response_text,
+          'created_at', response.created_at,
+          'created_by', response.created_by,
+          'updated_at', response.updated_at,
+          'updated_by', response.updated_by,
+          'revision', page_product.revision
+        )
+        ORDER BY criterion.sort_order, criterion.id
+      ) AS responses
+    FROM public.technical_configuration_reference_responses response
+    JOIN public.technical_configuration_baseline_criteria criterion
+      ON criterion.id = response.criterion_id
+     AND criterion.baseline_version_id = response.baseline_version_id
+    JOIN page page_product
+      ON page_product.id = response.reference_product_id
+    GROUP BY response.reference_product_id
+  ),
+  data AS (
+    SELECT COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'id', page.id,
+          'baseline_version_id', page.baseline_version_id,
+          'model', page.model,
+          'manufacturer', page.manufacturer,
+          'description', page.description,
+          'notes', page.notes,
+          'created_at', page.created_at,
+          'created_by', page.created_by,
+          'updated_at', page.updated_at,
+          'updated_by', page.updated_by,
+          'revision', page.revision,
+          'responses', COALESCE(responses.responses, '[]'::JSONB)
+        )
+        ORDER BY page.created_at, page.id
+      ),
+      '[]'::JSONB
+    ) AS products
+    FROM page
+    LEFT JOIN responses_by_product responses
+      ON responses.reference_product_id = page.id
+  )
+  SELECT jsonb_build_object(
+    'data', data.products,
+    'revision', snapshot.revision,
+    'total', snapshot.total,
+    'page', p_page,
+    'page_size', p_page_size
+  )
+  INTO v_result
+  FROM snapshot
+  CROSS JOIN data;
+
+  IF v_result IS NULL THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_reference_products_list(
+  UUID,
+  INTEGER,
+  INTEGER
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_reference_products_list(
+  UUID,
+  INTEGER,
+  INTEGER
+) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a superseding migration that widens list RPC offset arithmetic to bigint before multiplication
- preserve the existing signature, snapshot CTE, revision payload, grants, SECURITY DEFINER, and search_path contract
- add a migration contract regression test for the overflow fix
- align the local migration filename with live Supabase migration version `20260717151806`

## Verification
- TDD RED: focused contract suite failed only because the superseding migration was absent
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused Vitest: 13/13 passed
- React Doctor: 100/100
- live RPC: page `2147483647`, page size `100` returned an empty page with revision and total intact
- Supabase security and performance advisors run after apply

Fixes #768

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes integer overflow in reference product pagination by widening the list RPC’s OFFSET math to bigint via a superseding migration that keeps the function signature and security unchanged. Fixes #768.

- **Bug Fixes**
  - Use `(p_page::BIGINT - 1) * p_page_size` for OFFSET to handle large pages.
  - Add `supabase/migrations/20260717151806_technical_configuration_reference_products_pagination_bigint_offset.sql` and a regression test to lock grants, search_path, snapshot/revision behavior, and migration order.
  - No API changes; existing clients continue to work.

<sup>Written for commit a26a316c1f9a83814d7ec14fb5a844c262b1783b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

