### PR TITLE
P9B1: Add option evidence DB and source contracts

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -383,21 +383,21 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P9B1 - Supplier Option Evidence Contracts
 
-- [ ] P9B1.1 Thêm option-level document URL metadata và exact-comparison-set
+- [x] P9B1.1 Thêm option-level document URL metadata và exact-comparison-set
       criterion citations với composite ownership/FK guards.
-- [ ] P9B1.2 Document được dùng chung cho option trên nhiều baseline; citation
+- [x] P9B1.2 Document được dùng chung cho option trên nhiều baseline; citation
       chỉ thuộc exact option + baseline + criterion.
-- [ ] P9B1.3 List theo option + baseline không tạo comparison set, trả document
+- [x] P9B1.3 List theo option + baseline không tạo comparison set, trả document
       dùng chung, citations của exact set và tổng affected citation count trên
       mọi baseline.
-- [ ] P9B1.4 Reuse authoritative P7B1 HTTP(S) validator trong option document
+- [x] P9B1.4 Reuse authoritative P7B1 HTTP(S) validator trong option document
       create/update; exact caller set tăng từ bốn lên sáu.
-- [ ] P9B1.5 Document/citation mutations dùng dossier revision, vẫn cho phép khi
+- [x] P9B1.5 Document/citation mutations dùng dossier revision, vẫn cho phép khi
       baseline locked và từ chối khi dossier archived.
-- [ ] P9B1.6 Confirmed document delete xóa document cùng mọi citation liên quan
+- [x] P9B1.6 Confirmed document delete xóa document cùng mọi citation liên quan
       trong một transaction; không có unconfirmed mutation.
-- [ ] P9B1.7 Thêm typed RPC names/wire types/wrappers/allowlist mà chưa mở UI.
-- [ ] P9B1.8 Chạy migration/source, role/claim, RLS/grants/search_path,
+- [x] P9B1.7 Thêm typed RPC names/wire types/wrappers/allowlist mà chưa mở UI.
+- [x] P9B1.8 Chạy migration/source, role/claim, RLS/grants/search_path,
       owner/version isolation, raw URL, affected-count, cascade, stale revision
       và exact-six-caller phase gates.
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-document-rpc.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-document-rpc.test.ts
@@ -298,4 +298,81 @@ describe("technical configuration document RPC adapter", () => {
     expect(documentDeleteResult).toEqual(documentDelete)
     expect(citationDeleteResult).toEqual(citationDelete)
   })
+
+  it("delegates the six dormant P9B1 option evidence wrappers unchanged", async () => {
+    const { DOCUMENT_RPC_FUNCTIONS } = await importDocumentRpcManifest()
+    const adapter = await importDocumentRpcAdapter()
+    const cases = [
+      [
+        "listTechnicalConfigurationOptionDocuments",
+        DOCUMENT_RPC_FUNCTIONS.listOptionDocuments,
+        {
+          p_option_id: "option-1",
+          p_baseline_version_id: "version-1",
+          p_page: 2,
+          p_page_size: 25,
+        },
+      ],
+      [
+        "createTechnicalConfigurationOptionDocument",
+        DOCUMENT_RPC_FUNCTIONS.createOptionDocument,
+        {
+          p_option_id: "option-1",
+          p_name: "Shared guide",
+          p_url: "https://example.com/guide.pdf",
+          p_expected_revision: 1,
+        },
+      ],
+      [
+        "updateTechnicalConfigurationOptionDocument",
+        DOCUMENT_RPC_FUNCTIONS.updateOptionDocument,
+        {
+          p_option_document_id: "option-document-1",
+          p_name: "Updated guide",
+          p_url: "https://example.com/updated.pdf",
+          p_expected_revision: 2,
+        },
+      ],
+      [
+        "deleteTechnicalConfigurationOptionDocument",
+        DOCUMENT_RPC_FUNCTIONS.deleteOptionDocument,
+        {
+          p_option_document_id: "option-document-1",
+          p_expected_revision: 3,
+        },
+      ],
+      [
+        "upsertTechnicalConfigurationOptionCitation",
+        DOCUMENT_RPC_FUNCTIONS.upsertOptionCitation,
+        {
+          p_option_document_id: "option-document-1",
+          p_comparison_set_id: "comparison-set-1",
+          p_criterion_id: "criterion-1",
+          p_page_section: "p. 4",
+          p_excerpt: "Exact criterion evidence",
+          p_expected_revision: 4,
+        },
+      ],
+      [
+        "deleteTechnicalConfigurationOptionCitation",
+        DOCUMENT_RPC_FUNCTIONS.deleteOptionCitation,
+        {
+          p_option_citation_id: "option-citation-1",
+          p_expected_revision: 5,
+        },
+      ],
+    ] as const
+
+    callRpcMock.mockResolvedValue({ data: null })
+    for (const [wrapperName, rpcName, args] of cases) {
+      const wrapper = adapter[wrapperName]
+      expect(typeof wrapper).toBe("function")
+      if (typeof wrapper === "function") {
+        await wrapper(args)
+      }
+      expect(callRpcMock).toHaveBeenLastCalledWith(rpcName, args, {
+        signal: undefined,
+      })
+    }
+  })
 })

--- a/src/app/(app)/technical-configurations/document-types.ts
+++ b/src/app/(app)/technical-configurations/document-types.ts
@@ -51,6 +51,39 @@ export interface TechnicalConfigurationCitationDeleteWireResponse {
   }
 }
 
