### PR TITLE
P9B2: Add supplier option evidence workspace

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -403,20 +403,20 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P9B2 - Supplier Option Evidence Workspace
 
-- [ ] P9B2.1 Thêm option-specific evidence hook/component; không mở rộng
+- [x] P9B2.1 Thêm option-specific evidence hook/component; không mở rộng
       baseline/reference document hook bằng option-specific branching.
-- [ ] P9B2.2 Reuse P6B-proven `UrlDocumentForm`/`UrlDocumentList` và
+- [x] P9B2.2 Reuse P6B-proven `UrlDocumentForm`/`UrlDocumentList` và
       P7B2-proven owner-neutral citation editor behavior.
-- [ ] P9B2.3 First citation save dùng established comparison-set
+- [x] P9B2.3 First citation save dùng established comparison-set
       get-or-create revision chain; list/open vẫn side-effect-free.
-- [ ] P9B2.4 Thêm explicit save, dirty/conflict preservation, option-level
+- [x] P9B2.4 Thêm explicit save, dirty/conflict preservation, option-level
       document reuse và delete confirmation hiển thị tổng affected citations.
-- [ ] P9B2.5 Locked baseline vẫn cho sửa option evidence; archived dossier
+- [x] P9B2.5 Locked baseline vẫn cho sửa option evidence; archived dossier
       read-only; pending evidence state chặn identity/response mutations và
       navigation.
-- [ ] P9B2.6 Enforce cumulative Equipment + baseline + option exact
+- [x] P9B2.6 Enforce cumulative Equipment + baseline + option exact
       path/named-binding AST manifest và runtime-delegation assertions.
-- [ ] P9B2.7 Rerun baseline/reference SQL + React suites cùng option evidence
+- [x] P9B2.7 Rerun baseline/reference SQL + React suites cùng option evidence
       suites; chỉ leaf này mark TC-11-S01..S05 và TC-12-S01/S02 complete.
 
 ## Phase P10A - Comparison Read Contract

--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence.test.tsx
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 
@@ -59,5 +59,18 @@ describe("TechnicalConfigurationCitationEditor", () => {
         )
       )
     ).toBe(true)
+  })
+
+  it("remains owner-neutral without option-specific branches", () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        "src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx"
+      ),
+      "utf8"
+    )
+
+    expect(source).not.toContain("TechnicalConfigurationOptionDocumentWire")
+    expect(source).not.toMatch(/\boption_id\b/)
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/citation-editor-state.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/citation-editor-state.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from "vitest"
+
+import { getTechnicalConfigurationCitationValues } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState"
+
+it("does not inspect citations without an exact selected criterion", () => {
+  let citationReads = 0
+  const document = {
+    get citations() {
+      citationReads += 1
+      return []
+    },
+  }
+
+  expect(getTechnicalConfigurationCitationValues(document, null)).toEqual({
+    pageSection: "",
+    excerpt: "",
+  })
+  expect(citationReads).toBe(0)
+})

