### PR TITLE
feat: improve P8B3 option response workflow

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -300,30 +300,31 @@ Chi tiết phạm vi, dependency, file ownership, TDD gate và điểm dừng c�
 
 ## Phase P8B3 - Focused Option Response Comparison UX
 
-- [ ] P8B3.1 Giữ supplier selector và option identity editor ở vùng trên; chuyển
+- [x] P8B3.1 Giữ supplier selector và option identity editor ở vùng trên; chuyển
       exact-baseline response workspace thành một vùng desktop toàn chiều rộng
       bên dưới.
-- [ ] P8B3.2 Hiển thị ba vùng ổn định: criterion navigator, panel cấu hình cơ bản
+- [x] P8B3.2 Hiển thị ba vùng ổn định: criterion navigator, panel cấu hình cơ bản
       chỉ đọc và panel response/supplementary chỉnh sửa cho đúng criterion đang
       chọn; không render toàn bộ matrix.
-- [ ] P8B3.3 Hiển thị trạng thái `chưa có response`, `đã lưu` và `đang có thay đổi
+- [x] P8B3.3 Hiển thị trạng thái `chưa có response`, `đã lưu` và `đang có thay đổi
 chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
-- [ ] P8B3.4 Thêm nút `Sao chép từ cấu hình cơ bản`: chỉ copy
+- [x] P8B3.4 Thêm nút `Sao chép từ cấu hình cơ bản`: chỉ copy
       `requirement_text` vào response draft, giữ nguyên supplementary, vẫn cho
       sửa tiếp và không mutation trước explicit save; response không rỗng phải
       xác nhận trước khi ghi đè.
-- [ ] P8B3.5 Đổi action hiện tại thành secondary `Lưu` và thêm primary
+- [x] P8B3.5 Đổi action hiện tại thành secondary `Lưu` và thêm primary
       `Lưu & tiếp theo`; chỉ chuyển sau save thành công tới criterion liền sau
       theo canonical baseline order, không skip criterion đã lưu, không chuyển
       khi validation/conflict/persistence thất bại và criterion cuối chỉ hiển
       thị `Lưu`.
-- [ ] P8B3.6 Giữ nguyên P8B2 RPC/data semantics, locked-baseline editability,
+- [x] P8B3.6 Giữ nguyên P8B2 RPC/data semantics, locked-baseline editability,
       archived read-only, dirty navigation và conflict recovery; không thêm API,
       migration, data contract, live DB write, bulk-copy, batch-save hoặc mobile
       responsive acceptance.
