### PR TITLE
feat(technical-config): add P8A1 supplier contracts

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -998,47 +998,142 @@ Baseline/reference evidence persistence, URL validation, revision, lock, copy an
 
 A locked baseline preserves its own and each reference product's criterion-level URL evidence as immutable context.
 
-## Phase P8A - Supplier And Option Data Contracts
+## Phase P8A1 - Supplier Data Contracts
 
-**Depends on:** P4  
-**Requirements:** TC-02, TC-07, TC-09, TC-17, TC-20  
-**Deploy boundary:** backend contracts only; no supplier workspace
+**Depends on:** P1
+
+**Requirements:** TC-09, TC-20
+
+**Deploy boundary:** supplier persistence and RPC contracts only; no option,
+response, hook or UI surface
 
 ### Planned files
 
-- Create: `supabase/migrations/<ordered_timestamp>_technical_configuration_supplier_options.sql`
+- Create: `supabase/migrations/20260722010000_technical_configuration_suppliers.sql`
+- Create: `supabase/tests/technical_configuration_suppliers_phase_gate.sql`
+- Create: `src/lib/technical-configuration-supplier-option-rpcs.ts`
 - Create: `src/app/(app)/technical-configurations/supplier-option-types.ts`
-- Create: `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptions.ts`
+- Create: `src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts`
+- Create: `src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts`
 - Create: `src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts`
+- Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
+- Modify: `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+- Create: `openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md`
 
 ### Tasks
 
-- [ ] Add dossier-scoped supplier and option entities with multiple options per supplier.
-- [ ] Normalize supplier names by trim, whitespace collapse and lowercase; enforce normalized uniqueness per dossier.
-- [ ] Add option response dataset bound to exact baseline version and criterion.
-- [ ] Add model/manufacturer/option name and display-label contract.
-- [ ] Add separate supplementary information field.
-- [ ] Add optimistic concurrency for option metadata and responses.
-- [ ] Keep options directly editable with no lock/version lifecycle.
-- [ ] Reject supplier, option and response mutations when the owning dossier is archived.
-- [ ] Keep old baseline response datasets separate when a new baseline is selected.
-- [ ] Complete the mandatory DB phase gate, including phase-local role/claim tests, explicit live-write approval and post-apply advisors.
+- [x] Add dossier-scoped suppliers with trim, whitespace-collapse and lowercase
+      normalized-name uniqueness.
+- [x] Add list/create/update/delete RPCs guarded by the existing global/raw-admin
+      and editable-dossier authorization helpers.
+- [x] Use dossier revision as the optimistic-concurrency owner for supplier
+      mutations.
+- [x] Reject mutations for archived dossiers while allowing direct supplier
+      editing regardless of baseline lock state.
+- [x] Keep supplier tables RPC-only with RLS enabled, deny-by-default table
+      grants and exact authenticated RPC grants.
+- [x] Keep suppliers outside the baseline aggregate and baseline-copy flow.
+- [x] Prepare the phase-local DB gate without applying or executing it against
+      live DB before explicit approval.
 
 ### TDD and verification
 
-- Authorization tests for all required role/claim states.
-- Tests for multiple options under one supplier.
-- Tests for correct baseline-version/criterion binding and ownership/cascade.
-- Tests proving supplementary information is structurally separate from assessment data.
-- Tests proving no supplier lock/version backend contract exists.
+- Migration-source tests for ordering, schema, normalization, ownership,
+  cascade, authorization, concurrency, RLS and grants.
+- Type-level/runtime contract tests for supplier RPC names, wire values and the
+  module-local proxy adapter.
+- RPC allowlist tests proving exactly four supplier RPCs are exposed.
+- Local OpenSpec, formatting, typecheck, focused Vitest and React Doctor gates.
 
 ### Exit gate
 
-Secure supplier/option contracts exist, but no user-facing supplier workspace is available.
+Supplier persistence and secure RPC contracts can deploy independently. No
+option table, response dataset, hook or UI is present.
+
+## Phase P8A2 - Option Identity Data Contracts
+
+**Depends on:** P8A1
+
+**Requirements:** TC-09, TC-20
+
+**Deploy boundary:** option identity and metadata only; no baseline-bound responses
+
+### Planned files
+
+- Create: `supabase/migrations/<ordered_timestamp>_technical_configuration_options.sql`
+- Extend: `supabase/tests/technical_configuration_suppliers_phase_gate.sql`
+- Modify: `src/lib/technical-configuration-supplier-option-rpcs.ts`
+- Modify: `src/app/(app)/technical-configurations/supplier-option-types.ts`
+- Modify: `src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts`
+- Modify: `src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts`
+
+### Tasks
+
+- [ ] Add multiple options per supplier with model, manufacturer, option-name
+      and deterministic display-label contracts.
+- [ ] Add direct-edit option CRUD with dossier-revision optimistic concurrency.
+- [ ] Add ownership/cascade constraints and archived-dossier guards.
+- [ ] Define no option lock/version backend contract.
+- [ ] Keep option identity outside the baseline aggregate and baseline-copy flow.
+
+### TDD and verification
+
+- Tests for multiple options under one supplier and cross-dossier rejection.
+- Tests for display labels, stale dossier revisions and cascade behavior.
+- Tests proving no baseline lock/version dependency exists.
+- Phase-local authorization and RPC allowlist tests.
+
+### Exit gate
+
+Supplier and option identity contracts can deploy without response persistence or
+user-facing option workspace.
+
+## Phase P8A3 - Baseline-Bound Option Response Contracts
+
+**Depends on:** P4, P8A2
+
+**Requirements:** TC-02, TC-07, TC-09, TC-17, TC-20
+
+**Deploy boundary:** exact-baseline response persistence only; no hook or UI
+
+### Planned files
+
+- Create: `supabase/migrations/<ordered_timestamp>_technical_configuration_option_responses.sql`
+- Extend: `supabase/tests/technical_configuration_suppliers_phase_gate.sql`
+- Modify: `src/lib/technical-configuration-supplier-option-rpcs.ts`
+- Modify: `src/app/(app)/technical-configurations/supplier-option-types.ts`
+- Modify: `src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts`
+- Modify: `src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts`
+
+### Tasks
+
+- [ ] Add option response datasets bound to an exact baseline version and
+      criterion with ownership and cascade constraints.
+- [ ] Store supplementary information structurally apart from compliance and
+      future manual-assessment fields.
+- [ ] Use dossier-revision optimistic concurrency without baseline-lock checks.
+- [ ] Keep historical response datasets separate when a new baseline version is
+      selected; source updates preserve stable criterion linkage and audit
+      metadata instead of rewriting old datasets.
+- [ ] Complete the mandatory DB phase gate after separate explicit live-write
+      approval, followed by security and performance advisors.
+
+### TDD and verification
+
+- Tests for correct baseline-version/criterion binding and cross-owner rejection.
+- Tests proving supplementary information cannot alter compliance.
+- Tests for stale dossier revisions, cascade and historical dataset separation.
+- Tests proving baseline lock does not block supplier-option response editing.
+
+### Exit gate
+
+Secure supplier, option and exact-baseline response contracts exist, but no
+user-facing supplier workspace is available.
 
 ## Phase P8B - Supplier Option Manual Workspace
 
-**Depends on:** P3A, P8A  
+**Depends on:** P3A, P8A3
+
 **Requirements:** TC-04, TC-09, TC-17, TC-20  
 **Deploy boundary:** manual supplier-option entry without Excel or evidence
 
@@ -1047,6 +1142,7 @@ Secure supplier/option contracts exist, but no user-facing supplier workspace is
 - Create: `src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx`
 - Create: `src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionEditor.tsx`
 - Create: `src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses.tsx`
+- Create: `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptions.ts`
 - Create: `src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx`
 - Modify: `src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx`
 
@@ -1236,7 +1332,8 @@ Users can scan and inspect baseline versus selected options, but cannot yet save
 
 ## Phase P11 - Manual Evaluation Domain And Persistence
 
-**Depends on:** P4, P8A  
+**Depends on:** P4, P8A3
+
 **Requirements:** TC-02, TC-15, TC-16, TC-19, TC-20  
 **Deploy boundary:** backend/domain capability with minimal or test-only UI exposure
 

--- a/openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md
@@ -1,0 +1,78 @@
+# P8A TDD Plan
+
+## Scope Boundary
+
+P8A is split into three deploy-safe leaves:
+
+1. P8A1 adds dossier-scoped supplier persistence and RPC contracts.
+2. P8A2 adds option identity and multiple-option persistence.
+3. P8A3 adds exact-baseline response datasets and supplementary information.
+
+Supplier and option identity data remain outside the baseline aggregate. Baseline
+copy does not clone them, and baseline lock state does not block their direct
+editing. P8B owns hooks and UI. P9A, P9B and P10 remain out of scope.
+
+## P8A1 Red-Green-Refactor
+
+### RED
+
+- Create
+  `src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts`
+  to freeze migration order, schema, normalization, authorization, concurrency,
+  ownership, cascade, RLS and grants.
+- Create
+  `src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts`
+  to freeze supplier RPC names, wire types and module-local adapter behavior.
+- Extend
+  `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+  with the four supplier RPCs.
+- Run:
+
+```bash
+node scripts/npm-run.js exec vitest run \
+  src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts \
+  src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts \
+  'src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts'
+```
+
+The tests must fail because the P8A1 migration and TypeScript contracts do not
+exist yet.
+
+### GREEN
+
+- Create
+  `supabase/migrations/20260722010000_technical_configuration_suppliers.sql`.
+- Create `supabase/tests/technical_configuration_suppliers_phase_gate.sql`.
+- Create `src/lib/technical-configuration-supplier-option-rpcs.ts`.
+- Create
+  `src/app/(app)/technical-configurations/supplier-option-types.ts`.
+- Create
+  `src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts`.
+- Add only the supplier RPC manifest to the existing RPC allowlist.
+- Re-run the focused RED command until it passes.
+
+### REFACTOR AND VERIFY
+
+```bash
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js exec vitest run \
+  src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts \
+  src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts \
+  'src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts'
+node scripts/npm-run.js run react-doctor
+openspec validate add-technical-configuration-comparison \
+  --type change --strict --no-interactive
+```
+
+Run Code Review Graph and GitNexus change detection before commit. Commit and
+push P8A1 independently.
+
+## Live Database Boundary
+
+No migration apply, phase-gate execution, DDL, DML or other live write is
+authorized by approval of this plan. Applying the migration and running the
+transaction-wrapped SQL phase gate each require a separate explicit live-write
+approval. Supabase CLI is not used.

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -34,13 +34,15 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 | [P7A2](./implementation-plan.md#phase-p7a2---reference-product-workspace)                    | Workspace đối chiếu sản phẩm tham chiếu        | P7A1                   | TC-04, TC-06, TC-08, TC-20                      |
 | [P7B1](./implementation-plan.md#phase-p7b1---baseline-and-reference-evidence-contracts)      | Data contract tài liệu/trích dẫn cơ sở         | P4, P6B, P7A2          | TC-02, TC-04, TC-06, TC-11, TC-12, TC-20        |
 | [P7B2](./implementation-plan.md#phase-p7b2---baseline-and-reference-evidence-workspace)      | Workspace tài liệu/trích dẫn cơ sở             | P7B1                   | TC-04, TC-06, TC-11, TC-12, TC-20               |
-| [P8A](./implementation-plan.md#phase-p8a---supplier-and-option-data-contracts)               | Data contract nhà cung cấp và phương án        | P4                     | TC-02, TC-07, TC-09, TC-17, TC-20               |
-| [P8B](./implementation-plan.md#phase-p8b---supplier-option-manual-workspace)                 | UI nhập thủ công phương án                     | P3A, P8A               | TC-04, TC-09, TC-17, TC-20                      |
+| [P8A1](./implementation-plan.md#phase-p8a1---supplier-data-contracts)                        | Data contract nhà cung cấp                     | P1                     | TC-09, TC-20                                    |
+| [P8A2](./implementation-plan.md#phase-p8a2---option-identity-data-contracts)                 | Identity và metadata nhiều phương án           | P8A1                   | TC-09, TC-20                                    |
+| [P8A3](./implementation-plan.md#phase-p8a3---baseline-bound-option-response-contracts)       | Response phương án theo baseline version       | P4, P8A2               | TC-02, TC-07, TC-09, TC-17, TC-20               |
+| [P8B](./implementation-plan.md#phase-p8b---supplier-option-manual-workspace)                 | UI nhập thủ công phương án                     | P3A, P8A3              | TC-04, TC-09, TC-17, TC-20                      |
 | [P9A](./implementation-plan.md#phase-p9a---supplier-option-excel)                            | Excel phương án                                | P5A, P8B               | TC-10, TC-20                                    |
 | [P9B](./implementation-plan.md#phase-p9b---supplier-option-documents-and-citations)          | Tài liệu và trích dẫn phương án                | P6B, P7B2, P8B         | TC-02, TC-04, TC-11, TC-12, TC-20               |
 | [P10A](./implementation-plan.md#phase-p10a---comparison-read-contract)                       | Query contract cho so sánh                     | P7B2, P9B              | TC-02, TC-13, TC-17                             |
 | [P10B](./implementation-plan.md#phase-p10b---comparison-matrix-ui)                           | Ma trận so sánh                                | P3A, P10A              | TC-13, TC-17                                    |
-| [P11](./implementation-plan.md#phase-p11---manual-evaluation-domain-and-persistence)         | Domain và persistence đánh giá thủ công        | P4, P8A                | TC-02, TC-15, TC-16, TC-19, TC-20               |
+| [P11](./implementation-plan.md#phase-p11---manual-evaluation-domain-and-persistence)         | Domain và persistence đánh giá thủ công        | P4, P8A3               | TC-02, TC-15, TC-16, TC-19, TC-20               |
 | [P12A](./implementation-plan.md#phase-p12a---manual-evaluation-save-and-navigation-workflow) | Nhập đánh giá, save và navigation              | P10B, P11              | TC-04, TC-14, TC-15, TC-16, TC-17, TC-20        |
 | [P12B](./implementation-plan.md#phase-p12b---evaluation-progress-and-filters)                | Tiến độ và bộ lọc đánh giá                     | P12A                   | TC-14, TC-16                                    |
 | [P12C](./implementation-plan.md#phase-p12c---optional-reference-ranking)                     | Xếp hạng tham khảo                             | P12B                   | TC-18                                           |
@@ -237,13 +239,29 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
       `N/A` vì không có credentials và dev server được yêu cầu giữ dừng; không
       apply live DB.
 
-## Phase P8A - Supplier And Option Data Contracts
+## Phase P8A1 - Supplier Data Contracts
 
-- [ ] P8A.1 Thêm supplier, nhiều options và option response datasets theo baseline version.
-- [ ] P8A.2 Thêm supplementary information tách khỏi compliance.
-- [ ] P8A.3 Thêm direct-edit/no-lock/no-version contract và optimistic concurrency.
-- [ ] P8A.4 Chạy DB phase gate cho quyền, ownership, cascade và historical linkage.
-- [ ] P8A.5 Viết contract tests cho multiple options, baseline binding và source updates.
+- [x] P8A1.1 Thêm supplier dossier-scoped với normalized-name uniqueness.
+- [x] P8A1.2 Thêm list/create/update/delete RPC với global/raw-admin authorization.
+- [x] P8A1.3 Dùng dossier revision cho optimistic concurrency và từ chối mutation khi dossier archived.
+- [x] P8A1.4 Giữ supplier RPC-only, RLS deny-by-default và explicit grants.
+- [x] P8A1.5 Viết migration/source/RPC allowlist/authorization/ownership/cascade contract tests.
+- [x] P8A1.6 Chuẩn bị DB phase gate nhưng không apply hoặc chạy live trước explicit live-write approval.
+
+## Phase P8A2 - Option Identity Data Contracts
+
+- [ ] P8A2.1 Thêm nhiều options cho mỗi supplier với model/manufacturer/option-name/display-label contract.
+- [ ] P8A2.2 Thêm direct-edit/no-lock/no-version contract và optimistic concurrency.
+- [ ] P8A2.3 Giữ option identity ngoài baseline aggregate và không copy trong baseline-copy flow.
+- [ ] P8A2.4 Chạy contract/DB phase gate cho authorization, ownership, cascade và multiple options.
+
+## Phase P8A3 - Baseline-Bound Option Response Contracts
+
+- [ ] P8A3.1 Thêm option response datasets bound tới exact baseline version và criterion.
+- [ ] P8A3.2 Tách supplementary information khỏi compliance/evaluation fields.
+- [ ] P8A3.3 Giữ dataset lịch sử riêng khi nguồn/baseline version thay đổi; không sửa response cũ ngầm.
+- [ ] P8A3.4 Thêm optimistic concurrency và archived-dossier guard nhưng không bị baseline lock chặn.
+- [ ] P8A3.5 Chạy contract/DB phase gate cho baseline binding, ownership, cascade và historical linkage.
 
 ## Phase P8B - Supplier Option Manual Workspace
 

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  SUPPLIER_RPC_FUNCTION_NAMES,
+  SUPPLIER_RPC_FUNCTIONS,
+} from "@/lib/technical-configuration-supplier-option-rpcs"
+import {
+  createTechnicalConfigurationSupplier,
+  deleteTechnicalConfigurationSupplier,
+  listTechnicalConfigurationSuppliers,
+  updateTechnicalConfigurationSupplier,
+} from "../technical-configuration-supplier-option-rpc"
+import type {
+  TechnicalConfigurationSupplierDeleteWireResponse,
+  TechnicalConfigurationSupplierMutationWireResponse,
+  TechnicalConfigurationSuppliersListWireResponse,
+} from "../supplier-option-types"
+
+const callRpcMock = vi.fn()
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => callRpcMock(...args),
+}))
+
+describe("P8A1 supplier RPC contract", () => {
+  beforeEach(() => {
+    callRpcMock.mockReset()
+  })
+
+  it("freezes exactly the four supplier RPC names", () => {
+    expect(SUPPLIER_RPC_FUNCTIONS).toEqual({
+      listSuppliers: "technical_configuration_suppliers_list",
+      createSupplier: "technical_configuration_supplier_create",
+      updateSupplier: "technical_configuration_supplier_update",
+      deleteSupplier: "technical_configuration_supplier_delete",
+    })
+    expect(SUPPLIER_RPC_FUNCTION_NAMES).toEqual(Object.values(SUPPLIER_RPC_FUNCTIONS))
+  })
+
+  it("delegates list arguments and AbortSignal without remapping wire fields", async () => {
+    const args = {
+      p_dossier_id: "00000000-0000-0000-0000-000000000001",
+      p_page: 2,
+      p_page_size: 25,
+    }
+    const signal = new AbortController().signal
+    const response: TechnicalConfigurationSuppliersListWireResponse = {
+      data: [
+        {
+          id: "00000000-0000-0000-0000-000000000002",
+          dossier_id: args.p_dossier_id,
+          name: "Công ty Thiết bị A",
+          normalized_name: "công ty thiết bị a",
+          created_at: "2026-07-22T00:00:00Z",
+          created_by: 1,
+          updated_at: "2026-07-22T00:00:00Z",
+          updated_by: 1,
+          revision: 3,
+        },
+      ],
+      revision: 3,
+      total: 1,
+      page: 2,
+      page_size: 25,
+    }
+    callRpcMock.mockResolvedValueOnce(response)
+
+    await expect(listTechnicalConfigurationSuppliers(args, signal)).resolves.toEqual(response)
+    expect(callRpcMock).toHaveBeenCalledWith(SUPPLIER_RPC_FUNCTIONS.listSuppliers, args, {
+      signal,
+    })
+  })
+
+  it("routes create, update and delete through dossier-revision contracts", async () => {
+    const mutationResponse: TechnicalConfigurationSupplierMutationWireResponse = {
+      data: {
+        id: "00000000-0000-0000-0000-000000000002",
+        dossier_id: "00000000-0000-0000-0000-000000000001",
+        name: "Nhà cung cấp A",
+        normalized_name: "nhà cung cấp a",
+        created_at: "2026-07-22T00:00:00Z",
+        created_by: 1,
+        updated_at: "2026-07-22T00:01:00Z",
+        updated_by: 1,
+        revision: 4,
+      },
+    }
+    const deleteResponse: TechnicalConfigurationSupplierDeleteWireResponse = {
+      data: {
+        id: mutationResponse.data.id,
+        revision: 5,
+      },
+    }
+    const createArgs = {
+      p_dossier_id: mutationResponse.data.dossier_id,
+      p_name: "  Nhà   cung cấp A  ",
+      p_expected_revision: 3,
+    }
+    const updateArgs = {
+      p_supplier_id: mutationResponse.data.id,
+      p_name: "Nhà cung cấp A",
+      p_expected_revision: 4,
+    }
+    const deleteArgs = {
+      p_supplier_id: mutationResponse.data.id,
+      p_expected_revision: 4,
+    }
+    callRpcMock
+      .mockResolvedValueOnce(mutationResponse)
+      .mockResolvedValueOnce(mutationResponse)
+      .mockResolvedValueOnce(deleteResponse)
+
+    await expect(createTechnicalConfigurationSupplier(createArgs)).resolves.toEqual(
+      mutationResponse
+    )
+    await expect(updateTechnicalConfigurationSupplier(updateArgs)).resolves.toEqual(
+      mutationResponse
+    )
+    await expect(deleteTechnicalConfigurationSupplier(deleteArgs)).resolves.toEqual(deleteResponse)
+
+    expect(callRpcMock.mock.calls).toEqual([
+      [SUPPLIER_RPC_FUNCTIONS.createSupplier, createArgs, { signal: undefined }],
+      [SUPPLIER_RPC_FUNCTIONS.updateSupplier, updateArgs, { signal: undefined }],
+      [SUPPLIER_RPC_FUNCTIONS.deleteSupplier, deleteArgs, { signal: undefined }],
+    ])
+  })
+})

--- a/src/app/(app)/technical-configurations/supplier-option-types.ts
+++ b/src/app/(app)/technical-configurations/supplier-option-types.ts
@@ -1,0 +1,53 @@
+export interface TechnicalConfigurationSupplierWire {
+  id: string
+  dossier_id: string
+  name: string
+  normalized_name: string
+  created_at: string
+  created_by: number
+  updated_at: string
+  updated_by: number
+  revision: number
+}
+
+export interface TechnicalConfigurationSuppliersListWireResponse {
+  data: TechnicalConfigurationSupplierWire[]
+  revision: number
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface TechnicalConfigurationSupplierMutationWireResponse {
+  data: TechnicalConfigurationSupplierWire
+}
+
+export interface TechnicalConfigurationSupplierDeleteWireResponse {
+  data: {
+    id: string
+    revision: number
+  }
+}
+
+export interface TechnicalConfigurationSuppliersListRpcArgs {
+  p_dossier_id: string
+  p_page?: number
+  p_page_size?: number
+}
+
+export interface TechnicalConfigurationSupplierCreateRpcArgs {
+  p_dossier_id: string
+  p_name: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationSupplierUpdateRpcArgs {
+  p_supplier_id: string
+  p_name: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationSupplierDeleteRpcArgs {
+  p_supplier_id: string
+  p_expected_revision: number
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts
@@ -1,0 +1,51 @@
+import { SUPPLIER_RPC_FUNCTIONS } from "@/lib/technical-configuration-supplier-option-rpcs"
+import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
+import type {
+  TechnicalConfigurationSupplierCreateRpcArgs,
+  TechnicalConfigurationSupplierDeleteRpcArgs,
+  TechnicalConfigurationSupplierDeleteWireResponse,
+  TechnicalConfigurationSupplierMutationWireResponse,
+  TechnicalConfigurationSuppliersListRpcArgs,
+  TechnicalConfigurationSuppliersListWireResponse,
+  TechnicalConfigurationSupplierUpdateRpcArgs,
+} from "./supplier-option-types"
+
+/** Lists dossier-scoped suppliers with the owning dossier revision. */
+export function listTechnicalConfigurationSuppliers(
+  args: TechnicalConfigurationSuppliersListRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationSuppliersListWireResponse> {
+  return callTechnicalConfigurationRpc(SUPPLIER_RPC_FUNCTIONS.listSuppliers, args, {
+    signal,
+  })
+}
+
+/** Creates one supplier with optimistic dossier-revision protection. */
+export function createTechnicalConfigurationSupplier(
+  args: TechnicalConfigurationSupplierCreateRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationSupplierMutationWireResponse> {
+  return callTechnicalConfigurationRpc(SUPPLIER_RPC_FUNCTIONS.createSupplier, args, {
+    signal,
+  })
+}
+
+/** Updates one supplier with optimistic dossier-revision protection. */
+export function updateTechnicalConfigurationSupplier(
+  args: TechnicalConfigurationSupplierUpdateRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationSupplierMutationWireResponse> {
+  return callTechnicalConfigurationRpc(SUPPLIER_RPC_FUNCTIONS.updateSupplier, args, {
+    signal,
+  })
+}
+
+/** Deletes one supplier and returns the next dossier revision. */
+export function deleteTechnicalConfigurationSupplier(
+  args: TechnicalConfigurationSupplierDeleteRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationSupplierDeleteWireResponse> {
+  return callTechnicalConfigurationRpc(SUPPLIER_RPC_FUNCTIONS.deleteSupplier, args, {
+    signal,
+  })
+}

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -1,6 +1,7 @@
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
 import { DOCUMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-document-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
+import { SUPPLIER_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-supplier-option-rpcs"
 
 /** Whitelist RPCs allowed through the Next.js RPC proxy. */
 export const ALLOWED_FUNCTIONS = new Set<string>([
@@ -98,6 +99,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   ...BASELINE_RPC_FUNCTION_NAMES,
   ...REFERENCE_PRODUCT_RPC_FUNCTION_NAMES,
   ...DOCUMENT_RPC_FUNCTION_NAMES,
+  ...SUPPLIER_RPC_FUNCTION_NAMES,
   // AI Assistant (read-only)
   "ai_equipment_lookup",
   "ai_maintenance_plan_lookup",

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -6,6 +6,7 @@ import { ALLOWED_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
 import { POST } from "@/app/api/rpc/[fn]/route"
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
+import { SUPPLIER_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-supplier-option-rpcs"
 
 const DOSSIER_RPC_FUNCTIONS = [
   "technical_configuration_dossiers_list",
@@ -48,6 +49,13 @@ const BASELINE_RPC_FUNCTIONS = [
 const REFERENCE_RPC_FUNCTIONS = [
   ...P7A1_REFERENCE_RPC_FUNCTIONS,
   ...REFERENCE_DOCUMENT_RPC_FUNCTIONS,
+] as const
+
+const P8A1_SUPPLIER_RPC_FUNCTIONS = [
+  "technical_configuration_suppliers_list",
+  "technical_configuration_supplier_create",
+  "technical_configuration_supplier_update",
+  "technical_configuration_supplier_delete",
 ] as const
 
 async function invokeRpcProxy(fn: string) {
@@ -109,6 +117,32 @@ describe("technical configuration reference product RPC whitelist", () => {
 
   it.each(REFERENCE_RPC_FUNCTIONS)(
     'allows reference product RPC "%s" through the whitelist',
+    async (fn) => {
+      const response = await invokeRpcProxy(fn)
+
+      expect(response.status).toBe(411)
+      await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
+    }
+  )
+})
+
+describe("technical configuration supplier RPC whitelist", () => {
+  it("keeps the local P8A1 supplier prefix aligned with the shared manifest", () => {
+    expect(P8A1_SUPPLIER_RPC_FUNCTIONS).toEqual(SUPPLIER_RPC_FUNCTION_NAMES)
+  })
+
+  it("allowlists exactly the four P8A1 supplier RPCs", () => {
+    expect(
+      [...ALLOWED_FUNCTIONS].filter(
+        (fn) =>
+          fn === "technical_configuration_suppliers_list" ||
+          fn.startsWith("technical_configuration_supplier_")
+      )
+    ).toEqual(P8A1_SUPPLIER_RPC_FUNCTIONS)
+  })
+
+  it.each(P8A1_SUPPLIER_RPC_FUNCTIONS)(
+    'allows supplier RPC "%s" through the whitelist',
     async (fn) => {
       const response = await invokeRpcProxy(fn)
 

--- a/src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts
@@ -1,0 +1,192 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = path.resolve(process.cwd())
+const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
+const MIGRATION_FILE = "20260722010000_technical_configuration_suppliers.sql"
+const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const PHASE_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_suppliers_phase_gate.sql"
+)
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  const marker = `FUNCTION public.${functionName}(`
+  const start = source.indexOf(marker)
+  if (start === -1) return ""
+
+  const next = source.indexOf("\nCREATE OR REPLACE FUNCTION public.", start + marker.length)
+  return source.slice(start, next === -1 ? source.length : next)
+}
+
+function getTableBlock(source: string): string {
+  const start = source.indexOf("CREATE TABLE public.technical_configuration_suppliers")
+  if (start === -1) return ""
+
+  const end = source.indexOf("\n);", start)
+  return end === -1 ? "" : source.slice(start, end + 3)
+}
+
+const migrationSource = readIfExists(MIGRATION_PATH)
+const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+
+const SUPPLIER_RPC_SIGNATURES = [
+  "technical_configuration_suppliers_list(\n  p_dossier_id UUID,\n  p_page INTEGER DEFAULT 1,\n  p_page_size INTEGER DEFAULT 50",
+  "technical_configuration_supplier_create(\n  p_dossier_id UUID,\n  p_name TEXT,\n  p_expected_revision BIGINT",
+  "technical_configuration_supplier_update(\n  p_supplier_id UUID,\n  p_name TEXT,\n  p_expected_revision BIGINT",
+  "technical_configuration_supplier_delete(\n  p_supplier_id UUID,\n  p_expected_revision BIGINT",
+] as const
+
+const SUPPLIER_RPC_NAMES = [
+  "technical_configuration_suppliers_list",
+  "technical_configuration_supplier_create",
+  "technical_configuration_supplier_update",
+  "technical_configuration_supplier_delete",
+] as const
+
+describe("P8A1 technical configuration supplier migration", () => {
+  it("uses the approved deploy-safe migration boundary and ordering", () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true)
+    expect(
+      readdirSync(MIGRATIONS_DIR)
+        .filter((file) => file.includes("technical_configuration_suppliers"))
+        .sort()
+    ).toEqual([MIGRATION_FILE])
+    expect(
+      MIGRATION_FILE.localeCompare("20260712112500_technical_configuration_dossier_foundation.sql")
+    ).toBeGreaterThan(0)
+  })
+
+  it("creates only the dossier-scoped supplier aggregate", () => {
+    const tableBlock = getTableBlock(migrationSource)
+
+    expect(tableBlock).toContain("id UUID PRIMARY KEY DEFAULT gen_random_uuid()")
+    expect(tableBlock).toContain("dossier_id UUID NOT NULL")
+    expect(tableBlock).toContain("name TEXT NOT NULL")
+    expect(tableBlock).toContain("normalized_name TEXT GENERATED ALWAYS AS")
+    expect(tableBlock).toContain("created_by BIGINT NOT NULL")
+    expect(tableBlock).toContain("updated_by BIGINT NOT NULL")
+    expect(tableBlock).toContain("UNIQUE (id, dossier_id)")
+    expect(tableBlock).toContain("UNIQUE (dossier_id, normalized_name)")
+    expect(tableBlock).toContain("REFERENCES public.technical_configuration_dossiers (id)")
+    expect(tableBlock).toContain("ON DELETE CASCADE")
+    expect(tableBlock).not.toMatch(
+      /baseline_version_id|locked_at|locked_by|source_baseline_version_id/
+    )
+    expect(tableBlock).not.toMatch(/\brevision\b/)
+    expect(migrationSource).not.toContain("CREATE TABLE public.technical_configuration_options")
+    expect(migrationSource).not.toContain(
+      "CREATE TABLE public.technical_configuration_option_responses"
+    )
+  })
+
+  it("normalizes uniqueness while preserving a canonical display name", () => {
+    expect(migrationSource).toContain(
+      "CREATE OR REPLACE FUNCTION public._technical_configuration_normalize_supplier_name("
+    )
+    expect(migrationSource).toContain(
+      "lower(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'))"
+    )
+
+    for (const functionName of [
+      "technical_configuration_supplier_create",
+      "technical_configuration_supplier_update",
+    ]) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain(
+        "v_name TEXT := NULLIF(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'), '')"
+      )
+      expect(block).toContain("RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422'")
+      expect(block).toContain("RAISE EXCEPTION 'duplicate_supplier' USING ERRCODE = 'PT409'")
+    }
+  })
+
+  it("freezes the four RPC signatures and security contract", () => {
+    for (const signature of SUPPLIER_RPC_SIGNATURES) {
+      expect(migrationSource).toContain(`FUNCTION public.${signature}`)
+    }
+
+    for (const functionName of SUPPLIER_RPC_NAMES) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain("SECURITY DEFINER")
+      expect(block).toContain("SET search_path = public, pg_temp")
+      expect(migrationSource).toContain(`REVOKE ALL ON FUNCTION public.${functionName}`)
+      expect(migrationSource).toContain(`GRANT EXECUTE ON FUNCTION public.${functionName}`)
+    }
+  })
+
+  it("uses global reads and dossier-owned optimistic concurrency for mutations", () => {
+    const listBlock = getFunctionBlock(migrationSource, "technical_configuration_suppliers_list")
+    expect(listBlock).toContain("PERFORM public._technical_configuration_require_global_user()")
+    expect(listBlock).toContain("FROM public.technical_configuration_dossiers d")
+    expect(listBlock).toContain("FROM public.technical_configuration_suppliers s")
+    expect(listBlock).toContain("'revision', v_revision")
+    expect(listBlock).toContain("LIMIT p_page_size")
+    expect(listBlock).toContain("OFFSET (p_page - 1) * p_page_size")
+
+    const createBlock = getFunctionBlock(migrationSource, "technical_configuration_supplier_create")
+    expect(createBlock).toContain(
+      "v_user_id := public._technical_configuration_require_editable_dossier("
+    )
+    expect(createBlock).toContain("p_dossier_id,")
+    expect(createBlock).toContain("p_expected_revision")
+
+    for (const functionName of [
+      "technical_configuration_supplier_update",
+      "technical_configuration_supplier_delete",
+    ]) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain("FROM public.technical_configuration_suppliers s")
+      expect(block).toContain(
+        "v_user_id := public._technical_configuration_require_editable_dossier("
+      )
+      expect(block).toContain("v_dossier_id,")
+      expect(block).toContain("p_expected_revision")
+    }
+
+    for (const functionName of SUPPLIER_RPC_NAMES.slice(1)) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain("UPDATE public.technical_configuration_dossiers")
+      expect(block).toContain("revision = revision + 1")
+      expect(block).not.toContain("_technical_configuration_require_editable_baseline_version")
+    }
+  })
+
+  it("keeps the table RPC-only with deny-by-default RLS and explicit grants", () => {
+    expect(migrationSource).toContain(
+      "ALTER TABLE public.technical_configuration_suppliers ENABLE ROW LEVEL SECURITY"
+    )
+    expect(migrationSource).toContain(
+      "CREATE POLICY technical_configuration_suppliers_no_client_access"
+    )
+    expect(migrationSource).toContain(
+      "FOR ALL TO anon, authenticated USING (false) WITH CHECK (false)"
+    )
+    expect(migrationSource).toMatch(
+      /REVOKE ALL ON TABLE public\.technical_configuration_suppliers\s+FROM PUBLIC, anon, authenticated/
+    )
+    expect(migrationSource).toContain(
+      "GRANT ALL ON TABLE public.technical_configuration_suppliers TO service_role"
+    )
+  })
+
+  it("ships a phase-local SQL gate without coupling it to later option leaves", () => {
+    expect(existsSync(PHASE_GATE_PATH)).toBe(true)
+    expect(phaseGateSource).toContain("BEGIN;")
+    expect(phaseGateSource).toContain("ROLLBACK;")
+    expect(phaseGateSource).toContain("technical_configuration_suppliers_list")
+    expect(phaseGateSource).toContain("technical_configuration_supplier_create")
+    expect(phaseGateSource).toContain("technical_configuration_supplier_update")
+    expect(phaseGateSource).toContain("technical_configuration_supplier_delete")
+    expect(phaseGateSource).toContain("duplicate_supplier")
+    expect(phaseGateSource).toContain("stale_revision")
+    expect(phaseGateSource).toContain("archived_dossier")
+    expect(phaseGateSource).toContain("ON DELETE CASCADE")
+    expect(phaseGateSource).not.toMatch(/technical_configuration_options|option_responses/)
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts
@@ -90,7 +90,7 @@ describe("P8A1 technical configuration supplier migration", () => {
       "CREATE OR REPLACE FUNCTION public._technical_configuration_normalize_supplier_name("
     )
     expect(migrationSource).toContain(
-      "lower(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'))"
+      "lower(btrim(regexp_replace(p_name, '[[:space:]]+', ' ', 'g')))"
     )
 
     for (const functionName of [
@@ -99,7 +99,7 @@ describe("P8A1 technical configuration supplier migration", () => {
     ]) {
       const block = getFunctionBlock(migrationSource, functionName)
       expect(block).toContain(
-        "v_name TEXT := NULLIF(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'), '')"
+        "v_name TEXT := NULLIF(btrim(regexp_replace(p_name, '[[:space:]]+', ' ', 'g')), '')"
       )
       expect(block).toContain("RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422'")
       expect(block).toContain("RAISE EXCEPTION 'duplicate_supplier' USING ERRCODE = 'PT409'")
@@ -123,11 +123,17 @@ describe("P8A1 technical configuration supplier migration", () => {
   it("uses global reads and dossier-owned optimistic concurrency for mutations", () => {
     const listBlock = getFunctionBlock(migrationSource, "technical_configuration_suppliers_list")
     expect(listBlock).toContain("PERFORM public._technical_configuration_require_global_user()")
-    expect(listBlock).toContain("FROM public.technical_configuration_dossiers d")
-    expect(listBlock).toContain("FROM public.technical_configuration_suppliers s")
-    expect(listBlock).toContain("'revision', v_revision")
+    expect(listBlock).toContain("WITH dossier AS (")
+    expect(listBlock).toContain("supplier_page AS (")
+    expect(listBlock).toContain("supplier_summary AS (")
+    expect(listBlock).toContain("INTO v_result")
+    expect(listBlock).toContain("FROM dossier d")
+    expect(listBlock).toContain("CROSS JOIN supplier_summary summary")
+    expect(listBlock).not.toContain("INTO v_revision")
+    expect(listBlock).not.toContain("INTO v_total")
+    expect(listBlock).not.toContain("INTO v_data")
     expect(listBlock).toContain("LIMIT p_page_size")
-    expect(listBlock).toContain("OFFSET (p_page - 1) * p_page_size")
+    expect(listBlock).toContain("OFFSET (p_page::BIGINT - 1) * p_page_size::BIGINT")
 
     const createBlock = getFunctionBlock(migrationSource, "technical_configuration_supplier_create")
     expect(createBlock).toContain(
@@ -186,6 +192,28 @@ describe("P8A1 technical configuration supplier migration", () => {
     expect(phaseGateSource).toContain("duplicate_supplier")
     expect(phaseGateSource).toContain("stale_revision")
     expect(phaseGateSource).toContain("archived_dossier")
+    expect(phaseGateSource).toContain("boundary whitespace canonicalization")
+    expect(phaseGateSource).toContain("all-whitespace supplier rejected")
+    expect(phaseGateSource).toContain("FOREACH v_function_signature IN ARRAY")
+    expect(phaseGateSource).toMatch(
+      /has_function_privilege\(\s*'authenticated',\s*v_function_signature,\s*'EXECUTE'\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_function_privilege\(\s*'service_role',\s*v_function_signature,\s*'EXECUTE'\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_function_privilege\(\s*'anon',\s*v_function_signature,\s*'EXECUTE'\s*\)/
+    )
+    expect(phaseGateSource).toContain("FOREACH v_table_privilege IN ARRAY")
+    expect(phaseGateSource).toMatch(
+      /has_table_privilege\(\s*'authenticated',\s*'public\.technical_configuration_suppliers',\s*v_table_privilege\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_table_privilege\(\s*'anon',\s*'public\.technical_configuration_suppliers',\s*v_table_privilege\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_table_privilege\(\s*'service_role',\s*'public\.technical_configuration_suppliers',\s*v_table_privilege\s*\)/
+    )
     expect(phaseGateSource).toContain("ON DELETE CASCADE")
     expect(phaseGateSource).not.toMatch(/technical_configuration_options|option_responses/)
   })

--- a/src/lib/technical-configuration-supplier-option-rpcs.ts
+++ b/src/lib/technical-configuration-supplier-option-rpcs.ts
@@ -1,0 +1,10 @@
+/** Named P8A1 supplier RPCs shared by client and server code. */
+export const SUPPLIER_RPC_FUNCTIONS = {
+  listSuppliers: "technical_configuration_suppliers_list",
+  createSupplier: "technical_configuration_supplier_create",
+  updateSupplier: "technical_configuration_supplier_update",
+  deleteSupplier: "technical_configuration_supplier_delete",
+} as const
+
+/** Ordered P8A1 RPC names for allowlists and contract iteration. */
+export const SUPPLIER_RPC_FUNCTION_NAMES = Object.values(SUPPLIER_RPC_FUNCTIONS)

--- a/supabase/migrations/20260722010000_technical_configuration_suppliers.sql
+++ b/supabase/migrations/20260722010000_technical_configuration_suppliers.sql
@@ -9,7 +9,7 @@ IMMUTABLE
 STRICT
 SET search_path = public, pg_temp
 AS $$
-  SELECT lower(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'));
+  SELECT lower(btrim(regexp_replace(p_name, '[[:space:]]+', ' ', 'g')));
 $$;
 
 REVOKE ALL ON FUNCTION public._technical_configuration_normalize_supplier_name(TEXT)
@@ -32,7 +32,7 @@ CREATE TABLE public.technical_configuration_suppliers (
   UNIQUE (dossier_id, normalized_name),
   CHECK (
     name <> ''
-    AND name = regexp_replace(btrim(name), '[[:space:]]+', ' ', 'g')
+    AND name = btrim(regexp_replace(name, '[[:space:]]+', ' ', 'g'))
   ),
   FOREIGN KEY (dossier_id)
     REFERENCES public.technical_configuration_dossiers (id)
@@ -60,9 +60,7 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 DECLARE
-  v_revision BIGINT;
-  v_total BIGINT;
-  v_data JSONB;
+  v_result JSONB;
 BEGIN
   PERFORM public._technical_configuration_require_global_user();
 
@@ -74,39 +72,12 @@ BEGIN
     RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
   END IF;
 
-  SELECT d.revision
-  INTO v_revision
-  FROM public.technical_configuration_dossiers d
-  WHERE d.id = p_dossier_id;
-
-  IF NOT FOUND THEN
-    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
-  END IF;
-
-  SELECT count(*)
-  INTO v_total
-  FROM public.technical_configuration_suppliers s
-  WHERE s.dossier_id = p_dossier_id;
-
-  SELECT COALESCE(
-    jsonb_agg(
-      jsonb_build_object(
-        'id', page.id,
-        'dossier_id', page.dossier_id,
-        'name', page.name,
-        'normalized_name', page.normalized_name,
-        'created_at', page.created_at,
-        'created_by', page.created_by,
-        'updated_at', page.updated_at,
-        'updated_by', page.updated_by,
-        'revision', v_revision
-      )
-      ORDER BY page.normalized_name, page.id
-    ),
-    '[]'::JSONB
-  )
-  INTO v_data
-  FROM (
+  WITH dossier AS (
+    SELECT d.revision
+    FROM public.technical_configuration_dossiers d
+    WHERE d.id = p_dossier_id
+  ),
+  supplier_page AS (
     SELECT
       s.id,
       s.dossier_id,
@@ -120,16 +91,49 @@ BEGIN
     WHERE s.dossier_id = p_dossier_id
     ORDER BY s.normalized_name, s.id
     LIMIT p_page_size
-    OFFSET (p_page - 1) * p_page_size
-  ) page;
-
-  RETURN jsonb_build_object(
-    'data', v_data,
-    'revision', v_revision,
-    'total', v_total,
+    OFFSET (p_page::BIGINT - 1) * p_page_size::BIGINT
+  ),
+  supplier_summary AS (
+    SELECT count(*) AS total
+    FROM public.technical_configuration_suppliers s
+    WHERE s.dossier_id = p_dossier_id
+  )
+  SELECT jsonb_build_object(
+    'data',
+    COALESCE(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', page.id,
+            'dossier_id', page.dossier_id,
+            'name', page.name,
+            'normalized_name', page.normalized_name,
+            'created_at', page.created_at,
+            'created_by', page.created_by,
+            'updated_at', page.updated_at,
+            'updated_by', page.updated_by,
+            'revision', d.revision
+          )
+          ORDER BY page.normalized_name, page.id
+        )
+        FROM supplier_page page
+      ),
+      '[]'::JSONB
+    ),
+    'revision', d.revision,
+    'total', summary.total,
     'page', p_page,
     'page_size', p_page_size
-  );
+  )
+  INTO v_result
+  FROM dossier d
+  CROSS JOIN supplier_summary summary;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  RETURN v_result;
 END;
 $$;
 
@@ -147,7 +151,7 @@ DECLARE
   v_user_id BIGINT;
   v_revision BIGINT;
   v_data JSONB;
-  v_name TEXT := NULLIF(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'), '');
+  v_name TEXT := NULLIF(btrim(regexp_replace(p_name, '[[:space:]]+', ' ', 'g')), '');
 BEGIN
   v_user_id := public._technical_configuration_require_editable_dossier(
     p_dossier_id,
@@ -215,7 +219,7 @@ DECLARE
   v_dossier_id UUID;
   v_revision BIGINT;
   v_data JSONB;
-  v_name TEXT := NULLIF(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'), '');
+  v_name TEXT := NULLIF(btrim(regexp_replace(p_name, '[[:space:]]+', ' ', 'g')), '');
 BEGIN
   PERFORM public._technical_configuration_require_global_user();
 

--- a/supabase/migrations/20260722010000_technical_configuration_suppliers.sql
+++ b/supabase/migrations/20260722010000_technical_configuration_suppliers.sql
@@ -1,0 +1,353 @@
+-- P8A1: dossier-scoped supplier persistence and RPC contracts.
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_normalize_supplier_name(
+  p_name TEXT
+)
+RETURNS TEXT
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path = public, pg_temp
+AS $$
+  SELECT lower(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'));
+$$;
+
+REVOKE ALL ON FUNCTION public._technical_configuration_normalize_supplier_name(TEXT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_normalize_supplier_name(TEXT)
+  TO service_role;
+
+CREATE TABLE public.technical_configuration_suppliers (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  dossier_id UUID NOT NULL,
+  name TEXT NOT NULL,
+  normalized_name TEXT GENERATED ALWAYS AS (
+    public._technical_configuration_normalize_supplier_name(name)
+  ) STORED,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by BIGINT NOT NULL,
+  UNIQUE (id, dossier_id),
+  UNIQUE (dossier_id, normalized_name),
+  CHECK (
+    name <> ''
+    AND name = regexp_replace(btrim(name), '[[:space:]]+', ' ', 'g')
+  ),
+  FOREIGN KEY (dossier_id)
+    REFERENCES public.technical_configuration_dossiers (id)
+    ON DELETE CASCADE
+);
+
+ALTER TABLE public.technical_configuration_suppliers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY technical_configuration_suppliers_no_client_access
+  ON public.technical_configuration_suppliers
+  FOR ALL TO anon, authenticated USING (false) WITH CHECK (false);
+
+REVOKE ALL ON TABLE public.technical_configuration_suppliers
+  FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.technical_configuration_suppliers TO service_role;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_suppliers_list(
+  p_dossier_id UUID,
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_revision BIGINT;
+  v_total BIGINT;
+  v_data JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_page IS NULL
+     OR p_page < 1
+     OR p_page_size IS NULL
+     OR p_page_size < 1
+     OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  SELECT d.revision
+  INTO v_revision
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = p_dossier_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  SELECT count(*)
+  INTO v_total
+  FROM public.technical_configuration_suppliers s
+  WHERE s.dossier_id = p_dossier_id;
+
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', page.id,
+        'dossier_id', page.dossier_id,
+        'name', page.name,
+        'normalized_name', page.normalized_name,
+        'created_at', page.created_at,
+        'created_by', page.created_by,
+        'updated_at', page.updated_at,
+        'updated_by', page.updated_by,
+        'revision', v_revision
+      )
+      ORDER BY page.normalized_name, page.id
+    ),
+    '[]'::JSONB
+  )
+  INTO v_data
+  FROM (
+    SELECT
+      s.id,
+      s.dossier_id,
+      s.name,
+      s.normalized_name,
+      s.created_at,
+      s.created_by,
+      s.updated_at,
+      s.updated_by
+    FROM public.technical_configuration_suppliers s
+    WHERE s.dossier_id = p_dossier_id
+    ORDER BY s.normalized_name, s.id
+    LIMIT p_page_size
+    OFFSET (p_page - 1) * p_page_size
+  ) page;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'revision', v_revision,
+    'total', v_total,
+    'page', p_page,
+    'page_size', p_page_size
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_supplier_create(
+  p_dossier_id UUID,
+  p_name TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_revision BIGINT;
+  v_data JSONB;
+  v_name TEXT := NULLIF(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'), '');
+BEGIN
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    p_dossier_id,
+    p_expected_revision
+  );
+
+  IF v_name IS NULL THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.technical_configuration_suppliers (
+      dossier_id,
+      name,
+      created_by,
+      updated_by
+    )
+    VALUES (
+      p_dossier_id,
+      v_name,
+      v_user_id,
+      v_user_id
+    )
+    RETURNING jsonb_build_object(
+      'id', id,
+      'dossier_id', dossier_id,
+      'name', name,
+      'normalized_name', normalized_name,
+      'created_at', created_at,
+      'created_by', created_by,
+      'updated_at', updated_at,
+      'updated_by', updated_by
+    )
+    INTO v_data;
+  EXCEPTION
+    WHEN unique_violation THEN
+      RAISE EXCEPTION 'duplicate_supplier' USING ERRCODE = 'PT409';
+  END;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = p_dossier_id
+  RETURNING revision INTO v_revision;
+
+  v_data := v_data || jsonb_build_object('revision', v_revision);
+
+  RETURN jsonb_build_object('data', v_data);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_supplier_update(
+  p_supplier_id UUID,
+  p_name TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_revision BIGINT;
+  v_data JSONB;
+  v_name TEXT := NULLIF(regexp_replace(btrim(p_name), '[[:space:]]+', ' ', 'g'), '');
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT s.dossier_id
+  INTO v_dossier_id
+  FROM public.technical_configuration_suppliers s
+  WHERE s.id = p_supplier_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id,
+    p_expected_revision
+  );
+
+  IF v_name IS NULL THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  BEGIN
+    UPDATE public.technical_configuration_suppliers
+    SET name = v_name,
+        updated_at = now(),
+        updated_by = v_user_id
+    WHERE id = p_supplier_id
+      AND dossier_id = v_dossier_id
+    RETURNING jsonb_build_object(
+      'id', id,
+      'dossier_id', dossier_id,
+      'name', name,
+      'normalized_name', normalized_name,
+      'created_at', created_at,
+      'created_by', created_by,
+      'updated_at', updated_at,
+      'updated_by', updated_by
+    )
+    INTO v_data;
+  EXCEPTION
+    WHEN unique_violation THEN
+      RAISE EXCEPTION 'duplicate_supplier' USING ERRCODE = 'PT409';
+  END;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  v_data := v_data || jsonb_build_object('revision', v_revision);
+
+  RETURN jsonb_build_object('data', v_data);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_supplier_delete(
+  p_supplier_id UUID,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_deleted_id UUID;
+  v_revision BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT s.dossier_id
+  INTO v_dossier_id
+  FROM public.technical_configuration_suppliers s
+  WHERE s.id = p_supplier_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id,
+    p_expected_revision
+  );
+
+  DELETE FROM public.technical_configuration_suppliers
+  WHERE id = p_supplier_id
+    AND dossier_id = v_dossier_id
+  RETURNING id INTO v_deleted_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object(
+    'data',
+    jsonb_build_object(
+      'id', v_deleted_id,
+      'revision', v_revision
+    )
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_suppliers_list(UUID, INTEGER, INTEGER)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.technical_configuration_supplier_create(UUID, TEXT, BIGINT)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.technical_configuration_supplier_update(UUID, TEXT, BIGINT)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.technical_configuration_supplier_delete(UUID, BIGINT)
+  FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.technical_configuration_suppliers_list(UUID, INTEGER, INTEGER)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_supplier_create(UUID, TEXT, BIGINT)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_supplier_update(UUID, TEXT, BIGINT)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_supplier_delete(UUID, BIGINT)
+  TO authenticated, service_role;

--- a/supabase/tests/technical_configuration_suppliers_phase_gate.sql
+++ b/supabase/tests/technical_configuration_suppliers_phase_gate.sql
@@ -76,6 +76,8 @@ DECLARE
   v_response JSONB;
   v_count BIGINT;
   v_rls_enabled BOOLEAN;
+  v_function_signature TEXT;
+  v_table_privilege TEXT;
 BEGIN
   PERFORM pg_advisory_xact_lock(hashtext('technical_configuration_suppliers_phase_gate'));
 
@@ -172,9 +174,10 @@ BEGIN
   END IF;
 
   PERFORM pg_temp.set_claims('global', v_user_id);
+  -- boundary whitespace canonicalization
   v_response := public.technical_configuration_supplier_create(
     v_dossier_id,
-    '  Công ty   Thiết bị A  ',
+    E'\tCông ty \n Thiết bị A\t',
     v_revision
   );
   v_supplier_id := (v_response #>> '{data,id}')::UUID;
@@ -184,6 +187,18 @@ BEGIN
      OR v_response #>> '{data,normalized_name}' IS DISTINCT FROM 'công ty thiết bị a' THEN
     RAISE EXCEPTION 'supplier create must preserve canonical name and normalized identity';
   END IF;
+
+  PERFORM pg_temp.expect_error(
+    'all-whitespace supplier rejected',
+    format(
+      'SELECT public.technical_configuration_supplier_create(%L::UUID, %L, %s)',
+      v_dossier_id,
+      E'\n\t',
+      v_revision
+    ),
+    'PT422',
+    'validation_error'
+  );
 
   PERFORM pg_temp.expect_error(
     'normalized duplicate rejected',
@@ -283,17 +298,69 @@ BEGIN
     RAISE EXCEPTION 'supplier table must have RLS enabled';
   END IF;
 
-  IF has_table_privilege('authenticated', 'public.technical_configuration_suppliers', 'SELECT') THEN
-    RAISE EXCEPTION 'authenticated must not read supplier rows directly';
-  END IF;
-
-  IF NOT has_function_privilege(
-    'authenticated',
+  FOREACH v_function_signature IN ARRAY ARRAY[
     'public.technical_configuration_suppliers_list(UUID, INTEGER, INTEGER)',
-    'EXECUTE'
-  ) THEN
-    RAISE EXCEPTION 'authenticated must execute the supplier list RPC';
-  END IF;
+    'public.technical_configuration_supplier_create(UUID, TEXT, BIGINT)',
+    'public.technical_configuration_supplier_update(UUID, TEXT, BIGINT)',
+    'public.technical_configuration_supplier_delete(UUID, BIGINT)'
+  ]
+  LOOP
+    IF NOT has_function_privilege(
+      'authenticated',
+      v_function_signature,
+      'EXECUTE'
+    ) THEN
+      RAISE EXCEPTION 'authenticated must execute %', v_function_signature;
+    END IF;
+
+    IF NOT has_function_privilege(
+      'service_role',
+      v_function_signature,
+      'EXECUTE'
+    ) THEN
+      RAISE EXCEPTION 'service_role must execute %', v_function_signature;
+    END IF;
+
+    -- anon includes any privilege inherited from PUBLIC.
+    IF has_function_privilege('anon', v_function_signature, 'EXECUTE') THEN
+      RAISE EXCEPTION 'anon/PUBLIC must not execute %', v_function_signature;
+    END IF;
+  END LOOP;
+
+  FOREACH v_table_privilege IN ARRAY ARRAY[
+    'SELECT',
+    'INSERT',
+    'UPDATE',
+    'DELETE',
+    'TRUNCATE',
+    'REFERENCES',
+    'TRIGGER'
+  ]
+  LOOP
+    IF has_table_privilege(
+      'authenticated',
+      'public.technical_configuration_suppliers',
+      v_table_privilege
+    ) THEN
+      RAISE EXCEPTION 'authenticated must not have table privilege %', v_table_privilege;
+    END IF;
+
+    IF has_table_privilege(
+      'anon',
+      'public.technical_configuration_suppliers',
+      v_table_privilege
+    ) THEN
+      RAISE EXCEPTION 'anon/PUBLIC must not have table privilege %', v_table_privilege;
+    END IF;
+
+    IF NOT has_table_privilege(
+      'service_role',
+      'public.technical_configuration_suppliers',
+      v_table_privilege
+    ) THEN
+      RAISE EXCEPTION 'service_role must have table privilege %', v_table_privilege;
+    END IF;
+  END LOOP;
 END;
 $gate$;
 

--- a/supabase/tests/technical_configuration_suppliers_phase_gate.sql
+++ b/supabase/tests/technical_configuration_suppliers_phase_gate.sql
@@ -1,0 +1,300 @@
+-- supabase/tests/technical_configuration_suppliers_phase_gate.sql
+-- Purpose: prove P8A1 authorization, normalization, revision, and ownership invariants.
+-- Non-destructive: all fixture writes are wrapped in a transaction and rolled back.
+BEGIN;
+
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT,
+  p_statement TEXT,
+  p_expected_state TEXT,
+  p_expected_message TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION
+    WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+        v_state = RETURNED_SQLSTATE,
+        v_message = MESSAGE_TEXT;
+
+      IF v_state IS DISTINCT FROM p_expected_state
+         OR v_message IS DISTINCT FROM p_expected_message THEN
+        RAISE EXCEPTION
+          '%: expected [%] %, got [%] %',
+          p_label,
+          p_expected_state,
+          p_expected_message,
+          v_state,
+          v_message;
+      END IF;
+      RETURN;
+  END;
+
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.set_claims(
+  p_app_role TEXT,
+  p_user_id BIGINT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::TEXT,
+      'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_archived_dossier_id UUID;
+  v_cascade_dossier_id UUID;
+  v_supplier_id UUID;
+  v_cascade_supplier_id UUID;
+  v_revision BIGINT;
+  v_cascade_revision BIGINT;
+  v_response JSONB;
+  v_count BIGINT;
+  v_rls_enabled BOOLEAN;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('technical_configuration_suppliers_phase_gate'));
+
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P8A1 phase gate requires one active public.nhan_vien row';
+  END IF;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name,
+    name,
+    description,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    'P8A1 device ' || v_suffix,
+    'P8A1 dossier ' || v_suffix,
+    'Supplier phase-gate fixture',
+    v_user_id,
+    v_user_id
+  )
+  RETURNING id, revision INTO v_dossier_id, v_revision;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name,
+    name,
+    description,
+    archived_at,
+    archived_by,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    'P8A1 archived device ' || v_suffix,
+    'P8A1 archived dossier ' || v_suffix,
+    'Archived supplier fixture',
+    now(),
+    v_user_id,
+    v_user_id,
+    v_user_id
+  )
+  RETURNING id INTO v_archived_dossier_id;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    device_type_name,
+    name,
+    description,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    'P8A1 cascade device ' || v_suffix,
+    'P8A1 cascade dossier ' || v_suffix,
+    'ON DELETE CASCADE fixture',
+    v_user_id,
+    v_user_id
+  )
+  RETURNING id, revision INTO v_cascade_dossier_id, v_cascade_revision;
+
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims fail closed',
+    format(
+      'SELECT public.technical_configuration_suppliers_list(%L::UUID, 1, 50)',
+      v_dossier_id
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  PERFORM pg_temp.set_claims('to_qltb', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'non-global role denied',
+    format(
+      'SELECT public.technical_configuration_suppliers_list(%L::UUID, 1, 50)',
+      v_dossier_id
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  v_response := public.technical_configuration_suppliers_list(v_dossier_id, 1, 50);
+  IF v_response->>'revision' IS DISTINCT FROM v_revision::TEXT
+     OR v_response->>'total' IS DISTINCT FROM '0' THEN
+    RAISE EXCEPTION 'raw admin must read the empty supplier collection';
+  END IF;
+
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  v_response := public.technical_configuration_supplier_create(
+    v_dossier_id,
+    '  Công ty   Thiết bị A  ',
+    v_revision
+  );
+  v_supplier_id := (v_response #>> '{data,id}')::UUID;
+  v_revision := (v_response #>> '{data,revision}')::BIGINT;
+
+  IF v_response #>> '{data,name}' IS DISTINCT FROM 'Công ty Thiết bị A'
+     OR v_response #>> '{data,normalized_name}' IS DISTINCT FROM 'công ty thiết bị a' THEN
+    RAISE EXCEPTION 'supplier create must preserve canonical name and normalized identity';
+  END IF;
+
+  PERFORM pg_temp.expect_error(
+    'normalized duplicate rejected',
+    format(
+      'SELECT public.technical_configuration_supplier_create(%L::UUID, %L, %s)',
+      v_dossier_id,
+      'cÔnG Ty Thiết Bị A',
+      v_revision
+    ),
+    'PT409',
+    'duplicate_supplier'
+  );
+
+  v_response := public.technical_configuration_supplier_create(
+    v_cascade_dossier_id,
+    'CÔNG TY THIẾT BỊ A',
+    v_cascade_revision
+  );
+  v_cascade_supplier_id := (v_response #>> '{data,id}')::UUID;
+
+  PERFORM pg_temp.expect_error(
+    'stale revision rejected',
+    format(
+      'SELECT public.technical_configuration_supplier_update(%L::UUID, %L, %s)',
+      v_supplier_id,
+      'Nhà cung cấp A',
+      v_revision - 1
+    ),
+    'PT409',
+    'stale_revision'
+  );
+
+  v_response := public.technical_configuration_supplier_update(
+    v_supplier_id,
+    'Nhà cung cấp A',
+    v_revision
+  );
+  v_revision := (v_response #>> '{data,revision}')::BIGINT;
+
+  v_response := public.technical_configuration_suppliers_list(v_dossier_id, 1, 50);
+  IF v_response->>'revision' IS DISTINCT FROM v_revision::TEXT
+     OR v_response->>'total' IS DISTINCT FROM '1'
+     OR v_response #>> '{data,0,name}' IS DISTINCT FROM 'Nhà cung cấp A' THEN
+    RAISE EXCEPTION 'supplier list must return the dossier revision and canonical row';
+  END IF;
+
+  PERFORM pg_temp.expect_error(
+    'archived dossier rejects mutation',
+    format(
+      'SELECT public.technical_configuration_supplier_create(%L::UUID, %L, 1)',
+      v_archived_dossier_id,
+      'Archived supplier'
+    ),
+    'PT409',
+    'archived_dossier'
+  );
+
+  DELETE FROM public.technical_configuration_dossiers
+  WHERE id = v_cascade_dossier_id;
+
+  SELECT count(*)
+  INTO v_count
+  FROM public.technical_configuration_suppliers s
+  WHERE s.id = v_cascade_supplier_id;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'dossier delete must cascade to suppliers';
+  END IF;
+
+  v_response := public.technical_configuration_supplier_delete(
+    v_supplier_id,
+    v_revision
+  );
+  v_revision := (v_response #>> '{data,revision}')::BIGINT;
+
+  IF v_response #>> '{data,id}' IS DISTINCT FROM v_supplier_id::TEXT THEN
+    RAISE EXCEPTION 'supplier delete must return the deleted supplier id';
+  END IF;
+
+  SELECT count(*)
+  INTO v_count
+  FROM public.technical_configuration_suppliers s
+  WHERE s.dossier_id = v_dossier_id;
+
+  IF v_count <> 0 THEN
+    RAISE EXCEPTION 'supplier delete must remove the owned row';
+  END IF;
+
+  SELECT c.relrowsecurity
+  INTO v_rls_enabled
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'technical_configuration_suppliers';
+
+  IF v_rls_enabled IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'supplier table must have RLS enabled';
+  END IF;
+
+  IF has_table_privilege('authenticated', 'public.technical_configuration_suppliers', 'SELECT') THEN
+    RAISE EXCEPTION 'authenticated must not read supplier rows directly';
+  END IF;
+
+  IF NOT has_function_privilege(
+    'authenticated',
+    'public.technical_configuration_suppliers_list(UUID, INTEGER, INTEGER)',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION 'authenticated must execute the supplier list RPC';
+  END IF;
+END;
+$gate$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

- add dossier-scoped supplier persistence with normalized-name uniqueness and dossier cascade
- add guarded list/create/update/delete RPC contracts with dossier-revision optimistic concurrency
- expose typed RPC names, adapter contracts and proxy allowlist entries
- split the remaining P8A roadmap into deploy-safe P8A2 option identity and P8A3 baseline-bound responses

## Contract and security boundaries

- direct supplier editing remains outside baseline lock/version copying
- authorization and ownership reuse the existing technical-configuration dossier guards, including raw `admin`/global handling
- archived dossiers reject writes
- supplier table is RPC-only for authenticated clients with RLS deny and explicit grants
- list results, total count and dossier revision use one PostgreSQL statement snapshot

## Review fixes

The independent P8A1 review identified and this branch fixes:

- list snapshot inconsistency under `READ COMMITTED`
- integer pagination overflow
- whitespace normalization ordering for tabs/newlines
- incomplete table/function privilege assertions in the SQL phase gate

The same reviewer re-reviewed the fixes with no remaining findings.

## Verification

- format check
- `verify:no-explicit-any`
- `verify:dedupe`
- typecheck
- 129 focused technical-configuration tests
- React Doctor: 100/100
- OpenSpec strict validation and diff checks
- Lefthook pre-commit and pre-push gates

## Live database status

Applied through Supabase MCP with explicit approval:

- local migration: `20260722010000_technical_configuration_suppliers.sql`
- live migration version: `20260722020802`
- transaction-wrapped SQL phase gate passed and rolled back cleanly
- focused live verification confirmed constraints, cascade, RLS, grants and all four RPC contracts
- security/performance advisors found no focused P8A1 defect; remaining output is pre-existing project-wide noise or intentional guarded RPC exposure

No Supabase CLI was used.

## Out of scope

- P8A2 option identity and multiple options
- P8A3 baseline-bound option responses and supplementary information
- P8B UI/hooks
- P9A Excel
- P9B documents/citations
- P10 comparison


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds P8A1 supplier data contracts with dossier-scoped persistence and guarded list/create/update/delete RPCs using dossier revision for optimistic concurrency. Secures access with RLS deny-by-default and allowlists exactly four supplier RPCs; P8A is split into P8A2 (option identity) and P8A3 (baseline-bound responses).

- **New Features**
  - New `technical_configuration_suppliers` table with normalized-name uniqueness and dossier cascade.
  - Four RPCs: list, create, update, delete. List returns data, total, and dossier revision in one snapshot.
  - Authorization: global/raw-admin reads; editable-dossier guard for writes; archived dossiers reject writes; suppliers stay outside baseline lock/copy.
  - Security: RLS enabled, deny-by-default table grants, SECURITY DEFINER functions with explicit grants, RPC proxy allowlists the four names.
  - Tests and gates: phase-local SQL gate; migration and allowlist tests; typed RPC names and adapter contract tests.

- **Bug Fixes**
  - Fixed list snapshot inconsistency under READ COMMITTED.
  - Fixed integer pagination overflow.
  - Fixed whitespace normalization for tabs/newlines.
  - Added missing table/function privilege assertions in the SQL phase gate.

<sup>Written for commit 86f2cba2008d59a8312df2a0a3e9c341c331749b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added supplier management for technical configurations, including listing, creating, updating, and deleting suppliers.
  * Added supplier name normalization, duplicate detection, pagination, and revision-aware editing.
  * Added security controls restricting supplier data access and protecting changes to archived or outdated dossiers.

* **Documentation**
  * Split the technical configuration roadmap into distinct supplier, option identity, and baseline-bound response phases.

* **Tests**
  * Added comprehensive coverage for supplier operations, permissions, validation, concurrency, and deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->