### PR TITLE
P10B1: add core read-only technical configuration comparison matrix

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -458,19 +458,19 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P10B1 - Core Read-Only Comparison Matrix
 
-- [ ] P10B1.1 Thêm baseline-version selection, ordered selected-option controls
+- [x] P10B1.1 Thêm baseline-version selection, ordered selected-option controls
       tối đa 8 phương án và fixed criterion page size 50.
-- [ ] P10B1.2 Reuse một shared read-only option-list query seam mà không đổi P8
+- [x] P10B1.2 Reuse một shared read-only option-list query seam mà không đổi P8
       draft/mutation behavior.
-- [ ] P10B1.3 Hiển thị ordered groups/criteria theo hàng, sticky baseline,
+- [x] P10B1.3 Hiển thị ordered groups/criteria theo hàng, sticky baseline,
       dynamic option columns và bounded horizontal scroll.
-- [ ] P10B1.4 Thêm concise read-only cells cùng text-only detail panel cho full
+- [x] P10B1.4 Thêm concise read-only cells cùng text-only detail panel cho full
       requirement, response và supplementary information.
-- [ ] P10B1.5 Tích hợp và enable comparison tab nhưng giữ matrix state/data hooks
+- [x] P10B1.5 Tích hợp và enable comparison tab nhưng giữ matrix state/data hooks
       ngoài workspace shell.
-- [ ] P10B1.6 Khóa ownership: không response editor, copy, dirty draft, save,
+- [x] P10B1.6 Khóa ownership: không response editor, copy, dirty draft, save,
       assessment persistence, ranking hoặc derived compliance.
