### PR TITLE
feat: add nullable comparison set read RPC

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-contract.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import * as supplierOptionRpcManifest from "@/lib/technical-configuration-supplier-option-rpcs"
 import * as supplierOptionRpcAdapter from "../technical-configuration-supplier-option-rpc"
 import type {
+  TechnicalConfigurationComparisonSetGetRpcArgs,
   TechnicalConfigurationComparisonSetGetOrCreateRpcArgs,
+  TechnicalConfigurationComparisonSetReadWireResponse,
   TechnicalConfigurationComparisonSetWireResponse,
   TechnicalConfigurationOptionCreateRpcArgs,
   TechnicalConfigurationOptionDeleteRpcArgs,
@@ -19,6 +21,8 @@ import type {
 } from "../supplier-option-types"
 
 const {
+  OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
+  OPTION_RESPONSE_READ_RPC_FUNCTIONS,
   OPTION_RESPONSE_RPC_FUNCTION_NAMES,
   OPTION_RESPONSE_RPC_FUNCTIONS,
   OPTION_RPC_FUNCTION_NAMES,
@@ -31,6 +35,7 @@ const {
   createTechnicalConfigurationSupplier,
   deleteTechnicalConfigurationOption,
   deleteTechnicalConfigurationSupplier,
+  getTechnicalConfigurationComparisonSet,
   getOrCreateTechnicalConfigurationComparisonSet,
   listTechnicalConfigurationOptions,
   listTechnicalConfigurationSuppliers,
@@ -336,5 +341,93 @@ describe("P8A3 exact-baseline option response RPC contract", () => {
       [OPTION_RESPONSE_RPC_FUNCTIONS.getOrCreateComparisonSet, getOrCreateArgs, { signal }],
       [OPTION_RESPONSE_RPC_FUNCTIONS.upsertOptionResponse, upsertArgs, { signal: undefined }],
     ])
+  })
+})
+
+describe("P8A4 side-effect-free comparison-set read RPC contract", () => {
+  beforeEach(() => {
+    callRpcMock.mockReset()
+  })
+
+  it("freezes exactly one nullable read RPC without changing the P8A3 manifest", () => {
+    expect(OPTION_RESPONSE_READ_RPC_FUNCTIONS).toEqual({
+      getComparisonSet: "technical_configuration_comparison_set_get",
+    })
+    expect(OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES).toEqual(
+      Object.values(OPTION_RESPONSE_READ_RPC_FUNCTIONS)
+    )
+    expect(OPTION_RESPONSE_RPC_FUNCTIONS).toEqual({
+      getOrCreateComparisonSet: "technical_configuration_comparison_set_get_or_create",
+      upsertOptionResponse: "technical_configuration_option_response_upsert",
+    })
+  })
+
+  it("delegates only the option and baseline identifiers and preserves data null", async () => {
+    const argsWithExtraProperty = {
+      p_option_id: "00000000-0000-0000-0000-000000000003",
+      p_baseline_version_id: "00000000-0000-0000-0000-000000000005",
+      p_expected_revision: 4,
+    }
+    const expectedArgs: TechnicalConfigurationComparisonSetGetRpcArgs = {
+      p_option_id: argsWithExtraProperty.p_option_id,
+      p_baseline_version_id: argsWithExtraProperty.p_baseline_version_id,
+    }
+    const response: TechnicalConfigurationComparisonSetReadWireResponse = {
+      data: null,
+    }
+    const signal = new AbortController().signal
+    callRpcMock.mockResolvedValueOnce(response)
+
+    await expect(
+      getTechnicalConfigurationComparisonSet(argsWithExtraProperty, signal)
+    ).resolves.toEqual(response)
+    expect(callRpcMock).toHaveBeenCalledWith(
+      OPTION_RESPONSE_READ_RPC_FUNCTIONS.getComparisonSet,
+      expectedArgs,
+      { signal }
+    )
+  })
+
+  it("preserves existing ordered multiline response rows without remapping", async () => {
+    const args: TechnicalConfigurationComparisonSetGetRpcArgs = {
+      p_option_id: "00000000-0000-0000-0000-000000000003",
+      p_baseline_version_id: "00000000-0000-0000-0000-000000000005",
+    }
+    const response: TechnicalConfigurationComparisonSetReadWireResponse = {
+      data: {
+        id: "00000000-0000-0000-0000-000000000004",
+        dossier_id: "00000000-0000-0000-0000-000000000001",
+        option_id: args.p_option_id,
+        baseline_version_id: args.p_baseline_version_id,
+        created_at: "2026-07-22T00:00:00Z",
+        created_by: 1,
+        updated_at: "2026-07-22T00:00:00Z",
+        updated_by: 1,
+        revision: 5,
+        responses: [
+          {
+            id: "00000000-0000-0000-0000-000000000007",
+            comparison_set_id: "00000000-0000-0000-0000-000000000004",
+            baseline_version_id: args.p_baseline_version_id,
+            criterion_id: "00000000-0000-0000-0000-000000000006",
+            response_text: "Dòng 1\nDòng 2",
+            supplementary_information: "Tài liệu A\nTài liệu B",
+            created_at: "2026-07-22T00:00:00Z",
+            created_by: 1,
+            updated_at: "2026-07-22T00:01:00Z",
+            updated_by: 1,
+            revision: 5,
+          },
+        ],
+      },
+    }
+    callRpcMock.mockResolvedValueOnce(response)
+
+    await expect(getTechnicalConfigurationComparisonSet(args)).resolves.toEqual(response)
+    expect(callRpcMock).toHaveBeenCalledWith(
+      OPTION_RESPONSE_READ_RPC_FUNCTIONS.getComparisonSet,
+      args,
+      { signal: undefined }
+    )
   })
 })

