### PR TITLE
P7B2: add baseline and reference evidence workspace

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/p7-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p7-tdd-plan.md
@@ -373,7 +373,8 @@ node scripts/npm-run.js run test:run -- \
   src/components/url-documents/__tests__/url-document-utils.test.ts \
   src/components/url-documents/__tests__/UrlDocumentForm.test.tsx \
   src/components/url-documents/__tests__/UrlDocumentList.test.tsx \
-  src/components/url-documents/__tests__/url-document-source-contract.test.ts
+  src/components/url-documents/__tests__/url-document-source-contract.test.ts \
+  src/components/url-documents/__tests__/url-document-source-contract-extractor.test.ts
 ```
 
 Expected:

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -222,16 +222,16 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 
 ## Phase P7B2 - Baseline And Reference Evidence Workspace
 
-- [ ] P7B2.1 Thêm explicit save, dirty-state, expected-revision conflict preservation và tích hợp
+- [x] P7B2.1 Thêm explicit save, dirty-state, expected-revision conflict preservation và tích hợp
       P6B-proven primitives; enforce cumulative Equipment + baseline exact
       path/named-binding AST manifest và runtime-delegation assertions chống
       dead import/local duplicate form/list/URL parsing.
-- [ ] P7B2.2 Wire baseline/reference owner routing và nested same-version citations từ P7B1 aggregate.
-- [ ] P7B2.3 Hiển thị reference evidence bằng indicator/detail panel, không thêm permanent evidence columns.
-- [ ] P7B2.4 Hiển thị affected-link count trước editable delete confirmation.
-- [ ] P7B2.5 Chặn locked edit/delete trước confirmation flow.
-- [ ] P7B2.6 Tích hợp qua workspace/reference surfaces; không thêm document state vào baseline tab/editor hook.
-- [ ] P7B2.7 Viết owner-scope, reuse, raw create/update/list/render, URL
+- [x] P7B2.2 Wire baseline/reference owner routing và nested same-version citations từ P7B1 aggregate.
+- [x] P7B2.3 Hiển thị reference evidence bằng indicator/detail panel, không thêm permanent evidence columns.
+- [x] P7B2.4 Hiển thị affected-link count trước editable delete confirmation.
+- [x] P7B2.5 Chặn locked edit/delete trước confirmation flow.
+- [x] P7B2.6 Tích hợp qua workspace/reference surfaces; không thêm document state vào baseline tab/editor hook.
+- [x] P7B2.7 Viết owner-scope, reuse, raw create/update/list/render, URL
       rejection, delegation, deletion, locked, conflict và long-excerpt tests.
 - [ ] P7B2.8 Chạy focused React/source-contract/file-size/browser gates; không apply live DB.
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -233,7 +233,9 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 - [x] P7B2.6 Tích hợp qua workspace/reference surfaces; không thêm document state vào baseline tab/editor hook.
 - [x] P7B2.7 Viết owner-scope, reuse, raw create/update/list/render, URL
       rejection, delegation, deletion, locked, conflict và long-excerpt tests.
-- [ ] P7B2.8 Chạy focused React/source-contract/file-size/browser gates; không apply live DB.
+- [x] P7B2.8 Chạy focused React/source-contract/file-size gates; browser gate
+      `N/A` vì không có credentials và dev server được yêu cầu giữ dừng; không
+      apply live DB.
 
 ## Phase P8A - Supplier And Option Data Contracts
 

--- a/scripts/__tests__/check-heroui-import-boundary.test.ts
+++ b/scripts/__tests__/check-heroui-import-boundary.test.ts
@@ -34,6 +34,14 @@ describe("check-heroui-import-boundary", () => {
         content: 'import { TextArea, TextField } from "@heroui/react"\n',
       },
       {
+        path: "src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader.tsx",
+        content: 'import { Button, Chip } from "@heroui/react"\n',
+      },
+      {
+        path: "src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError.tsx",
+        content: 'import { Button } from "@heroui/react"\n',
+      },
+      {
         path: "src/components/equipment/equipment-toolbar.tsx",
         content: 'import { Button } from "@heroui/react"\n',
       },

--- a/scripts/__tests__/check-heroui-import-boundary.test.ts
+++ b/scripts/__tests__/check-heroui-import-boundary.test.ts
@@ -26,6 +26,14 @@ describe("check-heroui-import-boundary", () => {
         content: 'import { Popover } from "@heroui/react/popover"\n',
       },
       {
+        path: "src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx",
+        content: 'import { Button, Select } from "@heroui/react"\n',
+      },
+      {
+        path: "src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx",
+        content: 'import { TextArea, TextField } from "@heroui/react"\n',
+      },
+      {
         path: "src/components/equipment/equipment-toolbar.tsx",
         content: 'import { Button } from "@heroui/react"\n',
       },

--- a/scripts/check-heroui-import-boundary.js
+++ b/scripts/check-heroui-import-boundary.js
@@ -15,6 +15,8 @@ const ALLOWED_BOUNDARY_FILES = [
   "src/components/shared/ListFilterSearchCard.tsx",
   "src/components/shared/table-filters/FacetedMultiSelectFilter.tsx",
   "src/components/equipment/filter-bottom-sheet.tsx",
+  "src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx",
+  "src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx",
 ]
 
 function normalizePath(filePath) {

--- a/scripts/check-heroui-import-boundary.js
+++ b/scripts/check-heroui-import-boundary.js
@@ -17,6 +17,8 @@ const ALLOWED_BOUNDARY_FILES = [
   "src/components/equipment/filter-bottom-sheet.tsx",
   "src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx",
   "src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx",
+  "src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader.tsx",
+  "src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError.tsx",
 ]
 
 function normalizePath(filePath) {

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-citation-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-citation-cases.tsx
@@ -1,0 +1,267 @@
+import { act, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationCitationEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor"
+import { TechnicalConfigurationRpcError } from "@/app/(app)/technical-configurations/technical-configuration-rpc"
+import { baselineVersion, evidenceDocument } from "./baseline-evidence-fixtures"
+
+const criteria = [
+  {
+    id: "criterion-1",
+    criterionCode: "TC-0001",
+    title: "Nguồn điện",
+  },
+  {
+    id: "criterion-2",
+    criterionCode: "TC-0002",
+    title: "Môi trường vận hành",
+  },
+]
+
+export function registerBaselineEvidenceCitationTests() {
+  describe("TechnicalConfigurationCitationEditor behavior", () => {
+    it("keeps long Vietnamese citation input after a stale conflict", async () => {
+      const user = userEvent.setup()
+      const onSave = vi
+        .fn()
+        .mockRejectedValue(new TechnicalConfigurationRpcError(409, { message: "stale_revision" }))
+      const onDirtyChange = vi.fn()
+      const excerpt =
+        "Thiết bị phải duy trì nguồn điện ổn định trong toàn bộ chu kỳ vận hành, kể cả khi tải thay đổi đột ngột và hệ thống chuyển sang nguồn dự phòng."
+      render(
+        <TechnicalConfigurationCitationEditor
+          documents={[evidenceDocument("document-1", "baseline", baselineVersion.id)]}
+          criteria={criteria}
+          fixedCriterionId="criterion-1"
+          isPending={false}
+          disabled={false}
+          onSave={onSave}
+          onDelete={vi.fn()}
+          onDirtyChange={onDirtyChange}
+        />
+      )
+
+      await user.type(screen.getByLabelText("Trang hoặc mục"), "Mục 4.2")
+      await user.click(screen.getByLabelText("Trích đoạn"))
+      await user.paste(excerpt)
+      await user.click(screen.getByRole("button", { name: "Lưu trích dẫn" }))
+
+      expect(onSave).toHaveBeenCalledWith({
+        document: expect.objectContaining({ id: "document-1" }),
+        criterionId: "criterion-1",
+        pageSection: "Mục 4.2",
+        excerpt,
+      })
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent("Phiên bản đã thay đổi trên máy chủ")
+      )
+      expect(screen.getByLabelText("Trang hoặc mục")).toHaveValue("Mục 4.2")
+      expect(screen.getByLabelText("Trích đoạn")).toHaveValue(excerpt)
+      expect(onDirtyChange).toHaveBeenCalledWith(true)
+    })
+
+    it("hydrates an existing citation after documents load asynchronously", async () => {
+      const user = userEvent.setup()
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      const document = {
+        ...evidenceDocument("document-1", "baseline", baselineVersion.id),
+        citations: [
+          {
+            id: "citation-1",
+            criterion_id: "criterion-1",
+            page_section: "Mục 2",
+            excerpt: "Nguồn điện ổn định",
+          },
+        ],
+      }
+      const view = render(
+        <TechnicalConfigurationCitationEditor
+          documents={[]}
+          criteria={criteria}
+          fixedCriterionId="criterion-1"
+          isPending={false}
+          disabled={false}
+          onSave={onSave}
+          onDelete={vi.fn()}
+        />
+      )
+
+      view.rerender(
+        <TechnicalConfigurationCitationEditor
+          documents={[document]}
+          criteria={criteria}
+          fixedCriterionId="criterion-1"
+          isPending={false}
+          disabled={false}
+          onSave={onSave}
+          onDelete={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Trang hoặc mục")).toHaveValue("Mục 2")
+        expect(screen.getByLabelText("Trích đoạn")).toHaveValue("Nguồn điện ổn định")
+      })
+      await user.clear(screen.getByLabelText("Trang hoặc mục"))
+      await user.type(screen.getByLabelText("Trang hoặc mục"), "Mục 2.1")
+      await user.click(screen.getByRole("button", { name: "Lưu trích dẫn" }))
+
+      expect(onSave).toHaveBeenCalledWith({
+        document: expect.objectContaining({ id: document.id }),
+        criterionId: "criterion-1",
+        pageSection: "Mục 2.1",
+        excerpt: "Nguồn điện ổn định",
+      })
+    })
+
+    it("preserves a dirty citation when document selection is rejected", async () => {
+      const user = userEvent.setup()
+      const firstDocument = {
+        ...evidenceDocument("document-1", "baseline", baselineVersion.id),
+        citations: [
+          {
+            id: "citation-1",
+            criterion_id: "criterion-1",
+            page_section: "Mục 2",
+            excerpt: "Nguồn điện ổn định",
+          },
+        ],
+      }
+      const secondDocument = {
+        ...evidenceDocument("document-2", "baseline", baselineVersion.id),
+        citations: [
+          {
+            id: "citation-2",
+            criterion_id: "criterion-1",
+            page_section: "Mục 5",
+            excerpt: "Nguồn điện dự phòng",
+          },
+        ],
+      }
+      const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      render(
+        <TechnicalConfigurationCitationEditor
+          documents={[firstDocument, secondDocument]}
+          criteria={criteria}
+          fixedCriterionId="criterion-1"
+          isPending={false}
+          disabled={false}
+          onSave={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      )
+
+      await user.clear(screen.getByLabelText("Trích đoạn"))
+      await user.type(screen.getByLabelText("Trích đoạn"), "Bản nháp chưa lưu")
+      const documentPicker = screen.getByRole("button", { name: /Tài liệu/i })
+      act(() => documentPicker.focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: secondDocument.name }))
+
+      expect(confirm).toHaveBeenCalledWith(
+        "Chuyển lựa chọn sẽ bỏ nội dung trích dẫn chưa lưu. Tiếp tục?"
+      )
+      expect(screen.getByLabelText("Trích đoạn")).toHaveValue("Bản nháp chưa lưu")
+      expect(documentPicker).toHaveTextContent(firstDocument.name)
+      confirm.mockRestore()
+    })
+
+    it("preserves a dirty citation when the selected document disappears", async () => {
+      const user = userEvent.setup()
+      const firstDocument = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      const secondDocument = evidenceDocument("document-2", "baseline", baselineVersion.id)
+      const view = render(
+        <TechnicalConfigurationCitationEditor
+          documents={[firstDocument, secondDocument]}
+          criteria={criteria}
+          fixedCriterionId="criterion-1"
+          isPending={false}
+          disabled={false}
+          onSave={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      )
+
+      await user.type(screen.getByLabelText("Trích đoạn"), "Bản nháp chưa lưu")
+      view.rerender(
+        <TechnicalConfigurationCitationEditor
+          documents={[secondDocument]}
+          criteria={criteria}
+          fixedCriterionId="criterion-1"
+          isPending={false}
+          disabled={false}
+          onSave={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Tài liệu đang chỉnh sửa không còn trong danh sách"
+      )
+      expect(screen.getByLabelText("Trích đoạn")).toHaveValue("Bản nháp chưa lưu")
+      expect(screen.getByRole("button", { name: "Lưu trích dẫn" })).toBeDisabled()
+    })
+
+    it("renders citation deletion failures without an unhandled rejection", async () => {
+      const user = userEvent.setup()
+      const document = {
+        ...evidenceDocument("document-1", "baseline", baselineVersion.id),
+        citations: [
+          {
+            id: "citation-1",
+            criterion_id: "criterion-1",
+            page_section: "Mục 2",
+            excerpt: "Nguồn điện ổn định",
+          },
+        ],
+      }
+      render(
+        <TechnicalConfigurationCitationEditor
+          documents={[document]}
+          criteria={criteria}
+          fixedCriterionId="criterion-1"
+          isPending={false}
+          disabled={false}
+          onSave={vi.fn()}
+          onDelete={vi.fn().mockRejectedValue(new Error("delete_failed"))}
+        />
+      )
+
+      await user.click(screen.getByRole("button", { name: "Xóa trích dẫn" }))
+
+      expect(await screen.findByRole("alert")).toHaveTextContent("Không thể lưu trích dẫn")
+      expect(screen.getByLabelText("Trích đoạn")).toHaveValue("Nguồn điện ổn định")
+    })
+
+    it("renders locked citations read-only without save or delete actions", () => {
+      const document = {
+        ...evidenceDocument("document-1", "baseline", baselineVersion.id),
+        citations: [
+          {
+            id: "citation-1",
+            criterion_id: "criterion-1",
+            page_section: "Mục 2",
+            excerpt: "Nguồn điện ổn định",
+          },
+        ],
+      }
+      render(
+        <TechnicalConfigurationCitationEditor
+          documents={[document]}
+          criteria={criteria}
+          fixedCriterionId="criterion-1"
+          isPending={false}
+          disabled
+          onSave={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      )
+
+      expect(screen.getByLabelText("Trang hoặc mục")).toBeDisabled()
+      expect(screen.getByLabelText("Trích đoạn")).toBeDisabled()
+      expect(screen.queryByRole("button", { name: "Lưu trích dẫn" })).not.toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: "Xóa trích dẫn" })).not.toBeInTheDocument()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-citation-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-citation-cases.tsx
@@ -201,6 +201,16 @@ export function registerBaselineEvidenceCitationTests() {
       )
       expect(screen.getByLabelText("Trích đoạn")).toHaveValue("Bản nháp chưa lưu")
       expect(screen.getByRole("button", { name: "Lưu trích dẫn" })).toBeDisabled()
+
+      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
+      const documentPicker = screen.getByRole("button", { name: /Tài liệu/i })
+      act(() => documentPicker.focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: secondDocument.name }))
+
+      await waitFor(() => expect(screen.getByText(secondDocument.name)).toBeInTheDocument())
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+      confirm.mockRestore()
     })
 
     it("renders citation deletion failures without an unhandled rejection", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-delegation.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-delegation.test.tsx
@@ -1,0 +1,131 @@
+import { act, render, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationBaselineDocuments } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+import type { UrlDocumentFormProps } from "@/components/url-documents/UrlDocumentForm"
+import type { UrlDocumentListProps } from "@/components/url-documents/UrlDocumentList"
+
+const sharedPrimitives = vi.hoisted(() => ({
+  formProps: null as UrlDocumentFormProps | null,
+  listProps: null as UrlDocumentListProps | null,
+  parseAbsoluteUrl: vi.fn(),
+  isAllowedDocumentUrl: vi.fn(),
+}))
+
+const documentState = vi.hoisted(() => ({
+  documentsQuery: {
+    isLoading: false,
+    isError: false,
+    data: [],
+    refetch: vi.fn(),
+  },
+  documents: [] as TechnicalConfigurationDocumentWire[],
+  getDocumentsForOwner: vi.fn(),
+  isReadOnly: false,
+  isSaving: false,
+  isConflict: false,
+  mutationError: null as unknown,
+  createDocument: vi.fn(),
+  updateDocument: vi.fn(),
+  deleteDocument: vi.fn(),
+  upsertCitation: vi.fn(),
+  deleteCitation: vi.fn(),
+}))
+
+vi.mock("@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments", () => ({
+  useTechnicalConfigurationDocuments: () => documentState,
+}))
+
+vi.mock("@/components/url-documents/UrlDocumentForm", () => ({
+  UrlDocumentForm: (props: UrlDocumentFormProps) => {
+    sharedPrimitives.formProps = props
+    return <div data-testid="shared-url-document-form" />
+  },
+}))
+
+vi.mock("@/components/url-documents/UrlDocumentList", () => ({
+  UrlDocumentList: (props: UrlDocumentListProps) => {
+    sharedPrimitives.listProps = props
+    return <div data-testid="shared-url-document-list" />
+  },
+}))
+
+vi.mock("@/components/url-documents/url-document-utils", () => ({
+  parseAbsoluteUrl: sharedPrimitives.parseAbsoluteUrl,
+  isAllowedDocumentUrl: sharedPrimitives.isAllowedDocumentUrl,
+}))
+
+const baselineVersion: TechnicalConfigurationBaselineDraftWire = {
+  id: "version-1",
+  dossier_id: "dossier-1",
+  version_number: 1,
+  status: "draft",
+  source_baseline_version_id: null,
+  source_version_number: null,
+  next_criterion_number: 2,
+  revision: 5,
+  locked_at: null,
+  locked_by: null,
+  created_at: "2026-07-18T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-18T00:00:00.000Z",
+  updated_by: 1,
+  groups: [],
+}
+
+describe("P7B2 shared URL-document delegation", () => {
+  beforeEach(() => {
+    sharedPrimitives.formProps = null
+    sharedPrimitives.listProps = null
+    sharedPrimitives.parseAbsoluteUrl.mockReset()
+    sharedPrimitives.isAllowedDocumentUrl.mockReset()
+    sharedPrimitives.parseAbsoluteUrl.mockImplementation((raw: string) => ({
+      raw,
+      protocol: "https:",
+    }))
+    sharedPrimitives.isAllowedDocumentUrl.mockReturnValue(true)
+    Object.values(documentState)
+      .filter((value) => typeof value === "function")
+      .forEach((mock) => mock.mockReset())
+    documentState.getDocumentsForOwner.mockReturnValue([])
+    documentState.createDocument.mockResolvedValue({ data: { revision: 6 } })
+  })
+
+  it("drives active create and list workflows through the unchanged shared primitives", async () => {
+    const rawUrl = "HtTpS://EXAMPLE.com/a/../spec.pdf"
+    render(
+      <TechnicalConfigurationBaselineDocuments
+        baselineVersion={baselineVersion}
+        ownerType="baseline"
+        ownerId={baselineVersion.id}
+      />
+    )
+
+    expect(documentState.getDocumentsForOwner).toHaveBeenCalledWith("baseline", baselineVersion.id)
+    expect(sharedPrimitives.formProps).not.toBeNull()
+    expect(sharedPrimitives.listProps).toMatchObject({
+      items: [],
+      isLoading: false,
+    })
+
+    act(() => {
+      sharedPrimitives.formProps?.onNameChange("Hồ sơ kỹ thuật")
+      sharedPrimitives.formProps?.onUrlChange(rawUrl)
+    })
+    await waitFor(() => expect(sharedPrimitives.formProps?.url).toBe(rawUrl))
+    await act(async () => {
+      await sharedPrimitives.formProps?.onSubmit()
+    })
+
+    expect(sharedPrimitives.parseAbsoluteUrl).toHaveBeenCalledWith(rawUrl)
+    expect(sharedPrimitives.isAllowedDocumentUrl).toHaveBeenCalled()
+    expect(documentState.createDocument).toHaveBeenCalledWith({
+      ownerType: "baseline",
+      ownerId: baselineVersion.id,
+      name: "Hồ sơ kỹ thuật",
+      url: rawUrl,
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-document-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-document-cases.tsx
@@ -16,6 +16,13 @@ class ResizeObserverMock {
   disconnect() {}
 }
 
+const emptyDocumentListResponse = {
+  data: [],
+  total: 0,
+  page: 1,
+  page_size: 100,
+}
+
 export function registerBaselineEvidenceDocumentTests(documentRpc: DocumentRpcMocks) {
   describe("TechnicalConfigurationBaselineDocuments behavior", () => {
     beforeEach(() => {
@@ -114,12 +121,7 @@ export function registerBaselineEvidenceDocumentTests(documentRpc: DocumentRpcMo
 
     it("renders document submission failures while preserving the draft", async () => {
       const user = userEvent.setup()
-      documentRpc.listDocuments.mockResolvedValue({
-        data: [],
-        total: 0,
-        page: 1,
-        page_size: 100,
-      })
+      documentRpc.listDocuments.mockResolvedValue(emptyDocumentListResponse)
       documentRpc.createBaselineDocument.mockRejectedValue(new Error("create_failed"))
 
       render(
@@ -137,6 +139,77 @@ export function registerBaselineEvidenceDocumentTests(documentRpc: DocumentRpcMo
 
       expect(await screen.findByRole("alert")).toHaveTextContent("Không thể lưu thay đổi tài liệu")
       expect(screen.getByLabelText("Tên tài liệu")).toHaveValue("Hồ sơ chưa lưu")
+    })
+
+    it("blocks document controls until a failed initial load is retried", async () => {
+      const user = userEvent.setup()
+      documentRpc.listDocuments
+        .mockRejectedValueOnce(new Error("list_failed"))
+        .mockResolvedValueOnce(emptyDocumentListResponse)
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "Không thể tải tài liệu và trích dẫn"
+      )
+      expect(screen.queryByLabelText("Tên tài liệu")).not.toBeInTheDocument()
+      expect(screen.queryByText("Chưa có tài liệu")).not.toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Thử lại" }))
+
+      expect(await screen.findByLabelText("Tên tài liệu")).toBeInTheDocument()
+      expect(documentRpc.listDocuments).toHaveBeenCalledTimes(2)
+    })
+
+    it("blocks stale document controls when refresh fails after a successful write", async () => {
+      const user = userEvent.setup()
+      const createdDocument = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      documentRpc.listDocuments
+        .mockResolvedValueOnce(emptyDocumentListResponse)
+        .mockRejectedValueOnce(new Error("refresh_failed"))
+        .mockResolvedValueOnce({
+          data: [createdDocument],
+          total: 1,
+          page: 1,
+          page_size: 100,
+        })
+      documentRpc.createBaselineDocument.mockResolvedValue({
+        data: { ...createdDocument, revision: baselineVersion.revision + 1 },
+      })
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      await user.type(await screen.findByLabelText("Tên tài liệu"), createdDocument.name)
+      await user.type(screen.getByLabelText("Đường dẫn (URL)"), createdDocument.url)
+      await user.click(screen.getByRole("button", { name: "Thêm tài liệu" }))
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "Đã lưu thay đổi nhưng không thể làm mới danh sách"
+      )
+      expect(screen.getByLabelText("Tên tài liệu")).toBeDisabled()
+      expect(documentRpc.createBaselineDocument).toHaveBeenCalledTimes(1)
+
+      await user.click(screen.getByRole("button", { name: "Thử lại" }))
+
+      expect(
+        await screen.findByRole("button", { name: /Tài liệu đang chỉnh sửa/i })
+      ).toBeInTheDocument()
+      expect(screen.getByLabelText("Tên tài liệu")).not.toBeDisabled()
+      expect(documentRpc.listDocuments).toHaveBeenCalledTimes(3)
     })
 
     it("confirms document deletion with the affected citation count", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-document-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-document-cases.tsx
@@ -1,0 +1,260 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { TechnicalConfigurationBaselineDocuments } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+import {
+  baselineVersion,
+  evidenceDocument,
+  type DocumentRpcMocks,
+} from "./baseline-evidence-fixtures"
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+export function registerBaselineEvidenceDocumentTests(documentRpc: DocumentRpcMocks) {
+  describe("TechnicalConfigurationBaselineDocuments behavior", () => {
+    beforeEach(() => {
+      Object.values(documentRpc).forEach((mock) => mock.mockReset())
+      Object.defineProperty(globalThis, "ResizeObserver", {
+        configurable: true,
+        value: ResizeObserverMock,
+      })
+    })
+
+    it("selects an existing document and preserves the raw URL when updating", async () => {
+      const user = userEvent.setup()
+      const document = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      const rawUpdatedUrl = "HtTpS://EXAMPLE.com/a/../revised-spec.pdf"
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [document],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      documentRpc.updateBaselineDocument.mockResolvedValue({
+        data: { ...document, name: "Hồ sơ kỹ thuật cập nhật", url: rawUpdatedUrl, revision: 6 },
+      })
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      const documentPicker = await screen.findByRole("button", {
+        name: /Tài liệu đang chỉnh sửa/i,
+      })
+      act(() => documentPicker.focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: document.name }))
+      expect(screen.getByLabelText("Tên tài liệu")).toHaveValue(document.name)
+      expect(screen.getByLabelText("Đường dẫn (URL)")).toHaveValue(document.url)
+
+      const nameInput = screen.getByLabelText("Tên tài liệu")
+      await user.clear(nameInput)
+      await user.paste("Hồ sơ kỹ thuật cập nhật")
+      const urlInput = screen.getByLabelText("Đường dẫn (URL)")
+      await user.clear(urlInput)
+      await user.paste(rawUpdatedUrl)
+      await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+      await waitFor(() =>
+        expect(documentRpc.updateBaselineDocument).toHaveBeenCalledWith({
+          p_baseline_document_id: document.id,
+          p_name: "Hồ sơ kỹ thuật cập nhật",
+          p_url: rawUpdatedUrl,
+          p_expected_revision: baselineVersion.revision,
+        })
+      )
+    })
+
+    it("preserves a dirty document draft when creating a new document is rejected", async () => {
+      const user = userEvent.setup()
+      const document = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [document],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      const documentPicker = await screen.findByRole("button", {
+        name: /Tài liệu đang chỉnh sửa/i,
+      })
+      act(() => documentPicker.focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: document.name }))
+      await user.type(screen.getByLabelText("Tên tài liệu"), " chưa lưu")
+      await user.click(screen.getByRole("button", { name: "Tạo tài liệu mới" }))
+
+      expect(confirm).toHaveBeenCalledWith(
+        "Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?"
+      )
+      expect(screen.getByLabelText("Tên tài liệu")).toHaveValue(`${document.name} chưa lưu`)
+      confirm.mockRestore()
+    })
+
+    it("renders document submission failures while preserving the draft", async () => {
+      const user = userEvent.setup()
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        page_size: 100,
+      })
+      documentRpc.createBaselineDocument.mockRejectedValue(new Error("create_failed"))
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      await user.type(await screen.findByLabelText("Tên tài liệu"), "Hồ sơ chưa lưu")
+      await user.type(screen.getByLabelText("Đường dẫn (URL)"), "https://example.com/spec.pdf")
+      await user.click(screen.getByRole("button", { name: "Thêm tài liệu" }))
+
+      expect(await screen.findByRole("alert")).toHaveTextContent("Không thể lưu thay đổi tài liệu")
+      expect(screen.getByLabelText("Tên tài liệu")).toHaveValue("Hồ sơ chưa lưu")
+    })
+
+    it("confirms document deletion with the affected citation count", async () => {
+      const user = userEvent.setup()
+      const document = {
+        ...evidenceDocument("document-1", "baseline", baselineVersion.id),
+        citations: [
+          {
+            id: "citation-1",
+            criterion_id: "criterion-1",
+            page_section: "Mục 2",
+            excerpt: "Nguồn điện ổn định",
+          },
+        ],
+      }
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [document],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      documentRpc.deleteBaselineDocument.mockResolvedValue({
+        data: { affected_link_count: 1, revision: 6 },
+      })
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      await user.click(await screen.findByRole("button", { name: `Xóa ${document.name}` }))
+      expect(screen.getByRole("alertdialog")).toHaveTextContent("1 trích dẫn")
+      await user.click(screen.getByRole("button", { name: "Xóa tài liệu" }))
+
+      await waitFor(() =>
+        expect(documentRpc.deleteBaselineDocument).toHaveBeenCalledWith({
+          p_baseline_document_id: document.id,
+          p_expected_revision: baselineVersion.revision,
+        })
+      )
+    })
+
+    it("keeps deletion failures inside the confirmation dialog", async () => {
+      const user = userEvent.setup()
+      const document = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [document],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      documentRpc.deleteBaselineDocument.mockRejectedValue(new Error("delete_failed"))
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      await user.click(await screen.findByRole("button", { name: `Xóa ${document.name}` }))
+      const dialog = screen.getByRole("alertdialog")
+      await user.click(within(dialog).getByRole("button", { name: "Xóa tài liệu" }))
+
+      expect(await within(dialog).findByRole("alert")).toHaveTextContent("Không thể xóa tài liệu")
+    })
+
+    it("does not expose delete confirmation for a locked baseline", async () => {
+      const document = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [document],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={{ ...baselineVersion, status: "locked", locked_at: "2026-07-18" }}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      await screen.findByRole("link", { name: `${document.name} (mở trong tab mới)` })
+      expect(screen.queryByRole("button", { name: `Xóa ${document.name}` })).not.toBeInTheDocument()
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+    })
+
+    it("does not expose writable controls for an archived dossier", async () => {
+      const document = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [document],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+          readOnly
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      expect(await screen.findByLabelText("Tên tài liệu")).toBeDisabled()
+      expect(screen.queryByRole("button", { name: `Xóa ${document.name}` })).not.toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Thêm tài liệu" })).toBeDisabled()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-document-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-document-cases.tsx
@@ -83,6 +83,117 @@ export function registerBaselineEvidenceDocumentTests(documentRpc: DocumentRpcMo
       )
     })
 
+    it("adopts refreshed document values only while the local draft remains clean", async () => {
+      const user = userEvent.setup()
+      const document = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      const queryClient = createTestQueryClient()
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [document],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(queryClient) }
+      )
+
+      const documentPicker = await screen.findByRole("button", {
+        name: /Tài liệu đang chỉnh sửa/i,
+      })
+      act(() => documentPicker.focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: document.name }))
+
+      act(() => {
+        queryClient.setQueryData(
+          ["technical-configurations", "documents", baselineVersion.id],
+          [{ ...document, name: "Hồ sơ từ máy chủ", url: "https://example.com/server-v2.pdf" }]
+        )
+      })
+
+      await waitFor(() =>
+        expect(screen.getByLabelText("Tên tài liệu")).toHaveValue("Hồ sơ từ máy chủ")
+      )
+      expect(screen.getByLabelText("Đường dẫn (URL)")).toHaveValue(
+        "https://example.com/server-v2.pdf"
+      )
+
+      await user.type(screen.getByLabelText("Tên tài liệu"), " bản nháp")
+      act(() => {
+        queryClient.setQueryData(
+          ["technical-configurations", "documents", baselineVersion.id],
+          [{ ...document, name: "Hồ sơ từ máy chủ v3", url: "https://example.com/server-v3.pdf" }]
+        )
+      })
+
+      expect(screen.getByLabelText("Tên tài liệu")).toHaveValue("Hồ sơ từ máy chủ bản nháp")
+      expect(screen.getByLabelText("Đường dẫn (URL)")).toHaveValue(
+        "https://example.com/server-v2.pdf"
+      )
+    })
+
+    it("blocks stale document submission until another document is selected", async () => {
+      const user = userEvent.setup()
+      const firstDocument = evidenceDocument("document-1", "baseline", baselineVersion.id)
+      const secondDocument = evidenceDocument("document-2", "baseline", baselineVersion.id)
+      const queryClient = createTestQueryClient()
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [firstDocument, secondDocument],
+        total: 2,
+        page: 1,
+        page_size: 100,
+      })
+
+      render(
+        <TechnicalConfigurationBaselineDocuments
+          baselineVersion={baselineVersion}
+          ownerType="baseline"
+          ownerId={baselineVersion.id}
+        />,
+        { wrapper: createReactQueryWrapper(queryClient) }
+      )
+
+      const documentPicker = await screen.findByRole("button", {
+        name: /Tài liệu đang chỉnh sửa/i,
+      })
+      act(() => documentPicker.focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: firstDocument.name }))
+
+      act(() => {
+        queryClient.setQueryData(
+          ["technical-configurations", "documents", baselineVersion.id],
+          [secondDocument]
+        )
+      })
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "Tài liệu đang chỉnh sửa không còn trong danh sách"
+      )
+      expect(screen.getByRole("button", { name: "Lưu thay đổi" })).toBeDisabled()
+      expect(documentRpc.createBaselineDocument).not.toHaveBeenCalled()
+
+      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
+      const refreshedDocumentPicker = screen.getByRole("button", {
+        name: /Tài liệu đang chỉnh sửa/i,
+      })
+      act(() => refreshedDocumentPicker.focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: secondDocument.name }))
+
+      await waitFor(() => {
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+        expect(screen.getByLabelText("Tên tài liệu")).toHaveValue(secondDocument.name)
+      })
+      confirm.mockRestore()
+    })
+
     it("preserves a dirty document draft when creating a new document is rejected", async () => {
       const user = userEvent.setup()
       const document = evidenceDocument("document-1", "baseline", baselineVersion.id)

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-fixtures.tsx
@@ -1,0 +1,54 @@
+import type { Mock } from "vitest"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+
+export type DocumentRpcMocks = {
+  listDocuments: Mock
+  createBaselineDocument: Mock
+  updateBaselineDocument: Mock
+  deleteBaselineDocument: Mock
+  upsertBaselineCitation: Mock
+  deleteBaselineCitation: Mock
+  createReferenceDocument: Mock
+  updateReferenceDocument: Mock
+  deleteReferenceDocument: Mock
+  upsertReferenceCitation: Mock
+  deleteReferenceCitation: Mock
+}
+
+export const baselineVersion: TechnicalConfigurationBaselineDraftWire = {
+  id: "version-1",
+  dossier_id: "dossier-1",
+  version_number: 1,
+  status: "draft",
+  source_baseline_version_id: null,
+  source_version_number: null,
+  next_criterion_number: 2,
+  revision: 5,
+  locked_at: null,
+  locked_by: null,
+  created_at: "2026-07-18T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-18T00:00:00.000Z",
+  updated_by: 1,
+  groups: [],
+}
+
+export function evidenceDocument(
+  id: string,
+  ownerType: TechnicalConfigurationDocumentWire["owner_type"],
+  ownerId: string
+): TechnicalConfigurationDocumentWire {
+  return {
+    id,
+    owner_type: ownerType,
+    owner_id: ownerId,
+    name: `Tài liệu ${id}`,
+    url: `https://example.com/${id}.pdf`,
+    created_by: 1,
+    created_at: "2026-07-18T00:00:00.000Z",
+    updated_at: "2026-07-18T00:00:00.000Z",
+    citations: [],
+  }
+}

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-mutation-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-mutation-cases.tsx
@@ -1,0 +1,189 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { useTechnicalConfigurationDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+import {
+  baselineVersion,
+  evidenceDocument,
+  type DocumentRpcMocks,
+} from "./baseline-evidence-fixtures"
+
+export function registerBaselineEvidenceMutationTests(documentRpc: DocumentRpcMocks) {
+  describe("useTechnicalConfigurationDocuments remaining mutations", () => {
+    beforeEach(() => {
+      Object.values(documentRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("routes update, citation, and delete through the exact owner contract", async () => {
+      const baselineDocument = {
+        ...evidenceDocument("baseline-document", "baseline", baselineVersion.id),
+        citations: [
+          {
+            id: "baseline-citation",
+            criterion_id: "criterion-1",
+            page_section: "Mục 2",
+            excerpt: "Nguồn điện ổn định",
+          },
+        ],
+      }
+      const referenceDocument = evidenceDocument(
+        "reference-document",
+        "reference_product",
+        "reference-product-1"
+      )
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [baselineDocument, referenceDocument],
+        total: 2,
+        page: 1,
+        page_size: 100,
+      })
+      documentRpc.updateBaselineDocument.mockResolvedValue({
+        data: {
+          ...baselineDocument,
+          url: "HtTpS://EXAMPLE.com/a/../updated.pdf",
+          revision: 6,
+        },
+      })
+      documentRpc.upsertBaselineCitation.mockResolvedValue({
+        data: { ...baselineDocument.citations[0], revision: 7 },
+      })
+      documentRpc.deleteBaselineCitation.mockResolvedValue({
+        data: { id: "baseline-citation", revision: 8 },
+      })
+      documentRpc.deleteBaselineDocument.mockResolvedValue({
+        data: { id: baselineDocument.id, revision: 9, affected_link_count: 1 },
+      })
+      documentRpc.updateReferenceDocument.mockResolvedValue({
+        data: { ...referenceDocument, revision: 10 },
+      })
+      documentRpc.upsertReferenceCitation.mockResolvedValue({
+        data: {
+          id: "reference-citation",
+          criterion_id: "criterion-1",
+          page_section: null,
+          excerpt: "Đáp ứng yêu cầu",
+          revision: 11,
+        },
+      })
+      documentRpc.deleteReferenceCitation.mockResolvedValue({
+        data: { id: "reference-citation", revision: 12 },
+      })
+      documentRpc.deleteReferenceDocument.mockResolvedValue({
+        data: { id: referenceDocument.id, revision: 13, affected_link_count: 0 },
+      })
+      const queryClient = createTestQueryClient()
+      const { result } = renderHook(() => useTechnicalConfigurationDocuments({ baselineVersion }), {
+        wrapper: createReactQueryWrapper(queryClient),
+      })
+      await waitFor(() => expect(result.current.documentsQuery.isSuccess).toBe(true))
+
+      const rawUpdatedUrl = "HtTpS://EXAMPLE.com/a/../updated.pdf"
+      await act(async () => {
+        await result.current.updateDocument({
+          document: baselineDocument,
+          name: "Tài liệu cập nhật",
+          url: rawUpdatedUrl,
+        })
+        await result.current.upsertCitation({
+          document: baselineDocument,
+          criterionId: "criterion-1",
+          pageSection: "Mục 3",
+          excerpt: "Trích đoạn mới",
+        })
+        await result.current.deleteCitation({
+          document: baselineDocument,
+          citationId: "baseline-citation",
+        })
+        await expect(result.current.deleteDocument(baselineDocument)).resolves.toBe(1)
+        await result.current.updateDocument({
+          document: referenceDocument,
+          name: referenceDocument.name,
+          url: referenceDocument.url,
+        })
+        await result.current.upsertCitation({
+          document: referenceDocument,
+          criterionId: "criterion-1",
+          pageSection: null,
+          excerpt: "Đáp ứng yêu cầu",
+        })
+        await result.current.deleteCitation({
+          document: referenceDocument,
+          citationId: "reference-citation",
+        })
+        await expect(result.current.deleteDocument(referenceDocument)).resolves.toBe(0)
+      })
+
+      expect(documentRpc.updateBaselineDocument).toHaveBeenCalledWith({
+        p_baseline_document_id: baselineDocument.id,
+        p_name: "Tài liệu cập nhật",
+        p_url: rawUpdatedUrl,
+        p_expected_revision: 5,
+      })
+      expect(documentRpc.upsertBaselineCitation).toHaveBeenCalledWith({
+        p_baseline_document_id: baselineDocument.id,
+        p_criterion_id: "criterion-1",
+        p_page_section: "Mục 3",
+        p_excerpt: "Trích đoạn mới",
+        p_expected_revision: 6,
+      })
+      expect(documentRpc.deleteBaselineCitation).toHaveBeenCalledWith({
+        p_baseline_citation_id: "baseline-citation",
+        p_expected_revision: 7,
+      })
+      expect(documentRpc.deleteBaselineDocument).toHaveBeenCalledWith({
+        p_baseline_document_id: baselineDocument.id,
+        p_expected_revision: 8,
+      })
+      expect(documentRpc.updateReferenceDocument).toHaveBeenCalledWith({
+        p_reference_document_id: referenceDocument.id,
+        p_name: referenceDocument.name,
+        p_url: referenceDocument.url,
+        p_expected_revision: 9,
+      })
+      expect(documentRpc.upsertReferenceCitation).toHaveBeenCalledWith({
+        p_reference_document_id: referenceDocument.id,
+        p_criterion_id: "criterion-1",
+        p_page_section: null,
+        p_excerpt: "Đáp ứng yêu cầu",
+        p_expected_revision: 10,
+      })
+      expect(documentRpc.deleteReferenceCitation).toHaveBeenCalledWith({
+        p_reference_citation_id: "reference-citation",
+        p_expected_revision: 11,
+      })
+      expect(documentRpc.deleteReferenceDocument).toHaveBeenCalledWith({
+        p_reference_document_id: referenceDocument.id,
+        p_expected_revision: 12,
+      })
+    })
+
+    it("rejects locked mutations before any document RPC runs", async () => {
+      const lockedVersion = {
+        ...baselineVersion,
+        status: "locked" as const,
+        locked_at: "2026-07-18T01:00:00.000Z",
+        locked_by: 1,
+      }
+      const baselineDocument = evidenceDocument("baseline-document", "baseline", baselineVersion.id)
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [baselineDocument],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      const queryClient = createTestQueryClient()
+      const { result } = renderHook(
+        () => useTechnicalConfigurationDocuments({ baselineVersion: lockedVersion }),
+        { wrapper: createReactQueryWrapper(queryClient) }
+      )
+      await waitFor(() => expect(result.current.documentsQuery.isSuccess).toBe(true))
+
+      await expect(result.current.deleteDocument(baselineDocument)).rejects.toThrow(
+        "locked_version"
+      )
+      expect(documentRpc.deleteBaselineDocument).not.toHaveBeenCalled()
+      expect(documentRpc.deleteReferenceDocument).not.toHaveBeenCalled()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-query-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-query-cases.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useTechnicalConfigurationDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments"
+import { TechnicalConfigurationRpcError } from "@/app/(app)/technical-configurations/technical-configuration-rpc"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+import {
+  baselineVersion,
+  evidenceDocument,
+  type DocumentRpcMocks,
+} from "./baseline-evidence-fixtures"
+
+export function registerBaselineEvidenceQueryTests(documentRpc: DocumentRpcMocks) {
+  describe("useTechnicalConfigurationDocuments query and create", () => {
+    beforeEach(() => {
+      Object.values(documentRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("loads the aggregate once and routes documents by exact owner", async () => {
+      const baselineDocument = evidenceDocument("baseline-document", "baseline", baselineVersion.id)
+      const referenceDocument = evidenceDocument(
+        "reference-document",
+        "reference_product",
+        "reference-product-1"
+      )
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [baselineDocument, referenceDocument],
+        total: 2,
+        page: 1,
+        page_size: 100,
+      })
+      const queryClient = createTestQueryClient()
+      const { result } = renderHook(() => useTechnicalConfigurationDocuments({ baselineVersion }), {
+        wrapper: createReactQueryWrapper(queryClient),
+      })
+
+      await waitFor(() => expect(result.current.documentsQuery.isSuccess).toBe(true))
+
+      expect(documentRpc.listDocuments).toHaveBeenCalledWith(
+        {
+          p_baseline_version_id: baselineVersion.id,
+          p_page: 1,
+          p_page_size: 100,
+        },
+        expect.any(AbortSignal)
+      )
+      expect(result.current.getDocumentsForOwner("baseline", baselineVersion.id)).toEqual([
+        baselineDocument,
+      ])
+      expect(
+        result.current.getDocumentsForOwner("reference_product", "reference-product-1")
+      ).toEqual([referenceDocument])
+    })
+
+    it("routes baseline and reference creates with exact raw URLs and sequential revisions", async () => {
+      const onRevisionChange = vi.fn()
+      const onNavigationBlockedChange = vi.fn()
+      const rawBaselineUrl = "HtTpS://EXAMPLE.com/a/../baseline.pdf"
+      const rawReferenceUrl = "https://example.com/reference.pdf"
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        page_size: 100,
+      })
+      documentRpc.createBaselineDocument.mockResolvedValue({
+        data: {
+          ...evidenceDocument("baseline-document", "baseline", baselineVersion.id),
+          url: rawBaselineUrl,
+          revision: 6,
+        },
+      })
+      documentRpc.createReferenceDocument.mockResolvedValue({
+        data: {
+          ...evidenceDocument("reference-document", "reference_product", "reference-product-1"),
+          url: rawReferenceUrl,
+          revision: 7,
+        },
+      })
+      const queryClient = createTestQueryClient()
+      const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+      const { result } = renderHook(
+        () =>
+          useTechnicalConfigurationDocuments({
+            baselineVersion,
+            onRevisionChange,
+            onNavigationBlockedChange,
+          }),
+        { wrapper: createReactQueryWrapper(queryClient) }
+      )
+      await waitFor(() => expect(result.current.documentsQuery.isSuccess).toBe(true))
+
+      await act(async () => {
+        await result.current.createDocument({
+          ownerType: "baseline",
+          ownerId: baselineVersion.id,
+          name: "Hồ sơ cơ sở",
+          url: rawBaselineUrl,
+        })
+        await result.current.createDocument({
+          ownerType: "reference_product",
+          ownerId: "reference-product-1",
+          name: "Hồ sơ tham chiếu",
+          url: rawReferenceUrl,
+        })
+      })
+
+      expect(documentRpc.createBaselineDocument).toHaveBeenCalledWith({
+        p_baseline_version_id: baselineVersion.id,
+        p_name: "Hồ sơ cơ sở",
+        p_url: rawBaselineUrl,
+        p_expected_revision: 5,
+      })
+      expect(documentRpc.createReferenceDocument).toHaveBeenCalledWith({
+        p_reference_product_id: "reference-product-1",
+        p_name: "Hồ sơ tham chiếu",
+        p_url: rawReferenceUrl,
+        p_expected_revision: 6,
+      })
+      expect(onRevisionChange).toHaveBeenNthCalledWith(1, 6)
+      expect(onRevisionChange).toHaveBeenNthCalledWith(2, 7)
+      expect(onNavigationBlockedChange.mock.calls.flat()).toEqual([true, false, true, false])
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["technical-configurations", "documents", baselineVersion.id],
+        exact: true,
+      })
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["technical-configurations", "baseline-versions", baselineVersion.dossier_id],
+        exact: true,
+      })
+    })
+
+    it("marks stale conflicts while keeping the failed input under caller control", async () => {
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        page_size: 100,
+      })
+      documentRpc.createBaselineDocument.mockRejectedValue(
+        new TechnicalConfigurationRpcError(409, { message: "stale_revision" })
+      )
+      const rawUrl = "HtTpS://EXAMPLE.com/a/../retry.pdf"
+      const input = {
+        ownerType: "baseline" as const,
+        ownerId: baselineVersion.id,
+        name: "Giữ nguyên khi xung đột",
+        url: rawUrl,
+      }
+      const queryClient = createTestQueryClient()
+      const { result } = renderHook(() => useTechnicalConfigurationDocuments({ baselineVersion }), {
+        wrapper: createReactQueryWrapper(queryClient),
+      })
+      await waitFor(() => expect(result.current.documentsQuery.isSuccess).toBe(true))
+
+      await act(async () => {
+        await expect(result.current.createDocument(input)).rejects.toThrow("stale_revision")
+      })
+
+      expect(result.current.isConflict).toBe(true)
+      expect(result.current.mutationError).toMatchObject({ message: "stale_revision" })
+      expect(input).toEqual({
+        ownerType: "baseline",
+        ownerId: baselineVersion.id,
+        name: "Giữ nguyên khi xung đột",
+        url: rawUrl,
+      })
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-query-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-query-cases.tsx
@@ -130,6 +130,73 @@ export function registerBaselineEvidenceQueryTests(documentRpc: DocumentRpcMocks
       })
     })
 
+    it("rejects an overlapping mutation before it can reuse the current revision", async () => {
+      const onNavigationBlockedChange = vi.fn()
+      const firstDocument = evidenceDocument("baseline-document", "baseline", baselineVersion.id)
+      let resolveFirstMutation:
+        ((value: { data: typeof firstDocument & { revision: number } }) => void) | undefined
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        page_size: 100,
+      })
+      documentRpc.createBaselineDocument
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveFirstMutation = resolve
+            })
+        )
+        .mockResolvedValueOnce({
+          data: {
+            ...evidenceDocument("second-document", "baseline", baselineVersion.id),
+            revision: 7,
+          },
+        })
+      const queryClient = createTestQueryClient()
+      const { result } = renderHook(
+        () =>
+          useTechnicalConfigurationDocuments({
+            baselineVersion,
+            onNavigationBlockedChange,
+          }),
+        { wrapper: createReactQueryWrapper(queryClient) }
+      )
+      await waitFor(() => expect(result.current.documentsQuery.isSuccess).toBe(true))
+
+      let outcomes: PromiseSettledResult<unknown>[] = []
+      await act(async () => {
+        const firstMutation = result.current.createDocument({
+          ownerType: "baseline",
+          ownerId: baselineVersion.id,
+          name: "Hồ sơ thứ nhất",
+          url: "https://example.com/first.pdf",
+        })
+        const secondMutation = result.current.createDocument({
+          ownerType: "baseline",
+          ownerId: baselineVersion.id,
+          name: "Hồ sơ thứ hai",
+          url: "https://example.com/second.pdf",
+        })
+        resolveFirstMutation?.({
+          data: {
+            ...firstDocument,
+            revision: 6,
+          },
+        })
+        outcomes = await Promise.allSettled([firstMutation, secondMutation])
+      })
+
+      expect(outcomes[0]).toMatchObject({ status: "fulfilled" })
+      expect(outcomes[1]).toMatchObject({
+        status: "rejected",
+        reason: expect.objectContaining({ message: "mutation_in_progress" }),
+      })
+      expect(documentRpc.createBaselineDocument).toHaveBeenCalledTimes(1)
+      expect(onNavigationBlockedChange.mock.calls.flat()).toEqual([true, false])
+    })
+
     it("marks stale conflicts while keeping the failed input under caller control", async () => {
       documentRpc.listDocuments.mockResolvedValue({
         data: [],

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-workspace-cases.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, type Mock } from "vitest"
+
+import { TechnicalConfigurationBaselineEvidence } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEvidence"
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+import { baselineVersion, type DocumentRpcMocks } from "./baseline-evidence-fixtures"
+
+type BaselineRpcMocks = {
+  listVersions: Mock
+}
+
+const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy lọc thận",
+  name: "Cấu hình máy lọc thận",
+  description: null,
+  revision: 3,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-18T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-18T00:00:00.000Z",
+  updated_by: 1,
+}
+
+export function registerBaselineEvidenceWorkspaceTests({
+  baselineRpc,
+  documentRpc,
+}: {
+  baselineRpc: BaselineRpcMocks
+  documentRpc: DocumentRpcMocks
+}) {
+  describe("TechnicalConfigurationBaselineEvidence workspace", () => {
+    it("selects the current baseline and composes its evidence owner", async () => {
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baselineVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        page_size: 100,
+      })
+
+      render(<TechnicalConfigurationBaselineEvidence dossier={dossier} />, {
+        wrapper: createReactQueryWrapper(createTestQueryClient()),
+      })
+
+      expect(
+        await screen.findByRole("heading", { name: "Tài liệu và trích dẫn" })
+      ).toBeInTheDocument()
+      await waitFor(() =>
+        expect(documentRpc.listDocuments).toHaveBeenCalledWith(
+          {
+            p_baseline_version_id: baselineVersion.id,
+            p_page: 1,
+            p_page_size: 100,
+          },
+          expect.any(AbortSignal)
+        )
+      )
+    })
+
+    it("registers beforeunload protection while an evidence draft is dirty", async () => {
+      const user = userEvent.setup()
+      const addEventListener = vi.spyOn(window, "addEventListener")
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baselineVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        page_size: 100,
+      })
+
+      render(<TechnicalConfigurationBaselineEvidence dossier={dossier} />, {
+        wrapper: createReactQueryWrapper(createTestQueryClient()),
+      })
+
+      await user.type(await screen.findByLabelText("Tên tài liệu"), "Hồ sơ chưa lưu")
+      const beforeUnloadHandler = addEventListener.mock.calls.find(
+        ([eventName]) => eventName === "beforeunload"
+      )?.[1]
+      expect(beforeUnloadHandler).toBeTypeOf("function")
+      const dirtyEvent = new Event("beforeunload", { cancelable: true })
+      ;(beforeUnloadHandler as EventListener)(dirtyEvent)
+
+      expect(dirtyEvent.defaultPrevented).toBe(true)
+      addEventListener.mockRestore()
+    })
+
+    it("propagates archived dossier read-only state to evidence controls", async () => {
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baselineVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      documentRpc.listDocuments.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        page_size: 100,
+      })
+
+      render(
+        <TechnicalConfigurationBaselineEvidence
+          dossier={{
+            ...dossier,
+            archived_at: "2026-07-18T00:00:00.000Z",
+            archived_by: 1,
+          }}
+        />,
+        { wrapper: createReactQueryWrapper(createTestQueryClient()) }
+      )
+
+      expect(await screen.findByLabelText("Tên tài liệu")).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Thêm tài liệu" })).toBeDisabled()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence.test.tsx
@@ -1,0 +1,63 @@
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it, vi } from "vitest"
+
+import { registerBaselineEvidenceCitationTests } from "./baseline-evidence-citation-cases"
+import { registerBaselineEvidenceDocumentTests } from "./baseline-evidence-document-cases"
+import { registerBaselineEvidenceMutationTests } from "./baseline-evidence-mutation-cases"
+import { registerBaselineEvidenceQueryTests } from "./baseline-evidence-query-cases"
+import { registerBaselineEvidenceWorkspaceTests } from "./baseline-evidence-workspace-cases"
+
+const baselineRpc = vi.hoisted(() => ({
+  listVersions: vi.fn(),
+}))
+const documentRpc = vi.hoisted(() => ({
+  listDocuments: vi.fn(),
+  createBaselineDocument: vi.fn(),
+  updateBaselineDocument: vi.fn(),
+  deleteBaselineDocument: vi.fn(),
+  upsertBaselineCitation: vi.fn(),
+  deleteBaselineCitation: vi.fn(),
+  createReferenceDocument: vi.fn(),
+  updateReferenceDocument: vi.fn(),
+  deleteReferenceDocument: vi.fn(),
+  upsertReferenceCitation: vi.fn(),
+  deleteReferenceCitation: vi.fn(),
+}))
+
+vi.mock("@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline", () => ({
+  useTechnicalConfigurationBaseline: () => baselineRpc,
+}))
+
+vi.mock("@/app/(app)/technical-configurations/technical-configuration-document-rpc", () => ({
+  listTechnicalConfigurationBaselineDocuments: documentRpc.listDocuments,
+  createTechnicalConfigurationBaselineDocument: documentRpc.createBaselineDocument,
+  updateTechnicalConfigurationBaselineDocument: documentRpc.updateBaselineDocument,
+  deleteTechnicalConfigurationBaselineDocument: documentRpc.deleteBaselineDocument,
+  upsertTechnicalConfigurationBaselineCitation: documentRpc.upsertBaselineCitation,
+  deleteTechnicalConfigurationBaselineCitation: documentRpc.deleteBaselineCitation,
+  createTechnicalConfigurationReferenceDocument: documentRpc.createReferenceDocument,
+  updateTechnicalConfigurationReferenceDocument: documentRpc.updateReferenceDocument,
+  deleteTechnicalConfigurationReferenceDocument: documentRpc.deleteReferenceDocument,
+  upsertTechnicalConfigurationReferenceCitation: documentRpc.upsertReferenceCitation,
+  deleteTechnicalConfigurationReferenceCitation: documentRpc.deleteReferenceCitation,
+}))
+
+registerBaselineEvidenceQueryTests(documentRpc)
+registerBaselineEvidenceMutationTests(documentRpc)
+registerBaselineEvidenceCitationTests()
+registerBaselineEvidenceDocumentTests(documentRpc)
+registerBaselineEvidenceWorkspaceTests({ baselineRpc, documentRpc })
+
+describe("TechnicalConfigurationCitationEditor", () => {
+  it("exists at the planned P7B2 component path", () => {
+    expect(
+      existsSync(
+        join(
+          process.cwd(),
+          "src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx"
+        )
+      )
+    ).toBe(true)
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-evidence-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-evidence-cases.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, type Mock } from "vitest"
 
@@ -16,6 +16,8 @@ type BaselineDocumentsMock = {
     ownerId: string
     criterionId?: string | null
     readOnly?: boolean
+    onDirtyChange?: (dirty: boolean) => void
+    onNavigationBlockedChange?: (blocked: boolean) => void
   } | null
 }
 
@@ -77,6 +79,127 @@ export function registerReferenceProductEvidenceTests({
         ownerId: "product-1",
         criterionId: "criterion-1",
       })
+    })
+
+    it("closes stale evidence details when the baseline version changes", async () => {
+      const user = userEvent.setup()
+      const onEvidenceDirtyChange = vi.fn()
+      const onEvidenceNavigationBlockedChange = vi.fn()
+      const referenceProduct = toTechnicalConfigurationReferenceProductDraft(
+        product("product-1", "Model A")
+      )
+      evidenceState.getDocumentsForOwner.mockReturnValue([])
+      const view = renderWithQueryClient(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={baselineVersion}
+          products={[referenceProduct]}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+          onEvidenceDirtyChange={onEvidenceDirtyChange}
+          onEvidenceNavigationBlockedChange={onEvidenceNavigationBlockedChange}
+        />
+      )
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Bằng chứng Model A cho TC-0001: 0 tài liệu, 0 trích dẫn",
+        })
+      )
+      expect(screen.getByRole("dialog")).toBeInTheDocument()
+      baselineDocumentsMock.props?.onDirtyChange?.(true)
+      baselineDocumentsMock.props?.onNavigationBlockedChange?.(true)
+
+      view.rerender(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={{ ...baselineVersion, id: "version-2" }}
+          products={[referenceProduct]}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+          onEvidenceDirtyChange={onEvidenceDirtyChange}
+          onEvidenceNavigationBlockedChange={onEvidenceNavigationBlockedChange}
+        />
+      )
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+      await waitFor(() => {
+        expect(onEvidenceDirtyChange).toHaveBeenLastCalledWith(false)
+        expect(onEvidenceNavigationBlockedChange).toHaveBeenLastCalledWith(false)
+      })
+    })
+
+    it("keeps the evidence dialog open while a mutation blocks navigation", async () => {
+      const user = userEvent.setup()
+      const onNavigationBlockedChange = vi.fn()
+      const referenceProduct = toTechnicalConfigurationReferenceProductDraft(
+        product("product-1", "Model A")
+      )
+      evidenceState.getDocumentsForOwner.mockReturnValue([])
+      renderWithQueryClient(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={baselineVersion}
+          products={[referenceProduct]}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+          onEvidenceNavigationBlockedChange={onNavigationBlockedChange}
+        />
+      )
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Bằng chứng Model A cho TC-0001: 0 tài liệu, 0 trích dẫn",
+        })
+      )
+      baselineDocumentsMock.props?.onNavigationBlockedChange?.(true)
+      await user.click(screen.getByRole("button", { name: "Đóng" }))
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument()
+      expect(onNavigationBlockedChange).toHaveBeenCalledWith(true)
+
+      baselineDocumentsMock.props?.onNavigationBlockedChange?.(false)
+      await user.click(screen.getByRole("button", { name: "Đóng" }))
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+      expect(onNavigationBlockedChange).toHaveBeenCalledWith(false)
+    })
+
+    it("resolves evidence documents once per visible product", () => {
+      const referenceProduct = toTechnicalConfigurationReferenceProductDraft(
+        product("product-1", "Model A")
+      )
+      const firstCriterion = baselineVersion.groups[0].criteria[0]
+      const baselineWithTwoCriteria = {
+        ...baselineVersion,
+        groups: [
+          {
+            ...baselineVersion.groups[0],
+            criteria: [
+              firstCriterion,
+              {
+                ...firstCriterion,
+                id: "criterion-2",
+                criterion_code: "TC-0002",
+                sort_order: 2,
+              },
+            ],
+          },
+        ],
+      }
+      evidenceState.getDocumentsForOwner.mockReturnValue([])
+
+      renderWithQueryClient(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={baselineWithTwoCriteria}
+          products={[referenceProduct]}
+          readOnly={false}
+          onResponseChange={vi.fn()}
+        />
+      )
+
+      expect(evidenceState.getDocumentsForOwner).toHaveBeenCalledTimes(1)
+      expect(evidenceState.getDocumentsForOwner).toHaveBeenCalledWith(
+        "reference_product",
+        "product-1"
+      )
     })
 
     it("propagates archived read-only state into the reference evidence editor", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-evidence-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-evidence-cases.tsx
@@ -1,0 +1,132 @@
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, type Mock } from "vitest"
+
+import { TechnicalConfigurationReferenceComparison } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison"
+import { toTechnicalConfigurationReferenceProductDraft } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+import { baselineVersion, product, renderWithQueryClient } from "./reference-products-fixtures"
+
+type ReferenceEvidenceState = {
+  getDocumentsForOwner: Mock
+}
+
+type BaselineDocumentsMock = {
+  props: {
+    ownerType: string
+    ownerId: string
+    criterionId?: string | null
+    readOnly?: boolean
+  } | null
+}
+
+export function registerReferenceProductEvidenceTests({
+  evidenceState,
+  baselineDocumentsMock,
+}: {
+  evidenceState: ReferenceEvidenceState
+  baselineDocumentsMock: BaselineDocumentsMock
+}) {
+  describe("technical configuration reference evidence", () => {
+    it("shows an in-cell evidence indicator and opens a criterion detail panel", async () => {
+      const user = userEvent.setup()
+      const referenceProduct = toTechnicalConfigurationReferenceProductDraft(
+        product("product-1", "Model A")
+      )
+      evidenceState.getDocumentsForOwner.mockReturnValue([
+        {
+          id: "document-1",
+          owner_type: "reference_product",
+          owner_id: "product-1",
+          name: "Catalogue Model A",
+          url: "https://example.com/model-a.pdf",
+          citations: [
+            {
+              id: "citation-1",
+              criterion_id: "criterion-1",
+              page_section: "Mục 4.2",
+              excerpt: "Nguồn điện ổn định",
+            },
+          ],
+        },
+      ])
+
+      renderWithQueryClient(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={baselineVersion}
+          products={[referenceProduct]}
+          readOnly={false}
+          onResponseChange={() => undefined}
+        />
+      )
+
+      expect(
+        screen.queryByRole("columnheader", { name: /bằng chứng|tài liệu|trích dẫn/i })
+      ).not.toBeInTheDocument()
+      await user.click(
+        screen.getByRole("button", {
+          name: "Bằng chứng Model A cho TC-0001: 1 tài liệu, 1 trích dẫn",
+        })
+      )
+
+      expect(screen.getByRole("dialog")).toHaveTextContent("Model A · TC-0001")
+      expect(screen.getByTestId("reference-evidence-detail")).toHaveTextContent(
+        "reference_product:product-1:criterion-1"
+      )
+      expect(baselineDocumentsMock.props).toMatchObject({
+        ownerType: "reference_product",
+        ownerId: "product-1",
+        criterionId: "criterion-1",
+      })
+    })
+
+    it("propagates archived read-only state into the reference evidence editor", async () => {
+      const user = userEvent.setup()
+      const referenceProduct = toTechnicalConfigurationReferenceProductDraft(
+        product("product-1", "Model A")
+      )
+      evidenceState.getDocumentsForOwner.mockReturnValue([])
+
+      renderWithQueryClient(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={baselineVersion}
+          products={[referenceProduct]}
+          readOnly
+          onResponseChange={vi.fn()}
+        />
+      )
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Bằng chứng Model A cho TC-0001: 0 tài liệu, 0 trích dẫn",
+        })
+      )
+
+      expect(baselineDocumentsMock.props).toMatchObject({
+        ownerType: "reference_product",
+        ownerId: "product-1",
+        criterionId: "criterion-1",
+        readOnly: true,
+      })
+    })
+
+    it("does not offer evidence authoring for an unsaved reference product", () => {
+      const referenceProduct = {
+        ...toTechnicalConfigurationReferenceProductDraft(product("product-1", "Model A")),
+        persistedId: null,
+      }
+
+      renderWithQueryClient(
+        <TechnicalConfigurationReferenceComparison
+          baselineVersion={baselineVersion}
+          products={[referenceProduct]}
+          readOnly={false}
+          onResponseChange={() => undefined}
+        />
+      )
+
+      expect(
+        screen.queryByRole("button", { name: /Bằng chứng Model A cho TC-0001/i })
+      ).not.toBeInTheDocument()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
@@ -32,6 +32,8 @@ const baselineDocumentsMock = vi.hoisted(() => ({
     ownerId: string
     criterionId?: string | null
     readOnly?: boolean
+    onDirtyChange?: (dirty: boolean) => void
+    onNavigationBlockedChange?: (blocked: boolean) => void
   } | null,
 }))
 

--- a/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
@@ -1,7 +1,8 @@
-import { vi } from "vitest"
+import { beforeEach, vi } from "vitest"
 
 import { registerReferenceProductComparisonTests } from "./reference-products-comparison-cases"
 import { registerReferenceProductConflictTests } from "./reference-products-conflict-cases"
+import { registerReferenceProductEvidenceTests } from "./reference-products-evidence-cases"
 import { registerReferenceProductHookTests } from "./reference-products-hook-cases"
 import { registerReferenceProductOperationLockTests } from "./reference-products-operation-lock-cases"
 import { registerReferenceProductResilienceTests } from "./reference-products-resilience-cases"
@@ -20,6 +21,20 @@ const referenceRpc = vi.hoisted(() => ({
   upsertResponse: vi.fn(),
 }))
 
+const evidenceState = vi.hoisted(() => ({
+  documentsQuery: { isLoading: false },
+  getDocumentsForOwner: vi.fn(),
+}))
+
+const baselineDocumentsMock = vi.hoisted(() => ({
+  props: null as {
+    ownerType: string
+    ownerId: string
+    criterionId?: string | null
+    readOnly?: boolean
+  } | null,
+}))
+
 vi.mock("@/app/(app)/technical-configurations/technical-configuration-reference-rpc", () => ({
   listTechnicalConfigurationReferenceProducts: referenceRpc.listProducts,
   createTechnicalConfigurationReferenceProduct: referenceRpc.createProduct,
@@ -31,6 +46,26 @@ vi.mock("@/app/(app)/technical-configurations/technical-configuration-reference-
 vi.mock("@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline", () => ({
   useTechnicalConfigurationBaseline: () => baselineRpc,
 }))
+
+vi.mock("@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments", () => ({
+  useTechnicalConfigurationDocuments: () => evidenceState,
+}))
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments",
+  () => ({
+    TechnicalConfigurationBaselineDocuments: (
+      props: NonNullable<typeof baselineDocumentsMock.props>
+    ) => {
+      baselineDocumentsMock.props = props
+      return (
+        <div data-testid="reference-evidence-detail">
+          {props.ownerType}:{props.ownerId}:{props.criterionId}
+        </div>
+      )
+    },
+  })
+)
 
 vi.mock(
   "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab",
@@ -54,10 +89,17 @@ vi.mock(
   }
 )
 
+beforeEach(() => {
+  evidenceState.getDocumentsForOwner.mockReset()
+  evidenceState.getDocumentsForOwner.mockReturnValue([])
+  baselineDocumentsMock.props = null
+})
+
 registerReferenceProductHookTests(referenceRpc)
 registerReferenceProductOperationLockTests(referenceRpc)
 registerReferenceProductSaveResumeTests(referenceRpc)
 registerReferenceProductConflictTests(referenceRpc)
 registerReferenceProductComparisonTests()
+registerReferenceProductEvidenceTests({ evidenceState, baselineDocumentsMock })
 registerReferenceProductWorkspaceTests({ baselineRpc, referenceRpc })
 registerReferenceProductResilienceTests({ baselineRpc, referenceRpc })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -15,6 +15,11 @@ const baselineTabMock = vi.hoisted(() => ({
   navigationBlocked: false,
 }))
 
+const baselineEvidenceMock = vi.hoisted(() => ({
+  dirty: false,
+  navigationBlocked: false,
+}))
+
 vi.mock(
   "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab",
   async () => {
@@ -37,6 +42,29 @@ vi.mock(
           }
         }, [onDirtyChange, onNavigationBlockedChange])
         return <div>Baseline editor</div>
+      },
+    }
+  }
+)
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEvidence",
+  async () => {
+    const ReactModule = await import("react")
+
+    return {
+      TechnicalConfigurationBaselineEvidence: ({
+        onDirtyChange,
+        onNavigationBlockedChange,
+      }: {
+        onDirtyChange: (dirty: boolean) => void
+        onNavigationBlockedChange?: (blocked: boolean) => void
+      }) => {
+        ReactModule.useEffect(() => {
+          onDirtyChange(baselineEvidenceMock.dirty)
+          onNavigationBlockedChange?.(baselineEvidenceMock.navigationBlocked)
+        }, [onDirtyChange, onNavigationBlockedChange])
+        return <div>Baseline evidence workspace</div>
       },
     }
   }
