### PR TITLE
feat: add P8B2 exact-baseline option response workspace

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -285,14 +285,14 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 
 ## Phase P8B2 - Exact-Baseline Option Response Workspace
 
-- [ ] P8B2.1 Dùng P8A4 để đọc existing/null snapshot mà không tạo comparison set khi chọn option/baseline.
-- [ ] P8B2.2 Thêm manual response/supplementary editor với explicit save.
-- [ ] P8B2.3 Khi first save, chạy get-or-create rồi upsert bằng revision mới nhất
+- [x] P8B2.1 Dùng P8A4 để đọc existing/null snapshot mà không tạo comparison set khi chọn option/baseline.
+- [x] P8B2.2 Thêm manual response/supplementary editor với explicit save.
+- [x] P8B2.3 Khi first save, chạy get-or-create rồi upsert bằng revision mới nhất
       được trả về từ chính lời gọi get-or-create đó.
-- [ ] P8B2.4 Hiển thị `max(option.updated_at, response.updated_at)` cho editor context hiện tại.
-- [ ] P8B2.5 Giữ option/baseline/criterion/draft khi validation, persistence hoặc conflict thất bại.
-- [ ] P8B2.6 Thêm dirty navigation cho option/baseline/tab/dossier, archived read-only và draft/locked baseline tests.
-- [ ] P8B2.7 Viết no-write-on-open, exact-baseline, supplementary-non-scoring, responsive và no-lock-control tests.
+- [x] P8B2.4 Hiển thị `max(option.updated_at, response.updated_at)` cho editor context hiện tại.
+- [x] P8B2.5 Giữ option/baseline/criterion/draft khi validation, persistence hoặc conflict thất bại.
+- [x] P8B2.6 Thêm dirty navigation cho option/baseline/tab/dossier, archived read-only và draft/locked baseline tests.
+- [x] P8B2.7 Viết no-write-on-open, exact-baseline, supplementary-non-scoring, responsive và no-lock-control tests.
 
 ## Phase P9A - Supplier Option Excel
 

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-cases.tsx
@@ -1,0 +1,308 @@
+import { act, renderHook, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi, type Mock } from "vitest"
+
+import { TechnicalConfigurationOptionResponses } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses"
+import { useTechnicalConfigurationOptionResponses } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type {
+  TechnicalConfigurationComparisonSetWire,
+  TechnicalConfigurationOptionResponseWire,
+} from "@/app/(app)/technical-configurations/supplier-option-types"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+import {
+  dossier,
+  option,
+  renderWithQueryClient,
+  type SupplierOptionRpcMocks,
+} from "./supplier-options-fixtures"
+
+type ResponseTestMocks = {
+  baselineRpc: { listVersions: Mock }
+  fetchMock: Mock
+  supplierOptionRpc: SupplierOptionRpcMocks
+}
+
+const timestamp = "2026-07-23T00:00:00.000Z"
+
+export function baselineVersion(
+  overrides: Partial<TechnicalConfigurationBaselineDraftWire> = {}
+): TechnicalConfigurationBaselineDraftWire {
+  const id = overrides.id ?? "baseline-1"
+  return {
+    id,
+    dossier_id: dossier.id,
+    version_number: 1,
+    status: "draft",
+    source_baseline_version_id: null,
+    source_version_number: null,
+    next_criterion_number: 3,
+    revision: dossier.revision,
+    locked_at: null,
+    locked_by: null,
+    created_at: timestamp,
+    created_by: 1,
+    updated_at: timestamp,
+    updated_by: 1,
+    groups: [
+      {
+        id: `group-${id}`,
+        baseline_version_id: id,
+        name: "Yêu cầu chung",
+        sort_order: 1,
+        created_at: timestamp,
+        created_by: 1,
+        updated_at: timestamp,
+        updated_by: 1,
+        criteria: [
+          {
+            id: `criterion-${id}-1`,
+            baseline_version_id: id,
+            group_id: `group-${id}`,
+            criterion_code: "TC-0001",
+            title: "Nguồn điện",
+            requirement_text: "Dòng 1\nDòng 2",
+            sort_order: 1,
+            source_criterion_id: null,
+            created_at: timestamp,
+            created_by: 1,
+            updated_at: timestamp,
+            updated_by: 1,
+          },
+          {
+            id: `criterion-${id}-2`,
+            baseline_version_id: id,
+            group_id: `group-${id}`,
+            criterion_code: "TC-0002",
+            title: "Pin dự phòng",
+            requirement_text: "Hoạt động tối thiểu 30 phút",
+            sort_order: 2,
+            source_criterion_id: null,
+            created_at: timestamp,
+            created_by: 1,
+            updated_at: timestamp,
+            updated_by: 1,
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+export function optionResponse(
+  baseline: TechnicalConfigurationBaselineDraftWire,
+  overrides: Partial<TechnicalConfigurationOptionResponseWire> = {}
+): TechnicalConfigurationOptionResponseWire {
+  return {
+    id: "response-1",
+    comparison_set_id: "comparison-set-1",
+    baseline_version_id: baseline.id,
+    criterion_id: baseline.groups[0]?.criteria[0]?.id ?? "",
+    response_text: "Đáp ứng dòng 1\nĐáp ứng dòng 2",
+    supplementary_information: "Ghi chú bổ sung\nKhông dùng để chấm điểm",
+    created_at: timestamp,
+    created_by: 1,
+    updated_at: "2026-07-23T03:00:00.000Z",
+    updated_by: 1,
+    revision: dossier.revision,
+    ...overrides,
+  }
+}
+
+export function comparisonSet(
+  baseline: TechnicalConfigurationBaselineDraftWire,
+  responses: TechnicalConfigurationOptionResponseWire[] = [],
+  revision = dossier.revision
+): TechnicalConfigurationComparisonSetWire {
+  return {
+    id: "comparison-set-1",
+    dossier_id: dossier.id,
+    option_id: "option-1",
+    baseline_version_id: baseline.id,
+    created_at: timestamp,
+    created_by: 1,
+    updated_at: timestamp,
+    updated_by: 1,
+    revision,
+    responses,
+  }
+}
+
+export function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+export function getRequest(fetchMock: Mock, index: number) {
+  const [url, init] = fetchMock.mock.calls[index] ?? []
+  const request = init as RequestInit | undefined
+  return {
+    url,
+    body: JSON.parse(typeof request?.body === "string" ? request.body : "{}") as Record<
+      string,
+      unknown
+    >,
+  }
+}
+
+export function renderResponseHook({
+  baseline = baselineVersion(),
+  dossierValue = dossier,
+  onRevisionChange = () => undefined,
+  onNavigationBlockedChange = () => undefined,
+}: {
+  baseline?: TechnicalConfigurationBaselineDraftWire
+  dossierValue?: typeof dossier
+  onRevisionChange?: (revision: number) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+} = {}) {
+  const queryClient = createTestQueryClient()
+  const currentOption = option({ id: "option-1" })
+  const rendered = renderHook(
+    () =>
+      useTechnicalConfigurationOptionResponses({
+        dossier: dossierValue,
+        option: currentOption,
+        baselineVersion: baseline,
+        onRevisionChange,
+        onNavigationBlockedChange,
+      }),
+    { wrapper: createReactQueryWrapper(queryClient) }
+  )
+  return { ...rendered, queryClient, baseline, currentOption }
+}
+
+export function registerSupplierOptionResponseTests({ baselineRpc, fetchMock }: ResponseTestMocks) {
+  describe("technical configuration option responses", () => {
+    it("opens a null exact-baseline snapshot without creating comparison data", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: null }))
+
+      const { result, baseline, currentOption } = renderResponseHook()
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+
+      expect(result.current.draft).toEqual({
+        responseText: "",
+        supplementaryInformation: "",
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(getRequest(fetchMock, 0)).toEqual({
+        url: "/api/rpc/technical_configuration_comparison_set_get",
+        body: {
+          p_option_id: currentOption.id,
+          p_baseline_version_id: baseline.id,
+        },
+      })
+    })
+
+    it("preserves exact multiline response and supplementary information", async () => {
+      const baseline = baselineVersion()
+      const response = optionResponse(baseline)
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline, [response]) }))
+
+      const { result } = renderResponseHook({ baseline })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+
+      expect(result.current.draft.responseText).toBe(response.response_text)
+      expect(result.current.draft.supplementaryInformation).toBe(response.supplementary_information)
+    })
+
+    it("uses the get-or-create revision for the first explicit response save", async () => {
+      const onRevisionChange = vi.fn()
+      const baseline = baselineVersion()
+      const createdSet = comparisonSet(baseline, [], 4)
+      const savedResponse = optionResponse(baseline, {
+        response_text: "Đáp ứng đầy đủ",
+        supplementary_information: "Biên bản thử nghiệm số 12",
+        revision: 5,
+      })
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(jsonResponse({ data: createdSet }))
+        .mockResolvedValueOnce(jsonResponse({ data: savedResponse }))
+
+      const { result, currentOption } = renderResponseHook({ baseline, onRevisionChange })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+      act(() =>
+        result.current.updateDraft({
+          responseText: savedResponse.response_text,
+          supplementaryInformation: savedResponse.supplementary_information,
+        })
+      )
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+
+      await act(async () => result.current.save())
+
+      expect(getRequest(fetchMock, 1)).toEqual({
+        url: "/api/rpc/technical_configuration_comparison_set_get_or_create",
+        body: {
+          p_option_id: currentOption.id,
+          p_baseline_version_id: baseline.id,
+          p_expected_revision: dossier.revision,
+        },
+      })
+      expect(getRequest(fetchMock, 2)).toEqual({
+        url: "/api/rpc/technical_configuration_option_response_upsert",
+        body: {
+          p_comparison_set_id: createdSet.id,
+          p_criterion_id: baseline.groups[0]?.criteria[0]?.id,
+          p_response_text: savedResponse.response_text,
+          p_supplementary_information: savedResponse.supplementary_information,
+          p_expected_revision: createdSet.revision,
+        },
+      })
+      expect(onRevisionChange).toHaveBeenNthCalledWith(1, 4)
+      expect(onRevisionChange).toHaveBeenNthCalledWith(2, 5)
+      expect(result.current.isDirty).toBe(false)
+    })
+
+    it("keeps validation local and sends no mutation", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: null }))
+      const { result } = renderResponseHook()
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+
+      act(() => result.current.updateDraft({ responseText: "   " }))
+      await act(async () => result.current.save())
+
+      expect(result.current.validationError).toBe("Phản hồi tiêu chí là bắt buộc.")
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(result.current.draft.responseText).toBe("   ")
+    })
+
+    it("keeps locked baselines editable, archived dossiers read-only, and renders no lock controls", async () => {
+      const user = userEvent.setup()
+      const locked = baselineVersion({ status: "locked", locked_at: timestamp, locked_by: 9 })
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [locked],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      fetchMock.mockResolvedValue(jsonResponse({ data: null }))
+
+      const { rerender } = renderWithQueryClient(
+        <TechnicalConfigurationOptionResponses
+          dossier={dossier}
+          option={option({ id: "option-1" })}
+        />
+      )
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      expect(responseInput).toBeEnabled()
+      expect(screen.getByLabelText("Thông tin bổ sung")).toBeEnabled()
+      expect(screen.queryByText(/khóa phương án/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/phiên bản phương án/i)).not.toBeInTheDocument()
+      await user.type(responseInput, "Đáp ứng")
+
+      rerender(
+        <TechnicalConfigurationOptionResponses
+          dossier={{ ...dossier, archived_at: timestamp, archived_by: 9 }}
+          option={option({ id: "option-1" })}
+        />
+      )
+      expect(await screen.findByText("Chế độ chỉ đọc")).toBeInTheDocument()
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toBeDisabled()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-conflict-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-conflict-cases.tsx
@@ -88,6 +88,41 @@ export function registerSupplierOptionResponseConflictTests({
       })
     })
 
