### PR TITLE
P9A1: Add supplier option workbook codec

### DIFF
--- a/src/lib/__tests__/technical-configuration-option-excel.test.ts
+++ b/src/lib/__tests__/technical-configuration-option-excel.test.ts
@@ -1,5 +1,5 @@
 import type { CellValue, Workbook, Worksheet } from "exceljs"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import type { BulkImportWorkbookParser } from "@/components/bulk-import/bulk-import-types"
 import {
@@ -87,6 +87,12 @@ async function createWorkbook(): Promise<Workbook> {
     metadata: METADATA,
     rows: ROWS,
   })
+}
+
+function insertBlankRowBeforeSecondCriterion(workbook: Workbook): Worksheet {
+  const worksheet = workbook.getWorksheet("OptionResponses")!
+  worksheet.spliceRows(3, 0, [])
+  return worksheet
 }
 
 async function expectWorkbookIssue(
@@ -327,5 +333,79 @@ describe("technical configuration supplier-option workbook codec", () => {
     const malformedRow = await createWorkbook()
     malformedRow.getWorksheet("OptionResponses")!.getRow(2).getCell(1).value = 0
     await expectWorkbookIssue(malformedRow, "invalid_row")
+  })
+
+  it("validates response cells and columns after an interior blank row", async () => {
+    const unsupportedValue = await createWorkbook()
+    insertBlankRowBeforeSecondCriterion(unsupportedValue).getRow(4).getCell(8).value = {
+      formula: "1+1",
+      result: 2,
+    }
+    const unsupportedValueError = await expectWorkbookIssue(unsupportedValue, "invalid_cell_value")
+    expect(unsupportedValueError.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "invalid_cell_value",
+          row: 4,
+          column: "response_text",
+        }),
+      ])
+    )
+
+    const extraColumn = await createWorkbook()
+    insertBlankRowBeforeSecondCriterion(extraColumn).getRow(4).getCell(10).value = "extra"
+    await expectWorkbookIssue(extraColumn, "invalid_columns")
+  })
+
+  it("reports physical response row numbers after an interior blank row", async () => {
+    const workbook = await createWorkbook()
+    insertBlankRowBeforeSecondCriterion(workbook).getRow(4).getCell(5).value = "TC-9999"
+
+    const error = await expectWorkbookIssue(workbook, "changed_context")
+    expect(error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "changed_context",
+          row: 4,
+          column: "criterion_code",
+        }),
+      ])
+    )
+  })
+
+  it("does not materialize every missing row in a sparse response sheet", async () => {
+    const workbook = await createWorkbook()
+    const worksheet = workbook.getWorksheet("OptionResponses")!
+    const secondCriterionRow = worksheet.getRow(3)
+    const sparseRow = worksheet.getRow(1_000)
+    OPTION_WORKBOOK_COLUMNS.forEach((_, index) => {
+      sparseRow.getCell(index + 1).value = secondCriterionRow.getCell(index + 1).value
+    })
+    secondCriterionRow.values = []
+    const getRowSpy = vi.spyOn(worksheet, "getRow")
+
+    const result = await parseTechnicalConfigurationOptionWorkbook(
+      toExcelWorkbookAdapter(workbook),
+      PARSE_OPTIONS
+    )
+
+    expect(result.rows).toHaveLength(ROWS.length)
+    expect(getRowSpy.mock.calls.length).toBeLessThan(100)
+  })
+
+  it("rejects metadata content after an interior blank row", async () => {
+    const extraKey = await createWorkbook()
+    extraKey
+      .getWorksheet("_meta")!
+      .getRow(OPTION_WORKBOOK_META_KEYS.length + 3)
+      .getCell(1).value = "extra_key"
+    await expectWorkbookIssue(extraKey, "invalid_metadata")
+
+    const extraColumn = await createWorkbook()
+    extraColumn
+      .getWorksheet("_meta")!
+      .getRow(OPTION_WORKBOOK_META_KEYS.length + 3)
+      .getCell(3).value = "extra"
+    await expectWorkbookIssue(extraColumn, "invalid_metadata")
   })
 })