@@ -94,12 +122,28 @@ describe("technical configuration baseline workspace integration", () => {
     }
   })
 
+  it("renders baseline evidence in a separate workspace tab", async () => {
+    const user = userEvent.setup()
+    baselineTabMock.dirty = false
+
+    try {
+      render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={vi.fn()} />)
+      await user.click(screen.getByRole("tab", { name: "Tài liệu & trích dẫn" }))
+
+      expect(screen.getByText("Baseline evidence workspace")).toBeInTheDocument()
+      expect(screen.queryByText("Baseline editor")).not.toBeInTheDocument()
+    } finally {
+      baselineTabMock.dirty = true
+    }
+  })
+
   it("keeps the shell thin and baseline responsibilities extracted before the threshold", () => {
     const moduleRoot = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
     const files = [
       "TechnicalConfigurationsClient.tsx",
       "_components/TechnicalConfigurationWorkspaceShell.tsx",
       "_components/TechnicalConfigurationBaselineTab.tsx",
+      "_components/TechnicalConfigurationBaselineEvidence.tsx",
       "_components/TechnicalConfigurationBaselineAlerts.tsx",
       "_components/TechnicalConfigurationBaselineTabStates.tsx",
       "_components/TechnicalConfigurationBaselineEditor.tsx",
@@ -124,6 +168,7 @@ describe("technical configuration baseline workspace integration", () => {
       "utf8"
     )
     expect(shellSource).toContain("TechnicalConfigurationBaselineTab")
+    expect(shellSource).toContain("TechnicalConfigurationBaselineEvidence")
     expect(shellSource).not.toContain("useQuery")
     expect(shellSource).not.toContain("useMutation")
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-pagination.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-pagination.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { collectStableTechnicalConfigurationPages } from "@/app/(app)/technical-configurations/technical-configuration-pagination"
+
+type PageItem = {
+  id: string
+}
+
+type Page = {
+  data: PageItem[]
+  total: number
+}
+
+const snapshotError = "Pagination snapshot changed during load."
+
+function page(ids: string[], total: number): Page {
+  return {
+    data: ids.map((id) => ({ id })),
+    total,
+  }
+}
+
+describe("collectStableTechnicalConfigurationPages", () => {
+  it.each([
+    {
+      caseName: "a page is empty before the reported total is reached",
+      pages: [page(["item-1"], 2), page([], 2)],
+    },
+    {
+      caseName: "an item overlaps between pages",
+      pages: [page(["item-1"], 2), page(["item-1"], 2)],
+    },
+    {
+      caseName: "a page pushes the aggregate past the reported total",
+      pages: [page(["item-1"], 2), page(["item-2", "item-3"], 2)],
+    },
+  ])("rejects the aggregate when $caseName", async ({ pages }) => {
+    const loadPage = vi.fn((pageNumber: number) => Promise.resolve(pages[pageNumber - 1]!))
+
+    await expect(
+      collectStableTechnicalConfigurationPages({
+        loadPage,
+        snapshotError,
+        getItemKey: (item) => item.id,
+      })
+    ).rejects.toThrow(snapshotError)
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-pagination.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-pagination.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from "vitest"
 
 import { collectStableTechnicalConfigurationPages } from "@/app/(app)/technical-configurations/technical-configuration-pagination"
 
-type PageItem = {
+interface PageItem {
   id: string
 }
 
-type Page = {
+interface Page {
   data: PageItem[]
   total: number
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import * as React from "react"
-import { AlertDialog, Button, ListBox, Select } from "@heroui/react"
+import { ListBox, Select } from "@heroui/react"
 
 import { TechnicalConfigurationCitationEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor"
+import { TechnicalConfigurationDocumentDeleteDialog } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentDeleteDialog"
 import { TechnicalConfigurationDocumentsHeader } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader"
 import { TechnicalConfigurationDocumentsQueryError } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError"
+import { useTechnicalConfigurationDocumentDraft } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft"
 import { useTechnicalConfigurationDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments"
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
@@ -18,7 +20,7 @@ import {
 
 export type TechnicalConfigurationEvidenceOwnerType = "baseline" | "reference_product"
 
-type TechnicalConfigurationBaselineDocumentsProps = {
+interface TechnicalConfigurationBaselineDocumentsProps {
   baselineVersion: TechnicalConfigurationBaselineDraftWire
   ownerType: TechnicalConfigurationEvidenceOwnerType
   ownerId: string
@@ -39,10 +41,7 @@ export function TechnicalConfigurationBaselineDocuments({
   onRevisionChange,
   onDirtyChange,
   onNavigationBlockedChange,
-}: Readonly<TechnicalConfigurationBaselineDocumentsProps>) {
-  const [name, setName] = React.useState("")
-  const [url, setUrl] = React.useState("")
-  const [selectedDocumentId, setSelectedDocumentId] = React.useState<string | null>(null)
+}: Readonly<TechnicalConfigurationBaselineDocumentsProps>): React.JSX.Element {
   const [citationDirty, setCitationDirty] = React.useState(false)
   const [pendingDeleteDocument, setPendingDeleteDocument] =
     React.useState<TechnicalConfigurationDocumentWire | null>(null)
@@ -54,8 +53,18 @@ export function TechnicalConfigurationBaselineDocuments({
     onNavigationBlockedChange,
   })
   const ownerDocuments = documentState.getDocumentsForOwner(ownerType, ownerId)
-  const selectedDocument =
-    ownerDocuments.find((document) => document.id === selectedDocumentId) ?? null
+  const {
+    name,
+    url,
+    selectedDocumentId,
+    selectedDocument,
+    selectedDocumentMissing,
+    documentDirty,
+    setName,
+    setUrl,
+    clearDraft,
+    selectDocument: adoptSelectedDocument,
+  } = useTechnicalConfigurationDocumentDraft(ownerDocuments)
   const hasInitialDocumentsError =
     documentState.documentsQuery.isError && documentState.documentsQuery.data === undefined
   const hasStaleDocuments =
@@ -77,21 +86,11 @@ export function TechnicalConfigurationBaselineDocuments({
     url && !isAllowedDocumentUrl(parsedUrl)
       ? "Chỉ chấp nhận đường dẫn HTTP hoặc HTTPS hợp lệ."
       : null
-  const documentDirty =
-    selectedDocument === null
-      ? Boolean(name || url)
-      : name !== selectedDocument.name || url !== selectedDocument.url
   const isDirty = documentDirty || citationDirty
 
   React.useEffect(() => {
     onDirtyChange?.(isDirty)
   }, [isDirty, onDirtyChange])
-
-  const clearDraft = React.useCallback(() => {
-    setSelectedDocumentId(null)
-    setName("")
-    setUrl("")
-  }, [])
 
   const confirmDocumentChange = React.useCallback(
     () =>
@@ -110,16 +109,14 @@ export function TechnicalConfigurationBaselineDocuments({
       if (documentId === selectedDocumentId || !confirmDocumentChange()) return
       const document = ownerDocuments.find((item) => item.id === documentId)
       if (!document) return
-      setSelectedDocumentId(document.id)
-      setName(document.name)
-      setUrl(document.url)
+      adoptSelectedDocument(document)
     },
-    [confirmDocumentChange, ownerDocuments, selectedDocumentId]
+    [adoptSelectedDocument, confirmDocumentChange, ownerDocuments, selectedDocumentId]
   )
 
   const handleSubmit = React.useCallback(async () => {
     const acceptedUrl = parseAbsoluteUrl(url)
-    if (!name || !isAllowedDocumentUrl(acceptedUrl)) return
+    if (selectedDocumentMissing || !name || !isAllowedDocumentUrl(acceptedUrl)) return
 
     try {
       if (selectedDocument) {
@@ -140,7 +137,16 @@ export function TechnicalConfigurationBaselineDocuments({
     } catch {
       // Mutation state owns the rendered error while the controlled draft stays intact.
     }
-  }, [clearDraft, documentState, name, ownerId, ownerType, selectedDocument, url])
+  }, [
+    clearDraft,
+    documentState,
+    name,
+    ownerId,
+    ownerType,
+    selectedDocument,
+    selectedDocumentMissing,
+    url,
+  ])
 
   const requestDelete = React.useCallback(
     (documentId: string) => {
@@ -168,7 +174,7 @@ export function TechnicalConfigurationBaselineDocuments({
     <TechnicalConfigurationDocumentsHeader
       ownerType={ownerType}
       isReadOnly={documentState.isReadOnly}
-      hasSelectedDocument={selectedDocument !== null}
+      hasSelectedDocument={selectedDocumentId !== null}
       isCreateDisabled={hasStaleDocuments}
       onCreateNew={resetDraft}
     />
@@ -225,6 +231,13 @@ export function TechnicalConfigurationBaselineDocuments({
         </Select>
       ) : null}
 
+      {selectedDocumentMissing ? (
+        <p role="alert" className="text-sm text-destructive">
+          Tài liệu đang chỉnh sửa không còn trong danh sách. Chọn tài liệu khác hoặc tạo tài liệu
+          mới.
+        </p>
+      ) : null}
+
       <UrlDocumentForm
         name={name}
         url={url}
@@ -232,9 +245,9 @@ export function TechnicalConfigurationBaselineDocuments({
         onUrlChange={setUrl}
         onSubmit={handleSubmit}
         isPending={documentState.isSaving}
-        disabled={controlsDisabled}
+        disabled={controlsDisabled || selectedDocumentMissing}
         validationError={validationError}
-        submitLabel={selectedDocument ? "Lưu thay đổi" : "Thêm tài liệu"}
+        submitLabel={selectedDocumentId ? "Lưu thay đổi" : "Thêm tài liệu"}
       />
 
       {documentState.mutationError ? (
@@ -263,62 +276,16 @@ export function TechnicalConfigurationBaselineDocuments({
         onDirtyChange={setCitationDirty}
       />
 
-      <AlertDialog
-        isOpen={pendingDeleteDocument !== null}
-        onOpenChange={(isOpen) => {
-          if (!isOpen && !documentState.isSaving) {
-            setDeleteError(null)
-            setPendingDeleteDocument(null)
-          }
+      <TechnicalConfigurationDocumentDeleteDialog
+        document={pendingDeleteDocument}
+        deleteError={deleteError}
+        isSaving={documentState.isSaving}
+        onDismiss={() => {
+          setDeleteError(null)
+          setPendingDeleteDocument(null)
         }}
-      >
-        <Button className="hidden" aria-hidden="true">
-          Mở xác nhận xóa
-        </Button>
-        <AlertDialog.Backdrop>
-          <AlertDialog.Container>
-            <AlertDialog.Dialog className="sm:max-w-md">
-              <AlertDialog.Header>
-                <AlertDialog.Icon status="danger" />
-                <AlertDialog.Heading>Xóa tài liệu?</AlertDialog.Heading>
-              </AlertDialog.Header>
-              <AlertDialog.Body>
-                <p>
-                  Tài liệu <strong>{pendingDeleteDocument?.name}</strong>
-                  {pendingDeleteDocument?.citations.length
-                    ? ` đang có ${pendingDeleteDocument.citations.length} trích dẫn liên kết.`
-                    : " chưa có trích dẫn liên kết."}{" "}
-                  Hành động này không thể hoàn tác.
-                </p>
-                {deleteError ? (
-                  <p role="alert" className="mt-3 text-sm text-destructive">
-                    Không thể xóa tài liệu. Vui lòng thử lại.
-                  </p>
-                ) : null}
-              </AlertDialog.Body>
-              <AlertDialog.Footer>
-                <Button
-                  variant="tertiary"
-                  isDisabled={documentState.isSaving}
-                  onPress={() => {
-                    setDeleteError(null)
-                    setPendingDeleteDocument(null)
-                  }}
-                >
-                  Hủy
-                </Button>
-                <Button
-                  variant="danger"
-                  isPending={documentState.isSaving}
-                  onPress={() => void confirmDelete()}
-                >
-                  Xóa tài liệu
-                </Button>
-              </AlertDialog.Footer>
-            </AlertDialog.Dialog>
-          </AlertDialog.Container>
-        </AlertDialog.Backdrop>
-      </AlertDialog>
+        onConfirm={() => void confirmDelete()}
+      />
     </section>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx
@@ -1,9 +1,11 @@
 "use client"
 
 import * as React from "react"
-import { AlertDialog, Button, Chip, ListBox, Select } from "@heroui/react"
+import { AlertDialog, Button, ListBox, Select } from "@heroui/react"
 
 import { TechnicalConfigurationCitationEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor"
+import { TechnicalConfigurationDocumentsHeader } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader"
+import { TechnicalConfigurationDocumentsQueryError } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError"
 import { useTechnicalConfigurationDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments"
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
@@ -54,6 +56,11 @@ export function TechnicalConfigurationBaselineDocuments({
   const ownerDocuments = documentState.getDocumentsForOwner(ownerType, ownerId)
   const selectedDocument =
     ownerDocuments.find((document) => document.id === selectedDocumentId) ?? null
+  const hasInitialDocumentsError =
+    documentState.documentsQuery.isError && documentState.documentsQuery.data === undefined
+  const hasStaleDocuments =
+    documentState.documentsQuery.isError && documentState.documentsQuery.data !== undefined
+  const controlsDisabled = documentState.isReadOnly || hasStaleDocuments
   const criteria = React.useMemo(
     () =>
       baselineVersion.groups.flatMap((group) =>
@@ -157,34 +164,47 @@ export function TechnicalConfigurationBaselineDocuments({
     }
   }, [clearDraft, documentState, pendingDeleteDocument, selectedDocumentId])
 
+  const header = (
+    <TechnicalConfigurationDocumentsHeader
+      ownerType={ownerType}
+      isReadOnly={documentState.isReadOnly}
+      hasSelectedDocument={selectedDocument !== null}
+      isCreateDisabled={hasStaleDocuments}
+      onCreateNew={resetDraft}
+    />
+  )
+
+  if (hasInitialDocumentsError) {
+    return (
+      <section aria-label="Tài liệu và trích dẫn" className="space-y-5">
+        {header}
+        <TechnicalConfigurationDocumentsQueryError
+          isInitialLoad
+          isRetrying={documentState.documentsQuery.isFetching}
+          onRetry={() => void documentState.documentsQuery.refetch()}
+        />
+      </section>
+    )
+  }
+
   return (
     <section aria-label="Tài liệu và trích dẫn" className="space-y-5">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-3">
-        <div className="min-w-0">
-          <h2 className="text-base font-semibold">Tài liệu và trích dẫn</h2>
-          <p className="text-sm text-muted-foreground">
-            {ownerType === "baseline"
-              ? "Bằng chứng áp dụng cho cấu hình cơ sở."
-              : "Bằng chứng của sản phẩm tham chiếu đang chọn."}
-          </p>
-        </div>
-        {documentState.isReadOnly ? (
-          <Chip color="warning" size="sm" variant="soft">
-            Chỉ đọc
-          </Chip>
-        ) : selectedDocument ? (
-          <Button size="sm" variant="tertiary" onPress={resetDraft}>
-            Tạo tài liệu mới
-          </Button>
-        ) : null}
-      </div>
+      {header}
+
+      {hasStaleDocuments ? (
+        <TechnicalConfigurationDocumentsQueryError
+          isInitialLoad={false}
+          isRetrying={documentState.documentsQuery.isFetching}
+          onRetry={() => void documentState.documentsQuery.refetch()}
+        />
+      ) : null}
 
       {ownerDocuments.length > 0 ? (
         <Select
           className="max-w-md"
           selectedKey={selectedDocumentId}
           onSelectionChange={(key) => selectDocument(String(key))}
-          isDisabled={documentState.isReadOnly || documentState.isSaving}
+          isDisabled={controlsDisabled || documentState.isSaving}
           placeholder="Chọn tài liệu"
           aria-label="Tài liệu đang chỉnh sửa"
         >
@@ -212,7 +232,7 @@ export function TechnicalConfigurationBaselineDocuments({
         onUrlChange={setUrl}
         onSubmit={handleSubmit}
         isPending={documentState.isSaving}
-        disabled={documentState.isReadOnly}
+        disabled={controlsDisabled}
         validationError={validationError}
         submitLabel={selectedDocument ? "Lưu thay đổi" : "Thêm tài liệu"}
       />
@@ -228,8 +248,8 @@ export function TechnicalConfigurationBaselineDocuments({
       <UrlDocumentList
         items={ownerDocuments}
         isLoading={documentState.documentsQuery.isLoading}
-        onDelete={documentState.isReadOnly ? undefined : requestDelete}
-        disabled={documentState.isSaving}
+        onDelete={controlsDisabled ? undefined : requestDelete}
+        disabled={documentState.isSaving || hasStaleDocuments}
       />
 
       <TechnicalConfigurationCitationEditor
@@ -237,7 +257,7 @@ export function TechnicalConfigurationBaselineDocuments({
         criteria={criteria}
         fixedCriterionId={criterionId}
         isPending={documentState.isSaving}
-        disabled={documentState.isReadOnly}
+        disabled={controlsDisabled}
         onSave={documentState.upsertCitation}
         onDelete={documentState.deleteCitation}
         onDirtyChange={setCitationDirty}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx
@@ -1,0 +1,304 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog, Button, Chip, ListBox, Select } from "@heroui/react"
+
+import { TechnicalConfigurationCitationEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor"
+import { useTechnicalConfigurationDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+import { UrlDocumentForm } from "@/components/url-documents/UrlDocumentForm"
+import { UrlDocumentList } from "@/components/url-documents/UrlDocumentList"
+import {
+  isAllowedDocumentUrl,
+  parseAbsoluteUrl,
+} from "@/components/url-documents/url-document-utils"
+
+export type TechnicalConfigurationEvidenceOwnerType = "baseline" | "reference_product"
+
+type TechnicalConfigurationBaselineDocumentsProps = {
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  ownerType: TechnicalConfigurationEvidenceOwnerType
+  ownerId: string
+  criterionId?: string | null
+  readOnly?: boolean
+  onRevisionChange?: (revision: number) => void
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+/** Renders evidence-document controls for one baseline or reference-product owner. */
+export function TechnicalConfigurationBaselineDocuments({
+  baselineVersion,
+  ownerType,
+  ownerId,
+  criterionId = null,
+  readOnly = false,
+  onRevisionChange,
+  onDirtyChange,
+  onNavigationBlockedChange,
+}: Readonly<TechnicalConfigurationBaselineDocumentsProps>) {
+  const [name, setName] = React.useState("")
+  const [url, setUrl] = React.useState("")
+  const [selectedDocumentId, setSelectedDocumentId] = React.useState<string | null>(null)
+  const [citationDirty, setCitationDirty] = React.useState(false)
+  const [pendingDeleteDocument, setPendingDeleteDocument] =
+    React.useState<TechnicalConfigurationDocumentWire | null>(null)
+  const [deleteError, setDeleteError] = React.useState<unknown>(null)
+  const documentState = useTechnicalConfigurationDocuments({
+    baselineVersion,
+    readOnly,
+    onRevisionChange,
+    onNavigationBlockedChange,
+  })
+  const ownerDocuments = documentState.getDocumentsForOwner(ownerType, ownerId)
+  const selectedDocument =
+    ownerDocuments.find((document) => document.id === selectedDocumentId) ?? null
+  const criteria = React.useMemo(
+    () =>
+      baselineVersion.groups.flatMap((group) =>
+        group.criteria.map((criterion) => ({
+          id: criterion.id,
+          criterionCode: criterion.criterion_code,
+          title: criterion.title ?? criterion.requirement_text,
+        }))
+      ),
+    [baselineVersion.groups]
+  )
+  const parsedUrl = parseAbsoluteUrl(url)
+  const validationError =
+    url && !isAllowedDocumentUrl(parsedUrl)
+      ? "Chỉ chấp nhận đường dẫn HTTP hoặc HTTPS hợp lệ."
+      : null
+  const documentDirty =
+    selectedDocument === null
+      ? Boolean(name || url)
+      : name !== selectedDocument.name || url !== selectedDocument.url
+  const isDirty = documentDirty || citationDirty
+
+  React.useEffect(() => {
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
+
+  const clearDraft = React.useCallback(() => {
+    setSelectedDocumentId(null)
+    setName("")
+    setUrl("")
+  }, [])
+
+  const confirmDocumentChange = React.useCallback(
+    () =>
+      !documentDirty ||
+      window.confirm("Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?"),
+    [documentDirty]
+  )
+
+  const resetDraft = React.useCallback(() => {
+    if (!confirmDocumentChange()) return
+    clearDraft()
+  }, [clearDraft, confirmDocumentChange])
+
+  const selectDocument = React.useCallback(
+    (documentId: string) => {
+      if (documentId === selectedDocumentId || !confirmDocumentChange()) return
+      const document = ownerDocuments.find((item) => item.id === documentId)
+      if (!document) return
+      setSelectedDocumentId(document.id)
+      setName(document.name)
+      setUrl(document.url)
+    },
+    [confirmDocumentChange, ownerDocuments, selectedDocumentId]
+  )
+
+  const handleSubmit = React.useCallback(async () => {
+    const acceptedUrl = parseAbsoluteUrl(url)
+    if (!name || !isAllowedDocumentUrl(acceptedUrl)) return
+
+    try {
+      if (selectedDocument) {
+        await documentState.updateDocument({
+          document: selectedDocument,
+          name,
+          url,
+        })
+      } else {
+        await documentState.createDocument({
+          ownerType,
+          ownerId,
+          name,
+          url,
+        })
+      }
+      clearDraft()
+    } catch {
+      // Mutation state owns the rendered error while the controlled draft stays intact.
+    }
+  }, [clearDraft, documentState, name, ownerId, ownerType, selectedDocument, url])
+
+  const requestDelete = React.useCallback(
+    (documentId: string) => {
+      const document = ownerDocuments.find((item) => item.id === documentId)
+      if (!document || documentState.isReadOnly) return
+      setDeleteError(null)
+      setPendingDeleteDocument(document)
+    },
+    [documentState.isReadOnly, ownerDocuments]
+  )
+
+  const confirmDelete = React.useCallback(async () => {
+    if (!pendingDeleteDocument || documentState.isReadOnly) return
+    setDeleteError(null)
+    try {
+      await documentState.deleteDocument(pendingDeleteDocument)
+      if (selectedDocumentId === pendingDeleteDocument.id) clearDraft()
+      setPendingDeleteDocument(null)
+    } catch (error) {
+      setDeleteError(error)
+    }
+  }, [clearDraft, documentState, pendingDeleteDocument, selectedDocumentId])
+
+  return (
+    <section aria-label="Tài liệu và trích dẫn" className="space-y-5">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold">Tài liệu và trích dẫn</h2>
+          <p className="text-sm text-muted-foreground">
+            {ownerType === "baseline"
+              ? "Bằng chứng áp dụng cho cấu hình cơ sở."
+              : "Bằng chứng của sản phẩm tham chiếu đang chọn."}
+          </p>
+        </div>
+        {documentState.isReadOnly ? (
+          <Chip color="warning" size="sm" variant="soft">
+            Chỉ đọc
+          </Chip>
+        ) : selectedDocument ? (
+          <Button size="sm" variant="tertiary" onPress={resetDraft}>
+            Tạo tài liệu mới
+          </Button>
+        ) : null}
+      </div>
+
+      {ownerDocuments.length > 0 ? (
+        <Select
+          className="max-w-md"
+          selectedKey={selectedDocumentId}
+          onSelectionChange={(key) => selectDocument(String(key))}
+          isDisabled={documentState.isReadOnly || documentState.isSaving}
+          placeholder="Chọn tài liệu"
+          aria-label="Tài liệu đang chỉnh sửa"
+        >
+          <Select.Trigger>
+            <Select.Value />
+            <Select.Indicator />
+          </Select.Trigger>
+          <Select.Popover>
+            <ListBox>
+              {ownerDocuments.map((document) => (
+                <ListBox.Item key={document.id} id={document.id} textValue={document.name}>
+                  {document.name}
+                  <ListBox.ItemIndicator />
+                </ListBox.Item>
+              ))}
+            </ListBox>
+          </Select.Popover>
+        </Select>
+      ) : null}
+
+      <UrlDocumentForm
+        name={name}
+        url={url}
+        onNameChange={setName}
+        onUrlChange={setUrl}
+        onSubmit={handleSubmit}
+        isPending={documentState.isSaving}
+        disabled={documentState.isReadOnly}
+        validationError={validationError}
+        submitLabel={selectedDocument ? "Lưu thay đổi" : "Thêm tài liệu"}
+      />
+
+      {documentState.mutationError ? (
+        <p role="alert" className="text-sm text-destructive">
+          {documentState.isConflict
+            ? "Phiên bản đã thay đổi trên máy chủ. Nội dung đang nhập được giữ lại để thử lại."
+            : "Không thể lưu thay đổi tài liệu. Vui lòng thử lại."}
+        </p>
+      ) : null}
+
+      <UrlDocumentList
+        items={ownerDocuments}
+        isLoading={documentState.documentsQuery.isLoading}
+        onDelete={documentState.isReadOnly ? undefined : requestDelete}
+        disabled={documentState.isSaving}
+      />
+
+      <TechnicalConfigurationCitationEditor
+        documents={ownerDocuments}
+        criteria={criteria}
+        fixedCriterionId={criterionId}
+        isPending={documentState.isSaving}
+        disabled={documentState.isReadOnly}
+        onSave={documentState.upsertCitation}
+        onDelete={documentState.deleteCitation}
+        onDirtyChange={setCitationDirty}
+      />
+
+      <AlertDialog
+        isOpen={pendingDeleteDocument !== null}
+        onOpenChange={(isOpen) => {
+          if (!isOpen && !documentState.isSaving) {
+            setDeleteError(null)
+            setPendingDeleteDocument(null)
+          }
+        }}
+      >
+        <Button className="hidden" aria-hidden="true">
+          Mở xác nhận xóa
+        </Button>
+        <AlertDialog.Backdrop>
+          <AlertDialog.Container>
+            <AlertDialog.Dialog className="sm:max-w-md">
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="danger" />
+                <AlertDialog.Heading>Xóa tài liệu?</AlertDialog.Heading>
+              </AlertDialog.Header>
+              <AlertDialog.Body>
+                <p>
+                  Tài liệu <strong>{pendingDeleteDocument?.name}</strong>
+                  {pendingDeleteDocument?.citations.length
+                    ? ` đang có ${pendingDeleteDocument.citations.length} trích dẫn liên kết.`
+                    : " chưa có trích dẫn liên kết."}{" "}
+                  Hành động này không thể hoàn tác.
+                </p>
+                {deleteError ? (
+                  <p role="alert" className="mt-3 text-sm text-destructive">
+                    Không thể xóa tài liệu. Vui lòng thử lại.
+                  </p>
+                ) : null}
+              </AlertDialog.Body>
+              <AlertDialog.Footer>
+                <Button
+                  variant="tertiary"
+                  isDisabled={documentState.isSaving}
+                  onPress={() => {
+                    setDeleteError(null)
+                    setPendingDeleteDocument(null)
+                  }}
+                >
+                  Hủy
+                </Button>
+                <Button
+                  variant="danger"
+                  isPending={documentState.isSaving}
+                  onPress={() => void confirmDelete()}
+                >
+                  Xóa tài liệu
+                </Button>
+              </AlertDialog.Footer>
+            </AlertDialog.Dialog>
+          </AlertDialog.Container>
+        </AlertDialog.Backdrop>
+      </AlertDialog>
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEvidence.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEvidence.tsx
@@ -1,0 +1,93 @@
+import * as React from "react"
+import { AlertCircle, Loader2, RefreshCw } from "lucide-react"
+
+import { TechnicalConfigurationBaselineDocuments } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments"
+import { useTechnicalConfigurationBaselineVersionSelection } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersionSelection"
+import { useTechnicalConfigurationBeforeUnloadGuard } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard"
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+
+type TechnicalConfigurationBaselineEvidenceProps = {
+  dossier: TechnicalConfigurationDossierWire
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+/** Loads the current baseline version and composes its evidence workspace outside the editor. */
+export function TechnicalConfigurationBaselineEvidence({
+  dossier,
+  onDirtyChange,
+  onNavigationBlockedChange,
+}: Readonly<TechnicalConfigurationBaselineEvidenceProps>) {
+  const [isDirty, setIsDirty] = React.useState(false)
+  const selection = useTechnicalConfigurationBaselineVersionSelection(dossier.id)
+  const {
+    handleRevisionChange,
+    selectedVersion: baselineVersion,
+    synchronizeVersion,
+    versionState,
+  } = selection
+
+  React.useEffect(() => {
+    synchronizeVersion(isDirty)
+  }, [isDirty, synchronizeVersion])
+
+  React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+  useTechnicalConfigurationBeforeUnloadGuard(isDirty)
+
+  const handleDirtyChange = React.useCallback(
+    (dirty: boolean) => {
+      setIsDirty(dirty)
+      onDirtyChange?.(dirty)
+    },
+    [onDirtyChange]
+  )
+
+  if (versionState.versionsQuery.isLoading) {
+    return (
+      <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        Đang tải phiên bản cấu hình...
+      </div>
+    )
+  }
+
+  if (versionState.versionsQuery.isError && versionState.versions.length === 0) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="size-4" aria-hidden="true" />
+        <AlertTitle>Không thể tải phiên bản cấu hình</AlertTitle>
+        <AlertDescription>
+          <Button type="button" variant="outline" size="sm" onClick={versionState.retryVersions}>
+            <RefreshCw className="size-4" aria-hidden="true" />
+            Thử lại
+          </Button>
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (!baselineVersion) {
+    return (
+      <Alert>
+        <AlertTitle>Chưa có cấu hình cơ sở</AlertTitle>
+        <AlertDescription>
+          Tạo cấu hình cơ sở trước khi bổ sung tài liệu và trích dẫn.
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  return (
+    <TechnicalConfigurationBaselineDocuments
+      baselineVersion={baselineVersion}
+      ownerType="baseline"
+      ownerId={baselineVersion.id}
+      readOnly={Boolean(dossier.archived_at)}
+      onRevisionChange={handleRevisionChange}
+      onDirtyChange={handleDirtyChange}
+      onNavigationBlockedChange={onNavigationBlockedChange}
+    />
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEvidence.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineEvidence.tsx
@@ -19,7 +19,7 @@ export function TechnicalConfigurationBaselineEvidence({
   dossier,
   onDirtyChange,
   onNavigationBlockedChange,
-}: Readonly<TechnicalConfigurationBaselineEvidenceProps>) {
+}: Readonly<TechnicalConfigurationBaselineEvidenceProps>): React.JSX.Element {
   const [isDirty, setIsDirty] = React.useState(false)
   const selection = useTechnicalConfigurationBaselineVersionSelection(dossier.id)
   const {

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import { useTechnicalConfigurationBaselineEditor } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineEditor"
 import { useTechnicalConfigurationBaselineImport } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImport"
+import { useTechnicalConfigurationBeforeUnloadGuard } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard"
 import { useTechnicalConfigurationBulkEntrySessions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
 import { useTechnicalConfigurationInlineEditor } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationInlineEditor"
 import { validateTechnicalConfigurationBaselineEditorDraft } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
@@ -102,15 +103,7 @@ export function TechnicalConfigurationBaselineTab({
     return () => reportWorkspaceState(false, false)
   }, [baselineImport.isApplying, isUnsafeToLeave, reportWorkspaceState])
 
-  React.useEffect(() => {
-    if (!isUnsafeToLeave) return
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      event.preventDefault()
-      event.returnValue = ""
-    }
-    window.addEventListener("beforeunload", handleBeforeUnload)
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload)
-  }, [isUnsafeToLeave])
+  useTechnicalConfigurationBeforeUnloadGuard(isUnsafeToLeave)
 
   const handleReloadFromServer = async () => {
     if (bulkSessions.hasPendingInput || baselineImport.hasUnresolvedState) return

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
@@ -1,0 +1,306 @@
+"use client"
+
+import * as React from "react"
+import { Button, Chip, Input, Label, ListBox, Select, TextArea, TextField } from "@heroui/react"
+
+import {
+  getTechnicalConfigurationCitationValues,
+  type TechnicalConfigurationCitationSelectionSnapshot,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState"
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+import { isTechnicalConfigurationBaselineConflict } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
+
+export type TechnicalConfigurationCitationCriterion = {
+  id: string
+  criterionCode: string
+  title: string
+}
+
+export type TechnicalConfigurationCitationSaveInput = {
+  document: TechnicalConfigurationDocumentWire
+  criterionId: string
+  pageSection: string | null
+  excerpt: string | null
+}
+
+type TechnicalConfigurationCitationEditorProps = {
+  documents: readonly TechnicalConfigurationDocumentWire[]
+  criteria: readonly TechnicalConfigurationCitationCriterion[]
+  fixedCriterionId?: string | null
+  isPending: boolean
+  disabled: boolean
+  onSave: (input: TechnicalConfigurationCitationSaveInput) => Promise<unknown>
+  onDelete: (input: {
+    document: TechnicalConfigurationDocumentWire
+    citationId: string
+  }) => Promise<unknown>
+  onDirtyChange?: (dirty: boolean) => void
+}
+
+/** Renders controlled criterion-level citation fields with explicit persistence. */
+export function TechnicalConfigurationCitationEditor({
+  documents,
+  criteria,
+  fixedCriterionId = null,
+  isPending,
+  disabled,
+  onSave,
+  onDelete,
+  onDirtyChange,
+}: Readonly<TechnicalConfigurationCitationEditorProps>) {
+  const initialDocumentId = documents[0]?.id ?? null
+  const initialCriterionId = fixedCriterionId ?? criteria[0]?.id ?? null
+  const initialDocument = documents.find((document) => document.id === initialDocumentId) ?? null
+  const initialValues = getTechnicalConfigurationCitationValues(initialDocument, initialCriterionId)
+  const [selectedDocumentId, setSelectedDocumentId] = React.useState<string | null>(
+    initialDocumentId
+  )
+  const [selectedCriterionId, setSelectedCriterionId] = React.useState<string | null>(
+    initialCriterionId
+  )
+  const [pageSection, setPageSection] = React.useState(initialValues.pageSection)
+  const [excerpt, setExcerpt] = React.useState(initialValues.excerpt)
+  const [baseValues, setBaseValues] = React.useState(initialValues)
+  const [saveError, setSaveError] = React.useState<unknown>(null)
+  const observedSelectionRef = React.useRef<TechnicalConfigurationCitationSelectionSnapshot>({
+    documentId: initialDocumentId,
+    criterionId: initialCriterionId,
+    ...initialValues,
+  })
+  const selectedDocument = documents.find((document) => document.id === selectedDocumentId) ?? null
+  const selectedCriterion =
+    criteria.find((criterion) => criterion.id === selectedCriterionId) ?? null
+  const selectedCitation = selectedDocument?.citations.find(
+    (citation) => citation.criterion_id === selectedCriterionId
+  )
+  const isDirty = pageSection !== baseValues.pageSection || excerpt !== baseValues.excerpt
+  const canSave =
+    !disabled && !isPending && selectedDocument !== null && selectedCriterionId !== null && isDirty
+
+  React.useEffect(() => {
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
+
+  const adoptSelection = React.useCallback(
+    (documentId: string | null, criterionId: string | null) => {
+      const document = documents.find((item) => item.id === documentId) ?? null
+      const values = getTechnicalConfigurationCitationValues(document, criterionId)
+      observedSelectionRef.current = { documentId, criterionId, ...values }
+      setSelectedDocumentId(documentId)
+      setSelectedCriterionId(criterionId)
+      setPageSection(values.pageSection)
+      setExcerpt(values.excerpt)
+      setBaseValues(values)
+      setSaveError(null)
+    },
+    [documents]
+  )
+
+  React.useEffect(() => {
+    const documentId = selectedDocument?.id ?? documents[0]?.id ?? null
+    const criterionId = fixedCriterionId ?? selectedCriterion?.id ?? criteria[0]?.id ?? null
+    const document = documents.find((item) => item.id === documentId) ?? null
+    const values = getTechnicalConfigurationCitationValues(document, criterionId)
+    const observed = observedSelectionRef.current
+    const serverSelectionChanged =
+      observed.documentId !== documentId ||
+      observed.criterionId !== criterionId ||
+      observed.pageSection !== values.pageSection ||
+      observed.excerpt !== values.excerpt
+
+    if (!serverSelectionChanged || isDirty) return
+    adoptSelection(documentId, criterionId)
+  }, [
+    adoptSelection,
+    criteria,
+    documents,
+    fixedCriterionId,
+    isDirty,
+    selectedCriterion,
+    selectedDocument,
+  ])
+
+  const requestSelection = React.useCallback(
+    (documentId: string | null, criterionId: string | null) => {
+      if (documentId === selectedDocumentId && criterionId === selectedCriterionId) {
+        return
+      }
+      if (
+        isDirty &&
+        !window.confirm("Chuyển lựa chọn sẽ bỏ nội dung trích dẫn chưa lưu. Tiếp tục?")
+      ) {
+        return
+      }
+      adoptSelection(documentId, criterionId)
+    },
+    [adoptSelection, isDirty, selectedCriterionId, selectedDocumentId]
+  )
+
+  const handleSave = React.useCallback(async () => {
+    if (!canSave || !selectedDocument || !selectedCriterionId) return
+    setSaveError(null)
+    try {
+      await onSave({
+        document: selectedDocument,
+        criterionId: selectedCriterionId,
+        pageSection: pageSection || null,
+        excerpt: excerpt || null,
+      })
+      setBaseValues({ pageSection, excerpt })
+    } catch (error) {
+      setSaveError(error)
+    }
+  }, [canSave, excerpt, onSave, pageSection, selectedCriterionId, selectedDocument])
+
+  const handleDelete = React.useCallback(async () => {
+    if (disabled || isPending || !selectedDocument || !selectedCitation) return
+    setSaveError(null)
+    try {
+      await onDelete({
+        document: selectedDocument,
+        citationId: selectedCitation.id,
+      })
+      const emptyValues = { pageSection: "", excerpt: "" }
+      observedSelectionRef.current = {
+        documentId: selectedDocument.id,
+        criterionId: selectedCriterionId,
+        ...emptyValues,
+      }
+      setPageSection("")
+      setExcerpt("")
+      setBaseValues(emptyValues)
+    } catch (error) {
+      setSaveError(error)
+    }
+  }, [disabled, isPending, onDelete, selectedCitation, selectedCriterionId, selectedDocument])
+
+  if (documents.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Thêm ít nhất một tài liệu trước khi tạo trích dẫn.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-4 border-t pt-4">
+      <div className="flex flex-wrap items-end gap-3">
+        {documents.length === 1 ? (
+          <div className="space-y-1">
+            <p className="text-sm font-medium">Tài liệu</p>
+            <Chip size="sm" variant="soft">
+              {selectedDocument?.name}
+            </Chip>
+          </div>
+        ) : (
+          <Select
+            className="min-w-56 flex-1"
+            selectedKey={selectedDocument?.id ?? null}
+            onSelectionChange={(key) =>
+              requestSelection(key === null ? null : String(key), selectedCriterionId)
+            }
+            isDisabled={disabled || isPending}
+            placeholder="Chọn tài liệu"
+          >
+            <Label>Tài liệu</Label>
+            <Select.Trigger>
+              <Select.Value />
+              <Select.Indicator />
+            </Select.Trigger>
+            <Select.Popover>
+              <ListBox>
+                {documents.map((document) => (
+                  <ListBox.Item key={document.id} id={document.id} textValue={document.name}>
+                    {document.name}
+                    <ListBox.ItemIndicator />
+                  </ListBox.Item>
+                ))}
+              </ListBox>
+            </Select.Popover>
+          </Select>
+        )}
+
+        {fixedCriterionId ? (
+          <div className="min-w-0 flex-1 space-y-1">
+            <p className="text-sm font-medium">Tiêu chí</p>
+            <p className="truncate text-sm text-muted-foreground">
+              {selectedCriterion
+                ? `${selectedCriterion.criterionCode} · ${selectedCriterion.title}`
+                : "Tiêu chí đang chọn"}
+            </p>
+          </div>
+        ) : (
+          <Select
+            className="min-w-56 flex-1"
+            selectedKey={selectedCriterion?.id ?? null}
+            onSelectionChange={(key) =>
+              requestSelection(selectedDocumentId, key === null ? null : String(key))
+            }
+            isDisabled={disabled || isPending}
+            placeholder="Chọn tiêu chí"
+          >
+            <Label>Tiêu chí</Label>
+            <Select.Trigger>
+              <Select.Value />
+              <Select.Indicator />
+            </Select.Trigger>
+            <Select.Popover>
+              <ListBox>
+                {criteria.map((criterion) => (
+                  <ListBox.Item
+                    key={criterion.id}
+                    id={criterion.id}
+                    textValue={`${criterion.criterionCode} ${criterion.title}`}
+                  >
+                    {criterion.criterionCode} · {criterion.title}
+                    <ListBox.ItemIndicator />
+                  </ListBox.Item>
+                ))}
+              </ListBox>
+            </Select.Popover>
+          </Select>
+        )}
+      </div>
+
+      <TextField value={pageSection} onChange={setPageSection} isDisabled={disabled || isPending}>
+        <Label>Trang hoặc mục</Label>
+        <Input placeholder="Ví dụ: Trang 12, Mục 4.2" />
+      </TextField>
+      <TextField value={excerpt} onChange={setExcerpt} isDisabled={disabled || isPending}>
+        <Label>Trích đoạn</Label>
+        <TextArea rows={5} placeholder="Nhập nguyên văn đoạn chứng minh cho tiêu chí." />
+      </TextField>
+
+      {selectedDocumentId !== null && selectedDocument === null ? (
+        <p role="alert" className="text-sm text-destructive">
+          Tài liệu đang chỉnh sửa không còn trong danh sách. Nội dung chưa lưu được giữ lại.
+        </p>
+      ) : null}
+
+      {saveError ? (
+        <p role="alert" className="text-sm text-destructive">
+          {isTechnicalConfigurationBaselineConflict(saveError)
+            ? "Phiên bản đã thay đổi trên máy chủ. Nội dung trích dẫn được giữ lại để thử lại."
+            : "Không thể lưu trích dẫn. Vui lòng thử lại."}
+        </p>
+      ) : null}
+
+      {!disabled ? (
+        <div className="flex flex-wrap justify-end gap-2">
+          {selectedCitation ? (
+            <Button
+              variant="danger-soft"
+              isDisabled={isPending}
+              onPress={() => void handleDelete()}
+            >
+              Xóa trích dẫn
+            </Button>
+          ) : null}
+          <Button isPending={isPending} isDisabled={!canSave} onPress={() => void handleSave()}>
+            Lưu trích dẫn
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
@@ -47,7 +47,7 @@ export function TechnicalConfigurationCitationEditor({
   onSave,
   onDelete,
   onDirtyChange,
-}: Readonly<TechnicalConfigurationCitationEditorProps>) {
+}: Readonly<TechnicalConfigurationCitationEditorProps>): React.JSX.Element {
   const initialDocumentId = documents[0]?.id ?? null
   const initialCriterionId = fixedCriterionId ?? criteria[0]?.id ?? null
   const initialDocument = documents.find((document) => document.id === initialDocumentId) ?? null
@@ -185,7 +185,7 @@ export function TechnicalConfigurationCitationEditor({
   return (
     <div className="space-y-4 border-t pt-4">
       <div className="flex flex-wrap items-end gap-3">
-        {documents.length === 1 ? (
+        {documents.length === 1 && selectedDocument ? (
           <div className="space-y-1">
             <p className="text-sm font-medium">Tài liệu</p>
             <Chip size="sm" variant="soft">

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState.ts
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState.ts
@@ -1,0 +1,24 @@
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+
+export type TechnicalConfigurationCitationValues = {
+  pageSection: string
+  excerpt: string
+}
+
+export type TechnicalConfigurationCitationSelectionSnapshot =
+  TechnicalConfigurationCitationValues & {
+    documentId: string | null
+    criterionId: string | null
+  }
+
+/** Reads editable citation values for one exact document and criterion. */
+export function getTechnicalConfigurationCitationValues(
+  document: TechnicalConfigurationDocumentWire | null,
+  criterionId: string | null
+): TechnicalConfigurationCitationValues {
+  const citation = document?.citations.find((item) => item.criterion_id === criterionId)
+  return {
+    pageSection: citation?.page_section ?? "",
+    excerpt: citation?.excerpt ?? "",
+  }
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentDeleteDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentDeleteDialog.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { AlertDialog, Button } from "@heroui/react"
+
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+
+interface TechnicalConfigurationDocumentDeleteDialogProps {
+  document: TechnicalConfigurationDocumentWire | null
+  deleteError: unknown
+  isSaving: boolean
+  onDismiss: () => void
+  onConfirm: () => void
+}
+
+/** Confirms destructive evidence-document deletion and keeps mutation failures in context. */
+export function TechnicalConfigurationDocumentDeleteDialog({
+  document,
+  deleteError,
+  isSaving,
+  onDismiss,
+  onConfirm,
+}: Readonly<TechnicalConfigurationDocumentDeleteDialogProps>): React.JSX.Element {
+  return (
+    <AlertDialog
+      isOpen={document !== null}
+      onOpenChange={(isOpen) => {
+        if (!isOpen && !isSaving) onDismiss()
+      }}
+    >
+      <Button className="hidden" aria-hidden="true">
+        Mở xác nhận xóa
+      </Button>
+      <AlertDialog.Backdrop>
+        <AlertDialog.Container>
+          <AlertDialog.Dialog className="sm:max-w-md">
+            <AlertDialog.Header>
+              <AlertDialog.Icon status="danger" />
+              <AlertDialog.Heading>Xóa tài liệu?</AlertDialog.Heading>
+            </AlertDialog.Header>
+            <AlertDialog.Body>
+              <p>
+                Tài liệu <strong>{document?.name}</strong>
+                {document?.citations.length
+                  ? ` đang có ${document.citations.length} trích dẫn liên kết.`
+                  : " chưa có trích dẫn liên kết."}{" "}
+                Hành động này không thể hoàn tác.
+              </p>
+              {deleteError ? (
+                <p role="alert" className="mt-3 text-sm text-destructive">
+                  Không thể xóa tài liệu. Vui lòng thử lại.
+                </p>
+              ) : null}
+            </AlertDialog.Body>
+            <AlertDialog.Footer>
+              <Button variant="tertiary" isDisabled={isSaving} onPress={onDismiss}>
+                Hủy
+              </Button>
+              <Button variant="danger" isPending={isSaving} onPress={onConfirm}>
+                Xóa tài liệu
+              </Button>
+            </AlertDialog.Footer>
+          </AlertDialog.Dialog>
+        </AlertDialog.Container>
+      </AlertDialog.Backdrop>
+    </AlertDialog>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader.tsx
@@ -4,7 +4,7 @@ import { Button, Chip } from "@heroui/react"
 
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
 
-type TechnicalConfigurationDocumentsHeaderProps = {
+interface TechnicalConfigurationDocumentsHeaderProps {
   ownerType: TechnicalConfigurationDocumentWire["owner_type"]
   isReadOnly: boolean
   hasSelectedDocument: boolean

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { Button, Chip } from "@heroui/react"
+
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+
+type TechnicalConfigurationDocumentsHeaderProps = {
+  ownerType: TechnicalConfigurationDocumentWire["owner_type"]
+  isReadOnly: boolean
+  hasSelectedDocument: boolean
+  isCreateDisabled: boolean
+  onCreateNew: () => void
+}
+
+/** Renders the evidence-document section heading and owner-level actions. */
+export function TechnicalConfigurationDocumentsHeader({
+  ownerType,
+  isReadOnly,
+  hasSelectedDocument,
+  isCreateDisabled,
+  onCreateNew,
+}: TechnicalConfigurationDocumentsHeaderProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-3">
+      <div className="min-w-0">
+        <h2 className="text-base font-semibold">Tài liệu và trích dẫn</h2>
+        <p className="text-sm text-muted-foreground">
+          {ownerType === "baseline"
+            ? "Bằng chứng áp dụng cho cấu hình cơ sở."
+            : "Bằng chứng của sản phẩm tham chiếu đang chọn."}
+        </p>
+      </div>
+      {isReadOnly ? (
+        <Chip color="warning" size="sm" variant="soft">
+          Chỉ đọc
+        </Chip>
+      ) : hasSelectedDocument ? (
+        <Button size="sm" variant="tertiary" isDisabled={isCreateDisabled} onPress={onCreateNew}>
+          Tạo tài liệu mới
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@heroui/react"
 
-type TechnicalConfigurationDocumentsQueryErrorProps = {
+interface TechnicalConfigurationDocumentsQueryErrorProps {
   isInitialLoad: boolean
   isRetrying: boolean
   onRetry: () => void

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { Button } from "@heroui/react"
+
+type TechnicalConfigurationDocumentsQueryErrorProps = {
+  isInitialLoad: boolean
+  isRetrying: boolean
+  onRetry: () => void
+}
+
+/** Renders a blocking retry state when evidence documents cannot be refreshed. */
+export function TechnicalConfigurationDocumentsQueryError({
+  isInitialLoad,
+  isRetrying,
+  onRetry,
+}: TechnicalConfigurationDocumentsQueryErrorProps) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col gap-3 border border-destructive/30 bg-destructive/5 p-4 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-destructive">
+          {isInitialLoad
+            ? "Không thể tải tài liệu và trích dẫn."
+            : "Đã lưu thay đổi nhưng không thể làm mới danh sách."}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {isInitialLoad
+            ? "Dữ liệu hiện tại chưa được xác nhận. Hãy tải lại trước khi chỉnh sửa."
+            : "Danh sách đang hiển thị có thể đã cũ. Hãy tải lại trước khi tiếp tục chỉnh sửa."}
+        </p>
+      </div>
+      <Button size="sm" variant="secondary" isPending={isRetrying} onPress={onRetry}>
+        Thử lại
+      </Button>
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison.tsx
@@ -62,11 +62,20 @@ export function TechnicalConfigurationReferenceComparison({
     React.useState<TechnicalConfigurationReferenceFullTextDetail | null>(null)
   const [evidenceDetail, setEvidenceDetail] =
     React.useState<TechnicalConfigurationReferenceEvidenceDetail | null>(null)
+  const previousBaselineVersionIdRef = React.useRef(baselineVersion.id)
   const evidenceState = useTechnicalConfigurationDocuments({
     baselineVersion,
     onRevisionChange,
     onNavigationBlockedChange: onEvidenceNavigationBlockedChange,
   })
+  React.useEffect(() => {
+    if (previousBaselineVersionIdRef.current === baselineVersion.id) return
+    previousBaselineVersionIdRef.current = baselineVersion.id
+    setEvidenceDetail(null)
+    setFullTextDetail(null)
+    onEvidenceDirtyChange?.(false)
+    onEvidenceNavigationBlockedChange?.(false)
+  }, [baselineVersion.id, onEvidenceDirtyChange, onEvidenceNavigationBlockedChange])
   const reconciledColumnState = reconcileReferenceColumnState(
     columnState,
     baselineVersion.id,

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison.tsx
@@ -1,7 +1,14 @@
 import * as React from "react"
-import { ChevronLeft, ChevronRight, Maximize2 } from "lucide-react"
-
+import { ChevronLeft, ChevronRight } from "lucide-react"
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import {
+  TechnicalConfigurationReferenceComparisonTable,
+  type TechnicalConfigurationReferenceFullTextDetail,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonTable"
+import {
+  TechnicalConfigurationReferenceEvidenceDialog,
+  type TechnicalConfigurationReferenceEvidenceDetail,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence"
 import {
   clampReferenceProductPageIndex,
   getReferenceProductDisplayLabels,
@@ -9,6 +16,7 @@ import {
   REFERENCE_PRODUCT_PAGE_SIZE,
   type ReferenceColumnState,
 } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonUtils"
+import { useTechnicalConfigurationDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments"
 import {
   getTechnicalConfigurationReferenceProductName,
   type TechnicalConfigurationReferenceProductDraft,
@@ -23,18 +31,14 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
-
 type TechnicalConfigurationReferenceComparisonProps = {
   baselineVersion: TechnicalConfigurationBaselineDraftWire
   products: TechnicalConfigurationReferenceProductDraft[]
   readOnly: boolean
   onResponseChange: (productId: string, criterionId: string, responseText: string) => void
-}
-
-type FullTextDetail = {
-  title: string
-  text: string
+  onRevisionChange?: (revision: number) => void
+  onEvidenceDirtyChange?: (dirty: boolean) => void
+  onEvidenceNavigationBlockedChange?: (blocked: boolean) => void
 }
 
 /** Renders the baseline-first comparison matrix with user-selectable product columns. */
@@ -43,6 +47,9 @@ export function TechnicalConfigurationReferenceComparison({
   products,
   readOnly,
   onResponseChange,
+  onRevisionChange,
+  onEvidenceDirtyChange,
+  onEvidenceNavigationBlockedChange,
 }: Readonly<TechnicalConfigurationReferenceComparisonProps>) {
   const productIds = products.map((product) => product.id)
   const [columnState, setColumnState] = React.useState<ReferenceColumnState>(() => ({
@@ -51,7 +58,15 @@ export function TechnicalConfigurationReferenceComparison({
     hiddenProductIds: [],
     pageIndex: 0,
   }))
-  const [fullTextDetail, setFullTextDetail] = React.useState<FullTextDetail | null>(null)
+  const [fullTextDetail, setFullTextDetail] =
+    React.useState<TechnicalConfigurationReferenceFullTextDetail | null>(null)
+  const [evidenceDetail, setEvidenceDetail] =
+    React.useState<TechnicalConfigurationReferenceEvidenceDetail | null>(null)
+  const evidenceState = useTechnicalConfigurationDocuments({
+    baselineVersion,
+    onRevisionChange,
+    onNavigationBlockedChange: onEvidenceNavigationBlockedChange,
+  })
   const reconciledColumnState = reconcileReferenceColumnState(
     columnState,
     baselineVersion.id,
@@ -135,119 +150,17 @@ export function TechnicalConfigurationReferenceComparison({
         </div>
       </div>
 
-      <div
-        data-testid="reference-comparison-scroll"
-        className="w-full overflow-x-auto rounded-md border"
-      >
-        <table className="min-w-max border-separate border-spacing-0 text-left text-sm">
-          <thead>
-            <tr>
-              <th className="sticky left-0 z-30 w-[220px] min-w-[220px] border-b border-r bg-muted px-3 py-3 font-semibold">
-                Tiêu chí
-              </th>
-              <th className="sticky left-[220px] z-30 w-[360px] min-w-[360px] border-b border-r bg-muted px-3 py-3 font-semibold">
-                Yêu cầu cơ sở
-              </th>
-              {visibleProducts.map((product) => {
-                const productIndex = productIndexById.get(product.id) ?? 0
-                return (
-                  <th
-                    key={product.id}
-                    className="w-[320px] min-w-[320px] border-b border-r bg-muted px-3 py-3 font-semibold last:border-r-0"
-                  >
-                    {productLabelById.get(product.id) ??
-                      getTechnicalConfigurationReferenceProductName(product, productIndex)}
-                  </th>
-                )
-              })}
-            </tr>
-          </thead>
-          <tbody>
-            {baselineVersion.groups.map((group) => (
-              <React.Fragment key={group.id}>
-                <tr>
-                  <th
-                    colSpan={visibleProducts.length + 2}
-                    className="border-b bg-muted/40 px-3 py-2 font-semibold"
-                  >
-                    {group.name}
-                  </th>
-                </tr>
-                {group.criteria.map((criterion) => (
-                  <tr key={criterion.id} className="align-top">
-                    <th className="sticky left-0 z-20 border-b border-r bg-background px-3 py-3 font-medium">
-                      <span className="block text-xs text-muted-foreground">
-                        {criterion.criterion_code}
-                      </span>
-                      <span className="mt-1 block break-words">
-                        {criterion.title ?? "Chưa có tiêu đề"}
-                      </span>
-                    </th>
-                    <td className="sticky left-[220px] z-20 border-b border-r bg-background px-3 py-3">
-                      <p className="line-clamp-4 whitespace-pre-wrap break-words">
-                        {criterion.requirement_text}
-                      </p>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="mt-2 h-8 px-2"
-                        aria-label={`Xem đầy đủ yêu cầu ${criterion.criterion_code}`}
-                        onClick={() =>
-                          setFullTextDetail({
-                            title: `Yêu cầu ${criterion.criterion_code}`,
-                            text: criterion.requirement_text,
-                          })
-                        }
-                      >
-                        <Maximize2 className="size-4" aria-hidden="true" />
-                        Xem đầy đủ
-                      </Button>
-                    </td>
-                    {visibleProducts.map((product) => {
-                      const productIndex = productIndexById.get(product.id) ?? 0
-                      const productName =
-                        productLabelById.get(product.id) ??
-                        getTechnicalConfigurationReferenceProductName(product, productIndex)
-                      return (
-                        <td key={product.id} className="border-b border-r p-3 last:border-r-0">
-                          <Textarea
-                            value={product.responses[criterion.id] ?? ""}
-                            readOnly={readOnly}
-                            aria-label={`Phản hồi ${productName} cho ${criterion.criterion_code}`}
-                            className="min-h-[120px] resize-y whitespace-pre-wrap"
-                            onChange={(event) =>
-                              onResponseChange(product.id, criterion.id, event.target.value)
-                            }
-                          />
-                          {product.responses[criterion.id] ? (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="mt-2 h-8 px-2"
-                              aria-label={`Xem đầy đủ phản hồi ${productName} cho ${criterion.criterion_code}`}
-                              onClick={() =>
-                                setFullTextDetail({
-                                  title: `${productName} · ${criterion.criterion_code}`,
-                                  text: product.responses[criterion.id] ?? "",
-                                })
-                              }
-                            >
-                              <Maximize2 className="size-4" aria-hidden="true" />
-                              Xem đầy đủ
-                            </Button>
-                          ) : null}
-                        </td>
-                      )
-                    })}
-                  </tr>
-                ))}
-              </React.Fragment>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <TechnicalConfigurationReferenceComparisonTable
+        baselineVersion={baselineVersion}
+        visibleProducts={visibleProducts}
+        productIndexById={productIndexById}
+        productLabelById={productLabelById}
+        readOnly={readOnly}
+        evidenceState={evidenceState}
+        onResponseChange={onResponseChange}
+        onOpenFullText={setFullTextDetail}
+        onOpenEvidence={setEvidenceDetail}
+      />
 
       <div className="flex items-center justify-end gap-3">
         <Button
@@ -298,6 +211,15 @@ export function TechnicalConfigurationReferenceComparison({
           </DialogHeader>
         </DialogContent>
       </Dialog>
+      <TechnicalConfigurationReferenceEvidenceDialog
+        detail={evidenceDetail}
+        baselineVersion={baselineVersion}
+        readOnly={readOnly}
+        onClose={() => setEvidenceDetail(null)}
+        onRevisionChange={onRevisionChange}
+        onDirtyChange={onEvidenceDirtyChange}
+        onNavigationBlockedChange={onEvidenceNavigationBlockedChange}
+      />
     </section>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonTable.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonTable.tsx
@@ -1,0 +1,182 @@
+import * as React from "react"
+import { Maximize2 } from "lucide-react"
+
+import {
+  TechnicalConfigurationReferenceEvidenceIndicator,
+  type TechnicalConfigurationReferenceEvidenceDetail,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence"
+import type { useTechnicalConfigurationDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import {
+  getTechnicalConfigurationReferenceProductName,
+  type TechnicalConfigurationReferenceProductDraft,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+
+export type TechnicalConfigurationReferenceFullTextDetail = {
+  title: string
+  text: string
+}
+
+type TechnicalConfigurationReferenceComparisonTableProps = {
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  visibleProducts: TechnicalConfigurationReferenceProductDraft[]
+  productIndexById: ReadonlyMap<string, number>
+  productLabelById: ReadonlyMap<string, string>
+  readOnly: boolean
+  evidenceState: ReturnType<typeof useTechnicalConfigurationDocuments>
+  onResponseChange: (productId: string, criterionId: string, responseText: string) => void
+  onOpenFullText: (detail: TechnicalConfigurationReferenceFullTextDetail) => void
+  onOpenEvidence: (detail: TechnicalConfigurationReferenceEvidenceDetail) => void
+}
+
+/** Renders the sticky comparison matrix and its per-cell response and evidence controls. */
+export function TechnicalConfigurationReferenceComparisonTable({
+  baselineVersion,
+  visibleProducts,
+  productIndexById,
+  productLabelById,
+  readOnly,
+  evidenceState,
+  onResponseChange,
+  onOpenFullText,
+  onOpenEvidence,
+}: Readonly<TechnicalConfigurationReferenceComparisonTableProps>) {
+  return (
+    <div
+      data-testid="reference-comparison-scroll"
+      className="w-full overflow-x-auto rounded-md border"
+    >
+      <table className="min-w-max border-separate border-spacing-0 text-left text-sm">
+        <thead>
+          <tr>
+            <th className="sticky left-0 z-30 w-[220px] min-w-[220px] border-b border-r bg-muted px-3 py-3 font-semibold">
+              Tiêu chí
+            </th>
+            <th className="sticky left-[220px] z-30 w-[360px] min-w-[360px] border-b border-r bg-muted px-3 py-3 font-semibold">
+              Yêu cầu cơ sở
+            </th>
+            {visibleProducts.map((product) => {
+              const productIndex = productIndexById.get(product.id) ?? 0
+              return (
+                <th
+                  key={product.id}
+                  className="w-[320px] min-w-[320px] border-b border-r bg-muted px-3 py-3 font-semibold last:border-r-0"
+                >
+                  {productLabelById.get(product.id) ??
+                    getTechnicalConfigurationReferenceProductName(product, productIndex)}
+                </th>
+              )
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {baselineVersion.groups.map((group) => (
+            <React.Fragment key={group.id}>
+              <tr>
+                <th
+                  colSpan={visibleProducts.length + 2}
+                  className="border-b bg-muted/40 px-3 py-2 font-semibold"
+                >
+                  {group.name}
+                </th>
+              </tr>
+              {group.criteria.map((criterion) => (
+                <tr key={criterion.id} className="align-top">
+                  <th className="sticky left-0 z-20 border-b border-r bg-background px-3 py-3 font-medium">
+                    <span className="block text-xs text-muted-foreground">
+                      {criterion.criterion_code}
+                    </span>
+                    <span className="mt-1 block break-words">
+                      {criterion.title ?? "Chưa có tiêu đề"}
+                    </span>
+                  </th>
+                  <td className="sticky left-[220px] z-20 border-b border-r bg-background px-3 py-3">
+                    <p className="line-clamp-4 whitespace-pre-wrap break-words">
+                      {criterion.requirement_text}
+                    </p>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="mt-2 h-8 px-2"
+                      aria-label={`Xem đầy đủ yêu cầu ${criterion.criterion_code}`}
+                      onClick={() =>
+                        onOpenFullText({
+                          title: `Yêu cầu ${criterion.criterion_code}`,
+                          text: criterion.requirement_text,
+                        })
+                      }
+                    >
+                      <Maximize2 className="size-4" aria-hidden="true" />
+                      Xem đầy đủ
+                    </Button>
+                  </td>
+                  {visibleProducts.map((product) => {
+                    const productIndex = productIndexById.get(product.id) ?? 0
+                    const ownerId = product.persistedId
+                    const productName =
+                      productLabelById.get(product.id) ??
+                      getTechnicalConfigurationReferenceProductName(product, productIndex)
+                    return (
+                      <td key={product.id} className="border-b border-r p-3 last:border-r-0">
+                        <Textarea
+                          value={product.responses[criterion.id] ?? ""}
+                          readOnly={readOnly}
+                          aria-label={`Phản hồi ${productName} cho ${criterion.criterion_code}`}
+                          className="min-h-[120px] resize-y whitespace-pre-wrap"
+                          onChange={(event) =>
+                            onResponseChange(product.id, criterion.id, event.target.value)
+                          }
+                        />
+                        {product.responses[criterion.id] ? (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="mt-2 h-8 px-2"
+                            aria-label={`Xem đầy đủ phản hồi ${productName} cho ${criterion.criterion_code}`}
+                            onClick={() =>
+                              onOpenFullText({
+                                title: `${productName} · ${criterion.criterion_code}`,
+                                text: product.responses[criterion.id] ?? "",
+                              })
+                            }
+                          >
+                            <Maximize2 className="size-4" aria-hidden="true" />
+                            Xem đầy đủ
+                          </Button>
+                        ) : null}
+                        {ownerId ? (
+                          <TechnicalConfigurationReferenceEvidenceIndicator
+                            documents={evidenceState.getDocumentsForOwner(
+                              "reference_product",
+                              ownerId
+                            )}
+                            productName={productName}
+                            criterionId={criterion.id}
+                            criterionCode={criterion.criterion_code}
+                            isLoading={evidenceState.documentsQuery.isLoading}
+                            onOpen={() =>
+                              onOpenEvidence({
+                                ownerId,
+                                productName,
+                                criterionId: criterion.id,
+                                criterionCode: criterion.criterion_code,
+                              })
+                            }
+                          />
+                        ) : null}
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonTable.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparisonTable.tsx
@@ -43,6 +43,19 @@ export function TechnicalConfigurationReferenceComparisonTable({
   onOpenFullText,
   onOpenEvidence,
 }: Readonly<TechnicalConfigurationReferenceComparisonTableProps>) {
+  const { getDocumentsForOwner } = evidenceState
+  const evidenceDocumentsByOwnerId = React.useMemo(() => {
+    const documentsByOwnerId = new Map<string, ReturnType<typeof getDocumentsForOwner>>()
+    visibleProducts.forEach((product) => {
+      if (!product.persistedId) return
+      documentsByOwnerId.set(
+        product.persistedId,
+        getDocumentsForOwner("reference_product", product.persistedId)
+      )
+    })
+    return documentsByOwnerId
+  }, [getDocumentsForOwner, visibleProducts])
+
   return (
     <div
       data-testid="reference-comparison-scroll"
@@ -150,10 +163,7 @@ export function TechnicalConfigurationReferenceComparisonTable({
                         ) : null}
                         {ownerId ? (
                           <TechnicalConfigurationReferenceEvidenceIndicator
-                            documents={evidenceState.getDocumentsForOwner(
-                              "reference_product",
-                              ownerId
-                            )}
+                            documents={evidenceDocumentsByOwnerId.get(ownerId) ?? []}
                             productName={productName}
                             criterionId={criterion.id}
                             criterionCode={criterion.criterion_code}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence.tsx
@@ -1,0 +1,132 @@
+import * as React from "react"
+import { FileText } from "lucide-react"
+
+import { TechnicalConfigurationBaselineDocuments } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+export type TechnicalConfigurationReferenceEvidenceDetail = {
+  ownerId: string
+  productName: string
+  criterionId: string
+  criterionCode: string
+}
+
+type TechnicalConfigurationReferenceEvidenceIndicatorProps = {
+  documents: readonly TechnicalConfigurationDocumentWire[]
+  productName: string
+  criterionId: string
+  criterionCode: string
+  isLoading: boolean
+  onOpen: () => void
+}
+
+/** Renders a compact in-cell summary without adding a permanent evidence column. */
+export function TechnicalConfigurationReferenceEvidenceIndicator({
+  documents,
+  productName,
+  criterionId,
+  criterionCode,
+  isLoading,
+  onOpen,
+}: Readonly<TechnicalConfigurationReferenceEvidenceIndicatorProps>) {
+  const citationCount = documents.reduce(
+    (count, document) =>
+      count + document.citations.filter((citation) => citation.criterion_id === criterionId).length,
+    0
+  )
+  const label = `Bằng chứng ${productName} cho ${criterionCode}: ${documents.length} tài liệu, ${citationCount} trích dẫn`
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="mt-2 h-8 max-w-full px-2"
+      aria-label={label}
+      disabled={isLoading}
+      onClick={onOpen}
+    >
+      <FileText className="size-4 shrink-0" aria-hidden="true" />
+      <span className="truncate">
+        {citationCount > 0 ? `${citationCount} trích dẫn` : "Bằng chứng"}
+      </span>
+    </Button>
+  )
+}
+
+type TechnicalConfigurationReferenceEvidenceDialogProps = {
+  detail: TechnicalConfigurationReferenceEvidenceDetail | null
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  readOnly: boolean
+  onClose: () => void
+  onRevisionChange?: (revision: number) => void
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+/** Hosts reference-product evidence authoring for one criterion in a focused detail dialog. */
+export function TechnicalConfigurationReferenceEvidenceDialog({
+  detail,
+  baselineVersion,
+  readOnly,
+  onClose,
+  onRevisionChange,
+  onDirtyChange,
+  onNavigationBlockedChange,
+}: Readonly<TechnicalConfigurationReferenceEvidenceDialogProps>) {
+  const [isDirty, setIsDirty] = React.useState(false)
+
+  React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (open) return
+      if (isDirty && !window.confirm("Bạn có thay đổi bằng chứng chưa lưu. Đóng và bỏ thay đổi?")) {
+        return
+      }
+      setIsDirty(false)
+      onDirtyChange?.(false)
+      onClose()
+    },
+    [isDirty, onClose, onDirtyChange]
+  )
+
+  return (
+    <Dialog open={detail !== null} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl" closeLabel="Đóng">
+        <DialogHeader>
+          <DialogTitle>
+            {detail ? `${detail.productName} · ${detail.criterionCode}` : "Bằng chứng tham chiếu"}
+          </DialogTitle>
+          <DialogDescription>
+            Tài liệu và trích dẫn áp dụng cho sản phẩm tham chiếu tại tiêu chí đang chọn.
+          </DialogDescription>
+        </DialogHeader>
+        {detail ? (
+          <TechnicalConfigurationBaselineDocuments
+            baselineVersion={baselineVersion}
+            ownerType="reference_product"
+            ownerId={detail.ownerId}
+            criterionId={detail.criterionId}
+            readOnly={readOnly}
+            onRevisionChange={onRevisionChange}
+            onDirtyChange={(dirty) => {
+              setIsDirty(dirty)
+              onDirtyChange?.(dirty)
+            }}
+            onNavigationBlockedChange={onNavigationBlockedChange}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence.tsx
@@ -37,7 +37,7 @@ export function TechnicalConfigurationReferenceEvidenceIndicator({
   criterionCode,
   isLoading,
   onOpen,
-}: Readonly<TechnicalConfigurationReferenceEvidenceIndicatorProps>) {
+}: Readonly<TechnicalConfigurationReferenceEvidenceIndicatorProps>): React.JSX.Element {
   const citationCount = documents.reduce(
     (count, document) =>
       count + document.citations.filter((citation) => citation.criterion_id === criterionId).length,
@@ -82,22 +82,27 @@ export function TechnicalConfigurationReferenceEvidenceDialog({
   onRevisionChange,
   onDirtyChange,
   onNavigationBlockedChange,
-}: Readonly<TechnicalConfigurationReferenceEvidenceDialogProps>) {
-  const [isDirty, setIsDirty] = React.useState(false)
+}: Readonly<TechnicalConfigurationReferenceEvidenceDialogProps>): React.JSX.Element {
+  const isDirtyRef = React.useRef(false)
+  const isNavigationBlockedRef = React.useRef(false)
 
   React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
 
   const handleOpenChange = React.useCallback(
     (open: boolean) => {
       if (open) return
-      if (isDirty && !window.confirm("Bạn có thay đổi bằng chứng chưa lưu. Đóng và bỏ thay đổi?")) {
+      if (isNavigationBlockedRef.current) return
+      if (
+        isDirtyRef.current &&
+        !window.confirm("Bạn có thay đổi bằng chứng chưa lưu. Đóng và bỏ thay đổi?")
+      ) {
         return
       }
-      setIsDirty(false)
+      isDirtyRef.current = false
       onDirtyChange?.(false)
       onClose()
     },
-    [isDirty, onClose, onDirtyChange]
+    [onClose, onDirtyChange]
   )
 
   return (
@@ -120,10 +125,13 @@ export function TechnicalConfigurationReferenceEvidenceDialog({
             readOnly={readOnly}
             onRevisionChange={onRevisionChange}
             onDirtyChange={(dirty) => {
-              setIsDirty(dirty)
+              isDirtyRef.current = dirty
               onDirtyChange?.(dirty)
             }}
-            onNavigationBlockedChange={onNavigationBlockedChange}
+            onNavigationBlockedChange={(blocked) => {
+              isNavigationBlockedRef.current = blocked
+              onNavigationBlockedChange?.(blocked)
+            }}
           />
         ) : null}
       </DialogContent>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
@@ -2,11 +2,9 @@ import * as React from "react"
 import { AlertCircle, Archive, Loader2, LockKeyhole, Plus, RefreshCw, Save } from "lucide-react"
 
 import { TechnicalConfigurationReferenceProductsBody } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody"
-import { useTechnicalConfigurationBaseline } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline"
-import { useTechnicalConfigurationBaselineVersions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersions"
+import { useTechnicalConfigurationBaselineVersionSelection } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersionSelection"
+import { useTechnicalConfigurationBeforeUnloadGuard } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard"
 import { useTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts"
-import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
-import { selectTechnicalConfigurationBaselineVersion } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
@@ -33,93 +31,71 @@ export function TechnicalConfigurationReferenceProducts({
   onDirtyChange,
   onNavigationBlockedChange,
 }: Readonly<TechnicalConfigurationReferenceProductsProps>) {
-  const baselineRpc = useTechnicalConfigurationBaseline()
-  const versionState = useTechnicalConfigurationBaselineVersions({
-    dossierId: dossier.id,
-    listVersions: baselineRpc.listVersions,
-  })
-  const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null)
-  const [selectedVersion, setSelectedVersion] =
-    React.useState<TechnicalConfigurationBaselineDraftWire | null>(null)
-  const adoptVersion = React.useCallback(
-    (version: TechnicalConfigurationBaselineDraftWire | null) => {
-      setSelectedVersionId(version?.id ?? null)
-      setSelectedVersion(version)
+  const selection = useTechnicalConfigurationBaselineVersionSelection(dossier.id)
+  const {
+    adoptVersion,
+    handleRevisionChange,
+    selectedVersion,
+    synchronizeVersion,
+    versionOptions,
+    versionState,
+  } = selection
+  const [isEvidenceDirty, setIsEvidenceDirty] = React.useState(false)
+  const [isEvidenceNavigationBlocked, setIsEvidenceNavigationBlocked] = React.useState(false)
+  const [isReferenceNavigationBlocked, setIsReferenceNavigationBlocked] = React.useState(false)
+  const evidenceNavigationBlockedRef = React.useRef(false)
+  const referenceNavigationBlockedRef = React.useRef(false)
+  const handleEvidenceNavigationBlockedChange = React.useCallback(
+    (blocked: boolean) => {
+      evidenceNavigationBlockedRef.current = blocked
+      setIsEvidenceNavigationBlocked(blocked)
+      onNavigationBlockedChange?.(blocked || referenceNavigationBlockedRef.current)
     },
-    []
+    [onNavigationBlockedChange]
   )
-  const handleRevisionChange = React.useCallback(
-    (revision: number) => {
-      if (!selectedVersion) return
-      const nextVersion = { ...selectedVersion, revision }
-      setSelectedVersion(nextVersion)
-      versionState.cacheVersion(nextVersion)
+  const handleReferenceNavigationBlockedChange = React.useCallback(
+    (blocked: boolean) => {
+      referenceNavigationBlockedRef.current = blocked
+      setIsReferenceNavigationBlocked(blocked)
+      onNavigationBlockedChange?.(blocked || evidenceNavigationBlockedRef.current)
     },
-    [selectedVersion, versionState]
+    [onNavigationBlockedChange]
   )
   const referenceState = useTechnicalConfigurationReferenceProducts({
     baselineVersion: selectedVersion,
     isArchived: Boolean(dossier.archived_at),
     onRevisionChange: handleRevisionChange,
-    onNavigationBlockedChange,
+    onNavigationBlockedChange: handleReferenceNavigationBlockedChange,
   })
-  const isNavigationBlocked = referenceState.isSaving || referenceState.isReloading
+  const isDirty = referenceState.isDirty || isEvidenceDirty
+  const isNavigationBlocked =
+    isReferenceNavigationBlocked ||
+    isEvidenceNavigationBlocked ||
+    referenceState.isSaving ||
+    referenceState.isReloading
   const hasInitialProductsError =
     referenceState.productsQuery.isError && referenceState.productsQuery.data === undefined
   const isProductDataUnavailable = referenceState.productsQuery.isLoading || hasInitialProductsError
-  const versionOptions = React.useMemo(
-    () =>
-      selectedVersion && !versionState.versions.some((version) => version.id === selectedVersion.id)
-        ? [selectedVersion, ...versionState.versions]
-        : versionState.versions,
-    [selectedVersion, versionState.versions]
-  )
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent -- Baseline history arrives asynchronously; the shared selector must preserve dirty reference and evidence drafts.
+    synchronizeVersion(isDirty)
+  }, [isDirty, synchronizeVersion])
 
   React.useEffect(() => {
-    if (!versionState.versionsQuery.data || referenceState.isDirty) return
-    const nextVersion = selectTechnicalConfigurationBaselineVersion(
-      versionState.versions,
-      selectedVersionId,
-      selectedVersion,
-      Boolean(versionState.versionsQuery.hasNextPage)
-    )
-    if (
-      selectedVersion?.id === nextVersion?.id &&
-      selectedVersion?.revision === nextVersion?.revision &&
-      selectedVersion?.status === nextVersion?.status
-    ) {
-      return
-    }
-    adoptVersion(nextVersion)
-  }, [
-    adoptVersion,
-    referenceState.isDirty,
-    selectedVersion,
-    selectedVersionId,
-    versionState.versions,
-    versionState.versionsQuery.data,
-    versionState.versionsQuery.hasNextPage,
-  ])
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent -- The reference hook owns draft state while WorkspaceShell owns the cross-tab navigation guard.
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
 
   React.useEffect(() => {
-    onDirtyChange?.(referenceState.isDirty)
     return () => onDirtyChange?.(false)
-  }, [onDirtyChange, referenceState.isDirty])
+  }, [onDirtyChange])
 
-  React.useEffect(() => {
-    if (!referenceState.isDirty) return
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      event.preventDefault()
-      event.returnValue = ""
-    }
-    window.addEventListener("beforeunload", handleBeforeUnload)
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload)
-  }, [referenceState.isDirty])
+  useTechnicalConfigurationBeforeUnloadGuard(isDirty)
 
   const handleVersionChange = React.useCallback(
     (nextVersionId: string) => {
       if (
-        referenceState.isDirty &&
+        isDirty &&
         !window.confirm("Bạn có thay đổi chưa lưu. Chuyển phiên bản và bỏ các thay đổi?")
       ) {
         return
@@ -127,7 +103,7 @@ export function TechnicalConfigurationReferenceProducts({
       const nextVersion = versionOptions.find((version) => version.id === nextVersionId)
       if (nextVersion) adoptVersion(nextVersion)
     },
-    [adoptVersion, referenceState.isDirty, versionOptions]
+    [adoptVersion, isDirty, versionOptions]
   )
 
   const handleVersionSelect = React.useCallback(
@@ -144,7 +120,7 @@ export function TechnicalConfigurationReferenceProducts({
   const handleReload = React.useCallback(async () => {
     if (!selectedVersion) return
     if (
-      referenceState.isDirty &&
+      isDirty &&
       !window.confirm("Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?")
     ) {
       return
@@ -155,7 +131,7 @@ export function TechnicalConfigurationReferenceProducts({
         versionState.cacheVersion(refreshedVersion)
       }
     })
-  }, [referenceState, selectedVersion, versionState])
+  }, [isDirty, referenceState, selectedVersion, versionState])
 
   if (versionState.versionsQuery.isLoading) {
     return (
@@ -323,6 +299,9 @@ export function TechnicalConfigurationReferenceProducts({
         baselineVersion={selectedVersion}
         referenceState={referenceState}
         navigationBlocked={isNavigationBlocked}
+        onRevisionChange={handleRevisionChange}
+        onEvidenceDirtyChange={setIsEvidenceDirty}
+        onEvidenceNavigationBlockedChange={handleEvidenceNavigationBlockedChange}
       />
     </div>
   )

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
@@ -12,6 +12,9 @@ type TechnicalConfigurationReferenceProductsBodyProps = {
   baselineVersion: TechnicalConfigurationBaselineDraftWire
   referenceState: ReturnType<typeof useTechnicalConfigurationReferenceProducts>
   navigationBlocked: boolean
+  onRevisionChange?: (revision: number) => void
+  onEvidenceDirtyChange?: (dirty: boolean) => void
+  onEvidenceNavigationBlockedChange?: (blocked: boolean) => void
 }
 
 /** Renders reference-product query states, metadata editors, and comparison matrix. */
@@ -19,6 +22,9 @@ export function TechnicalConfigurationReferenceProductsBody({
   baselineVersion,
   referenceState,
   navigationBlocked,
+  onRevisionChange,
+  onEvidenceDirtyChange,
+  onEvidenceNavigationBlockedChange,
 }: Readonly<TechnicalConfigurationReferenceProductsBodyProps>) {
   const invalidProductIdSet = React.useMemo(
     () => new Set(referenceState.invalidProductIds),
@@ -80,6 +86,9 @@ export function TechnicalConfigurationReferenceProductsBody({
           products={referenceState.products}
           readOnly={referenceState.isReadOnly || navigationBlocked}
           onResponseChange={referenceState.updateResponse}
+          onRevisionChange={onRevisionChange}
+          onEvidenceDirtyChange={onEvidenceDirtyChange}
+          onEvidenceNavigationBlockedChange={onEvidenceNavigationBlockedChange}
         />
       ) : null}
     </>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import {
   ArrowLeft,
   ClipboardList,
+  FileText,
   GitCompareArrows,
   LibraryBig,
   ListChecks,
@@ -13,6 +14,7 @@ import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import { TechnicalConfigurationBaselineTab } from "./TechnicalConfigurationBaselineTab"
+import { TechnicalConfigurationBaselineEvidence } from "./TechnicalConfigurationBaselineEvidence"
 import { TechnicalConfigurationReferenceProducts } from "./TechnicalConfigurationReferenceProducts"
 
 type TechnicalConfigurationWorkspaceShellProps = {
@@ -28,10 +30,13 @@ export function TechnicalConfigurationWorkspaceShell({
   const [activeTab, setActiveTab] = React.useState("baseline")
   const [isBaselineDirty, setIsBaselineDirty] = React.useState(false)
   const [isBaselineNavigationBlocked, setIsBaselineNavigationBlocked] = React.useState(false)
+  const [isEvidenceDirty, setIsEvidenceDirty] = React.useState(false)
+  const [isEvidenceNavigationBlocked, setIsEvidenceNavigationBlocked] = React.useState(false)
   const [isReferenceDirty, setIsReferenceDirty] = React.useState(false)
   const [isReferenceNavigationBlocked, setIsReferenceNavigationBlocked] = React.useState(false)
-  const isDirty = isBaselineDirty || isReferenceDirty
-  const isNavigationBlocked = isBaselineNavigationBlocked || isReferenceNavigationBlocked
+  const isDirty = isBaselineDirty || isEvidenceDirty || isReferenceDirty
+  const isNavigationBlocked =
+    isBaselineNavigationBlocked || isEvidenceNavigationBlocked || isReferenceNavigationBlocked
 
   const handleBack = React.useCallback(() => {
     if (isNavigationBlocked) return
@@ -45,9 +50,11 @@ export function TechnicalConfigurationWorkspaceShell({
     (nextTab: string) => {
       const isCurrentTabDirty =
         (activeTab === "baseline" && isBaselineDirty) ||
+        (activeTab === "evidence" && isEvidenceDirty) ||
         (activeTab === "references" && isReferenceDirty)
       const isCurrentTabBlocked =
         (activeTab === "baseline" && isBaselineNavigationBlocked) ||
+        (activeTab === "evidence" && isEvidenceNavigationBlocked) ||
         (activeTab === "references" && isReferenceNavigationBlocked)
       if (isCurrentTabBlocked) return
       if (
@@ -62,6 +69,8 @@ export function TechnicalConfigurationWorkspaceShell({
       activeTab,
       isBaselineDirty,
       isBaselineNavigationBlocked,
+      isEvidenceDirty,
+      isEvidenceNavigationBlocked,
       isReferenceDirty,
       isReferenceNavigationBlocked,
     ]
@@ -96,10 +105,14 @@ export function TechnicalConfigurationWorkspaceShell({
       </header>
 
       <Tabs value={activeTab} onValueChange={handleTabChange} className="mt-6">
-        <TabsList className="grid h-auto w-full grid-cols-1 gap-1 sm:grid-cols-4">
+        <TabsList className="grid h-auto w-full grid-cols-1 gap-1 sm:grid-cols-5">
           <TabsTrigger value="baseline" className="min-h-10 gap-2">
             <ListChecks className="size-4" aria-hidden="true" />
             Cấu hình cơ sở
+          </TabsTrigger>
+          <TabsTrigger value="evidence" className="min-h-10 gap-2">
+            <FileText className="size-4" aria-hidden="true" />
+            Tài liệu &amp; trích dẫn
           </TabsTrigger>
           <TabsTrigger value="references" className="min-h-10 gap-2">
             <LibraryBig className="size-4" aria-hidden="true" />
@@ -120,6 +133,13 @@ export function TechnicalConfigurationWorkspaceShell({
             dossier={dossier}
             onDirtyChange={setIsBaselineDirty}
             onNavigationBlockedChange={setIsBaselineNavigationBlocked}
+          />
+        </TabsContent>
+        <TabsContent value="evidence" className="mt-6">
+          <TechnicalConfigurationBaselineEvidence
+            dossier={dossier}
+            onDirtyChange={setIsEvidenceDirty}
+            onNavigationBlockedChange={setIsEvidenceNavigationBlocked}
           />
         </TabsContent>
         <TabsContent value="references" className="mt-6">

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersionSelection.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersionSelection.ts
@@ -1,0 +1,80 @@
+import * as React from "react"
+
+import { useTechnicalConfigurationBaseline } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline"
+import { useTechnicalConfigurationBaselineVersions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersions"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import { selectTechnicalConfigurationBaselineVersion } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
+
+/** Shares active-version selection and revision cache updates across read-oriented workspaces. */
+export function useTechnicalConfigurationBaselineVersionSelection(dossierId: string) {
+  const baselineRpc = useTechnicalConfigurationBaseline()
+  const versionState = useTechnicalConfigurationBaselineVersions({
+    dossierId,
+    listVersions: baselineRpc.listVersions,
+  })
+  const { cacheVersion, versions, versionsQuery } = versionState
+  const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null)
+  const [selectedVersion, setSelectedVersion] =
+    React.useState<TechnicalConfigurationBaselineDraftWire | null>(null)
+  const adoptVersion = React.useCallback(
+    (version: TechnicalConfigurationBaselineDraftWire | null) => {
+      setSelectedVersionId(version?.id ?? null)
+      setSelectedVersion(version)
+    },
+    []
+  )
+  const versionOptions = React.useMemo(
+    () =>
+      selectedVersion && !versionState.versions.some((version) => version.id === selectedVersion.id)
+        ? [selectedVersion, ...versions]
+        : versions,
+    [selectedVersion, versions]
+  )
+  const synchronizeVersion = React.useCallback(
+    (replacementBlocked: boolean) => {
+      if (!versionsQuery.data || replacementBlocked) return
+      const nextVersion = selectTechnicalConfigurationBaselineVersion(
+        versions,
+        selectedVersionId,
+        selectedVersion,
+        Boolean(versionsQuery.hasNextPage)
+      )
+      if (
+        selectedVersion?.id === nextVersion?.id &&
+        selectedVersion?.revision === nextVersion?.revision &&
+        selectedVersion?.status === nextVersion?.status
+      ) {
+        return
+      }
+      adoptVersion(nextVersion)
+    },
+    [
+      adoptVersion,
+      selectedVersion,
+      selectedVersionId,
+      versions,
+      versionsQuery.data,
+      versionsQuery.hasNextPage,
+    ]
+  )
+  const handleRevisionChange = React.useCallback(
+    (revision: number) => {
+      setSelectedVersion((current) => {
+        if (!current) return current
+        const nextVersion = { ...current, revision }
+        cacheVersion(nextVersion)
+        return nextVersion
+      })
+    },
+    [cacheVersion]
+  )
+
+  return {
+    versionState,
+    selectedVersion,
+    versionOptions,
+    adoptVersion,
+    synchronizeVersion,
+    handleRevisionChange,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersionSelection.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersionSelection.ts
@@ -5,8 +5,19 @@ import { useTechnicalConfigurationBaselineVersions } from "@/app/(app)/technical
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
 import { selectTechnicalConfigurationBaselineVersion } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
 
+export interface TechnicalConfigurationBaselineVersionSelectionResult {
+  versionState: ReturnType<typeof useTechnicalConfigurationBaselineVersions>
+  selectedVersion: TechnicalConfigurationBaselineDraftWire | null
+  versionOptions: TechnicalConfigurationBaselineDraftWire[]
+  adoptVersion: (version: TechnicalConfigurationBaselineDraftWire | null) => void
+  synchronizeVersion: (replacementBlocked: boolean) => void
+  handleRevisionChange: (revision: number) => void
+}
+
 /** Shares active-version selection and revision cache updates across read-oriented workspaces. */
-export function useTechnicalConfigurationBaselineVersionSelection(dossierId: string) {
+export function useTechnicalConfigurationBaselineVersionSelection(
+  dossierId: string
+): TechnicalConfigurationBaselineVersionSelectionResult {
   const baselineRpc = useTechnicalConfigurationBaseline()
   const versionState = useTechnicalConfigurationBaselineVersions({
     dossierId,
@@ -25,7 +36,7 @@ export function useTechnicalConfigurationBaselineVersionSelection(dossierId: str
   )
   const versionOptions = React.useMemo(
     () =>
-      selectedVersion && !versionState.versions.some((version) => version.id === selectedVersion.id)
+      selectedVersion && !versions.some((version) => version.id === selectedVersion.id)
         ? [selectedVersion, ...versions]
         : versions,
     [selectedVersion, versions]

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard.ts
@@ -1,0 +1,17 @@
+"use client"
+
+import * as React from "react"
+
+/** Prevents accidental browser unload while a technical-configuration draft is dirty. */
+export function useTechnicalConfigurationBeforeUnloadGuard(isDirty: boolean) {
+  React.useEffect(() => {
+    if (!isDirty) return
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ""
+    }
+    window.addEventListener("beforeunload", handleBeforeUnload)
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload)
+  }, [isDirty])
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard.ts
@@ -3,7 +3,7 @@
 import * as React from "react"
 
 /** Prevents accidental browser unload while a technical-configuration draft is dirty. */
-export function useTechnicalConfigurationBeforeUnloadGuard(isDirty: boolean) {
+export function useTechnicalConfigurationBeforeUnloadGuard(isDirty: boolean): void {
   React.useEffect(() => {
     if (!isDirty) return
 

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
@@ -1,0 +1,97 @@
+import * as React from "react"
+
+import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+
+interface TechnicalConfigurationDocumentDraftState {
+  name: string
+  url: string
+  selectedDocumentId: string | null
+  selectedDocument: TechnicalConfigurationDocumentWire | null
+  selectedDocumentMissing: boolean
+  documentDirty: boolean
+  setName: React.Dispatch<React.SetStateAction<string>>
+  setUrl: React.Dispatch<React.SetStateAction<string>>
+  clearDraft: () => void
+  selectDocument: (document: TechnicalConfigurationDocumentWire) => void
+}
+
+/** Reconciles clean document drafts with refreshed server values while preserving user edits. */
+export function useTechnicalConfigurationDocumentDraft(
+  documents: readonly TechnicalConfigurationDocumentWire[]
+): TechnicalConfigurationDocumentDraftState {
+  const [name, setName] = React.useState("")
+  const [url, setUrl] = React.useState("")
+  const [selectedDocumentId, setSelectedDocumentId] = React.useState<string | null>(null)
+  const adoptedDocumentRef = React.useRef<Pick<
+    TechnicalConfigurationDocumentWire,
+    "id" | "name" | "url"
+  > | null>(null)
+  const selectedDocument = documents.find((document) => document.id === selectedDocumentId) ?? null
+  const selectedDocumentMissing = selectedDocumentId !== null && selectedDocument === null
+  const adoptedDocument = adoptedDocumentRef.current
+  const draftMatchesAdoptedDocument =
+    selectedDocument !== null &&
+    adoptedDocument?.id === selectedDocument.id &&
+    name === adoptedDocument.name &&
+    url === adoptedDocument.url
+  const documentDirty =
+    selectedDocument === null
+      ? Boolean(name || url)
+      : !draftMatchesAdoptedDocument &&
+        (name !== selectedDocument.name || url !== selectedDocument.url)
+
+  const adoptDocument = React.useCallback((document: TechnicalConfigurationDocumentWire) => {
+    adoptedDocumentRef.current = {
+      id: document.id,
+      name: document.name,
+      url: document.url,
+    }
+    setName(document.name)
+    setUrl(document.url)
+  }, [])
+
+  React.useEffect(() => {
+    if (!selectedDocument) return
+    const lastAdoptedDocument = adoptedDocumentRef.current
+    if (lastAdoptedDocument?.id !== selectedDocument.id) {
+      adoptDocument(selectedDocument)
+      return
+    }
+
+    const draftIsClean = name === lastAdoptedDocument.name && url === lastAdoptedDocument.url
+    const selectedDocumentWasRefreshed =
+      selectedDocument.name !== lastAdoptedDocument.name ||
+      selectedDocument.url !== lastAdoptedDocument.url
+    if (draftIsClean && selectedDocumentWasRefreshed) {
+      adoptDocument(selectedDocument)
+    }
+  }, [adoptDocument, name, selectedDocument, url])
+
+  const clearDraft = React.useCallback(() => {
+    adoptedDocumentRef.current = null
+    setSelectedDocumentId(null)
+    setName("")
+    setUrl("")
+  }, [])
+
+  const selectDocument = React.useCallback(
+    (document: TechnicalConfigurationDocumentWire) => {
+      setSelectedDocumentId(document.id)
+      adoptDocument(document)
+    },
+    [adoptDocument]
+  )
+
+  return {
+    name,
+    url,
+    selectedDocumentId,
+    selectedDocument,
+    selectedDocumentMissing,
+    documentDirty,
+    setName,
+    setUrl,
+    clearDraft,
+    selectDocument,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments.ts
@@ -104,6 +104,7 @@ export function useTechnicalConfigurationDocuments({
 }: UseTechnicalConfigurationDocumentsOptions) {
   const queryClient = useQueryClient()
   const revisionRef = React.useRef(baselineVersion.revision)
+  const mutationInFlightRef = React.useRef(false)
   const [isSaving, setIsSaving] = React.useState(false)
   const [isConflict, setIsConflict] = React.useState(false)
   const [mutationError, setMutationError] = React.useState<unknown>(null)
@@ -143,6 +144,9 @@ export function useTechnicalConfigurationDocuments({
     async <TResponse extends RevisionedMutationResponse>(
       request: (expectedRevision: number) => Promise<TResponse>
     ): Promise<TResponse> => {
+      if (mutationInFlightRef.current) {
+        throw new Error("mutation_in_progress")
+      }
       if (baselineVersion.locked_at !== null) {
         throw new Error("locked_version")
       }
@@ -150,6 +154,7 @@ export function useTechnicalConfigurationDocuments({
         throw new Error("read_only")
       }
 
+      mutationInFlightRef.current = true
       setIsSaving(true)
       setIsConflict(false)
       setMutationError(null)
@@ -163,6 +168,7 @@ export function useTechnicalConfigurationDocuments({
         setIsConflict(isTechnicalConfigurationBaselineConflict(error))
         throw error
       } finally {
+        mutationInFlightRef.current = false
         setIsSaving(false)
         onNavigationBlockedChange?.(false)
       }

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments.ts
@@ -1,0 +1,277 @@
+"use client"
+
+import * as React from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type {
+  TechnicalConfigurationCitationDeleteWireResponse,
+  TechnicalConfigurationCitationMutationWireResponse,
+  TechnicalConfigurationDocumentDeleteWireResponse,
+  TechnicalConfigurationDocumentMutationWireResponse,
+  TechnicalConfigurationDocumentWire,
+} from "@/app/(app)/technical-configurations/document-types"
+import {
+  createTechnicalConfigurationBaselineDocument,
+  createTechnicalConfigurationReferenceDocument,
+  deleteTechnicalConfigurationBaselineCitation,
+  deleteTechnicalConfigurationBaselineDocument,
+  deleteTechnicalConfigurationReferenceCitation,
+  deleteTechnicalConfigurationReferenceDocument,
+  listTechnicalConfigurationBaselineDocuments,
+  updateTechnicalConfigurationBaselineDocument,
+  updateTechnicalConfigurationReferenceDocument,
+  upsertTechnicalConfigurationBaselineCitation,
+  upsertTechnicalConfigurationReferenceCitation,
+} from "@/app/(app)/technical-configurations/technical-configuration-document-rpc"
+import {
+  technicalConfigurationBaselineVersionsQueryKey,
+  technicalConfigurationDocumentsQueryKey,
+} from "@/app/(app)/technical-configurations/technical-configuration-query-keys"
+import { isTechnicalConfigurationBaselineConflict } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
+import { collectStableTechnicalConfigurationPages } from "@/app/(app)/technical-configurations/technical-configuration-pagination"
+
+const DOCUMENT_PAGE_SIZE = 100
+const EMPTY_DOCUMENTS: TechnicalConfigurationDocumentWire[] = []
+
+type UseTechnicalConfigurationDocumentsOptions = {
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  readOnly?: boolean
+  onRevisionChange?: (revision: number) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+type CreateTechnicalConfigurationDocumentInput = {
+  ownerType: TechnicalConfigurationDocumentWire["owner_type"]
+  ownerId: string
+  name: string
+  url: string
+}
+
+type UpdateTechnicalConfigurationDocumentInput = {
+  document: TechnicalConfigurationDocumentWire
+  name: string
+  url: string
+}
+
+type UpsertTechnicalConfigurationCitationInput = {
+  document: TechnicalConfigurationDocumentWire
+  criterionId: string
+  pageSection: string | null
+  excerpt: string | null
+}
+
+type DeleteTechnicalConfigurationCitationInput = {
+  document: TechnicalConfigurationDocumentWire
+  citationId: string
+}
+
+type RevisionedMutationResponse =
+  | TechnicalConfigurationDocumentMutationWireResponse
+  | TechnicalConfigurationDocumentDeleteWireResponse
+  | TechnicalConfigurationCitationMutationWireResponse
+  | TechnicalConfigurationCitationDeleteWireResponse
+
+async function listAllTechnicalConfigurationDocuments(
+  baselineVersionId: string,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationDocumentWire[]> {
+  const { items } = await collectStableTechnicalConfigurationPages<
+    TechnicalConfigurationDocumentWire,
+    Awaited<ReturnType<typeof listTechnicalConfigurationBaselineDocuments>>
+  >({
+    loadPage: (page) =>
+      listTechnicalConfigurationBaselineDocuments(
+        {
+          p_baseline_version_id: baselineVersionId,
+          p_page: page,
+          p_page_size: DOCUMENT_PAGE_SIZE,
+        },
+        signal
+      ),
+    snapshotError: "Evidence-document pagination snapshot changed during load.",
+  })
+  return items
+}
+
+/** Owns P7B2 evidence-document queries and mutations for one baseline version. */
+export function useTechnicalConfigurationDocuments({
+  baselineVersion,
+  readOnly = false,
+  onRevisionChange,
+  onNavigationBlockedChange,
+}: UseTechnicalConfigurationDocumentsOptions) {
+  const queryClient = useQueryClient()
+  const revisionRef = React.useRef(baselineVersion.revision)
+  const [isSaving, setIsSaving] = React.useState(false)
+  const [isConflict, setIsConflict] = React.useState(false)
+  const [mutationError, setMutationError] = React.useState<unknown>(null)
+  React.useEffect(() => {
+    revisionRef.current = baselineVersion.revision
+  }, [baselineVersion.id, baselineVersion.revision])
+
+  const queryKey = technicalConfigurationDocumentsQueryKey(baselineVersion.id)
+  const documentsQuery = useQuery({
+    queryKey,
+    queryFn: ({ signal }) => listAllTechnicalConfigurationDocuments(baselineVersion.id, signal),
+    staleTime: 30_000,
+  })
+  const documents = documentsQuery.data ?? EMPTY_DOCUMENTS
+  const getDocumentsForOwner = React.useCallback(
+    (ownerType: TechnicalConfigurationDocumentWire["owner_type"], ownerId: string) =>
+      documents.filter(
+        (document) => document.owner_type === ownerType && document.owner_id === ownerId
+      ),
+    [documents]
+  )
+  const refreshAfterMutation = React.useCallback(
+    async (revision: number) => {
+      revisionRef.current = revision
+      onRevisionChange?.(revision)
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey, exact: true }),
+        queryClient.invalidateQueries({
+          queryKey: technicalConfigurationBaselineVersionsQueryKey(baselineVersion.dossier_id),
+          exact: true,
+        }),
+      ])
+    },
+    [baselineVersion.dossier_id, onRevisionChange, queryClient, queryKey]
+  )
+  const runMutation = React.useCallback(
+    async <TResponse extends RevisionedMutationResponse>(
+      request: (expectedRevision: number) => Promise<TResponse>
+    ): Promise<TResponse> => {
+      if (baselineVersion.locked_at !== null) {
+        throw new Error("locked_version")
+      }
+      if (readOnly) {
+        throw new Error("read_only")
+      }
+
+      setIsSaving(true)
+      setIsConflict(false)
+      setMutationError(null)
+      onNavigationBlockedChange?.(true)
+      try {
+        const response = await request(revisionRef.current)
+        await refreshAfterMutation(response.data.revision)
+        return response
+      } catch (error) {
+        setMutationError(error)
+        setIsConflict(isTechnicalConfigurationBaselineConflict(error))
+        throw error
+      } finally {
+        setIsSaving(false)
+        onNavigationBlockedChange?.(false)
+      }
+    },
+    [baselineVersion.locked_at, onNavigationBlockedChange, readOnly, refreshAfterMutation]
+  )
+  const createDocument = React.useCallback(
+    ({ ownerType, ownerId, name, url }: CreateTechnicalConfigurationDocumentInput) =>
+      runMutation((expectedRevision) =>
+        ownerType === "baseline"
+          ? createTechnicalConfigurationBaselineDocument({
+              p_baseline_version_id: ownerId,
+              p_name: name,
+              p_url: url,
+              p_expected_revision: expectedRevision,
+            })
+          : createTechnicalConfigurationReferenceDocument({
+              p_reference_product_id: ownerId,
+              p_name: name,
+              p_url: url,
+              p_expected_revision: expectedRevision,
+            })
+      ),
+    [runMutation]
+  )
+  const updateDocument = React.useCallback(
+    ({ document, name, url }: UpdateTechnicalConfigurationDocumentInput) =>
+      runMutation((expectedRevision) =>
+        document.owner_type === "baseline"
+          ? updateTechnicalConfigurationBaselineDocument({
+              p_baseline_document_id: document.id,
+              p_name: name,
+              p_url: url,
+              p_expected_revision: expectedRevision,
+            })
+          : updateTechnicalConfigurationReferenceDocument({
+              p_reference_document_id: document.id,
+              p_name: name,
+              p_url: url,
+              p_expected_revision: expectedRevision,
+            })
+      ),
+    [runMutation]
+  )
+  const deleteDocument = React.useCallback(
+    async (document: TechnicalConfigurationDocumentWire) => {
+      const response = await runMutation((expectedRevision) =>
+        document.owner_type === "baseline"
+          ? deleteTechnicalConfigurationBaselineDocument({
+              p_baseline_document_id: document.id,
+              p_expected_revision: expectedRevision,
+            })
+          : deleteTechnicalConfigurationReferenceDocument({
+              p_reference_document_id: document.id,
+              p_expected_revision: expectedRevision,
+            })
+      )
+      return response.data.affected_link_count
+    },
+    [runMutation]
+  )
+  const upsertCitation = React.useCallback(
+    ({ document, criterionId, pageSection, excerpt }: UpsertTechnicalConfigurationCitationInput) =>
+      runMutation((expectedRevision) =>
+        document.owner_type === "baseline"
+          ? upsertTechnicalConfigurationBaselineCitation({
+              p_baseline_document_id: document.id,
+              p_criterion_id: criterionId,
+              p_page_section: pageSection,
+              p_excerpt: excerpt,
+              p_expected_revision: expectedRevision,
+            })
+          : upsertTechnicalConfigurationReferenceCitation({
+              p_reference_document_id: document.id,
+              p_criterion_id: criterionId,
+              p_page_section: pageSection,
+              p_excerpt: excerpt,
+              p_expected_revision: expectedRevision,
+            })
+      ),
+    [runMutation]
+  )
+  const deleteCitation = React.useCallback(
+    ({ document, citationId }: DeleteTechnicalConfigurationCitationInput) =>
+      runMutation((expectedRevision) =>
+        document.owner_type === "baseline"
+          ? deleteTechnicalConfigurationBaselineCitation({
+              p_baseline_citation_id: citationId,
+              p_expected_revision: expectedRevision,
+            })
+          : deleteTechnicalConfigurationReferenceCitation({
+              p_reference_citation_id: citationId,
+              p_expected_revision: expectedRevision,
+            })
+      ),
+    [runMutation]
+  )
+
+  return {
+    documentsQuery,
+    documents,
+    getDocumentsForOwner,
+    isReadOnly: readOnly || baselineVersion.locked_at !== null,
+    isSaving,
+    isConflict,
+    mutationError,
+    createDocument,
+    updateDocument,
+    deleteDocument,
+    upsertCitation,
+    deleteCitation,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments.ts
@@ -90,6 +90,7 @@ async function listAllTechnicalConfigurationDocuments(
         signal
       ),
     snapshotError: "Evidence-document pagination snapshot changed during load.",
+    getItemKey: (document) => document.id,
   })
   return items
 }

--- a/src/app/(app)/technical-configurations/technical-configuration-pagination.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-pagination.ts
@@ -1,0 +1,41 @@
+type TechnicalConfigurationPage<TItem> = {
+  data: TItem[]
+  total: number
+}
+
+type CollectStableTechnicalConfigurationPagesOptions<
+  TItem,
+  TPage extends TechnicalConfigurationPage<TItem>,
+> = {
+  loadPage: (page: number) => Promise<TPage>
+  snapshotError: string
+  isSameSnapshot?: (firstPage: TPage, nextPage: TPage) => boolean
+}
+
+/** Collects every page while rejecting totals or snapshot metadata that change mid-load. */
+export async function collectStableTechnicalConfigurationPages<
+  TItem,
+  TPage extends TechnicalConfigurationPage<TItem>,
+>({
+  loadPage,
+  snapshotError,
+  isSameSnapshot = () => true,
+}: CollectStableTechnicalConfigurationPagesOptions<TItem, TPage>): Promise<{
+  items: TItem[]
+  firstPage: TPage
+}> {
+  let page = 1
+  let currentPage = await loadPage(page)
+  const firstPage = currentPage
+  const items = [...firstPage.data]
+
+  while (items.length < firstPage.total && currentPage.data.length > 0) {
+    currentPage = await loadPage(++page)
+    if (currentPage.total !== firstPage.total || !isSameSnapshot(firstPage, currentPage)) {
+      throw new Error(snapshotError)
+    }
+    items.push(...currentPage.data)
+  }
+
+  return { items, firstPage }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-pagination.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-pagination.ts
@@ -9,16 +9,18 @@ type CollectStableTechnicalConfigurationPagesOptions<
 > = {
   loadPage: (page: number) => Promise<TPage>
   snapshotError: string
+  getItemKey: (item: TItem) => string
   isSameSnapshot?: (firstPage: TPage, nextPage: TPage) => boolean
 }
 
-/** Collects every page while rejecting totals or snapshot metadata that change mid-load. */
+/** Collects every page while rejecting incomplete, duplicate, or changed snapshots. */
 export async function collectStableTechnicalConfigurationPages<
   TItem,
   TPage extends TechnicalConfigurationPage<TItem>,
 >({
   loadPage,
   snapshotError,
+  getItemKey,
   isSameSnapshot = () => true,
 }: CollectStableTechnicalConfigurationPagesOptions<TItem, TPage>): Promise<{
   items: TItem[]
@@ -27,14 +29,31 @@ export async function collectStableTechnicalConfigurationPages<
   let page = 1
   let currentPage = await loadPage(page)
   const firstPage = currentPage
-  const items = [...firstPage.data]
+  const items: TItem[] = []
+  const itemKeys = new Set<string>()
+  const appendPage = (pageItems: TItem[]) => {
+    if (pageItems.length === 0 && items.length < firstPage.total) {
+      throw new Error(snapshotError)
+    }
 
-  while (items.length < firstPage.total && currentPage.data.length > 0) {
+    for (const item of pageItems) {
+      const itemKey = getItemKey(item)
+      if (itemKeys.has(itemKey)) throw new Error(snapshotError)
+      itemKeys.add(itemKey)
+      items.push(item)
+    }
+
+    if (items.length > firstPage.total) throw new Error(snapshotError)
+  }
+
+  appendPage(firstPage.data)
+
+  while (items.length < firstPage.total) {
     currentPage = await loadPage(++page)
     if (currentPage.total !== firstPage.total || !isSameSnapshot(firstPage, currentPage)) {
       throw new Error(snapshotError)
     }
-    items.push(...currentPage.data)
+    appendPage(currentPage.data)
   }
 
   return { items, firstPage }

--- a/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
@@ -18,3 +18,8 @@ export function technicalConfigurationBaselineVersionsQueryKey(dossierId: string
 export function technicalConfigurationReferenceProductsQueryKey(baselineVersionId: string) {
   return ["technical-configurations", "reference-products", baselineVersionId] as const
 }
+
+/** Builds the cache key for baseline and reference evidence under one baseline version. */
+export function technicalConfigurationDocumentsQueryKey(baselineVersionId: string) {
+  return ["technical-configurations", "documents", baselineVersionId] as const
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-reference-product-operations.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-reference-product-operations.ts
@@ -63,6 +63,7 @@ export async function listAllTechnicalConfigurationReferenceProducts(
         signal
       ),
     snapshotError: "Reference-product pagination snapshot changed during load.",
+    getItemKey: (product) => product.id,
     isSameSnapshot: (first, next) => first.revision === next.revision,
   })
 

--- a/src/app/(app)/technical-configurations/technical-configuration-reference-product-operations.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-reference-product-operations.ts
@@ -3,6 +3,7 @@ import type {
   TechnicalConfigurationReferenceProductWire,
   TechnicalConfigurationReferenceProductsSnapshot,
 } from "@/app/(app)/technical-configurations/reference-product-types"
+import { collectStableTechnicalConfigurationPages } from "@/app/(app)/technical-configurations/technical-configuration-pagination"
 import { isTechnicalConfigurationBaselineConflict } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
 import {
   cloneTechnicalConfigurationReferenceProductDrafts,
@@ -48,34 +49,24 @@ export async function listAllTechnicalConfigurationReferenceProducts(
   baselineVersionId: string,
   signal?: AbortSignal
 ): Promise<TechnicalConfigurationReferenceProductsSnapshot> {
-  const products: TechnicalConfigurationReferenceProductWire[] = []
-  let page = 1
-  let total = Number.POSITIVE_INFINITY
-  let revision: number | null = null
+  const { items: products, firstPage } = await collectStableTechnicalConfigurationPages<
+    TechnicalConfigurationReferenceProductWire,
+    Awaited<ReturnType<typeof listTechnicalConfigurationReferenceProducts>>
+  >({
+    loadPage: (page) =>
+      listTechnicalConfigurationReferenceProducts(
+        {
+          p_baseline_version_id: baselineVersionId,
+          p_page: page,
+          p_page_size: REFERENCE_PRODUCT_PAGE_SIZE,
+        },
+        signal
+      ),
+    snapshotError: "Reference-product pagination snapshot changed during load.",
+    isSameSnapshot: (first, next) => first.revision === next.revision,
+  })
 
-  while (products.length < total) {
-    const response = await listTechnicalConfigurationReferenceProducts(
-      {
-        p_baseline_version_id: baselineVersionId,
-        p_page: page,
-        p_page_size: REFERENCE_PRODUCT_PAGE_SIZE,
-      },
-      signal
-    )
-    if (
-      (revision !== null && response.revision !== revision) ||
-      (Number.isFinite(total) && response.total !== total)
-    ) {
-      throw new Error("Reference-product pagination snapshot changed during load.")
-    }
-    revision ??= response.revision
-    products.push(...response.data)
-    total = response.total
-    if (response.data.length === 0) break
-    page += 1
-  }
-
-  return { products, revision: revision ?? 0 }
+  return { products, revision: firstPage.revision }
 }
 
 /** Persists reference-product drafts with resumable optimistic-concurrency progress. */

--- a/src/components/url-documents/__tests__/url-document-source-contract-extractor.test.ts
+++ b/src/components/url-documents/__tests__/url-document-source-contract-extractor.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest"
+
+import { extractModuleReferences } from "./url-document-module-reference-helpers"
+import {
+  assertExactSet,
+  assertNoForbiddenSourcePatterns,
+  expectedProductionModules,
+  isProductionModulePath,
+  supportedExtensions,
+} from "./url-document-source-contract-fixtures"
+
+describe("URL document source-contract extractor", () => {
+  it("extracts every supported literal module-reference form", () => {
+    const source = `
+      import defaultValue from "static-default"
+      import type { TypeValue } from "static-type"
+      import equalsValue = require("import-equals")
+      export { value } from "named-export"
+      export * from "star-export"
+      void import("dynamic-import")
+      void import("dynamic-import-with-attributes", { with: { type: "json" } })
+      const required = require("required-module")
+      declare const window: { require(id: string): unknown }
+      const ambientMemberRequired = window.require("ambient-member-required")
+      const moduleRequired = module.require("module-required")
+      const computedModuleRequired = module["require"]("computed-module-required")
+      type Imported = import("import-type").Imported
+    `
+
+    expect(extractModuleReferences(source)).toEqual([
+      "ambient-member-required",
+      "computed-module-required",
+      "dynamic-import",
+      "dynamic-import-with-attributes",
+      "import-equals",
+      "import-type",
+      "module-required",
+      "named-export",
+      "required-module",
+      "star-export",
+      "static-default",
+      "static-type",
+    ])
+  })
+
+  it("distinguishes allowed and denied static imports through exact set equality", () => {
+    const observed = extractModuleReferences(`
+      import type { Allowed } from "allowed"
+      import { Denied } from "allowed/denied"
+    `)
+
+    expect(() => assertExactSet(observed, ["allowed"], "fixture imports")).toThrow(
+      /unexpected=\[allowed\/denied\]/
+    )
+  })
+
+  it.each([
+    ["dynamic import", "const moduleName = 'dynamic'; void import(moduleName)"],
+    ["require", "const moduleName = 'required'; require(moduleName)"],
+    ["import type", "type ModuleName = 'types'; type Value = import(ModuleName).Value"],
+  ])("fails closed for a computed %s reference", (_kind, source) => {
+    expect(() => extractModuleReferences(source)).toThrow(/must use a string literal/)
+  })
+
+  it("fails closed when require is aliased instead of called directly", () => {
+    expect(() =>
+      extractModuleReferences(`
+        const load = require
+        load("@/app/(app)/equipment/_hooks/use-equipment-attachments")
+      `)
+    ).toThrow(/require must be called directly/)
+  })
+
+  it("fails closed when the ambient module object is aliased", () => {
+    expect(() =>
+      extractModuleReferences(`
+        const runtime = module
+        runtime.require("@tanstack/react-query")
+      `)
+    ).toThrow(/module must be accessed directly/)
+  })
+
+  it("fails closed when an ambient member require uses a computed specifier", () => {
+    expect(() =>
+      extractModuleReferences(`
+        declare const window: { require(id: string): unknown }
+        const moduleName = "@tanstack/react-query"
+        window.require(moduleName)
+      `)
+    ).toThrow(/ambient require must use a string literal/)
+  })
+
+  it("fails closed when an indirect module loader chain is called", () => {
+    expect(() =>
+      extractModuleReferences('module.constructor._load("@tanstack/react-query")')
+    ).toThrow(/module calls must use direct module\.require/)
+  })
+
+  it.each([
+    [
+      "require parameter",
+      `
+        function load(require: (name: string) => unknown) {
+          return require("local-adapter")
+        }
+      `,
+    ],
+    [
+      "module parameter",
+      `
+        function load(module: { require: (name: string) => unknown }) {
+          return module.require("local-adapter")
+        }
+      `,
+    ],
+  ])("ignores a locally shadowed CommonJS %s", (_name, source) => {
+    expect(extractModuleReferences(source)).toEqual([])
+  })
+
+  it("ignores a locally shadowed member require", () => {
+    expect(
+      extractModuleReferences(`
+        function load(runtime: { require(name: string): unknown }) {
+          return runtime.require("local-adapter")
+        }
+      `)
+    ).toEqual([])
+  })
+
+  it("ignores CommonJS export assignment because it is not a module reference", () => {
+    expect(extractModuleReferences("module.exports = {};", "fixture.cjs")).toEqual([])
+  })
+
+  it("treats an ambient require declaration as non-runtime", () => {
+    expect(
+      extractModuleReferences(`
+        declare const require: (id: string) => unknown
+        require("@tanstack/react-query")
+      `)
+    ).toEqual(["@tanstack/react-query"])
+  })
+
+  it("fails closed when a computed module member could hide require", () => {
+    expect(() =>
+      extractModuleReferences(`
+        const method = "require"
+        module[method]("@tanstack/react-query")
+      `)
+    ).toThrow(/module member must be a static require reference/)
+  })
+
+  it.each([...supportedExtensions])(
+    "treats an added production %s module as inventory drift",
+    (extension) => {
+      const observed = [...expectedProductionModules, `nested/extra${extension}`].filter(
+        isProductionModulePath
+      )
+
+      expect(() =>
+        assertExactSet(observed, expectedProductionModules, "production inventory")
+      ).toThrow(/unexpected=\[nested\/extra/)
+    }
+  )
+
+  it("ignores test modules while detecting missing production modules", () => {
+    const observed = [
+      "UrlDocumentForm.tsx",
+      "url-document-utils.ts",
+      "__tests__/UrlDocumentList.test.tsx",
+      "helper.spec.js",
+    ].filter(isProductionModulePath)
+
+    expect(() =>
+      assertExactSet(observed, expectedProductionModules, "production inventory")
+    ).toThrow(/missing=\[UrlDocumentList\.tsx\]/)
+  })
+
+  it("reports both missing and unexpected module specifiers", () => {
+    expect(() =>
+      assertExactSet(
+        ["react", "unexpected-module"],
+        ["react", "lucide-react"],
+        "fixture references"
+      )
+    ).toThrow(/missing=\[lucide-react\]; unexpected=\[unexpected-module\]/)
+  })
+
+  it.each([
+    ["localStorage", "localStorage.setItem('draft', 'value')"],
+    [
+      "ambient fetch declaration",
+      "declare const fetch: (url: string) => Promise<unknown>; void fetch('/api/documents')",
+    ],
+    ["sessionStorage", "window.sessionStorage.removeItem('draft')"],
+    ["indexedDB", "globalThis.indexedDB.open('documents')"],
+    ["XMLHttpRequest", "const request = new XMLHttpRequest()"],
+    ["sendBeacon", "navigator.sendBeacon('/documents', payload)"],
+    ["window.open", "window.open('/documents')"],
+    ["top.open", "top.open('/documents')"],
+    ["parent.open", "parent.open('/documents')"],
+    ["global open", "open('/documents', '_blank')"],
+    ["CacheStorage", "caches.open('documents')"],
+    [
+      "BroadcastChannel",
+      "const channel = new BroadcastChannel('documents'); channel.postMessage('refresh')",
+    ],
+    ["EventSource", "new EventSource('/documents')"],
+    ["Image", "const image = new Image(); image.src = '/documents/preview.png'"],
+    ["Worker", "new Worker('/documents/worker.js')"],
+    ["self.fetch", "self.fetch('/documents')"],
+    ["location.assign", "location.assign('/documents')"],
+    ["history.pushState", "history.pushState({}, '', '/documents')"],
+    ["computed sendBeacon", "navigator['sendBeacon']('/documents', payload)"],
+    ["WebSocket", "const socket = new WebSocket('wss://example.com/documents')"],
+    ["document.cookie", "document.cookie = 'draft=value'"],
+    [
+      "destructured sendBeacon",
+      "const { sendBeacon } = navigator; sendBeacon('/documents', payload)",
+    ],
+    ["aliased localStorage", "const storage = localStorage; storage.setItem('draft', 'value')"],
+    ["computed window.open", "window['op' + 'en']('/documents')"],
+    ["aliased window root", "const browser = window; browser.open('/documents')"],
+    ["aliased globalThis root", "const runtime = globalThis; runtime.fetch('/documents')"],
+    [
+      "assignment-destructured sendBeacon",
+      "let send; ({ sendBeacon: send } = navigator); send('/documents', payload)",
+    ],
+    [
+      "nested-destructured sendBeacon",
+      "const { navigator: { sendBeacon } } = window; sendBeacon('/documents', payload)",
+    ],
+    [
+      "identifier-computed window capability",
+      "const method = 'fetch'; window[method]('/documents')",
+    ],
+    [
+      "identifier-computed globalThis capability",
+      "const method = 'fetch'; globalThis[method]('/documents')",
+    ],
+    [
+      "identifier-computed navigator capability",
+      "const method = 'sendBeacon'; navigator[method]('/documents', payload)",
+    ],
+  ])("detects the browser-side effect %s without relying on imports", (_name, source) => {
+    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).toThrow(
+      /fixture source references browser capability/
+    )
+  })
+
+  it("allows a locally shadowed browser-global name", () => {
+    const source = "function run(fetch: () => void) { fetch() }"
+
+    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
+  })
+
+  it("allows an identifier-computed member on a locally shadowed browser root", () => {
+    const source = `
+      function run(window: Record<string, () => void>, method: string) {
+        window[method]()
+      }
+    `
+
+    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
+  })
+
+  it("allows a browser-global name shadowed in a switch case block", () => {
+    const source = `
+      switch (kind) {
+        case "local":
+          const fetch = () => undefined
+          fetch()
+          break
+      }
+    `
+
+    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
+  })
+
+  it.each([
+    ["named function expression", "const run = function fetch() { fetch() }"],
+    [
+      "function-scoped var from a nested block",
+      "function run() { if (condition) { var fetch = () => undefined } fetch() }",
+    ],
+    ["named class expression", "const Local = class fetch { static current() { return fetch } }"],
+  ])("allows a browser-global name shadowed by a %s", (_name, source) => {
+    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
+  })
+
+  it("allows a browser-global name used only in a type position", () => {
+    const source = `
+      type Image = { src: string }
+      const preview: Image = { src: "" }
+    `
+
+    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
+  })
+
+  it("allows the pure URL constructor through globalThis", () => {
+    expect(() =>
+      assertNoForbiddenSourcePatterns(
+        'new globalThis.URL("https://example.com/document.pdf")',
+        "fixture source"
+      )
+    ).not.toThrow()
+  })
+})

--- a/src/components/url-documents/__tests__/url-document-source-contract.test.ts
+++ b/src/components/url-documents/__tests__/url-document-source-contract.test.ts
@@ -6,31 +6,29 @@ import {
   collectUrlDocumentConsumers,
   inspectUrlDocumentConsumer,
 } from "./url-document-consumer-contract-helpers"
-import { extractModuleReferences } from "./url-document-module-reference-helpers"
-import {
-  assertExactSet,
-  assertNoForbiddenSourcePatterns,
-  expectedProductionModules,
-  isProductionModulePath,
-  supportedExtensions,
-} from "./url-document-source-contract-fixtures"
+import { assertExactSet } from "./url-document-source-contract-fixtures"
 
 const applicationSourceRoot = join(process.cwd(), "src")
 const equipmentConsumerPath =
   "app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailFilesTab.tsx"
+const baselineConsumerPath =
+  "app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx"
 
 describe("URL document consumer source contract", () => {
-  it("keeps the cumulative P6B consumer manifest exact", () => {
+  it("keeps the cumulative P7B2 consumer manifest exact", () => {
     assertExactSet(
       collectUrlDocumentConsumers(applicationSourceRoot),
-      [equipmentConsumerPath],
-      "P6B URL document consumers"
+      [equipmentConsumerPath, baselineConsumerPath],
+      "P7B2 URL document consumers"
     )
   })
 
-  it("delegates Equipment presentation through exact shared bindings", () => {
-    const source = readFileSync(join(applicationSourceRoot, equipmentConsumerPath), "utf8")
-    const contract = inspectUrlDocumentConsumer(source, equipmentConsumerPath)
+  it.each([
+    ["Equipment", equipmentConsumerPath],
+    ["baseline evidence", baselineConsumerPath],
+  ])("delegates %s presentation through exact shared bindings", (_label, consumerPath) => {
+    const source = readFileSync(join(applicationSourceRoot, consumerPath), "utf8")
+    const contract = inspectUrlDocumentConsumer(source, consumerPath)
 
     expect(contract.sharedImports).toEqual([
       "@/components/url-documents/UrlDocumentForm:UrlDocumentForm->UrlDocumentForm",
@@ -47,302 +45,5 @@ describe("URL document consumer source contract", () => {
     expect(contract.forbiddenImports).toEqual([])
     expect(contract.forbiddenPresentationElements).toEqual([])
     expect(contract.constructsUrlDirectly).toBe(false)
-  })
-})
-
-describe("URL document source-contract extractor", () => {
-  it("extracts every supported literal module-reference form", () => {
-    const source = `
-      import defaultValue from "static-default"
-      import type { TypeValue } from "static-type"
-      import equalsValue = require("import-equals")
-      export { value } from "named-export"
-      export * from "star-export"
-      void import("dynamic-import")
-      void import("dynamic-import-with-attributes", { with: { type: "json" } })
-      const required = require("required-module")
-      declare const window: { require(id: string): unknown }
-      const ambientMemberRequired = window.require("ambient-member-required")
-      const moduleRequired = module.require("module-required")
-      const computedModuleRequired = module["require"]("computed-module-required")
-      type Imported = import("import-type").Imported
-    `
-
-    expect(extractModuleReferences(source)).toEqual([
-      "ambient-member-required",
-      "computed-module-required",
-      "dynamic-import",
-      "dynamic-import-with-attributes",
-      "import-equals",
-      "import-type",
-      "module-required",
-      "named-export",
-      "required-module",
-      "star-export",
-      "static-default",
-      "static-type",
-    ])
-  })
-
-  it("distinguishes allowed and denied static imports through exact set equality", () => {
-    const observed = extractModuleReferences(`
-      import type { Allowed } from "allowed"
-      import { Denied } from "allowed/denied"
-    `)
-
-    expect(() => assertExactSet(observed, ["allowed"], "fixture imports")).toThrow(
-      /unexpected=\[allowed\/denied\]/
-    )
-  })
-
-  it.each([
-    ["dynamic import", "const moduleName = 'dynamic'; void import(moduleName)"],
-    ["require", "const moduleName = 'required'; require(moduleName)"],
-    ["import type", "type ModuleName = 'types'; type Value = import(ModuleName).Value"],
-  ])("fails closed for a computed %s reference", (_kind, source) => {
-    expect(() => extractModuleReferences(source)).toThrow(/must use a string literal/)
-  })
-
-  it("fails closed when require is aliased instead of called directly", () => {
-    expect(() =>
-      extractModuleReferences(`
-        const load = require
-        load("@/app/(app)/equipment/_hooks/use-equipment-attachments")
-      `)
-    ).toThrow(/require must be called directly/)
-  })
-
-  it("fails closed when the ambient module object is aliased", () => {
-    expect(() =>
-      extractModuleReferences(`
-        const runtime = module
-        runtime.require("@tanstack/react-query")
-      `)
-    ).toThrow(/module must be accessed directly/)
-  })
-
-  it("fails closed when an ambient member require uses a computed specifier", () => {
-    expect(() =>
-      extractModuleReferences(`
-        declare const window: { require(id: string): unknown }
-        const moduleName = "@tanstack/react-query"
-        window.require(moduleName)
-      `)
-    ).toThrow(/ambient require must use a string literal/)
-  })
-
-  it("fails closed when an indirect module loader chain is called", () => {
-    expect(() =>
-      extractModuleReferences('module.constructor._load("@tanstack/react-query")')
-    ).toThrow(/module calls must use direct module\.require/)
-  })
-
-  it.each([
-    [
-      "require parameter",
-      `
-        function load(require: (name: string) => unknown) {
-          return require("local-adapter")
-        }
-      `,
-    ],
-    [
-      "module parameter",
-      `
-        function load(module: { require: (name: string) => unknown }) {
-          return module.require("local-adapter")
-        }
-      `,
-    ],
-  ])("ignores a locally shadowed CommonJS %s", (_name, source) => {
-    expect(extractModuleReferences(source)).toEqual([])
-  })
-
-  it("ignores a locally shadowed member require", () => {
-    expect(
-      extractModuleReferences(`
-        function load(runtime: { require(name: string): unknown }) {
-          return runtime.require("local-adapter")
-        }
-      `)
-    ).toEqual([])
-  })
-
-  it("ignores CommonJS export assignment because it is not a module reference", () => {
-    expect(extractModuleReferences("module.exports = {};", "fixture.cjs")).toEqual([])
-  })
-
-  it("treats an ambient require declaration as non-runtime", () => {
-    expect(
-      extractModuleReferences(`
-        declare const require: (id: string) => unknown
-        require("@tanstack/react-query")
-      `)
-    ).toEqual(["@tanstack/react-query"])
-  })
-
-  it("fails closed when a computed module member could hide require", () => {
-    expect(() =>
-      extractModuleReferences(`
-        const method = "require"
-        module[method]("@tanstack/react-query")
-      `)
-    ).toThrow(/module member must be a static require reference/)
-  })
-
-  it.each([...supportedExtensions])(
-    "treats an added production %s module as inventory drift",
-    (extension) => {
-      const observed = [...expectedProductionModules, `nested/extra${extension}`].filter(
-        isProductionModulePath
-      )
-
-      expect(() =>
-        assertExactSet(observed, expectedProductionModules, "production inventory")
-      ).toThrow(/unexpected=\[nested\/extra/)
-    }
-  )
-
-  it("ignores test modules while detecting missing production modules", () => {
-    const observed = [
-      "UrlDocumentForm.tsx",
-      "url-document-utils.ts",
-      "__tests__/UrlDocumentList.test.tsx",
-      "helper.spec.js",
-    ].filter(isProductionModulePath)
-
-    expect(() =>
-      assertExactSet(observed, expectedProductionModules, "production inventory")
-    ).toThrow(/missing=\[UrlDocumentList\.tsx\]/)
-  })
-
-  it("reports both missing and unexpected module specifiers", () => {
-    expect(() =>
-      assertExactSet(
-        ["react", "unexpected-module"],
-        ["react", "lucide-react"],
-        "fixture references"
-      )
-    ).toThrow(/missing=\[lucide-react\]; unexpected=\[unexpected-module\]/)
-  })
-
-  it.each([
-    ["localStorage", "localStorage.setItem('draft', 'value')"],
-    [
-      "ambient fetch declaration",
-      "declare const fetch: (url: string) => Promise<unknown>; void fetch('/api/documents')",
-    ],
-    ["sessionStorage", "window.sessionStorage.removeItem('draft')"],
-    ["indexedDB", "globalThis.indexedDB.open('documents')"],
-    ["XMLHttpRequest", "const request = new XMLHttpRequest()"],
-    ["sendBeacon", "navigator.sendBeacon('/documents', payload)"],
-    ["window.open", "window.open('/documents')"],
-    ["top.open", "top.open('/documents')"],
-    ["parent.open", "parent.open('/documents')"],
-    ["global open", "open('/documents', '_blank')"],
-    ["CacheStorage", "caches.open('documents')"],
-    [
-      "BroadcastChannel",
-      "const channel = new BroadcastChannel('documents'); channel.postMessage('refresh')",
-    ],
-    ["EventSource", "new EventSource('/documents')"],
-    ["Image", "const image = new Image(); image.src = '/documents/preview.png'"],
-    ["Worker", "new Worker('/documents/worker.js')"],
-    ["self.fetch", "self.fetch('/documents')"],
-    ["location.assign", "location.assign('/documents')"],
-    ["history.pushState", "history.pushState({}, '', '/documents')"],
-    ["computed sendBeacon", "navigator['sendBeacon']('/documents', payload)"],
-    ["WebSocket", "const socket = new WebSocket('wss://example.com/documents')"],
-    ["document.cookie", "document.cookie = 'draft=value'"],
-    [
-      "destructured sendBeacon",
-      "const { sendBeacon } = navigator; sendBeacon('/documents', payload)",
-    ],
-    ["aliased localStorage", "const storage = localStorage; storage.setItem('draft', 'value')"],
-    ["computed window.open", "window['op' + 'en']('/documents')"],
-    ["aliased window root", "const browser = window; browser.open('/documents')"],
-    ["aliased globalThis root", "const runtime = globalThis; runtime.fetch('/documents')"],
-    [
-      "assignment-destructured sendBeacon",
-      "let send; ({ sendBeacon: send } = navigator); send('/documents', payload)",
-    ],
-    [
-      "nested-destructured sendBeacon",
-      "const { navigator: { sendBeacon } } = window; sendBeacon('/documents', payload)",
-    ],
-    [
-      "identifier-computed window capability",
-      "const method = 'fetch'; window[method]('/documents')",
-    ],
-    [
-      "identifier-computed globalThis capability",
-      "const method = 'fetch'; globalThis[method]('/documents')",
-    ],
-    [
-      "identifier-computed navigator capability",
-      "const method = 'sendBeacon'; navigator[method]('/documents', payload)",
-    ],
-  ])("detects the browser-side effect %s without relying on imports", (_name, source) => {
-    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).toThrow(
-      /fixture source references browser capability/
-    )
-  })
-
-  it("allows a locally shadowed browser-global name", () => {
-    const source = "function run(fetch: () => void) { fetch() }"
-
-    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
-  })
-
-  it("allows an identifier-computed member on a locally shadowed browser root", () => {
-    const source = `
-      function run(window: Record<string, () => void>, method: string) {
-        window[method]()
-      }
-    `
-
-    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
-  })
-
-  it("allows a browser-global name shadowed in a switch case block", () => {
-    const source = `
-      switch (kind) {
-        case "local":
-          const fetch = () => undefined
-          fetch()
-          break
-      }
-    `
-
-    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
-  })
-
-  it.each([
-    ["named function expression", "const run = function fetch() { fetch() }"],
-    [
-      "function-scoped var from a nested block",
-      "function run() { if (condition) { var fetch = () => undefined } fetch() }",
-    ],
-    ["named class expression", "const Local = class fetch { static current() { return fetch } }"],
-  ])("allows a browser-global name shadowed by a %s", (_name, source) => {
-    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
-  })
-
-  it("allows a browser-global name used only in a type position", () => {
-    const source = `
-      type Image = { src: string }
-      const preview: Image = { src: "" }
-    `
-
-    expect(() => assertNoForbiddenSourcePatterns(source, "fixture source")).not.toThrow()
-  })
-
-  it("allows the pure URL constructor through globalThis", () => {
-    expect(() =>
-      assertNoForbiddenSourcePatterns(
-        'new globalThis.URL("https://example.com/document.pdf")',
-        "fixture source"
-      )
-    ).not.toThrow()
   })
 })


### PR DESCRIPTION
## Summary

- add the P7B2 baseline/reference URL-document and citation workspace on top of the P7B1 aggregate and mutation contracts
- reuse the P6 `UrlDocumentForm`, `UrlDocumentList`, and shared WHATWG URL policy while keeping accepted raw URLs unchanged
- add HeroUI v3 evidence selectors, indicator/detail surfaces, explicit dirty/conflict handling, affected-link delete confirmation, and locked/archived read-only guards
- consolidate stable pagination and before-unload behavior, extend the cumulative consumer/source-contract manifest, and add focused `user-event` regression coverage

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:heroui-boundary`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- P7B2 focused Vitest suite: 11 files, 222 tests passed
- `node scripts/npm-run.js run react-doctor`: 91/100, no issues
- `openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`
- `git diff --check`
- changed source files remain below the repository size thresholds

## Known Verification Gap

Browser long-text/responsive verification was intentionally not run because credentials are unavailable and the user requested that the dev server remain stopped. `P7B2.8` records this browser gate as `N/A`; no browser behavior is claimed here.

## Scope Notes

- no migration or live DB write
- no P7B1 contract changes
- no P9B, P13, or Equipment behavior changes
- shared P6 primitive HeroUI migration is tracked separately in #772

Closes #771

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Evidence workspace for technical configurations with a new Evidence tab, inline reference indicators, and safe editing with conflict handling, read‑only guards, and before‑unload protection.

- **New Features**
  - Evidence tab with document list, citation editor, delete confirmation, and blocking retry UI for refresh failures.
  - Inline reference evidence indicators and dialog with full-text detail; opens by product/criterion.
  - Shared documents hook routes baseline/reference owner operations; preserves document drafts across refreshes.
  - Reuses P6 `UrlDocumentForm` and `UrlDocumentList` with the WHATWG URL policy; raw URLs unchanged.
  - Evidence UI built with `@heroui/react` v3.

- **Refactors**
  - Added `useTechnicalConfigurationDocuments`, `technicalConfigurationDocumentsQueryKey`, `useTechnicalConfigurationBaselineVersionSelection`, and `useTechnicalConfigurationBeforeUnloadGuard` to unify evidence under one baseline version and guard unloads.
  - Introduced `collectStableTechnicalConfigurationPages` and integrated it into reference-product operations; snapshot consistency tests added.
  - Split comparison table and evidence components; expanded `check-heroui` import boundary allowlist.
  - Extended URL-document consumer/source-contract tests and added the extractor suite.

<sup>Written for commit a64ee0d547050b0182f02480bf46b4534fb9b920. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Tài liệu & trích dẫn” evidence workspace for technical configurations.
  * Manage baseline and reference-product documents, URL entry/validation, and criterion citations.
  * From the comparison table, open evidence dialogs with full-text and evidence details.
* **Bug Fixes**
  * Improved conflict/stale data handling with clearer alerts while preserving unsaved edits.
  * Added stronger protection against losing drafts during navigation/tab switching; archived/locked modes now enforce read-only/disabled actions.
  * Enhanced document query error and deletion confirmation flows (including retry and better error display).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