+    it("keeps conflict blocked until an explicit reload after the draft returns to base", async () => {
+      const baseline = baselineVersion({ revision: 7 })
+      const persistedResponse = optionResponse(baseline, {
+        response_text: "Nội dung đã lưu",
+        revision: 7,
+      })
+      const existingSet = comparisonSet(baseline, [persistedResponse], 7)
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: existingSet }))
+        .mockResolvedValueOnce(conflictResponse())
+
+      const { result } = renderResponseHook({
+        baseline,
+        dossierValue: { ...dossier, revision: 7 },
+      })
+      await waitFor(() => expect(result.current.draft.responseText).toBe("Nội dung đã lưu"))
+      act(() => result.current.updateDraft({ responseText: "Nội dung mới" }))
+      await act(async () => result.current.save())
+      expect(result.current.isConflict).toBe(true)
+
+      await act(async () => {
+        result.current.updateDraft({ responseText: persistedResponse.response_text })
+        await Promise.resolve()
+      })
+
+      expect(result.current.isDirty).toBe(false)
+      expect(result.current.isConflict).toBe(true)
+      expect(result.current.operationError).toMatch(/Tải lại dữ liệu/)
+
+      act(() => result.current.updateDraft({ responseText: "Nội dung mới lần nữa" }))
+      await act(async () => result.current.save())
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
     it("adopts the created revision after upsert failure and reloads without losing the draft", async () => {
       const onRevisionChange = vi.fn()
       const baseline = baselineVersion()

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-conflict-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-conflict-cases.tsx
@@ -1,0 +1,195 @@
+import { act, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest"
+
+import { TechnicalConfigurationSuppliers } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers"
+import {
+  dossier,
+  option,
+  optionsResponse,
+  renderWithQueryClient,
+  supplier,
+  suppliersResponse,
+  type SupplierOptionRpcMocks,
+} from "./supplier-options-fixtures"
+import {
+  baselineVersion,
+  comparisonSet,
+  getRequest,
+  jsonResponse,
+  optionResponse,
+  renderResponseHook,
+} from "./supplier-option-response-cases"
+
+type ResponseConflictTestMocks = {
+  baselineRpc: { listVersions: Mock }
+  fetchMock: Mock
+  supplierOptionRpc: SupplierOptionRpcMocks
+}
+
+function conflictResponse() {
+  return jsonResponse({ code: "PT409", message: "stale_revision" }, 409)
+}
+
+export function registerSupplierOptionResponseConflictTests({
+  baselineRpc,
+  fetchMock,
+  supplierOptionRpc,
+}: ResponseConflictTestMocks) {
+  const originalScrollIntoView = Element.prototype.scrollIntoView
+
+  beforeAll(() => {
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    })
+  })
+
+  afterAll(() => {
+    if (originalScrollIntoView) {
+      Object.defineProperty(Element.prototype, "scrollIntoView", {
+        configurable: true,
+        value: originalScrollIntoView,
+      })
+      return
+    }
+    Reflect.deleteProperty(Element.prototype, "scrollIntoView")
+  })
+
+  describe("technical configuration option response conflicts and navigation", () => {
+    beforeEach(() => {
+      Object.values(supplierOptionRpc).forEach((mock) => mock.mockReset())
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([]))
+    })
+
+    it("preserves the exact selection and local text when get-or-create conflicts", async () => {
+      const baseline = baselineVersion()
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(conflictResponse())
+      const { result } = renderResponseHook({ baseline })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+
+      act(() =>
+        result.current.updateDraft({
+          responseText: "Nội dung cục bộ",
+          supplementaryInformation: "Ghi chú cục bộ",
+        })
+      )
+      const selectedCriterionId = result.current.selectedCriterionId
+      await act(async () => result.current.save())
+
+      expect(result.current.isConflict).toBe(true)
+      expect(result.current.selectedCriterionId).toBe(selectedCriterionId)
+      expect(result.current.draft).toEqual({
+        responseText: "Nội dung cục bộ",
+        supplementaryInformation: "Ghi chú cục bộ",
+      })
+    })
+
+    it("adopts the created revision after upsert failure and reloads without losing the draft", async () => {
+      const onRevisionChange = vi.fn()
+      const baseline = baselineVersion()
+      const createdSet = comparisonSet(baseline, [], 4)
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(jsonResponse({ data: createdSet }))
+        .mockResolvedValueOnce(conflictResponse())
+        .mockResolvedValueOnce(jsonResponse({ data: createdSet }))
+
+      const { result } = renderResponseHook({ baseline, onRevisionChange })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+      act(() => result.current.updateDraft({ responseText: "Giữ nội dung này" }))
+
+      await act(async () => result.current.save())
+      expect(onRevisionChange).toHaveBeenCalledWith(4)
+      expect(result.current.isConflict).toBe(true)
+      expect(result.current.draft.responseText).toBe("Giữ nội dung này")
+
+      await act(async () => result.current.reload())
+      expect(getRequest(fetchMock, 3).url).toBe(
+        "/api/rpc/technical_configuration_comparison_set_get"
+      )
+      expect(result.current.isConflict).toBe(false)
+      expect(result.current.draft.responseText).toBe("Giữ nội dung này")
+    })
+
+    it("guards dirty option, baseline, and criterion changes with the shared confirmation", async () => {
+      const user = userEvent.setup()
+      const currentSupplier = supplier("supplier-1", "Công ty Thiết bị A")
+      const firstOption = option({ id: "option-1", model: "Model A" })
+      const secondOption = option({ id: "option-2", model: "Model B" })
+      const firstBaseline = baselineVersion()
+      const secondBaseline = baselineVersion({
+        id: "baseline-2",
+        version_number: 2,
+      })
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [firstBaseline, secondBaseline],
+        total: 2,
+        page: 1,
+        page_size: 100,
+      })
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([currentSupplier]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([firstOption, secondOption]))
+      fetchMock.mockResolvedValue(jsonResponse({ data: null }))
+
+      renderWithQueryClient(<TechnicalConfigurationSuppliers dossier={dossier} />)
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      const firstOptionButton = screen.getByRole("button", {
+        name: firstOption.display_label,
+      })
+      await user.type(responseInput, "Bản nháp chưa lưu")
+
+      await user.click(screen.getByRole("button", { name: secondOption.display_label }))
+      expect(await screen.findByRole("alertdialog")).toHaveTextContent("Bỏ thay đổi chưa lưu?")
+      expect(firstOptionButton).toHaveAttribute("aria-pressed", "true")
+      await user.click(
+        within(screen.getByRole("alertdialog")).getByRole("button", {
+          name: "Hủy",
+        })
+      )
+
+      act(() => screen.getByLabelText("Phiên bản cấu hình cơ sở").focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: /Phiên bản 1/ }))
+      expect(await screen.findByRole("alertdialog")).toHaveTextContent("Chuyển phiên bản")
+      await user.click(
+        within(screen.getByRole("alertdialog")).getByRole("button", {
+          name: "Hủy",
+        })
+      )
+
+      await user.click(screen.getByRole("button", { name: /TC-0002/ }))
+      expect(await screen.findByRole("alertdialog")).toHaveTextContent("Chuyển tiêu chí")
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toHaveValue("Bản nháp chưa lưu")
+    })
+
+    it("shows max option/response update time and keeps supplementary text outside scoring UI", async () => {
+      const baseline = baselineVersion()
+      const response = optionResponse(baseline, {
+        updated_at: "2026-07-24T05:30:00.000Z",
+      })
+      const currentSupplier = supplier("supplier-1", "Công ty Thiết bị A")
+      const currentOption = option({ id: "option-1" })
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baseline],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([currentSupplier]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([currentOption]))
+      fetchMock.mockResolvedValue(
+        jsonResponse({ data: comparisonSet(baseline, [response], response.revision) })
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationSuppliers dossier={dossier} />)
+
+      expect(await screen.findByText(/Cập nhật phản hồi gần nhất/)).toHaveTextContent("24")
+      expect(screen.getByText("Thông tin bổ sung không dùng để chấm điểm.")).toBeInTheDocument()
+      expect(screen.queryByText(/tuân thủ|xếp hạng|đánh giá/i)).not.toBeInTheDocument()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-coordination-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-coordination-cases.tsx
@@ -1,0 +1,120 @@
+import { act, renderHook, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, type Mock } from "vitest"
+
+import { TechnicalConfigurationSuppliers } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers"
+import { useTechnicalConfigurationOptionResponses } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+import { deferred } from "./technical-configuration-baseline-tab-fixtures"
+import {
+  dossier,
+  option,
+  optionsResponse,
+  renderWithQueryClient,
+  supplier,
+  suppliersResponse,
+  type SupplierOptionRpcMocks,
+} from "./supplier-options-fixtures"
+import {
+  baselineVersion,
+  comparisonSet,
+  getRequest,
+  jsonResponse,
+  optionResponse,
+} from "./supplier-option-response-cases"
+
+type ResponseCoordinationTestMocks = {
+  baselineRpc: { listVersions: Mock }
+  fetchMock: Mock
+  supplierOptionRpc: SupplierOptionRpcMocks
+}
+
+export function registerSupplierOptionResponseCoordinationTests({
+  baselineRpc,
+  fetchMock,
+  supplierOptionRpc,
+}: ResponseCoordinationTestMocks) {
+  describe("technical configuration option response coordination", () => {
+    beforeEach(() => {
+      Object.values(supplierOptionRpc).forEach((mock) => mock.mockReset())
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([]))
+    })
+
+    it("uses a newer dossier revision while the response draft remains dirty", async () => {
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const createdSet = comparisonSet(baseline, [], 9)
+      const savedResponse = optionResponse(baseline, {
+        response_text: "Bản nháp dùng revision mới",
+        revision: 10,
+      })
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(jsonResponse({ data: createdSet }))
+        .mockResolvedValueOnce(jsonResponse({ data: savedResponse }))
+      const queryClient = createTestQueryClient()
+      const { result, rerender } = renderHook(
+        ({ revision }: { revision: number }) =>
+          useTechnicalConfigurationOptionResponses({
+            dossier: { ...dossier, revision },
+            option: currentOption,
+            baselineVersion: baseline,
+          }),
+        {
+          initialProps: { revision: dossier.revision },
+          wrapper: createReactQueryWrapper(queryClient),
+        }
+      )
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+      act(() => result.current.updateDraft({ responseText: savedResponse.response_text }))
+      expect(result.current.isDirty).toBe(true)
+
+      rerender({ revision: 8 })
+      await act(async () => result.current.save())
+
+      expect(getRequest(fetchMock, 1).body.p_expected_revision).toBe(8)
+    })
+
+    it("blocks supplier mutations while a response save is pending", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentSupplier = supplier("supplier-1", "Công ty Thiết bị A")
+      const currentOption = option({ id: "option-1", supplier_id: currentSupplier.id })
+      const createdSet = comparisonSet(baseline, [], 4)
+      const savedResponse = optionResponse(baseline, {
+        response_text: "Đang lưu phản hồi",
+        revision: 5,
+      })
+      const createRequest = deferred<Response>()
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baseline],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([currentSupplier]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([currentOption]))
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockImplementationOnce(() => createRequest.promise)
+        .mockResolvedValueOnce(jsonResponse({ data: savedResponse }))
+
+      renderWithQueryClient(<TechnicalConfigurationSuppliers dossier={dossier} />)
+      await user.type(
+        await screen.findByLabelText("Phản hồi tiêu chí"),
+        savedResponse.response_text
+      )
+      await user.click(screen.getByRole("button", { name: "Lưu phản hồi" }))
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Lưu nhà cung cấp" })).toBeDisabled()
+      )
+      expect(screen.getByRole("button", { name: "Xóa nhà cung cấp" })).toBeDisabled()
+      expect(supplierOptionRpc.updateSupplier).not.toHaveBeenCalled()
+
+      act(() => createRequest.resolve(jsonResponse({ data: createdSet })))
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-recovery-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-recovery-cases.tsx
@@ -392,7 +392,26 @@ export function registerSupplierOptionResponseRecoveryTests({
       })
       supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([currentSupplier]))
       supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([firstOption, secondOption]))