--- a/src/lib/__tests__/technical-configuration-option-excel.test.ts
+++ b/src/lib/__tests__/technical-configuration-option-excel.test.ts
@@ -1,0 +1,324 @@
+import type { CellValue, Workbook, Worksheet } from "exceljs"
+import { describe, expect, it } from "vitest"
+
+import type { BulkImportWorkbookParser } from "@/components/bulk-import/bulk-import-types"
+import {
+  OPTION_WORKBOOK_COLUMNS,
+  OPTION_WORKBOOK_META_KEYS,
+  TechnicalConfigurationOptionWorkbookError,
+  type TechnicalConfigurationOptionWorkbookIssueCode,
+  type TechnicalConfigurationOptionWorkbookMetadata,
+  type TechnicalConfigurationOptionWorkbookParseOptions,
+  type TechnicalConfigurationOptionWorkbookRow,
+} from "@/lib/technical-configuration-option-excel-contract"
+import { createTechnicalConfigurationOptionWorkbook } from "@/lib/technical-configuration-option-excel-export"
+import {
+  createTechnicalConfigurationOptionWorkbookParser,
+  parseTechnicalConfigurationOptionWorkbook,
+} from "@/lib/technical-configuration-option-excel-parse"
+import { readExcelFile, type ExcelWorkbook } from "@/lib/excel-workbook"
+
+const METADATA: TechnicalConfigurationOptionWorkbookMetadata = {
+  template_kind: "technical_configuration_option",
+  template_version: 1,
+  dossier_id: "dossier-1",
+  option_id: "option-1",
+  baseline_version_id: "baseline-1",
+  dossier_revision: 7,
+  generated_at: "2026-07-24T14:00:00.000Z",
+}
+
+const ROWS: TechnicalConfigurationOptionWorkbookRow[] = [
+  {
+    group_order: 1,
+    group_name: "Yêu cầu kỹ thuật",
+    criterion_order: 1,
+    criterion_id: "criterion-1",
+    criterion_code: "TC-0001",
+    criterion_title: "Nguồn điện",
+    requirement_text: "Điện áp 220 V\nTần số 50 Hz",
+    response_text: "Đáp ứng đầy đủ\nKhông cần bộ chuyển đổi",
+    supplementary_information: "Tài liệu kỹ thuật trang 12",
+  },
+  {
+    group_order: 1,
+    group_name: "Yêu cầu kỹ thuật",
+    criterion_order: 2,
+    criterion_id: "criterion-2",
+    criterion_code: "TC-0002",
+    criterion_title: null,
+    requirement_text: "Hoạt động ổn định trong môi trường nhiệt đới",
+    response_text: "Có",
+    supplementary_information: "",
+  },
+]
+
+const PARSE_OPTIONS: TechnicalConfigurationOptionWorkbookParseOptions = {
+  expectedMetadata: {
+    dossier_id: METADATA.dossier_id,
+    option_id: METADATA.option_id,
+    baseline_version_id: METADATA.baseline_version_id,
+    dossier_revision: METADATA.dossier_revision,
+  },
+  expectedCriteria: ROWS.map(
+    ({ response_text: _responseText, supplementary_information: _supplementary, ...criterion }) =>
+      criterion
+  ),
+}
+
+function toExcelWorkbookAdapter(workbook: Workbook): ExcelWorkbook {
+  return {
+    SheetNames: workbook.worksheets.map((worksheet) => worksheet.name),
+    Sheets: Object.fromEntries(workbook.worksheets.map((worksheet) => [worksheet.name, worksheet])),
+    _workbook: workbook,
+  }
+}
+
+function getRowValues(worksheet: Worksheet, rowNumber: number, columnCount: number): unknown[] {
+  return Array.from({ length: columnCount }, (_, index) => {
+    const value = worksheet.getRow(rowNumber).getCell(index + 1).value
+    return value === undefined ? null : value
+  })
+}
+
+async function createWorkbook(): Promise<Workbook> {
+  return createTechnicalConfigurationOptionWorkbook({
+    metadata: METADATA,
+    rows: ROWS,
+  })
+}
+
+async function expectWorkbookIssue(
+  workbook: Workbook,
+  code: TechnicalConfigurationOptionWorkbookIssueCode
+): Promise<TechnicalConfigurationOptionWorkbookError> {
+  try {
+    await parseTechnicalConfigurationOptionWorkbook(toExcelWorkbookAdapter(workbook), PARSE_OPTIONS)
+  } catch (error) {
+    expect(error).toBeInstanceOf(TechnicalConfigurationOptionWorkbookError)
+    const workbookError = error as TechnicalConfigurationOptionWorkbookError
+    expect(workbookError.issues).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code })])
+    )
+    return workbookError
+  }
+
+  throw new Error(`Expected workbook issue: ${code}`)
+}
+
+describe("technical configuration supplier-option workbook codec", () => {
+  it("generates the exact OptionResponses and hidden _meta contract", async () => {
+    const rowWithExcludedFields = {
+      ...ROWS[0],
+      document_url: "https://example.com/spec.pdf",
+      citation: "Trang 12",
+      assessment: "Đạt",
+      supplier_id: "supplier-1",
+      option_name: "Phương án A",
+    }
+    const workbook = await createTechnicalConfigurationOptionWorkbook({
+      metadata: METADATA,
+      rows: [rowWithExcludedFields, ROWS[1]],
+    })
+
+    expect(
+      workbook.worksheets.map((worksheet) => ({
+        name: worksheet.name,
+        state: worksheet.state,
+      }))
+    ).toEqual([
+      { name: "OptionResponses", state: "visible" },
+      { name: "_meta", state: "hidden" },
+    ])
+
+    const responseSheet = workbook.getWorksheet("OptionResponses")
+    const metaSheet = workbook.getWorksheet("_meta")
+    expect(responseSheet).toBeDefined()
+    expect(metaSheet).toBeDefined()
+    expect(getRowValues(responseSheet!, 1, OPTION_WORKBOOK_COLUMNS.length)).toEqual(
+      OPTION_WORKBOOK_COLUMNS
+    )
+    expect(getRowValues(responseSheet!, 2, OPTION_WORKBOOK_COLUMNS.length)).toEqual(
+      OPTION_WORKBOOK_COLUMNS.map((column) => ROWS[0][column])
+    )
+    expect(getRowValues(metaSheet!, 1, 2)).toEqual(["key", "value"])
+    expect(
+      metaSheet!
+        .getRows(2, OPTION_WORKBOOK_META_KEYS.length)
+        ?.map((row) => getRowValues(metaSheet!, row.number, 2))
+    ).toEqual(OPTION_WORKBOOK_META_KEYS.map((key) => [key, METADATA[key]]))
+    expect(metaSheet!.actualRowCount).toBe(OPTION_WORKBOOK_META_KEYS.length + 1)
+    expect(responseSheet!.columnCount).toBe(OPTION_WORKBOOK_COLUMNS.length)
+    expect(getRowValues(responseSheet!, 2, responseSheet!.columnCount)).toEqual(
+      OPTION_WORKBOOK_COLUMNS.map((column) => ROWS[0][column])
+    )
+  })
+
+  it("round-trips Unicode and multiline text through the shared P5A loader and parser seam", async () => {
+    const workbook = await createWorkbook()
+    const buffer = await workbook.xlsx.writeBuffer()
+    const file = {
+      arrayBuffer: async () => buffer,
+    } as File
+    const loadedWorkbook = await readExcelFile(file)
+    const parser: BulkImportWorkbookParser<
+      Awaited<ReturnType<typeof parseTechnicalConfigurationOptionWorkbook>>
+    > = createTechnicalConfigurationOptionWorkbookParser(PARSE_OPTIONS)
+
+    await expect(parser(loadedWorkbook)).resolves.toEqual([
+      {
+        metadata: METADATA,
+        rows: ROWS,
+      },
+    ])
+  })
+
+  it("canonicalizes blank response cells to empty strings", async () => {
+    const workbook = await createWorkbook()
+    const responseSheet = workbook.getWorksheet("OptionResponses")!
+    responseSheet.getRow(2).getCell(8).value = null
+    responseSheet.getRow(2).getCell(9).value = undefined
+
+    await expect(
+      parseTechnicalConfigurationOptionWorkbook(toExcelWorkbookAdapter(workbook), PARSE_OPTIONS)
+    ).resolves.toMatchObject({
+      rows: [
+        {
+          criterion_id: "criterion-1",
+          response_text: "",
+          supplementary_information: "",
+        },
+        ROWS[1],
+      ],
+    })
+  })
+
+  it("requires every expected criterion exactly once", async () => {
+    const missingWorkbook = await createWorkbook()
+    missingWorkbook.getWorksheet("OptionResponses")!.spliceRows(3, 1)
+    await expectWorkbookIssue(missingWorkbook, "missing_criterion")
+
+    const unknownWorkbook = await createWorkbook()
+    unknownWorkbook.getWorksheet("OptionResponses")!.getRow(3).getCell(4).value =
+      "criterion-unknown"
+    await expectWorkbookIssue(unknownWorkbook, "unknown_criterion")
+
+    const duplicateWorkbook = await createWorkbook()
+    duplicateWorkbook.getWorksheet("OptionResponses")!.getRow(3).getCell(4).value = "criterion-1"
+    await expectWorkbookIssue(duplicateWorkbook, "duplicate_criterion")
+  })
+
+  it.each([
+    ["group_order", 2],
+    ["group_name", "Yêu cầu khác"],
+    ["criterion_order", 9],
+    ["criterion_code", "TC-9999"],
+    ["criterion_title", "Tiêu đề đã sửa"],
+    ["requirement_text", "Yêu cầu đã sửa"],
+  ] satisfies ReadonlyArray<[keyof TechnicalConfigurationOptionWorkbookRow, CellValue]>)(
+    "rejects altered read-only context field %s",
+    async (column, value) => {
+      const workbook = await createWorkbook()
+      const columnNumber = OPTION_WORKBOOK_COLUMNS.indexOf(column) + 1
+      workbook.getWorksheet("OptionResponses")!.getRow(2).getCell(columnNumber).value = value
+
+      const error = await expectWorkbookIssue(workbook, "changed_context")
+      expect(error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "changed_context",
+            row: 2,
+            column,
+          }),
+        ])
+      )
+    }
+  )
+
+  it.each([
+    ["dossier_id", "dossier-other"],
+    ["option_id", "option-other"],
+    ["baseline_version_id", "baseline-other"],
+    ["dossier_revision", 8],
+  ] as const)("rejects mismatched target metadata %s", async (key, value) => {
+    const workbook = await createWorkbook()
+    const metaRow = OPTION_WORKBOOK_META_KEYS.indexOf(key) + 2
+    workbook.getWorksheet("_meta")!.getRow(metaRow).getCell(2).value = value
+
+    await expectWorkbookIssue(workbook, "target_mismatch")
+  })
+
+  it("rejects missing, malformed and unsupported workbook metadata", async () => {
+    const missingMetadataSheet = await createWorkbook()
+    missingMetadataSheet.removeWorksheet(missingMetadataSheet.getWorksheet("_meta")!.id)
+    await expectWorkbookIssue(missingMetadataSheet, "missing_sheet")
+
+    const missingMetadata = await createWorkbook()
+    missingMetadata.getWorksheet("_meta")!.spliceRows(4, 1)
+    await expectWorkbookIssue(missingMetadata, "invalid_metadata")
+
+    const wrongTemplateKind = await createWorkbook()
+    const templateKindRow = OPTION_WORKBOOK_META_KEYS.indexOf("template_kind") + 2
+    wrongTemplateKind.getWorksheet("_meta")!.getRow(templateKindRow).getCell(2).value =
+      "technical_configuration_baseline"
+    await expectWorkbookIssue(wrongTemplateKind, "invalid_metadata")
+
+    const wrongVersion = await createWorkbook()
+    const versionRow = OPTION_WORKBOOK_META_KEYS.indexOf("template_version") + 2
+    wrongVersion.getWorksheet("_meta")!.getRow(versionRow).getCell(2).value = 2
+    await expectWorkbookIssue(wrongVersion, "version_mismatch")
+
+    const stringVersion = await createWorkbook()
+    stringVersion.getWorksheet("_meta")!.getRow(versionRow).getCell(2).value = "1"
+    await expectWorkbookIssue(stringVersion, "version_mismatch")
+
+    const stringRevision = await createWorkbook()
+    const revisionRow = OPTION_WORKBOOK_META_KEYS.indexOf("dossier_revision") + 2
+    stringRevision.getWorksheet("_meta")!.getRow(revisionRow).getCell(2).value = "7"
+    await expectWorkbookIssue(stringRevision, "invalid_metadata")
+
+    const invalidTimestamp = await createWorkbook()
+    const generatedAtRow = OPTION_WORKBOOK_META_KEYS.indexOf("generated_at") + 2
+    invalidTimestamp.getWorksheet("_meta")!.getRow(generatedAtRow).getCell(2).value = "not-a-date"
+    await expectWorkbookIssue(invalidTimestamp, "invalid_metadata")
+
+    const numericTimestamp = await createWorkbook()
+    numericTimestamp.getWorksheet("_meta")!.getRow(generatedAtRow).getCell(2).value = 0
+    await expectWorkbookIssue(numericTimestamp, "invalid_metadata")
+  })
+
+  it("rejects extra sheets, columns and invalid sheet visibility", async () => {
+    const extraSheet = await createWorkbook()
+    extraSheet.addWorksheet("Other")
+    await expectWorkbookIssue(extraSheet, "unexpected_sheet")
+
+    const extraColumn = await createWorkbook()
+    extraColumn.getWorksheet("OptionResponses")!.getRow(1).getCell(10).value = "extra"
+    await expectWorkbookIssue(extraColumn, "invalid_columns")
+
+    const extraMetadataColumn = await createWorkbook()
+    extraMetadataColumn.getWorksheet("_meta")!.getRow(2).getCell(3).value = "extra"
+    await expectWorkbookIssue(extraMetadataColumn, "invalid_metadata")
+
+    const visibleMetadata = await createWorkbook()
+    visibleMetadata.getWorksheet("_meta")!.state = "visible"
+    await expectWorkbookIssue(visibleMetadata, "invalid_sheet_visibility")
+
+    const hiddenResponses = await createWorkbook()
+    hiddenResponses.getWorksheet("OptionResponses")!.state = "hidden"
+    await expectWorkbookIssue(hiddenResponses, "invalid_sheet_visibility")
+  })
+
+  it("rejects unsupported cell values and malformed rows", async () => {
+    const unsupportedValue = await createWorkbook()
+    unsupportedValue.getWorksheet("OptionResponses")!.getRow(2).getCell(8).value = {
+      formula: "1+1",
+      result: 2,
+    }
+    await expectWorkbookIssue(unsupportedValue, "invalid_cell_value")
+
+    const malformedRow = await createWorkbook()
+    malformedRow.getWorksheet("OptionResponses")!.getRow(2).getCell(1).value = 0
+    await expectWorkbookIssue(malformedRow, "invalid_row")
+  })
+})