--- a/src/app/(app)/technical-configurations/__tests__/option-evidence-delegation.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/option-evidence-delegation.test.tsx
@@ -131,7 +131,6 @@ describe("P9B2 shared option-evidence delegation", () => {
             {
               id: "group-1",
               baseline_version_id: baselineVersion.id,
-              code: "NHOM-01",
               name: "Yêu cầu chung",
               sort_order: 1,
               created_at: baselineVersion.created_at,
@@ -141,11 +140,13 @@ describe("P9B2 shared option-evidence delegation", () => {
               criteria: [
                 {
                   id: "criterion-1",
-                  baseline_group_id: "group-1",
+                  baseline_version_id: baselineVersion.id,
+                  group_id: "group-1",
                   criterion_code: "TC-0001",
                   title: "Nguồn điện",
                   requirement_text: "220V",
                   sort_order: 1,
+                  source_criterion_id: null,
                   created_at: baselineVersion.created_at,
                   created_by: 1,
                   updated_at: baselineVersion.updated_at,

--- a/src/app/(app)/technical-configurations/__tests__/option-evidence-delegation.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/option-evidence-delegation.test.tsx
@@ -1,0 +1,189 @@
+import { act, render, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationOptionDocuments } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionDocuments"
+import type {
+  TechnicalConfigurationCitationSaveInput,
+  TechnicalConfigurationCitationCriterion,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor"
+import type { TechnicalConfigurationOptionDocumentWire } from "@/app/(app)/technical-configurations/document-types"
+import type { UrlDocumentFormProps } from "@/components/url-documents/UrlDocumentForm"
+import type { UrlDocumentListProps } from "@/components/url-documents/UrlDocumentList"
+
+import { baselineVersion } from "./baseline-evidence-fixtures"
+import { dossier, option } from "./supplier-options-fixtures"
+
+type CitationEditorProps = {
+  documents: readonly {
+    id: string
+    name: string
+    citations: readonly {
+      id: string
+      criterion_id: string
+      page_section: string | null
+      excerpt: string | null
+    }[]
+  }[]
+  criteria: readonly TechnicalConfigurationCitationCriterion[]
+  fixedCriterionId?: string | null
+  isPending: boolean
+  disabled: boolean
+  onSave: (input: TechnicalConfigurationCitationSaveInput) => Promise<unknown>
+  onDelete: (input: { document: { id: string }; citationId: string }) => Promise<unknown>
+  onDirtyChange?: (dirty: boolean) => void
+}
+
+const sharedPrimitives = vi.hoisted(() => ({
+  formProps: null as UrlDocumentFormProps | null,
+  listProps: null as UrlDocumentListProps | null,
+  citationProps: null as CitationEditorProps | null,
+  parseAbsoluteUrl: vi.fn(),
+  isAllowedDocumentUrl: vi.fn(),
+}))
+
+const evidenceState = vi.hoisted(() => ({
+  documentsQuery: {
+    isLoading: false,
+    isError: false,
+    data: [] as TechnicalConfigurationOptionDocumentWire[],
+    refetch: vi.fn(),
+  },
+  documents: [] as TechnicalConfigurationOptionDocumentWire[],
+  isReadOnly: false,
+  isSaving: false,
+  isConflict: false,
+  mutationError: null as unknown,
+  createDocument: vi.fn(),
+  updateDocument: vi.fn(),
+  deleteDocument: vi.fn(),
+  upsertCitation: vi.fn(),
+  deleteCitation: vi.fn(),
+}))
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionDocuments",
+  () => ({
+    useTechnicalConfigurationOptionDocuments: () => evidenceState,
+  })
+)
+
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor",
+  () => ({
+    TechnicalConfigurationCitationEditor: (props: CitationEditorProps) => {
+      sharedPrimitives.citationProps = props
+      return <div data-testid="shared-citation-editor" />
+    },
+  })
+)
+
+vi.mock("@/components/url-documents/UrlDocumentForm", () => ({
+  UrlDocumentForm: (props: UrlDocumentFormProps) => {
+    sharedPrimitives.formProps = props
+    return <div data-testid="shared-url-document-form" />
+  },
+}))
+
+vi.mock("@/components/url-documents/UrlDocumentList", () => ({
+  UrlDocumentList: (props: UrlDocumentListProps) => {
+    sharedPrimitives.listProps = props
+    return <div data-testid="shared-url-document-list" />
+  },
+}))
+
+vi.mock("@/components/url-documents/url-document-utils", () => ({
+  parseAbsoluteUrl: sharedPrimitives.parseAbsoluteUrl,
+  isAllowedDocumentUrl: sharedPrimitives.isAllowedDocumentUrl,
+}))
+
+const currentOption = option({ id: "option-1" })
+
+describe("P9B2 shared option-evidence delegation", () => {
+  beforeEach(() => {
+    sharedPrimitives.formProps = null
+    sharedPrimitives.listProps = null
+    sharedPrimitives.citationProps = null
+    sharedPrimitives.parseAbsoluteUrl.mockReset()
+    sharedPrimitives.isAllowedDocumentUrl.mockReset()
+    sharedPrimitives.parseAbsoluteUrl.mockImplementation((raw: string) => ({
+      raw,
+      protocol: "https:",
+    }))
+    sharedPrimitives.isAllowedDocumentUrl.mockReturnValue(true)
+    Object.values(evidenceState)
+      .filter((value) => typeof value === "function")
+      .forEach((mock) => mock.mockReset())
+    evidenceState.documents = []
+    evidenceState.documentsQuery.data = []
+    evidenceState.createDocument.mockResolvedValue({ data: { revision: 4 } })
+  })
+
+  it("drives option create/list/citation workflows through the established shared contracts", async () => {
+    const rawUrl = "HtTpS://EXAMPLE.com/a/../option-spec.pdf"
+    render(
+      <TechnicalConfigurationOptionDocuments
+        dossier={dossier}
+        option={currentOption}
+        baselineVersion={{
+          ...baselineVersion,
+          dossier_id: dossier.id,
+          groups: [
+            {
+              id: "group-1",
+              baseline_version_id: baselineVersion.id,
+              code: "NHOM-01",
+              name: "Yêu cầu chung",
+              sort_order: 1,
+              created_at: baselineVersion.created_at,
+              created_by: 1,
+              updated_at: baselineVersion.updated_at,
+              updated_by: 1,
+              criteria: [
+                {
+                  id: "criterion-1",
+                  baseline_group_id: "group-1",
+                  criterion_code: "TC-0001",
+                  title: "Nguồn điện",
+                  requirement_text: "220V",
+                  sort_order: 1,
+                  created_at: baselineVersion.created_at,
+                  created_by: 1,
+                  updated_at: baselineVersion.updated_at,
+                  updated_by: 1,
+                },
+              ],
+            },
+          ],
+        }}
+        criterionId="criterion-1"
+      />
+    )
+
+    expect(sharedPrimitives.formProps).not.toBeNull()
+    expect(sharedPrimitives.listProps).toMatchObject({
+      items: [],
+      isLoading: false,
+    })
+    expect(sharedPrimitives.citationProps).toMatchObject({
+      fixedCriterionId: "criterion-1",
+      disabled: false,
+      isPending: false,
+    })
+
+    act(() => {
+      sharedPrimitives.formProps?.onNameChange("Hồ sơ phương án")
+      sharedPrimitives.formProps?.onUrlChange(rawUrl)
+    })
+    await waitFor(() => expect(sharedPrimitives.formProps?.url).toBe(rawUrl))
+    await act(async () => {
+      await sharedPrimitives.formProps?.onSubmit()
+    })
+
+    expect(sharedPrimitives.parseAbsoluteUrl).toHaveBeenCalledWith(rawUrl)
+    expect(sharedPrimitives.isAllowedDocumentUrl).toHaveBeenCalled()
+    expect(evidenceState.createDocument).toHaveBeenCalledWith({
+      name: "Hồ sơ phương án",
+      url: rawUrl,
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/option-evidence-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/option-evidence-workspace-cases.tsx
@@ -1,0 +1,318 @@
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, type Mock } from "vitest"
+
+import { TechnicalConfigurationOptionDocuments } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionDocuments"
+import type {
+  TechnicalConfigurationOptionDocumentWire,
+  TechnicalConfigurationOptionDocumentsListWireResponse,
+} from "@/app/(app)/technical-configurations/document-types"
+import { TechnicalConfigurationRpcError } from "@/app/(app)/technical-configurations/technical-configuration-rpc"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+
+import { baselineVersion, comparisonSet } from "./supplier-option-response-cases"
+import { dossier, option } from "./supplier-options-fixtures"
+
+type OptionEvidenceRpcMocks = {
+  listDocuments: Mock
+  createDocument: Mock
+  updateDocument: Mock
+  deleteDocument: Mock
+  upsertCitation: Mock
+  deleteCitation: Mock
+  getOrCreateComparisonSet: Mock
+  fetchDossierRevision: Mock
+}
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const currentOption = option({ id: "option-1" })
+
+function optionDocument({
+  id = "document-1",
+  citations = [],
+  affectedCitationCount = citations.length,
+}: {
+  id?: string
+  citations?: TechnicalConfigurationOptionDocumentWire["citations"]
+  affectedCitationCount?: number
+} = {}): TechnicalConfigurationOptionDocumentWire {
+  return {
+    id,
+    option_id: currentOption.id,
+    name: `Tài liệu ${id}`,
+    url: `https://example.com/${id}.pdf`,
+    created_by: 1,
+    created_at: "2026-07-26T00:00:00.000Z",
+    updated_at: "2026-07-26T00:00:00.000Z",
+    affected_citation_count: affectedCitationCount,
+    citations,
+  }
+}
+
+function documentsResponse(
+  data: TechnicalConfigurationOptionDocumentWire[]
+): TechnicalConfigurationOptionDocumentsListWireResponse {
+  return {
+    data,
+    total: data.length,
+    page: 1,
+    page_size: 100,
+  }
+}
+
+function renderOptionEvidence({
+  baseline = baselineVersion(),
+  dossierValue = dossier,
+}: {
+  baseline?: ReturnType<typeof baselineVersion>
+  dossierValue?: typeof dossier
+} = {}) {
+  const queryClient = createTestQueryClient()
+  return render(
+    <TechnicalConfigurationOptionDocuments
+      dossier={dossierValue}
+      option={currentOption}
+      baselineVersion={baseline}
+      criterionId={baseline.groups[0]?.criteria[0]?.id}
+    />,
+    { wrapper: createReactQueryWrapper(queryClient) }
+  )
+}
+
+export function registerOptionEvidenceWorkspaceTests(rpc: OptionEvidenceRpcMocks) {
+  describe("TechnicalConfigurationOptionDocuments behavior", () => {
+    beforeEach(() => {
+      Object.defineProperty(globalThis, "ResizeObserver", {
+        configurable: true,
+        value: ResizeObserverMock,
+      })
+      Object.values(rpc).forEach((mock) => mock.mockReset())
+      rpc.listDocuments.mockResolvedValue(documentsResponse([]))
+    })
+
+    it("reuses one option document across baseline selections while rendering exact citations", async () => {
+      const firstBaseline = baselineVersion({ id: "baseline-1", version_number: 1 })
+      const secondBaseline = baselineVersion({ id: "baseline-2", version_number: 2 })
+      const firstCriterionId = firstBaseline.groups[0]?.criteria[0]?.id ?? ""
+      const secondCriterionId = secondBaseline.groups[0]?.criteria[0]?.id ?? ""
+      const firstDocument = optionDocument({
+        citations: [
+          {
+            id: "citation-baseline-1",
+            criterion_id: firstCriterionId,
+            page_section: "Trang 1",
+            excerpt: "Bằng chứng baseline 1",
+          },
+        ],
+        affectedCitationCount: 2,
+      })
+      const secondDocument = optionDocument({
+        citations: [
+          {
+            id: "citation-baseline-2",
+            criterion_id: secondCriterionId,
+            page_section: "Trang 2",
+            excerpt: "Bằng chứng baseline 2",
+          },
+        ],
+        affectedCitationCount: 2,
+      })
+      rpc.listDocuments
+        .mockResolvedValueOnce(documentsResponse([firstDocument]))
+        .mockResolvedValueOnce(documentsResponse([secondDocument]))
+
+      const view = renderOptionEvidence({ baseline: firstBaseline })
+      expect(await screen.findByLabelText("Trích đoạn")).toHaveValue("Bằng chứng baseline 1")
+      expect(
+        screen.getAllByRole("link", {
+          name: `${firstDocument.name} (mở trong tab mới)`,
+        })
+      ).toHaveLength(1)
+
+      view.rerender(
+        <TechnicalConfigurationOptionDocuments
+          dossier={dossier}
+          option={currentOption}
+          baselineVersion={secondBaseline}
+          criterionId={secondCriterionId}
+        />
+      )
+
+      await waitFor(() =>
+        expect(rpc.listDocuments).toHaveBeenLastCalledWith(
+          expect.objectContaining({ p_baseline_version_id: secondBaseline.id }),
+          expect.any(AbortSignal)
+        )
+      )
+      expect(await screen.findByLabelText("Trích đoạn")).toHaveValue("Bằng chứng baseline 2")
+      expect(
+        screen.getAllByRole("link", {
+          name: `${secondDocument.name} (mở trong tab mới)`,
+        })
+      ).toHaveLength(1)
+      expect(rpc.getOrCreateComparisonSet).not.toHaveBeenCalled()
+    })
+
+    it("shows the global affected citation count and mutates only after confirmation", async () => {
+      const user = userEvent.setup()
+      const document = optionDocument({ affectedCitationCount: 7 })
+      rpc.listDocuments.mockResolvedValue(documentsResponse([document]))
+      rpc.deleteDocument.mockResolvedValue({
+        data: {
+          id: document.id,
+          revision: dossier.revision + 1,
+          affected_citation_count: document.affected_citation_count,
+        },
+      })
+      renderOptionEvidence()
+
+      await user.click(
+        await screen.findByRole("button", {
+          name: `Xóa ${document.name}`,
+        })
+      )
+      const dialog = await screen.findByRole("alertdialog")
+      expect(within(dialog).getByText(/đang có 7 trích dẫn liên kết/)).toBeInTheDocument()
+      expect(rpc.deleteDocument).not.toHaveBeenCalled()
+
+      await user.click(within(dialog).getByRole("button", { name: "Hủy" }))
+      expect(rpc.deleteDocument).not.toHaveBeenCalled()
+
+      await user.click(screen.getByRole("button", { name: `Xóa ${document.name}` }))
+      await user.click(
+        within(await screen.findByRole("alertdialog")).getByRole("button", {
+          name: "Xóa tài liệu",
+        })
+      )
+      await waitFor(() =>
+        expect(rpc.deleteDocument).toHaveBeenCalledWith({
+          p_option_document_id: document.id,
+          p_expected_revision: dossier.revision,
+        })
+      )
+    })
+
+    it("preserves the exact raw document draft after a stale conflict and allows retry", async () => {
+      const user = userEvent.setup()
+      const rawUrl = "HtTpS://EXAMPLE.com/a/../retry-option-spec.pdf"
+      rpc.createDocument
+        .mockRejectedValueOnce(
+          new TechnicalConfigurationRpcError(409, {
+            code: "PT409",
+            message: "stale_revision",
+          })
+        )
+        .mockResolvedValueOnce({
+          data: {
+            ...optionDocument(),
+            name: "Hồ sơ thử lại",
+            url: rawUrl,
+            revision: dossier.revision + 2,
+          },
+        })
+      rpc.fetchDossierRevision.mockResolvedValue(dossier.revision + 1)
+      renderOptionEvidence()
+
+      await user.type(screen.getByLabelText("Tên tài liệu"), "Hồ sơ thử lại")
+      await user.type(screen.getByLabelText("Đường dẫn (URL)"), rawUrl)
+      await user.click(screen.getByRole("button", { name: "Thêm tài liệu" }))
+
+      expect(
+        await screen.findByText(
+          "Hồ sơ đã thay đổi trên máy chủ. Nội dung đang nhập được giữ lại để thử lại."
+        )
+      ).toBeInTheDocument()
+      expect(screen.getByLabelText("Tên tài liệu")).toHaveValue("Hồ sơ thử lại")
+      expect(screen.getByLabelText("Đường dẫn (URL)")).toHaveValue(rawUrl)
+
+      await user.click(screen.getByRole("button", { name: "Thêm tài liệu" }))
+      await waitFor(() => expect(rpc.createDocument).toHaveBeenCalledTimes(2))
+      expect(rpc.createDocument).toHaveBeenLastCalledWith({
+        p_option_id: currentOption.id,
+        p_name: "Hồ sơ thử lại",
+        p_url: rawUrl,
+        p_expected_revision: dossier.revision + 1,
+      })
+    })
+
+    it("preserves a dirty citation and reuses the created comparison set after upsert failure", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const criterionId = baseline.groups[0]?.criteria[0]?.id ?? ""
+      const document = optionDocument()
+      const createdComparisonSet = comparisonSet(baseline, [], dossier.revision + 1)
+      rpc.listDocuments.mockResolvedValue(documentsResponse([document]))
+      rpc.getOrCreateComparisonSet.mockResolvedValue(createdComparisonSet)
+      rpc.upsertCitation
+        .mockRejectedValueOnce(
+          new TechnicalConfigurationRpcError(409, {
+            code: "PT409",
+            message: "stale_revision",
+          })
+        )
+        .mockResolvedValueOnce({
+          data: {
+            id: "citation-1",
+            criterion_id: criterionId,
+            page_section: "Trang 12",
+            excerpt: "Đáp ứng đúng tiêu chí",
+            revision: createdComparisonSet.revision + 2,
+          },
+        })
+      rpc.fetchDossierRevision.mockResolvedValue(createdComparisonSet.revision + 1)
+      renderOptionEvidence({ baseline })
+
+      await user.type(await screen.findByLabelText("Trang hoặc mục"), "Trang 12")
+      await user.type(screen.getByLabelText("Trích đoạn"), "Đáp ứng đúng tiêu chí")
+      await user.click(screen.getByRole("button", { name: "Lưu trích dẫn" }))
+
+      expect(
+        await screen.findByText(
+          "Phiên bản đã thay đổi trên máy chủ. Nội dung trích dẫn được giữ lại để thử lại."
+        )
+      ).toBeInTheDocument()
+      expect(screen.getByLabelText("Trang hoặc mục")).toHaveValue("Trang 12")
+      expect(screen.getByLabelText("Trích đoạn")).toHaveValue("Đáp ứng đúng tiêu chí")
+
+      await user.click(screen.getByRole("button", { name: "Lưu trích dẫn" }))
+
+      await waitFor(() => expect(rpc.upsertCitation).toHaveBeenCalledTimes(2))
+      expect(rpc.getOrCreateComparisonSet).toHaveBeenCalledTimes(1)
+      expect(rpc.upsertCitation).toHaveBeenLastCalledWith({
+        p_option_document_id: document.id,
+        p_comparison_set_id: createdComparisonSet.id,
+        p_criterion_id: criterionId,
+        p_page_section: "Trang 12",
+        p_excerpt: "Đáp ứng đúng tiêu chí",
+        p_expected_revision: createdComparisonSet.revision + 1,
+      })
+    })
+
+    it("keeps locked baselines editable and archived dossiers read-only", async () => {
+      const lockedBaseline = baselineVersion({
+        status: "locked",
+        locked_at: "2026-07-26T01:00:00.000Z",
+        locked_by: 1,
+      })
+      const lockedView = renderOptionEvidence({ baseline: lockedBaseline })
+      expect(await screen.findByLabelText("Tên tài liệu")).toBeEnabled()
+      lockedView.unmount()
+
+      renderOptionEvidence({
+        baseline: lockedBaseline,
+        dossierValue: {
+          ...dossier,
+          archived_at: "2026-07-26T02:00:00.000Z",
+          archived_by: 1,
+        },
+      })
+      expect(await screen.findByLabelText("Tên tài liệu")).toBeDisabled()
+      expect(screen.getByText("Chỉ đọc")).toBeInTheDocument()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/option-evidence-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/option-evidence-workspace-cases.tsx
@@ -158,6 +158,81 @@ export function registerOptionEvidenceWorkspaceTests(rpc: OptionEvidenceRpcMocks
       expect(rpc.getOrCreateComparisonSet).not.toHaveBeenCalled()
     })
 
+    it("switches to the exact comparison set when the selected option changes", async () => {
+      const user = userEvent.setup()
+      const firstOption = option({ id: "option-1" })
+      const secondOption = option({ id: "option-2" })
+      const firstBaseline = baselineVersion({ id: "baseline-1" })
+      const secondBaseline = baselineVersion({ id: "baseline-2" })
+      const secondCriterionId = secondBaseline.groups[0]?.criteria[0]?.id ?? ""
+      const firstComparisonSet = {
+        ...comparisonSet(firstBaseline, [], dossier.revision + 5),
+        id: "comparison-set-option-1",
+        option_id: firstOption.id,
+      }
+      const secondComparisonSet = {
+        ...comparisonSet(secondBaseline, [], dossier.revision + 1),
+        id: "comparison-set-option-2",
+        option_id: secondOption.id,
+      }
+      const firstDocument = optionDocument({ id: "document-option-1" })
+      const secondDocument = {
+        ...optionDocument({ id: "document-option-2" }),
+        option_id: secondOption.id,
+      }
+      rpc.listDocuments
+        .mockResolvedValueOnce(documentsResponse([firstDocument]))
+        .mockResolvedValueOnce(documentsResponse([secondDocument]))
+      rpc.upsertCitation.mockResolvedValue({
+        data: {
+          id: "citation-option-2",
+          criterion_id: secondCriterionId,
+          page_section: "Trang 8",
+          excerpt: "Đúng phương án 2",
+          revision: firstComparisonSet.revision + 1,
+        },
+      })
+      const queryClient = createTestQueryClient()
+      const view = render(
+        <TechnicalConfigurationOptionDocuments
+          dossier={dossier}
+          option={firstOption}
+          baselineVersion={firstBaseline}
+          comparisonSet={firstComparisonSet}
+          criterionId={firstBaseline.groups[0]?.criteria[0]?.id}
+        />,
+        { wrapper: createReactQueryWrapper(queryClient) }
+      )
+      await screen.findByRole("link", {
+        name: `${firstDocument.name} (mở trong tab mới)`,
+      })
+
+      view.rerender(
+        <TechnicalConfigurationOptionDocuments
+          dossier={dossier}
+          option={secondOption}
+          baselineVersion={secondBaseline}
+          comparisonSet={secondComparisonSet}
+          criterionId={secondCriterionId}
+        />
+      )
+      await screen.findByRole("link", {
+        name: `${secondDocument.name} (mở trong tab mới)`,
+      })
+      await user.type(screen.getByLabelText("Trang hoặc mục"), "Trang 8")
+      await user.type(screen.getByLabelText("Trích đoạn"), "Đúng phương án 2")
+      await user.click(screen.getByRole("button", { name: "Lưu trích dẫn" }))
+
+      await waitFor(() =>
+        expect(rpc.upsertCitation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            p_comparison_set_id: secondComparisonSet.id,
+          })
+        )
+      )
+      expect(rpc.getOrCreateComparisonSet).not.toHaveBeenCalled()
+    })
+
     it("shows the global affected citation count and mutates only after confirmation", async () => {
       const user = userEvent.setup()
       const document = optionDocument({ affectedCitationCount: 7 })

--- a/src/app/(app)/technical-configurations/__tests__/option-evidence.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/option-evidence.test.tsx
@@ -1,0 +1,455 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useTechnicalConfigurationOptionDocuments } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionDocuments"
+import {
+  technicalConfigurationOptionDocumentsQueryKey,
+  technicalConfigurationOptionResponsesQueryKey,
+} from "@/app/(app)/technical-configurations/technical-configuration-query-keys"
+import type {
+  TechnicalConfigurationOptionDocumentWire,
+  TechnicalConfigurationOptionDocumentsListWireResponse,
+} from "@/app/(app)/technical-configurations/document-types"
+import type { TechnicalConfigurationComparisonSetWire } from "@/app/(app)/technical-configurations/supplier-option-types"
+import { createReactQueryWrapper, createTestQueryClient } from "@/test-utils/react-query"
+
+import { baselineVersion } from "./baseline-evidence-fixtures"
+import { registerOptionEvidenceWorkspaceTests } from "./option-evidence-workspace-cases"
+import { dossier, option } from "./supplier-options-fixtures"
+
+const rpc = vi.hoisted(() => ({
+  listDocuments: vi.fn(),
+  createDocument: vi.fn(),
+  updateDocument: vi.fn(),
+  deleteDocument: vi.fn(),
+  upsertCitation: vi.fn(),
+  deleteCitation: vi.fn(),
+  getOrCreateComparisonSet: vi.fn(),
+  fetchDossierRevision: vi.fn(),
+}))
+
+vi.mock("@/app/(app)/technical-configurations/technical-configuration-document-rpc", () => ({
+  listTechnicalConfigurationOptionDocuments: rpc.listDocuments,
+  createTechnicalConfigurationOptionDocument: rpc.createDocument,
+  updateTechnicalConfigurationOptionDocument: rpc.updateDocument,
+  deleteTechnicalConfigurationOptionDocument: rpc.deleteDocument,
+  upsertTechnicalConfigurationOptionCitation: rpc.upsertCitation,
+  deleteTechnicalConfigurationOptionCitation: rpc.deleteCitation,
+}))
+
+vi.mock(
+  "@/app/(app)/technical-configurations/technical-configuration-option-response-operations",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/app/(app)/technical-configurations/technical-configuration-option-response-operations")
+    >()),
+    getOrCreateTechnicalConfigurationComparisonSet: rpc.getOrCreateComparisonSet,
+  })
+)
+
+vi.mock(
+  "@/app/(app)/technical-configurations/technical-configuration-dossier-revision-cache",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/app/(app)/technical-configurations/technical-configuration-dossier-revision-cache")
+    >()),
+    fetchTechnicalConfigurationDossierRevision: rpc.fetchDossierRevision,
+  })
+)
+
+const currentOption = option({ id: "option-1" })
+const currentBaseline = {
+  ...baselineVersion,
+  dossier_id: dossier.id,
+}
+
+function optionDocument(
+  id: string,
+  citations: TechnicalConfigurationOptionDocumentWire["citations"] = [],
+  affectedCitationCount = citations.length
+): TechnicalConfigurationOptionDocumentWire {
+  return {
+    id,
+    option_id: currentOption.id,
+    name: `Tài liệu ${id}`,
+    url: `https://example.com/${id}.pdf`,
+    created_by: 1,
+    created_at: "2026-07-26T00:00:00.000Z",
+    updated_at: "2026-07-26T00:00:00.000Z",
+    affected_citation_count: affectedCitationCount,
+    citations,
+  }
+}
+
+function documentsResponse(
+  data: TechnicalConfigurationOptionDocumentWire[]
+): TechnicalConfigurationOptionDocumentsListWireResponse {
+  return {
+    data,
+    total: data.length,
+    page: 1,
+    page_size: 100,
+  }
+}
+
+function comparisonSet(revision: number): TechnicalConfigurationComparisonSetWire {
+  return {
+    id: "comparison-set-1",
+    dossier_id: dossier.id,
+    option_id: currentOption.id,
+    baseline_version_id: currentBaseline.id,
+    created_at: "2026-07-26T00:00:00.000Z",
+    created_by: 1,
+    updated_at: "2026-07-26T00:00:00.000Z",
+    updated_by: 1,
+    revision,
+    responses: [],
+  }
+}
+
+function renderOptionDocumentsHook({
+  baseline = currentBaseline,
+  dossierValue = dossier,
+  initialComparisonSet = null,
+  onRevisionChange = vi.fn(),
+  onNavigationBlockedChange = vi.fn(),
+  queryClient = createTestQueryClient(),
+}: {
+  baseline?: typeof currentBaseline
+  dossierValue?: typeof dossier
+  initialComparisonSet?: TechnicalConfigurationComparisonSetWire | null
+  onRevisionChange?: (revision: number) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+  queryClient?: ReturnType<typeof createTestQueryClient>
+} = {}) {
+  const responseQueryKey = technicalConfigurationOptionResponsesQueryKey(
+    currentOption.id,
+    baseline.id
+  )
+  queryClient.setQueryDefaults(responseQueryKey, { gcTime: Number.POSITIVE_INFINITY })
+  if (initialComparisonSet) {
+    queryClient.setQueryData(responseQueryKey, initialComparisonSet)
+  }
+  const rendered = renderHook(
+    () =>
+      useTechnicalConfigurationOptionDocuments({
+        dossier: dossierValue,
+        option: currentOption,
+        baselineVersion: baseline,
+        comparisonSet: initialComparisonSet,
+        onRevisionChange,
+        onNavigationBlockedChange,
+      }),
+    { wrapper: createReactQueryWrapper(queryClient) }
+  )
+  return { ...rendered, queryClient, onRevisionChange, onNavigationBlockedChange }
+}
+
+describe("useTechnicalConfigurationOptionDocuments", () => {
+  beforeEach(() => {
+    Object.values(rpc).forEach((mock) => mock.mockReset())
+    rpc.listDocuments.mockResolvedValue(documentsResponse([]))
+  })
+
+  it("lists shared option documents for the exact baseline without creating a comparison set", async () => {
+    const sharedDocument = optionDocument("document-1")
+    rpc.listDocuments.mockResolvedValue(documentsResponse([sharedDocument]))
+
+    const { result } = renderOptionDocumentsHook()
+
+    await waitFor(() => expect(result.current.documentsQuery.isSuccess).toBe(true))
+    expect(result.current.documents).toEqual([sharedDocument])
+    expect(rpc.listDocuments).toHaveBeenCalledWith(
+      {
+        p_option_id: currentOption.id,
+        p_baseline_version_id: currentBaseline.id,
+        p_page: 1,
+        p_page_size: 100,
+      },
+      expect.any(AbortSignal)
+    )
+    expect(rpc.getOrCreateComparisonSet).not.toHaveBeenCalled()
+  })
+
+  it("uses separate exact-baseline query keys while retaining the shared option document identity", () => {
+    expect(
+      technicalConfigurationOptionDocumentsQueryKey(currentOption.id, currentBaseline.id)
+    ).not.toEqual(
+      technicalConfigurationOptionDocumentsQueryKey(currentOption.id, "baseline-version-2")
+    )
+  })
+
+  it("refreshes another cached baseline after a shared option document mutation", async () => {
+    const firstBaseline = { ...currentBaseline, id: "baseline-version-1" }
+    const secondBaseline = { ...currentBaseline, id: "baseline-version-2" }
+    const staleSecondDocument = {
+      ...optionDocument("document-1"),
+      name: "Tài liệu cũ",
+      affected_citation_count: 1,
+    }
+    const refreshedSecondDocument = {
+      ...staleSecondDocument,
+      name: "Tài liệu mới",
+      affected_citation_count: 2,
+    }
+    const queryClient = createTestQueryClient()
+    queryClient.setQueryDefaults(
+      technicalConfigurationOptionDocumentsQueryKey(currentOption.id, secondBaseline.id),
+      { gcTime: Number.POSITIVE_INFINITY }
+    )
+    queryClient.setQueryData(
+      technicalConfigurationOptionDocumentsQueryKey(currentOption.id, secondBaseline.id),
+      [staleSecondDocument]
+    )
+    rpc.listDocuments.mockImplementation(
+      ({ p_baseline_version_id }: { p_baseline_version_id: string }) =>
+        Promise.resolve(
+          documentsResponse(
+            p_baseline_version_id === secondBaseline.id ? [refreshedSecondDocument] : []
+          )
+        )
+    )
+    rpc.createDocument.mockResolvedValue({
+      data: {
+        ...optionDocument("document-2"),
+        revision: dossier.revision + 1,
+      },
+    })
+
+    const firstView = renderOptionDocumentsHook({
+      baseline: firstBaseline,
+      queryClient,
+    })
+    await waitFor(() => expect(firstView.result.current.documentsQuery.isSuccess).toBe(true))
+    await act(async () => {
+      await firstView.result.current.createDocument({
+        name: "Tài liệu mới",
+        url: "https://example.com/document-2.pdf",
+      })
+    })
+    expect(
+      queryClient.getQueryState(
+        technicalConfigurationOptionDocumentsQueryKey(currentOption.id, secondBaseline.id)
+      )?.isInvalidated
+    ).toBe(true)
+    firstView.unmount()
+
+    const secondView = renderOptionDocumentsHook({
+      baseline: secondBaseline,
+      queryClient,
+    })
+    await waitFor(() =>
+      expect(secondView.result.current.documents).toEqual([refreshedSecondDocument])
+    )
+    expect(rpc.listDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ p_baseline_version_id: secondBaseline.id }),
+      expect.any(AbortSignal)
+    )
+  })
+
+  it("gets or creates the comparison set before the first explicit citation upsert", async () => {
+    const document = optionDocument("document-1")
+    const expectedRevision = Math.max(dossier.revision, currentBaseline.revision)
+    const createdComparisonSet = comparisonSet(expectedRevision + 1)
+    rpc.listDocuments.mockResolvedValue(documentsResponse([document]))
+    rpc.getOrCreateComparisonSet.mockResolvedValue(createdComparisonSet)
+    rpc.upsertCitation.mockResolvedValue({
+      data: {
+        id: "citation-1",
+        criterion_id: "criterion-1",
+        page_section: "Trang 12",
+        excerpt: "Đáp ứng 220V",
+        revision: createdComparisonSet.revision + 1,
+      },
+    })
+    const rendered = renderOptionDocumentsHook()
+    await waitFor(() => expect(rendered.result.current.documentsQuery.isSuccess).toBe(true))
+
+    await act(async () => {
+      await rendered.result.current.upsertCitation({
+        document,
+        criterionId: "criterion-1",
+        pageSection: "Trang 12",
+        excerpt: "Đáp ứng 220V",
+      })
+    })
+
+    expect(rpc.getOrCreateComparisonSet).toHaveBeenCalledWith({
+      p_option_id: currentOption.id,
+      p_baseline_version_id: currentBaseline.id,
+      p_expected_revision: expectedRevision,
+    })
+    expect(rpc.upsertCitation).toHaveBeenCalledWith({
+      p_option_document_id: document.id,
+      p_comparison_set_id: createdComparisonSet.id,
+      p_criterion_id: "criterion-1",
+      p_page_section: "Trang 12",
+      p_excerpt: "Đáp ứng 220V",
+      p_expected_revision: createdComparisonSet.revision,
+    })
+    expect(rpc.getOrCreateComparisonSet.mock.invocationCallOrder[0]).toBeLessThan(
+      rpc.upsertCitation.mock.invocationCallOrder[0]
+    )
+    expect(
+      rendered.queryClient.getQueryData(
+        technicalConfigurationOptionResponsesQueryKey(currentOption.id, currentBaseline.id)
+      )
+    ).toEqual(createdComparisonSet)
+    expect(rendered.onRevisionChange).toHaveBeenNthCalledWith(1, createdComparisonSet.revision)
+    expect(rendered.onRevisionChange).toHaveBeenLastCalledWith(createdComparisonSet.revision + 1)
+  })
+
+  it("uses an existing exact-baseline comparison set without calling get-or-create", async () => {
+    const document = optionDocument("document-1")
+    const existingComparisonSet = comparisonSet(dossier.revision + 4)
+    const rendered = renderOptionDocumentsHook({
+      dossierValue: { ...dossier, revision: existingComparisonSet.revision },
+      initialComparisonSet: existingComparisonSet,
+    })
+    rpc.upsertCitation.mockResolvedValue({
+      data: {
+        id: "citation-1",
+        criterion_id: "criterion-1",
+        page_section: null,
+        excerpt: "Đạt",
+        revision: existingComparisonSet.revision + 1,
+      },
+    })
+    await waitFor(() => expect(rendered.result.current.documentsQuery.isSuccess).toBe(true))
+
+    await act(async () => {
+      await rendered.result.current.upsertCitation({
+        document,
+        criterionId: "criterion-1",
+        pageSection: null,
+        excerpt: "Đạt",
+      })
+    })
+
+    expect(rpc.getOrCreateComparisonSet).not.toHaveBeenCalled()
+    expect(rpc.upsertCitation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        p_comparison_set_id: existingComparisonSet.id,
+        p_expected_revision: existingComparisonSet.revision,
+      })
+    )
+  })
+
+  it("advances the expected revision across consecutive citation saves", async () => {
+    const document = optionDocument("document-1")
+    const existingComparisonSet = comparisonSet(dossier.revision + 4)
+    const rendered = renderOptionDocumentsHook({
+      dossierValue: { ...dossier, revision: existingComparisonSet.revision },
+      initialComparisonSet: existingComparisonSet,
+    })
+    rpc.upsertCitation
+      .mockResolvedValueOnce({
+        data: {
+          id: "citation-1",
+          criterion_id: "criterion-1",
+          page_section: "Trang 1",
+          excerpt: "Đạt lần một",
+          revision: existingComparisonSet.revision + 1,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          id: "citation-1",
+          criterion_id: "criterion-1",
+          page_section: "Trang 2",
+          excerpt: "Đạt lần hai",
+          revision: existingComparisonSet.revision + 2,
+        },
+      })
+    await waitFor(() => expect(rendered.result.current.documentsQuery.isSuccess).toBe(true))
+
+    await act(async () => {
+      await rendered.result.current.upsertCitation({
+        document,
+        criterionId: "criterion-1",
+        pageSection: "Trang 1",
+        excerpt: "Đạt lần một",
+      })
+    })
+    await act(async () => {
+      await rendered.result.current.upsertCitation({
+        document,
+        criterionId: "criterion-1",
+        pageSection: "Trang 2",
+        excerpt: "Đạt lần hai",
+      })
+    })
+
+    expect(rpc.upsertCitation).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        p_expected_revision: existingComparisonSet.revision,
+      })
+    )
+    expect(rpc.upsertCitation).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        p_expected_revision: existingComparisonSet.revision + 1,
+      })
+    )
+  })
+
+  it("returns the global affected citation count from confirmed document deletion", async () => {
+    const document = optionDocument("document-1", [], 7)
+    rpc.deleteDocument.mockResolvedValue({
+      data: {
+        id: document.id,
+        revision: dossier.revision + 1,
+        affected_citation_count: 7,
+      },
+    })
+    const rendered = renderOptionDocumentsHook()
+    await waitFor(() => expect(rendered.result.current.documentsQuery.isSuccess).toBe(true))
+
+    await expect(act(async () => rendered.result.current.deleteDocument(document))).resolves.toBe(7)
+  })
+
+  it("allows evidence mutations for locked baselines but blocks archived dossiers", async () => {
+    rpc.createDocument.mockResolvedValue({
+      data: {
+        ...optionDocument("document-1"),
+        revision: dossier.revision + 1,
+      },
+    })
+    const locked = renderOptionDocumentsHook({
+      baseline: {
+        ...currentBaseline,
+        status: "locked",
+        locked_at: "2026-07-26T01:00:00.000Z",
+        locked_by: 1,
+      },
+    })
+    await waitFor(() => expect(locked.result.current.documentsQuery.isSuccess).toBe(true))
+
+    await act(async () => {
+      await locked.result.current.createDocument({
+        name: "Tài liệu khóa",
+        url: "https://example.com/locked.pdf",
+      })
+    })
+    expect(rpc.createDocument).toHaveBeenCalledTimes(1)
+
+    const archived = renderOptionDocumentsHook({
+      dossierValue: {
+        ...dossier,
+        archived_at: "2026-07-26T02:00:00.000Z",
+        archived_by: 1,
+      },
+    })
+    await waitFor(() => expect(archived.result.current.documentsQuery.isSuccess).toBe(true))
+    await expect(
+      archived.result.current.createDocument({
+        name: "Không được lưu",
+        url: "https://example.com/read-only.pdf",
+      })
+    ).rejects.toThrow("read_only")
+    expect(rpc.createDocument).toHaveBeenCalledTimes(1)
+  })
+})
+
+registerOptionEvidenceWorkspaceTests(rpc)