--- a/src/app/(app)/technical-configurations/supplier-option-types.ts
+++ b/src/app/(app)/technical-configurations/supplier-option-types.ts
@@ -149,8 +149,17 @@ export interface TechnicalConfigurationComparisonSetWireResponse {
   data: TechnicalConfigurationComparisonSetWire
 }
 
+export interface TechnicalConfigurationComparisonSetReadWireResponse {
+  data: TechnicalConfigurationComparisonSetWire | null
+}
+
 export interface TechnicalConfigurationOptionResponseWireResponse {
   data: TechnicalConfigurationOptionResponseWire
+}
+
+export interface TechnicalConfigurationComparisonSetGetRpcArgs {
+  p_option_id: string
+  p_baseline_version_id: string
 }
 
 export interface TechnicalConfigurationComparisonSetGetOrCreateRpcArgs {

--- a/src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc.ts
@@ -1,11 +1,14 @@
 import {
+  OPTION_RESPONSE_READ_RPC_FUNCTIONS,
   OPTION_RESPONSE_RPC_FUNCTIONS,
   OPTION_RPC_FUNCTIONS,
   SUPPLIER_RPC_FUNCTIONS,
 } from "@/lib/technical-configuration-supplier-option-rpcs"
 import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
 import type {
+  TechnicalConfigurationComparisonSetGetRpcArgs,
   TechnicalConfigurationComparisonSetGetOrCreateRpcArgs,
+  TechnicalConfigurationComparisonSetReadWireResponse,
   TechnicalConfigurationComparisonSetWireResponse,
   TechnicalConfigurationOptionCreateRpcArgs,
   TechnicalConfigurationOptionDeleteRpcArgs,
@@ -103,6 +106,21 @@ export function deleteTechnicalConfigurationOption(
   return callTechnicalConfigurationRpc(OPTION_RPC_FUNCTIONS.deleteOption, args, {
     signal,
   })
+}
+
+/** Reads the response dataset without creating it when the pair is missing. */
+export function getTechnicalConfigurationComparisonSet(
+  args: TechnicalConfigurationComparisonSetGetRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationComparisonSetReadWireResponse> {
+  return callTechnicalConfigurationRpc(
+    OPTION_RESPONSE_READ_RPC_FUNCTIONS.getComparisonSet,
+    {
+      p_option_id: args.p_option_id,
+      p_baseline_version_id: args.p_baseline_version_id,
+    },
+    { signal }
+  )
 }
 
 /** Gets or creates the response dataset for one option and exact baseline version. */

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -2,6 +2,7 @@ import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-basel
 import { DOCUMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-document-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
 import {
+  OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
   OPTION_RESPONSE_RPC_FUNCTION_NAMES,
   OPTION_RPC_FUNCTION_NAMES,
   SUPPLIER_RPC_FUNCTION_NAMES,
@@ -106,6 +107,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   ...SUPPLIER_RPC_FUNCTION_NAMES,
   ...OPTION_RPC_FUNCTION_NAMES,
   ...OPTION_RESPONSE_RPC_FUNCTION_NAMES,
+  ...OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
   // AI Assistant (read-only)
   "ai_equipment_lookup",
   "ai_maintenance_plan_lookup",

--- a/src/app/api/rpc/__tests__/technical-configuration-comparison-set-read-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-comparison-set-read-migration.test.ts
@@ -1,0 +1,171 @@
+import { createHash } from "node:crypto"
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = path.resolve(process.cwd())
+const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
+const MIGRATION_FILE = "20260723110549_technical_configuration_comparison_set_read.sql"
+const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const PHASE_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_comparison_set_read_phase_gate.sql"
+)
+const P8A3_MIGRATION_PATH = path.join(
+  MIGRATIONS_DIR,
+  "20260722072748_technical_configuration_option_responses.sql"
+)
+const P8A3_MIGRATION_SHA256 = "80af359add898c9d07bdce11f64b549d50819c247842a10d39f90c60a63730fb"
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function countLines(source: string): number {
+  return source === "" ? 0 : source.trimEnd().split("\n").length
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  const marker = `FUNCTION public.${functionName}(`
+  const start = source.indexOf(marker)
+  if (start === -1) return ""
+
+  const nextFunction = source.indexOf("\nCREATE OR REPLACE FUNCTION public.", start + marker.length)
+  return source.slice(start, nextFunction === -1 ? source.length : nextFunction)
+}
+
+const migrationSource = readIfExists(MIGRATION_PATH)
+const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+const readFunctionBlock = getFunctionBlock(
+  migrationSource,
+  "technical_configuration_comparison_set_get"
+)
+
+describe("P8A4 technical configuration comparison-set read migration", () => {
+  it("uses one ordered migration after the immutable P8A3 response migration", () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true)
+    expect(
+      readdirSync(MIGRATIONS_DIR)
+        .filter((file) => file.includes("technical_configuration_comparison_set_read"))
+        .sort()
+    ).toEqual([MIGRATION_FILE])
+    expect(
+      MIGRATION_FILE.localeCompare("20260722072748_technical_configuration_option_responses.sql")
+    ).toBeGreaterThan(0)
+  })
+
+  it("freezes the nullable two-argument RPC and explicit execute grants", () => {
+    expect(migrationSource).toContain(
+      "FUNCTION public.technical_configuration_comparison_set_get(\n" +
+        "  p_option_id UUID,\n" +
+        "  p_baseline_version_id UUID\n" +
+        ")"
+    )
+    expect(readFunctionBlock).toContain("RETURNS JSONB")
+    expect(readFunctionBlock).toContain("SECURITY DEFINER")
+    expect(readFunctionBlock).toContain("SET search_path = public, pg_temp")
+    expect(migrationSource).toContain(
+      "REVOKE ALL ON FUNCTION public.technical_configuration_comparison_set_get(\n" +
+        "  UUID, UUID\n" +
+        ") FROM PUBLIC, anon, authenticated, service_role"
+    )
+    expect(migrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public.technical_configuration_comparison_set_get(\n" +
+        "  UUID, UUID\n" +
+        ") TO authenticated, service_role"
+    )
+  })
+
+  it("validates global access and exact dossier ownership while keeping archived reads available", () => {
+    expect(readFunctionBlock).toContain(
+      "PERFORM public._technical_configuration_require_global_user()"
+    )
+    expect(readFunctionBlock).toContain("FROM public.technical_configuration_options o")
+    expect(readFunctionBlock).toContain("FROM public.technical_configuration_baseline_versions v")
+    expect(readFunctionBlock).toContain(
+      "IF v_option_dossier_id IS DISTINCT FROM v_version_dossier_id THEN"
+    )
+    expect(readFunctionBlock).not.toContain(
+      "public._technical_configuration_require_editable_dossier("
+    )
+    expect(readFunctionBlock).not.toContain("archived_dossier")
+  })
+
+  it("returns data null for a missing pair without locks, writes, revisions or audit changes", () => {
+    expect(readFunctionBlock).toContain("RETURN jsonb_build_object('data', NULL)")
+    expect(readFunctionBlock).not.toMatch(/\bINSERT\s+INTO\b/i)
+    expect(readFunctionBlock).not.toMatch(/\bUPDATE\b/i)
+    expect(readFunctionBlock).not.toMatch(/\bDELETE\s+FROM\b/i)
+    expect(readFunctionBlock).not.toMatch(/\bMERGE\s+INTO\b/i)
+    expect(readFunctionBlock).not.toMatch(/\bTRUNCATE\b/i)
+    expect(readFunctionBlock).not.toMatch(
+      /\bFOR\s+(?:KEY\s+SHARE|NO\s+KEY\s+UPDATE|SHARE|UPDATE)\b/i
+    )
+    expect(readFunctionBlock).not.toContain("p_expected_revision")
+    expect(readFunctionBlock).not.toContain("revision = revision + 1")
+  })
+
+  it("returns the existing comparison-set wire shape with deterministic multiline responses", () => {
+    for (const mapping of [
+      "'id', cs.id",
+      "'dossier_id', cs.dossier_id",
+      "'option_id', cs.option_id",
+      "'baseline_version_id', cs.baseline_version_id",
+      "'created_at', cs.created_at",
+      "'created_by', cs.created_by",
+      "'updated_at', cs.updated_at",
+      "'updated_by', cs.updated_by",
+      "'revision', d.revision",
+      "'id', r.id",
+      "'comparison_set_id', r.comparison_set_id",
+      "'baseline_version_id', r.baseline_version_id",
+      "'criterion_id', r.criterion_id",
+      "'response_text', r.response_text",
+      "'supplementary_information', r.supplementary_information",
+      "'created_at', r.created_at",
+      "'created_by', r.created_by",
+      "'updated_at', r.updated_at",
+      "'updated_by', r.updated_by",
+    ]) {
+      expect(readFunctionBlock).toContain(mapping)
+    }
+    expect(readFunctionBlock.match(/'revision', d\.revision/g)).toHaveLength(2)
+    expect(readFunctionBlock).toContain("'responses', COALESCE(")
+    expect(readFunctionBlock).toContain("ORDER BY bg.sort_order, bc.sort_order, bc.id")
+    expect(readFunctionBlock).toContain("'[]'::JSONB")
+  })
+
+  it("does not modify the applied P8A3 migration source contract", () => {
+    const source = readFileSync(P8A3_MIGRATION_PATH)
+    expect(createHash("sha256").update(source).digest("hex")).toBe(P8A3_MIGRATION_SHA256)
+  })
+
+  it("ships a rollback-only phase gate for read behavior and privileges", () => {
+    expect(existsSync(PHASE_GATE_PATH)).toBe(true)
+    expect(countLines(migrationSource)).toBeLessThanOrEqual(450)
+
+    for (const marker of [
+      "BEGIN;",
+      "ROLLBACK;",
+      "missing claims rejected",
+      "malformed claims rejected",
+      "nonnumeric user id rejected",
+      "non-global role rejected",
+      "raw admin accepted",
+      "missing pair returns data null",
+      "missing pair creates no comparison data",
+      "missing pair preserves dossier revision and audit metadata",
+      "existing pair returns ordered exact multiline responses",
+      "complete existing payload matches stored snapshot",
+      "existing pair preserves dossier revision and audit metadata",
+      "archived existing data remains readable",
+      "cross-dossier option baseline rejected",
+      "authenticated executes read RPC",
+      "service role executes read RPC",
+      "anon cannot execute read RPC",
+      "fixed search_path",
+    ]) {
+      expect(phaseGateSource).toContain(marker)
+    }
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-comparison-set-read-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-comparison-set-read-migration.test.ts
@@ -26,12 +26,15 @@ function countLines(source: string): number {
 }
 
 function getFunctionBlock(source: string, functionName: string): string {
-  const marker = `FUNCTION public.${functionName}(`
-  const start = source.indexOf(marker)
-  if (start === -1) return ""
+  const functions = [
+    ...source.matchAll(/^CREATE(?: OR REPLACE)? FUNCTION public\.([a-z0-9_]+)\(/gim),
+  ]
+  const index = functions.findIndex((match) => match[1] === functionName)
+  if (index === -1) return ""
 
-  const nextFunction = source.indexOf("\nCREATE OR REPLACE FUNCTION public.", start + marker.length)
-  return source.slice(start, nextFunction === -1 ? source.length : nextFunction)
+  const start = functions[index].index ?? 0
+  const end = functions[index + 1]?.index ?? source.length
+  return source.slice(start, end)
 }
 
 const migrationSource = readIfExists(MIGRATION_PATH)
@@ -42,6 +45,20 @@ const readFunctionBlock = getFunctionBlock(
 )
 
 describe("P8A4 technical configuration comparison-set read migration", () => {
+  it("extracts only the requested function across both function DDL forms", () => {
+    const source = [
+      "CREATE OR REPLACE FUNCTION public.target_function()",
+      "RETURNS TEXT",
+      "AS $$ SELECT 'target' $$;",
+      "CREATE FUNCTION public.followup_function()",
+      "RETURNS TEXT",
+      "AS $$ SELECT 'followup' $$;",
+    ].join("\n")
+
+    expect(getFunctionBlock(source, "target_function")).toContain("'target'")
+    expect(getFunctionBlock(source, "target_function")).not.toContain("'followup'")
+  })
+
   it("uses one ordered migration after the immutable P8A3 response migration", () => {
     expect(existsSync(MIGRATION_PATH)).toBe(true)
     expect(
@@ -136,13 +153,16 @@ describe("P8A4 technical configuration comparison-set read migration", () => {
   })
 
   it("does not modify the applied P8A3 migration source contract", () => {
-    const source = readFileSync(P8A3_MIGRATION_PATH)
+    const source = readFileSync(P8A3_MIGRATION_PATH, "utf8")
     expect(createHash("sha256").update(source).digest("hex")).toBe(P8A3_MIGRATION_SHA256)
+    expect(source).toContain("UNIQUE (option_id, baseline_version_id)")
   })
 
   it("ships a rollback-only phase gate for read behavior and privileges", () => {
     expect(existsSync(PHASE_GATE_PATH)).toBe(true)
     expect(countLines(migrationSource)).toBeLessThanOrEqual(450)
+    expect(phaseGateSource).not.toMatch(/\bCOMMIT\s*;/i)
+    expect(phaseGateSource.trimEnd()).toMatch(/\bROLLBACK\s*;$/i)
 
     for (const marker of [
       "BEGIN;",

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -9,6 +9,7 @@ import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configurat
 import * as supplierOptionRpcManifest from "@/lib/technical-configuration-supplier-option-rpcs"
 
 const {
+  OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
   OPTION_RESPONSE_RPC_FUNCTION_NAMES,
   OPTION_RPC_FUNCTION_NAMES,
   SUPPLIER_RPC_FUNCTION_NAMES,
@@ -74,6 +75,10 @@ const P8A2_OPTION_RPC_FUNCTIONS = [
 const P8A3_OPTION_RESPONSE_RPC_FUNCTIONS = [
   "technical_configuration_comparison_set_get_or_create",
   "technical_configuration_option_response_upsert",
+] as const
+
+const P8A4_OPTION_RESPONSE_READ_RPC_FUNCTIONS = [
+  "technical_configuration_comparison_set_get",
 ] as const
 
 async function invokeRpcProxy(fn: string) {
@@ -199,17 +204,21 @@ describe("technical configuration option response RPC whitelist", () => {
     expect(OPTION_RESPONSE_RPC_FUNCTION_NAMES).toEqual(P8A3_OPTION_RESPONSE_RPC_FUNCTIONS)
   })
 
-  it("allowlists exactly the two P8A3 response RPCs", () => {
+  it("keeps the P8A4 nullable read prefix aligned with its shared manifest", () => {
+    expect(OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES).toEqual(P8A4_OPTION_RESPONSE_READ_RPC_FUNCTIONS)
+  })
+
+  it("allowlists exactly the P8A3 mutation RPCs plus the P8A4 read RPC", () => {
     expect(
       [...ALLOWED_FUNCTIONS].filter(
         (fn) =>
           fn.startsWith("technical_configuration_comparison_set_") ||
           fn.startsWith("technical_configuration_option_response_")
       )
-    ).toEqual(P8A3_OPTION_RESPONSE_RPC_FUNCTIONS)
+    ).toEqual([...P8A3_OPTION_RESPONSE_RPC_FUNCTIONS, ...P8A4_OPTION_RESPONSE_READ_RPC_FUNCTIONS])
   })
 
-  it.each(P8A3_OPTION_RESPONSE_RPC_FUNCTIONS)(
+  it.each([...P8A3_OPTION_RESPONSE_RPC_FUNCTIONS, ...P8A4_OPTION_RESPONSE_READ_RPC_FUNCTIONS])(
     'allows option response RPC "%s" through the whitelist',
     async (fn) => {
       const response = await invokeRpcProxy(fn)

--- a/src/lib/technical-configuration-supplier-option-rpcs.ts
+++ b/src/lib/technical-configuration-supplier-option-rpcs.ts
@@ -28,3 +28,13 @@ export const OPTION_RESPONSE_RPC_FUNCTIONS = {
 
 /** Ordered P8A3 response RPC names for allowlists and contract iteration. */
 export const OPTION_RESPONSE_RPC_FUNCTION_NAMES = Object.values(OPTION_RESPONSE_RPC_FUNCTIONS)
+
+/** Named P8A4 side-effect-free response read RPC shared by client and server code. */
+export const OPTION_RESPONSE_READ_RPC_FUNCTIONS = {
+  getComparisonSet: "technical_configuration_comparison_set_get",
+} as const
+
+/** Ordered P8A4 nullable read RPC names for allowlists and contract iteration. */
+export const OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES = Object.values(
+  OPTION_RESPONSE_READ_RPC_FUNCTIONS
+)

--- a/supabase/migrations/20260723110549_technical_configuration_comparison_set_read.sql
+++ b/supabase/migrations/20260723110549_technical_configuration_comparison_set_read.sql
@@ -1,0 +1,102 @@
+-- P8A4: nullable side-effect-free read for one option and exact baseline version.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_comparison_set_get(
+  p_option_id UUID,
+  p_baseline_version_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_option_dossier_id UUID;
+  v_version_dossier_id UUID;
+  v_data JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT o.dossier_id
+  INTO v_option_dossier_id
+  FROM public.technical_configuration_options o
+  WHERE o.id = p_option_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  SELECT v.dossier_id
+  INTO v_version_dossier_id
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.id = p_baseline_version_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  IF v_option_dossier_id IS DISTINCT FROM v_version_dossier_id THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'id', cs.id,
+    'dossier_id', cs.dossier_id,
+    'option_id', cs.option_id,
+    'baseline_version_id', cs.baseline_version_id,
+    'created_at', cs.created_at,
+    'created_by', cs.created_by,
+    'updated_at', cs.updated_at,
+    'updated_by', cs.updated_by,
+    'revision', d.revision,
+    'responses', COALESCE(
+      (
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'id', r.id,
+            'comparison_set_id', r.comparison_set_id,
+            'baseline_version_id', r.baseline_version_id,
+            'criterion_id', r.criterion_id,
+            'response_text', r.response_text,
+            'supplementary_information', r.supplementary_information,
+            'created_at', r.created_at,
+            'created_by', r.created_by,
+            'updated_at', r.updated_at,
+            'updated_by', r.updated_by,
+            'revision', d.revision
+          )
+          ORDER BY bg.sort_order, bc.sort_order, bc.id
+        )
+        FROM public.technical_configuration_option_responses r
+        JOIN public.technical_configuration_baseline_criteria bc
+          ON bc.id = r.criterion_id
+         AND bc.baseline_version_id = r.baseline_version_id
+        JOIN public.technical_configuration_baseline_groups bg
+          ON bg.id = bc.group_id
+         AND bg.baseline_version_id = bc.baseline_version_id
+        WHERE r.comparison_set_id = cs.id
+      ),
+      '[]'::JSONB
+    )
+  )
+  INTO v_data
+  FROM public.technical_configuration_comparison_sets cs
+  JOIN public.technical_configuration_dossiers d
+    ON d.id = cs.dossier_id
+  WHERE cs.option_id = p_option_id
+    AND cs.baseline_version_id = p_baseline_version_id;
+
+  IF v_data IS NULL THEN
+    RETURN jsonb_build_object('data', NULL);
+  END IF;
+
+  RETURN jsonb_build_object('data', v_data);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_comparison_set_get(
+  UUID, UUID
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_comparison_set_get(
+  UUID, UUID
+) TO authenticated, service_role;
+
+COMMIT;

--- a/supabase/tests/technical_configuration_comparison_set_read_phase_gate.sql
+++ b/supabase/tests/technical_configuration_comparison_set_read_phase_gate.sql
@@ -1,0 +1,653 @@
+-- P8A4 rollback-only nullable comparison-set read, audit, and privilege gate.
+BEGIN;
+
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT,
+  p_statement TEXT,
+  p_expected_state TEXT,
+  p_expected_message TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+DECLARE
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION
+    WHEN OTHERS THEN
+      GET STACKED DIAGNOSTICS
+        v_state = RETURNED_SQLSTATE,
+        v_message = MESSAGE_TEXT;
+      IF v_state IS DISTINCT FROM p_expected_state
+         OR v_message IS DISTINCT FROM p_expected_message THEN
+        RAISE EXCEPTION '%: expected [%] %, got [%] %',
+          p_label, p_expected_state, p_expected_message, v_state, v_message;
+      END IF;
+      RETURN;
+  END;
+
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role,
+      'role', 'authenticated',
+      'user_id', p_user_id::TEXT,
+      'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $gate$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN
+    RAISE EXCEPTION '%', p_label;
+  END IF;
+END;
+$gate$;
+
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossier_id UUID := gen_random_uuid();
+  v_other_dossier_id UUID := gen_random_uuid();
+  v_archived_dossier_id UUID := gen_random_uuid();
+  v_supplier_id UUID := gen_random_uuid();
+  v_other_supplier_id UUID := gen_random_uuid();
+  v_archived_supplier_id UUID := gen_random_uuid();
+  v_existing_option_id UUID := gen_random_uuid();
+  v_missing_option_id UUID := gen_random_uuid();
+  v_other_option_id UUID := gen_random_uuid();
+  v_archived_option_id UUID := gen_random_uuid();
+  v_version_id UUID := gen_random_uuid();
+  v_other_version_id UUID := gen_random_uuid();
+  v_archived_version_id UUID := gen_random_uuid();
+  v_first_group_id UUID := gen_random_uuid();
+  v_second_group_id UUID := gen_random_uuid();
+  v_other_group_id UUID := gen_random_uuid();
+  v_archived_group_id UUID := gen_random_uuid();
+  v_first_criterion_id UUID := gen_random_uuid();
+  v_second_criterion_id UUID := gen_random_uuid();
+  v_other_criterion_id UUID := gen_random_uuid();
+  v_archived_criterion_id UUID := gen_random_uuid();
+  v_set_id UUID := gen_random_uuid();
+  v_archived_set_id UUID := gen_random_uuid();
+  v_first_response_id UUID := gen_random_uuid();
+  v_second_response_id UUID := gen_random_uuid();
+  v_response JSONB;
+  v_expected_data JSONB;
+  v_before_revision BIGINT;
+  v_before_updated_at TIMESTAMPTZ;
+  v_before_updated_by BIGINT;
+  v_set_updated_at TIMESTAMPTZ;
+  v_set_updated_by BIGINT;
+  v_comparison_count BIGINT;
+  v_response_count BIGINT;
+  v_function_config TEXT[];
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_comparison_set_read_phase_gate')
+  );
+
+  SELECT nv.id
+  INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P8A4 phase gate requires one active public.nhan_vien row';
+  END IF;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    id,
+    device_type_name,
+    name,
+    archived_at,
+    archived_by,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (
+      v_dossier_id,
+      'P8A4 device ' || v_suffix,
+      'P8A4 dossier ' || v_suffix,
+      NULL,
+      NULL,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_other_dossier_id,
+      'P8A4 other device ' || v_suffix,
+      'P8A4 other dossier ' || v_suffix,
+      NULL,
+      NULL,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_archived_dossier_id,
+      'P8A4 archived device ' || v_suffix,
+      'P8A4 archived dossier ' || v_suffix,
+      now(),
+      v_user_id,
+      v_user_id,
+      v_user_id
+    );
+
+  INSERT INTO public.technical_configuration_suppliers (
+    id,
+    dossier_id,
+    name,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (v_supplier_id, v_dossier_id, 'P8A4 Supplier', v_user_id, v_user_id),
+    (
+      v_other_supplier_id,
+      v_other_dossier_id,
+      'P8A4 Other Supplier',
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_archived_supplier_id,
+      v_archived_dossier_id,
+      'P8A4 Archived Supplier',
+      v_user_id,
+      v_user_id
+    );
+
+  INSERT INTO public.technical_configuration_options (
+    id,
+    dossier_id,
+    supplier_id,
+    option_name,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (
+      v_existing_option_id,
+      v_dossier_id,
+      v_supplier_id,
+      'Existing Option',
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_missing_option_id,
+      v_dossier_id,
+      v_supplier_id,
+      'Missing Option',
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_other_option_id,
+      v_other_dossier_id,
+      v_other_supplier_id,
+      'Other Option',
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_archived_option_id,
+      v_archived_dossier_id,
+      v_archived_supplier_id,
+      'Archived Option',
+      v_user_id,
+      v_user_id
+    );
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id,
+    dossier_id,
+    version_number,
+    status,
+    next_criterion_number,
+    revision,
+    locked_at,
+    locked_by,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (
+      v_version_id,
+      v_dossier_id,
+      1,
+      'locked',
+      3,
+      1,
+      now(),
+      v_user_id,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_other_version_id,
+      v_other_dossier_id,
+      1,
+      'locked',
+      2,
+      1,
+      now(),
+      v_user_id,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_archived_version_id,
+      v_archived_dossier_id,
+      1,
+      'locked',
+      2,
+      1,
+      now(),
+      v_user_id,
+      v_user_id,
+      v_user_id
+    );
+
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id,
+    baseline_version_id,
+    name,
+    sort_order,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (v_first_group_id, v_version_id, 'First Group', 1, v_user_id, v_user_id),
+    (v_second_group_id, v_version_id, 'Second Group', 2, v_user_id, v_user_id),
+    (
+      v_other_group_id,
+      v_other_version_id,
+      'Other Group',
+      1,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_archived_group_id,
+      v_archived_version_id,
+      'Archived Group',
+      1,
+      v_user_id,
+      v_user_id
+    );
+
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id,
+    baseline_version_id,
+    group_id,
+    criterion_code,
+    requirement_text,
+    sort_order,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (
+      v_first_criterion_id,
+      v_version_id,
+      v_first_group_id,
+      'TC-0001',
+      'First criterion',
+      1,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_second_criterion_id,
+      v_version_id,
+      v_second_group_id,
+      'TC-0002',
+      'Second criterion',
+      1,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_other_criterion_id,
+      v_other_version_id,
+      v_other_group_id,
+      'TC-0001',
+      'Other criterion',
+      1,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_archived_criterion_id,
+      v_archived_version_id,
+      v_archived_group_id,
+      'TC-0001',
+      'Archived criterion',
+      1,
+      v_user_id,
+      v_user_id
+    );
+
+  INSERT INTO public.technical_configuration_comparison_sets (
+    id,
+    dossier_id,
+    option_id,
+    baseline_version_id,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (
+      v_set_id,
+      v_dossier_id,
+      v_existing_option_id,
+      v_version_id,
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_archived_set_id,
+      v_archived_dossier_id,
+      v_archived_option_id,
+      v_archived_version_id,
+      v_user_id,
+      v_user_id
+    );
+
+  INSERT INTO public.technical_configuration_option_responses (
+    id,
+    comparison_set_id,
+    baseline_version_id,
+    criterion_id,
+    response_text,
+    supplementary_information,
+    created_by,
+    updated_by
+  )
+  VALUES
+    (
+      v_second_response_id,
+      v_set_id,
+      v_version_id,
+      v_second_criterion_id,
+      E'Second line 1\nSecond line 2',
+      E'Second doc 1\nSecond doc 2',
+      v_user_id,
+      v_user_id
+    ),
+    (
+      v_first_response_id,
+      v_set_id,
+      v_version_id,
+      v_first_criterion_id,
+      E'First line 1\nFirst line 2',
+      E'First doc 1\nFirst doc 2',
+      v_user_id,
+      v_user_id
+    );
+
+  SELECT revision, updated_at, updated_by
+  INTO v_before_revision, v_before_updated_at, v_before_updated_by
+  FROM public.technical_configuration_dossiers
+  WHERE id = v_dossier_id;
+  SELECT updated_at, updated_by
+  INTO v_set_updated_at, v_set_updated_by
+  FROM public.technical_configuration_comparison_sets
+  WHERE id = v_set_id;
+  SELECT count(*)
+  INTO v_comparison_count
+  FROM public.technical_configuration_comparison_sets;
+  SELECT count(*)
+  INTO v_response_count
+  FROM public.technical_configuration_option_responses;
+  SELECT jsonb_build_object(
+    'id', cs.id,
+    'dossier_id', cs.dossier_id,
+    'option_id', cs.option_id,
+    'baseline_version_id', cs.baseline_version_id,
+    'created_at', cs.created_at,
+    'created_by', cs.created_by,
+    'updated_at', cs.updated_at,
+    'updated_by', cs.updated_by,
+    'revision', d.revision,
+    'responses', (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', r.id,
+          'comparison_set_id', r.comparison_set_id,
+          'baseline_version_id', r.baseline_version_id,
+          'criterion_id', r.criterion_id,
+          'response_text', r.response_text,
+          'supplementary_information', r.supplementary_information,
+          'created_at', r.created_at,
+          'created_by', r.created_by,
+          'updated_at', r.updated_at,
+          'updated_by', r.updated_by,
+          'revision', d.revision
+        )
+        ORDER BY bg.sort_order, bc.sort_order, bc.id
+      )
+      FROM public.technical_configuration_option_responses r
+      JOIN public.technical_configuration_baseline_criteria bc
+        ON bc.id = r.criterion_id
+       AND bc.baseline_version_id = r.baseline_version_id
+      JOIN public.technical_configuration_baseline_groups bg
+        ON bg.id = bc.group_id
+       AND bg.baseline_version_id = bc.baseline_version_id
+      WHERE r.comparison_set_id = cs.id
+    )
+  )
+  INTO v_expected_data
+  FROM public.technical_configuration_comparison_sets cs
+  JOIN public.technical_configuration_dossiers d
+    ON d.id = cs.dossier_id
+  WHERE cs.id = v_set_id;
+
+  -- missing claims rejected
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims rejected',
+    format(
+      'SELECT public.technical_configuration_comparison_set_get(%L::UUID, %L::UUID)',
+      v_missing_option_id,
+      v_version_id
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  -- malformed claims rejected
+  PERFORM set_config('request.jwt.claims', '{', true);
+  PERFORM pg_temp.expect_error(
+    'malformed claims rejected',
+    format(
+      'SELECT public.technical_configuration_comparison_set_get(%L::UUID, %L::UUID)',
+      v_missing_option_id,
+      v_version_id
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  -- nonnumeric user id rejected
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', 'global',
+      'role', 'authenticated',
+      'user_id', 'not-a-number'
+    )::TEXT,
+    true
+  );
+  PERFORM pg_temp.expect_error(
+    'nonnumeric user id rejected',
+    format(
+      'SELECT public.technical_configuration_comparison_set_get(%L::UUID, %L::UUID)',
+      v_missing_option_id,
+      v_version_id
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  -- non-global role rejected
+  PERFORM pg_temp.set_claims('to_qltb', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'non-global role rejected',
+    format(
+      'SELECT public.technical_configuration_comparison_set_get(%L::UUID, %L::UUID)',
+      v_missing_option_id,
+      v_version_id
+    ),
+    '42501',
+    'permission_denied'
+  );
+
+  -- cross-dossier option baseline rejected
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'cross-dossier option baseline rejected',
+    format(
+      'SELECT public.technical_configuration_comparison_set_get(%L::UUID, %L::UUID)',
+      v_existing_option_id,
+      v_other_version_id
+    ),
+    'PT422',
+    'validation_error'
+  );
+
+  -- missing pair returns data null
+  SELECT public.technical_configuration_comparison_set_get(
+    v_missing_option_id,
+    v_version_id
+  )
+  INTO v_response;
+  PERFORM pg_temp.assert_true(
+    'missing pair returns data null',
+    v_response = '{"data": null}'::JSONB
+  );
+  PERFORM pg_temp.assert_true(
+    'missing pair creates no comparison data',
+    (SELECT count(*) FROM public.technical_configuration_comparison_sets)
+      = v_comparison_count
+      AND (SELECT count(*) FROM public.technical_configuration_option_responses)
+        = v_response_count
+  );
+  PERFORM pg_temp.assert_true(
+    'missing pair preserves dossier revision and audit metadata',
+    (SELECT revision FROM public.technical_configuration_dossiers
+     WHERE id = v_dossier_id) = v_before_revision
+      AND (SELECT updated_at FROM public.technical_configuration_dossiers
+           WHERE id = v_dossier_id) = v_before_updated_at
+      AND (SELECT updated_by FROM public.technical_configuration_dossiers
+           WHERE id = v_dossier_id) = v_before_updated_by
+  );
+
+  -- raw admin accepted
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  SELECT public.technical_configuration_comparison_set_get(
+    v_existing_option_id,
+    v_version_id
+  )
+  INTO v_response;
+  PERFORM pg_temp.assert_true(
+    'existing pair returns ordered exact multiline responses',
+    (v_response->'data'->>'id')::UUID = v_set_id
+      AND (v_response->'data'->'responses'->0->>'id')::UUID = v_first_response_id
+      AND (v_response->'data'->'responses'->1->>'id')::UUID = v_second_response_id
+      AND v_response->'data'->'responses'->0->>'response_text'
+        = E'First line 1\nFirst line 2'
+      AND v_response->'data'->'responses'->0->>'supplementary_information'
+        = E'First doc 1\nFirst doc 2'
+  );
+  PERFORM pg_temp.assert_true(
+    'complete existing payload matches stored snapshot',
+    v_response->'data' = v_expected_data
+  );
+  PERFORM pg_temp.assert_true(
+    'existing pair preserves dossier revision and audit metadata',
+    (v_response->'data'->>'revision')::BIGINT = v_before_revision
+      AND (SELECT revision FROM public.technical_configuration_dossiers
+           WHERE id = v_dossier_id) = v_before_revision
+      AND (SELECT updated_at FROM public.technical_configuration_dossiers
+           WHERE id = v_dossier_id) = v_before_updated_at
+      AND (SELECT updated_by FROM public.technical_configuration_dossiers
+           WHERE id = v_dossier_id) = v_before_updated_by
+      AND (SELECT updated_at FROM public.technical_configuration_comparison_sets
+           WHERE id = v_set_id) = v_set_updated_at
+      AND (SELECT updated_by FROM public.technical_configuration_comparison_sets
+           WHERE id = v_set_id) = v_set_updated_by
+  );
+
+  -- archived existing data remains readable
+  SELECT public.technical_configuration_comparison_set_get(
+    v_archived_option_id,
+    v_archived_version_id
+  )
+  INTO v_response;
+  PERFORM pg_temp.assert_true(
+    'archived existing data remains readable',
+    (v_response->'data'->>'id')::UUID = v_archived_set_id
+  );
+
+  PERFORM pg_temp.assert_true(
+    'authenticated executes read RPC',
+    has_function_privilege(
+      'authenticated',
+      'public.technical_configuration_comparison_set_get(uuid,uuid)',
+      'EXECUTE'
+    )
+  );
+  PERFORM pg_temp.assert_true(
+    'service role executes read RPC',
+    has_function_privilege(
+      'service_role',
+      'public.technical_configuration_comparison_set_get(uuid,uuid)',
+      'EXECUTE'
+    )
+  );
+  PERFORM pg_temp.assert_true(
+    'anon cannot execute read RPC',
+    NOT has_function_privilege(
+      'anon',
+      'public.technical_configuration_comparison_set_get(uuid,uuid)',
+      'EXECUTE'
+    )
+  );
+
+  SELECT p.proconfig
+  INTO v_function_config
+  FROM pg_proc p
+  WHERE p.oid =
+    'public.technical_configuration_comparison_set_get(uuid,uuid)'::regprocedure;
+  PERFORM pg_temp.assert_true(
+    'fixed search_path',
+    v_function_config = ARRAY['search_path=public, pg_temp']
+  );
+END;
+$gate$;
+
+-- rollback leaves zero fixture rows
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add P8A4 `technical_configuration_comparison_set_get(uuid, uuid)` as a side-effect-free nullable read RPC
- return `{ "data": null }` when no comparison set exists without inserting data, incrementing dossier revision, or writing audit metadata
- add the dedicated P8A4 manifest, client types/adapter, proxy allowlist entry, migration contract tests, and rollback-only live phase gate

## Scope
- P8A4 only
- no P8B1 or P8B2 implementation

## Verification
- three subagent review rounds completed; final round: zero findings
- format check, no-explicit-any, dedupe, typecheck: passed
- focused Vitest: 78/78 passed
- React Doctor: 100/100
- Supabase migration `technical_configuration_comparison_set_read` applied successfully
- live rollback-only phase gate passed
- post-gate live verification confirmed signature, fixed search path, grants, no DML/locking/audit writes, and zero fixture residue
- Supabase security/performance advisors reviewed; no P8A4-specific regression found

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only RPC to fetch a technical configuration comparison set by option and exact baseline. Missing pairs return {"data": null} with no inserts, revision bumps, or audit writes.

- **New Features**
  - RPC `technical_configuration_comparison_set_get(uuid, uuid)` for nullable, side-effect-free reads.
  - Client support: `getTechnicalConfigurationComparisonSet(...)`, `TechnicalConfigurationComparisonSetReadWireResponse`, `TechnicalConfigurationComparisonSetGetRpcArgs`.
  - Shared manifest and API proxy allowlist: `OPTION_RESPONSE_READ_RPC_FUNCTIONS`, `OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES`.

- **Migration**
  - SQL adds the function with SECURITY DEFINER, fixed `search_path`, and EXECUTE grants for `authenticated` and `service_role` only.
  - Adds a rollback-only phase gate and a migration contract test that freeze ordering after P8A3, validate function DDL and grants, enforce deterministic response ordering, archived reads, cross-dossier validation, and no DML/locks; also verifies the P8A3 migration SHA and zero fixture residue.

<sup>Written for commit cad46c4f854c764431541df1c4a58660ad82f8ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only access to existing technical configuration comparison sets.
  * Comparison sets now return associated responses in a consistent, ordered format.
  * Missing option and baseline combinations return an empty result without creating data.
  * Added access validation for global permissions, dossier ownership, archived records, and authorized RPC access.

* **Tests**
  * Added comprehensive coverage for response data, permissions, validation, privileges, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->