### PR TITLE
refactor(ui): add shared HeroUI SingleSelect primitive and migrate baseline VersionBar

### DIFF
--- a/scripts/__tests__/check-heroui-import-boundary.test.ts
+++ b/scripts/__tests__/check-heroui-import-boundary.test.ts
@@ -3,6 +3,39 @@ import { describe, expect, it } from "vitest"
 import { findHeroUIImportViolations } from "../check-heroui-import-boundary"
 
 describe("check-heroui-import-boundary", () => {
+  it("allows shared HeroUI primitives without allowing direct consumer imports", () => {
+    const violations = findHeroUIImportViolations([
+      {
+        path: "src/components/ui/heroui/SingleSelect.tsx",
+        content: [
+          'import { ListBox } from "@heroui/react/list-box"',
+          'import { Select } from "@heroui/react/select"',
+        ].join("\n"),
+      },
+      {
+        path: "src/components/ui/button.tsx",
+        content: 'import { Button } from "@heroui/react/button"\n',
+      },
+      {
+        path: "src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx",
+        content: 'import { Select } from "@heroui/react/select"\n',
+      },
+    ])
+
+    expect(violations).toEqual([
+      {
+        path: "src/components/ui/button.tsx",
+        line: 1,
+        importPath: "@heroui/react/button",
+      },
+      {
+        path: "src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx",
+        line: 1,
+        importPath: "@heroui/react/select",
+      },
+    ])
+  })
+
   it("allows HeroUI imports only inside approved boundary folders", () => {
     const violations = findHeroUIImportViolations([
       {

--- a/scripts/check-heroui-import-boundary.js
+++ b/scripts/check-heroui-import-boundary.js
@@ -9,6 +9,7 @@ const HEROUI_IMPORT_RE =
 const ALLOWED_BOUNDARY_PREFIXES = [
   "src/components/equipment/heroui-pilot/",
   "src/components/shared/floating-actions/",
+  "src/components/ui/heroui/",
 ]
 const ALLOWED_BOUNDARY_FILES = [
   "src/components/shared/SearchInput.tsx",

--- a/src/app/(app)/technical-configurations/__tests__/TechnicalConfigurationVersionBar.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/TechnicalConfigurationVersionBar.test.tsx
@@ -1,0 +1,86 @@
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationVersionBar } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar"
+
+import {
+  createDraft,
+  createLockedVersion,
+  openBaselineVersionSelect,
+} from "./technical-configuration-baseline-tab-fixtures"
+
+const idleStatus = {
+  hasDraft: false,
+  isCreating: false,
+  isLocking: false,
+  isCopying: false,
+  isLoadingMoreVersions: false,
+  hasLoadMoreError: false,
+  isNavigationDisabled: false,
+  hasMoreVersions: false,
+  isDownloadingTemplate: false,
+  isImportBusy: false,
+  isImportBlocked: false,
+}
+
+describe("TechnicalConfigurationVersionBar", () => {
+  it("renders the preserved historical selection through a visible HeroUI trigger", async () => {
+    const user = userEvent.setup()
+    const selectedVersion = createLockedVersion({ id: "version-1", version_number: 1 })
+    const visibleVersion = createLockedVersion({ id: "version-2", version_number: 2 })
+
+    render(
+      <TechnicalConfigurationVersionBar
+        versions={[visibleVersion]}
+        selectedVersion={selectedVersion}
+        lockBlockedReason={null}
+        status={{ ...idleStatus, hasMoreVersions: true }}
+        onSelectVersion={vi.fn()}
+        onLoadMoreVersions={vi.fn()}
+        onRequestLock={vi.fn()}
+        onCreateBlank={vi.fn()}
+        onCopy={vi.fn()}
+        onDownloadTemplate={vi.fn()}
+        onRequestImport={vi.fn()}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: /Lịch sử phiên bản/ })
+    expect(trigger).toHaveTextContent("Phiên bản 1 · Đã khóa")
+    expect(screen.queryByRole("combobox", { name: "Lịch sử phiên bản" })).not.toBeInTheDocument()
+
+    await openBaselineVersionSelect(user)
+    expect(screen.getByRole("option", { name: "Phiên bản 1 · Đã khóa" })).toBeInTheDocument()
+  })
+
+  it("uses the preserved draft snapshot for a same-id selector option", async () => {
+    const user = userEvent.setup()
+    const selectedVersion = createDraft({ id: "version-1", version_number: 1 })
+    const serverVersion = createLockedVersion({ id: selectedVersion.id, version_number: 1 })
+
+    render(
+      <TechnicalConfigurationVersionBar
+        versions={[serverVersion]}
+        selectedVersion={selectedVersion}
+        lockBlockedReason={null}
+        status={{ ...idleStatus, hasDraft: true }}
+        onSelectVersion={vi.fn()}
+        onLoadMoreVersions={vi.fn()}
+        onRequestLock={vi.fn()}
+        onCreateBlank={vi.fn()}
+        onCopy={vi.fn()}
+        onDownloadTemplate={vi.fn()}
+        onRequestImport={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toHaveTextContent(
+      "Phiên bản 1 · Bản nháp"
+    )
+    await openBaselineVersionSelect(user)
+    expect(screen.getByRole("option", { name: "Phiên bản 1 · Bản nháp" })).toBeInTheDocument()
+    expect(screen.queryByRole("option", { name: "Phiên bản 1 · Đã khóa" })).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-locking.test.tsx
@@ -15,6 +15,7 @@ import {
   groupMutation,
   mockVersions,
   renderTab,
+  selectBaselineVersion,
 } from "./technical-configuration-baseline-tab-fixtures"
 
 const rpc = getBaselineRpcMock()
@@ -205,7 +206,7 @@ describe("technical configuration baseline locking and history", () => {
     const requirement = await screen.findByLabelText("Nội dung yêu cầu 1.1")
     await user.clear(requirement)
     await user.type(requirement, "Nội dung đang sửa")
-    await user.selectOptions(screen.getByRole("combobox", { name: "Lịch sử phiên bản" }), locked.id)
+    await selectBaselineVersion(user, "Phiên bản 1 · Đã khóa")
 
     expect(nativeConfirm).not.toHaveBeenCalled()
     const discardDialog = await screen.findByRole("alertdialog")
@@ -236,12 +237,12 @@ describe("technical configuration baseline locking and history", () => {
     await user.click(screen.getByRole("button", { name: "Lưu" }))
 
     await waitFor(() => expect(rpc.updateGroup).toHaveBeenCalled())
-    expect(screen.getByRole("combobox", { name: "Lịch sử phiên bản" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeDisabled()
     expect(screen.getByRole("button", { name: "Tải thêm phiên bản" })).toBeDisabled()
 
     pending.resolve({ data: groupMutation(5, "Yêu cầu kỹ thuật chung") })
     await waitFor(() =>
-      expect(screen.getByRole("combobox", { name: "Lịch sử phiên bản" })).toBeEnabled()
+      expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeEnabled()
     )
   })
 
@@ -277,12 +278,12 @@ describe("technical configuration baseline locking and history", () => {
     await user.click(await screen.findByRole("button", { name: "Sao chép thành bản nháp" }))
 
     await waitFor(() => expect(rpc.listVersions).toHaveBeenCalledTimes(2))
-    expect(screen.getByRole("combobox", { name: "Lịch sử phiên bản" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeDisabled()
     expect(screen.getByRole("button", { name: "Tải thêm phiên bản" })).toBeDisabled()
 
     pending.reject(new Error("network_error"))
     await waitFor(() =>
-      expect(screen.getByRole("combobox", { name: "Lịch sử phiên bản" })).toBeEnabled()
+      expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeEnabled()
     )
     expect(screen.getByText("Xung đột dữ liệu")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Sao chép thành bản nháp" })).toBeEnabled()

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab-fixtures.tsx
@@ -1,5 +1,5 @@
 import { QueryClient } from "@tanstack/react-query"
-import { render } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import { vi } from "vitest"
 
 import { TechnicalConfigurationBaselineTab } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineTab"
@@ -303,6 +303,23 @@ export function renderTab(
       }
     ),
   }
+}
+
+type VersionSelectUser = {
+  click: (element: Element) => Promise<void>
+  keyboard: (text: string) => Promise<void>
+}
+
+export async function openBaselineVersionSelect(user: VersionSelectUser) {
+  const trigger = screen.getByRole("button", { name: /Lịch sử phiên bản/ })
+  act(() => trigger.focus())
+  await user.keyboard("{ArrowDown}")
+  return trigger
+}
+
+export async function selectBaselineVersion(user: VersionSelectUser, optionName: string) {
+  await openBaselineVersionSelect(user)
+  await user.click(await screen.findByRole("option", { name: optionName }))
 }
 
 export function deferred<T>() {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-tab.test.tsx
@@ -430,28 +430,12 @@ describe("technical configuration baseline tab", () => {
     expect(
       await screen.findByRole("region", { name: "Lịch sử phiên bản cấu hình cơ sở" })
     ).toBeInTheDocument()
-    expect(screen.getByRole("combobox", { name: "Lịch sử phiên bản" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeInTheDocument()
     expect(screen.getByRole("region", { name: "Nội dung phiên bản đã khóa" })).toBeInTheDocument()
     expect(screen.getByText("Nội dung chỉ đọc")).toBeInTheDocument()
     expect(screen.getByText("TC-0001")).toBeInTheDocument()
     expect(screen.getByText(/Dòng 1/)).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Lưu" })).not.toBeInTheDocument()
     expect(screen.queryByDisplayValue("Yêu cầu chung")).not.toBeInTheDocument()
-  })
-
-  it("registers beforeunload protection only while the form is dirty", async () => {
-    const user = userEvent.setup()
-    renderTab()
-
-    const cleanEvent = new Event("beforeunload", { cancelable: true })
-    window.dispatchEvent(cleanEvent)
-    expect(cleanEvent.defaultPrevented).toBe(false)
-
-    const nameInput = await screen.findByDisplayValue("Yêu cầu chung")
-    await user.type(nameInput, " thay đổi")
-
-    const dirtyEvent = new Event("beforeunload", { cancelable: true })
-    window.dispatchEvent(dirtyEvent)
-    expect(dirtyEvent.defaultPrevented).toBe(true)
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-beforeunload.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-beforeunload.test.tsx
@@ -1,0 +1,50 @@
+import "@testing-library/jest-dom"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  baselineVersionsResponse,
+  createDraft,
+  dossier,
+  getBaselineRpcMock,
+  renderTab,
+} from "./technical-configuration-baseline-tab-fixtures"
+
+const rpc = getBaselineRpcMock()
+
+describe("technical configuration beforeunload protection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rpc.listVersions.mockReset()
+    rpc.getDossier.mockResolvedValue({ data: dossier })
+    rpc.listVersions.mockResolvedValue(baselineVersionsResponse([createDraft()]))
+  })
+
+  it("registers beforeunload protection only while the form is dirty", async () => {
+    const user = userEvent.setup()
+    const addEventListener = vi.spyOn(window, "addEventListener")
+    renderTab()
+
+    const cleanHandlerCount = addEventListener.mock.calls.filter(
+      ([eventName]) => eventName === "beforeunload"
+    ).length
+
+    const nameInput = await screen.findByDisplayValue("Yêu cầu chung")
+    await user.type(nameInput, " thay đổi")
+
+    await waitFor(() =>
+      expect(
+        addEventListener.mock.calls.filter(([eventName]) => eventName === "beforeunload")
+      ).toHaveLength(cleanHandlerCount + 1)
+    )
+    const beforeUnloadHandler = addEventListener.mock.calls
+      .filter(([eventName]) => eventName === "beforeunload")
+      .at(-1)?.[1]
+    expect(beforeUnloadHandler).toBeTypeOf("function")
+    const dirtyEvent = new Event("beforeunload", { cancelable: true })
+    ;(beforeUnloadHandler as EventListener)(dirtyEvent)
+    expect(dirtyEvent.defaultPrevented).toBe(true)
+    addEventListener.mockRestore()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-beforeunload.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-beforeunload.test.tsx
@@ -24,27 +24,31 @@ describe("technical configuration beforeunload protection", () => {
   it("registers beforeunload protection only while the form is dirty", async () => {
     const user = userEvent.setup()
     const addEventListener = vi.spyOn(window, "addEventListener")
-    renderTab()
 
-    const cleanHandlerCount = addEventListener.mock.calls.filter(
-      ([eventName]) => eventName === "beforeunload"
-    ).length
+    try {
+      renderTab()
 
-    const nameInput = await screen.findByDisplayValue("Yêu cầu chung")
-    await user.type(nameInput, " thay đổi")
+      const cleanHandlerCount = addEventListener.mock.calls.filter(
+        ([eventName]) => eventName === "beforeunload"
+      ).length
 
-    await waitFor(() =>
-      expect(
-        addEventListener.mock.calls.filter(([eventName]) => eventName === "beforeunload")
-      ).toHaveLength(cleanHandlerCount + 1)
-    )
-    const beforeUnloadHandler = addEventListener.mock.calls
-      .filter(([eventName]) => eventName === "beforeunload")
-      .at(-1)?.[1]
-    expect(beforeUnloadHandler).toBeTypeOf("function")
-    const dirtyEvent = new Event("beforeunload", { cancelable: true })
-    ;(beforeUnloadHandler as EventListener)(dirtyEvent)
-    expect(dirtyEvent.defaultPrevented).toBe(true)
-    addEventListener.mockRestore()
+      const nameInput = await screen.findByDisplayValue("Yêu cầu chung")
+      await user.type(nameInput, " thay đổi")
+
+      await waitFor(() =>
+        expect(
+          addEventListener.mock.calls.filter(([eventName]) => eventName === "beforeunload")
+        ).toHaveLength(cleanHandlerCount + 1)
+      )
+      const beforeUnloadHandler = addEventListener.mock.calls
+        .filter(([eventName]) => eventName === "beforeunload")
+        .at(-1)?.[1]
+      expect(beforeUnloadHandler).toBeTypeOf("function")
+      const dirtyEvent = new Event("beforeunload", { cancelable: true })
+      ;(beforeUnloadHandler as EventListener)(dirtyEvent)
+      expect(dirtyEvent.defaultPrevented).toBe(true)
+    } finally {
+      addEventListener.mockRestore()
+    }
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-inline-workflow.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-inline-workflow.test.tsx
@@ -180,30 +180,36 @@ describe("technical configuration inline workflow", () => {
     const user = userEvent.setup()
     const onDirtyChange = vi.fn()
     const addEventListener = vi.spyOn(window, "addEventListener")
-    render(<TechnicalConfigurationBaselineTab dossier={dossier} onDirtyChange={onDirtyChange} />)
 
-    await user.click(await screen.findByRole("tab", { name: "Nhập nhiều dòng" }))
-    await user.type(screen.getByLabelText("Nội dung nhập nhanh"), "Buffer nhóm 1")
+    try {
+      render(<TechnicalConfigurationBaselineTab dossier={dossier} onDirtyChange={onDirtyChange} />)
 
-    expect(screen.getByText("Hoàn tất hoặc hủy phần nhập nhiều dòng trước khi lưu.")).toBeVisible()
-    expect(screen.getByRole("button", { name: "Lưu" })).toBeDisabled()
-    expect(onDirtyChange).toHaveBeenLastCalledWith(true)
-    const beforeUnloadHandler = addEventListener.mock.calls
-      .filter(([eventName]) => eventName === "beforeunload")
-      .at(-1)?.[1]
-    expect(beforeUnloadHandler).toBeTypeOf("function")
-    const unsafeEvent = new Event("beforeunload", { cancelable: true })
-    ;(beforeUnloadHandler as EventListener)(unsafeEvent)
-    expect(unsafeEvent.defaultPrevented).toBe(true)
+      await user.click(await screen.findByRole("tab", { name: "Nhập nhiều dòng" }))
+      await user.type(screen.getByLabelText("Nội dung nhập nhanh"), "Buffer nhóm 1")
 
-    await user.click(screen.getByRole("tab", { name: /Yêu cầu kỹ thuật/ }))
-    expect(screen.getByLabelText("Nội dung nhập nhanh")).toHaveValue("")
-    await user.type(screen.getByLabelText("Nội dung nhập nhanh"), "Buffer nhóm 2")
+      expect(
+        screen.getByText("Hoàn tất hoặc hủy phần nhập nhiều dòng trước khi lưu.")
+      ).toBeVisible()
+      expect(screen.getByRole("button", { name: "Lưu" })).toBeDisabled()
+      expect(onDirtyChange).toHaveBeenLastCalledWith(true)
+      const beforeUnloadHandler = addEventListener.mock.calls
+        .filter(([eventName]) => eventName === "beforeunload")
+        .at(-1)?.[1]
+      expect(beforeUnloadHandler).toBeTypeOf("function")
+      const unsafeEvent = new Event("beforeunload", { cancelable: true })
+      ;(beforeUnloadHandler as EventListener)(unsafeEvent)
+      expect(unsafeEvent.defaultPrevented).toBe(true)
 
-    await user.click(screen.getByRole("tab", { name: /Yêu cầu chung/ }))
-    expect(screen.getByLabelText("Nội dung nhập nhanh")).toHaveValue("Buffer nhóm 1")
-    expect(baseline.onSave).not.toHaveBeenCalled()
-    addEventListener.mockRestore()
+      await user.click(screen.getByRole("tab", { name: /Yêu cầu kỹ thuật/ }))
+      expect(screen.getByLabelText("Nội dung nhập nhanh")).toHaveValue("")
+      await user.type(screen.getByLabelText("Nội dung nhập nhanh"), "Buffer nhóm 2")
+
+      await user.click(screen.getByRole("tab", { name: /Yêu cầu chung/ }))
+      expect(screen.getByLabelText("Nội dung nhập nhanh")).toHaveValue("Buffer nhóm 1")
+      expect(baseline.onSave).not.toHaveBeenCalled()
+    } finally {
+      addEventListener.mockRestore()
+    }
   })
 
   it("keeps pending-buffer delete and reload controls focusable while blocking actions", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-inline-workflow.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-inline-workflow.test.tsx
@@ -179,6 +179,7 @@ describe("technical configuration inline workflow", () => {
   it("preserves group buffers and treats clean-draft bulk input as unsafe", async () => {
     const user = userEvent.setup()
     const onDirtyChange = vi.fn()
+    const addEventListener = vi.spyOn(window, "addEventListener")
     render(<TechnicalConfigurationBaselineTab dossier={dossier} onDirtyChange={onDirtyChange} />)
 
     await user.click(await screen.findByRole("tab", { name: "Nhập nhiều dòng" }))
@@ -187,8 +188,12 @@ describe("technical configuration inline workflow", () => {
     expect(screen.getByText("Hoàn tất hoặc hủy phần nhập nhiều dòng trước khi lưu.")).toBeVisible()
     expect(screen.getByRole("button", { name: "Lưu" })).toBeDisabled()
     expect(onDirtyChange).toHaveBeenLastCalledWith(true)
+    const beforeUnloadHandler = addEventListener.mock.calls
+      .filter(([eventName]) => eventName === "beforeunload")
+      .at(-1)?.[1]
+    expect(beforeUnloadHandler).toBeTypeOf("function")
     const unsafeEvent = new Event("beforeunload", { cancelable: true })
-    window.dispatchEvent(unsafeEvent)
+    ;(beforeUnloadHandler as EventListener)(unsafeEvent)
     expect(unsafeEvent.defaultPrevented).toBe(true)
 
     await user.click(screen.getByRole("tab", { name: /Yêu cầu kỹ thuật/ }))
@@ -198,6 +203,7 @@ describe("technical configuration inline workflow", () => {
     await user.click(screen.getByRole("tab", { name: /Yêu cầu chung/ }))
     expect(screen.getByLabelText("Nội dung nhập nhanh")).toHaveValue("Buffer nhóm 1")
     expect(baseline.onSave).not.toHaveBeenCalled()
+    addEventListener.mockRestore()
   })
 
   it("keeps pending-buffer delete and reload controls focusable while blocking actions", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-version-workflow-review.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-version-workflow-review.test.tsx
@@ -1,9 +1,8 @@
 import "@testing-library/jest-dom"
-import { act, render, screen, waitFor, within } from "@testing-library/react"
+import { act, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { TechnicalConfigurationVersionBar } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar"
 import { TechnicalConfigurationRpcError } from "@/app/(app)/technical-configurations/technical-configuration-rpc"
 
 import {
@@ -14,7 +13,9 @@ import {
   dossier,
   getBaselineRpcMock,
   mockVersions,
+  openBaselineVersionSelect,
   renderTab,
+  selectBaselineVersion,
 } from "./technical-configuration-baseline-tab-fixtures"
 
 const rpc = getBaselineRpcMock()
@@ -35,7 +36,7 @@ describe("technical configuration version workflow review regressions", () => {
     const requirement = await screen.findByLabelText("Nội dung yêu cầu 1.1")
     await user.clear(requirement)
     await user.type(requirement, "Nội dung đang sửa")
-    await user.selectOptions(screen.getByRole("combobox", { name: "Lịch sử phiên bản" }), locked.id)
+    await selectBaselineVersion(user, "Phiên bản 1 · Đã khóa")
     await user.click(
       within(await screen.findByRole("alertdialog")).getByRole("button", {
         name: "Bỏ thay đổi",
@@ -56,7 +57,7 @@ describe("technical configuration version workflow review regressions", () => {
     renderTab()
     await user.click(await screen.findByRole("tab", { name: "Nhập nhiều dòng" }))
     await user.type(screen.getByLabelText("Nội dung nhập nhanh"), "Nội dung chưa áp dụng")
-    await user.selectOptions(screen.getByRole("combobox", { name: "Lịch sử phiên bản" }), locked.id)
+    await selectBaselineVersion(user, "Phiên bản 1 · Đã khóa")
     await user.click(
       within(await screen.findByRole("alertdialog")).getByRole("button", {
         name: "Bỏ thay đổi",
@@ -98,7 +99,7 @@ describe("technical configuration version workflow review regressions", () => {
       await pending.promise
     })
     await waitFor(() =>
-      expect(screen.getByRole("combobox", { name: "Lịch sử phiên bản" })).toBeEnabled()
+      expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeEnabled()
     )
 
     expect(lockWasDisabled).toBe(true)
@@ -143,7 +144,7 @@ describe("technical configuration version workflow review regressions", () => {
       await pending.promise
     })
     await waitFor(() =>
-      expect(screen.getByRole("combobox", { name: "Lịch sử phiên bản" })).toBeEnabled()
+      expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toBeEnabled()
     )
 
     expect(createWasDisabled).toBe(true)
@@ -224,6 +225,7 @@ describe("technical configuration version workflow review regressions", () => {
     })
     await waitFor(() => expect(secondRetry).toBeEnabled())
     await user.click(secondRetry)
+    await openBaselineVersionSelect(user)
 
     expect(
       await screen.findByRole("option", { name: "Phiên bản 201 · Đã khóa" })
@@ -234,76 +236,6 @@ describe("technical configuration version workflow review regressions", () => {
       p_page: 1,
       p_page_size: 100,
     })
-  })
-
-  it("keeps a preserved historical selection represented in the selector", () => {
-    const selectedVersion = createLockedVersion({ id: "version-1", version_number: 1 })
-    const visibleVersion = createLockedVersion({ id: "version-2", version_number: 2 })
-
-    render(
-      <TechnicalConfigurationVersionBar
-        versions={[visibleVersion]}
-        selectedVersion={selectedVersion}
-        lockBlockedReason={null}
-        status={{
-          hasDraft: false,
-          isCreating: false,
-          isLocking: false,
-          isCopying: false,
-          isLoadingMoreVersions: false,
-          isNavigationDisabled: false,
-          hasMoreVersions: true,
-        }}
-        onSelectVersion={vi.fn()}
-        onLoadMoreVersions={vi.fn()}
-        onRequestLock={vi.fn()}
-        onCreateBlank={vi.fn()}
-        onCopy={vi.fn()}
-      />
-    )
-
-    const selector = screen.getByRole("combobox", {
-      name: "Lịch sử phiên bản",
-    }) as HTMLSelectElement
-    expect(selector.value).toBe(selectedVersion.id)
-    expect(
-      within(selector).getByRole("option", { name: "Phiên bản 1 · Đã khóa" })
-    ).toBeInTheDocument()
-  })
-
-  it("uses the preserved draft snapshot for a same-id selector option", () => {
-    const selectedVersion = createDraft({ id: "version-1", version_number: 1 })
-    const serverVersion = createLockedVersion({ id: selectedVersion.id, version_number: 1 })
-
-    render(
-      <TechnicalConfigurationVersionBar
-        versions={[serverVersion]}
-        selectedVersion={selectedVersion}
-        lockBlockedReason={null}
-        status={{
-          hasDraft: true,
-          isCreating: false,
-          isLocking: false,
-          isCopying: false,
-          isLoadingMoreVersions: false,
-          isNavigationDisabled: false,
-          hasMoreVersions: false,
-        }}
-        onSelectVersion={vi.fn()}
-        onLoadMoreVersions={vi.fn()}
-        onRequestLock={vi.fn()}
-        onCreateBlank={vi.fn()}
-        onCopy={vi.fn()}
-      />
-    )
-
-    const selector = screen.getByRole("combobox", { name: "Lịch sử phiên bản" })
-    expect(
-      within(selector).getByRole("option", { name: "Phiên bản 1 · Bản nháp" })
-    ).toBeInTheDocument()
-    expect(
-      within(selector).queryByRole("option", { name: "Phiên bản 1 · Đã khóa" })
-    ).not.toBeInTheDocument()
   })
 
   it("clears the creation alert after adopting a concurrently created draft", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/use-technical-configuration-baseline-import-lifecycle.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/use-technical-configuration-baseline-import-lifecycle.test.tsx
@@ -1,0 +1,101 @@
+import "@testing-library/jest-dom"
+import { act, fireEvent, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  createBaselineImportFile,
+  createBaselineImportPayload,
+  createBaselineImportPreview,
+  createDraft,
+  createPersistentQueryClient,
+  deferred,
+  dossier,
+  getBaselineImportCodecMock,
+  getBaselineRpcMock,
+  mockVersions,
+  renderTab,
+} from "./technical-configuration-baseline-tab-fixtures"
+
+const rpc = getBaselineRpcMock()
+const codec = getBaselineImportCodecMock()
+
+describe("useTechnicalConfigurationBaselineImport lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rpc.getDossier.mockResolvedValue({ data: dossier })
+    codec.readExcelFile.mockResolvedValue({
+      SheetNames: ["Baseline", "_meta"],
+      Sheets: {},
+      _workbook: {},
+    })
+    codec.parseWorkbook.mockResolvedValue([createBaselineImportPayload()])
+    rpc.previewImport.mockResolvedValue(createBaselineImportPreview())
+  })
+
+  it("blocks dismissal while the atomic apply request is in flight", async () => {
+    const user = userEvent.setup()
+    const draft = createDraft()
+    const pendingApply = deferred<{ data: ReturnType<typeof createDraft> }>()
+    const onNavigationBlockedChange = vi.fn()
+    mockVersions([draft])
+    rpc.applyImport.mockReturnValue(pendingApply.promise)
+
+    renderTab(vi.fn(), createPersistentQueryClient(), onNavigationBlockedChange)
+    await user.click(await screen.findByRole("button", { name: "Nhập từ Excel" }))
+    fireEvent.change(screen.getByLabelText("Chọn template cấu hình cơ sở"), {
+      target: { files: [createBaselineImportFile("pending-baseline.xlsx")] },
+    })
+    expect(await screen.findByText("TC-0002")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Đóng" })).toBeEnabled()
+
+    await user.click(screen.getByRole("button", { name: "Nhập 2 dòng" }))
+    await waitFor(() => expect(rpc.applyImport).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(true))
+
+    expect(screen.queryByRole("button", { name: "Đóng" })).not.toBeInTheDocument()
+    await user.keyboard("{Escape}")
+    expect(screen.getByRole("dialog", { name: "Nhập cấu hình cơ sở từ Excel" })).toBeInTheDocument()
+    expect(screen.getByText("pending-baseline.xlsx")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Khóa phiên bản", hidden: true })).toBeDisabled()
+
+    await act(async () => {
+      pendingApply.resolve({ data: createDraft({ revision: 5 }) })
+      await pendingApply.promise
+    })
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "Nhập cấu hình cơ sở từ Excel" })
+      ).not.toBeInTheDocument()
+    )
+    expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it("keeps an in-flight preview alive across parent state rerenders", async () => {
+    const user = userEvent.setup()
+    const pendingPreview = deferred<ReturnType<typeof createBaselineImportPreview>>()
+    mockVersions([createDraft()])
+    rpc.previewImport.mockReturnValue(pendingPreview.promise)
+
+    renderTab()
+    await user.click(await screen.findByRole("button", { name: "Nhập từ Excel" }))
+    fireEvent.change(screen.getByLabelText("Chọn template cấu hình cơ sở"), {
+      target: { files: [createBaselineImportFile()] },
+    })
+
+    await waitFor(() => expect(rpc.previewImport).toHaveBeenCalledTimes(1))
+    expect(screen.getByText("Đang tạo bản xem trước từ máy chủ...")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Đóng" })).not.toBeInTheDocument()
+    await user.keyboard("{Escape}")
+    expect(screen.getByRole("dialog", { name: "Nhập cấu hình cơ sở từ Excel" })).toBeInTheDocument()
+
+    await act(async () => {
+      pendingPreview.resolve(createBaselineImportPreview())
+      await pendingPreview.promise
+    })
+
+    expect(await screen.findByText("TC-0002")).toBeInTheDocument()
+    expect(rpc.previewImport).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/use-technical-configuration-baseline-import.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/use-technical-configuration-baseline-import.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom"
-import { act, fireEvent, screen, waitFor, within } from "@testing-library/react"
+import { fireEvent, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -18,7 +18,6 @@ import {
   createDraft,
   createLockedVersion,
   createPersistentQueryClient,
-  deferred,
   dossier,
   getBaselineImportCodecMock,
   getBaselineRpcMock,
@@ -311,75 +310,11 @@ describe("useTechnicalConfigurationBaselineImport workflow", () => {
     await user.click(screen.getByRole("button", { name: "Nhập 2 dòng" }))
 
     await waitFor(() => expect(rpc.listVersions).toHaveBeenCalledTimes(2))
-    expect(screen.getByLabelText("Lịch sử phiên bản")).toHaveValue(draft.id)
+    const versionTrigger = screen.getByLabelText("Lịch sử phiên bản")
+    expect(versionTrigger.tagName).toBe("BUTTON")
+    expect(versionTrigger).toHaveTextContent("Phiên bản 1 · Đã khóa")
     expect(screen.getByText("locked-target.xlsx")).toBeInTheDocument()
     expect(screen.getByText("TC-0002")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Nhập 2 dòng" })).toBeDisabled()
-  })
-
-  it("blocks dismissal while the atomic apply request is in flight", async () => {
-    const user = userEvent.setup()
-    const draft = createDraft()
-    const pendingApply = deferred<{ data: ReturnType<typeof createDraft> }>()
-    const onNavigationBlockedChange = vi.fn()
-    mockVersions([draft])
-    rpc.applyImport.mockReturnValue(pendingApply.promise)
-
-    renderTab(vi.fn(), createPersistentQueryClient(), onNavigationBlockedChange)
-    await user.click(await screen.findByRole("button", { name: "Nhập từ Excel" }))
-    fireEvent.change(screen.getByLabelText("Chọn template cấu hình cơ sở"), {
-      target: { files: [createBaselineImportFile("pending-baseline.xlsx")] },
-    })
-    expect(await screen.findByText("TC-0002")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Đóng" })).toBeEnabled()
-
-    await user.click(screen.getByRole("button", { name: "Nhập 2 dòng" }))
-    await waitFor(() => expect(rpc.applyImport).toHaveBeenCalledTimes(1))
-    await waitFor(() => expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(true))
-
-    expect(screen.queryByRole("button", { name: "Đóng" })).not.toBeInTheDocument()
-    await user.keyboard("{Escape}")
-    expect(screen.getByRole("dialog", { name: "Nhập cấu hình cơ sở từ Excel" })).toBeInTheDocument()
-    expect(screen.getByText("pending-baseline.xlsx")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Khóa phiên bản", hidden: true })).toBeDisabled()
-
-    await act(async () => {
-      pendingApply.resolve({ data: createDraft({ revision: 5 }) })
-      await pendingApply.promise
-    })
-
-    await waitFor(() =>
-      expect(
-        screen.queryByRole("dialog", { name: "Nhập cấu hình cơ sở từ Excel" })
-      ).not.toBeInTheDocument()
-    )
-    expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(false)
-  })
-
-  it("keeps an in-flight preview alive across parent state rerenders", async () => {
-    const user = userEvent.setup()
-    const pendingPreview = deferred<ReturnType<typeof createBaselineImportPreview>>()
-    mockVersions([createDraft()])
-    rpc.previewImport.mockReturnValue(pendingPreview.promise)
-
-    renderTab()
-    await user.click(await screen.findByRole("button", { name: "Nhập từ Excel" }))
-    fireEvent.change(screen.getByLabelText("Chọn template cấu hình cơ sở"), {
-      target: { files: [createBaselineImportFile()] },
-    })
-
-    await waitFor(() => expect(rpc.previewImport).toHaveBeenCalledTimes(1))
-    expect(screen.getByText("Đang tạo bản xem trước từ máy chủ...")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Đóng" })).not.toBeInTheDocument()
-    await user.keyboard("{Escape}")
-    expect(screen.getByRole("dialog", { name: "Nhập cấu hình cơ sở từ Excel" })).toBeInTheDocument()
-
-    await act(async () => {
-      pendingPreview.resolve(createBaselineImportPreview())
-      await pendingPreview.promise
-    })
-
-    expect(await screen.findByText("TC-0002")).toBeInTheDocument()
-    expect(rpc.previewImport).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationVersionBar.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Copy, Download, FilePlus2, History, LockKeyhole, Upload } 
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { SingleSelect } from "@/components/ui/heroui/SingleSelect"
 import { formatVietnamDateTime } from "@/lib/date-utils"
 
 type TechnicalConfigurationVersionBarProps = {
@@ -67,6 +68,12 @@ export function TechnicalConfigurationVersionBar({
     selectedVersion,
     ...versions.filter((version) => version.id !== selectedVersion.id),
   ].toSorted((left, right) => right.version_number - left.version_number)
+  const versionOptions = selectableVersions.map((version) => ({
+    value: version.id,
+    label: `Phiên bản ${version.version_number} · ${
+      version.status === "locked" ? "Đã khóa" : "Bản nháp"
+    }`,
+  }))
 
   return (
     <section className="border-y py-4" aria-label="Lịch sử phiên bản cấu hình cơ sở">
@@ -82,20 +89,14 @@ export function TechnicalConfigurationVersionBar({
             </Badge>
           </div>
 
-          <select
+          <SingleSelect
             value={selectedVersion.id}
-            aria-label="Lịch sử phiên bản"
-            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm sm:w-[280px]"
+            ariaLabel="Lịch sử phiên bản"
+            className="w-full sm:w-[280px]"
             disabled={isNavigationDisabled}
-            onChange={(event) => onSelectVersion(event.target.value)}
-          >
-            {selectableVersions.map((version) => (
-              <option key={version.id} value={version.id}>
-                Phiên bản {version.version_number} ·{" "}
-                {version.status === "locked" ? "Đã khóa" : "Bản nháp"}
-              </option>
-            ))}
-          </select>
+            onValueChange={onSelectVersion}
+            options={versionOptions}
+          />
           {hasMoreVersions ? (
             <Button
               type="button"

--- a/src/components/ui/heroui/SingleSelect.tsx
+++ b/src/components/ui/heroui/SingleSelect.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { ListBox } from "@heroui/react/list-box"
+import { Select } from "@heroui/react/select"
+
+export interface SingleSelectOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+export interface SingleSelectProps {
+  value: string | null
+  onValueChange: (value: string) => void
+  options: readonly SingleSelectOption[]
+  ariaLabel: string
+  disabled?: boolean
+  placeholder?: string
+  className?: string
+}
+
+/** Renders a non-clearable app-level HeroUI single-select control. */
+export function SingleSelect({
+  value,
+  onValueChange,
+  options,
+  ariaLabel,
+  disabled = false,
+  placeholder,
+  className,
+}: Readonly<SingleSelectProps>) {
+  return (
+    <Select
+      aria-label={ariaLabel}
+      className={className}
+      fullWidth
+      isDisabled={disabled}
+      onSelectionChange={(selectedKey) => {
+        if (selectedKey !== null) {
+          onValueChange(String(selectedKey))
+        }
+      }}
+      placeholder={placeholder}
+      selectedKey={value}
+    >
+      <Select.Trigger className="h-10 w-full">
+        <Select.Value />
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox>
+          {options.map((option) => (
+            <ListBox.Item
+              id={option.value}
+              isDisabled={option.disabled}
+              key={option.value}
+              textValue={option.label}
+            >
+              {option.label}
+              <ListBox.ItemIndicator />
+            </ListBox.Item>
+          ))}
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  )
+}

--- a/src/components/ui/heroui/SingleSelect.tsx
+++ b/src/components/ui/heroui/SingleSelect.tsx
@@ -2,6 +2,7 @@
 
 import { ListBox } from "@heroui/react/list-box"
 import { Select } from "@heroui/react/select"
+import type { ReactElement } from "react"
 
 export interface SingleSelectOption {
   value: string
@@ -28,7 +29,7 @@ export function SingleSelect({
   disabled = false,
   placeholder,
   className,
-}: Readonly<SingleSelectProps>) {
+}: Readonly<SingleSelectProps>): ReactElement {
   return (
     <Select
       aria-label={ariaLabel}

--- a/src/components/ui/heroui/__tests__/SingleSelect.backing.test.tsx
+++ b/src/components/ui/heroui/__tests__/SingleSelect.backing.test.tsx
@@ -1,0 +1,193 @@
+import type { ButtonHTMLAttributes, HTMLAttributes, Key, ReactNode } from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+type MockSelectProps = HTMLAttributes<HTMLDivElement> & {
+  children?: ReactNode
+  fullWidth?: boolean
+  selectedKey?: Key | null
+  onSelectionChange?: (key: Key | null) => void
+  isDisabled?: boolean
+  placeholder?: string
+  "aria-label"?: string
+}
+
+type MockListBoxItemProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children?: ReactNode
+  id?: Key
+  textValue?: string
+  isDisabled?: boolean
+}
+
+vi.mock("@heroui/react/select", async () => {
+  const ReactRuntime = await import("react")
+
+  const SelectRoot = ({
+    children,
+    fullWidth,
+    selectedKey,
+    onSelectionChange,
+    isDisabled,
+    placeholder,
+    ...props
+  }: MockSelectProps) =>
+    ReactRuntime.createElement(
+      "div",
+      {
+        ...props,
+        "data-disabled": String(Boolean(isDisabled)),
+        "data-full-width": String(Boolean(fullWidth)),
+        "data-placeholder": placeholder,
+        "data-selected-key": selectedKey === null ? "" : String(selectedKey),
+        "data-testid": "heroui-select-root",
+      },
+      children,
+      ReactRuntime.createElement(
+        "button",
+        {
+          "data-testid": "select-next",
+          onClick: () => onSelectionChange?.("next"),
+          type: "button",
+        },
+        "Select next"
+      ),
+      ReactRuntime.createElement(
+        "button",
+        {
+          "data-testid": "clear-selection",
+          onClick: () => onSelectionChange?.(null),
+          type: "button",
+        },
+        "Clear selection"
+      )
+    )
+
+  const Select = Object.assign(SelectRoot, {
+    Trigger: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) =>
+      ReactRuntime.createElement(
+        "button",
+        { ...props, "data-testid": "heroui-select-trigger", type: "button" },
+        children
+      ),
+    Value: ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) =>
+      ReactRuntime.createElement(
+        "span",
+        { ...props, "data-testid": "heroui-select-value" },
+        children
+      ),
+    Indicator: ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) =>
+      ReactRuntime.createElement(
+        "span",
+        { ...props, "data-testid": "heroui-select-indicator" },
+        children
+      ),
+    Popover: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) =>
+      ReactRuntime.createElement(
+        "div",
+        { ...props, "data-testid": "heroui-select-popover" },
+        children
+      ),
+  })
+
+  return { Select }
+})
+
+vi.mock("@heroui/react/list-box", async () => {
+  const ReactRuntime = await import("react")
+
+  const ItemIndicator = ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) =>
+    ReactRuntime.createElement(
+      "span",
+      { ...props, "data-testid": "heroui-listbox-item-indicator" },
+      children
+    )
+  const Item = Object.assign(
+    ({ children, id, textValue, isDisabled, ...props }: MockListBoxItemProps) =>
+      ReactRuntime.createElement(
+        "button",
+        {
+          ...props,
+          "data-id": id === undefined ? "" : String(id),
+          "data-text-value": textValue,
+          "data-testid": "heroui-listbox-item",
+          disabled: isDisabled,
+          type: "button",
+        },
+        children
+      ),
+    { Indicator: ItemIndicator }
+  )
+  const ListBox = Object.assign(
+    ({ children, ...props }: HTMLAttributes<HTMLDivElement>) =>
+      ReactRuntime.createElement("div", { ...props, "data-testid": "heroui-listbox" }, children),
+    {
+      Item,
+      ItemIndicator,
+    }
+  )
+
+  return { ListBox }
+})
+
+import { SingleSelect } from "../SingleSelect"
+
+describe("SingleSelect HeroUI backing", () => {
+  it("maps the app contract onto HeroUI compound components", () => {
+    render(
+      <SingleSelect
+        ariaLabel="Lịch sử phiên bản"
+        className="sm:w-[280px]"
+        disabled
+        onValueChange={vi.fn()}
+        options={[
+          { value: "draft-2", label: "Phiên bản 2 · Bản nháp" },
+          {
+            value: "locked-1",
+            label: "Phiên bản 1 · Đã khóa",
+            disabled: true,
+          },
+        ]}
+        placeholder="Chọn phiên bản"
+        value="draft-2"
+      />
+    )
+
+    const root = screen.getByTestId("heroui-select-root")
+    expect(root).toHaveClass("sm:w-[280px]")
+    expect(root).toHaveAttribute("aria-label", "Lịch sử phiên bản")
+    expect(root).toHaveAttribute("data-disabled", "true")
+    expect(root).toHaveAttribute("data-full-width", "true")
+    expect(root).toHaveAttribute("data-placeholder", "Chọn phiên bản")
+    expect(root).toHaveAttribute("data-selected-key", "draft-2")
+    expect(screen.getByTestId("heroui-select-trigger")).toHaveClass("h-10", "w-full")
+    expect(screen.getByTestId("heroui-select-value")).toBeInTheDocument()
+    expect(screen.getByTestId("heroui-select-popover")).toContainElement(
+      screen.getByTestId("heroui-listbox")
+    )
+    expect(screen.getAllByTestId("heroui-listbox-item")[1]).toHaveAttribute(
+      "data-text-value",
+      "Phiên bản 1 · Đã khóa"
+    )
+    expect(screen.getAllByTestId("heroui-listbox-item")[1]).toBeDisabled()
+    expect(screen.getAllByTestId("heroui-listbox-item-indicator")).toHaveLength(2)
+  })
+
+  it("forwards string selections and ignores null selections", () => {
+    const onValueChange = vi.fn()
+
+    render(
+      <SingleSelect
+        ariaLabel="Lịch sử phiên bản"
+        onValueChange={onValueChange}
+        options={[]}
+        value={null}
+      />
+    )
+
+    fireEvent.click(screen.getByTestId("select-next"))
+    fireEvent.click(screen.getByTestId("clear-selection"))
+
+    expect(onValueChange).toHaveBeenCalledTimes(1)
+    expect(onValueChange).toHaveBeenCalledWith("next")
+  })
+})

--- a/src/components/ui/heroui/__tests__/SingleSelect.test.tsx
+++ b/src/components/ui/heroui/__tests__/SingleSelect.test.tsx
@@ -1,0 +1,111 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { SingleSelect } from "../SingleSelect"
+
+const OPTIONS = [
+  { value: "draft-2", label: "Phiên bản 2 · Bản nháp" },
+  { value: "locked-1", label: "Phiên bản 1 · Đã khóa" },
+] as const
+
+describe("SingleSelect", () => {
+  it("renders the selected label and placeholder", () => {
+    const { rerender } = render(
+      <SingleSelect
+        ariaLabel="Lịch sử phiên bản"
+        onValueChange={vi.fn()}
+        options={OPTIONS}
+        placeholder="Chọn phiên bản"
+        value="locked-1"
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toHaveTextContent(
+      "Phiên bản 1 · Đã khóa"
+    )
+
+    rerender(
+      <SingleSelect
+        ariaLabel="Lịch sử phiên bản"
+        onValueChange={vi.fn()}
+        options={OPTIONS}
+        placeholder="Chọn phiên bản"
+        value={null}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /Lịch sử phiên bản/ })).toHaveTextContent(
+      "Chọn phiên bản"
+    )
+  })
+
+  it("opens with ArrowDown and reports an option click", async () => {
+    const user = userEvent.setup()
+    const onValueChange = vi.fn()
+
+    render(
+      <SingleSelect
+        ariaLabel="Lịch sử phiên bản"
+        onValueChange={onValueChange}
+        options={OPTIONS}
+        value="locked-1"
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: /Lịch sử phiên bản/ })
+    act(() => trigger.focus())
+    await user.keyboard("{ArrowDown}")
+
+    await user.click(await screen.findByRole("option", { name: "Phiên bản 2 · Bản nháp" }))
+
+    expect(onValueChange).toHaveBeenCalledWith("draft-2")
+    await waitFor(() => expect(trigger).toHaveAttribute("aria-expanded", "false"))
+  })
+
+  it("keeps a disabled trigger and disabled option non-interactive", async () => {
+    const user = userEvent.setup()
+    const onValueChange = vi.fn()
+
+    const { rerender } = render(
+      <SingleSelect
+        ariaLabel="Lịch sử phiên bản"
+        disabled
+        onValueChange={onValueChange}
+        options={OPTIONS}
+        value="locked-1"
+      />
+    )
+
+    const disabledTrigger = screen.getByRole("button", { name: /Lịch sử phiên bản/ })
+    expect(disabledTrigger).toBeDisabled()
+    act(() => disabledTrigger.focus())
+    await user.keyboard("{ArrowDown}")
+    expect(screen.queryByRole("option")).not.toBeInTheDocument()
+
+    rerender(
+      <SingleSelect
+        ariaLabel="Lịch sử phiên bản"
+        onValueChange={onValueChange}
+        options={[
+          OPTIONS[0],
+          {
+            ...OPTIONS[1],
+            disabled: true,
+          },
+        ]}
+        value="draft-2"
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: /Lịch sử phiên bản/ })
+    await user.click(trigger)
+    const disabledOption = await screen.findByRole("option", {
+      name: "Phiên bản 1 · Đã khóa",
+    })
+
+    expect(disabledOption).toHaveAttribute("aria-disabled", "true")
+    fireEvent.click(disabledOption)
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- add the app-level HeroUI `SingleSelect` primitive with real React Aria interaction coverage and mocked compound backing tests
- migrate `TechnicalConfigurationVersionBar` while preserving selected snapshot precedence, descending order, disabled navigation, load-more, locking, import, and discard workflows
- split the planned technical-configuration tests and isolate `beforeunload` handlers from React Aria's JSDOM teardown listener
- keep repo-wide Select rollout in #779; leave #772 unchanged

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused primitive, boundary, and all technical-configuration Vitest: 35 files, 248 tests passed
- `node scripts/npm-run.js run verify:heroui-boundary`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run react-doctor`: 100/100
- `git diff --check`
- changed TypeScript files remain below the 450-line hard ceiling

## Browser QA

Browser testing was explicitly waived by the maintainer on July 19, 2026. Automated interaction coverage and the listed local/CI verification remain the acceptance evidence for this PR.

Closes #766

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `HeroUI` `SingleSelect` primitive and migrates the baseline VersionBar to use it, preserving existing behavior and accessibility. Addresses Linear #766 and updates the import boundary for safe `@heroui` usage.

- **New Features**
  - Added app-level `SingleSelect` backed by `@heroui/react/select` and `@heroui/react/list-box`.
  - Supports keyboard/mouse interactions, disabled states, and placeholder text.

- **Refactors**
  - Migrated `TechnicalConfigurationVersionBar` to `SingleSelect` while keeping selected snapshot precedence, sort order, disabled navigation, load-more, locking, import, and discard flows.
  - Consolidated and hardened tests: added `SingleSelect` component/backing tests, introduced helpers for version selection, split beforeunload and import lifecycle suites, and updated assertions for the new button trigger and keyboard open.
  - Updated boundary script and tests to allow `src/components/ui/heroui/` and block direct consumer imports of `@heroui` components.

<sup>Written for commit 5fde39a4b40dc35d70872e246edf81c817cc4a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable single-selection control with keyboard navigation, disabled options, placeholders, and accessible labels.
  * Updated technical configuration version history selection with clearer status labels for locked and draft versions.

* **Bug Fixes**
  * Improved navigation protection for unsaved technical configuration changes and in-progress baseline imports.

* **Tests**
  * Expanded coverage for version selection, draft and locked workflows, import lifecycle behavior, accessibility, and unsaved-change protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->