### PR TITLE
fix(technical-config): reject text workbook order values

### DIFF
--- a/src/lib/__tests__/technical-configuration-option-excel.test.ts
+++ b/src/lib/__tests__/technical-configuration-option-excel.test.ts
@@ -335,6 +335,17 @@ describe("technical configuration supplier-option workbook codec", () => {
     await expectWorkbookIssue(malformedRow, "invalid_row")
   })
 
+  it.each(["group_order", "criterion_order"] as const)(
+    "rejects text-formatted numeric %s values",
+    async (column) => {
+      const workbook = await createWorkbook()
+      const columnNumber = OPTION_WORKBOOK_COLUMNS.indexOf(column) + 1
+      workbook.getWorksheet("OptionResponses")!.getRow(2).getCell(columnNumber).value = "1"
+
+      await expectWorkbookIssue(workbook, "invalid_row")
+    }
+  )
+
   it("validates response cells and columns after an interior blank row", async () => {
     const unsupportedValue = await createWorkbook()
     insertBlankRowBeforeSecondCriterion(unsupportedValue).getRow(4).getCell(8).value = {

--- a/src/lib/technical-configuration-option-excel-parse.ts
+++ b/src/lib/technical-configuration-option-excel-parse.ts
@@ -204,8 +204,14 @@ function parseRow(
   issues: TechnicalConfigurationOptionWorkbookIssue[]
 ): TechnicalConfigurationOptionWorkbookRow | null {
   const criterionId = toOptionWorkbookCellText(record.criterion_id)
-  const groupOrder = toPositiveOptionWorkbookInteger(record.group_order)
-  const criterionOrder = toPositiveOptionWorkbookInteger(record.criterion_order)
+  const groupOrder =
+    typeof record.group_order === "number"
+      ? toPositiveOptionWorkbookInteger(record.group_order)
+      : null
+  const criterionOrder =
+    typeof record.criterion_order === "number"
+      ? toPositiveOptionWorkbookInteger(record.criterion_order)
+      : null
   const expectedCriterion = expectedCriteria.get(criterionId)
 
   if (!criterionId || groupOrder === null || criterionOrder === null) {


### PR DESCRIPTION
## Summary
- reject text-formatted numeric `group_order` and `criterion_order` cells through the existing `invalid_row` path
- add focused regression coverage for both order columns
- keep the existing sparse-safe `eachRow`/`eachCell` iteration unchanged

## Review triage
- Fixed: `parseRow` now requires numeric order cells before positive-integer validation, matching metadata validation.
- Skipped: four suggestions to replace row iteration with `worksheet.rowCount`; current code already uses `eachRow`/`eachCell`, which validates populated rows after gaps without materializing every missing sparse row.

## Validation
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- src/lib/__tests__/technical-configuration-option-excel.test.ts` (24 passed)
- `node scripts/npm-run.js run react-doctor` (100/100)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject text-formatted numbers in `group_order` and `criterion_order` when parsing the technical configuration option workbook, marking those rows as `invalid_row`. This matches metadata validation, keeps the sparse `eachRow`/`eachCell` iteration, and adds focused tests for both columns.

<sup>Written for commit a18f6cd368382cce6264f507269c9866225e2755. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excel imports now reject text-formatted numeric values for group and criterion order fields.
  * Invalid rows are reported consistently when these ordering values are missing, non-positive, or incorrectly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->