### PR TITLE
P10B2: Add comparison column visibility, pinning and focus mode

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-column-controls.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-column-controls.test.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationMatrixColumnControls } from "../_components/comparison/TechnicalConfigurationMatrixColumnControls"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+
+function createOption(index: number): TechnicalConfigurationOptionWire {
+  const suffix = String(index).padStart(12, "0")
+  return {
+    id: `00000000-0000-0000-0000-${suffix}`,
+    dossier_id: "00000000-0000-0000-0000-000000000100",
+    supplier_id: `00000000-0000-0000-0001-${suffix}`,
+    supplier_name: `Nhà cung cấp ${index}`,
+    model: `Model ${index}`,
+    manufacturer: null,
+    option_name: null,
+    notes: null,
+    display_label: `Nhà cung cấp ${index} · Model ${index}`,
+    created_at: "2026-07-28T00:00:00Z",
+    created_by: 1,
+    updated_at: "2026-07-28T00:00:00Z",
+    updated_by: 1,
+    revision: index,
+  }
+}
+
+function ColumnControlsHarness({ options }: { options: TechnicalConfigurationOptionWire[] }) {
+  const optionIds = options.map((option) => option.id)
+  const [visibleOptionIds, setVisibleOptionIds] = useState(optionIds)
+  const [pinnedOptionIds, setPinnedOptionIds] = useState<readonly string[]>([])
+  const [focusedOptionId, setFocusedOptionId] = useState<string | null>(null)
+  const toggleVisibility = (optionId: string) =>
+    setVisibleOptionIds((current) =>
+      current.includes(optionId)
+        ? current.filter((id) => id !== optionId)
+        : optionIds.filter((id) => current.includes(id) || id === optionId)
+    )
+  const togglePin = (optionId: string) =>
+    setPinnedOptionIds((current) => {
+      if (current.includes(optionId)) return current.filter((id) => id !== optionId)
+      return current.length >= 2
+        ? current
+        : optionIds.filter((id) => current.includes(id) || id === optionId)
+    })
+
+  return (
+    <TechnicalConfigurationMatrixColumnControls
+      selectedOptions={options}
+      visibleOptionIds={visibleOptionIds}
+      pinnedOptionIds={pinnedOptionIds}
+      focusedOptionId={focusedOptionId}
+      onToggleOptionVisibility={toggleVisibility}
+      onToggleOptionPin={togglePin}
+      onFocusOption={setFocusedOptionId}
+      onExitFocus={() => setFocusedOptionId(null)}
+    />
+  )
+}
+
+const NOOP = vi.fn()
+
+describe("P10B2 clean column controls", () => {
+  it("applies keyboard actions immediately and focuses hidden selected options", async () => {
+    const user = userEvent.setup()
+    const options = Array.from({ length: 3 }, (_, index) => createOption(index + 1))
+    render(<ColumnControlsHarness options={options} />)
+
+    const trigger = screen.getByRole("button", { name: "Tùy chỉnh cột so sánh" })
+    trigger.focus()
+    await user.keyboard("{Enter}")
+
+    expect(screen.getByRole("dialog", { name: "Cột phương án" })).toHaveTextContent(
+      "Yêu cầu cơ sở luôn hiển thị · Ghim tối đa 2 cột"
+    )
+    expect(screen.queryByRole("button", { name: /Lưu|Thêm|Áp dụng/i })).not.toBeInTheDocument()
+
+    const visibility = screen.getByRole("checkbox", {
+      name: `Hiển thị ${options[0].display_label}`,
+    })
+    visibility.focus()
+    await user.keyboard(" ")
+    expect(visibility).not.toBeChecked()
+    const pinButton = screen.getByRole("button", { name: `Ghim ${options[1].display_label}` })
+    pinButton.focus()
+    await user.keyboard("{Enter}")
+    expect(
+      screen.getByRole("button", { name: `Bỏ ghim ${options[1].display_label}` })
+    ).toHaveFocus()
+    const focusButton = screen.getByRole("button", {
+      name: `Tập trung ${options[0].display_label}`,
+    })
+    focusButton.focus()
+    await user.keyboard("{Enter}")
+
+    const exitFocusButton = await screen.findByRole("button", {
+      name: "Thoát chế độ tập trung",
+    })
+    expect(exitFocusButton).toHaveAttribute("title", "Thoát chế độ tập trung")
+    await waitFor(() => expect(exitFocusButton).toHaveFocus())
+    await user.keyboard("{Enter}")
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+
+  it("returns focus when focused state is reconciled externally", async () => {
+    const options = [createOption(1), createOption(2)]
+    const props = {
+      selectedOptions: options,
+      visibleOptionIds: options.map((option) => option.id),
+      pinnedOptionIds: [],
+      onToggleOptionVisibility: NOOP,
+      onToggleOptionPin: NOOP,
+      onFocusOption: NOOP,
+      onExitFocus: NOOP,
+    }
+    const { rerender } = render(
+      <TechnicalConfigurationMatrixColumnControls {...props} focusedOptionId={options[0].id} />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Thoát chế độ tập trung" })).toHaveFocus()
+    )
+    rerender(<TechnicalConfigurationMatrixColumnControls {...props} focusedOptionId={null} />)
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Tùy chỉnh cột so sánh" })).toHaveFocus()
+    )
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-column-controls.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-column-controls.test.tsx
@@ -127,4 +127,28 @@ describe("P10B2 clean column controls", () => {
       expect(screen.getByRole("button", { name: "Tùy chỉnh cột so sánh" })).toHaveFocus()
     )
   })
+
+  it("keeps column controls available when the focused option no longer resolves", async () => {
+    const user = userEvent.setup()
+    const options = [createOption(1)]
+    render(
+      <TechnicalConfigurationMatrixColumnControls
+        selectedOptions={options}
+        visibleOptionIds={options.map((option) => option.id)}
+        pinnedOptionIds={[]}
+        focusedOptionId="missing-option"
+        onToggleOptionVisibility={NOOP}
+        onToggleOptionPin={NOOP}
+        onFocusOption={NOOP}
+        onExitFocus={NOOP}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: "Tùy chỉnh cột so sánh" })
+    expect(trigger).toBeEnabled()
+    expect(screen.queryByRole("button", { name: "Thoát chế độ tập trung" })).not.toBeInTheDocument()
+
+    await user.click(trigger)
+    expect(screen.getByRole("dialog", { name: "Cột phương án" })).toBeInTheDocument()
+  })
 })

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
@@ -1,0 +1,361 @@
+import { createElement, type PropsWithChildren } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
+import { useTechnicalConfigurationComparisonMatrix } from "../_hooks/useTechnicalConfigurationComparisonMatrix"
+import {
+  technicalConfigurationComparisonQueryKey,
+  technicalConfigurationOptionsQueryKey,
+} from "../technical-configuration-query-keys"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+
+import { createComparisonResult } from "./comparison-matrix-test-fixtures"
+
+const listAllOptionsMock = vi.fn()
+const listBaselineVersionsMock = vi.fn()
+const getComparisonMock = vi.fn()
+
+vi.mock("../technical-configuration-supplier-option-operations", () => ({
+  listAllTechnicalConfigurationOptions: (...args: unknown[]) => listAllOptionsMock(...args),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationBaseline", () => ({
+  useTechnicalConfigurationBaseline: () => ({
+    listVersions: (...args: unknown[]) => listBaselineVersionsMock(...args),
+  }),
+}))
+
+vi.mock("../technical-configuration-comparison-rpc", () => ({
+  getTechnicalConfigurationComparison: (...args: unknown[]) => getComparisonMock(...args),
+}))
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+}
+
+function createQueryWrapper(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: PropsWithChildren) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function createOption(index: number): TechnicalConfigurationOptionWire {
+  const suffix = String(index).padStart(12, "0")
+  return {
+    id: `00000000-0000-0000-0000-${suffix}`,
+    dossier_id: "00000000-0000-0000-0000-000000000100",
+    supplier_id: `00000000-0000-0000-0001-${suffix}`,
+    supplier_name: `Nhà cung cấp ${index}`,
+    model: `Model ${index}`,
+    manufacturer: null,
+    option_name: null,
+    notes: null,
+    display_label: `Nhà cung cấp ${index} · Model ${index}`,
+    created_at: "2026-07-28T00:00:00Z",
+    created_by: 1,
+    updated_at: "2026-07-28T00:00:00Z",
+    updated_by: 1,
+    revision: index,
+  }
+}
+
+function createBaselineVersion(id: string) {
+  return {
+    id,
+    dossier_id: "00000000-0000-0000-0000-000000000100",
+    version_number: 2,
+    status: "locked" as const,
+    groups: [],
+  }
+}
+
+function createManyOptionResult() {
+  const result = createComparisonResult()
+  const options = Array.from({ length: 8 }, (_, index) => ({
+    id: `option-${index + 1}`,
+    supplierId: `supplier-${index + 1}`,
+    supplierName: `Nhà cung cấp ${index + 1}`,
+    model: `Model ${index + 1}`,
+    manufacturer: null,
+    optionName: null,
+    displayLabel: `Nhà cung cấp ${index + 1} · Model ${index + 1}`,
+  }))
+
+  return {
+    ...result,
+    page: 1,
+    total: result.data.criteria.length,
+    data: {
+      ...result.data,
+      options,
+      criteria: result.data.criteria.map((row) => ({ ...row, optionValues: [] })),
+    },
+  }
+}
+
+describe("P10B2 comparison column view state", () => {
+  const dossierId = "00000000-0000-0000-0000-000000000100"
+  const baseline = createBaselineVersion("00000000-0000-0000-0000-000000000201")
+  const options = Array.from({ length: 4 }, (_, index) => createOption(index + 1))
+
+  beforeEach(() => {
+    listAllOptionsMock.mockReset()
+    listBaselineVersionsMock.mockReset()
+    getComparisonMock.mockReset()
+    listAllOptionsMock.mockResolvedValue({ options, revision: 4 })
+    listBaselineVersionsMock.mockResolvedValue({
+      data: [baseline],
+      total: 1,
+      page: 1,
+      page_size: 50,
+    })
+    getComparisonMock.mockImplementation(
+      async (request: {
+        baselineVersionId: string
+        optionIds: readonly string[]
+        page: number
+        pageSize: number
+      }) => ({
+        data: {
+          dossier: {
+            id: dossierId,
+            deviceTypeName: "Máy siêu âm",
+            name: "Cấu hình máy siêu âm",
+            revision: 4,
+            archivedAt: null,
+          },
+          baselineVersion: {
+            id: request.baselineVersionId,
+            dossierId,
+            versionNumber: 2,
+            status: "locked",
+            revision: 2,
+          },
+          options: [],
+          criteria: [],
+        },
+        total: 0,
+        page: request.page,
+        pageSize: request.pageSize,
+      })
+    )
+  })
+
+  it("hides and shows an option without changing request membership or the query key", async () => {
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useTechnicalConfigurationComparisonMatrix(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+    await waitFor(() => expect(result.current.optionsQuery.isSuccess).toBe(true))
+    act(() => {
+      result.current.selectBaselineVersion(baseline.id)
+      result.current.addOption(options[2].id)
+      result.current.addOption(options[0].id)
+      result.current.addOption(options[1].id)
+    })
+    await waitFor(() => expect(getComparisonMock).toHaveBeenCalledTimes(1))
+    const requestOptionIds = [options[2].id, options[0].id, options[1].id]
+    const queryKeyBeforeVisibilityChange = result.current.comparison.queryKey
+
+    act(() => result.current.toggleOptionVisibility(options[0].id))
+
+    expect(result.current.selectedOptionIds).toEqual(requestOptionIds)
+    expect(result.current.visibleOptionIds).toEqual([options[2].id, options[1].id])
+    expect(result.current.comparison.queryKey).toEqual(queryKeyBeforeVisibilityChange)
+    expect(result.current.comparison.queryKey).toEqual(
+      technicalConfigurationComparisonQueryKey({
+        baselineVersionId: baseline.id,
+        optionIds: requestOptionIds,
+        page: 1,
+        pageSize: 50,
+      })
+    )
+    expect(getComparisonMock).toHaveBeenCalledTimes(1)
+
+    act(() => result.current.toggleOptionVisibility(options[0].id))
+
+    expect(result.current.visibleOptionIds).toEqual(requestOptionIds)
+    expect(result.current.selectedOptionIds).toEqual(requestOptionIds)
+  })
+
+  it("reconciles visible IDs as an ordered subset after option refresh and removal", async () => {
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useTechnicalConfigurationComparisonMatrix(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+    await waitFor(() => expect(result.current.optionsQuery.isSuccess).toBe(true))
+    act(() => {
+      result.current.addOption(options[2].id)
+      result.current.addOption(options[0].id)
+      result.current.addOption(options[1].id)
+      result.current.toggleOptionVisibility(options[0].id)
+    })
+    expect(result.current.visibleOptionIds).toEqual([options[2].id, options[1].id])
+    act(() => {
+      queryClient.setQueryData(technicalConfigurationOptionsQueryKey(dossierId), {
+        options: [options[0], options[1]],
+        revision: 5,
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedOptionIds).toEqual([options[0].id, options[1].id])
+      expect(result.current.visibleOptionIds).toEqual([options[1].id])
+    })
+
+    act(() => result.current.removeOption(options[1].id))
+
+    expect(result.current.selectedOptionIds).toEqual([options[0].id])
+    expect(result.current.visibleOptionIds).toEqual([])
+  })
+
+  it("pins at most two visible options in selected order and reconciles hidden pins", async () => {
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useTechnicalConfigurationComparisonMatrix(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+    await waitFor(() => expect(result.current.optionsQuery.isSuccess).toBe(true))
+    act(() => {
+      result.current.addOption(options[2].id)
+      result.current.addOption(options[0].id)
+      result.current.addOption(options[1].id)
+      result.current.addOption(options[3].id)
+      result.current.toggleOptionPin(options[1].id)
+      result.current.toggleOptionPin(options[2].id)
+      result.current.toggleOptionPin(options[0].id)
+    })
+    expect(result.current.pinnedOptionIds).toEqual([options[2].id, options[1].id])
+    act(() => result.current.toggleOptionVisibility(options[2].id))
+
+    expect(result.current.visibleOptionIds).toEqual([options[0].id, options[1].id, options[3].id])
+    expect(result.current.pinnedOptionIds).toEqual([options[1].id])
+
+    act(() => result.current.removeOption(options[1].id))
+
+    expect(result.current.pinnedOptionIds).toEqual([])
+    expect(result.current.visibleOptionIds).toEqual([options[0].id, options[3].id])
+  })
+
+  it("enters and exits focus mode without mutating visible or pinned state", async () => {
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(() => useTechnicalConfigurationComparisonMatrix(dossierId), {
+      wrapper: createQueryWrapper(queryClient),
+    })
+    await waitFor(() => expect(result.current.optionsQuery.isSuccess).toBe(true))
+
+    act(() => {
+      options.slice(0, 4).forEach((option) => result.current.addOption(option.id))
+      result.current.toggleOptionVisibility(options[1].id)
+      result.current.toggleOptionPin(options[0].id)
+      result.current.focusOption(options[2].id)
+    })
+
+    expect(result.current.focusedOptionId).toBe(options[2].id)
+    expect(result.current.visibleOptionIds).toEqual([options[0].id, options[2].id, options[3].id])
+    expect(result.current.pinnedOptionIds).toEqual([options[0].id])
+
+    act(() => result.current.exitFocusMode())
+
+    expect(result.current.focusedOptionId).toBeNull()
+    expect(result.current.visibleOptionIds).toEqual([options[0].id, options[2].id, options[3].id])
+    expect(result.current.pinnedOptionIds).toEqual([options[0].id])
+  })
+})
+
+describe("P10B2 pinned matrix columns", () => {
+  it("renders pinned options first with deterministic sticky offsets", () => {
+    const result = createManyOptionResult()
+    const visibleOptionIds = result.data.options.map((option) => option.id)
+    const pinnedOptionIds = [result.data.options[3].id, result.data.options[1].id]
+
+    render(
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={result}
+        visibleOptionIds={visibleOptionIds}
+        pinnedOptionIds={pinnedOptionIds}
+        focusedOptionId={null}
+        onOpenDetail={vi.fn()}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    const optionHeaders = screen.getAllByTestId("comparison-option-header")
+    expect(optionHeaders.map((header) => header.dataset.optionId)).toEqual([
+      result.data.options[1].id,
+      result.data.options[3].id,
+      result.data.options[0].id,
+      result.data.options[2].id,
+      result.data.options[4].id,
+      result.data.options[5].id,
+      result.data.options[6].id,
+      result.data.options[7].id,
+    ])
+
+    const pinnedHeaders = optionHeaders.filter((header) => header.dataset.pinned === "true")
+    expect(pinnedHeaders).toHaveLength(2)
+    pinnedHeaders.forEach((header) => expect(header).toHaveClass("z-50"))
+    expect(pinnedHeaders[0]).toHaveStyle({ left: "580px" })
+    expect(pinnedHeaders[1]).toHaveStyle({ left: "900px" })
+
+    const firstRowPinnedCells = screen
+      .getAllByTestId("comparison-option-cell")
+      .filter((cell) => cell.dataset.criterionId === "criterion-2")
+      .filter((cell) => cell.dataset.pinned === "true")
+    expect(firstRowPinnedCells[0]).toHaveStyle({ left: "580px" })
+    expect(firstRowPinnedCells[1]).toHaveStyle({ left: "900px" })
+  })
+
+  it("keeps the sticky baseline visible when every option column is hidden", () => {
+    render(
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={createManyOptionResult()}
+        visibleOptionIds={[]}
+        pinnedOptionIds={[]}
+        focusedOptionId={null}
+        onOpenDetail={vi.fn()}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId("comparison-baseline-header")).toBeInTheDocument()
+    expect(screen.queryAllByTestId("comparison-option-header")).toHaveLength(0)
+  })
+
+  it("renders only the focused option while preserving stable desktop dimensions", () => {
+    const result = createManyOptionResult()
+    render(
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={result}
+        visibleOptionIds={result.data.options.map((option) => option.id)}
+        pinnedOptionIds={[result.data.options[0].id, result.data.options[1].id]}
+        focusedOptionId={result.data.options[6].id}
+        onOpenDetail={vi.fn()}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByTestId("comparison-option-header")).toHaveLength(1)
+    expect(screen.getByTestId("comparison-option-header")).toHaveTextContent(
+      result.data.options[6].displayLabel
+    )
+    expect(screen.getByTestId("comparison-option-header")).toHaveClass(
+      "w-[320px]",
+      "min-w-[320px]",
+      "max-w-[320px]"
+    )
+    expect(screen.getByTestId("comparison-matrix-scroll")).toHaveClass("overflow-auto")
+    expect(screen.getByRole("table")).toHaveClass("min-w-max")
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-columns.test.tsx
@@ -1,6 +1,7 @@
 import { createElement, type PropsWithChildren } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { act, render, renderHook, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
@@ -329,6 +330,38 @@ describe("P10B2 pinned matrix columns", () => {
 
     expect(screen.getByTestId("comparison-baseline-header")).toBeInTheDocument()
     expect(screen.queryAllByTestId("comparison-option-header")).toHaveLength(0)
+  })
+
+  it("passes the displayed fallback title to baseline and option details", async () => {
+    const user = userEvent.setup()
+    const result = createManyOptionResult()
+    const onOpenDetail = vi.fn()
+    render(
+      <TechnicalConfigurationMatrix
+        hasRequest
+        result={result}
+        visibleOptionIds={result.data.options.map((option) => option.id)}
+        pinnedOptionIds={[]}
+        focusedOptionId={null}
+        onOpenDetail={onOpenDetail}
+        onPageChange={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Xem chi tiết TS-01 · Yêu cầu cơ sở" }))
+    expect(onOpenDetail).toHaveBeenLastCalledWith(
+      expect.objectContaining({ criterionTitle: "Chưa có tiêu đề" })
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Xem chi tiết TS-01 · ${result.data.options[0].displayLabel}`,
+      })
+    )
+    expect(onOpenDetail).toHaveBeenLastCalledWith(
+      expect.objectContaining({ criterionTitle: "Chưa có tiêu đề" })
+    )
   })
 
   it("renders only the focused option while preserving stable desktop dimensions", () => {

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-rendering-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-rendering-cases.tsx
@@ -80,12 +80,19 @@ export function registerComparisonMatrixRenderingTests() {
         options: [optionA, optionB, optionC],
         optionsQuery: { isLoading: false, isError: false },
         selectedOptions: [optionB, optionA],
+        visibleOptionIds: [optionB.id, optionA.id],
+        pinnedOptionIds: [],
+        focusedOptionId: null,
         onSelectBaselineVersion: vi.fn(),
         onLoadMoreVersions: vi.fn(),
         onRetryVersions: vi.fn(),
         onRetryOptions: vi.fn(),
         onAddOption,
         onRemoveOption,
+        onToggleOptionVisibility: vi.fn(),
+        onToggleOptionPin: vi.fn(),
+        onFocusOption: vi.fn(),
+        onExitFocus: vi.fn(),
       }
       const { rerender } = render(
         <TechnicalConfigurationMatrixToolbar {...toolbarProps} isSelectionLimitReached={false} />

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-shell-source.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-shell-source.test.ts
@@ -20,11 +20,16 @@ describe("technical configuration workspace shell source boundaries", () => {
       "_components/TechnicalConfigurationBulkEntryWorkbench.tsx",
       "_components/TechnicalConfigurationAllGroupsOverview.tsx",
       "_components/TechnicalConfigurationGroupNavigator.tsx",
+      "_components/comparison/TechnicalConfigurationMatrix.tsx",
+      "_components/comparison/TechnicalConfigurationMatrixRow.tsx",
+      "_components/comparison/TechnicalConfigurationMatrixToolbar.tsx",
+      "_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx",
       "_hooks/useTechnicalConfigurationBaselineEditor.ts",
       "_hooks/useTechnicalConfigurationBaselineImport.ts",
       "_hooks/useTechnicalConfigurationBulkEntrySessions.ts",
       "_hooks/useTechnicalConfigurationInlineEditor.ts",
       "_hooks/useTechnicalConfigurationOptionResponses.ts",
+      "_hooks/useTechnicalConfigurationComparisonMatrix.ts",
       "__tests__/comparison-matrix-rendering-cases.tsx",
       "__tests__/technical-configuration-baseline-workspace.test.tsx",
     ]
@@ -43,6 +48,14 @@ describe("technical configuration workspace shell source boundaries", () => {
     expect(shellSource).toContain("TechnicalConfigurationBaselineEvidence")
     expect(shellSource).not.toContain("useQuery")
     expect(shellSource).not.toContain("useMutation")
+
+    const matrixSource = fs.readFileSync(
+      path.join(moduleRoot, "_components/comparison/TechnicalConfigurationMatrix.tsx"),
+      "utf8"
+    )
+    expect(matrixSource).toContain("overflow-auto")
+    expect(matrixSource).toContain("min-w-max")
+    expect(matrixSource).toContain("w-[320px] min-w-[320px] max-w-[320px]")
 
     for (const file of [
       "_components/TechnicalConfigurationBaselineTab.tsx",

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-shell-source.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-workspace-shell-source.test.ts
@@ -20,10 +20,12 @@ describe("technical configuration workspace shell source boundaries", () => {
       "_components/TechnicalConfigurationBulkEntryWorkbench.tsx",
       "_components/TechnicalConfigurationAllGroupsOverview.tsx",
       "_components/TechnicalConfigurationGroupNavigator.tsx",
+      "_components/comparison/TechnicalConfigurationComparisonTab.tsx",
       "_components/comparison/TechnicalConfigurationMatrix.tsx",
       "_components/comparison/TechnicalConfigurationMatrixRow.tsx",
       "_components/comparison/TechnicalConfigurationMatrixToolbar.tsx",
       "_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx",
+      "comparison-matrix-constants.ts",
       "_hooks/useTechnicalConfigurationBaselineEditor.ts",
       "_hooks/useTechnicalConfigurationBaselineImport.ts",
       "_hooks/useTechnicalConfigurationBulkEntrySessions.ts",
@@ -55,7 +57,23 @@ describe("technical configuration workspace shell source boundaries", () => {
     )
     expect(matrixSource).toContain("overflow-auto")
     expect(matrixSource).toContain("min-w-max")
-    expect(matrixSource).toContain("w-[320px] min-w-[320px] max-w-[320px]")
+
+    const matrixConstantsSource = fs.readFileSync(
+      path.join(moduleRoot, "comparison-matrix-constants.ts"),
+      "utf8"
+    )
+    expect(matrixConstantsSource).toContain("pinnedOptions: 2")
+    expect(matrixConstantsSource).toContain("w-[320px] min-w-[320px] max-w-[320px]")
+
+    for (const file of [
+      "_components/comparison/TechnicalConfigurationMatrix.tsx",
+      "_components/comparison/TechnicalConfigurationMatrixRow.tsx",
+      "_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx",
+      "_hooks/useTechnicalConfigurationComparisonMatrix.ts",
+    ]) {
+      const source = fs.readFileSync(path.join(moduleRoot, file), "utf8")
+      expect(source).toContain("comparison-matrix-constants")
+    }
 
     for (const file of [
       "_components/TechnicalConfigurationBaselineTab.tsx",

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
@@ -39,6 +39,9 @@ export function TechnicalConfigurationComparisonTab({
         options={matrix.options}
         optionsQuery={matrix.optionsQuery}
         selectedOptions={matrix.selectedOptions}
+        visibleOptionIds={matrix.visibleOptionIds}
+        pinnedOptionIds={matrix.pinnedOptionIds}
+        focusedOptionId={matrix.focusedOptionId}
         isSelectionLimitReached={matrix.isSelectionLimitReached}
         onSelectBaselineVersion={matrix.selectBaselineVersion}
         onLoadMoreVersions={() => void matrix.loadMoreVersions()}
@@ -46,11 +49,18 @@ export function TechnicalConfigurationComparisonTab({
         onRetryOptions={() => void matrix.optionsQuery.refetch()}
         onAddOption={matrix.addOption}
         onRemoveOption={matrix.removeOption}
+        onToggleOptionVisibility={matrix.toggleOptionVisibility}
+        onToggleOptionPin={matrix.toggleOptionPin}
+        onFocusOption={matrix.focusOption}
+        onExitFocus={matrix.exitFocusMode}
       />
 
       <TechnicalConfigurationMatrix
         hasRequest={hasRequest}
         result={comparisonQuery.data}
+        visibleOptionIds={matrix.visibleOptionIds}
+        pinnedOptionIds={matrix.pinnedOptionIds}
+        focusedOptionId={matrix.focusedOptionId}
         isLoading={comparisonQuery.isLoading}
         isError={comparisonQuery.isError}
         error={comparisonQuery.error}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -2,6 +2,10 @@
 
 import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react"
 
+import {
+  COMPARISON_MATRIX_LAYOUT,
+  getPinnedComparisonOptionLeft,
+} from "@/app/(app)/technical-configurations/comparison-matrix-constants"
 import type { TechnicalConfigurationComparisonResult } from "@/app/(app)/technical-configurations/comparison-types"
 import { Button } from "@/components/ui/button"
 
@@ -157,14 +161,14 @@ export function TechnicalConfigurationMatrix({
             <tr>
               <th
                 data-testid="comparison-criterion-header"
-                className="sticky left-0 top-0 z-50 w-[220px] min-w-[220px] max-w-[220px] border-b border-r bg-muted px-3 py-3 font-semibold"
+                className={`sticky left-0 top-0 z-50 ${COMPARISON_MATRIX_LAYOUT.criterionWidthClass} border-b border-r bg-muted px-3 py-3 font-semibold`}
                 scope="col"
               >
                 Tiêu chí
               </th>
               <th
                 data-testid="comparison-baseline-header"
-                className="sticky left-[220px] top-0 z-50 w-[360px] min-w-[360px] max-w-[360px] border-b border-r bg-muted px-3 py-3 font-semibold"
+                className={`sticky ${COMPARISON_MATRIX_LAYOUT.baselineStickyLeftClass} top-0 z-50 ${COMPARISON_MATRIX_LAYOUT.baselineWidthClass} border-b border-r bg-muted px-3 py-3 font-semibold`}
                 scope="col"
               >
                 Yêu cầu cơ sở
@@ -178,10 +182,12 @@ export function TechnicalConfigurationMatrix({
                     data-testid="comparison-option-header"
                     data-option-id={option.id}
                     data-pinned={isPinned ? "true" : "false"}
-                    className={`sticky top-0 w-[320px] min-w-[320px] max-w-[320px] border-b border-r bg-muted px-3 py-3 font-semibold ${
+                    className={`sticky top-0 ${COMPARISON_MATRIX_LAYOUT.optionWidthClass} border-b border-r bg-muted px-3 py-3 font-semibold ${
                       isPinned ? "z-50" : "z-40"
                     }`}
-                    style={isPinned ? { left: `${580 + pinnedIndex * 320}px` } : undefined}
+                    style={
+                      isPinned ? { left: getPinnedComparisonOptionLeft(pinnedIndex) } : undefined
+                    }
                     scope="col"
                   >
                     <span className="block break-words">{option.displayLabel}</span>

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -2,10 +2,11 @@
 
 import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react"
 
-import type { TechnicalConfigurationComparisonResult } from "../../comparison-types"
+import type { TechnicalConfigurationComparisonResult } from "@/app/(app)/technical-configurations/comparison-types"
+import { Button } from "@/components/ui/button"
+
 import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
 import { TechnicalConfigurationMatrixRow } from "./TechnicalConfigurationMatrixRow"
-import { Button } from "@/components/ui/button"
 
 type TechnicalConfigurationMatrixProps = {
   hasRequest: boolean

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -2,29 +2,23 @@
 
 import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react"
 
-import type {
-  TechnicalConfigurationComparisonEvidence,
-  TechnicalConfigurationComparisonOptionValue,
-  TechnicalConfigurationComparisonResult,
-} from "../../comparison-types"
+import type { TechnicalConfigurationComparisonResult } from "../../comparison-types"
 import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
+import { TechnicalConfigurationMatrixRow } from "./TechnicalConfigurationMatrixRow"
 import { Button } from "@/components/ui/button"
 
 type TechnicalConfigurationMatrixProps = {
   hasRequest: boolean
   result?: TechnicalConfigurationComparisonResult
+  visibleOptionIds?: readonly string[]
+  pinnedOptionIds?: readonly string[]
+  focusedOptionId?: string | null
   isLoading?: boolean
   isError?: boolean
   error?: Error | null
   onRetry: () => void
   onPageChange: (page: number) => void
   onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
-}
-
-const EMPTY_EVIDENCE: TechnicalConfigurationComparisonEvidence = {
-  documentCount: 0,
-  citationCount: 0,
-  hasEvidence: false,
 }
 
 type ComparisonCriterionRow = TechnicalConfigurationComparisonResult["data"]["criteria"][number]
@@ -51,11 +45,6 @@ function groupCriterionRows(criteria: readonly ComparisonCriterionRow[]) {
   return groups
 }
 
-function formatEvidenceSummary(evidence: TechnicalConfigurationComparisonEvidence) {
-  if (!evidence.hasEvidence) return "Chưa có bằng chứng"
-  return `${evidence.documentCount} tài liệu · ${evidence.citationCount} trích dẫn`
-}
-
 function MatrixState({ children, role }: { children: React.ReactNode; role?: "alert" | "status" }) {
   return (
     <div
@@ -71,6 +60,9 @@ function MatrixState({ children, role }: { children: React.ReactNode; role?: "al
 export function TechnicalConfigurationMatrix({
   hasRequest,
   result,
+  visibleOptionIds,
+  pinnedOptionIds = [],
+  focusedOptionId = null,
   isLoading = false,
   isError = false,
   error,
@@ -128,6 +120,26 @@ export function TechnicalConfigurationMatrix({
   }
 
   const { criteria, options } = result.data
+  const effectiveVisibleOptionIds =
+    focusedOptionId === null
+      ? (visibleOptionIds ?? options.map((option) => option.id))
+      : [focusedOptionId]
+  const visibleOptionIdSet = new Set(effectiveVisibleOptionIds)
+  const pinnedOptionIdSet = new Set(focusedOptionId === null ? pinnedOptionIds : [])
+  const renderedOptions = [
+    ...options.filter(
+      (option) => visibleOptionIdSet.has(option.id) && pinnedOptionIdSet.has(option.id)
+    ),
+    ...options.filter(
+      (option) => visibleOptionIdSet.has(option.id) && !pinnedOptionIdSet.has(option.id)
+    ),
+  ]
+  const renderedPinnedOptionIds: string[] = []
+  for (const option of renderedOptions) {
+    if (pinnedOptionIdSet.has(option.id)) {
+      renderedPinnedOptionIds.push(option.id)
+    }
+  }
   const criterionGroups = groupCriterionRows(criteria)
   const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize))
   const startItem = (result.page - 1) * result.pageSize + 1
@@ -156,16 +168,25 @@ export function TechnicalConfigurationMatrix({
               >
                 Yêu cầu cơ sở
               </th>
-              {options.map((option) => (
-                <th
-                  key={option.id}
-                  data-testid="comparison-option-header"
-                  className="sticky top-0 z-40 w-[320px] min-w-[320px] max-w-[320px] border-b border-r bg-muted px-3 py-3 font-semibold"
-                  scope="col"
-                >
-                  <span className="block break-words">{option.displayLabel}</span>
-                </th>
-              ))}
+              {renderedOptions.map((option) => {
+                const pinnedIndex = renderedPinnedOptionIds.indexOf(option.id)
+                const isPinned = pinnedIndex >= 0
+                return (
+                  <th
+                    key={option.id}
+                    data-testid="comparison-option-header"
+                    data-option-id={option.id}
+                    data-pinned={isPinned ? "true" : "false"}
+                    className={`sticky top-0 w-[320px] min-w-[320px] max-w-[320px] border-b border-r bg-muted px-3 py-3 font-semibold ${
+                      isPinned ? "z-50" : "z-40"
+                    }`}
+                    style={isPinned ? { left: `${580 + pinnedIndex * 320}px` } : undefined}
+                    scope="col"
+                  >
+                    <span className="block break-words">{option.displayLabel}</span>
+                  </th>
+                )
+              })}
             </tr>
           </thead>
           {criterionGroups.map((group) => (
@@ -173,17 +194,18 @@ export function TechnicalConfigurationMatrix({
               <tr>
                 <th
                   className="border-b bg-muted/70 px-3 py-2 text-xs font-semibold uppercase text-muted-foreground"
-                  colSpan={options.length + 2}
+                  colSpan={renderedOptions.length + 2}
                   scope="rowgroup"
                 >
                   {group.name}
                 </th>
               </tr>
               {group.rows.map((row) => (
-                <MatrixRow
+                <TechnicalConfigurationMatrixRow
                   key={row.criterion.id}
                   row={row}
-                  options={options}
+                  options={renderedOptions}
+                  pinnedOptionIds={renderedPinnedOptionIds}
                   valueByOptionId={
                     new Map(row.optionValues.map((value) => [value.optionId, value]))
                   }
@@ -223,100 +245,5 @@ export function TechnicalConfigurationMatrix({
         </div>
       </div>
     </div>
-  )
-}
-
-type MatrixRowProps = {
-  row: TechnicalConfigurationComparisonResult["data"]["criteria"][number]
-  options: TechnicalConfigurationComparisonResult["data"]["options"]
-  valueByOptionId: ReadonlyMap<string, TechnicalConfigurationComparisonOptionValue>
-  onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
-}
-
-function MatrixRow({ row, options, valueByOptionId, onOpenDetail }: Readonly<MatrixRowProps>) {
-  const title = row.criterion.title ?? "Chưa có tiêu đề"
-
-  return (
-    <tr
-      data-testid="comparison-criterion-row"
-      data-criterion-id={row.criterion.id}
-      className="align-top"
-    >
-      <th
-        className="sticky left-0 z-30 w-[220px] min-w-[220px] max-w-[220px] border-b border-r bg-background px-3 py-3 font-medium"
-        scope="row"
-      >
-        <span className="block text-xs text-muted-foreground">{row.criterion.criterionCode}</span>
-        <span className="mt-1 block break-words">{title}</span>
-      </th>
-      <td className="sticky left-[220px] z-30 w-[360px] min-w-[360px] max-w-[360px] border-b border-r bg-background p-0">
-        <button
-          type="button"
-          className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-          aria-label={`Xem chi tiết ${row.criterion.criterionCode} · Yêu cầu cơ sở`}
-          onClick={() =>
-            onOpenDetail({
-              criterionCode: row.criterion.criterionCode,
-              criterionTitle: row.criterion.title,
-              optionLabel: null,
-              requirementText: row.criterion.requirementText,
-              responseText: null,
-              supplementaryInformation: null,
-              evidence: row.baselineEvidence,
-            })
-          }
-        >
-          <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
-            {row.criterion.requirementText}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            {formatEvidenceSummary(row.baselineEvidence)}
-          </p>
-        </button>
-      </td>
-      {options.map((option) => {
-        const value = valueByOptionId.get(option.id)
-        const response = value?.response
-        const evidence = value?.evidence ?? EMPTY_EVIDENCE
-
-        return (
-          <td
-            key={option.id}
-            className="w-[320px] min-w-[320px] max-w-[320px] border-b border-r bg-background p-0"
-          >
-            <button
-              type="button"
-              className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-              aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
-              onClick={() =>
-                onOpenDetail({
-                  criterionCode: row.criterion.criterionCode,
-                  criterionTitle: row.criterion.title,
-                  optionLabel: option.displayLabel,
-                  requirementText: row.criterion.requirementText,
-                  responseText: response?.responseText ?? null,
-                  supplementaryInformation: response?.supplementaryInformation ?? null,
-                  evidence,
-                })
-              }
-            >
-              {response ? (
-                <>
-                  <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
-                    {response.responseText}
-                  </p>
-                  {response.supplementaryInformation ? (
-                    <p className="text-xs font-medium text-foreground">Có thông tin bổ sung</p>
-                  ) : null}
-                </>
-              ) : (
-                <p className="text-muted-foreground">Chưa có phản hồi</p>
-              )}
-              <p className="text-xs text-muted-foreground">{formatEvidenceSummary(evidence)}</p>
-            </button>
-          </td>
-        )
-      })}
-    </tr>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { Columns3, Focus, Pin, PinOff, X } from "lucide-react"
 
+import { COMPARISON_MATRIX_LIMITS } from "@/app/(app)/technical-configurations/comparison-matrix-constants"
 import type { TechnicalConfigurationOptionWire } from "@/app/(app)/technical-configurations/supplier-option-types"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -33,29 +34,33 @@ export function TechnicalConfigurationMatrixColumnControls({
   const [open, setOpen] = React.useState(false)
   const triggerRef = React.useRef<HTMLButtonElement | null>(null)
   const exitFocusRef = React.useRef<HTMLButtonElement | null>(null)
-  const wasFocusedRef = React.useRef(focusedOptionId !== null)
   const visibleOptionIdSet = React.useMemo(() => new Set(visibleOptionIds), [visibleOptionIds])
   const pinnedOptionIdSet = React.useMemo(() => new Set(pinnedOptionIds), [pinnedOptionIds])
   const focusedOption = selectedOptions.find((option) => option.id === focusedOptionId)
+  const resolvedFocusedOptionId = focusedOption?.id ?? null
+  const wasFocusedRef = React.useRef(resolvedFocusedOptionId !== null)
 
   React.useEffect(() => {
-    if (focusedOptionId === null) return
+    if (resolvedFocusedOptionId === null) return
     const frame = window.requestAnimationFrame(() => exitFocusRef.current?.focus())
     return () => window.cancelAnimationFrame(frame)
-  }, [focusedOptionId])
+  }, [resolvedFocusedOptionId])
 
   React.useEffect(() => {
     const wasFocused = wasFocusedRef.current
-    wasFocusedRef.current = focusedOptionId !== null
-    if (!wasFocused || focusedOptionId !== null) return
+    wasFocusedRef.current = resolvedFocusedOptionId !== null
+    if (!wasFocused || resolvedFocusedOptionId !== null) return
 
     const frame = window.requestAnimationFrame(() => triggerRef.current?.focus())
     return () => window.cancelAnimationFrame(frame)
-  }, [focusedOptionId])
+  }, [resolvedFocusedOptionId])
 
   return (
     <div className="flex min-h-9 items-center gap-2">
-      <Popover open={open} onOpenChange={(nextOpen) => setOpen(focusedOptionId ? false : nextOpen)}>
+      <Popover
+        open={open}
+        onOpenChange={(nextOpen) => setOpen(resolvedFocusedOptionId ? false : nextOpen)}
+      >
         <PopoverTrigger asChild>
           <Button
             ref={triggerRef}
@@ -64,7 +69,7 @@ export function TechnicalConfigurationMatrixColumnControls({
             size="sm"
             className="h-9"
             aria-label="Tùy chỉnh cột so sánh"
-            disabled={selectedOptions.length === 0 || focusedOptionId !== null}
+            disabled={selectedOptions.length === 0 || resolvedFocusedOptionId !== null}
           >
             <Columns3 aria-hidden="true" />
             Cột
@@ -83,14 +88,16 @@ export function TechnicalConfigurationMatrixColumnControls({
               Cột phương án
             </p>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Yêu cầu cơ sở luôn hiển thị · Ghim tối đa 2 cột
+              Yêu cầu cơ sở luôn hiển thị · Ghim tối đa {COMPARISON_MATRIX_LIMITS.pinnedOptions} cột
             </p>
           </div>
           <div className="max-h-80 overflow-y-auto p-1.5">
             {selectedOptions.map((option) => {
               const isVisible = visibleOptionIdSet.has(option.id)
               const isPinned = pinnedOptionIdSet.has(option.id)
-              const pinDisabled = !isVisible || (!isPinned && pinnedOptionIds.length >= 2)
+              const pinDisabled =
+                !isVisible ||
+                (!isPinned && pinnedOptionIds.length >= COMPARISON_MATRIX_LIMITS.pinnedOptions)
 
               return (
                 <div

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import * as React from "react"
+import { Columns3, Focus, Pin, PinOff, X } from "lucide-react"
+
+import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+
+type TechnicalConfigurationMatrixColumnControlsProps = {
+  selectedOptions: readonly TechnicalConfigurationOptionWire[]
+  visibleOptionIds: readonly string[]
+  pinnedOptionIds: readonly string[]
+  focusedOptionId: string | null
+  onToggleOptionVisibility: (optionId: string) => void
+  onToggleOptionPin: (optionId: string) => void
+  onFocusOption: (optionId: string) => void
+  onExitFocus: () => void
+}
+
+/** Keeps view-only column actions behind one compact, immediate-action control. */
+export function TechnicalConfigurationMatrixColumnControls({
+  selectedOptions,
+  visibleOptionIds,
+  pinnedOptionIds,
+  focusedOptionId,
+  onToggleOptionVisibility,
+  onToggleOptionPin,
+  onFocusOption,
+  onExitFocus,
+}: Readonly<TechnicalConfigurationMatrixColumnControlsProps>) {
+  const [open, setOpen] = React.useState(false)
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null)
+  const exitFocusRef = React.useRef<HTMLButtonElement | null>(null)
+  const wasFocusedRef = React.useRef(focusedOptionId !== null)
+  const visibleOptionIdSet = React.useMemo(() => new Set(visibleOptionIds), [visibleOptionIds])
+  const pinnedOptionIdSet = React.useMemo(() => new Set(pinnedOptionIds), [pinnedOptionIds])
+  const focusedOption = selectedOptions.find((option) => option.id === focusedOptionId)
+
+  React.useEffect(() => {
+    if (focusedOptionId === null) return
+    const frame = window.requestAnimationFrame(() => exitFocusRef.current?.focus())
+    return () => window.cancelAnimationFrame(frame)
+  }, [focusedOptionId])
+
+  React.useEffect(() => {
+    const wasFocused = wasFocusedRef.current
+    wasFocusedRef.current = focusedOptionId !== null
+    if (!wasFocused || focusedOptionId !== null) return
+
+    const frame = window.requestAnimationFrame(() => triggerRef.current?.focus())
+    return () => window.cancelAnimationFrame(frame)
+  }, [focusedOptionId])
+
+  return (
+    <div className="flex min-h-9 items-center gap-2">
+      <Popover open={open} onOpenChange={(nextOpen) => setOpen(focusedOptionId ? false : nextOpen)}>
+        <PopoverTrigger asChild>
+          <Button
+            ref={triggerRef}
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-9"
+            aria-label="Tùy chỉnh cột so sánh"
+            disabled={selectedOptions.length === 0 || focusedOptionId !== null}
+          >
+            <Columns3 aria-hidden="true" />
+            Cột
+            <span className="text-muted-foreground">
+              {visibleOptionIds.length}/{selectedOptions.length}
+            </span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          className="w-[420px] p-0"
+          aria-labelledby="comparison-column-controls-title"
+        >
+          <div className="border-b px-3 py-2.5">
+            <p id="comparison-column-controls-title" className="text-sm font-medium">
+              Cột phương án
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Yêu cầu cơ sở luôn hiển thị · Ghim tối đa 2 cột
+            </p>
+          </div>
+          <div className="max-h-80 overflow-y-auto p-1.5">
+            {selectedOptions.map((option) => {
+              const isVisible = visibleOptionIdSet.has(option.id)
+              const isPinned = pinnedOptionIdSet.has(option.id)
+              const pinDisabled = !isVisible || (!isPinned && pinnedOptionIds.length >= 2)
+
+              return (
+                <div
+                  key={option.id}
+                  className="grid min-h-10 grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-2 px-2 py-1"
+                >
+                  <Checkbox
+                    id={`comparison-column-${option.id}`}
+                    checked={isVisible}
+                    aria-label={`Hiển thị ${option.display_label}`}
+                    onCheckedChange={() => onToggleOptionVisibility(option.id)}
+                  />
+                  <label
+                    htmlFor={`comparison-column-${option.id}`}
+                    className="min-w-0 cursor-pointer truncate text-sm"
+                    title={option.display_label}
+                  >
+                    {option.display_label}
+                  </label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    aria-label={`${isPinned ? "Bỏ ghim" : "Ghim"} ${option.display_label}`}
+                    title={isPinned ? "Bỏ ghim" : "Ghim cột"}
+                    disabled={pinDisabled}
+                    onClick={() => onToggleOptionPin(option.id)}
+                  >
+                    {isPinned ? <PinOff aria-hidden="true" /> : <Pin aria-hidden="true" />}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    aria-label={`Tập trung ${option.display_label}`}
+                    title="Tập trung cột"
+                    onClick={() => {
+                      setOpen(false)
+                      onFocusOption(option.id)
+                    }}
+                  >
+                    <Focus aria-hidden="true" />
+                  </Button>
+                </div>
+              )
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {focusedOption ? (
+        <div
+          className="flex h-9 min-w-0 max-w-[360px] items-center gap-2 border bg-muted/40 pl-3 pr-1 text-sm"
+          role="status"
+        >
+          <span className="truncate">Đang tập trung: {focusedOption.display_label}</span>
+          <Button
+            ref={exitFocusRef}
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0"
+            aria-label="Thoát chế độ tập trung"
+            title="Thoát chế độ tập trung"
+            onClick={onExitFocus}
+          >
+            <X aria-hidden="true" />
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixColumnControls.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Columns3, Focus, Pin, PinOff, X } from "lucide-react"
 
-import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import type { TechnicalConfigurationOptionWire } from "@/app/(app)/technical-configurations/supplier-option-types"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
@@ -1,3 +1,7 @@
+import {
+  COMPARISON_MATRIX_LAYOUT,
+  getPinnedComparisonOptionLeft,
+} from "@/app/(app)/technical-configurations/comparison-matrix-constants"
 import type {
   TechnicalConfigurationComparisonEvidence,
   TechnicalConfigurationComparisonOptionValue,
@@ -42,13 +46,15 @@ export function TechnicalConfigurationMatrixRow({
       className="align-top"
     >
       <th
-        className="sticky left-0 z-30 w-[220px] min-w-[220px] max-w-[220px] border-b border-r bg-background px-3 py-3 font-medium"
+        className={`sticky left-0 z-30 ${COMPARISON_MATRIX_LAYOUT.criterionWidthClass} border-b border-r bg-background px-3 py-3 font-medium`}
         scope="row"
       >
         <span className="block text-xs text-muted-foreground">{row.criterion.criterionCode}</span>
         <span className="mt-1 block break-words">{title}</span>
       </th>
-      <td className="sticky left-[220px] z-30 w-[360px] min-w-[360px] max-w-[360px] border-b border-r bg-background p-0">
+      <td
+        className={`sticky ${COMPARISON_MATRIX_LAYOUT.baselineStickyLeftClass} z-30 ${COMPARISON_MATRIX_LAYOUT.baselineWidthClass} border-b border-r bg-background p-0`}
+      >
         <button
           type="button"
           className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
@@ -87,10 +93,10 @@ export function TechnicalConfigurationMatrixRow({
             data-criterion-id={row.criterion.id}
             data-option-id={option.id}
             data-pinned={isPinned ? "true" : "false"}
-            className={`w-[320px] min-w-[320px] max-w-[320px] border-b border-r bg-background p-0 ${
+            className={`${COMPARISON_MATRIX_LAYOUT.optionWidthClass} border-b border-r bg-background p-0 ${
               isPinned ? "sticky z-20" : ""
             }`}
-            style={isPinned ? { left: `${580 + pinnedIndex * 320}px` } : undefined}
+            style={isPinned ? { left: getPinnedComparisonOptionLeft(pinnedIndex) } : undefined}
           >
             <button
               type="button"

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
@@ -2,7 +2,8 @@ import type {
   TechnicalConfigurationComparisonEvidence,
   TechnicalConfigurationComparisonOptionValue,
   TechnicalConfigurationComparisonResult,
-} from "../../comparison-types"
+} from "@/app/(app)/technical-configurations/comparison-types"
+
 import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
 
 const EMPTY_EVIDENCE: TechnicalConfigurationComparisonEvidence = {
@@ -55,7 +56,7 @@ export function TechnicalConfigurationMatrixRow({
           onClick={() =>
             onOpenDetail({
               criterionCode: row.criterion.criterionCode,
-              criterionTitle: row.criterion.title,
+              criterionTitle: title,
               optionLabel: null,
               requirementText: row.criterion.requirementText,
               responseText: null,
@@ -98,7 +99,7 @@ export function TechnicalConfigurationMatrixRow({
               onClick={() =>
                 onOpenDetail({
                   criterionCode: row.criterion.criterionCode,
-                  criterionTitle: row.criterion.title,
+                  criterionTitle: title,
                   optionLabel: option.displayLabel,
                   requirementText: row.criterion.requirementText,
                   responseText: response?.responseText ?? null,

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
@@ -1,0 +1,129 @@
+import type {
+  TechnicalConfigurationComparisonEvidence,
+  TechnicalConfigurationComparisonOptionValue,
+  TechnicalConfigurationComparisonResult,
+} from "../../comparison-types"
+import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
+
+const EMPTY_EVIDENCE: TechnicalConfigurationComparisonEvidence = {
+  documentCount: 0,
+  citationCount: 0,
+  hasEvidence: false,
+}
+
+type TechnicalConfigurationMatrixRowProps = {
+  row: TechnicalConfigurationComparisonResult["data"]["criteria"][number]
+  options: TechnicalConfigurationComparisonResult["data"]["options"]
+  pinnedOptionIds: readonly string[]
+  valueByOptionId: ReadonlyMap<string, TechnicalConfigurationComparisonOptionValue>
+  onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
+}
+
+function formatEvidenceSummary(evidence: TechnicalConfigurationComparisonEvidence) {
+  if (!evidence.hasEvidence) return "Chưa có bằng chứng"
+  return `${evidence.documentCount} tài liệu · ${evidence.citationCount} trích dẫn`
+}
+
+/** Renders one criterion across the sticky baseline and visible option columns. */
+export function TechnicalConfigurationMatrixRow({
+  row,
+  options,
+  pinnedOptionIds,
+  valueByOptionId,
+  onOpenDetail,
+}: Readonly<TechnicalConfigurationMatrixRowProps>) {
+  const title = row.criterion.title ?? "Chưa có tiêu đề"
+
+  return (
+    <tr
+      data-testid="comparison-criterion-row"
+      data-criterion-id={row.criterion.id}
+      className="align-top"
+    >
+      <th
+        className="sticky left-0 z-30 w-[220px] min-w-[220px] max-w-[220px] border-b border-r bg-background px-3 py-3 font-medium"
+        scope="row"
+      >
+        <span className="block text-xs text-muted-foreground">{row.criterion.criterionCode}</span>
+        <span className="mt-1 block break-words">{title}</span>
+      </th>
+      <td className="sticky left-[220px] z-30 w-[360px] min-w-[360px] max-w-[360px] border-b border-r bg-background p-0">
+        <button
+          type="button"
+          className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+          aria-label={`Xem chi tiết ${row.criterion.criterionCode} · Yêu cầu cơ sở`}
+          onClick={() =>
+            onOpenDetail({
+              criterionCode: row.criterion.criterionCode,
+              criterionTitle: row.criterion.title,
+              optionLabel: null,
+              requirementText: row.criterion.requirementText,
+              responseText: null,
+              supplementaryInformation: null,
+              evidence: row.baselineEvidence,
+            })
+          }
+        >
+          <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
+            {row.criterion.requirementText}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {formatEvidenceSummary(row.baselineEvidence)}
+          </p>
+        </button>
+      </td>
+      {options.map((option) => {
+        const value = valueByOptionId.get(option.id)
+        const response = value?.response
+        const evidence = value?.evidence ?? EMPTY_EVIDENCE
+        const pinnedIndex = pinnedOptionIds.indexOf(option.id)
+        const isPinned = pinnedIndex >= 0
+
+        return (
+          <td
+            key={option.id}
+            data-testid="comparison-option-cell"
+            data-criterion-id={row.criterion.id}
+            data-option-id={option.id}
+            data-pinned={isPinned ? "true" : "false"}
+            className={`w-[320px] min-w-[320px] max-w-[320px] border-b border-r bg-background p-0 ${
+              isPinned ? "sticky z-20" : ""
+            }`}
+            style={isPinned ? { left: `${580 + pinnedIndex * 320}px` } : undefined}
+          >
+            <button
+              type="button"
+              className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
+              onClick={() =>
+                onOpenDetail({
+                  criterionCode: row.criterion.criterionCode,
+                  criterionTitle: row.criterion.title,
+                  optionLabel: option.displayLabel,
+                  requirementText: row.criterion.requirementText,
+                  responseText: response?.responseText ?? null,
+                  supplementaryInformation: response?.supplementaryInformation ?? null,
+                  evidence,
+                })
+              }
+            >
+              {response ? (
+                <>
+                  <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
+                    {response.responseText}
+                  </p>
+                  {response.supplementaryInformation ? (
+                    <p className="text-xs font-medium text-foreground">Có thông tin bổ sung</p>
+                  ) : null}
+                </>
+              ) : (
+                <p className="text-muted-foreground">Chưa có phản hồi</p>
+              )}
+              <p className="text-xs text-muted-foreground">{formatEvidenceSummary(evidence)}</p>
+            </button>
+          </td>
+        )
+      })}
+    </tr>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixToolbar.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixToolbar.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, RefreshCw, X } from "lucide-react"
 
 import type { TechnicalConfigurationBaselineDraftWire } from "../../baseline-types"
 import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import { TechnicalConfigurationMatrixColumnControls } from "./TechnicalConfigurationMatrixColumnControls"
 import { FacetedMultiSelectFilter } from "@/components/shared/table-filters/FacetedMultiSelectFilter"
 import { Button } from "@/components/ui/button"
 import { SingleSelect } from "@/components/ui/heroui/SingleSelect"
@@ -30,6 +31,9 @@ type TechnicalConfigurationMatrixToolbarProps = {
   options: TechnicalConfigurationOptionWire[]
   optionsQuery: OptionsQueryState
   selectedOptions: TechnicalConfigurationOptionWire[]
+  visibleOptionIds: readonly string[]
+  pinnedOptionIds: readonly string[]
+  focusedOptionId: string | null
   isSelectionLimitReached: boolean
   onSelectBaselineVersion: (versionId: string) => void
   onLoadMoreVersions: () => void
@@ -37,6 +41,10 @@ type TechnicalConfigurationMatrixToolbarProps = {
   onRetryOptions: () => void
   onAddOption: (optionId: string) => void
   onRemoveOption: (optionId: string) => void
+  onToggleOptionVisibility: (optionId: string) => void
+  onToggleOptionPin: (optionId: string) => void
+  onFocusOption: (optionId: string) => void
+  onExitFocus: () => void
 }
 
 function getVersionLabel(version: TechnicalConfigurationBaselineDraftWire) {
@@ -53,6 +61,9 @@ export function TechnicalConfigurationMatrixToolbar({
   options,
   optionsQuery,
   selectedOptions,
+  visibleOptionIds,
+  pinnedOptionIds,
+  focusedOptionId,
   isSelectionLimitReached,
   onSelectBaselineVersion,
   onLoadMoreVersions,
@@ -60,6 +71,10 @@ export function TechnicalConfigurationMatrixToolbar({
   onRetryOptions,
   onAddOption,
   onRemoveOption,
+  onToggleOptionVisibility,
+  onToggleOptionPin,
+  onFocusOption,
+  onExitFocus,
 }: Readonly<TechnicalConfigurationMatrixToolbarProps>) {
   const selectedOptionIds = React.useMemo(
     () => selectedOptions.map((option) => option.id),
@@ -141,9 +156,21 @@ export function TechnicalConfigurationMatrixToolbar({
         <div className="min-w-0 space-y-3 p-4">
           <div className="flex min-h-10 items-start justify-between gap-4">
             <h2 className="text-sm font-semibold">Phương án so sánh</h2>
-            <span className="shrink-0 text-xs font-medium text-muted-foreground">
-              {selectedOptions.length}/8 phương án
-            </span>
+            <div className="flex items-center gap-3">
+              <span className="shrink-0 text-xs font-medium text-muted-foreground">
+                {selectedOptions.length}/8 phương án
+              </span>
+              <TechnicalConfigurationMatrixColumnControls
+                selectedOptions={selectedOptions}
+                visibleOptionIds={visibleOptionIds}
+                pinnedOptionIds={pinnedOptionIds}
+                focusedOptionId={focusedOptionId}
+                onToggleOptionVisibility={onToggleOptionVisibility}
+                onToggleOptionPin={onToggleOptionPin}
+                onFocusOption={onFocusOption}
+                onExitFocus={onExitFocus}
+              />
+            </div>
           </div>
 
           {optionsQuery.isError ? (

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonMatrix.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonMatrix.ts
@@ -2,6 +2,8 @@
 
 import * as React from "react"
 
+import { COMPARISON_MATRIX_LIMITS } from "@/app/(app)/technical-configurations/comparison-matrix-constants"
+
 import { useTechnicalConfigurationBaseline } from "./useTechnicalConfigurationBaseline"
 import { useTechnicalConfigurationBaselineVersions } from "./useTechnicalConfigurationBaselineVersions"
 import { useTechnicalConfigurationComparison } from "./useTechnicalConfigurationComparison"
@@ -9,7 +11,6 @@ import { useTechnicalConfigurationOptionListQuery } from "./useTechnicalConfigur
 import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 
 const COMPARISON_PAGE_SIZE = 50
-const MAX_SELECTED_OPTIONS = 8
 const EMPTY_OPTIONS: TechnicalConfigurationOptionWire[] = []
 
 type ComparisonRequestState = {
@@ -99,7 +100,7 @@ function comparisonMatrixReducer(
       if (
         !action.availableOptionIds.has(action.optionId) ||
         state.request.selectedOptionIds.includes(action.optionId) ||
-        state.request.selectedOptionIds.length >= MAX_SELECTED_OPTIONS
+        state.request.selectedOptionIds.length >= COMPARISON_MATRIX_LIMITS.selectedOptions
       ) {
         return state
       }
@@ -178,7 +179,7 @@ function comparisonMatrixReducer(
       if (pinnedOptionIdSet.has(action.optionId)) {
         pinnedOptionIdSet.delete(action.optionId)
       } else {
-        if (pinnedOptionIdSet.size >= 2) return state
+        if (pinnedOptionIdSet.size >= COMPARISON_MATRIX_LIMITS.pinnedOptions) return state
         pinnedOptionIdSet.add(action.optionId)
       }
 
@@ -295,7 +296,7 @@ export function useTechnicalConfigurationComparisonMatrix(dossierId: string) {
     focusedOptionId,
     page,
     pageSize: COMPARISON_PAGE_SIZE,
-    isSelectionLimitReached: selectedOptionIds.length >= MAX_SELECTED_OPTIONS,
+    isSelectionLimitReached: selectedOptionIds.length >= COMPARISON_MATRIX_LIMITS.selectedOptions,
     comparison,
     selectBaselineVersion,
     addOption,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonMatrix.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonMatrix.ts
@@ -18,61 +18,188 @@ type ComparisonRequestState = {
   page: number
 }
 
-type ComparisonRequestAction =
+type ComparisonViewState = {
+  visibleOptionIds: readonly string[]
+  pinnedOptionIds: readonly string[]
+  focusedOptionId: string | null
+}
+
+type ComparisonMatrixState = {
+  request: ComparisonRequestState
+  view: ComparisonViewState
+}
+
+type ComparisonMatrixAction =
   | { type: "reconcile-options"; availableOptionIds: ReadonlySet<string> }
   | { type: "select-baseline"; baselineVersionId: string | null }
   | { type: "add-option"; optionId: string; availableOptionIds: ReadonlySet<string> }
   | { type: "remove-option"; optionId: string }
   | { type: "set-page"; page: number }
+  | { type: "toggle-option-visibility"; optionId: string }
+  | { type: "toggle-option-pin"; optionId: string }
+  | { type: "focus-option"; optionId: string }
+  | { type: "exit-focus" }
 
-const INITIAL_REQUEST_STATE: ComparisonRequestState = {
-  baselineVersionId: null,
-  selectedOptionIds: [],
-  page: 1,
+const INITIAL_MATRIX_STATE: ComparisonMatrixState = {
+  request: {
+    baselineVersionId: null,
+    selectedOptionIds: [],
+    page: 1,
+  },
+  view: {
+    visibleOptionIds: [],
+    pinnedOptionIds: [],
+    focusedOptionId: null,
+  },
 }
 
-function comparisonRequestReducer(
-  state: ComparisonRequestState,
-  action: ComparisonRequestAction
-): ComparisonRequestState {
+function comparisonMatrixReducer(
+  state: ComparisonMatrixState,
+  action: ComparisonMatrixAction
+): ComparisonMatrixState {
   switch (action.type) {
     case "reconcile-options": {
-      const selectedOptionIds = state.selectedOptionIds.filter((optionId) =>
+      const selectedOptionIds = state.request.selectedOptionIds.filter((optionId) =>
         action.availableOptionIds.has(optionId)
       )
-      return selectedOptionIds.length === state.selectedOptionIds.length
-        ? state
-        : { ...state, selectedOptionIds, page: 1 }
+      if (selectedOptionIds.length === state.request.selectedOptionIds.length) {
+        return state
+      }
+
+      const selectedOptionIdSet = new Set(selectedOptionIds)
+      const visibleOptionIds = state.view.visibleOptionIds.filter((optionId) =>
+        selectedOptionIdSet.has(optionId)
+      )
+      const visibleOptionIdSet = new Set(visibleOptionIds)
+      return {
+        request: { ...state.request, selectedOptionIds, page: 1 },
+        view: {
+          visibleOptionIds,
+          pinnedOptionIds: state.view.pinnedOptionIds.filter((optionId) =>
+            visibleOptionIdSet.has(optionId)
+          ),
+          focusedOptionId: selectedOptionIdSet.has(state.view.focusedOptionId ?? "")
+            ? state.view.focusedOptionId
+            : null,
+        },
+      }
     }
     case "select-baseline":
-      return state.baselineVersionId === action.baselineVersionId
+      return state.request.baselineVersionId === action.baselineVersionId
         ? state
-        : { ...state, baselineVersionId: action.baselineVersionId, page: 1 }
+        : {
+            ...state,
+            request: {
+              ...state.request,
+              baselineVersionId: action.baselineVersionId,
+              page: 1,
+            },
+          }
     case "add-option":
       if (
         !action.availableOptionIds.has(action.optionId) ||
-        state.selectedOptionIds.includes(action.optionId) ||
-        state.selectedOptionIds.length >= MAX_SELECTED_OPTIONS
+        state.request.selectedOptionIds.includes(action.optionId) ||
+        state.request.selectedOptionIds.length >= MAX_SELECTED_OPTIONS
       ) {
         return state
       }
       return {
         ...state,
-        selectedOptionIds: [...state.selectedOptionIds, action.optionId],
-        page: 1,
+        request: {
+          ...state.request,
+          selectedOptionIds: [...state.request.selectedOptionIds, action.optionId],
+          page: 1,
+        },
+        view: {
+          visibleOptionIds: [...state.view.visibleOptionIds, action.optionId],
+          pinnedOptionIds: state.view.pinnedOptionIds,
+          focusedOptionId: state.view.focusedOptionId,
+        },
       }
     case "remove-option": {
-      const selectedOptionIds = state.selectedOptionIds.filter(
+      const selectedOptionIds = state.request.selectedOptionIds.filter(
         (optionId) => optionId !== action.optionId
       )
-      return selectedOptionIds.length === state.selectedOptionIds.length
+      return selectedOptionIds.length === state.request.selectedOptionIds.length
         ? state
-        : { ...state, selectedOptionIds, page: 1 }
+        : {
+            request: { ...state.request, selectedOptionIds, page: 1 },
+            view: {
+              visibleOptionIds: state.view.visibleOptionIds.filter(
+                (optionId) => optionId !== action.optionId
+              ),
+              pinnedOptionIds: state.view.pinnedOptionIds.filter(
+                (optionId) => optionId !== action.optionId
+              ),
+              focusedOptionId:
+                state.view.focusedOptionId === action.optionId ? null : state.view.focusedOptionId,
+            },
+          }
     }
     case "set-page":
-      return Number.isInteger(action.page) && action.page >= 1 && action.page !== state.page
-        ? { ...state, page: action.page }
+      return Number.isInteger(action.page) && action.page >= 1 && action.page !== state.request.page
+        ? { ...state, request: { ...state.request, page: action.page } }
         : state
+    case "toggle-option-visibility": {
+      if (!state.request.selectedOptionIds.includes(action.optionId)) return state
+
+      const visibleOptionIdSet = new Set(state.view.visibleOptionIds)
+      if (visibleOptionIdSet.has(action.optionId)) {
+        return {
+          ...state,
+          view: {
+            visibleOptionIds: state.view.visibleOptionIds.filter(
+              (optionId) => optionId !== action.optionId
+            ),
+            pinnedOptionIds: state.view.pinnedOptionIds.filter(
+              (optionId) => optionId !== action.optionId
+            ),
+            focusedOptionId: state.view.focusedOptionId,
+          },
+        }
+      }
+
+      visibleOptionIdSet.add(action.optionId)
+      return {
+        ...state,
+        view: {
+          visibleOptionIds: state.request.selectedOptionIds.filter((optionId) =>
+            visibleOptionIdSet.has(optionId)
+          ),
+          pinnedOptionIds: state.view.pinnedOptionIds,
+          focusedOptionId: state.view.focusedOptionId,
+        },
+      }
+    }
+    case "toggle-option-pin": {
+      if (!state.view.visibleOptionIds.includes(action.optionId)) return state
+
+      const pinnedOptionIdSet = new Set(state.view.pinnedOptionIds)
+      if (pinnedOptionIdSet.has(action.optionId)) {
+        pinnedOptionIdSet.delete(action.optionId)
+      } else {
+        if (pinnedOptionIdSet.size >= 2) return state
+        pinnedOptionIdSet.add(action.optionId)
+      }
+
+      return {
+        ...state,
+        view: {
+          ...state.view,
+          pinnedOptionIds: state.request.selectedOptionIds.filter((optionId) =>
+            pinnedOptionIdSet.has(optionId)
+          ),
+        },
+      }
+    }
+    case "focus-option":
+      return state.request.selectedOptionIds.includes(action.optionId)
+        ? { ...state, view: { ...state.view, focusedOptionId: action.optionId } }
+        : state
+    case "exit-focus":
+      return state.view.focusedOptionId === null
+        ? state
+        : { ...state, view: { ...state.view, focusedOptionId: null } }
   }
 }
 
@@ -86,10 +213,12 @@ export function useTechnicalConfigurationComparisonMatrix(dossierId: string) {
     })
   const { optionsQuery } = useTechnicalConfigurationOptionListQuery(dossierId)
   const options = optionsQuery.data?.options ?? EMPTY_OPTIONS
-  const [{ baselineVersionId, selectedOptionIds, page }, dispatch] = React.useReducer(
-    comparisonRequestReducer,
-    INITIAL_REQUEST_STATE
+  const [{ request, view }, dispatch] = React.useReducer(
+    comparisonMatrixReducer,
+    INITIAL_MATRIX_STATE
   )
+  const { baselineVersionId, selectedOptionIds, page } = request
+  const { visibleOptionIds, pinnedOptionIds, focusedOptionId } = view
 
   const availableOptionIds = React.useMemo(
     () => new Set(options.map((option) => option.id)),
@@ -119,6 +248,22 @@ export function useTechnicalConfigurationComparisonMatrix(dossierId: string) {
     dispatch({ type: "set-page", page: nextPage })
   }, [])
 
+  const toggleOptionVisibility = React.useCallback((optionId: string) => {
+    dispatch({ type: "toggle-option-visibility", optionId })
+  }, [])
+
+  const toggleOptionPin = React.useCallback((optionId: string) => {
+    dispatch({ type: "toggle-option-pin", optionId })
+  }, [])
+
+  const focusOption = React.useCallback((optionId: string) => {
+    dispatch({ type: "focus-option", optionId })
+  }, [])
+
+  const exitFocusMode = React.useCallback(() => {
+    dispatch({ type: "exit-focus" })
+  }, [])
+
   const selectedOptions = React.useMemo(() => {
     const optionById = new Map(options.map((option) => [option.id, option]))
     return selectedOptionIds.flatMap((optionId) => {
@@ -145,6 +290,9 @@ export function useTechnicalConfigurationComparisonMatrix(dossierId: string) {
     baselineVersionId,
     selectedOptionIds,
     selectedOptions,
+    visibleOptionIds,
+    pinnedOptionIds,
+    focusedOptionId,
     page,
     pageSize: COMPARISON_PAGE_SIZE,
     isSelectionLimitReached: selectedOptionIds.length >= MAX_SELECTED_OPTIONS,
@@ -153,5 +301,9 @@ export function useTechnicalConfigurationComparisonMatrix(dossierId: string) {
     addOption,
     removeOption,
     setPage,
+    toggleOptionVisibility,
+    toggleOptionPin,
+    focusOption,
+    exitFocusMode,
   }
 }

--- a/src/app/(app)/technical-configurations/comparison-matrix-constants.ts
+++ b/src/app/(app)/technical-configurations/comparison-matrix-constants.ts
@@ -1,0 +1,23 @@
+/** Shared request and view limits for the comparison matrix. */
+export const COMPARISON_MATRIX_LIMITS = {
+  selectedOptions: 8,
+  pinnedOptions: 2,
+} as const
+
+/** Stable desktop column geometry shared by matrix headers and body rows. */
+export const COMPARISON_MATRIX_LAYOUT = {
+  criterionWidth: 220,
+  baselineWidth: 360,
+  optionWidth: 320,
+  criterionWidthClass: "w-[220px] min-w-[220px] max-w-[220px]",
+  baselineWidthClass: "w-[360px] min-w-[360px] max-w-[360px]",
+  optionWidthClass: "w-[320px] min-w-[320px] max-w-[320px]",
+  baselineStickyLeftClass: "left-[220px]",
+} as const
+
+/** Returns the sticky left offset for a pinned option column. */
+export function getPinnedComparisonOptionLeft(pinnedIndex: number): string {
+  const fixedColumnWidth =
+    COMPARISON_MATRIX_LAYOUT.criterionWidth + COMPARISON_MATRIX_LAYOUT.baselineWidth
+  return `${fixedColumnWidth + pinnedIndex * COMPARISON_MATRIX_LAYOUT.optionWidth}px`
+}


### PR DESCRIPTION
## Summary
- separate comparison request membership/order from view-only visible, pinned, and focused option state
- add one compact `Cột` control with immediate visibility, pin, and focus actions; no Save, Add, or Apply workflow
- keep at most two pinned visible options in selected order with stable offsets, and render baseline plus one selected option in focus mode
- preserve deterministic keyboard focus, accessible popover naming, horizontal access, and production file-size boundaries

## Verification
- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- `typecheck`
- focused/upstream Vitest: 8 files, 140 tests passed
- React Doctor staged diff: 100/100, 10 files scanned
- OpenSpec strict validation
- Hallmark source audit
- pre-commit and pre-push Lefthook gates

Browser, Playwright, agent-browser, screenshots, mobile optimization, SQL, DB, and RPC changes are intentionally excluded from this leaf.

## Review
- two fresh-context reviews completed
- all accessibility, focus reconciliation, hidden-option focus, pin-limit messaging, and file-size findings resolved
- `tasks.md` remains unchecked until the PR is merged and the landed state is verified

Closes #813

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compact column controls to the comparison matrix with instant show/hide, pin (max 2), and one‑column focus mode. Keeps column view state separate from the comparison request so queries and cache keys stay stable.

- **New Features**
  - Added `Cột` control in the toolbar for immediate visibility and pin/unpin; baseline always visible; pinned columns render first with stable sticky offsets.
  - One‑column focus mode shows baseline + one option, disables the control, shows an exit pill, returns keyboard focus on exit, and keeps the control available if the focused option disappears.

- **Refactors**
  - Split view-only state (`visibleOptionIds`, `pinnedOptionIds`, `focusedOptionId`) from request membership in `useTechnicalConfigurationComparisonMatrix`; comparison query key no longer changes on view actions.
  - Introduced `comparison-matrix-constants` for limits and column geometry; headers and cells share deterministic offsets; extracted `TechnicalConfigurationMatrixRow` and preserved stable widths/scroll and fallback criterion titles in detail.

<sup>Written for commit 1fb3f37d4fd8e989cc884cdaaa022bc080b5e87c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added column controls to show/hide comparison options, including a focus mode to spotlight a single column.
  * Added pinning for up to two visible columns with sticky positioning to keep them in view while scrolling.
  * Improved comparison matrix rendering, including pinned ordering and enhanced row/detail behavior.
* **Tests**
  * Added Vitest/React Testing Library coverage for keyboard navigation, focus transitions/exiting, visibility/pinning reconciliation, and key rendering/layout scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->