--- a/src/lib/__tests__/technical-configuration-option-excel.test.ts
+++ b/src/lib/__tests__/technical-configuration-option-excel.test.ts
@@ -6,6 +6,7 @@ import {
   OPTION_WORKBOOK_COLUMNS,
   OPTION_WORKBOOK_META_KEYS,
   TechnicalConfigurationOptionWorkbookError,
+  toPositiveOptionWorkbookInteger,
   type TechnicalConfigurationOptionWorkbookIssueCode,
   type TechnicalConfigurationOptionWorkbookMetadata,
   type TechnicalConfigurationOptionWorkbookParseOptions,
@@ -107,6 +108,12 @@ async function expectWorkbookIssue(
 }
 
 describe("technical configuration supplier-option workbook codec", () => {
+  it("rejects non-string and non-number values as positive workbook integers", () => {
+    expect(toPositiveOptionWorkbookInteger(true)).toBeNull()
+    expect(toPositiveOptionWorkbookInteger(["1"])).toBeNull()
+    expect(toPositiveOptionWorkbookInteger({ valueOf: () => 1 })).toBeNull()
+  })
+
   it("generates the exact OptionResponses and hidden _meta contract", async () => {
     const rowWithExcludedFields = {
       ...ROWS[0],

--- a/src/lib/technical-configuration-option-excel-contract.ts
+++ b/src/lib/technical-configuration-option-excel-contract.ts
@@ -1,0 +1,252 @@
+import type { CellValue, Worksheet } from "exceljs"
+
+import type { ExcelWorkbook } from "@/lib/excel-workbook"
+
+/** Visible worksheet containing one exact-baseline supplier-option response snapshot. */
+export const OPTION_WORKBOOK_SHEET_NAME = "OptionResponses"
+
+/** Hidden worksheet containing the workbook ownership metadata. */
+export const OPTION_WORKBOOK_META_SHEET_NAME = "_meta"
+
+/** Stable discriminator for supplier-option response workbooks. */
+export const OPTION_WORKBOOK_TEMPLATE_KIND = "technical_configuration_option"
+
+/** Supported supplier-option workbook contract version. */
+export const OPTION_WORKBOOK_TEMPLATE_VERSION = 1
+
+/** Exact ordered columns accepted on the OptionResponses worksheet. */
+export const OPTION_WORKBOOK_COLUMNS = [
+  "group_order",
+  "group_name",
+  "criterion_order",
+  "criterion_id",
+  "criterion_code",
+  "criterion_title",
+  "requirement_text",
+  "response_text",
+  "supplementary_information",
+] as const
+
+/** Exact ordered metadata keys accepted on the hidden worksheet. */
+export const OPTION_WORKBOOK_META_KEYS = [
+  "template_kind",
+  "template_version",
+  "dossier_id",
+  "option_id",
+  "baseline_version_id",
+  "dossier_revision",
+  "generated_at",
+] as const
+
+export interface TechnicalConfigurationOptionWorkbookMetadata {
+  template_kind: typeof OPTION_WORKBOOK_TEMPLATE_KIND
+  template_version: typeof OPTION_WORKBOOK_TEMPLATE_VERSION
+  dossier_id: string
+  option_id: string
+  baseline_version_id: string
+  dossier_revision: number
+  generated_at: string
+}
+
+export type TechnicalConfigurationOptionWorkbookTargetMetadata = Pick<
+  TechnicalConfigurationOptionWorkbookMetadata,
+  "dossier_id" | "option_id" | "baseline_version_id" | "dossier_revision"
+>
+
+export interface TechnicalConfigurationOptionWorkbookCriterion {
+  group_order: number
+  group_name: string
+  criterion_order: number
+  criterion_id: string
+  criterion_code: string
+  criterion_title: string | null
+  requirement_text: string
+}
+
+export interface TechnicalConfigurationOptionWorkbookRow extends TechnicalConfigurationOptionWorkbookCriterion {
+  response_text: string
+  supplementary_information: string
+}
+
+export interface TechnicalConfigurationOptionWorkbookParseOptions {
+  expectedMetadata: TechnicalConfigurationOptionWorkbookTargetMetadata
+  expectedCriteria: readonly TechnicalConfigurationOptionWorkbookCriterion[]
+}
+
+export interface TechnicalConfigurationOptionWorkbookParseResult {
+  metadata: TechnicalConfigurationOptionWorkbookMetadata
+  rows: TechnicalConfigurationOptionWorkbookRow[]
+}
+
+export type TechnicalConfigurationOptionWorkbookIssueCode =
+  | "unexpected_sheet"
+  | "missing_sheet"
+  | "invalid_sheet_visibility"
+  | "invalid_columns"
+  | "invalid_cell_value"
+  | "invalid_metadata"
+  | "version_mismatch"
+  | "target_mismatch"
+  | "invalid_row"
+  | "missing_criterion"
+  | "unknown_criterion"
+  | "duplicate_criterion"
+  | "changed_context"
+
+export interface TechnicalConfigurationOptionWorkbookIssue {
+  code: TechnicalConfigurationOptionWorkbookIssueCode
+  message: string
+  row?: number
+  column?: string
+}
+
+/** Aggregate parse error containing every supplier-option workbook contract issue found. */
+export class TechnicalConfigurationOptionWorkbookError extends Error {
+  readonly issues: TechnicalConfigurationOptionWorkbookIssue[]
+
+  constructor(issues: TechnicalConfigurationOptionWorkbookIssue[]) {
+    super(
+      issues.map((issue) => `${issue.row ? `Dòng ${issue.row}: ` : ""}${issue.message}`).join("\n")
+    )
+    this.name = "TechnicalConfigurationOptionWorkbookError"
+    this.issues = issues
+  }
+}
+
+/** Throws one aggregate error when supplier-option workbook issues are present. */
+export function throwIfOptionWorkbookIssues(
+  issues: TechnicalConfigurationOptionWorkbookIssue[]
+): void {
+  if (issues.length > 0) {
+    throw new TechnicalConfigurationOptionWorkbookError(issues)
+  }
+}
+
+/** Returns whether a cell contains contract-visible content. */
+export function hasOptionWorkbookCellValue(value: CellValue): boolean {
+  return value !== null && value !== undefined && value !== ""
+}
+
+/** Restricts workbook cells to empty, string or numeric primitive values. */
+export function isSupportedOptionWorkbookCellValue(value: CellValue): boolean {
+  return (
+    value === null || value === undefined || typeof value === "string" || typeof value === "number"
+  )
+}
+
+/** Converts a supported cell value to text without trimming or newline normalization. */
+export function toOptionWorkbookCellText(value: unknown): string {
+  return value === null || value === undefined ? "" : String(value)
+}
+
+/** Converts an empty supported cell to null for nullable read-only context. */
+export function toNullableOptionWorkbookCellText(value: unknown): string | null {
+  const text = toOptionWorkbookCellText(value)
+  return text === "" ? null : text
+}
+
+/** Parses a supported order cell as a positive integer. */
+export function toPositiveOptionWorkbookInteger(value: unknown): number | null {
+  const number = typeof value === "number" ? value : Number(value)
+  return Number.isInteger(number) && number > 0 ? number : null
+}
+
+/** Validates exact sheet names and visibility states. */
+export function collectOptionWorkbookStructureIssues(
+  workbook: ExcelWorkbook
+): TechnicalConfigurationOptionWorkbookIssue[] {
+  const issues: TechnicalConfigurationOptionWorkbookIssue[] = []
+  const expectedSheetNames = new Set([OPTION_WORKBOOK_SHEET_NAME, OPTION_WORKBOOK_META_SHEET_NAME])
+
+  for (const worksheet of workbook._workbook.worksheets) {
+    if (!expectedSheetNames.has(worksheet.name)) {
+      issues.push({
+        code: "unexpected_sheet",
+        message: `Sheet "${worksheet.name}" không thuộc contract.`,
+      })
+    }
+  }
+
+  for (const sheetName of expectedSheetNames) {
+    if (!workbook._workbook.getWorksheet(sheetName)) {
+      issues.push({
+        code: "missing_sheet",
+        message: `Thiếu sheet bắt buộc "${sheetName}".`,
+      })
+    }
+  }
+
+  const responseSheet = workbook._workbook.getWorksheet(OPTION_WORKBOOK_SHEET_NAME)
+  const metaSheet = workbook._workbook.getWorksheet(OPTION_WORKBOOK_META_SHEET_NAME)
+  if (responseSheet && responseSheet.state !== "visible") {
+    issues.push({
+      code: "invalid_sheet_visibility",
+      message: `Sheet "${OPTION_WORKBOOK_SHEET_NAME}" phải hiển thị.`,
+    })
+  }
+  if (metaSheet && metaSheet.state !== "hidden") {
+    issues.push({
+      code: "invalid_sheet_visibility",
+      message: `Sheet "${OPTION_WORKBOOK_META_SHEET_NAME}" phải ở trạng thái hidden.`,
+    })
+  }
+
+  return issues
+}
+
+/** Validates the exact ordered response header and rejects extra content columns. */
+export function collectOptionWorkbookColumnIssues(
+  worksheet: Worksheet
+): TechnicalConfigurationOptionWorkbookIssue[] {
+  const headers = OPTION_WORKBOOK_COLUMNS.map((_, index) =>
+    toOptionWorkbookCellText(worksheet.getRow(1).getCell(index + 1).value)
+  )
+  const hasWrongHeader = headers.some((header, index) => header !== OPTION_WORKBOOK_COLUMNS[index])
+  let hasExtraContent = false
+
+  for (let rowNumber = 1; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
+    for (
+      let columnNumber = OPTION_WORKBOOK_COLUMNS.length + 1;
+      columnNumber <= worksheet.columnCount;
+      columnNumber += 1
+    ) {
+      if (hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(columnNumber).value)) {
+        hasExtraContent = true
+        break
+      }
+    }
+  }
+
+  return hasWrongHeader || hasExtraContent
+    ? [
+        {
+          code: "invalid_columns",
+          message: "Sheet OptionResponses phải có đúng chín cột theo contract.",
+        },
+      ]
+    : []
+}
+
+/** Rejects unsupported Excel cell value shapes before shared worksheet conversion. */
+export function collectOptionWorkbookCellValueIssues(
+  worksheet: Worksheet
+): TechnicalConfigurationOptionWorkbookIssue[] {
+  const issues: TechnicalConfigurationOptionWorkbookIssue[] = []
+
+  for (let rowNumber = 1; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
+    for (let columnNumber = 1; columnNumber <= OPTION_WORKBOOK_COLUMNS.length; columnNumber += 1) {
+      if (
+        !isSupportedOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(columnNumber).value)
+      ) {
+        issues.push({
+          code: "invalid_cell_value",
+          row: rowNumber,
+          column: OPTION_WORKBOOK_COLUMNS[columnNumber - 1],
+          message: "Workbook chỉ chấp nhận ô text, số hoặc để trống.",
+        })
+      }
+    }
+  }
+
+  return issues
+}

--- a/src/lib/technical-configuration-option-excel-contract.ts
+++ b/src/lib/technical-configuration-option-excel-contract.ts
@@ -147,6 +147,9 @@ export function toNullableOptionWorkbookCellText(value: unknown): string | null 
 
 /** Parses a supported order cell as a positive integer. */
 export function toPositiveOptionWorkbookInteger(value: unknown): number | null {
+  if (typeof value !== "number" && typeof value !== "string") return null
+  if (typeof value === "string" && value.trim() === "") return null
+
   const number = typeof value === "number" ? value : Number(value)
   return Number.isInteger(number) && number > 0 ? number : null
 }

--- a/src/lib/technical-configuration-option-excel-contract.ts
+++ b/src/lib/technical-configuration-option-excel-contract.ts
@@ -207,18 +207,13 @@ export function collectOptionWorkbookColumnIssues(
   const hasWrongHeader = headers.some((header, index) => header !== OPTION_WORKBOOK_COLUMNS[index])
   let hasExtraContent = false
 
-  for (let rowNumber = 1; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
-    for (
-      let columnNumber = OPTION_WORKBOOK_COLUMNS.length + 1;
-      columnNumber <= worksheet.columnCount;
-      columnNumber += 1
-    ) {
-      if (hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(columnNumber).value)) {
+  worksheet.eachRow((row) => {
+    row.eachCell((cell, columnNumber) => {
+      if (columnNumber > OPTION_WORKBOOK_COLUMNS.length && hasOptionWorkbookCellValue(cell.value)) {
         hasExtraContent = true
-        break
       }
-    }
-  }
+    })
+  })
 
   return hasWrongHeader || hasExtraContent
     ? [
@@ -236,10 +231,11 @@ export function collectOptionWorkbookCellValueIssues(
 ): TechnicalConfigurationOptionWorkbookIssue[] {
   const issues: TechnicalConfigurationOptionWorkbookIssue[] = []
 
-  for (let rowNumber = 1; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
-    for (let columnNumber = 1; columnNumber <= OPTION_WORKBOOK_COLUMNS.length; columnNumber += 1) {
+  worksheet.eachRow((row, rowNumber) => {
+    row.eachCell((cell, columnNumber) => {
       if (
-        !isSupportedOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(columnNumber).value)
+        columnNumber <= OPTION_WORKBOOK_COLUMNS.length &&
+        !isSupportedOptionWorkbookCellValue(cell.value)
       ) {
         issues.push({
           code: "invalid_cell_value",
@@ -248,8 +244,8 @@ export function collectOptionWorkbookCellValueIssues(
           message: "Workbook chỉ chấp nhận ô text, số hoặc để trống.",
         })
       }
-    }
-  }
+    })
+  })
 
   return issues
 }

--- a/src/lib/technical-configuration-option-excel-export.ts
+++ b/src/lib/technical-configuration-option-excel-export.ts
@@ -1,0 +1,39 @@
+import type { Workbook } from "exceljs"
+
+import {
+  OPTION_WORKBOOK_COLUMNS,
+  OPTION_WORKBOOK_META_KEYS,
+  OPTION_WORKBOOK_META_SHEET_NAME,
+  OPTION_WORKBOOK_SHEET_NAME,
+  type TechnicalConfigurationOptionWorkbookMetadata,
+  type TechnicalConfigurationOptionWorkbookRow,
+} from "@/lib/technical-configuration-option-excel-contract"
+import { createExcelWorkbook } from "@/lib/excel-workbook"
+
+export interface CreateTechnicalConfigurationOptionWorkbookOptions {
+  metadata: TechnicalConfigurationOptionWorkbookMetadata
+  rows: readonly TechnicalConfigurationOptionWorkbookRow[]
+}
+
+/** Builds one versioned supplier-option snapshot on the shared P5A workbook primitive. */
+export async function createTechnicalConfigurationOptionWorkbook({
+  metadata,
+  rows,
+}: CreateTechnicalConfigurationOptionWorkbookOptions): Promise<Workbook> {
+  const workbook = await createExcelWorkbook()
+  const responseSheet = workbook.addWorksheet(OPTION_WORKBOOK_SHEET_NAME)
+
+  responseSheet.addRow([...OPTION_WORKBOOK_COLUMNS])
+  rows.forEach((row) => {
+    responseSheet.addRow(OPTION_WORKBOOK_COLUMNS.map((column) => row[column]))
+  })
+
+  const metaSheet = workbook.addWorksheet(OPTION_WORKBOOK_META_SHEET_NAME)
+  metaSheet.state = "hidden"
+  metaSheet.addRow(["key", "value"])
+  OPTION_WORKBOOK_META_KEYS.forEach((key) => {
+    metaSheet.addRow([key, metadata[key]])
+  })
+
+  return workbook
+}

--- a/src/lib/technical-configuration-option-excel-parse.ts
+++ b/src/lib/technical-configuration-option-excel-parse.ts
@@ -1,0 +1,331 @@
+import type { Worksheet } from "exceljs"
+
+import type { BulkImportWorkbookParser } from "@/components/bulk-import/bulk-import-types"
+import {
+  OPTION_WORKBOOK_COLUMNS,
+  OPTION_WORKBOOK_META_KEYS,
+  OPTION_WORKBOOK_META_SHEET_NAME,
+  OPTION_WORKBOOK_SHEET_NAME,
+  OPTION_WORKBOOK_TEMPLATE_KIND,
+  OPTION_WORKBOOK_TEMPLATE_VERSION,
+  TechnicalConfigurationOptionWorkbookError,
+  collectOptionWorkbookCellValueIssues,
+  collectOptionWorkbookColumnIssues,
+  collectOptionWorkbookStructureIssues,
+  hasOptionWorkbookCellValue,
+  isSupportedOptionWorkbookCellValue,
+  throwIfOptionWorkbookIssues,
+  toNullableOptionWorkbookCellText,
+  toOptionWorkbookCellText,
+  toPositiveOptionWorkbookInteger,
+  type TechnicalConfigurationOptionWorkbookCriterion,
+  type TechnicalConfigurationOptionWorkbookIssue,
+  type TechnicalConfigurationOptionWorkbookMetadata,
+  type TechnicalConfigurationOptionWorkbookParseOptions,
+  type TechnicalConfigurationOptionWorkbookParseResult,
+  type TechnicalConfigurationOptionWorkbookRow,
+} from "@/lib/technical-configuration-option-excel-contract"
+import { worksheetToJson, type ExcelWorkbook } from "@/lib/excel-workbook"
+
+function parseMetadata(
+  worksheet: Worksheet,
+  options: TechnicalConfigurationOptionWorkbookParseOptions
+): {
+  metadata: TechnicalConfigurationOptionWorkbookMetadata | null
+  issues: TechnicalConfigurationOptionWorkbookIssue[]
+} {
+  const issues: TechnicalConfigurationOptionWorkbookIssue[] = []
+  const header = [
+    toOptionWorkbookCellText(worksheet.getRow(1).getCell(1).value),
+    toOptionWorkbookCellText(worksheet.getRow(1).getCell(2).value),
+  ]
+  const values: Record<string, unknown> = {}
+
+  if (header[0] !== "key" || header[1] !== "value") {
+    issues.push({
+      code: "invalid_metadata",
+      message: "Sheet _meta phải bắt đầu bằng hai cột key và value.",
+    })
+  }
+
+  for (let rowNumber = 1; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
+    for (let columnNumber = 3; columnNumber <= worksheet.columnCount; columnNumber += 1) {
+      if (hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(columnNumber).value)) {
+        issues.push({
+          code: "invalid_metadata",
+          row: rowNumber,
+          message: "Sheet _meta chỉ được chứa hai cột key và value.",
+        })
+        break
+      }
+    }
+  }
+
+  OPTION_WORKBOOK_META_KEYS.forEach((expectedKey, index) => {
+    const rowNumber = index + 2
+    const keyCell = worksheet.getRow(rowNumber).getCell(1)
+    const valueCell = worksheet.getRow(rowNumber).getCell(2)
+    const key = toOptionWorkbookCellText(keyCell.value)
+
+    if (key !== expectedKey || !isSupportedOptionWorkbookCellValue(valueCell.value)) {
+      issues.push({
+        code: "invalid_metadata",
+        row: rowNumber,
+        message: `Metadata phải chứa đúng khóa "${expectedKey}" theo thứ tự contract.`,
+      })
+      return
+    }
+    values[expectedKey] = valueCell.value
+  })
+
+  for (
+    let rowNumber = OPTION_WORKBOOK_META_KEYS.length + 2;
+    rowNumber <= worksheet.actualRowCount;
+    rowNumber += 1
+  ) {
+    if (
+      hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(1).value) ||
+      hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(2).value)
+    ) {
+      issues.push({
+        code: "invalid_metadata",
+        row: rowNumber,
+        message: "Sheet _meta không được chứa khóa bổ sung.",
+      })
+    }
+  }
+
+  const templateKind = typeof values.template_kind === "string" ? values.template_kind : ""
+  if (templateKind !== OPTION_WORKBOOK_TEMPLATE_KIND) {
+    issues.push({
+      code: "invalid_metadata",
+      message: "Workbook không phải template phản hồi phương án kỹ thuật.",
+    })
+  }
+
+  const templateVersion =
+    typeof values.template_version === "number" ? values.template_version : null
+  if (templateVersion !== OPTION_WORKBOOK_TEMPLATE_VERSION) {
+    issues.push({
+      code: "version_mismatch",
+      message: "Phiên bản template phản hồi phương án không được hỗ trợ.",
+    })
+  }
+
+  const dossierRevision =
+    typeof values.dossier_revision === "number"
+      ? toPositiveOptionWorkbookInteger(values.dossier_revision)
+      : null
+  const generatedAt = typeof values.generated_at === "string" ? values.generated_at : ""
+  if (dossierRevision === null || generatedAt === "" || Number.isNaN(Date.parse(generatedAt))) {
+    issues.push({
+      code: "invalid_metadata",
+      message: "Metadata revision hoặc generated_at không hợp lệ.",
+    })
+  }
+
+  const dossierId = typeof values.dossier_id === "string" ? values.dossier_id : ""
+  const optionId = typeof values.option_id === "string" ? values.option_id : ""
+  const baselineVersionId =
+    typeof values.baseline_version_id === "string" ? values.baseline_version_id : ""
+  if (!dossierId || !optionId || !baselineVersionId) {
+    issues.push({
+      code: "invalid_metadata",
+      message: "Metadata dossier, option và baseline phải là chuỗi không rỗng.",
+    })
+  }
+
+  const targetValues = {
+    dossier_id: dossierId,
+    option_id: optionId,
+    baseline_version_id: baselineVersionId,
+    dossier_revision: dossierRevision,
+  }
+  if (
+    targetValues.dossier_id !== options.expectedMetadata.dossier_id ||
+    targetValues.option_id !== options.expectedMetadata.option_id ||
+    targetValues.baseline_version_id !== options.expectedMetadata.baseline_version_id ||
+    targetValues.dossier_revision !== options.expectedMetadata.dossier_revision
+  ) {
+    issues.push({
+      code: "target_mismatch",
+      message: "Workbook không thuộc đúng hồ sơ, phương án, baseline hoặc revision hiện tại.",
+    })
+  }
+
+  if (issues.length > 0 || dossierRevision === null) {
+    return { metadata: null, issues }
+  }
+
+  return {
+    metadata: {
+      template_kind: OPTION_WORKBOOK_TEMPLATE_KIND,
+      template_version: OPTION_WORKBOOK_TEMPLATE_VERSION,
+      dossier_id: targetValues.dossier_id,
+      option_id: targetValues.option_id,
+      baseline_version_id: targetValues.baseline_version_id,
+      dossier_revision: dossierRevision,
+      generated_at: generatedAt,
+    },
+    issues,
+  }
+}
+
+function getDataRowNumbers(worksheet: Worksheet): number[] {
+  const rowNumbers: number[] = []
+
+  for (let rowNumber = 2; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
+    const hasData = OPTION_WORKBOOK_COLUMNS.some((_, index) =>
+      hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(index + 1).value)
+    )
+    if (hasData) rowNumbers.push(rowNumber)
+  }
+
+  return rowNumbers
+}
+
+function parseRow(
+  record: Record<string, unknown>,
+  rowNumber: number,
+  expectedCriteria: Map<string, TechnicalConfigurationOptionWorkbookCriterion>,
+  seenCriterionIds: Set<string>,
+  issues: TechnicalConfigurationOptionWorkbookIssue[]
+): TechnicalConfigurationOptionWorkbookRow | null {
+  const criterionId = toOptionWorkbookCellText(record.criterion_id)
+  const groupOrder = toPositiveOptionWorkbookInteger(record.group_order)
+  const criterionOrder = toPositiveOptionWorkbookInteger(record.criterion_order)
+  const expectedCriterion = expectedCriteria.get(criterionId)
+
+  if (!criterionId || groupOrder === null || criterionOrder === null) {
+    issues.push({
+      code: "invalid_row",
+      row: rowNumber,
+      message: "Dòng phản hồi phải có mã tiêu chí và thứ tự dương hợp lệ.",
+    })
+    return null
+  }
+  if (seenCriterionIds.has(criterionId)) {
+    issues.push({
+      code: "duplicate_criterion",
+      row: rowNumber,
+      column: "criterion_id",
+      message: `Tiêu chí "${criterionId}" xuất hiện nhiều hơn một lần.`,
+    })
+    return null
+  }
+  seenCriterionIds.add(criterionId)
+
+  if (!expectedCriterion) {
+    issues.push({
+      code: "unknown_criterion",
+      row: rowNumber,
+      column: "criterion_id",
+      message: `Tiêu chí "${criterionId}" không thuộc baseline mục tiêu.`,
+    })
+    return null
+  }
+
+  const parsedContext: TechnicalConfigurationOptionWorkbookCriterion = {
+    group_order: groupOrder,
+    group_name: toOptionWorkbookCellText(record.group_name),
+    criterion_order: criterionOrder,
+    criterion_id: criterionId,
+    criterion_code: toOptionWorkbookCellText(record.criterion_code),
+    criterion_title: toNullableOptionWorkbookCellText(record.criterion_title),
+    requirement_text: toOptionWorkbookCellText(record.requirement_text),
+  }
+  const contextColumns: readonly (keyof TechnicalConfigurationOptionWorkbookCriterion)[] = [
+    "group_order",
+    "group_name",
+    "criterion_order",
+    "criterion_id",
+    "criterion_code",
+    "criterion_title",
+    "requirement_text",
+  ]
+  contextColumns.forEach((column) => {
+    if (parsedContext[column] !== expectedCriterion[column]) {
+      issues.push({
+        code: "changed_context",
+        row: rowNumber,
+        column,
+        message: `Cột chỉ đọc "${column}" không khớp baseline mục tiêu.`,
+      })
+    }
+  })
+
+  return {
+    ...expectedCriterion,
+    response_text: toOptionWorkbookCellText(record.response_text),
+    supplementary_information: toOptionWorkbookCellText(record.supplementary_information),
+  }
+}
+
+/** Parses and validates one authoritative supplier-option response workbook snapshot. */
+export async function parseTechnicalConfigurationOptionWorkbook(
+  workbook: ExcelWorkbook,
+  options: TechnicalConfigurationOptionWorkbookParseOptions
+): Promise<TechnicalConfigurationOptionWorkbookParseResult> {
+  throwIfOptionWorkbookIssues(collectOptionWorkbookStructureIssues(workbook))
+
+  const responseSheet = workbook._workbook.getWorksheet(OPTION_WORKBOOK_SHEET_NAME)
+  const metaSheet = workbook._workbook.getWorksheet(OPTION_WORKBOOK_META_SHEET_NAME)
+  if (!responseSheet || !metaSheet) {
+    throw new TechnicalConfigurationOptionWorkbookError([
+      {
+        code: "missing_sheet",
+        message: "Thiếu sheet bắt buộc của template phản hồi phương án.",
+      },
+    ])
+  }
+
+  const worksheetIssues = [
+    ...collectOptionWorkbookColumnIssues(responseSheet),
+    ...collectOptionWorkbookCellValueIssues(responseSheet),
+  ]
+  const { metadata, issues: metadataIssues } = parseMetadata(metaSheet, options)
+  throwIfOptionWorkbookIssues([...worksheetIssues, ...metadataIssues])
+
+  const records = await worksheetToJson(responseSheet)
+  const rowNumbers = getDataRowNumbers(responseSheet)
+  const expectedCriteria = new Map(
+    options.expectedCriteria.map((criterion) => [criterion.criterion_id, criterion])
+  )
+  const seenCriterionIds = new Set<string>()
+  const parsedRows = new Map<string, TechnicalConfigurationOptionWorkbookRow>()
+  const rowIssues: TechnicalConfigurationOptionWorkbookIssue[] = []
+
+  records.forEach((record, index) => {
+    const row = parseRow(
+      record,
+      rowNumbers[index] ?? index + 2,
+      expectedCriteria,
+      seenCriterionIds,
+      rowIssues
+    )
+    if (row) parsedRows.set(row.criterion_id, row)
+  })
+
+  options.expectedCriteria.forEach((criterion) => {
+    if (!seenCriterionIds.has(criterion.criterion_id)) {
+      rowIssues.push({
+        code: "missing_criterion",
+        column: "criterion_id",
+        message: `Thiếu tiêu chí bắt buộc "${criterion.criterion_id}".`,
+      })
+    }
+  })
+  throwIfOptionWorkbookIssues(rowIssues)
+
+  return {
+    metadata: metadata!,
+    rows: options.expectedCriteria.map((criterion) => parsedRows.get(criterion.criterion_id)!),
+  }
+}
+
+/** Adapts the option codec to the shared bulk-import workbook parser seam. */
+export function createTechnicalConfigurationOptionWorkbookParser(
+  options: TechnicalConfigurationOptionWorkbookParseOptions
+): BulkImportWorkbookParser<TechnicalConfigurationOptionWorkbookParseResult> {
+  return async (workbook) => [await parseTechnicalConfigurationOptionWorkbook(workbook, options)]
+}

--- a/src/lib/technical-configuration-option-excel-parse.ts
+++ b/src/lib/technical-configuration-option-excel-parse.ts
@@ -48,18 +48,21 @@ function parseMetadata(
     })
   }
 
