### PR TITLE
test(technical-config): align dossier shell option-tab expectation

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -198,7 +198,7 @@ describe("technical configuration dossier shell", () => {
       "Phương án",
       "So sánh & đánh giá",
     ])
-    expect(screen.getByRole("tab", { name: "Phương án" })).toBeDisabled()
+    expect(screen.getByRole("tab", { name: "Phương án" })).toBeEnabled()
     expect(screen.getByRole("tab", { name: "So sánh & đánh giá" })).toBeDisabled()
     expect(screen.queryByRole("button", { name: "Thêm nhóm" })).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary
- align the dossier-shell test with the enabled `Phương án` tab
- keep `So sánh & đánh giá` explicitly covered as disabled
- make no production, P9A3, or P9B behavior changes

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused dossier-shell suite: 15/15
- full technical-configurations suite: 328/328
- React Doctor against the actual PR base: 100/100

Refs #799

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the dossier shell test with current UI: the "Phương án" tab is expected to be enabled; "So sánh & đánh giá" remains explicitly disabled. Test-only change with no production or P9A3/P9B behavior changes; matches tab-state requirements in #799.

<sup>Written for commit 3c2f832704d4b334e82bedcd880d5364bae6cb78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