--- a/src/app/(app)/technical-configurations/__tests__/supplier-option-response-coordination-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-option-response-coordination-cases.tsx
@@ -26,12 +26,17 @@ import {
 type ResponseCoordinationTestMocks = {
   baselineRpc: { listVersions: Mock }
   fetchMock: Mock
+  optionEvidenceRpc: {
+    listDocuments: Mock
+    createDocument: Mock
+  }
   supplierOptionRpc: SupplierOptionRpcMocks
 }
 
 export function registerSupplierOptionResponseCoordinationTests({
   baselineRpc,
   fetchMock,
+  optionEvidenceRpc,
   supplierOptionRpc,
 }: ResponseCoordinationTestMocks) {
   describe("technical configuration option response coordination", () => {
@@ -115,6 +120,79 @@ export function registerSupplierOptionResponseCoordinationTests({
 
       act(() => createRequest.resolve(jsonResponse({ data: createdSet })))
       await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    })
+
+    it("blocks response and identity writes while option evidence is dirty or pending", async () => {
+      const user = userEvent.setup()
+      const baseline = baselineVersion()
+      const currentSupplier = supplier("supplier-1", "Công ty Thiết bị A")
+      const currentOption = option({ id: "option-1", supplierId: currentSupplier.id })
+      const evidenceCreateRequest = deferred<{
+        data: {
+          id: string
+          option_id: string
+          name: string
+          url: string
+          created_by: number
+          created_at: string
+          updated_at: string
+          affected_citation_count: number
+          citations: []
+          revision: number
+        }
+      }>()
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baseline],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      supplierOptionRpc.listSuppliers.mockResolvedValue(suppliersResponse([currentSupplier]))
+      supplierOptionRpc.listOptions.mockResolvedValue(optionsResponse([currentOption]))
+      fetchMock.mockResolvedValueOnce(jsonResponse({ data: comparisonSet(baseline) }))
+      optionEvidenceRpc.createDocument.mockImplementationOnce(() => evidenceCreateRequest.promise)
+
+      renderWithQueryClient(<TechnicalConfigurationSuppliers dossier={dossier} />)
+      const supplierNameInput = await screen.findByLabelText("Tên nhà cung cấp")
+      await user.type(supplierNameInput, " cập nhật")
+      expect(screen.getByRole("button", { name: "Lưu nhà cung cấp" })).toBeEnabled()
+
+      await user.type(await screen.findByLabelText("Tên tài liệu"), "Hồ sơ chứng minh")
+
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toBeDisabled()
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Lưu nhà cung cấp" })).toBeDisabled()
+      )
+      expect(supplierOptionRpc.updateSupplier).not.toHaveBeenCalled()
+
+      await user.type(
+        screen.getByLabelText("Đường dẫn (URL)"),
+        "https://example.com/option-evidence.pdf"
+      )
+      await user.click(screen.getByRole("button", { name: "Thêm tài liệu" }))
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Thêm nhà cung cấp" })).toBeDisabled()
+      )
+      expect(screen.getByLabelText("Phản hồi tiêu chí")).toBeDisabled()
+
+      act(() =>
+        evidenceCreateRequest.resolve({
+          data: {
+            id: "document-1",
+            option_id: currentOption.id,
+            name: "Hồ sơ chứng minh",
+            url: "https://example.com/option-evidence.pdf",
+            created_by: 1,
+            created_at: "2026-07-26T00:00:00.000Z",
+            updated_at: "2026-07-26T00:00:00.000Z",
+            affected_citation_count: 0,
+            citations: [],
+            revision: dossier.revision + 1,
+          },
+        })
+      )
+      await waitFor(() => expect(optionEvidenceRpc.createDocument).toHaveBeenCalledTimes(1))
     })
   })
 }