-- [ ] P8B3.7 Viết focused state/React/browser tests cho desktop layout, selected
-      criterion binding, status indicators, copy/confirm/cancel, supplementary
-      preservation, explicit save và save-next ordering.
+- [x] P8B3.7 Viết focused state/React tests cho desktop layout, selected criterion
+      binding, status indicators, copy/confirm/cancel, supplementary preservation,
+      explicit save và save-next ordering. Browser test được bỏ theo chỉ định thực
+      thi ngày 2026-07-25.
 
 ## Phase P9A1 - Supplier Option Workbook Codec
 

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-availability-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-availability-cases.tsx
@@ -1,0 +1,186 @@
+import { QueryClientProvider } from "@tanstack/react-query"
+import { act, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi, type Mock } from "vitest"
+
+import { TechnicalConfigurationOptionResponseEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor"
+import { technicalConfigurationOptionResponsesQueryKey } from "@/app/(app)/technical-configurations/technical-configuration-query-keys"
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+import { createTestQueryClient } from "@/test-utils/react-query"
+import { dossier, option } from "./supplier-options-fixtures"
+import {
+  baselineVersion,
+  comparisonSet,
+  getRequest,
+  jsonResponse,
+  optionResponse,
+} from "./supplier-option-response-cases"
+import { deferred } from "./technical-configuration-baseline-tab-fixtures"
+
+type ResponseAvailabilityTestMocks = {
+  fetchMock: Mock
+}
+
+function renderEditor({
+  dossierValue = dossier,
+  queryClient = createTestQueryClient(),
+  onRevisionChange,
+}: {
+  dossierValue?: TechnicalConfigurationDossierWire
+  queryClient?: ReturnType<typeof createTestQueryClient>
+  onRevisionChange?: (revision: number) => void
+} = {}) {
+  const baseline = baselineVersion()
+  const currentOption = option({ id: "option-1" })
+  const renderNode = (nextDossier: TechnicalConfigurationDossierWire) => (
+    <QueryClientProvider client={queryClient}>
+      <TechnicalConfigurationOptionResponseEditor
+        dossier={nextDossier}
+        option={currentOption}
+        baselineVersion={baseline}
+        onRevisionChange={onRevisionChange}
+        requestDiscardConfirmation={() => undefined}
+      />
+    </QueryClientProvider>
+  )
+  const rendered = render(renderNode(dossierValue))
+  return {
+    ...rendered,
+    baseline,
+    currentOption,
+    queryClient,
+    rerenderDossier: (nextDossier: TechnicalConfigurationDossierWire) =>
+      rendered.rerender(renderNode(nextDossier)),
+  }
+}
+
+export function registerSupplierOptionResponseAvailabilityTests({
+  fetchMock,
+}: ResponseAvailabilityTestMocks) {
+  describe("technical configuration option response availability", () => {
+    it("keeps criterion response status neutral while the initial query is loading", async () => {
+      const responseRequest = deferred<Response>()
+      fetchMock.mockReturnValueOnce(responseRequest.promise)
+
+      const { baseline } = renderEditor()
+
+      expect(
+        await screen.findByRole("button", { name: /TC-0001.*Đang tải phản hồi/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: /TC-0001.*Chưa phản hồi/i })
+      ).not.toBeInTheDocument()
+
+      act(() => responseRequest.resolve(jsonResponse({ data: comparisonSet(baseline) })))
+      await responseRequest.promise
+      expect(await screen.findByLabelText("Phản hồi tiêu chí")).toBeInTheDocument()
+    })
+
+    it("keeps criterion statuses unavailable after an initial response read failure", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ message: "Không thể đọc phản hồi" }, 500))
+
+      renderEditor()
+
+      expect(await screen.findByText("Không thể tải phản hồi phương án")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /TC-0001.*Chưa xác định/i })).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: /TC-0001.*Chưa phản hồi/i })
+      ).not.toBeInTheDocument()
+      expect(screen.queryByLabelText("Phản hồi tiêu chí")).not.toBeInTheDocument()
+    })
+
+    it("renders warm cached response state before adoption effects run", () => {
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const firstCriterionId = baseline.groups[0]?.criteria[0]?.id ?? ""
+      const secondCriterionId = baseline.groups[0]?.criteria[1]?.id ?? ""
+      const cachedComparisonSet = comparisonSet(baseline, [
+        optionResponse(baseline, {
+          criterion_id: firstCriterionId,
+          response_text: "Phản hồi cache thứ nhất",
+        }),
+        optionResponse(baseline, {
+          id: "response-2",
+          criterion_id: secondCriterionId,
+          response_text: "Phản hồi cache thứ hai",
+        }),
+      ])
+      const queryClient = createTestQueryClient()
+      queryClient.setQueryData(
+        technicalConfigurationOptionResponsesQueryKey(currentOption.id, baseline.id),
+        cachedComparisonSet
+      )
+
+      const html = renderToStaticMarkup(
+        <QueryClientProvider client={queryClient}>
+          <TechnicalConfigurationOptionResponseEditor
+            dossier={dossier}
+            option={currentOption}
+            baselineVersion={baseline}
+            requestDiscardConfirmation={() => undefined}
+          />
+        </QueryClientProvider>
+      )
+
+      expect(html).toContain("Phản hồi cache thứ nhất")
+      expect(html.match(/Đã lưu/g)).toHaveLength(2)
+      expect(html).not.toContain("Chưa phản hồi")
+    })
+
+    it("propagates and saves with a newer warm cached revision", async () => {
+      const user = userEvent.setup()
+      const cachedRevision = 8
+      const onRevisionChange = vi.fn()
+      const queryClient = createTestQueryClient()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const persisted = optionResponse(baseline, { revision: cachedRevision })
+      const saved = optionResponse(baseline, {
+        response_text: "Phản hồi sau cache",
+        revision: cachedRevision + 1,
+      })
+      queryClient.setQueryData(
+        technicalConfigurationOptionResponsesQueryKey(currentOption.id, baseline.id),
+        comparisonSet(baseline, [persisted], cachedRevision)
+      )
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: saved }))
+
+      renderEditor({ queryClient, onRevisionChange })
+
+      await waitFor(() => expect(onRevisionChange).toHaveBeenCalledWith(cachedRevision))
+      const responseInput = screen.getByLabelText("Phản hồi tiêu chí")
+      await user.clear(responseInput)
+      await user.type(responseInput, saved.response_text)
+      await user.click(screen.getByRole("button", { name: "Lưu" }))
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+      expect(getRequest(fetchMock, 0).body.p_expected_revision).toBe(cachedRevision)
+    })
+
+    it("closes overwrite confirmation when the dossier becomes archived", async () => {
+      const user = userEvent.setup()
+      const queryClient = createTestQueryClient()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      queryClient.setQueryData(
+        technicalConfigurationOptionResponsesQueryKey(currentOption.id, baseline.id),
+        comparisonSet(baseline, [optionResponse(baseline)])
+      )
+
+      const { rerenderDossier } = renderEditor({ queryClient })
+
+      await user.click(screen.getByRole("button", { name: "Sao chép từ cấu hình cơ bản" }))
+      expect(await screen.findByText("Ghi đè phản hồi hiện tại?")).toBeInTheDocument()
+
+      rerenderDossier({
+        ...dossier,
+        archived_at: "2026-07-25T00:00:00.000Z",
+        archived_by: 9,
+      })
+
+      expect(screen.queryByText("Ghi đè phản hồi hiện tại?")).not.toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Sao chép từ cấu hình cơ bản" })).toBeDisabled()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-coordination-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-coordination-cases.tsx
@@ -105,7 +105,7 @@ export function registerSupplierOptionResponseCoordinationTests({
         await screen.findByLabelText("Phản hồi tiêu chí"),
         savedResponse.response_text
       )
-      await user.click(screen.getByRole("button", { name: "Lưu phản hồi" }))
+      await user.click(screen.getByRole("button", { name: "Lưu" }))
 
       await waitFor(() =>
         expect(screen.getByRole("button", { name: "Lưu nhà cung cấp" })).toBeDisabled()

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-recovery-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-recovery-cases.tsx
@@ -365,7 +365,7 @@ export function registerSupplierOptionResponseRecoveryTests({
       await waitFor(() => expect(result.current.responseQuery.isSuccess).toBe(true))
       act(() => result.current.updateDraft({ responseText: savedResponse.response_text }))
 
-      let savePromise: Promise<void> | undefined
+      let savePromise: Promise<boolean> | undefined
       act(() => {
         savePromise = result.current.save()
       })
@@ -377,7 +377,7 @@ export function registerSupplierOptionResponseRecoveryTests({
       expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(false)
     })
 
-    it("switches option and baseline with read-only calls and responsive navigation", async () => {
+    it("switches option and baseline with read-only calls and existing criterion navigation", async () => {
       const user = userEvent.setup()
       const firstBaseline = baselineVersion()
       const secondBaseline = baselineVersion({ id: "baseline-2", version_number: 2 })
@@ -417,7 +417,7 @@ export function registerSupplierOptionResponseRecoveryTests({
       expect(await screen.findByTestId("option-response-workspace")).toHaveClass(
         "grid",
         "min-w-0",
-        "lg:grid-cols-[minmax(12rem,0.45fr)_minmax(0,1fr)]"
+        "lg:grid-cols-[minmax(14rem,0.32fr)_minmax(0,1fr)]"
       )
       expect(
         screen.getByRole("navigation", { name: "Tiêu chí cấu hình cơ sở" }).querySelector("div")

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-ux-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-ux-cases.tsx
@@ -295,7 +295,6 @@ export function registerSupplierOptionResponseUxTests({
       expect(await screen.findByLabelText("Phản hồi tiêu chí")).toBeEnabled()
       expect(screen.getByRole("button", { name: "Sao chép từ cấu hình cơ bản" })).toBeEnabled()
 
-      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(locked) }))
       rerender(
         <TechnicalConfigurationOptionResponses
           dossier={{

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-ux-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-ux-cases.tsx
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, type Mock } from "vitest"
+import { act, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { TechnicalConfigurationOptionResponses } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses"
+import { TechnicalConfigurationSuppliers } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import {
+  dossier,
+  option,
+  optionsResponse,
+  renderWithQueryClient,
+  supplier,
+  suppliersResponse,
+  type SupplierOptionRpcMocks,
+} from "./supplier-options-fixtures"
+import {
+  baselineVersion,
+  comparisonSet,
+  jsonResponse,
+  optionResponse,
+} from "./supplier-option-response-cases"
+import { deferred } from "./technical-configuration-baseline-tab-fixtures"
+
+type ResponseUxTestMocks = {
+  baselineRpc: { listVersions: Mock }
+  fetchMock: Mock
+  supplierOptionRpc: SupplierOptionRpcMocks
+}
+
+function setBaselineVersion(
+  baselineRpc: ResponseUxTestMocks["baselineRpc"],
+  baseline: TechnicalConfigurationBaselineDraftWire
+) {
+  baselineRpc.listVersions.mockResolvedValue({
+    data: [baseline],
+    total: 1,
+    page: 1,
+    page_size: 100,
+  })
+}
+
+function renderResponses(
+  baselineRpc: ResponseUxTestMocks["baselineRpc"],
+  baseline: TechnicalConfigurationBaselineDraftWire,
+  dossierValue = dossier
+) {
+  setBaselineVersion(baselineRpc, baseline)
+  return renderWithQueryClient(
+    <TechnicalConfigurationOptionResponses
+      dossier={dossierValue}
+      option={option({ id: "option-1" })}
+    />
+  )
+}
+
+export function registerSupplierOptionResponseUxTests({
+  baselineRpc,
+  fetchMock,
+  supplierOptionRpc,
+}: ResponseUxTestMocks) {
+  describe("technical configuration option response desktop UX", () => {
+    beforeEach(() => {
+      Object.values(supplierOptionRpc).forEach((mock) => mock.mockReset())
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([]))
+    })
+
+    it("keeps supplier identity above a full-width response workspace", async () => {
+      const baseline = baselineVersion()
+      const currentSupplier = supplier("supplier-1", "Công ty Thiết bị A")
+      const currentOption = option({ id: "option-1", supplierId: currentSupplier.id })
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([currentSupplier]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([currentOption]))
+      setBaselineVersion(baselineRpc, baseline)
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline) }))
+
+      renderWithQueryClient(<TechnicalConfigurationSuppliers dossier={dossier} />)
+
+      const responseWorkspace = await screen.findByTestId("option-response-workspace")
+      const identityRegion = screen.getByTestId("supplier-option-identity-region")
+      const responseRegion = screen.getByTestId("supplier-option-response-region")
+      expect(identityRegion).not.toContainElement(responseWorkspace)
+      expect(responseRegion).toHaveClass("w-full")
+      expect(responseRegion.parentElement).toBe(identityRegion.parentElement)
+      expect(responseRegion.previousElementSibling).toBe(identityRegion)
+      expect(responseRegion.className).not.toMatch(/max-w-|w-\[/)
+    })
+
+    it("shows empty, persisted, and current dirty criterion states", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const secondCriterionId = baseline.groups[0]?.criteria[1]?.id ?? ""
+      const persistedSecond = optionResponse(baseline, {
+        id: "response-2",
+        criterion_id: secondCriterionId,
+        response_text: "Đã đáp ứng bằng pin 45 phút",
+      })
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: comparisonSet(baseline, [persistedSecond]) })
+      )
+
+      renderResponses(baselineRpc, baseline)
+
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      expect(screen.getByRole("button", { name: /TC-0001.*Chưa phản hồi/i })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /TC-0002.*Đã lưu/i })).toBeInTheDocument()
+
+      await user.type(responseInput, "Bản nháp đang nhập")
+      expect(screen.getByRole("button", { name: /TC-0001.*Đang chỉnh sửa/i })).toBeInTheDocument()
+    })
+
+    it("copies only the baseline requirement into an empty editable response", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline) }))
+
+      renderResponses(baselineRpc, baseline)
+
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      const supplementaryInput = screen.getByLabelText("Thông tin bổ sung")
+      await user.type(supplementaryInput, "Giữ nguyên ghi chú này")
+      await user.click(screen.getByRole("button", { name: "Sao chép từ cấu hình cơ bản" }))
+
+      expect(responseInput).toHaveValue(baseline.groups[0]?.criteria[0]?.requirement_text)
+      expect(supplementaryInput).toHaveValue("Giữ nguyên ghi chú này")
+      expect(responseInput).toBeEnabled()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("confirms before replacing a non-empty response and preserves supplementary text", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const persisted = optionResponse(baseline, {
+        response_text: "Phản hồi đang có",
+        supplementary_information: "Thông tin bổ sung đang có",
+      })
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline, [persisted]) }))
+
+      renderResponses(baselineRpc, baseline)
+
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      const supplementaryInput = screen.getByLabelText("Thông tin bổ sung")
+      const copyButton = screen.getByRole("button", {
+        name: "Sao chép từ cấu hình cơ bản",
+      })
+
+      await user.click(copyButton)
+      expect(await screen.findByText("Ghi đè phản hồi hiện tại?")).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Hủy" }))
+      expect(responseInput).toHaveValue("Phản hồi đang có")
+      expect(supplementaryInput).toHaveValue("Thông tin bổ sung đang có")
+
+      await user.click(copyButton)
+      await user.click(await screen.findByRole("button", { name: "Ghi đè phản hồi" }))
+      expect(responseInput).toHaveValue(baseline.groups[0]?.criteria[0]?.requirement_text)
+      expect(supplementaryInput).toHaveValue("Thông tin bổ sung đang có")
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("keeps the selected criterion after secondary save succeeds", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const persisted = optionResponse(baseline)
+      const saved = optionResponse(baseline, { response_text: "Phản hồi vừa lưu", revision: 4 })
+      const saveRequest = deferred<Response>()
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline, [persisted]) }))
+        .mockImplementationOnce(() => saveRequest.promise)
+
+      renderResponses(baselineRpc, baseline)
+
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      await user.clear(responseInput)
+      await user.type(responseInput, saved.response_text)
+      await user.click(screen.getByRole("button", { name: "Lưu" }))
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+      expect(screen.getByRole("button", { name: /TC-0001/ })).toHaveAttribute(
+        "aria-current",
+        "true"
+      )
+      expect(responseInput).toHaveValue(saved.response_text)
+      expect(screen.getByRole("button", { name: "Lưu" })).toBeDisabled()
+
+      act(() => saveRequest.resolve(jsonResponse({ data: saved })))
+      await saveRequest.promise
+
+      expect(await screen.findByText("Đã lưu phản hồi phương án.")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /TC-0001.*Đã lưu/i })).toHaveAttribute(
+        "aria-current",
+        "true"
+      )
+      expect(screen.getByRole("button", { name: "Lưu" })).toBeDisabled()
+    })
+
+    it("saves then advances to the immediate next persisted criterion", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const firstCriterionId = baseline.groups[0]?.criteria[0]?.id ?? ""
+      const secondCriterionId = baseline.groups[0]?.criteria[1]?.id ?? ""
+      const persistedSecond = optionResponse(baseline, {
+        id: "response-2",
+        criterion_id: secondCriterionId,
+        response_text: "Phản hồi tiêu chí thứ hai",
+      })
+      const savedFirst = optionResponse(baseline, {
+        criterion_id: firstCriterionId,
+        response_text: "Phản hồi tiêu chí thứ nhất",
+        revision: 4,
+      })
+      const saveRequest = deferred<Response>()
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline, [persistedSecond]) }))
+        .mockImplementationOnce(() => saveRequest.promise)
+
+      renderResponses(baselineRpc, baseline)
+
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      await user.type(responseInput, savedFirst.response_text)
+      await user.click(screen.getByRole("button", { name: "Lưu & tiếp theo" }))
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+      expect(screen.getByRole("button", { name: /TC-0001/ })).toHaveAttribute(
+        "aria-current",
+        "true"
+      )
+      expect(responseInput).toHaveValue(savedFirst.response_text)
+      expect(screen.getByRole("button", { name: "Lưu & tiếp theo" })).toBeDisabled()
+
+      act(() => saveRequest.resolve(jsonResponse({ data: savedFirst })))
+      await saveRequest.promise
+
+      await waitFor(() => expect(responseInput).toHaveValue(persistedSecond.response_text))
+      expect(screen.getByRole("button", { name: /TC-0002/ })).toHaveAttribute(
+        "aria-current",
+        "true"
+      )
+      expect(screen.queryByRole("button", { name: "Lưu & tiếp theo" })).not.toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Lưu" })).toBeInTheDocument()
+    })
+
+    it("does not advance when save-next fails without a conflict", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline) }))
+        .mockRejectedValueOnce(new Error("network_down"))
+
+      renderResponses(baselineRpc, baseline)
+
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      await user.type(responseInput, "Giữ nguyên khi lưu lỗi")
+      await user.click(screen.getByRole("button", { name: "Lưu & tiếp theo" }))
+
+      expect(await screen.findByText("network_down")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /TC-0001/ })).toHaveAttribute(
+        "aria-current",
+        "true"
+      )
+      expect(responseInput).toHaveValue("Giữ nguyên khi lưu lỗi")
+    })
+
+    it("preserves the current criterion and unsaved response when save-next conflicts", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline) }))
+        .mockResolvedValueOnce(jsonResponse({ code: "PT409", message: "stale_revision" }, 409))
+
+      renderResponses(baselineRpc, baseline)
+
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      await user.type(responseInput, "Giữ nguyên khi conflict")
+      await user.click(screen.getByRole("button", { name: "Lưu & tiếp theo" }))
+
+      expect(await screen.findByText("Dữ liệu đã thay đổi")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /TC-0001/ })).toHaveAttribute(
+        "aria-current",
+        "true"
+      )
+      expect(responseInput).toHaveValue("Giữ nguyên khi conflict")
+    })
+
+    it("keeps locked baselines editable and disables P8B3 actions for archived dossiers", async () => {
+      const locked = baselineVersion({
+        status: "locked",
+        locked_at: "2026-07-23T00:00:00.000Z",
+        locked_by: 9,
+      })
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(locked) }))
+
+      const { rerender } = renderResponses(baselineRpc, locked)
+
+      expect(await screen.findByLabelText("Phản hồi tiêu chí")).toBeEnabled()
+      expect(screen.getByRole("button", { name: "Sao chép từ cấu hình cơ bản" })).toBeEnabled()
+
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(locked) }))
+      rerender(
+        <TechnicalConfigurationOptionResponses
+          dossier={{
+            ...dossier,
+            archived_at: "2026-07-23T04:00:00.000Z",
+            archived_by: 9,
+          }}
+          option={option({ id: "option-1" })}
+        />
+      )
+
+      expect(await screen.findByText("Chế độ chỉ đọc")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Sao chép từ cấu hình cơ bản" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Lưu" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Lưu & tiếp theo" })).toBeDisabled()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
@@ -1,9 +1,11 @@
 import { beforeEach, vi } from "vitest"
 
+import { registerSupplierOptionResponseAvailabilityTests } from "./supplier-option-response-availability-cases"
 import { registerSupplierOptionResponseCoordinationTests } from "./supplier-option-response-coordination-cases"
 import { registerSupplierOptionResponseConflictTests } from "./supplier-option-response-conflict-cases"
 import { registerSupplierOptionResponseTests } from "./supplier-option-response-cases"
 import { registerSupplierOptionResponseRecoveryTests } from "./supplier-option-response-recovery-cases"
+import { registerSupplierOptionResponseUxTests } from "./supplier-option-response-ux-cases"
 import { registerSupplierOptionConflictTests } from "./supplier-options-conflict-cases"
 import { registerSupplierOptionHookTests } from "./supplier-options-hook-cases"
 import { registerSupplierOptionWorkspaceTests } from "./supplier-options-workspace-cases"
@@ -72,6 +74,14 @@ registerSupplierOptionResponseRecoveryTests({
   supplierOptionRpc,
 })
 registerSupplierOptionResponseCoordinationTests({
+  baselineRpc,
+  fetchMock: optionResponseFetch,
+  supplierOptionRpc,
+})
+registerSupplierOptionResponseAvailabilityTests({
+  fetchMock: optionResponseFetch,
+})
+registerSupplierOptionResponseUxTests({
   baselineRpc,
   fetchMock: optionResponseFetch,
   supplierOptionRpc,

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
@@ -1,17 +1,31 @@
 "use client"
 
 import * as React from "react"
-import { AlertCircle, Archive, Loader2, RefreshCw, Save } from "lucide-react"
+import {
+  AlertCircle,
+  Archive,
+  CheckCircle2,
+  Circle,
+  Loader2,
+  PencilLine,
+  RefreshCw,
+} from "lucide-react"
 
 import { useTechnicalConfigurationOptionResponses } from "../_hooks/useTechnicalConfigurationOptionResponses"
 import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import {
+  copyTechnicalConfigurationBaselineRequirementToResponseDraft,
+  getNextTechnicalConfigurationOptionResponseCriterionId,
+  getTechnicalConfigurationOptionResponseCriterionStatus,
+  type TechnicalConfigurationOptionResponseCriterionStatus,
+} from "../technical-configuration-option-response-state"
 import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 import type { TechnicalConfigurationDossierWire } from "../types"
+import { DestructiveConfirmDialog } from "@/components/shared/DestructiveConfirmDialog"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
-import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
-import { formatVietnamDateTime } from "@/lib/vietnam-date-format"
+
+import { TechnicalConfigurationOptionResponsePanels } from "./TechnicalConfigurationOptionResponsePanels"
 
 type TechnicalConfigurationOptionResponseEditorProps = {
   dossier: TechnicalConfigurationDossierWire
@@ -22,6 +36,13 @@ type TechnicalConfigurationOptionResponseEditorProps = {
   onRevisionChange?: (revision: number) => void
   requestDiscardConfirmation: (description: React.ReactNode, action: () => void) => void
 }
+
+const CRITERION_STATUS_LABELS: Record<TechnicalConfigurationOptionResponseCriterionStatus, string> =
+  {
+    empty: "Chưa phản hồi",
+    persisted: "Đã lưu",
+    dirty: "Đang chỉnh sửa",
+  }
 
 /** Renders one exact-baseline criterion navigator and explicit response editor. */
 export function TechnicalConfigurationOptionResponseEditor({
@@ -40,6 +61,7 @@ export function TechnicalConfigurationOptionResponseEditor({
     onRevisionChange,
     onNavigationBlockedChange,
   })
+  const [isCopyConfirmationOpen, setIsCopyConfirmationOpen] = React.useState(false)
 
   React.useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- The response hook owns the draft while the supplier workspace combines cross-surface dirty state.
@@ -58,10 +80,44 @@ export function TechnicalConfigurationOptionResponseEditor({
       }
       state.selectCriterion(criterionId)
     },
-    [requestDiscardConfirmation, state]
+    [requestDiscardConfirmation, state.isDirty, state.selectCriterion]
   )
+  const applyRequirementCopy = React.useCallback(() => {
+    if (!state.selectedCriterion) return
+    state.updateDraft(
+      copyTechnicalConfigurationBaselineRequirementToResponseDraft(
+        state.draft,
+        state.selectedCriterion.requirement_text
+      )
+    )
+  }, [state.draft, state.selectedCriterion, state.updateDraft])
+  const handleCopyRequirement = React.useCallback(() => {
+    if (state.draft.responseText.trim()) {
+      setIsCopyConfirmationOpen(true)
+      return
+    }
+    applyRequirementCopy()
+  }, [applyRequirementCopy, state.draft.responseText])
+  const handleConfirmRequirementCopy = React.useCallback(() => {
+    setIsCopyConfirmationOpen(false)
+    applyRequirementCopy()
+  }, [applyRequirementCopy])
+  const nextCriterionId = getNextTechnicalConfigurationOptionResponseCriterionId(
+    state.criteria,
+    state.selectedCriterionId
+  )
+  const handleSaveNext = React.useCallback(async () => {
+    if (!nextCriterionId) return
+    const didSave = await state.save()
+    if (didSave) state.selectCriterion(nextCriterionId)
+  }, [nextCriterionId, state.save, state.selectCriterion])
   const hasInitialError = state.responseQuery.isError && state.responseQuery.data === undefined
-  const isUnavailable = state.responseQuery.isLoading || hasInitialError
+  const isUnavailable = !state.hasAdoptedSnapshot || hasInitialError
+  const responseStatusAvailability = state.hasAdoptedSnapshot
+    ? "ready"
+    : hasInitialError
+      ? "unavailable"
+      : "loading"
 
   return (
     <div className="space-y-4">
@@ -96,35 +152,65 @@ export function TechnicalConfigurationOptionResponseEditor({
 
       <div
         data-testid="option-response-workspace"
-        className="grid min-w-0 gap-5 lg:grid-cols-[minmax(12rem,0.45fr)_minmax(0,1fr)]"
+        className="grid min-w-0 gap-6 lg:grid-cols-[minmax(14rem,0.32fr)_minmax(0,1fr)]"
       >
         <nav aria-label="Tiêu chí cấu hình cơ sở" className="min-w-0 border-y py-3">
           <p className="mb-2 text-sm font-medium">Tiêu chí</p>
           <div className="flex gap-2 overflow-x-auto pb-1 lg:flex-col lg:overflow-visible">
-            {state.criteria.map((criterion) => (
-              <Button
-                key={criterion.id}
-                type="button"
-                variant={criterion.id === state.selectedCriterionId ? "secondary" : "ghost"}
-                className="h-auto min-w-44 justify-start whitespace-normal text-left lg:min-w-0"
-                disabled={state.isPending}
-                onClick={() => handleCriterionChange(criterion.id)}
-              >
-                <span className="min-w-0">
-                  <span className="block text-xs text-muted-foreground">
-                    {criterion.criterion_code}
+            {state.criteria.map((criterion) => {
+              const status = getTechnicalConfigurationOptionResponseCriterionStatus({
+                snapshot: state.snapshot,
+                criterionId: criterion.id,
+                selectedCriterionId: state.selectedCriterionId,
+                isDirty: state.isDirty,
+              })
+              const StatusIcon =
+                status === "dirty" ? PencilLine : status === "persisted" ? CheckCircle2 : Circle
+
+              return (
+                <Button
+                  key={criterion.id}
+                  type="button"
+                  variant={criterion.id === state.selectedCriterionId ? "secondary" : "ghost"}
+                  className="h-auto min-w-44 justify-start whitespace-normal text-left lg:min-w-0"
+                  aria-current={criterion.id === state.selectedCriterionId ? "true" : undefined}
+                  disabled={state.isPending}
+                  onClick={() => handleCriterionChange(criterion.id)}
+                >
+                  <span className="min-w-0">
+                    <span className="block text-xs text-muted-foreground">
+                      {criterion.criterion_code}
+                    </span>
+                    <span className="block break-words">
+                      {criterion.title ?? criterion.requirement_text}
+                    </span>
+                    <span className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                      {responseStatusAvailability === "loading" ? (
+                        <>
+                          <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+                          Đang tải phản hồi
+                        </>
+                      ) : responseStatusAvailability === "unavailable" ? (
+                        <>
+                          <AlertCircle className="size-3" aria-hidden="true" />
+                          Chưa xác định
+                        </>
+                      ) : (
+                        <>
+                          <StatusIcon className="size-3" aria-hidden="true" />
+                          {CRITERION_STATUS_LABELS[status]}
+                        </>
+                      )}
+                    </span>
                   </span>
-                  <span className="block break-words">
-                    {criterion.title ?? criterion.requirement_text}
-                  </span>
-                </span>
-              </Button>
-            ))}
+                </Button>
+              )
+            })}
           </div>
         </nav>
 
         <section className="min-w-0 space-y-4">
-          {state.responseQuery.isLoading ? (
+          {!state.hasAdoptedSnapshot && !hasInitialError ? (
             <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="size-4 animate-spin" aria-hidden="true" />
               Đang tải phản hồi...
@@ -141,85 +227,36 @@ export function TechnicalConfigurationOptionResponseEditor({
           ) : null}
 
           {!isUnavailable && state.selectedCriterion ? (
-            <>
-              <div className="border-b pb-3">
-                <p className="text-sm font-medium">
-                  {state.selectedCriterion.criterion_code} ·{" "}
-                  {state.selectedCriterion.title ?? "Không có tiêu đề"}
-                </p>
-                <p className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
-                  {state.selectedCriterion.requirement_text}
-                </p>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Cập nhật phản hồi gần nhất: {formatVietnamDateTime(state.updatedAt)}
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="technical-option-response-text">Phản hồi tiêu chí</Label>
-                <Textarea
-                  id="technical-option-response-text"
-                  value={state.draft.responseText}
-                  rows={7}
-                  disabled={state.isReadOnly || state.isPending}
-                  onChange={(event) => state.updateDraft({ responseText: event.target.value })}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="technical-option-supplementary-information">
-                  Thông tin bổ sung
-                </Label>
-                <Textarea
-                  id="technical-option-supplementary-information"
-                  value={state.draft.supplementaryInformation}
-                  rows={5}
-                  disabled={state.isReadOnly || state.isPending}
-                  onChange={(event) =>
-                    state.updateDraft({ supplementaryInformation: event.target.value })
-                  }
-                />
-                <p className="text-xs text-muted-foreground">
-                  Thông tin bổ sung không dùng để chấm điểm.
-                </p>
-              </div>
-
-              <div className="flex flex-wrap justify-end gap-2 border-t pt-4">
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={state.isPending}
-                  onClick={() => void state.reload()}
-                >
-                  <RefreshCw
-                    className={`size-4 ${state.isReloading ? "animate-spin" : ""}`}
-                    aria-hidden="true"
-                  />
-                  Tải lại dữ liệu
-                </Button>
-                {!state.isReadOnly ? (
-                  <Button
-                    type="button"
-                    disabled={!state.isDirty || state.isPending || state.isConflict}
-                    onClick={() => void state.save()}
-                  >
-                    {state.isSaving ? (
-                      <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                    ) : (
-                      <Save className="size-4" aria-hidden="true" />
-                    )}
-                    Lưu phản hồi
-                  </Button>
-                ) : null}
-              </div>
-              {state.saveStatus === "saved" ? (
-                <p role="status" className="text-sm text-emerald-700">
-                  Đã lưu phản hồi phương án.
-                </p>
-              ) : null}
-            </>
+            <TechnicalConfigurationOptionResponsePanels
+              criterion={state.selectedCriterion}
+              draft={state.draft}
+              updatedAt={state.updatedAt}
+              mode={state.isReadOnly ? "read-only" : "editable"}
+              draftState={state.isConflict ? "conflict" : state.isDirty ? "dirty" : "clean"}
+              operation={state.isSaving ? "saving" : state.isReloading ? "reloading" : "idle"}
+              saveStatus={state.saveStatus}
+              hasNextCriterion={nextCriterionId !== null}
+              onResponseChange={(responseText) => state.updateDraft({ responseText })}
+              onSupplementaryChange={(supplementaryInformation) =>
+                state.updateDraft({ supplementaryInformation })
+              }
+              onCopyRequirement={handleCopyRequirement}
+              onReload={() => void state.reload()}
+              onSave={() => void state.save()}
+              onSaveNext={() => void handleSaveNext()}
+            />
           ) : null}
         </section>
       </div>
+      <DestructiveConfirmDialog
+        open={isCopyConfirmationOpen && !state.isReadOnly}
+        onOpenChange={setIsCopyConfirmationOpen}
+        title="Ghi đè phản hồi hiện tại?"
+        description="Phản hồi hiện tại sẽ được thay bằng nội dung cấu hình cơ bản. Thông tin bổ sung được giữ nguyên."
+        confirmLabel="Ghi đè phản hồi"
+        isPending={state.isPending || state.isReadOnly}
+        onConfirm={handleConfirmRequirementCopy}
+      />
     </div>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponsePanels.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponsePanels.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import { ArrowRight, Copy, Loader2, RefreshCw, Save } from "lucide-react"
+
+import type { TechnicalConfigurationBaselineCriterionWire } from "../baseline-types"
+import type { TechnicalConfigurationOptionResponseDraft } from "../technical-configuration-option-response-state"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { formatVietnamDateTime } from "@/lib/vietnam-date-format"
+
+type TechnicalConfigurationOptionResponsePanelsProps = {
+  criterion: TechnicalConfigurationBaselineCriterionWire
+  draft: TechnicalConfigurationOptionResponseDraft
+  updatedAt: string
+  mode: "editable" | "read-only"
+  draftState: "clean" | "dirty" | "conflict"
+  operation: "idle" | "saving" | "reloading"
+  saveStatus: "idle" | "saved"
+  hasNextCriterion: boolean
+  onResponseChange: (value: string) => void
+  onSupplementaryChange: (value: string) => void
+  onCopyRequirement: () => void
+  onReload: () => void
+  onSave: () => void
+  onSaveNext: () => void
+}
+
+/** Shows the selected baseline criterion beside its editable supplier response. */
+export function TechnicalConfigurationOptionResponsePanels({
+  criterion,
+  draft,
+  updatedAt,
+  mode,
+  draftState,
+  operation,
+  saveStatus,
+  hasNextCriterion,
+  onResponseChange,
+  onSupplementaryChange,
+  onCopyRequirement,
+  onReload,
+  onSave,
+  onSaveNext,
+}: Readonly<TechnicalConfigurationOptionResponsePanelsProps>) {
+  const isReadOnly = mode === "read-only"
+  const isDirty = draftState === "dirty"
+  const isConflict = draftState === "conflict"
+  const isSaving = operation === "saving"
+  const isReloading = operation === "reloading"
+  const isPending = operation !== "idle"
+  const isSaveDisabled = isReadOnly || !isDirty || isPending || isConflict
+
+  return (
+    <div
+      data-testid="selected-criterion-response-panels"
+      className="grid min-w-0 gap-6 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]"
+    >
+      <section
+        aria-label="Cấu hình cơ bản"
+        className="min-w-0 border-y py-4 xl:border-y-0 xl:border-r xl:py-0 xl:pr-6"
+      >
+        <p className="text-xs font-medium text-muted-foreground">Cấu hình cơ bản</p>
+        <h3 className="mt-2 text-base font-semibold">
+          {criterion.criterion_code} · {criterion.title ?? "Không có tiêu đề"}
+        </h3>
+        <p className="mt-3 whitespace-pre-wrap break-words text-sm leading-6">
+          {criterion.requirement_text}
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          className="mt-4"
+          disabled={isReadOnly || isPending}
+          onClick={onCopyRequirement}
+        >
+          <Copy className="size-4" aria-hidden="true" />
+          Sao chép từ cấu hình cơ bản
+        </Button>
+      </section>
+
+      <section aria-label="Phản hồi phương án" className="min-w-0 space-y-4">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground">Phản hồi phương án</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Cập nhật phản hồi gần nhất: {formatVietnamDateTime(updatedAt)}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="technical-option-response-text">Phản hồi tiêu chí</Label>
+          <Textarea
+            id="technical-option-response-text"
+            value={draft.responseText}
+            rows={9}
+            disabled={isReadOnly || isPending}
+            onChange={(event) => onResponseChange(event.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="technical-option-supplementary-information">Thông tin bổ sung</Label>
+          <Textarea
+            id="technical-option-supplementary-information"
+            value={draft.supplementaryInformation}
+            rows={6}
+            disabled={isReadOnly || isPending}
+            onChange={(event) => onSupplementaryChange(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            Thông tin bổ sung không dùng để chấm điểm.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap justify-end gap-2 border-t pt-4">
+          <Button type="button" variant="ghost" disabled={isPending} onClick={onReload}>
+            <RefreshCw
+              className={`size-4 ${isReloading ? "animate-spin" : ""}`}
+              aria-hidden="true"
+            />
+            Tải lại dữ liệu
+          </Button>
+          <Button type="button" variant="outline" disabled={isSaveDisabled} onClick={onSave}>
+            {isSaving ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Save className="size-4" aria-hidden="true" />
+            )}
+            Lưu
+          </Button>
+          {hasNextCriterion ? (
+            <Button type="button" disabled={isSaveDisabled} onClick={onSaveNext}>
+              {isSaving ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <ArrowRight className="size-4" aria-hidden="true" />
+              )}
+              Lưu & tiếp theo
+            </Button>
+          ) : null}
+        </div>
+        {saveStatus === "saved" ? (
+          <p role="status" className="text-sm text-emerald-700">
+            Đã lưu phản hồi phương án.
+          </p>
+        ) : null}
+      </section>
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses.tsx
@@ -146,7 +146,7 @@ export function TechnicalConfigurationOptionResponses({
   }
 
   return (
-    <div className="space-y-5 border-t pt-5">
+    <div className="space-y-5">
       <div className="min-w-0">
         <Label htmlFor="option-response-baseline-version">Phiên bản cấu hình cơ sở</Label>
         <Select

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx
@@ -214,7 +214,10 @@ export function TechnicalConfigurationSuppliers({
         </Alert>
       ) : null}
 
-      <div className="grid min-w-0 gap-6 lg:grid-cols-[minmax(16rem,0.8fr)_minmax(0,1.5fr)]">
+      <div
+        data-testid="supplier-option-identity-region"
+        className="grid min-w-0 gap-6 lg:grid-cols-[minmax(16rem,0.8fr)_minmax(0,1.5fr)]"
+      >
         <TechnicalConfigurationSupplierSelector
           state={state}
           selectedSupplier={selectedSupplier}
@@ -278,20 +281,26 @@ export function TechnicalConfigurationSuppliers({
                     : undefined
                 }
               />
-              {selectedOption ? (
-                <TechnicalConfigurationOptionResponses
-                  key={selectedOption.id}
-                  dossier={dossier}
-                  option={selectedOption}
-                  onDirtyChange={setIsResponseDirty}
-                  onNavigationBlockedChange={setIsResponseNavigationBlocked}
-                  onRevisionChange={onRevisionChange}
-                />
-              ) : null}
             </div>
           ) : null}
         </main>
       </div>
+
+      {selectedOption ? (
+        <section
+          data-testid="supplier-option-response-region"
+          className="w-full min-w-0 border-t pt-6"
+        >
+          <TechnicalConfigurationOptionResponses
+            key={selectedOption.id}
+            dossier={dossier}
+            option={selectedOption}
+            onDirtyChange={setIsResponseDirty}
+            onNavigationBlockedChange={setIsResponseNavigationBlocked}
+            onRevisionChange={onRevisionChange}
+          />
+        </section>
+      ) : null}
 
       {discardConfirmationDialog}
       <DestructiveConfirmDialog

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
@@ -57,27 +57,6 @@ export function useTechnicalConfigurationOptionResponses({
     () => flattenTechnicalConfigurationBaselineCriteria(baselineVersion),
     [baselineVersion]
   )
-  const [selectedCriterionId, setSelectedCriterionId] = React.useState<string | null>(
-    criteria[0]?.id ?? null
-  )
-  const [snapshot, setSnapshot] = React.useState<TechnicalConfigurationComparisonSetWire | null>(
-    null
-  )
-  const [baseDraft, setBaseDraft] = React.useState<TechnicalConfigurationOptionResponseDraft>(() =>
-    toTechnicalConfigurationOptionResponseDraft(null)
-  )
-  const [draft, setDraft] = React.useState<TechnicalConfigurationOptionResponseDraft>(() =>
-    toTechnicalConfigurationOptionResponseDraft(null)
-  )
-  const [isSaving, setIsSaving] = React.useState(false)
-  const [isReloading, setIsReloading] = React.useState(false)
-  const [isConflict, setIsConflict] = React.useState(false)
-  const [validationError, setValidationError] = React.useState<string | null>(null)
-  const [operationError, setOperationError] = React.useState<string | null>(null)
-  const [saveStatus, setSaveStatus] = React.useState<"idle" | "saved">("idle")
-  const activeOperationRef = React.useRef<"save" | "reload" | null>(null)
-  const adoptedQueryAtRef = React.useRef(0)
-  const revisionRef = React.useRef(dossier.revision)
   const responseQuery = useQuery({
     queryKey,
     queryFn: ({ signal }) =>
@@ -92,13 +71,49 @@ export function useTechnicalConfigurationOptionResponses({
     retry: false,
     refetchOnWindowFocus: false,
   })
+  const initialResponseState = React.useMemo(() => {
+    const selectedCriterionId = criteria[0]?.id ?? null
+    const snapshot = responseQuery.data ?? null
+    const draft = toTechnicalConfigurationOptionResponseDraft(
+      findTechnicalConfigurationOptionResponse(snapshot, selectedCriterionId)
+    )
+    return { selectedCriterionId, snapshot, draft }
+  }, [criteria, responseQuery.data])
+  const [selectedCriterionId, setSelectedCriterionId] = React.useState<string | null>(
+    initialResponseState.selectedCriterionId
+  )
+  const [snapshot, setSnapshot] = React.useState<TechnicalConfigurationComparisonSetWire | null>(
+    initialResponseState.snapshot
+  )
+  const [baseDraft, setBaseDraft] = React.useState<TechnicalConfigurationOptionResponseDraft>(
+    () => initialResponseState.draft
+  )
+  const [draft, setDraft] = React.useState<TechnicalConfigurationOptionResponseDraft>(
+    () => initialResponseState.draft
+  )
+  const [isSaving, setIsSaving] = React.useState(false)
+  const [isReloading, setIsReloading] = React.useState(false)
+  const [isConflict, setIsConflict] = React.useState(false)
+  const [validationError, setValidationError] = React.useState<string | null>(null)
+  const [operationError, setOperationError] = React.useState<string | null>(null)
+  const [saveStatus, setSaveStatus] = React.useState<"idle" | "saved">("idle")
+  const activeOperationRef = React.useRef<"save" | "reload" | null>(null)
+  const adoptedQueryAtRef = React.useRef(0)
+  const revisionRef = React.useRef<number | null>(null)
+  if (revisionRef.current === null) {
+    revisionRef.current = Math.max(dossier.revision, initialResponseState.snapshot?.revision ?? 0)
+  }
   const isReadOnly = Boolean(dossier.archived_at)
   const isDirty =
     !isReadOnly && !areTechnicalConfigurationOptionResponseDraftsEqual(baseDraft, draft)
   const visibleDraft = isReadOnly ? baseDraft : draft
   const commitRevision = React.useCallback(
     (nextRevision: number) => {
-      const committedRevision = Math.max(revisionRef.current, dossier.revision, nextRevision)
+      const committedRevision = Math.max(
+        revisionRef.current ?? dossier.revision,
+        dossier.revision,
+        nextRevision
+      )
       revisionRef.current = committedRevision
       onRevisionChange?.(committedRevision)
       updateTechnicalConfigurationDossierRevisionCache(queryClient, dossier, committedRevision)
@@ -131,7 +146,7 @@ export function useTechnicalConfigurationOptionResponses({
     if (nextRevision > dossier.revision) {
       commitRevision(nextRevision) // react-doctor-disable-line react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent
     } else {
-      revisionRef.current = Math.max(revisionRef.current, nextRevision)
+      revisionRef.current = Math.max(revisionRef.current ?? dossier.revision, nextRevision)
     }
     setIsConflict(false) // react-doctor-disable-line react-doctor/no-adjust-state-on-prop-change
     setOperationError(null) // react-doctor-disable-line react-doctor/no-adjust-state-on-prop-change
@@ -148,7 +163,7 @@ export function useTechnicalConfigurationOptionResponses({
   ])
 
   React.useEffect(() => {
-    revisionRef.current = Math.max(revisionRef.current, dossier.revision)
+    revisionRef.current = Math.max(revisionRef.current ?? dossier.revision, dossier.revision)
   }, [dossier.revision])
 
   useTechnicalConfigurationBeforeUnloadGuard(isDirty)
@@ -186,13 +201,13 @@ export function useTechnicalConfigurationOptionResponses({
   )
 
   const save = React.useCallback(async () => {
-    if (isReadOnly || activeOperationRef.current || isConflict) return
+    if (isReadOnly || activeOperationRef.current || isConflict) return false
     const error = validateTechnicalConfigurationOptionResponseDraft(draft, selectedCriterionId)
     if (error) {
       setValidationError(error)
-      return
+      return false
     }
-    if (!selectedCriterionId) return
+    if (!selectedCriterionId) return false
 
     activeOperationRef.current = "save"
     setIsSaving(true)
@@ -208,7 +223,7 @@ export function useTechnicalConfigurationOptionResponses({
         criterionId: selectedCriterionId,
         responseText: draft.responseText,
         supplementaryInformation: draft.supplementaryInformation,
-        expectedRevision: revisionRef.current,
+        expectedRevision: revisionRef.current ?? dossier.revision,
         comparisonSet: snapshot,
         onComparisonSetReady: (comparisonSet) => {
           setSnapshot(comparisonSet)
@@ -228,6 +243,7 @@ export function useTechnicalConfigurationOptionResponses({
       setDraft(nextDraft)
       setIsConflict(false)
       setSaveStatus("saved")
+      return true
     } catch (caught) {
       const sourceError =
         caught instanceof TechnicalConfigurationOptionResponseSaveFailure
@@ -249,6 +265,7 @@ export function useTechnicalConfigurationOptionResponses({
           "Không thể lưu phản hồi phương án."
         )
       )
+      return false
     } finally {
       activeOperationRef.current = null
       setIsSaving(false)
@@ -257,6 +274,7 @@ export function useTechnicalConfigurationOptionResponses({
   }, [
     baselineVersion.id,
     commitRevision,
+    dossier.revision,
     draft,
     isConflict,
     isReadOnly,
@@ -316,6 +334,7 @@ export function useTechnicalConfigurationOptionResponses({
 
   const selectedCriterion =
     criteria.find((criterion) => criterion.id === selectedCriterionId) ?? null
+  const hasAdoptedSnapshot = snapshot !== null || responseQuery.data === null
   const updatedAt = getTechnicalConfigurationOptionResponseUpdatedAt(
     option,
     snapshot,
@@ -328,6 +347,7 @@ export function useTechnicalConfigurationOptionResponses({
     selectedCriterion,
     selectedCriterionId,
     snapshot,
+    hasAdoptedSnapshot,
     draft: visibleDraft,
     isDirty,
     isReadOnly,

--- a/src/app/(app)/technical-configurations/technical-configuration-option-response-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-option-response-state.ts
@@ -16,6 +16,8 @@ export type TechnicalConfigurationOptionResponseDraft = {
 export type TechnicalConfigurationOptionResponseDraftPatch =
   Partial<TechnicalConfigurationOptionResponseDraft>
 
+export type TechnicalConfigurationOptionResponseCriterionStatus = "empty" | "persisted" | "dirty"
+
 /** Empty local draft used when an exact-baseline comparison set has no response yet. */
 export const EMPTY_OPTION_RESPONSE_DRAFT: TechnicalConfigurationOptionResponseDraft = {
   responseText: "",
@@ -43,6 +45,31 @@ export function findTechnicalConfigurationOptionResponse(
   return snapshot.responses.find((response) => response.criterion_id === criterionId) ?? null
 }
 
+/** Classifies each criterion for compact navigation without mutating the response snapshot. */
+export function getTechnicalConfigurationOptionResponseCriterionStatus({
+  snapshot,
+  criterionId,
+  selectedCriterionId,
+  isDirty,
+}: {
+  snapshot: TechnicalConfigurationComparisonSetWire | null
+  criterionId: string
+  selectedCriterionId: string | null
+  isDirty: boolean
+}): TechnicalConfigurationOptionResponseCriterionStatus {
+  if (criterionId === selectedCriterionId && isDirty) return "dirty"
+  return findTechnicalConfigurationOptionResponse(snapshot, criterionId) ? "persisted" : "empty"
+}
+
+/** Returns the immediate next criterion in canonical baseline order. */
+export function getNextTechnicalConfigurationOptionResponseCriterionId(
+  criteria: TechnicalConfigurationBaselineCriterionWire[],
+  selectedCriterionId: string | null
+): string | null {
+  const selectedIndex = criteria.findIndex((criterion) => criterion.id === selectedCriterionId)
+  return selectedIndex >= 0 ? (criteria[selectedIndex + 1]?.id ?? null) : null
+}
+
 /** Converts a persisted response into the local multiline editor shape. */
 export function toTechnicalConfigurationOptionResponseDraft(
   response: TechnicalConfigurationOptionResponseWire | null
@@ -63,6 +90,17 @@ export function areTechnicalConfigurationOptionResponseDraftsEqual(
     left.responseText === right.responseText &&
     left.supplementaryInformation === right.supplementaryInformation
   )
+}
+
+/** Copies only the baseline requirement while preserving non-scoring supplementary information. */
+export function copyTechnicalConfigurationBaselineRequirementToResponseDraft(
+  draft: TechnicalConfigurationOptionResponseDraft,
+  requirementText: string
+): TechnicalConfigurationOptionResponseDraft {
+  return {
+    ...draft,
+    responseText: requirementText,
+  }
 }
 
 /** Requires a scoring response while keeping supplementary text optional and non-scoring. */


### PR DESCRIPTION
## Summary
- move the desktop option-response workspace below supplier and option identity at full available width
- add explicit criterion response states, immutable requirement copying with overwrite confirmation, and supplementary-text preservation
- coordinate save and save-next behavior, including warm-cache revision adoption and conflict-safe navigation

## Scope
- P8B3 frontend desktop only
- no mobile work
- no P9A2, P9A3, or P10B work
- no backend, API, contract, migration, database, or live DB changes

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused `supplier-options.test.tsx`: 64/64 passed using `user-event`
- `node scripts/npm-run.js run react-doctor`: 100/100, no findings
- `node scripts/npm-run.js run verify:heroui-boundary`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `openspec validate add-technical-configuration-comparison --strict`
- fresh-context review-fix loop: zero findings

Browser tests were intentionally not run per task direction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the P8B3 desktop option-response UX to make responses faster to edit and safer to save. Moves the workspace below supplier/option identity, adds clear per-criterion status (with loading/unavailable), and coordinates Save/Save & Next with warm-cache revision handling.

- **New Features**
  - Desktop layout: supplier/option identity stays on top; response workspace is a full-width sibling section below.
  - Focused view: criterion navigator + read-only baseline panel + editable response panel for the selected criterion.
  - Criterion states: shows empty/persisted/dirty with icons; shows loading/unavailable until the snapshot is adopted.
  - Copy from baseline: copies only `requirement_text`, preserves supplementary text, confirms before overwrite, and auto-closes the dialog if the dossier becomes archived.
  - Save controls: “Lưu” and “Lưu & tiếp theo”; advances only after a successful save, stays put on error/conflict; last criterion shows only “Lưu”.
  - Read-only rules: archived dossiers disable P8B3 actions; locked baselines remain editable.
  - Warm-cache: renders cached comparison data before adoption; adopts newer cached revision and propagates it; sends `expected_revision` on save; navigation stays conflict-safe.

- **Refactors**
  - Extracted `TechnicalConfigurationOptionResponsePanels` and added criterion status/next-criterion helpers in `technical-configuration-option-response-state`.
  - Updated `useTechnicalConfigurationOptionResponses` to initialize from the cache, expose `hasAdoptedSnapshot`, propagate cached revision via `onRevisionChange`, and return a boolean from `save()`.
  - Added focused tests for desktop layout, availability states, UX flows, warm-cache revision propagation, and coordinated save behaviors.

<sup>Written for commit a4bc5cad2a576220b591b9729b5c29ae38844534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a focused technical configuration response editor with criterion navigation, response status indicators, copy-from-baseline, reload, save, and save-and-next actions.
  * Added read-only handling for locked baselines and archived dossiers.
  * Added confirmation before overwriting existing response text while preserving supplementary information.
  * Improved loading, conflict, validation, and unavailable-response states.

* **Tests**
  * Added comprehensive coverage for response availability, editing workflows, caching, navigation, conflicts, and archive restrictions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->