### PR TITLE
Order liquidation equipment last in Equipments

### DIFF
--- a/src/app/(app)/equipment/__tests__/equipment-detail-dialog-decommission-date.test.tsx
+++ b/src/app/(app)/equipment/__tests__/equipment-detail-dialog-decommission-date.test.tsx
@@ -144,16 +144,18 @@ describe("EquipmentDetailDialog decommission date", () => {
     render(
       <EquipmentDetailDialog
         {...baseProps}
-        equipment={{
-          id: 42,
-          ma_thiet_bi: "EQ-042",
-          ten_thiet_bi: "Monitor",
-          khoa_phong_quan_ly: "ICU",
-          vi_tri_lap_dat: "P-01",
-          nguoi_dang_truc_tiep_quan_ly: "Nguyễn Văn A",
-          tinh_trang_hien_tai: "Ngưng sử dụng",
-          ngay_ngung_su_dung: null,
-        } as Equipment}
+        equipment={
+          {
+            id: 42,
+            ma_thiet_bi: "EQ-042",
+            ten_thiet_bi: "Monitor",
+            khoa_phong_quan_ly: "ICU",
+            vi_tri_lap_dat: "P-01",
+            nguoi_dang_truc_tiep_quan_ly: "Nguyễn Văn A",
+            tinh_trang_hien_tai: "Ngưng sử dụng",
+            ngay_ngung_su_dung: null,
+          } as Equipment
+        }
       />
     )
 
@@ -171,16 +173,18 @@ describe("EquipmentDetailDialog decommission date", () => {
       render(
         <EquipmentDetailDialog
           {...baseProps}
-          equipment={{
-            id: 7,
-            ma_thiet_bi: "EQ-007",
-            ten_thiet_bi: "Infusion Pump",
-            khoa_phong_quan_ly: "ICU",
-            vi_tri_lap_dat: "P-02",
-            nguoi_dang_truc_tiep_quan_ly: "Trần Văn B",
-            tinh_trang_hien_tai: "Hoạt động",
-            ngay_ngung_su_dung: null,
-          } as Equipment}
+          equipment={
+            {
+              id: 7,
+              ma_thiet_bi: "EQ-007",
+              ten_thiet_bi: "Infusion Pump",
+              khoa_phong_quan_ly: "ICU",
+              vi_tri_lap_dat: "P-02",
+              nguoi_dang_truc_tiep_quan_ly: "Trần Văn B",
+              tinh_trang_hien_tai: "Hoạt động",
+              ngay_ngung_su_dung: null,
+            } as Equipment
+          }
         />
       )
 
@@ -189,6 +193,9 @@ describe("EquipmentDetailDialog decommission date", () => {
       const decommissionDateInput = await screen.findByLabelText("Ngày ngừng sử dụng")
       expect(decommissionDateInput).toHaveValue("")
 
+      fireEvent.change(screen.getByLabelText(/Khoa\/Phòng quản lý/), {
+        target: { value: "VT-TBYT- KHO THANH LÍ" },
+      })
       fireEvent.change(screen.getAllByRole("combobox")[0], {
         target: { value: "Ngưng sử dụng" },
       })
@@ -201,9 +208,15 @@ describe("EquipmentDetailDialog decommission date", () => {
         expect(mockUpdateEquipment).toHaveBeenCalledWith({
           id: 7,
           patch: expect.objectContaining({
+            khoa_phong_quan_ly: "VT-TBYT- KHO THANH LÍ",
             tinh_trang_hien_tai: "Ngưng sử dụng",
             ngay_ngung_su_dung: "2026-03-25",
           }),
+          successToast: {
+            title: "Đã chuyển thiết bị",
+            description:
+              "Thiết bị đã được chuyển về cuối danh sách vì đang Ngưng sử dụng và thuộc Kho thanh lý.",
+          },
         })
       })
     } finally {
@@ -222,12 +235,7 @@ describe("EquipmentDetailDialog decommission date", () => {
       tinh_trang_hien_tai: "Hoạt động",
     } as Equipment
 
-    const view = render(
-      <EquipmentDetailDialog
-        {...baseProps}
-        equipment={equipment}
-      />
-    )
+    const view = render(<EquipmentDetailDialog {...baseProps} equipment={equipment} />)
 
     fireEvent.click(screen.getByRole("button", { name: "Sửa thông tin" }))
 
@@ -237,21 +245,9 @@ describe("EquipmentDetailDialog decommission date", () => {
     fireEvent.change(nameInput, { target: { value: "Giá trị chỉnh tạm" } })
     expect(nameInput).toHaveValue("Giá trị chỉnh tạm")
 
-    view.rerender(
-      <EquipmentDetailDialog
-        {...baseProps}
-        equipment={equipment}
-        open={false}
-      />
-    )
+    view.rerender(<EquipmentDetailDialog {...baseProps} equipment={equipment} open={false} />)
 
-    view.rerender(
-      <EquipmentDetailDialog
-        {...baseProps}
-        equipment={equipment}
-        open
-      />
-    )
+    view.rerender(<EquipmentDetailDialog {...baseProps} equipment={equipment} open />)
 
     const reopenEditButton = screen.queryByRole("button", { name: "Sửa thông tin" })
     if (reopenEditButton) {
@@ -269,15 +265,17 @@ describe("EquipmentDetailDialog decommission date", () => {
     render(
       <EquipmentDetailDialog
         {...baseProps}
-        equipment={{
-          id: 12,
-          ma_thiet_bi: "EQ-012",
-          ten_thiet_bi: "Máy thở",
-          khoa_phong_quan_ly: "ICU",
-          vi_tri_lap_dat: "P-04",
-          nguoi_dang_truc_tiep_quan_ly: "Phạm Văn D",
-          tinh_trang_hien_tai: "Hoạt động",
-        } as Equipment}
+        equipment={
+          {
+            id: 12,
+            ma_thiet_bi: "EQ-012",
+            ten_thiet_bi: "Máy thở",
+            khoa_phong_quan_ly: "ICU",
+            vi_tri_lap_dat: "P-04",
+            nguoi_dang_truc_tiep_quan_ly: "Phạm Văn D",
+            tinh_trang_hien_tai: "Hoạt động",
+          } as Equipment
+        }
       />
     )
 

--- a/src/app/(app)/equipment/__tests__/equipment-liquidation-order-scope.test.ts
+++ b/src/app/(app)/equipment/__tests__/equipment-liquidation-order-scope.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const MAIN_EQUIPMENT_HOOK = "src/app/(app)/equipment/_hooks/useEquipmentData.ts"
+const NON_MAIN_CALLERS = [
+  "src/app/(app)/equipment/_hooks/useEquipmentExport.ts",
+  "src/components/transfer-dialog.data.ts",
+  "src/hooks/useAddTasksEquipment.ts",
+  "src/hooks/use-cached-equipment.ts",
+] as const
+
+function readSource(relativePath: string) {
+  return readFileSync(path.resolve(process.cwd(), relativePath), "utf8")
+}
+
+describe("equipment liquidation-last caller scope", () => {
+  it("enables liquidation-last ordering exactly once in the main Equipments hook", () => {
+    const mainSource = readSource(MAIN_EQUIPMENT_HOOK)
+
+    expect(mainSource.match(/p_liquidation_last:\s*true/g)).toHaveLength(1)
+    expect(mainSource.match(/liquidationLast:\s*true/g)).toHaveLength(1)
+  })
+
+  it.each(NON_MAIN_CALLERS)("does not enable liquidation-last ordering in %s", (caller) => {
+    const source = readSource(caller)
+
+    expect(source).not.toMatch(/p_liquidation_last:\s*true/)
+    expect(source).not.toMatch(/liquidationLast:\s*true/)
+  })
+})

--- a/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
+++ b/src/app/(app)/equipment/__tests__/useEquipmentData.test.ts
@@ -1,17 +1,17 @@
-import { renderHook, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import * as React from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { EQUIPMENT_ATTENTION_STATUSES } from '@/lib/equipment-attention-preset'
+import { renderHook, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { EQUIPMENT_ATTENTION_STATUSES } from "@/lib/equipment-attention-preset"
 
 // Mock callRpc
 const mockCallRpc = vi.fn()
-vi.mock('@/lib/rpc-client', () => ({
+vi.mock("@/lib/rpc-client", () => ({
   callRpc: (args: unknown) => mockCallRpc(args),
 }))
 
 // Mock useActiveUsageLogs
-vi.mock('@/hooks/use-usage-logs', () => ({
+vi.mock("@/hooks/use-usage-logs", () => ({
   useActiveUsageLogs: () => ({
     data: [],
     isLoading: false,
@@ -19,22 +19,24 @@ vi.mock('@/hooks/use-usage-logs', () => ({
 }))
 
 // Import after mocking
-import { useEquipmentData } from '../_hooks/useEquipmentData'
-import type { Equipment } from '@/types/database'
-import type { UseEquipmentDataParams } from '../_hooks/useEquipmentData'
+import { useEquipmentData } from "../_hooks/useEquipmentData"
+import type { Equipment } from "@/types/database"
+import type { UseEquipmentDataParams } from "../_hooks/useEquipmentData"
 
 // Default params for tests - now includes context values that were previously from useFacilityFilter
-const createDefaultParams = (overrides?: Partial<UseEquipmentDataParams>): UseEquipmentDataParams => ({
+const createDefaultParams = (
+  overrides?: Partial<UseEquipmentDataParams>
+): UseEquipmentDataParams => ({
   isGlobal: false,
   isRegionalLeader: false,
-  userRole: 'user',
+  userRole: "user",
   userDiaBanId: undefined,
   shouldFetchEquipment: true,
-  effectiveTenantKey: '5',
+  effectiveTenantKey: "5",
   selectedDonVi: 5,
   currentTenantId: 5,
-  debouncedSearch: '',
-  sortParam: 'id.asc',
+  debouncedSearch: "",
+  sortParam: "id.asc",
   pagination: { pageIndex: 0, pageSize: 20 },
   selectedDepartments: [],
   selectedUsers: [],
@@ -50,35 +52,36 @@ const createDefaultParams = (overrides?: Partial<UseEquipmentDataParams>): UseEq
   ...overrides,
 })
 
-// Helper to create wrapper with QueryClient
-const createWrapper = () => {
-  const queryClient = new QueryClient({
+const createQueryClient = () =>
+  new QueryClient({
     defaultOptions: {
       queries: { retry: false, gcTime: 0 },
       mutations: { retry: false },
     },
   })
 
+// Helper to create wrapper with QueryClient
+const createWrapper = (queryClient = createQueryClient()) => {
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return React.createElement(QueryClientProvider, { client: queryClient }, children)
   }
 }
 
-describe('useEquipmentData', () => {
+describe("useEquipmentData", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Default mock implementations
     mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
       switch (fn) {
-        case 'equipment_list_enhanced':
+        case "equipment_list_enhanced":
           return Promise.resolve({ data: [], total: 0 })
-        case 'tenant_list':
+        case "tenant_list":
           return Promise.resolve([])
-        case 'equipment_filter_buckets':
+        case "equipment_filter_buckets":
           return Promise.resolve({})
-        case 'equipment_department_distribution':
+        case "equipment_department_distribution":
           return Promise.resolve([])
-        case 'get_facilities_with_equipment_count':
+        case "get_facilities_with_equipment_count":
           return Promise.resolve([])
         default:
           return Promise.resolve(null)
@@ -90,14 +93,14 @@ describe('useEquipmentData', () => {
     vi.clearAllMocks()
   })
 
-  describe('Equipment List Query', () => {
-    it('should fetch equipment list when enabled', async () => {
+  describe("Equipment List Query", () => {
+    it("should fetch equipment list when enabled", async () => {
       const mockEquipment = [
-        { id: 1, ma_thiet_bi: 'EQ-001', ten_thiet_bi: 'Test Equipment 1' },
-        { id: 2, ma_thiet_bi: 'EQ-002', ten_thiet_bi: 'Test Equipment 2' },
+        { id: 1, ma_thiet_bi: "EQ-001", ten_thiet_bi: "Test Equipment 1" },
+        { id: 2, ma_thiet_bi: "EQ-002", ten_thiet_bi: "Test Equipment 2" },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: mockEquipment, total: 2 })
         }
         return Promise.resolve([])
@@ -115,23 +118,23 @@ describe('useEquipmentData', () => {
       expect(result.current.total).toBe(2)
     })
 
-    it('should preserve active repair request id returned by equipment_list_enhanced', async () => {
+    it("should preserve active repair request id returned by equipment_list_enhanced", async () => {
       const mockEquipment = [
         {
           id: 1,
-          ma_thiet_bi: 'EQ-001',
-          ten_thiet_bi: 'Test Equipment 1',
+          ma_thiet_bi: "EQ-001",
+          ten_thiet_bi: "Test Equipment 1",
           active_repair_request_id: 33801,
         } satisfies Equipment,
         {
           id: 2,
-          ma_thiet_bi: 'EQ-002',
-          ten_thiet_bi: 'Test Equipment 2',
+          ma_thiet_bi: "EQ-002",
+          ten_thiet_bi: "Test Equipment 2",
           active_repair_request_id: null,
         } satisfies Equipment,
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: mockEquipment, total: 2 })
         }
         return Promise.resolve([])
@@ -149,17 +152,17 @@ describe('useEquipmentData', () => {
       expect(result.current.data[1]?.active_repair_request_id).toBeNull()
     })
 
-    it('should reflect active-only server contract (deleted fixtures excluded upstream)', async () => {
-      const activeEquipment = { id: 1, ma_thiet_bi: 'EQ-001', ten_thiet_bi: 'Active Equipment' }
+    it("should reflect active-only server contract (deleted fixtures excluded upstream)", async () => {
+      const activeEquipment = { id: 1, ma_thiet_bi: "EQ-001", ten_thiet_bi: "Active Equipment" }
       const deletedFixture = {
         id: 2,
-        ma_thiet_bi: 'EQ-DEL-001',
-        ten_thiet_bi: 'Deleted Equipment',
+        ma_thiet_bi: "EQ-DEL-001",
+        ten_thiet_bi: "Deleted Equipment",
         is_deleted: true,
       }
 
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           // Server contract after soft-delete Task 3: deleted rows are excluded.
           return Promise.resolve({ data: [activeEquipment], total: 1 })
         }
@@ -181,7 +184,7 @@ describe('useEquipmentData', () => {
       expect(result.current.total).toBe(1)
     })
 
-    it('should not fetch equipment when shouldFetchEquipment is false', async () => {
+    it("should not fetch equipment when shouldFetchEquipment is false", async () => {
       const { result } = renderHook(
         () => useEquipmentData(createDefaultParams({ shouldFetchEquipment: false })),
         { wrapper: createWrapper() }
@@ -191,14 +194,15 @@ describe('useEquipmentData', () => {
       await new Promise((r) => setTimeout(r, 100))
 
       expect(mockCallRpc).not.toHaveBeenCalledWith(
-        expect.objectContaining({ fn: 'equipment_list_enhanced' })
+        expect.objectContaining({ fn: "equipment_list_enhanced" })
       )
       expect(result.current.data).toEqual([])
     })
 
-    it('should pass correct parameters to RPC', async () => {
+    it("should pass correct parameters to RPC", async () => {
+      const queryClient = createQueryClient()
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
@@ -208,36 +212,45 @@ describe('useEquipmentData', () => {
         () =>
           useEquipmentData(
             createDefaultParams({
-              debouncedSearch: 'test search',
-              sortParam: 'ten_thiet_bi.desc',
+              debouncedSearch: "test search",
+              sortParam: "ten_thiet_bi.desc",
               pagination: { pageIndex: 2, pageSize: 50 },
               selectedDonVi: 10,
-              selectedDepartments: ['Khoa A'],
-              selectedStatuses: ['Hoat dong'],
+              selectedDepartments: ["Khoa A"],
+              selectedStatuses: ["Hoat dong"],
             })
           ),
-        { wrapper: createWrapper() }
+        { wrapper: createWrapper(queryClient) }
       )
 
       await waitFor(() => {
         expect(mockCallRpc).toHaveBeenCalledWith(
           expect.objectContaining({
-            fn: 'equipment_list_enhanced',
+            fn: "equipment_list_enhanced",
             args: expect.objectContaining({
-              p_q: 'test search',
-              p_sort: 'ten_thiet_bi.desc',
+              p_q: "test search",
+              p_sort: "ten_thiet_bi.desc",
               p_page: 3, // pageIndex + 1
               p_page_size: 50,
               p_don_vi: 10,
-              p_khoa_phong_array: ['Khoa A'],
-              p_tinh_trang_array: ['Hoat dong'],
+              p_khoa_phong_array: ["Khoa A"],
+              p_tinh_trang_array: ["Hoat dong"],
+              p_liquidation_last: true,
             }),
           })
         )
       })
+
+      const equipmentListQuery = queryClient
+        .getQueryCache()
+        .findAll({ queryKey: ["equipment_list_enhanced"] })[0]
+
+      expect(equipmentListQuery?.queryKey[1]).toEqual(
+        expect.objectContaining({ liquidationLast: true })
+      )
     })
 
-    it('should handle empty search and filters', async () => {
+    it("should handle empty search and filters", async () => {
       renderHook(() => useEquipmentData(createDefaultParams()), {
         wrapper: createWrapper(),
       })
@@ -245,7 +258,7 @@ describe('useEquipmentData', () => {
       await waitFor(() => {
         expect(mockCallRpc).toHaveBeenCalledWith(
           expect.objectContaining({
-            fn: 'equipment_list_enhanced',
+            fn: "equipment_list_enhanced",
             args: expect.objectContaining({
               p_q: null,
               p_khoa_phong_array: null,
@@ -260,13 +273,13 @@ describe('useEquipmentData', () => {
     })
   })
 
-  describe('Attention preset tenant isolation', () => {
-    it('should pass preset statuses without changing non-regional tenant scope', async () => {
+  describe("Attention preset tenant isolation", () => {
+    it("should pass preset statuses without changing non-regional tenant scope", async () => {
       renderHook(
         () =>
           useEquipmentData(
             createDefaultParams({
-              userRole: 'user',
+              userRole: "user",
               isGlobal: false,
               isRegionalLeader: false,
               selectedDonVi: 5,
@@ -281,7 +294,7 @@ describe('useEquipmentData', () => {
       await waitFor(() => {
         expect(mockCallRpc).toHaveBeenCalledWith(
           expect.objectContaining({
-            fn: 'equipment_list_enhanced',
+            fn: "equipment_list_enhanced",
             args: expect.objectContaining({
               p_tinh_trang_array: [...EQUIPMENT_ATTENTION_STATUSES],
               p_don_vi: 5,
@@ -291,19 +304,19 @@ describe('useEquipmentData', () => {
       })
 
       const equipmentListCall = mockCallRpc.mock.calls.find(
-        (call) => call[0].fn === 'equipment_list_enhanced'
+        (call) => call[0].fn === "equipment_list_enhanced"
       )?.[0]
 
-      expect(equipmentListCall?.args).not.toHaveProperty('selectedFacilityId')
-      expect(equipmentListCall?.args).not.toHaveProperty('p_selected_facility_id')
+      expect(equipmentListCall?.args).not.toHaveProperty("selectedFacilityId")
+      expect(equipmentListCall?.args).not.toHaveProperty("p_selected_facility_id")
     })
 
-    it('should keep regional-leader tenant selection behavior with preset statuses', async () => {
+    it("should keep regional-leader tenant selection behavior with preset statuses", async () => {
       renderHook(
         () =>
           useEquipmentData(
             createDefaultParams({
-              userRole: 'regional_leader',
+              userRole: "regional_leader",
               isGlobal: false,
               isRegionalLeader: true,
               selectedDonVi: 5,
@@ -317,7 +330,7 @@ describe('useEquipmentData', () => {
       await waitFor(() => {
         expect(mockCallRpc).toHaveBeenCalledWith(
           expect.objectContaining({
-            fn: 'equipment_list_enhanced',
+            fn: "equipment_list_enhanced",
             args: expect.objectContaining({
               p_tinh_trang_array: [...EQUIPMENT_ATTENTION_STATUSES],
               p_don_vi: 42,
@@ -328,21 +341,21 @@ describe('useEquipmentData', () => {
     })
   })
 
-  describe('Filter Options Queries', () => {
-    it('fetches department distribution using current search and filters without pagination', async () => {
+  describe("Filter Options Queries", () => {
+    it("fetches department distribution using current search and filters without pagination", async () => {
       const mockDistribution = [
-        { department: 'Khoa Ngoai', label: 'Khoa Ngoai', count: 7 },
-        { department: null, label: 'Chưa cập nhật', count: 2 },
+        { department: "Khoa Ngoai", label: "Khoa Ngoai", count: 7 },
+        { department: null, label: "Chưa cập nhật", count: 2 },
       ]
 
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 9 })
         }
-        if (fn === 'equipment_filter_buckets') {
+        if (fn === "equipment_filter_buckets") {
           return Promise.resolve({})
         }
-        if (fn === 'equipment_department_distribution') {
+        if (fn === "equipment_department_distribution") {
           return Promise.resolve(mockDistribution)
         }
         return Promise.resolve([])
@@ -352,14 +365,14 @@ describe('useEquipmentData', () => {
         () =>
           useEquipmentData(
             createDefaultParams({
-              debouncedSearch: 'bom tiem dien',
+              debouncedSearch: "bom tiem dien",
               pagination: { pageIndex: 3, pageSize: 25 },
-              selectedDepartments: ['Khoa Ngoai'],
-              selectedUsers: ['Nguyen Van A'],
-              selectedLocations: ['Phong 101'],
-              selectedStatuses: ['Hoat dong'],
-              selectedClassifications: ['May loai A'],
-              selectedFundingSources: ['Ngan sach'],
+              selectedDepartments: ["Khoa Ngoai"],
+              selectedUsers: ["Nguyen Van A"],
+              selectedLocations: ["Phong 101"],
+              selectedStatuses: ["Hoat dong"],
+              selectedClassifications: ["May loai A"],
+              selectedFundingSources: ["Ngan sach"],
             })
           ),
         { wrapper: createWrapper() }
@@ -370,36 +383,36 @@ describe('useEquipmentData', () => {
       })
 
       const distributionCall = mockCallRpc.mock.calls.find(
-        (call) => call[0].fn === 'equipment_department_distribution'
+        (call) => call[0].fn === "equipment_department_distribution"
       )?.[0]
 
       expect(distributionCall?.args).toEqual({
-        p_q: 'bom tiem dien',
+        p_q: "bom tiem dien",
         p_don_vi: 5,
-        p_khoa_phong_array: ['Khoa Ngoai'],
-        p_nguoi_su_dung_array: ['Nguyen Van A'],
-        p_vi_tri_lap_dat_array: ['Phong 101'],
-        p_tinh_trang_array: ['Hoat dong'],
-        p_phan_loai_array: ['May loai A'],
-        p_nguon_kinh_phi_array: ['Ngan sach'],
+        p_khoa_phong_array: ["Khoa Ngoai"],
+        p_nguoi_su_dung_array: ["Nguyen Van A"],
+        p_vi_tri_lap_dat_array: ["Phong 101"],
+        p_tinh_trang_array: ["Hoat dong"],
+        p_phan_loai_array: ["May loai A"],
+        p_nguon_kinh_phi_array: ["Ngan sach"],
       })
-      expect(distributionCall?.args).not.toHaveProperty('p_page')
-      expect(distributionCall?.args).not.toHaveProperty('p_page_size')
+      expect(distributionCall?.args).not.toHaveProperty("p_page")
+      expect(distributionCall?.args).not.toHaveProperty("p_page_size")
     })
 
-    it('should fetch all filter option buckets with a single RPC', async () => {
+    it("should fetch all filter option buckets with a single RPC", async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
-        if (fn === 'equipment_filter_buckets') {
+        if (fn === "equipment_filter_buckets") {
           return Promise.resolve({
-            department: [{ name: 'Khoa A', count: 5 }],
-            user: [{ name: 'Nguyen Van A', count: 3 }],
-            location: [{ name: 'Phong 101', count: 2 }],
-            status: [{ name: 'Hoat dong', count: 10 }],
-            classification: [{ name: 'Loai B', count: 7 }],
-            fundingSource: [{ name: 'Ngân sách nhà nước', count: 4 }],
+            department: [{ name: "Khoa A", count: 5 }],
+            user: [{ name: "Nguyen Van A", count: 3 }],
+            location: [{ name: "Phong 101", count: 2 }],
+            status: [{ name: "Hoat dong", count: 10 }],
+            classification: [{ name: "Loai B", count: 7 }],
+            fundingSource: [{ name: "Ngân sách nhà nước", count: 4 }],
           })
         }
         return Promise.resolve([])
@@ -411,31 +424,31 @@ describe('useEquipmentData', () => {
 
       await waitFor(() => {
         expect(result.current.filterData.department).toEqual([
-          { id: 'Khoa A', label: 'Khoa A', count: 5 },
+          { id: "Khoa A", label: "Khoa A", count: 5 },
         ])
       })
 
-      expect(result.current.departments).toEqual(['Khoa A'])
-      expect(result.current.users).toEqual(['Nguyen Van A'])
-      expect(result.current.locations).toEqual(['Phong 101'])
-      expect(result.current.statuses).toEqual(['Hoat dong'])
-      expect(result.current.classifications).toEqual(['Loai B'])
-      expect(result.current.fundingSources).toEqual(['Ngân sách nhà nước'])
+      expect(result.current.departments).toEqual(["Khoa A"])
+      expect(result.current.users).toEqual(["Nguyen Van A"])
+      expect(result.current.locations).toEqual(["Phong 101"])
+      expect(result.current.statuses).toEqual(["Hoat dong"])
+      expect(result.current.classifications).toEqual(["Loai B"])
+      expect(result.current.fundingSources).toEqual(["Ngân sách nhà nước"])
 
       expect(mockCallRpc).toHaveBeenCalledWith(
         expect.objectContaining({
-          fn: 'equipment_filter_buckets',
+          fn: "equipment_filter_buckets",
           args: expect.objectContaining({ p_don_vi: 5 }),
         })
       )
 
       const facetRpcNames = [
-        'departments_list_for_tenant',
-        'equipment_users_list_for_tenant',
-        'equipment_locations_list_for_tenant',
-        'equipment_statuses_list_for_tenant',
-        'equipment_classifications_list_for_tenant',
-        'equipment_funding_sources_list_for_tenant',
+        "departments_list_for_tenant",
+        "equipment_users_list_for_tenant",
+        "equipment_locations_list_for_tenant",
+        "equipment_statuses_list_for_tenant",
+        "equipment_classifications_list_for_tenant",
+        "equipment_funding_sources_list_for_tenant",
       ]
       const calledFacetRpcs = mockCallRpc.mock.calls
         .map((call) => call[0].fn)
@@ -444,16 +457,16 @@ describe('useEquipmentData', () => {
       expect(calledFacetRpcs).toEqual([])
     })
 
-    it('should expose department buckets for tenant', async () => {
+    it("should expose department buckets for tenant", async () => {
       const mockDepartments = [
-        { name: 'Khoa Noi', count: 10 },
-        { name: 'Khoa Ngoai', count: 5 },
+        { name: "Khoa Noi", count: 10 },
+        { name: "Khoa Ngoai", count: 5 },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_filter_buckets') {
+        if (fn === "equipment_filter_buckets") {
           return Promise.resolve({ department: mockDepartments })
         }
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
@@ -464,20 +477,20 @@ describe('useEquipmentData', () => {
       })
 
       await waitFor(() => {
-        expect(result.current.departments).toEqual(['Khoa Noi', 'Khoa Ngoai'])
+        expect(result.current.departments).toEqual(["Khoa Noi", "Khoa Ngoai"])
       })
     })
 
-    it('should expose user buckets for tenant', async () => {
+    it("should expose user buckets for tenant", async () => {
       const mockUsers = [
-        { name: 'Nguyen Van A', count: 3 },
-        { name: 'Tran Thi B', count: 2 },
+        { name: "Nguyen Van A", count: 3 },
+        { name: "Tran Thi B", count: 2 },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_filter_buckets') {
+        if (fn === "equipment_filter_buckets") {
           return Promise.resolve({ user: mockUsers })
         }
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
@@ -488,20 +501,20 @@ describe('useEquipmentData', () => {
       })
 
       await waitFor(() => {
-        expect(result.current.users).toEqual(['Nguyen Van A', 'Tran Thi B'])
+        expect(result.current.users).toEqual(["Nguyen Van A", "Tran Thi B"])
       })
     })
 
-    it('should expose status buckets for tenant', async () => {
+    it("should expose status buckets for tenant", async () => {
       const mockStatuses = [
-        { name: 'Hoat dong', count: 50 },
-        { name: 'Cho sua chua', count: 10 },
+        { name: "Hoat dong", count: 50 },
+        { name: "Cho sua chua", count: 10 },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_filter_buckets') {
+        if (fn === "equipment_filter_buckets") {
           return Promise.resolve({ status: mockStatuses })
         }
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
@@ -512,20 +525,20 @@ describe('useEquipmentData', () => {
       })
 
       await waitFor(() => {
-        expect(result.current.statuses).toEqual(['Hoat dong', 'Cho sua chua'])
+        expect(result.current.statuses).toEqual(["Hoat dong", "Cho sua chua"])
       })
     })
 
-    it('should build filterData correctly', async () => {
+    it("should build filterData correctly", async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
         switch (fn) {
-          case 'equipment_list_enhanced':
+          case "equipment_list_enhanced":
             return Promise.resolve({ data: [], total: 0 })
-          case 'equipment_filter_buckets':
+          case "equipment_filter_buckets":
             return Promise.resolve({
-              department: [{ name: 'Khoa A', count: 5 }],
-              status: [{ name: 'Hoat dong', count: 10 }],
-              location: [{ name: 'Phong 101', count: 3 }],
+              department: [{ name: "Khoa A", count: 5 }],
+              status: [{ name: "Hoat dong", count: 10 }],
+              location: [{ name: "Phong 101", count: 3 }],
             })
           default:
             return Promise.resolve([])
@@ -538,29 +551,29 @@ describe('useEquipmentData', () => {
 
       await waitFor(() => {
         expect(result.current.filterData.department).toEqual([
-          { id: 'Khoa A', label: 'Khoa A', count: 5 },
+          { id: "Khoa A", label: "Khoa A", count: 5 },
         ])
         expect(result.current.filterData.status).toEqual([
-          { id: 'Hoat dong', label: 'Hoat dong', count: 10 },
+          { id: "Hoat dong", label: "Hoat dong", count: 10 },
         ])
         expect(result.current.filterData.location).toEqual([
-          { id: 'Phong 101', label: 'Phong 101', count: 3 },
+          { id: "Phong 101", label: "Phong 101", count: 3 },
         ])
       })
     })
   })
 
-  describe('Global User Tenant List', () => {
-    it('should fetch tenant list for global users', async () => {
+  describe("Global User Tenant List", () => {
+    it("should fetch tenant list for global users", async () => {
       const mockTenants = [
-        { id: 1, name: 'Hospital A', code: 'HA' },
-        { id: 2, name: 'Hospital B', code: 'HB' },
+        { id: 1, name: "Hospital A", code: "HA" },
+        { id: 2, name: "Hospital B", code: "HB" },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'tenant_list') {
+        if (fn === "tenant_list") {
           return Promise.resolve(mockTenants)
         }
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
@@ -576,26 +589,27 @@ describe('useEquipmentData', () => {
       })
     })
 
-    it('should not fetch tenant list for non-global users', async () => {
-      const { result } = renderHook(() => useEquipmentData(createDefaultParams({ isGlobal: false })), {
-        wrapper: createWrapper(),
-      })
+    it("should not fetch tenant list for non-global users", async () => {
+      const { result } = renderHook(
+        () => useEquipmentData(createDefaultParams({ isGlobal: false })),
+        {
+          wrapper: createWrapper(),
+        }
+      )
 
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false)
       })
 
-      expect(mockCallRpc).not.toHaveBeenCalledWith(
-        expect.objectContaining({ fn: 'tenant_list' })
-      )
+      expect(mockCallRpc).not.toHaveBeenCalledWith(expect.objectContaining({ fn: "tenant_list" }))
     })
   })
 
-  describe('Error Handling', () => {
-    it('should handle RPC errors gracefully', async () => {
+  describe("Error Handling", () => {
+    it("should handle RPC errors gracefully", async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
-          return Promise.reject(new Error('Network error'))
+        if (fn === "equipment_list_enhanced") {
+          return Promise.reject(new Error("Network error"))
         }
         return Promise.resolve([])
       })
@@ -612,9 +626,9 @@ describe('useEquipmentData', () => {
       expect(result.current.data).toEqual([])
     })
 
-    it('should handle null response from RPC', async () => {
+    it("should handle null response from RPC", async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve(null)
         }
         return Promise.resolve([])
@@ -633,18 +647,18 @@ describe('useEquipmentData', () => {
     })
   })
 
-  describe('Cache Invalidation', () => {
-    it('should provide invalidateEquipmentForCurrentTenant function', async () => {
+  describe("Cache Invalidation", () => {
+    it("should provide invalidateEquipmentForCurrentTenant function", async () => {
       const { result } = renderHook(() => useEquipmentData(createDefaultParams()), {
         wrapper: createWrapper(),
       })
 
-      expect(typeof result.current.invalidateEquipmentForCurrentTenant).toBe('function')
+      expect(typeof result.current.invalidateEquipmentForCurrentTenant).toBe("function")
     })
 
-    it('should respond to equipment-cache-invalidated event', async () => {
+    it("should respond to equipment-cache-invalidated event", async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [{ id: 1 }], total: 1 })
         }
         return Promise.resolve([])
@@ -660,44 +674,47 @@ describe('useEquipmentData', () => {
 
       // Capture call count before event
       const callCountBeforeEvent = mockCallRpc.mock.calls.filter(
-        (call) => call[0].fn === 'equipment_list_enhanced'
+        (call) => call[0].fn === "equipment_list_enhanced"
       ).length
       const distributionCallCountBeforeEvent = mockCallRpc.mock.calls.filter(
-        (call) => call[0].fn === 'equipment_department_distribution'
+        (call) => call[0].fn === "equipment_department_distribution"
       ).length
 
       // Dispatch event
-      window.dispatchEvent(new CustomEvent('equipment-cache-invalidated'))
+      window.dispatchEvent(new CustomEvent("equipment-cache-invalidated"))
 
       // Should trigger refetch - call count should increase
       await waitFor(() => {
         const callCountAfterEvent = mockCallRpc.mock.calls.filter(
-          (call) => call[0].fn === 'equipment_list_enhanced'
+          (call) => call[0].fn === "equipment_list_enhanced"
         ).length
         expect(callCountAfterEvent).toBeGreaterThan(callCountBeforeEvent)
 
         const distributionCallCountAfterEvent = mockCallRpc.mock.calls.filter(
-          (call) => call[0].fn === 'equipment_department_distribution'
+          (call) => call[0].fn === "equipment_department_distribution"
         ).length
         expect(distributionCallCountAfterEvent).toBeGreaterThan(distributionCallCountBeforeEvent)
       })
     })
   })
 
-  describe('Regional Leader', () => {
-    it('should not fetch data when regional leader has no facility selected', async () => {
+  describe("Regional Leader", () => {
+    it("should not fetch data when regional leader has no facility selected", async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
       })
 
       const { result } = renderHook(
-        () => useEquipmentData(createDefaultParams({
-          isRegionalLeader: true,
-          selectedFacilityId: undefined,  // Not selected yet
-        })),
+        () =>
+          useEquipmentData(
+            createDefaultParams({
+              isRegionalLeader: true,
+              selectedFacilityId: undefined, // Not selected yet
+            })
+          ),
         { wrapper: createWrapper() }
       )
 
@@ -707,20 +724,23 @@ describe('useEquipmentData', () => {
       expect(result.current.shouldFetchData).toBe(false)
     })
 
-    it('should fetch data when regional leader has facility selected', async () => {
+    it("should fetch data when regional leader has facility selected", async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
       })
 
       const { result } = renderHook(
-        () => useEquipmentData(createDefaultParams({
-          isRegionalLeader: true,
-          selectedFacilityId: 42,
-          shouldFetchEquipment: true,
-        })),
+        () =>
+          useEquipmentData(
+            createDefaultParams({
+              isRegionalLeader: true,
+              selectedFacilityId: 42,
+              shouldFetchEquipment: true,
+            })
+          ),
         { wrapper: createWrapper() }
       )
 
@@ -730,17 +750,17 @@ describe('useEquipmentData', () => {
 
       expect(mockCallRpc).toHaveBeenCalledWith(
         expect.objectContaining({
-          fn: 'equipment_list_enhanced',
+          fn: "equipment_list_enhanced",
           args: expect.objectContaining({
-            p_don_vi: 42,  // Should use selectedFacilityId for regional leader
+            p_don_vi: 42, // Should use selectedFacilityId for regional leader
           }),
         })
       )
     })
 
-    it('should pass selectedDonVi to RPC when not regional leader', async () => {
+    it("should pass selectedDonVi to RPC when not regional leader", async () => {
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
@@ -754,7 +774,7 @@ describe('useEquipmentData', () => {
       await waitFor(() => {
         expect(mockCallRpc).toHaveBeenCalledWith(
           expect.objectContaining({
-            fn: 'equipment_list_enhanced',
+            fn: "equipment_list_enhanced",
             args: expect.objectContaining({
               p_don_vi: 42,
             }),
@@ -764,8 +784,8 @@ describe('useEquipmentData', () => {
     })
   })
 
-  describe('Facility Filter from Context', () => {
-    it('should expose showFacilityFilter from params', async () => {
+  describe("Facility Filter from Context", () => {
+    it("should expose showFacilityFilter from params", async () => {
       const { result } = renderHook(
         () => useEquipmentData(createDefaultParams({ showSelector: true })),
         { wrapper: createWrapper() }
@@ -774,55 +794,61 @@ describe('useEquipmentData', () => {
       expect(result.current.showFacilityFilter).toBe(true)
     })
 
-    it('should expose facilities from params', async () => {
+    it("should expose facilities from params", async () => {
       const mockFacilities = [
-        { id: 1, name: 'Facility 1', count: 10 },
-        { id: 2, name: 'Facility 2', count: 20 },
+        { id: 1, name: "Facility 1", count: 10 },
+        { id: 2, name: "Facility 2", count: 20 },
       ]
 
       const { result } = renderHook(
-        () => useEquipmentData(createDefaultParams({
-          showSelector: true,
-          facilities: mockFacilities,
-        })),
+        () =>
+          useEquipmentData(
+            createDefaultParams({
+              showSelector: true,
+              facilities: mockFacilities,
+            })
+          ),
         { wrapper: createWrapper() }
       )
 
       expect(result.current.facilities).toHaveLength(2)
-      expect(result.current.facilities[0].name).toBe('Facility 1')
+      expect(result.current.facilities[0].name).toBe("Facility 1")
     })
 
-    it('should compute activeFacility correctly', async () => {
+    it("should compute activeFacility correctly", async () => {
       const mockFacilities = [
-        { id: 1, name: 'Facility 1', count: 10 },
-        { id: 2, name: 'Facility 2', count: 20 },
+        { id: 1, name: "Facility 1", count: 10 },
+        { id: 2, name: "Facility 2", count: 20 },
       ]
 
       const { result } = renderHook(
-        () => useEquipmentData(createDefaultParams({
-          showSelector: true,
-          facilities: mockFacilities,
-          selectedFacilityId: 2,
-        })),
+        () =>
+          useEquipmentData(
+            createDefaultParams({
+              showSelector: true,
+              facilities: mockFacilities,
+              selectedFacilityId: 2,
+            })
+          ),
         { wrapper: createWrapper() }
       )
 
       expect(result.current.activeFacility?.id).toBe(2)
-      expect(result.current.activeFacility?.name).toBe('Facility 2')
+      expect(result.current.activeFacility?.name).toBe("Facility 2")
     })
   })
 
-  describe('Funding Source Filter', () => {
-    it('should expose funding source buckets for tenant', async () => {
+  describe("Funding Source Filter", () => {
+    it("should expose funding source buckets for tenant", async () => {
       const mockFundingSources = [
-        { name: 'Ngân sách nhà nước', count: 42 },
-        { name: 'Chưa có', count: 15 },
+        { name: "Ngân sách nhà nước", count: 42 },
+        { name: "Chưa có", count: 15 },
       ]
       mockCallRpc.mockImplementation(({ fn }: { fn: string }) => {
-        if (fn === 'equipment_filter_buckets') {
+        if (fn === "equipment_filter_buckets") {
           return Promise.resolve({ fundingSource: mockFundingSources })
         }
-        if (fn === 'equipment_list_enhanced') {
+        if (fn === "equipment_list_enhanced") {
           return Promise.resolve({ data: [], total: 0 })
         }
         return Promise.resolve([])
@@ -833,24 +859,27 @@ describe('useEquipmentData', () => {
       })
 
       await waitFor(() => {
-        expect(result.current.fundingSources).toEqual(['Ngân sách nhà nước', 'Chưa có'])
+        expect(result.current.fundingSources).toEqual(["Ngân sách nhà nước", "Chưa có"])
       })
     })
 
-    it('should pass funding sources filter to equipment_list_enhanced', async () => {
+    it("should pass funding sources filter to equipment_list_enhanced", async () => {
       const { result } = renderHook(
-        () => useEquipmentData(createDefaultParams({
-          selectedFundingSources: ['Ngân sách nhà nước', 'Chưa có'],
-        })),
+        () =>
+          useEquipmentData(
+            createDefaultParams({
+              selectedFundingSources: ["Ngân sách nhà nước", "Chưa có"],
+            })
+          ),
         { wrapper: createWrapper() }
       )
 
       await waitFor(() => {
         expect(mockCallRpc).toHaveBeenCalledWith(
           expect.objectContaining({
-            fn: 'equipment_list_enhanced',
+            fn: "equipment_list_enhanced",
             args: expect.objectContaining({
-              p_nguon_kinh_phi_array: ['Ngân sách nhà nước', 'Chưa có'],
+              p_nguon_kinh_phi_array: ["Ngân sách nhà nước", "Chưa có"],
             }),
           })
         )

--- a/src/app/(app)/equipment/__tests__/useEquipmentTable.selection.test.tsx
+++ b/src/app/(app)/equipment/__tests__/useEquipmentTable.selection.test.tsx
@@ -165,6 +165,50 @@ describe("useEquipmentTable row selection", () => {
   })
 })
 
+describe("useEquipmentTable server sorting", () => {
+  it("preserves server-provided row order when sorting state is controlled", () => {
+    const serverOrderedData = [
+      { ...createEquipment(1), ten_thiet_bi: "A - normal priority" },
+      { ...createEquipment(2), ten_thiet_bi: "Z - liquidation priority" },
+    ]
+    const serverColumns: ColumnDef<Equipment>[] = [
+      {
+        accessorKey: "ten_thiet_bi",
+        header: "Tên thiết bị",
+      },
+    ]
+
+    const { result } = renderHook(() => {
+      const [sorting, setSorting] = React.useState([{ id: "ten_thiet_bi", desc: true }])
+      const [columnFilters, setColumnFilters] = React.useState([])
+      const [searchTerm, setSearchTerm] = React.useState("")
+      const [pagination, setPagination] = React.useState({
+        pageIndex: 0,
+        pageSize: 20,
+      })
+
+      return useEquipmentTable({
+        data: serverOrderedData,
+        total: serverOrderedData.length,
+        columns: serverColumns,
+        sorting,
+        setSorting,
+        columnFilters,
+        setColumnFilters,
+        debouncedSearch: searchTerm,
+        setSearchTerm,
+        pagination,
+        setPagination,
+        selectedDonVi: 5,
+        selectedFacilityId: 5,
+      })
+    })
+
+    expect(result.current.table.options.manualSorting).toBe(true)
+    expect(result.current.table.getRowModel().rows.map((row) => row.id)).toEqual(["1", "2"])
+  })
+})
+
 describe("useEquipmentTable responsive visibility", () => {
   it("auto-hides the desktop-only columns on 768px-1800px screens", async () => {
     setMediaQueryResponses({

--- a/src/app/(app)/equipment/_components/EquipmentDetailDialog/index.tsx
+++ b/src/app/(app)/equipment/_components/EquipmentDetailDialog/index.tsx
@@ -35,11 +35,18 @@ import {
   DEFAULT_EQUIPMENT_FORM_VALUES,
   equipmentToFormValues,
 } from "@/components/equipment-edit/EquipmentEditFormDefaults"
+import { didEnterLiquidationEndState } from "@/components/equipment-edit/EquipmentEditTransitions"
 import { useEquipmentEditUpdate } from "@/components/equipment-edit/useEquipmentEditUpdate"
 import { useEquipmentHistory } from "./hooks/useEquipmentHistory"
 import { useEquipmentAttachments } from "./hooks/useEquipmentAttachments"
 import { EquipmentDetailFooter } from "./EquipmentDetailFooter"
 import { EquipmentDetailTabs } from "./EquipmentDetailTabs"
+
+const LIQUIDATION_SUCCESS_TOAST = {
+  title: "Đã chuyển thiết bị",
+  description:
+    "Thiết bị đã được chuyển về cuối danh sách vì đang Ngưng sử dụng và thuộc Kho thanh lý.",
+}
 
 export interface EquipmentDetailDialogProps {
   equipment: Equipment | null
@@ -139,8 +146,15 @@ function EquipmentDetailDialogState({
   // Handlers
   const onSubmitInlineEdit = async (values: EquipmentFormValues): Promise<void> => {
     if (!equipment) return
+    const previousValues = savedValues ?? equipmentToFormValues(equipment)
+    const enteredLiquidationEndState = didEnterLiquidationEndState(previousValues, values)
+
     try {
-      await updateEquipment({ id: equipment.id, patch: values })
+      await updateEquipment({
+        id: equipment.id,
+        patch: values,
+        ...(enteredLiquidationEndState ? { successToast: LIQUIDATION_SUCCESS_TOAST } : {}),
+      })
     } catch {
       // The mutation toast already reports the failure; keep submit handlers from leaking rejections.
     }

--- a/src/app/(app)/equipment/_hooks/useEquipmentData.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentData.ts
@@ -183,6 +183,7 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
         page: pagination.pageIndex,
         size: pagination.pageSize,
         sort: sortParam,
+        liquidationLast: true,
       },
     ],
     enabled: shouldFetchData,
@@ -194,6 +195,7 @@ export function useEquipmentData(params: UseEquipmentDataParams): UseEquipmentDa
           p_sort: sortParam,
           p_page: effectivePage,
           p_page_size: effectivePageSize,
+          p_liquidation_last: true,
         },
         signal,
       })

--- a/src/app/(app)/equipment/_hooks/useEquipmentTable.ts
+++ b/src/app/(app)/equipment/_hooks/useEquipmentTable.ts
@@ -9,12 +9,7 @@ import type {
   VisibilityState,
   Table,
 } from "@tanstack/react-table"
-import {
-  getCoreRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
-  useReactTable,
-} from "@tanstack/react-table"
+import { getCoreRowModel, getPaginationRowModel, useReactTable } from "@tanstack/react-table"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useIsMobile } from "@/hooks/use-mobile"
 import {
@@ -25,7 +20,7 @@ import { DEFAULT_COLUMN_VISIBILITY } from "@/app/(app)/equipment/_constants/equi
 import type { Equipment } from "../types"
 
 // Columns to hide on medium screens (768px-1800px)
-const RESPONSIVE_HIDE_COLUMNS = ['serial', 'phan_loai_theo_nd98', 'so_luu_hanh'] as const
+const RESPONSIVE_HIDE_COLUMNS = ["serial", "phan_loai_theo_nd98", "so_luu_hanh"] as const
 
 function restoreResponsivePreference(
   visibility: VisibilityState,
@@ -222,7 +217,6 @@ export function useEquipmentTable(params: UseEquipmentTableParams): UseEquipment
     onRowSelectionChange: setRowSelection,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     getRowId: (row) => String(row.id),
     onColumnVisibilityChange: setColumnVisibility,
     onGlobalFilterChange: (value: string) => setSearchTerm(value),
@@ -237,6 +231,7 @@ export function useEquipmentTable(params: UseEquipmentTableParams): UseEquipment
     },
     manualPagination: true,
     manualFiltering: true,
+    manualSorting: true,
     pageCount: pageCount,
   })
 

--- a/src/app/api/rpc/__tests__/equipment-list-liquidation-order-migration.test.ts
+++ b/src/app/api/rpc/__tests__/equipment-list-liquidation-order-migration.test.ts
@@ -1,0 +1,89 @@
+import { readdirSync, readFileSync } from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const MIGRATION_SUFFIX = "equipment_list_liquidation_last.sql"
+const PREVIOUS_MIGRATION = "20260704074500_align_equipment_list_filters_with_bucket_labels.sql"
+
+function getMigration() {
+  const migrationsDir = path.resolve(process.cwd(), "supabase/migrations")
+  const migrationFiles = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith(MIGRATION_SUFFIX))
+    .sort()
+
+  expect(migrationFiles).toHaveLength(1)
+
+  const migrationFile = migrationFiles[0] ?? ""
+  expect(migrationFile > PREVIOUS_MIGRATION).toBe(true)
+
+  return {
+    file: migrationFile,
+    source: migrationFile ? readFileSync(path.join(migrationsDir, migrationFile), "utf8") : "",
+  }
+}
+
+function compactSql(source: string) {
+  return source.replace(/\s+/g, " ").trim()
+}
+
+describe("equipment list liquidation-last migration", () => {
+  it("replaces the sole RPC signature with a backward-compatible opt-in flag", () => {
+    const { source } = getMigration()
+    const compact = compactSql(source)
+    const dropPosition = compact.indexOf(
+      "DROP FUNCTION IF EXISTS public.equipment_list_enhanced( text, text, integer, integer, bigint, text, text[], text, text[], text, text[], text, text[], text, text[], text, text[] )"
+    )
+    const createPosition = compact.indexOf(
+      "CREATE OR REPLACE FUNCTION public.equipment_list_enhanced("
+    )
+
+    expect(dropPosition).toBeGreaterThanOrEqual(0)
+    expect(createPosition).toBeGreaterThan(dropPosition)
+    expect(compact).toContain("p_liquidation_last boolean DEFAULT false ) RETURNS jsonb")
+    expect(compact).toContain("SECURITY DEFINER")
+    expect(compact).toContain("SET search_path = public, pg_temp")
+  })
+
+  it("prioritizes only exact both-condition matches before requested sorting and pagination", () => {
+    const { source } = getMigration()
+    const compact = compactSql(source)
+    const flagBranch = compact.indexOf("IF p_liquidation_last THEN")
+    const priorityStart = compact.indexOf("CASE", flagBranch)
+    const priorityEnd = compact.indexOf("END ASC", priorityStart)
+    const requestedSort = compact.indexOf("tb.%I %s", priorityEnd)
+    const dynamicOrder = compact.indexOf("ORDER BY %s", requestedSort)
+    const offset = compact.indexOf("OFFSET %s LIMIT %s", dynamicOrder)
+    const priorityExpression = compact.slice(priorityStart, priorityEnd).replace(/''/g, "'")
+
+    expect(flagBranch).toBeGreaterThanOrEqual(0)
+    expect(priorityStart).toBeGreaterThanOrEqual(0)
+    expect(priorityEnd).toBeGreaterThan(priorityStart)
+    expect(priorityExpression).toContain(
+      "public._normalize_department_scope(tb.khoa_phong_quan_ly) = public._normalize_department_scope('VT-TBYT- KHO THANH LÍ')"
+    )
+    expect(priorityExpression).toContain("AND btrim(tb.tinh_trang_hien_tai) = 'Ngưng sử dụng'")
+    expect(priorityExpression).not.toMatch(/\b(?:LIKE|ILIKE)\b/i)
+    expect(requestedSort).toBeGreaterThan(priorityEnd)
+    expect(dynamicOrder).toBeGreaterThan(requestedSort)
+    expect(offset).toBeGreaterThan(dynamicOrder)
+    expect(compact).toContain("ELSE v_order_by := format('tb.%I %s', v_sort_col, v_sort_dir)")
+  })
+
+  it("restores least-privilege execute grants for the 18-argument signature", () => {
+    const { source } = getMigration()
+    const compact = compactSql(source)
+    const signature =
+      "text, text, integer, integer, bigint, text, text[], text, text[], text, text[], text, text[], text, text[], text, text[], boolean"
+
+    expect(compact).toContain(
+      `REVOKE ALL ON FUNCTION public.equipment_list_enhanced( ${signature} ) FROM PUBLIC`
+    )
+    expect(compact).toContain(
+      `REVOKE ALL ON FUNCTION public.equipment_list_enhanced( ${signature} ) FROM anon`
+    )
+    expect(compact).toContain(
+      `GRANT EXECUTE ON FUNCTION public.equipment_list_enhanced( ${signature} ) TO authenticated`
+    )
+  })
+})

--- a/src/components/__tests__/useEquipmentEditUpdate.test.tsx
+++ b/src/components/__tests__/useEquipmentEditUpdate.test.tsx
@@ -16,6 +16,12 @@ vi.mock("@/lib/rpc-client", () => ({
 
 import { useEquipmentEditUpdate } from "../equipment-edit/useEquipmentEditUpdate"
 
+const specialToast = {
+  title: "Đã chuyển thiết bị",
+  description:
+    "Thiết bị đã được chuyển về cuối danh sách vì đang Ngưng sử dụng và thuộc Kho thanh lý.",
+}
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -25,11 +31,7 @@ function createWrapper() {
   })
 
   return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
-    )
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   }
 }
 
@@ -38,7 +40,7 @@ describe("useEquipmentEditUpdate", () => {
     vi.clearAllMocks()
   })
 
-  it("submits equipment_update with the patch and shows the success toast", async () => {
+  it("submits equipment_update with the patch and shows one success toast", async () => {
     mockCallRpc.mockResolvedValueOnce(undefined)
     const onSuccess = vi.fn()
 
@@ -66,19 +68,36 @@ describe("useEquipmentEditUpdate", () => {
       },
     })
     expect(onSuccess).toHaveBeenCalledWith(patch)
+    expect(mockToast).toHaveBeenCalledTimes(1)
     expect(mockToast).toHaveBeenCalledWith({
       title: "Thành công",
       description: "Đã cập nhật thông tin thiết bị.",
     })
   })
 
-  it("shows the normalized error toast and preserves the hook error state", async () => {
+  it("replaces the generic toast with one per-mutation success toast", async () => {
+    mockCallRpc.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useEquipmentEditUpdate(), {
+      wrapper: createWrapper(),
+    })
+
+    await result.current.updateEquipment({
+      id: 16,
+      patch: { ten_thiet_bi: "Máy theo dõi" },
+      successToast: specialToast,
+    })
+
+    expect(mockToast).toHaveBeenCalledTimes(1)
+    expect(mockToast).toHaveBeenCalledWith(specialToast)
+    expect(mockToast).not.toHaveBeenCalledWith(expect.objectContaining({ title: "Thành công" }))
+  })
+
+  it("shows one normalized error toast and preserves the hook error state", async () => {
     mockCallRpc.mockRejectedValueOnce({ message: "Permission denied" })
 
-    const { result } = renderHook(
-      () => useEquipmentEditUpdate(),
-      { wrapper: createWrapper() }
-    )
+    const { result } = renderHook(() => useEquipmentEditUpdate(), {
+      wrapper: createWrapper(),
+    })
 
     await expect(
       result.current.updateEquipment({
@@ -88,6 +107,7 @@ describe("useEquipmentEditUpdate", () => {
     ).rejects.toEqual({ message: "Permission denied" })
 
     await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledTimes(1)
       expect(mockToast).toHaveBeenCalledWith({
         variant: "destructive",
         title: "Lỗi",

--- a/src/components/equipment-edit/EquipmentEditTransitions.ts
+++ b/src/components/equipment-edit/EquipmentEditTransitions.ts
@@ -1,0 +1,45 @@
+/** Canonical department label used to identify the liquidation warehouse. */
+export const LIQUIDATION_DEPARTMENT_NAME = "VT-TBYT- KHO THANH LÍ"
+/** Canonical equipment status used for decommissioned equipment. */
+export const DECOMMISSIONED_EQUIPMENT_STATUS = "Ngưng sử dụng"
+
+interface EquipmentLiquidationStateValues {
+  khoa_phong_quan_ly?: string | null
+  tinh_trang_hien_tai?: string | null
+}
+
+function normalizeBusinessValue(value: string | null | undefined): string {
+  return (value ?? "").normalize("NFC").trim().toLocaleLowerCase("vi-VN")
+}
+
+function normalizeDepartmentScope(value: string | null | undefined): string {
+  return (value ?? "")
+    .normalize("NFC")
+    .replace(/\u00a0/g, " ")
+    .replace(/[\r\n\t]/g, " ")
+    .replace(/-+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLocaleLowerCase("vi-VN")
+}
+
+const NORMALIZED_LIQUIDATION_DEPARTMENT = normalizeDepartmentScope(LIQUIDATION_DEPARTMENT_NAME)
+const NORMALIZED_DECOMMISSIONED_STATUS = normalizeBusinessValue(DECOMMISSIONED_EQUIPMENT_STATUS)
+
+/** Returns whether the equipment satisfies both liquidation-list conditions. */
+export function isLiquidationEndState(
+  values: EquipmentLiquidationStateValues | null | undefined
+): boolean {
+  return (
+    normalizeDepartmentScope(values?.khoa_phong_quan_ly) === NORMALIZED_LIQUIDATION_DEPARTMENT &&
+    normalizeBusinessValue(values?.tinh_trang_hien_tai) === NORMALIZED_DECOMMISSIONED_STATUS
+  )
+}
+
+/** Returns whether an edit moved equipment into the liquidation-list end state. */
+export function didEnterLiquidationEndState(
+  before: EquipmentLiquidationStateValues | null | undefined,
+  after: EquipmentLiquidationStateValues | null | undefined
+): boolean {
+  return !isLiquidationEndState(before) && isLiquidationEndState(after)
+}

--- a/src/components/equipment-edit/EquipmentEditTransitions.ts
+++ b/src/components/equipment-edit/EquipmentEditTransitions.ts
@@ -8,10 +8,6 @@ interface EquipmentLiquidationStateValues {
   tinh_trang_hien_tai?: string | null
 }
 
-function normalizeBusinessValue(value: string | null | undefined): string {
-  return (value ?? "").normalize("NFC").trim().toLocaleLowerCase("vi-VN")
-}
-
 function normalizeDepartmentScope(value: string | null | undefined): string {
   return (value ?? "")
     .normalize("NFC")
@@ -24,7 +20,6 @@ function normalizeDepartmentScope(value: string | null | undefined): string {
 }
 
 const NORMALIZED_LIQUIDATION_DEPARTMENT = normalizeDepartmentScope(LIQUIDATION_DEPARTMENT_NAME)
-const NORMALIZED_DECOMMISSIONED_STATUS = normalizeBusinessValue(DECOMMISSIONED_EQUIPMENT_STATUS)
 
 /** Returns whether the equipment satisfies both liquidation-list conditions. */
 export function isLiquidationEndState(
@@ -32,7 +27,7 @@ export function isLiquidationEndState(
 ): boolean {
   return (
     normalizeDepartmentScope(values?.khoa_phong_quan_ly) === NORMALIZED_LIQUIDATION_DEPARTMENT &&
-    normalizeBusinessValue(values?.tinh_trang_hien_tai) === NORMALIZED_DECOMMISSIONED_STATUS
+    (values?.tinh_trang_hien_tai ?? "").trim() === DECOMMISSIONED_EQUIPMENT_STATUS
   )
 }
 

--- a/src/components/equipment-edit/__tests__/EquipmentEditTransitions.test.ts
+++ b/src/components/equipment-edit/__tests__/EquipmentEditTransitions.test.ts
@@ -71,18 +71,35 @@ describe("equipment liquidation transition", () => {
     expect(didEnterLiquidationEndState(liquidationEquipment, liquidationEquipment)).toBe(false)
   })
 
-  it("uses strict equality after NFC, trim, and locale-aware case normalization", () => {
+  it("normalizes the department while accepting the trimmed canonical status", () => {
     const equivalentValues = {
       khoa_phong_quan_ly: ` ${LIQUIDATION_DEPARTMENT_NAME.normalize("NFD").toLocaleLowerCase(
         "vi-VN"
       )} `,
-      tinh_trang_hien_tai: ` ${DECOMMISSIONED_EQUIPMENT_STATUS.normalize("NFD").toLocaleUpperCase(
-        "vi-VN"
-      )} `,
+      tinh_trang_hien_tai: ` ${DECOMMISSIONED_EQUIPMENT_STATUS} `,
     }
 
     expect(isLiquidationEndState(equivalentValues)).toBe(true)
     expect(didEnterLiquidationEndState(activeEquipment, equivalentValues)).toBe(true)
+  })
+
+  it.each([
+    {
+      name: "case variant",
+      status: DECOMMISSIONED_EQUIPMENT_STATUS.toLocaleUpperCase("vi-VN"),
+    },
+    {
+      name: "Unicode decomposition variant",
+      status: DECOMMISSIONED_EQUIPMENT_STATUS.normalize("NFD"),
+    },
+  ])("rejects a non-canonical status $name", ({ status }) => {
+    const nonCanonicalValues = {
+      khoa_phong_quan_ly: LIQUIDATION_DEPARTMENT_NAME,
+      tinh_trang_hien_tai: status,
+    }
+
+    expect(isLiquidationEndState(nonCanonicalValues)).toBe(false)
+    expect(didEnterLiquidationEndState(activeEquipment, nonCanonicalValues)).toBe(false)
   })
 
   it("matches the server department normalization for hyphens and internal whitespace", () => {

--- a/src/components/equipment-edit/__tests__/EquipmentEditTransitions.test.ts
+++ b/src/components/equipment-edit/__tests__/EquipmentEditTransitions.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  DECOMMISSIONED_EQUIPMENT_STATUS,
+  didEnterLiquidationEndState,
+  isLiquidationEndState,
+  LIQUIDATION_DEPARTMENT_NAME,
+} from "../EquipmentEditTransitions"
+
+const activeEquipment = {
+  khoa_phong_quan_ly: "Khoa Hồi sức",
+  tinh_trang_hien_tai: "Hoạt động",
+}
+
+const liquidationEquipment = {
+  khoa_phong_quan_ly: LIQUIDATION_DEPARTMENT_NAME,
+  tinh_trang_hien_tai: DECOMMISSIONED_EQUIPMENT_STATUS,
+}
+
+describe("equipment liquidation transition", () => {
+  it("detects entering the end state when both required values change", () => {
+    expect(didEnterLiquidationEndState(activeEquipment, liquidationEquipment)).toBe(true)
+  })
+
+  it.each([
+    {
+      name: "only status matches",
+      after: {
+        khoa_phong_quan_ly: activeEquipment.khoa_phong_quan_ly,
+        tinh_trang_hien_tai: DECOMMISSIONED_EQUIPMENT_STATUS,
+      },
+    },
+    {
+      name: "only department matches",
+      after: {
+        khoa_phong_quan_ly: LIQUIDATION_DEPARTMENT_NAME,
+        tinh_trang_hien_tai: activeEquipment.tinh_trang_hien_tai,
+      },
+    },
+    {
+      name: "department is only a partial match",
+      after: {
+        khoa_phong_quan_ly: `${LIQUIDATION_DEPARTMENT_NAME} PHỤ`,
+        tinh_trang_hien_tai: DECOMMISSIONED_EQUIPMENT_STATUS,
+      },
+    },
+  ])("returns false when $name", ({ after }) => {
+    expect(didEnterLiquidationEndState(activeEquipment, after)).toBe(false)
+  })
+
+  it("does not report a transition for an unrelated edit to an already matching device", () => {
+    expect(didEnterLiquidationEndState(liquidationEquipment, liquidationEquipment)).toBe(false)
+  })
+
+  it("uses strict equality after NFC, trim, and locale-aware case normalization", () => {
+    const equivalentValues = {
+      khoa_phong_quan_ly: ` ${LIQUIDATION_DEPARTMENT_NAME.normalize("NFD").toLocaleLowerCase(
+        "vi-VN"
+      )} `,
+      tinh_trang_hien_tai: ` ${DECOMMISSIONED_EQUIPMENT_STATUS.normalize("NFD").toLocaleUpperCase(
+        "vi-VN"
+      )} `,
+    }
+
+    expect(isLiquidationEndState(equivalentValues)).toBe(true)
+    expect(didEnterLiquidationEndState(activeEquipment, equivalentValues)).toBe(true)
+  })
+
+  it("matches the server department normalization for hyphens and internal whitespace", () => {
+    const serverEquivalentValues = {
+      khoa_phong_quan_ly: "\u00a0VT---TBYT\tKHO   THANH LÍ\n",
+      tinh_trang_hien_tai: DECOMMISSIONED_EQUIPMENT_STATUS,
+    }
+
+    expect(isLiquidationEndState(serverEquivalentValues)).toBe(true)
+    expect(didEnterLiquidationEndState(activeEquipment, serverEquivalentValues)).toBe(true)
+  })
+})

--- a/src/components/equipment-edit/__tests__/EquipmentEditTransitions.test.ts
+++ b/src/components/equipment-edit/__tests__/EquipmentEditTransitions.test.ts
@@ -18,8 +18,27 @@ const liquidationEquipment = {
 }
 
 describe("equipment liquidation transition", () => {
-  it("detects entering the end state when both required values change", () => {
-    expect(didEnterLiquidationEndState(activeEquipment, liquidationEquipment)).toBe(true)
+  it.each([
+    {
+      name: "only department changes because status already matches",
+      before: {
+        khoa_phong_quan_ly: activeEquipment.khoa_phong_quan_ly,
+        tinh_trang_hien_tai: DECOMMISSIONED_EQUIPMENT_STATUS,
+      },
+    },
+    {
+      name: "only status changes because department already matches",
+      before: {
+        khoa_phong_quan_ly: LIQUIDATION_DEPARTMENT_NAME,
+        tinh_trang_hien_tai: activeEquipment.tinh_trang_hien_tai,
+      },
+    },
+    {
+      name: "both required values change",
+      before: activeEquipment,
+    },
+  ])("detects entering the end state when $name", ({ before }) => {
+    expect(didEnterLiquidationEndState(before, liquidationEquipment)).toBe(true)
   })
 
   it.each([

--- a/src/components/equipment-edit/useEquipmentEditUpdate.ts
+++ b/src/components/equipment-edit/useEquipmentEditUpdate.ts
@@ -15,6 +15,10 @@ interface UseEquipmentEditUpdateOptions {
 interface UpdateEquipmentParams {
   id: number
   patch: Partial<EquipmentFormValues>
+  successToast?: {
+    title: string
+    description: string
+  }
 }
 
 interface UseEquipmentEditUpdateReturn {
@@ -23,6 +27,7 @@ interface UseEquipmentEditUpdateReturn {
   error: Error | null
 }
 
+/** Updates equipment data and reports the mutation result through toast callbacks. */
 export function useEquipmentEditUpdate({
   onSuccess,
   onError,
@@ -39,8 +44,13 @@ export function useEquipmentEditUpdate({
       })
       return vars.patch
     },
-    onSuccess: (savedPatch) => {
-      toast({ title: "Thành công", description: successMessage })
+    onSuccess: (savedPatch, variables) => {
+      const selectedToast = variables.successToast ?? {
+        title: "Thành công",
+        description: successMessage,
+      }
+
+      toast(selectedToast)
       onSuccess?.(savedPatch)
     },
     onError: (error: Error) => {

--- a/supabase/migrations/20260722094302_equipment_list_liquidation_last.sql
+++ b/supabase/migrations/20260722094302_equipment_list_liquidation_last.sql
@@ -1,0 +1,383 @@
+-- Keep liquidation equipment at the end of the main Equipments result when requested.
+--
+-- The final flag defaults to false so existing RPC consumers retain their
+-- current ordering. The main Equipments table opts in explicitly.
+--
+-- Forward-only rollback: add a later migration that restores the
+-- equipment_list_enhanced body from
+-- 20260704074500_align_equipment_list_filters_with_bucket_labels.sql.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+);
+
+CREATE OR REPLACE FUNCTION public.equipment_list_enhanced(
+  p_q text DEFAULT NULL::text,
+  p_sort text DEFAULT 'id.asc'::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung text DEFAULT NULL::text,
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat text DEFAULT NULL::text,
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang text DEFAULT NULL::text,
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai text DEFAULT NULL::text,
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi text DEFAULT NULL::text,
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[],
+  p_liquidation_last boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role TEXT := '';
+  v_user_id TEXT := NULL;
+  v_claim_donvi BIGINT := NULL;
+  v_allowed_don_vi BIGINT[];
+  v_effective_donvi BIGINT := NULL;
+  v_department_scope TEXT;
+  v_sort_col TEXT := 'id';
+  v_sort_dir TEXT := 'ASC';
+  v_order_by TEXT;
+  v_limit INT := GREATEST(p_page_size, 1);
+  v_offset INT := GREATEST(p_page - 1, 0) * GREATEST(p_page_size, 1);
+  v_where TEXT := '1=1 AND is_deleted = false';
+  v_total BIGINT := 0;
+  v_data JSONB := '[]'::jsonb;
+  v_jwt_claims JSONB;
+  v_sanitized_q TEXT;
+  v_unclassified_label CONSTANT TEXT := 'Chưa phân loại';
+  v_empty_user_label CONSTANT TEXT := 'Chưa có người sử dụng';
+  v_empty_location_label CONSTANT TEXT := 'Chưa có vị trí';
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := COALESCE(
+    v_jwt_claims ->>'app_role',
+    v_jwt_claims ->>'role',
+    ''
+  );
+  v_user_id := NULLIF(v_jwt_claims ->>'user_id', '');
+  v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
+  END IF;
+
+  IF p_sort IS NOT NULL AND p_sort != '' THEN
+    v_sort_col := split_part(p_sort, '.', 1);
+    v_sort_dir := UPPER(COALESCE(NULLIF(split_part(p_sort, '.', 2), ''), 'ASC'));
+    IF v_sort_dir NOT IN ('ASC', 'DESC') THEN
+      v_sort_dir := 'ASC';
+    END IF;
+    IF v_sort_col NOT IN (
+      'id', 'ma_thiet_bi', 'ten_thiet_bi', 'model', 'serial',
+      'khoa_phong_quan_ly', 'tinh_trang_hien_tai', 'vi_tri_lap_dat',
+      'nguoi_dang_truc_tiep_quan_ly', 'phan_loai_theo_nd98', 'nguon_kinh_phi', 'don_vi',
+      'gia_goc', 'ngay_nhap', 'ngay_dua_vao_su_dung', 'ngay_bt_tiep_theo',
+      'so_luu_hanh'
+    ) THEN
+      v_sort_col := 'id';
+    END IF;
+  END IF;
+
+  IF p_liquidation_last THEN
+    v_order_by := format(
+      'CASE
+         WHEN public._normalize_department_scope(tb.khoa_phong_quan_ly)
+                = public._normalize_department_scope(''VT-TBYT- KHO THANH LÍ'')
+          AND btrim(tb.tinh_trang_hien_tai) = ''Ngưng sử dụng''
+         THEN 1
+         ELSE 0
+       END ASC,
+       tb.%I %s,
+       tb.id ASC',
+      v_sort_col,
+      v_sort_dir
+    );
+  ELSE
+    v_order_by := format('tb.%I %s', v_sort_col, v_sort_dir);
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF lower(v_role) IN ('global', 'admin') THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective_donvi := p_don_vi;
+    ELSE
+      v_effective_donvi := NULL;
+    END IF;
+  ELSE
+    IF v_allowed_don_vi IS NOT NULL AND array_length(v_allowed_don_vi, 1) > 0 THEN
+      IF p_don_vi IS NOT NULL THEN
+        IF p_don_vi = ANY(v_allowed_don_vi) THEN
+          v_effective_donvi := p_don_vi;
+        ELSE
+          RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'Access denied for tenant');
+        END IF;
+      ELSE
+        v_effective_donvi := NULL;
+      END IF;
+    ELSE
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'No tenant access');
+    END IF;
+  END IF;
+
+  IF lower(v_role) = 'user' AND v_department_scope IS NULL THEN
+    RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+  END IF;
+
+  IF v_effective_donvi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ' || v_effective_donvi;
+  END IF;
+
+  IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin') AND v_allowed_don_vi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = '
+      || quote_literal(v_department_scope);
+  END IF;
+
+  IF p_khoa_phong_array IS NOT NULL AND array_length(p_khoa_phong_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_khoa_phong_array) AS x), ',') || '])';
+  ELSIF p_khoa_phong IS NOT NULL AND trim(p_khoa_phong) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_khoa_phong);
+  END IF;
+
+  IF p_nguoi_su_dung_array IS NOT NULL AND array_length(p_nguoi_su_dung_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''''), ' || quote_literal(v_empty_user_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguoi_su_dung_array) AS x), ',') || '])';
+  ELSIF p_nguoi_su_dung IS NOT NULL AND trim(p_nguoi_su_dung) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''''), ' || quote_literal(v_empty_user_label) || ') = ' || quote_literal(p_nguoi_su_dung);
+  END IF;
+
+  IF p_vi_tri_lap_dat_array IS NOT NULL AND array_length(p_vi_tri_lap_dat_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''''), ' || quote_literal(v_empty_location_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_vi_tri_lap_dat_array) AS x), ',') || '])';
+  ELSIF p_vi_tri_lap_dat IS NOT NULL AND trim(p_vi_tri_lap_dat) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''''), ' || quote_literal(v_empty_location_label) || ') = ' || quote_literal(p_vi_tri_lap_dat);
+  END IF;
+
+  IF p_tinh_trang_array IS NOT NULL AND array_length(p_tinh_trang_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_tinh_trang_array) AS x), ',') || '])';
+  ELSIF p_tinh_trang IS NOT NULL AND trim(p_tinh_trang) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_tinh_trang);
+  END IF;
+
+  IF p_phan_loai_array IS NOT NULL AND array_length(p_phan_loai_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_phan_loai_array) AS x), ',') || '])';
+  ELSIF p_phan_loai IS NOT NULL AND trim(p_phan_loai) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_phan_loai);
+  END IF;
+
+  IF p_nguon_kinh_phi_array IS NOT NULL AND array_length(p_nguon_kinh_phi_array, 1) > 0 THEN
+    IF 'Chưa có' = ANY(p_nguon_kinh_phi_array) THEN
+      DECLARE v_non_empty_sources TEXT[];
+      BEGIN
+        SELECT ARRAY(SELECT x FROM unnest(p_nguon_kinh_phi_array) AS x WHERE x != 'Chưa có') INTO v_non_empty_sources;
+        IF v_non_empty_sources IS NOT NULL AND array_length(v_non_empty_sources, 1) > 0 THEN
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''' OR TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+            array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(v_non_empty_sources) AS x), ',') || ']))';
+        ELSE
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+        END IF;
+      END;
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+        array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguon_kinh_phi_array) AS x), ',') || '])';
+    END IF;
+  ELSIF p_nguon_kinh_phi IS NOT NULL AND trim(p_nguon_kinh_phi) != '' THEN
+    IF p_nguon_kinh_phi = 'Chưa có' THEN
+      v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ' || quote_literal(p_nguon_kinh_phi);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_where := v_where || ' AND (ten_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR ma_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR serial ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR so_luu_hanh ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR model ILIKE ' || quote_literal('%' || v_sanitized_q || '%') || ')';
+  END IF;
+
+  EXECUTE format('SELECT count(*) FROM public.thiet_bi WHERE %s', v_where) INTO v_total;
+
+  EXECUTE format(
+    'SELECT COALESCE(jsonb_agg(t), ''[]''::jsonb) FROM (
+       SELECT (jsonb_build_object(
+         ''ma_thiet_bi'', tb.ma_thiet_bi,
+         ''ten_thiet_bi'', tb.ten_thiet_bi,
+         ''model'', tb.model,
+         ''serial'', tb.serial,
+         ''cau_hinh_thiet_bi'', tb.cau_hinh_thiet_bi,
+         ''phu_kien_kem_theo'', tb.phu_kien_kem_theo,
+         ''hang_san_xuat'', tb.hang_san_xuat,
+         ''noi_san_xuat'', tb.noi_san_xuat,
+         ''nam_san_xuat'', tb.nam_san_xuat,
+         ''ngay_nhap'', tb.ngay_nhap,
+         ''ngay_dua_vao_su_dung'', tb.ngay_dua_vao_su_dung,
+         ''nguon_kinh_phi'', tb.nguon_kinh_phi,
+         ''gia_goc'', tb.gia_goc,
+         ''nam_tinh_hao_mon'', tb.nam_tinh_hao_mon,
+         ''ty_le_hao_mon'', tb.ty_le_hao_mon,
+         ''han_bao_hanh'', tb.han_bao_hanh,
+         ''vi_tri_lap_dat'', tb.vi_tri_lap_dat,
+         ''nguoi_dang_truc_tiep_quan_ly'', tb.nguoi_dang_truc_tiep_quan_ly,
+         ''khoa_phong_quan_ly'', tb.khoa_phong_quan_ly,
+         ''tinh_trang_hien_tai'', tb.tinh_trang_hien_tai,
+         ''ghi_chu'', tb.ghi_chu,
+         ''chu_ky_bt_dinh_ky'', tb.chu_ky_bt_dinh_ky,
+         ''ngay_bt_tiep_theo'', tb.ngay_bt_tiep_theo,
+         ''chu_ky_hc_dinh_ky'', tb.chu_ky_hc_dinh_ky,
+         ''ngay_hc_tiep_theo'', tb.ngay_hc_tiep_theo,
+         ''chu_ky_kd_dinh_ky'', tb.chu_ky_kd_dinh_ky,
+         ''ngay_kd_tiep_theo'', tb.ngay_kd_tiep_theo,
+         ''phan_loai_theo_nd98'', tb.phan_loai_theo_nd98,
+         ''id'', tb.id,
+         ''created_at'', tb.created_at,
+         ''don_vi'', tb.don_vi,
+         ''nguon_nhap'', tb.nguon_nhap,
+         ''so_luu_hanh'', tb.so_luu_hanh,
+         ''nhom_thiet_bi_id'', tb.nhom_thiet_bi_id,
+         ''is_deleted'', tb.is_deleted,
+         ''ngay_ngung_su_dung'', tb.ngay_ngung_su_dung,
+         ''google_drive_folder_url'', dv.google_drive_folder_url,
+         ''don_vi_name'', dv.name,
+         ''active_repair_request_id'', ar.active_id
+       )) AS t
+       FROM public.thiet_bi tb
+       LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+       LEFT JOIN LATERAL (
+         SELECT r.id AS active_id
+         FROM public.yeu_cau_sua_chua r
+         WHERE r.thiet_bi_id = tb.id
+           AND r.trang_thai IN (''Chờ xử lý'', ''Đã duyệt'')
+         ORDER BY r.ngay_yeu_cau DESC, r.id DESC
+         LIMIT 1
+       ) ar ON TRUE
+       WHERE %s
+       ORDER BY %s
+       OFFSET %s LIMIT %s
+     ) sub',
+    v_where, v_order_by, v_offset, v_limit
+  ) INTO v_data;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'total', v_total,
+    'page', p_page,
+    'pageSize', p_page_size
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  boolean
+) FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  boolean
+) FROM anon;
+
+GRANT EXECUTE ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  boolean
+) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/equipment_list_enhanced_liquidation_order_smoke.sql
+++ b/supabase/tests/equipment_list_enhanced_liquidation_order_smoke.sql
@@ -1,0 +1,204 @@
+-- Purpose: smoke-test optional liquidation-last ordering across server pagination.
+-- Non-destructive: wrapped in a transaction and rolled back.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION pg_temp._ele_liquidation_set_claims(
+  p_role text,
+  p_user_id bigint,
+  p_don_vi bigint
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_role,
+      'role', p_role,
+      'user_id', p_user_id::text,
+      'don_vi', p_don_vi::text,
+      'khoa_phong', ''
+    )::text,
+    true
+  );
+END;
+$$;
+
+DO $$
+DECLARE
+  v_tenant_id bigint;
+  v_user_id bigint := 3383002;
+  v_payload jsonb;
+  v_codes text[];
+BEGIN
+  INSERT INTO public.don_vi(name)
+  VALUES ('Tenant equipment liquidation order smoke')
+  RETURNING id INTO v_tenant_id;
+
+  INSERT INTO public.thiet_bi(
+    ma_thiet_bi,
+    ten_thiet_bi,
+    don_vi,
+    khoa_phong_quan_ly,
+    tinh_trang_hien_tai
+  )
+  VALUES
+    (
+      'ELE-LIQ-1',
+      'Liquidation Z',
+      v_tenant_id,
+      'VT-TBYT- KHO THANH LÍ',
+      'Ngưng sử dụng'
+    ),
+    (
+      'ELE-LIQ-2',
+      'Status only Y',
+      v_tenant_id,
+      'Khoa A',
+      'Ngưng sử dụng'
+    ),
+    (
+      'ELE-LIQ-3',
+      'Department only X',
+      v_tenant_id,
+      'VT-TBYT- KHO THANH LÍ',
+      'Hoạt động'
+    ),
+    (
+      'ELE-LIQ-4',
+      'Normal W',
+      v_tenant_id,
+      'Khoa B',
+      'Hoạt động'
+    ),
+    (
+      'ELE-LIQ-5',
+      'Liquidation V',
+      v_tenant_id,
+      'VT-TBYT- KHO THANH LÍ',
+      'Ngưng sử dụng'
+    );
+
+  PERFORM pg_temp._ele_liquidation_set_claims('to_qltb', v_user_id, v_tenant_id);
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'id.asc',
+    p_page => 1,
+    p_page_size => 10,
+    p_don_vi => v_tenant_id,
+    p_liquidation_last => false
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-1',
+    'ELE-LIQ-2',
+    'ELE-LIQ-3',
+    'ELE-LIQ-4',
+    'ELE-LIQ-5'
+  ]::text[] THEN
+    RAISE EXCEPTION 'Flag false failed: expected ID order, got %', v_codes;
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'id.asc',
+    p_page => 1,
+    p_page_size => 10,
+    p_don_vi => v_tenant_id,
+    p_liquidation_last => true
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-2',
+    'ELE-LIQ-3',
+    'ELE-LIQ-4',
+    'ELE-LIQ-1',
+    'ELE-LIQ-5'
+  ]::text[] THEN
+    RAISE EXCEPTION 'Flag true failed: expected liquidation rows last, got %', v_codes;
+  END IF;
+
+  IF (v_payload->>'total')::integer <> 5 THEN
+    RAISE EXCEPTION 'Expected unchanged total 5, got %', v_payload->>'total';
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'id.asc',
+    p_page => 1,
+    p_page_size => 3,
+    p_don_vi => v_tenant_id,
+    p_liquidation_last => true
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-2',
+    'ELE-LIQ-3',
+    'ELE-LIQ-4'
+  ]::text[] THEN
+    RAISE EXCEPTION 'Page 1 failed: expected only normal-priority rows, got %', v_codes;
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'id.asc',
+    p_page => 2,
+    p_page_size => 3,
+    p_don_vi => v_tenant_id,
+    p_liquidation_last => true
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-1',
+    'ELE-LIQ-5'
+  ]::text[] THEN
+    RAISE EXCEPTION 'Final page failed: expected liquidation rows, got %', v_codes;
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'ten_thiet_bi.desc',
+    p_page => 1,
+    p_page_size => 10,
+    p_don_vi => v_tenant_id,
+    p_liquidation_last => true
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-2',
+    'ELE-LIQ-4',
+    'ELE-LIQ-3',
+    'ELE-LIQ-1',
+    'ELE-LIQ-5'
+  ]::text[] THEN
+    RAISE EXCEPTION 'Secondary sort failed: expected grouped name DESC order, got %', v_codes;
+  END IF;
+
+  RAISE NOTICE 'equipment_list_enhanced_liquidation_order smoke: ALL SCENARIOS PASSED';
+END;
+$$;
+
+ROLLBACK;

--- a/supabase/tests/equipment_list_enhanced_overload_regression.sql
+++ b/supabase/tests/equipment_list_enhanced_overload_regression.sql
@@ -1,9 +1,10 @@
--- Purpose: ensure equipment_list_enhanced has only the 17-parameter signature (no legacy p_fields overload).
+-- Purpose: ensure equipment_list_enhanced has only the 18-parameter signature (no legacy p_fields overload).
 
 DO $$
 DECLARE
   v_overload_count integer;
   v_legacy_count integer;
+  v_liquidation_flag_count integer;
 BEGIN
   SELECT COUNT(*)
   INTO v_overload_count
@@ -26,5 +27,18 @@ BEGIN
 
   IF v_legacy_count <> 0 THEN
     RAISE EXCEPTION 'Legacy p_fields overload still exists';
+  END IF;
+
+  SELECT COUNT(*)
+  INTO v_liquidation_flag_count
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'equipment_list_enhanced'
+    AND pg_get_function_identity_arguments(p.oid)
+      LIKE '%p_liquidation_last boolean%';
+
+  IF v_liquidation_flag_count <> 1 THEN
+    RAISE EXCEPTION 'Expected the sole overload to include p_liquidation_last boolean';
   END IF;
 END $$;


### PR DESCRIPTION
## Summary
- Add opt-in server-side ordering to `equipment_list_enhanced` so equipment is placed after active rows only when both conditions match: status `Ngưng sử dụng` and managing department `VT-TBYT- KHO THANH LÍ`.
- Enable the rule only for the main Equipments table, preserving existing ordering for every other RPC caller through the default-disabled parameter.
- Keep TanStack Table in manual sorting mode and show a dedicated success toast only when an edit transitions equipment into both liquidation conditions.

## Verification
- [x] `node scripts/npm-run.js run verify:ts-docstrings`
- [x] `node scripts/npm-run.js run format:check`
- [x] `node scripts/npm-run.js run verify:no-explicit-any`
- [x] `node scripts/npm-run.js run verify:dedupe`
- [x] `node scripts/npm-run.js run typecheck`
- [x] Focused Vitest: 7 files, 59 tests passed
- [x] `node scripts/npm-run.js run react-doctor` - no findings, score 83/100
- [x] `git diff --cached --check`

## Database rollout
- The migration has not been applied to the live Supabase project.
- The transactional SQL smoke fixture has not been run because it performs live `INSERT` operations followed by `ROLLBACK` and requires explicit authorization.
- Deploy the migration before deploying the client change, then run the overload regression, ordering smoke fixture, and Supabase security/performance advisors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep liquidation equipment at the end of the main Equipments table with a server-side opt-in flag. Other callers keep their order, and a success toast shows only when an edit moves a device into liquidation.

- **New Features**
  - Added a `p_liquidation_last` flag (default false) to the `equipment_list_enhanced` RPC; the main Equipments hook opts in with `liquidationLast: true` / `p_liquidation_last: true` (tests ensure it’s enabled only there).
  - Ordering pushes rows last only when both match: department “VT-TBYT- KHO THANH LÍ” and status “Ngưng sử dụng”; client-side detection normalizes department like the server and requires the canonical status.
  - Kept `@tanstack/react-table` in manual sorting mode to preserve server order.
  - Edit success toasts are now per-mutation; when an edit enters liquidation, a dedicated toast is shown.

- **Migration**
  - Supabase migration replaces the RPC with an 18-arg signature (adds `p_liquidation_last boolean DEFAULT false`) and restores least-privilege grants.
  - Apply the migration before deploying the client; includes pagination-aware smoke tests and an updated overload-regression check.

<sup>Written for commit 82ab6eea3bd08a2199b614c74b79c18caee92308. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Equipment lists can now prioritize decommissioned items at the end of results.
  * Equipment edits display a specialized success message when moving an item into the decommissioned state.
  * Table sorting is handled consistently by the server while preserving server-provided ordering.

* **Bug Fixes**
  * Improved equipment filtering, pagination, tenant isolation, cache refresh, and handling of empty or unavailable results.
  * Enhanced form updates and success/error notifications for equipment edits.

* **Tests**
  * Expanded coverage for liquidation ordering, filtering, sorting, transitions, notifications, and data-loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->