-- [ ] P10B1.7 Viết ordered-selection, paging, long-text, empty/loading/error,
+- [x] P10B1.7 Viết ordered-selection, paging, long-text, empty/loading/error,
       keyboard, responsive-source và P8 regression tests; không browser test.
 
 ## Phase P10B2 - Many-Option Column Ergonomics

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-core.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-core.test.tsx
@@ -1,0 +1,276 @@
+import { createElement, type PropsWithChildren } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useTechnicalConfigurationComparisonMatrix } from "../_hooks/useTechnicalConfigurationComparisonMatrix"
+import { useTechnicalConfigurationOptionListQuery } from "../_hooks/useTechnicalConfigurationOptionListQuery"
+import {
+  technicalConfigurationComparisonQueryKey,
+  technicalConfigurationOptionsQueryKey,
+} from "../technical-configuration-query-keys"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+
+import { registerComparisonMatrixRenderingTests } from "./comparison-matrix-rendering-cases"
+
+const listAllOptionsMock = vi.fn()
+const listBaselineVersionsMock = vi.fn()
+const getComparisonMock = vi.fn()
+
+vi.mock("../technical-configuration-supplier-option-operations", () => ({
+  listAllTechnicalConfigurationOptions: (...args: unknown[]) => listAllOptionsMock(...args),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationBaseline", () => ({
+  useTechnicalConfigurationBaseline: () => ({
+    listVersions: (...args: unknown[]) => listBaselineVersionsMock(...args),
+  }),
+}))
+
+vi.mock("../technical-configuration-comparison-rpc", () => ({
+  getTechnicalConfigurationComparison: (...args: unknown[]) => getComparisonMock(...args),
+}))
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+}
+
+function createQueryWrapper(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: PropsWithChildren) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function createOption(index: number): TechnicalConfigurationOptionWire {
+  const suffix = String(index).padStart(12, "0")
+  return {
+    id: `00000000-0000-0000-0000-${suffix}`,
+    dossier_id: "00000000-0000-0000-0000-000000000100",
+    supplier_id: `00000000-0000-0000-0001-${suffix}`,
+    supplier_name: `Nhà cung cấp ${index}`,
+    model: `Model ${index}`,
+    manufacturer: null,
+    option_name: null,
+    notes: null,
+    display_label: `Nhà cung cấp ${index} · Model ${index}`,
+    created_at: "2026-07-28T00:00:00Z",
+    created_by: 1,
+    updated_at: "2026-07-28T00:00:00Z",
+    updated_by: 1,
+    revision: index,
+  }
+}
+
+function createBaselineVersion(id: string, versionNumber: number) {
+  return {
+    id,
+    dossier_id: "00000000-0000-0000-0000-000000000100",
+    version_number: versionNumber,
+    status: "locked" as const,
+    source_baseline_version_id: null,
+    source_version_number: null,
+    next_criterion_number: 1,
+    revision: versionNumber,
+    locked_at: "2026-07-28T00:00:00Z",
+    locked_by: 1,
+    created_at: "2026-07-28T00:00:00Z",
+    created_by: 1,
+    updated_at: "2026-07-28T00:00:00Z",
+    updated_by: 1,
+    groups: [],
+  }
+}
+
+describe("P10B1 shared option list query", () => {
+  beforeEach(() => {
+    listAllOptionsMock.mockReset()
+  })
+
+  it("uses the dossier option key and delegates once with an AbortSignal", async () => {
+    const dossierId = "00000000-0000-0000-0000-000000000001"
+    const snapshot = { options: [], revision: 4 }
+    const queryClient = createTestQueryClient()
+    listAllOptionsMock.mockResolvedValueOnce(snapshot)
+
+    const { result } = renderHook(() => useTechnicalConfigurationOptionListQuery(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.optionsQuery.data).toEqual(snapshot))
+
+    expect(listAllOptionsMock).toHaveBeenCalledTimes(1)
+    expect(listAllOptionsMock).toHaveBeenCalledWith(dossierId, expect.any(AbortSignal))
+    expect(result.current.queryKey).toEqual(technicalConfigurationOptionsQueryKey(dossierId))
+    expect(queryClient.getQueryData(technicalConfigurationOptionsQueryKey(dossierId))).toEqual(
+      snapshot
+    )
+  })
+
+  it("keeps the shared read query stable and side-effect free", async () => {
+    const dossierId = "00000000-0000-0000-0000-000000000002"
+    const queryClient = createTestQueryClient()
+    listAllOptionsMock.mockResolvedValueOnce({ options: [], revision: 2 })
+
+    const { result } = renderHook(() => useTechnicalConfigurationOptionListQuery(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.optionsQuery.isSuccess).toBe(true))
+
+    const query = queryClient
+      .getQueryCache()
+      .find({ queryKey: technicalConfigurationOptionsQueryKey(dossierId), exact: true })
+
+    expect(query?.options.staleTime).toBe(30_000)
+    expect(query?.options.retry).toBe(false)
+    expect(query?.options.refetchOnWindowFocus).toBe(false)
+  })
+})
+
+describe("P10B1 ordered comparison request state", () => {
+  const dossierId = "00000000-0000-0000-0000-000000000100"
+  const baselineOne = createBaselineVersion("00000000-0000-0000-0000-000000000201", 1)
+  const baselineTwo = createBaselineVersion("00000000-0000-0000-0000-000000000202", 2)
+  const options = Array.from({ length: 9 }, (_, index) => createOption(index + 1))
+
+  beforeEach(() => {
+    listAllOptionsMock.mockReset()
+    listBaselineVersionsMock.mockReset()
+    getComparisonMock.mockReset()
+    listAllOptionsMock.mockResolvedValue({ options, revision: 9 })
+    listBaselineVersionsMock.mockResolvedValue({
+      data: [baselineTwo, baselineOne],
+      total: 2,
+      page: 1,
+      page_size: 50,
+    })
+    getComparisonMock.mockImplementation(async (request) => ({
+      data: {
+        dossier: {
+          id: dossierId,
+          deviceTypeName: "Máy siêu âm",
+          name: "Cấu hình máy siêu âm",
+          revision: 9,
+          archivedAt: null,
+        },
+        baselineVersion: {
+          id: request.baselineVersionId,
+          dossierId,
+          versionNumber: 2,
+          status: "locked",
+          revision: 2,
+        },
+        options: [],
+        criteria: [],
+      },
+      total: 0,
+      page: request.page,
+      pageSize: request.pageSize,
+    }))
+  })
+
+  it("appends and removes options without sorting or accepting duplicates", async () => {
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useTechnicalConfigurationComparisonMatrix(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.optionsQuery.isSuccess).toBe(true))
+
+    act(() => {
+      result.current.addOption(options[2].id)
+      result.current.addOption(options[0].id)
+      result.current.addOption(options[1].id)
+      result.current.addOption(options[0].id)
+      result.current.removeOption(options[0].id)
+    })
+
+    expect(result.current.selectedOptionIds).toEqual([options[2].id, options[1].id])
+  })
+
+  it("blocks a ninth option while leaving it available for a later request", async () => {
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useTechnicalConfigurationComparisonMatrix(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.optionsQuery.isSuccess).toBe(true))
+
+    act(() => {
+      options.forEach((option) => result.current.addOption(option.id))
+    })
+
+    expect(result.current.selectedOptionIds).toEqual(options.slice(0, 8).map((option) => option.id))
+    expect(result.current.isSelectionLimitReached).toBe(true)
+    expect(result.current.options).toContainEqual(options[8])
+  })
+
+  it("filters stale option ids without changing the order of survivors", async () => {
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useTechnicalConfigurationComparisonMatrix(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.optionsQuery.isSuccess).toBe(true))
+
+    act(() => {
+      result.current.addOption(options[2].id)
+      result.current.addOption(options[0].id)
+      result.current.addOption(options[1].id)
+    })
+    act(() => {
+      queryClient.setQueryData(technicalConfigurationOptionsQueryKey(dossierId), {
+        options: [options[1], options[2]],
+        revision: 10,
+      })
+    })
+
+    await waitFor(() =>
+      expect(result.current.selectedOptionIds).toEqual([options[2].id, options[1].id])
+    )
+  })
+
+  it("resets page one and uses a fixed immutable comparison request", async () => {
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useTechnicalConfigurationComparisonMatrix(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+
+    await waitFor(() => expect(result.current.versionsQuery.isSuccess).toBe(true))
+    expect(result.current.comparison.comparisonQuery.fetchStatus).toBe("idle")
+
+    act(() => {
+      result.current.selectBaselineVersion(baselineTwo.id)
+      result.current.setPage(3)
+    })
+    expect(result.current.page).toBe(3)
+    expect(result.current.comparison.comparisonQuery.fetchStatus).toBe("idle")
+
+    act(() => result.current.addOption(options[2].id))
+    expect(result.current.page).toBe(1)
+
+    await waitFor(() => expect(getComparisonMock).toHaveBeenCalledTimes(1))
+    const firstQueryKey = result.current.comparison.queryKey
+    expect(firstQueryKey).toEqual(
+      technicalConfigurationComparisonQueryKey({
+        baselineVersionId: baselineTwo.id,
+        optionIds: [options[2].id],
+        page: 1,
+        pageSize: 50,
+      })
+    )
+
+    act(() => {
+      result.current.setPage(4)
+      result.current.selectBaselineVersion(baselineOne.id)
+    })
+    expect(result.current.page).toBe(1)
+    expect(firstQueryKey[3]).toEqual([options[2].id])
+  })
+})
+
+registerComparisonMatrixRenderingTests()

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-core.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-core.test.tsx
@@ -12,6 +12,7 @@ import {
 import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 
 import { registerComparisonMatrixRenderingTests } from "./comparison-matrix-rendering-cases"
+import { registerComparisonMatrixReviewRegressionTests } from "./comparison-matrix-review-regression-cases"
 
 const listAllOptionsMock = vi.fn()
 const listBaselineVersionsMock = vi.fn()
@@ -274,3 +275,4 @@ describe("P10B1 ordered comparison request state", () => {
 })
 
 registerComparisonMatrixRenderingTests()
+registerComparisonMatrixReviewRegressionTests()

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-rendering-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-rendering-cases.tsx
@@ -1,151 +1,19 @@
-import * as React from "react"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
-import {
-  TechnicalConfigurationCriterionPanel,
-  type TechnicalConfigurationCriterionDetail,
-} from "../_components/comparison/TechnicalConfigurationCriterionPanel"
+import { TechnicalConfigurationCriterionPanel } from "../_components/comparison/TechnicalConfigurationCriterionPanel"
 import { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
 import { TechnicalConfigurationMatrixToolbar } from "../_components/comparison/TechnicalConfigurationMatrixToolbar"
 import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
-import type { TechnicalConfigurationComparisonResult } from "../comparison-types"
 import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 
-const LONG_REQUIREMENT =
-  "Yêu cầu cơ sở rất dài để xác nhận ô ma trận chỉ hiển thị nội dung rút gọn nhưng panel chi tiết vẫn giữ nguyên toàn bộ văn bản kỹ thuật."
-const LONG_RESPONSE =
-  "Phản hồi phương án rất dài để xác nhận người dùng có thể mở phần chi tiết bằng bàn phím và đọc toàn bộ nội dung."
-
-function createComparisonResult(): TechnicalConfigurationComparisonResult {
-  return {
-    data: {
-      dossier: {
-        id: "dossier-1",
-        deviceTypeName: "Máy siêu âm",
-        name: "Cấu hình máy siêu âm",
-        revision: 4,
-        archivedAt: null,
-      },
-      baselineVersion: {
-        id: "baseline-1",
-        dossierId: "dossier-1",
-        versionNumber: 2,
-        status: "locked",
-        revision: 2,
-      },
-      options: [
-        {
-          id: "option-b",
-          supplierId: "supplier-b",
-          supplierName: "Nhà cung cấp B",
-          model: null,
-          manufacturer: null,
-          optionName: "Phương án B",
-          displayLabel: "Nhà cung cấp B · Phương án B",
-        },
-        {
-          id: "option-a",
-          supplierId: "supplier-a",
-          supplierName: "Nhà cung cấp A",
-          model: "A-100",
-          manufacturer: "Hãng A",
-          optionName: null,
-          displayLabel: "Nhà cung cấp A · A-100",
-        },
-      ],
-      criteria: [
-        {
-          group: { id: "group-1", name: "Thông số chính", sortOrder: 1 },
-          criterion: {
-            id: "criterion-2",
-            criterionCode: "TS-02",
-            title: "Độ phân giải",
-            requirementText: LONG_REQUIREMENT,
-            sortOrder: 2,
-          },
-          baselineEvidence: { documentCount: 2, citationCount: 1, hasEvidence: true },
-          optionValues: [
-            {
-              optionId: "option-b",
-              comparisonSetId: "set-b",
-              response: {
-                id: "response-b",
-                responseText: LONG_RESPONSE,
-                supplementaryInformation: "Có đầu dò bổ sung.",
-              },
-              evidence: { documentCount: 1, citationCount: 1, hasEvidence: true },
-            },
-            {
-              optionId: "option-a",
-              comparisonSetId: null,
-              response: null,
-              evidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
-            },
-          ],
-        },
-        {
-          group: { id: "group-1", name: "Thông số chính", sortOrder: 1 },
-          criterion: {
-            id: "criterion-1",
-            criterionCode: "TS-01",
-            title: null,
-            requirementText: "Tần số tối thiểu 10 MHz",
-            sortOrder: 1,
-          },
-          baselineEvidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
-          optionValues: [],
-        },
-        {
-          group: { id: "group-2", name: "Phụ kiện", sortOrder: 2 },
-          criterion: {
-            id: "criterion-3",
-            criterionCode: "PK-01",
-            title: "Xe đẩy",
-            requirementText: "Có xe đẩy chuyên dụng",
-            sortOrder: 1,
-          },
-          baselineEvidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
-          optionValues: [],
-        },
-      ],
-    },
-    total: 120,
-    page: 2,
-    pageSize: 50,
-  }
-}
-
-function ComparisonDetailHarness() {
-  const [detail, setDetail] = React.useState<TechnicalConfigurationCriterionDetail | null>(null)
-  const detailReturnFocusRef = React.useRef<HTMLElement | null>(null)
-  const openDetail = (nextDetail: TechnicalConfigurationCriterionDetail) => {
-    detailReturnFocusRef.current =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null
-    setDetail(nextDetail)
-  }
-
-  return (
-    <>
-      <TechnicalConfigurationMatrix
-        hasRequest
-        result={createComparisonResult()}
-        onOpenDetail={openDetail}
-        onPageChange={vi.fn()}
-        onRetry={vi.fn()}
-      />
-      <TechnicalConfigurationCriterionPanel
-        detail={detail}
-        open={detail !== null}
-        returnFocusRef={detailReturnFocusRef}
-        onOpenChange={(open) => {
-          if (!open) setDetail(null)
-        }}
-      />
-    </>
-  )
-}
+import {
+  ComparisonDetailHarness,
+  createComparisonResult,
+  LONG_REQUIREMENT,
+  LONG_RESPONSE,
+} from "./comparison-matrix-test-fixtures"
 
 export function registerComparisonMatrixRenderingTests() {
   describe("P10B1 core comparison matrix rendering", () => {

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-rendering-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-rendering-cases.tsx
@@ -1,0 +1,450 @@
+import * as React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  TechnicalConfigurationCriterionPanel,
+  type TechnicalConfigurationCriterionDetail,
+} from "../_components/comparison/TechnicalConfigurationCriterionPanel"
+import { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
+import { TechnicalConfigurationMatrixToolbar } from "../_components/comparison/TechnicalConfigurationMatrixToolbar"
+import type { TechnicalConfigurationBaselineDraftWire } from "../baseline-types"
+import type { TechnicalConfigurationComparisonResult } from "../comparison-types"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+
+const LONG_REQUIREMENT =
+  "Yêu cầu cơ sở rất dài để xác nhận ô ma trận chỉ hiển thị nội dung rút gọn nhưng panel chi tiết vẫn giữ nguyên toàn bộ văn bản kỹ thuật."
+const LONG_RESPONSE =
+  "Phản hồi phương án rất dài để xác nhận người dùng có thể mở phần chi tiết bằng bàn phím và đọc toàn bộ nội dung."
+
+function createComparisonResult(): TechnicalConfigurationComparisonResult {
+  return {
+    data: {
+      dossier: {
+        id: "dossier-1",
+        deviceTypeName: "Máy siêu âm",
+        name: "Cấu hình máy siêu âm",
+        revision: 4,
+        archivedAt: null,
+      },
+      baselineVersion: {
+        id: "baseline-1",
+        dossierId: "dossier-1",
+        versionNumber: 2,
+        status: "locked",
+        revision: 2,
+      },
+      options: [
+        {
+          id: "option-b",
+          supplierId: "supplier-b",
+          supplierName: "Nhà cung cấp B",
+          model: null,
+          manufacturer: null,
+          optionName: "Phương án B",
+          displayLabel: "Nhà cung cấp B · Phương án B",
+        },
+        {
+          id: "option-a",
+          supplierId: "supplier-a",
+          supplierName: "Nhà cung cấp A",
+          model: "A-100",
+          manufacturer: "Hãng A",
+          optionName: null,
+          displayLabel: "Nhà cung cấp A · A-100",
+        },
+      ],
+      criteria: [
+        {
+          group: { id: "group-1", name: "Thông số chính", sortOrder: 1 },
+          criterion: {
+            id: "criterion-2",
+            criterionCode: "TS-02",
+            title: "Độ phân giải",
+            requirementText: LONG_REQUIREMENT,
+            sortOrder: 2,
+          },
+          baselineEvidence: { documentCount: 2, citationCount: 1, hasEvidence: true },
+          optionValues: [
+            {
+              optionId: "option-b",
+              comparisonSetId: "set-b",
+              response: {
+                id: "response-b",
+                responseText: LONG_RESPONSE,
+                supplementaryInformation: "Có đầu dò bổ sung.",
+              },
+              evidence: { documentCount: 1, citationCount: 1, hasEvidence: true },
+            },
+            {
+              optionId: "option-a",
+              comparisonSetId: null,
+              response: null,
+              evidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
+            },
+          ],
+        },
+        {
+          group: { id: "group-1", name: "Thông số chính", sortOrder: 1 },
+          criterion: {
+            id: "criterion-1",
+            criterionCode: "TS-01",
+            title: null,
+            requirementText: "Tần số tối thiểu 10 MHz",
+            sortOrder: 1,
+          },
+          baselineEvidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
+          optionValues: [],
+        },
+        {
+          group: { id: "group-2", name: "Phụ kiện", sortOrder: 2 },
+          criterion: {
+            id: "criterion-3",
+            criterionCode: "PK-01",
+            title: "Xe đẩy",
+            requirementText: "Có xe đẩy chuyên dụng",
+            sortOrder: 1,
+          },
+          baselineEvidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
+          optionValues: [],
+        },
+      ],
+    },
+    total: 120,
+    page: 2,
+    pageSize: 50,
+  }
+}
+
+function ComparisonDetailHarness() {
+  const [detail, setDetail] = React.useState<TechnicalConfigurationCriterionDetail | null>(null)
+  const detailReturnFocusRef = React.useRef<HTMLElement | null>(null)
+  const openDetail = (nextDetail: TechnicalConfigurationCriterionDetail) => {
+    detailReturnFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+    setDetail(nextDetail)
+  }
+
+  return (
+    <>
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={createComparisonResult()}
+        onOpenDetail={openDetail}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+      <TechnicalConfigurationCriterionPanel
+        detail={detail}
+        open={detail !== null}
+        returnFocusRef={detailReturnFocusRef}
+        onOpenChange={(open) => {
+          if (!open) setDetail(null)
+        }}
+      />
+    </>
+  )
+}
+
+export function registerComparisonMatrixRenderingTests() {
+  describe("P10B1 core comparison matrix rendering", () => {
+    it("renders desktop request controls and preserves selected option order", async () => {
+      const user = userEvent.setup()
+      const onAddOption = vi.fn()
+      const onRemoveOption = vi.fn()
+      const versions = [
+        {
+          id: "baseline-2",
+          dossier_id: "dossier-1",
+          version_number: 2,
+          status: "locked",
+          source_baseline_version_id: null,
+          source_version_number: null,
+          next_criterion_number: 1,
+          revision: 2,
+          locked_at: "2026-07-28T00:00:00Z",
+          locked_by: 1,
+          created_at: "2026-07-28T00:00:00Z",
+          created_by: 1,
+          updated_at: "2026-07-28T00:00:00Z",
+          updated_by: 1,
+          groups: [],
+        },
+      ] satisfies TechnicalConfigurationBaselineDraftWire[]
+      const optionA = {
+        id: "option-a",
+        dossier_id: "dossier-1",
+        supplier_id: "supplier-a",
+        supplier_name: "Nhà cung cấp A",
+        model: "A-100",
+        manufacturer: null,
+        option_name: null,
+        notes: null,
+        display_label: "Nhà cung cấp A · A-100",
+        created_at: "2026-07-28T00:00:00Z",
+        created_by: 1,
+        updated_at: "2026-07-28T00:00:00Z",
+        updated_by: 1,
+        revision: 1,
+      } satisfies TechnicalConfigurationOptionWire
+      const optionB = {
+        ...optionA,
+        id: "option-b",
+        supplier_id: "supplier-b",
+        supplier_name: "Nhà cung cấp B",
+        model: "B-200",
+        display_label: "Nhà cung cấp B · B-200",
+      }
+      const optionC = {
+        ...optionA,
+        id: "option-c",
+        supplier_id: "supplier-c",
+        supplier_name: "Nhà cung cấp C",
+        model: "C-300",
+        display_label: "Nhà cung cấp C · C-300",
+      }
+
+      const toolbarProps = {
+        baselineVersionId: versions[0].id,
+        versions,
+        versionsQuery: { isLoading: false, isError: false, hasNextPage: false },
+        options: [optionA, optionB, optionC],
+        optionsQuery: { isLoading: false, isError: false },
+        selectedOptions: [optionB, optionA],
+        onSelectBaselineVersion: vi.fn(),
+        onLoadMoreVersions: vi.fn(),
+        onRetryVersions: vi.fn(),
+        onRetryOptions: vi.fn(),
+        onAddOption,
+        onRemoveOption,
+      }
+      const { rerender } = render(
+        <TechnicalConfigurationMatrixToolbar {...toolbarProps} isSelectionLimitReached={false} />
+      )
+
+      expect(
+        screen.getAllByTestId("selected-option-label").map((label) => label.textContent)
+      ).toEqual(["1. Nhà cung cấp B · B-200", "2. Nhà cung cấp A · A-100"])
+
+      await user.click(
+        screen.getByRole("button", { name: "Bỏ phương án 1: Nhà cung cấp B · B-200" })
+      )
+      expect(onRemoveOption).toHaveBeenCalledWith(optionB.id)
+
+      await user.click(screen.getByRole("button", { name: /Chọn phương án/ }))
+      await user.click(screen.getByRole("button", { name: optionC.display_label }))
+      expect(onAddOption).toHaveBeenCalledWith(optionC.id)
+
+      rerender(<TechnicalConfigurationMatrixToolbar {...toolbarProps} isSelectionLimitReached />)
+      expect(screen.getByRole("button", { name: optionC.display_label })).toBeInTheDocument()
+
+      rerender(
+        <TechnicalConfigurationMatrixToolbar
+          {...toolbarProps}
+          versionsQuery={{
+            ...toolbarProps.versionsQuery,
+            isError: true,
+            error: new Error("Không thể tải thêm lịch sử"),
+          }}
+          isSelectionLimitReached={false}
+        />
+      )
+      expect(screen.getByLabelText("Chọn phiên bản cấu hình cơ sở")).toBeEnabled()
+      expect(screen.getByText("Không thể tải thêm lịch sử")).toBeInTheDocument()
+    })
+
+    it("renders canonical rows and frozen columns in request order", () => {
+      render(
+        <TechnicalConfigurationMatrix
+          hasRequest
+          result={createComparisonResult()}
+          onOpenDetail={vi.fn()}
+          onPageChange={vi.fn()}
+          onRetry={vi.fn()}
+        />
+      )
+
+      expect(
+        screen.getAllByTestId("comparison-option-header").map((header) => header.textContent)
+      ).toEqual(["Nhà cung cấp B · Phương án B", "Nhà cung cấp A · A-100"])
+      expect(
+        screen.getAllByTestId("comparison-criterion-row").map((row) => row.dataset.criterionId)
+      ).toEqual(["criterion-2", "criterion-1", "criterion-3"])
+      expect(screen.getByTestId("comparison-matrix-scroll")).toHaveClass("overflow-auto")
+      expect(screen.getByTestId("comparison-criterion-header")).toHaveClass(
+        "sticky",
+        "left-0",
+        "w-[220px]",
+        "min-w-[220px]",
+        "max-w-[220px]"
+      )
+      expect(screen.getByTestId("comparison-baseline-header")).toHaveClass(
+        "sticky",
+        "left-[220px]",
+        "w-[360px]",
+        "min-w-[360px]",
+        "max-w-[360px]"
+      )
+      screen
+        .getAllByTestId("comparison-option-header")
+        .forEach((header) =>
+          expect(header).toHaveClass("w-[320px]", "min-w-[320px]", "max-w-[320px]")
+        )
+    })
+
+    it("renders each logical group as a semantic row group", () => {
+      const { container } = render(
+        <TechnicalConfigurationMatrix
+          hasRequest
+          result={createComparisonResult()}
+          onOpenDetail={vi.fn()}
+          onPageChange={vi.fn()}
+          onRetry={vi.fn()}
+        />
+      )
+
+      const groupBodies = container.querySelectorAll('tbody[data-testid="comparison-group-body"]')
+      expect(groupBodies).toHaveLength(2)
+      expect(groupBodies[0].querySelector('th[scope="rowgroup"]')).toHaveTextContent(
+        "Thông số chính"
+      )
+      expect(
+        groupBodies[0].querySelectorAll(
+          'tr[data-testid="comparison-criterion-row"] > th[scope="row"]'
+        )
+      ).toHaveLength(2)
+      expect(groupBodies[1].querySelector('th[scope="rowgroup"]')).toHaveTextContent("Phụ kiện")
+      expect(
+        groupBodies[1].querySelectorAll(
+          'tr[data-testid="comparison-criterion-row"] > th[scope="row"]'
+        )
+      ).toHaveLength(1)
+    })
+
+    it("keeps cells concise and exposes full text through keyboard interaction", async () => {
+      const user = userEvent.setup()
+      const onOpenDetail = vi.fn()
+      render(
+        <TechnicalConfigurationMatrix
+          hasRequest
+          result={createComparisonResult()}
+          onOpenDetail={onOpenDetail}
+          onPageChange={vi.fn()}
+          onRetry={vi.fn()}
+        />
+      )
+
+      expect(screen.getAllByText("Chưa có phản hồi")).not.toHaveLength(0)
+      expect(screen.getByText("Có thông tin bổ sung")).toBeInTheDocument()
+      expect(screen.getByText("1 tài liệu · 1 trích dẫn")).toBeInTheDocument()
+      expect(screen.getByText(LONG_RESPONSE)).toHaveClass("line-clamp-4")
+
+      const detailButton = screen.getByRole("button", {
+        name: "Xem chi tiết TS-02 · Nhà cung cấp B · Phương án B",
+      })
+      detailButton.focus()
+      await user.keyboard("{Enter}")
+
+      expect(onOpenDetail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          criterionCode: "TS-02",
+          requirementText: LONG_REQUIREMENT,
+          responseText: LONG_RESPONSE,
+          supplementaryInformation: "Có đầu dò bổ sung.",
+        })
+      )
+    })
+
+    it("restores focus to the matrix cell after closing keyboard-opened detail", async () => {
+      const user = userEvent.setup()
+      render(<ComparisonDetailHarness />)
+      const detailButton = screen.getByRole("button", {
+        name: "Xem chi tiết TS-02 · Nhà cung cấp B · Phương án B",
+      })
+
+      detailButton.focus()
+      await user.keyboard("{Enter}")
+      expect(screen.getByRole("dialog")).toBeInTheDocument()
+
+      await user.keyboard("{Escape}")
+      await waitFor(() => expect(detailButton).toHaveFocus())
+    })
+
+    it("renders no-selection, loading, error, retry, and empty-page states", async () => {
+      const user = userEvent.setup()
+      const onRetry = vi.fn()
+      const { rerender } = render(
+        <TechnicalConfigurationMatrix
+          hasRequest={false}
+          onOpenDetail={vi.fn()}
+          onPageChange={vi.fn()}
+          onRetry={onRetry}
+        />
+      )
+      expect(
+        screen.getByText("Chọn phiên bản cơ sở và ít nhất một phương án để bắt đầu so sánh.")
+      ).toBeInTheDocument()
+
+      rerender(
+        <TechnicalConfigurationMatrix
+          hasRequest
+          isLoading
+          onOpenDetail={vi.fn()}
+          onPageChange={vi.fn()}
+          onRetry={onRetry}
+        />
+      )
+      expect(screen.getByText("Đang tải ma trận so sánh...")).toBeInTheDocument()
+
+      rerender(
+        <TechnicalConfigurationMatrix
+          error={new Error("Không thể tải ma trận")}
+          hasRequest
+          isError
+          onOpenDetail={vi.fn()}
+          onPageChange={vi.fn()}
+          onRetry={onRetry}
+        />
+      )
+      await user.click(screen.getByRole("button", { name: "Thử lại" }))
+      expect(onRetry).toHaveBeenCalledTimes(1)
+
+      const emptyResult = createComparisonResult()
+      emptyResult.data.criteria = []
+      rerender(
+        <TechnicalConfigurationMatrix
+          hasRequest
+          result={emptyResult}
+          onOpenDetail={vi.fn()}
+          onPageChange={vi.fn()}
+          onRetry={onRetry}
+        />
+      )
+      expect(screen.getByText("Trang này chưa có tiêu chí để so sánh.")).toBeInTheDocument()
+    })
+
+    it("renders a text-only detail without authoring or assessment controls", () => {
+      const detail: TechnicalConfigurationCriterionDetail = {
+        criterionCode: "TS-02",
+        criterionTitle: "Độ phân giải",
+        optionLabel: "Nhà cung cấp B · Phương án B",
+        requirementText: LONG_REQUIREMENT,
+        responseText: LONG_RESPONSE,
+        supplementaryInformation: "Có đầu dò bổ sung.",
+        evidence: { documentCount: 1, citationCount: 1, hasEvidence: true },
+      }
+      render(<TechnicalConfigurationCriterionPanel detail={detail} open onOpenChange={vi.fn()} />)
+
+      expect(screen.getByText(LONG_REQUIREMENT)).toBeInTheDocument()
+      expect(screen.getByText(LONG_RESPONSE)).toBeInTheDocument()
+      expect(
+        screen.getByText("Không dùng thông tin bổ sung để chấm điểm hoặc xác định mức đáp ứng.")
+      ).toBeInTheDocument()
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+      expect(screen.queryByText("Sao chép từ cấu hình cơ sở")).not.toBeInTheDocument()
+      expect(screen.queryByText("Lưu")).not.toBeInTheDocument()
+      expect(screen.queryByText("Đánh giá")).not.toBeInTheDocument()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-review-regression-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-review-regression-cases.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationCriterionPanel } from "../_components/comparison/TechnicalConfigurationCriterionPanel"
+import { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
+
+import { createComparisonResult } from "./comparison-matrix-test-fixtures"
+
+export function registerComparisonMatrixReviewRegressionTests() {
+  describe("P10B1 review regressions", () => {
+    it("lets users return from an empty later page", async () => {
+      const user = userEvent.setup()
+      const onPageChange = vi.fn()
+      const emptyLaterPage = createComparisonResult()
+      emptyLaterPage.data.criteria = []
+      emptyLaterPage.total = 40
+      emptyLaterPage.page = 2
+
+      render(
+        <TechnicalConfigurationMatrix
+          hasRequest
+          result={emptyLaterPage}
+          onOpenDetail={vi.fn()}
+          onPageChange={onPageChange}
+          onRetry={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText("Trang này chưa có tiêu chí để so sánh.")).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Trang trước" }))
+      expect(onPageChange).toHaveBeenCalledWith(1)
+    })
+
+    it("shows only baseline-relevant fields in baseline detail", () => {
+      render(
+        <TechnicalConfigurationCriterionPanel
+          detail={{
+            criterionCode: "TS-01",
+            criterionTitle: "Độ phân giải",
+            optionLabel: null,
+            requirementText: "Độ phân giải tối thiểu 1920 x 1080",
+            responseText: null,
+            supplementaryInformation: null,
+            evidence: { documentCount: 2, citationCount: 1, hasEvidence: true },
+          }}
+          open
+          onOpenChange={vi.fn()}
+        />
+      )
+
+      expect(screen.getByText("Yêu cầu cơ sở")).toBeInTheDocument()
+      expect(screen.getByText("Độ phân giải tối thiểu 1920 x 1080")).toBeInTheDocument()
+      expect(screen.queryByText("Phản hồi phương án")).not.toBeInTheDocument()
+      expect(screen.queryByText("Thông tin bổ sung")).not.toBeInTheDocument()
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-test-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-test-fixtures.tsx
@@ -1,0 +1,143 @@
+import * as React from "react"
+import { vi } from "vitest"
+
+import {
+  TechnicalConfigurationCriterionPanel,
+  type TechnicalConfigurationCriterionDetail,
+} from "../_components/comparison/TechnicalConfigurationCriterionPanel"
+import { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
+import type { TechnicalConfigurationComparisonResult } from "../comparison-types"
+
+export const LONG_REQUIREMENT =
+  "Yêu cầu cơ sở rất dài để xác nhận ô ma trận chỉ hiển thị nội dung rút gọn nhưng panel chi tiết vẫn giữ nguyên toàn bộ văn bản kỹ thuật."
+export const LONG_RESPONSE =
+  "Phản hồi phương án rất dài để xác nhận người dùng có thể mở phần chi tiết bằng bàn phím và đọc toàn bộ nội dung."
+
+export function createComparisonResult(): TechnicalConfigurationComparisonResult {
+  return {
+    data: {
+      dossier: {
+        id: "dossier-1",
+        deviceTypeName: "Máy siêu âm",
+        name: "Cấu hình máy siêu âm",
+        revision: 4,
+        archivedAt: null,
+      },
+      baselineVersion: {
+        id: "baseline-1",
+        dossierId: "dossier-1",
+        versionNumber: 2,
+        status: "locked",
+        revision: 2,
+      },
+      options: [
+        {
+          id: "option-b",
+          supplierId: "supplier-b",
+          supplierName: "Nhà cung cấp B",
+          model: null,
+          manufacturer: null,
+          optionName: "Phương án B",
+          displayLabel: "Nhà cung cấp B · Phương án B",
+        },
+        {
+          id: "option-a",
+          supplierId: "supplier-a",
+          supplierName: "Nhà cung cấp A",
+          model: "A-100",
+          manufacturer: "Hãng A",
+          optionName: null,
+          displayLabel: "Nhà cung cấp A · A-100",
+        },
+      ],
+      criteria: [
+        {
+          group: { id: "group-1", name: "Thông số chính", sortOrder: 1 },
+          criterion: {
+            id: "criterion-2",
+            criterionCode: "TS-02",
+            title: "Độ phân giải",
+            requirementText: LONG_REQUIREMENT,
+            sortOrder: 2,
+          },
+          baselineEvidence: { documentCount: 2, citationCount: 1, hasEvidence: true },
+          optionValues: [
+            {
+              optionId: "option-b",
+              comparisonSetId: "set-b",
+              response: {
+                id: "response-b",
+                responseText: LONG_RESPONSE,
+                supplementaryInformation: "Có đầu dò bổ sung.",
+              },
+              evidence: { documentCount: 1, citationCount: 1, hasEvidence: true },
+            },
+            {
+              optionId: "option-a",
+              comparisonSetId: null,
+              response: null,
+              evidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
+            },
+          ],
+        },
+        {
+          group: { id: "group-1", name: "Thông số chính", sortOrder: 1 },
+          criterion: {
+            id: "criterion-1",
+            criterionCode: "TS-01",
+            title: null,
+            requirementText: "Tần số tối thiểu 10 MHz",
+            sortOrder: 1,
+          },
+          baselineEvidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
+          optionValues: [],
+        },
+        {
+          group: { id: "group-2", name: "Phụ kiện", sortOrder: 2 },
+          criterion: {
+            id: "criterion-3",
+            criterionCode: "PK-01",
+            title: "Xe đẩy",
+            requirementText: "Có xe đẩy chuyên dụng",
+            sortOrder: 1,
+          },
+          baselineEvidence: { documentCount: 0, citationCount: 0, hasEvidence: false },
+          optionValues: [],
+        },
+      ],
+    },
+    total: 120,
+    page: 2,
+    pageSize: 50,
+  }
+}
+
+export function ComparisonDetailHarness() {
+  const [detail, setDetail] = React.useState<TechnicalConfigurationCriterionDetail | null>(null)
+  const detailReturnFocusRef = React.useRef<HTMLElement | null>(null)
+  const openDetail = (nextDetail: TechnicalConfigurationCriterionDetail) => {
+    detailReturnFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+    setDetail(nextDetail)
+  }
+
+  return (
+    <>
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={createComparisonResult()}
+        onOpenDetail={openDetail}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+      <TechnicalConfigurationCriterionPanel
+        detail={detail}
+        open={detail !== null}
+        returnFocusRef={detailReturnFocusRef}
+        onOpenChange={(open) => {
+          if (!open) setDetail(null)
+        }}
+      />
+    </>
+  )
+}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -120,6 +120,13 @@ vi.mock(
   }
 )
 
+vi.mock(
+  "@/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab",
+  () => ({
+    TechnicalConfigurationComparisonTab: () => <div>Comparison matrix workspace</div>,
+  })
+)
+
 const dossier: TechnicalConfigurationDossierWire = {
   id: "dossier-1",
   device_type_name: "Máy lọc thận",
@@ -227,6 +234,24 @@ describe("technical configuration baseline workspace integration", () => {
       await user.click(screen.getByRole("tab", { name: "Tài liệu & trích dẫn" }))
 
       expect(screen.getByText("Baseline evidence workspace")).toBeInTheDocument()
+      expect(screen.queryByText("Baseline editor")).not.toBeInTheDocument()
+    } finally {
+      baselineTabMock.dirty = true
+    }
+  })
+
+  it("enables the complete comparison workspace in its own tab", async () => {
+    const user = userEvent.setup()
+    baselineTabMock.dirty = false
+
+    try {
+      render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={vi.fn()} />)
+      const comparisonTab = screen.getByRole("tab", { name: "So sánh & đánh giá" })
+
+      expect(comparisonTab).toBeEnabled()
+      await user.click(comparisonTab)
+
+      expect(screen.getByText("Comparison matrix workspace")).toBeInTheDocument()
       expect(screen.queryByText("Baseline editor")).not.toBeInTheDocument()
     } finally {
       baselineTabMock.dirty = true

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-baseline-workspace.test.tsx
@@ -1,6 +1,3 @@
-import fs from "node:fs"
-import path from "node:path"
-
 import * as React from "react"
 import "@testing-library/jest-dom"
 import { render, screen, within } from "@testing-library/react"
@@ -320,53 +317,6 @@ describe("technical configuration baseline workspace integration", () => {
       expect(await screen.findByText("Baseline revision 4")).toBeInTheDocument()
     } finally {
       baselineTabMock.dirty = true
-    }
-  })
-
-  it("keeps the shell thin and baseline responsibilities extracted before the threshold", () => {
-    const moduleRoot = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
-    const files = [
-      "TechnicalConfigurationsClient.tsx",
-      "_components/TechnicalConfigurationWorkspaceShell.tsx",
-      "_components/TechnicalConfigurationBaselineTab.tsx",
-      "_components/TechnicalConfigurationBaselineEvidence.tsx",
-      "_components/TechnicalConfigurationBaselineAlerts.tsx",
-      "_components/TechnicalConfigurationOptionResponseEditor.tsx",
-      "_components/TechnicalConfigurationOptionResponses.tsx",
-      "_components/TechnicalConfigurationBaselineTabStates.tsx",
-      "_components/TechnicalConfigurationBaselineEditor.tsx",
-      "_components/TechnicalConfigurationCriteriaSpreadsheet.tsx",
-      "_components/TechnicalConfigurationBulkEntryWorkbench.tsx",
-      "_components/TechnicalConfigurationAllGroupsOverview.tsx",
-      "_components/TechnicalConfigurationGroupNavigator.tsx",
-      "_hooks/useTechnicalConfigurationBaselineEditor.ts",
-      "_hooks/useTechnicalConfigurationBaselineImport.ts",
-      "_hooks/useTechnicalConfigurationBulkEntrySessions.ts",
-      "_hooks/useTechnicalConfigurationInlineEditor.ts",
-      "_hooks/useTechnicalConfigurationOptionResponses.ts",
-    ]
-
-    for (const file of files) {
-      const source = fs.readFileSync(path.join(moduleRoot, file), "utf8")
-      const lineCount = source.split("\n").length
-      expect(lineCount).toBeLessThan(350)
-    }
-
-    const shellSource = fs.readFileSync(
-      path.join(moduleRoot, "_components/TechnicalConfigurationWorkspaceShell.tsx"),
-      "utf8"
-    )
-    expect(shellSource).toContain("TechnicalConfigurationBaselineTab")
-    expect(shellSource).toContain("TechnicalConfigurationBaselineEvidence")
-    expect(shellSource).not.toContain("useQuery")
-    expect(shellSource).not.toContain("useMutation")
-
-    for (const file of [
-      "_components/TechnicalConfigurationBaselineTab.tsx",
-      "_hooks/useTechnicalConfigurationBaselineEditor.ts",
-    ]) {
-      const source = fs.readFileSync(path.join(moduleRoot, file), "utf8")
-      expect(source).not.toMatch(/reference[-_ ]?product/i)
     }
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-dossier-shell.test.tsx
@@ -199,7 +199,7 @@ describe("technical configuration dossier shell", () => {
       "So sánh & đánh giá",
     ])
     expect(screen.getByRole("tab", { name: "Phương án" })).toBeEnabled()
-    expect(screen.getByRole("tab", { name: "So sánh & đánh giá" })).toBeDisabled()
+    expect(screen.getByRole("tab", { name: "So sánh & đánh giá" })).toBeEnabled()
     expect(screen.queryByRole("button", { name: "Thêm nhóm" })).not.toBeInTheDocument()
   })
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-shell-source.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-shell-source.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+describe("technical configuration workspace shell source boundaries", () => {
+  it("keeps the shell thin and baseline responsibilities extracted before the threshold", () => {
+    const moduleRoot = path.resolve(process.cwd(), "src/app/(app)/technical-configurations")
+    const files = [
+      "TechnicalConfigurationsClient.tsx",
+      "_components/TechnicalConfigurationWorkspaceShell.tsx",
+      "_components/TechnicalConfigurationBaselineTab.tsx",
+      "_components/TechnicalConfigurationBaselineEvidence.tsx",
+      "_components/TechnicalConfigurationBaselineAlerts.tsx",
+      "_components/TechnicalConfigurationOptionResponseEditor.tsx",
+      "_components/TechnicalConfigurationOptionResponses.tsx",
+      "_components/TechnicalConfigurationBaselineTabStates.tsx",
+      "_components/TechnicalConfigurationBaselineEditor.tsx",
+      "_components/TechnicalConfigurationCriteriaSpreadsheet.tsx",
+      "_components/TechnicalConfigurationBulkEntryWorkbench.tsx",
+      "_components/TechnicalConfigurationAllGroupsOverview.tsx",
+      "_components/TechnicalConfigurationGroupNavigator.tsx",
+      "_hooks/useTechnicalConfigurationBaselineEditor.ts",
+      "_hooks/useTechnicalConfigurationBaselineImport.ts",
+      "_hooks/useTechnicalConfigurationBulkEntrySessions.ts",
+      "_hooks/useTechnicalConfigurationInlineEditor.ts",
+      "_hooks/useTechnicalConfigurationOptionResponses.ts",
+      "__tests__/comparison-matrix-rendering-cases.tsx",
+      "__tests__/technical-configuration-baseline-workspace.test.tsx",
+    ]
+
+    for (const file of files) {
+      const source = fs.readFileSync(path.join(moduleRoot, file), "utf8")
+      const lineCount = source.split("\n").length
+      expect(lineCount).toBeLessThan(350)
+    }
+
+    const shellSource = fs.readFileSync(
+      path.join(moduleRoot, "_components/TechnicalConfigurationWorkspaceShell.tsx"),
+      "utf8"
+    )
+    expect(shellSource).toContain("TechnicalConfigurationBaselineTab")
+    expect(shellSource).toContain("TechnicalConfigurationBaselineEvidence")
+    expect(shellSource).not.toContain("useQuery")
+    expect(shellSource).not.toContain("useMutation")
+
+    for (const file of [
+      "_components/TechnicalConfigurationBaselineTab.tsx",
+      "_hooks/useTechnicalConfigurationBaselineEditor.ts",
+    ]) {
+      const source = fs.readFileSync(path.join(moduleRoot, file), "utf8")
+      expect(source).not.toMatch(/reference[-_ ]?product/i)
+    }
+  })
+})

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -25,6 +25,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
 import { TechnicalConfigurationBaselineTab } from "./TechnicalConfigurationBaselineTab"
 import { TechnicalConfigurationBaselineEvidence } from "./TechnicalConfigurationBaselineEvidence"
+import { TechnicalConfigurationComparisonTab } from "./comparison/TechnicalConfigurationComparisonTab"
 import { TechnicalConfigurationReferenceProducts } from "./TechnicalConfigurationReferenceProducts"
 import { TechnicalConfigurationSuppliers } from "./TechnicalConfigurationSuppliers"
 
@@ -197,7 +198,7 @@ export function TechnicalConfigurationWorkspaceShell({
             <PackageSearch className="size-4" aria-hidden="true" />
             Phương án
           </TabsTrigger>
-          <TabsTrigger value="comparison" className="min-h-10 gap-2" disabled>
+          <TabsTrigger value="comparison" className="min-h-10 gap-2">
             <GitCompareArrows className="size-4" aria-hidden="true" />
             So sánh &amp; đánh giá
           </TabsTrigger>
@@ -231,6 +232,9 @@ export function TechnicalConfigurationWorkspaceShell({
             onNavigationBlockedChange={setIsOptionNavigationBlocked}
             onRevisionChange={handleRevisionChange}
           />
+        </TabsContent>
+        <TabsContent value="comparison" className="mt-6">
+          <TechnicalConfigurationComparisonTab dossier={workspaceDossier} />
         </TabsContent>
       </Tabs>
 

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import * as React from "react"
+
+import type { TechnicalConfigurationDossierWire } from "../../types"
+import { useTechnicalConfigurationComparisonMatrix } from "../../_hooks/useTechnicalConfigurationComparisonMatrix"
+import {
+  TechnicalConfigurationCriterionPanel,
+  type TechnicalConfigurationCriterionDetail,
+} from "./TechnicalConfigurationCriterionPanel"
+import { TechnicalConfigurationMatrix } from "./TechnicalConfigurationMatrix"
+import { TechnicalConfigurationMatrixToolbar } from "./TechnicalConfigurationMatrixToolbar"
+
+type TechnicalConfigurationComparisonTabProps = {
+  dossier: TechnicalConfigurationDossierWire
+}
+
+/** Composes the read-only P10B1 comparison request, matrix, and criterion detail. */
+export function TechnicalConfigurationComparisonTab({
+  dossier,
+}: Readonly<TechnicalConfigurationComparisonTabProps>) {
+  const matrix = useTechnicalConfigurationComparisonMatrix(dossier.id)
+  const [detail, setDetail] = React.useState<TechnicalConfigurationCriterionDetail | null>(null)
+  const detailReturnFocusRef = React.useRef<HTMLElement | null>(null)
+  const { comparisonQuery } = matrix.comparison
+  const hasRequest = matrix.baselineVersionId !== null && matrix.selectedOptionIds.length > 0
+  const openDetail = React.useCallback((nextDetail: TechnicalConfigurationCriterionDetail) => {
+    detailReturnFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+    setDetail(nextDetail)
+  }, [])
+
+  return (
+    <section className="min-w-0 space-y-4" aria-label="Ma trận so sánh cấu hình kỹ thuật">
+      <TechnicalConfigurationMatrixToolbar
+        baselineVersionId={matrix.baselineVersionId}
+        versions={matrix.versions}
+        versionsQuery={matrix.versionsQuery}
+        options={matrix.options}
+        optionsQuery={matrix.optionsQuery}
+        selectedOptions={matrix.selectedOptions}
+        isSelectionLimitReached={matrix.isSelectionLimitReached}
+        onSelectBaselineVersion={matrix.selectBaselineVersion}
+        onLoadMoreVersions={() => void matrix.loadMoreVersions()}
+        onRetryVersions={() => void matrix.retryVersions()}
+        onRetryOptions={() => void matrix.optionsQuery.refetch()}
+        onAddOption={matrix.addOption}
+        onRemoveOption={matrix.removeOption}
+      />
+
+      <TechnicalConfigurationMatrix
+        hasRequest={hasRequest}
+        result={comparisonQuery.data}
+        isLoading={comparisonQuery.isLoading}
+        isError={comparisonQuery.isError}
+        error={comparisonQuery.error}
+        onRetry={() => void comparisonQuery.refetch()}
+        onPageChange={matrix.setPage}
+        onOpenDetail={openDetail}
+      />
+
+      <TechnicalConfigurationCriterionPanel
+        detail={detail}
+        open={detail !== null}
+        returnFocusRef={detailReturnFocusRef}
+        onOpenChange={(open) => {
+          if (!open) setDetail(null)
+        }}
+      />
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+
+import type { TechnicalConfigurationComparisonEvidence } from "../../comparison-types"
+import { SideSheetShell } from "@/components/shared/SideSheetShell"
+
+export type TechnicalConfigurationCriterionDetail = {
+  criterionCode: string
+  criterionTitle: string | null
+  optionLabel: string | null
+  requirementText: string
+  responseText: string | null
+  supplementaryInformation: string | null
+  evidence: TechnicalConfigurationComparisonEvidence
+}
+
+type TechnicalConfigurationCriterionPanelProps = {
+  detail: TechnicalConfigurationCriterionDetail | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  returnFocusRef?: React.RefObject<HTMLElement | null>
+}
+
+function formatEvidenceSummary(evidence: TechnicalConfigurationComparisonEvidence) {
+  if (!evidence.hasEvidence) return "Chưa có bằng chứng"
+  return `${evidence.documentCount} tài liệu · ${evidence.citationCount} trích dẫn`
+}
+
+/** Renders full comparison text without loading evidence documents or assessment controls. */
+export function TechnicalConfigurationCriterionPanel({
+  detail,
+  open,
+  onOpenChange,
+  returnFocusRef,
+}: Readonly<TechnicalConfigurationCriterionPanelProps>) {
+  return (
+    <SideSheetShell
+      open={open}
+      onOpenChange={onOpenChange}
+      closeLabel="Đóng chi tiết tiêu chí"
+      title={
+        detail
+          ? `${detail.criterionCode} · ${detail.criterionTitle ?? "Chưa có tiêu đề"}`
+          : "Chi tiết tiêu chí"
+      }
+      description={detail?.optionLabel ?? "Yêu cầu cấu hình cơ sở"}
+      contentClassName="sm:max-w-xl lg:max-w-2xl"
+      bodyClassName="overflow-y-auto"
+      onCloseAutoFocus={(event) => {
+        const returnFocusTarget = returnFocusRef?.current
+        if (!returnFocusTarget) return
+        event.preventDefault()
+        returnFocusTarget.focus()
+      }}
+    >
+      {detail ? (
+        <div className="space-y-5 p-5 text-sm">
+          <section className="space-y-2 border-b pb-5">
+            <h3 className="font-semibold">Yêu cầu cơ sở</h3>
+            <p className="whitespace-pre-wrap break-words leading-6">{detail.requirementText}</p>
+          </section>
+
+          <section className="space-y-2 border-b pb-5">
+            <h3 className="font-semibold">Phản hồi phương án</h3>
+            <p className="whitespace-pre-wrap break-words leading-6">
+              {detail.responseText || "Chưa có phản hồi."}
+            </p>
+          </section>
+
+          <section className="space-y-2 border-b pb-5">
+            <h3 className="font-semibold">Thông tin bổ sung</h3>
+            <p className="text-xs text-muted-foreground">
+              Không dùng thông tin bổ sung để chấm điểm hoặc xác định mức đáp ứng.
+            </p>
+            <p className="whitespace-pre-wrap break-words leading-6">
+              {detail.supplementaryInformation || "Không có thông tin bổ sung."}
+            </p>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="font-semibold">Tóm tắt bằng chứng</h3>
+            <p className="text-muted-foreground">{formatEvidenceSummary(detail.evidence)}</p>
+          </section>
+        </div>
+      ) : null}
+    </SideSheetShell>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
@@ -61,22 +61,26 @@ export function TechnicalConfigurationCriterionPanel({
             <p className="whitespace-pre-wrap break-words leading-6">{detail.requirementText}</p>
           </section>
 
-          <section className="space-y-2 border-b pb-5">
-            <h3 className="font-semibold">Phản hồi phương án</h3>
-            <p className="whitespace-pre-wrap break-words leading-6">
-              {detail.responseText || "Chưa có phản hồi."}
-            </p>
-          </section>
+          {detail.optionLabel !== null ? (
+            <>
+              <section className="space-y-2 border-b pb-5">
+                <h3 className="font-semibold">Phản hồi phương án</h3>
+                <p className="whitespace-pre-wrap break-words leading-6">
+                  {detail.responseText || "Chưa có phản hồi."}
+                </p>
+              </section>
 
-          <section className="space-y-2 border-b pb-5">
-            <h3 className="font-semibold">Thông tin bổ sung</h3>
-            <p className="text-xs text-muted-foreground">
-              Không dùng thông tin bổ sung để chấm điểm hoặc xác định mức đáp ứng.
-            </p>
-            <p className="whitespace-pre-wrap break-words leading-6">
-              {detail.supplementaryInformation || "Không có thông tin bổ sung."}
-            </p>
-          </section>
+              <section className="space-y-2 border-b pb-5">
+                <h3 className="font-semibold">Thông tin bổ sung</h3>
+                <p className="text-xs text-muted-foreground">
+                  Không dùng thông tin bổ sung để chấm điểm hoặc xác định mức đáp ứng.
+                </p>
+                <p className="whitespace-pre-wrap break-words leading-6">
+                  {detail.supplementaryInformation || "Không có thông tin bổ sung."}
+                </p>
+              </section>
+            </>
+          ) : null}
 
           <section className="space-y-2">
             <h3 className="font-semibold">Tóm tắt bằng chứng</h3>

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -1,0 +1,301 @@
+"use client"
+
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react"
+
+import type {
+  TechnicalConfigurationComparisonEvidence,
+  TechnicalConfigurationComparisonOptionValue,
+  TechnicalConfigurationComparisonResult,
+} from "../../comparison-types"
+import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
+import { Button } from "@/components/ui/button"
+
+type TechnicalConfigurationMatrixProps = {
+  hasRequest: boolean
+  result?: TechnicalConfigurationComparisonResult
+  isLoading?: boolean
+  isError?: boolean
+  error?: Error | null
+  onRetry: () => void
+  onPageChange: (page: number) => void
+  onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
+}
+
+const EMPTY_EVIDENCE: TechnicalConfigurationComparisonEvidence = {
+  documentCount: 0,
+  citationCount: 0,
+  hasEvidence: false,
+}
+
+type ComparisonCriterionRow = TechnicalConfigurationComparisonResult["data"]["criteria"][number]
+
+type ComparisonCriterionGroup = {
+  id: string
+  name: string
+  rows: ComparisonCriterionRow[]
+}
+
+function groupCriterionRows(criteria: readonly ComparisonCriterionRow[]) {
+  const groups: ComparisonCriterionGroup[] = []
+
+  for (const row of criteria) {
+    const currentGroup = groups[groups.length - 1]
+
+    if (currentGroup?.id === row.group.id) {
+      currentGroup.rows.push(row)
+    } else {
+      groups.push({ id: row.group.id, name: row.group.name, rows: [row] })
+    }
+  }
+
+  return groups
+}
+
+function formatEvidenceSummary(evidence: TechnicalConfigurationComparisonEvidence) {
+  if (!evidence.hasEvidence) return "Chưa có bằng chứng"
+  return `${evidence.documentCount} tài liệu · ${evidence.citationCount} trích dẫn`
+}
+
+function MatrixState({ children, role }: { children: React.ReactNode; role?: "alert" | "status" }) {
+  return (
+    <div
+      className="flex min-h-72 items-center justify-center border-y px-6 py-12 text-center text-sm text-muted-foreground"
+      role={role}
+    >
+      {children}
+    </div>
+  )
+}
+
+/** Renders the bounded read-only comparison page with frozen desktop columns. */
+export function TechnicalConfigurationMatrix({
+  hasRequest,
+  result,
+  isLoading = false,
+  isError = false,
+  error,
+  onRetry,
+  onPageChange,
+  onOpenDetail,
+}: Readonly<TechnicalConfigurationMatrixProps>) {
+  if (!hasRequest) {
+    return (
+      <MatrixState>Chọn phiên bản cơ sở và ít nhất một phương án để bắt đầu so sánh.</MatrixState>
+    )
+  }
+
+  if (isLoading) {
+    return <MatrixState role="status">Đang tải ma trận so sánh...</MatrixState>
+  }
+
+  if (isError) {
+    return (
+      <MatrixState role="alert">
+        <div className="space-y-3">
+          <p>{error?.message || "Không thể tải ma trận so sánh."}</p>
+          <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+            <RefreshCw aria-hidden="true" />
+            Thử lại
+          </Button>
+        </div>
+      </MatrixState>
+    )
+  }
+
+  if (!result || result.data.criteria.length === 0) {
+    return <MatrixState>Trang này chưa có tiêu chí để so sánh.</MatrixState>
+  }
+
+  const { criteria, options } = result.data
+  const criterionGroups = groupCriterionRows(criteria)
+  const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize))
+  const startItem = (result.page - 1) * result.pageSize + 1
+  const endItem = Math.min(result.page * result.pageSize, result.total)
+
+  return (
+    <div className="space-y-3">
+      <div
+        data-testid="comparison-matrix-scroll"
+        className="relative max-h-[calc(100vh-20rem)] min-h-[28rem] w-full overflow-auto rounded-md border"
+      >
+        <table className="min-w-max border-separate border-spacing-0 text-left text-sm">
+          <thead>
+            <tr>
+              <th
+                data-testid="comparison-criterion-header"
+                className="sticky left-0 top-0 z-50 w-[220px] min-w-[220px] max-w-[220px] border-b border-r bg-muted px-3 py-3 font-semibold"
+                scope="col"
+              >
+                Tiêu chí
+              </th>
+              <th
+                data-testid="comparison-baseline-header"
+                className="sticky left-[220px] top-0 z-50 w-[360px] min-w-[360px] max-w-[360px] border-b border-r bg-muted px-3 py-3 font-semibold"
+                scope="col"
+              >
+                Yêu cầu cơ sở
+              </th>
+              {options.map((option) => (
+                <th
+                  key={option.id}
+                  data-testid="comparison-option-header"
+                  className="sticky top-0 z-40 w-[320px] min-w-[320px] max-w-[320px] border-b border-r bg-muted px-3 py-3 font-semibold"
+                  scope="col"
+                >
+                  <span className="block break-words">{option.displayLabel}</span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          {criterionGroups.map((group) => (
+            <tbody key={group.id} data-testid="comparison-group-body">
+              <tr>
+                <th
+                  className="border-b bg-muted/70 px-3 py-2 text-xs font-semibold uppercase text-muted-foreground"
+                  colSpan={options.length + 2}
+                  scope="rowgroup"
+                >
+                  {group.name}
+                </th>
+              </tr>
+              {group.rows.map((row) => (
+                <MatrixRow
+                  key={row.criterion.id}
+                  row={row}
+                  options={options}
+                  valueByOptionId={
+                    new Map(row.optionValues.map((value) => [value.optionId, value]))
+                  }
+                  onOpenDetail={onOpenDetail}
+                />
+              ))}
+            </tbody>
+          ))}
+        </table>
+      </div>
+
+      <div className="flex min-h-10 items-center justify-between gap-4 text-sm">
+        <p className="text-muted-foreground">
+          Tiêu chí {startItem}-{endItem} trên {result.total} · Trang {result.page}/{totalPages}
+        </p>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            aria-label="Trang trước"
+            disabled={result.page <= 1}
+            onClick={() => onPageChange(result.page - 1)}
+          >
+            <ChevronLeft aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            aria-label="Trang tiếp theo"
+            disabled={result.page >= totalPages}
+            onClick={() => onPageChange(result.page + 1)}
+          >
+            <ChevronRight aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type MatrixRowProps = {
+  row: TechnicalConfigurationComparisonResult["data"]["criteria"][number]
+  options: TechnicalConfigurationComparisonResult["data"]["options"]
+  valueByOptionId: ReadonlyMap<string, TechnicalConfigurationComparisonOptionValue>
+  onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
+}
+
+function MatrixRow({ row, options, valueByOptionId, onOpenDetail }: Readonly<MatrixRowProps>) {
+  const title = row.criterion.title ?? "Chưa có tiêu đề"
+
+  return (
+    <tr
+      data-testid="comparison-criterion-row"
+      data-criterion-id={row.criterion.id}
+      className="align-top"
+    >
+      <th
+        className="sticky left-0 z-30 w-[220px] min-w-[220px] max-w-[220px] border-b border-r bg-background px-3 py-3 font-medium"
+        scope="row"
+      >
+        <span className="block text-xs text-muted-foreground">{row.criterion.criterionCode}</span>
+        <span className="mt-1 block break-words">{title}</span>
+      </th>
+      <td className="sticky left-[220px] z-30 w-[360px] min-w-[360px] max-w-[360px] border-b border-r bg-background p-0">
+        <button
+          type="button"
+          className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+          aria-label={`Xem chi tiết ${row.criterion.criterionCode} · Yêu cầu cơ sở`}
+          onClick={() =>
+            onOpenDetail({
+              criterionCode: row.criterion.criterionCode,
+              criterionTitle: row.criterion.title,
+              optionLabel: null,
+              requirementText: row.criterion.requirementText,
+              responseText: null,
+              supplementaryInformation: null,
+              evidence: row.baselineEvidence,
+            })
+          }
+        >
+          <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
+            {row.criterion.requirementText}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {formatEvidenceSummary(row.baselineEvidence)}
+          </p>
+        </button>
+      </td>
+      {options.map((option) => {
+        const value = valueByOptionId.get(option.id)
+        const response = value?.response
+        const evidence = value?.evidence ?? EMPTY_EVIDENCE
+
+        return (
+          <td
+            key={option.id}
+            className="w-[320px] min-w-[320px] max-w-[320px] border-b border-r bg-background p-0"
+          >
+            <button
+              type="button"
+              className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
+              onClick={() =>
+                onOpenDetail({
+                  criterionCode: row.criterion.criterionCode,
+                  criterionTitle: row.criterion.title,
+                  optionLabel: option.displayLabel,
+                  requirementText: row.criterion.requirementText,
+                  responseText: response?.responseText ?? null,
+                  supplementaryInformation: response?.supplementaryInformation ?? null,
+                  evidence,
+                })
+              }
+            >
+              {response ? (
+                <>
+                  <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
+                    {response.responseText}
+                  </p>
+                  {response.supplementaryInformation ? (
+                    <p className="text-xs font-medium text-foreground">Có thông tin bổ sung</p>
+                  ) : null}
+                </>
+              ) : (
+                <p className="text-muted-foreground">Chưa có phản hồi</p>
+              )}
+              <p className="text-xs text-muted-foreground">{formatEvidenceSummary(evidence)}</p>
+            </button>
+          </td>
+        )
+      })}
+    </tr>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -102,8 +102,29 @@ export function TechnicalConfigurationMatrix({
     )
   }
 
-  if (!result || result.data.criteria.length === 0) {
+  if (!result) {
     return <MatrixState>Trang này chưa có tiêu chí để so sánh.</MatrixState>
+  }
+
+  if (result.data.criteria.length === 0) {
+    return (
+      <MatrixState>
+        <div className="space-y-3">
+          <p>Trang này chưa có tiêu chí để so sánh.</p>
+          {result.page > 1 ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(result.page - 1)}
+            >
+              <ChevronLeft aria-hidden="true" />
+              Trang trước
+            </Button>
+          ) : null}
+        </div>
+      </MatrixState>
+    )
   }
 
   const { criteria, options } = result.data

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixToolbar.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixToolbar.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import * as React from "react"
+import { ChevronDown, RefreshCw, X } from "lucide-react"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "../../baseline-types"
+import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
+import { Button } from "@/components/ui/button"
+import { SingleSelect } from "@/components/ui/heroui/SingleSelect"
+
+type VersionsQueryState = {
+  isLoading: boolean
+  isError: boolean
+  error?: Error | null
+  hasNextPage?: boolean
+  isFetchingNextPage?: boolean
+}
+
+type OptionsQueryState = {
+  isLoading: boolean
+  isError: boolean
+  error?: Error | null
+}
+
+type TechnicalConfigurationMatrixToolbarProps = {
+  baselineVersionId: string | null
+  versions: TechnicalConfigurationBaselineDraftWire[]
+  versionsQuery: VersionsQueryState
+  options: TechnicalConfigurationOptionWire[]
+  optionsQuery: OptionsQueryState
+  selectedOptions: TechnicalConfigurationOptionWire[]
+  isSelectionLimitReached: boolean
+  onSelectBaselineVersion: (versionId: string) => void
+  onLoadMoreVersions: () => void
+  onRetryVersions: () => void
+  onRetryOptions: () => void
+  onAddOption: (optionId: string) => void
+  onRemoveOption: (optionId: string) => void
+}
+
+function getVersionLabel(version: TechnicalConfigurationBaselineDraftWire) {
+  return `Phiên bản ${version.version_number} · ${
+    version.status === "locked" ? "Đã khóa" : "Bản nháp"
+  }`
+}
+
+/** Renders the desktop request controls while preserving ordered option selection. */
+export function TechnicalConfigurationMatrixToolbar({
+  baselineVersionId,
+  versions,
+  versionsQuery,
+  options,
+  optionsQuery,
+  selectedOptions,
+  isSelectionLimitReached,
+  onSelectBaselineVersion,
+  onLoadMoreVersions,
+  onRetryVersions,
+  onRetryOptions,
+  onAddOption,
+  onRemoveOption,
+}: Readonly<TechnicalConfigurationMatrixToolbarProps>) {
+  const selectedOptionIds = React.useMemo(
+    () => selectedOptions.map((option) => option.id),
+    [selectedOptions]
+  )
+  const selectedOptionIdSet = React.useMemo(() => new Set(selectedOptionIds), [selectedOptionIds])
+  const versionOptions = React.useMemo(
+    () =>
+      versions.map((version) => ({
+        value: version.id,
+        label: getVersionLabel(version),
+      })),
+    [versions]
+  )
+  const optionChoices = React.useMemo(
+    () =>
+      options.map((option) => ({
+        value: option.id,
+        label: option.display_label,
+      })),
+    [options]
+  )
+
+  const handleOptionSelectionChange = React.useCallback(
+    (nextOptionIds: string[]) => {
+      const nextOptionIdSet = new Set(nextOptionIds)
+
+      for (const optionId of selectedOptionIds) {
+        if (!nextOptionIdSet.has(optionId)) onRemoveOption(optionId)
+      }
+      for (const optionId of nextOptionIds) {
+        if (!selectedOptionIdSet.has(optionId)) onAddOption(optionId)
+      }
+    },
+    [onAddOption, onRemoveOption, selectedOptionIdSet, selectedOptionIds]
+  )
+
+  return (
+    <section className="border-y" aria-label="Thiết lập ma trận so sánh">
+      <div className="grid min-w-[760px] grid-cols-[360px_minmax(0,1fr)] divide-x">
+        <div className="space-y-3 p-4">
+          <div className="flex min-h-10 items-start">
+            <h2 className="text-sm font-semibold">Phiên bản cơ sở</h2>
+          </div>
+
+          <SingleSelect
+            value={baselineVersionId}
+            ariaLabel="Chọn phiên bản cấu hình cơ sở"
+            disabled={versionsQuery.isLoading || versions.length === 0}
+            onValueChange={onSelectBaselineVersion}
+            options={versionOptions}
+            placeholder={versionsQuery.isLoading ? "Đang tải phiên bản..." : "Chọn phiên bản"}
+          />
+
+          {versionsQuery.isError ? (
+            <div className="flex min-h-9 items-center justify-between gap-3 text-xs" role="alert">
+              <span className="text-destructive">
+                {versionsQuery.error?.message || "Không thể tải lịch sử phiên bản."}
+              </span>
+              <Button type="button" variant="outline" size="sm" onClick={onRetryVersions}>
+                <RefreshCw aria-hidden="true" />
+                Thử lại
+              </Button>
+            </div>
+          ) : versionsQuery.hasNextPage ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={versionsQuery.isFetchingNextPage}
+              onClick={onLoadMoreVersions}
+            >
+              <ChevronDown aria-hidden="true" />
+              {versionsQuery.isFetchingNextPage ? "Đang tải..." : "Tải thêm phiên bản"}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="min-w-0 space-y-3 p-4">
+          <div className="flex min-h-10 items-start justify-between gap-4">
+            <h2 className="text-sm font-semibold">Phương án so sánh</h2>
+            <span className="shrink-0 text-xs font-medium text-muted-foreground">
+              {selectedOptions.length}/8 phương án
+            </span>
+          </div>
+
+          {optionsQuery.isError ? (
+            <div className="flex min-h-9 items-center justify-between gap-3 text-xs" role="alert">
+              <span className="text-destructive">
+                {optionsQuery.error?.message || "Không thể tải danh sách phương án."}
+              </span>
+              <Button type="button" variant="outline" size="sm" onClick={onRetryOptions}>
+                <RefreshCw aria-hidden="true" />
+                Thử lại
+              </Button>
+            </div>
+          ) : optionsQuery.isLoading ? (
+            <div className="flex h-9 items-center text-sm text-muted-foreground" role="status">
+              Đang tải phương án...
+            </div>
+          ) : (
+            <FacetedMultiSelectFilter<unknown, string>
+              title="Chọn phương án"
+              options={optionChoices}
+              value={selectedOptionIds}
+              onChange={handleOptionSelectionChange}
+              searchPlaceholder="Tìm nhà cung cấp, model hoặc phương án..."
+              emptySearchMessage={
+                isSelectionLimitReached
+                  ? "Đã đạt giới hạn 8 phương án"
+                  : "Không tìm thấy phương án phù hợp"
+              }
+              contentClassName="w-[420px]"
+            />
+          )}
+
+          <div className="min-h-10">
+            {selectedOptions.length > 0 ? (
+              <ol className="flex flex-wrap gap-2" aria-label="Thứ tự phương án đã chọn">
+                {selectedOptions.map((option, index) => (
+                  <li
+                    key={option.id}
+                    className="flex h-9 max-w-[320px] items-center gap-2 border bg-muted/40 pl-3 pr-1 text-sm"
+                  >
+                    <span data-testid="selected-option-label" className="truncate">
+                      {index + 1}. {option.display_label}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="size-7 shrink-0"
+                      aria-label={`Bỏ phương án ${index + 1}: ${option.display_label}`}
+                      onClick={() => onRemoveOption(option.id)}
+                    >
+                      <X aria-hidden="true" />
+                    </Button>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="flex h-10 items-center text-sm text-muted-foreground">
+                Chưa chọn phương án.
+              </p>
+            )}
+          </div>
+
+          {isSelectionLimitReached ? (
+            <p className="text-xs font-medium text-foreground" role="status">
+              Đã đạt giới hạn 8 phương án. Bỏ một phương án để chọn phương án khác.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonMatrix.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonMatrix.ts
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+
+import { useTechnicalConfigurationBaseline } from "./useTechnicalConfigurationBaseline"
+import { useTechnicalConfigurationBaselineVersions } from "./useTechnicalConfigurationBaselineVersions"
+import { useTechnicalConfigurationComparison } from "./useTechnicalConfigurationComparison"
+import { useTechnicalConfigurationOptionListQuery } from "./useTechnicalConfigurationOptionListQuery"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+
+const COMPARISON_PAGE_SIZE = 50
+const MAX_SELECTED_OPTIONS = 8
+const EMPTY_OPTIONS: TechnicalConfigurationOptionWire[] = []
+
+type ComparisonRequestState = {
+  baselineVersionId: string | null
+  selectedOptionIds: readonly string[]
+  page: number
+}
+
+type ComparisonRequestAction =
+  | { type: "reconcile-options"; availableOptionIds: ReadonlySet<string> }
+  | { type: "select-baseline"; baselineVersionId: string | null }
+  | { type: "add-option"; optionId: string; availableOptionIds: ReadonlySet<string> }
+  | { type: "remove-option"; optionId: string }
+  | { type: "set-page"; page: number }
+
+const INITIAL_REQUEST_STATE: ComparisonRequestState = {
+  baselineVersionId: null,
+  selectedOptionIds: [],
+  page: 1,
+}
+
+function comparisonRequestReducer(
+  state: ComparisonRequestState,
+  action: ComparisonRequestAction
+): ComparisonRequestState {
+  switch (action.type) {
+    case "reconcile-options": {
+      const selectedOptionIds = state.selectedOptionIds.filter((optionId) =>
+        action.availableOptionIds.has(optionId)
+      )
+      return selectedOptionIds.length === state.selectedOptionIds.length
+        ? state
+        : { ...state, selectedOptionIds, page: 1 }
+    }
+    case "select-baseline":
+      return state.baselineVersionId === action.baselineVersionId
+        ? state
+        : { ...state, baselineVersionId: action.baselineVersionId, page: 1 }
+    case "add-option":
+      if (
+        !action.availableOptionIds.has(action.optionId) ||
+        state.selectedOptionIds.includes(action.optionId) ||
+        state.selectedOptionIds.length >= MAX_SELECTED_OPTIONS
+      ) {
+        return state
+      }
+      return {
+        ...state,
+        selectedOptionIds: [...state.selectedOptionIds, action.optionId],
+        page: 1,
+      }
+    case "remove-option": {
+      const selectedOptionIds = state.selectedOptionIds.filter(
+        (optionId) => optionId !== action.optionId
+      )
+      return selectedOptionIds.length === state.selectedOptionIds.length
+        ? state
+        : { ...state, selectedOptionIds, page: 1 }
+    }
+    case "set-page":
+      return Number.isInteger(action.page) && action.page >= 1 && action.page !== state.page
+        ? { ...state, page: action.page }
+        : state
+  }
+}
+
+/** Owns the ordered, bounded request state for the read-only comparison matrix. */
+export function useTechnicalConfigurationComparisonMatrix(dossierId: string) {
+  const baselineRpc = useTechnicalConfigurationBaseline()
+  const { versionsQuery, versions, retryVersions, loadMoreVersions, hasHistoryRecoveryError } =
+    useTechnicalConfigurationBaselineVersions({
+      dossierId,
+      listVersions: baselineRpc.listVersions,
+    })
+  const { optionsQuery } = useTechnicalConfigurationOptionListQuery(dossierId)
+  const options = optionsQuery.data?.options ?? EMPTY_OPTIONS
+  const [{ baselineVersionId, selectedOptionIds, page }, dispatch] = React.useReducer(
+    comparisonRequestReducer,
+    INITIAL_REQUEST_STATE
+  )
+
+  const availableOptionIds = React.useMemo(
+    () => new Set(options.map((option) => option.id)),
+    [options]
+  )
+
+  React.useEffect(() => {
+    dispatch({ type: "reconcile-options", availableOptionIds })
+  }, [availableOptionIds])
+
+  const selectBaselineVersion = React.useCallback((nextBaselineVersionId: string | null) => {
+    dispatch({ type: "select-baseline", baselineVersionId: nextBaselineVersionId })
+  }, [])
+
+  const addOption = React.useCallback(
+    (optionId: string) => {
+      dispatch({ type: "add-option", optionId, availableOptionIds })
+    },
+    [availableOptionIds]
+  )
+
+  const removeOption = React.useCallback((optionId: string) => {
+    dispatch({ type: "remove-option", optionId })
+  }, [])
+
+  const setPage = React.useCallback((nextPage: number) => {
+    dispatch({ type: "set-page", page: nextPage })
+  }, [])
+
+  const selectedOptions = React.useMemo(() => {
+    const optionById = new Map(options.map((option) => [option.id, option]))
+    return selectedOptionIds.flatMap((optionId) => {
+      const option = optionById.get(optionId)
+      return option ? [option] : []
+    })
+  }, [options, selectedOptionIds])
+
+  const comparison = useTechnicalConfigurationComparison({
+    baselineVersionId,
+    optionIds: selectedOptionIds,
+    page,
+    pageSize: COMPARISON_PAGE_SIZE,
+  })
+
+  return {
+    versionsQuery,
+    versions,
+    retryVersions,
+    loadMoreVersions,
+    hasHistoryRecoveryError,
+    optionsQuery,
+    options,
+    baselineVersionId,
+    selectedOptionIds,
+    selectedOptions,
+    page,
+    pageSize: COMPARISON_PAGE_SIZE,
+    isSelectionLimitReached: selectedOptionIds.length >= MAX_SELECTED_OPTIONS,
+    comparison,
+    selectBaselineVersion,
+    addOption,
+    removeOption,
+    setPage,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionListQuery.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptionListQuery.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import * as React from "react"
+import { useQuery } from "@tanstack/react-query"
+
+import { listAllTechnicalConfigurationOptions } from "../technical-configuration-supplier-option-operations"
+import { technicalConfigurationOptionsQueryKey } from "../technical-configuration-query-keys"
+
+/** Shares the dossier-scoped read-only option snapshot across authoring and comparison flows. */
+export function useTechnicalConfigurationOptionListQuery(dossierId: string) {
+  const queryKey = React.useMemo(
+    () => technicalConfigurationOptionsQueryKey(dossierId),
+    [dossierId]
+  )
+
+  const optionsQuery = useQuery({
+    queryKey,
+    queryFn: ({ signal }) => listAllTechnicalConfigurationOptions(dossierId, signal),
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+
+  return { queryKey, optionsQuery }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptions.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationOptions.ts
@@ -4,11 +4,9 @@ import * as React from "react"
 import { useQuery } from "@tanstack/react-query"
 
 import { useTechnicalConfigurationBeforeUnloadGuard } from "./useTechnicalConfigurationBeforeUnloadGuard"
+import { useTechnicalConfigurationOptionListQuery } from "./useTechnicalConfigurationOptionListQuery"
 import { useTechnicalConfigurationOptionOperations } from "./useTechnicalConfigurationOptionOperations"
-import {
-  listAllTechnicalConfigurationOptions,
-  listAllTechnicalConfigurationSuppliers,
-} from "../technical-configuration-supplier-option-operations"
+import { listAllTechnicalConfigurationSuppliers } from "../technical-configuration-supplier-option-operations"
 import {
   createEmptyTechnicalConfigurationOptionDraft,
   createEmptyTechnicalConfigurationSupplierDraft,
@@ -19,10 +17,7 @@ import {
   toTechnicalConfigurationSupplierDraft,
   type TechnicalConfigurationOptionDraftPatch,
 } from "../technical-configuration-supplier-option-state"
-import {
-  technicalConfigurationOptionsQueryKey,
-  technicalConfigurationSuppliersQueryKey,
-} from "../technical-configuration-query-keys"
+import { technicalConfigurationSuppliersQueryKey } from "../technical-configuration-query-keys"
 import type {
   TechnicalConfigurationOptionWire,
   TechnicalConfigurationSupplierWire,
@@ -50,10 +45,6 @@ export function useTechnicalConfigurationOptions({
     () => technicalConfigurationSuppliersQueryKey(dossier.id),
     [dossier.id]
   )
-  const optionQueryKey = React.useMemo(
-    () => technicalConfigurationOptionsQueryKey(dossier.id),
-    [dossier.id]
-  )
   const suppliersQuery = useQuery({
     queryKey: supplierQueryKey,
     queryFn: ({ signal }) => listAllTechnicalConfigurationSuppliers(dossier.id, signal),
@@ -61,13 +52,9 @@ export function useTechnicalConfigurationOptions({
     retry: false,
     refetchOnWindowFocus: false,
   })
-  const optionsQuery = useQuery({
-    queryKey: optionQueryKey,
-    queryFn: ({ signal }) => listAllTechnicalConfigurationOptions(dossier.id, signal),
-    staleTime: 30_000,
-    retry: false,
-    refetchOnWindowFocus: false,
-  })
+  const { queryKey: optionQueryKey, optionsQuery } = useTechnicalConfigurationOptionListQuery(
+    dossier.id
+  )
   const suppliers = suppliersQuery.data?.suppliers ?? EMPTY_SUPPLIERS
   const options = optionsQuery.data?.options ?? EMPTY_OPTIONS
   const hasSnapshotMismatch = Boolean(

--- a/src/components/shared/SideSheetShell.tsx
+++ b/src/components/shared/SideSheetShell.tsx
@@ -27,6 +27,7 @@ export interface SideSheetShellProps {
   readonly headerClassName?: string
   readonly bodyClassName?: string
   readonly footerClassName?: string
+  readonly onCloseAutoFocus?: React.ComponentProps<typeof SheetContent>["onCloseAutoFocus"]
 }
 
 /**
@@ -46,6 +47,7 @@ export function SideSheetShell({
   headerClassName,
   bodyClassName,
   footerClassName,
+  onCloseAutoFocus,
 }: SideSheetShellProps): React.JSX.Element {
   const hasHeader = title !== null && title !== undefined
 
@@ -56,6 +58,7 @@ export function SideSheetShell({
         closeLabel={closeLabel}
         hideCloseButton={hideCloseButton}
         className={cn("w-full p-0", contentClassName)}
+        onCloseAutoFocus={onCloseAutoFocus}
       >
         <div className="flex h-full flex-col">
           {hasHeader ? (


### PR DESCRIPTION
## Summary

- add a shared read-only option-list query seam and reducer-driven ordered comparison request state with an 8-option limit and fixed page size 50
- render the desktop frozen-pane comparison matrix with stable 220/360/320px columns, semantic row groups, concise cells, pagination, and a text-only detail sheet with focus restoration
- enable the comparison workspace tab while preserving P8 supplier-option authoring behavior and keeping P10B2/P10B3/P12A concerns out of scope

## Review fixes

- preserve a previous-page action when a later comparison page becomes empty
- show only baseline-relevant fields in baseline detail; option response and supplementary sections remain option-only
- extract comparison fixtures/regression cases and workspace source contracts so all reviewed test modules remain below 350 lines

## Design review

- Hallmark source audit passed for the dense operational hierarchy, restrained token-based styling, clear focus/error/loading states, and absence of nested cards, decorative gradients, fabricated content, or marketing-style composition
- desktop-only layout is intentional because this feature is hidden on mobile viewports

## Verification

- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused/upstream Vitest: 6 files, 131 tests passed
- React Doctor changed-scope scan: 100/100, no issues across 16 changed files
- `openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`
- `git diff --cached --check`
- reviewed test modules: 318, 58, 143, 322, and 55 lines
- keyboard and focus flows covered with `@testing-library/user-event`; browser, Playwright, agent-browser, and screenshot tests intentionally not used

Closes #811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only technical configuration comparison workspace with a selectable baseline and up to eight options in an ordered, paginated matrix.
  * Included grouped criteria rendering with evidence summaries, plus loading/error/empty states and retry support.
  * Added a criterion detail side panel with keyboard focus restoration.
  * Enabled the comparison tab in the workspace shell.
* **Tests**
  * Expanded coverage for option selection, pagination edge-cases, rendering/accessibility, and review regression behavior.
  * Updated workspace/tab and refined existing tests for clearer, deterministic setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->