-  for (let rowNumber = 1; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
-    for (let columnNumber = 3; columnNumber <= worksheet.columnCount; columnNumber += 1) {
-      if (hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(columnNumber).value)) {
-        issues.push({
-          code: "invalid_metadata",
-          row: rowNumber,
-          message: "Sheet _meta chỉ được chứa hai cột key và value.",
-        })
-        break
+  worksheet.eachRow((row, rowNumber) => {
+    let hasExtraColumnValue = false
+    row.eachCell((cell, columnNumber) => {
+      if (columnNumber > 2 && hasOptionWorkbookCellValue(cell.value)) {
+        hasExtraColumnValue = true
       }
+    })
+    if (hasExtraColumnValue) {
+      issues.push({
+        code: "invalid_metadata",
+        row: rowNumber,
+        message: "Sheet _meta chỉ được chứa hai cột key và value.",
+      })
     }
-  }
+  })
 
   OPTION_WORKBOOK_META_KEYS.forEach((expectedKey, index) => {
     const rowNumber = index + 2
@@ -78,22 +81,23 @@ function parseMetadata(
     values[expectedKey] = valueCell.value
   })
 
-  for (
-    let rowNumber = OPTION_WORKBOOK_META_KEYS.length + 2;
-    rowNumber <= worksheet.actualRowCount;
-    rowNumber += 1
-  ) {
-    if (
-      hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(1).value) ||
-      hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(2).value)
-    ) {
+  worksheet.eachRow((row, rowNumber) => {
+    if (rowNumber < OPTION_WORKBOOK_META_KEYS.length + 2) return
+
+    let hasExtraMetadataValue = false
+    row.eachCell((cell, columnNumber) => {
+      if (columnNumber <= 2 && hasOptionWorkbookCellValue(cell.value)) {
+        hasExtraMetadataValue = true
+      }
+    })
+    if (hasExtraMetadataValue) {
       issues.push({
         code: "invalid_metadata",
         row: rowNumber,
         message: "Sheet _meta không được chứa khóa bổ sung.",
       })
     }
-  }
+  })
 
   const templateKind = typeof values.template_kind === "string" ? values.template_kind : ""
   if (templateKind !== OPTION_WORKBOOK_TEMPLATE_KIND) {
@@ -174,12 +178,20 @@ function parseMetadata(
 function getDataRowNumbers(worksheet: Worksheet): number[] {
   const rowNumbers: number[] = []
 
-  for (let rowNumber = 2; rowNumber <= worksheet.actualRowCount; rowNumber += 1) {
-    const hasData = OPTION_WORKBOOK_COLUMNS.some((_, index) =>
-      hasOptionWorkbookCellValue(worksheet.getRow(rowNumber).getCell(index + 1).value)
-    )
+  worksheet.eachRow((row, rowNumber) => {
+    if (rowNumber === 1) return
+
+    let hasData = false
+    row.eachCell((cell, columnNumber) => {
+      if (
+        columnNumber <= OPTION_WORKBOOK_COLUMNS.length &&
+        hasOptionWorkbookCellValue(cell.value)
+      ) {
+        hasData = true
+      }
+    })
     if (hasData) rowNumbers.push(rowNumber)
-  }
+  })
 
   return rowNumbers
 }


### PR DESCRIPTION
## Summary

- add the supplier-option workbook v1 contract with exact sheets, columns and metadata
- add deterministic export on the shared P5A Excel workbook primitive
- add strict full-snapshot parsing for target metadata, criterion membership and read-only baseline context
- canonicalize blank response fields to empty strings and reject unsupported or extra workbook content

## Scope Boundary

This PR contains only P9A1 contract/export/parser code and focused tests. It adds no RPC, migration, UI, live DB write, document, citation, assessment or option-evidence behavior.

## TDD Evidence

- RED: focused Vitest failed because the three option workbook modules did not exist
- GREEN: focused option codec suite passes 17/17 tests
- review-fix loop completed with three review rounds; final two rounds returned zero findings

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/lib/__tests__/technical-configuration-option-excel.test.ts src/lib/__tests__/technical-configuration-baseline-excel.test.ts src/lib/__tests__/excel-workbook.test.ts src/lib/__tests__/excel-template-generation.test.ts` (57 passed, 4 skipped)
- `node scripts/npm-run.js run react-doctor` (100/100)
- `openspec validate add-technical-configuration-comparison --strict`

Closes #792

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the P9A1 supplier option workbook codec with a v1 Excel contract, deterministic export, and a strict parser. Parsing now correctly handles sparse sheets and reports physical row numbers.

- **New Features**
  - Defines v1 contract: `OptionResponses` (visible) and `_meta` (hidden), 9 exact columns and 7 exact metadata keys.
  - Adds `createTechnicalConfigurationOptionWorkbook` for deterministic export of rows and metadata.
  - Adds `parseTechnicalConfigurationOptionWorkbook` and `createTechnicalConfigurationOptionWorkbookParser` with strict validation (sheet names/visibility, headers/columns, cell types, target metadata, criterion membership, read-only context); blanks canonicalized to "" and aggregated errors via `TechnicalConfigurationOptionWorkbookError`.

- **Bug Fixes**
  - Rejects coercible workbook integers; only primitive number or string is accepted. `dossier_revision` must be a number.
  - Handles sparse response sheets: skips empty rows, validates after interior gaps, and reports the correct physical row numbers without materializing missing rows.

<sup>Written for commit 5226c7e6ee78a4078065273dcc92e132a8701216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Excel workbook export and import support for technical configuration options.
  - Workbooks include a visible response sheet and hidden metadata sheet.
  - Added validation for workbook structure, metadata, criteria, read-only fields, supported values, and template compatibility.
  - Added clear, structured error reporting for invalid or incomplete workbooks.
  - Preserves Unicode, multiline text, and empty response values during round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->