-      fetchMock.mockResolvedValue(jsonResponse({ data: null }))
+      fetchMock.mockImplementation((_url, init?: RequestInit) => {
+        const body = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as Record<
+          string,
+          unknown
+        >
+        const optionId = String(body.p_option_id)
+        const selectedBaseline =
+          body.p_baseline_version_id === firstBaseline.id ? firstBaseline : secondBaseline
+        const responseText = `${optionId}-${selectedBaseline.id}`
+        return Promise.resolve(
+          jsonResponse({
+            data: {
+              ...comparisonSet(selectedBaseline, [
+                optionResponse(selectedBaseline, { response_text: responseText }),
+              ]),
+              option_id: optionId,
+            },
+          })
+        )
+      })
 
       renderWithQueryClient(<TechnicalConfigurationSuppliers dossier={dossier} />)
       expect(await screen.findByTestId("option-response-workspace")).toHaveClass(
@@ -403,14 +422,18 @@ export function registerSupplierOptionResponseRecoveryTests({
       expect(
         screen.getByRole("navigation", { name: "Tiêu chí cấu hình cơ sở" }).querySelector("div")
       ).toHaveClass("overflow-x-auto", "lg:flex-col", "lg:overflow-visible")
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      expect(responseInput).toHaveValue("option-1-baseline-2")
 
       await user.click(screen.getByRole("button", { name: secondOption.display_label }))
       await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toHaveValue("option-2-baseline-2")
 
       act(() => screen.getByLabelText("Phiên bản cấu hình cơ sở").focus())
       await user.keyboard("{ArrowDown}")
       await user.click(await screen.findByRole("option", { name: /Phiên bản 1/ }))
       await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toHaveValue("option-2-baseline-1")
 
       expect(fetchMock.mock.calls.map((_, index) => getRequest(fetchMock, index).url)).toEqual([
         "/api/rpc/technical_configuration_comparison_set_get",

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-recovery-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-recovery-cases.tsx
@@ -1,0 +1,360 @@
+import { act, renderHook, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest"
+
+import { TechnicalConfigurationSuppliers } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers"
+import { useTechnicalConfigurationIdentityMutationState } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationIdentityMutationState"
+import {
+  technicalConfigurationDossierDetailQueryKey,
+  technicalConfigurationOptionsQueryKey,
+  technicalConfigurationSuppliersQueryKey,
+} from "@/app/(app)/technical-configurations/technical-configuration-query-keys"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+import { deferred } from "./technical-configuration-baseline-tab-fixtures"
+import {
+  dossier,
+  option,
+  optionsResponse,
+  renderWithQueryClient,
+  supplier,
+  suppliersResponse,
+  type SupplierOptionRpcMocks,
+} from "./supplier-options-fixtures"
+import {
+  baselineVersion,
+  comparisonSet,
+  getRequest,
+  jsonResponse,
+  optionResponse,
+  renderResponseHook,
+} from "./supplier-option-response-cases"
+
+type ResponseRecoveryTestMocks = {
+  baselineRpc: { listVersions: Mock }
+  fetchMock: Mock
+  supplierOptionRpc: SupplierOptionRpcMocks
+}
+
+function conflictResponse() {
+  return jsonResponse({ code: "PT409", message: "stale_revision" }, 409)
+}
+
+export function registerSupplierOptionResponseRecoveryTests({
+  baselineRpc,
+  fetchMock,
+  supplierOptionRpc,
+}: ResponseRecoveryTestMocks) {
+  const originalScrollIntoView = Element.prototype.scrollIntoView
+
+  beforeAll(() => {
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    })
+  })
+
+  afterAll(() => {
+    if (originalScrollIntoView) {
+      Object.defineProperty(Element.prototype, "scrollIntoView", {
+        configurable: true,
+        value: originalScrollIntoView,
+      })
+      return
+    }
+    Reflect.deleteProperty(Element.prototype, "scrollIntoView")
+  })
+
+  beforeEach(() => {
+    Object.values(supplierOptionRpc).forEach((mock) => mock.mockReset())
+  })
+
+  describe("technical configuration option response recovery", () => {
+    it("upserts an existing set with its loaded revision and keeps conflict guidance visible", async () => {
+      const baseline = baselineVersion({ revision: 7 })
+      const existingSet = comparisonSet(
+        baseline,
+        [optionResponse(baseline, { response_text: "Đáp ứng cũ", revision: 7 })],
+        7
+      )
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: existingSet }))
+        .mockResolvedValueOnce(conflictResponse())
+
+      const { result } = renderResponseHook({
+        baseline,
+        dossierValue: { ...dossier, revision: 7 },
+      })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+      act(() => result.current.updateDraft({ responseText: "Đáp ứng mới" }))
+
+      await act(async () => result.current.save())
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(getRequest(fetchMock, 1)).toEqual({
+        url: "/api/rpc/technical_configuration_option_response_upsert",
+        body: {
+          p_comparison_set_id: existingSet.id,
+          p_criterion_id: baseline.groups[0]?.criteria[0]?.id,
+          p_response_text: "Đáp ứng mới",
+          p_supplementary_information: existingSet.responses[0]?.supplementary_information,
+          p_expected_revision: 7,
+        },
+      })
+      expect(result.current.isConflict).toBe(true)
+      expect(result.current.operationError).toMatch(/Tải lại dữ liệu/)
+
+      act(() => result.current.updateDraft({ supplementaryInformation: "Giữ hướng dẫn" }))
+      expect(result.current.operationError).toMatch(/Tải lại dữ liệu/)
+    })
+
+    it("keeps an advanced dossier revision after a stale existing-set conflict", async () => {
+      const baseline = baselineVersion({ revision: 7 })
+      const existingSet = comparisonSet(
+        baseline,
+        [optionResponse(baseline, { response_text: "Đáp ứng cũ", revision: 7 })],
+        7
+      )
+      const savedResponse = optionResponse(baseline, {
+        response_text: "Đáp ứng mới",
+        revision: 9,
+      })
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: existingSet }))
+        .mockResolvedValueOnce(conflictResponse())
+        .mockResolvedValueOnce(jsonResponse({ data: existingSet }))
+        .mockResolvedValueOnce(jsonResponse({ data: savedResponse }))
+
+      const onRevisionChange = vi.fn()
+      const { result, queryClient } = renderResponseHook({
+        baseline,
+        dossierValue: { ...dossier, revision: 8 },
+        onRevisionChange,
+      })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+      const detailQueryKey = technicalConfigurationDossierDetailQueryKey(dossier.id)
+      queryClient.setQueryDefaults(detailQueryKey, { gcTime: Number.POSITIVE_INFINITY })
+      queryClient.setQueryData(detailQueryKey, {
+        data: { ...dossier, revision: 8 },
+      })
+      act(() => result.current.updateDraft({ responseText: savedResponse.response_text }))
+
+      await act(async () => result.current.save())
+
+      expect(
+        queryClient.getQueryData<{ data: typeof dossier }>(detailQueryKey)?.data.revision
+      ).toBe(8)
+      expect(onRevisionChange).not.toHaveBeenCalledWith(7)
+
+      await act(async () => result.current.reload())
+      await act(async () => result.current.save())
+
+      expect(getRequest(fetchMock, 3).body).toMatchObject({ p_expected_revision: 8 })
+    })
+
+    it("refreshes a null-set conflict revision and retries without losing the draft", async () => {
+      const baseline = baselineVersion()
+      const createdSet = comparisonSet(baseline, [], 9)
+      const savedResponse = optionResponse(baseline, {
+        response_text: "Giữ nội dung này",
+        supplementary_information: "Giữ bổ sung này",
+        revision: 10,
+      })
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(conflictResponse())
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(jsonResponse({ data: { ...dossier, revision: 8 } }))
+        .mockResolvedValueOnce(jsonResponse({ data: createdSet }))
+        .mockResolvedValueOnce(jsonResponse({ data: savedResponse }))
+
+      const { result } = renderResponseHook({ baseline })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+      act(() =>
+        result.current.updateDraft({
+          responseText: savedResponse.response_text,
+          supplementaryInformation: savedResponse.supplementary_information,
+        })
+      )
+
+      await act(async () => result.current.save())
+      expect(result.current.isConflict).toBe(true)
+
+      await act(async () => result.current.reload())
+      expect(getRequest(fetchMock, 3)).toEqual({
+        url: "/api/rpc/technical_configuration_dossiers_get",
+        body: { p_id: dossier.id },
+      })
+      expect(result.current.draft.responseText).toBe(savedResponse.response_text)
+      expect(result.current.isConflict).toBe(false)
+
+      await act(async () => result.current.save())
+      expect(getRequest(fetchMock, 4).body).toMatchObject({ p_expected_revision: 8 })
+      expect(getRequest(fetchMock, 5).body).toMatchObject({ p_expected_revision: 9 })
+      expect(result.current.isDirty).toBe(false)
+    })
+
+    it("adopts refreshed server text when reload starts from a clean editor", async () => {
+      const baseline = baselineVersion({ revision: 4 })
+      const originalSet = comparisonSet(
+        baseline,
+        [optionResponse(baseline, { response_text: "Bản cũ", revision: 4 })],
+        4
+      )
+      const refreshedSet = comparisonSet(
+        baseline,
+        [optionResponse(baseline, { response_text: "Bản mới", revision: 5 })],
+        5
+      )
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: originalSet }))
+        .mockResolvedValueOnce(jsonResponse({ data: refreshedSet }))
+
+      const { result } = renderResponseHook({
+        baseline,
+        dossierValue: { ...dossier, revision: 4 },
+      })
+      await waitFor(() => expect(result.current.draft.responseText).toBe("Bản cũ"))
+
+      await act(async () => result.current.reload())
+
+      expect(result.current.draft.responseText).toBe("Bản mới")
+      expect(result.current.isDirty).toBe(false)
+    })
+
+    it("adopts server text when retrying an initial read error", async () => {
+      const baseline = baselineVersion()
+      const refreshedSet = comparisonSet(baseline, [
+        optionResponse(baseline, { response_text: "Đã phục hồi" }),
+      ])
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ message: "read_failed" }, 500))
+        .mockResolvedValueOnce(jsonResponse({ data: refreshedSet }))
+
+      const { result } = renderResponseHook({ baseline })
+      await waitFor(() => expect(result.current.responseQuery.isError).toBe(true))
+
+      await act(async () => result.current.reload())
+
+      expect(result.current.draft.responseText).toBe("Đã phục hồi")
+      expect(result.current.isDirty).toBe(false)
+    })
+
+    it("updates the dossier detail cache after a successful response save", async () => {
+      const baseline = baselineVersion()
+      const createdSet = comparisonSet(baseline, [], 4)
+      const savedResponse = optionResponse(baseline, { response_text: "Đã lưu", revision: 5 })
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(jsonResponse({ data: createdSet }))
+        .mockResolvedValueOnce(jsonResponse({ data: savedResponse }))
+
+      const { result, queryClient } = renderResponseHook({ baseline })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+      const detailQueryKey = technicalConfigurationDossierDetailQueryKey(dossier.id)
+      queryClient.setQueryDefaults(detailQueryKey, { gcTime: Number.POSITIVE_INFINITY })
+      queryClient.setQueryData(detailQueryKey, {
+        data: dossier,
+      })
+      act(() => result.current.updateDraft({ responseText: savedResponse.response_text }))
+
+      await act(async () => result.current.save())
+
+      expect(
+        queryClient.getQueryData<{ data: typeof dossier }>(detailQueryKey)?.data.revision
+      ).toBe(5)
+    })
+
+    it("tracks a newer workspace revision for later identity mutations", async () => {
+      const queryClient = createTestQueryClient()
+      const { result, rerender } = renderHook(
+        ({ revision }: { revision: number }) =>
+          useTechnicalConfigurationIdentityMutationState({
+            dossier: { ...dossier, revision },
+            supplierQueryKey: technicalConfigurationSuppliersQueryKey(dossier.id),
+            optionQueryKey: technicalConfigurationOptionsQueryKey(dossier.id),
+          }),
+        {
+          initialProps: { revision: dossier.revision },
+          wrapper: createReactQueryWrapper(queryClient),
+        }
+      )
+
+      rerender({ revision: 8 })
+
+      await waitFor(() => expect(result.current.revisionRef.current).toBe(8))
+    })
+
+    it("blocks navigation for the full response save window", async () => {
+      const baseline = baselineVersion()
+      const createdSet = comparisonSet(baseline, [], 4)
+      const savedResponse = optionResponse(baseline, { response_text: "Đang lưu", revision: 5 })
+      const createRequest = deferred<Response>()
+      const onNavigationBlockedChange = vi.fn()
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockImplementationOnce(() => createRequest.promise)
+        .mockResolvedValueOnce(jsonResponse({ data: savedResponse }))
+
+      const { result } = renderResponseHook({ baseline, onNavigationBlockedChange })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+      act(() => result.current.updateDraft({ responseText: savedResponse.response_text }))
+
+      let savePromise: Promise<void> | undefined
+      act(() => {
+        savePromise = result.current.save()
+      })
+      await waitFor(() => expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(true))
+
+      createRequest.resolve(jsonResponse({ data: createdSet }))
+      await act(async () => savePromise)
+
+      expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(false)
+    })
+
+    it("switches option and baseline with read-only calls and responsive navigation", async () => {
+      const user = userEvent.setup()
+      const firstBaseline = baselineVersion()
+      const secondBaseline = baselineVersion({ id: "baseline-2", version_number: 2 })
+      const currentSupplier = supplier("supplier-1", "Công ty Thiết bị A")
+      const firstOption = option({ id: "option-1", model: "Model A" })
+      const secondOption = option({ id: "option-2", model: "Model B" })
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [firstBaseline, secondBaseline],
+        total: 2,
+        page: 1,
+        page_size: 100,
+      })
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([currentSupplier]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([firstOption, secondOption]))
+      fetchMock.mockResolvedValue(jsonResponse({ data: null }))
+
+      renderWithQueryClient(<TechnicalConfigurationSuppliers dossier={dossier} />)
+      expect(await screen.findByTestId("option-response-workspace")).toHaveClass(
+        "grid",
+        "min-w-0",
+        "lg:grid-cols-[minmax(12rem,0.45fr)_minmax(0,1fr)]"
+      )
+      expect(
+        screen.getByRole("navigation", { name: "Tiêu chí cấu hình cơ sở" }).querySelector("div")
+      ).toHaveClass("overflow-x-auto", "lg:flex-col", "lg:overflow-visible")
+
+      await user.click(screen.getByRole("button", { name: secondOption.display_label }))
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+      act(() => screen.getByLabelText("Phiên bản cấu hình cơ sở").focus())
+      await user.keyboard("{ArrowDown}")
+      await user.click(await screen.findByRole("option", { name: /Phiên bản 1/ }))
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+
+      expect(fetchMock.mock.calls.map((_, index) => getRequest(fetchMock, index).url)).toEqual([
+        "/api/rpc/technical_configuration_comparison_set_get",
+        "/api/rpc/technical_configuration_comparison_set_get",
+        "/api/rpc/technical_configuration_comparison_set_get",
+      ])
+      expect(getRequest(fetchMock, 2).body).toEqual({
+        p_option_id: secondOption.id,
+        p_baseline_version_id: firstBaseline.id,
+      })
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-recovery-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-recovery-cases.tsx
@@ -2,6 +2,7 @@ import { act, renderHook, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest"
 
+import { TechnicalConfigurationOptionResponseEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor"
 import { TechnicalConfigurationSuppliers } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers"
 import { useTechnicalConfigurationIdentityMutationState } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationIdentityMutationState"
 import {
@@ -237,6 +238,71 @@ export function registerSupplierOptionResponseRecoveryTests({
 
       expect(result.current.draft.responseText).toBe("Đã phục hồi")
       expect(result.current.isDirty).toBe(false)
+    })
+
+    it("keeps the existing editor and dirty draft visible when reload fails", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const persistedResponse = optionResponse(baseline, { response_text: "Nội dung đã lưu" })
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline, [persistedResponse]) }))
+        .mockResolvedValueOnce(jsonResponse({ message: "read_failed" }, 500))
+
+      renderWithQueryClient(
+        <TechnicalConfigurationOptionResponseEditor
+          dossier={dossier}
+          option={option({ id: "option-1" })}
+          baselineVersion={baseline}
+          requestDiscardConfirmation={(_description, action) => action()}
+        />
+      )
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      await waitFor(() => expect(responseInput).toHaveValue("Nội dung đã lưu"))
+      await user.clear(responseInput)
+      await user.type(responseInput, "Bản nháp cục bộ")
+
+      await user.click(screen.getByRole("button", { name: "Tải lại dữ liệu" }))
+
+      expect((await screen.findAllByText("read_failed")).length).toBeGreaterThan(0)
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toHaveValue("Bản nháp cục bộ")
+    })
+
+    it("shows persisted response text and clears dirty state when the dossier becomes archived", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const persistedResponse = optionResponse(baseline, { response_text: "Nội dung đã lưu" })
+      const onDirtyChange = vi.fn()
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: comparisonSet(baseline, [persistedResponse]) })
+      )
+      const editor = (dossierValue: typeof dossier): React.ReactElement => (
+        <TechnicalConfigurationOptionResponseEditor
+          dossier={dossierValue}
+          option={currentOption}
+          baselineVersion={baseline}
+          onDirtyChange={onDirtyChange}
+          requestDiscardConfirmation={(_description, action) => action()}
+        />
+      )
+      const { rerender } = renderWithQueryClient(editor(dossier))
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      await waitFor(() => expect(responseInput).toHaveValue("Nội dung đã lưu"))
+      await user.clear(responseInput)
+      await user.type(responseInput, "Bản nháp chưa lưu")
+      await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(true))
+
+      rerender(
+        editor({
+          ...dossier,
+          archived_at: "2026-07-24T00:00:00.000Z",
+          archived_by: 1,
+        })
+      )
+
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toBeDisabled()
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toHaveValue("Nội dung đã lưu")
+      await waitFor(() => expect(onDirtyChange).toHaveBeenLastCalledWith(false))
     })
 
     it("updates the dossier detail cache after a successful response save", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, vi } from "vitest"
 
