### PR TITLE
feat(technical-config): add P8A2 option identity contracts

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -1072,14 +1072,14 @@ option table, response dataset, hook or UI is present.
 
 ### Tasks
 
-- [ ] Add multiple options per supplier with model, manufacturer, option-name,
+- [x] Add multiple options per supplier with model, manufacturer, option-name,
       notes, audit metadata and deterministic display-label contracts.
-- [ ] Add dossier/supplier ownership and supporting index contracts without
+- [x] Add dossier/supplier ownership and supporting index contracts without
       speculative option uniqueness or user-managed ordering.
-- [ ] Add direct-edit option CRUD with dossier-revision optimistic concurrency.
-- [ ] Add ownership/cascade constraints and archived-dossier guards.
-- [ ] Define no option lock/version backend contract.
-- [ ] Keep option identity outside the baseline aggregate and baseline-copy flow.
+- [x] Add direct-edit option CRUD with dossier-revision optimistic concurrency.
+- [x] Add ownership/cascade constraints and archived-dossier guards.
+- [x] Define no option lock/version backend contract.
+- [x] Keep option identity outside the baseline aggregate and baseline-copy flow.
 
 ### TDD and verification
 

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -1061,6 +1061,9 @@ option table, response dataset, hook or UI is present.
 ### Planned files
 
 - Create: `supabase/migrations/20260722034323_technical_configuration_options.sql`
+- Create:
+  `supabase/migrations/20260722060629_technical_configuration_options_supplier_fk_index.sql`
+  as the ordered follow-up for the supplier-first composite-FK covering index.
 - Create: `supabase/tests/technical_configuration_options_phase_gate.sql`
 - Create: `src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts`
 - Modify: `src/lib/technical-configuration-supplier-option-rpcs.ts`

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -1060,17 +1060,22 @@ option table, response dataset, hook or UI is present.
 
 ### Planned files
 
-- Create: `supabase/migrations/<ordered_timestamp>_technical_configuration_options.sql`
-- Extend: `supabase/tests/technical_configuration_suppliers_phase_gate.sql`
+- Create: `supabase/migrations/20260722034323_technical_configuration_options.sql`
+- Create: `supabase/tests/technical_configuration_options_phase_gate.sql`
+- Create: `src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts`
 - Modify: `src/lib/technical-configuration-supplier-option-rpcs.ts`
 - Modify: `src/app/(app)/technical-configurations/supplier-option-types.ts`
 - Modify: `src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts`
 - Modify: `src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts`
+- Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
+- Modify: `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
 
 ### Tasks
 
-- [ ] Add multiple options per supplier with model, manufacturer, option-name
-      and deterministic display-label contracts.
+- [ ] Add multiple options per supplier with model, manufacturer, option-name,
+      notes, audit metadata and deterministic display-label contracts.
+- [ ] Add dossier/supplier ownership and supporting index contracts without
+      speculative option uniqueness or user-managed ordering.
 - [ ] Add direct-edit option CRUD with dossier-revision optimistic concurrency.
 - [ ] Add ownership/cascade constraints and archived-dossier guards.
 - [ ] Define no option lock/version backend contract.
@@ -1080,6 +1085,7 @@ option table, response dataset, hook or UI is present.
 
 - Tests for multiple options under one supplier and cross-dossier rejection.
 - Tests for display labels, stale dossier revisions and cascade behavior.
+- Tests for current-revision increments, archived reads and audit metadata.
 - Tests proving no baseline lock/version dependency exists.
 - Phase-local authorization and RPC allowlist tests.
 

--- a/openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md
@@ -155,6 +155,11 @@ and adapter functions do not exist yet.
 
 - Create
   `supabase/migrations/20260722034323_technical_configuration_options.sql`.
+- After the live performance advisor identifies the supplier-first composite FK
+  as uncovered, keep the applied migration immutable and create
+  `supabase/migrations/20260722060629_technical_configuration_options_supplier_fk_index.sql`
+  with an index on `(supplier_id, dossier_id)`. Retain the original
+  `(dossier_id, supplier_id)` index for dossier-first list reads.
 - Create
   `supabase/tests/technical_configuration_options_phase_gate.sql`; do not grow
   the P8A1 supplier phase gate past the repository file-size ceiling.
@@ -234,6 +239,7 @@ node scripts/npm-run.js run react-doctor
 openspec validate add-technical-configuration-comparison \
   --type change --strict --no-interactive
 test "$(wc -l < supabase/migrations/20260722034323_technical_configuration_options.sql)" -le 450
+test "$(wc -l < supabase/migrations/20260722060629_technical_configuration_options_supplier_fk_index.sql)" -le 450
 test "$(wc -l < supabase/tests/technical_configuration_options_phase_gate.sql)" -le 450
 ```
 

--- a/openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md
@@ -70,6 +70,143 @@ openspec validate add-technical-configuration-comparison \
 Run Code Review Graph and GitNexus change detection before commit. Commit and
 push P8A1 independently.
 
+## P8A2 Red-Green-Refactor
+
+### Contract Decisions
+
+- Create `public.technical_configuration_options` as dossier-scoped option
+  identity owned by one supplier through a composite
+  `(supplier_id, dossier_id)` foreign key.
+- Store nullable canonical `model`, `manufacturer`, `option_name` and `notes`
+  plus mandatory `created_at`, `created_by`, `updated_at` and `updated_by`
+  audit metadata. Collapse boundary/internal whitespace for the three identity
+  fields, preserve internal note formatting, and require at least one of
+  `model` or `option_name`.
+- Return a derived `display_label` as
+  `supplier name · model`, falling back to `supplier name · option_name`.
+  Do not persist or accept `display_label` as input.
+- Do not add option identity uniqueness or user-managed ordering because the
+  OpenSpec does not require either contract. List results are deterministic by
+  supplier normalized name, option display key and option ID.
+- List by dossier with an optional supplier filter so P8B can load option
+  identity without one RPC call per supplier.
+- Add an index on `(dossier_id, supplier_id)` for dossier reads, optional
+  supplier filtering and composite-FK cascade checks.
+- Use the dossier revision for every option mutation. Option identity remains
+  directly editable, has no lock/version column and is not copied with a
+  baseline version.
+- Keep the shared `callTechnicalConfigurationRpc` contract unchanged.
+
+### RPC And Wire Contract
+
+- `technical_configuration_options_list(UUID, UUID, INTEGER, INTEGER)` accepts
+  `p_dossier_id`, optional `p_supplier_id DEFAULT NULL`, `p_page DEFAULT 1` and
+  `p_page_size DEFAULT 50`.
+- `technical_configuration_option_create(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)`
+  accepts `p_supplier_id`, nullable `p_model`, `p_manufacturer`,
+  `p_option_name`, `p_notes` and `p_expected_revision`.
+- `technical_configuration_option_update(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)`
+  accepts `p_option_id`, the same nullable identity fields and
+  `p_expected_revision`.
+- `technical_configuration_option_delete(UUID, BIGINT)` accepts `p_option_id`
+  and `p_expected_revision`.
+- List returns `{ data, revision, total, page, page_size }`. Each option item
+  returns `id`, `dossier_id`, `supplier_id`, `supplier_name`, `model`,
+  `manufacturer`, `option_name`, `notes`, `display_label`, all audit fields and
+  the owning dossier `revision`.
+- Create/update return `{ data: optionItem }` with the incremented dossier
+  revision. Delete returns `{ data: { id, revision } }`.
+
+### RED
+
+- Create
+  `src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts`
+  to freeze migration order, schema, composite ownership, CRUD/list signatures,
+  audit metadata, supporting index, authorization, concurrency, cascade, RLS,
+  grants, file-size limits and the dedicated phase gate.
+- Extend
+  `src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts`
+  with exactly four option RPC names, wire types and module-local adapter calls.
+- Extend
+  `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+  with exactly the four option RPCs.
+- Run:
+
+```bash
+node scripts/npm-run.js run test:run -- \
+  src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts \
+  src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts \
+  'src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts'
+```
+
+The tests must fail because the P8A2 migration, option RPC manifest, wire types
+and adapter functions do not exist yet.
+
+### GREEN
+
+- Create
+  `supabase/migrations/20260722034323_technical_configuration_options.sql`.
+- Create
+  `supabase/tests/technical_configuration_options_phase_gate.sql`; do not grow
+  the P8A1 supplier phase gate past the repository file-size ceiling.
+- Add `technical_configuration_options_list`,
+  `technical_configuration_option_create`,
+  `technical_configuration_option_update` and
+  `technical_configuration_option_delete`.
+- Reuse `_technical_configuration_require_global_user()` and
+  `_technical_configuration_require_editable_dossier()` instead of introducing
+  another authorization or revision helper.
+- Extend the supplier-option RPC manifest, wire types and module-local adapter.
+- Add only the four option RPC names to the existing route allowlist.
+- Re-run the focused RED command until it passes.
+
+### SQL Phase Gate
+
+The dedicated transaction-wrapped phase gate must prove:
+
+- missing claims and non-global roles fail closed while raw `admin` and
+  `global` are accepted;
+- multiple options can belong to one supplier and the same identity values are
+  not rejected by an unapproved uniqueness rule;
+- list pagination, optional supplier filtering and deterministic display labels;
+- archived dossiers remain readable through list while all option mutations are
+  rejected;
+- cross-dossier supplier ownership rejection;
+- create/update/delete with the current revision increment exactly once and
+  return the new revision;
+- create sets all audit fields, while update preserves `created_at`/`created_by`
+  and advances `updated_at`/`updated_by` for the current actor;
+- stale dossier revisions are rejected without changing option data or dossier
+  revision;
+- option create/update/delete still work when the dossier has a locked
+  baseline, proving no baseline lock/version dependency;
+- deleting a supplier or dossier cascades to options;
+- authenticated and anon cannot access the table directly, authenticated and
+  service-role can execute only the public option RPCs, and anon cannot;
+- the transaction ends with `ROLLBACK`.
+
+### REFACTOR AND VERIFY
+
+```bash
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run test:run -- \
+  src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts \
+  src/app/api/rpc/__tests__/technical-configuration-suppliers-migration.test.ts \
+  src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts \
+  'src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts'
+node scripts/npm-run.js run react-doctor
+openspec validate add-technical-configuration-comparison \
+  --type change --strict --no-interactive
+test "$(wc -l < supabase/migrations/20260722034323_technical_configuration_options.sql)" -le 450
+test "$(wc -l < supabase/tests/technical_configuration_options_phase_gate.sql)" -le 450
+```
+
+Run Code Review Graph and GitNexus change detection before commit. Commit and
+push P8A2 as one branch and one PR.
+
 ## Live Database Boundary
 
 No migration apply, phase-gate execution, DDL, DML or other live write is

--- a/openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p8a-tdd-plan.md
@@ -72,6 +72,15 @@ push P8A1 independently.
 
 ## P8A2 Red-Green-Refactor
 
+### Pre-Edit Workflow
+
+- Invoke `/react-best-practices` before editing the TypeScript contracts,
+  adapters or route allowlist.
+- Run Code Review Graph first to narrow the affected files and symbols, then
+  run GitNexus context/impact analysis for those symbols before implementation.
+  If GitNexus reports HIGH or CRITICAL impact, stop and warn the user before
+  editing.
+
 ### Contract Decisions
 
 - Create `public.technical_configuration_options` as dossier-scoped option
@@ -185,7 +194,31 @@ The dedicated transaction-wrapped phase gate must prove:
   service-role can execute only the public option RPCs, and anon cannot;
 - the transaction ends with `ROLLBACK`.
 
+The phase-gate `ROLLBACK` only reverts its test fixtures and assertions. If the
+P8A2 migration has been applied and must be reversed, create a new superseding
+migration rather than editing the applied migration. Provided no later migration
+depends on P8A2, reverse it in this order:
+
+1. Revoke and drop
+   `technical_configuration_option_delete(UUID, BIGINT)`,
+   `technical_configuration_option_update(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)`,
+   `technical_configuration_option_create(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)`
+   and
+   `technical_configuration_options_list(UUID, UUID, INTEGER, INTEGER)`.
+2. Drop `public.technical_configuration_options`; its policy and index are
+   removed with the table.
+3. Preserve `public.technical_configuration_suppliers`,
+   `_technical_configuration_require_global_user()` and
+   `_technical_configuration_require_editable_dossier(UUID, BIGINT)` because
+   they belong to P8A1.
+
+Any live reversal requires separate explicit write authorization and the same
+post-migration read-only schema, grant, RLS and advisor verification.
+
 ### REFACTOR AND VERIFY
+
+The pre-edit `/react-best-practices` and graph-analysis gates above are workflow
+steps, not shell commands. Then run:
 
 ```bash
 node scripts/npm-run.js run format:check