+export interface TechnicalConfigurationOptionDocumentWire {
+  id: string
+  option_id: string
+  name: string
+  url: string
+  created_by: number
+  created_at: string
+  updated_at: string
+  affected_citation_count: number
+  citations: TechnicalConfigurationCitationWire[]
+}
+
+export interface TechnicalConfigurationOptionDocumentsListWireResponse {
+  data: TechnicalConfigurationOptionDocumentWire[]
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface TechnicalConfigurationOptionDocumentMutationWireResponse {
+  data: TechnicalConfigurationOptionDocumentWire & {
+    revision: number
+  }
+}
+
+export interface TechnicalConfigurationOptionDocumentDeleteWireResponse {
+  data: {
+    id: string
+    revision: number
+    affected_citation_count: number
+  }
+}
+
 export interface TechnicalConfigurationBaselineDocumentsListRpcArgs {
   p_baseline_version_id: string
   p_page?: number
@@ -118,5 +151,45 @@ export interface TechnicalConfigurationReferenceCitationUpsertRpcArgs {
 
 export interface TechnicalConfigurationReferenceCitationDeleteRpcArgs {
   p_reference_citation_id: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionDocumentsListRpcArgs {
+  p_option_id: string
+  p_baseline_version_id: string
+  p_page?: number
+  p_page_size?: number
+}
+
+export interface TechnicalConfigurationOptionDocumentCreateRpcArgs {
+  p_option_id: string
+  p_name: string
+  p_url: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionDocumentUpdateRpcArgs {
+  p_option_document_id: string
+  p_name: string
+  p_url: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionDocumentDeleteRpcArgs {
+  p_option_document_id: string
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionCitationUpsertRpcArgs {
+  p_option_document_id: string
+  p_comparison_set_id: string
+  p_criterion_id: string
+  p_page_section: string | null
+  p_excerpt: string | null
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationOptionCitationDeleteRpcArgs {
+  p_option_citation_id: string
   p_expected_revision: number
 }

--- a/src/app/(app)/technical-configurations/technical-configuration-document-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-document-rpc.ts
@@ -12,6 +12,15 @@ import type {
   TechnicalConfigurationDocumentDeleteWireResponse,
   TechnicalConfigurationDocumentMutationWireResponse,
   TechnicalConfigurationDocumentsListWireResponse,
+  TechnicalConfigurationOptionCitationDeleteRpcArgs,
+  TechnicalConfigurationOptionCitationUpsertRpcArgs,
+  TechnicalConfigurationOptionDocumentCreateRpcArgs,
+  TechnicalConfigurationOptionDocumentDeleteRpcArgs,
+  TechnicalConfigurationOptionDocumentDeleteWireResponse,
+  TechnicalConfigurationOptionDocumentsListRpcArgs,
+  TechnicalConfigurationOptionDocumentsListWireResponse,
+  TechnicalConfigurationOptionDocumentMutationWireResponse,
+  TechnicalConfigurationOptionDocumentUpdateRpcArgs,
   TechnicalConfigurationReferenceCitationDeleteRpcArgs,
   TechnicalConfigurationReferenceCitationUpsertRpcArgs,
   TechnicalConfigurationReferenceDocumentCreateRpcArgs,
@@ -125,6 +134,66 @@ export function deleteTechnicalConfigurationReferenceCitation(
   signal?: AbortSignal
 ): Promise<TechnicalConfigurationCitationDeleteWireResponse> {
   return callTechnicalConfigurationRpc(DOCUMENT_RPC_FUNCTIONS.deleteReferenceCitation, args, {
+    signal,
+  })
+}
+
+/** Lists option-owned evidence documents for one exact baseline comparison. */
+export function listTechnicalConfigurationOptionDocuments(
+  args: TechnicalConfigurationOptionDocumentsListRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionDocumentsListWireResponse> {
+  return callTechnicalConfigurationRpc(DOCUMENT_RPC_FUNCTIONS.listOptionDocuments, args, {
+    signal,
+  })
+}
+
+/** Creates one option-owned evidence document. */
+export function createTechnicalConfigurationOptionDocument(
+  args: TechnicalConfigurationOptionDocumentCreateRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionDocumentMutationWireResponse> {
+  return callTechnicalConfigurationRpc(DOCUMENT_RPC_FUNCTIONS.createOptionDocument, args, {
+    signal,
+  })
+}
+
+/** Updates one option-owned evidence document with dossier revision control. */
+export function updateTechnicalConfigurationOptionDocument(
+  args: TechnicalConfigurationOptionDocumentUpdateRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionDocumentMutationWireResponse> {
+  return callTechnicalConfigurationRpc(DOCUMENT_RPC_FUNCTIONS.updateOptionDocument, args, {
+    signal,
+  })
+}
+
+/** Deletes an option document and all exact-baseline citations linked to it. */
+export function deleteTechnicalConfigurationOptionDocument(
+  args: TechnicalConfigurationOptionDocumentDeleteRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionDocumentDeleteWireResponse> {
+  return callTechnicalConfigurationRpc(DOCUMENT_RPC_FUNCTIONS.deleteOptionDocument, args, {
+    signal,
+  })
+}
+
+/** Creates or updates an option citation for one exact comparison-set criterion. */
+export function upsertTechnicalConfigurationOptionCitation(
+  args: TechnicalConfigurationOptionCitationUpsertRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationCitationMutationWireResponse> {
+  return callTechnicalConfigurationRpc(DOCUMENT_RPC_FUNCTIONS.upsertOptionCitation, args, {
+    signal,
+  })
+}
+
+/** Deletes one exact option citation with dossier revision control. */
+export function deleteTechnicalConfigurationOptionCitation(
+  args: TechnicalConfigurationOptionCitationDeleteRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationCitationDeleteWireResponse> {
+  return callTechnicalConfigurationRpc(DOCUMENT_RPC_FUNCTIONS.deleteOptionCitation, args, {
     signal,
   })
 }

--- a/src/app/api/rpc/__tests__/technical-configuration-option-documents-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-option-documents-migration.test.ts
@@ -387,6 +387,8 @@ $$;
 
   it("ships the rollback-only P9B1 phase gate contract", () => {
     expect(existsSync(PHASE_GATE_PATH)).toBe(true)
+    expect(phaseGateSource).toContain("SHARE ROW EXCLUSIVE")
+    expect(phaseGateSource).toContain("quiesced maintenance window")
     for (const marker of [
       "BEGIN;",
       "pg_advisory_xact_lock",

--- a/src/app/api/rpc/__tests__/technical-configuration-option-documents-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-option-documents-migration.test.ts
@@ -1,0 +1,436 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = process.cwd()
+const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
+const MIGRATION_FILE = "20260726020000_technical_configuration_option_evidence.sql"
+const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const PHASE_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_option_documents_phase_gate.sql"
+)
+const RPC_NAMES_PATH = path.join(REPO_ROOT, "src/lib/technical-configuration-document-rpcs.ts")
+const TYPES_PATH = path.join(REPO_ROOT, "src/app/(app)/technical-configurations/document-types.ts")
+const ADAPTER_PATH = path.join(
+  REPO_ROOT,
+  "src/app/(app)/technical-configurations/technical-configuration-document-rpc.ts"
+)
+const ALLOWLIST_PATH = path.join(REPO_ROOT, "src/app/api/rpc/[fn]/allowed-functions.ts")
+
+const TABLE_NAMES = [
+  "technical_configuration_option_documents",
+  "technical_configuration_option_citations",
+] as const
+
+const OPTION_DOCUMENT_RPC_FUNCTIONS = {
+  listOptionDocuments: "technical_configuration_option_documents_list",
+  createOptionDocument: "technical_configuration_option_document_create",
+  updateOptionDocument: "technical_configuration_option_document_update",
+  deleteOptionDocument: "technical_configuration_option_document_delete",
+  upsertOptionCitation: "technical_configuration_option_citation_upsert",
+  deleteOptionCitation: "technical_configuration_option_citation_delete",
+} as const
+
+const OPTION_DOCUMENT_RPC_NAMES = Object.values(OPTION_DOCUMENT_RPC_FUNCTIONS)
+
+const RPC_ARGUMENTS: Record<(typeof OPTION_DOCUMENT_RPC_NAMES)[number], string> = {
+  technical_configuration_option_documents_list:
+    "p_option_id UUID, p_baseline_version_id UUID, p_page INTEGER DEFAULT 1, p_page_size INTEGER DEFAULT 50",
+  technical_configuration_option_document_create:
+    "p_option_id UUID, p_name TEXT, p_url TEXT, p_expected_revision BIGINT",
+  technical_configuration_option_document_update:
+    "p_option_document_id UUID, p_name TEXT, p_url TEXT, p_expected_revision BIGINT",
+  technical_configuration_option_document_delete:
+    "p_option_document_id UUID, p_expected_revision BIGINT",
+  technical_configuration_option_citation_upsert:
+    "p_option_document_id UUID, p_comparison_set_id UUID, p_criterion_id UUID, p_page_section TEXT, p_excerpt TEXT, p_expected_revision BIGINT",
+  technical_configuration_option_citation_delete:
+    "p_option_citation_id UUID, p_expected_revision BIGINT",
+}
+
+const RPC_ARG_INTERFACES: Record<string, string[]> = {
+  TechnicalConfigurationOptionDocumentsListRpcArgs: [
+    "p_option_id: string",
+    "p_baseline_version_id: string",
+    "p_page?: number",
+    "p_page_size?: number",
+  ],
+  TechnicalConfigurationOptionDocumentCreateRpcArgs: [
+    "p_option_id: string",
+    "p_name: string",
+    "p_url: string",
+    "p_expected_revision: number",
+  ],
+  TechnicalConfigurationOptionDocumentUpdateRpcArgs: [
+    "p_option_document_id: string",
+    "p_name: string",
+    "p_url: string",
+    "p_expected_revision: number",
+  ],
+  TechnicalConfigurationOptionDocumentDeleteRpcArgs: [
+    "p_option_document_id: string",
+    "p_expected_revision: number",
+  ],
+  TechnicalConfigurationOptionCitationUpsertRpcArgs: [
+    "p_option_document_id: string",
+    "p_comparison_set_id: string",
+    "p_criterion_id: string",
+    "p_page_section: string | null",
+    "p_excerpt: string | null",
+    "p_expected_revision: number",
+  ],
+  TechnicalConfigurationOptionCitationDeleteRpcArgs: [
+    "p_option_citation_id: string",
+    "p_expected_revision: number",
+  ],
+}
+
+const URL_VALIDATOR_FUNCTION = "_technical_configuration_validate_document_url"
+const EXPECTED_URL_CALLERS = [
+  "technical_configuration_baseline_document_create",
+  "technical_configuration_baseline_document_update",
+  "technical_configuration_reference_document_create",
+  "technical_configuration_reference_document_update",
+  "technical_configuration_option_document_create",
+  "technical_configuration_option_document_update",
+]
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function countOccurrences(source: string, needle: string): number {
+  return source.split(needle).length - 1
+}
+
+function normalizeSql(source: string): string {
+  return source.replace(/\s+/g, " ").replace(/\(\s+/g, "(").replace(/\s+\)/g, ")").trim()
+}
+
+function getCreateTableBlock(source: string, tableName: string): string {
+  const start = source.indexOf(`CREATE TABLE public.${tableName} (`)
+  if (start < 0) return ""
+  const end = source.indexOf("\n);", start)
+  return end < 0 ? source.slice(start) : source.slice(start, end + 3)
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  const start = source.indexOf(`CREATE OR REPLACE FUNCTION public.${functionName}(`)
+  if (start < 0) return ""
+  const end = source.indexOf("$$;", start)
+  return end < 0 ? source.slice(start) : source.slice(start, end + 3)
+}
+
+function getFunctionArguments(source: string, functionName: string): string {
+  const block = getFunctionBlock(source, functionName)
+  const match = block.match(
+    new RegExp(
+      `CREATE OR REPLACE FUNCTION public\\.${functionName}\\(([\\s\\S]*?)\\)\\s*RETURNS JSONB`
+    )
+  )
+  return match ? normalizeSql(match[1]) : ""
+}
+
+function getInterfaceFields(source: string, interfaceName: string): string[] {
+  const match = source.match(new RegExp(`export interface ${interfaceName} \\{([\\s\\S]*?)\\n\\}`))
+  if (!match) return []
+  return match[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+const migrationSource = readIfExists(MIGRATION_PATH)
+const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+const rpcNamesSource = readIfExists(RPC_NAMES_PATH)
+const typesSource = readIfExists(TYPES_PATH)
+const adapterSource = readIfExists(ADAPTER_PATH)
+const allowlistSource = readIfExists(ALLOWLIST_PATH)
+
+describe("technical configuration P9B1 option evidence contracts", () => {
+  it("ships one correctly ordered migration after P9A2", () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true)
+    expect(MIGRATION_FILE > "20260725060000_technical_configuration_option_import.sql").toBe(true)
+    expect(migrationSource).toContain("BEGIN;")
+    expect(migrationSource).toContain("COMMIT;")
+  })
+
+  it("creates option-owned documents and exact comparison-set citations", () => {
+    const createdTables = [
+      ...migrationSource.matchAll(/CREATE TABLE public\.(technical_configuration_[a-z_]+)/g),
+    ].map((match) => match[1])
+    expect(createdTables).toEqual(TABLE_NAMES)
+
+    for (const tableName of TABLE_NAMES) {
+      const block = getCreateTableBlock(migrationSource, tableName)
+      expect(block).toContain("id UUID PRIMARY KEY DEFAULT gen_random_uuid()")
+      expect(block).toContain("created_at TIMESTAMPTZ NOT NULL DEFAULT now()")
+      expect(block).toContain("created_by BIGINT NOT NULL")
+      expect(block).toContain("updated_at TIMESTAMPTZ NOT NULL DEFAULT now()")
+      expect(block).toContain("updated_by BIGINT NOT NULL")
+    }
+
+    const documentBlock = getCreateTableBlock(
+      migrationSource,
+      "technical_configuration_option_documents"
+    )
+    expect(documentBlock).toContain("option_id UUID NOT NULL")
+    expect(documentBlock).not.toContain("baseline_version_id")
+    expect(documentBlock).toContain("UNIQUE (id, option_id)")
+    expect(documentBlock).toMatch(
+      /FOREIGN KEY \(option_id\)\s+REFERENCES public\.technical_configuration_options \(id\)\s+ON DELETE CASCADE/
+    )
+
+    const citationBlock = getCreateTableBlock(
+      migrationSource,
+      "technical_configuration_option_citations"
+    )
+    for (const column of [
+      "option_id UUID NOT NULL",
+      "baseline_version_id UUID NOT NULL",
+      "comparison_set_id UUID NOT NULL",
+      "option_document_id UUID NOT NULL",
+      "criterion_id UUID NOT NULL",
+    ]) {
+      expect(citationBlock).toContain(column)
+    }
+    expect(citationBlock).toContain("UNIQUE (option_document_id, comparison_set_id, criterion_id)")
+
+    const normalized = normalizeSql(migrationSource)
+    expect(normalized).toContain("UNIQUE (id, option_id, baseline_version_id)")
+    for (const foreignKey of [
+      "FOREIGN KEY (option_document_id, option_id) REFERENCES public.technical_configuration_option_documents (id, option_id) ON DELETE CASCADE",
+      "FOREIGN KEY (comparison_set_id, option_id, baseline_version_id) REFERENCES public.technical_configuration_comparison_sets (id, option_id, baseline_version_id) ON DELETE CASCADE",
+      "FOREIGN KEY (criterion_id, baseline_version_id) REFERENCES public.technical_configuration_baseline_criteria (id, baseline_version_id) ON DELETE CASCADE",
+    ]) {
+      expect(normalized).toContain(foreignKey)
+    }
+  })
+
+  it("indexes every option document and citation ownership lookup", () => {
+    const normalized = normalizeSql(migrationSource)
+    for (const indexColumns of [
+      "technical_configuration_option_documents (option_id)",
+      "technical_configuration_option_citations (option_document_id, option_id)",
+      "technical_configuration_option_citations (comparison_set_id, option_id, baseline_version_id)",
+      "technical_configuration_option_citations (criterion_id, baseline_version_id)",
+    ]) {
+      expect(normalized).toContain(`ON public.${indexColumns}`)
+    }
+  })
+
+  it("keeps both tables deny-by-default behind service-role access", () => {
+    const normalized = normalizeSql(migrationSource)
+    for (const tableName of TABLE_NAMES) {
+      expect(normalized).toContain(`ALTER TABLE public.${tableName} ENABLE ROW LEVEL SECURITY;`)
+      expect(normalized).toContain(
+        `REVOKE ALL ON TABLE public.${tableName} FROM PUBLIC, anon, authenticated;`
+      )
+      expect(normalized).toContain(
+        `GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.${tableName} TO service_role;`
+      )
+    }
+  })
+
+  it("defines exactly six secured option evidence RPC signatures", () => {
+    const normalized = normalizeSql(migrationSource)
+    const createdFunctions = [
+      ...migrationSource.matchAll(
+        /CREATE OR REPLACE FUNCTION public\.(technical_configuration_option_(?:documents_list|document_create|document_update|document_delete|citation_upsert|citation_delete))\(/g
+      ),
+    ].map((match) => match[1])
+    expect(createdFunctions).toEqual(OPTION_DOCUMENT_RPC_NAMES)
+
+    for (const functionName of OPTION_DOCUMENT_RPC_NAMES) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(getFunctionArguments(migrationSource, functionName)).toBe(
+        normalizeSql(RPC_ARGUMENTS[functionName])
+      )
+      expect(block).toContain("RETURNS JSONB")
+      expect(block).toContain("SECURITY DEFINER")
+      expect(block).toContain("SET search_path = public, pg_temp")
+      expect(migrationSource).toContain(`REVOKE ALL ON FUNCTION public.${functionName}(`)
+      expect(migrationSource).toContain(`GRANT EXECUTE ON FUNCTION public.${functionName}(`)
+    }
+    expect(countOccurrences(normalized, "TO authenticated;")).toBe(OPTION_DOCUMENT_RPC_NAMES.length)
+    expect(normalized).not.toContain("TO authenticated, service_role;")
+  })
+
+  it("keeps list side-effect-free and exact-set scoped", () => {
+    const block = getFunctionBlock(
+      migrationSource,
+      OPTION_DOCUMENT_RPC_FUNCTIONS.listOptionDocuments
+    )
+    const citationCountsBlock = block.slice(
+      block.indexOf("citation_counts AS"),
+      block.indexOf("exact_citations AS")
+    )
+    expect(block).toContain("public._technical_configuration_require_global_user()")
+    expect(block).toContain("p_option_id")
+    expect(block).toContain("p_baseline_version_id")
+    expect(block).toContain("technical_configuration_comparison_sets")
+    expect(block).toContain("affected_citation_count")
+    expect(block).toContain("'citations'")
+    expect(block).toContain("'[]'::JSONB")
+    expect(block).toContain("OFFSET ((v_page - 1)::BIGINT * v_page_size)")
+    expect(normalizeSql(citationCountsBlock)).toContain(
+      "FROM paged p JOIN public.technical_configuration_option_citations c ON c.option_document_id = p.id"
+    )
+    expect(citationCountsBlock).not.toContain("WHERE c.option_id = p_option_id")
+    expect(block).not.toMatch(/\bINSERT INTO\b/)
+    expect(block).not.toMatch(/\bUPDATE public\./)
+    expect(block).not.toMatch(/\bDELETE FROM\b/)
+    expect(block).not.toContain("FOR UPDATE")
+  })
+
+  it("authorizes every mutation before any object lookup", () => {
+    for (const functionName of OPTION_DOCUMENT_RPC_NAMES.slice(1)) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      const begin = block.indexOf("BEGIN")
+      const globalGuard = block.indexOf(
+        "public._technical_configuration_require_global_user()",
+        begin
+      )
+      const firstLookup = block.indexOf("\n  SELECT", begin)
+
+      expect(globalGuard).toBeGreaterThan(begin)
+      expect(firstLookup).toBeGreaterThan(globalGuard)
+    }
+  })
+
+  it("uses dossier revision mutations without baseline lock guards", () => {
+    for (const functionName of OPTION_DOCUMENT_RPC_NAMES.slice(1)) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain("public._technical_configuration_require_editable_dossier(")
+      expect(block).toContain("p_expected_revision")
+      expect(block).toContain("UPDATE public.technical_configuration_dossiers")
+      expect(block).not.toContain(
+        "public._technical_configuration_require_editable_baseline_version("
+      )
+      expect(block).not.toMatch(/status\s*=\s*'locked'/)
+    }
+  })
+
+  it("calls the authoritative URL validator from exactly six create/update RPCs", () => {
+    const documentMigrationSource = readdirSync(MIGRATIONS_DIR)
+      .filter((file) => file.endsWith(".sql"))
+      .sort()
+      .map((file) => readFileSync(path.join(MIGRATIONS_DIR, file), "utf8"))
+      .join("\n")
+    const functionNames = [
+      ...documentMigrationSource.matchAll(/CREATE OR REPLACE FUNCTION public\.([a-z0-9_]+)\(/g),
+    ].map((match) => match[1])
+    const callers = [...new Set(functionNames)]
+      .filter((functionName) =>
+        getFunctionBlock(documentMigrationSource, functionName).includes(
+          `public.${URL_VALIDATOR_FUNCTION}(p_url)`
+        )
+      )
+      .sort()
+
+    expect(callers).toEqual([...EXPECTED_URL_CALLERS].sort())
+
+    for (const functionName of [
+      OPTION_DOCUMENT_RPC_FUNCTIONS.createOptionDocument,
+      OPTION_DOCUMENT_RPC_FUNCTIONS.updateOptionDocument,
+    ]) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      const validatorCall = block.indexOf(`public.${URL_VALIDATOR_FUNCTION}(p_url)`)
+      const write = functionName.endsWith("_create")
+        ? block.indexOf("INSERT INTO public.technical_configuration_option_documents")
+        : block.indexOf("UPDATE public.technical_configuration_option_documents")
+      const revisionBump = block.indexOf("UPDATE public.technical_configuration_dossiers")
+      expect(countOccurrences(block, `public.${URL_VALIDATOR_FUNCTION}(p_url)`)).toBe(1)
+      expect(validatorCall).toBeGreaterThanOrEqual(0)
+      expect(write).toBeGreaterThan(validatorCall)
+      expect(revisionBump).toBeGreaterThan(write)
+    }
+  })
+
+  it("cascades confirmed document deletion and reports affected citations", () => {
+    const block = getFunctionBlock(
+      migrationSource,
+      OPTION_DOCUMENT_RPC_FUNCTIONS.deleteOptionDocument
+    )
+    expect(block).toContain("technical_configuration_option_citations")
+    expect(block).toContain("affected_citation_count")
+    expect(block).toContain("DELETE FROM public.technical_configuration_option_documents")
+    expect(block).not.toContain("COMMIT")
+  })
+
+  it("ships the rollback-only P9B1 phase gate contract", () => {
+    expect(existsSync(PHASE_GATE_PATH)).toBe(true)
+    for (const marker of [
+      "BEGIN;",
+      "pg_advisory_xact_lock",
+      "technical_configuration_option_documents",
+      "technical_configuration_option_citations",
+      "technical_configuration_option_documents_list",
+      "technical_configuration_option_document_delete",
+      "technical_configuration_option_citation_upsert",
+      "SAVEPOINT",
+      "ROLLBACK TO SAVEPOINT",
+      "SET LOCAL request.jwt.claims",
+      "has zero policies",
+      "denies PUBLIC table access",
+      "denies anon table access",
+      "allows service_role table CRUD",
+      "denies PUBLIC function execute",
+      "denies service_role function execute",
+      "unauthorized create hides missing option",
+      "unauthorized update hides missing document",
+      "unauthorized document delete hides missing document",
+      "unauthorized citation upsert hides missing document",
+      "unauthorized citation delete hides missing citation",
+      "raw admin role accepted",
+      "archived dossier list remains readable",
+      "large page remains valid",
+      "document update succeeds",
+      "citation delete succeeds",
+      "invalid URL performs zero writes",
+      "failure injection",
+      "ROLLBACK;",
+    ]) {
+      expect(phaseGateSource).toContain(marker)
+    }
+    expect(phaseGateSource).toContain("'42501', 'permission_denied'")
+    expect(phaseGateSource).toContain("'PT409', 'archived_dossier'")
+    expect(phaseGateSource).not.toContain("'42501', 'Missing role claim'")
+    expect(phaseGateSource).not.toContain("'PT409', 'archived'")
+  })
+
+  it("adds the dormant manifest, wire contracts, wrappers, and allowlist only", () => {
+    for (const [key, rpcName] of Object.entries(OPTION_DOCUMENT_RPC_FUNCTIONS)) {
+      expect(rpcNamesSource).toContain(`${key}: "${rpcName}"`)
+      expect(allowlistSource).toContain("...DOCUMENT_RPC_FUNCTION_NAMES")
+    }
+
+    for (const exportName of [
+      "TechnicalConfigurationOptionDocumentWire",
+      "TechnicalConfigurationOptionDocumentsListWireResponse",
+      "TechnicalConfigurationOptionDocumentMutationWireResponse",
+      "TechnicalConfigurationOptionDocumentDeleteWireResponse",
+    ]) {
+      expect(typesSource).toContain(`export interface ${exportName}`)
+    }
+    expect(typesSource).toContain("option_id: string")
+    expect(typesSource).toContain("affected_citation_count: number")
+    expect(typesSource).toContain("citations: TechnicalConfigurationCitationWire[]")
+
+    for (const [interfaceName, fields] of Object.entries(RPC_ARG_INTERFACES)) {
+      expect(getInterfaceFields(typesSource, interfaceName)).toEqual(fields)
+    }
+
+    for (const functionName of [
+      "listTechnicalConfigurationOptionDocuments",
+      "createTechnicalConfigurationOptionDocument",
+      "updateTechnicalConfigurationOptionDocument",
+      "deleteTechnicalConfigurationOptionDocument",
+      "upsertTechnicalConfigurationOptionCitation",
+      "deleteTechnicalConfigurationOptionCitation",
+    ]) {
+      expect(adapterSource).toContain(`export function ${functionName}(`)
+    }
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-option-documents-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-option-documents-migration.test.ts
@@ -116,7 +116,7 @@ function getCreateTableBlock(source: string, tableName: string): string {
 }
 
 function getFunctionBlock(source: string, functionName: string): string {
-  const start = source.indexOf(`CREATE OR REPLACE FUNCTION public.${functionName}(`)
+  const start = source.lastIndexOf(`CREATE OR REPLACE FUNCTION public.${functionName}(`)
   if (start < 0) return ""
   const end = source.indexOf("$$;", start)
   return end < 0 ? source.slice(start) : source.slice(start, end + 3)
@@ -154,6 +154,32 @@ describe("technical configuration P9B1 option evidence contracts", () => {
     expect(MIGRATION_FILE > "20260725060000_technical_configuration_option_import.sql").toBe(true)
     expect(migrationSource).toContain("BEGIN;")
     expect(migrationSource).toContain("COMMIT;")
+  })
+
+  it("reads the latest function definition from concatenated migration history", () => {
+    const history = `
+CREATE OR REPLACE FUNCTION public.example_document_rpc()
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN '{"version":"old"}'::JSONB;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.example_document_rpc()
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN '{"version":"current"}'::JSONB;
+END;
+$$;
+`
+
+    const block = getFunctionBlock(history, "example_document_rpc")
+    expect(block).toContain('{"version":"current"}')
+    expect(block).not.toContain('{"version":"old"}')
   })
 
   it("creates option-owned documents and exact comparison-set citations", () => {

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -39,6 +39,15 @@ const REFERENCE_DOCUMENT_RPC_FUNCTIONS = [
   "technical_configuration_reference_citation_delete",
 ] as const
 
+const OPTION_DOCUMENT_RPC_FUNCTIONS = [
+  "technical_configuration_option_documents_list",
+  "technical_configuration_option_document_create",
+  "technical_configuration_option_document_update",
+  "technical_configuration_option_document_delete",
+  "technical_configuration_option_citation_upsert",
+  "technical_configuration_option_citation_delete",
+] as const
+
 const P7A1_REFERENCE_RPC_FUNCTIONS = [
   "technical_configuration_reference_products_list",
   "technical_configuration_reference_product_create",
@@ -106,7 +115,7 @@ describe("technical configuration dossier RPC whitelist", () => {
 })
 
 describe("technical configuration baseline RPC whitelist", () => {
-  it("keeps the ordered P7B1 document RPC manifest split by owner", async () => {
+  it("keeps the ordered P7B1/P9B1 document RPC manifest split by owner", async () => {
     const { DOCUMENT_RPC_FUNCTION_NAMES } = (await vi.importActual(
       "@/lib/technical-configuration-document-rpcs"
     )) as { DOCUMENT_RPC_FUNCTION_NAMES: readonly string[] }
@@ -114,6 +123,7 @@ describe("technical configuration baseline RPC whitelist", () => {
     expect(DOCUMENT_RPC_FUNCTION_NAMES).toEqual([
       ...BASELINE_DOCUMENT_RPC_FUNCTIONS,
       ...REFERENCE_DOCUMENT_RPC_FUNCTIONS,
+      ...OPTION_DOCUMENT_RPC_FUNCTIONS,
     ])
   })
 
@@ -191,7 +201,9 @@ describe("technical configuration option RPC whitelist", () => {
           fn === "technical_configuration_options_list" ||
           (fn.startsWith("technical_configuration_option_") &&
             !fn.startsWith("technical_configuration_option_import_") &&
-            !fn.startsWith("technical_configuration_option_response_"))
+            !fn.startsWith("technical_configuration_option_response_") &&
+            !fn.startsWith("technical_configuration_option_document") &&
+            !fn.startsWith("technical_configuration_option_citation_"))
       )
     ).toEqual(P8A2_OPTION_RPC_FUNCTIONS)
   })
@@ -202,6 +214,29 @@ describe("technical configuration option RPC whitelist", () => {
     expect(response.status).toBe(411)
     await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
   })
+
+  it("allowlists exactly the six P9B1 option evidence RPCs", () => {
+    expect(
+      [...ALLOWED_FUNCTIONS].filter(
+        (fn) =>
+          fn === "technical_configuration_option_documents_list" ||
+          fn.startsWith("technical_configuration_option_document_") ||
+          fn.startsWith("technical_configuration_option_citation_")
+      )
+    ).toEqual(OPTION_DOCUMENT_RPC_FUNCTIONS)
+  })
+
+  it.each(OPTION_DOCUMENT_RPC_FUNCTIONS)(
+    'allows option evidence RPC "%s" through the whitelist',
+    async (fn) => {
+      const response = await invokeRpcProxy(fn)
+
+      expect(response.status).toBe(411)
+      await expect(response.json()).resolves.toEqual({
+        error: "Content-Length header required",
+      })
+    }
+  )
 })
 
 describe("technical configuration option response RPC whitelist", () => {

--- a/src/lib/technical-configuration-document-rpcs.ts
+++ b/src/lib/technical-configuration-document-rpcs.ts
@@ -1,4 +1,4 @@
-/** Named P7B1 evidence RPCs shared by client and server code. */
+/** Named P7B1/P9B1 evidence RPCs shared by client and server code. */
 export const DOCUMENT_RPC_FUNCTIONS = {
   listBaselineDocuments: "technical_configuration_baseline_documents_list",
   createBaselineDocument: "technical_configuration_baseline_document_create",
@@ -11,7 +11,13 @@ export const DOCUMENT_RPC_FUNCTIONS = {
   deleteReferenceDocument: "technical_configuration_reference_document_delete",
   upsertReferenceCitation: "technical_configuration_reference_citation_upsert",
   deleteReferenceCitation: "technical_configuration_reference_citation_delete",
+  listOptionDocuments: "technical_configuration_option_documents_list",
+  createOptionDocument: "technical_configuration_option_document_create",
+  updateOptionDocument: "technical_configuration_option_document_update",
+  deleteOptionDocument: "technical_configuration_option_document_delete",
+  upsertOptionCitation: "technical_configuration_option_citation_upsert",
+  deleteOptionCitation: "technical_configuration_option_citation_delete",
 } as const
 
-/** Ordered P7B1 RPC names for allowlists and contract iteration. */
+/** Ordered P7B1/P9B1 RPC names for allowlists and contract iteration. */
 export const DOCUMENT_RPC_FUNCTION_NAMES = Object.values(DOCUMENT_RPC_FUNCTIONS)

--- a/supabase/migrations/20260726020000_technical_configuration_option_evidence.sql
+++ b/supabase/migrations/20260726020000_technical_configuration_option_evidence.sql
@@ -1,0 +1,554 @@
+-- P9B1: option-owned URL documents and exact-baseline criterion citations.
+BEGIN;
+
+ALTER TABLE public.technical_configuration_comparison_sets
+  ADD CONSTRAINT technical_configuration_comparison_sets_id_option_version_key
+  UNIQUE (id, option_id, baseline_version_id);
+
+CREATE TABLE public.technical_configuration_option_documents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  option_id UUID NOT NULL,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by BIGINT NOT NULL,
+  UNIQUE (id, option_id),
+  CHECK (btrim(name) <> ''),
+  FOREIGN KEY (option_id)
+    REFERENCES public.technical_configuration_options (id)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE public.technical_configuration_option_citations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  option_id UUID NOT NULL,
+  baseline_version_id UUID NOT NULL,
+  comparison_set_id UUID NOT NULL,
+  option_document_id UUID NOT NULL,
+  criterion_id UUID NOT NULL,
+  page_section TEXT,
+  excerpt TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by BIGINT NOT NULL,
+  UNIQUE (option_document_id, comparison_set_id, criterion_id),
+  FOREIGN KEY (option_document_id, option_id)
+    REFERENCES public.technical_configuration_option_documents (id, option_id)
+    ON DELETE CASCADE,
+  FOREIGN KEY (comparison_set_id, option_id, baseline_version_id)
+    REFERENCES public.technical_configuration_comparison_sets (
+      id, option_id, baseline_version_id
+    )
+    ON DELETE CASCADE,
+  FOREIGN KEY (criterion_id, baseline_version_id)
+    REFERENCES public.technical_configuration_baseline_criteria (id, baseline_version_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX technical_configuration_option_documents_option_idx
+  ON public.technical_configuration_option_documents (option_id);
+CREATE INDEX technical_configuration_option_citations_document_option_idx
+  ON public.technical_configuration_option_citations (option_document_id, option_id);
+CREATE INDEX technical_configuration_option_citations_set_option_version_idx
+  ON public.technical_configuration_option_citations (
+    comparison_set_id, option_id, baseline_version_id
+  );
+CREATE INDEX technical_configuration_option_citations_criterion_version_idx
+  ON public.technical_configuration_option_citations (criterion_id, baseline_version_id);
+
+ALTER TABLE public.technical_configuration_option_documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.technical_configuration_option_citations ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.technical_configuration_option_documents
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.technical_configuration_option_citations
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE public.technical_configuration_option_documents TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE public.technical_configuration_option_citations TO service_role;
+
+CREATE OR REPLACE FUNCTION public._technical_configuration_option_document_payload(
+  p_option_document_id UUID,
+  p_baseline_version_id UUID DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT jsonb_build_object(
+    'id', d.id,
+    'option_id', d.option_id,
+    'name', d.name,
+    'url', d.url,
+    'created_by', d.created_by,
+    'created_at', d.created_at,
+    'updated_at', d.updated_at,
+    'affected_citation_count', (
+      SELECT count(*)
+      FROM public.technical_configuration_option_citations linked
+      WHERE linked.option_document_id = d.id
+    ),
+    'citations', CASE
+      WHEN p_baseline_version_id IS NULL THEN '[]'::JSONB
+      ELSE COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+          'id', c.id,
+          'criterion_id', c.criterion_id,
+          'page_section', c.page_section,
+          'excerpt', c.excerpt
+        ) ORDER BY c.created_at, c.id)
+        FROM public.technical_configuration_option_citations c
+        WHERE c.option_document_id = d.id
+          AND c.option_id = d.option_id
+          AND c.baseline_version_id = p_baseline_version_id
+      ), '[]'::JSONB)
+    END
+  )
+  FROM public.technical_configuration_option_documents d
+  WHERE d.id = p_option_document_id;
+$$;
+
+REVOKE ALL ON FUNCTION public._technical_configuration_option_document_payload(
+  UUID, UUID
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_option_document_payload(
+  UUID, UUID
+) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_documents_list(
+  p_option_id UUID,
+  p_baseline_version_id UUID,
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_page INTEGER := COALESCE(p_page, 1);
+  v_page_size INTEGER := COALESCE(p_page_size, 50);
+  v_option_dossier_id UUID;
+  v_version_dossier_id UUID;
+  v_result JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  IF v_page < 1 OR v_page_size < 1 OR v_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  SELECT o.dossier_id
+  INTO v_option_dossier_id
+  FROM public.technical_configuration_options o
+  WHERE o.id = p_option_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  SELECT v.dossier_id
+  INTO v_version_dossier_id
+  FROM public.technical_configuration_baseline_versions v
+  WHERE v.id = p_baseline_version_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  IF v_option_dossier_id IS DISTINCT FROM v_version_dossier_id THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  WITH documents AS (
+    SELECT d.*
+    FROM public.technical_configuration_option_documents d
+    WHERE d.option_id = p_option_id
+  ),
+  paged AS (
+    SELECT d.*
+    FROM documents d
+    ORDER BY d.created_at, d.id
+    LIMIT v_page_size
+    OFFSET ((v_page - 1)::BIGINT * v_page_size)
+  ),
+  citation_counts AS (
+    SELECT c.option_document_id, count(*) AS affected_citation_count
+    FROM paged p
+    JOIN public.technical_configuration_option_citations c
+      ON c.option_document_id = p.id
+    GROUP BY c.option_document_id
+  ),
+  exact_citations AS (
+    SELECT
+      c.option_document_id,
+      jsonb_agg(jsonb_build_object(
+        'id', c.id,
+        'criterion_id', c.criterion_id,
+        'page_section', c.page_section,
+        'excerpt', c.excerpt
+      ) ORDER BY c.created_at, c.id) AS citations
+    FROM public.technical_configuration_option_citations c
+    JOIN public.technical_configuration_comparison_sets comparison_set
+      ON comparison_set.id = c.comparison_set_id
+     AND comparison_set.option_id = p_option_id
+     AND comparison_set.baseline_version_id = p_baseline_version_id
+    GROUP BY c.option_document_id
+  )
+  SELECT jsonb_build_object(
+    'data', COALESCE(jsonb_agg(jsonb_build_object(
+      'id', d.id,
+      'option_id', d.option_id,
+      'name', d.name,
+      'url', d.url,
+      'created_by', d.created_by,
+      'created_at', d.created_at,
+      'updated_at', d.updated_at,
+      'affected_citation_count', COALESCE(counts.affected_citation_count, 0),
+      'citations', COALESCE(exact.citations, '[]'::JSONB)
+    ) ORDER BY d.created_at, d.id), '[]'::JSONB),
+    'total', (SELECT count(*) FROM documents),
+    'page', v_page,
+    'page_size', v_page_size
+  )
+  INTO v_result
+  FROM paged d
+  LEFT JOIN citation_counts counts ON counts.option_document_id = d.id
+  LEFT JOIN exact_citations exact ON exact.option_document_id = d.id;
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_document_create(
+  p_option_id UUID,
+  p_name TEXT,
+  p_url TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dossier_id UUID;
+  v_user_id BIGINT;
+  v_document_id UUID;
+  v_revision BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT o.dossier_id INTO v_dossier_id
+  FROM public.technical_configuration_options o
+  WHERE o.id = p_option_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id, p_expected_revision
+  );
+  IF p_name IS NULL OR btrim(p_name) = '' THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  PERFORM public._technical_configuration_validate_document_url(p_url);
+
+  INSERT INTO public.technical_configuration_option_documents (
+    option_id, name, url, created_by, updated_by
+  )
+  VALUES (p_option_id, btrim(p_name), p_url, v_user_id, v_user_id)
+  RETURNING id INTO v_document_id;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1, updated_at = now(), updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object(
+    'data',
+    public._technical_configuration_option_document_payload(v_document_id, NULL)
+      || jsonb_build_object('revision', v_revision)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_document_update(
+  p_option_document_id UUID,
+  p_name TEXT,
+  p_url TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dossier_id UUID;
+  v_user_id BIGINT;
+  v_revision BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT o.dossier_id INTO v_dossier_id
+  FROM public.technical_configuration_option_documents d
+  JOIN public.technical_configuration_options o ON o.id = d.option_id
+  WHERE d.id = p_option_document_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id, p_expected_revision
+  );
+  IF p_name IS NULL OR btrim(p_name) = '' THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  PERFORM public._technical_configuration_validate_document_url(p_url);
+
+  UPDATE public.technical_configuration_option_documents
+  SET name = btrim(p_name), url = p_url, updated_at = now(), updated_by = v_user_id
+  WHERE id = p_option_document_id;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1, updated_at = now(), updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object(
+    'data',
+    public._technical_configuration_option_document_payload(p_option_document_id, NULL)
+      || jsonb_build_object('revision', v_revision)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_document_delete(
+  p_option_document_id UUID,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dossier_id UUID;
+  v_user_id BIGINT;
+  v_revision BIGINT;
+  v_affected_citation_count BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT o.dossier_id INTO v_dossier_id
+  FROM public.technical_configuration_option_documents d
+  JOIN public.technical_configuration_options o ON o.id = d.option_id
+  WHERE d.id = p_option_document_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id, p_expected_revision
+  );
+  SELECT count(*) INTO v_affected_citation_count
+  FROM public.technical_configuration_option_citations
+  WHERE option_document_id = p_option_document_id;
+
+  DELETE FROM public.technical_configuration_option_documents
+  WHERE id = p_option_document_id;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1, updated_at = now(), updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object('data', jsonb_build_object(
+    'id', p_option_document_id,
+    'revision', v_revision,
+    'affected_citation_count', v_affected_citation_count
+  ));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_citation_upsert(
+  p_option_document_id UUID,
+  p_comparison_set_id UUID,
+  p_criterion_id UUID,
+  p_page_section TEXT,
+  p_excerpt TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_option_id UUID;
+  v_dossier_id UUID;
+  v_set_option_id UUID;
+  v_set_dossier_id UUID;
+  v_baseline_version_id UUID;
+  v_criterion_version_id UUID;
+  v_user_id BIGINT;
+  v_citation_id UUID;
+  v_revision BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT d.option_id, o.dossier_id
+  INTO v_option_id, v_dossier_id
+  FROM public.technical_configuration_option_documents d
+  JOIN public.technical_configuration_options o ON o.id = d.option_id
+  WHERE d.id = p_option_document_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  SELECT cs.option_id, cs.dossier_id, cs.baseline_version_id
+  INTO v_set_option_id, v_set_dossier_id, v_baseline_version_id
+  FROM public.technical_configuration_comparison_sets cs
+  WHERE cs.id = p_comparison_set_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  IF v_option_id IS DISTINCT FROM v_set_option_id
+     OR v_dossier_id IS DISTINCT FROM v_set_dossier_id THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  SELECT c.baseline_version_id INTO v_criterion_version_id
+  FROM public.technical_configuration_baseline_criteria c
+  WHERE c.id = p_criterion_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  IF v_baseline_version_id IS DISTINCT FROM v_criterion_version_id THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id, p_expected_revision
+  );
+  INSERT INTO public.technical_configuration_option_citations (
+    option_id, baseline_version_id, comparison_set_id, option_document_id,
+    criterion_id, page_section, excerpt, created_by, updated_by
+  )
+  VALUES (
+    v_option_id, v_baseline_version_id, p_comparison_set_id, p_option_document_id,
+    p_criterion_id, p_page_section, p_excerpt, v_user_id, v_user_id
+  )
+  ON CONFLICT (option_document_id, comparison_set_id, criterion_id) DO UPDATE
+  SET page_section = EXCLUDED.page_section,
+      excerpt = EXCLUDED.excerpt,
+      updated_at = now(),
+      updated_by = EXCLUDED.updated_by
+  RETURNING id INTO v_citation_id;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1, updated_at = now(), updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object('data', (
+    SELECT jsonb_build_object(
+      'id', c.id,
+      'criterion_id', c.criterion_id,
+      'page_section', c.page_section,
+      'excerpt', c.excerpt,
+      'revision', v_revision
+    )
+    FROM public.technical_configuration_option_citations c
+    WHERE c.id = v_citation_id
+  ));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_option_citation_delete(
+  p_option_citation_id UUID,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_dossier_id UUID;
+  v_user_id BIGINT;
+  v_revision BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  SELECT o.dossier_id INTO v_dossier_id
+  FROM public.technical_configuration_option_citations c
+  JOIN public.technical_configuration_option_documents d
+    ON d.id = c.option_document_id
+  JOIN public.technical_configuration_options o ON o.id = d.option_id
+  WHERE c.id = p_option_citation_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  v_user_id := public._technical_configuration_require_editable_dossier(
+    v_dossier_id, p_expected_revision
+  );
+  DELETE FROM public.technical_configuration_option_citations
+  WHERE id = p_option_citation_id;
+
+  UPDATE public.technical_configuration_dossiers
+  SET revision = revision + 1, updated_at = now(), updated_by = v_user_id
+  WHERE id = v_dossier_id
+  RETURNING revision INTO v_revision;
+
+  RETURN jsonb_build_object('data', jsonb_build_object(
+    'id', p_option_citation_id,
+    'revision', v_revision
+  ));
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_option_documents_list(
+  UUID, UUID, INTEGER, INTEGER
+) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_document_create(
+  UUID, TEXT, TEXT, BIGINT
+) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_document_update(
+  UUID, TEXT, TEXT, BIGINT
+) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_document_delete(
+  UUID, BIGINT
+) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_citation_upsert(
+  UUID, UUID, UUID, TEXT, TEXT, BIGINT
+) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_option_citation_delete(
+  UUID, BIGINT
+) FROM PUBLIC, anon, authenticated, service_role;
+
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_documents_list(
+  UUID, UUID, INTEGER, INTEGER
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_document_create(
+  UUID, TEXT, TEXT, BIGINT
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_document_update(
+  UUID, TEXT, TEXT, BIGINT
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_document_delete(
+  UUID, BIGINT
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_citation_upsert(
+  UUID, UUID, UUID, TEXT, TEXT, BIGINT
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_option_citation_delete(
+  UUID, BIGINT
+) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/technical_configuration_option_documents_phase_gate.sql
+++ b/supabase/tests/technical_configuration_option_documents_phase_gate.sql
@@ -1,0 +1,601 @@
+-- Rollback-only P9B1 option evidence contract and behavior gate.
+BEGIN;
+SET LOCAL request.jwt.claims = '{}';
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT COALESCE(p_condition, false) THEN
+    RAISE EXCEPTION 'assertion_failed: %', p_label;
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.set_claims(p_role TEXT, p_user_id BIGINT)
+RETURNS VOID
+LANGUAGE sql
+AS $$
+  SELECT set_config(
+    'request.jwt.claims',
+    jsonb_build_object('app_role', p_role, 'user_id', p_user_id::TEXT)::TEXT,
+    true
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.expect_error(
+  p_label TEXT,
+  p_sql TEXT,
+  p_expected_state TEXT,
+  p_expected_message TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_state TEXT;
+  v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_sql;
+    RAISE EXCEPTION 'expected_error_not_raised: %', p_label;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_state = RETURNED_SQLSTATE, v_message = MESSAGE_TEXT;
+    IF v_state = 'P0001' AND v_message LIKE 'expected_error_not_raised:%' THEN
+      RAISE;
+    END IF;
+    IF v_state IS DISTINCT FROM p_expected_state
+       OR v_message IS DISTINCT FROM p_expected_message THEN
+      RAISE EXCEPTION '% expected [%] %, got [%] %',
+        p_label, p_expected_state, p_expected_message, v_state, v_message;
+    END IF;
+  END;
+END;
+$$;
+
+DO $$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossier_id UUID := gen_random_uuid();
+  v_archived_dossier_id UUID := gen_random_uuid();
+  v_other_dossier_id UUID := gen_random_uuid();
+  v_supplier_id UUID := gen_random_uuid();
+  v_archived_supplier_id UUID := gen_random_uuid();
+  v_other_supplier_id UUID := gen_random_uuid();
+  v_option_id UUID := gen_random_uuid();
+  v_archived_option_id UUID := gen_random_uuid();
+  v_other_option_id UUID := gen_random_uuid();
+  v_version_id UUID := gen_random_uuid();
+  v_second_version_id UUID := gen_random_uuid();
+  v_empty_version_id UUID := gen_random_uuid();
+  v_archived_version_id UUID := gen_random_uuid();
+  v_other_version_id UUID := gen_random_uuid();
+  v_group_id UUID := gen_random_uuid();
+  v_second_group_id UUID := gen_random_uuid();
+  v_empty_group_id UUID := gen_random_uuid();
+  v_archived_group_id UUID := gen_random_uuid();
+  v_other_group_id UUID := gen_random_uuid();
+  v_criterion_id UUID := gen_random_uuid();
+  v_second_criterion_id UUID := gen_random_uuid();
+  v_empty_criterion_id UUID := gen_random_uuid();
+  v_archived_criterion_id UUID := gen_random_uuid();
+  v_other_criterion_id UUID := gen_random_uuid();
+  v_set_id UUID := gen_random_uuid();
+  v_second_set_id UUID := gen_random_uuid();
+  v_other_set_id UUID := gen_random_uuid();
+  v_document_id UUID;
+  v_citation_id UUID;
+  v_response JSONB;
+  v_revision BIGINT;
+  v_before_count BIGINT;
+  v_function_oid OID;
+  v_function_signature TEXT;
+  v_table_name TEXT;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_option_documents_phase_gate')
+  );
+
+  SELECT nv.id INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P9B1 phase gate requires one active public.nhan_vien row';
+  END IF;
+
+  FOREACH v_table_name IN ARRAY ARRAY[
+    'technical_configuration_option_documents',
+    'technical_configuration_option_citations'
+  ] LOOP
+    PERFORM pg_temp.assert_true(
+      v_table_name || ' has RLS',
+      (SELECT c.relrowsecurity
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public' AND c.relname = v_table_name)
+    );
+    PERFORM pg_temp.assert_true(
+      v_table_name || ' has zero policies',
+      (SELECT count(*) = 0
+       FROM pg_policies
+       WHERE schemaname = 'public' AND tablename = v_table_name)
+    );
+    PERFORM pg_temp.assert_true(
+      v_table_name || ' denies PUBLIC table access',
+      NOT has_table_privilege(0::OID, format('public.%I', v_table_name), 'SELECT')
+      AND NOT has_table_privilege(0::OID, format('public.%I', v_table_name), 'INSERT')
+      AND NOT has_table_privilege(0::OID, format('public.%I', v_table_name), 'UPDATE')
+      AND NOT has_table_privilege(0::OID, format('public.%I', v_table_name), 'DELETE')
+    );
+    PERFORM pg_temp.assert_true(
+      v_table_name || ' denies anon table access',
+      NOT has_table_privilege('anon', format('public.%I', v_table_name), 'SELECT')
+      AND NOT has_table_privilege('anon', format('public.%I', v_table_name), 'INSERT')
+      AND NOT has_table_privilege('anon', format('public.%I', v_table_name), 'UPDATE')
+      AND NOT has_table_privilege('anon', format('public.%I', v_table_name), 'DELETE')
+    );
+    PERFORM pg_temp.assert_true(
+      v_table_name || ' denies authenticated table access',
+      NOT has_table_privilege(
+        'authenticated', format('public.%I', v_table_name), 'SELECT'
+      )
+      AND NOT has_table_privilege(
+        'authenticated', format('public.%I', v_table_name), 'INSERT'
+      )
+      AND NOT has_table_privilege(
+        'authenticated', format('public.%I', v_table_name), 'UPDATE'
+      )
+      AND NOT has_table_privilege(
+        'authenticated', format('public.%I', v_table_name), 'DELETE'
+      )
+    );
+    PERFORM pg_temp.assert_true(
+      v_table_name || ' allows service_role table CRUD',
+      has_table_privilege('service_role', format('public.%I', v_table_name), 'SELECT')
+      AND has_table_privilege(
+        'service_role', format('public.%I', v_table_name), 'INSERT'
+      )
+      AND has_table_privilege(
+        'service_role', format('public.%I', v_table_name), 'UPDATE'
+      )
+      AND has_table_privilege(
+        'service_role', format('public.%I', v_table_name), 'DELETE'
+      )
+    );
+  END LOOP;
+
+  FOREACH v_function_signature IN ARRAY ARRAY[
+    'technical_configuration_option_documents_list(uuid,uuid,integer,integer)',
+    'technical_configuration_option_document_create(uuid,text,text,bigint)',
+    'technical_configuration_option_document_update(uuid,text,text,bigint)',
+    'technical_configuration_option_document_delete(uuid,bigint)',
+    'technical_configuration_option_citation_upsert(uuid,uuid,uuid,text,text,bigint)',
+    'technical_configuration_option_citation_delete(uuid,bigint)'
+  ] LOOP
+    v_function_oid := to_regprocedure('public.' || v_function_signature);
+    PERFORM pg_temp.assert_true(v_function_signature || ' exists', v_function_oid IS NOT NULL);
+    PERFORM pg_temp.assert_true(
+      v_function_signature || ' is security definer',
+      (SELECT p.prosecdef FROM pg_proc p WHERE p.oid = v_function_oid)
+    );
+    PERFORM pg_temp.assert_true(
+      v_function_signature || ' fixes search_path',
+      (SELECT 'search_path=public, pg_temp' = ANY (p.proconfig)
+       FROM pg_proc p WHERE p.oid = v_function_oid)
+    );
+    PERFORM pg_temp.assert_true(
+      v_function_signature || ' denies PUBLIC function execute',
+      NOT has_function_privilege(0::OID, v_function_oid, 'EXECUTE')
+    );
+    PERFORM pg_temp.assert_true(
+      v_function_signature || ' denies anon function execute',
+      NOT has_function_privilege('anon', v_function_oid, 'EXECUTE')
+    );
+    PERFORM pg_temp.assert_true(
+      v_function_signature || ' allows authenticated function execute',
+      has_function_privilege('authenticated', v_function_oid, 'EXECUTE')
+    );
+    PERFORM pg_temp.assert_true(
+      v_function_signature || ' denies service_role function execute',
+      NOT has_function_privilege('service_role', v_function_oid, 'EXECUTE')
+    );
+  END LOOP;
+
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, archived_at, archived_by, created_by, updated_by
+  ) VALUES
+    (v_dossier_id, 'P9B1 device ' || v_suffix, 'P9B1 dossier ' || v_suffix,
+      NULL, NULL, v_user_id, v_user_id),
+    (v_archived_dossier_id, 'P9B1 archived device ' || v_suffix,
+      'P9B1 archived dossier ' || v_suffix, now(), v_user_id, v_user_id, v_user_id),
+    (v_other_dossier_id, 'P9B1 other device ' || v_suffix,
+      'P9B1 other dossier ' || v_suffix, NULL, NULL, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_suppliers (
+    id, dossier_id, name, created_by, updated_by
+  ) VALUES
+    (v_supplier_id, v_dossier_id, 'P9B1 Supplier', v_user_id, v_user_id),
+    (v_archived_supplier_id, v_archived_dossier_id, 'P9B1 Archived Supplier',
+      v_user_id, v_user_id),
+    (v_other_supplier_id, v_other_dossier_id, 'P9B1 Other Supplier',
+      v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_options (
+    id, dossier_id, supplier_id, option_name, created_by, updated_by
+  ) VALUES
+    (v_option_id, v_dossier_id, v_supplier_id, 'Main Option', v_user_id, v_user_id),
+    (v_archived_option_id, v_archived_dossier_id, v_archived_supplier_id,
+      'Archived Option', v_user_id, v_user_id),
+    (v_other_option_id, v_other_dossier_id, v_other_supplier_id,
+      'Other Option', v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id, dossier_id, version_number, status, next_criterion_number, revision,
+    locked_at, locked_by, created_by, updated_by
+  ) VALUES
+    (v_version_id, v_dossier_id, 1, 'locked', 2, 1, now(), v_user_id,
+      v_user_id, v_user_id),
+    (v_second_version_id, v_dossier_id, 2, 'locked', 2, 1, now(), v_user_id,
+      v_user_id, v_user_id),
+    (v_empty_version_id, v_dossier_id, 3, 'locked', 2, 1, now(), v_user_id,
+      v_user_id, v_user_id),
+    (v_archived_version_id, v_archived_dossier_id, 1, 'locked', 2, 1, now(),
+      v_user_id, v_user_id, v_user_id),
+    (v_other_version_id, v_other_dossier_id, 1, 'locked', 2, 1, now(), v_user_id,
+      v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id, baseline_version_id, name, sort_order, created_by, updated_by
+  ) VALUES
+    (v_group_id, v_version_id, 'Main Group', 1, v_user_id, v_user_id),
+    (v_second_group_id, v_second_version_id, 'Second Group', 1, v_user_id, v_user_id),
+    (v_empty_group_id, v_empty_version_id, 'Empty Group', 1, v_user_id, v_user_id),
+    (v_archived_group_id, v_archived_version_id, 'Archived Group', 1,
+      v_user_id, v_user_id),
+    (v_other_group_id, v_other_version_id, 'Other Group', 1, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id, baseline_version_id, group_id, criterion_code, requirement_text,
+    sort_order, created_by, updated_by
+  ) VALUES
+    (v_criterion_id, v_version_id, v_group_id, 'TC-0001', 'Main criterion',
+      1, v_user_id, v_user_id),
+    (v_second_criterion_id, v_second_version_id, v_second_group_id,
+      'TC-0001', 'Second criterion', 1, v_user_id, v_user_id),
+    (v_empty_criterion_id, v_empty_version_id, v_empty_group_id,
+      'TC-0001', 'Empty criterion', 1, v_user_id, v_user_id),
+    (v_archived_criterion_id, v_archived_version_id, v_archived_group_id,
+      'TC-0001', 'Archived criterion', 1, v_user_id, v_user_id),
+    (v_other_criterion_id, v_other_version_id, v_other_group_id,
+      'TC-0001', 'Other criterion', 1, v_user_id, v_user_id);
+
+  INSERT INTO public.technical_configuration_comparison_sets (
+    id, dossier_id, option_id, baseline_version_id, created_by, updated_by
+  ) VALUES
+    (v_set_id, v_dossier_id, v_option_id, v_version_id, v_user_id, v_user_id),
+    (v_second_set_id, v_dossier_id, v_option_id, v_second_version_id,
+      v_user_id, v_user_id),
+    (v_other_set_id, v_other_dossier_id, v_other_option_id, v_other_version_id,
+      v_user_id, v_user_id);
+
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims rejected',
+    format(
+      'SELECT public.technical_configuration_option_documents_list(%L,%L,1,50)',
+      v_option_id, v_version_id
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('user', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'non-global role rejected',
+    format(
+      'SELECT public.technical_configuration_option_documents_list(%L,%L,1,50)',
+      v_option_id, v_version_id
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.expect_error(
+    'unauthorized create hides missing option',
+    format(
+      'SELECT public.technical_configuration_option_document_create(%L,%L,%L,1)',
+      gen_random_uuid(), 'Hidden guide', 'https://example.com/hidden.pdf'
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.expect_error(
+    'unauthorized update hides missing document',
+    format(
+      'SELECT public.technical_configuration_option_document_update(%L,%L,%L,1)',
+      gen_random_uuid(), 'Hidden guide', 'https://example.com/hidden.pdf'
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.expect_error(
+    'unauthorized document delete hides missing document',
+    format(
+      'SELECT public.technical_configuration_option_document_delete(%L,1)',
+      gen_random_uuid()
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.expect_error(
+    'unauthorized citation upsert hides missing document',
+    format(
+      'SELECT public.technical_configuration_option_citation_upsert(%L,%L,%L,NULL,NULL,1)',
+      gen_random_uuid(), gen_random_uuid(), gen_random_uuid()
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.expect_error(
+    'unauthorized citation delete hides missing citation',
+    format(
+      'SELECT public.technical_configuration_option_citation_delete(%L,1)',
+      gen_random_uuid()
+    ),
+    '42501', 'permission_denied'
+  );
+
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  v_response := public.technical_configuration_option_documents_list(
+    v_option_id, v_version_id, 1, 50
+  );
+  PERFORM pg_temp.assert_true(
+    'raw admin role accepted',
+    jsonb_array_length(v_response->'data') = 0
+  );
+
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  v_response := public.technical_configuration_option_documents_list(
+    v_archived_option_id, v_archived_version_id, 1, 50
+  );
+  PERFORM pg_temp.assert_true(
+    'archived dossier list remains readable',
+    jsonb_array_length(v_response->'data') = 0
+  );
+
+  v_response := public.technical_configuration_option_document_create(
+    v_option_id, 'Shared guide', 'HtTpS://EXAMPLE.com/a/../guide.pdf', 1
+  );
+  v_document_id := (v_response->'data'->>'id')::UUID;
+  v_revision := (v_response->'data'->>'revision')::BIGINT;
+  PERFORM pg_temp.assert_true('document create bumps dossier revision', v_revision = 2);
+  PERFORM pg_temp.assert_true(
+    'raw accepted URL is preserved',
+    v_response->'data'->>'url' = 'HtTpS://EXAMPLE.com/a/../guide.pdf'
+  );
+
+  v_response := public.technical_configuration_option_document_update(
+    v_document_id, 'Shared guide updated', 'https://example.com/updated.pdf', 2
+  );
+  v_revision := (v_response->'data'->>'revision')::BIGINT;
+  PERFORM pg_temp.assert_true(
+    'document update succeeds',
+    v_revision = 3
+    AND v_response->'data'->>'name' = 'Shared guide updated'
+    AND v_response->'data'->>'url' = 'https://example.com/updated.pdf'
+  );
+
+  v_response := public.technical_configuration_option_citation_upsert(
+    v_document_id, v_set_id, v_criterion_id, 'p. 2', 'Main excerpt', 3
+  );
+  v_citation_id := (v_response->'data'->>'id')::UUID;
+  PERFORM pg_temp.assert_true(
+    'locked baseline first citation succeeds',
+    (v_response->'data'->>'revision')::BIGINT = 4
+  );
+  v_response := public.technical_configuration_option_citation_delete(
+    v_citation_id, 4
+  );
+  PERFORM pg_temp.assert_true(
+    'citation delete succeeds',
+    (v_response->'data'->>'revision')::BIGINT = 5
+    AND NOT EXISTS (
+      SELECT 1 FROM public.technical_configuration_option_citations
+      WHERE id = v_citation_id
+    )
+  );
+  v_response := public.technical_configuration_option_citation_upsert(
+    v_document_id, v_set_id, v_criterion_id, 'p. 2', 'Main excerpt', 5
+  );
+  PERFORM pg_temp.assert_true(
+    'deleted citation can be restored',
+    (v_response->'data'->>'revision')::BIGINT = 6
+  );
+  v_response := public.technical_configuration_option_citation_upsert(
+    v_document_id, v_second_set_id, v_second_criterion_id,
+    'section B', 'Second excerpt', 6
+  );
+  PERFORM pg_temp.assert_true(
+    'one document supports another locked baseline',
+    (v_response->'data'->>'revision')::BIGINT = 7
+  );
+
+  v_response := public.technical_configuration_option_documents_list(
+    v_option_id, v_version_id, 1, 50
+  );
+  PERFORM pg_temp.assert_true(
+    'first baseline returns one exact citation',
+    jsonb_array_length(v_response->'data'->0->'citations') = 1
+    AND v_response->'data'->0->'citations'->0->>'criterion_id' = v_criterion_id::TEXT
+    AND (v_response->'data'->0->>'affected_citation_count')::BIGINT = 2
+  );
+  v_response := public.technical_configuration_option_documents_list(
+    v_option_id, v_second_version_id, 1, 50
+  );
+  PERFORM pg_temp.assert_true(
+    'second baseline returns only its exact citation',
+    jsonb_array_length(v_response->'data'->0->'citations') = 1
+    AND v_response->'data'->0->'citations'->0->>'criterion_id'
+      = v_second_criterion_id::TEXT
+  );
+  v_response := public.technical_configuration_option_documents_list(
+    v_option_id, v_empty_version_id, 1, 50
+  );
+  PERFORM pg_temp.assert_true(
+    'missing comparison set returns shared document with empty citations',
+    jsonb_array_length(v_response->'data') = 1
+    AND jsonb_array_length(v_response->'data'->0->'citations') = 0
+  );
+  v_response := public.technical_configuration_option_documents_list(
+    v_option_id, v_version_id, 2147483647, 50
+  );
+  PERFORM pg_temp.assert_true(
+    'large page remains valid',
+    jsonb_array_length(v_response->'data') = 0
+    AND (v_response->>'total')::BIGINT = 1
+  );
+
+  PERFORM pg_temp.expect_error(
+    'cross-option comparison set rejected',
+    format(
+      'SELECT public.technical_configuration_option_citation_upsert(%L,%L,%L,NULL,NULL,7)',
+      v_document_id, v_other_set_id, v_other_criterion_id
+    ),
+    'PT422', 'validation_error'
+  );
+  PERFORM pg_temp.expect_error(
+    'cross-baseline criterion rejected',
+    format(
+      'SELECT public.technical_configuration_option_citation_upsert(%L,%L,%L,NULL,NULL,7)',
+      v_document_id, v_set_id, v_second_criterion_id
+    ),
+    'PT422', 'validation_error'
+  );
+
+  SELECT count(*) INTO v_before_count
+  FROM public.technical_configuration_option_documents
+  WHERE option_id = v_option_id;
+  PERFORM pg_temp.expect_error(
+    'invalid URL performs zero writes',
+    format(
+      'SELECT public.technical_configuration_option_document_create(%L,%L,%L,7)',
+      v_option_id, 'Invalid guide', 'ftp://example.com/invalid.pdf'
+    ),
+    'PT422', 'validation_error'
+  );
+  PERFORM pg_temp.assert_true(
+    'invalid URL preserves document count and revision',
+    v_before_count = (
+      SELECT count(*) FROM public.technical_configuration_option_documents
+      WHERE option_id = v_option_id
+    )
+    AND 7 = (
+      SELECT revision FROM public.technical_configuration_dossiers
+      WHERE id = v_dossier_id
+    )
+  );
+  PERFORM pg_temp.expect_error(
+    'stale document create performs zero writes',
+    format(
+      'SELECT public.technical_configuration_option_document_create(%L,%L,%L,1)',
+      v_option_id, 'Stale guide', 'https://example.com/stale.pdf'
+    ),
+    'PT409', 'stale_revision'
+  );
+  PERFORM pg_temp.assert_true(
+    'stale create leaves document count unchanged',
+    v_before_count = (
+      SELECT count(*) FROM public.technical_configuration_option_documents
+      WHERE option_id = v_option_id
+    )
+  );
+  PERFORM pg_temp.expect_error(
+    'archived dossier mutation rejected',
+    format(
+      'SELECT public.technical_configuration_option_document_create(%L,%L,%L,1)',
+      v_archived_option_id, 'Archived guide', 'https://example.com/archived.pdf'
+    ),
+    'PT409', 'archived_dossier'
+  );
+
+  PERFORM set_config('p9b1.failure_document', v_document_id::TEXT, true);
+  PERFORM set_config('p9b1.dossier', v_dossier_id::TEXT, true);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.p9b1_fail_citation_delete()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.option_document_id::TEXT
+     = current_setting('p9b1.failure_document', true) THEN
+    RAISE EXCEPTION 'injected_delete_failure';
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER p9b1_fail_citation_delete
+BEFORE DELETE ON public.technical_configuration_option_citations
+FOR EACH ROW EXECUTE FUNCTION pg_temp.p9b1_fail_citation_delete();
+
+-- failure injection must keep the document, citations, and revision unchanged.
+SAVEPOINT option_document_delete_failure;
+DO $$
+DECLARE
+  v_document_id UUID := current_setting('p9b1.failure_document')::UUID;
+  v_dossier_id UUID := current_setting('p9b1.dossier')::UUID;
+BEGIN
+  PERFORM pg_temp.expect_error(
+    'confirmed delete rolls back on cascade failure',
+    format(
+      'SELECT public.technical_configuration_option_document_delete(%L,7)',
+      v_document_id
+    ),
+    'P0001', 'injected_delete_failure'
+  );
+  PERFORM pg_temp.assert_true(
+    'failed delete preserves document and citations',
+    EXISTS (
+      SELECT 1 FROM public.technical_configuration_option_documents
+      WHERE id = v_document_id
+    )
+    AND 2 = (
+      SELECT count(*) FROM public.technical_configuration_option_citations
+      WHERE option_document_id = v_document_id
+    )
+    AND 7 = (
+      SELECT revision FROM public.technical_configuration_dossiers
+      WHERE id = v_dossier_id
+    )
+  );
+END;
+$$;
+ROLLBACK TO SAVEPOINT option_document_delete_failure;
+
+DROP TRIGGER p9b1_fail_citation_delete
+  ON public.technical_configuration_option_citations;
+DROP FUNCTION pg_temp.p9b1_fail_citation_delete();
+
+DO $$
+DECLARE
+  v_document_id UUID := current_setting('p9b1.failure_document')::UUID;
+  v_response JSONB;
+BEGIN
+  v_response := public.technical_configuration_option_document_delete(
+    v_document_id, 7
+  );
+  PERFORM pg_temp.assert_true(
+    'confirmed delete removes document and every citation transactionally',
+    (v_response->'data'->>'affected_citation_count')::BIGINT = 2
+    AND (v_response->'data'->>'revision')::BIGINT = 8
+    AND NOT EXISTS (
+      SELECT 1 FROM public.technical_configuration_option_documents
+      WHERE id = v_document_id
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM public.technical_configuration_option_citations
+      WHERE option_document_id = v_document_id
+    )
+  );
+END;
+$$;
+
+ROLLBACK;

--- a/supabase/tests/technical_configuration_option_documents_phase_gate.sql
+++ b/supabase/tests/technical_configuration_option_documents_phase_gate.sql
@@ -1,4 +1,6 @@
 -- Rollback-only P9B1 option evidence contract and behavior gate.
+-- CREATE TRIGGER holds a SHARE ROW EXCLUSIVE lock on the citation table until
+-- ROLLBACK, so run this gate only during a quiesced maintenance window.
 BEGIN;
 SET LOCAL request.jwt.claims = '{}';
 


### PR DESCRIPTION
## Summary
- add option-owned evidence documents shared across baseline versions
- constrain citations to the exact option, comparison set, baseline version, and criterion
- add six secured RPCs plus dormant manifest, wire types, adapters, and allowlist contracts
- add rollback-only P9B1 phase gate coverage without introducing P9B2 hooks or UI

## Contract semantics
- documents belong to `option_id`; `affected_citation_count` spans all baselines
- list remains read-only and returns shared documents with `citations: []` when no comparison set exists
- locked baselines allow evidence mutations; archived dossiers and stale revisions reject writes
- document deletion cascades citations transactionally; there is no `p_confirmed` DB argument
- RPC `EXECUTE` grants match deployed P7B1: `authenticated` only; evidence tables remain deny-by-default with `service_role` CRUD

## TDD and review
- RED: P9B1 contract suite failed while contracts were absent
- GREEN: focused migration, P7B1 regression, whitelist, and adapter suites pass 105/105
- migration review-fix loop completed with the same subagent and ended CLEAN on round 3
- live Supabase inspection was read-only only

## Verification
- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- `typecheck`
- focused Vitest: 4 files, 105/105 tests
- React Doctor: 100/100
- `openspec validate add-technical-configuration-comparison --strict`
- `git diff --check`

## Deployment status
- migration `20260726020000_technical_configuration_option_evidence.sql` has **not** been applied
- P9B1 and P7B1 SQL phase gates have **not** been executed on live DB
- no live DB writes were performed in this branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds option-owned evidence documents and exact-baseline citations (P9B1) with new DB tables, six secured RPCs, and thin client wrappers. Includes a rollback-only phase gate; no UI hooks yet.

- **New Features**
  - New tables: `technical_configuration_option_documents`, `technical_configuration_option_citations` (deny-by-default; `service_role` table CRUD).
  - Six RPCs (`SECURITY DEFINER`, `authenticated` EXECUTE) to list/create/update/delete documents and upsert/delete citations; create/update validate URLs via `_technical_configuration_validate_document_url`.
  - Evidence semantics: documents are shared across baselines; citations are scoped to option+comparison set+baseline version+criterion; document delete cascades citations; dossier revision control rejects archived dossiers and stale revisions; added wire types, wrappers via `DOCUMENT_RPC_FUNCTIONS`, and allowlist/manifest entries.

- **Migration**
  - Apply `supabase/migrations/20260726020000_technical_configuration_option_evidence.sql`.
  - Run `supabase/tests/technical_configuration_option_documents_phase_gate.sql`; it is rollback-only and documents a trigger-held SHARE ROW EXCLUSIVE lock—run during a quiesced maintenance window.
  - `openspec` tasks updated to mark P9B1 complete.

<sup>Written for commit 9b284d487f9a168dd3e453b0f18f01bb689761aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing evidence documents associated with technical configuration options, including list/create/update/delete with pagination and revision tracking.
  * Added option citation management (upsert/delete) tied to baseline criteria, with page section/excerpt details and returned affected-citation counts.

* **Bug Fixes**
  * Strengthened permission, URL, and revision validations, including baseline/cross-reference rules and transactional cascade delete behavior.

* **Tests / Validation**
  * Added contract and whitelist coverage for the new option evidence RPCs, including phase-gate rollback verification and wrapper behavior checks.

* **Documentation**
  * Updated P9B1 checklist items to completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->