### PR TITLE
fix: replace technical configuration native confirms

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-citation-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-citation-cases.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
@@ -139,7 +139,7 @@ export function registerBaselineEvidenceCitationTests() {
           },
         ],
       }
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
       render(
         <TechnicalConfigurationCitationEditor
           documents={[firstDocument, secondDocument]}
@@ -159,12 +159,17 @@ export function registerBaselineEvidenceCitationTests() {
       await user.keyboard("{ArrowDown}")
       await user.click(await screen.findByRole("option", { name: secondDocument.name }))
 
-      expect(confirm).toHaveBeenCalledWith(
-        "Chuyển lựa chọn sẽ bỏ nội dung trích dẫn chưa lưu. Tiếp tục?"
-      )
+      expect(nativeConfirm).not.toHaveBeenCalled()
+      const dialog = await screen.findByRole("alertdialog")
+      expect(within(dialog).getByText("Bỏ thay đổi chưa lưu?")).toBeInTheDocument()
+      expect(
+        within(dialog).getByText("Chuyển lựa chọn sẽ bỏ nội dung trích dẫn chưa lưu. Tiếp tục?")
+      ).toBeInTheDocument()
       expect(screen.getByLabelText("Trích đoạn")).toHaveValue("Bản nháp chưa lưu")
       expect(documentPicker).toHaveTextContent(firstDocument.name)
-      confirm.mockRestore()
+      await user.click(within(dialog).getByRole("button", { name: "Hủy" }))
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+      nativeConfirm.mockRestore()
     })
 
     it("preserves a dirty citation when the selected document disappears", async () => {
@@ -202,15 +207,18 @@ export function registerBaselineEvidenceCitationTests() {
       expect(screen.getByLabelText("Trích đoạn")).toHaveValue("Bản nháp chưa lưu")
       expect(screen.getByRole("button", { name: "Lưu trích dẫn" })).toBeDisabled()
 
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
       const documentPicker = screen.getByRole("button", { name: /Tài liệu/i })
       act(() => documentPicker.focus())
       await user.keyboard("{ArrowDown}")
       await user.click(await screen.findByRole("option", { name: secondDocument.name }))
+      await user.click(
+        within(await screen.findByRole("alertdialog")).getByRole("button", {
+          name: "Bỏ thay đổi",
+        })
+      )
 
       await waitFor(() => expect(screen.getByText(secondDocument.name)).toBeInTheDocument())
       expect(screen.queryByRole("alert")).not.toBeInTheDocument()
-      confirm.mockRestore()
     })
 
     it("renders citation deletion failures without an unhandled rejection", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-document-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-document-cases.tsx
@@ -179,25 +179,28 @@ export function registerBaselineEvidenceDocumentTests(documentRpc: DocumentRpcMo
       expect(screen.getByRole("button", { name: "Lưu thay đổi" })).toBeDisabled()
       expect(documentRpc.createBaselineDocument).not.toHaveBeenCalled()
 
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
       const refreshedDocumentPicker = screen.getByRole("button", {
         name: /Tài liệu đang chỉnh sửa/i,
       })
       act(() => refreshedDocumentPicker.focus())
       await user.keyboard("{ArrowDown}")
       await user.click(await screen.findByRole("option", { name: secondDocument.name }))
+      await user.click(
+        within(await screen.findByRole("alertdialog")).getByRole("button", {
+          name: "Bỏ thay đổi",
+        })
+      )
 
       await waitFor(() => {
         expect(screen.queryByRole("alert")).not.toBeInTheDocument()
         expect(screen.getByLabelText("Tên tài liệu")).toHaveValue(secondDocument.name)
       })
-      confirm.mockRestore()
     })
 
     it("preserves a dirty document draft when creating a new document is rejected", async () => {
       const user = userEvent.setup()
       const document = evidenceDocument("document-1", "baseline", baselineVersion.id)
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
       documentRpc.listDocuments.mockResolvedValue({
         data: [document],
         total: 1,
@@ -223,11 +226,15 @@ export function registerBaselineEvidenceDocumentTests(documentRpc: DocumentRpcMo
       await user.type(screen.getByLabelText("Tên tài liệu"), " chưa lưu")
       await user.click(screen.getByRole("button", { name: "Tạo tài liệu mới" }))
 
-      expect(confirm).toHaveBeenCalledWith(
-        "Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?"
-      )
+      expect(nativeConfirm).not.toHaveBeenCalled()
+      const dialog = await screen.findByRole("alertdialog")
+      expect(
+        within(dialog).getByText("Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?")
+      ).toBeInTheDocument()
       expect(screen.getByLabelText("Tên tài liệu")).toHaveValue(`${document.name} chưa lưu`)
-      confirm.mockRestore()
+      await user.click(within(dialog).getByRole("button", { name: "Hủy" }))
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+      nativeConfirm.mockRestore()
     })
 
     it("renders document submission failures while preserving the draft", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
@@ -133,13 +133,7 @@ describe("technical configuration baseline locking and history", () => {
       page_size: 100,
     })
     await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
-    const discardDialog = await screen.findByRole("alertdialog")
     expect(nativeConfirm).not.toHaveBeenCalled()
-    await user.click(
-      within(discardDialog).getByRole("button", {
-        name: "Bỏ thay đổi",
-      })
-    )
 
     expect(await screen.findByText("Nội dung chỉ đọc")).toBeInTheDocument()
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument()

--- a/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
@@ -108,7 +108,7 @@ describe("technical configuration baseline locking and history", () => {
 
   it("reloads a concurrently locked draft into read-only history", async () => {
     const user = userEvent.setup()
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
+    const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
     const draft = createDraft()
     const locked = createLockedVersion()
     mockVersions([draft])
@@ -133,10 +133,17 @@ describe("technical configuration baseline locking and history", () => {
       page_size: 100,
     })
     await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
+    const discardDialog = await screen.findByRole("alertdialog")
+    expect(nativeConfirm).not.toHaveBeenCalled()
+    await user.click(
+      within(discardDialog).getByRole("button", {
+        name: "Bỏ thay đổi",
+      })
+    )
 
-    expect(confirm).toHaveBeenCalled()
     expect(await screen.findByText("Nội dung chỉ đọc")).toBeInTheDocument()
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+    nativeConfirm.mockRestore()
   })
 
   it("copies a locked version into a new editable draft", async () => {
@@ -198,7 +205,7 @@ describe("technical configuration baseline locking and history", () => {
     const locked = createLockedVersion()
     const draft = createDraft({ id: "draft-2", version_number: 2 })
     mockVersions([draft, locked])
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+    const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
 
     renderTab()
     const requirement = await screen.findByLabelText("Nội dung yêu cầu 1.1")
@@ -206,10 +213,13 @@ describe("technical configuration baseline locking and history", () => {
     await user.type(requirement, "Nội dung đang sửa")
     await user.selectOptions(screen.getByRole("combobox", { name: "Lịch sử phiên bản" }), locked.id)
 
-    expect(confirm).toHaveBeenCalledWith("Chuyển phiên bản sẽ bỏ các thay đổi chưa lưu. Tiếp tục?")
+    expect(nativeConfirm).not.toHaveBeenCalled()
+    const discardDialog = await screen.findByRole("alertdialog")
+    await user.click(within(discardDialog).getByRole("button", { name: "Hủy" }))
     expect(requirement).toHaveValue("Nội dung đang sửa")
     expect(screen.getByText("Phiên bản 2")).toBeInTheDocument()
     expect(screen.queryByText("Nội dung chỉ đọc")).not.toBeInTheDocument()
+    nativeConfirm.mockRestore()
   })
 
   it("blocks history navigation while a save is pending", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-evidence-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-evidence-cases.tsx
@@ -187,6 +187,7 @@ export function registerReferenceProductEvidenceTests({
             name: "Bằng chứng Model A cho TC-0001: 0 tài liệu, 0 trích dẫn",
           })
         )
+        await user.type(screen.getByRole("textbox", { name: "Bản nháp bằng chứng" }), "Đang sửa")
         baselineDocumentsMock.props?.onDirtyChange?.(true)
         await user.click(screen.getByRole("button", { name: "Đóng" }))
 
@@ -195,6 +196,7 @@ export function registerReferenceProductEvidenceTests({
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
         await user.click(within(discardDialog).getByRole("button", { name: "Hủy" }))
         expect(screen.getByRole("dialog")).toBeInTheDocument()
+        expect(screen.getByRole("textbox", { name: "Bản nháp bằng chứng" })).toHaveValue("Đang sửa")
 
         await user.click(screen.getByRole("button", { name: "Đóng" }))
         await user.click(

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-evidence-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-evidence-cases.tsx
@@ -1,6 +1,6 @@
-import { screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, type Mock } from "vitest"
+import { describe, expect, it, vi, type Mock } from "vitest"
 
 import { TechnicalConfigurationReferenceComparison } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison"
 import { toTechnicalConfigurationReferenceProductDraft } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
@@ -160,6 +160,53 @@ export function registerReferenceProductEvidenceTests({
 
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
       expect(onNavigationBlockedChange).toHaveBeenCalledWith(false)
+    })
+
+    it("uses an alert dialog before closing dirty evidence", async () => {
+      const user = userEvent.setup()
+      const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      const onEvidenceDirtyChange = vi.fn()
+      const referenceProduct = toTechnicalConfigurationReferenceProductDraft(
+        product("product-1", "Model A")
+      )
+      evidenceState.getDocumentsForOwner.mockReturnValue([])
+
+      try {
+        renderWithQueryClient(
+          <TechnicalConfigurationReferenceComparison
+            baselineVersion={baselineVersion}
+            products={[referenceProduct]}
+            readOnly={false}
+            onResponseChange={vi.fn()}
+            onEvidenceDirtyChange={onEvidenceDirtyChange}
+          />
+        )
+
+        await user.click(
+          screen.getByRole("button", {
+            name: "Bằng chứng Model A cho TC-0001: 0 tài liệu, 0 trích dẫn",
+          })
+        )
+        baselineDocumentsMock.props?.onDirtyChange?.(true)
+        await user.click(screen.getByRole("button", { name: "Đóng" }))
+
+        expect(nativeConfirm).not.toHaveBeenCalled()
+        const discardDialog = await screen.findByRole("alertdialog")
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+        await user.click(within(discardDialog).getByRole("button", { name: "Hủy" }))
+        expect(screen.getByRole("dialog")).toBeInTheDocument()
+
+        await user.click(screen.getByRole("button", { name: "Đóng" }))
+        await user.click(
+          within(await screen.findByRole("alertdialog")).getByRole("button", {
+            name: "Bỏ thay đổi",
+          })
+        )
+        await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
+        expect(onEvidenceDirtyChange).toHaveBeenLastCalledWith(false)
+      } finally {
+        nativeConfirm.mockRestore()
+      }
     })
 
     it("resolves evidence documents once per visible product", () => {

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
@@ -127,7 +127,6 @@ export function registerReferenceProductResilienceTests({
 
     it("blocks version and product navigation while version refresh is pending", async () => {
       const user = userEvent.setup()
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
       let resolveVersions:
         | ((value: {
             data: Array<typeof baselineVersion>
@@ -156,6 +155,7 @@ export function registerReferenceProductResilienceTests({
       await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
       await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
       await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+      await user.click(await screen.findByRole("button", { name: "Bỏ thay đổi" }))
 
       expect(screen.getByRole("combobox", { name: "Phiên bản cấu hình cơ sở" })).toBeDisabled()
       expect(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeDisabled()
@@ -169,7 +169,6 @@ export function registerReferenceProductResilienceTests({
       await waitFor(() =>
         expect(screen.getByRole("combobox", { name: "Phiên bản cấu hình cơ sở" })).toBeEnabled()
       )
-      confirm.mockRestore()
     })
 
     it("wires visible product update, response upsert, and delete through explicit save", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
@@ -67,6 +67,44 @@ export function registerReferenceProductWorkspaceTests({
       expect(versionPicker.tagName).toBe("BUTTON")
     })
 
+    it("uses an alert dialog before switching a dirty reference workspace version", async () => {
+      const user = userEvent.setup()
+      const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      const lockedVersion = {
+        ...baselineVersion,
+        id: "version-2",
+        version_number: 2,
+        status: "locked" as const,
+        locked_at: "2026-07-18T00:00:00.000Z",
+        locked_by: 1,
+      }
+      baselineRpc.listVersions.mockResolvedValueOnce({
+        data: [baselineVersion, lockedVersion],
+        total: 2,
+        page: 1,
+        page_size: 20,
+      })
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+      await screen.findByText("Chưa có sản phẩm tham chiếu.")
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+      await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
+
+      const versionPicker = screen.getByRole("combobox", {
+        name: "Phiên bản cấu hình cơ sở",
+      })
+      fireEvent.keyDown(versionPicker, { key: "ArrowDown" })
+      fireEvent.click(await screen.findByRole("option", { name: "Phiên bản 2 · Đã khóa" }))
+
+      expect(nativeConfirm).not.toHaveBeenCalled()
+      const discardDialog = await screen.findByRole("alertdialog")
+      await user.click(within(discardDialog).getByRole("button", { name: "Hủy" }))
+      expect(versionPicker).not.toHaveTextContent("Phiên bản 2")
+      expect(screen.getByDisplayValue("Model chưa lưu")).toBeInTheDocument()
+      nativeConfirm.mockRestore()
+    })
+
     it("reloads a clean reference-product workspace on demand", async () => {
       const user = userEvent.setup()
       referenceRpc.listProducts
@@ -149,7 +187,6 @@ export function registerReferenceProductWorkspaceTests({
     it("supports zero products, reload, and explicit save without premature mutations", async () => {
       const user = userEvent.setup()
       const onDirtyChange = vi.fn()
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
       const created = product("product-1", "Model lưu", 6)
       referenceRpc.listProducts
         .mockResolvedValueOnce(listResponse([]))
@@ -168,6 +205,7 @@ export function registerReferenceProductWorkspaceTests({
       await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(true))
 
       await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+      await user.click(await screen.findByRole("button", { name: "Bỏ thay đổi" }))
       await waitFor(() => expect(screen.queryByDisplayValue("Model tạm")).not.toBeInTheDocument())
 
       await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
@@ -186,7 +224,6 @@ export function registerReferenceProductWorkspaceTests({
         })
       )
       expect(await screen.findByRole("columnheader", { name: "Model lưu" })).toBeInTheDocument()
-      confirm.mockRestore()
     })
 
     it("preserves a dirty draft when the versions query selects a newer draft", async () => {
@@ -269,7 +306,7 @@ export function registerReferenceProductWorkspaceTests({
 
     it("preserves a dirty draft when reload confirmation is rejected", async () => {
       const user = userEvent.setup()
-      const confirm = vi.spyOn(window, "confirm").mockReturnValue(false)
+      const nativeConfirm = vi.spyOn(window, "confirm").mockReturnValue(false)
       referenceRpc.listProducts.mockResolvedValue(listResponse([]))
 
       renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
@@ -279,12 +316,17 @@ export function registerReferenceProductWorkspaceTests({
       await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
       await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
 
-      expect(confirm).toHaveBeenCalledWith(
-        "Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?"
-      )
+      expect(nativeConfirm).not.toHaveBeenCalled()
+      const discardDialog = await screen.findByRole("alertdialog")
+      expect(
+        within(discardDialog).getByText(
+          "Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?"
+        )
+      ).toBeInTheDocument()
+      await user.click(within(discardDialog).getByRole("button", { name: "Hủy" }))
       expect(referenceRpc.listProducts).toHaveBeenCalledTimes(1)
       expect(screen.getByDisplayValue("Model chưa lưu")).toBeInTheDocument()
-      confirm.mockRestore()
+      nativeConfirm.mockRestore()
     })
 
     it("registers beforeunload protection while the reference draft is dirty", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
@@ -63,6 +63,7 @@ vi.mock(
       return (
         <div data-testid="reference-evidence-detail">
           {props.ownerType}:{props.ownerId}:{props.criterionId}
+          <input aria-label="Bản nháp bằng chứng" />
         </div>
       )
     },

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
@@ -253,9 +253,9 @@ describe("technical configuration baseline tab", () => {
       ),
     })
     rpc.listVersions.mockResolvedValueOnce(baselineVersionsResponse([reloadedDraft]))
-    vi.spyOn(window, "confirm").mockReturnValueOnce(true)
 
     await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
+    await user.click(await screen.findByRole("button", { name: "Bỏ thay đổi" }))
 
     expect(await screen.findByDisplayValue("Tên mới từ máy chủ")).toBeInTheDocument()
     await waitFor(() => {
@@ -281,9 +281,9 @@ describe("technical configuration baseline tab", () => {
 
     const pending = deferred<ReturnType<typeof baselineVersionsResponse>>()
     rpc.listVersions.mockReturnValueOnce(pending.promise)
-    vi.spyOn(window, "confirm").mockReturnValueOnce(true)
 
     await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
+    await user.click(await screen.findByRole("button", { name: "Bỏ thay đổi" }))
 
     const pendingButton = screen.getByRole("button", { name: "Đang tải lại..." })
     expect(pendingButton).toBeDisabled()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
@@ -229,6 +229,35 @@ describe("technical configuration baseline tab", () => {
     expect(screen.getByRole("button", { name: "Tải lại từ máy chủ" })).toBeEnabled()
   })
 
+  it("reloads a clean draft without discard confirmation", async () => {
+    const user = userEvent.setup()
+    rpc.updateGroup.mockRejectedValue(
+      new TechnicalConfigurationRpcError(409, {
+        code: "PT409",
+        message: "stale_revision",
+      })
+    )
+    renderTab()
+
+    const nameInput = await screen.findByDisplayValue("Yêu cầu chung")
+    await user.clear(nameInput)
+    await user.type(nameInput, "Tên đang xung đột")
+    await user.click(screen.getByRole("button", { name: "Lưu" }))
+    expect(await screen.findByText("Xung đột dữ liệu")).toBeInTheDocument()
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "Yêu cầu chung")
+    const listVersionsCallCount = rpc.listVersions.mock.calls.length
+    rpc.listVersions.mockResolvedValueOnce(baselineVersionsResponse([createDraft({ revision: 8 })]))
+
+    await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(rpc.listVersions).toHaveBeenCalledTimes(listVersionsCallCount + 1)
+    })
+  })
+
   it("keeps the explicitly reloaded server draft instead of restoring stale query data", async () => {
     const user = userEvent.setup()
     rpc.updateGroup.mockRejectedValue(

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-focus-transitions.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-focus-transitions.test.tsx
@@ -112,9 +112,9 @@ describe("technical configuration focus transitions", () => {
       ),
     })
     rpc.listVersions.mockResolvedValueOnce(baselineVersionsResponse([reloadedDraft]))
-    vi.spyOn(window, "confirm").mockReturnValueOnce(true)
 
     await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
+    await user.click(await screen.findByRole("button", { name: "Bỏ thay đổi" }))
 
     const firstGroupTab = await screen.findByRole("tab", { name: /Tên mới từ máy chủ/ })
     await waitFor(() => expect(firstGroupTab).toHaveFocus())

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-version-workflow-review.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-version-workflow-review.test.tsx
@@ -88,11 +88,7 @@ describe("technical configuration version workflow review regressions", () => {
 
     rpc.listVersions.mockReturnValueOnce(pending.promise)
     await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
-    await user.click(
-      within(await screen.findByRole("alertdialog")).getByRole("button", {
-        name: "Bỏ thay đổi",
-      })
-    )
+    await waitFor(() => expect(rpc.listVersions).toHaveBeenCalledTimes(2))
 
     const lockWasDisabled = screen
       .getByRole("button", { name: "Khóa phiên bản" })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-version-workflow-review.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-version-workflow-review.test.tsx
@@ -29,7 +29,6 @@ describe("technical configuration version workflow review regressions", () => {
     const user = userEvent.setup()
     const locked = createLockedVersion()
     const draft = createDraft({ id: "draft-2", version_number: 2 })
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
     mockVersions([draft, locked])
 
     renderTab()
@@ -37,8 +36,12 @@ describe("technical configuration version workflow review regressions", () => {
     await user.clear(requirement)
     await user.type(requirement, "Nội dung đang sửa")
     await user.selectOptions(screen.getByRole("combobox", { name: "Lịch sử phiên bản" }), locked.id)
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Bỏ thay đổi",
+      })
+    )
 
-    expect(confirm).toHaveBeenCalledWith("Chuyển phiên bản sẽ bỏ các thay đổi chưa lưu. Tiếp tục?")
     expect(await screen.findByText("Phiên bản 1")).toBeInTheDocument()
     expect(screen.getByText("Nội dung chỉ đọc")).toBeInTheDocument()
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
@@ -48,15 +51,18 @@ describe("technical configuration version workflow review regressions", () => {
     const user = userEvent.setup()
     const locked = createLockedVersion()
     const draft = createDraft({ id: "draft-2", version_number: 2 })
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true)
     mockVersions([draft, locked])
 
     renderTab()
     await user.click(await screen.findByRole("tab", { name: "Nhập nhiều dòng" }))
     await user.type(screen.getByLabelText("Nội dung nhập nhanh"), "Nội dung chưa áp dụng")
     await user.selectOptions(screen.getByRole("combobox", { name: "Lịch sử phiên bản" }), locked.id)
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Bỏ thay đổi",
+      })
+    )
 
-    expect(confirm).toHaveBeenCalledWith("Chuyển phiên bản sẽ bỏ các thay đổi chưa lưu. Tiếp tục?")
     expect(await screen.findByText("Phiên bản 1")).toBeInTheDocument()
     expect(screen.getByText("Nội dung chỉ đọc")).toBeInTheDocument()
     expect(screen.queryByLabelText("Nội dung nhập nhanh")).not.toBeInTheDocument()
@@ -81,8 +87,12 @@ describe("technical configuration version workflow review regressions", () => {
     expect(await screen.findByText("Xung đột dữ liệu")).toBeInTheDocument()
 
     rpc.listVersions.mockReturnValueOnce(pending.promise)
-    vi.spyOn(window, "confirm").mockReturnValueOnce(true)
     await user.click(screen.getByRole("button", { name: "Tải lại từ máy chủ" }))
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Bỏ thay đổi",
+      })
+    )
 
     const lockWasDisabled = screen
       .getByRole("button", { name: "Khóa phiên bản" })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx
@@ -7,6 +7,7 @@ import { TechnicalConfigurationCitationEditor } from "@/app/(app)/technical-conf
 import { TechnicalConfigurationDocumentDeleteDialog } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentDeleteDialog"
 import { TechnicalConfigurationDocumentsHeader } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsHeader"
 import { TechnicalConfigurationDocumentsQueryError } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentsQueryError"
+import { useTechnicalConfigurationDiscardConfirmation } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation"
 import { useTechnicalConfigurationDocumentDraft } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft"
 import { useTechnicalConfigurationDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments"
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
@@ -46,6 +47,8 @@ export function TechnicalConfigurationBaselineDocuments({
   const [pendingDeleteDocument, setPendingDeleteDocument] =
     React.useState<TechnicalConfigurationDocumentWire | null>(null)
   const [deleteError, setDeleteError] = React.useState<unknown>(null)
+  const { discardConfirmationDialog, requestDiscardConfirmation } =
+    useTechnicalConfigurationDiscardConfirmation()
   const documentState = useTechnicalConfigurationDocuments({
     baselineVersion,
     readOnly,
@@ -92,26 +95,38 @@ export function TechnicalConfigurationBaselineDocuments({
     onDirtyChange?.(isDirty)
   }, [isDirty, onDirtyChange])
 
-  const confirmDocumentChange = React.useCallback(
-    () =>
-      !documentDirty ||
-      window.confirm("Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?"),
-    [documentDirty]
-  )
-
   const resetDraft = React.useCallback(() => {
-    if (!confirmDocumentChange()) return
+    if (documentDirty) {
+      requestDiscardConfirmation(
+        "Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?",
+        clearDraft
+      )
+      return
+    }
     clearDraft()
-  }, [clearDraft, confirmDocumentChange])
+  }, [clearDraft, documentDirty, requestDiscardConfirmation])
 
   const selectDocument = React.useCallback(
     (documentId: string) => {
-      if (documentId === selectedDocumentId || !confirmDocumentChange()) return
+      if (documentId === selectedDocumentId) return
       const document = ownerDocuments.find((item) => item.id === documentId)
       if (!document) return
+      if (documentDirty) {
+        requestDiscardConfirmation(
+          "Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?",
+          () => adoptSelectedDocument(document)
+        )
+        return
+      }
       adoptSelectedDocument(document)
     },
-    [adoptSelectedDocument, confirmDocumentChange, ownerDocuments, selectedDocumentId]
+    [
+      adoptSelectedDocument,
+      documentDirty,
+      ownerDocuments,
+      requestDiscardConfirmation,
+      selectedDocumentId,
+    ]
   )
 
   const handleSubmit = React.useCallback(async () => {
@@ -275,6 +290,8 @@ export function TechnicalConfigurationBaselineDocuments({
         onDelete={documentState.deleteCitation}
         onDirtyChange={setCitationDirty}
       />
+
+      {discardConfirmationDialog}
 
       <TechnicalConfigurationDocumentDeleteDialog
         document={pendingDeleteDocument}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
@@ -126,6 +126,10 @@ export function TechnicalConfigurationBaselineTab({
       void baseline.onRefreshVersions().catch(() => undefined)
       return
     }
+    if (!isUnsafeToLeave) {
+      void reloadDraftFromServer()
+      return
+    }
     requestDiscardConfirmation(
       "Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?",
       () => void reloadDraftFromServer()

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab.tsx
@@ -4,6 +4,7 @@ import { useTechnicalConfigurationBaselineEditor } from "@/app/(app)/technical-c
 import { useTechnicalConfigurationBaselineImport } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineImport"
 import { useTechnicalConfigurationBeforeUnloadGuard } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard"
 import { useTechnicalConfigurationBulkEntrySessions } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBulkEntrySessions"
+import { useTechnicalConfigurationDiscardConfirmation } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation"
 import { useTechnicalConfigurationInlineEditor } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationInlineEditor"
 import { validateTechnicalConfigurationBaselineEditorDraft } from "@/app/(app)/technical-configurations/technical-configuration-baseline-editor"
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
@@ -34,6 +35,8 @@ export function TechnicalConfigurationBaselineTab({
 }: Readonly<TechnicalConfigurationBaselineTabProps>) {
   const [isLockDialogOpen, setIsLockDialogOpen] = React.useState(false)
   const [hasUnresolvedImportState, setHasUnresolvedImportState] = React.useState(false)
+  const { discardConfirmationDialog, requestDiscardConfirmation } =
+    useTechnicalConfigurationDiscardConfirmation()
   const bulkSessions = useTechnicalConfigurationBulkEntrySessions()
   const baseline = useTechnicalConfigurationBaselineEditor({
     dossier,
@@ -105,20 +108,7 @@ export function TechnicalConfigurationBaselineTab({
 
   useTechnicalConfigurationBeforeUnloadGuard(isUnsafeToLeave)
 
-  const handleReloadFromServer = async () => {
-    if (bulkSessions.hasPendingInput || baselineImport.hasUnresolvedState) return
-    if (selectedVersion?.status === "locked") {
-      try {
-        await baseline.onRefreshVersions()
-      } catch {
-        return
-      }
-      return
-    }
-    const confirmed = window.confirm(
-      "Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?"
-    )
-    if (!confirmed) return
+  const reloadDraftFromServer = async () => {
     bulkSessions.clearAll()
     try {
       const reloadedDraft = await baseline.onReloadFromServer()
@@ -130,20 +120,38 @@ export function TechnicalConfigurationBaselineTab({
     }
   }
 
+  const handleReloadFromServer = () => {
+    if (bulkSessions.hasPendingInput || baselineImport.hasUnresolvedState) return
+    if (selectedVersion?.status === "locked") {
+      void baseline.onRefreshVersions().catch(() => undefined)
+      return
+    }
+    requestDiscardConfirmation(
+      "Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?",
+      () => void reloadDraftFromServer()
+    )
+  }
+
   const handleSelectVersion = (versionId: string) => {
     const nextVersion = baseline.versions.find((version) => version.id === versionId)
     if (!nextVersion || nextVersion.id === selectedVersion?.id) return
-    if (
-      isUnsafeToLeave &&
-      !window.confirm("Chuyển phiên bản sẽ bỏ các thay đổi chưa lưu. Tiếp tục?")
-    ) {
+
+    const selectVersion = () => {
+      bulkSessions.clearAll()
+      baselineImport.reset()
+      baseline.onSelectVersion(versionId, { force: isUnsafeToLeave })
+      inlineEditor.prepareForReload(nextVersion.groups[0]?.id ?? "")
+    }
+
+    if (isUnsafeToLeave) {
+      requestDiscardConfirmation(
+        "Chuyển phiên bản sẽ bỏ các thay đổi chưa lưu. Tiếp tục?",
+        selectVersion
+      )
       return
     }
 
-    bulkSessions.clearAll()
-    baselineImport.reset()
-    baseline.onSelectVersion(versionId, { force: isUnsafeToLeave })
-    inlineEditor.prepareForReload(nextVersion.groups[0]?.id ?? "")
+    selectVersion()
   }
 
   const handleConfirmLock = async () => {
@@ -280,6 +288,8 @@ export function TechnicalConfigurationBaselineTab({
           onConfirm={() => void handleConfirmLock()}
         />
       ) : null}
+
+      {discardConfirmationDialog}
     </div>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
@@ -7,6 +7,7 @@ import {
   getTechnicalConfigurationCitationValues,
   type TechnicalConfigurationCitationSelectionSnapshot,
 } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState"
+import { useTechnicalConfigurationDiscardConfirmation } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation"
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
 import { isTechnicalConfigurationBaselineConflict } from "@/app/(app)/technical-configurations/technical-configuration-baseline-version-state"
 
@@ -62,6 +63,8 @@ export function TechnicalConfigurationCitationEditor({
   const [excerpt, setExcerpt] = React.useState(initialValues.excerpt)
   const [baseValues, setBaseValues] = React.useState(initialValues)
   const [saveError, setSaveError] = React.useState<unknown>(null)
+  const { discardConfirmationDialog, requestDiscardConfirmation } =
+    useTechnicalConfigurationDiscardConfirmation()
   const observedSelectionRef = React.useRef<TechnicalConfigurationCitationSelectionSnapshot>({
     documentId: initialDocumentId,
     criterionId: initialCriterionId,
@@ -125,15 +128,16 @@ export function TechnicalConfigurationCitationEditor({
       if (documentId === selectedDocumentId && criterionId === selectedCriterionId) {
         return
       }
-      if (
-        isDirty &&
-        !window.confirm("Chuyển lựa chọn sẽ bỏ nội dung trích dẫn chưa lưu. Tiếp tục?")
-      ) {
+      if (isDirty) {
+        requestDiscardConfirmation(
+          "Chuyển lựa chọn sẽ bỏ nội dung trích dẫn chưa lưu. Tiếp tục?",
+          () => adoptSelection(documentId, criterionId)
+        )
         return
       }
       adoptSelection(documentId, criterionId)
     },
-    [adoptSelection, isDirty, selectedCriterionId, selectedDocumentId]
+    [adoptSelection, isDirty, requestDiscardConfirmation, selectedCriterionId, selectedDocumentId]
   )
 
   const handleSave = React.useCallback(async () => {
@@ -284,6 +288,8 @@ export function TechnicalConfigurationCitationEditor({
             : "Không thể lưu trích dẫn. Vui lòng thử lại."}
         </p>
       ) : null}
+
+      {discardConfirmationDialog}
 
       {!disabled ? (
         <div className="flex flex-wrap justify-end gap-2">

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { FileText } from "lucide-react"
 
 import { TechnicalConfigurationBaselineDocuments } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments"
+import { useTechnicalConfigurationDiscardConfirmation } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation"
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
 import { Button } from "@/components/ui/button"
@@ -85,56 +86,66 @@ export function TechnicalConfigurationReferenceEvidenceDialog({
 }: Readonly<TechnicalConfigurationReferenceEvidenceDialogProps>): React.JSX.Element {
   const isDirtyRef = React.useRef(false)
   const isNavigationBlockedRef = React.useRef(false)
+  const { discardConfirmationDialog, isDiscardConfirmationOpen, requestDiscardConfirmation } =
+    useTechnicalConfigurationDiscardConfirmation()
 
   React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+
+  const closeEvidence = React.useCallback(() => {
+    isDirtyRef.current = false
+    onDirtyChange?.(false)
+    onClose()
+  }, [onClose, onDirtyChange])
 
   const handleOpenChange = React.useCallback(
     (open: boolean) => {
       if (open) return
       if (isNavigationBlockedRef.current) return
-      if (
-        isDirtyRef.current &&
-        !window.confirm("Bạn có thay đổi bằng chứng chưa lưu. Đóng và bỏ thay đổi?")
-      ) {
+      if (isDirtyRef.current) {
+        requestDiscardConfirmation(
+          "Bạn có thay đổi bằng chứng chưa lưu. Đóng và bỏ thay đổi?",
+          closeEvidence
+        )
         return
       }
-      isDirtyRef.current = false
-      onDirtyChange?.(false)
-      onClose()
+      closeEvidence()
     },
-    [onClose, onDirtyChange]
+    [closeEvidence, requestDiscardConfirmation]
   )
 
   return (
-    <Dialog open={detail !== null} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl" closeLabel="Đóng">
-        <DialogHeader>
-          <DialogTitle>
-            {detail ? `${detail.productName} · ${detail.criterionCode}` : "Bằng chứng tham chiếu"}
-          </DialogTitle>
-          <DialogDescription>
-            Tài liệu và trích dẫn áp dụng cho sản phẩm tham chiếu tại tiêu chí đang chọn.
-          </DialogDescription>
-        </DialogHeader>
-        {detail ? (
-          <TechnicalConfigurationBaselineDocuments
-            baselineVersion={baselineVersion}
-            ownerType="reference_product"
-            ownerId={detail.ownerId}
-            criterionId={detail.criterionId}
-            readOnly={readOnly}
-            onRevisionChange={onRevisionChange}
-            onDirtyChange={(dirty) => {
-              isDirtyRef.current = dirty
-              onDirtyChange?.(dirty)
-            }}
-            onNavigationBlockedChange={(blocked) => {
-              isNavigationBlockedRef.current = blocked
-              onNavigationBlockedChange?.(blocked)
-            }}
-          />
-        ) : null}
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog open={detail !== null && !isDiscardConfirmationOpen} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl" closeLabel="Đóng">
+          <DialogHeader>
+            <DialogTitle>
+              {detail ? `${detail.productName} · ${detail.criterionCode}` : "Bằng chứng tham chiếu"}
+            </DialogTitle>
+            <DialogDescription>
+              Tài liệu và trích dẫn áp dụng cho sản phẩm tham chiếu tại tiêu chí đang chọn.
+            </DialogDescription>
+          </DialogHeader>
+          {detail ? (
+            <TechnicalConfigurationBaselineDocuments
+              baselineVersion={baselineVersion}
+              ownerType="reference_product"
+              ownerId={detail.ownerId}
+              criterionId={detail.criterionId}
+              readOnly={readOnly}
+              onRevisionChange={onRevisionChange}
+              onDirtyChange={(dirty) => {
+                isDirtyRef.current = dirty
+                onDirtyChange?.(dirty)
+              }}
+              onNavigationBlockedChange={(blocked) => {
+                isNavigationBlockedRef.current = blocked
+                onNavigationBlockedChange?.(blocked)
+              }}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+      {discardConfirmationDialog}
+    </>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceEvidence.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { createPortal } from "react-dom"
 import { FileText } from "lucide-react"
 
 import { TechnicalConfigurationBaselineDocuments } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments"
@@ -86,10 +87,25 @@ export function TechnicalConfigurationReferenceEvidenceDialog({
 }: Readonly<TechnicalConfigurationReferenceEvidenceDialogProps>): React.JSX.Element {
   const isDirtyRef = React.useRef(false)
   const isNavigationBlockedRef = React.useRef(false)
+  const evidencePortalRef = React.useRef<HTMLDivElement | null>(null)
+  const [evidencePortal, setEvidencePortal] = React.useState<HTMLDivElement | null>(null)
   const { discardConfirmationDialog, isDiscardConfirmationOpen, requestDiscardConfirmation } =
     useTechnicalConfigurationDiscardConfirmation()
 
   React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+  React.useEffect(() => () => evidencePortalRef.current?.remove(), [])
+
+  const attachEvidencePortal = React.useCallback((host: HTMLDivElement | null) => {
+    if (!host) return
+    let portal = evidencePortalRef.current
+    if (!portal) {
+      portal = document.createElement("div")
+      portal.className = "contents"
+      evidencePortalRef.current = portal
+      setEvidencePortal(portal)
+    }
+    host.append(portal)
+  }, [])
 
   const closeEvidence = React.useCallback(() => {
     isDirtyRef.current = false
@@ -125,7 +141,11 @@ export function TechnicalConfigurationReferenceEvidenceDialog({
               Tài liệu và trích dẫn áp dụng cho sản phẩm tham chiếu tại tiêu chí đang chọn.
             </DialogDescription>
           </DialogHeader>
-          {detail ? (
+          <div ref={attachEvidencePortal} />
+        </DialogContent>
+      </Dialog>
+      {detail && evidencePortal
+        ? createPortal(
             <TechnicalConfigurationBaselineDocuments
               baselineVersion={baselineVersion}
               ownerType="reference_product"
@@ -141,10 +161,10 @@ export function TechnicalConfigurationReferenceEvidenceDialog({
                 isNavigationBlockedRef.current = blocked
                 onNavigationBlockedChange?.(blocked)
               }}
-            />
-          ) : null}
-        </DialogContent>
-      </Dialog>
+            />,
+            evidencePortal
+          )
+        : null}
       {discardConfirmationDialog}
     </>
   )

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, Archive, Loader2, LockKeyhole, Plus, RefreshCw, Save } fro
 import { TechnicalConfigurationReferenceProductsBody } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody"
 import { useTechnicalConfigurationBaselineVersionSelection } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersionSelection"
 import { useTechnicalConfigurationBeforeUnloadGuard } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard"
+import { useTechnicalConfigurationDiscardConfirmation } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation"
 import { useTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts"
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -43,6 +44,8 @@ export function TechnicalConfigurationReferenceProducts({
   const [isEvidenceDirty, setIsEvidenceDirty] = React.useState(false)
   const [isEvidenceNavigationBlocked, setIsEvidenceNavigationBlocked] = React.useState(false)
   const [isReferenceNavigationBlocked, setIsReferenceNavigationBlocked] = React.useState(false)
+  const { discardConfirmationDialog, requestDiscardConfirmation } =
+    useTechnicalConfigurationDiscardConfirmation()
   const evidenceNavigationBlockedRef = React.useRef(false)
   const referenceNavigationBlockedRef = React.useRef(false)
   const handleEvidenceNavigationBlockedChange = React.useCallback(
@@ -94,16 +97,18 @@ export function TechnicalConfigurationReferenceProducts({
 
   const handleVersionChange = React.useCallback(
     (nextVersionId: string) => {
-      if (
-        isDirty &&
-        !window.confirm("Bạn có thay đổi chưa lưu. Chuyển phiên bản và bỏ các thay đổi?")
-      ) {
+      const nextVersion = versionOptions.find((version) => version.id === nextVersionId)
+      if (!nextVersion) return
+      if (isDirty) {
+        requestDiscardConfirmation(
+          "Bạn có thay đổi chưa lưu. Chuyển phiên bản và bỏ các thay đổi?",
+          () => adoptVersion(nextVersion)
+        )
         return
       }
-      const nextVersion = versionOptions.find((version) => version.id === nextVersionId)
-      if (nextVersion) adoptVersion(nextVersion)
+      adoptVersion(nextVersion)
     },
-    [adoptVersion, isDirty, versionOptions]
+    [adoptVersion, isDirty, requestDiscardConfirmation, versionOptions]
   )
 
   const handleVersionSelect = React.useCallback(
@@ -117,21 +122,27 @@ export function TechnicalConfigurationReferenceProducts({
     [handleVersionChange, versionState.loadMoreVersions]
   )
 
-  const handleReload = React.useCallback(async () => {
+  const reloadReferenceProducts = React.useCallback(async () => {
     if (!selectedVersion) return
-    if (
-      isDirty &&
-      !window.confirm("Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?")
-    ) {
-      return
-    }
     await referenceState.reload(async () => {
       const refreshedVersion = await versionState.refreshVersions(selectedVersion.id)
       if (refreshedVersion) {
         versionState.cacheVersion(refreshedVersion)
       }
     })
-  }, [isDirty, referenceState, selectedVersion, versionState])
+  }, [referenceState, selectedVersion, versionState])
+
+  const handleReload = React.useCallback(() => {
+    if (!selectedVersion) return
+    if (isDirty) {
+      requestDiscardConfirmation(
+        "Tải lại từ máy chủ sẽ thay thế các thay đổi chưa lưu. Tiếp tục?",
+        () => void reloadReferenceProducts()
+      )
+      return
+    }
+    void reloadReferenceProducts()
+  }, [isDirty, reloadReferenceProducts, requestDiscardConfirmation, selectedVersion])
 
   if (versionState.versionsQuery.isLoading) {
     return (
@@ -303,6 +314,8 @@ export function TechnicalConfigurationReferenceProducts({
         onEvidenceDirtyChange={setIsEvidenceDirty}
         onEvidenceNavigationBlockedChange={handleEvidenceNavigationBlockedChange}
       />
+
+      {discardConfirmationDialog}
     </div>
   )
 }

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation.tsx
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+
+import { DestructiveConfirmDialog } from "@/components/shared/DestructiveConfirmDialog"
+
+interface PendingDiscardConfirmation {
+  description: React.ReactNode
+  onConfirm: () => void
+}
+
+interface TechnicalConfigurationDiscardConfirmationState {
+  discardConfirmationDialog: React.JSX.Element
+  isDiscardConfirmationOpen: boolean
+  requestDiscardConfirmation: (
+    description: React.ReactNode,
+    onConfirm: PendingDiscardConfirmation["onConfirm"]
+  ) => void
+}
+
+/** Queues one destructive draft-discard action behind the shared alert dialog. */
+export function useTechnicalConfigurationDiscardConfirmation(): TechnicalConfigurationDiscardConfirmationState {
+  const [pendingConfirmation, setPendingConfirmation] =
+    React.useState<PendingDiscardConfirmation | null>(null)
+
+  const requestDiscardConfirmation = React.useCallback(
+    (description: React.ReactNode, onConfirm: PendingDiscardConfirmation["onConfirm"]) => {
+      setPendingConfirmation({ description, onConfirm })
+    },
+    []
+  )
+
+  const handleOpenChange = React.useCallback((open: boolean) => {
+    if (!open) setPendingConfirmation(null)
+  }, [])
+
+  const handleConfirm = React.useCallback(() => {
+    const onConfirm = pendingConfirmation?.onConfirm
+    setPendingConfirmation(null)
+    onConfirm?.()
+  }, [pendingConfirmation])
+
+  return {
+    isDiscardConfirmationOpen: pendingConfirmation !== null,
+    requestDiscardConfirmation,
+    discardConfirmationDialog: (
+      <DestructiveConfirmDialog
+        open={pendingConfirmation !== null}
+        onOpenChange={handleOpenChange}
+        title="Bỏ thay đổi chưa lưu?"
+        description={pendingConfirmation?.description ?? ""}
+        confirmLabel="Bỏ thay đổi"
+        isPending={false}
+        onConfirm={handleConfirm}
+      />
+    ),
+  }
+}

--- a/src/components/shared/DestructiveConfirmDialog.tsx
+++ b/src/components/shared/DestructiveConfirmDialog.tsx
@@ -25,7 +25,7 @@ export interface DestructiveConfirmDialogProps {
 }
 
 /**
- * Shared destructive confirmation shell for feature-owned delete flows.
+ * Shared destructive confirmation shell for irreversible user actions.
  */
 export function DestructiveConfirmDialog({
   open,


### PR DESCRIPTION
## Summary
- replace all 7 production `window.confirm` flows in Technical Configurations with controlled `AlertDialog` confirmation
- reuse `DestructiveConfirmDialog` through a module-owned discard-confirmation hook
- cover document selection/reset, citation selection, baseline reload/version switch, reference evidence close, and reference-product reload/version switch
- temporarily hide the reference evidence `Dialog` while its discard alert is open to avoid nested modal focus traps

## TDD evidence
- RED: 8 focused regressions failed because native confirm was still called or no `alertdialog` existed
- GREEN: 9 focused files, 136/136 tests passed
- production scan: 0 native confirm calls under `technical-configurations`

## Validation
- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- `verify:heroui-boundary`
- `typecheck`
- focused tests: 136/136
- React Doctor: no findings, changed-scope score 83/100 across 16 files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all `window.confirm` flows in Technical Configurations with an accessible alert dialog using a shared `DestructiveConfirmDialog` and the new `useTechnicalConfigurationDiscardConfirmation` hook. Improves UX consistency and accessibility, removes native dialogs, and fixes nested modal focus issues in reference evidence.

- **Refactors**
  - Migrated confirmations for: document selection/reset, citation selection, baseline reload/version switch, reference evidence close, and reference-product reload/version switch.
  - Added a shared discard-confirmation hook to queue one destructive action and render a single dialog.
  - Updated tests to assert `alertdialog` and use explicit confirm/cancel actions.

- **Bug Fixes**
  - Rendered reference evidence content through a portal and hid its `Dialog` while the discard alert is open to prevent nested modal focus traps.
  - Skipped discard confirmation when reloading a clean draft.

<sup>Written for commit 44b02aedec475f9546bb2278506973f143e6e648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app confirmation dialogs when actions may discard unsaved technical configuration changes.
  * Users can cancel or confirm discarding edits when switching documents, versions, reloading data, or closing evidence editors.
* **Bug Fixes**
  * Preserved unsaved drafts when users cancel discard prompts.
  * Improved handling of stale documents and pending reload or navigation conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->