+import { registerSupplierOptionResponseCoordinationTests } from "./supplier-option-response-coordination-cases"
 import { registerSupplierOptionResponseConflictTests } from "./supplier-option-response-conflict-cases"
 import { registerSupplierOptionResponseTests } from "./supplier-option-response-cases"
 import { registerSupplierOptionResponseRecoveryTests } from "./supplier-option-response-recovery-cases"
@@ -66,6 +67,11 @@ registerSupplierOptionResponseConflictTests({
   supplierOptionRpc,
 })
 registerSupplierOptionResponseRecoveryTests({
+  baselineRpc,
+  fetchMock: optionResponseFetch,
+  supplierOptionRpc,
+})
+registerSupplierOptionResponseCoordinationTests({
   baselineRpc,
   fetchMock: optionResponseFetch,
   supplierOptionRpc,

--- a/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
@@ -1,8 +1,15 @@
-import { vi } from "vitest"
+import { beforeEach, vi } from "vitest"
 
+import { registerSupplierOptionResponseConflictTests } from "./supplier-option-response-conflict-cases"
+import { registerSupplierOptionResponseTests } from "./supplier-option-response-cases"
+import { registerSupplierOptionResponseRecoveryTests } from "./supplier-option-response-recovery-cases"
 import { registerSupplierOptionConflictTests } from "./supplier-options-conflict-cases"
 import { registerSupplierOptionHookTests } from "./supplier-options-hook-cases"
 import { registerSupplierOptionWorkspaceTests } from "./supplier-options-workspace-cases"
+
+const baselineRpc = vi.hoisted(() => ({
+  listVersions: vi.fn(),
+}))
 
 const supplierOptionRpc = vi.hoisted(() => ({
   listSuppliers: vi.fn(),
@@ -13,6 +20,12 @@ const supplierOptionRpc = vi.hoisted(() => ({
   createOption: vi.fn(),
   updateOption: vi.fn(),
   deleteOption: vi.fn(),
+}))
+
+const optionResponseFetch = vi.hoisted(() => vi.fn())
+
+vi.mock("@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline", () => ({
+  useTechnicalConfigurationBaseline: () => baselineRpc,
 }))
 
 vi.mock("@/app/(app)/technical-configurations/technical-configuration-supplier-option-rpc", () => ({
@@ -26,6 +39,34 @@ vi.mock("@/app/(app)/technical-configurations/technical-configuration-supplier-o
   deleteTechnicalConfigurationOption: supplierOptionRpc.deleteOption,
 }))
 
+vi.stubGlobal("fetch", optionResponseFetch)
+
+beforeEach(() => {
+  baselineRpc.listVersions.mockReset()
+  baselineRpc.listVersions.mockResolvedValue({
+    data: [],
+    total: 0,
+    page: 1,
+    page_size: 100,
+  })
+  optionResponseFetch.mockReset()
+})
+
 registerSupplierOptionHookTests(supplierOptionRpc)
 registerSupplierOptionWorkspaceTests(supplierOptionRpc)
 registerSupplierOptionConflictTests(supplierOptionRpc)
+registerSupplierOptionResponseTests({
+  baselineRpc,
+  fetchMock: optionResponseFetch,
+  supplierOptionRpc,
+})
+registerSupplierOptionResponseConflictTests({
+  baselineRpc,
+  fetchMock: optionResponseFetch,
+  supplierOptionRpc,
+})
+registerSupplierOptionResponseRecoveryTests({
+  baselineRpc,
+  fetchMock: optionResponseFetch,
+  supplierOptionRpc,
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -279,6 +279,8 @@ describe("technical configuration baseline workspace integration", () => {
       "_components/TechnicalConfigurationBaselineTab.tsx",
       "_components/TechnicalConfigurationBaselineEvidence.tsx",
       "_components/TechnicalConfigurationBaselineAlerts.tsx",
+      "_components/TechnicalConfigurationOptionResponseEditor.tsx",
+      "_components/TechnicalConfigurationOptionResponses.tsx",
       "_components/TechnicalConfigurationBaselineTabStates.tsx",
       "_components/TechnicalConfigurationBaselineEditor.tsx",
       "_components/TechnicalConfigurationCriteriaSpreadsheet.tsx",
@@ -289,6 +291,7 @@ describe("technical configuration baseline workspace integration", () => {
       "_hooks/useTechnicalConfigurationBaselineImport.ts",
       "_hooks/useTechnicalConfigurationBulkEntrySessions.ts",
       "_hooks/useTechnicalConfigurationInlineEditor.ts",
+      "_hooks/useTechnicalConfigurationOptionResponses.ts",
     ]
 
     for (const file of files) {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-beforeunload.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-beforeunload.test.tsx
@@ -10,6 +10,7 @@ import {
   supplier,
   suppliersResponse,
 } from "./supplier-options-fixtures"
+import { baselineVersion, jsonResponse, renderResponseHook } from "./supplier-option-response-cases"
 import {
   baselineVersionsResponse,
   createDraft,
@@ -111,6 +112,37 @@ describe("technical configuration beforeunload protection", () => {
       expect(dirtyEvent.defaultPrevented).toBe(true)
     } finally {
       addEventListener.mockRestore()
+    }
+  })
+
+  it("registers beforeunload protection for a dirty exact-baseline response draft", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+    fetchMock.mockResolvedValueOnce(jsonResponse({ data: null }))
+    const addEventListener = vi.spyOn(window, "addEventListener")
+
+    try {
+      const cleanHandlerCount = addEventListener.mock.calls.filter(
+        ([eventName]) => eventName === "beforeunload"
+      ).length
+      const { result } = renderResponseHook({ baseline: baselineVersion() })
+      await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
+
+      act(() => result.current.updateDraft({ responseText: "Phản hồi chưa lưu" }))
+
+      await waitFor(() =>
+        expect(
+          addEventListener.mock.calls.filter(([eventName]) => eventName === "beforeunload")
+        ).toHaveLength(cleanHandlerCount + 1)
+      )
+      const beforeUnloadHandler = addEventListener.mock.calls
+        .filter(([eventName]) => eventName === "beforeunload")
+        .at(-1)?.[1]
+      const dirtyEvent = new Event("beforeunload", { cancelable: true })
+      ;(beforeUnloadHandler as EventListener)(dirtyEvent)
+      expect(dirtyEvent.defaultPrevented).toBe(true)
+    } finally {
+      addEventListener.mockRestore()
+      fetchMock.mockRestore()
     }
   })
 })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
@@ -1,0 +1,225 @@
+"use client"
+
+import * as React from "react"
+import { AlertCircle, Archive, Loader2, RefreshCw, Save } from "lucide-react"
+
+import { useTechnicalConfigurationOptionResponses } from "../_hooks/useTechnicalConfigurationOptionResponses"
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "../types"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { formatVietnamDateTime } from "@/lib/vietnam-date-format"
+
+type TechnicalConfigurationOptionResponseEditorProps = {
+  dossier: TechnicalConfigurationDossierWire
+  option: TechnicalConfigurationOptionWire
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+  onRevisionChange?: (revision: number) => void
+  requestDiscardConfirmation: (description: React.ReactNode, action: () => void) => void
+}
+
+/** Renders one exact-baseline criterion navigator and explicit response editor. */
+export function TechnicalConfigurationOptionResponseEditor({
+  dossier,
+  option,
+  baselineVersion,
+  onDirtyChange,
+  onNavigationBlockedChange,
+  onRevisionChange,
+  requestDiscardConfirmation,
+}: Readonly<TechnicalConfigurationOptionResponseEditorProps>) {
+  const state = useTechnicalConfigurationOptionResponses({
+    dossier,
+    option,
+    baselineVersion,
+    onRevisionChange,
+    onNavigationBlockedChange,
+  })
+
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- The response hook owns the draft while the supplier workspace combines cross-surface dirty state.
+    onDirtyChange?.(state.isDirty)
+  }, [onDirtyChange, state.isDirty])
+
+  React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+
+  const handleCriterionChange = React.useCallback(
+    (criterionId: string) => {
+      if (state.isDirty) {
+        requestDiscardConfirmation("Chuyển tiêu chí sẽ bỏ phản hồi chưa lưu. Tiếp tục?", () =>
+          state.selectCriterion(criterionId)
+        )
+        return
+      }
+      state.selectCriterion(criterionId)
+    },
+    [requestDiscardConfirmation, state]
+  )
+  const hasInitialError = state.responseQuery.isError && !state.responseQuery.isSuccess
+  const isUnavailable = state.responseQuery.isLoading || hasInitialError
+
+  return (
+    <div className="space-y-4">
+      {dossier.archived_at ? (
+        <Alert>
+          <Archive className="size-4" aria-hidden="true" />
+          <AlertTitle>Chế độ chỉ đọc</AlertTitle>
+          <AlertDescription>Hồ sơ đã lưu trữ. Phản hồi phương án chỉ được xem.</AlertDescription>
+        </Alert>
+      ) : null}
+
+      {hasInitialError ? (
+        <Alert variant="destructive">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          <AlertTitle>Không thể tải phản hồi phương án</AlertTitle>
+          <AlertDescription>
+            <Button type="button" variant="outline" size="sm" onClick={() => void state.reload()}>
+              <RefreshCw className="size-4" aria-hidden="true" />
+              Thử lại
+            </Button>
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      {state.validationError || state.operationError ? (
+        <Alert variant="destructive" role="alert">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          <AlertTitle>{state.isConflict ? "Dữ liệu đã thay đổi" : "Không thể lưu"}</AlertTitle>
+          <AlertDescription>{state.validationError ?? state.operationError}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div
+        data-testid="option-response-workspace"
+        className="grid min-w-0 gap-5 lg:grid-cols-[minmax(12rem,0.45fr)_minmax(0,1fr)]"
+      >
+        <nav aria-label="Tiêu chí cấu hình cơ sở" className="min-w-0 border-y py-3">
+          <p className="mb-2 text-sm font-medium">Tiêu chí</p>
+          <div className="flex gap-2 overflow-x-auto pb-1 lg:flex-col lg:overflow-visible">
+            {state.criteria.map((criterion) => (
+              <Button
+                key={criterion.id}
+                type="button"
+                variant={criterion.id === state.selectedCriterionId ? "secondary" : "ghost"}
+                className="h-auto min-w-44 justify-start whitespace-normal text-left lg:min-w-0"
+                disabled={state.isPending}
+                onClick={() => handleCriterionChange(criterion.id)}
+              >
+                <span className="min-w-0">
+                  <span className="block text-xs text-muted-foreground">
+                    {criterion.criterion_code}
+                  </span>
+                  <span className="block break-words">
+                    {criterion.title ?? criterion.requirement_text}
+                  </span>
+                </span>
+              </Button>
+            ))}
+          </div>
+        </nav>
+
+        <section className="min-w-0 space-y-4">
+          {state.responseQuery.isLoading ? (
+            <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              Đang tải phản hồi...
+            </div>
+          ) : null}
+
+          {!isUnavailable && !state.selectedCriterion ? (
+            <Alert>
+              <AlertTitle>Phiên bản chưa có tiêu chí</AlertTitle>
+              <AlertDescription>
+                Thêm tiêu chí cấu hình cơ sở trước khi nhập phản hồi.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          {!isUnavailable && state.selectedCriterion ? (
+            <>
+              <div className="border-b pb-3">
+                <p className="text-sm font-medium">
+                  {state.selectedCriterion.criterion_code} ·{" "}
+                  {state.selectedCriterion.title ?? "Không có tiêu đề"}
+                </p>
+                <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
+                  {state.selectedCriterion.requirement_text}
+                </p>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Cập nhật phản hồi gần nhất: {formatVietnamDateTime(state.updatedAt)}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="technical-option-response-text">Phản hồi tiêu chí</Label>
+                <Textarea
+                  id="technical-option-response-text"
+                  value={state.draft.responseText}
+                  rows={7}
+                  disabled={state.isReadOnly || state.isPending}
+                  onChange={(event) => state.updateDraft({ responseText: event.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="technical-option-supplementary-information">
+                  Thông tin bổ sung
+                </Label>
+                <Textarea
+                  id="technical-option-supplementary-information"
+                  value={state.draft.supplementaryInformation}
+                  rows={5}
+                  disabled={state.isReadOnly || state.isPending}
+                  onChange={(event) =>
+                    state.updateDraft({ supplementaryInformation: event.target.value })
+                  }
+                />
+                <p className="text-xs text-muted-foreground">
+                  Thông tin bổ sung không dùng để chấm điểm.
+                </p>
+              </div>
+
+              <div className="flex flex-wrap justify-end gap-2 border-t pt-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={state.isPending}
+                  onClick={() => void state.reload()}
+                >
+                  <RefreshCw
+                    className={`size-4 ${state.isReloading ? "animate-spin" : ""}`}
+                    aria-hidden="true"
+                  />
+                  Tải lại dữ liệu
+                </Button>
+                {!state.isReadOnly ? (
+                  <Button
+                    type="button"
+                    disabled={!state.isDirty || state.isPending || state.isConflict}
+                    onClick={() => void state.save()}
+                  >
+                    {state.isSaving ? (
+                      <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                    ) : (
+                      <Save className="size-4" aria-hidden="true" />
+                    )}
+                    Lưu phản hồi
+                  </Button>
+                ) : null}
+              </div>
+              {state.saveStatus === "saved" ? (
+                <p role="status" className="text-sm text-emerald-700">
+                  Đã lưu phản hồi phương án.
+                </p>
+              ) : null}
+            </>
+          ) : null}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
@@ -60,7 +60,7 @@ export function TechnicalConfigurationOptionResponseEditor({
     },
     [requestDiscardConfirmation, state]
   )
-  const hasInitialError = state.responseQuery.isError && !state.responseQuery.isSuccess
+  const hasInitialError = state.responseQuery.isError && state.responseQuery.data === undefined
   const isUnavailable = state.responseQuery.isLoading || hasInitialError
 
   return (

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses.tsx
@@ -1,0 +1,202 @@
+"use client"
+
+import * as React from "react"
+import { AlertCircle, Loader2, RefreshCw } from "lucide-react"
+
+import { useTechnicalConfigurationBaselineVersionSelection } from "../_hooks/useTechnicalConfigurationBaselineVersionSelection"
+import { useTechnicalConfigurationDiscardConfirmation } from "../_hooks/useTechnicalConfigurationDiscardConfirmation"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "../types"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+import { TechnicalConfigurationOptionResponseEditor } from "./TechnicalConfigurationOptionResponseEditor"
+type TechnicalConfigurationOptionResponsesProps = {
+  dossier: TechnicalConfigurationDossierWire
+  option: TechnicalConfigurationOptionWire
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+  onRevisionChange?: (revision: number) => void
+}
+
+const LOAD_MORE_BASELINE_VERSIONS_VALUE = "__load-more-option-response-baselines__"
+
+/** Renders manual option responses bound to one exact baseline version. */
+export function TechnicalConfigurationOptionResponses({
+  dossier,
+  option,
+  onDirtyChange,
+  onNavigationBlockedChange,
+  onRevisionChange,
+}: Readonly<TechnicalConfigurationOptionResponsesProps>) {
+  const selection = useTechnicalConfigurationBaselineVersionSelection(dossier.id)
+  const {
+    adoptVersion,
+    handleRevisionChange,
+    selectedVersion,
+    synchronizeVersion,
+    versionOptions,
+    versionState,
+  } = selection
+  const [isDirty, setIsDirty] = React.useState(false)
+  const [isNavigationBlocked, setIsNavigationBlocked] = React.useState(false)
+  const { discardConfirmationDialog, requestDiscardConfirmation } =
+    useTechnicalConfigurationDiscardConfirmation()
+
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent -- Baseline history refresh must not replace an exact-baseline response draft.
+    synchronizeVersion(isDirty)
+  }, [isDirty, synchronizeVersion])
+
+  const handleDirtyChange = React.useCallback(
+    (dirty: boolean) => {
+      setIsDirty(dirty)
+      onDirtyChange?.(dirty)
+    },
+    [onDirtyChange]
+  )
+  const handleNavigationBlockedChange = React.useCallback(
+    (blocked: boolean) => {
+      setIsNavigationBlocked(blocked)
+      onNavigationBlockedChange?.(blocked)
+    },
+    [onNavigationBlockedChange]
+  )
+  const handleResponseRevisionChange = React.useCallback(
+    (revision: number) => {
+      handleRevisionChange(revision)
+      onRevisionChange?.(revision)
+    },
+    [handleRevisionChange, onRevisionChange]
+  )
+  const handleVersionChange = React.useCallback(
+    (versionId: string) => {
+      const nextVersion = versionOptions.find((version) => version.id === versionId)
+      if (!nextVersion) return
+      if (isDirty) {
+        requestDiscardConfirmation("Chuyển phiên bản sẽ bỏ phản hồi chưa lưu. Tiếp tục?", () =>
+          adoptVersion(nextVersion)
+        )
+        return
+      }
+      adoptVersion(nextVersion)
+    },
+    [adoptVersion, isDirty, requestDiscardConfirmation, versionOptions]
+  )
+  const handleVersionSelect = React.useCallback(
+    (value: string) => {
+      if (value === LOAD_MORE_BASELINE_VERSIONS_VALUE) {
+        void versionState.loadMoreVersions()
+        return
+      }
+      handleVersionChange(value)
+    },
+    [handleVersionChange, versionState.loadMoreVersions]
+  )
+
+  React.useEffect(
+    () => () => {
+      onDirtyChange?.(false)
+      onNavigationBlockedChange?.(false)
+    },
+    [onDirtyChange, onNavigationBlockedChange]
+  )
+
+  if (versionState.versionsQuery.isLoading) {
+    return (
+      <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        Đang tải phiên bản cấu hình...
+      </div>
+    )
+  }
+
+  if (versionState.versionsQuery.isError && versionOptions.length === 0) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="size-4" aria-hidden="true" />
+        <AlertTitle>Không thể tải phiên bản cấu hình</AlertTitle>
+        <AlertDescription>
+          <Button type="button" variant="outline" size="sm" onClick={versionState.retryVersions}>
+            <RefreshCw className="size-4" aria-hidden="true" />
+            Thử lại
+          </Button>
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (!selectedVersion) {
+    return (
+      <div className="border-y py-5">
+        <p className="text-sm font-medium">Chưa có phiên bản cấu hình cơ sở</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Tạo cấu hình cơ sở trước khi nhập phản hồi cho phương án.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-5 border-t pt-5">
+      <div className="min-w-0">
+        <Label htmlFor="option-response-baseline-version">Phiên bản cấu hình cơ sở</Label>
+        <Select
+          value={selectedVersion.id}
+          disabled={isNavigationBlocked}
+          onValueChange={handleVersionSelect}
+        >
+          <SelectTrigger
+            id="option-response-baseline-version"
+            aria-label="Phiên bản cấu hình cơ sở"
+            className="mt-2 w-full sm:w-[320px]"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {versionOptions
+              .toSorted((left, right) => right.version_number - left.version_number)
+              .map((version) => (
+                <SelectItem key={version.id} value={version.id}>
+                  Phiên bản {version.version_number} ·{" "}
+                  {version.status === "locked" ? "Đã khóa" : "Bản nháp"}
+                </SelectItem>
+              ))}
+            {versionState.versionsQuery.hasNextPage || versionState.hasHistoryRecoveryError ? (
+              <SelectItem
+                value={LOAD_MORE_BASELINE_VERSIONS_VALUE}
+                disabled={versionState.versionsQuery.isFetchingNextPage}
+              >
+                {versionState.versionsQuery.isFetchingNextPage
+                  ? "Đang tải phiên bản..."
+                  : versionState.hasHistoryRecoveryError
+                    ? "Thử tải lại lịch sử phiên bản"
+                    : "Tải thêm phiên bản"}
+              </SelectItem>
+            ) : null}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <TechnicalConfigurationOptionResponseEditor
+        key={`${option.id}:${selectedVersion.id}`}
+        dossier={dossier}
+        option={option}
+        baselineVersion={selectedVersion}
+        onDirtyChange={handleDirtyChange}
+        onNavigationBlockedChange={handleNavigationBlockedChange}
+        onRevisionChange={handleResponseRevisionChange}
+        requestDiscardConfirmation={requestDiscardConfirmation}
+      />
+      {discardConfirmationDialog}
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSupplierSelector.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSupplierSelector.tsx
@@ -16,6 +16,7 @@ type TechnicalConfigurationSupplierSelectorProps = {
   state: TechnicalConfigurationOptionsState
   selectedSupplier: TechnicalConfigurationSupplierWire | null
   isLoadingDeleteCount: boolean
+  isMutationBlocked: boolean
   requestIdentityChange: (description: React.ReactNode, action: () => void) => void
   onDeleteSupplier: () => void
 }
@@ -25,6 +26,7 @@ export function TechnicalConfigurationSupplierSelector({
   state,
   selectedSupplier,
   isLoadingDeleteCount,
+  isMutationBlocked,
   requestIdentityChange,
   onDeleteSupplier,
 }: Readonly<TechnicalConfigurationSupplierSelectorProps>) {
@@ -56,7 +58,9 @@ export function TechnicalConfigurationSupplierSelector({
                       state.selectSupplier(supplier.id)
                     )
                   }
-                  disabled={state.isPending || state.isConflict || isLoadingDeleteCount}
+                  disabled={
+                    state.isPending || state.isConflict || isLoadingDeleteCount || isMutationBlocked
+                  }
                 >
                   <span className="break-words font-medium">{supplier.name}</span>
                 </Button>
@@ -76,7 +80,12 @@ export function TechnicalConfigurationSupplierSelector({
                           state.selectOption(option.id)
                         )
                       }
-                      disabled={state.isPending || state.isConflict || isLoadingDeleteCount}
+                      disabled={
+                        state.isPending ||
+                        state.isConflict ||
+                        isLoadingDeleteCount ||
+                        isMutationBlocked
+                      }
                     >
                       <span className="break-words">{option.display_label}</span>
                     </Button>
@@ -97,7 +106,11 @@ export function TechnicalConfigurationSupplierSelector({
               value={state.supplierDraft.name}
               onChange={(event) => state.updateSupplierDraft(event.target.value)}
               disabled={
-                state.isReadOnly || state.isPending || state.isConflict || isLoadingDeleteCount
+                state.isReadOnly ||
+                state.isPending ||
+                state.isConflict ||
+                isLoadingDeleteCount ||
+                isMutationBlocked
               }
             />
           </div>
@@ -106,7 +119,11 @@ export function TechnicalConfigurationSupplierSelector({
               type="button"
               onClick={() => void state.saveSupplier()}
               disabled={
-                state.isReadOnly || state.isPending || state.isConflict || isLoadingDeleteCount
+                state.isReadOnly ||
+                state.isPending ||
+                state.isConflict ||
+                isLoadingDeleteCount ||
+                isMutationBlocked
               }
             >
               <Save className="size-4" aria-hidden="true" />
@@ -121,6 +138,7 @@ export function TechnicalConfigurationSupplierSelector({
                 state.isPending ||
                 state.isConflict ||
                 isLoadingDeleteCount ||
+                isMutationBlocked ||
                 state.isCreatingSupplier ||
                 !selectedSupplier
               }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx
@@ -37,6 +37,7 @@ export function TechnicalConfigurationSuppliers({
   const [isResponseNavigationBlocked, setIsResponseNavigationBlocked] = React.useState(false)
   const state = useTechnicalConfigurationOptions({
     dossier,
+    isMutationBlocked: isResponseNavigationBlocked,
     onRevisionChange,
     onNavigationBlockedChange: setIsIdentityNavigationBlocked,
   })
@@ -53,6 +54,8 @@ export function TechnicalConfigurationSuppliers({
   const isInitialLoading = state.suppliersQuery.isLoading || state.optionsQuery.isLoading
   const isDirty = state.isDirty || isResponseDirty
   const isNavigationBlocked = isIdentityNavigationBlocked || isResponseNavigationBlocked
+  const isIdentityMutationBlocked =
+    state.isPending || state.isConflict || isResponseNavigationBlocked
 
   React.useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- WorkspaceShell owns cross-tab dirty navigation while this component owns supplier/option drafts.
@@ -86,7 +89,7 @@ export function TechnicalConfigurationSuppliers({
   )
 
   const handleSupplierDeleteRequest = React.useCallback(async () => {
-    if (!selectedSupplier || state.isPending || state.isConflict) return
+    if (!selectedSupplier || isIdentityMutationBlocked) return
     const supplier = selectedSupplier
     setDeleteCountError(null)
     setIsLoadingDeleteCount(true)
@@ -103,16 +106,16 @@ export function TechnicalConfigurationSuppliers({
     } finally {
       setIsLoadingDeleteCount(false)
     }
-  }, [selectedSupplier, state])
+  }, [isIdentityMutationBlocked, selectedSupplier, state])
 
   const handleConfirmDelete = React.useCallback(() => {
-    if (!pendingDelete) return
+    if (!pendingDelete || isResponseNavigationBlocked) return
     const action =
       pendingDelete.kind === "option"
         ? () => state.deleteOption(pendingDelete.id)
         : () => state.deleteSupplier(pendingDelete.id)
     void action().finally(() => setPendingDelete(null))
-  }, [pendingDelete, state.deleteOption, state.deleteSupplier])
+  }, [isResponseNavigationBlocked, pendingDelete, state.deleteOption, state.deleteSupplier])
 
   if (isInitialLoading) {
     return (
@@ -161,7 +164,7 @@ export function TechnicalConfigurationSuppliers({
               state.startSupplierCreate
             )
           }
-          disabled={state.isReadOnly || state.isPending || state.isConflict || isLoadingDeleteCount}
+          disabled={state.isReadOnly || isIdentityMutationBlocked || isLoadingDeleteCount}
         >
           <Plus className="size-4" aria-hidden="true" />
           Thêm nhà cung cấp
@@ -216,6 +219,7 @@ export function TechnicalConfigurationSuppliers({
           state={state}
           selectedSupplier={selectedSupplier}
           isLoadingDeleteCount={isLoadingDeleteCount}
+          isMutationBlocked={isResponseNavigationBlocked}
           requestIdentityChange={requestIdentityChange}
           onDeleteSupplier={() => void handleSupplierDeleteRequest()}
         />
@@ -230,13 +234,7 @@ export function TechnicalConfigurationSuppliers({
                 type="button"
                 variant="outline"
                 onClick={() => state.startOptionCreate(selectedSupplier.id)}
-                disabled={
-                  state.isReadOnly ||
-                  state.isPending ||
-                  state.isConflict ||
-                  isLoadingDeleteCount ||
-                  isResponseNavigationBlocked
-                }
+                disabled={state.isReadOnly || isIdentityMutationBlocked || isLoadingDeleteCount}
               >
                 <PackagePlus className="size-4" aria-hidden="true" />
                 Thêm phương án
@@ -255,13 +253,7 @@ export function TechnicalConfigurationSuppliers({
                       state.startOptionCreate(selectedSupplier.id)
                     )
                   }
-                  disabled={
-                    state.isReadOnly ||
-                    state.isPending ||
-                    state.isConflict ||
-                    isLoadingDeleteCount ||
-                    isResponseNavigationBlocked
-                  }
+                  disabled={state.isReadOnly || isIdentityMutationBlocked || isLoadingDeleteCount}
                 >
                   <PackagePlus className="size-4" aria-hidden="true" />
                   Thêm phương án
@@ -272,13 +264,7 @@ export function TechnicalConfigurationSuppliers({
                 draft={state.optionDraft}
                 option={selectedOption}
                 mode={state.isCreatingOption ? "create" : "edit"}
-                disabled={
-                  state.isReadOnly ||
-                  state.isPending ||
-                  state.isConflict ||
-                  isLoadingDeleteCount ||
-                  isResponseNavigationBlocked
-                }
+                disabled={state.isReadOnly || isIdentityMutationBlocked || isLoadingDeleteCount}
                 isPending={state.isPending}
                 onChange={state.updateOptionDraft}
                 onSave={() => void state.saveOption()}
@@ -320,7 +306,7 @@ export function TechnicalConfigurationSuppliers({
             : `${pendingDelete?.label ?? ""}. Các response datasets phụ thuộc của phương án cũng sẽ bị xóa.`
         }
         confirmLabel={pendingDelete?.kind === "supplier" ? "Xóa nhà cung cấp" : "Xóa phương án"}
-        isPending={state.isPending}
+        isPending={state.isPending || isResponseNavigationBlocked}
         onConfirm={handleConfirmDelete}
       />
     </div>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx
@@ -11,6 +11,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 
 import { TechnicalConfigurationOptionEditor } from "./TechnicalConfigurationOptionEditor"
+import { TechnicalConfigurationOptionResponses } from "./TechnicalConfigurationOptionResponses"
 import { TechnicalConfigurationSupplierSelector } from "./TechnicalConfigurationSupplierSelector"
 
 type TechnicalConfigurationSuppliersProps = {
@@ -31,10 +32,13 @@ export function TechnicalConfigurationSuppliers({
   onNavigationBlockedChange,
   onRevisionChange,
 }: Readonly<TechnicalConfigurationSuppliersProps>) {
+  const [isIdentityNavigationBlocked, setIsIdentityNavigationBlocked] = React.useState(false)
+  const [isResponseDirty, setIsResponseDirty] = React.useState(false)
+  const [isResponseNavigationBlocked, setIsResponseNavigationBlocked] = React.useState(false)
   const state = useTechnicalConfigurationOptions({
     dossier,
     onRevisionChange,
-    onNavigationBlockedChange,
+    onNavigationBlockedChange: setIsIdentityNavigationBlocked,
   })
   const { discardConfirmationDialog, requestDiscardConfirmation } =
     useTechnicalConfigurationDiscardConfirmation()
@@ -47,24 +51,38 @@ export function TechnicalConfigurationSuppliers({
     (state.suppliersQuery.isError && !state.suppliersQuery.data) ||
     (state.optionsQuery.isError && !state.optionsQuery.data)
   const isInitialLoading = state.suppliersQuery.isLoading || state.optionsQuery.isLoading
+  const isDirty = state.isDirty || isResponseDirty
+  const isNavigationBlocked = isIdentityNavigationBlocked || isResponseNavigationBlocked
 
   React.useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- WorkspaceShell owns cross-tab dirty navigation while this component owns supplier/option drafts.
-    onDirtyChange?.(state.isDirty)
-  }, [onDirtyChange, state.isDirty])
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
 
-  React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- Identity and response mutations share one cross-tab navigation block.
+    onNavigationBlockedChange?.(isNavigationBlocked)
+  }, [isNavigationBlocked, onNavigationBlockedChange])
+
+  React.useEffect(
+    () => () => {
+      onDirtyChange?.(false)
+      onNavigationBlockedChange?.(false)
+    },
+    [onDirtyChange, onNavigationBlockedChange]
+  )
 
   const requestIdentityChange = React.useCallback(
     (description: React.ReactNode, action: () => void) => {
+      if (isNavigationBlocked) return
       setDeleteCountError(null)
-      if (!state.isDirty) {
+      if (!isDirty) {
         action()
         return
       }
       requestDiscardConfirmation(description, action)
     },
-    [requestDiscardConfirmation, state.isDirty]
+    [isDirty, isNavigationBlocked, requestDiscardConfirmation]
   )
 
   const handleSupplierDeleteRequest = React.useCallback(async () => {
@@ -213,7 +231,11 @@ export function TechnicalConfigurationSuppliers({
                 variant="outline"
                 onClick={() => state.startOptionCreate(selectedSupplier.id)}
                 disabled={
-                  state.isReadOnly || state.isPending || state.isConflict || isLoadingDeleteCount
+                  state.isReadOnly ||
+                  state.isPending ||
+                  state.isConflict ||
+                  isLoadingDeleteCount ||
+                  isResponseNavigationBlocked
                 }
               >
                 <PackagePlus className="size-4" aria-hidden="true" />
@@ -234,7 +256,11 @@ export function TechnicalConfigurationSuppliers({
                     )
                   }
                   disabled={
-                    state.isReadOnly || state.isPending || state.isConflict || isLoadingDeleteCount
+                    state.isReadOnly ||
+                    state.isPending ||
+                    state.isConflict ||
+                    isLoadingDeleteCount ||
+                    isResponseNavigationBlocked
                   }
                 >
                   <PackagePlus className="size-4" aria-hidden="true" />
@@ -247,7 +273,11 @@ export function TechnicalConfigurationSuppliers({
                 option={selectedOption}
                 mode={state.isCreatingOption ? "create" : "edit"}
                 disabled={
-                  state.isReadOnly || state.isPending || state.isConflict || isLoadingDeleteCount
+                  state.isReadOnly ||
+                  state.isPending ||
+                  state.isConflict ||
+                  isLoadingDeleteCount ||
+                  isResponseNavigationBlocked
                 }
                 isPending={state.isPending}
                 onChange={state.updateOptionDraft}
@@ -262,6 +292,16 @@ export function TechnicalConfigurationSuppliers({
                     : undefined
                 }
               />
+              {selectedOption ? (
+                <TechnicalConfigurationOptionResponses
+                  key={selectedOption.id}
+                  dossier={dossier}
+                  option={selectedOption}
+                  onDirtyChange={setIsResponseDirty}
+                  onNavigationBlockedChange={setIsResponseNavigationBlocked}
+                  onRevisionChange={onRevisionChange}
+                />
+              ) : null}
             </div>
           ) : null}
         </main>

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationIdentityMutationState.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationIdentityMutationState.ts
@@ -4,18 +4,15 @@ import * as React from "react"
 import { useQueryClient } from "@tanstack/react-query"
 
 import {
-  technicalConfigurationDossierDetailQueryKey,
   type technicalConfigurationOptionsQueryKey,
   type technicalConfigurationSuppliersQueryKey,
 } from "../technical-configuration-query-keys"
+import { updateTechnicalConfigurationDossierRevisionCache } from "../technical-configuration-dossier-revision-cache"
 import type {
   TechnicalConfigurationOptionsSnapshot,
   TechnicalConfigurationSuppliersSnapshot,
 } from "../technical-configuration-supplier-option-operations"
-import type {
-  TechnicalConfigurationDossierWire,
-  TechnicalConfigurationDossierWireResponse,
-} from "../types"
+import type { TechnicalConfigurationDossierWire } from "../types"
 import {
   getTechnicalConfigurationBaselineErrorMessage,
   isTechnicalConfigurationBaselineConflict,
@@ -58,14 +55,15 @@ export function useTechnicalConfigurationIdentityMutationState({
   const [refreshWarning, setRefreshWarning] = React.useState<string | null>(null)
   const isReadOnly = Boolean(dossier.archived_at)
 
+  React.useEffect(() => {
+    revisionRef.current = Math.max(revisionRef.current, dossier.revision)
+  }, [dossier.revision])
+
   const commitRevision = React.useCallback(
     (revision: number) => {
       revisionRef.current = revision
       onRevisionChange?.(revision)
-      queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(
-        technicalConfigurationDossierDetailQueryKey(dossier.id),
-        (current) => (current ? { data: { ...current.data, revision } } : current)
-      )
+      updateTechnicalConfigurationDossierRevisionCache(queryClient, dossier, revision)
       queryClient.setQueryData<TechnicalConfigurationSuppliersSnapshot>(
         supplierQueryKey,
         (current) => (current ? { ...current, revision } : current)
@@ -74,7 +72,7 @@ export function useTechnicalConfigurationIdentityMutationState({
         current ? { ...current, revision } : current
       )
     },
-    [dossier.id, onRevisionChange, optionQueryKey, queryClient, supplierQueryKey]
+    [dossier, onRevisionChange, optionQueryKey, queryClient, supplierQueryKey]
   )
 
   const refreshQueries = React.useCallback(async () => {

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionOperations.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionOperations.ts
@@ -56,6 +56,7 @@ type TechnicalConfigurationOptionOperationsArgs = {
   suppliersQuery: UseQueryResult<TechnicalConfigurationSuppliersSnapshot>
   optionsQuery: UseQueryResult<TechnicalConfigurationOptionsSnapshot>
   isSnapshotConflict: boolean
+  isMutationBlocked: boolean
   hasLocalDraftChanges: boolean
   adoptSelection: AdoptSelection
   setSelectedSupplierId: SetState<string | null>
@@ -92,6 +93,7 @@ export function useTechnicalConfigurationOptionOperations({
   suppliersQuery,
   optionsQuery,
   isSnapshotConflict,
+  isMutationBlocked,
   hasLocalDraftChanges,
   adoptSelection,
   setSelectedSupplierId,
@@ -112,7 +114,7 @@ export function useTechnicalConfigurationOptionOperations({
     dossier,
     supplierQueryKey,
     optionQueryKey,
-    isMutationBlocked: isSnapshotConflict,
+    isMutationBlocked: isSnapshotConflict || isMutationBlocked,
     onRevisionChange,
     onNavigationBlockedChange,
   })

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
@@ -148,9 +148,8 @@ export function useTechnicalConfigurationOptionResponses({
   ])
 
   React.useEffect(() => {
-    if (isDirty) return
     revisionRef.current = Math.max(revisionRef.current, dossier.revision)
-  }, [dossier.revision, isDirty])
+  }, [dossier.revision])
 
   useTechnicalConfigurationBeforeUnloadGuard(isDirty)
 

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
@@ -1,0 +1,347 @@
+import * as React from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useTechnicalConfigurationBeforeUnloadGuard } from "./useTechnicalConfigurationBeforeUnloadGuard"
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import { isTechnicalConfigurationBaselineConflict } from "../technical-configuration-baseline-version-state"
+import {
+  fetchTechnicalConfigurationDossierRevision,
+  updateTechnicalConfigurationDossierRevisionCache,
+} from "../technical-configuration-dossier-revision-cache"
+import {
+  readTechnicalConfigurationComparisonSet,
+  saveTechnicalConfigurationOptionResponse,
+  TechnicalConfigurationOptionResponseSaveFailure,
+} from "../technical-configuration-option-response-operations"
+import {
+  areTechnicalConfigurationOptionResponseDraftsEqual,
+  findTechnicalConfigurationOptionResponse,
+  flattenTechnicalConfigurationBaselineCriteria,
+  getTechnicalConfigurationOptionResponseErrorMessage,
+  getTechnicalConfigurationOptionResponseUpdatedAt,
+  replaceTechnicalConfigurationOptionResponse,
+  toTechnicalConfigurationOptionResponseDraft,
+  validateTechnicalConfigurationOptionResponseDraft,
+  type TechnicalConfigurationOptionResponseDraft,
+  type TechnicalConfigurationOptionResponseDraftPatch,
+} from "../technical-configuration-option-response-state"
+import { technicalConfigurationOptionResponsesQueryKey } from "../technical-configuration-query-keys"
+import type {
+  TechnicalConfigurationComparisonSetWire,
+  TechnicalConfigurationOptionWire,
+} from "../supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "../types"
+
+type UseTechnicalConfigurationOptionResponsesArgs = {
+  dossier: TechnicalConfigurationDossierWire
+  option: TechnicalConfigurationOptionWire
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  onRevisionChange?: (revision: number) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+/** Owns one option/exact-baseline response snapshot, local criterion draft, and explicit save. */
+export function useTechnicalConfigurationOptionResponses({
+  dossier,
+  option,
+  baselineVersion,
+  onRevisionChange,
+  onNavigationBlockedChange,
+}: UseTechnicalConfigurationOptionResponsesArgs) {
+  const queryClient = useQueryClient()
+  const queryKey = React.useMemo(
+    () => technicalConfigurationOptionResponsesQueryKey(option.id, baselineVersion.id),
+    [baselineVersion.id, option.id]
+  )
+  const criteria = React.useMemo(
+    () => flattenTechnicalConfigurationBaselineCriteria(baselineVersion),
+    [baselineVersion]
+  )
+  const [selectedCriterionId, setSelectedCriterionId] = React.useState<string | null>(
+    criteria[0]?.id ?? null
+  )
+  const [snapshot, setSnapshot] = React.useState<TechnicalConfigurationComparisonSetWire | null>(
+    null
+  )
+  const [baseDraft, setBaseDraft] = React.useState<TechnicalConfigurationOptionResponseDraft>(() =>
+    toTechnicalConfigurationOptionResponseDraft(null)
+  )
+  const [draft, setDraft] = React.useState<TechnicalConfigurationOptionResponseDraft>(() =>
+    toTechnicalConfigurationOptionResponseDraft(null)
+  )
+  const [isSaving, setIsSaving] = React.useState(false)
+  const [isReloading, setIsReloading] = React.useState(false)
+  const [isConflict, setIsConflict] = React.useState(false)
+  const [validationError, setValidationError] = React.useState<string | null>(null)
+  const [operationError, setOperationError] = React.useState<string | null>(null)
+  const [saveStatus, setSaveStatus] = React.useState<"idle" | "saved">("idle")
+  const activeOperationRef = React.useRef<"save" | "reload" | null>(null)
+  const adoptedQueryAtRef = React.useRef(0)
+  const revisionRef = React.useRef(dossier.revision)
+  const responseQuery = useQuery({
+    queryKey,
+    queryFn: ({ signal }) =>
+      readTechnicalConfigurationComparisonSet(
+        {
+          p_option_id: option.id,
+          p_baseline_version_id: baselineVersion.id,
+        },
+        signal
+      ),
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+  const isDirty = React.useMemo(
+    () => !areTechnicalConfigurationOptionResponseDraftsEqual(baseDraft, draft),
+    [baseDraft, draft]
+  )
+  const isReadOnly = Boolean(dossier.archived_at)
+  const commitRevision = React.useCallback(
+    (nextRevision: number) => {
+      const committedRevision = Math.max(revisionRef.current, dossier.revision, nextRevision)
+      revisionRef.current = committedRevision
+      onRevisionChange?.(committedRevision)
+      updateTechnicalConfigurationDossierRevisionCache(queryClient, dossier, committedRevision)
+    },
+    [dossier, onRevisionChange, queryClient]
+  )
+  React.useEffect(() => {
+    if (
+      !responseQuery.isSuccess ||
+      responseQuery.dataUpdatedAt === adoptedQueryAtRef.current ||
+      isDirty ||
+      activeOperationRef.current
+    ) {
+      return
+    }
+    adoptedQueryAtRef.current = responseQuery.dataUpdatedAt
+    const nextSnapshot = responseQuery.data
+    const nextCriterionId = criteria.some((criterion) => criterion.id === selectedCriterionId)
+      ? selectedCriterionId
+      : (criteria[0]?.id ?? null)
+    const nextDraft = toTechnicalConfigurationOptionResponseDraft(
+      findTechnicalConfigurationOptionResponse(nextSnapshot, nextCriterionId)
+    )
+    setSnapshot(nextSnapshot)
+    setSelectedCriterionId(nextCriterionId)
+    setBaseDraft(nextDraft)
+    setDraft(nextDraft)
+    const nextRevision = Math.max(nextSnapshot?.revision ?? 0, dossier.revision)
+    if (nextRevision > dossier.revision) {
+      commitRevision(nextRevision) // react-doctor-disable-line react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent
+    } else {
+      revisionRef.current = Math.max(revisionRef.current, nextRevision)
+    }
+    setIsConflict(false) // react-doctor-disable-line react-doctor/no-adjust-state-on-prop-change
+    setOperationError(null) // react-doctor-disable-line react-doctor/no-adjust-state-on-prop-change
+  }, [
+    commitRevision,
+    criteria,
+    dossier.revision,
+    isDirty,
+    responseQuery.data,
+    responseQuery.dataUpdatedAt,
+    responseQuery.isSuccess,
+    selectedCriterionId,
+  ])
+
+  React.useEffect(() => {
+    if (isDirty) return
+    revisionRef.current = Math.max(revisionRef.current, dossier.revision)
+  }, [dossier.revision, isDirty])
+
+  useTechnicalConfigurationBeforeUnloadGuard(isDirty)
+
+  const updateDraft = React.useCallback(
+    (patch: TechnicalConfigurationOptionResponseDraftPatch) => {
+      if (isReadOnly || activeOperationRef.current) return
+      setDraft((current) => ({ ...current, ...patch }))
+      setValidationError(null)
+      if (!isConflict) setOperationError(null)
+      setSaveStatus("idle")
+    },
+    [isConflict, isReadOnly]
+  )
+
+  const selectCriterion = React.useCallback(
+    (criterionId: string) => {
+      if (
+        activeOperationRef.current ||
+        !criteria.some((criterion) => criterion.id === criterionId)
+      ) {
+        return
+      }
+      const nextDraft = toTechnicalConfigurationOptionResponseDraft(
+        findTechnicalConfigurationOptionResponse(snapshot, criterionId)
+      )
+      setSelectedCriterionId(criterionId)
+      setBaseDraft(nextDraft)
+      setDraft(nextDraft)
+      setValidationError(null)
+      if (!isConflict) setOperationError(null)
+      setSaveStatus("idle")
+    },
+    [criteria, isConflict, snapshot]
+  )
+
+  const save = React.useCallback(async () => {
+    if (isReadOnly || activeOperationRef.current || isConflict) return
+    const error = validateTechnicalConfigurationOptionResponseDraft(draft, selectedCriterionId)
+    if (error) {
+      setValidationError(error)
+      return
+    }
+    if (!selectedCriterionId) return
+
+    activeOperationRef.current = "save"
+    setIsSaving(true)
+    setValidationError(null)
+    setOperationError(null)
+    setSaveStatus("idle")
+    onNavigationBlockedChange?.(true)
+
+    try {
+      const saved = await saveTechnicalConfigurationOptionResponse({
+        optionId: option.id,
+        baselineVersionId: baselineVersion.id,
+        criterionId: selectedCriterionId,
+        responseText: draft.responseText,
+        supplementaryInformation: draft.supplementaryInformation,
+        expectedRevision: revisionRef.current,
+        comparisonSet: snapshot,
+        onComparisonSetReady: (comparisonSet) => {
+          setSnapshot(comparisonSet)
+          commitRevision(comparisonSet.revision)
+        },
+      })
+      const nextSnapshot = replaceTechnicalConfigurationOptionResponse(
+        saved.comparisonSet,
+        saved.response
+      )
+      const nextDraft = toTechnicalConfigurationOptionResponseDraft(saved.response)
+      queryClient.setQueryData(queryKey, nextSnapshot)
+      adoptedQueryAtRef.current = Date.now()
+      setSnapshot(nextSnapshot)
+      commitRevision(saved.response.revision)
+      setBaseDraft(nextDraft)
+      setDraft(nextDraft)
+      setIsConflict(false)
+      setSaveStatus("saved")
+    } catch (caught) {
+      const sourceError =
+        caught instanceof TechnicalConfigurationOptionResponseSaveFailure
+          ? caught.originalError
+          : caught
+      if (caught instanceof TechnicalConfigurationOptionResponseSaveFailure) {
+        setSnapshot(caught.comparisonSet)
+        queryClient.setQueryData(queryKey, caught.comparisonSet)
+        commitRevision(caught.comparisonSet.revision)
+      }
+      setIsConflict(
+        caught instanceof TechnicalConfigurationOptionResponseSaveFailure
+          ? caught.isConflict
+          : isTechnicalConfigurationBaselineConflict(caught)
+      )
+      setOperationError(
+        getTechnicalConfigurationOptionResponseErrorMessage(
+          sourceError,
+          "Không thể lưu phản hồi phương án."
+        )
+      )
+    } finally {
+      activeOperationRef.current = null
+      setIsSaving(false)
+      onNavigationBlockedChange?.(false)
+    }
+  }, [
+    baselineVersion.id,
+    commitRevision,
+    draft,
+    isConflict,
+    isReadOnly,
+    onNavigationBlockedChange,
+    option.id,
+    queryClient,
+    queryKey,
+    selectedCriterionId,
+    snapshot,
+  ])
+
+  const reload = React.useCallback(async () => {
+    if (activeOperationRef.current) return
+    const preserveDraft = isDirty
+    activeOperationRef.current = "reload"
+    setIsReloading(true)
+    setOperationError(null)
+    onNavigationBlockedChange?.(true)
+    try {
+      const refreshed = await responseQuery.refetch({ throwOnError: true })
+      adoptedQueryAtRef.current = refreshed.dataUpdatedAt
+      const nextSnapshot = refreshed.data ?? null
+      const nextRevision =
+        nextSnapshot?.revision ??
+        (await fetchTechnicalConfigurationDossierRevision(queryClient, dossier.id))
+      const nextBaseDraft = toTechnicalConfigurationOptionResponseDraft(
+        findTechnicalConfigurationOptionResponse(nextSnapshot, selectedCriterionId)
+      )
+      setSnapshot(nextSnapshot)
+      setBaseDraft(nextBaseDraft)
+      if (!preserveDraft) setDraft(nextBaseDraft)
+      commitRevision(nextRevision)
+      setIsConflict(false)
+      setValidationError(null)
+      setSaveStatus("idle")
+    } catch (caught) {
+      setOperationError(
+        getTechnicalConfigurationOptionResponseErrorMessage(
+          caught,
+          "Không thể tải lại phản hồi phương án."
+        )
+      )
+    } finally {
+      activeOperationRef.current = null
+      setIsReloading(false)
+      onNavigationBlockedChange?.(false)
+    }
+  }, [
+    commitRevision,
+    dossier.id,
+    isDirty,
+    onNavigationBlockedChange,
+    queryClient,
+    responseQuery,
+    selectedCriterionId,
+  ])
+
+  const selectedCriterion =
+    criteria.find((criterion) => criterion.id === selectedCriterionId) ?? null
+  const updatedAt = getTechnicalConfigurationOptionResponseUpdatedAt(
+    option,
+    snapshot,
+    selectedCriterionId
+  )
+
+  return {
+    responseQuery,
+    criteria,
+    selectedCriterion,
+    selectedCriterionId,
+    snapshot,
+    draft,
+    isDirty,
+    isReadOnly,
+    isSaving,
+    isReloading,
+    isPending: isSaving || isReloading,
+    isConflict,
+    validationError,
+    operationError,
+    saveStatus,
+    updatedAt,
+    updateDraft,
+    selectCriterion,
+    save,
+    reload,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
@@ -92,11 +92,10 @@ export function useTechnicalConfigurationOptionResponses({
     retry: false,
     refetchOnWindowFocus: false,
   })
-  const isDirty = React.useMemo(
-    () => !areTechnicalConfigurationOptionResponseDraftsEqual(baseDraft, draft),
-    [baseDraft, draft]
-  )
   const isReadOnly = Boolean(dossier.archived_at)
+  const isDirty =
+    !isReadOnly && !areTechnicalConfigurationOptionResponseDraftsEqual(baseDraft, draft)
+  const visibleDraft = isReadOnly ? baseDraft : draft
   const commitRevision = React.useCallback(
     (nextRevision: number) => {
       const committedRevision = Math.max(revisionRef.current, dossier.revision, nextRevision)
@@ -111,6 +110,7 @@ export function useTechnicalConfigurationOptionResponses({
       !responseQuery.isSuccess ||
       responseQuery.dataUpdatedAt === adoptedQueryAtRef.current ||
       isDirty ||
+      isConflict ||
       activeOperationRef.current
     ) {
       return
@@ -139,6 +139,7 @@ export function useTechnicalConfigurationOptionResponses({
     commitRevision,
     criteria,
     dossier.revision,
+    isConflict,
     isDirty,
     responseQuery.data,
     responseQuery.dataUpdatedAt,
@@ -328,7 +329,7 @@ export function useTechnicalConfigurationOptionResponses({
     selectedCriterion,
     selectedCriterionId,
     snapshot,
-    draft,
+    draft: visibleDraft,
     isDirty,
     isReadOnly,
     isSaving,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptions.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptions.ts
@@ -34,6 +34,7 @@ const EMPTY_OPTIONS: TechnicalConfigurationOptionWire[] = []
 
 type TechnicalConfigurationOptionsHookArgs = {
   dossier: TechnicalConfigurationDossierWire
+  isMutationBlocked?: boolean
   onRevisionChange?: (revision: number) => void
   onNavigationBlockedChange?: (blocked: boolean) => void
 }
@@ -41,6 +42,7 @@ type TechnicalConfigurationOptionsHookArgs = {
 /** Owns dossier-scoped supplier/option snapshots and their local editable drafts. */
 export function useTechnicalConfigurationOptions({
   dossier,
+  isMutationBlocked = false,
   onRevisionChange,
   onNavigationBlockedChange,
 }: TechnicalConfigurationOptionsHookArgs) {
@@ -160,6 +162,7 @@ export function useTechnicalConfigurationOptions({
     suppliersQuery,
     optionsQuery,
     isSnapshotConflict: hasSnapshotConflict,
+    isMutationBlocked,
     hasLocalDraftChanges: isDirty,
     adoptSelection,
     setSelectedSupplierId,

--- a/src/app/(app)/technical-configurations/technical-configuration-dossier-revision-cache.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-dossier-revision-cache.ts
@@ -1,0 +1,38 @@
+import type { QueryClient } from "@tanstack/react-query"
+
+import { technicalConfigurationDossierDetailQueryKey } from "./technical-configuration-query-keys"
+import { getTechnicalConfigurationDossier } from "./technical-configuration-rpc"
+import type {
+  TechnicalConfigurationDossierWire,
+  TechnicalConfigurationDossierWireResponse,
+} from "./types"
+
+/** Keeps the cached dossier detail revision aligned with successful child mutations. */
+export function updateTechnicalConfigurationDossierRevisionCache(
+  queryClient: QueryClient,
+  dossier: TechnicalConfigurationDossierWire,
+  revision: number
+) {
+  queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(
+    technicalConfigurationDossierDetailQueryKey(dossier.id),
+    (current) => {
+      const nextRevision = Math.max(current?.data.revision ?? 0, dossier.revision, revision)
+      return {
+        data: { ...(current?.data ?? dossier), revision: nextRevision },
+      }
+    }
+  )
+}
+
+/** Fetches the current dossier revision when a nullable child snapshot has no revision. */
+export async function fetchTechnicalConfigurationDossierRevision(
+  queryClient: QueryClient,
+  dossierId: string
+): Promise<number> {
+  const response = await queryClient.fetchQuery({
+    queryKey: technicalConfigurationDossierDetailQueryKey(dossierId),
+    queryFn: ({ signal }) => getTechnicalConfigurationDossier(dossierId, signal),
+    staleTime: 0,
+  })
+  return response.data.revision
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-option-response-operations.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-option-response-operations.ts
@@ -1,0 +1,111 @@
+import { isTechnicalConfigurationBaselineConflict } from "./technical-configuration-baseline-version-state"
+import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
+import type {
+  TechnicalConfigurationComparisonSetGetOrCreateRpcArgs,
+  TechnicalConfigurationComparisonSetGetRpcArgs,
+  TechnicalConfigurationComparisonSetReadWireResponse,
+  TechnicalConfigurationComparisonSetWire,
+  TechnicalConfigurationComparisonSetWireResponse,
+  TechnicalConfigurationOptionResponseUpsertRpcArgs,
+  TechnicalConfigurationOptionResponseWire,
+  TechnicalConfigurationOptionResponseWireResponse,
+} from "./supplier-option-types"
+
+/** Reads a nullable comparison set without creating data or incrementing revisions. */
+export async function readTechnicalConfigurationComparisonSet(
+  args: TechnicalConfigurationComparisonSetGetRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationComparisonSetWire | null> {
+  const response =
+    await callTechnicalConfigurationRpc<TechnicalConfigurationComparisonSetReadWireResponse>(
+      "technical_configuration_comparison_set_get",
+      args,
+      { signal }
+    )
+  return response.data
+}
+
+/** Gets or creates the comparison set only after an explicit save action. */
+export async function getOrCreateTechnicalConfigurationComparisonSet(
+  args: TechnicalConfigurationComparisonSetGetOrCreateRpcArgs
+): Promise<TechnicalConfigurationComparisonSetWire> {
+  const response =
+    await callTechnicalConfigurationRpc<TechnicalConfigurationComparisonSetWireResponse>(
+      "technical_configuration_comparison_set_get_or_create",
+      args
+    )
+  return response.data
+}
+
+/** Persists one exact-baseline criterion response with optimistic concurrency. */
+export async function upsertTechnicalConfigurationOptionResponse(
+  args: TechnicalConfigurationOptionResponseUpsertRpcArgs
+): Promise<TechnicalConfigurationOptionResponseWire> {
+  const response =
+    await callTechnicalConfigurationRpc<TechnicalConfigurationOptionResponseWireResponse>(
+      "technical_configuration_option_response_upsert",
+      args
+    )
+  return response.data
+}
+
+/** Carries the now-existing set when step two of the first save fails. */
+export class TechnicalConfigurationOptionResponseSaveFailure extends Error {
+  readonly comparisonSet: TechnicalConfigurationComparisonSetWire
+  readonly isConflict: boolean
+  readonly originalError: unknown
+
+  constructor(error: unknown, comparisonSet: TechnicalConfigurationComparisonSetWire) {
+    super(error instanceof Error && error.message ? error.message : "option_response_save_failed")
+    this.name = "TechnicalConfigurationOptionResponseSaveFailure"
+    this.comparisonSet = comparisonSet
+    this.isConflict = isTechnicalConfigurationBaselineConflict(error)
+    this.originalError = error
+  }
+}
+
+/** Runs the recoverable get-or-create then upsert sequence for one explicit save. */
+export async function saveTechnicalConfigurationOptionResponse({
+  optionId,
+  baselineVersionId,
+  criterionId,
+  responseText,
+  supplementaryInformation,
+  expectedRevision,
+  comparisonSet: existingComparisonSet,
+  onComparisonSetReady,
+}: {
+  optionId: string
+  baselineVersionId: string
+  criterionId: string
+  responseText: string
+  supplementaryInformation: string
+  expectedRevision: number
+  comparisonSet: TechnicalConfigurationComparisonSetWire | null
+  onComparisonSetReady?: (comparisonSet: TechnicalConfigurationComparisonSetWire) => void
+}): Promise<{
+  comparisonSet: TechnicalConfigurationComparisonSetWire
+  response: TechnicalConfigurationOptionResponseWire
+}> {
+  const comparisonSet =
+    existingComparisonSet ??
+    (await getOrCreateTechnicalConfigurationComparisonSet({
+      p_option_id: optionId,
+      p_baseline_version_id: baselineVersionId,
+      p_expected_revision: expectedRevision,
+    }))
+  if (!existingComparisonSet) onComparisonSetReady?.(comparisonSet)
+
+  try {
+    const response = await upsertTechnicalConfigurationOptionResponse({
+      p_comparison_set_id: comparisonSet.id,
+      p_criterion_id: criterionId,
+      p_response_text: responseText,
+      p_supplementary_information: supplementaryInformation,
+      p_expected_revision: existingComparisonSet ? expectedRevision : comparisonSet.revision,
+    })
+    return { comparisonSet, response }
+  } catch (error) {
+    throw new TechnicalConfigurationOptionResponseSaveFailure(error, comparisonSet)
+  }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-option-response-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-option-response-state.ts
@@ -1,0 +1,122 @@
+import type {
+  TechnicalConfigurationBaselineCriterionWire,
+  TechnicalConfigurationBaselineDraftWire,
+} from "./baseline-types"
+import type {
+  TechnicalConfigurationComparisonSetWire,
+  TechnicalConfigurationOptionResponseWire,
+  TechnicalConfigurationOptionWire,
+} from "./supplier-option-types"
+
+export type TechnicalConfigurationOptionResponseDraft = {
+  responseText: string
+  supplementaryInformation: string
+}
+
+export type TechnicalConfigurationOptionResponseDraftPatch =
+  Partial<TechnicalConfigurationOptionResponseDraft>
+
+/** Empty local draft used when an exact-baseline comparison set has no response yet. */
+export const EMPTY_OPTION_RESPONSE_DRAFT: TechnicalConfigurationOptionResponseDraft = {
+  responseText: "",
+  supplementaryInformation: "",
+}
+
+/** Flattens exact-version criteria without changing the canonical baseline snapshot. */
+export function flattenTechnicalConfigurationBaselineCriteria(
+  baselineVersion: TechnicalConfigurationBaselineDraftWire | null
+): TechnicalConfigurationBaselineCriterionWire[] {
+  if (!baselineVersion) return []
+  return baselineVersion.groups
+    .toSorted((left, right) => left.sort_order - right.sort_order)
+    .flatMap((group) =>
+      group.criteria.toSorted((left, right) => left.sort_order - right.sort_order)
+    )
+}
+
+/** Finds the response bound to one criterion inside an exact-baseline comparison set. */
+export function findTechnicalConfigurationOptionResponse(
+  snapshot: TechnicalConfigurationComparisonSetWire | null,
+  criterionId: string | null
+): TechnicalConfigurationOptionResponseWire | null {
+  if (!snapshot || !criterionId) return null
+  return snapshot.responses.find((response) => response.criterion_id === criterionId) ?? null
+}
+
+/** Converts a persisted response into the local multiline editor shape. */
+export function toTechnicalConfigurationOptionResponseDraft(
+  response: TechnicalConfigurationOptionResponseWire | null
+): TechnicalConfigurationOptionResponseDraft {
+  if (!response) return { ...EMPTY_OPTION_RESPONSE_DRAFT }
+  return {
+    responseText: response.response_text,
+    supplementaryInformation: response.supplementary_information,
+  }
+}
+
+/** Compares local response text without normalizing meaningful whitespace or line breaks. */
+export function areTechnicalConfigurationOptionResponseDraftsEqual(
+  left: TechnicalConfigurationOptionResponseDraft,
+  right: TechnicalConfigurationOptionResponseDraft
+): boolean {
+  return (
+    left.responseText === right.responseText &&
+    left.supplementaryInformation === right.supplementaryInformation
+  )
+}
+
+/** Requires a scoring response while keeping supplementary text optional and non-scoring. */
+export function validateTechnicalConfigurationOptionResponseDraft(
+  draft: TechnicalConfigurationOptionResponseDraft,
+  criterionId: string | null
+): string | null {
+  if (!criterionId) return "Chưa có tiêu chí để lưu phản hồi."
+  return draft.responseText.trim() ? null : "Phản hồi tiêu chí là bắt buộc."
+}
+
+/** Replaces one criterion response while preserving the remaining exact-baseline responses. */
+export function replaceTechnicalConfigurationOptionResponse(
+  snapshot: TechnicalConfigurationComparisonSetWire,
+  response: TechnicalConfigurationOptionResponseWire
+): TechnicalConfigurationComparisonSetWire {
+  const hasResponse = snapshot.responses.some((item) => item.criterion_id === response.criterion_id)
+  return {
+    ...snapshot,
+    revision: response.revision,
+    updated_at: response.updated_at,
+    updated_by: response.updated_by,
+    responses: hasResponse
+      ? snapshot.responses.map((item) =>
+          item.criterion_id === response.criterion_id ? response : item
+        )
+      : [...snapshot.responses, response],
+  }
+}
+
+/** Returns the latest timestamp visible for the current option/criterion context. */
+export function getTechnicalConfigurationOptionResponseUpdatedAt(
+  option: TechnicalConfigurationOptionWire,
+  snapshot: TechnicalConfigurationComparisonSetWire | null,
+  criterionId: string | null
+): string {
+  const response = findTechnicalConfigurationOptionResponse(snapshot, criterionId)
+  if (!response) return option.updated_at
+  return new Date(response.updated_at).getTime() > new Date(option.updated_at).getTime()
+    ? response.updated_at
+    : option.updated_at
+}
+
+/** Maps option-response persistence failures to one actionable workspace message. */
+export function getTechnicalConfigurationOptionResponseErrorMessage(
+  error: unknown,
+  fallback: string
+): string {
+  if (!(error instanceof Error)) return fallback
+  if (error.message === "stale_revision") {
+    return "Dữ liệu hồ sơ đã thay đổi. Tải lại dữ liệu trước khi lưu lại."
+  }
+  if (error.message === "archived_dossier") {
+    return "Hồ sơ đã lưu trữ và chỉ được xem."
+  }
+  return error.message || fallback
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
@@ -33,3 +33,11 @@ export function technicalConfigurationSuppliersQueryKey(dossierId: string) {
 export function technicalConfigurationOptionsQueryKey(dossierId: string) {
   return ["technical-configurations", "options", dossierId] as const
 }
+
+/** Builds the cache key for one option's nullable exact-baseline response snapshot. */
+export function technicalConfigurationOptionResponsesQueryKey(
+  optionId: string,
+  baselineVersionId: string
+) {
+  return ["technical-configurations", "option-responses", optionId, baselineVersionId] as const
+}


### PR DESCRIPTION
## Summary
- implement the P8B2 exact-baseline option response workspace with manual multiline response and separate supplementary information editing
- keep workspace opening read-only through the nullable P8A4 snapshot; the first explicit save performs get-or-create and upserts with the revision returned by that call
- add exact option/baseline query isolation, dirty and pending navigation guards, archived read-only behavior, conflict recovery, monotonic dossier revision propagation, and updated-at context
- complete only OpenSpec tasks P8B2.1 through P8B2.7; P9 remains out of scope

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused Vitest: 3 files, 55 tests passed
- `node scripts/npm-run.js run react-doctor`: 100/100, no issues
- `openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`
- `node scripts/npm-run.js run verify:heroui-boundary`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `git diff --check origin/main`

## Live Supabase check
- verified the P8 read/get-or-create/upsert chain with temporary fixtures inside an intentionally rolled-back PL/pgSQL subtransaction
- confirmed nullable open did not write or advance revision; get-or-create advanced revision 2 -> 3; upsert used revision 3 and returned revision 4
- confirmed multiline response and supplementary information round-tripped against the exact baseline
- after rollback, all P8 table counts remained zero and the dossier revision remained 2
- no migration or persistent live database write was performed

Browser testing was skipped as requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an exact-baseline option response workspace in the supplier view that opens read‑only from a nullable snapshot and saves via get‑or‑create then upsert with the returned revision. Coordinates response mutations with identity edits using shared dirty/navigation blocking; completes OpenSpec P8B2.1–P8B2.7.

- **New Features**
  - Editor with criterion navigator; shows max(option/response) updated‑at; responsive layout; baseline version selector with “load more”.
  - Integrated into `TechnicalConfigurationSuppliers`; supplier selector respects mutation blocking; beforeunload guard for dirty response drafts.
  - Archived dossiers are read‑only; locked baselines remain editable; no lock controls; no write on open.

- **Bug Fixes**
  - Coordinated mutation flow to prevent races between identity and response saves; block supplier switching while pending; adopt created/advanced revisions on conflict; fetch dossier revision when a null set reloads; preserve draft/selection across reloads or errors; keep conflict guidance visible; update the dossier detail cache after successful saves.

<sup>Written for commit fe7c64a61e609c92c220a3cb15f22b06bab5e43c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an exact-baseline workspace to review and edit supplier option responses, including criterion navigation, response/supplementary fields, baseline version selection, reload/save actions, and “saved” feedback with last-updated time.
  * Added archived/read-only behavior for locked scenarios.
* **Bug Fixes**
  * Improved revision tracking, conflict handling, and recovery to preserve drafts and selections across retries and reloads.
  * Strengthened unsaved-changes protection during navigation and baseline switching.
* **Tests**
  * Expanded UI tests for save/validation flows, conflicts, recovery, navigation blocking, and read-only states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->