### PR TITLE
fix: export technical configuration draft state

### DIFF
--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
 
-interface TechnicalConfigurationDocumentDraftState {
+export interface TechnicalConfigurationDocumentDraftState {
   name: string
   url: string
   selectedDocumentId: string | null


### PR DESCRIPTION
## Summary
- export `TechnicalConfigurationDocumentDraftState` from its hook module

## Review comment triage
- skipped the delete-dialog context refactor: current technical-configurations code has no shared dialog context carrying the requested state/handlers; the parent remains the sole owner
- skipped the React namespace import: the current TypeScript configuration resolves `React.JSX.Element`, and baseline/current typecheck passes without a runtime React reference

## Validation
- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- `typecheck`
- `baseline-evidence.test.tsx` (27/27)
- React Doctor 100/100

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported `TechnicalConfigurationDocumentDraftState` from the `useTechnicalConfigurationDocumentDraft` hook so other modules can import the draft state type. No runtime changes; this only fixes type visibility for the technical configuration review flow.

<sup>Written for commit 6e57a9edf0d59e0a342b0da0a265fe253efec0cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

