### PR TITLE
P9A3: Add supplier option import workspace

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-import-conflict-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-import-conflict-cases.tsx
@@ -1,0 +1,270 @@
+import { act, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationSuppliers } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers"
+
+import {
+  confirmOptionImport,
+  mockParsedWorkbook,
+  renderImportResponses,
+  setImportBaselineVersion,
+  uploadOptionWorkbook,
+  workbookPayload,
+  type SupplierOptionImportTestMocks,
+} from "./supplier-option-import-fixtures"
+import {
+  baselineVersion,
+  comparisonSet,
+  getRequest,
+  jsonResponse,
+  optionResponse,
+} from "./supplier-option-response-cases"
+import {
+  dossier,
+  option,
+  optionsResponse,
+  renderWithQueryClient,
+  supplier,
+  suppliersResponse,
+} from "./supplier-options-fixtures"
+import { deferred } from "./technical-configuration-baseline-tab-fixtures"
+
+export function registerSupplierOptionImportConflictTests(mocks: SupplierOptionImportTestMocks) {
+  const { fetchMock, supplierOptionRpc, workbookCodec } = mocks
+
+  describe("technical configuration supplier option import coordination", () => {
+    beforeEach(() => {
+      Object.values(supplierOptionRpc).forEach((mock) => mock.mockReset())
+      workbookCodec.readWorkbook.mockReset()
+      workbookCodec.createParser.mockReset()
+      workbookCodec.createWorkbook.mockReset()
+      workbookCodec.downloadBlob.mockReset()
+
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([]))
+      workbookCodec.readWorkbook.mockResolvedValue({})
+    })
+
+    it("preserves file rows and preview while refreshing and re-previewing a stale apply", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const payload = workbookPayload({ baseline, currentOption })
+      const refreshedPayload = {
+        ...payload,
+        metadata: { ...payload.metadata, dossier_revision: 4 },
+      }
+      mockParsedWorkbook(workbookCodec, payload)
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(jsonResponse({ data: payload, errors: [] }))
+        .mockResolvedValueOnce(jsonResponse({ code: "PT409", message: "stale_revision" }, 409))
+        .mockResolvedValueOnce(jsonResponse({ data: { ...dossier, revision: 4 } }))
+        .mockResolvedValueOnce(jsonResponse({ data: refreshedPayload, errors: [] }))
+        .mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline, [], 4) }))
+
+      renderImportResponses({ mocks, baseline, currentOption })
+      await screen.findByLabelText("Phản hồi tiêu chí")
+      await uploadOptionWorkbook(user, "stale-option.xlsx")
+      await screen.findByText("stale-option.xlsx")
+      await confirmOptionImport(user)
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5))
+      expect(screen.getByText("stale-option.xlsx")).toBeInTheDocument()
+      expect(getRequest(fetchMock, 4).body).toMatchObject({
+        p_expected_revision: 4,
+        p_template_metadata: expect.objectContaining({ dossier_revision: 4 }),
+        p_rows: payload.rows,
+      })
+
+      await confirmOptionImport(user)
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(6))
+      expect(getRequest(fetchMock, 5).body.p_expected_revision).toBe(4)
+    })
+
+    it("adopts a successful import after a clean response conflict", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const persisted = optionResponse(baseline, {
+        response_text: "Phản hồi hiện tại",
+      })
+      const rows = workbookPayload({ baseline, currentOption }).rows.map((row, index) =>
+        index === 0 ? { ...row, response_text: "Phản hồi import" } : row
+      )
+      const payload = workbookPayload({
+        baseline,
+        currentOption,
+        rows,
+      })
+      const applied = comparisonSet(
+        baseline,
+        [
+          optionResponse(baseline, {
+            response_text: "Phản hồi import",
+            revision: 4,
+          }),
+        ],
+        4
+      )
+      mockParsedWorkbook(workbookCodec, payload)
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline, [persisted]) }))
+        .mockResolvedValueOnce(jsonResponse({ code: "PT409", message: "stale_revision" }, 409))
+        .mockResolvedValueOnce(jsonResponse({ data: payload, errors: [] }))
+        .mockResolvedValueOnce(jsonResponse({ data: applied }))
+
+      renderImportResponses({ mocks, baseline, currentOption })
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      await user.clear(responseInput)
+      await user.type(responseInput, "Phản hồi cục bộ")
+      await user.click(screen.getByRole("button", { name: "Lưu" }))
+      expect(await screen.findByText("Dữ liệu đã thay đổi")).toBeInTheDocument()
+
+      await user.clear(responseInput)
+      await user.type(responseInput, persisted.response_text)
+      await uploadOptionWorkbook(user)
+      await confirmOptionImport(user)
+
+      await waitFor(() => expect(responseInput).toHaveValue("Phản hồi import"))
+      expect(screen.queryByText("Dữ liệu đã thay đổi")).not.toBeInTheDocument()
+    })
+
+    it("focus-manages confirmation and clears it before the import dialog reopens", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const payload = workbookPayload({ baseline, currentOption })
+      mockParsedWorkbook(workbookCodec, payload)
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockResolvedValueOnce(jsonResponse({ data: payload, errors: [] }))
+
+      renderImportResponses({ mocks, baseline, currentOption })
+      await screen.findByLabelText("Phản hồi tiêu chí")
+      await uploadOptionWorkbook(user)
+      await user.click(screen.getByRole("button", { name: /Nhập 2 dòng/ }))
+
+      const confirmation = await screen.findByRole("alertdialog", {
+        name: "Ghi đè toàn bộ phản hồi phương án?",
+      })
+      const importDialog = screen.getByRole("dialog", {
+        name: "Nhập phản hồi phương án từ Excel",
+        hidden: true,
+      })
+      expect(confirmation).toContainElement(document.activeElement as HTMLElement)
+      expect(
+        within(importDialog).queryByRole("button", { name: "Đóng", hidden: true })
+      ).not.toBeInTheDocument()
+      expect(
+        within(importDialog).getByRole("button", { name: "Đặt lại", hidden: true })
+      ).toBeDisabled()
+
+      await user.click(within(confirmation).getByRole("button", { name: "Hủy" }))
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("alertdialog", {
+            name: "Ghi đè toàn bộ phản hồi phương án?",
+          })
+        ).not.toBeInTheDocument()
+      )
+      await waitFor(() =>
+        expect(
+          screen.getByRole("dialog", {
+            name: "Nhập phản hồi phương án từ Excel",
+          })
+        ).toBeInTheDocument()
+      )
+      await user.click(
+        within(
+          screen.getByRole("dialog", {
+            name: "Nhập phản hồi phương án từ Excel",
+          })
+        ).getByRole("button", { name: "Đóng" })
+      )
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("dialog", {
+            name: "Nhập phản hồi phương án từ Excel",
+          })
+        ).not.toBeInTheDocument()
+      )
+      await user.click(screen.getByRole("button", { name: "Nhập phản hồi từ Excel" }))
+
+      expect(
+        screen.queryByRole("alertdialog", {
+          name: "Ghi đè toàn bộ phản hồi phương án?",
+        })
+      ).not.toBeInTheDocument()
+      await user.click(
+        within(
+          screen.getByRole("dialog", {
+            name: "Nhập phản hồi phương án từ Excel",
+          })
+        ).getByRole("button", { name: "Đóng" })
+      )
+    })
+
+    it("blocks identity, option, response, baseline, and outer navigation while pending and dirty", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentSupplier = supplier("supplier-1", "Công ty Thiết bị A")
+      const currentOption = option({
+        id: "option-1",
+        supplierId: currentSupplier.id,
+        model: "Model A",
+      })
+      const otherOption = option({
+        id: "option-2",
+        supplierId: currentSupplier.id,
+        model: "Model B",
+      })
+      const payload = workbookPayload({ baseline, currentOption })
+      const previewRequest = deferred<Response>()
+      const onNavigationBlockedChange = vi.fn()
+      setImportBaselineVersion(mocks.baselineRpc, baseline)
+      mockParsedWorkbook(workbookCodec, payload)
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([currentSupplier]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([currentOption, otherOption]))
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: null }))
+        .mockImplementationOnce(() => previewRequest.promise)
+
+      renderWithQueryClient(
+        <TechnicalConfigurationSuppliers
+          dossier={dossier}
+          onNavigationBlockedChange={onNavigationBlockedChange}
+        />
+      )
+      await user.click(await screen.findByRole("button", { name: /Model A/ }))
+      await screen.findByLabelText("Phản hồi tiêu chí")
+      const otherOptionButton = screen.getByRole("button", { name: /Model B/ })
+      await uploadOptionWorkbook(user)
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+      const addOptionButton = Array.from(
+        screen.getByTestId("supplier-option-identity-region").querySelectorAll("button")
+      ).find((button) => button.textContent?.includes("Thêm phương án"))
+      expect(addOptionButton).toBeDisabled()
+      expect(otherOptionButton).toBeDisabled()
+      expect(document.getElementById("option-response-baseline-version")).toBeDisabled()
+      expect(document.getElementById("technical-option-response-text")).toBeDisabled()
+      expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(true)
+
+      await act(async () => {
+        previewRequest.resolve(jsonResponse({ data: payload, errors: [] }))
+        await previewRequest.promise
+      })
+      await waitFor(() =>
+        expect(screen.queryByText("Đang tạo bản xem trước từ máy chủ...")).not.toBeInTheDocument()
+      )
+
+      expect(addOptionButton).toBeDisabled()
+      expect(otherOptionButton).toBeDisabled()
+      expect(document.getElementById("option-response-baseline-version")).toBeDisabled()
+      expect(document.getElementById("technical-option-response-text")).toBeDisabled()
+      expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(true)
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-import-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-import-fixtures.tsx
@@ -1,0 +1,171 @@
+import { screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi, type Mock } from "vitest"
+
+import { TechnicalConfigurationOptionResponses } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses"
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationOptionWire } from "@/app/(app)/technical-configurations/supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
+import {
+  OPTION_WORKBOOK_TEMPLATE_KIND,
+  OPTION_WORKBOOK_TEMPLATE_VERSION,
+  type TechnicalConfigurationOptionWorkbookParseResult,
+  type TechnicalConfigurationOptionWorkbookRow,
+} from "@/lib/technical-configuration-option-excel-contract"
+
+import { baselineVersion, comparisonSet, optionResponse } from "./supplier-option-response-cases"
+import {
+  dossier,
+  option,
+  renderWithQueryClient,
+  type SupplierOptionRpcMocks,
+} from "./supplier-options-fixtures"
+
+export type SupplierOptionWorkbookCodecMocks = {
+  readWorkbook: Mock
+  createParser: Mock
+  createWorkbook: Mock
+  downloadBlob: Mock
+}
+
+export type SupplierOptionImportTestMocks = {
+  baselineRpc: { listVersions: Mock }
+  fetchMock: Mock
+  supplierOptionRpc: SupplierOptionRpcMocks
+  workbookCodec: SupplierOptionWorkbookCodecMocks
+}
+
+export function setImportBaselineVersion(
+  baselineRpc: SupplierOptionImportTestMocks["baselineRpc"],
+  baseline: TechnicalConfigurationBaselineDraftWire
+) {
+  baselineRpc.listVersions.mockResolvedValue({
+    data: [baseline],
+    total: 1,
+    page: 1,
+    page_size: 100,
+  })
+  return baseline
+}
+
+export function toWorkbookRows(
+  baseline: TechnicalConfigurationBaselineDraftWire,
+  values: Record<
+    string,
+    Pick<TechnicalConfigurationOptionWorkbookRow, "response_text" | "supplementary_information">
+  > = {}
+): TechnicalConfigurationOptionWorkbookRow[] {
+  return baseline.groups.flatMap((group) =>
+    group.criteria.map((criterion) => ({
+      group_order: group.sort_order,
+      group_name: group.name,
+      criterion_order: criterion.sort_order,
+      criterion_id: criterion.id,
+      criterion_code: criterion.criterion_code,
+      criterion_title: criterion.title,
+      requirement_text: criterion.requirement_text,
+      response_text: values[criterion.id]?.response_text ?? "",
+      supplementary_information: values[criterion.id]?.supplementary_information ?? "",
+    }))
+  )
+}
+
+export function workbookPayload({
+  baseline,
+  currentOption,
+  revision = dossier.revision,
+  rows = toWorkbookRows(baseline),
+}: {
+  baseline: TechnicalConfigurationBaselineDraftWire
+  currentOption: TechnicalConfigurationOptionWire
+  revision?: number
+  rows?: TechnicalConfigurationOptionWorkbookRow[]
+}): TechnicalConfigurationOptionWorkbookParseResult {
+  return {
+    metadata: {
+      template_kind: OPTION_WORKBOOK_TEMPLATE_KIND,
+      template_version: OPTION_WORKBOOK_TEMPLATE_VERSION,
+      dossier_id: dossier.id,
+      option_id: currentOption.id,
+      baseline_version_id: baseline.id,
+      dossier_revision: revision,
+      generated_at: "2026-07-25T00:00:00.000Z",
+    },
+    rows,
+  }
+}
+
+export function renderImportResponses({
+  mocks,
+  baseline = baselineVersion(),
+  currentOption = option({ id: "option-1" }),
+  dossierValue = dossier,
+  onRevisionChange = vi.fn(),
+}: {
+  mocks: SupplierOptionImportTestMocks
+  baseline?: TechnicalConfigurationBaselineDraftWire
+  currentOption?: TechnicalConfigurationOptionWire
+  dossierValue?: TechnicalConfigurationDossierWire
+  onRevisionChange?: (revision: number) => void
+}) {
+  setImportBaselineVersion(mocks.baselineRpc, baseline)
+  return {
+    ...renderWithQueryClient(
+      <TechnicalConfigurationOptionResponses
+        dossier={dossierValue}
+        option={currentOption}
+        onRevisionChange={onRevisionChange}
+      />
+    ),
+    baseline,
+    currentOption,
+    onRevisionChange,
+  }
+}
+
+export function mockParsedWorkbook(
+  workbookCodec: SupplierOptionWorkbookCodecMocks,
+  payload: TechnicalConfigurationOptionWorkbookParseResult
+) {
+  workbookCodec.createParser.mockReturnValue(async () => [payload])
+}
+
+export async function uploadOptionWorkbook(
+  user: ReturnType<typeof userEvent.setup>,
+  fileName = "option.xlsx"
+) {
+  await user.click(screen.getByRole("button", { name: "Nhập phản hồi từ Excel" }))
+  await user.upload(
+    screen.getByLabelText("Chọn template phản hồi phương án"),
+    new File(["workbook"], fileName, {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    })
+  )
+}
+
+export async function confirmOptionImport(user: ReturnType<typeof userEvent.setup>) {
+  let confirmation = screen.queryByRole("alertdialog")
+  if (!confirmation) {
+    await user.click(screen.getByRole("button", { name: /Nhập 2 dòng/ }))
+    confirmation = await screen.findByRole("alertdialog")
+  }
+  await user.click(within(confirmation).getByRole("button", { name: "Áp dụng import" }))
+}
+
+export function persistedImportResponse(
+  baseline: TechnicalConfigurationBaselineDraftWire,
+  revision = dossier.revision
+) {
+  return optionResponse(baseline, {
+    response_text: "Phản hồi hiện tại",
+    supplementary_information: "Thông tin bổ sung cũ",
+    revision,
+  })
+}
+
+export function persistedImportSet(
+  baseline: TechnicalConfigurationBaselineDraftWire,
+  revision = dossier.revision
+) {
+  return comparisonSet(baseline, [persistedImportResponse(baseline, revision)], revision)
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-import-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-import-workspace-cases.tsx
@@ -1,0 +1,340 @@
+import { QueryObserver } from "@tanstack/react-query"
+import { act, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  technicalConfigurationDossierDetailQueryKey,
+  technicalConfigurationOptionResponsesQueryKey,
+} from "@/app/(app)/technical-configurations/technical-configuration-query-keys"
+import type { TechnicalConfigurationOptionImportPreviewWireResponse } from "@/app/(app)/technical-configurations/supplier-option-types"
+import type { TechnicalConfigurationDossierWireResponse } from "@/app/(app)/technical-configurations/types"
+
+import {
+  confirmOptionImport,
+  mockParsedWorkbook,
+  persistedImportResponse,
+  renderImportResponses,
+  setImportBaselineVersion,
+  toWorkbookRows,
+  uploadOptionWorkbook,
+  workbookPayload,
+  type SupplierOptionImportTestMocks,
+} from "./supplier-option-import-fixtures"
+import {
+  baselineVersion,
+  comparisonSet,
+  getRequest,
+  jsonResponse,
+  optionResponse,
+} from "./supplier-option-response-cases"
+import { dossier, option, optionsResponse, suppliersResponse } from "./supplier-options-fixtures"
+import { deferred } from "./technical-configuration-baseline-tab-fixtures"
+
+export function registerSupplierOptionImportWorkspaceTests(mocks: SupplierOptionImportTestMocks) {
+  const { fetchMock, supplierOptionRpc, workbookCodec } = mocks
+
+  describe("technical configuration supplier option import workspace", () => {
+    beforeEach(() => {
+      Object.values(supplierOptionRpc).forEach((mock) => mock.mockReset())
+      workbookCodec.readWorkbook.mockReset()
+      workbookCodec.createParser.mockReset()
+      workbookCodec.createWorkbook.mockReset()
+      workbookCodec.downloadBlob.mockReset()
+
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([]))
+      workbookCodec.readWorkbook.mockResolvedValue({})
+      workbookCodec.createWorkbook.mockResolvedValue({
+        xlsx: {
+          writeBuffer: async () => new Uint8Array([1, 2, 3]),
+        },
+      })
+    })
+
+    it("downloads the exact locked-baseline template through the P9A1 codec", async () => {
+      const user = userEvent.setup()
+      const baseline = setImportBaselineVersion(
+        mocks.baselineRpc,
+        baselineVersion({ status: "locked", revision: 5 })
+      )
+      const currentOption = option({ id: "option-1", revision: 5 })
+      const persisted = persistedImportResponse(baseline, 5)
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ data: comparisonSet(baseline, [persisted], 5) })
+      )
+
+      renderImportResponses({
+        mocks,
+        baseline,
+        currentOption,
+        dossierValue: { ...dossier, revision: 5 },
+      })
+      await screen.findByLabelText("Phản hồi tiêu chí")
+      await user.click(screen.getByRole("button", { name: "Tải template phản hồi" }))
+
+      expect(workbookCodec.createWorkbook).toHaveBeenCalledWith({
+        metadata: expect.objectContaining({
+          dossier_id: dossier.id,
+          option_id: currentOption.id,
+          baseline_version_id: baseline.id,
+          dossier_revision: 5,
+        }),
+        rows: toWorkbookRows(baseline, {
+          [persisted.criterion_id]: {
+            response_text: persisted.response_text,
+            supplementary_information: persisted.supplementary_information,
+          },
+        }),
+      })
+      expect(workbookCodec.downloadBlob).toHaveBeenCalledWith(
+        expect.any(Blob),
+        "Mau_Phan_Hoi_Phuong_An_Phien_Ban_1.xlsx"
+      )
+    })
+
+    it("previews without mutation, confirms once, clears blanks, and adopts caches", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const persisted = persistedImportResponse(baseline)
+      const rows = toWorkbookRows(baseline, {
+        [persisted.criterion_id]: {
+          response_text: "Phản hồi import",
+          supplementary_information: "",
+        },
+      })
+      const payload = workbookPayload({ baseline, currentOption, rows })
+      const preview: TechnicalConfigurationOptionImportPreviewWireResponse = {
+        data: payload,
+        errors: [],
+      }
+      const applied = comparisonSet(
+        baseline,
+        [
+          optionResponse(baseline, {
+            response_text: "Phản hồi import",
+            supplementary_information: "",
+            revision: 4,
+          }),
+        ],
+        4
+      )
+      mockParsedWorkbook(workbookCodec, payload)
+      fetchMock
+        .mockResolvedValueOnce(
+          jsonResponse({ data: comparisonSet(baseline, [persisted], dossier.revision) })
+        )
+        .mockResolvedValueOnce(jsonResponse(preview))
+        .mockResolvedValueOnce(jsonResponse({ data: applied }))
+
+      const rendered = renderImportResponses({ mocks, baseline, currentOption })
+      const detailQueryKey = technicalConfigurationDossierDetailQueryKey(dossier.id)
+      rendered.queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(detailQueryKey, {
+        data: dossier,
+      })
+      const detailObserver = new QueryObserver(rendered.queryClient, {
+        queryKey: detailQueryKey,
+        enabled: false,
+      })
+      const unsubscribeDetailObserver = detailObserver.subscribe(() => undefined)
+      await screen.findByDisplayValue("Thông tin bổ sung cũ")
+      await uploadOptionWorkbook(user)
+      await screen.findByText("option.xlsx")
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(screen.getByText("Xóa phản hồi đã lưu")).toBeInTheDocument()
+      expect(screen.getAllByText("Xóa thông tin bổ sung")).toHaveLength(2)
+      expect(String(getRequest(fetchMock, 1).url)).toContain(
+        "technical_configuration_option_import_preview"
+      )
+      expect(getRequest(fetchMock, 1).body.p_rows).toEqual(rows)
+
+      await user.click(screen.getByRole("button", { name: /Nhập 2 dòng/ }))
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      await confirmOptionImport(user)
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+      expect(String(getRequest(fetchMock, 2).url)).toContain(
+        "technical_configuration_option_import_apply"
+      )
+      await waitFor(() =>
+        expect(screen.getByLabelText("Phản hồi tiêu chí")).toHaveValue("Phản hồi import")
+      )
+      expect(screen.getByLabelText("Thông tin bổ sung")).toHaveValue("")
+      expect(rendered.onRevisionChange).toHaveBeenCalledWith(4)
+      expect(
+        rendered.queryClient.getQueryData(
+          technicalConfigurationOptionResponsesQueryKey(currentOption.id, baseline.id)
+        )
+      ).toEqual(applied)
+      expect(
+        rendered.queryClient.getQueryData<TechnicalConfigurationDossierWireResponse>(detailQueryKey)
+          ?.data.revision
+      ).toBe(4)
+      unsubscribeDetailObserver()
+    })
+
+    it("keeps imported response and dossier caches newer than in-flight refetches", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const persisted = persistedImportResponse(baseline)
+      const existingSet = comparisonSet(baseline, [persisted], dossier.revision)
+      const payload = workbookPayload({ baseline, currentOption })
+      const applied = comparisonSet(
+        baseline,
+        [
+          optionResponse(baseline, {
+            response_text: "Phản hồi import mới",
+            revision: 4,
+          }),
+        ],
+        4
+      )
+      const staleResponseRequest = deferred<Response>()
+      const staleDetailRequest = deferred<TechnicalConfigurationDossierWireResponse>()
+      mockParsedWorkbook(workbookCodec, payload)
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: existingSet }))
+        .mockImplementationOnce(() => staleResponseRequest.promise)
+        .mockResolvedValueOnce(jsonResponse({ data: payload, errors: [] }))
+        .mockResolvedValueOnce(jsonResponse({ data: applied }))
+
+      const rendered = renderImportResponses({ mocks, baseline, currentOption })
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      const responseQueryKey = technicalConfigurationOptionResponsesQueryKey(
+        currentOption.id,
+        baseline.id
+      )
+      const detailQueryKey = technicalConfigurationDossierDetailQueryKey(dossier.id)
+      rendered.queryClient.setQueryData<TechnicalConfigurationDossierWireResponse>(detailQueryKey, {
+        data: dossier,
+      })
+      const detailObserver = new QueryObserver(rendered.queryClient, {
+        queryKey: detailQueryKey,
+        enabled: false,
+      })
+      const unsubscribeDetailObserver = detailObserver.subscribe(() => undefined)
+      const responseRefetch = rendered.queryClient.refetchQueries({
+        queryKey: responseQueryKey,
+        exact: true,
+      })
+      const detailRefetch = rendered.queryClient
+        .fetchQuery({
+          queryKey: detailQueryKey,
+          queryFn: () => staleDetailRequest.promise,
+          staleTime: 0,
+        })
+        .catch(() => undefined)
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+      await uploadOptionWorkbook(user)
+      await confirmOptionImport(user)
+      await waitFor(() => expect(responseInput).toHaveValue("Phản hồi import mới"))
+
+      await act(async () => {
+        staleResponseRequest.resolve(jsonResponse({ data: existingSet }))
+        staleDetailRequest.resolve({ data: dossier })
+        await Promise.all([responseRefetch, detailRefetch])
+      })
+
+      expect(rendered.queryClient.getQueryData(responseQueryKey)).toEqual(applied)
+      expect(
+        rendered.queryClient.getQueryData<TechnicalConfigurationDossierWireResponse>(detailQueryKey)
+          ?.data.revision
+      ).toBe(4)
+      expect(responseInput).toHaveValue("Phản hồi import mới")
+      unsubscribeDetailObserver()
+    })
+
+    it("rejects a lower-revision response cache publication after import", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      const existingSet = comparisonSet(
+        baseline,
+        [persistedImportResponse(baseline)],
+        dossier.revision
+      )
+      const payload = workbookPayload({ baseline, currentOption })
+      const applied = comparisonSet(
+        baseline,
+        [
+          optionResponse(baseline, {
+            response_text: "Phản hồi import mới",
+            revision: 4,
+          }),
+        ],
+        4
+      )
+      mockParsedWorkbook(workbookCodec, payload)
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ data: existingSet }))
+        .mockResolvedValueOnce(jsonResponse({ data: payload, errors: [] }))
+        .mockResolvedValueOnce(jsonResponse({ data: applied }))
+
+      const rendered = renderImportResponses({ mocks, baseline, currentOption })
+      const responseInput = await screen.findByLabelText("Phản hồi tiêu chí")
+      const responseQueryKey = technicalConfigurationOptionResponsesQueryKey(
+        currentOption.id,
+        baseline.id
+      )
+      await uploadOptionWorkbook(user)
+      await confirmOptionImport(user)
+      await waitFor(() => expect(responseInput).toHaveValue("Phản hồi import mới"))
+
+      act(() => {
+        rendered.queryClient.setQueryData(responseQueryKey, existingSet)
+      })
+
+      await waitFor(() =>
+        expect(rendered.queryClient.getQueryData(responseQueryKey)).toEqual(applied)
+      )
+      expect(responseInput).toHaveValue("Phản hồi import mới")
+    })
+
+    it("shows parser missing-row errors without previewing or applying", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentOption = option({ id: "option-1" })
+      workbookCodec.createParser.mockReturnValue(async () => {
+        throw new Error("Thiếu dòng tiêu chí TC-0002.")
+      })
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: null }))
+
+      renderImportResponses({ mocks, baseline, currentOption })
+      await screen.findByLabelText("Phản hồi tiêu chí")
+      await uploadOptionWorkbook(user, "missing-row.xlsx")
+
+      expect(
+        await screen.findByText(/Da co loi xay ra khi doc file: Thiếu dòng tiêu chí TC-0002\./)
+      ).toBeInTheDocument()
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(
+        screen.queryByRole("alertdialog", { name: "Xác nhận ghi đè phản hồi phương án" })
+      ).not.toBeInTheDocument()
+    })
+
+    it("keeps download and import read-only for archived dossiers", async () => {
+      const baseline = baselineVersion({ status: "locked" })
+      const currentOption = option({ id: "option-1" })
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline) }))
+
+      renderImportResponses({
+        mocks,
+        baseline,
+        currentOption,
+        dossierValue: {
+          ...dossier,
+          archived_at: "2026-07-25T00:00:00.000Z",
+          archived_by: 9,
+        },
+      })
+
+      expect(await screen.findByLabelText("Phản hồi tiêu chí")).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Tải template phản hồi" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Nhập phản hồi từ Excel" })).toBeDisabled()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
@@ -1,5 +1,7 @@
 import { beforeEach, vi } from "vitest"
 