@@ -204,7 +237,7 @@ test "$(wc -l < supabase/migrations/20260722034323_technical_configuration_optio
 test "$(wc -l < supabase/tests/technical_configuration_options_phase_gate.sql)" -le 450
 ```
 
-Run Code Review Graph and GitNexus change detection before commit. Commit and
+Run a final Code Review Graph change-detection pass before commit. Commit and
 push P8A2 as one branch and one PR.
 
 ## Live Database Boundary

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -250,9 +250,9 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 
 ## Phase P8A2 - Option Identity Data Contracts
 
-- [ ] P8A2.1 Thêm nhiều options cho mỗi supplier với model/manufacturer/option-name/notes/audit/display-label contract.
-- [ ] P8A2.2 Thêm direct-edit/no-lock/no-version contract và optimistic concurrency.
-- [ ] P8A2.3 Giữ option identity ngoài baseline aggregate và không copy trong baseline-copy flow.
+- [x] P8A2.1 Thêm nhiều options cho mỗi supplier với model/manufacturer/option-name/notes/audit/display-label contract.
+- [x] P8A2.2 Thêm direct-edit/no-lock/no-version contract và optimistic concurrency.
+- [x] P8A2.3 Giữ option identity ngoài baseline aggregate và không copy trong baseline-copy flow.
 - [ ] P8A2.4 Chạy contract/DB phase gate cho authorization, archived reads, ownership, index, cascade và multiple options.
 
 ## Phase P8A3 - Baseline-Bound Option Response Contracts

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -250,10 +250,10 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 
 ## Phase P8A2 - Option Identity Data Contracts
 
-- [ ] P8A2.1 Thêm nhiều options cho mỗi supplier với model/manufacturer/option-name/display-label contract.
+- [ ] P8A2.1 Thêm nhiều options cho mỗi supplier với model/manufacturer/option-name/notes/audit/display-label contract.
 - [ ] P8A2.2 Thêm direct-edit/no-lock/no-version contract và optimistic concurrency.
 - [ ] P8A2.3 Giữ option identity ngoài baseline aggregate và không copy trong baseline-copy flow.
-- [ ] P8A2.4 Chạy contract/DB phase gate cho authorization, ownership, cascade và multiple options.
+- [ ] P8A2.4 Chạy contract/DB phase gate cho authorization, archived reads, ownership, index, cascade và multiple options.
 
 ## Phase P8A3 - Baseline-Bound Option Response Contracts
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -253,7 +253,7 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 - [x] P8A2.1 Thêm nhiều options cho mỗi supplier với model/manufacturer/option-name/notes/audit/display-label contract.
 - [x] P8A2.2 Thêm direct-edit/no-lock/no-version contract và optimistic concurrency.
 - [x] P8A2.3 Giữ option identity ngoài baseline aggregate và không copy trong baseline-copy flow.
-- [ ] P8A2.4 Chạy contract/DB phase gate cho authorization, archived reads, ownership, index, cascade và multiple options.
+- [x] P8A2.4 Chạy contract/DB phase gate cho authorization, archived reads, ownership, index, cascade và multiple options.
 
 ## Phase P8A3 - Baseline-Bound Option Response Contracts
 

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts
@@ -2,16 +2,32 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import * as supplierOptionRpcManifest from "@/lib/technical-configuration-supplier-option-rpcs"
 import * as supplierOptionRpcAdapter from "../technical-configuration-supplier-option-rpc"
 import type {
+  TechnicalConfigurationOptionCreateRpcArgs,
+  TechnicalConfigurationOptionDeleteRpcArgs,
+  TechnicalConfigurationOptionDeleteWireResponse,
+  TechnicalConfigurationOptionMutationWireResponse,
+  TechnicalConfigurationOptionsListRpcArgs,
+  TechnicalConfigurationOptionsListWireResponse,
+  TechnicalConfigurationOptionUpdateRpcArgs,
   TechnicalConfigurationSupplierDeleteWireResponse,
   TechnicalConfigurationSupplierMutationWireResponse,
   TechnicalConfigurationSuppliersListWireResponse,
 } from "../supplier-option-types"
 
-const { SUPPLIER_RPC_FUNCTION_NAMES, SUPPLIER_RPC_FUNCTIONS } = supplierOptionRpcManifest
 const {
+  OPTION_RPC_FUNCTION_NAMES,
+  OPTION_RPC_FUNCTIONS,
+  SUPPLIER_RPC_FUNCTION_NAMES,
+  SUPPLIER_RPC_FUNCTIONS,
+} = supplierOptionRpcManifest
+const {
+  createTechnicalConfigurationOption,
   createTechnicalConfigurationSupplier,
+  deleteTechnicalConfigurationOption,
   deleteTechnicalConfigurationSupplier,
+  listTechnicalConfigurationOptions,
   listTechnicalConfigurationSuppliers,
+  updateTechnicalConfigurationOption,
   updateTechnicalConfigurationSupplier,
 } = supplierOptionRpcAdapter
 
@@ -130,42 +146,25 @@ describe("P8A2 option RPC contract", () => {
     callRpcMock.mockReset()
   })
 
-  function getManifestValue(name: string): unknown {
-    return (supplierOptionRpcManifest as Record<string, unknown>)[name]
-  }
-
-  function getAdapter(
-    name: string
-  ): (args: Record<string, unknown>, signal?: AbortSignal) => Promise<unknown> {
-    const adapter = (supplierOptionRpcAdapter as Record<string, unknown>)[name]
-    expect(adapter).toBeTypeOf("function")
-    return adapter as (args: Record<string, unknown>, signal?: AbortSignal) => Promise<unknown>
-  }
-
   it("freezes exactly the four option RPC names", () => {
-    const optionFunctions = getManifestValue("OPTION_RPC_FUNCTIONS")
-
-    expect(optionFunctions).toEqual({
+    expect(OPTION_RPC_FUNCTIONS).toEqual({
       listOptions: "technical_configuration_options_list",
       createOption: "technical_configuration_option_create",
       updateOption: "technical_configuration_option_update",
       deleteOption: "technical_configuration_option_delete",
     })
-    expect(getManifestValue("OPTION_RPC_FUNCTION_NAMES")).toEqual(
-      Object.values(optionFunctions as Record<string, string>)
-    )
+    expect(OPTION_RPC_FUNCTION_NAMES).toEqual(Object.values(OPTION_RPC_FUNCTIONS))
   })
 
   it("delegates dossier list filtering and preserves the complete option wire shape", async () => {
-    const listOptions = getAdapter("listTechnicalConfigurationOptions")
-    const args = {
+    const args: TechnicalConfigurationOptionsListRpcArgs = {
       p_dossier_id: "00000000-0000-0000-0000-000000000001",
       p_supplier_id: "00000000-0000-0000-0000-000000000002",
       p_page: 2,
       p_page_size: 25,
     }
     const signal = new AbortController().signal
-    const response = {
+    const response: TechnicalConfigurationOptionsListWireResponse = {
       data: [
         {
           id: "00000000-0000-0000-0000-000000000003",
@@ -191,19 +190,14 @@ describe("P8A2 option RPC contract", () => {
     }
     callRpcMock.mockResolvedValueOnce(response)
 
-    await expect(listOptions(args, signal)).resolves.toEqual(response)
-    expect(callRpcMock).toHaveBeenCalledWith("technical_configuration_options_list", args, {
-      signal,
-    })
+    await expect(listTechnicalConfigurationOptions(args, signal)).resolves.toEqual(response)
+    expect(callRpcMock).toHaveBeenCalledWith(OPTION_RPC_FUNCTIONS.listOptions, args, { signal })
   })
 
   it("routes create, update and delete through nullable identity and dossier revision", async () => {
-    const createOption = getAdapter("createTechnicalConfigurationOption")
-    const updateOption = getAdapter("updateTechnicalConfigurationOption")
-    const deleteOption = getAdapter("deleteTechnicalConfigurationOption")
     const optionId = "00000000-0000-0000-0000-000000000003"
     const supplierId = "00000000-0000-0000-0000-000000000002"
-    const mutationResponse = {
+    const mutationResponse: TechnicalConfigurationOptionMutationWireResponse = {
       data: {
         id: optionId,
         dossier_id: "00000000-0000-0000-0000-000000000001",
@@ -221,8 +215,10 @@ describe("P8A2 option RPC contract", () => {
         revision: 5,
       },
     }
-    const deleteResponse = { data: { id: optionId, revision: 6 } }
-    const createArgs = {
+    const deleteResponse: TechnicalConfigurationOptionDeleteWireResponse = {
+      data: { id: optionId, revision: 6 },
+    }
+    const createArgs: TechnicalConfigurationOptionCreateRpcArgs = {
       p_supplier_id: supplierId,
       p_model: null,
       p_manufacturer: "  Hãng   A  ",
@@ -230,7 +226,7 @@ describe("P8A2 option RPC contract", () => {
       p_notes: null,
       p_expected_revision: 4,
     }
-    const updateArgs = {
+    const updateArgs: TechnicalConfigurationOptionUpdateRpcArgs = {
       p_option_id: optionId,
       p_model: "Model A",
       p_manufacturer: "Hãng A",
@@ -238,7 +234,7 @@ describe("P8A2 option RPC contract", () => {
       p_notes: "Ghi chú",
       p_expected_revision: 4,
     }
-    const deleteArgs = {
+    const deleteArgs: TechnicalConfigurationOptionDeleteRpcArgs = {
       p_option_id: optionId,
       p_expected_revision: 5,
     }
@@ -247,14 +243,14 @@ describe("P8A2 option RPC contract", () => {
       .mockResolvedValueOnce(mutationResponse)
       .mockResolvedValueOnce(deleteResponse)
 
-    await expect(createOption(createArgs)).resolves.toEqual(mutationResponse)
-    await expect(updateOption(updateArgs)).resolves.toEqual(mutationResponse)
-    await expect(deleteOption(deleteArgs)).resolves.toEqual(deleteResponse)
+    await expect(createTechnicalConfigurationOption(createArgs)).resolves.toEqual(mutationResponse)
+    await expect(updateTechnicalConfigurationOption(updateArgs)).resolves.toEqual(mutationResponse)
+    await expect(deleteTechnicalConfigurationOption(deleteArgs)).resolves.toEqual(deleteResponse)
 
     expect(callRpcMock.mock.calls).toEqual([
-      ["technical_configuration_option_create", createArgs, { signal: undefined }],
-      ["technical_configuration_option_update", updateArgs, { signal: undefined }],
-      ["technical_configuration_option_delete", deleteArgs, { signal: undefined }],
+      [OPTION_RPC_FUNCTIONS.createOption, createArgs, { signal: undefined }],
+      [OPTION_RPC_FUNCTIONS.updateOption, updateArgs, { signal: undefined }],
+      [OPTION_RPC_FUNCTIONS.deleteOption, deleteArgs, { signal: undefined }],
     ])
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts
@@ -1,19 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import {
-  SUPPLIER_RPC_FUNCTION_NAMES,
-  SUPPLIER_RPC_FUNCTIONS,
-} from "@/lib/technical-configuration-supplier-option-rpcs"
-import {
-  createTechnicalConfigurationSupplier,
-  deleteTechnicalConfigurationSupplier,
-  listTechnicalConfigurationSuppliers,
-  updateTechnicalConfigurationSupplier,
-} from "../technical-configuration-supplier-option-rpc"
+import * as supplierOptionRpcManifest from "@/lib/technical-configuration-supplier-option-rpcs"
+import * as supplierOptionRpcAdapter from "../technical-configuration-supplier-option-rpc"
 import type {
   TechnicalConfigurationSupplierDeleteWireResponse,
   TechnicalConfigurationSupplierMutationWireResponse,
   TechnicalConfigurationSuppliersListWireResponse,
 } from "../supplier-option-types"
+
+const { SUPPLIER_RPC_FUNCTION_NAMES, SUPPLIER_RPC_FUNCTIONS } = supplierOptionRpcManifest
+const {
+  createTechnicalConfigurationSupplier,
+  deleteTechnicalConfigurationSupplier,
+  listTechnicalConfigurationSuppliers,
+  updateTechnicalConfigurationSupplier,
+} = supplierOptionRpcAdapter
 
 const callRpcMock = vi.fn()
 
@@ -121,6 +121,140 @@ describe("P8A1 supplier RPC contract", () => {
       [SUPPLIER_RPC_FUNCTIONS.createSupplier, createArgs, { signal: undefined }],
       [SUPPLIER_RPC_FUNCTIONS.updateSupplier, updateArgs, { signal: undefined }],
       [SUPPLIER_RPC_FUNCTIONS.deleteSupplier, deleteArgs, { signal: undefined }],
+    ])
+  })
+})
+
+describe("P8A2 option RPC contract", () => {
+  beforeEach(() => {
+    callRpcMock.mockReset()
+  })
+
+  function getManifestValue(name: string): unknown {
+    return (supplierOptionRpcManifest as Record<string, unknown>)[name]
+  }
+
+  function getAdapter(
+    name: string
+  ): (args: Record<string, unknown>, signal?: AbortSignal) => Promise<unknown> {
+    const adapter = (supplierOptionRpcAdapter as Record<string, unknown>)[name]
+    expect(adapter).toBeTypeOf("function")
+    return adapter as (args: Record<string, unknown>, signal?: AbortSignal) => Promise<unknown>
+  }
+
+  it("freezes exactly the four option RPC names", () => {
+    const optionFunctions = getManifestValue("OPTION_RPC_FUNCTIONS")
+
+    expect(optionFunctions).toEqual({
+      listOptions: "technical_configuration_options_list",
+      createOption: "technical_configuration_option_create",
+      updateOption: "technical_configuration_option_update",
+      deleteOption: "technical_configuration_option_delete",
+    })
+    expect(getManifestValue("OPTION_RPC_FUNCTION_NAMES")).toEqual(
+      Object.values(optionFunctions as Record<string, string>)
+    )
+  })
+
+  it("delegates dossier list filtering and preserves the complete option wire shape", async () => {
+    const listOptions = getAdapter("listTechnicalConfigurationOptions")
+    const args = {
+      p_dossier_id: "00000000-0000-0000-0000-000000000001",
+      p_supplier_id: "00000000-0000-0000-0000-000000000002",
+      p_page: 2,
+      p_page_size: 25,
+    }
+    const signal = new AbortController().signal
+    const response = {
+      data: [
+        {
+          id: "00000000-0000-0000-0000-000000000003",
+          dossier_id: args.p_dossier_id,
+          supplier_id: args.p_supplier_id,
+          supplier_name: "Công ty Thiết bị A",
+          model: "Model A",
+          manufacturer: "Hãng A",
+          option_name: null,
+          notes: "Ghi chú\nnhiều dòng",
+          display_label: "Công ty Thiết bị A · Model A",
+          created_at: "2026-07-22T00:00:00Z",
+          created_by: 1,
+          updated_at: "2026-07-22T00:01:00Z",
+          updated_by: 1,
+          revision: 4,
+        },
+      ],
+      revision: 4,
+      total: 1,
+      page: 2,
+      page_size: 25,
+    }
+    callRpcMock.mockResolvedValueOnce(response)
+
+    await expect(listOptions(args, signal)).resolves.toEqual(response)
+    expect(callRpcMock).toHaveBeenCalledWith("technical_configuration_options_list", args, {
+      signal,
+    })
+  })
+
+  it("routes create, update and delete through nullable identity and dossier revision", async () => {
+    const createOption = getAdapter("createTechnicalConfigurationOption")
+    const updateOption = getAdapter("updateTechnicalConfigurationOption")
+    const deleteOption = getAdapter("deleteTechnicalConfigurationOption")
+    const optionId = "00000000-0000-0000-0000-000000000003"
+    const supplierId = "00000000-0000-0000-0000-000000000002"
+    const mutationResponse = {
+      data: {
+        id: optionId,
+        dossier_id: "00000000-0000-0000-0000-000000000001",
+        supplier_id: supplierId,
+        supplier_name: "Công ty Thiết bị A",
+        model: null,
+        manufacturer: "Hãng A",
+        option_name: "Phương án A",
+        notes: null,
+        display_label: "Công ty Thiết bị A · Phương án A",
+        created_at: "2026-07-22T00:00:00Z",
+        created_by: 1,
+        updated_at: "2026-07-22T00:01:00Z",
+        updated_by: 1,
+        revision: 5,
+      },
+    }
+    const deleteResponse = { data: { id: optionId, revision: 6 } }
+    const createArgs = {
+      p_supplier_id: supplierId,
+      p_model: null,
+      p_manufacturer: "  Hãng   A  ",
+      p_option_name: "  Phương   án A  ",
+      p_notes: null,
+      p_expected_revision: 4,
+    }
+    const updateArgs = {
+      p_option_id: optionId,
+      p_model: "Model A",
+      p_manufacturer: "Hãng A",
+      p_option_name: null,
+      p_notes: "Ghi chú",
+      p_expected_revision: 4,
+    }
+    const deleteArgs = {
+      p_option_id: optionId,
+      p_expected_revision: 5,
+    }
+    callRpcMock
+      .mockResolvedValueOnce(mutationResponse)
+      .mockResolvedValueOnce(mutationResponse)
+      .mockResolvedValueOnce(deleteResponse)
+
+    await expect(createOption(createArgs)).resolves.toEqual(mutationResponse)
+    await expect(updateOption(updateArgs)).resolves.toEqual(mutationResponse)
+    await expect(deleteOption(deleteArgs)).resolves.toEqual(deleteResponse)
+
+    expect(callRpcMock.mock.calls).toEqual([
+      ["technical_configuration_option_create", createArgs, { signal: undefined }],
+      ["technical_configuration_option_update", updateArgs, { signal: undefined }],
+      ["technical_configuration_option_delete", deleteArgs, { signal: undefined }],
     ])
   })
 })

--- a/src/app/(app)/technical-configurations/supplier-option-types.ts
+++ b/src/app/(app)/technical-configurations/supplier-option-types.ts
@@ -51,3 +51,69 @@ export interface TechnicalConfigurationSupplierDeleteRpcArgs {
   p_supplier_id: string
   p_expected_revision: number
 }
+
+export interface TechnicalConfigurationOptionWire {
+  id: string
+  dossier_id: string
+  supplier_id: string
+  supplier_name: string
+  model: string | null
+  manufacturer: string | null
+  option_name: string | null
+  notes: string | null
+  display_label: string
+  created_at: string
+  created_by: number
+  updated_at: string
+  updated_by: number
+  revision: number
+}
+
+export interface TechnicalConfigurationOptionsListWireResponse {
+  data: TechnicalConfigurationOptionWire[]
+  revision: number
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface TechnicalConfigurationOptionMutationWireResponse {
+  data: TechnicalConfigurationOptionWire
+}
+
+export interface TechnicalConfigurationOptionDeleteWireResponse {
+  data: {
+    id: string
+    revision: number
+  }
+}
+
+export interface TechnicalConfigurationOptionsListRpcArgs {
+  p_dossier_id: string
+  p_supplier_id?: string | null
+  p_page?: number
+  p_page_size?: number
+}
+
+export interface TechnicalConfigurationOptionCreateRpcArgs {
+  p_supplier_id: string
+  p_model: string | null
+  p_manufacturer: string | null
+  p_option_name: string | null
+  p_notes: string | null
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionUpdateRpcArgs {
+  p_option_id: string
+  p_model: string | null
+  p_manufacturer: string | null
+  p_option_name: string | null
+  p_notes: string | null
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionDeleteRpcArgs {
+  p_option_id: string
+  p_expected_revision: number
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts
@@ -1,6 +1,16 @@
-import { SUPPLIER_RPC_FUNCTIONS } from "@/lib/technical-configuration-supplier-option-rpcs"
+import {
+  OPTION_RPC_FUNCTIONS,
+  SUPPLIER_RPC_FUNCTIONS,
+} from "@/lib/technical-configuration-supplier-option-rpcs"
 import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
 import type {
+  TechnicalConfigurationOptionCreateRpcArgs,
+  TechnicalConfigurationOptionDeleteRpcArgs,
+  TechnicalConfigurationOptionDeleteWireResponse,
+  TechnicalConfigurationOptionMutationWireResponse,
+  TechnicalConfigurationOptionsListRpcArgs,
+  TechnicalConfigurationOptionsListWireResponse,
+  TechnicalConfigurationOptionUpdateRpcArgs,
   TechnicalConfigurationSupplierCreateRpcArgs,
   TechnicalConfigurationSupplierDeleteRpcArgs,
   TechnicalConfigurationSupplierDeleteWireResponse,
@@ -46,6 +56,46 @@ export function deleteTechnicalConfigurationSupplier(
   signal?: AbortSignal
 ): Promise<TechnicalConfigurationSupplierDeleteWireResponse> {
   return callTechnicalConfigurationRpc(SUPPLIER_RPC_FUNCTIONS.deleteSupplier, args, {
+    signal,
+  })
+}
+
+/** Lists dossier-scoped options with optional supplier filtering. */
+export function listTechnicalConfigurationOptions(
+  args: TechnicalConfigurationOptionsListRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionsListWireResponse> {
+  return callTechnicalConfigurationRpc(OPTION_RPC_FUNCTIONS.listOptions, args, {
+    signal,
+  })
+}
+
+/** Creates one option with optimistic dossier-revision protection. */
+export function createTechnicalConfigurationOption(
+  args: TechnicalConfigurationOptionCreateRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionMutationWireResponse> {
+  return callTechnicalConfigurationRpc(OPTION_RPC_FUNCTIONS.createOption, args, {
+    signal,
+  })
+}
+
+/** Updates one option with optimistic dossier-revision protection. */
+export function updateTechnicalConfigurationOption(
+  args: TechnicalConfigurationOptionUpdateRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionMutationWireResponse> {
+  return callTechnicalConfigurationRpc(OPTION_RPC_FUNCTIONS.updateOption, args, {
+    signal,
+  })
+}
+
+/** Deletes one option and returns the next dossier revision. */
+export function deleteTechnicalConfigurationOption(
+  args: TechnicalConfigurationOptionDeleteRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionDeleteWireResponse> {
+  return callTechnicalConfigurationRpc(OPTION_RPC_FUNCTIONS.deleteOption, args, {
     signal,
   })
 }

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -1,7 +1,10 @@
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
 import { DOCUMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-document-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
-import { SUPPLIER_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-supplier-option-rpcs"
+import {
+  OPTION_RPC_FUNCTION_NAMES,
+  SUPPLIER_RPC_FUNCTION_NAMES,
+} from "@/lib/technical-configuration-supplier-option-rpcs"
 
 /** Whitelist RPCs allowed through the Next.js RPC proxy. */
 export const ALLOWED_FUNCTIONS = new Set<string>([
@@ -100,6 +103,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   ...REFERENCE_PRODUCT_RPC_FUNCTION_NAMES,
   ...DOCUMENT_RPC_FUNCTION_NAMES,
   ...SUPPLIER_RPC_FUNCTION_NAMES,
+  ...OPTION_RPC_FUNCTION_NAMES,
   // AI Assistant (read-only)
   "ai_equipment_lookup",
   "ai_maintenance_plan_lookup",

--- a/src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts
@@ -188,6 +188,8 @@ describe("P8A2 technical configuration option migration", () => {
       "ROLLBACK;",
       "multiple options under one supplier",
       "duplicate option identity remains allowed",
+      "cross-dossier supplier ownership rejected",
+      "option list pagination",
       "supplier filter stays dossier scoped",
       "archived dossier remains readable",
       "archived dossier rejects option mutation",

--- a/src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts
@@ -48,6 +48,23 @@ const OPTION_RPC_NAMES = [
   "technical_configuration_option_delete",
 ] as const
 
+const OPTION_ITEM_WIRE_FIELDS = [
+  "'id'",
+  "'dossier_id'",
+  "'supplier_id'",
+  "'supplier_name'",
+  "'model'",
+  "'manufacturer'",
+  "'option_name'",
+  "'notes'",
+  "'display_label'",
+  "'created_at'",
+  "'created_by'",
+  "'updated_at'",
+  "'updated_by'",
+  "'revision'",
+] as const
+
 describe("P8A2 technical configuration option migration", () => {
   it("uses one ordered deploy-safe migration after the applied supplier contract", () => {
     expect(existsSync(MIGRATION_PATH)).toBe(true)
@@ -85,6 +102,7 @@ describe("P8A2 technical configuration option migration", () => {
     }
 
     expect(tableBlock).toContain("CHECK (model IS NOT NULL OR option_name IS NOT NULL)")
+    expect(tableBlock).toContain("notes <> ''")
     expect(tableBlock).toContain("FOREIGN KEY (supplier_id, dossier_id)")
     expect(tableBlock).toContain(
       "REFERENCES public.technical_configuration_suppliers (id, dossier_id)"
@@ -116,26 +134,27 @@ describe("P8A2 technical configuration option migration", () => {
     }
 
     const listBlock = getFunctionBlock(migrationSource, "technical_configuration_options_list")
-    for (const wireField of [
-      "'id'",
-      "'dossier_id'",
-      "'supplier_id'",
-      "'supplier_name'",
-      "'model'",
-      "'manufacturer'",
-      "'option_name'",
-      "'notes'",
-      "'display_label'",
-      "'created_at'",
-      "'created_by'",
-      "'updated_at'",
-      "'updated_by'",
-      "'revision'",
-    ]) {
+    for (const wireField of OPTION_ITEM_WIRE_FIELDS) {
       expect(listBlock).toContain(wireField)
     }
     expect(listBlock).toContain("COALESCE(o.model, o.option_name)")
     expect(listBlock).toContain("s.name || ' · ' || COALESCE(o.model, o.option_name)")
+    expect(listBlock).toContain(
+      "ORDER BY s.normalized_name, COALESCE(o.model, o.option_name), o.id"
+    )
+    expect(listBlock).toContain(
+      "ORDER BY page.supplier_normalized_name, page.identity_label, page.id"
+    )
+
+    for (const functionName of [
+      "technical_configuration_option_create",
+      "technical_configuration_option_update",
+    ]) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      for (const wireField of OPTION_ITEM_WIRE_FIELDS) {
+        expect(block).toContain(wireField)
+      }
+    }
   })
 
   it("uses global reads and dossier revision ownership for every mutation", () => {
@@ -188,16 +207,20 @@ describe("P8A2 technical configuration option migration", () => {
       "ROLLBACK;",
       "multiple options under one supplier",
       "duplicate option identity remains allowed",
+      "empty notes rejected",
       "cross-dossier supplier ownership rejected",
       "option list pagination",
+      "deterministic option ordering and fallback label",
       "supplier filter stays dossier scoped",
       "archived dossier remains readable",
       "archived dossier rejects option mutation",
+      "archived mutations leave option and dossier unchanged",
       "current revision increments exactly once",
       "stale revision leaves option and dossier unchanged",
       "locked baseline does not block option mutation",
       "option create audit metadata",
       "option update preserves creation audit",
+      "option update advances updated_at",
       "supplier delete cascades options",
       "dossier delete cascades options",
       "FOREACH v_function_signature IN ARRAY",

--- a/src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts
@@ -6,6 +6,9 @@ const REPO_ROOT = path.resolve(process.cwd())
 const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
 const MIGRATION_FILE = "20260722034323_technical_configuration_options.sql"
 const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const FK_INDEX_MIGRATION_FILE =
+  "20260722060629_technical_configuration_options_supplier_fk_index.sql"
+const FK_INDEX_MIGRATION_PATH = path.join(MIGRATIONS_DIR, FK_INDEX_MIGRATION_FILE)
 const PHASE_GATE_PATH = path.join(
   REPO_ROOT,
   "supabase/tests/technical_configuration_options_phase_gate.sql"
@@ -32,6 +35,7 @@ function getFunctionBlock(source: string, functionName: string): string {
 }
 
 const migrationSource = readIfExists(MIGRATION_PATH)
+const fkIndexMigrationSource = readIfExists(FK_INDEX_MIGRATION_PATH)
 const phaseGateSource = readIfExists(PHASE_GATE_PATH)
 
 const OPTION_RPC_SIGNATURES = [
@@ -66,16 +70,17 @@ const OPTION_ITEM_WIRE_FIELDS = [
 ] as const
 
 describe("P8A2 technical configuration option migration", () => {
-  it("uses one ordered deploy-safe migration after the applied supplier contract", () => {
+  it("uses ordered deploy-safe migrations after the applied supplier contract", () => {
     expect(existsSync(MIGRATION_PATH)).toBe(true)
     expect(
       readdirSync(MIGRATIONS_DIR)
         .filter((file) => file.includes("technical_configuration_options"))
         .sort()
-    ).toEqual([MIGRATION_FILE])
+    ).toEqual([MIGRATION_FILE, FK_INDEX_MIGRATION_FILE])
     expect(
       MIGRATION_FILE.localeCompare("20260722010000_technical_configuration_suppliers.sql")
     ).toBeGreaterThan(0)
+    expect(FK_INDEX_MIGRATION_FILE.localeCompare(MIGRATION_FILE)).toBeGreaterThan(0)
   })
 
   it("creates dossier-consistent option identity with audit metadata and no version state", () => {
@@ -117,6 +122,16 @@ describe("P8A2 technical configuration option migration", () => {
     )
     expect(migrationSource).toContain(
       "ON public.technical_configuration_options (dossier_id, supplier_id)"
+    )
+  })
+
+  it("adds a supplier-first covering index for the composite supplier foreign key", () => {
+    expect(existsSync(FK_INDEX_MIGRATION_PATH)).toBe(true)
+    expect(fkIndexMigrationSource).toContain(
+      "CREATE INDEX technical_configuration_options_supplier_dossier_idx"
+    )
+    expect(fkIndexMigrationSource).toContain(
+      "ON public.technical_configuration_options (supplier_id, dossier_id)"
     )
   })
 

--- a/src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-options-migration.test.ts
@@ -1,0 +1,226 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = path.resolve(process.cwd())
+const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
+const MIGRATION_FILE = "20260722034323_technical_configuration_options.sql"
+const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const PHASE_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_options_phase_gate.sql"
+)
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function getSqlBlock(source: string, marker: string, nextMarker: string): string {
+  const start = source.indexOf(marker)
+  if (start === -1) return ""
+
+  const next = source.indexOf(nextMarker, start + marker.length)
+  return source.slice(start, next === -1 ? source.length : next)
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  return getSqlBlock(
+    source,
+    `FUNCTION public.${functionName}(`,
+    "\nCREATE OR REPLACE FUNCTION public."
+  )
+}
+
+const migrationSource = readIfExists(MIGRATION_PATH)
+const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+
+const OPTION_RPC_SIGNATURES = [
+  "technical_configuration_options_list(\n  p_dossier_id UUID,\n  p_supplier_id UUID DEFAULT NULL,\n  p_page INTEGER DEFAULT 1,\n  p_page_size INTEGER DEFAULT 50",
+  "technical_configuration_option_create(\n  p_supplier_id UUID,\n  p_model TEXT,\n  p_manufacturer TEXT,\n  p_option_name TEXT,\n  p_notes TEXT,\n  p_expected_revision BIGINT",
+  "technical_configuration_option_update(\n  p_option_id UUID,\n  p_model TEXT,\n  p_manufacturer TEXT,\n  p_option_name TEXT,\n  p_notes TEXT,\n  p_expected_revision BIGINT",
+  "technical_configuration_option_delete(\n  p_option_id UUID,\n  p_expected_revision BIGINT",
+] as const
+
+const OPTION_RPC_NAMES = [
+  "technical_configuration_options_list",
+  "technical_configuration_option_create",
+  "technical_configuration_option_update",
+  "technical_configuration_option_delete",
+] as const
+
+describe("P8A2 technical configuration option migration", () => {
+  it("uses one ordered deploy-safe migration after the applied supplier contract", () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true)
+    expect(
+      readdirSync(MIGRATIONS_DIR)
+        .filter((file) => file.includes("technical_configuration_options"))
+        .sort()
+    ).toEqual([MIGRATION_FILE])
+    expect(
+      MIGRATION_FILE.localeCompare("20260722010000_technical_configuration_suppliers.sql")
+    ).toBeGreaterThan(0)
+  })
+
+  it("creates dossier-consistent option identity with audit metadata and no version state", () => {
+    const tableBlock = getSqlBlock(
+      migrationSource,
+      "CREATE TABLE public.technical_configuration_options",
+      "\n);"
+    )
+
+    for (const column of [
+      "id UUID PRIMARY KEY DEFAULT gen_random_uuid()",
+      "dossier_id UUID NOT NULL",
+      "supplier_id UUID NOT NULL",
+      "model TEXT",
+      "manufacturer TEXT",
+      "option_name TEXT",
+      "notes TEXT",
+      "created_at TIMESTAMPTZ NOT NULL DEFAULT now()",
+      "created_by BIGINT NOT NULL",
+      "updated_at TIMESTAMPTZ NOT NULL DEFAULT now()",
+      "updated_by BIGINT NOT NULL",
+    ]) {
+      expect(tableBlock).toContain(column)
+    }
+
+    expect(tableBlock).toContain("CHECK (model IS NOT NULL OR option_name IS NOT NULL)")
+    expect(tableBlock).toContain("FOREIGN KEY (supplier_id, dossier_id)")
+    expect(tableBlock).toContain(
+      "REFERENCES public.technical_configuration_suppliers (id, dossier_id)"
+    )
+    expect(tableBlock).toContain("ON DELETE CASCADE")
+    expect(tableBlock).not.toMatch(/\bUNIQUE\b/)
+    expect(tableBlock).not.toMatch(
+      /\brevision\b|baseline_version_id|locked_at|locked_by|source_baseline_version_id/
+    )
+    expect(migrationSource).toContain(
+      "CREATE INDEX technical_configuration_options_dossier_supplier_idx"
+    )
+    expect(migrationSource).toContain(
+      "ON public.technical_configuration_options (dossier_id, supplier_id)"
+    )
+  })
+
+  it("freezes the four RPC signatures, wire fields and derived display label", () => {
+    for (const signature of OPTION_RPC_SIGNATURES) {
+      expect(migrationSource).toContain(`FUNCTION public.${signature}`)
+    }
+
+    for (const functionName of OPTION_RPC_NAMES) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain("SECURITY DEFINER")
+      expect(block).toContain("SET search_path = public, pg_temp")
+      expect(migrationSource).toContain(`REVOKE ALL ON FUNCTION public.${functionName}`)
+      expect(migrationSource).toContain(`GRANT EXECUTE ON FUNCTION public.${functionName}`)
+    }
+
+    const listBlock = getFunctionBlock(migrationSource, "technical_configuration_options_list")
+    for (const wireField of [
+      "'id'",
+      "'dossier_id'",
+      "'supplier_id'",
+      "'supplier_name'",
+      "'model'",
+      "'manufacturer'",
+      "'option_name'",
+      "'notes'",
+      "'display_label'",
+      "'created_at'",
+      "'created_by'",
+      "'updated_at'",
+      "'updated_by'",
+      "'revision'",
+    ]) {
+      expect(listBlock).toContain(wireField)
+    }
+    expect(listBlock).toContain("COALESCE(o.model, o.option_name)")
+    expect(listBlock).toContain("s.name || ' · ' || COALESCE(o.model, o.option_name)")
+  })
+
+  it("uses global reads and dossier revision ownership for every mutation", () => {
+    const listBlock = getFunctionBlock(migrationSource, "technical_configuration_options_list")
+    expect(listBlock).toContain("PERFORM public._technical_configuration_require_global_user()")
+    expect(listBlock).not.toContain("_technical_configuration_require_editable_dossier")
+    expect(listBlock).toContain("p_supplier_id IS NULL OR o.supplier_id = p_supplier_id")
+    expect(listBlock).toContain("LIMIT p_page_size")
+    expect(listBlock).toContain("OFFSET (p_page::BIGINT - 1) * p_page_size::BIGINT")
+
+    for (const functionName of OPTION_RPC_NAMES.slice(1)) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain(
+        "v_user_id := public._technical_configuration_require_editable_dossier("
+      )
+      expect(block).toContain("p_expected_revision")
+      expect(block).toContain("UPDATE public.technical_configuration_dossiers")
+      expect(block).toContain("revision = revision + 1")
+      expect(block).not.toMatch(
+        /_technical_configuration_require_editable_baseline_version|baseline_version_id/
+      )
+    }
+  })
+
+  it("keeps options RPC-only with deny-by-default RLS and explicit grants", () => {
+    expect(migrationSource).toContain(
+      "ALTER TABLE public.technical_configuration_options ENABLE ROW LEVEL SECURITY"
+    )
+    expect(migrationSource).toContain(
+      "CREATE POLICY technical_configuration_options_no_client_access"
+    )
+    expect(migrationSource).toContain(
+      "FOR ALL TO anon, authenticated USING (false) WITH CHECK (false)"
+    )
+    expect(migrationSource).toMatch(
+      /REVOKE ALL ON TABLE public\.technical_configuration_options\s+FROM PUBLIC, anon, authenticated/
+    )
+    expect(migrationSource).toContain(
+      "GRANT ALL ON TABLE public.technical_configuration_options TO service_role"
+    )
+  })
+
+  it("ships a bounded transaction phase gate for the complete P8A2 contract", () => {
+    expect(existsSync(PHASE_GATE_PATH)).toBe(true)
+    expect(migrationSource.split("\n").length).toBeLessThanOrEqual(450)
+    expect(phaseGateSource.split("\n").length).toBeLessThanOrEqual(450)
+
+    for (const contractMarker of [
+      "BEGIN;",
+      "ROLLBACK;",
+      "multiple options under one supplier",
+      "duplicate option identity remains allowed",
+      "supplier filter stays dossier scoped",
+      "archived dossier remains readable",
+      "archived dossier rejects option mutation",
+      "current revision increments exactly once",
+      "stale revision leaves option and dossier unchanged",
+      "locked baseline does not block option mutation",
+      "option create audit metadata",
+      "option update preserves creation audit",
+      "supplier delete cascades options",
+      "dossier delete cascades options",
+      "FOREACH v_function_signature IN ARRAY",
+      "FOREACH v_table_privilege IN ARRAY",
+    ]) {
+      expect(phaseGateSource).toContain(contractMarker)
+    }
+
+    expect(phaseGateSource).toMatch(
+      /has_function_privilege\(\s*'authenticated',\s*v_function_signature,\s*'EXECUTE'\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_function_privilege\(\s*'service_role',\s*v_function_signature,\s*'EXECUTE'\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_function_privilege\(\s*'anon',\s*v_function_signature,\s*'EXECUTE'\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_table_privilege\(\s*'authenticated',\s*'public\.technical_configuration_options',\s*v_table_privilege\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_table_privilege\(\s*'anon',\s*'public\.technical_configuration_options',\s*v_table_privilege\s*\)/
+    )
+    expect(phaseGateSource).toMatch(
+      /has_table_privilege\(\s*'service_role',\s*'public\.technical_configuration_options',\s*v_table_privilege\s*\)/
+    )
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -8,7 +8,7 @@ import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-basel
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
 import * as supplierOptionRpcManifest from "@/lib/technical-configuration-supplier-option-rpcs"
 
-const { SUPPLIER_RPC_FUNCTION_NAMES } = supplierOptionRpcManifest
+const { OPTION_RPC_FUNCTION_NAMES, SUPPLIER_RPC_FUNCTION_NAMES } = supplierOptionRpcManifest
 
 const DOSSIER_RPC_FUNCTIONS = [
   "technical_configuration_dossiers_list",
@@ -163,9 +163,7 @@ describe("technical configuration supplier RPC whitelist", () => {
 
 describe("technical configuration option RPC whitelist", () => {
   it("keeps the local P8A2 option prefix aligned with the shared manifest", () => {
-    expect(
-      (supplierOptionRpcManifest as Record<string, unknown>).OPTION_RPC_FUNCTION_NAMES
-    ).toEqual(P8A2_OPTION_RPC_FUNCTIONS)
+    expect(OPTION_RPC_FUNCTION_NAMES).toEqual(P8A2_OPTION_RPC_FUNCTIONS)
   })
 
   it("allowlists exactly the four P8A2 option RPCs", () => {

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -6,7 +6,9 @@ import { ALLOWED_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
 import { POST } from "@/app/api/rpc/[fn]/route"
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
-import { SUPPLIER_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-supplier-option-rpcs"
+import * as supplierOptionRpcManifest from "@/lib/technical-configuration-supplier-option-rpcs"
+
+const { SUPPLIER_RPC_FUNCTION_NAMES } = supplierOptionRpcManifest
 
 const DOSSIER_RPC_FUNCTIONS = [
   "technical_configuration_dossiers_list",
@@ -56,6 +58,13 @@ const P8A1_SUPPLIER_RPC_FUNCTIONS = [
   "technical_configuration_supplier_create",
   "technical_configuration_supplier_update",
   "technical_configuration_supplier_delete",
+] as const
+
+const P8A2_OPTION_RPC_FUNCTIONS = [
+  "technical_configuration_options_list",
+  "technical_configuration_option_create",
+  "technical_configuration_option_update",
+  "technical_configuration_option_delete",
 ] as const
 
 async function invokeRpcProxy(fn: string) {
@@ -150,4 +159,29 @@ describe("technical configuration supplier RPC whitelist", () => {
       await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
     }
   )
+})
+
+describe("technical configuration option RPC whitelist", () => {
+  it("keeps the local P8A2 option prefix aligned with the shared manifest", () => {
+    expect(
+      (supplierOptionRpcManifest as Record<string, unknown>).OPTION_RPC_FUNCTION_NAMES
+    ).toEqual(P8A2_OPTION_RPC_FUNCTIONS)
+  })
+
+  it("allowlists exactly the four P8A2 option RPCs", () => {
+    expect(
+      [...ALLOWED_FUNCTIONS].filter(
+        (fn) =>
+          fn === "technical_configuration_options_list" ||
+          fn.startsWith("technical_configuration_option_")
+      )
+    ).toEqual(P8A2_OPTION_RPC_FUNCTIONS)
+  })
+
+  it.each(P8A2_OPTION_RPC_FUNCTIONS)('allows option RPC "%s" through the whitelist', async (fn) => {
+    const response = await invokeRpcProxy(fn)
+
+    expect(response.status).toBe(411)
+    await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
+  })
 })

--- a/src/lib/technical-configuration-supplier-option-rpcs.ts
+++ b/src/lib/technical-configuration-supplier-option-rpcs.ts
@@ -8,3 +8,14 @@ export const SUPPLIER_RPC_FUNCTIONS = {
 
 /** Ordered P8A1 RPC names for allowlists and contract iteration. */
 export const SUPPLIER_RPC_FUNCTION_NAMES = Object.values(SUPPLIER_RPC_FUNCTIONS)
+
+/** Named P8A2 option RPCs shared by client and server code. */
+export const OPTION_RPC_FUNCTIONS = {
+  listOptions: "technical_configuration_options_list",
+  createOption: "technical_configuration_option_create",
+  updateOption: "technical_configuration_option_update",
+  deleteOption: "technical_configuration_option_delete",
+} as const
+
+/** Ordered P8A2 RPC names for allowlists and contract iteration. */
+export const OPTION_RPC_FUNCTION_NAMES = Object.values(OPTION_RPC_FUNCTIONS)

--- a/supabase/migrations/20260722034323_technical_configuration_options.sql
+++ b/supabase/migrations/20260722034323_technical_configuration_options.sql
@@ -1,0 +1,444 @@
+-- P8A2: dossier-scoped supplier option identity and RPC contracts.
+
+CREATE TABLE public.technical_configuration_options (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  dossier_id UUID NOT NULL,
+  supplier_id UUID NOT NULL,
+  model TEXT,
+  manufacturer TEXT,
+  option_name TEXT,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by BIGINT NOT NULL,
+  CHECK (model IS NOT NULL OR option_name IS NOT NULL),
+  CHECK (
+    (model IS NULL OR (
+      model <> ''
+      AND model = btrim(regexp_replace(model, '[[:space:]]+', ' ', 'g'))
+    ))
+    AND (manufacturer IS NULL OR (
+      manufacturer <> ''
+      AND manufacturer = btrim(regexp_replace(manufacturer, '[[:space:]]+', ' ', 'g'))
+    ))
+    AND (option_name IS NULL OR (
+      option_name <> ''
+      AND option_name = btrim(regexp_replace(option_name, '[[:space:]]+', ' ', 'g'))
+    ))
+    AND (
+      notes IS NULL
+      OR notes = regexp_replace(notes, '^[[:space:]]+|[[:space:]]+$', '', 'g')
+    )
+  ),
+  FOREIGN KEY (supplier_id, dossier_id)
+    REFERENCES public.technical_configuration_suppliers (id, dossier_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX technical_configuration_options_dossier_supplier_idx
+  ON public.technical_configuration_options (dossier_id, supplier_id);
+
+ALTER TABLE public.technical_configuration_options ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY technical_configuration_options_no_client_access
+  ON public.technical_configuration_options
+  FOR ALL TO anon, authenticated USING (false) WITH CHECK (false);
+
+REVOKE ALL ON TABLE public.technical_configuration_options
+  FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.technical_configuration_options TO service_role;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_options_list(
+  p_dossier_id UUID,
+  p_supplier_id UUID DEFAULT NULL,
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_page IS NULL
+     OR p_page_size IS NULL
+     OR p_page < 1
+     OR p_page_size < 1
+     OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  WITH scope AS (
+    SELECT d.revision
+    FROM public.technical_configuration_dossiers d
+    WHERE d.id = p_dossier_id
+      AND (
+        p_supplier_id IS NULL
+        OR EXISTS (
+          SELECT 1
+          FROM public.technical_configuration_suppliers supplier_filter
+          WHERE supplier_filter.id = p_supplier_id
+            AND supplier_filter.dossier_id = d.id
+        )
+      )
+  ),
+  option_page AS (
+    SELECT
+      o.id,
+      o.dossier_id,
+      o.supplier_id,
+      s.name AS supplier_name,
+      s.normalized_name AS supplier_normalized_name,
+      o.model,
+      o.manufacturer,
+      o.option_name,
+      o.notes,
+      s.name || ' · ' || COALESCE(o.model, o.option_name) AS display_label,
+      COALESCE(o.model, o.option_name) AS identity_label,
+      o.created_at,
+      o.created_by,
+      o.updated_at,
+      o.updated_by
+    FROM public.technical_configuration_options o
+    JOIN public.technical_configuration_suppliers s
+      ON s.id = o.supplier_id
+     AND s.dossier_id = o.dossier_id
+    CROSS JOIN scope
+    WHERE o.dossier_id = p_dossier_id
+      AND (p_supplier_id IS NULL OR o.supplier_id = p_supplier_id)
+    ORDER BY s.normalized_name, COALESCE(o.model, o.option_name), o.id
+    LIMIT p_page_size
+    OFFSET (p_page::BIGINT - 1) * p_page_size::BIGINT
+  ),
+  option_summary AS (
+    SELECT count(*) AS total
+    FROM public.technical_configuration_options o
+    CROSS JOIN scope
+    WHERE o.dossier_id = p_dossier_id
+      AND (p_supplier_id IS NULL OR o.supplier_id = p_supplier_id)
+  )
+  SELECT jsonb_build_object(
+    'data',
+    COALESCE(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', page.id,
+            'dossier_id', page.dossier_id,
+            'supplier_id', page.supplier_id,
+            'supplier_name', page.supplier_name,
+            'model', page.model,
+            'manufacturer', page.manufacturer,
+            'option_name', page.option_name,
+            'notes', page.notes,
+            'display_label', page.display_label,
+            'created_at', page.created_at,
+            'created_by', page.created_by,
+            'updated_at', page.updated_at,
+            'updated_by', page.updated_by,
+            'revision', d.revision
+          )
+          ORDER BY page.supplier_normalized_name, page.identity_label, page.id
+        )
+        FROM option_page page
+      ),
+      '[]'::JSONB
+    ),
+    'revision', d.revision,
+    'total', summary.total,
+    'page', p_page,
+    'page_size', p_page_size
+  )
+  INTO v_result
+  FROM scope d
+  CROSS JOIN option_summary summary;
+
+  IF v_result IS NULL THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_create(
+  p_supplier_id UUID,
+  p_model TEXT,
+  p_manufacturer TEXT,
+  p_option_name TEXT,
+  p_notes TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_supplier_name TEXT;
+  v_revision BIGINT;
+  v_data JSONB;
+  v_model TEXT := NULLIF(btrim(regexp_replace(p_model, '[[:space:]]+', ' ', 'g')), '');
+  v_manufacturer TEXT := NULLIF(btrim(regexp_replace(p_manufacturer, '[[:space:]]+', ' ', 'g')), '');
+  v_option_name TEXT := NULLIF(btrim(regexp_replace(p_option_name, '[[:space:]]+', ' ', 'g')), '');
+  v_notes TEXT := NULLIF(
+    regexp_replace(p_notes, '^[[:space:]]+|[[:space:]]+$', '', 'g'),
+    ''
+  );
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT s.dossier_id
+  INTO v_dossier_id
+  FROM public.technical_configuration_suppliers s
+  WHERE s.id = p_supplier_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id,
+    p_expected_revision
+  );
+
+  SELECT s.name
+  INTO v_supplier_name
+  FROM public.technical_configuration_suppliers s
+  WHERE s.id = p_supplier_id
+    AND s.dossier_id = v_dossier_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  IF v_model IS NULL AND v_option_name IS NULL THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  INSERT INTO public.technical_configuration_options (
+    dossier_id, supplier_id, model, manufacturer, option_name, notes,
+    created_by, updated_by
+  )
+  VALUES (
+    v_dossier_id, p_supplier_id, v_model, v_manufacturer, v_option_name, v_notes,
+    v_user_id, v_user_id
+  )
+  RETURNING jsonb_build_object(
+    'id', id,
+    'dossier_id', dossier_id,
+    'supplier_id', supplier_id,
+    'supplier_name', v_supplier_name,
+    'model', model,
+    'manufacturer', manufacturer,
+    'option_name', option_name,
+    'notes', notes,
+    'display_label', v_supplier_name || ' · ' || COALESCE(model, option_name),
+    'created_at', created_at,
+    'created_by', created_by,
+    'updated_at', updated_at,
+    'updated_by', updated_by
+  )
+  INTO v_data;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object(
+    'data',
+    v_data || jsonb_build_object('revision', v_revision)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_update(
+  p_option_id UUID,
+  p_model TEXT,
+  p_manufacturer TEXT,
+  p_option_name TEXT,
+  p_notes TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_supplier_id UUID;
+  v_supplier_name TEXT;
+  v_revision BIGINT;
+  v_data JSONB;
+  v_model TEXT := NULLIF(btrim(regexp_replace(p_model, '[[:space:]]+', ' ', 'g')), '');
+  v_manufacturer TEXT := NULLIF(btrim(regexp_replace(p_manufacturer, '[[:space:]]+', ' ', 'g')), '');
+  v_option_name TEXT := NULLIF(btrim(regexp_replace(p_option_name, '[[:space:]]+', ' ', 'g')), '');
+  v_notes TEXT := NULLIF(
+    regexp_replace(p_notes, '^[[:space:]]+|[[:space:]]+$', '', 'g'),
+    ''
+  );
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT o.dossier_id, o.supplier_id
+  INTO v_dossier_id, v_supplier_id
+  FROM public.technical_configuration_options o
+  WHERE o.id = p_option_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id,
+    p_expected_revision
+  );
+
+  SELECT s.name
+  INTO v_supplier_name
+  FROM public.technical_configuration_options o
+  JOIN public.technical_configuration_suppliers s
+    ON s.id = o.supplier_id
+   AND s.dossier_id = o.dossier_id
+  WHERE o.id = p_option_id
+    AND o.dossier_id = v_dossier_id
+    AND o.supplier_id = v_supplier_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  IF v_model IS NULL AND v_option_name IS NULL THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  UPDATE public.technical_configuration_options
+  SET model = v_model,
+      manufacturer = v_manufacturer,
+      option_name = v_option_name,
+      notes = v_notes,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = p_option_id
+    AND dossier_id = v_dossier_id
+    AND supplier_id = v_supplier_id
+  RETURNING jsonb_build_object(
+    'id', id,
+    'dossier_id', dossier_id,
+    'supplier_id', supplier_id,
+    'supplier_name', v_supplier_name,
+    'model', model,
+    'manufacturer', manufacturer,
+    'option_name', option_name,
+    'notes', notes,
+    'display_label', v_supplier_name || ' · ' || COALESCE(model, option_name),
+    'created_at', created_at,
+    'created_by', created_by,
+    'updated_at', updated_at,
+    'updated_by', updated_by
+  )
+  INTO v_data;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object(
+    'data',
+    v_data || jsonb_build_object('revision', v_revision)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_delete(
+  p_option_id UUID,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_supplier_id UUID;
+  v_deleted_id UUID;
+  v_revision BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT o.dossier_id, o.supplier_id
+  INTO v_dossier_id, v_supplier_id
+  FROM public.technical_configuration_options o
+  WHERE o.id = p_option_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id,
+    p_expected_revision
+  );
+
+  DELETE FROM public.technical_configuration_options
+  WHERE id = p_option_id
+    AND dossier_id = v_dossier_id
+    AND supplier_id = v_supplier_id
+  RETURNING id INTO v_deleted_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object(
+    'data',
+    jsonb_build_object('id', v_deleted_id, 'revision', v_revision)
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_options_list(UUID, UUID, INTEGER, INTEGER)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_create(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_update(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)
+  FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_delete(UUID, BIGINT)
+  FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.technical_configuration_options_list(UUID, UUID, INTEGER, INTEGER)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_create(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_update(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_delete(UUID, BIGINT)
+  TO authenticated, service_role;

--- a/supabase/migrations/20260722034323_technical_configuration_options.sql
+++ b/supabase/migrations/20260722034323_technical_configuration_options.sql
@@ -28,7 +28,10 @@ CREATE TABLE public.technical_configuration_options (
     ))
     AND (
       notes IS NULL
-      OR notes = regexp_replace(notes, '^[[:space:]]+|[[:space:]]+$', '', 'g')
+      OR (
+        notes <> ''
+        AND notes = regexp_replace(notes, '^[[:space:]]+|[[:space:]]+$', '', 'g')
+      )
     )
   ),
   FOREIGN KEY (supplier_id, dossier_id)

--- a/supabase/migrations/20260722060629_technical_configuration_options_supplier_fk_index.sql
+++ b/supabase/migrations/20260722060629_technical_configuration_options_supplier_fk_index.sql
@@ -1,0 +1,4 @@
+-- P8A2 follow-up: cover the composite supplier foreign key in FK column order.
+
+CREATE INDEX technical_configuration_options_supplier_dossier_idx
+  ON public.technical_configuration_options (supplier_id, dossier_id);

--- a/supabase/tests/technical_configuration_options_phase_gate.sql
+++ b/supabase/tests/technical_configuration_options_phase_gate.sql
@@ -139,6 +139,16 @@ BEGIN
     (v_dossier_cascade_option_id, v_cascade_dossier_id, v_cascade_supplier_id,
       'Dossier Cascade Option', v_user_id, v_user_id);
 
+  PERFORM pg_temp.expect_error(
+    'cross-dossier supplier ownership rejected',
+    format(
+      'INSERT INTO public.technical_configuration_options (dossier_id, supplier_id, option_name, created_by, updated_by) VALUES (%L::UUID, %L::UUID, %L, %s, %s)',
+      v_dossier_id, v_archived_supplier_id, 'Cross-dossier Option', v_user_id, v_user_id
+    ),
+    '23503',
+    'insert or update on table "technical_configuration_options" violates foreign key constraint "technical_configuration_options_supplier_id_dossier_id_fkey"'
+  );
+
   PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
   PERFORM pg_temp.expect_error(
     'missing claims fail closed',
@@ -226,6 +236,17 @@ BEGIN
     AND o.model = 'Model X'
     AND o.option_name = 'Choice A';
   PERFORM pg_temp.assert_true('duplicate option identity remains allowed', v_count = 2);
+
+  v_response := public.technical_configuration_options_list(
+    v_dossier_id, v_supplier_a_id, 2, 1
+  );
+  PERFORM pg_temp.assert_true(
+    'option list pagination',
+    v_response->>'total' = '2'
+      AND v_response->>'page' = '2'
+      AND v_response->>'page_size' = '1'
+      AND jsonb_array_length(v_response->'data') = 1
+  );
 
   v_response := public.technical_configuration_option_create(
     v_supplier_b_id, NULL, NULL, E' Series   B ', NULL, v_revision

--- a/supabase/tests/technical_configuration_options_phase_gate.sql
+++ b/supabase/tests/technical_configuration_options_phase_gate.sql
@@ -1,6 +1,5 @@
 -- P8A2 rollback-only authorization, identity, revision, cascade, and grant gate.
 BEGIN;
-
 CREATE FUNCTION pg_temp.expect_error(
   p_label TEXT,
   p_statement TEXT,
@@ -11,8 +10,7 @@ RETURNS VOID
 LANGUAGE plpgsql
 AS $gate$
 DECLARE
-  v_state TEXT;
-  v_message TEXT;
+  v_state TEXT; v_message TEXT;
 BEGIN
   BEGIN
     EXECUTE p_statement;
@@ -31,7 +29,6 @@ BEGIN
   RAISE EXCEPTION '%: expected statement to fail', p_label;
 END;
 $gate$;
-
 CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -49,7 +46,6 @@ BEGIN
   );
 END;
 $gate$;
-
 CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
 RETURNS VOID
 LANGUAGE plpgsql
@@ -60,7 +56,6 @@ BEGIN
   END IF;
 END;
 $gate$;
-
 DO $gate$
 DECLARE
   v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
@@ -88,9 +83,9 @@ DECLARE
   v_rls_enabled BOOLEAN;
   v_function_signature TEXT;
   v_table_privilege TEXT;
+  v_statement TEXT;
 BEGIN
   PERFORM pg_advisory_xact_lock(hashtext('technical_configuration_options_phase_gate'));
-
   SELECT nv.id
   INTO v_user_id
   FROM public.nhan_vien nv
@@ -100,7 +95,6 @@ BEGIN
   IF v_user_id IS NULL THEN
     RAISE EXCEPTION 'P8A2 phase gate requires one active public.nhan_vien row';
   END IF;
-
   INSERT INTO public.technical_configuration_dossiers (
     id, device_type_name, name, archived_at, archived_by, created_by, updated_by
   )
@@ -111,7 +105,6 @@ BEGIN
       'P8A2 archived dossier ' || v_suffix, now(), v_user_id, v_user_id, v_user_id),
     (v_cascade_dossier_id, 'P8A2 cascade device ' || v_suffix,
       'P8A2 cascade dossier ' || v_suffix, NULL, NULL, v_user_id, v_user_id);
-
   INSERT INTO public.technical_configuration_suppliers (
     id, dossier_id, name, created_by, updated_by
   )
@@ -123,13 +116,11 @@ BEGIN
       v_user_id, v_user_id),
     (v_cascade_supplier_id, v_cascade_dossier_id, 'Dossier Cascade Medical',
       v_user_id, v_user_id);
-
   INSERT INTO public.technical_configuration_baseline_versions (
     dossier_id, version_number, status, revision, locked_at, locked_by,
     created_by, updated_by
   )
   VALUES (v_dossier_id, 1, 'locked', 1, now(), v_user_id, v_user_id, v_user_id);
-
   INSERT INTO public.technical_configuration_options (
     id, dossier_id, supplier_id, option_name, created_by, updated_by
   )
@@ -138,7 +129,6 @@ BEGIN
       'Archived Option', v_user_id, v_user_id),
     (v_dossier_cascade_option_id, v_cascade_dossier_id, v_cascade_supplier_id,
       'Dossier Cascade Option', v_user_id, v_user_id);
-
   PERFORM pg_temp.expect_error(
     'cross-dossier supplier ownership rejected',
     format(
@@ -148,28 +138,33 @@ BEGIN
     '23503',
     'insert or update on table "technical_configuration_options" violates foreign key constraint "technical_configuration_options_supplier_id_dossier_id_fkey"'
   );
-
+  PERFORM pg_temp.expect_error(
+    'empty notes rejected',
+    format(
+      'INSERT INTO public.technical_configuration_options (dossier_id, supplier_id, model, notes, created_by, updated_by) VALUES (%L::UUID, %L::UUID, %L, %L, %s, %s)',
+      v_dossier_id, v_supplier_a_id, 'Model', '', v_user_id, v_user_id
+    ),
+    '23514',
+    'new row for relation "technical_configuration_options" violates check constraint "technical_configuration_options_check1"'
+  );
   PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
   PERFORM pg_temp.expect_error(
     'missing claims fail closed',
     format('SELECT public.technical_configuration_options_list(%L::UUID)', v_dossier_id),
     '42501', 'permission_denied'
   );
-
   PERFORM pg_temp.set_claims('to_qltb', v_user_id);
   PERFORM pg_temp.expect_error(
     'non-global role denied',
     format('SELECT public.technical_configuration_options_list(%L::UUID)', v_dossier_id),
     '42501', 'permission_denied'
   );
-
   PERFORM pg_temp.set_claims('admin', v_user_id);
   v_response := public.technical_configuration_options_list(v_dossier_id);
   PERFORM pg_temp.assert_true(
     'raw admin must read option collections',
     v_response->>'total' = '0' AND v_response->>'revision' = '1'
   );
-
   PERFORM pg_temp.set_claims('global', v_user_id);
   PERFORM pg_temp.expect_error(
     'bounded pagination validation',
@@ -195,7 +190,6 @@ BEGIN
     ),
     'PT422', 'validation_error'
   );
-
   v_before_revision := v_revision;
   v_response := public.technical_configuration_option_create(
     v_supplier_a_id, E' Model   X ', E' Maker   A ', 'Choice A',
@@ -219,7 +213,6 @@ BEGIN
       AND v_created_by = v_user_id
       AND v_response #>> '{data,updated_by}' = v_user_id::TEXT
   );
-
   v_response := public.technical_configuration_option_create(
     v_supplier_a_id, 'Model X', 'Maker A', 'Choice A',
     E'line one\n  line two', v_revision
@@ -236,7 +229,6 @@ BEGIN
     AND o.model = 'Model X'
     AND o.option_name = 'Choice A';
   PERFORM pg_temp.assert_true('duplicate option identity remains allowed', v_count = 2);
-
   v_response := public.technical_configuration_options_list(
     v_dossier_id, v_supplier_a_id, 2, 1
   );
@@ -247,13 +239,11 @@ BEGIN
       AND v_response->>'page_size' = '1'
       AND jsonb_array_length(v_response->'data') = 1
   );
-
   v_response := public.technical_configuration_option_create(
     v_supplier_b_id, NULL, NULL, E' Series   B ', NULL, v_revision
   );
   v_other_option_id := (v_response #>> '{data,id}')::UUID;
   v_revision := (v_response #>> '{data,revision}')::BIGINT;
-
   v_response := public.technical_configuration_options_list(
     v_dossier_id, v_supplier_a_id, 1, 50
   );
@@ -263,6 +253,19 @@ BEGIN
       AND v_response #>> '{data,0,display_label}' = 'Alpha Medical · Model X'
       AND v_response #>> '{data,1,display_label}' = 'Alpha Medical · Model X'
   );
+  INSERT INTO public.technical_configuration_options (
+    dossier_id, supplier_id, model, created_by, updated_by
+  ) VALUES (v_dossier_id, v_supplier_a_id, 'Model A', v_user_id, v_user_id);
+  v_response := public.technical_configuration_options_list(v_dossier_id, NULL, 1, 50);
+  PERFORM pg_temp.assert_true(
+    'deterministic option ordering and fallback label',
+    v_response->>'total' = '4'
+      AND v_response #>> '{data,0,model}' = 'Model A'
+      AND (v_response #>> '{data,1,id}')::UUID = LEAST(v_option_id, v_duplicate_option_id)
+      AND (v_response #>> '{data,2,id}')::UUID = GREATEST(v_option_id, v_duplicate_option_id)
+      AND v_response #>> '{data,3,id}' = v_other_option_id::TEXT
+      AND v_response #>> '{data,3,display_label}' = 'Beta Medical · Series B'
+  );
   PERFORM pg_temp.expect_error(
     'supplier filter stays dossier scoped',
     format(
@@ -271,7 +274,6 @@ BEGIN
     ),
     'PT404', 'not_found'
   );
-
   v_response := public.technical_configuration_options_list(
     v_archived_dossier_id, v_archived_supplier_id, 1, 50
   );
@@ -281,15 +283,23 @@ BEGIN
       AND v_response #>> '{data,0,display_label}'
         = 'Archived Medical · Archived Option'
   );
-  PERFORM pg_temp.expect_error(
-    'archived dossier rejects option mutation',
-    format(
-      'SELECT public.technical_configuration_option_create(%L::UUID, NULL, NULL, %L, NULL, 1)',
-      v_archived_supplier_id, 'Blocked Option'
-    ),
-    'PT409', 'archived_dossier'
+  FOREACH v_statement IN ARRAY ARRAY[
+    format('SELECT public.technical_configuration_option_create(%L::UUID, NULL, NULL, %L, NULL, 1)', v_archived_supplier_id, 'Blocked Option'),
+    format('SELECT public.technical_configuration_option_update(%L::UUID, NULL, NULL, %L, NULL, 1)', v_archived_option_id, 'Blocked Option'),
+    format('SELECT public.technical_configuration_option_delete(%L::UUID, 1)', v_archived_option_id)
+  ]
+  LOOP
+    PERFORM pg_temp.expect_error(
+      'archived dossier rejects option mutation', v_statement, 'PT409', 'archived_dossier'
+    );
+  END LOOP;
+  PERFORM pg_temp.assert_true(
+    'archived mutations leave option and dossier unchanged',
+    (SELECT o.option_name FROM public.technical_configuration_options o
+     WHERE o.id = v_archived_option_id) = 'Archived Option'
+      AND (SELECT d.revision FROM public.technical_configuration_dossiers d
+           WHERE d.id = v_archived_dossier_id) = 1
   );
-
   v_before_revision := v_revision;
   PERFORM pg_temp.expect_error(
     'stale option update rejected',
@@ -306,7 +316,9 @@ BEGIN
       AND (SELECT d.revision FROM public.technical_configuration_dossiers d
            WHERE d.id = v_dossier_id) = v_before_revision
   );
-
+  UPDATE public.technical_configuration_options
+  SET updated_at = v_created_at - INTERVAL '1 hour'
+  WHERE id = v_option_id;
   v_response := public.technical_configuration_option_update(
     v_option_id, E' Model   Y ', E' Maker   B ', E' Choice   B ',
     E'\n\t row one\n    row two \t\n', v_revision
@@ -328,7 +340,12 @@ BEGIN
       AND v_response #>> '{data,updated_by}' = v_user_id::TEXT
       AND v_response #>> '{data,notes}' = E'row one\n    row two'
   );
-
+  PERFORM pg_temp.assert_true(
+    'option update advances updated_at',
+    (v_response #>> '{data,updated_at}')::TIMESTAMPTZ > v_created_at - INTERVAL '1 hour'
+      AND (SELECT o.updated_at FROM public.technical_configuration_options o
+           WHERE o.id = v_option_id) = (v_response #>> '{data,updated_at}')::TIMESTAMPTZ
+  );
   v_before_revision := v_revision;
   v_response := public.technical_configuration_option_delete(
     v_duplicate_option_id, v_revision
@@ -343,7 +360,6 @@ BEGIN
         WHERE o.id = v_duplicate_option_id
       )
   );
-
   INSERT INTO public.technical_configuration_options (
     id, dossier_id, supplier_id, option_name, created_by, updated_by
   )
@@ -360,7 +376,6 @@ BEGIN
       WHERE o.id = v_supplier_cascade_option_id
     )
   );
-
   DELETE FROM public.technical_configuration_dossiers
   WHERE id = v_cascade_dossier_id;
   PERFORM pg_temp.assert_true(
@@ -370,7 +385,6 @@ BEGIN
       WHERE o.id = v_dossier_cascade_option_id
     )
   );
-
   SELECT c.relrowsecurity
   INTO v_rls_enabled
   FROM pg_class c
@@ -387,7 +401,6 @@ BEGIN
           AND p.policyname = 'technical_configuration_options_no_client_access'
       )
   );
-
   FOREACH v_function_signature IN ARRAY ARRAY[
     'public.technical_configuration_options_list(UUID, UUID, INTEGER, INTEGER)',
     'public.technical_configuration_option_create(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)',
@@ -411,7 +424,6 @@ BEGIN
       RAISE EXCEPTION 'anon/PUBLIC must not execute %', v_function_signature;
     END IF;
   END LOOP;
-
   FOREACH v_table_privilege IN ARRAY ARRAY[
     'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'
   ]
@@ -434,5 +446,4 @@ BEGIN
   END LOOP;
 END;
 $gate$;
-
 ROLLBACK;

--- a/supabase/tests/technical_configuration_options_phase_gate.sql
+++ b/supabase/tests/technical_configuration_options_phase_gate.sql
@@ -1,0 +1,417 @@
+-- P8A2 rollback-only authorization, identity, revision, cascade, and grant gate.
+BEGIN;
+
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT,
+  p_statement TEXT,
+  p_expected_state TEXT,
+  p_expected_message TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION
+    WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+        v_state = RETURNED_SQLSTATE,
+        v_message = MESSAGE_TEXT;
+      IF v_state IS DISTINCT FROM p_expected_state
+         OR v_message IS DISTINCT FROM p_expected_message THEN
+        RAISE EXCEPTION '%: expected [%] %, got [%] %',
+          p_label, p_expected_state, p_expected_message, v_state, v_message;
+      END IF;
+      RETURN;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::TEXT,
+      'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN
+    RAISE EXCEPTION '%', p_label;
+  END IF;
+END;
+$gate$;
+
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossier_id UUID := gen_random_uuid();
+  v_archived_dossier_id UUID := gen_random_uuid();
+  v_cascade_dossier_id UUID := gen_random_uuid();
+  v_supplier_a_id UUID := gen_random_uuid();
+  v_supplier_b_id UUID := gen_random_uuid();
+  v_supplier_cascade_id UUID := gen_random_uuid();
+  v_archived_supplier_id UUID := gen_random_uuid();
+  v_cascade_supplier_id UUID := gen_random_uuid();
+  v_option_id UUID;
+  v_duplicate_option_id UUID;
+  v_other_option_id UUID;
+  v_archived_option_id UUID := gen_random_uuid();
+  v_supplier_cascade_option_id UUID := gen_random_uuid();
+  v_dossier_cascade_option_id UUID := gen_random_uuid();
+  v_revision BIGINT := 1;
+  v_before_revision BIGINT;
+  v_created_at TIMESTAMPTZ;
+  v_created_by BIGINT;
+  v_response JSONB;
+  v_count BIGINT;
+  v_rls_enabled BOOLEAN;
+  v_function_signature TEXT;
+  v_table_privilege TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('technical_configuration_options_phase_gate'));
+
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P8A2 phase gate requires one active public.nhan_vien row';
+  END IF;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, archived_at, archived_by, created_by, updated_by
+  )
+  VALUES
+    (v_dossier_id, 'P8A2 device ' || v_suffix, 'P8A2 dossier ' || v_suffix,
+      NULL, NULL, v_user_id, v_user_id),
+    (v_archived_dossier_id, 'P8A2 archived device ' || v_suffix,
+      'P8A2 archived dossier ' || v_suffix, now(), v_user_id, v_user_id, v_user_id),
+    (v_cascade_dossier_id, 'P8A2 cascade device ' || v_suffix,
+      'P8A2 cascade dossier ' || v_suffix, NULL, NULL, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_suppliers (
+    id, dossier_id, name, created_by, updated_by
+  )
+  VALUES
+    (v_supplier_a_id, v_dossier_id, 'Alpha Medical', v_user_id, v_user_id),
+    (v_supplier_b_id, v_dossier_id, 'Beta Medical', v_user_id, v_user_id),
+    (v_supplier_cascade_id, v_dossier_id, 'Cascade Medical', v_user_id, v_user_id),
+    (v_archived_supplier_id, v_archived_dossier_id, 'Archived Medical',
+      v_user_id, v_user_id),
+    (v_cascade_supplier_id, v_cascade_dossier_id, 'Dossier Cascade Medical',
+      v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    dossier_id, version_number, status, revision, locked_at, locked_by,
+    created_by, updated_by
+  )
+  VALUES (v_dossier_id, 1, 'locked', 1, now(), v_user_id, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_options (
+    id, dossier_id, supplier_id, option_name, created_by, updated_by
+  )
+  VALUES
+    (v_archived_option_id, v_archived_dossier_id, v_archived_supplier_id,
+      'Archived Option', v_user_id, v_user_id),
+    (v_dossier_cascade_option_id, v_cascade_dossier_id, v_cascade_supplier_id,
+      'Dossier Cascade Option', v_user_id, v_user_id);
+
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims fail closed',
+    format('SELECT public.technical_configuration_options_list(%L::UUID)', v_dossier_id),
+    '42501', 'permission_denied'
+  );
+
+  PERFORM pg_temp.set_claims('to_qltb', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'non-global role denied',
+    format('SELECT public.technical_configuration_options_list(%L::UUID)', v_dossier_id),
+    '42501', 'permission_denied'
+  );
+
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  v_response := public.technical_configuration_options_list(v_dossier_id);
+  PERFORM pg_temp.assert_true(
+    'raw admin must read option collections',
+    v_response->>'total' = '0' AND v_response->>'revision' = '1'
+  );
+
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'bounded pagination validation',
+    format(
+      'SELECT public.technical_configuration_options_list(%L::UUID, NULL, 0, 50)',
+      v_dossier_id
+    ),
+    'PT422', 'validation_error'
+  );
+  PERFORM pg_temp.expect_error(
+    'missing supplier rejected',
+    format(
+      'SELECT public.technical_configuration_option_create(%L::UUID, %L, NULL, NULL, NULL, 1)',
+      gen_random_uuid(), 'Model'
+    ),
+    'PT404', 'not_found'
+  );
+  PERFORM pg_temp.expect_error(
+    'invalid option identity rejected',
+    format(
+      'SELECT public.technical_configuration_option_create(%L::UUID, %L, NULL, %L, NULL, 1)',
+      v_supplier_a_id, E' \t ', E'\n'
+    ),
+    'PT422', 'validation_error'
+  );
+
+  v_before_revision := v_revision;
+  v_response := public.technical_configuration_option_create(
+    v_supplier_a_id, E' Model   X ', E' Maker   A ', 'Choice A',
+    E'\t\n  line one\n  line two \n\t', v_revision
+  );
+  v_option_id := (v_response #>> '{data,id}')::UUID;
+  v_revision := (v_response #>> '{data,revision}')::BIGINT;
+  v_created_at := (v_response #>> '{data,created_at}')::TIMESTAMPTZ;
+  v_created_by := (v_response #>> '{data,created_by}')::BIGINT;
+  PERFORM pg_temp.assert_true(
+    'current revision increments exactly once',
+    v_revision = v_before_revision + 1
+      AND (SELECT d.revision FROM public.technical_configuration_dossiers d
+           WHERE d.id = v_dossier_id) = v_revision
+  );
+  PERFORM pg_temp.assert_true(
+    'option create audit metadata',
+    v_response #>> '{data,model}' = 'Model X'
+      AND v_response #>> '{data,manufacturer}' = 'Maker A'
+      AND v_response #>> '{data,notes}' = E'line one\n  line two'
+      AND v_created_by = v_user_id
+      AND v_response #>> '{data,updated_by}' = v_user_id::TEXT
+  );
+
+  v_response := public.technical_configuration_option_create(
+    v_supplier_a_id, 'Model X', 'Maker A', 'Choice A',
+    E'line one\n  line two', v_revision
+  );
+  v_duplicate_option_id := (v_response #>> '{data,id}')::UUID;
+  v_revision := (v_response #>> '{data,revision}')::BIGINT;
+  PERFORM pg_temp.assert_true(
+    'multiple options under one supplier',
+    v_duplicate_option_id <> v_option_id
+  );
+  SELECT count(*) INTO v_count
+  FROM public.technical_configuration_options o
+  WHERE o.supplier_id = v_supplier_a_id
+    AND o.model = 'Model X'
+    AND o.option_name = 'Choice A';
+  PERFORM pg_temp.assert_true('duplicate option identity remains allowed', v_count = 2);
+
+  v_response := public.technical_configuration_option_create(
+    v_supplier_b_id, NULL, NULL, E' Series   B ', NULL, v_revision
+  );
+  v_other_option_id := (v_response #>> '{data,id}')::UUID;
+  v_revision := (v_response #>> '{data,revision}')::BIGINT;
+
+  v_response := public.technical_configuration_options_list(
+    v_dossier_id, v_supplier_a_id, 1, 50
+  );
+  PERFORM pg_temp.assert_true(
+    'supplier filtering and display labels',
+    v_response->>'total' = '2'
+      AND v_response #>> '{data,0,display_label}' = 'Alpha Medical · Model X'
+      AND v_response #>> '{data,1,display_label}' = 'Alpha Medical · Model X'
+  );
+  PERFORM pg_temp.expect_error(
+    'supplier filter stays dossier scoped',
+    format(
+      'SELECT public.technical_configuration_options_list(%L::UUID, %L::UUID, 1, 50)',
+      v_dossier_id, v_archived_supplier_id
+    ),
+    'PT404', 'not_found'
+  );
+
+  v_response := public.technical_configuration_options_list(
+    v_archived_dossier_id, v_archived_supplier_id, 1, 50
+  );
+  PERFORM pg_temp.assert_true(
+    'archived dossier remains readable',
+    v_response->>'total' = '1'
+      AND v_response #>> '{data,0,display_label}'
+        = 'Archived Medical · Archived Option'
+  );
+  PERFORM pg_temp.expect_error(
+    'archived dossier rejects option mutation',
+    format(
+      'SELECT public.technical_configuration_option_create(%L::UUID, NULL, NULL, %L, NULL, 1)',
+      v_archived_supplier_id, 'Blocked Option'
+    ),
+    'PT409', 'archived_dossier'
+  );
+
+  v_before_revision := v_revision;
+  PERFORM pg_temp.expect_error(
+    'stale option update rejected',
+    format(
+      'SELECT public.technical_configuration_option_update(%L::UUID, %L, NULL, NULL, NULL, %s)',
+      v_option_id, 'Stale Model', v_revision - 1
+    ),
+    'PT409', 'stale_revision'
+  );
+  PERFORM pg_temp.assert_true(
+    'stale revision leaves option and dossier unchanged',
+    (SELECT o.model FROM public.technical_configuration_options o
+     WHERE o.id = v_option_id) = 'Model X'
+      AND (SELECT d.revision FROM public.technical_configuration_dossiers d
+           WHERE d.id = v_dossier_id) = v_before_revision
+  );
+
+  v_response := public.technical_configuration_option_update(
+    v_option_id, E' Model   Y ', E' Maker   B ', E' Choice   B ',
+    E'\n\t row one\n    row two \t\n', v_revision
+  );
+  v_revision := (v_response #>> '{data,revision}')::BIGINT;
+  PERFORM pg_temp.assert_true(
+    'locked baseline does not block option mutation',
+    EXISTS (
+      SELECT 1 FROM public.technical_configuration_baseline_versions b
+      WHERE b.dossier_id = v_dossier_id AND b.status = 'locked'
+    )
+      AND v_revision = v_before_revision + 1
+      AND v_response #>> '{data,model}' = 'Model Y'
+  );
+  PERFORM pg_temp.assert_true(
+    'option update preserves creation audit',
+    (v_response #>> '{data,created_at}')::TIMESTAMPTZ = v_created_at
+      AND (v_response #>> '{data,created_by}')::BIGINT = v_created_by
+      AND v_response #>> '{data,updated_by}' = v_user_id::TEXT
+      AND v_response #>> '{data,notes}' = E'row one\n    row two'
+  );
+
+  v_before_revision := v_revision;
+  v_response := public.technical_configuration_option_delete(
+    v_duplicate_option_id, v_revision
+  );
+  v_revision := (v_response #>> '{data,revision}')::BIGINT;
+  PERFORM pg_temp.assert_true(
+    'option delete returns id and revision',
+    v_response #>> '{data,id}' = v_duplicate_option_id::TEXT
+      AND v_revision = v_before_revision + 1
+      AND NOT EXISTS (
+        SELECT 1 FROM public.technical_configuration_options o
+        WHERE o.id = v_duplicate_option_id
+      )
+  );
+
+  INSERT INTO public.technical_configuration_options (
+    id, dossier_id, supplier_id, option_name, created_by, updated_by
+  )
+  VALUES (
+    v_supplier_cascade_option_id, v_dossier_id, v_supplier_cascade_id,
+    'Supplier Cascade Option', v_user_id, v_user_id
+  );
+  DELETE FROM public.technical_configuration_suppliers
+  WHERE id = v_supplier_cascade_id;
+  PERFORM pg_temp.assert_true(
+    'supplier delete cascades options',
+    NOT EXISTS (
+      SELECT 1 FROM public.technical_configuration_options o
+      WHERE o.id = v_supplier_cascade_option_id
+    )
+  );
+
+  DELETE FROM public.technical_configuration_dossiers
+  WHERE id = v_cascade_dossier_id;
+  PERFORM pg_temp.assert_true(
+    'dossier delete cascades options',
+    NOT EXISTS (
+      SELECT 1 FROM public.technical_configuration_options o
+      WHERE o.id = v_dossier_cascade_option_id
+    )
+  );
+
+  SELECT c.relrowsecurity
+  INTO v_rls_enabled
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'technical_configuration_options';
+  PERFORM pg_temp.assert_true(
+    'option RLS and deny policy enabled',
+    v_rls_enabled
+      AND EXISTS (
+        SELECT 1 FROM pg_policies p
+        WHERE p.schemaname = 'public'
+          AND p.tablename = 'technical_configuration_options'
+          AND p.policyname = 'technical_configuration_options_no_client_access'
+      )
+  );
+
+  FOREACH v_function_signature IN ARRAY ARRAY[
+    'public.technical_configuration_options_list(UUID, UUID, INTEGER, INTEGER)',
+    'public.technical_configuration_option_create(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)',
+    'public.technical_configuration_option_update(UUID, TEXT, TEXT, TEXT, TEXT, BIGINT)',
+    'public.technical_configuration_option_delete(UUID, BIGINT)'
+  ]
+  LOOP
+    IF NOT has_function_privilege(
+      'authenticated', v_function_signature, 'EXECUTE'
+    ) THEN
+      RAISE EXCEPTION 'authenticated must execute %', v_function_signature;
+    END IF;
+    IF NOT has_function_privilege(
+      'service_role', v_function_signature, 'EXECUTE'
+    ) THEN
+      RAISE EXCEPTION 'service_role must execute %', v_function_signature;
+    END IF;
+    IF has_function_privilege(
+      'anon', v_function_signature, 'EXECUTE'
+    ) THEN
+      RAISE EXCEPTION 'anon/PUBLIC must not execute %', v_function_signature;
+    END IF;
+  END LOOP;
+
+  FOREACH v_table_privilege IN ARRAY ARRAY[
+    'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'
+  ]
+  LOOP
+    IF has_table_privilege(
+      'authenticated', 'public.technical_configuration_options', v_table_privilege
+    ) THEN
+      RAISE EXCEPTION 'authenticated must not have table privilege %', v_table_privilege;
+    END IF;
+    IF has_table_privilege(
+      'anon', 'public.technical_configuration_options', v_table_privilege
+    ) THEN
+      RAISE EXCEPTION 'anon/PUBLIC must not have table privilege %', v_table_privilege;
+    END IF;
+    IF NOT has_table_privilege(
+      'service_role', 'public.technical_configuration_options', v_table_privilege
+    ) THEN
+      RAISE EXCEPTION 'service_role must have table privilege %', v_table_privilege;
+    END IF;
+  END LOOP;
+END;
+$gate$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add dossier-scoped supplier option identity with multiple options, canonical identity fields, audit metadata, and derived display labels
- add list/create/update/delete RPC contracts with dossier-revision optimistic concurrency, archived guards, ownership/cascade constraints, and RPC-only RLS/grants
- add typed client manifests, wire/argument types, module-local adapters, route allowlist entries, contract tests, and a dedicated rollback-only SQL phase gate

## Scope boundary
- no exact-baseline-version option responses or supplementary/compliance data
- no P8B UI/hooks, P9A Excel, P9B documents/citations, or P10 comparison
- supplier/option identity stays outside baseline locking, versioning, and copy flows

## TDD and review
- RED contract failures were observed before migration/client implementation
- SQL spec review added executable composite-FK rejection and list-pagination coverage
- one independent migration reviewer found four actionable gaps: empty-note canonicalization, archived update/delete coverage, updated_at advancement coverage, and deterministic ordering/fallback/full wire checks
- all four findings were fixed test-first; the same reviewer re-reviewed the current SQL artifacts and returned Zero findings
- SQL quality/security review confirmed dossier-first locking, one-statement list snapshot, bounded pagination, explicit grants/RLS, and no N+1 or SELECT *
- Code Review Graph and GitNexus found no affected existing execution flows; the central RPC allowlist is covered by route tests

## Verification
- format:check
- verify:no-explicit-any
- verify:dedupe
- typecheck
- focused Vitest: 73/73 passed
- React Doctor: 100/100
- strict OpenSpec validation
- migration 447 lines; phase gate 449 lines; git diff --check

## Live database boundary
Read-only Supabase MCP verification on July 22, 2026 confirms P8A1 is live as migration 20260722020802 and P8A2 option objects are absent. The P8A2 migration has not been applied and the transaction-wrapped phase gate has not been executed; each operation requires separate explicit live-write approval. Supabase CLI was not used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dossier-scoped technical configuration options with model, manufacturer, option name, and notes.
  * Added option listing with supplier filtering and pagination.
  * Added create, update, and delete actions with automatically generated display labels.
* **Bug Fixes**
  * Added safeguards against stale edits, invalid ownership, unauthorized access, and changes to archived dossiers.
  * Option changes now update dossier revision and audit information consistently.
* **Security**
  * Restricted direct data access and exposed option actions only through authorized application operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->