### PR TITLE
feat(technical-config): add P10A2 comparison read client

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/comparison-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-contract.test.ts
@@ -1,13 +1,13 @@
-import { readFileSync } from "node:fs"
-import path from "node:path"
 import { createElement, type PropsWithChildren } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { renderHook, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest"
 
 import { COMPARISON_READ_RPC_FUNCTIONS } from "@/lib/technical-configuration-comparison-rpcs"
 import { useTechnicalConfigurationComparison } from "../_hooks/useTechnicalConfigurationComparison"
 import type {
+  TechnicalConfigurationComparisonCriterion,
+  TechnicalConfigurationComparisonCriterionWire,
   TechnicalConfigurationComparisonRequest,
   TechnicalConfigurationComparisonWireResponse,
 } from "../comparison-types"
@@ -15,10 +15,6 @@ import { getTechnicalConfigurationComparison } from "../technical-configuration-
 import { technicalConfigurationComparisonQueryKey } from "../technical-configuration-query-keys"
 
 const callRpcMock = vi.fn()
-const comparisonTypesSource = readFileSync(
-  path.resolve(process.cwd(), "src/app/(app)/technical-configurations/comparison-types.ts"),
-  "utf8"
-)
 
 vi.mock("../technical-configuration-rpc", () => ({
   callTechnicalConfigurationRpc: (...args: unknown[]) => callRpcMock(...args),
@@ -44,7 +40,12 @@ describe("P10A2 comparison read adapter contract", () => {
   })
 
   it("keeps nullable criterion titles aligned with the baseline contract", () => {
-    expect(comparisonTypesSource.match(/title: string \| null/g)).toHaveLength(2)
+    expectTypeOf<TechnicalConfigurationComparisonCriterionWire["title"]>().toEqualTypeOf<
+      string | null
+    >()
+    expectTypeOf<TechnicalConfigurationComparisonCriterion["title"]>().toEqualTypeOf<
+      string | null
+    >()
   })
 
   it("forwards the ordered request once and normalizes the fixed response envelope", async () => {
@@ -394,6 +395,9 @@ describe("P10A2 dormant comparison query hook", () => {
       },
       { signal: expect.any(AbortSignal) }
     )
+    const forwardedArgs = callRpcMock.mock.calls[0]?.[1] as
+      { p_option_ids: readonly string[] } | undefined
+    expect(forwardedArgs?.p_option_ids).not.toBe(validInput.optionIds)
   })
 
   it("aborts the shared transport when the query is cancelled", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/comparison-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-contract.test.ts
@@ -1,0 +1,419 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { createElement, type PropsWithChildren } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { COMPARISON_READ_RPC_FUNCTIONS } from "@/lib/technical-configuration-comparison-rpcs"
+import { useTechnicalConfigurationComparison } from "../_hooks/useTechnicalConfigurationComparison"
+import type {
+  TechnicalConfigurationComparisonRequest,
+  TechnicalConfigurationComparisonWireResponse,
+} from "../comparison-types"
+import { getTechnicalConfigurationComparison } from "../technical-configuration-comparison-rpc"
+import { technicalConfigurationComparisonQueryKey } from "../technical-configuration-query-keys"
+
+const callRpcMock = vi.fn()
+const comparisonTypesSource = readFileSync(
+  path.resolve(process.cwd(), "src/app/(app)/technical-configurations/comparison-types.ts"),
+  "utf8"
+)
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => callRpcMock(...args),
+}))
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+}
+
+function createQueryWrapper(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: PropsWithChildren) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe("P10A2 comparison read adapter contract", () => {
+  beforeEach(() => {
+    callRpcMock.mockReset()
+  })
+
+  it("keeps nullable criterion titles aligned with the baseline contract", () => {
+    expect(comparisonTypesSource.match(/title: string \| null/g)).toHaveLength(2)
+  })
+
+  it("forwards the ordered request once and normalizes the fixed response envelope", async () => {
+    const request: TechnicalConfigurationComparisonRequest = {
+      baselineVersionId: "00000000-0000-0000-0000-000000000005",
+      optionIds: ["00000000-0000-0000-0000-000000000003", "00000000-0000-0000-0000-000000000002"],
+      page: 2,
+      pageSize: 25,
+    }
+    const signal = new AbortController().signal
+    const wireResponse: TechnicalConfigurationComparisonWireResponse = {
+      data: {
+        dossier: {
+          id: "00000000-0000-0000-0000-000000000001",
+          device_type_name: "Máy siêu âm",
+          name: "Cấu hình máy siêu âm",
+          revision: 8,
+          archived_at: null,
+        },
+        baseline_version: {
+          id: request.baselineVersionId,
+          dossier_id: "00000000-0000-0000-0000-000000000001",
+          version_number: 4,
+          status: "locked",
+          revision: 6,
+        },
+        options: [
+          {
+            id: request.optionIds[0],
+            supplier_id: "00000000-0000-0000-0000-000000000011",
+            supplier_name: "Nhà cung cấp A",
+            model: "A-100",
+            manufacturer: "Hãng A",
+            option_name: null,
+            display_label: "Nhà cung cấp A · A-100",
+          },
+          {
+            id: request.optionIds[1],
+            supplier_id: "00000000-0000-0000-0000-000000000012",
+            supplier_name: "Nhà cung cấp B",
+            model: null,
+            manufacturer: null,
+            option_name: "Phương án B",
+            display_label: "Nhà cung cấp B · Phương án B",
+          },
+        ],
+        criteria: [
+          {
+            group: {
+              id: "00000000-0000-0000-0000-000000000021",
+              name: "Thông số chính",
+              sort_order: 1,
+            },
+            criterion: {
+              id: "00000000-0000-0000-0000-000000000022",
+              criterion_code: "TS-01",
+              title: null,
+              requirement_text: "Tối thiểu 10 MHz",
+              sort_order: 2,
+            },
+            baseline_evidence: {
+              document_count: 2,
+              citation_count: 3,
+              has_evidence: true,
+            },
+            option_values: [
+              {
+                option_id: request.optionIds[0],
+                comparison_set_id: "00000000-0000-0000-0000-000000000031",
+                response: {
+                  id: "00000000-0000-0000-0000-000000000032",
+                  response_text: "12 MHz",
+                  supplementary_information: "Đáp ứng",
+                },
+                evidence: {
+                  document_count: 1,
+                  citation_count: 1,
+                  has_evidence: true,
+                },
+              },
+              {
+                option_id: request.optionIds[1],
+                comparison_set_id: null,
+                response: null,
+                evidence: {
+                  document_count: 0,
+                  citation_count: 0,
+                  has_evidence: false,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      total: 42,
+      page: request.page,
+      page_size: request.pageSize,
+    }
+    callRpcMock.mockResolvedValueOnce(wireResponse)
+
+    await expect(getTechnicalConfigurationComparison(request, signal)).resolves.toEqual({
+      data: {
+        dossier: {
+          id: wireResponse.data.dossier.id,
+          deviceTypeName: "Máy siêu âm",
+          name: "Cấu hình máy siêu âm",
+          revision: 8,
+          archivedAt: null,
+        },
+        baselineVersion: {
+          id: request.baselineVersionId,
+          dossierId: wireResponse.data.baseline_version.dossier_id,
+          versionNumber: 4,
+          status: "locked",
+          revision: 6,
+        },
+        options: [
+          {
+            id: request.optionIds[0],
+            supplierId: "00000000-0000-0000-0000-000000000011",
+            supplierName: "Nhà cung cấp A",
+            model: "A-100",
+            manufacturer: "Hãng A",
+            optionName: null,
+            displayLabel: "Nhà cung cấp A · A-100",
+          },
+          {
+            id: request.optionIds[1],
+            supplierId: "00000000-0000-0000-0000-000000000012",
+            supplierName: "Nhà cung cấp B",
+            model: null,
+            manufacturer: null,
+            optionName: "Phương án B",
+            displayLabel: "Nhà cung cấp B · Phương án B",
+          },
+        ],
+        criteria: [
+          {
+            group: {
+              id: "00000000-0000-0000-0000-000000000021",
+              name: "Thông số chính",
+              sortOrder: 1,
+            },
+            criterion: {
+              id: "00000000-0000-0000-0000-000000000022",
+              criterionCode: "TS-01",
+              title: null,
+              requirementText: "Tối thiểu 10 MHz",
+              sortOrder: 2,
+            },
+            baselineEvidence: {
+              documentCount: 2,
+              citationCount: 3,
+              hasEvidence: true,
+            },
+            optionValues: [
+              {
+                optionId: request.optionIds[0],
+                comparisonSetId: "00000000-0000-0000-0000-000000000031",
+                response: {
+                  id: "00000000-0000-0000-0000-000000000032",
+                  responseText: "12 MHz",
+                  supplementaryInformation: "Đáp ứng",
+                },
+                evidence: {
+                  documentCount: 1,
+                  citationCount: 1,
+                  hasEvidence: true,
+                },
+              },
+              {
+                optionId: request.optionIds[1],
+                comparisonSetId: null,
+                response: null,
+                evidence: {
+                  documentCount: 0,
+                  citationCount: 0,
+                  hasEvidence: false,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      total: 42,
+      page: 2,
+      pageSize: 25,
+    })
+
+    expect(callRpcMock).toHaveBeenCalledTimes(1)
+    expect(callRpcMock).toHaveBeenCalledWith(
+      COMPARISON_READ_RPC_FUNCTIONS.getComparison,
+      {
+        p_baseline_version_id: request.baselineVersionId,
+        p_option_ids: request.optionIds,
+        p_page: request.page,
+        p_page_size: request.pageSize,
+      },
+      { signal }
+    )
+  })
+})
+
+describe("P10A2 ordered comparison query key", () => {
+  it("preserves option order and snapshots every request dimension", () => {
+    const optionIds = ["option-a", "option-b"]
+    const key = technicalConfigurationComparisonQueryKey({
+      baselineVersionId: "baseline-a",
+      optionIds,
+      page: 2,
+      pageSize: 25,
+    })
+
+    optionIds.reverse()
+
+    expect(key).toEqual([
+      "technical-configurations",
+      "comparison",
+      "baseline-a",
+      ["option-a", "option-b"],
+      2,
+      25,
+    ])
+    expect(
+      technicalConfigurationComparisonQueryKey({
+        baselineVersionId: "baseline-a",
+        optionIds: ["option-b", "option-a"],
+        page: 2,
+        pageSize: 25,
+      })
+    ).not.toEqual(key)
+  })
+
+  it.each([
+    ["baseline version", { baselineVersionId: "baseline-b" }],
+    ["page", { page: 3 }],
+    ["page size", { pageSize: 50 }],
+  ])("changes when %s changes", (_dimension, overrides) => {
+    const input = {
+      baselineVersionId: "baseline-a",
+      optionIds: ["option-a", "option-b"],
+      page: 2,
+      pageSize: 25,
+    }
+
+    expect(technicalConfigurationComparisonQueryKey({ ...input, ...overrides })).not.toEqual(
+      technicalConfigurationComparisonQueryKey(input)
+    )
+  })
+})
+
+describe("P10A2 dormant comparison query hook", () => {
+  const validInput: Parameters<typeof useTechnicalConfigurationComparison>[0] = {
+    baselineVersionId: "00000000-0000-0000-0000-000000000005",
+    optionIds: ["00000000-0000-0000-0000-000000000003", "00000000-0000-0000-0000-000000000002"],
+    page: 1,
+    pageSize: 25,
+  }
+
+  beforeEach(() => {
+    callRpcMock.mockReset()
+  })
+
+  it.each<[string, Partial<typeof validInput>]>([
+    ["missing baseline", { baselineVersionId: null }],
+    ["zero options", { optionIds: [] }],
+    ["duplicate options", { optionIds: ["option-a", "option-a"] }],
+    [
+      "more than eight options",
+      { optionIds: Array.from({ length: 9 }, (_, index) => `option-${index}`) },
+    ],
+    ["page below one", { page: 0 }],
+    ["fractional page", { page: 1.5 }],
+    ["page size below one", { pageSize: 0 }],
+    ["page size above 100", { pageSize: 101 }],
+    ["fractional page size", { pageSize: 25.5 }],
+  ])("does not fetch for %s", async (_name, overrides) => {
+    const queryClient = createTestQueryClient()
+    renderHook(() => useTechnicalConfigurationComparison({ ...validInput, ...overrides }), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+
+    await Promise.resolve()
+    expect(callRpcMock).not.toHaveBeenCalled()
+  })
+
+  it("fetches once for valid inputs with fixed policy and forwards cancellation", async () => {
+    const queryClient = createTestQueryClient()
+    const wireResponse: TechnicalConfigurationComparisonWireResponse = {
+      data: {
+        dossier: {
+          id: "00000000-0000-0000-0000-000000000001",
+          device_type_name: "Máy siêu âm",
+          name: "Cấu hình máy siêu âm",
+          revision: 8,
+          archived_at: null,
+        },
+        baseline_version: {
+          id: validInput.baselineVersionId,
+          dossier_id: "00000000-0000-0000-0000-000000000001",
+          version_number: 4,
+          status: "locked",
+          revision: 6,
+        },
+        options: [],
+        criteria: [],
+      },
+      total: 0,
+      page: validInput.page,
+      page_size: validInput.pageSize,
+    }
+    callRpcMock.mockResolvedValueOnce(wireResponse)
+
+    const { result } = renderHook(() => useTechnicalConfigurationComparison(validInput), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.comparisonQuery.isSuccess).toBe(true))
+    expect(result.current.queryKey).toEqual([
+      "technical-configurations",
+      "comparison",
+      validInput.baselineVersionId,
+      validInput.optionIds,
+      validInput.page,
+      validInput.pageSize,
+    ])
+    expect(
+      queryClient.getQueryCache().find({ queryKey: result.current.queryKey })?.options
+    ).toMatchObject({
+      staleTime: 30_000,
+      retry: false,
+      refetchOnWindowFocus: false,
+    })
+    expect(result.current.comparisonQuery.data).toMatchObject({
+      total: 0,
+      page: 1,
+      pageSize: 25,
+    })
+    expect(callRpcMock).toHaveBeenCalledTimes(1)
+    expect(callRpcMock).toHaveBeenCalledWith(
+      COMPARISON_READ_RPC_FUNCTIONS.getComparison,
+      {
+        p_baseline_version_id: validInput.baselineVersionId,
+        p_option_ids: validInput.optionIds,
+        p_page: validInput.page,
+        p_page_size: validInput.pageSize,
+      },
+      { signal: expect.any(AbortSignal) }
+    )
+  })
+
+  it("aborts the shared transport when the query is cancelled", async () => {
+    const queryClient = createTestQueryClient()
+    let forwardedSignal: AbortSignal | undefined
+    callRpcMock.mockImplementationOnce(
+      (_fn: unknown, _args: unknown, { signal }: { signal: AbortSignal }) => {
+        forwardedSignal = signal
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true })
+        })
+      }
+    )
+
+    const { result } = renderHook(() => useTechnicalConfigurationComparison(validInput), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+    await waitFor(() => expect(forwardedSignal).toBeDefined())
+
+    await queryClient.cancelQueries({ queryKey: result.current.queryKey })
+    expect(forwardedSignal?.aborted).toBe(true)
+  })
+})

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparison.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparison.ts
@@ -1,0 +1,69 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import type {
+  TechnicalConfigurationComparisonRequest,
+  TechnicalConfigurationComparisonResult,
+} from "../comparison-types"
+import { getTechnicalConfigurationComparison } from "../technical-configuration-comparison-rpc"
+import { technicalConfigurationComparisonQueryKey } from "../technical-configuration-query-keys"
+
+interface UseTechnicalConfigurationComparisonInput {
+  baselineVersionId: string | null
+  optionIds: readonly string[]
+  page: number
+  pageSize: number
+}
+
+function isValidComparisonRequest(request: TechnicalConfigurationComparisonRequest): boolean {
+  return (
+    request.baselineVersionId !== "" &&
+    request.optionIds.length >= 1 &&
+    request.optionIds.length <= 8 &&
+    new Set(request.optionIds).size === request.optionIds.length &&
+    Number.isInteger(request.page) &&
+    request.page >= 1 &&
+    Number.isInteger(request.pageSize) &&
+    request.pageSize >= 1 &&
+    request.pageSize <= 100
+  )
+}
+
+/** Exposes the P10A2 comparison read without mounting any matrix UI. */
+export function useTechnicalConfigurationComparison({
+  baselineVersionId,
+  optionIds,
+  page,
+  pageSize,
+}: UseTechnicalConfigurationComparisonInput) {
+  const queryKey = technicalConfigurationComparisonQueryKey({
+    baselineVersionId: baselineVersionId ?? "",
+    optionIds,
+    page,
+    pageSize,
+  })
+  const request: TechnicalConfigurationComparisonRequest = {
+    baselineVersionId: queryKey[2],
+    optionIds: queryKey[3],
+    page: queryKey[4],
+    pageSize: queryKey[5],
+  }
+  const enabled = isValidComparisonRequest(request)
+  const comparisonQuery = useQuery<TechnicalConfigurationComparisonResult>({
+    queryKey,
+    queryFn: ({ signal }) => {
+      if (!enabled) {
+        return Promise.reject(new Error("Technical configuration comparison query is disabled"))
+      }
+
+      return getTechnicalConfigurationComparison(request, signal)
+    },
+    enabled,
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+
+  return { queryKey, comparisonQuery }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparison.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparison.ts
@@ -37,18 +37,13 @@ export function useTechnicalConfigurationComparison({
   page,
   pageSize,
 }: UseTechnicalConfigurationComparisonInput) {
-  const queryKey = technicalConfigurationComparisonQueryKey({
+  const request: TechnicalConfigurationComparisonRequest = {
     baselineVersionId: baselineVersionId ?? "",
-    optionIds,
+    optionIds: [...optionIds],
     page,
     pageSize,
-  })
-  const request: TechnicalConfigurationComparisonRequest = {
-    baselineVersionId: queryKey[2],
-    optionIds: queryKey[3],
-    page: queryKey[4],
-    pageSize: queryKey[5],
   }
+  const queryKey = technicalConfigurationComparisonQueryKey(request)
   const enabled = isValidComparisonRequest(request)
   const comparisonQuery = useQuery<TechnicalConfigurationComparisonResult>({
     queryKey,

--- a/src/app/(app)/technical-configurations/comparison-types.ts
+++ b/src/app/(app)/technical-configurations/comparison-types.ts
@@ -1,0 +1,175 @@
+import type { TechnicalConfigurationBaselineStatus } from "./baseline-types"
+
+export interface TechnicalConfigurationComparisonRequest {
+  baselineVersionId: string
+  optionIds: readonly string[]
+  page: number
+  pageSize: number
+}
+
+export interface TechnicalConfigurationComparisonRpcArgs {
+  p_baseline_version_id: string
+  p_option_ids: readonly string[]
+  p_page: number
+  p_page_size: number
+}
+
+export interface TechnicalConfigurationComparisonEvidenceWire {
+  document_count: number
+  citation_count: number
+  has_evidence: boolean
+}
+
+export interface TechnicalConfigurationComparisonResponseWire {
+  id: string
+  response_text: string
+  supplementary_information: string
+}
+
+export interface TechnicalConfigurationComparisonOptionValueWire {
+  option_id: string
+  comparison_set_id: string | null
+  response: TechnicalConfigurationComparisonResponseWire | null
+  evidence: TechnicalConfigurationComparisonEvidenceWire
+}
+
+export interface TechnicalConfigurationComparisonGroupWire {
+  id: string
+  name: string
+  sort_order: number
+}
+
+export interface TechnicalConfigurationComparisonCriterionWire {
+  id: string
+  criterion_code: string
+  title: string | null
+  requirement_text: string
+  sort_order: number
+}
+
+export interface TechnicalConfigurationComparisonCriterionRowWire {
+  group: TechnicalConfigurationComparisonGroupWire
+  criterion: TechnicalConfigurationComparisonCriterionWire
+  baseline_evidence: TechnicalConfigurationComparisonEvidenceWire
+  option_values: TechnicalConfigurationComparisonOptionValueWire[]
+}
+
+export interface TechnicalConfigurationComparisonDossierWire {
+  id: string
+  device_type_name: string
+  name: string
+  revision: number
+  archived_at: string | null
+}
+
+export interface TechnicalConfigurationComparisonBaselineVersionWire {
+  id: string
+  dossier_id: string
+  version_number: number
+  status: TechnicalConfigurationBaselineStatus
+  revision: number
+}
+
+export interface TechnicalConfigurationComparisonOptionWire {
+  id: string
+  supplier_id: string
+  supplier_name: string
+  model: string | null
+  manufacturer: string | null
+  option_name: string | null
+  display_label: string
+}
+
+export interface TechnicalConfigurationComparisonDataWire {
+  dossier: TechnicalConfigurationComparisonDossierWire
+  baseline_version: TechnicalConfigurationComparisonBaselineVersionWire
+  options: TechnicalConfigurationComparisonOptionWire[]
+  criteria: TechnicalConfigurationComparisonCriterionRowWire[]
+}
+
+export interface TechnicalConfigurationComparisonWireResponse {
+  data: TechnicalConfigurationComparisonDataWire
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface TechnicalConfigurationComparisonEvidence {
+  documentCount: number
+  citationCount: number
+  hasEvidence: boolean
+}
+
+export interface TechnicalConfigurationComparisonResponse {
+  id: string
+  responseText: string
+  supplementaryInformation: string
+}
+
+export interface TechnicalConfigurationComparisonOptionValue {
+  optionId: string
+  comparisonSetId: string | null
+  response: TechnicalConfigurationComparisonResponse | null
+  evidence: TechnicalConfigurationComparisonEvidence
+}
+
+export interface TechnicalConfigurationComparisonGroup {
+  id: string
+  name: string
+  sortOrder: number
+}
+
+export interface TechnicalConfigurationComparisonCriterion {
+  id: string
+  criterionCode: string
+  title: string | null
+  requirementText: string
+  sortOrder: number
+}
+
+export interface TechnicalConfigurationComparisonCriterionRow {
+  group: TechnicalConfigurationComparisonGroup
+  criterion: TechnicalConfigurationComparisonCriterion
+  baselineEvidence: TechnicalConfigurationComparisonEvidence
+  optionValues: TechnicalConfigurationComparisonOptionValue[]
+}
+
+export interface TechnicalConfigurationComparisonDossier {
+  id: string
+  deviceTypeName: string
+  name: string
+  revision: number
+  archivedAt: string | null
+}
+
+export interface TechnicalConfigurationComparisonBaselineVersion {
+  id: string
+  dossierId: string
+  versionNumber: number
+  status: TechnicalConfigurationBaselineStatus
+  revision: number
+}
+
+export interface TechnicalConfigurationComparisonOption {
+  id: string
+  supplierId: string
+  supplierName: string
+  model: string | null
+  manufacturer: string | null
+  optionName: string | null
+  displayLabel: string
+}
+
+export interface TechnicalConfigurationComparisonData {
+  dossier: TechnicalConfigurationComparisonDossier
+  baselineVersion: TechnicalConfigurationComparisonBaselineVersion
+  options: TechnicalConfigurationComparisonOption[]
+  criteria: TechnicalConfigurationComparisonCriterionRow[]
+}
+
+export interface TechnicalConfigurationComparisonResult {
+  data: TechnicalConfigurationComparisonData
+  total: number
+  page: number
+  pageSize: number
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-comparison-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-comparison-rpc.ts
@@ -1,0 +1,121 @@
+import { COMPARISON_READ_RPC_FUNCTIONS } from "@/lib/technical-configuration-comparison-rpcs"
+import type {
+  TechnicalConfigurationComparisonCriterionRow,
+  TechnicalConfigurationComparisonCriterionRowWire,
+  TechnicalConfigurationComparisonEvidence,
+  TechnicalConfigurationComparisonEvidenceWire,
+  TechnicalConfigurationComparisonOptionValue,
+  TechnicalConfigurationComparisonOptionValueWire,
+  TechnicalConfigurationComparisonRequest,
+  TechnicalConfigurationComparisonResponse,
+  TechnicalConfigurationComparisonResponseWire,
+  TechnicalConfigurationComparisonResult,
+  TechnicalConfigurationComparisonRpcArgs,
+  TechnicalConfigurationComparisonWireResponse,
+} from "./comparison-types"
+import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
+
+function normalizeEvidence(
+  evidence: TechnicalConfigurationComparisonEvidenceWire
+): TechnicalConfigurationComparisonEvidence {
+  return {
+    documentCount: evidence.document_count,
+    citationCount: evidence.citation_count,
+    hasEvidence: evidence.has_evidence,
+  }
+}
+
+function normalizeResponse(
+  response: TechnicalConfigurationComparisonResponseWire | null
+): TechnicalConfigurationComparisonResponse | null {
+  if (response === null) return null
+
+  return {
+    id: response.id,
+    responseText: response.response_text,
+    supplementaryInformation: response.supplementary_information,
+  }
+}
+
+function normalizeOptionValue(
+  value: TechnicalConfigurationComparisonOptionValueWire
+): TechnicalConfigurationComparisonOptionValue {
+  return {
+    optionId: value.option_id,
+    comparisonSetId: value.comparison_set_id,
+    response: normalizeResponse(value.response),
+    evidence: normalizeEvidence(value.evidence),
+  }
+}
+
+function normalizeCriterionRow(
+  row: TechnicalConfigurationComparisonCriterionRowWire
+): TechnicalConfigurationComparisonCriterionRow {
+  return {
+    group: {
+      id: row.group.id,
+      name: row.group.name,
+      sortOrder: row.group.sort_order,
+    },
+    criterion: {
+      id: row.criterion.id,
+      criterionCode: row.criterion.criterion_code,
+      title: row.criterion.title,
+      requirementText: row.criterion.requirement_text,
+      sortOrder: row.criterion.sort_order,
+    },
+    baselineEvidence: normalizeEvidence(row.baseline_evidence),
+    optionValues: row.option_values.map(normalizeOptionValue),
+  }
+}
+
+/** Reads one bounded comparison page through the fixed P10A1 RPC contract. */
+export async function getTechnicalConfigurationComparison(
+  request: TechnicalConfigurationComparisonRequest,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationComparisonResult> {
+  const args: TechnicalConfigurationComparisonRpcArgs = {
+    p_baseline_version_id: request.baselineVersionId,
+    p_option_ids: request.optionIds,
+    p_page: request.page,
+    p_page_size: request.pageSize,
+  }
+  const response =
+    await callTechnicalConfigurationRpc<TechnicalConfigurationComparisonWireResponse>(
+      COMPARISON_READ_RPC_FUNCTIONS.getComparison,
+      args,
+      { signal }
+    )
+
+  return {
+    data: {
+      dossier: {
+        id: response.data.dossier.id,
+        deviceTypeName: response.data.dossier.device_type_name,
+        name: response.data.dossier.name,
+        revision: response.data.dossier.revision,
+        archivedAt: response.data.dossier.archived_at,
+      },
+      baselineVersion: {
+        id: response.data.baseline_version.id,
+        dossierId: response.data.baseline_version.dossier_id,
+        versionNumber: response.data.baseline_version.version_number,
+        status: response.data.baseline_version.status,
+        revision: response.data.baseline_version.revision,
+      },
+      options: response.data.options.map((option) => ({
+        id: option.id,
+        supplierId: option.supplier_id,
+        supplierName: option.supplier_name,
+        model: option.model,
+        manufacturer: option.manufacturer,
+        optionName: option.option_name,
+        displayLabel: option.display_label,
+      })),
+      criteria: response.data.criteria.map(normalizeCriterionRow),
+    },
+    total: response.total,
+    page: response.page,
+    pageSize: response.page_size,
+  }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
@@ -57,3 +57,25 @@ export function technicalConfigurationOptionResponsesQueryKey(
 ) {
   return ["technical-configurations", "option-responses", optionId, baselineVersionId] as const
 }
+
+/** Builds the ordered cache key for one bounded comparison page. */
+export function technicalConfigurationComparisonQueryKey({
+  baselineVersionId,
+  optionIds,
+  page,
+  pageSize,
+}: {
+  baselineVersionId: string
+  optionIds: readonly string[]
+  page: number
+  pageSize: number
+}) {
+  return [
+    "technical-configurations",
+    "comparison",
+    baselineVersionId,
+    [...optionIds],
+    page,
+    pageSize,
+  ] as const
+}

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -1,4 +1,5 @@
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
+import { COMPARISON_READ_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-comparison-rpcs"
 import { DOCUMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-document-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
 import {
@@ -110,6 +111,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   ...OPTION_RESPONSE_RPC_FUNCTION_NAMES,
   ...OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
   ...OPTION_IMPORT_RPC_FUNCTION_NAMES,
+  ...COMPARISON_READ_RPC_FUNCTION_NAMES,
   // AI Assistant (read-only)
   "ai_equipment_lookup",
   "ai_maintenance_plan_lookup",

--- a/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts
@@ -5,6 +5,10 @@ vi.mock("server-only", () => ({}))
 import { ALLOWED_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
 import { POST } from "@/app/api/rpc/[fn]/route"
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
+import {
+  COMPARISON_READ_RPC_FUNCTION_NAMES,
+  COMPARISON_READ_RPC_FUNCTIONS,
+} from "@/lib/technical-configuration-comparison-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
 import {
   OPTION_IMPORT_RPC_FUNCTION_NAMES,
@@ -283,6 +287,32 @@ describe("technical configuration option import RPC whitelist", () => {
   it.each(P9A2_OPTION_IMPORT_RPC_FUNCTIONS)(
     'allows option import RPC "%s" through the whitelist',
     async (fn) => {
+      const response = await invokeRpcProxy(fn)
+
+      expect(response.status).toBe(411)
+      await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
+    }
+  )
+})
+
+describe("technical configuration comparison read RPC whitelist", () => {
+  it("freezes exactly one read-only P10A2 comparison RPC name", () => {
+    expect(COMPARISON_READ_RPC_FUNCTIONS).toEqual({
+      getComparison: "technical_configuration_comparison_get",
+    })
+    expect(COMPARISON_READ_RPC_FUNCTION_NAMES).toEqual(Object.values(COMPARISON_READ_RPC_FUNCTIONS))
+    expect(COMPARISON_READ_RPC_FUNCTION_NAMES).not.toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/_(?:create|update|delete|upsert|get_or_create)$/),
+      ])
+    )
+  })
+
+  it.each(COMPARISON_READ_RPC_FUNCTION_NAMES)(
+    'allows comparison read RPC "%s" through the whitelist',
+    async (fn) => {
+      expect(ALLOWED_FUNCTIONS.has(fn)).toBe(true)
+
       const response = await invokeRpcProxy(fn)
 
       expect(response.status).toBe(411)

--- a/src/lib/technical-configuration-comparison-rpcs.ts
+++ b/src/lib/technical-configuration-comparison-rpcs.ts
@@ -1,0 +1,7 @@
+/** Named P10A2 side-effect-free comparison read RPC shared by client and server code. */
+export const COMPARISON_READ_RPC_FUNCTIONS = {
+  getComparison: "technical_configuration_comparison_get",
+} as const
+
+/** Ordered P10A2 comparison read RPC names for allowlists and contract iteration. */
+export const COMPARISON_READ_RPC_FUNCTION_NAMES = Object.values(COMPARISON_READ_RPC_FUNCTIONS)


### PR DESCRIPTION
## Summary
- expose the read-only `technical_configuration_comparison_get` RPC through a shared manifest and the proxy allowlist
- add exact P10A1 wire/domain types plus a typed adapter that preserves option order and forwards `AbortSignal`
- add an ordered immutable query key and dormant TanStack Query hook with bounded enablement and fixed read policy

## Dependencies and scope
- based on `main` at `b8277ce7` after P10A1 PR #808; the design/plan lineage is PR #806
- confirmed the P10A1 live gate tracked by Issue #807 was complete before implementation
- no SQL or migration changes and no live database writes
- no P10B/UI, response authoring, cache invalidation, or P8/P9 hook changes
- shared `callTechnicalConfigurationRpc` remains unchanged

## TDD and review
- RED/GREEN 1: RPC manifest and append-only proxy exposure
- RED/GREEN 2: exact request forwarding, one call, cancellation propagation, and wire-to-domain normalization
- RED/GREEN 3: ordered snapshot query key, input gates, and dormant hook policy
- two independent reviews caught nullable criterion titles; locked with a regression fixture and corrected to `string | null`
- final two-agent review strengthened independent cache-key dimensions, all paging gates, and real `QueryClientProvider` fetch/cancellation coverage

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused Vitest: 3 files, 98/98 tests
- React Doctor: 100/100
- `openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`
- `git diff --check` and explicit dormant/scope checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only client for P10A2 technical configuration comparisons, exposing `technical_configuration_comparison_get` and a typed `@tanstack/react-query` hook to fetch one ordered comparison page. Tightens input gates, query keys, and cancellation; addresses review feedback on nullable titles and cloning request arrays.

- New Features
  - Allowlisted `technical_configuration_comparison_get` via a shared manifest and the RPC whitelist.
  - Added exact wire/domain types and a normalizing adapter (snake_case → camelCase) that preserves option order and forwards `AbortSignal`.
  - Introduced `technicalConfigurationComparisonQueryKey` that snapshots all request dimensions in order.
  - Added `useTechnicalConfigurationComparison` with bounded enablement (baseline non-empty, 1–8 unique options, integer page ≥1, pageSize 1–100) and fixed read policy (staleTime 30s, no retry, no refetch on focus).
  - Follow-up fixes: `title` typed as `string | null`, clone `optionIds` before forwarding, and strengthened whitelist/cancellation tests.

<sup>Written for commit ae3bd49dc64c6b9d8ddfcfa3adffa2ac7800b9b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added technical configuration comparison retrieval with pagination (baseline + selected options), including criteria, evidence, and response details.
  * Introduced a client hook with strict input validation, caching, stable query keys, and request cancellation.
  * Enabled comparison read RPCs through the RPC proxy access layer.

* **Tests**
  * Added contract tests for response/type normalization and query-key behavior.
  * Added tests to verify the comparison-read RPC whitelist and read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->