+import { registerSupplierOptionImportConflictTests } from "./supplier-option-import-conflict-cases"
+import { registerSupplierOptionImportWorkspaceTests } from "./supplier-option-import-workspace-cases"
 import { registerSupplierOptionResponseAvailabilityTests } from "./supplier-option-response-availability-cases"
 import { registerSupplierOptionResponseCoordinationTests } from "./supplier-option-response-coordination-cases"
 import { registerSupplierOptionResponseConflictTests } from "./supplier-option-response-conflict-cases"
@@ -27,6 +29,13 @@ const supplierOptionRpc = vi.hoisted(() => ({
 
 const optionResponseFetch = vi.hoisted(() => vi.fn())
 
+const workbookCodec = vi.hoisted(() => ({
+  readWorkbook: vi.fn(),
+  createParser: vi.fn(),
+  createWorkbook: vi.fn(),
+  downloadBlob: vi.fn(),
+}))
+
 vi.mock("@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaseline", () => ({
   useTechnicalConfigurationBaseline: () => baselineRpc,
 }))
@@ -40,6 +49,23 @@ vi.mock("@/app/(app)/technical-configurations/technical-configuration-supplier-o
   createTechnicalConfigurationOption: supplierOptionRpc.createOption,
   updateTechnicalConfigurationOption: supplierOptionRpc.updateOption,
   deleteTechnicalConfigurationOption: supplierOptionRpc.deleteOption,
+}))
+
+vi.mock("@/lib/excel-utils", () => ({
+  readExcelFile: workbookCodec.readWorkbook,
+  worksheetToJson: vi.fn(),
+}))
+
+vi.mock("@/lib/excel-workbook", () => ({
+  downloadBlob: workbookCodec.downloadBlob,
+}))
+
+vi.mock("@/lib/technical-configuration-option-excel-export", () => ({
+  createTechnicalConfigurationOptionWorkbook: workbookCodec.createWorkbook,
+}))
+
+vi.mock("@/lib/technical-configuration-option-excel-parse", () => ({
+  createTechnicalConfigurationOptionWorkbookParser: workbookCodec.createParser,
 }))
 
 vi.stubGlobal("fetch", optionResponseFetch)
@@ -58,6 +84,18 @@ beforeEach(() => {
 registerSupplierOptionHookTests(supplierOptionRpc)
 registerSupplierOptionWorkspaceTests(supplierOptionRpc)
 registerSupplierOptionConflictTests(supplierOptionRpc)
+registerSupplierOptionImportWorkspaceTests({
+  baselineRpc,
+  fetchMock: optionResponseFetch,
+  supplierOptionRpc,
+  workbookCodec,
+})
+registerSupplierOptionImportConflictTests({
+  baselineRpc,
+  fetchMock: optionResponseFetch,
+  supplierOptionRpc,
+  workbookCodec,
+})
 registerSupplierOptionResponseTests({
   baselineRpc,
   fetchMock: optionResponseFetch,

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -255,6 +255,33 @@ describe("technical configuration baseline workspace integration", () => {
     }
   })
 
+  it("blocks outer back and tab navigation while the option workspace is pending", async () => {
+    const user = userEvent.setup()
+    const onBack = vi.fn()
+    baselineTabMock.dirty = false
+    supplierOptionsMock.dirty = true
+    supplierOptionsMock.navigationBlocked = true
+
+    try {
+      render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />)
+      await user.click(screen.getByRole("tab", { name: "Phương án" }))
+      expect(await screen.findByText(/Supplier option workspace revision/)).toBeInTheDocument()
+
+      const backButton = screen.getByRole("button", { name: "Danh sách hồ sơ" })
+      expect(backButton).toBeDisabled()
+      await user.click(backButton)
+      await user.click(screen.getByRole("tab", { name: "Sản phẩm tham chiếu" }))
+
+      expect(onBack).not.toHaveBeenCalled()
+      expect(screen.getByText(/Supplier option workspace revision/)).toBeInTheDocument()
+      expect(screen.queryByText("Reference product workspace")).not.toBeInTheDocument()
+    } finally {
+      baselineTabMock.dirty = true
+      supplierOptionsMock.dirty = false
+      supplierOptionsMock.navigationBlocked = false
+    }
+  })
+
   it("propagates an option mutation revision to another workspace tab", async () => {
     const user = userEvent.setup()
     baselineTabMock.dirty = false

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -198,7 +198,7 @@ describe("technical configuration dossier shell", () => {
       "Phương án",
       "So sánh & đánh giá",
     ])
-    expect(screen.getByRole("tab", { name: "Phương án" })).toBeDisabled()
+    expect(screen.getByRole("tab", { name: "Phương án" })).toBeEnabled()
     expect(screen.getByRole("tab", { name: "So sánh & đánh giá" })).toBeDisabled()
     expect(screen.queryByRole("button", { name: "Thêm nhóm" })).not.toBeInTheDocument()
   })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionImportDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionImportDialog.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import * as React from "react"
+
+import type { UseTechnicalConfigurationOptionImportResult } from "../technical-configuration-option-import-types"
+import {
+  BulkImportErrorAlert,
+  BulkImportFileInput,
+  BulkImportSubmitButton,
+  BulkImportSuccessMessage,
+  BulkImportValidationErrors,
+} from "@/components/bulk-import"
+import { DestructiveConfirmDialog } from "@/components/shared/DestructiveConfirmDialog"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+import { TechnicalConfigurationOptionImportPreview } from "./TechnicalConfigurationOptionImportPreview"
+
+/** Composes shared P5A import parts with the P9A2 authoritative preview/apply flow. */
+export function TechnicalConfigurationOptionImportDialog({
+  workflow,
+}: Readonly<{
+  workflow: UseTechnicalConfigurationOptionImportResult
+}>) {
+  const [isConfirmationOpen, setIsConfirmationOpen] = React.useState(false)
+  const {
+    open,
+    state,
+    fileInputRef,
+    preview,
+    operationError,
+    isPreviewing,
+    isApplying,
+    isPreviewStale,
+    onOpenChange,
+    handleFileChange,
+    reset,
+    applyPreview,
+  } = workflow
+  const payload = state.parsedData[0] ?? null
+  const recordCount = preview?.data.rows.length ?? payload?.rows.length ?? 0
+  const validationErrors = [
+    ...state.validationErrors,
+    ...(preview?.errors.map((error) => error.message) ?? []),
+  ]
+  const isBusy = isPreviewing || isApplying
+
+  const handleReset = React.useCallback(() => {
+    setIsConfirmationOpen(false)
+    reset()
+  }, [reset])
+  const handleConfirm = React.useCallback(() => {
+    setIsConfirmationOpen(false)
+    void applyPreview()
+  }, [applyPreview])
+  const handleDialogOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) setIsConfirmationOpen(false)
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange]
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+      <DialogContent
+        className="max-h-[92vh] overflow-y-auto sm:max-w-4xl"
+        showCloseButton={!isBusy && !isConfirmationOpen}
+        closeLabel="Đóng"
+        onEscapeKeyDown={(event) => {
+          if (isConfirmationOpen) event.preventDefault()
+        }}
+        onInteractOutside={(event) => {
+          if (isConfirmationOpen) event.preventDefault()
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>Nhập phản hồi phương án từ Excel</DialogTitle>
+          <DialogDescription>
+            Template là ảnh chụp đầy đủ của phương án trên đúng phiên bản cấu hình đã chọn.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <BulkImportFileInput
+            id="technical-configuration-option-import-file"
+            fileInputRef={fileInputRef}
+            onFileChange={(event) => void handleFileChange(event)}
+            disabled={isBusy || isConfirmationOpen}
+            accept=".xlsx, .xls"
+            label="Chọn template phản hồi phương án"
+          />
+          <div
+            role="alert"
+            aria-label="Lỗi nhập phản hồi phương án"
+            aria-live="assertive"
+            aria-atomic="true"
+            className="space-y-2"
+          >
+            <BulkImportErrorAlert error={state.parseError ?? operationError} />
+            <BulkImportValidationErrors errors={validationErrors} />
+          </div>
+
+          {state.selectedFile && payload ? (
+            <BulkImportSuccessMessage
+              fileName={state.selectedFile.name}
+              recordCount={payload.rows.length}
+            />
+          ) : null}
+
+          {isPreviewing ? (
+            <p className="text-sm text-muted-foreground" role="status">
+              Đang tạo bản xem trước từ máy chủ...
+            </p>
+          ) : null}
+
+          {preview ? (
+            <TechnicalConfigurationOptionImportPreview preview={preview} isStale={isPreviewStale} />
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleReset}
+            disabled={isBusy || isConfirmationOpen}
+          >
+            Đặt lại
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleDialogOpenChange(false)}
+            disabled={isBusy || isConfirmationOpen}
+          >
+            Hủy
+          </Button>
+          <BulkImportSubmitButton
+            isSubmitting={isApplying}
+            disabled={
+              isBusy ||
+              isConfirmationOpen ||
+              isPreviewStale ||
+              !preview ||
+              preview.errors.length > 0 ||
+              recordCount === 0
+            }
+            recordCount={recordCount}
+            labelSingular="dòng"
+            labelPlural="dòng"
+            onClick={() => setIsConfirmationOpen(true)}
+          />
+        </DialogFooter>
+      </DialogContent>
+      <DestructiveConfirmDialog
+        open={open && isConfirmationOpen}
+        onOpenChange={setIsConfirmationOpen}
+        title="Ghi đè toàn bộ phản hồi phương án?"
+        description="Mọi tiêu chí sẽ được đồng bộ theo bản xem trước. Ô trống sẽ xóa giá trị cũ tương ứng."
+        confirmLabel="Áp dụng import"
+        isPending={isApplying}
+        onConfirm={handleConfirm}
+      />
+    </Dialog>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionImportPreview.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionImportPreview.tsx
@@ -1,0 +1,63 @@
+import type { TechnicalConfigurationOptionImportPreviewWireResponse } from "../supplier-option-types"
+
+/** Renders the authoritative full-snapshot preview without exposing editable controls. */
+export function TechnicalConfigurationOptionImportPreview({
+  preview,
+  isStale,
+}: Readonly<{
+  preview: TechnicalConfigurationOptionImportPreviewWireResponse
+  isStale: boolean
+}>) {
+  const clearedRowCount = preview.data.rows.filter(
+    (row) => !row.response_text && !row.supplementary_information
+  ).length
+
+  return (
+    <section aria-label="Bản xem trước import" className="space-y-3 border-y py-4 text-sm">
+      <div>
+        <p className="font-medium">Bản xem trước toàn bộ {preview.data.rows.length} dòng</p>
+        <p className="mt-1 text-muted-foreground">
+          {clearedRowCount} dòng trống hoàn toàn sẽ xóa phản hồi đã lưu sau khi xác nhận.
+        </p>
+        {isStale ? (
+          <p className="mt-2 text-destructive">
+            Bản xem trước đang được xác thực lại theo revision mới.
+          </p>
+        ) : null}
+      </div>
+
+      <div className="max-h-80 overflow-y-auto border-y">
+        <ol className="divide-y">
+          {preview.data.rows.map((row) => (
+            <li key={row.criterion_id} className="space-y-3 py-3">
+              <div>
+                <p className="font-medium">{row.criterion_code}</p>
+                <p className="text-muted-foreground">
+                  {row.criterion_title ?? row.requirement_text}
+                </p>
+              </div>
+              <dl className="grid gap-3 sm:grid-cols-2">
+                <div>
+                  <dt className="text-xs font-medium text-muted-foreground">Phản hồi</dt>
+                  <dd className="mt-1 whitespace-pre-wrap break-words">
+                    {row.response_text || (
+                      <span className="text-destructive">Xóa phản hồi đã lưu</span>
+                    )}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-medium text-muted-foreground">Thông tin bổ sung</dt>
+                  <dd className="mt-1 whitespace-pre-wrap break-words">
+                    {row.supplementary_information || (
+                      <span className="text-destructive">Xóa thông tin bổ sung</span>
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
@@ -35,6 +35,7 @@ type TechnicalConfigurationOptionResponseEditorProps = {
   onNavigationBlockedChange?: (blocked: boolean) => void
   onRevisionChange?: (revision: number) => void
   requestDiscardConfirmation: (description: React.ReactNode, action: () => void) => void
+  isExternalMutationBlocked?: boolean
 }
 
 const CRITERION_STATUS_LABELS: Record<TechnicalConfigurationOptionResponseCriterionStatus, string> =
@@ -53,6 +54,7 @@ export function TechnicalConfigurationOptionResponseEditor({
   onNavigationBlockedChange,
   onRevisionChange,
   requestDiscardConfirmation,
+  isExternalMutationBlocked = false,
 }: Readonly<TechnicalConfigurationOptionResponseEditorProps>) {
   const state = useTechnicalConfigurationOptionResponses({
     dossier,
@@ -60,6 +62,7 @@ export function TechnicalConfigurationOptionResponseEditor({
     baselineVersion,
     onRevisionChange,
     onNavigationBlockedChange,
+    isMutationBlocked: isExternalMutationBlocked,
   })
   const [isCopyConfirmationOpen, setIsCopyConfirmationOpen] = React.useState(false)
 
@@ -231,7 +234,7 @@ export function TechnicalConfigurationOptionResponseEditor({
               criterion={state.selectedCriterion}
               draft={state.draft}
               updatedAt={state.updatedAt}
-              mode={state.isReadOnly ? "read-only" : "editable"}
+              mode={state.isReadOnly || state.isMutationBlocked ? "read-only" : "editable"}
               draftState={state.isConflict ? "conflict" : state.isDirty ? "dirty" : "clean"}
               operation={state.isSaving ? "saving" : state.isReloading ? "reloading" : "idle"}
               saveStatus={state.saveStatus}
@@ -249,12 +252,12 @@ export function TechnicalConfigurationOptionResponseEditor({
         </section>
       </div>
       <DestructiveConfirmDialog
-        open={isCopyConfirmationOpen && !state.isReadOnly}
+        open={isCopyConfirmationOpen && !state.isReadOnly && !state.isMutationBlocked}
         onOpenChange={setIsCopyConfirmationOpen}
         title="Ghi đè phản hồi hiện tại?"
         description="Phản hồi hiện tại sẽ được thay bằng nội dung cấu hình cơ bản. Thông tin bổ sung được giữ nguyên."
         confirmLabel="Ghi đè phản hồi"
-        isPending={state.isPending || state.isReadOnly}
+        isPending={state.isPending || state.isReadOnly || state.isMutationBlocked}
         onConfirm={handleConfirmRequirementCopy}
       />
     </div>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponses.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import * as React from "react"
-import { AlertCircle, Loader2, RefreshCw } from "lucide-react"
+import { AlertCircle, Download, Loader2, RefreshCw, Upload } from "lucide-react"
 
 import { useTechnicalConfigurationBaselineVersionSelection } from "../_hooks/useTechnicalConfigurationBaselineVersionSelection"
 import { useTechnicalConfigurationDiscardConfirmation } from "../_hooks/useTechnicalConfigurationDiscardConfirmation"
+import { useTechnicalConfigurationOptionImport } from "../_hooks/useTechnicalConfigurationOptionImport"
 import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 import type { TechnicalConfigurationDossierWire } from "../types"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -18,7 +19,9 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 
+import { TechnicalConfigurationOptionImportDialog } from "./TechnicalConfigurationOptionImportDialog"
 import { TechnicalConfigurationOptionResponseEditor } from "./TechnicalConfigurationOptionResponseEditor"
+
 type TechnicalConfigurationOptionResponsesProps = {
   dossier: TechnicalConfigurationDossierWire
   option: TechnicalConfigurationOptionWire
@@ -46,30 +49,10 @@ export function TechnicalConfigurationOptionResponses({
     versionOptions,
     versionState,
   } = selection
-  const [isDirty, setIsDirty] = React.useState(false)
-  const [isNavigationBlocked, setIsNavigationBlocked] = React.useState(false)
+  const [isResponseDirty, setIsResponseDirty] = React.useState(false)
+  const [isResponseNavigationBlocked, setIsResponseNavigationBlocked] = React.useState(false)
   const { discardConfirmationDialog, requestDiscardConfirmation } =
     useTechnicalConfigurationDiscardConfirmation()
-
-  React.useEffect(() => {
-    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent -- Baseline history refresh must not replace an exact-baseline response draft.
-    synchronizeVersion(isDirty)
-  }, [isDirty, synchronizeVersion])
-
-  const handleDirtyChange = React.useCallback(
-    (dirty: boolean) => {
-      setIsDirty(dirty)
-      onDirtyChange?.(dirty)
-    },
-    [onDirtyChange]
-  )
-  const handleNavigationBlockedChange = React.useCallback(
-    (blocked: boolean) => {
-      setIsNavigationBlocked(blocked)
-      onNavigationBlockedChange?.(blocked)
-    },
-    [onNavigationBlockedChange]
-  )
   const handleResponseRevisionChange = React.useCallback(
     (revision: number) => {
       handleRevisionChange(revision)
@@ -77,6 +60,35 @@ export function TechnicalConfigurationOptionResponses({
     },
     [handleRevisionChange, onRevisionChange]
   )
+  const importWorkflow = useTechnicalConfigurationOptionImport({
+    dossier,
+    option,
+    baselineVersion: selectedVersion,
+    isBlocked: isResponseDirty || isResponseNavigationBlocked,
+    onRevisionChange: handleResponseRevisionChange,
+  })
+  const isDirty = isResponseDirty || importWorkflow.isDirty
+  const isNavigationBlocked = isResponseNavigationBlocked || importWorkflow.isNavigationBlocked
+
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent -- Baseline history refresh must not replace an exact-baseline response draft.
+    synchronizeVersion(isDirty)
+  }, [isDirty, synchronizeVersion])
+
+  const handleDirtyChange = React.useCallback((dirty: boolean) => {
+    setIsResponseDirty(dirty)
+  }, [])
+  const handleNavigationBlockedChange = React.useCallback((blocked: boolean) => {
+    setIsResponseNavigationBlocked(blocked)
+  }, [])
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Manual response drafts and transient import state share one workspace dirty contract.
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Manual response operations and import lifecycle share one navigation block.
+    onNavigationBlockedChange?.(isNavigationBlocked)
+  }, [isNavigationBlocked, onNavigationBlockedChange])
   const handleVersionChange = React.useCallback(
     (versionId: string) => {
       const nextVersion = versionOptions.find((version) => version.id === versionId)
@@ -147,43 +159,69 @@ export function TechnicalConfigurationOptionResponses({
 
   return (
     <div className="space-y-5">
-      <div className="min-w-0">
-        <Label htmlFor="option-response-baseline-version">Phiên bản cấu hình cơ sở</Label>
-        <Select
-          value={selectedVersion.id}
-          disabled={isNavigationBlocked}
-          onValueChange={handleVersionSelect}
-        >
-          <SelectTrigger
-            id="option-response-baseline-version"
-            aria-label="Phiên bản cấu hình cơ sở"
-            className="mt-2 w-full sm:w-[320px]"
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0">
+          <Label htmlFor="option-response-baseline-version">Phiên bản cấu hình cơ sở</Label>
+          <Select
+            value={selectedVersion.id}
+            disabled={isNavigationBlocked}
+            onValueChange={handleVersionSelect}
           >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {versionOptions
-              .toSorted((left, right) => right.version_number - left.version_number)
-              .map((version) => (
-                <SelectItem key={version.id} value={version.id}>
-                  Phiên bản {version.version_number} ·{" "}
-                  {version.status === "locked" ? "Đã khóa" : "Bản nháp"}
+            <SelectTrigger
+              id="option-response-baseline-version"
+              aria-label="Phiên bản cấu hình cơ sở"
+              className="mt-2 w-full sm:w-[320px]"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {versionOptions
+                .toSorted((left, right) => right.version_number - left.version_number)
+                .map((version) => (
+                  <SelectItem key={version.id} value={version.id}>
+                    Phiên bản {version.version_number} ·{" "}
+                    {version.status === "locked" ? "Đã khóa" : "Bản nháp"}
+                  </SelectItem>
+                ))}
+              {versionState.versionsQuery.hasNextPage || versionState.hasHistoryRecoveryError ? (
+                <SelectItem
+                  value={LOAD_MORE_BASELINE_VERSIONS_VALUE}
+                  disabled={versionState.versionsQuery.isFetchingNextPage}
+                >
+                  {versionState.versionsQuery.isFetchingNextPage
+                    ? "Đang tải phiên bản..."
+                    : versionState.hasHistoryRecoveryError
+                      ? "Thử tải lại lịch sử phiên bản"
+                      : "Tải thêm phiên bản"}
                 </SelectItem>
-              ))}
-            {versionState.versionsQuery.hasNextPage || versionState.hasHistoryRecoveryError ? (
-              <SelectItem
-                value={LOAD_MORE_BASELINE_VERSIONS_VALUE}
-                disabled={versionState.versionsQuery.isFetchingNextPage}
-              >
-                {versionState.versionsQuery.isFetchingNextPage
-                  ? "Đang tải phiên bản..."
-                  : versionState.hasHistoryRecoveryError
-                    ? "Thử tải lại lịch sử phiên bản"
-                    : "Tải thêm phiên bản"}
-              </SelectItem>
-            ) : null}
-          </SelectContent>
-        </Select>
+              ) : null}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!importWorkflow.canUseActions || importWorkflow.isDownloading}
+            onClick={() => void importWorkflow.downloadTemplate()}
+          >
+            {importWorkflow.isDownloading ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Download className="size-4" aria-hidden="true" />
+            )}
+            Tải template phản hồi
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!importWorkflow.canUseActions}
+            onClick={importWorkflow.openDialog}
+          >
+            <Upload className="size-4" aria-hidden="true" />
+            Nhập phản hồi từ Excel
+          </Button>
+        </div>
       </div>
 
       <TechnicalConfigurationOptionResponseEditor
@@ -195,7 +233,9 @@ export function TechnicalConfigurationOptionResponses({
         onNavigationBlockedChange={handleNavigationBlockedChange}
         onRevisionChange={handleResponseRevisionChange}
         requestDiscardConfirmation={requestDiscardConfirmation}
+        isExternalMutationBlocked={importWorkflow.isNavigationBlocked}
       />
+      <TechnicalConfigurationOptionImportDialog workflow={importWorkflow} />
       {discardConfirmationDialog}
     </div>
   )

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionImport.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionImport.ts
@@ -1,0 +1,334 @@
+"use client"
+
+import * as React from "react"
+import { useQueryClient } from "@tanstack/react-query"
+
+import { useTechnicalConfigurationBeforeUnloadGuard } from "./useTechnicalConfigurationBeforeUnloadGuard"
+import { useTechnicalConfigurationOptionResponsesQuery } from "./useTechnicalConfigurationOptionResponsesQuery"
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import { isTechnicalConfigurationBaselineConflict } from "../technical-configuration-baseline-version-state"
+import {
+  fetchTechnicalConfigurationDossierRevision,
+  updateTechnicalConfigurationDossierRevisionCache,
+} from "../technical-configuration-dossier-revision-cache"
+import { technicalConfigurationDossierDetailQueryKey } from "../technical-configuration-query-keys"
+import {
+  getTechnicalConfigurationOptionImportErrorMessage,
+  toTechnicalConfigurationOptionWorkbookCriteria,
+  validateParsedTechnicalConfigurationOptionWorkbook,
+  withTechnicalConfigurationOptionImportRevision,
+} from "../technical-configuration-option-import-state"
+import { downloadTechnicalConfigurationOptionTemplate } from "../technical-configuration-option-import-download"
+import { selectNewestTechnicalConfigurationOptionResponseSnapshot } from "../technical-configuration-option-response-state"
+import {
+  applyTechnicalConfigurationOptionImport,
+  previewTechnicalConfigurationOptionImport,
+} from "../technical-configuration-option-import-rpc"
+import type {
+  UseTechnicalConfigurationOptionImportOptions,
+  UseTechnicalConfigurationOptionImportResult,
+} from "../technical-configuration-option-import-types"
+import type {
+  TechnicalConfigurationComparisonSetWire,
+  TechnicalConfigurationOptionImportPreviewWireResponse,
+} from "../supplier-option-types"
+import { useBulkImportState } from "@/components/bulk-import"
+import { type TechnicalConfigurationOptionWorkbookParseResult } from "@/lib/technical-configuration-option-excel-contract"
+import { createTechnicalConfigurationOptionWorkbookParser } from "@/lib/technical-configuration-option-excel-parse"
+
+/** Owns the transient P9A3 option workbook, preview, apply, and stale-retry lifecycle. */
+export function useTechnicalConfigurationOptionImport({
+  dossier,
+  option,
+  baselineVersion,
+  isBlocked,
+  onRevisionChange,
+}: UseTechnicalConfigurationOptionImportOptions): UseTechnicalConfigurationOptionImportResult {
+  const queryClient = useQueryClient()
+  const { queryKey, responseQuery } = useTechnicalConfigurationOptionResponsesQuery({
+    optionId: option.id,
+    baselineVersionId: baselineVersion?.id ?? null,
+  })
+  const [open, setOpen] = React.useState(false)
+  const [preview, setPreview] =
+    React.useState<TechnicalConfigurationOptionImportPreviewWireResponse | null>(null)
+  const [operationError, setOperationError] = React.useState<string | null>(null)
+  const [isPreviewing, setIsPreviewing] = React.useState(false)
+  const [isApplying, setIsApplying] = React.useState(false)
+  const [isPreviewStale, setIsPreviewStale] = React.useState(false)
+  const [isDownloading, setIsDownloading] = React.useState(false)
+  const [revisionOverride, setRevisionOverride] = React.useState<number | null>(null)
+  const previewedPayloadRef = React.useRef<TechnicalConfigurationOptionWorkbookParseResult | null>(
+    null
+  )
+  const currentRevision = Math.max(
+    dossier.revision,
+    option.revision,
+    baselineVersion?.revision ?? 0,
+    responseQuery.data?.revision ?? 0,
+    revisionOverride ?? 0
+  )
+  const expectedCriteria = React.useMemo(
+    () => (baselineVersion ? toTechnicalConfigurationOptionWorkbookCriteria(baselineVersion) : []),
+    [baselineVersion]
+  )
+  const parseWorkbook = React.useMemo(
+    () =>
+      createTechnicalConfigurationOptionWorkbookParser({
+        expectedMetadata: {
+          dossier_id: dossier.id,
+          option_id: option.id,
+          baseline_version_id: baselineVersion?.id ?? "",
+          dossier_revision: currentRevision,
+        },
+        expectedCriteria,
+      }),
+    [baselineVersion?.id, currentRevision, dossier.id, expectedCriteria, option.id]
+  )
+  const bulkImport = useBulkImportState<
+    TechnicalConfigurationOptionWorkbookParseResult,
+    TechnicalConfigurationOptionWorkbookParseResult
+  >({
+    parseWorkbook,
+    validateData: validateParsedTechnicalConfigurationOptionWorkbook,
+  })
+  const parsedPayload = bulkImport.state.parsedData[0] ?? null
+  const payload = React.useMemo(
+    () =>
+      parsedPayload
+        ? withTechnicalConfigurationOptionImportRevision(parsedPayload, currentRevision)
+        : null,
+    [currentRevision, parsedPayload]
+  )
+  const isReadOnly = Boolean(dossier.archived_at)
+  const isDirty = Boolean(
+    bulkImport.state.selectedFile ||
+    bulkImport.state.parseError ||
+    bulkImport.state.validationErrors.length > 0 ||
+    preview ||
+    isPreviewing ||
+    isApplying
+  )
+  const isNavigationBlocked = isDirty || isDownloading
+  const canUseActions =
+    baselineVersion !== null && !isReadOnly && !isBlocked && responseQuery.isSuccess
+
+  useTechnicalConfigurationBeforeUnloadGuard(isDirty)
+
+  const reset = React.useCallback(() => {
+    previewedPayloadRef.current = null
+    bulkImport.resetState()
+    setPreview(null)
+    setOperationError(null)
+    setIsPreviewStale(false)
+  }, [bulkImport])
+
+  const recoverFromConflict = React.useCallback(async () => {
+    setIsPreviewStale(true)
+    setOperationError(
+      "Hồ sơ đã thay đổi trên máy chủ. File, dữ liệu chuẩn hóa và bản xem trước vẫn được giữ."
+    )
+    try {
+      const refreshedRevision = await fetchTechnicalConfigurationDossierRevision(
+        queryClient,
+        dossier.id
+      )
+      setRevisionOverride(refreshedRevision)
+      onRevisionChange?.(refreshedRevision)
+    } catch {
+      setOperationError(
+        "Hồ sơ đã thay đổi nhưng không thể tải revision mới. File và bản xem trước vẫn được giữ."
+      )
+    }
+  }, [dossier.id, onRevisionChange, queryClient])
+
+  React.useEffect(() => {
+    if (!baselineVersion || !open || !payload || isBlocked || isReadOnly || isApplying) return
+
+    let cancelled = false
+    setIsPreviewing(true)
+    setOperationError(null)
+    previewedPayloadRef.current = null
+
+    void previewTechnicalConfigurationOptionImport({
+      p_option_id: option.id,
+      p_baseline_version_id: baselineVersion.id,
+      p_template_metadata: payload.metadata,
+      p_rows: payload.rows,
+      p_expected_revision: currentRevision,
+    })
+      .then((response) => {
+        if (cancelled) return
+        previewedPayloadRef.current = payload
+        setPreview(response)
+        setIsPreviewStale(false)
+      })
+      .catch(async (error: unknown) => {
+        if (cancelled) return
+        if (isTechnicalConfigurationBaselineConflict(error)) {
+          await recoverFromConflict()
+          return
+        }
+        setOperationError(
+          getTechnicalConfigurationOptionImportErrorMessage(
+            error,
+            "Không thể tạo bản xem trước phản hồi phương án."
+          )
+        )
+      })
+      .finally(() => {
+        if (!cancelled) setIsPreviewing(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    baselineVersion,
+    currentRevision,
+    isApplying,
+    isBlocked,
+    isReadOnly,
+    open,
+    option.id,
+    payload,
+    recoverFromConflict,
+  ])
+
+  const openDialog = React.useCallback(() => {
+    if (canUseActions) setOpen(true)
+  }, [canUseActions])
+  const onOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen && (isPreviewing || isApplying)) return
+      setOpen(nextOpen)
+    },
+    [isApplying, isPreviewing]
+  )
+  const handleFileChange = React.useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (!canUseActions) return
+      previewedPayloadRef.current = null
+      setPreview(null)
+      setOperationError(null)
+      setIsPreviewStale(false)
+      await bulkImport.handleFileChange(event)
+    },
+    [bulkImport, canUseActions]
+  )
+  const downloadTemplate = React.useCallback(async () => {
+    if (!canUseActions || !baselineVersion) return
+    setIsDownloading(true)
+    setOperationError(null)
+    try {
+      await downloadTechnicalConfigurationOptionTemplate({
+        dossier,
+        option,
+        baselineVersion,
+        comparisonSet: responseQuery.data ?? null,
+        revision: currentRevision,
+      })
+    } catch (error: unknown) {
+      setOperationError(
+        getTechnicalConfigurationOptionImportErrorMessage(
+          error,
+          "Không thể tải template phản hồi phương án."
+        )
+      )
+    } finally {
+      setIsDownloading(false)
+    }
+  }, [baselineVersion, canUseActions, currentRevision, dossier.id, option.id, responseQuery.data])
+  const applyPreview = React.useCallback(async () => {
+    const previewedPayload = previewedPayloadRef.current
+    if (
+      !baselineVersion ||
+      !previewedPayload ||
+      !preview ||
+      preview.errors.length > 0 ||
+      isPreviewStale ||
+      !canUseActions
+    ) {
+      return
+    }
+
+    setIsApplying(true)
+    setOperationError(null)
+    try {
+      const response = await applyTechnicalConfigurationOptionImport({
+        p_option_id: option.id,
+        p_baseline_version_id: baselineVersion.id,
+        p_template_metadata: previewedPayload.metadata,
+        p_rows: previewedPayload.rows,
+        p_expected_revision: previewedPayload.metadata.dossier_revision,
+      })
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey, exact: true }),
+        queryClient.cancelQueries({
+          queryKey: technicalConfigurationDossierDetailQueryKey(dossier.id),
+          exact: true,
+        }),
+      ])
+      const adoptedSnapshot =
+        queryClient.setQueryData<TechnicalConfigurationComparisonSetWire | null>(
+          queryKey,
+          (current) =>
+            selectNewestTechnicalConfigurationOptionResponseSnapshot(current, response.data)
+        ) ?? response.data
+      updateTechnicalConfigurationDossierRevisionCache(
+        queryClient,
+        dossier,
+        adoptedSnapshot.revision
+      )
+      onRevisionChange?.(adoptedSnapshot.revision)
+      reset()
+      setOpen(false)
+    } catch (error: unknown) {
+      if (isTechnicalConfigurationBaselineConflict(error)) {
+        await recoverFromConflict()
+      } else {
+        setOperationError(
+          getTechnicalConfigurationOptionImportErrorMessage(
+            error,
+            "Không thể áp dụng phản hồi phương án."
+          )
+        )
+      }
+    } finally {
+      setIsApplying(false)
+    }
+  }, [
+    baselineVersion,
+    canUseActions,
+    dossier,
+    isPreviewStale,
+    onRevisionChange,
+    option.id,
+    preview,
+    queryClient,
+    queryKey,
+    recoverFromConflict,
+    reset,
+  ])
+
+  return {
+    open,
+    state: bulkImport.state,
+    fileInputRef: bulkImport.fileInputRef,
+    preview,
+    operationError,
+    isPreviewing,
+    isApplying,
+    isPreviewStale,
+    isDownloading,
+    isDirty,
+    isNavigationBlocked,
+    canUseActions,
+    openDialog,
+    onOpenChange,
+    handleFileChange,
+    reset,
+    downloadTemplate,
+    applyPreview,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponseRevision.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponseRevision.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import * as React from "react"
+import { useQueryClient } from "@tanstack/react-query"
+
+import { updateTechnicalConfigurationDossierRevisionCache } from "../technical-configuration-dossier-revision-cache"
+import type { TechnicalConfigurationDossierWire } from "../types"
+
+/** Tracks and commits the monotonic dossier revision shared by option-response writes. */
+export function useTechnicalConfigurationOptionResponseRevision({
+  dossier,
+  initialRevision = dossier.revision,
+  onRevisionChange,
+}: {
+  dossier: TechnicalConfigurationDossierWire
+  initialRevision?: number
+  onRevisionChange?: (revision: number) => void
+}) {
+  const queryClient = useQueryClient()
+  const revisionRef = React.useRef<number | null>(null)
+  if (revisionRef.current === null) {
+    revisionRef.current = Math.max(dossier.revision, initialRevision)
+  }
+
+  const commitRevision = React.useCallback(
+    (nextRevision: number) => {
+      const committedRevision = Math.max(
+        revisionRef.current ?? dossier.revision,
+        dossier.revision,
+        nextRevision
+      )
+      revisionRef.current = committedRevision
+      onRevisionChange?.(committedRevision)
+      updateTechnicalConfigurationDossierRevisionCache(queryClient, dossier, committedRevision)
+    },
+    [dossier, onRevisionChange, queryClient]
+  )
+
+  React.useEffect(() => {
+    revisionRef.current = Math.max(revisionRef.current ?? dossier.revision, dossier.revision)
+  }, [dossier.revision])
+
+  return { commitRevision, revisionRef }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponses.ts
@@ -1,20 +1,19 @@
 import * as React from "react"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQueryClient } from "@tanstack/react-query"
 
 import { useTechnicalConfigurationBeforeUnloadGuard } from "./useTechnicalConfigurationBeforeUnloadGuard"
+import { useTechnicalConfigurationOptionResponseRevision } from "./useTechnicalConfigurationOptionResponseRevision"
+import { useTechnicalConfigurationOptionResponsesQuery } from "./useTechnicalConfigurationOptionResponsesQuery"
 import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
 import { isTechnicalConfigurationBaselineConflict } from "../technical-configuration-baseline-version-state"
+import { fetchTechnicalConfigurationDossierRevision } from "../technical-configuration-dossier-revision-cache"
 import {
-  fetchTechnicalConfigurationDossierRevision,
-  updateTechnicalConfigurationDossierRevisionCache,
-} from "../technical-configuration-dossier-revision-cache"
-import {
-  readTechnicalConfigurationComparisonSet,
   saveTechnicalConfigurationOptionResponse,
   TechnicalConfigurationOptionResponseSaveFailure,
 } from "../technical-configuration-option-response-operations"
 import {
   areTechnicalConfigurationOptionResponseDraftsEqual,
+  createTechnicalConfigurationOptionResponseInitialState,
   findTechnicalConfigurationOptionResponse,
   flattenTechnicalConfigurationBaselineCriteria,
   getTechnicalConfigurationOptionResponseErrorMessage,
@@ -25,7 +24,6 @@ import {
   type TechnicalConfigurationOptionResponseDraft,
   type TechnicalConfigurationOptionResponseDraftPatch,
 } from "../technical-configuration-option-response-state"
-import { technicalConfigurationOptionResponsesQueryKey } from "../technical-configuration-query-keys"
 import type {
   TechnicalConfigurationComparisonSetWire,
   TechnicalConfigurationOptionWire,
@@ -38,6 +36,7 @@ type UseTechnicalConfigurationOptionResponsesArgs = {
   baselineVersion: TechnicalConfigurationBaselineDraftWire
   onRevisionChange?: (revision: number) => void
   onNavigationBlockedChange?: (blocked: boolean) => void
+  isMutationBlocked?: boolean
 }
 
 /** Owns one option/exact-baseline response snapshot, local criterion draft, and explicit save. */
@@ -47,38 +46,22 @@ export function useTechnicalConfigurationOptionResponses({
   baselineVersion,
   onRevisionChange,
   onNavigationBlockedChange,
+  isMutationBlocked = false,
 }: UseTechnicalConfigurationOptionResponsesArgs) {
   const queryClient = useQueryClient()
-  const queryKey = React.useMemo(
-    () => technicalConfigurationOptionResponsesQueryKey(option.id, baselineVersion.id),
-    [baselineVersion.id, option.id]
-  )
+  const { queryKey, responseQuery } = useTechnicalConfigurationOptionResponsesQuery({
+    optionId: option.id,
+    baselineVersionId: baselineVersion.id,
+  })
   const criteria = React.useMemo(
     () => flattenTechnicalConfigurationBaselineCriteria(baselineVersion),
     [baselineVersion]
   )
-  const responseQuery = useQuery({
-    queryKey,
-    queryFn: ({ signal }) =>
-      readTechnicalConfigurationComparisonSet(
-        {
-          p_option_id: option.id,
-          p_baseline_version_id: baselineVersion.id,
-        },
-        signal
-      ),
-    staleTime: 30_000,
-    retry: false,
-    refetchOnWindowFocus: false,
-  })
-  const initialResponseState = React.useMemo(() => {
-    const selectedCriterionId = criteria[0]?.id ?? null
-    const snapshot = responseQuery.data ?? null
-    const draft = toTechnicalConfigurationOptionResponseDraft(
-      findTechnicalConfigurationOptionResponse(snapshot, selectedCriterionId)
-    )
-    return { selectedCriterionId, snapshot, draft }
-  }, [criteria, responseQuery.data])
+  const initialResponseState = React.useMemo(
+    () =>
+      createTechnicalConfigurationOptionResponseInitialState(criteria, responseQuery.data ?? null),
+    [criteria, responseQuery.data]
+  )
   const [selectedCriterionId, setSelectedCriterionId] = React.useState<string | null>(
     initialResponseState.selectedCriterionId
   )
@@ -99,39 +82,32 @@ export function useTechnicalConfigurationOptionResponses({
   const [saveStatus, setSaveStatus] = React.useState<"idle" | "saved">("idle")
   const activeOperationRef = React.useRef<"save" | "reload" | null>(null)
   const adoptedQueryAtRef = React.useRef(0)
-  const revisionRef = React.useRef<number | null>(null)
-  if (revisionRef.current === null) {
-    revisionRef.current = Math.max(dossier.revision, initialResponseState.snapshot?.revision ?? 0)
-  }
+  const { commitRevision, revisionRef } = useTechnicalConfigurationOptionResponseRevision({
+    dossier,
+    initialRevision: initialResponseState.snapshot?.revision,
+    onRevisionChange,
+  })
   const isReadOnly = Boolean(dossier.archived_at)
   const isDirty =
     !isReadOnly && !areTechnicalConfigurationOptionResponseDraftsEqual(baseDraft, draft)
   const visibleDraft = isReadOnly ? baseDraft : draft
-  const commitRevision = React.useCallback(
-    (nextRevision: number) => {
-      const committedRevision = Math.max(
-        revisionRef.current ?? dossier.revision,
-        dossier.revision,
-        nextRevision
-      )
-      revisionRef.current = committedRevision
-      onRevisionChange?.(committedRevision)
-      updateTechnicalConfigurationDossierRevisionCache(queryClient, dossier, committedRevision)
-    },
-    [dossier, onRevisionChange, queryClient]
-  )
   React.useEffect(() => {
+    const nextSnapshot = responseQuery.data ?? null
+    const hasNewerSnapshot =
+      (nextSnapshot?.revision ?? 0) > (snapshot?.revision ?? dossier.revision)
+    const wouldRegressSnapshot =
+      snapshot !== null && (nextSnapshot === null || nextSnapshot.revision < snapshot.revision)
     if (
       !responseQuery.isSuccess ||
       responseQuery.dataUpdatedAt === adoptedQueryAtRef.current ||
       isDirty ||
-      isConflict ||
+      (isConflict && !hasNewerSnapshot) ||
+      wouldRegressSnapshot ||
       activeOperationRef.current
     ) {
       return
     }
     adoptedQueryAtRef.current = responseQuery.dataUpdatedAt
-    const nextSnapshot = responseQuery.data
     const nextCriterionId = criteria.some((criterion) => criterion.id === selectedCriterionId)
       ? selectedCriterionId
       : (criteria[0]?.id ?? null)
@@ -159,29 +135,27 @@ export function useTechnicalConfigurationOptionResponses({
     responseQuery.data,
     responseQuery.dataUpdatedAt,
     responseQuery.isSuccess,
+    revisionRef,
     selectedCriterionId,
+    snapshot,
   ])
-
-  React.useEffect(() => {
-    revisionRef.current = Math.max(revisionRef.current ?? dossier.revision, dossier.revision)
-  }, [dossier.revision])
-
   useTechnicalConfigurationBeforeUnloadGuard(isDirty)
 
   const updateDraft = React.useCallback(
     (patch: TechnicalConfigurationOptionResponseDraftPatch) => {
-      if (isReadOnly || activeOperationRef.current) return
+      if (isReadOnly || isMutationBlocked || activeOperationRef.current) return
       setDraft((current) => ({ ...current, ...patch }))
       setValidationError(null)
       if (!isConflict) setOperationError(null)
       setSaveStatus("idle")
     },
-    [isConflict, isReadOnly]
+    [isConflict, isMutationBlocked, isReadOnly]
   )
 
   const selectCriterion = React.useCallback(
     (criterionId: string) => {
       if (
+        isMutationBlocked ||
         activeOperationRef.current ||
         !criteria.some((criterion) => criterion.id === criterionId)
       ) {
@@ -197,11 +171,11 @@ export function useTechnicalConfigurationOptionResponses({
       if (!isConflict) setOperationError(null)
       setSaveStatus("idle")
     },
-    [criteria, isConflict, snapshot]
+    [criteria, isConflict, isMutationBlocked, snapshot]
   )
 
   const save = React.useCallback(async () => {
-    if (isReadOnly || activeOperationRef.current || isConflict) return false
+    if (isReadOnly || isMutationBlocked || activeOperationRef.current || isConflict) return false
     const error = validateTechnicalConfigurationOptionResponseDraft(draft, selectedCriterionId)
     if (error) {
       setValidationError(error)
@@ -277,17 +251,19 @@ export function useTechnicalConfigurationOptionResponses({
     dossier.revision,
     draft,
     isConflict,
+    isMutationBlocked,
     isReadOnly,
     onNavigationBlockedChange,
     option.id,
     queryClient,
     queryKey,
+    revisionRef,
     selectedCriterionId,
     snapshot,
   ])
 
   const reload = React.useCallback(async () => {
-    if (activeOperationRef.current) return
+    if (isMutationBlocked || activeOperationRef.current) return
     const preserveDraft = isDirty
     activeOperationRef.current = "reload"
     setIsReloading(true)
@@ -326,6 +302,7 @@ export function useTechnicalConfigurationOptionResponses({
     commitRevision,
     dossier.id,
     isDirty,
+    isMutationBlocked,
     onNavigationBlockedChange,
     queryClient,
     responseQuery,
@@ -351,9 +328,10 @@ export function useTechnicalConfigurationOptionResponses({
     draft: visibleDraft,
     isDirty,
     isReadOnly,
+    isMutationBlocked,
     isSaving,
     isReloading,
-    isPending: isSaving || isReloading,
+    isPending: isSaving || isReloading || isMutationBlocked,
     isConflict,
     validationError,
     operationError,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponsesQuery.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionResponsesQuery.ts
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import { useQuery } from "@tanstack/react-query"
+
+import { readTechnicalConfigurationComparisonSet } from "../technical-configuration-option-response-operations"
+import { selectNewestTechnicalConfigurationOptionResponseSnapshot } from "../technical-configuration-option-response-state"
+import { technicalConfigurationOptionResponsesQueryKey } from "../technical-configuration-query-keys"
+import type { TechnicalConfigurationComparisonSetWire } from "../supplier-option-types"
+
+/** Reads one option/exact-baseline response snapshot through the shared query contract. */
+export function useTechnicalConfigurationOptionResponsesQuery({
+  optionId,
+  baselineVersionId,
+}: {
+  optionId: string
+  baselineVersionId: string | null
+}) {
+  const queryKey = React.useMemo(
+    () => technicalConfigurationOptionResponsesQueryKey(optionId, baselineVersionId ?? ""),
+    [baselineVersionId, optionId]
+  )
+  const responseQuery = useQuery<TechnicalConfigurationComparisonSetWire | null>({
+    queryKey,
+    queryFn: ({ signal }) => {
+      if (!baselineVersionId) return Promise.resolve(null)
+      return readTechnicalConfigurationComparisonSet(
+        {
+          p_option_id: optionId,
+          p_baseline_version_id: baselineVersionId,
+        },
+        signal
+      )
+    },
+    enabled: baselineVersionId !== null,
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+    structuralSharing: (current, incoming) =>
+      selectNewestTechnicalConfigurationOptionResponseSnapshot(
+        current as TechnicalConfigurationComparisonSetWire | null | undefined,
+        incoming as TechnicalConfigurationComparisonSetWire | null
+      ),
+  })
+
+  return { queryKey, responseQuery }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-option-import-download.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-option-import-download.ts
@@ -1,0 +1,49 @@
+import type { TechnicalConfigurationBaselineDraftWire } from "./baseline-types"
+import {
+  OPTION_WORKBOOK_MIME_TYPE,
+  toTechnicalConfigurationOptionWorkbookRows,
+} from "./technical-configuration-option-import-state"
+import type {
+  TechnicalConfigurationComparisonSetWire,
+  TechnicalConfigurationOptionWire,
+} from "./supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "./types"
+import { downloadBlob } from "@/lib/excel-workbook"
+import {
+  OPTION_WORKBOOK_TEMPLATE_KIND,
+  OPTION_WORKBOOK_TEMPLATE_VERSION,
+} from "@/lib/technical-configuration-option-excel-contract"
+import { createTechnicalConfigurationOptionWorkbook } from "@/lib/technical-configuration-option-excel-export"
+
+/** Downloads one exact-baseline supplier-option response snapshot through the P9A1 codec. */
+export async function downloadTechnicalConfigurationOptionTemplate({
+  dossier,
+  option,
+  baselineVersion,
+  comparisonSet,
+  revision,
+}: {
+  dossier: TechnicalConfigurationDossierWire
+  option: TechnicalConfigurationOptionWire
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  comparisonSet: TechnicalConfigurationComparisonSetWire | null
+  revision: number
+}) {
+  const workbook = await createTechnicalConfigurationOptionWorkbook({
+    metadata: {
+      template_kind: OPTION_WORKBOOK_TEMPLATE_KIND,
+      template_version: OPTION_WORKBOOK_TEMPLATE_VERSION,
+      dossier_id: dossier.id,
+      option_id: option.id,
+      baseline_version_id: baselineVersion.id,
+      dossier_revision: revision,
+      generated_at: new Date().toISOString(),
+    },
+    rows: toTechnicalConfigurationOptionWorkbookRows(baselineVersion, comparisonSet),
+  })
+  const buffer = await workbook.xlsx.writeBuffer()
+  downloadBlob(
+    new Blob([buffer], { type: OPTION_WORKBOOK_MIME_TYPE }),
+    `Mau_Phan_Hoi_Phuong_An_Phien_Ban_${baselineVersion.version_number}.xlsx`
+  )
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-option-import-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-option-import-state.ts
@@ -1,0 +1,94 @@
+import type { ValidationResult } from "@/components/bulk-import"
+import type {
+  TechnicalConfigurationOptionWorkbookCriterion,
+  TechnicalConfigurationOptionWorkbookParseResult,
+  TechnicalConfigurationOptionWorkbookRow,
+} from "@/lib/technical-configuration-option-excel-contract"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "./baseline-types"
+import type { TechnicalConfigurationComparisonSetWire } from "./supplier-option-types"
+
+/** MIME type used for supplier-option workbook downloads. */
+export const OPTION_WORKBOOK_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+/** Validates the shared parser boundary before authoritative preview. */
+export function validateParsedTechnicalConfigurationOptionWorkbook(
+  payloads: TechnicalConfigurationOptionWorkbookParseResult[]
+): ValidationResult<TechnicalConfigurationOptionWorkbookParseResult> {
+  if (payloads.length !== 1) {
+    return {
+      isValid: false,
+      validRecords: [],
+      errors: ["Template phải tạo đúng một payload phản hồi phương án."],
+    }
+  }
+
+  return {
+    isValid: true,
+    validRecords: payloads,
+    errors: [],
+  }
+}
+
+/** Converts an exact baseline into the ordered read-only workbook context. */
+export function toTechnicalConfigurationOptionWorkbookCriteria(
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+): TechnicalConfigurationOptionWorkbookCriterion[] {
+  return baselineVersion.groups
+    .toSorted((left, right) => left.sort_order - right.sort_order)
+    .flatMap((group) =>
+      group.criteria
+        .toSorted((left, right) => left.sort_order - right.sort_order)
+        .map((criterion) => ({
+          group_order: group.sort_order,
+          group_name: group.name,
+          criterion_order: criterion.sort_order,
+          criterion_id: criterion.id,
+          criterion_code: criterion.criterion_code,
+          criterion_title: criterion.title,
+          requirement_text: criterion.requirement_text,
+        }))
+    )
+}
+
+/** Builds the authoritative full-snapshot workbook rows from the cached response set. */
+export function toTechnicalConfigurationOptionWorkbookRows(
+  baselineVersion: TechnicalConfigurationBaselineDraftWire,
+  comparisonSet: TechnicalConfigurationComparisonSetWire | null
+): TechnicalConfigurationOptionWorkbookRow[] {
+  const responses = new Map(
+    comparisonSet?.responses.map((response) => [response.criterion_id, response]) ?? []
+  )
+
+  return toTechnicalConfigurationOptionWorkbookCriteria(baselineVersion).map((criterion) => {
+    const response = responses.get(criterion.criterion_id)
+    return {
+      ...criterion,
+      response_text: response?.response_text ?? "",
+      supplementary_information: response?.supplementary_information ?? "",
+    }
+  })
+}
+
+/** Rebinds transient parsed data to the refreshed dossier revision before re-preview. */
+export function withTechnicalConfigurationOptionImportRevision(
+  payload: TechnicalConfigurationOptionWorkbookParseResult,
+  revision: number
+): TechnicalConfigurationOptionWorkbookParseResult {
+  return {
+    metadata: {
+      ...payload.metadata,
+      dossier_revision: revision,
+    },
+    rows: payload.rows,
+  }
+}
+
+/** Returns a usable import error while preserving server-provided detail. */
+export function getTechnicalConfigurationOptionImportErrorMessage(
+  error: unknown,
+  fallback: string
+): string {
+  return error instanceof Error && error.message ? error.message : fallback
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-option-import-types.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-option-import-types.ts
@@ -1,0 +1,39 @@
+import type * as React from "react"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "./baseline-types"
+import type {
+  TechnicalConfigurationOptionImportPreviewWireResponse,
+  TechnicalConfigurationOptionWire,
+} from "./supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "./types"
+import type { BulkImportState } from "@/components/bulk-import/bulk-import-types"
+import type { TechnicalConfigurationOptionWorkbookParseResult } from "@/lib/technical-configuration-option-excel-contract"
+
+export type UseTechnicalConfigurationOptionImportOptions = {
+  dossier: TechnicalConfigurationDossierWire
+  option: TechnicalConfigurationOptionWire
+  baselineVersion: TechnicalConfigurationBaselineDraftWire | null
+  isBlocked: boolean
+  onRevisionChange?: (revision: number) => void
+}
+
+export interface UseTechnicalConfigurationOptionImportResult {
+  open: boolean
+  state: BulkImportState<TechnicalConfigurationOptionWorkbookParseResult>
+  fileInputRef: React.RefObject<HTMLInputElement | null>
+  preview: TechnicalConfigurationOptionImportPreviewWireResponse | null
+  operationError: string | null
+  isPreviewing: boolean
+  isApplying: boolean
+  isPreviewStale: boolean
+  isDownloading: boolean
+  isDirty: boolean
+  isNavigationBlocked: boolean
+  canUseActions: boolean
+  openDialog: () => void
+  onOpenChange: (open: boolean) => void
+  handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => Promise<void>
+  reset: () => void
+  downloadTemplate: () => Promise<void>
+  applyPreview: () => Promise<void>
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-option-response-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-option-response-state.ts
@@ -18,10 +18,25 @@ export type TechnicalConfigurationOptionResponseDraftPatch =
 
 export type TechnicalConfigurationOptionResponseCriterionStatus = "empty" | "persisted" | "dirty"
 
+export type TechnicalConfigurationOptionResponseInitialState = {
+  selectedCriterionId: string | null
+  snapshot: TechnicalConfigurationComparisonSetWire | null
+  draft: TechnicalConfigurationOptionResponseDraft
+}
+
 /** Empty local draft used when an exact-baseline comparison set has no response yet. */
 export const EMPTY_OPTION_RESPONSE_DRAFT: TechnicalConfigurationOptionResponseDraft = {
   responseText: "",
   supplementaryInformation: "",
+}
+
+/** Prevents exact-baseline response snapshots from moving backward in dossier revision. */
+export function selectNewestTechnicalConfigurationOptionResponseSnapshot(
+  current: TechnicalConfigurationComparisonSetWire | null | undefined,
+  incoming: TechnicalConfigurationComparisonSetWire | null
+): TechnicalConfigurationComparisonSetWire | null {
+  if (current && (!incoming || current.revision > incoming.revision)) return current
+  return incoming
 }
 
 /** Flattens exact-version criteria without changing the canonical baseline snapshot. */
@@ -78,6 +93,21 @@ export function toTechnicalConfigurationOptionResponseDraft(
   return {
     responseText: response.response_text,
     supplementaryInformation: response.supplementary_information,
+  }
+}
+
+/** Creates the first selected criterion, snapshot, and local draft for one response query. */
+export function createTechnicalConfigurationOptionResponseInitialState(
+  criteria: TechnicalConfigurationBaselineCriterionWire[],
+  snapshot: TechnicalConfigurationComparisonSetWire | null
+): TechnicalConfigurationOptionResponseInitialState {
+  const selectedCriterionId = criteria[0]?.id ?? null
+  return {
+    selectedCriterionId,
+    snapshot,
+    draft: toTechnicalConfigurationOptionResponseDraft(
+      findTechnicalConfigurationOptionResponse(snapshot, selectedCriterionId)
+    ),
   }
 }
 


### PR DESCRIPTION
## Summary

- add template download/import actions to the exact-baseline option-response workspace using the P9A1 codec, Blob helper, `useBulkImportState`, and shared dialog parts
- connect the P9A2 authoritative preview/apply flow with explicit confirmation, stale-revision preservation/re-preview, and complete snapshot cache adoption
- coordinate import pending/dirty state with supplier identity, manual response, baseline, tab, and dossier navigation guards while keeping locked baselines editable and archived dossiers read-only

## Scope

- P9A3 only
- no P9B evidence behavior
- no migration, RPC, schema, or live database writes

## Verification

- `format:check`, `verify:no-explicit-any`, `verify:dedupe`, TypeScript docstrings, and `typecheck`
- focused P9A3/dependency suite: 153/153 passed
- React Doctor changed scan: 100/100
- OpenSpec strict validation passed
- full technical-configuration module: 327/328 passed; the sole failure is the unchanged stale option-tab assertion tracked in #799

Closes #798

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Excel import to the supplier option workspace with template download, authoritative preview, and safe apply. Blocks edits/navigation while pending and keeps caches consistent across revisions and refetches.

- **New Features**
  - Template download via P9A1 codec using `createTechnicalConfigurationOptionWorkbook` and `downloadBlob`; includes exact baseline, persisted responses, and current dossier revision with a versioned filename.
  - Import dialog with file input, server-side preview, explicit confirmation, and apply; preview flags blank rows that will clear values and shows stale-preview status before auto re-preview.
  - Preserves file and preview on stale revision, refreshes revision, then re-previews before apply.
  - Blocks supplier/option/baseline/editor and outer navigation while import is pending or dirty; unified with manual response state; archived dossiers remain read-only.
  - Adopts the applied snapshot into caches, keeps it over in-flight refetches, and prevents lower-revision overwrites for `technicalConfigurationOptionResponses` and `technicalConfigurationDossierDetail`.

- **Refactors**
  - Added `useTechnicalConfigurationOptionImport`, `useTechnicalConfigurationOptionResponsesQuery`, and `useTechnicalConfigurationOptionResponseRevision`.
  - Introduced `TechnicalConfigurationOptionImportDialog` and `TechnicalConfigurationOptionImportPreview`, plus helpers for workbook criteria/rows and error mapping; added snapshot regression guard and initial state factory in response state.

<sup>Written for commit ddde986686baf55233dc26e7163863d0c8ac7015. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Excel template download and bulk import for supplier option responses.
  * Added import previews showing affected rows and responses that will be cleared.
  * Added confirmation prompts before applying imports.
  * Added conflict handling that refreshes previews when data changes.
  * Archived dossiers remain read-only, and navigation/editing is blocked during pending imports.

* **Bug Fixes**
  * Improved revision and cache handling to prevent stale imports or newer changes from being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->