--- a/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/supplier-options.test.tsx
@@ -29,6 +29,15 @@ const supplierOptionRpc = vi.hoisted(() => ({
 
 const optionResponseFetch = vi.hoisted(() => vi.fn())
 
+const optionEvidenceRpc = vi.hoisted(() => ({
+  listDocuments: vi.fn(),
+  createDocument: vi.fn(),
+  updateDocument: vi.fn(),
+  deleteDocument: vi.fn(),
+  upsertCitation: vi.fn(),
+  deleteCitation: vi.fn(),
+}))
+
 const workbookCodec = vi.hoisted(() => ({
   readWorkbook: vi.fn(),
   createParser: vi.fn(),
@@ -49,6 +58,15 @@ vi.mock("@/app/(app)/technical-configurations/technical-configuration-supplier-o
   createTechnicalConfigurationOption: supplierOptionRpc.createOption,
   updateTechnicalConfigurationOption: supplierOptionRpc.updateOption,
   deleteTechnicalConfigurationOption: supplierOptionRpc.deleteOption,
+}))
+
+vi.mock("@/app/(app)/technical-configurations/technical-configuration-document-rpc", () => ({
+  listTechnicalConfigurationOptionDocuments: optionEvidenceRpc.listDocuments,
+  createTechnicalConfigurationOptionDocument: optionEvidenceRpc.createDocument,
+  updateTechnicalConfigurationOptionDocument: optionEvidenceRpc.updateDocument,
+  deleteTechnicalConfigurationOptionDocument: optionEvidenceRpc.deleteDocument,
+  upsertTechnicalConfigurationOptionCitation: optionEvidenceRpc.upsertCitation,
+  deleteTechnicalConfigurationOptionCitation: optionEvidenceRpc.deleteCitation,
 }))
 
 vi.mock("@/lib/excel-utils", () => ({
@@ -79,6 +97,13 @@ beforeEach(() => {
     page_size: 100,
   })
   optionResponseFetch.mockReset()
+  Object.values(optionEvidenceRpc).forEach((mock) => mock.mockReset())
+  optionEvidenceRpc.listDocuments.mockResolvedValue({
+    data: [],
+    total: 0,
+    page: 1,
+    page_size: 100,
+  })
 })
 
 registerSupplierOptionHookTests(supplierOptionRpc)
@@ -114,6 +139,7 @@ registerSupplierOptionResponseRecoveryTests({
 registerSupplierOptionResponseCoordinationTests({
   baselineRpc,
   fetchMock: optionResponseFetch,
+  optionEvidenceRpc,
   supplierOptionRpc,
 })
 registerSupplierOptionResponseAvailabilityTests({

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
@@ -4,7 +4,9 @@ import * as React from "react"
 import { Button, Chip, Input, Label, ListBox, Select, TextArea, TextField } from "@heroui/react"
 
 import {
+  createTechnicalConfigurationCitationEditorState,
   getTechnicalConfigurationCitationValues,
+  reduceTechnicalConfigurationCitationEditorState,
   type TechnicalConfigurationCitationSelectionSnapshot,
 } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState"
 import { useTechnicalConfigurationDiscardConfirmation } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation"
@@ -17,29 +19,37 @@ export type TechnicalConfigurationCitationCriterion = {
   title: string
 }
 
-export type TechnicalConfigurationCitationSaveInput = {
-  document: TechnicalConfigurationDocumentWire
+type TechnicalConfigurationCitationDocument = Pick<
+  TechnicalConfigurationDocumentWire,
+  "id" | "name" | "citations"
+>
+
+export type TechnicalConfigurationCitationSaveInput<
+  TDocument extends TechnicalConfigurationCitationDocument = TechnicalConfigurationDocumentWire,
+> = {
+  document: TDocument
   criterionId: string
   pageSection: string | null
   excerpt: string | null
 }
 
-type TechnicalConfigurationCitationEditorProps = {
-  documents: readonly TechnicalConfigurationDocumentWire[]
+type TechnicalConfigurationCitationEditorProps<
+  TDocument extends TechnicalConfigurationCitationDocument,
+> = {
+  documents: readonly TDocument[]
   criteria: readonly TechnicalConfigurationCitationCriterion[]
   fixedCriterionId?: string | null
   isPending: boolean
   disabled: boolean
-  onSave: (input: TechnicalConfigurationCitationSaveInput) => Promise<unknown>
-  onDelete: (input: {
-    document: TechnicalConfigurationDocumentWire
-    citationId: string
-  }) => Promise<unknown>
+  onSave: (input: TechnicalConfigurationCitationSaveInput<TDocument>) => Promise<unknown>
+  onDelete: (input: { document: TDocument; citationId: string }) => Promise<unknown>
   onDirtyChange?: (dirty: boolean) => void
 }
 
 /** Renders controlled criterion-level citation fields with explicit persistence. */
-export function TechnicalConfigurationCitationEditor({
+export function TechnicalConfigurationCitationEditor<
+  TDocument extends TechnicalConfigurationCitationDocument,
+>({
   documents,
   criteria,
   fixedCriterionId = null,
@@ -48,21 +58,21 @@ export function TechnicalConfigurationCitationEditor({
   onSave,
   onDelete,
   onDirtyChange,
-}: Readonly<TechnicalConfigurationCitationEditorProps>): React.JSX.Element {
+}: Readonly<TechnicalConfigurationCitationEditorProps<TDocument>>): React.JSX.Element {
   const initialDocumentId = documents[0]?.id ?? null
   const initialCriterionId = fixedCriterionId ?? criteria[0]?.id ?? null
   const initialDocument = documents.find((document) => document.id === initialDocumentId) ?? null
   const initialValues = getTechnicalConfigurationCitationValues(initialDocument, initialCriterionId)
-  const [selectedDocumentId, setSelectedDocumentId] = React.useState<string | null>(
-    initialDocumentId
+  const [editorState, dispatch] = React.useReducer(
+    reduceTechnicalConfigurationCitationEditorState,
+    createTechnicalConfigurationCitationEditorState(
+      initialDocumentId,
+      initialCriterionId,
+      initialValues
+    )
   )
-  const [selectedCriterionId, setSelectedCriterionId] = React.useState<string | null>(
-    initialCriterionId
-  )
-  const [pageSection, setPageSection] = React.useState(initialValues.pageSection)
-  const [excerpt, setExcerpt] = React.useState(initialValues.excerpt)
-  const [baseValues, setBaseValues] = React.useState(initialValues)
-  const [saveError, setSaveError] = React.useState<unknown>(null)
+  const { selectedDocumentId, selectedCriterionId, pageSection, excerpt, baseValues, saveError } =
+    editorState
   const { discardConfirmationDialog, requestDiscardConfirmation } =
     useTechnicalConfigurationDiscardConfirmation()
   const observedSelectionRef = React.useRef<TechnicalConfigurationCitationSelectionSnapshot>({
@@ -89,12 +99,7 @@ export function TechnicalConfigurationCitationEditor({
       const document = documents.find((item) => item.id === documentId) ?? null
       const values = getTechnicalConfigurationCitationValues(document, criterionId)
       observedSelectionRef.current = { documentId, criterionId, ...values }
-      setSelectedDocumentId(documentId)
-      setSelectedCriterionId(criterionId)
-      setPageSection(values.pageSection)
-      setExcerpt(values.excerpt)
-      setBaseValues(values)
-      setSaveError(null)
+      dispatch({ type: "adopt-selection", documentId, criterionId, values })
     },
     [documents]
   )
@@ -142,7 +147,7 @@ export function TechnicalConfigurationCitationEditor({
 
   const handleSave = React.useCallback(async () => {
     if (!canSave || !selectedDocument || !selectedCriterionId) return
-    setSaveError(null)
+    dispatch({ type: "save-start" })
     try {
       await onSave({
         document: selectedDocument,
@@ -150,15 +155,15 @@ export function TechnicalConfigurationCitationEditor({
         pageSection: pageSection || null,
         excerpt: excerpt || null,
       })
-      setBaseValues({ pageSection, excerpt })
+      dispatch({ type: "save-success", values: { pageSection, excerpt } })
     } catch (error) {
-      setSaveError(error)
+      dispatch({ type: "save-error", error })
     }
   }, [canSave, excerpt, onSave, pageSection, selectedCriterionId, selectedDocument])
 
   const handleDelete = React.useCallback(async () => {
     if (disabled || isPending || !selectedDocument || !selectedCitation) return
-    setSaveError(null)
+    dispatch({ type: "save-start" })
     try {
       await onDelete({
         document: selectedDocument,
@@ -170,11 +175,9 @@ export function TechnicalConfigurationCitationEditor({
         criterionId: selectedCriterionId,
         ...emptyValues,
       }
-      setPageSection("")
-      setExcerpt("")
-      setBaseValues(emptyValues)
+      dispatch({ type: "delete-success" })
     } catch (error) {
-      setSaveError(error)
+      dispatch({ type: "save-error", error })
     }
   }, [disabled, isPending, onDelete, selectedCitation, selectedCriterionId, selectedDocument])
 
@@ -266,11 +269,19 @@ export function TechnicalConfigurationCitationEditor({
         )}
       </div>
 
-      <TextField value={pageSection} onChange={setPageSection} isDisabled={disabled || isPending}>
+      <TextField
+        value={pageSection}
+        onChange={(value) => dispatch({ type: "set-page-section", value })}
+        isDisabled={disabled || isPending}
+      >
         <Label>Trang hoặc mục</Label>
         <Input placeholder="Ví dụ: Trang 12, Mục 4.2" />
       </TextField>
-      <TextField value={excerpt} onChange={setExcerpt} isDisabled={disabled || isPending}>
+      <TextField
+        value={excerpt}
+        onChange={(value) => dispatch({ type: "set-excerpt", value })}
+        isDisabled={disabled || isPending}
+      >
         <Label>Trích đoạn</Label>
         <TextArea rows={5} placeholder="Nhập nguyên văn đoạn chứng minh cho tiêu chí." />
       </TextField>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditor.tsx
@@ -19,7 +19,7 @@ export type TechnicalConfigurationCitationCriterion = {
   title: string
 }
 
-type TechnicalConfigurationCitationDocument = Pick<
+export type TechnicalConfigurationCitationDocument = Pick<
   TechnicalConfigurationDocumentWire,
   "id" | "name" | "citations"
 >
@@ -33,7 +33,7 @@ export type TechnicalConfigurationCitationSaveInput<
   excerpt: string | null
 }
 
-type TechnicalConfigurationCitationEditorProps<
+export type TechnicalConfigurationCitationEditorProps<
   TDocument extends TechnicalConfigurationCitationDocument,
 > = {
   documents: readonly TDocument[]

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState.ts
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState.ts
@@ -99,7 +99,10 @@ export function getTechnicalConfigurationCitationValues(
   document: TechnicalConfigurationCitationValuesDocument | null,
   criterionId: string | null
 ): TechnicalConfigurationCitationValues {
-  const citation = document?.citations.find((item) => item.criterion_id === criterionId)
+  if (!document || !criterionId) {
+    return { pageSection: "", excerpt: "" }
+  }
+  const citation = document.citations.find((item) => item.criterion_id === criterionId)
   return {
     pageSection: citation?.page_section ?? "",
     excerpt: citation?.excerpt ?? "",

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState.ts
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationCitationEditorState.ts
@@ -1,5 +1,3 @@
-import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
-
 export type TechnicalConfigurationCitationValues = {
   pageSection: string
   excerpt: string
@@ -11,9 +9,94 @@ export type TechnicalConfigurationCitationSelectionSnapshot =
     criterionId: string | null
   }
 
+export type TechnicalConfigurationCitationEditorState = {
+  selectedDocumentId: string | null
+  selectedCriterionId: string | null
+  pageSection: string
+  excerpt: string
+  baseValues: TechnicalConfigurationCitationValues
+  saveError: unknown
+}
+
+export type TechnicalConfigurationCitationEditorAction =
+  | {
+      type: "adopt-selection"
+      documentId: string | null
+      criterionId: string | null
+      values: TechnicalConfigurationCitationValues
+    }
+  | { type: "set-page-section"; value: string }
+  | { type: "set-excerpt"; value: string }
+  | { type: "save-start" }
+  | { type: "save-success"; values: TechnicalConfigurationCitationValues }
+  | { type: "save-error"; error: unknown }
+  | { type: "delete-success" }
+
+type TechnicalConfigurationCitationValuesDocument = {
+  citations: readonly {
+    criterion_id: string
+    page_section: string | null
+    excerpt: string | null
+  }[]
+}
+
+/** Creates the controlled citation editor state for one initial selection. */
+export function createTechnicalConfigurationCitationEditorState(
+  documentId: string | null,
+  criterionId: string | null,
+  values: TechnicalConfigurationCitationValues
+): TechnicalConfigurationCitationEditorState {
+  return {
+    selectedDocumentId: documentId,
+    selectedCriterionId: criterionId,
+    pageSection: values.pageSection,
+    excerpt: values.excerpt,
+    baseValues: values,
+    saveError: null,
+  }
+}
+
+/** Applies one atomic citation editor transition. */
+export function reduceTechnicalConfigurationCitationEditorState(
+  state: TechnicalConfigurationCitationEditorState,
+  action: TechnicalConfigurationCitationEditorAction
+): TechnicalConfigurationCitationEditorState {
+  switch (action.type) {
+    case "adopt-selection":
+      return {
+        selectedDocumentId: action.documentId,
+        selectedCriterionId: action.criterionId,
+        pageSection: action.values.pageSection,
+        excerpt: action.values.excerpt,
+        baseValues: action.values,
+        saveError: null,
+      }
+    case "set-page-section":
+      return { ...state, pageSection: action.value }
+    case "set-excerpt":
+      return { ...state, excerpt: action.value }
+    case "save-start":
+      return { ...state, saveError: null }
+    case "save-success":
+      return { ...state, baseValues: action.values }
+    case "save-error":
+      return { ...state, saveError: action.error }
+    case "delete-success": {
+      const emptyValues = { pageSection: "", excerpt: "" }
+      return {
+        ...state,
+        pageSection: "",
+        excerpt: "",
+        baseValues: emptyValues,
+        saveError: null,
+      }
+    }
+  }
+}
+
 /** Reads editable citation values for one exact document and criterion. */
 export function getTechnicalConfigurationCitationValues(
-  document: TechnicalConfigurationDocumentWire | null,
+  document: TechnicalConfigurationCitationValuesDocument | null,
   criterionId: string | null
 ): TechnicalConfigurationCitationValues {
   const citation = document?.citations.find((item) => item.criterion_id === criterionId)

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentDeleteDialog.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationDocumentDeleteDialog.tsx
@@ -4,8 +4,14 @@ import { AlertDialog, Button } from "@heroui/react"
 
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
 
+type TechnicalConfigurationDeleteDocument = Pick<
+  TechnicalConfigurationDocumentWire,
+  "name" | "citations"
+>
+
 interface TechnicalConfigurationDocumentDeleteDialogProps {
-  document: TechnicalConfigurationDocumentWire | null
+  document: TechnicalConfigurationDeleteDocument | null
+  affectedCitationCount?: number
   deleteError: unknown
   isSaving: boolean
   onDismiss: () => void
@@ -15,11 +21,14 @@ interface TechnicalConfigurationDocumentDeleteDialogProps {
 /** Confirms destructive evidence-document deletion and keeps mutation failures in context. */
 export function TechnicalConfigurationDocumentDeleteDialog({
   document,
+  affectedCitationCount,
   deleteError,
   isSaving,
   onDismiss,
   onConfirm,
 }: Readonly<TechnicalConfigurationDocumentDeleteDialogProps>): React.JSX.Element {
+  const citationCount = affectedCitationCount ?? document?.citations.length ?? 0
+
   return (
     <AlertDialog
       isOpen={document !== null}
@@ -40,8 +49,8 @@ export function TechnicalConfigurationDocumentDeleteDialog({
             <AlertDialog.Body>
               <p>
                 Tài liệu <strong>{document?.name}</strong>
-                {document?.citations.length
-                  ? ` đang có ${document.citations.length} trích dẫn liên kết.`
+                {citationCount
+                  ? ` đang có ${citationCount} trích dẫn liên kết.`
                   : " chưa có trích dẫn liên kết."}{" "}
                 Hành động này không thể hoàn tác.
               </p>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionDocuments.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionDocuments.tsx
@@ -1,0 +1,309 @@
+"use client"
+
+import * as React from "react"
+import { Chip, ListBox, Select } from "@heroui/react"
+
+import { TechnicalConfigurationCitationEditor } from "./TechnicalConfigurationCitationEditor"
+import { TechnicalConfigurationDocumentDeleteDialog } from "./TechnicalConfigurationDocumentDeleteDialog"
+import { TechnicalConfigurationDocumentsQueryError } from "./TechnicalConfigurationDocumentsQueryError"
+import { useTechnicalConfigurationDiscardConfirmation } from "../_hooks/useTechnicalConfigurationDiscardConfirmation"
+import { useTechnicalConfigurationDocumentDraft } from "../_hooks/useTechnicalConfigurationDocumentDraft"
+import { useTechnicalConfigurationOptionDocuments } from "../_hooks/useTechnicalConfigurationOptionDocuments"
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import type { TechnicalConfigurationOptionDocumentWire } from "../document-types"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+import type { TechnicalConfigurationComparisonSetWire } from "../supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "../types"
+import { UrlDocumentForm } from "@/components/url-documents/UrlDocumentForm"
+import { UrlDocumentList } from "@/components/url-documents/UrlDocumentList"
+import {
+  isAllowedDocumentUrl,
+  parseAbsoluteUrl,
+} from "@/components/url-documents/url-document-utils"
+
+type TechnicalConfigurationOptionDocumentsProps = {
+  dossier: TechnicalConfigurationDossierWire
+  option: TechnicalConfigurationOptionWire
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  comparisonSet?: TechnicalConfigurationComparisonSetWire | null
+  criterionId?: string | null
+  isExternalMutationBlocked?: boolean
+  onRevisionChange?: (revision: number) => void
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+/** Renders shared option documents with citations scoped to one exact baseline. */
+export function TechnicalConfigurationOptionDocuments({
+  dossier,
+  option,
+  baselineVersion,
+  comparisonSet = null,
+  criterionId = null,
+  isExternalMutationBlocked = false,
+  onRevisionChange,
+  onDirtyChange,
+  onNavigationBlockedChange,
+}: Readonly<TechnicalConfigurationOptionDocumentsProps>): React.JSX.Element {
+  const [citationDirty, setCitationDirty] = React.useState(false)
+  const [pendingDeleteDocument, setPendingDeleteDocument] =
+    React.useState<TechnicalConfigurationOptionDocumentWire | null>(null)
+  const [deleteError, setDeleteError] = React.useState<unknown>(null)
+  const { discardConfirmationDialog, requestDiscardConfirmation } =
+    useTechnicalConfigurationDiscardConfirmation()
+  const documentState = useTechnicalConfigurationOptionDocuments({
+    dossier,
+    option,
+    baselineVersion,
+    comparisonSet,
+    isMutationBlocked: isExternalMutationBlocked,
+    onRevisionChange,
+    onNavigationBlockedChange,
+  })
+  const {
+    name,
+    url,
+    selectedDocumentId,
+    selectedDocument,
+    selectedDocumentMissing,
+    documentDirty,
+    setName,
+    setUrl,
+    clearDraft,
+    selectDocument: adoptSelectedDocument,
+  } = useTechnicalConfigurationDocumentDraft(documentState.documents)
+  const hasInitialDocumentsError =
+    documentState.documentsQuery.isError && documentState.documentsQuery.data === undefined
+  const hasStaleDocuments =
+    documentState.documentsQuery.isError && documentState.documentsQuery.data !== undefined
+  const controlsDisabled =
+    documentState.isReadOnly || documentState.isMutationBlocked || hasStaleDocuments
+  const criteria = React.useMemo(
+    () =>
+      baselineVersion.groups.flatMap((group) =>
+        group.criteria.map((criterion) => ({
+          id: criterion.id,
+          criterionCode: criterion.criterion_code,
+          title: criterion.title ?? criterion.requirement_text,
+        }))
+      ),
+    [baselineVersion.groups]
+  )
+  const parsedUrl = parseAbsoluteUrl(url)
+  const validationError =
+    url && !isAllowedDocumentUrl(parsedUrl)
+      ? "Chỉ chấp nhận đường dẫn HTTP hoặc HTTPS hợp lệ."
+      : null
+  const isDirty = documentDirty || citationDirty
+
+  React.useEffect(() => {
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
+  React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+
+  const resetDraft = React.useCallback(() => {
+    if (documentDirty) {
+      requestDiscardConfirmation(
+        "Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?",
+        clearDraft
+      )
+      return
+    }
+    clearDraft()
+  }, [clearDraft, documentDirty, requestDiscardConfirmation])
+
+  const selectDocument = React.useCallback(
+    (documentId: string) => {
+      if (documentId === selectedDocumentId) return
+      const document = documentState.documents.find((item) => item.id === documentId)
+      if (!document) return
+      if (documentDirty) {
+        requestDiscardConfirmation(
+          "Chuyển tài liệu sẽ bỏ nội dung tài liệu chưa lưu. Tiếp tục?",
+          () => adoptSelectedDocument(document)
+        )
+        return
+      }
+      adoptSelectedDocument(document)
+    },
+    [
+      adoptSelectedDocument,
+      documentDirty,
+      documentState.documents,
+      requestDiscardConfirmation,
+      selectedDocumentId,
+    ]
+  )
+
+  const handleSubmit = React.useCallback(async () => {
+    const acceptedUrl = parseAbsoluteUrl(url)
+    if (selectedDocumentMissing || !name || !isAllowedDocumentUrl(acceptedUrl)) return
+    try {
+      if (selectedDocument) {
+        await documentState.updateDocument({ document: selectedDocument, name, url })
+      } else {
+        await documentState.createDocument({ name, url })
+      }
+      clearDraft()
+    } catch {
+      // The hook owns the mutation error while the controlled draft remains retryable.
+    }
+  }, [clearDraft, documentState, name, selectedDocument, selectedDocumentMissing, url])
+
+  const requestDelete = React.useCallback(
+    (documentId: string) => {
+      const document = documentState.documents.find((item) => item.id === documentId)
+      if (!document || controlsDisabled) return
+      setDeleteError(null)
+      setPendingDeleteDocument(document)
+    },
+    [controlsDisabled, documentState.documents]
+  )
+
+  const confirmDelete = React.useCallback(async () => {
+    if (!pendingDeleteDocument || controlsDisabled) return
+    setDeleteError(null)
+    try {
+      await documentState.deleteDocument(pendingDeleteDocument)
+      if (selectedDocumentId === pendingDeleteDocument.id) clearDraft()
+      setPendingDeleteDocument(null)
+    } catch (error) {
+      setDeleteError(error)
+    }
+  }, [clearDraft, controlsDisabled, documentState, pendingDeleteDocument, selectedDocumentId])
+
+  const header = (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-3">
+      <div className="min-w-0">
+        <h3 className="text-base font-semibold">Tài liệu và trích dẫn phương án</h3>
+        <p className="text-sm text-muted-foreground">
+          Tài liệu dùng chung cho phương án; trích dẫn theo đúng phiên bản và tiêu chí đang chọn.
+        </p>
+      </div>
+      {documentState.isReadOnly ? (
+        <Chip color="warning" size="sm" variant="soft">
+          Chỉ đọc
+        </Chip>
+      ) : selectedDocumentId ? (
+        <button
+          type="button"
+          className="text-sm font-medium text-primary hover:underline disabled:text-muted-foreground"
+          disabled={hasStaleDocuments || documentState.isSaving}
+          onClick={resetDraft}
+        >
+          Tạo tài liệu mới
+        </button>
+      ) : null}
+    </div>
+  )
+
+  if (hasInitialDocumentsError) {
+    return (
+      <section aria-label="Tài liệu và trích dẫn phương án" className="space-y-5 border-t pt-5">
+        {header}
+        <TechnicalConfigurationDocumentsQueryError
+          isInitialLoad
+          isRetrying={documentState.documentsQuery.isFetching}
+          onRetry={() => void documentState.documentsQuery.refetch()}
+        />
+      </section>
+    )
+  }
+
+  return (
+    <section aria-label="Tài liệu và trích dẫn phương án" className="space-y-5 border-t pt-5">
+      {header}
+      {hasStaleDocuments ? (
+        <TechnicalConfigurationDocumentsQueryError
+          isInitialLoad={false}
+          isRetrying={documentState.documentsQuery.isFetching}
+          onRetry={() => void documentState.documentsQuery.refetch()}
+        />
+      ) : null}
+
+      {documentState.documents.length > 0 ? (
+        <Select
+          className="max-w-md"
+          selectedKey={selectedDocumentId}
+          onSelectionChange={(key) => selectDocument(String(key))}
+          isDisabled={controlsDisabled || documentState.isSaving}
+          placeholder="Chọn tài liệu"
+          aria-label="Tài liệu phương án đang chỉnh sửa"
+        >
+          <Select.Trigger>
+            <Select.Value />
+            <Select.Indicator />
+          </Select.Trigger>
+          <Select.Popover>
+            <ListBox>
+              {documentState.documents.map((document) => (
+                <ListBox.Item key={document.id} id={document.id} textValue={document.name}>
+                  {document.name}
+                  <ListBox.ItemIndicator />
+                </ListBox.Item>
+              ))}
+            </ListBox>
+          </Select.Popover>
+        </Select>
+      ) : null}
+
+      {selectedDocumentMissing ? (
+        <p role="alert" className="text-sm text-destructive">
+          Tài liệu đang chỉnh sửa không còn trong danh sách. Chọn tài liệu khác hoặc tạo tài liệu
+          mới.
+        </p>
+      ) : null}
+
+      <UrlDocumentForm
+        name={name}
+        url={url}
+        onNameChange={setName}
+        onUrlChange={setUrl}
+        onSubmit={handleSubmit}
+        isPending={documentState.isSaving}
+        disabled={controlsDisabled || selectedDocumentMissing}
+        validationError={validationError}
+        submitLabel={selectedDocumentId ? "Lưu thay đổi" : "Thêm tài liệu"}
+      />
+
+      {documentState.mutationError ? (
+        <p role="alert" className="text-sm text-destructive">
+          {documentState.isConflict
+            ? "Hồ sơ đã thay đổi trên máy chủ. Nội dung đang nhập được giữ lại để thử lại."
+            : "Không thể lưu thay đổi tài liệu. Vui lòng thử lại."}
+        </p>
+      ) : null}
+
+      <UrlDocumentList
+        items={documentState.documents}
+        isLoading={documentState.documentsQuery.isLoading}
+        onDelete={controlsDisabled ? undefined : requestDelete}
+        disabled={documentState.isSaving || hasStaleDocuments}
+      />
+
+      <TechnicalConfigurationCitationEditor
+        documents={documentState.documents}
+        criteria={criteria}
+        fixedCriterionId={criterionId}
+        isPending={documentState.isSaving}
+        disabled={controlsDisabled}
+        onSave={documentState.upsertCitation}
+        onDelete={documentState.deleteCitation}
+        onDirtyChange={setCitationDirty}
+      />
+
+      {discardConfirmationDialog}
+      <TechnicalConfigurationDocumentDeleteDialog
+        document={pendingDeleteDocument}
+        affectedCitationCount={pendingDeleteDocument?.affected_citation_count}
+        deleteError={deleteError}
+        isSaving={documentState.isSaving}
+        onDismiss={() => {
+          setDeleteError(null)
+          setPendingDeleteDocument(null)
+        }}
+        onConfirm={() => void confirmDelete()}
+      />
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionDocuments.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionDocuments.tsx
@@ -97,9 +97,16 @@ export function TechnicalConfigurationOptionDocuments({
   const isDirty = documentDirty || citationDirty
 
   React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- The evidence component owns both drafts while the supplier workspace combines cross-surface dirty state.
     onDirtyChange?.(isDirty)
   }, [isDirty, onDirtyChange])
-  React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+  React.useEffect(
+    () => () => {
+      // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- Clear the evidence contribution when this exact-baseline editor unmounts.
+      onDirtyChange?.(false)
+    },
+    [onDirtyChange]
+  )
 
   const resetDraft = React.useCallback(() => {
     if (documentDirty) {

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationOptionResponseEditor.tsx
@@ -26,6 +26,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 
 import { TechnicalConfigurationOptionResponsePanels } from "./TechnicalConfigurationOptionResponsePanels"
+import { TechnicalConfigurationOptionDocuments } from "./TechnicalConfigurationOptionDocuments"
 
 type TechnicalConfigurationOptionResponseEditorProps = {
   dossier: TechnicalConfigurationDossierWire
@@ -56,26 +57,42 @@ export function TechnicalConfigurationOptionResponseEditor({
   requestDiscardConfirmation,
   isExternalMutationBlocked = false,
 }: Readonly<TechnicalConfigurationOptionResponseEditorProps>) {
+  const [isResponseNavigationBlocked, setIsResponseNavigationBlocked] = React.useState(false)
+  const [isEvidenceDirty, setIsEvidenceDirty] = React.useState(false)
+  const [isEvidenceNavigationBlocked, setIsEvidenceNavigationBlocked] = React.useState(false)
   const state = useTechnicalConfigurationOptionResponses({
     dossier,
     option,
     baselineVersion,
     onRevisionChange,
-    onNavigationBlockedChange,
-    isMutationBlocked: isExternalMutationBlocked,
+    onNavigationBlockedChange: setIsResponseNavigationBlocked,
+    isMutationBlocked: isExternalMutationBlocked || isEvidenceNavigationBlocked,
   })
   const [isCopyConfirmationOpen, setIsCopyConfirmationOpen] = React.useState(false)
+  const isDirty = state.isDirty || isEvidenceDirty
+  const isNavigationBlocked = isResponseNavigationBlocked || isEvidenceNavigationBlocked
 
   React.useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- The response hook owns the draft while the supplier workspace combines cross-surface dirty state.
-    onDirtyChange?.(state.isDirty)
-  }, [onDirtyChange, state.isDirty])
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
 
-  React.useEffect(() => () => onDirtyChange?.(false), [onDirtyChange])
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- Response and evidence mutations share one exact-baseline navigation block.
+    onNavigationBlockedChange?.(isNavigationBlocked)
+  }, [isNavigationBlocked, onNavigationBlockedChange])
+
+  React.useEffect(
+    () => () => {
+      onDirtyChange?.(false)
+      onNavigationBlockedChange?.(false)
+    },
+    [onDirtyChange, onNavigationBlockedChange]
+  )
 
   const handleCriterionChange = React.useCallback(
     (criterionId: string) => {
-      if (state.isDirty) {
+      if (isDirty) {
         requestDiscardConfirmation("Chuyển tiêu chí sẽ bỏ phản hồi chưa lưu. Tiếp tục?", () =>
           state.selectCriterion(criterionId)
         )
@@ -83,7 +100,7 @@ export function TechnicalConfigurationOptionResponseEditor({
       }
       state.selectCriterion(criterionId)
     },
-    [requestDiscardConfirmation, state.isDirty, state.selectCriterion]
+    [isDirty, requestDiscardConfirmation, state.selectCriterion]
   )
   const applyRequirementCopy = React.useCallback(() => {
     if (!state.selectedCriterion) return
@@ -177,7 +194,7 @@ export function TechnicalConfigurationOptionResponseEditor({
                   variant={criterion.id === state.selectedCriterionId ? "secondary" : "ghost"}
                   className="h-auto min-w-44 justify-start whitespace-normal text-left lg:min-w-0"
                   aria-current={criterion.id === state.selectedCriterionId ? "true" : undefined}
-                  disabled={state.isPending}
+                  disabled={state.isPending || isEvidenceNavigationBlocked}
                   onClick={() => handleCriterionChange(criterion.id)}
                 >
                   <span className="min-w-0">
@@ -234,7 +251,11 @@ export function TechnicalConfigurationOptionResponseEditor({
               criterion={state.selectedCriterion}
               draft={state.draft}
               updatedAt={state.updatedAt}
-              mode={state.isReadOnly || state.isMutationBlocked ? "read-only" : "editable"}
+              mode={
+                state.isReadOnly || state.isMutationBlocked || isEvidenceDirty
+                  ? "read-only"
+                  : "editable"
+              }
               draftState={state.isConflict ? "conflict" : state.isDirty ? "dirty" : "clean"}
               operation={state.isSaving ? "saving" : state.isReloading ? "reloading" : "idle"}
               saveStatus={state.saveStatus}
@@ -247,6 +268,20 @@ export function TechnicalConfigurationOptionResponseEditor({
               onReload={() => void state.reload()}
               onSave={() => void state.save()}
               onSaveNext={() => void handleSaveNext()}
+            />
+          ) : null}
+          {!isUnavailable && state.selectedCriterion ? (
+            <TechnicalConfigurationOptionDocuments
+              key={`${option.id}:${baselineVersion.id}:${state.selectedCriterion.id}`}
+              dossier={dossier}
+              option={option}
+              baselineVersion={baselineVersion}
+              comparisonSet={state.snapshot}
+              criterionId={state.selectedCriterion.id}
+              isExternalMutationBlocked={isExternalMutationBlocked || isResponseNavigationBlocked}
+              onDirtyChange={setIsEvidenceDirty}
+              onNavigationBlockedChange={setIsEvidenceNavigationBlocked}
+              onRevisionChange={onRevisionChange}
             />
           ) : null}
         </section>

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSupplierSelector.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSupplierSelector.tsx
@@ -16,7 +16,8 @@ type TechnicalConfigurationSupplierSelectorProps = {
   state: TechnicalConfigurationOptionsState
   selectedSupplier: TechnicalConfigurationSupplierWire | null
   isLoadingDeleteCount: boolean
-  isMutationBlocked: boolean
+  isNavigationBlocked: boolean
+  isWriteBlocked: boolean
   requestIdentityChange: (description: React.ReactNode, action: () => void) => void
   onDeleteSupplier: () => void
 }
@@ -26,7 +27,8 @@ export function TechnicalConfigurationSupplierSelector({
   state,
   selectedSupplier,
   isLoadingDeleteCount,
-  isMutationBlocked,
+  isNavigationBlocked,
+  isWriteBlocked,
   requestIdentityChange,
   onDeleteSupplier,
 }: Readonly<TechnicalConfigurationSupplierSelectorProps>) {
@@ -59,7 +61,10 @@ export function TechnicalConfigurationSupplierSelector({
                     )
                   }
                   disabled={
-                    state.isPending || state.isConflict || isLoadingDeleteCount || isMutationBlocked
+                    state.isPending ||
+                    state.isConflict ||
+                    isLoadingDeleteCount ||
+                    isNavigationBlocked
                   }
                 >
                   <span className="break-words font-medium">{supplier.name}</span>
@@ -84,7 +89,7 @@ export function TechnicalConfigurationSupplierSelector({
                         state.isPending ||
                         state.isConflict ||
                         isLoadingDeleteCount ||
-                        isMutationBlocked
+                        isNavigationBlocked
                       }
                     >
                       <span className="break-words">{option.display_label}</span>
@@ -110,7 +115,7 @@ export function TechnicalConfigurationSupplierSelector({
                 state.isPending ||
                 state.isConflict ||
                 isLoadingDeleteCount ||
-                isMutationBlocked
+                isWriteBlocked
               }
             />
           </div>
@@ -123,7 +128,7 @@ export function TechnicalConfigurationSupplierSelector({
                 state.isPending ||
                 state.isConflict ||
                 isLoadingDeleteCount ||
-                isMutationBlocked
+                isWriteBlocked
               }
             >
               <Save className="size-4" aria-hidden="true" />
@@ -138,7 +143,7 @@ export function TechnicalConfigurationSupplierSelector({
                 state.isPending ||
                 state.isConflict ||
                 isLoadingDeleteCount ||
-                isMutationBlocked ||
+                isWriteBlocked ||
                 state.isCreatingSupplier ||
                 !selectedSupplier
               }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationSuppliers.tsx
@@ -54,8 +54,8 @@ export function TechnicalConfigurationSuppliers({
   const isInitialLoading = state.suppliersQuery.isLoading || state.optionsQuery.isLoading
   const isDirty = state.isDirty || isResponseDirty
   const isNavigationBlocked = isIdentityNavigationBlocked || isResponseNavigationBlocked
-  const isIdentityMutationBlocked =
-    state.isPending || state.isConflict || isResponseNavigationBlocked
+  const isIdentityActionBlocked = state.isPending || state.isConflict || isResponseNavigationBlocked
+  const isIdentityWriteBlocked = isIdentityActionBlocked || isResponseDirty
 
   React.useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-prop-callback-in-effect, react-doctor/no-pass-data-to-parent, react-doctor/no-pass-live-state-to-parent -- WorkspaceShell owns cross-tab dirty navigation while this component owns supplier/option drafts.
@@ -89,7 +89,7 @@ export function TechnicalConfigurationSuppliers({
   )
 
   const handleSupplierDeleteRequest = React.useCallback(async () => {
-    if (!selectedSupplier || isIdentityMutationBlocked) return
+    if (!selectedSupplier || isIdentityWriteBlocked) return
     const supplier = selectedSupplier
     setDeleteCountError(null)
     setIsLoadingDeleteCount(true)
@@ -106,7 +106,7 @@ export function TechnicalConfigurationSuppliers({
     } finally {
       setIsLoadingDeleteCount(false)
     }
-  }, [isIdentityMutationBlocked, selectedSupplier, state])
+  }, [isIdentityWriteBlocked, selectedSupplier, state])
 
   const handleConfirmDelete = React.useCallback(() => {
     if (!pendingDelete || isResponseNavigationBlocked) return
@@ -164,7 +164,7 @@ export function TechnicalConfigurationSuppliers({
               state.startSupplierCreate
             )
           }
-          disabled={state.isReadOnly || isIdentityMutationBlocked || isLoadingDeleteCount}
+          disabled={state.isReadOnly || isIdentityActionBlocked || isLoadingDeleteCount}
         >
           <Plus className="size-4" aria-hidden="true" />
           Thêm nhà cung cấp
@@ -222,7 +222,8 @@ export function TechnicalConfigurationSuppliers({
           state={state}
           selectedSupplier={selectedSupplier}
           isLoadingDeleteCount={isLoadingDeleteCount}
-          isMutationBlocked={isResponseNavigationBlocked}
+          isNavigationBlocked={isResponseNavigationBlocked}
+          isWriteBlocked={isIdentityWriteBlocked}
           requestIdentityChange={requestIdentityChange}
           onDeleteSupplier={() => void handleSupplierDeleteRequest()}
         />
@@ -237,7 +238,7 @@ export function TechnicalConfigurationSuppliers({
                 type="button"
                 variant="outline"
                 onClick={() => state.startOptionCreate(selectedSupplier.id)}
-                disabled={state.isReadOnly || isIdentityMutationBlocked || isLoadingDeleteCount}
+                disabled={state.isReadOnly || isIdentityActionBlocked || isLoadingDeleteCount}
               >
                 <PackagePlus className="size-4" aria-hidden="true" />
                 Thêm phương án
@@ -256,7 +257,7 @@ export function TechnicalConfigurationSuppliers({
                       state.startOptionCreate(selectedSupplier.id)
                     )
                   }
-                  disabled={state.isReadOnly || isIdentityMutationBlocked || isLoadingDeleteCount}
+                  disabled={state.isReadOnly || isIdentityActionBlocked || isLoadingDeleteCount}
                 >
                   <PackagePlus className="size-4" aria-hidden="true" />
                   Thêm phương án
@@ -267,7 +268,7 @@ export function TechnicalConfigurationSuppliers({
                 draft={state.optionDraft}
                 option={selectedOption}
                 mode={state.isCreatingOption ? "create" : "edit"}
-                disabled={state.isReadOnly || isIdentityMutationBlocked || isLoadingDeleteCount}
+                disabled={state.isReadOnly || isIdentityWriteBlocked || isLoadingDeleteCount}
                 isPending={state.isPending}
                 onChange={state.updateOptionDraft}
                 onSave={() => void state.saveOption()}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
 
-type TechnicalConfigurationDocumentDraftItem = Pick<
+export type TechnicalConfigurationDocumentDraftItem = Pick<
   TechnicalConfigurationDocumentWire,
   "id" | "name" | "url"
 >

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocumentDraft.ts
@@ -2,23 +2,30 @@ import * as React from "react"
 
 import type { TechnicalConfigurationDocumentWire } from "@/app/(app)/technical-configurations/document-types"
 
-export interface TechnicalConfigurationDocumentDraftState {
+type TechnicalConfigurationDocumentDraftItem = Pick<
+  TechnicalConfigurationDocumentWire,
+  "id" | "name" | "url"
+>
+
+export interface TechnicalConfigurationDocumentDraftState<
+  TDocument extends TechnicalConfigurationDocumentDraftItem,
+> {
   name: string
   url: string
   selectedDocumentId: string | null
-  selectedDocument: TechnicalConfigurationDocumentWire | null
+  selectedDocument: TDocument | null
   selectedDocumentMissing: boolean
   documentDirty: boolean
   setName: React.Dispatch<React.SetStateAction<string>>
   setUrl: React.Dispatch<React.SetStateAction<string>>
   clearDraft: () => void
-  selectDocument: (document: TechnicalConfigurationDocumentWire) => void
+  selectDocument: (document: TDocument) => void
 }
 
 /** Reconciles clean document drafts with refreshed server values while preserving user edits. */
-export function useTechnicalConfigurationDocumentDraft(
-  documents: readonly TechnicalConfigurationDocumentWire[]
-): TechnicalConfigurationDocumentDraftState {
+export function useTechnicalConfigurationDocumentDraft<
+  TDocument extends TechnicalConfigurationDocumentDraftItem,
+>(documents: readonly TDocument[]): TechnicalConfigurationDocumentDraftState<TDocument> {
   const [name, setName] = React.useState("")
   const [url, setUrl] = React.useState("")
   const [selectedDocumentId, setSelectedDocumentId] = React.useState<string | null>(null)
@@ -40,7 +47,7 @@ export function useTechnicalConfigurationDocumentDraft(
       : !draftMatchesAdoptedDocument &&
         (name !== selectedDocument.name || url !== selectedDocument.url)
 
-  const adoptDocument = React.useCallback((document: TechnicalConfigurationDocumentWire) => {
+  const adoptDocument = React.useCallback((document: TDocument) => {
     adoptedDocumentRef.current = {
       id: document.id,
       name: document.name,
@@ -75,7 +82,7 @@ export function useTechnicalConfigurationDocumentDraft(
   }, [])
 
   const selectDocument = React.useCallback(
-    (document: TechnicalConfigurationDocumentWire) => {
+    (document: TDocument) => {
       setSelectedDocumentId(document.id)
       adoptDocument(document)
     },

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionDocuments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionDocuments.ts
@@ -130,13 +130,8 @@ export function useTechnicalConfigurationOptionDocuments({
     ) ?? null
   const comparisonSetRef = React.useRef(comparisonSet ?? cachedComparisonSet)
   React.useEffect(() => {
-    if (
-      comparisonSet &&
-      comparisonSet.revision >= (comparisonSetRef.current?.revision ?? Number.NEGATIVE_INFINITY)
-    ) {
-      comparisonSetRef.current = comparisonSet
-    }
-  }, [comparisonSet])
+    comparisonSetRef.current = comparisonSet ?? cachedComparisonSet
+  }, [baselineVersion.id, cachedComparisonSet, comparisonSet, option.id])
   const { commitRevision, revisionRef } = useTechnicalConfigurationOptionResponseRevision({
     dossier,
     initialRevision: Math.max(

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionDocuments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionDocuments.ts
@@ -1,0 +1,333 @@
+"use client"
+
+import * as React from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useTechnicalConfigurationOptionResponseRevision } from "./useTechnicalConfigurationOptionResponseRevision"
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import type {
+  TechnicalConfigurationCitationDeleteWireResponse,
+  TechnicalConfigurationCitationMutationWireResponse,
+  TechnicalConfigurationOptionDocumentDeleteWireResponse,
+  TechnicalConfigurationOptionDocumentMutationWireResponse,
+  TechnicalConfigurationOptionDocumentWire,
+} from "../document-types"
+import {
+  createTechnicalConfigurationOptionDocument,
+  deleteTechnicalConfigurationOptionCitation,
+  deleteTechnicalConfigurationOptionDocument,
+  listTechnicalConfigurationOptionDocuments,
+  updateTechnicalConfigurationOptionDocument,
+  upsertTechnicalConfigurationOptionCitation,
+} from "../technical-configuration-document-rpc"
+import { getOrCreateTechnicalConfigurationComparisonSet } from "../technical-configuration-option-response-operations"
+import {
+  technicalConfigurationBaselineVersionsQueryKey,
+  technicalConfigurationOptionDocumentsQueryKey,
+  technicalConfigurationOptionDocumentsQueryKeyPrefix,
+  technicalConfigurationOptionResponsesQueryKey,
+} from "../technical-configuration-query-keys"
+import { isTechnicalConfigurationBaselineConflict } from "../technical-configuration-baseline-version-state"
+import { fetchTechnicalConfigurationDossierRevision } from "../technical-configuration-dossier-revision-cache"
+import { collectStableTechnicalConfigurationPages } from "../technical-configuration-pagination"
+import type {
+  TechnicalConfigurationComparisonSetWire,
+  TechnicalConfigurationOptionWire,
+} from "../supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "../types"
+
+const DOCUMENT_PAGE_SIZE = 100
+const EMPTY_DOCUMENTS: TechnicalConfigurationOptionDocumentWire[] = []
+
+type UseTechnicalConfigurationOptionDocumentsOptions = {
+  dossier: TechnicalConfigurationDossierWire
+  option: TechnicalConfigurationOptionWire
+  baselineVersion: TechnicalConfigurationBaselineDraftWire
+  comparisonSet?: TechnicalConfigurationComparisonSetWire | null
+  readOnly?: boolean
+  isMutationBlocked?: boolean
+  onRevisionChange?: (revision: number) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+type CreateTechnicalConfigurationOptionDocumentInput = {
+  name: string
+  url: string
+}
+
+type UpdateTechnicalConfigurationOptionDocumentInput = {
+  document: TechnicalConfigurationOptionDocumentWire
+  name: string
+  url: string
+}
+
+type UpsertTechnicalConfigurationOptionCitationInput = {
+  document: TechnicalConfigurationOptionDocumentWire
+  criterionId: string
+  pageSection: string | null
+  excerpt: string | null
+}
+
+type DeleteTechnicalConfigurationOptionCitationInput = {
+  document: TechnicalConfigurationOptionDocumentWire
+  citationId: string
+}
+
+type RevisionedMutationResponse =
+  | TechnicalConfigurationOptionDocumentMutationWireResponse
+  | TechnicalConfigurationOptionDocumentDeleteWireResponse
+  | TechnicalConfigurationCitationMutationWireResponse
+  | TechnicalConfigurationCitationDeleteWireResponse
+
+async function listAllTechnicalConfigurationOptionDocuments(
+  optionId: string,
+  baselineVersionId: string,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationOptionDocumentWire[]> {
+  const { items } = await collectStableTechnicalConfigurationPages<
+    TechnicalConfigurationOptionDocumentWire,
+    Awaited<ReturnType<typeof listTechnicalConfigurationOptionDocuments>>
+  >({
+    loadPage: (page) =>
+      listTechnicalConfigurationOptionDocuments(
+        {
+          p_option_id: optionId,
+          p_baseline_version_id: baselineVersionId,
+          p_page: page,
+          p_page_size: DOCUMENT_PAGE_SIZE,
+        },
+        signal
+      ),
+    snapshotError: "Option-evidence pagination snapshot changed during load.",
+    getItemKey: (document) => document.id,
+  })
+  return items
+}
+
+/** Owns shared option documents and exact-baseline citation mutations. */
+export function useTechnicalConfigurationOptionDocuments({
+  dossier,
+  option,
+  baselineVersion,
+  comparisonSet = null,
+  readOnly = false,
+  isMutationBlocked = false,
+  onRevisionChange,
+  onNavigationBlockedChange,
+}: UseTechnicalConfigurationOptionDocumentsOptions) {
+  const queryClient = useQueryClient()
+  const documentsQueryKey = technicalConfigurationOptionDocumentsQueryKey(
+    option.id,
+    baselineVersion.id
+  )
+  const comparisonSetQueryKey = technicalConfigurationOptionResponsesQueryKey(
+    option.id,
+    baselineVersion.id
+  )
+  const cachedComparisonSet =
+    queryClient.getQueryData<TechnicalConfigurationComparisonSetWire | null>(
+      comparisonSetQueryKey
+    ) ?? null
+  const comparisonSetRef = React.useRef(comparisonSet ?? cachedComparisonSet)
+  React.useEffect(() => {
+    if (
+      comparisonSet &&
+      comparisonSet.revision >= (comparisonSetRef.current?.revision ?? Number.NEGATIVE_INFINITY)
+    ) {
+      comparisonSetRef.current = comparisonSet
+    }
+  }, [comparisonSet])
+  const { commitRevision, revisionRef } = useTechnicalConfigurationOptionResponseRevision({
+    dossier,
+    initialRevision: Math.max(
+      baselineVersion.revision,
+      comparisonSet?.revision ?? dossier.revision,
+      cachedComparisonSet?.revision ?? dossier.revision
+    ),
+    onRevisionChange,
+  })
+  const mutationInFlightRef = React.useRef(false)
+  const [isSaving, setIsSaving] = React.useState(false)
+  const [isConflict, setIsConflict] = React.useState(false)
+  const [mutationError, setMutationError] = React.useState<unknown>(null)
+  const isReadOnly = readOnly || dossier.archived_at !== null
+
+  const documentsQuery = useQuery({
+    queryKey: documentsQueryKey,
+    queryFn: ({ signal }) =>
+      listAllTechnicalConfigurationOptionDocuments(option.id, baselineVersion.id, signal),
+    staleTime: 30_000,
+  })
+  const documents = documentsQuery.data ?? EMPTY_DOCUMENTS
+
+  const refreshAfterMutation = React.useCallback(
+    async (revision: number) => {
+      commitRevision(revision)
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: technicalConfigurationOptionDocumentsQueryKeyPrefix(option.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: technicalConfigurationBaselineVersionsQueryKey(dossier.id),
+          exact: true,
+        }),
+      ])
+    },
+    [commitRevision, dossier.id, option.id, queryClient]
+  )
+
+  const runMutation = React.useCallback(
+    async <TResponse extends RevisionedMutationResponse>(
+      request: (expectedRevision: number) => Promise<TResponse>
+    ): Promise<TResponse> => {
+      if (mutationInFlightRef.current) throw new Error("mutation_in_progress")
+      if (isMutationBlocked) throw new Error("mutation_blocked")
+      if (isReadOnly) throw new Error("read_only")
+
+      mutationInFlightRef.current = true
+      setIsSaving(true)
+      setIsConflict(false)
+      setMutationError(null)
+      onNavigationBlockedChange?.(true)
+      try {
+        const response = await request(revisionRef.current ?? dossier.revision)
+        await refreshAfterMutation(response.data.revision)
+        return response
+      } catch (error) {
+        const isConflict = isTechnicalConfigurationBaselineConflict(error)
+        setMutationError(error)
+        setIsConflict(isConflict)
+        if (isConflict) {
+          try {
+            const refreshedRevision = await fetchTechnicalConfigurationDossierRevision(
+              queryClient,
+              dossier.id
+            )
+            commitRevision(refreshedRevision)
+          } catch {
+            // Keep the original conflict visible and preserve the local draft for another retry.
+          }
+        }
+        throw error
+      } finally {
+        mutationInFlightRef.current = false
+        setIsSaving(false)
+        onNavigationBlockedChange?.(false)
+      }
+    },
+    [
+      dossier.revision,
+      isMutationBlocked,
+      isReadOnly,
+      onNavigationBlockedChange,
+      commitRevision,
+      dossier.id,
+      queryClient,
+      refreshAfterMutation,
+      revisionRef,
+    ]
+  )
+
+  const createDocument = React.useCallback(
+    ({ name, url }: CreateTechnicalConfigurationOptionDocumentInput) =>
+      runMutation((expectedRevision) =>
+        createTechnicalConfigurationOptionDocument({
+          p_option_id: option.id,
+          p_name: name,
+          p_url: url,
+          p_expected_revision: expectedRevision,
+        })
+      ),
+    [option.id, runMutation]
+  )
+
+  const updateDocument = React.useCallback(
+    ({ document, name, url }: UpdateTechnicalConfigurationOptionDocumentInput) =>
+      runMutation((expectedRevision) =>
+        updateTechnicalConfigurationOptionDocument({
+          p_option_document_id: document.id,
+          p_name: name,
+          p_url: url,
+          p_expected_revision: expectedRevision,
+        })
+      ),
+    [runMutation]
+  )
+
+  const deleteDocument = React.useCallback(
+    async (document: TechnicalConfigurationOptionDocumentWire) => {
+      const response = await runMutation((expectedRevision) =>
+        deleteTechnicalConfigurationOptionDocument({
+          p_option_document_id: document.id,
+          p_expected_revision: expectedRevision,
+        })
+      )
+      return response.data.affected_citation_count
+    },
+    [runMutation]
+  )
+
+  const upsertCitation = React.useCallback(
+    ({
+      document,
+      criterionId,
+      pageSection,
+      excerpt,
+    }: UpsertTechnicalConfigurationOptionCitationInput) =>
+      runMutation(async (expectedRevision) => {
+        let citationExpectedRevision = expectedRevision
+        let activeComparisonSet =
+          comparisonSetRef.current ??
+          queryClient.getQueryData<TechnicalConfigurationComparisonSetWire | null>(
+            comparisonSetQueryKey
+          ) ??
+          null
+        if (!activeComparisonSet) {
+          activeComparisonSet = await getOrCreateTechnicalConfigurationComparisonSet({
+            p_option_id: option.id,
+            p_baseline_version_id: baselineVersion.id,
+            p_expected_revision: expectedRevision,
+          })
+          comparisonSetRef.current = activeComparisonSet
+          queryClient.setQueryData(comparisonSetQueryKey, activeComparisonSet)
+          commitRevision(activeComparisonSet.revision)
+          citationExpectedRevision = activeComparisonSet.revision
+        }
+        return upsertTechnicalConfigurationOptionCitation({
+          p_option_document_id: document.id,
+          p_comparison_set_id: activeComparisonSet.id,
+          p_criterion_id: criterionId,
+          p_page_section: pageSection,
+          p_excerpt: excerpt,
+          p_expected_revision: citationExpectedRevision,
+        })
+      }),
+    [baselineVersion.id, commitRevision, comparisonSetQueryKey, option.id, queryClient, runMutation]
+  )
+
+  const deleteCitation = React.useCallback(
+    ({ citationId }: DeleteTechnicalConfigurationOptionCitationInput) =>
+      runMutation((expectedRevision) =>
+        deleteTechnicalConfigurationOptionCitation({
+          p_option_citation_id: citationId,
+          p_expected_revision: expectedRevision,
+        })
+      ),
+    [runMutation]
+  )
+
+  return {
+    documentsQuery,
+    documents,
+    isReadOnly,
+    isMutationBlocked,
+    isSaving,
+    isConflict,
+    mutationError,
+    createDocument,
+    updateDocument,
+    deleteDocument,
+    upsertCitation,
+    deleteCitation,
+  }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
@@ -24,6 +24,22 @@ export function technicalConfigurationDocumentsQueryKey(baselineVersionId: strin
   return ["technical-configurations", "documents", baselineVersionId] as const
 }
 
+/** Builds the cache-key prefix for one option's documents across every baseline. */
+export function technicalConfigurationOptionDocumentsQueryKeyPrefix(optionId: string) {
+  return ["technical-configurations", "option-documents", optionId] as const
+}
+
+/** Builds the cache key for one option's shared documents and exact-baseline citations. */
+export function technicalConfigurationOptionDocumentsQueryKey(
+  optionId: string,
+  baselineVersionId: string
+) {
+  return [
+    ...technicalConfigurationOptionDocumentsQueryKeyPrefix(optionId),
+    baselineVersionId,
+  ] as const
+}
+
 /** Builds the cache key for supplier identities in one dossier. */
 export function technicalConfigurationSuppliersQueryKey(dossierId: string) {
   return ["technical-configurations", "suppliers", dossierId] as const

--- a/src/components/url-documents/__tests__/url-document-source-contract.test.ts
+++ b/src/components/url-documents/__tests__/url-document-source-contract.test.ts
@@ -13,19 +13,22 @@ const equipmentConsumerPath =
   "app/(app)/equipment/_components/EquipmentDetailDialog/EquipmentDetailFilesTab.tsx"
 const baselineConsumerPath =
   "app/(app)/technical-configurations/_components/TechnicalConfigurationBaselineDocuments.tsx"
+const optionConsumerPath =
+  "app/(app)/technical-configurations/_components/TechnicalConfigurationOptionDocuments.tsx"
 
 describe("URL document consumer source contract", () => {
-  it("keeps the cumulative P7B2 consumer manifest exact", () => {
+  it("keeps the cumulative P9B2 consumer manifest exact", () => {
     assertExactSet(
       collectUrlDocumentConsumers(applicationSourceRoot),
-      [equipmentConsumerPath, baselineConsumerPath],
-      "P7B2 URL document consumers"
+      [equipmentConsumerPath, baselineConsumerPath, optionConsumerPath],
+      "P9B2 URL document consumers"
     )
   })
 
   it.each([
     ["Equipment", equipmentConsumerPath],
     ["baseline evidence", baselineConsumerPath],
+    ["option evidence", optionConsumerPath],
   ])("delegates %s presentation through exact shared bindings", (_label, consumerPath) => {
     const source = readFileSync(join(applicationSourceRoot, consumerPath), "utf8")
     const contract = inspectUrlDocumentConsumer(source, consumerPath)


### PR DESCRIPTION
## Summary

- add the option-specific evidence hook and workspace without branching the baseline/reference document hook
- keep documents shared by `option_id` while scoping citations to the exact baseline/comparison-set criterion and showing the global affected citation count
- coordinate evidence dirty/pending state with response, supplier/option identity, baseline, criterion, and outer navigation guards
- keep shared URL/document/citation contracts owner-neutral and replace citation editor state transitions with a reducer
- invalidate every cached baseline for a shared option document and adopt authoritative revisions before stale retries
- complete OpenSpec P9B2.1-P9B2.7 and TC-11/TC-12 leaf verification

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- OpenSpec P9B2 GREEN leaf: 10 files, 257 tests passed
- `node scripts/npm-run.js run react-doctor` (97/100, no issues)
- `openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`
- Supabase MCP read-only contract inspection
- rollback-only live phase gates, run after explicit approval:
  - `technical_configuration_option_documents_phase_gate.sql`
  - `technical_configuration_baseline_documents_phase_gate.sql`
- post-gate cleanup: zero option documents/citations, zero P9B1/P7B1 fixtures, no failure trigger
- browser auth-boundary smoke at desktop/mobile; authenticated workspace interaction remains covered by focused React integration tests

Closes #803

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the supplier option evidence workspace (P9B2) with shared option documents and exact-baseline citations, integrated into the option response editor for coordinated edits and reliable conflict recovery. Completes #803 and P9B2.1–P9B2.7.

- New Features
  - Added `TechnicalConfigurationOptionDocuments` and `useTechnicalConfigurationOptionDocuments`; stable pagination, exact-baseline query keys, and cross-baseline cache invalidation when shared documents change.
  - Embedded in `TechnicalConfigurationOptionResponseEditor`; blocks response and supplier identity writes while evidence is dirty or pending; locked baselines remain editable, archived dossiers are read-only.
  - Reused `UrlDocumentForm`/`UrlDocumentList` and an owner-neutral `TechnicalConfigurationCitationEditor` with a reducer; first citation save uses get-or-create comparison set, advances expected revisions, and preserves drafts on conflicts.
  - Delete dialog shows global affected citation counts; tests enforce the URL-document consumer contract and no option-specific branching in the citation editor.

- Bug Fixes
  - Reset the option evidence scope when switching baseline/option/criterion to prevent stale state, and avoid citation reads without an exact selected criterion.

<sup>Written for commit 1c833b0eb18a32b7b9d75d04704c9d8675989fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an option-evidence workspace for managing shared documents and citation edits by baseline and criterion.
  * Added evidence-aware document editing: URL handling, retry on stale updates, and deletion confirmation with affected-citation counts.
* **Bug Fixes**
  * Improved conflict recovery by preserving unsaved changes during retries.
  * Refined UI locking so actions are properly disabled for archived/dirty/pending states, including navigation vs write blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->