### PR TITLE
fix: use alert dialog for technical navigation

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -348,23 +348,29 @@ export function registerReferenceProductWorkspaceTests({
     it("preserves a dirty reference draft when dossier-back navigation is rejected", async () => {
       const user = userEvent.setup()
       const onBack = vi.fn()
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
       referenceRpc.listProducts.mockResolvedValue(listResponse([]))
 
-      renderWithQueryClient(
-        <TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />
-      )
-      await user.click(screen.getByRole("tab", { name: "Sản phẩm tham chiếu" }))
-      await user.click(await screen.findByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
-      await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
-      await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
+      try {
+        renderWithQueryClient(
+          <TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />
+        )
+        await user.click(screen.getByRole("tab", { name: "Sản phẩm tham chiếu" }))
+        await user.click(await screen.findByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+        await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
+        await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
 
-      expect(confirm).toHaveBeenCalledWith(
-        "Bạn có thay đổi chưa lưu. Rời hồ sơ và bỏ các thay đổi?"
-      )
-      expect(onBack).not.toHaveBeenCalled()
-      expect(screen.getByDisplayValue("Model chưa lưu")).toBeInTheDocument()
-      confirm.mockRestore()
+        expect(nativeConfirm).not.toHaveBeenCalled()
+        await user.click(
+          within(await screen.findByRole("alertdialog")).getByRole("button", {
+            name: "Tiếp tục chỉnh sửa",
+          })
+        )
+        expect(onBack).not.toHaveBeenCalled()
+        expect(screen.getByDisplayValue("Model chưa lưu")).toBeInTheDocument()
+      } finally {
+        nativeConfirm.mockRestore()
+      }
     })
   })
 }

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -3,7 +3,7 @@ import path from "node:path"
 
 import * as React from "react"
 import "@testing-library/jest-dom"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
@@ -85,20 +85,66 @@ const dossier: TechnicalConfigurationDossierWire = {
 }
 
 describe("technical configuration baseline workspace integration", () => {
-  it("keeps dirty form state when dossier-back confirmation is rejected", async () => {
+  it("uses an alert dialog before leaving a dirty dossier", async () => {
     const user = userEvent.setup()
     const onBack = vi.fn()
-    const confirm = vi.spyOn(window, "confirm").mockReturnValueOnce(false).mockReturnValueOnce(true)
+    const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
 
-    render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />)
-    await waitFor(() => expect(screen.getByText("Baseline editor")).toBeInTheDocument())
+    try {
+      render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />)
+      await waitFor(() => expect(screen.getByText("Baseline editor")).toBeInTheDocument())
 
-    await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
-    expect(confirm).toHaveBeenCalledWith("Bạn có thay đổi chưa lưu. Rời hồ sơ và bỏ các thay đổi?")
-    expect(onBack).not.toHaveBeenCalled()
+      await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
 
-    await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
-    expect(onBack).toHaveBeenCalledTimes(1)
+      expect(nativeConfirm).not.toHaveBeenCalled()
+      const dialog = await screen.findByRole("alertdialog")
+      expect(within(dialog).getByText("Bỏ thay đổi chưa lưu?")).toBeInTheDocument()
+      expect(onBack).not.toHaveBeenCalled()
+
+      await user.click(
+        within(dialog).getByRole("button", {
+          name: "Tiếp tục chỉnh sửa",
+        })
+      )
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+      expect(screen.getByText("Baseline editor")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
+      await user.click(
+        within(await screen.findByRole("alertdialog")).getByRole("button", {
+          name: "Bỏ thay đổi",
+        })
+      )
+      expect(onBack).toHaveBeenCalledTimes(1)
+    } finally {
+      nativeConfirm.mockRestore()
+    }
+  })
+
+  it("uses an alert dialog before switching away from a dirty workspace", async () => {
+    const user = userEvent.setup()
+    const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+
+    try {
+      render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={vi.fn()} />)
+      await waitFor(() => expect(screen.getByText("Baseline editor")).toBeInTheDocument())
+
+      await user.click(screen.getByRole("tab", { name: "Tài liệu & trích dẫn" }))
+
+      expect(nativeConfirm).not.toHaveBeenCalled()
+      expect(screen.queryByText("Baseline evidence workspace")).not.toBeInTheDocument()
+
+      await user.click(
+        within(await screen.findByRole("alertdialog")).getByRole("button", {
+          name: "Bỏ thay đổi",
+        })
+      )
+
+      expect(screen.getByText("Baseline evidence workspace")).toBeInTheDocument()
+      expect(screen.queryByText("Baseline editor")).not.toBeInTheDocument()
+    } finally {
+      nativeConfirm.mockRestore()
+    }
   })
 
   it("blocks dossier navigation while an atomic baseline apply is pending", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -3,7 +3,7 @@ import path from "node:path"
 
 import * as React from "react"
 import "@testing-library/jest-dom"
-import { render, screen, waitFor, within } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
@@ -92,7 +92,7 @@ describe("technical configuration baseline workspace integration", () => {
 
     try {
       render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />)
-      await waitFor(() => expect(screen.getByText("Baseline editor")).toBeInTheDocument())
+      await screen.findByText("Baseline editor")
 
       await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
 
@@ -127,7 +127,7 @@ describe("technical configuration baseline workspace integration", () => {
 
     try {
       render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={vi.fn()} />)
-      await waitFor(() => expect(screen.getByText("Baseline editor")).toBeInTheDocument())
+      await screen.findByText("Baseline editor")
 
       await user.click(screen.getByRole("tab", { name: "Tài liệu & trích dẫn" }))
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -193,6 +193,7 @@ describe("technical configuration dossier shell", () => {
     expect(await screen.findByRole("heading", { name: dossier.name })).toBeInTheDocument()
     expect(screen.getAllByRole("tab").map((tab) => tab.textContent?.trim())).toEqual([
       "Cấu hình cơ sở",
+      "Tài liệu & trích dẫn",
       "Sản phẩm tham chiếu",
       "Phương án",
       "So sánh & đánh giá",

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -10,6 +10,16 @@ import {
 } from "lucide-react"
 
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
@@ -22,12 +32,21 @@ type TechnicalConfigurationWorkspaceShellProps = {
   onBack: () => void
 }
 
+type PendingWorkspaceNavigation =
+  | { kind: "back" }
+  | {
+      kind: "tab"
+      value: string
+    }
+
 /** Renders the dossier workspace tabs available in the current delivery phase. */
 export function TechnicalConfigurationWorkspaceShell({
   dossier,
   onBack,
 }: Readonly<TechnicalConfigurationWorkspaceShellProps>) {
   const [activeTab, setActiveTab] = React.useState("baseline")
+  const [pendingNavigation, setPendingNavigation] =
+    React.useState<PendingWorkspaceNavigation | null>(null)
   const [isBaselineDirty, setIsBaselineDirty] = React.useState(false)
   const [isBaselineNavigationBlocked, setIsBaselineNavigationBlocked] = React.useState(false)
   const [isEvidenceDirty, setIsEvidenceDirty] = React.useState(false)
@@ -40,7 +59,8 @@ export function TechnicalConfigurationWorkspaceShell({
 
   const handleBack = React.useCallback(() => {
     if (isNavigationBlocked) return
-    if (isDirty && !window.confirm("Bạn có thay đổi chưa lưu. Rời hồ sơ và bỏ các thay đổi?")) {
+    if (isDirty) {
+      setPendingNavigation({ kind: "back" })
       return
     }
     onBack()
@@ -48,6 +68,7 @@ export function TechnicalConfigurationWorkspaceShell({
 
   const handleTabChange = React.useCallback(
     (nextTab: string) => {
+      if (nextTab === activeTab) return
       const isCurrentTabDirty =
         (activeTab === "baseline" && isBaselineDirty) ||
         (activeTab === "evidence" && isEvidenceDirty) ||
@@ -57,10 +78,8 @@ export function TechnicalConfigurationWorkspaceShell({
         (activeTab === "evidence" && isEvidenceNavigationBlocked) ||
         (activeTab === "references" && isReferenceNavigationBlocked)
       if (isCurrentTabBlocked) return
-      if (
-        isCurrentTabDirty &&
-        !window.confirm("Bạn có thay đổi chưa lưu. Chuyển khu vực và bỏ các thay đổi?")
-      ) {
+      if (isCurrentTabDirty) {
+        setPendingNavigation({ kind: "tab", value: nextTab })
         return
       }
       setActiveTab(nextTab)
@@ -75,6 +94,20 @@ export function TechnicalConfigurationWorkspaceShell({
       isReferenceNavigationBlocked,
     ]
   )
+
+  const dismissPendingNavigation = React.useCallback(() => {
+    setPendingNavigation(null)
+  }, [])
+
+  const confirmPendingNavigation = React.useCallback(() => {
+    if (!pendingNavigation) return
+    setPendingNavigation(null)
+    if (pendingNavigation.kind === "back") {
+      onBack()
+      return
+    }
+    setActiveTab(pendingNavigation.value)
+  }, [onBack, pendingNavigation])
 
   return (
     <div className="w-full">
@@ -150,6 +183,32 @@ export function TechnicalConfigurationWorkspaceShell({
           />
         </TabsContent>
       </Tabs>
+
+      <AlertDialog
+        open={pendingNavigation !== null}
+        onOpenChange={(open) => {
+          if (!open) dismissPendingNavigation()
+        }}
+      >
+        <AlertDialogContent className="sm:max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Bỏ thay đổi chưa lưu?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Các thay đổi chưa lưu sẽ bị mất nếu bạn tiếp tục. Hãy tiếp tục chỉnh sửa để lưu hoặc
+              xác nhận bỏ thay đổi.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Tiếp tục chỉnh sửa</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={confirmPendingNavigation}
+            >
+              Bỏ thay đổi
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
 
-interface TechnicalConfigurationDocumentDraftState {
+export interface TechnicalConfigurationDocumentDraftState {
   name: string
   url: string
   selectedDocumentId: string | null


### PR DESCRIPTION
## Summary
- replace `window.confirm` in `TechnicalConfigurationWorkspaceShell` with the shared controlled `AlertDialog`
- preserve dirty drafts when users cancel leaving a dossier or switching workspace tabs
- execute back/tab navigation only after explicit discard confirmation
- keep the browser-native `beforeunload` guard for reload, close-tab, and external unload flows

## TDD evidence
- RED: 2 workspace tests failed because `window.confirm` was called
- GREEN: workspace suite 5/5 and reference-product suite 40/40

## Validation
- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- `verify:heroui-boundary`
- `typecheck`
- React Doctor 100/100

## Known baseline gap
`technical-configuration-dossier-shell.test.tsx` has a pre-existing stale tab-list assertion on `origin/main`; tracked separately in #776.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a controlled `AlertDialog` for back and tab navigation in Technical Configuration. Prevents accidental data loss by requiring explicit discard; no native confirm dialogs.

- **Bug Fixes**
  - Replace `window.confirm` with a discard `AlertDialog` on dirty leave or tab switch; tests use async `alertdialog` queries; cancel keeps edits.
  - Proceed only after confirm; keep the browser `beforeunload` guard for reload/close.

- **Refactors**
  - Export `TechnicalConfigurationDocumentDraftState` for reuse.

<sup>Written for commit 6f46dc17162609c007aa99470f742266045d8674. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

