### PR TITLE
P9A2: Add atomic supplier option import contracts

### DIFF
--- a/src/app/(app)/technical-configurations/supplier-option-types.ts
+++ b/src/app/(app)/technical-configurations/supplier-option-types.ts
@@ -1,3 +1,8 @@
+import type {
+  TechnicalConfigurationOptionWorkbookMetadata,
+  TechnicalConfigurationOptionWorkbookRow,
+} from "@/lib/technical-configuration-option-excel-contract"
+
 export interface TechnicalConfigurationSupplierWire {
   id: string
   dossier_id: string
@@ -174,4 +179,35 @@ export interface TechnicalConfigurationOptionResponseUpsertRpcArgs {
   p_response_text: string | null
   p_supplementary_information: string | null
   p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionImportRpcArgs {
+  p_option_id: string
+  p_baseline_version_id: string
+  p_template_metadata: TechnicalConfigurationOptionWorkbookMetadata
+  p_rows: TechnicalConfigurationOptionWorkbookRow[]
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionImportPreviewWireResponse {
+  data: {
+    metadata: TechnicalConfigurationOptionWorkbookMetadata
+    rows: TechnicalConfigurationOptionWorkbookRow[]
+  }
+  errors: TechnicalConfigurationOptionImportIssue[]
+}
+
+export type TechnicalConfigurationOptionImportApplyWireResponse =
+  TechnicalConfigurationComparisonSetWireResponse
+
+export interface TechnicalConfigurationOptionImportIssue {
+  code:
+    | "invalid_row_shape"
+    | "changed_context"
+    | "missing_criterion"
+    | "unknown_criterion"
+    | "duplicate_criterion"
+  message: string
+  row?: number
+  criterion_id?: string
 }

--- a/src/app/(app)/technical-configurations/technical-configuration-option-import-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-option-import-rpc.ts
@@ -1,0 +1,27 @@
+import { OPTION_IMPORT_RPC_FUNCTIONS } from "@/lib/technical-configuration-supplier-option-rpcs"
+import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
+import type {
+  TechnicalConfigurationOptionImportApplyWireResponse,
+  TechnicalConfigurationOptionImportPreviewWireResponse,
+  TechnicalConfigurationOptionImportRpcArgs,
+} from "./supplier-option-types"
+
+/** Validates one complete supplier-option response snapshot without persistence. */
+export function previewTechnicalConfigurationOptionImport(
+  args: TechnicalConfigurationOptionImportRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionImportPreviewWireResponse> {
+  return callTechnicalConfigurationRpc(OPTION_IMPORT_RPC_FUNCTIONS.previewOptionImport, args, {
+    signal,
+  })
+}
+
+/** Atomically applies one authoritative supplier-option response snapshot. */
+export function applyTechnicalConfigurationOptionImport(
+  args: TechnicalConfigurationOptionImportRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionImportApplyWireResponse> {
+  return callTechnicalConfigurationRpc(OPTION_IMPORT_RPC_FUNCTIONS.applyOptionImport, args, {
+    signal,
+  })
+}

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -2,6 +2,7 @@ import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-basel
 import { DOCUMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-document-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
 import {
+  OPTION_IMPORT_RPC_FUNCTION_NAMES,
   OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
   OPTION_RESPONSE_RPC_FUNCTION_NAMES,
   OPTION_RPC_FUNCTION_NAMES,
@@ -108,6 +109,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   ...OPTION_RPC_FUNCTION_NAMES,
   ...OPTION_RESPONSE_RPC_FUNCTION_NAMES,
   ...OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
+  ...OPTION_IMPORT_RPC_FUNCTION_NAMES,
   // AI Assistant (read-only)
   "ai_equipment_lookup",
   "ai_maintenance_plan_lookup",

--- a/src/app/api/rpc/__tests__/technical-configuration-option-import-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-option-import-migration.test.ts
@@ -141,6 +141,12 @@ describe("P9A2 technical configuration supplier option import migration", () => 
     }
   })
 
+  it("parenthesizes CASE expressions inside PL/pgSQL IF conditions", () => {
+    expect(validatorBlock).toMatch(
+      /OR \(CASE\s+WHEN v_row->'criterion_title' = 'null'::JSONB THEN NULL\s+ELSE v_row->>'criterion_title'\s+END\) IS DISTINCT FROM/
+    )
+  })
+
   it("preloads canonical criteria once before validating imported rows", () => {
     const criteriaLoadMarker = "FROM public.technical_configuration_baseline_criteria c"
     const criteriaLoadIndex = validatorBlock.indexOf(criteriaLoadMarker)

--- a/src/app/api/rpc/__tests__/technical-configuration-option-import-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-option-import-migration.test.ts
@@ -1,0 +1,327 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import * as optionImportRpcManifest from "@/lib/technical-configuration-supplier-option-rpcs"
+import type {
+  TechnicalConfigurationOptionWorkbookMetadata,
+  TechnicalConfigurationOptionWorkbookRow,
+} from "@/lib/technical-configuration-option-excel-contract"
+import * as optionImportRpcAdapter from "@/app/(app)/technical-configurations/technical-configuration-option-import-rpc"
+import type {
+  TechnicalConfigurationOptionImportApplyWireResponse,
+  TechnicalConfigurationOptionImportPreviewWireResponse,
+  TechnicalConfigurationOptionImportRpcArgs,
+} from "@/app/(app)/technical-configurations/supplier-option-types"
+
+const MIGRATIONS_DIR = path.resolve(process.cwd(), "supabase/migrations")
+const MIGRATION_FILE = "20260725060000_technical_configuration_option_import.sql"
+const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const PHASE_GATE_PATH = path.resolve(
+  process.cwd(),
+  "supabase/tests/technical_configuration_option_import_phase_gate.sql"
+)
+const LATEST_DEPENDENCY_MIGRATION = "20260723110549_technical_configuration_comparison_set_read.sql"
+const VALIDATOR_FUNCTION = "_technical_configuration_option_import_validate"
+const PREVIEW_FUNCTION = "technical_configuration_option_import_preview"
+const APPLY_FUNCTION = "technical_configuration_option_import_apply"
+const { OPTION_IMPORT_RPC_FUNCTION_NAMES, OPTION_IMPORT_RPC_FUNCTIONS } = optionImportRpcManifest
+const { applyTechnicalConfigurationOptionImport, previewTechnicalConfigurationOptionImport } =
+  optionImportRpcAdapter
+const callRpcMock = vi.fn()
+
+vi.mock("@/app/(app)/technical-configurations/technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => callRpcMock(...args),
+}))
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  const functions = [
+    ...source.matchAll(/^CREATE(?: OR REPLACE)? FUNCTION public\.([a-z0-9_]+)\(/gim),
+  ]
+  const index = functions.findIndex((match) => match[1] === functionName)
+  if (index === -1) return ""
+
+  const start = functions[index].index ?? 0
+  const end = functions[index + 1]?.index ?? source.length
+  return source.slice(start, end)
+}
+
+const migrationSource = readIfExists(MIGRATION_PATH)
+const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+const validatorBlock = getFunctionBlock(migrationSource, VALIDATOR_FUNCTION)
+const previewBlock = getFunctionBlock(migrationSource, PREVIEW_FUNCTION)
+const applyBlock = getFunctionBlock(migrationSource, APPLY_FUNCTION)
+
+describe("P9A2 technical configuration supplier option import migration", () => {
+  it("uses one ordered migration after option responses and comparison-set read", () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true)
+    expect(
+      readdirSync(MIGRATIONS_DIR)
+        .filter((file) => file.includes("technical_configuration_option_import"))
+        .sort()
+    ).toEqual([MIGRATION_FILE])
+    expect(MIGRATION_FILE.localeCompare(LATEST_DEPENDENCY_MIGRATION)).toBeGreaterThan(0)
+  })
+
+  it("freezes the shared validator plus exact secured preview and apply signatures", () => {
+    expect(migrationSource).toContain(
+      `CREATE OR REPLACE FUNCTION public.${VALIDATOR_FUNCTION}(\n` +
+        "  p_option_id UUID,\n" +
+        "  p_baseline_version_id UUID,\n" +
+        "  p_template_metadata JSONB,\n" +
+        "  p_rows JSONB,\n" +
+        "  p_expected_revision BIGINT\n" +
+        ")"
+    )
+
+    for (const functionName of [PREVIEW_FUNCTION, APPLY_FUNCTION]) {
+      expect(migrationSource).toContain(
+        `CREATE OR REPLACE FUNCTION public.${functionName}(\n` +
+          "  p_option_id UUID,\n" +
+          "  p_baseline_version_id UUID,\n" +
+          "  p_template_metadata JSONB,\n" +
+          "  p_rows JSONB,\n" +
+          "  p_expected_revision BIGINT\n" +
+          ")"
+      )
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain("RETURNS JSONB")
+      expect(block).toContain("SECURITY DEFINER")
+      expect(block).toContain("SET search_path = public, pg_temp")
+      expect(block).toContain(VALIDATOR_FUNCTION)
+    }
+
+    expect(validatorBlock).toContain("SECURITY DEFINER")
+    expect(validatorBlock).toContain("SET search_path = public, pg_temp")
+  })
+
+  it("validates exact target metadata and complete untampered canonical rows", () => {
+    for (const key of [
+      "template_kind",
+      "template_version",
+      "dossier_id",
+      "option_id",
+      "baseline_version_id",
+      "dossier_revision",
+      "generated_at",
+    ]) {
+      expect(validatorBlock).toContain(key)
+    }
+
+    for (const key of [
+      "group_order",
+      "group_name",
+      "criterion_order",
+      "criterion_id",
+      "criterion_code",
+      "criterion_title",
+      "requirement_text",
+      "response_text",
+      "supplementary_information",
+    ]) {
+      expect(validatorBlock).toContain(key)
+    }
+
+    for (const marker of [
+      "technical_configuration_option",
+      "template_mismatch",
+      "invalid_row_shape",
+      "changed_context",
+      "missing_criterion",
+      "unknown_criterion",
+      "duplicate_criterion",
+      "row_errors",
+    ]) {
+      expect(validatorBlock).toContain(marker)
+    }
+  })
+
+  it("preloads canonical criteria once before validating imported rows", () => {
+    const criteriaLoadMarker = "FROM public.technical_configuration_baseline_criteria c"
+    const criteriaLoadIndex = validatorBlock.indexOf(criteriaLoadMarker)
+    const rowLoopIndex = validatorBlock.indexOf("FOR v_row, v_row_number IN")
+
+    expect(criteriaLoadIndex).toBeGreaterThanOrEqual(0)
+    expect(criteriaLoadIndex).toBeLessThan(rowLoopIndex)
+    expect(validatorBlock.split(criteriaLoadMarker)).toHaveLength(2)
+    expect(validatorBlock).toContain("jsonb_object_agg")
+    expect(validatorBlock).toContain("array_agg")
+  })
+
+  it("keeps preview side-effect-free and validates revision without taking the write lock", () => {
+    expect(previewBlock).toContain("_technical_configuration_require_global_user")
+    expect(previewBlock).not.toContain("_technical_configuration_require_editable_dossier")
+    expect(previewBlock).not.toMatch(/\b(?:INSERT INTO|UPDATE|DELETE FROM)\s+public\./)
+    expect(previewBlock).toContain("'errors'")
+    expect(previewBlock).toContain("'data'")
+    expect(validatorBlock).toMatch(
+      /FROM public\.technical_configuration_dossiers d[\s\S]*?FOR SHARE;/
+    )
+  })
+
+  it("locks and revalidates before the first apply mutation", () => {
+    const lockIndex = applyBlock.indexOf("_technical_configuration_require_editable_dossier")
+    const validationIndex = applyBlock.indexOf(VALIDATOR_FUNCTION)
+    const mutationIndex = applyBlock.search(/\b(?:INSERT INTO|UPDATE|DELETE FROM)\s+public\./)
+
+    expect(lockIndex).toBeGreaterThanOrEqual(0)
+    expect(validationIndex).toBeGreaterThan(lockIndex)
+    expect(mutationIndex).toBeGreaterThan(validationIndex)
+    expect(applyBlock).toContain("technical_configuration_comparison_sets")
+    expect(applyBlock).toContain("technical_configuration_option_responses")
+    expect(applyBlock).toContain("revision = revision + 1")
+  })
+
+  it("reconciles the full response snapshot and deletes canonical blank rows", () => {
+    expect(applyBlock).toMatch(/INSERT INTO public\.technical_configuration_comparison_sets/)
+    expect(applyBlock).toMatch(/INSERT INTO public\.technical_configuration_option_responses/)
+    expect(applyBlock).toMatch(/UPDATE public\.technical_configuration_option_responses/)
+    expect(applyBlock).toMatch(/DELETE FROM public\.technical_configuration_option_responses/)
+    expect(applyBlock).toMatch(/row->>'response_text'\s*=\s*''/)
+    expect(applyBlock).toMatch(/row->>'supplementary_information'\s*=\s*''/)
+  })
+
+  it("keeps the helper private and exposes only preview/apply through explicit grants", () => {
+    const helperSignature = `${VALIDATOR_FUNCTION}(UUID, UUID, JSONB, JSONB, BIGINT)`
+    const rpcSignatures = [
+      `${PREVIEW_FUNCTION}(UUID, UUID, JSONB, JSONB, BIGINT)`,
+      `${APPLY_FUNCTION}(UUID, UUID, JSONB, JSONB, BIGINT)`,
+    ]
+
+    expect(migrationSource).toContain(
+      `REVOKE ALL ON FUNCTION public.${helperSignature} FROM PUBLIC, anon, authenticated, service_role;`
+    )
+    expect(migrationSource).toContain(
+      `GRANT EXECUTE ON FUNCTION public.${helperSignature} TO service_role;`
+    )
+
+    for (const signature of rpcSignatures) {
+      expect(migrationSource).toContain(
+        `REVOKE ALL ON FUNCTION public.${signature} FROM PUBLIC, anon, authenticated, service_role;`
+      )
+      expect(migrationSource).toContain(
+        `GRANT EXECUTE ON FUNCTION public.${signature} TO authenticated, service_role;`
+      )
+    }
+  })
+
+  it("ships a rollback-only phase gate for trust, stale zero-write and atomicity", () => {
+    expect(phaseGateSource).not.toMatch(/^\\i[r]?\b/m)
+
+    for (const marker of [
+      "BEGIN;",
+      "ROLLBACK;",
+      "raw admin preview succeeds",
+      "global apply succeeds",
+      "missing claims fail closed",
+      "invalid claims fail closed",
+      "non-global role denied",
+      "preview is read-only",
+      "preview issue",
+      "wrong option metadata zero writes",
+      "wrong baseline metadata zero writes",
+      "malformed rows zero writes",
+      "tampered rows zero writes",
+      "missing criterion zero writes",
+      "unknown criterion zero writes",
+      "duplicate criterion zero writes",
+      "stale preview zero writes",
+      "stale apply zero writes",
+      "archived target zero writes",
+      "creates comparison set inside apply",
+      "reconciles complete snapshot",
+      "blank canonical row deletes response",
+      "increments dossier revision exactly once",
+      "late failure rolls back comparison set and responses",
+      "CREATE TRIGGER technical_configuration_option_import_fail_revision",
+      "injected_late_failure",
+      "draft baseline accepted",
+      "locked baseline accepted",
+      PREVIEW_FUNCTION,
+      APPLY_FUNCTION,
+    ]) {
+      expect(phaseGateSource).toContain(marker)
+    }
+  })
+})
+
+describe("P9A2 atomic supplier option import RPC contract", () => {
+  beforeEach(() => {
+    callRpcMock.mockReset()
+  })
+
+  it("freezes exactly the preview and apply RPC names", () => {
+    expect(OPTION_IMPORT_RPC_FUNCTIONS).toEqual({
+      previewOptionImport: "technical_configuration_option_import_preview",
+      applyOptionImport: "technical_configuration_option_import_apply",
+    })
+    expect(OPTION_IMPORT_RPC_FUNCTION_NAMES).toEqual(Object.values(OPTION_IMPORT_RPC_FUNCTIONS))
+  })
+
+  it("delegates canonical metadata and rows without remapping transient import state", async () => {
+    const metadata: TechnicalConfigurationOptionWorkbookMetadata = {
+      template_kind: "technical_configuration_option",
+      template_version: 1,
+      dossier_id: "00000000-0000-0000-0000-000000000001",
+      option_id: "00000000-0000-0000-0000-000000000003",
+      baseline_version_id: "00000000-0000-0000-0000-000000000005",
+      dossier_revision: 7,
+      generated_at: "2026-07-25T00:00:00.000Z",
+    }
+    const rows: TechnicalConfigurationOptionWorkbookRow[] = [
+      {
+        group_order: 1,
+        group_name: "Yêu cầu kỹ thuật",
+        criterion_order: 1,
+        criterion_id: "00000000-0000-0000-0000-000000000006",
+        criterion_code: "TC-0001",
+        criterion_title: "Nguồn điện",
+        requirement_text: "Điện áp 220 V",
+        response_text: "Đáp ứng",
+        supplementary_information: "",
+      },
+    ]
+    const args: TechnicalConfigurationOptionImportRpcArgs = {
+      p_option_id: metadata.option_id,
+      p_baseline_version_id: metadata.baseline_version_id,
+      p_template_metadata: metadata,
+      p_rows: rows,
+      p_expected_revision: metadata.dossier_revision,
+    }
+    const previewResponse: TechnicalConfigurationOptionImportPreviewWireResponse = {
+      data: { metadata, rows },
+      errors: [],
+    }
+    const applyResponse: TechnicalConfigurationOptionImportApplyWireResponse = {
+      data: {
+        id: "00000000-0000-0000-0000-000000000004",
+        dossier_id: metadata.dossier_id,
+        option_id: metadata.option_id,
+        baseline_version_id: metadata.baseline_version_id,
+        created_at: "2026-07-25T00:00:00.000Z",
+        created_by: 1,
+        updated_at: "2026-07-25T00:01:00.000Z",
+        updated_by: 1,
+        revision: 8,
+        responses: [],
+      },
+    }
+    const signal = new AbortController().signal
+    callRpcMock.mockResolvedValueOnce(previewResponse).mockResolvedValueOnce(applyResponse)
+
+    await expect(previewTechnicalConfigurationOptionImport(args, signal)).resolves.toEqual(
+      previewResponse
+    )
+    await expect(applyTechnicalConfigurationOptionImport(args)).resolves.toEqual(applyResponse)
+
+    expect(callRpcMock.mock.calls).toEqual([
+      [OPTION_IMPORT_RPC_FUNCTIONS.previewOptionImport, args, { signal }],
+      [OPTION_IMPORT_RPC_FUNCTIONS.applyOptionImport, args, { signal: undefined }],
+    ])
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -6,14 +6,13 @@ import { ALLOWED_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
 import { POST } from "@/app/api/rpc/[fn]/route"
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
-import * as supplierOptionRpcManifest from "@/lib/technical-configuration-supplier-option-rpcs"
-
-const {
+import {
+  OPTION_IMPORT_RPC_FUNCTION_NAMES,
   OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
   OPTION_RESPONSE_RPC_FUNCTION_NAMES,
   OPTION_RPC_FUNCTION_NAMES,
   SUPPLIER_RPC_FUNCTION_NAMES,
-} = supplierOptionRpcManifest
+} from "@/lib/technical-configuration-supplier-option-rpcs"
 
 const DOSSIER_RPC_FUNCTIONS = [
   "technical_configuration_dossiers_list",
@@ -56,6 +55,11 @@ const BASELINE_RPC_FUNCTIONS = [
 const REFERENCE_RPC_FUNCTIONS = [
   ...P7A1_REFERENCE_RPC_FUNCTIONS,
   ...REFERENCE_DOCUMENT_RPC_FUNCTIONS,
+] as const
+
+const P9A2_OPTION_IMPORT_RPC_FUNCTIONS = [
+  "technical_configuration_option_import_preview",
+  "technical_configuration_option_import_apply",
 ] as const
 
 const P8A1_SUPPLIER_RPC_FUNCTIONS = [
@@ -186,6 +190,7 @@ describe("technical configuration option RPC whitelist", () => {
         (fn) =>
           fn === "technical_configuration_options_list" ||
           (fn.startsWith("technical_configuration_option_") &&
+            !fn.startsWith("technical_configuration_option_import_") &&
             !fn.startsWith("technical_configuration_option_response_"))
       )
     ).toEqual(P8A2_OPTION_RPC_FUNCTIONS)
@@ -220,6 +225,28 @@ describe("technical configuration option response RPC whitelist", () => {
 
   it.each([...P8A3_OPTION_RESPONSE_RPC_FUNCTIONS, ...P8A4_OPTION_RESPONSE_READ_RPC_FUNCTIONS])(
     'allows option response RPC "%s" through the whitelist',
+    async (fn) => {
+      const response = await invokeRpcProxy(fn)
+
+      expect(response.status).toBe(411)
+      await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
+    }
+  )
+})
+
+describe("technical configuration option import RPC whitelist", () => {
+  it("keeps the P9A2 import prefix aligned with its shared manifest", () => {
+    expect(OPTION_IMPORT_RPC_FUNCTION_NAMES).toEqual(P9A2_OPTION_IMPORT_RPC_FUNCTIONS)
+  })
+
+  it("allowlists exactly the two dormant P9A2 import RPCs", () => {
+    expect(
+      [...ALLOWED_FUNCTIONS].filter((fn) => fn.startsWith("technical_configuration_option_import_"))
+    ).toEqual(P9A2_OPTION_IMPORT_RPC_FUNCTIONS)
+  })
+
+  it.each(P9A2_OPTION_IMPORT_RPC_FUNCTIONS)(
+    'allows option import RPC "%s" through the whitelist',
     async (fn) => {
       const response = await invokeRpcProxy(fn)
 

--- a/src/lib/technical-configuration-supplier-option-rpcs.ts
+++ b/src/lib/technical-configuration-supplier-option-rpcs.ts
@@ -38,3 +38,12 @@ export const OPTION_RESPONSE_READ_RPC_FUNCTIONS = {
 export const OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES = Object.values(
   OPTION_RESPONSE_READ_RPC_FUNCTIONS
 )
+
+/** Named P9A2 atomic supplier-option import RPCs shared by client and server code. */
+export const OPTION_IMPORT_RPC_FUNCTIONS = {
+  previewOptionImport: "technical_configuration_option_import_preview",
+  applyOptionImport: "technical_configuration_option_import_apply",
+} as const
+
+/** Ordered P9A2 import RPC names for allowlists and contract iteration. */
+export const OPTION_IMPORT_RPC_FUNCTION_NAMES = Object.values(OPTION_IMPORT_RPC_FUNCTIONS)

--- a/supabase/migrations/20260725060000_technical_configuration_option_import.sql
+++ b/supabase/migrations/20260725060000_technical_configuration_option_import.sql
@@ -1,0 +1,443 @@
+-- P9A2: authoritative supplier-option import preview and atomic full-snapshot apply.
+BEGIN;
+CREATE OR REPLACE FUNCTION public._technical_configuration_option_import_validate(
+  p_option_id UUID,
+  p_baseline_version_id UUID,
+  p_template_metadata JSONB,
+  p_rows JSONB,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dossier_id UUID;
+  v_version_dossier_id UUID;
+  v_revision BIGINT;
+  v_archived_at TIMESTAMPTZ;
+  v_key_count INTEGER;
+  v_row JSONB;
+  v_row_number INTEGER;
+  v_group_order INTEGER;
+  v_criterion_order INTEGER;
+  v_criterion_id UUID;
+  v_target JSONB;
+  v_targets JSONB;
+  v_target_criterion_ids UUID[];
+  v_seen_criterion_ids UUID[] := ARRAY[]::UUID[];
+  v_normalized_rows JSONB := '[]'::JSONB;
+  v_errors JSONB := '[]'::JSONB;
+BEGIN
+  SELECT o.dossier_id
+  INTO v_dossier_id
+  FROM public.technical_configuration_options o
+  WHERE o.id = p_option_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  SELECT v.dossier_id
+  INTO v_version_dossier_id
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.id = p_baseline_version_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  IF v_dossier_id IS DISTINCT FROM v_version_dossier_id THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  SELECT d.revision, d.archived_at
+  INTO v_revision, v_archived_at
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = v_dossier_id
+  FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  IF v_archived_at IS NOT NULL THEN
+    RAISE EXCEPTION 'archived_dossier' USING ERRCODE = 'PT409';
+  END IF;
+  IF v_revision IS DISTINCT FROM p_expected_revision THEN
+    RAISE EXCEPTION 'stale_revision' USING ERRCODE = 'PT409';
+  END IF;
+  IF p_template_metadata IS NULL
+     OR jsonb_typeof(p_template_metadata) <> 'object' THEN
+    RAISE EXCEPTION 'template_mismatch'
+      USING ERRCODE = 'PT422', DETAIL = 'template metadata must be an object';
+  END IF;
+  SELECT count(*) INTO v_key_count FROM jsonb_object_keys(p_template_metadata);
+  IF v_key_count <> 7
+     OR NOT p_template_metadata ?& ARRAY[
+       'template_kind',
+       'template_version',
+       'dossier_id',
+       'option_id',
+       'baseline_version_id',
+       'dossier_revision',
+       'generated_at'
+     ]
+     OR jsonb_typeof(p_template_metadata->'template_kind') <> 'string'
+     OR jsonb_typeof(p_template_metadata->'template_version') <> 'number'
+     OR jsonb_typeof(p_template_metadata->'dossier_id') <> 'string'
+     OR jsonb_typeof(p_template_metadata->'option_id') <> 'string'
+     OR jsonb_typeof(p_template_metadata->'baseline_version_id') <> 'string'
+     OR jsonb_typeof(p_template_metadata->'dossier_revision') <> 'number'
+     OR jsonb_typeof(p_template_metadata->'generated_at') <> 'string' THEN
+    RAISE EXCEPTION 'template_mismatch'
+      USING ERRCODE = 'PT422', DETAIL = 'template metadata has an invalid shape';
+  END IF;
+  BEGIN
+    PERFORM (p_template_metadata->>'generated_at')::TIMESTAMPTZ;
+    IF p_template_metadata->>'template_kind' <> 'technical_configuration_option'
+       OR p_template_metadata->>'template_version' <> '1'
+       OR (p_template_metadata->>'dossier_id')::UUID IS DISTINCT FROM v_dossier_id
+       OR (p_template_metadata->>'option_id')::UUID IS DISTINCT FROM p_option_id
+       OR (p_template_metadata->>'baseline_version_id')::UUID
+         IS DISTINCT FROM p_baseline_version_id
+       OR (p_template_metadata->>'dossier_revision')::BIGINT
+         IS DISTINCT FROM p_expected_revision THEN
+      RAISE EXCEPTION 'template_mismatch'
+        USING ERRCODE = 'PT422', DETAIL = 'template metadata does not match the target';
+    END IF;
+  EXCEPTION
+    WHEN invalid_text_representation
+      OR invalid_datetime_format
+      OR datetime_field_overflow
+      OR numeric_value_out_of_range THEN
+      RAISE EXCEPTION 'template_mismatch'
+        USING ERRCODE = 'PT422', DETAIL = 'template metadata contains invalid values';
+  END;
+  IF p_rows IS NULL OR jsonb_typeof(p_rows) <> 'array' THEN
+    RAISE EXCEPTION 'validation_error'
+      USING ERRCODE = 'PT422', DETAIL = 'canonical rows must be an array';
+  END IF;
+  SELECT
+    COALESCE(
+      jsonb_object_agg(
+        c.id::TEXT,
+        jsonb_build_object(
+          'group_order', g.sort_order,
+          'group_name', g.name,
+          'criterion_order', c.sort_order,
+          'criterion_code', c.criterion_code,
+          'criterion_title', c.title,
+          'requirement_text', c.requirement_text
+        )
+      ),
+      '{}'::JSONB
+    ),
+    COALESCE(
+      array_agg(c.id ORDER BY g.sort_order, c.sort_order, c.id),
+      ARRAY[]::UUID[]
+    )
+  INTO v_targets, v_target_criterion_ids
+  FROM public.technical_configuration_baseline_criteria c
+  JOIN public.technical_configuration_baseline_groups g
+    ON g.id = c.group_id
+   AND g.baseline_version_id = c.baseline_version_id
+  WHERE c.baseline_version_id = p_baseline_version_id;
+  FOR v_row, v_row_number IN
+    SELECT value, ordinality::INTEGER
+    FROM jsonb_array_elements(p_rows) WITH ORDINALITY
+  LOOP
+    IF jsonb_typeof(v_row) <> 'object' THEN
+      v_errors := v_errors || jsonb_build_array(jsonb_build_object(
+        'row', v_row_number, 'code', 'invalid_row_shape',
+        'message', 'canonical row must be an object'
+      ));
+      CONTINUE;
+    END IF;
+    SELECT count(*) INTO v_key_count FROM jsonb_object_keys(v_row);
+    IF v_key_count <> 9
+       OR NOT v_row ?& ARRAY[
+         'group_order',
+         'group_name',
+         'criterion_order',
+         'criterion_id',
+         'criterion_code',
+         'criterion_title',
+         'requirement_text',
+         'response_text',
+         'supplementary_information'
+       ]
+       OR jsonb_typeof(v_row->'group_order') <> 'number'
+       OR jsonb_typeof(v_row->'group_name') <> 'string'
+       OR jsonb_typeof(v_row->'criterion_order') <> 'number'
+       OR jsonb_typeof(v_row->'criterion_id') <> 'string'
+       OR jsonb_typeof(v_row->'criterion_code') <> 'string'
+       OR jsonb_typeof(v_row->'criterion_title') NOT IN ('string', 'null')
+       OR jsonb_typeof(v_row->'requirement_text') <> 'string'
+       OR jsonb_typeof(v_row->'response_text') <> 'string'
+       OR jsonb_typeof(v_row->'supplementary_information') <> 'string'
+       OR v_row->>'group_order' !~ '^[0-9]+$'
+       OR v_row->>'criterion_order' !~ '^[0-9]+$' THEN
+      v_errors := v_errors || jsonb_build_array(jsonb_build_object(
+        'row', v_row_number, 'code', 'invalid_row_shape',
+        'message', 'canonical row has unsupported or missing fields'
+      ));
+      CONTINUE;
+    END IF;
+    BEGIN
+      v_group_order := (v_row->>'group_order')::INTEGER;
+      v_criterion_order := (v_row->>'criterion_order')::INTEGER;
+      v_criterion_id := (v_row->>'criterion_id')::UUID;
+    EXCEPTION
+      WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+        v_errors := v_errors || jsonb_build_array(jsonb_build_object(
+          'row', v_row_number, 'code', 'invalid_row_shape',
+          'message', 'canonical row contains invalid identifiers or order values'
+        ));
+        CONTINUE;
+    END;
+    IF v_group_order <= 0 OR v_criterion_order <= 0 THEN
+      v_errors := v_errors || jsonb_build_array(jsonb_build_object(
+        'row', v_row_number, 'code', 'invalid_row_shape',
+        'message', 'canonical row order values must be positive'
+      ));
+      CONTINUE;
+    END IF;
+    IF v_criterion_id = ANY(v_seen_criterion_ids) THEN
+      v_errors := v_errors || jsonb_build_array(jsonb_build_object(
+        'row', v_row_number, 'criterion_id', v_criterion_id,
+        'code', 'duplicate_criterion', 'message', 'criterion is duplicated'
+      ));
+      CONTINUE;
+    END IF;
+    v_seen_criterion_ids := array_append(v_seen_criterion_ids, v_criterion_id);
+    v_target := v_targets->v_criterion_id::TEXT;
+    IF v_target IS NULL THEN
+      v_errors := v_errors || jsonb_build_array(jsonb_build_object(
+        'row', v_row_number, 'criterion_id', v_criterion_id,
+        'code', 'unknown_criterion', 'message', 'criterion does not belong to the target'
+      ));
+      CONTINUE;
+    END IF;
+    IF v_group_order IS DISTINCT FROM (v_target->>'group_order')::INTEGER
+       OR v_row->>'group_name' IS DISTINCT FROM v_target->>'group_name'
+       OR v_criterion_order IS DISTINCT FROM (v_target->>'criterion_order')::INTEGER
+       OR v_row->>'criterion_code' IS DISTINCT FROM v_target->>'criterion_code'
+       OR CASE
+         WHEN v_row->'criterion_title' = 'null'::JSONB THEN NULL
+         ELSE v_row->>'criterion_title'
+       END IS DISTINCT FROM v_target->>'criterion_title'
+       OR v_row->>'requirement_text' IS DISTINCT FROM v_target->>'requirement_text' THEN
+      v_errors := v_errors || jsonb_build_array(jsonb_build_object(
+        'row', v_row_number, 'criterion_id', v_criterion_id,
+        'code', 'changed_context', 'message', 'read-only criterion context was changed'
+      ));
+      CONTINUE;
+    END IF;
+    v_normalized_rows := v_normalized_rows || jsonb_build_array(jsonb_build_object(
+      'group_order', (v_target->>'group_order')::INTEGER,
+      'group_name', v_target->>'group_name',
+      'criterion_order', (v_target->>'criterion_order')::INTEGER,
+      'criterion_id', v_criterion_id,
+      'criterion_code', v_target->>'criterion_code',
+      'criterion_title', v_target->'criterion_title',
+      'requirement_text', v_target->>'requirement_text',
+      'response_text', v_row->>'response_text',
+      'supplementary_information', v_row->>'supplementary_information'
+    ));
+  END LOOP;
+  FOREACH v_criterion_id IN ARRAY v_target_criterion_ids LOOP
+    IF NOT (v_criterion_id = ANY(v_seen_criterion_ids)) THEN
+      v_errors := v_errors || jsonb_build_array(jsonb_build_object(
+        'criterion_id', v_criterion_id, 'code', 'missing_criterion',
+        'message', 'criterion is missing from the complete snapshot'
+      ));
+    END IF;
+  END LOOP;
+  RETURN jsonb_build_object(
+    'dossier_id', v_dossier_id,
+    'metadata', jsonb_build_object(
+      'template_kind', 'technical_configuration_option',
+      'template_version', 1,
+      'dossier_id', v_dossier_id,
+      'option_id', p_option_id,
+      'baseline_version_id', p_baseline_version_id,
+      'dossier_revision', v_revision,
+      'generated_at', p_template_metadata->>'generated_at'
+    ),
+    'rows', v_normalized_rows,
+    'row_errors', v_errors
+  );
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_import_preview(
+  p_option_id UUID,
+  p_baseline_version_id UUID,
+  p_template_metadata JSONB,
+  p_rows JSONB,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_validation JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  v_validation := public._technical_configuration_option_import_validate(
+    p_option_id,
+    p_baseline_version_id,
+    p_template_metadata,
+    p_rows,
+    p_expected_revision
+  );
+  RETURN jsonb_build_object(
+    'data', jsonb_build_object(
+      'metadata', v_validation->'metadata',
+      'rows', v_validation->'rows'
+    ),
+    'errors', v_validation->'row_errors'
+  );
+END;
+$$;
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_import_apply(
+  p_option_id UUID,
+  p_baseline_version_id UUID,
+  p_template_metadata JSONB,
+  p_rows JSONB,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_validation JSONB;
+  v_errors JSONB;
+  v_comparison_set_id UUID;
+  v_revision BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  SELECT o.dossier_id
+  INTO v_dossier_id
+  FROM public.technical_configuration_options o
+  WHERE o.id = p_option_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id,
+    p_expected_revision
+  );
+  PERFORM 1
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.id = p_baseline_version_id
+    AND v.dossier_id = v_dossier_id
+  FOR SHARE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  v_validation := public._technical_configuration_option_import_validate(
+    p_option_id,
+    p_baseline_version_id,
+    p_template_metadata,
+    p_rows,
+    p_expected_revision
+  );
+  v_errors := v_validation->'row_errors';
+  IF jsonb_array_length(v_errors) > 0 THEN
+    RAISE EXCEPTION 'validation_error'
+      USING ERRCODE = 'PT422', DETAIL = v_errors::TEXT;
+  END IF;
+  SELECT cs.id
+  INTO v_comparison_set_id
+  FROM public.technical_configuration_comparison_sets cs
+  WHERE cs.option_id = p_option_id
+    AND cs.baseline_version_id = p_baseline_version_id
+  FOR UPDATE;
+  IF v_comparison_set_id IS NULL THEN
+    INSERT INTO public.technical_configuration_comparison_sets (
+      dossier_id,
+      option_id,
+      baseline_version_id,
+      created_by,
+      updated_by
+    )
+    VALUES (
+      v_dossier_id,
+      p_option_id,
+      p_baseline_version_id,
+      v_user_id,
+      v_user_id
+    )
+    RETURNING id INTO v_comparison_set_id;
+  ELSE
+    UPDATE public.technical_configuration_comparison_sets
+    SET updated_at = now(),
+        updated_by = v_user_id
+    WHERE id = v_comparison_set_id;
+  END IF;
+  DELETE FROM public.technical_configuration_option_responses r
+  USING jsonb_array_elements(v_validation->'rows') AS incoming(row)
+  WHERE r.comparison_set_id = v_comparison_set_id
+    AND r.criterion_id = (incoming.row->>'criterion_id')::UUID
+    AND incoming.row->>'response_text' = ''
+    AND incoming.row->>'supplementary_information' = '';
+  UPDATE public.technical_configuration_option_responses r
+  SET response_text = incoming.row->>'response_text',
+      supplementary_information = incoming.row->>'supplementary_information',
+      updated_at = now(),
+      updated_by = v_user_id
+  FROM jsonb_array_elements(v_validation->'rows') AS incoming(row)
+  WHERE r.comparison_set_id = v_comparison_set_id
+    AND r.criterion_id = (incoming.row->>'criterion_id')::UUID
+    AND NOT (
+      incoming.row->>'response_text' = ''
+      AND incoming.row->>'supplementary_information' = ''
+    );
+  INSERT INTO public.technical_configuration_option_responses (
+    comparison_set_id,
+    baseline_version_id,
+    criterion_id,
+    response_text,
+    supplementary_information,
+    created_by,
+    updated_by
+  )
+  SELECT
+    v_comparison_set_id,
+    p_baseline_version_id,
+    (incoming.row->>'criterion_id')::UUID,
+    incoming.row->>'response_text',
+    incoming.row->>'supplementary_information',
+    v_user_id,
+    v_user_id
+  FROM jsonb_array_elements(v_validation->'rows') AS incoming(row)
+  WHERE NOT (
+      incoming.row->>'response_text' = ''
+      AND incoming.row->>'supplementary_information' = ''
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.technical_configuration_option_responses r
+      WHERE r.comparison_set_id = v_comparison_set_id
+        AND r.criterion_id = (incoming.row->>'criterion_id')::UUID
+    );
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1,
+      updated_at = now(),
+      updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+  RETURN public.technical_configuration_comparison_set_get(
+    p_option_id,
+    p_baseline_version_id
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public._technical_configuration_option_import_validate(UUID, UUID, JSONB, JSONB, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_import_preview(UUID, UUID, JSONB, JSONB, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_import_apply(UUID, UUID, JSONB, JSONB, BIGINT) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_option_import_validate(UUID, UUID, JSONB, JSONB, BIGINT) TO service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_import_preview(UUID, UUID, JSONB, JSONB, BIGINT) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_import_apply(UUID, UUID, JSONB, JSONB, BIGINT) TO authenticated, service_role;
+COMMIT;

--- a/supabase/migrations/20260725060000_technical_configuration_option_import.sql
+++ b/supabase/migrations/20260725060000_technical_configuration_option_import.sql
@@ -217,10 +217,10 @@ BEGIN
        OR v_row->>'group_name' IS DISTINCT FROM v_target->>'group_name'
        OR v_criterion_order IS DISTINCT FROM (v_target->>'criterion_order')::INTEGER
        OR v_row->>'criterion_code' IS DISTINCT FROM v_target->>'criterion_code'
-       OR CASE
+       OR (CASE
          WHEN v_row->'criterion_title' = 'null'::JSONB THEN NULL
          ELSE v_row->>'criterion_title'
-       END IS DISTINCT FROM v_target->>'criterion_title'
+       END) IS DISTINCT FROM v_target->>'criterion_title'
        OR v_row->>'requirement_text' IS DISTINCT FROM v_target->>'requirement_text' THEN
       v_errors := v_errors || jsonb_build_array(jsonb_build_object(
         'row', v_row_number, 'criterion_id', v_criterion_id,

--- a/supabase/tests/technical_configuration_option_import_phase_gate.sql
+++ b/supabase/tests/technical_configuration_option_import_phase_gate.sql
@@ -1,0 +1,511 @@
+-- P9A2 rollback-only supplier-option import trust, validation, and atomicity gate.
+-- Execute as one SQL batch through Supabase MCP after explicit live-write approval.
+BEGIN;
+
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role, 'role', 'authenticated',
+      'user_id', p_user_id::TEXT, 'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN
+    RAISE EXCEPTION '%', p_label;
+  END IF;
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.option_metadata(
+  p_dossier_id UUID, p_option_id UUID, p_baseline_version_id UUID, p_revision BIGINT
+)
+RETURNS JSONB LANGUAGE sql AS $gate$
+  SELECT jsonb_build_object(
+    'template_kind', 'technical_configuration_option', 'template_version', 1,
+    'dossier_id', p_dossier_id, 'option_id', p_option_id,
+    'baseline_version_id', p_baseline_version_id, 'dossier_revision', p_revision,
+    'generated_at', clock_timestamp()
+  );
+$gate$;
+
+CREATE FUNCTION pg_temp.option_row(
+  p_group_order INTEGER, p_group_name TEXT, p_criterion_order INTEGER,
+  p_criterion_id UUID, p_criterion_code TEXT, p_criterion_title TEXT,
+  p_requirement_text TEXT, p_response_text TEXT, p_supplementary_information TEXT
+)
+RETURNS JSONB LANGUAGE sql AS $gate$
+  SELECT jsonb_build_object(
+    'group_order', p_group_order, 'group_name', p_group_name,
+    'criterion_order', p_criterion_order, 'criterion_id', p_criterion_id,
+    'criterion_code', p_criterion_code, 'criterion_title', p_criterion_title,
+    'requirement_text', p_requirement_text, 'response_text', p_response_text,
+    'supplementary_information', p_supplementary_information
+  );
+$gate$;
+
+CREATE FUNCTION pg_temp.option_import_snapshot(
+  p_dossier_id UUID, p_option_id UUID, p_baseline_version_id UUID
+)
+RETURNS JSONB LANGUAGE sql AS $gate$
+  SELECT jsonb_build_object(
+    'dossier', (
+      SELECT to_jsonb(d) FROM public.technical_configuration_dossiers d
+      WHERE d.id = p_dossier_id
+    ),
+    'sets', COALESCE((
+      SELECT jsonb_agg(to_jsonb(cs) ORDER BY cs.id)
+      FROM public.technical_configuration_comparison_sets cs
+      WHERE cs.option_id = p_option_id
+        AND cs.baseline_version_id = p_baseline_version_id
+    ), '[]'::JSONB),
+    'responses', COALESCE((
+      SELECT jsonb_agg(to_jsonb(r) ORDER BY r.criterion_id)
+      FROM public.technical_configuration_option_responses r
+      JOIN public.technical_configuration_comparison_sets cs
+        ON cs.id = r.comparison_set_id
+      WHERE cs.option_id = p_option_id
+        AND cs.baseline_version_id = p_baseline_version_id
+    ), '[]'::JSONB)
+  );
+$gate$;
+
+CREATE FUNCTION pg_temp.expect_no_write_error(
+  p_label TEXT, p_statement TEXT, p_expected_state TEXT, p_expected_message TEXT,
+  p_dossier_id UUID, p_option_id UUID, p_baseline_version_id UUID
+)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+DECLARE
+  v_before JSONB;
+  v_after JSONB;
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  v_before := pg_temp.option_import_snapshot(
+    p_dossier_id, p_option_id, p_baseline_version_id
+  );
+  BEGIN
+    EXECUTE p_statement;
+    RAISE EXCEPTION 'expected_error_was_not_raised';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_state = RETURNED_SQLSTATE, v_message = MESSAGE_TEXT;
+  END;
+  IF v_state IS DISTINCT FROM p_expected_state
+     OR v_message IS DISTINCT FROM p_expected_message THEN
+    RAISE EXCEPTION '%: expected [%] %, got [%] %',
+      p_label, p_expected_state, p_expected_message, v_state, v_message;
+  END IF;
+  v_after := pg_temp.option_import_snapshot(
+    p_dossier_id, p_option_id, p_baseline_version_id
+  );
+  PERFORM pg_temp.assert_true(p_label || ' zero writes', v_after = v_before);
+END;
+$gate$;
+
+CREATE FUNCTION pg_temp.expect_option_import_error(
+  p_label TEXT, p_function_name TEXT, p_dossier_id UUID, p_option_id UUID,
+  p_baseline_version_id UUID, p_metadata JSONB, p_rows JSONB,
+  p_expected_revision BIGINT, p_expected_state TEXT, p_expected_message TEXT
+)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  PERFORM pg_temp.expect_no_write_error(
+    p_label,
+    format(
+      'SELECT public.%I(%L::UUID,%L::UUID,%L::JSONB,%L::JSONB,%s)',
+      p_function_name, p_option_id, p_baseline_version_id,
+      p_metadata, p_rows, p_expected_revision
+    ),
+    p_expected_state, p_expected_message,
+    p_dossier_id, p_option_id, p_baseline_version_id
+  );
+END;
+$gate$;
+
+CREATE FUNCTION public._p9a2_option_import_fail_revision_update()
+RETURNS TRIGGER LANGUAGE plpgsql AS $gate$
+BEGIN
+  IF NEW.id::TEXT = current_setting('p9a2.failure_dossier', true) THEN
+    RAISE EXCEPTION 'injected_late_failure';
+  END IF;
+  RETURN NEW;
+END;
+$gate$;
+
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossiers UUID[] := ARRAY[gen_random_uuid(), gen_random_uuid(), gen_random_uuid()];
+  v_suppliers UUID[] := ARRAY[gen_random_uuid(), gen_random_uuid(), gen_random_uuid()];
+  v_options UUID[] := ARRAY[
+    gen_random_uuid(), gen_random_uuid(), gen_random_uuid(),
+    gen_random_uuid(), gen_random_uuid(), gen_random_uuid()
+  ];
+  v_versions UUID[] := ARRAY[
+    gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), gen_random_uuid()
+  ];
+  v_groups UUID[] := ARRAY[
+    gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), gen_random_uuid()
+  ];
+  v_criteria UUID[] := ARRAY[
+    gen_random_uuid(), gen_random_uuid(), gen_random_uuid(),
+    gen_random_uuid(), gen_random_uuid(), gen_random_uuid()
+  ];
+  v_rows JSONB;
+  v_draft_rows JSONB;
+  v_archived_rows JSONB;
+  v_metadata JSONB;
+  v_response JSONB;
+  v_before JSONB;
+  v_after JSONB;
+  v_set_id UUID;
+  v_function_signature TEXT;
+  v_error_message TEXT;
+  v_case RECORD;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_option_import_phase_gate')
+  );
+  SELECT nv.id INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P9A2 phase gate requires one active public.nhan_vien row';
+  END IF;
+
+  -- Array indexes: main, other, archived; option also has metadata, failure and draft.
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, archived_at, archived_by, created_by, updated_by
+  ) VALUES
+    (v_dossiers[1], 'P9A2 device ' || v_suffix, 'P9A2 dossier ' || v_suffix,
+      NULL, NULL, v_user_id, v_user_id),
+    (v_dossiers[2], 'P9A2 other device ' || v_suffix, 'P9A2 other ' || v_suffix,
+      NULL, NULL, v_user_id, v_user_id),
+    (v_dossiers[3], 'P9A2 archived device ' || v_suffix, 'P9A2 archived ' || v_suffix,
+      now(), v_user_id, v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_suppliers (
+    id, dossier_id, name, created_by, updated_by
+  ) VALUES
+    (v_suppliers[1], v_dossiers[1], 'P9A2 Supplier', v_user_id, v_user_id),
+    (v_suppliers[2], v_dossiers[2], 'P9A2 Other Supplier', v_user_id, v_user_id),
+    (v_suppliers[3], v_dossiers[3], 'P9A2 Archived Supplier', v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_options (
+    id, dossier_id, supplier_id, option_name, created_by, updated_by
+  ) VALUES
+    (v_options[1], v_dossiers[1], v_suppliers[1], 'Import Option', v_user_id, v_user_id),
+    (v_options[2], v_dossiers[1], v_suppliers[1], 'Metadata Option', v_user_id, v_user_id),
+    (v_options[3], v_dossiers[1], v_suppliers[1], 'Failure Option', v_user_id, v_user_id),
+    (v_options[4], v_dossiers[1], v_suppliers[1], 'Draft Option', v_user_id, v_user_id),
+    (v_options[5], v_dossiers[2], v_suppliers[2], 'Other Option', v_user_id, v_user_id),
+    (v_options[6], v_dossiers[3], v_suppliers[3], 'Archived Option', v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id, dossier_id, version_number, status, next_criterion_number, revision,
+    locked_at, locked_by, created_by, updated_by
+  ) VALUES
+    (v_versions[1], v_dossiers[1], 1, 'locked', 3, 1, now(), v_user_id,
+      v_user_id, v_user_id),
+    (v_versions[2], v_dossiers[1], 2, 'draft', 2, 1, NULL, NULL,
+      v_user_id, v_user_id),
+    (v_versions[3], v_dossiers[2], 1, 'locked', 2, 1, now(), v_user_id,
+      v_user_id, v_user_id),
+    (v_versions[4], v_dossiers[3], 1, 'locked', 2, 1, now(), v_user_id,
+      v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id, baseline_version_id, name, sort_order, created_by, updated_by
+  ) VALUES
+    (v_groups[1], v_versions[1], 'Main Group', 1, v_user_id, v_user_id),
+    (v_groups[2], v_versions[2], 'Draft Group', 1, v_user_id, v_user_id),
+    (v_groups[3], v_versions[3], 'Other Group', 1, v_user_id, v_user_id),
+    (v_groups[4], v_versions[4], 'Archived Group', 1, v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id, baseline_version_id, group_id, criterion_code, title, requirement_text,
+    sort_order, created_by, updated_by
+  ) VALUES
+    (v_criteria[1], v_versions[1], v_groups[1], 'TC-0001', 'Power',
+      'Main criterion', 1, v_user_id, v_user_id),
+    (v_criteria[2], v_versions[1], v_groups[1], 'TC-0002', NULL,
+      'Second criterion', 2, v_user_id, v_user_id),
+    (v_criteria[3], v_versions[2], v_groups[2], 'TC-0001', NULL,
+      'Draft criterion', 1, v_user_id, v_user_id),
+    (v_criteria[4], v_versions[3], v_groups[3], 'TC-0001', NULL,
+      'Other criterion', 1, v_user_id, v_user_id),
+    (v_criteria[5], v_versions[4], v_groups[4], 'TC-0001', NULL,
+      'Archived criterion', 1, v_user_id, v_user_id);
+
+  v_rows := jsonb_build_array(
+    pg_temp.option_row(
+      1, 'Main Group', 1, v_criteria[1], 'TC-0001', 'Power',
+      'Main criterion', E'Line 1\nLine 2', 'Doc A'
+    ),
+    pg_temp.option_row(
+      1, 'Main Group', 2, v_criteria[2], 'TC-0002', NULL,
+      'Second criterion', 'Second response', 'Doc B'
+    )
+  );
+  v_draft_rows := jsonb_build_array(pg_temp.option_row(
+    1, 'Draft Group', 1, v_criteria[3], 'TC-0001', NULL,
+    'Draft criterion', 'Draft response', ''
+  ));
+  v_archived_rows := jsonb_build_array(pg_temp.option_row(
+    1, 'Archived Group', 1, v_criteria[5], 'TC-0001', NULL,
+    'Archived criterion', 'Blocked', ''
+  ));
+  v_metadata := pg_temp.option_metadata(v_dossiers[1], v_options[1], v_versions[1], 1);
+
+  -- missing and invalid claims fail closed; non-global role denied
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_option_import_error(
+    'missing claims fail closed', 'technical_configuration_option_import_preview',
+    v_dossiers[1], v_options[1], v_versions[1], v_metadata, v_rows, 1,
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('global', -1);
+  PERFORM pg_temp.expect_option_import_error(
+    'invalid claims fail closed', 'technical_configuration_option_import_preview',
+    v_dossiers[1], v_options[1], v_versions[1], v_metadata, v_rows, 1,
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('to_qltb', v_user_id);
+  PERFORM pg_temp.expect_option_import_error(
+    'non-global role denied', 'technical_configuration_option_import_apply',
+    v_dossiers[1], v_options[1], v_versions[1], v_metadata, v_rows, 1,
+    '42501', 'permission_denied'
+  );
+
+  -- raw admin preview succeeds and is read-only
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  v_before := pg_temp.option_import_snapshot(v_dossiers[1], v_options[1], v_versions[1]);
+  SELECT public.technical_configuration_option_import_preview(
+    v_options[1], v_versions[1], v_metadata, v_rows, 1
+  ) INTO v_response;
+  v_after := pg_temp.option_import_snapshot(v_dossiers[1], v_options[1], v_versions[1]);
+  PERFORM pg_temp.assert_true(
+    'raw admin preview succeeds',
+    jsonb_array_length(v_response->'errors') = 0
+      AND jsonb_array_length(v_response->'data'->'rows') = 2
+  );
+  PERFORM pg_temp.assert_true('preview is read-only', v_after = v_before);
+
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  FOR v_case IN SELECT * FROM (VALUES
+    ('wrong option metadata zero writes', v_dossiers[1], v_options[1], v_versions[1],
+      pg_temp.option_metadata(v_dossiers[1], v_options[2], v_versions[1], 1),
+      v_rows, 1::BIGINT, 'PT422', 'template_mismatch'),
+    ('wrong baseline metadata zero writes', v_dossiers[1], v_options[1], v_versions[1],
+      pg_temp.option_metadata(v_dossiers[1], v_options[1], v_versions[2], 1),
+      v_rows, 1::BIGINT, 'PT422', 'template_mismatch'),
+    ('cross-dossier target zero writes', v_dossiers[1], v_options[1], v_versions[3],
+      pg_temp.option_metadata(v_dossiers[1], v_options[1], v_versions[3], 1),
+      v_rows, 1::BIGINT, 'PT422', 'validation_error'),
+    ('stale preview zero writes', v_dossiers[1], v_options[1], v_versions[1],
+      pg_temp.option_metadata(v_dossiers[1], v_options[1], v_versions[1], 0),
+      v_rows, 0::BIGINT, 'PT409', 'stale_revision'),
+    ('stale apply zero writes', v_dossiers[1], v_options[3], v_versions[1],
+      pg_temp.option_metadata(v_dossiers[1], v_options[3], v_versions[1], 0),
+      v_rows, 0::BIGINT, 'PT409', 'stale_revision'),
+    ('archived preview zero writes', v_dossiers[3], v_options[6], v_versions[4],
+      pg_temp.option_metadata(v_dossiers[3], v_options[6], v_versions[4], 1),
+      v_archived_rows, 1::BIGINT, 'PT409', 'archived_dossier'),
+    ('archived target zero writes', v_dossiers[3], v_options[6], v_versions[4],
+      pg_temp.option_metadata(v_dossiers[3], v_options[6], v_versions[4], 1),
+      v_archived_rows, 1::BIGINT, 'PT409', 'archived_dossier')
+  ) AS cases(
+    label, dossier_id, option_id, baseline_version_id, metadata, rows,
+    expected_revision, expected_state, expected_message
+  ) LOOP
+    PERFORM pg_temp.expect_option_import_error(
+      v_case.label,
+      CASE WHEN v_case.label = 'stale preview zero writes'
+             OR v_case.label = 'archived preview zero writes'
+        THEN 'technical_configuration_option_import_preview'
+        ELSE 'technical_configuration_option_import_apply'
+      END,
+      v_case.dossier_id, v_case.option_id, v_case.baseline_version_id,
+      v_case.metadata, v_case.rows, v_case.expected_revision,
+      v_case.expected_state, v_case.expected_message
+    );
+  END LOOP;
+
+  -- Row issues are returned by preview and rejected by apply with zero writes.
+  FOR v_case IN SELECT * FROM (VALUES
+    ('malformed rows zero writes',
+      jsonb_build_array(jsonb_build_object('criterion_id', v_criteria[1])),
+      'invalid_row_shape'::TEXT, 1::INTEGER, NULL::UUID),
+    ('tampered rows zero writes',
+      jsonb_set(v_rows, '{0,requirement_text}', '"Tampered"'::JSONB),
+      'changed_context', 1, v_criteria[1]),
+    ('missing criterion zero writes',
+      jsonb_build_array(v_rows->0), 'missing_criterion', NULL, v_criteria[2]),
+    ('unknown criterion zero writes',
+      jsonb_set(v_rows, '{1,criterion_id}', to_jsonb(v_criteria[6]::TEXT)),
+      'unknown_criterion', 2, v_criteria[6]),
+    ('duplicate criterion zero writes',
+      jsonb_build_array(v_rows->0, v_rows->0),
+      'duplicate_criterion', 2, v_criteria[1])
+  ) AS cases(label, rows, issue_code, row_number, criterion_id) LOOP
+    PERFORM pg_temp.expect_option_import_error(
+      v_case.label,
+      'technical_configuration_option_import_apply',
+      v_dossiers[1], v_options[1], v_versions[1],
+      v_metadata, v_case.rows, 1, 'PT422', 'validation_error'
+    );
+    v_before := pg_temp.option_import_snapshot(v_dossiers[1], v_options[1], v_versions[1]);
+    SELECT public.technical_configuration_option_import_preview(
+      v_options[1], v_versions[1], v_metadata, v_case.rows, 1
+    ) INTO v_response;
+    v_after := pg_temp.option_import_snapshot(v_dossiers[1], v_options[1], v_versions[1]);
+    PERFORM pg_temp.assert_true(
+      v_case.issue_code || ' preview issue',
+      v_after = v_before
+        AND v_response->'errors'->0->>'code' = v_case.issue_code
+        AND COALESCE((v_response->'errors'->0->>'row')::INTEGER, 0)
+          = COALESCE(v_case.row_number, 0)
+        AND COALESCE(v_response->'errors'->0->>'criterion_id', '')
+          = COALESCE(v_case.criterion_id::TEXT, '')
+    );
+  END LOOP;
+
+  -- Global apply accepts locked baselines, creates the set, and reconciles all rows.
+  SELECT public.technical_configuration_option_import_apply(
+    v_options[1], v_versions[1], v_metadata, v_rows, 1
+  ) INTO v_response;
+  v_set_id := (v_response->'data'->>'id')::UUID;
+  PERFORM pg_temp.assert_true(
+    'global apply succeeds',
+    (v_response->'data'->>'revision')::BIGINT = 2
+  );
+  PERFORM pg_temp.assert_true(
+    'locked baseline accepted',
+    (SELECT status FROM public.technical_configuration_baseline_versions
+     WHERE id = v_versions[1]) = 'locked'
+  );
+  PERFORM pg_temp.assert_true(
+    'creates comparison set inside apply',
+    EXISTS (SELECT 1 FROM public.technical_configuration_comparison_sets
+            WHERE id = v_set_id)
+  );
+  PERFORM pg_temp.assert_true(
+    'reconciles complete snapshot',
+    (SELECT count(*) FROM public.technical_configuration_option_responses
+     WHERE comparison_set_id = v_set_id) = 2
+      AND (SELECT revision FROM public.technical_configuration_dossiers
+           WHERE id = v_dossiers[1]) = 2
+  );
+
+  -- Blank canonical row deletes its response; remaining values update exactly.
+  v_rows := jsonb_set(v_rows, '{0,response_text}', '"Updated"'::JSONB);
+  v_rows := jsonb_set(v_rows, '{1,response_text}', '""'::JSONB);
+  v_rows := jsonb_set(v_rows, '{1,supplementary_information}', '""'::JSONB);
+  PERFORM public.technical_configuration_option_import_apply(
+    v_options[1], v_versions[1],
+    pg_temp.option_metadata(v_dossiers[1], v_options[1], v_versions[1], 2),
+    v_rows, 2
+  );
+  PERFORM pg_temp.assert_true(
+    'blank canonical row deletes response',
+    (SELECT count(*) FROM public.technical_configuration_option_responses
+     WHERE comparison_set_id = v_set_id) = 1
+      AND EXISTS (
+        SELECT 1 FROM public.technical_configuration_option_responses
+        WHERE comparison_set_id = v_set_id
+          AND criterion_id = v_criteria[1]
+          AND response_text = 'Updated'
+          AND supplementary_information = 'Doc A'
+      )
+  );
+  PERFORM pg_temp.assert_true(
+    'increments dossier revision exactly once',
+    (SELECT revision FROM public.technical_configuration_dossiers
+     WHERE id = v_dossiers[1]) = 3
+  );
+
+  -- Inject a failure at the final revision update inside apply and prove rollback.
+  PERFORM set_config('p9a2.failure_dossier', v_dossiers[1]::TEXT, true);
+  CREATE TRIGGER technical_configuration_option_import_fail_revision
+  BEFORE UPDATE OF revision ON public.technical_configuration_dossiers
+  FOR EACH ROW EXECUTE FUNCTION public._p9a2_option_import_fail_revision_update();
+  v_before := pg_temp.option_import_snapshot(v_dossiers[1], v_options[3], v_versions[1]);
+  v_error_message := NULL;
+  BEGIN
+    PERFORM public.technical_configuration_option_import_apply(
+      v_options[3], v_versions[1],
+      pg_temp.option_metadata(v_dossiers[1], v_options[3], v_versions[1], 3),
+      v_rows, 3
+    );
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_error_message = MESSAGE_TEXT;
+  END;
+  DROP TRIGGER technical_configuration_option_import_fail_revision
+    ON public.technical_configuration_dossiers;
+  DROP FUNCTION public._p9a2_option_import_fail_revision_update();
+  v_after := pg_temp.option_import_snapshot(v_dossiers[1], v_options[3], v_versions[1]);
+  PERFORM pg_temp.assert_true(
+    'late failure rolls back comparison set and responses',
+    v_error_message = 'injected_late_failure'
+      AND v_after = v_before
+      AND (SELECT revision FROM public.technical_configuration_dossiers
+           WHERE id = v_dossiers[1]) = 3
+  );
+
+  -- Draft baseline accepted.
+  SELECT public.technical_configuration_option_import_apply(
+    v_options[4], v_versions[2],
+    pg_temp.option_metadata(v_dossiers[1], v_options[4], v_versions[2], 3),
+    v_draft_rows, 3
+  ) INTO v_response;
+  PERFORM pg_temp.assert_true(
+    'draft baseline accepted',
+    (SELECT status FROM public.technical_configuration_baseline_versions
+     WHERE id = v_versions[2]) = 'draft'
+      AND jsonb_array_length(v_response->'data'->'responses') = 1
+      AND (v_response->'data'->>'revision')::BIGINT = 4
+  );
+
+  FOREACH v_function_signature IN ARRAY ARRAY[
+    'public.technical_configuration_option_import_preview(uuid,uuid,jsonb,jsonb,bigint)',
+    'public.technical_configuration_option_import_apply(uuid,uuid,jsonb,jsonb,bigint)'
+  ] LOOP
+    PERFORM pg_temp.assert_true(
+      'authenticated executes ' || v_function_signature,
+      has_function_privilege('authenticated', v_function_signature, 'EXECUTE')
+    );
+    PERFORM pg_temp.assert_true(
+      'service role executes ' || v_function_signature,
+      has_function_privilege('service_role', v_function_signature, 'EXECUTE')
+    );
+    PERFORM pg_temp.assert_true(
+      'anon cannot execute ' || v_function_signature,
+      NOT has_function_privilege('anon', v_function_signature, 'EXECUTE')
+    );
+  END LOOP;
+  PERFORM pg_temp.assert_true(
+    'validator hidden from authenticated',
+    NOT has_function_privilege(
+      'authenticated',
+      'public._technical_configuration_option_import_validate(uuid,uuid,jsonb,jsonb,bigint)',
+      'EXECUTE'
+    )
+  );
+  PERFORM pg_temp.assert_true(
+    'service role executes validator',
+    has_function_privilege(
+      'service_role',
+      'public._technical_configuration_option_import_validate(uuid,uuid,jsonb,jsonb,bigint)',
+      'EXECUTE'
+    )
+  );
+END;
+$gate$;
+
+ROLLBACK;

--- a/supabase/tests/technical_configuration_option_import_phase_gate.sql
+++ b/supabase/tests/technical_configuration_option_import_phase_gate.sql
@@ -1,5 +1,7 @@
 -- P9A2 rollback-only supplier-option import trust, validation, and atomicity gate.
 -- Execute as one SQL batch through Supabase MCP after explicit live-write approval.
+-- The failure trigger holds a table DDL lock until ROLLBACK; use an acceptable
+-- write-blocking window when running this gate against live infrastructure.
 BEGIN;
 
 CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)


### PR DESCRIPTION
## Summary

- add dormant `technical_configuration_option_import_preview` and `technical_configuration_option_import_apply` RPCs backed by one secured validator/normalizer
- enforce authoritative full-snapshot validation, dossier revision concurrency, archived/claim guards, exact comparison-set targeting, and atomic response reconciliation
- expose typed RPC wrappers through the shared manifest and API proxy allowlist without adding a P9A3 UI caller
- add focused migration contracts and a rollback-only SQL phase gate covering trust, stale zero-write behavior, preview issue payloads, draft/locked baselines, blank-row deletion, and injected late-failure rollback

## Correctness Notes

- preview holds a dossier `FOR SHARE` lock while validating revision and canonical criteria
- apply takes the existing dossier write lock, locks the baseline, revalidates, then mutates
- canonical criteria are preloaded once before row validation to avoid per-row database queries
- dossier revision increments exactly once after successful reconciliation

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused P9A2 suite: 4 files, 94 tests passed
- `node scripts/npm-run.js run react-doctor`: 100/100, zero findings
- `node scripts/npm-run.js exec -- openspec validate add-technical-configuration-comparison --strict`
- `git diff --check`
- two independent follow-up reviews: zero findings

## Live Database

The migration and rollback phase gate were not executed on the live Supabase project because no live-write permission was requested or granted. This PR contains the dormant migration and contracts only.

Closes #796

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dormant supplier option import with secure preview/apply RPCs and atomic reconciliation. Provides typed client wrappers and RPC allowlists, plus a guarded migration and rollback-only phase gate. No UI caller yet.

- New Features
  - Added `technical_configuration_option_import_preview` and `technical_configuration_option_import_apply` with a shared secured validator that checks full-snapshot integrity, stale revisions, archived/claim guards, and canonical metadata/rows.
  - Apply atomically creates/updates the comparison set and responses, deletes blank canonical rows, and increments dossier revision exactly once.
  - Exposed typed wrappers (`previewTechnicalConfigurationOptionImport`, `applyTechnicalConfigurationOptionImport`) and allowlisted RPCs via `OPTION_IMPORT_RPC_FUNCTION_NAMES`, with focused whitelist and migration contract tests.

- Migration
  - Introduces SQL functions with strict grants (validator service-role only; preview/apply for `authenticated` and `service_role`), preview returns issues without writes, apply locks/revalidates before mutating.
  - Ships a rollback-only phase gate to verify trust, zero-write behavior on errors, and full rollback on injected late failure; also fixes SQL parsing by parenthesizing CASE expressions in IF conditions.

<sup>Written for commit 6aca95fa280ac89dba7a0429721da30917a9bd3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preview and apply support for importing technical configuration options.
  * Added validation feedback for invalid, duplicate, missing, or read-only import data.
  * Added import handling that updates option responses and revision history while preserving data integrity.
  * Enabled the new import operations through the application’s RPC interface.

* **Tests**
  * Added comprehensive coverage for permissions, validation, preview safety, successful imports, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->