### PR TITLE
docs: propose liquidation equipment chronology

### DIFF
--- a/openspec/changes/update-equipment-liquidation-group-ordering/design.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/design.md
@@ -1,0 +1,222 @@
+## Context
+
+The existing `p_liquidation_last` behavior was introduced to keep equipment that
+is both decommissioned and assigned to the liquidation warehouse at the end of
+the main Equipments result. The current effective order is:
+
+1. non-liquidation rows before liquidation rows;
+2. requested table sort inside each group;
+3. equipment ID as the deterministic tie-breaker.
+
+The client uses server-side manual sorting and does not reorder the returned
+page. The default empty table sort becomes `id.asc`, and persisted user sorting
+can replace that secondary key.
+
+The target warehouse currently contains only rows that satisfy the liquidation
+condition. Therefore, filtering to that warehouse removes all variation from
+the first priority key and exposes the requested sort as the visible top-level
+order.
+
+`public.thiet_bi` has no `updated_at` column. It does have
+`ngay_ngung_su_dung`, stored as nullable ISO `YYYY-MM-DD` text. The edit form
+auto-populates today's Vietnam date when status transitions from a
+non-decommissioned status to `Ngưng sử dụng` and the field is empty.
+
+Read-only live evidence on 2026-07-29:
+
+- 272 visible rows matched the exact liquidation condition;
+- 200 rows had ISO-shaped decommission dates;
+- 72 rows had null dates;
+- 0 rows had non-ISO non-null dates;
+- 1 row had `ngay_ngung_su_dung = '2026-07-29'`.
+
+## Goals
+
+- Keep the whole liquidation group at the end of the complete filtered result.
+- Keep newly dated liquidation entries at the end of that group.
+- Produce the same chronology with and without the warehouse filter.
+- Preserve server pagination, requested sorting, RPC compatibility, security,
+  grants, and caller scope.
+- Keep the implementation limited to one SQL function replacement and focused
+  regression coverage.
+
+## Non-Goals
+
+- Record the exact timestamp when equipment enters the liquidation warehouse.
+- Define exact arrival order between multiple devices decommissioned on the
+  same date.
+- Backfill the 72 legacy null dates.
+- Change how `ngay_ngung_su_dung` is entered, validated, or displayed.
+- Add or use `updated_at`.
+- Change export, transfer, maintenance-selection, cached-search, or other
+  `equipment_list_enhanced` consumers.
+- Change frontend table state, session storage, or TanStack Table behavior.
+
+## Decisions
+
+### 1. Use `ngay_ngung_su_dung` as the v1 chronology key
+
+The implementation will use the existing decommission date rather than adding a
+new warehouse-entry timestamp.
+
+Rationale:
+
+- it already exists in the RPC output and edit contract;
+- the current transition flow auto-fills the date;
+- ISO text sorts chronologically in ascending lexical order;
+- no schema, payload, type, or frontend change is required;
+- the observed bug is fixed for the approved status-plus-department transition.
+
+Accepted limitation:
+
+- if equipment was already `Ngưng sử dụng` and only its department changes to
+  the liquidation warehouse, its existing date may be old or null;
+- multiple entries on the same date are ordered by the requested sort and ID,
+  not by exact transition time.
+
+If exact warehouse-entry time becomes a requirement, it should be a separate
+change introducing a dedicated `liquidation_entered_at timestamptz` contract and
+a DB-owned transition mechanism.
+
+### 2. Keep legacy null/blank dates before dated liquidation rows
+
+Null or blank dates represent legacy/unknown chronology. They will receive an
+empty internal sort key, which sorts before valid ISO dates in ascending order.
+
+This avoids an unsafe date cast and prevents legacy null records from occupying
+the final positions after newly dated entries. No backfill is included.
+
+### 3. Make chronology stronger than the requested sort
+
+When `p_liquidation_last = true`, the effective order will be equivalent to:
+
+```sql
+CASE
+  WHEN <exact liquidation condition> THEN 1
+  ELSE 0
+END ASC,
+CASE
+  WHEN <exact liquidation condition>
+    THEN COALESCE(NULLIF(btrim(tb.ngay_ngung_su_dung), ''), '')
+  ELSE ''
+END ASC,
+tb.<validated_sort_column> <validated_sort_direction>,
+tb.id ASC
+```
+
+Consequences:
+
+- normal rows remain ordered by the requested sort because their chronology key
+  is constant;
+- liquidation rows with older/unknown dates appear before newer dates;
+- a custom user sort cannot move a newer dated liquidation row above an older
+  dated row;
+- rows with the same date retain the requested user sort and deterministic ID
+  tie-breaker.
+
+### 4. Preserve exact condition and caller scope
+
+The liquidation condition remains:
+
+- normalized department equals `VT-TBYT- KHO THANH LÍ`; and
+- trimmed status equals `Ngưng sử dụng`.
+
+The behavior remains guarded by `p_liquidation_last`. The parameter keeps its
+default `false`, and only the main Equipments hook continues to opt in.
+
+### 5. Use a superseding migration
+
+The implementation will create a new migration that sorts after
+`20260722094302_equipment_list_liquidation_last.sql`. It will replace the current
+18-argument function without changing:
+
+- function name, parameter order, defaults, or JSON response;
+- JWT guards and allowed-tenant logic;
+- `SECURITY DEFINER`;
+- `SET search_path = public, pg_temp`;
+- explicit execute grants and revokes;
+- filters, search behavior, count behavior, selected columns, or pagination.
+
+No existing migration will be edited or renamed.
+
+## Test Strategy
+
+### Source-contract test
+
+Extend the existing migration test to require:
+
+- a new migration after the current liquidation-order migration;
+- the liquidation priority key before the chronology key;
+- the chronology key before the requested dynamic sort;
+- the requested sort before `OFFSET/LIMIT`;
+- unchanged opt-out ordering when the flag is false;
+- unchanged signature, security attributes, and grants.
+
+### Transactional SQL smoke
+
+Extend the rollback-only smoke fixture with:
+
+- normal rows;
+- liquidation rows with null, older, same-day, and newest dates;
+- an unfiltered call;
+- a call filtered to the liquidation warehouse;
+- a custom requested sort that would otherwise put the newest row first;
+- an unfiltered page boundary proving the newest dated liquidation cohort
+  remains on the final applicable page;
+- a warehouse-filtered page boundary proving the same chronology remains on the
+  final applicable page.
+
+The smoke must prove identical liquidation chronology with and without the
+warehouse filter.
+
+### Existing caller-scope and overload regressions
+
+Run the existing caller-scope Vitest file in PR 2 without changing it. Run the
+read-only `supabase/tests/equipment_list_enhanced_overload_regression.sql`
+against live database metadata after the migration is applied. No new frontend
+behavior test is required unless implementation unexpectedly touches client
+code.
+
+## Rollout
+
+1. Merge the focused SQL/TDD implementation PR without applying live changes.
+2. Request explicit user authorization for the exact live migration apply and
+   transactional smoke write set.
+3. Inspect the live signature and migration state through Supabase MCP.
+4. Apply the superseding migration through Supabase MCP.
+5. Verify the live function definition and execute grants read-only.
+6. Run the read-only overload regression SQL.
+7. Run the approved rollback-only smoke fixture.
+8. Run Supabase security and performance advisors.
+9. Record rollout evidence, then archive the OpenSpec change in a separate PR.
+
+Rollback is forward-only: if rollout verification finds a regression, create
+and apply a new superseding migration that restores the previous `v_order_by`
+expression. Do not edit migration metadata or mutate an already applied file.
+
+## PR Boundaries
+
+### PR 1 - OpenSpec proposal
+
+Documentation only: proposal, design, tasklist, and spec delta. No runtime code
+or live DB writes.
+
+### PR 2 - SQL ordering contract
+
+One superseding migration plus the focused source-contract and transactional
+smoke test files. This PR has a hard cap of three changed files and is organized
+as four small work packages: failing source contract, minimal SQL change,
+transactional behavior proof, and regression gates. No frontend changes, helper
+extraction, unrelated SQL cleanup, or live DB apply belongs in the PR. Any need
+for an additional source file or schema change requires a separate follow-up
+proposal rather than expanding this boundary.
+
+### Operational checkpoint
+
+Apply and verify the migration only after explicit approval. This is tracked as
+a phase but does not require an artificial code PR.
+
+### PR 3 - OpenSpec archive
+
+Archive the completed change and publish the capability spec after successful
+deployment verification. No runtime changes.

--- a/openspec/changes/update-equipment-liquidation-group-ordering/design.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/design.md
@@ -150,14 +150,23 @@ Extend the existing migration test to require:
 - the chronology key before the requested dynamic sort;
 - the requested sort before `OFFSET/LIMIT`;
 - unchanged opt-out ordering when the flag is false;
-- unchanged signature, security attributes, and grants.
+- unchanged 18-argument signature and default-false flag;
+- unchanged JWT claim extraction and guards, tenant-scope clauses,
+  `SECURITY DEFINER`, fixed `search_path`, and grants;
+- unchanged filters, result envelope, and pagination clauses.
+
+These invariants remain assertions in the existing source-contract test file.
+This avoids relying on manual migration review without introducing another test
+file.
 
 ### Transactional SQL smoke
 
 Extend the rollback-only smoke fixture with:
 
 - normal rows;
-- liquidation rows with null, older, same-day, and newest dates;
+- liquidation rows with null/blank, older, same-day, and newest dates;
+- same-day rows with different requested-sort values;
+- same-day rows with equal requested-sort values and different IDs;
 - an unfiltered call;
 - a call filtered to the liquidation warehouse;
 - a custom requested sort that would otherwise put the newest row first;
@@ -169,13 +178,19 @@ Extend the rollback-only smoke fixture with:
 The smoke must prove identical liquidation chronology with and without the
 warehouse filter.
 
+PR 2 prepares and reviews this SQL fixture but does not execute it against the
+currently deployed function, because the new migration is intentionally not
+applied during the code PR. Execute the fixture only in the approved Phase 2
+checkpoint after the migration is live, and confirm its transaction rolls back.
+
 ### Existing caller-scope and overload regressions
 
 Run the existing caller-scope Vitest file in PR 2 without changing it. Run the
 read-only `supabase/tests/equipment_list_enhanced_overload_regression.sql`
 against live database metadata after the migration is applied. No new frontend
-behavior test is required unless implementation unexpectedly touches client
-code.
+or authorization-negative test file is required: the existing source-contract
+test locks the JWT and tenant-scope clauses, while Phase 2 verifies the deployed
+definition and grants read-only.
 
 ## Rollout
 
@@ -193,6 +208,11 @@ code.
 Rollback is forward-only: if rollout verification finds a regression, create
 and apply a new superseding migration that restores the previous `v_order_by`
 expression. Do not edit migration metadata or mutate an already applied file.
+Stop the rollout before preparing that migration, review it in a separate
+rollback PR, and request explicit user authorization for the exact rollback
+apply. Authorization for the original migration or smoke fixture does not
+authorize the rollback write. After an authorized rollback, re-run the overload
+regression, function-security inspection, and applicable ordering smoke.
 
 ## PR Boundaries
 

--- a/openspec/changes/update-equipment-liquidation-group-ordering/proposal.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+The main Equipments list already places equipment at the end of the complete
+server-paginated result when both conditions match:
+
+- `tinh_trang_hien_tai = 'Ngưng sử dụng'`
+- normalized `khoa_phong_quan_ly = 'VT-TBYT- KHO THANH LÍ'`
+
+However, the current ordering only creates a liquidation group and then applies
+the requested table sort inside that group. With the default `id.asc` sort, an
+older equipment record that is moved into the liquidation warehouse can appear
+at the start of the liquidation group. Filtering the list to the liquidation
+warehouse makes that same row appear at the top of the filtered result.
+
+Read-only live inspection on 2026-07-29 confirmed that all 272 visible rows in
+the liquidation warehouse are already `Ngưng sử dụng`, so the current priority
+key is identical for every filtered row. The newly moved row has an old ID but a
+current `ngay_ngung_su_dung`, which demonstrates that ID order does not represent
+warehouse-entry chronology.
+
+## What Changes
+
+- Refine the opt-in `equipment_list_enhanced` ordering so liquidation rows are
+  ordered by `ngay_ngung_su_dung` ascending inside the liquidation group.
+- Treat null or blank decommission dates as legacy/unknown records and place
+  them before dated liquidation rows.
+- Keep the requested user sort after the liquidation chronology key, so it only
+  orders rows that share the same decommission date.
+- Apply the same ordering whether the user views the general Equipments list or
+  filters specifically to `VT-TBYT- KHO THANH LÍ`.
+- Keep the ordering before `OFFSET/LIMIT`, so the newest dated liquidation rows
+  remain at the end of the complete filtered result.
+- Preserve the existing opt-in scope: only the main Equipments table sends
+  `p_liquidation_last = true`; export and other RPC consumers keep their current
+  order.
+- Do not add an `updated_at` column, audit join, warehouse-entry timestamp,
+  frontend sort override, or client-side reordering in this change.
+
+The v1 guarantee is decommission-date chronology, not exact warehouse-entry
+chronology. Rows sharing one date still use the requested sort and ID, while an
+already-decommissioned device moved later into the warehouse may retain an old
+or missing date. Exact transition ordering requires a separate timestamp-backed
+change.
+
+## Runtime Impact
+
+This proposal does not change runtime behavior by itself. Runtime behavior
+changes only after the implementation migration is reviewed and explicitly
+applied to live Supabase through MCP.
+
+After rollout, the newest decommission-date cohort in the liquidation group
+appears after older dated cohorts in both the general list and a
+liquidation-warehouse-filtered list. Rows outside the liquidation group and RPC
+calls with `p_liquidation_last = false` remain unchanged.
+
+## Impact
+
+- Affected capability: `equipment-liquidation-ordering` (new capability).
+- Expected implementation files:
+  - a superseding migration after
+    `20260722094302_equipment_list_liquidation_last.sql`
+  - `src/app/api/rpc/__tests__/equipment-list-liquidation-order-migration.test.ts`
+  - `supabase/tests/equipment_list_enhanced_liquidation_order_smoke.sql`
+- No planned TypeScript/React runtime changes.
+- No schema column, index, RPC signature, or API payload changes.
+- Live migration apply and transactional smoke fixtures require explicit user
+  permission before each approved write set.

--- a/openspec/changes/update-equipment-liquidation-group-ordering/specs/equipment-liquidation-ordering/spec.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/specs/equipment-liquidation-ordering/spec.md
@@ -56,10 +56,17 @@ old or missing decommission date.
 
 #### Scenario: Same-date rows retain requested deterministic sorting
 
-- **GIVEN** multiple liquidation rows share the same decommission date
+- **GIVEN** multiple liquidation rows share the same decommission date and have
+  different values for the requested sortable column
 - **WHEN** the user requests a sortable column and direction
 - **THEN** those same-date rows follow the requested sort
-- **AND** equipment ID provides the final deterministic tie-breaker
+
+#### Scenario: Equal chronology and sort values use equipment ID
+
+- **GIVEN** multiple liquidation rows share the same decommission date and the
+  same requested-sort value
+- **WHEN** the list builds the final deterministic order
+- **THEN** those rows are ordered by equipment ID ascending
 
 #### Scenario: General-list chronology is applied before pagination
 

--- a/openspec/changes/update-equipment-liquidation-group-ordering/specs/equipment-liquidation-ordering/spec.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/specs/equipment-liquidation-ordering/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: Liquidation equipment forms a final result group
+
+When liquidation-last ordering is enabled, the system MUST place equipment
+after all non-matching equipment only when both the normalized management
+department is `VT-TBYT- KHO THANH LÍ` and the trimmed current status is
+`Ngưng sử dụng`.
+
+#### Scenario: General Equipments list keeps the liquidation group last
+
+- **GIVEN** the main Equipments result contains normal rows and exact
+  liquidation-condition rows
+- **WHEN** the list requests `p_liquidation_last = true`
+- **THEN** all normal rows appear before every liquidation row
+- **AND** the grouping is applied before pagination
+
+#### Scenario: A partial condition does not enter the liquidation group
+
+- **GIVEN** equipment matches only the department or only the status
+- **WHEN** the list requests `p_liquidation_last = true`
+- **THEN** that equipment remains in the normal requested-sort group
+
+### Requirement: Liquidation rows use decommission-date chronology
+
+Within the liquidation group, the system MUST order normalized non-blank
+`ngay_ngung_su_dung` ISO values ascending so newer dated rows appear after older
+dated rows. This requirement defines date-cohort chronology and does not
+guarantee exact warehouse-entry order within one date or for rows retaining an
+old or missing decommission date.
+
+#### Scenario: The newest decommission-date cohort appears last in the group
+
+- **GIVEN** liquidation rows have older ISO decommission dates and one row has
+  the newest ISO decommission date
+- **WHEN** the list requests `p_liquidation_last = true`
+- **THEN** the row with the newest decommission date appears after the older
+  dated liquidation rows
+
+#### Scenario: Legacy missing dates precede dated liquidation rows
+
+- **GIVEN** a liquidation row has a null or blank `ngay_ngung_su_dung`
+- **AND** other liquidation rows have valid ISO dates
+- **WHEN** the list requests `p_liquidation_last = true`
+- **THEN** the null or blank legacy row appears before the dated liquidation
+  rows
+- **AND** no data backfill is required
+
+#### Scenario: Requested sort is limited to a chronology cohort
+
+- **GIVEN** liquidation rows have different decommission dates
+- **WHEN** the user requests a sortable column and direction
+- **THEN** decommission-date chronology remains stronger than the requested
+  sort
+- **AND** the requested sort orders rows only after the chronology key
+
+#### Scenario: Same-date rows retain requested deterministic sorting
+
+- **GIVEN** multiple liquidation rows share the same decommission date
+- **WHEN** the user requests a sortable column and direction
+- **THEN** those same-date rows follow the requested sort
+- **AND** equipment ID provides the final deterministic tie-breaker
+
+#### Scenario: General-list chronology is applied before pagination
+
+- **GIVEN** the general result spans multiple pages and contains liquidation
+  rows with older and newer decommission dates
+- **WHEN** the list requests `p_liquidation_last = true`
+- **THEN** the newest dated liquidation cohort remains on the final applicable
+  page
+- **AND** liquidation rows are not reordered only within the current browser
+  page
+
+### Requirement: Warehouse filtering preserves liquidation chronology
+
+Filtering the main Equipments list to the liquidation warehouse MUST NOT remove
+or reverse the decommission-date chronology.
+
+#### Scenario: Filtered liquidation warehouse keeps the newest row last
+
+- **GIVEN** every visible filtered row matches the liquidation condition
+- **WHEN** the user filters to `VT-TBYT- KHO THANH LÍ`
+- **THEN** legacy and older dated rows appear before newer dated rows
+- **AND** the newest dated row appears at the end of the complete filtered
+  result
+
+#### Scenario: Filtered chronology is applied before pagination
+
+- **GIVEN** the filtered liquidation result spans multiple pages
+- **WHEN** the newest dated row sorts beyond the current page
+- **THEN** the newest dated row remains on the final applicable page
+- **AND** it is not moved to the end of only the current browser page
+
+### Requirement: Non-opted-in callers remain compatible
+
+The system MUST preserve the existing ordering contract when
+`p_liquidation_last` is false or omitted.
+
+#### Scenario: Opt-out ordering remains unchanged
+
+- **GIVEN** an RPC caller omits `p_liquidation_last` or passes `false`
+- **WHEN** `equipment_list_enhanced` builds its order
+- **THEN** it applies the validated requested sort without the liquidation
+  grouping or chronology keys
+
+#### Scenario: Only the main Equipments table opts in
+
+- **GIVEN** export, transfer, maintenance-selection, cached-search, or other
+  existing `equipment_list_enhanced` consumers
+- **WHEN** they request equipment
+- **THEN** they retain their existing order
+- **AND** no frontend or API payload change is required

--- a/openspec/changes/update-equipment-liquidation-group-ordering/tasks.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/tasks.md
@@ -49,41 +49,48 @@ SQL cleanup, or live DB apply.
       superseding migration.
 - [ ] 1.6 Add the null-safe ISO-text `ngay_ngung_su_dung` chronology key between
       the liquidation bucket and requested sort.
-- [ ] 1.7 Verify that the 18-argument signature and default-false flag are
-      unchanged in the migration.
-- [ ] 1.8 Verify that JWT guards, tenant scope, `SECURITY DEFINER`, fixed
-      `search_path`, and grants are unchanged in the migration.
-- [ ] 1.9 Verify that filters, the result envelope, and pagination are unchanged
-      in the migration.
+- [ ] 1.7 Add or retain source-contract assertions for the unchanged 18-argument
+      signature and default-false flag.
+- [ ] 1.8 Add or retain source-contract assertions for unchanged JWT guards,
+      tenant scope, `SECURITY DEFINER`, fixed `search_path`, and grants.
+- [ ] 1.9 Add or retain source-contract assertions for unchanged filters, result
+      envelope, and pagination.
 - [ ] 1.10 Run the focused migration source-contract test and confirm it passes.
 
-### Phase 1C - Prove behavior through the transactional smoke test
+### Phase 1C - Prepare the transactional smoke coverage
 
 - [ ] 1.11 Extend the transactional smoke fixture with null, old, same-day, and
       newest liquidation dates.
-- [ ] 1.12 Add an unfiltered smoke expectation proving the newest dated
+- [ ] 1.12 Add an exact-sequence expectation proving null or blank legacy dates
+      precede every dated liquidation row.
+- [ ] 1.13 Add a same-date expectation proving the requested sort orders rows
+      within that date cohort.
+- [ ] 1.14 Add an equal-date-and-sort expectation proving equipment ID ascending
+      is the final tie-breaker.
+- [ ] 1.15 Add an unfiltered smoke expectation proving the newest dated
       liquidation row is last in the liquidation group.
-- [ ] 1.13 Add a warehouse-filtered smoke expectation proving the same newest
+- [ ] 1.16 Add a warehouse-filtered smoke expectation proving the same newest
       row is last in the filtered result.
-- [ ] 1.14 Add a custom-sort expectation proving liquidation chronology remains
+- [ ] 1.17 Add a custom-sort expectation proving liquidation chronology remains
       stronger than the requested sort.
-- [ ] 1.15 Add an unfiltered page-boundary expectation proving chronology is
+- [ ] 1.18 Add an unfiltered page-boundary expectation proving chronology is
       applied before pagination.
-- [ ] 1.16 Add a warehouse-filtered page-boundary expectation proving the same
+- [ ] 1.19 Add a warehouse-filtered page-boundary expectation proving the same
       chronology is applied before pagination.
-- [ ] 1.17 Run the focused transactional smoke test.
+- [ ] 1.20 Review the SQL fixture and expected sequences without executing it
+      against the currently deployed function.
 
 ### Phase 1D - Regression gates and PR handoff
 
-- [ ] 1.18 Run the focused migration source-contract Vitest file.
-- [ ] 1.19 Run the existing caller-scope Vitest file.
-- [ ] 1.20 Run `node scripts/npm-run.js run format:check`.
-- [ ] 1.21 Run `node scripts/npm-run.js run verify:no-explicit-any`.
-- [ ] 1.22 Run `node scripts/npm-run.js run verify:dedupe`.
-- [ ] 1.23 Run `node scripts/npm-run.js run typecheck`.
-- [ ] 1.24 Run
+- [ ] 1.21 Run the focused migration source-contract Vitest file.
+- [ ] 1.22 Run the existing caller-scope Vitest file.
+- [ ] 1.23 Run `node scripts/npm-run.js run format:check`.
+- [ ] 1.24 Run `node scripts/npm-run.js run verify:no-explicit-any`.
+- [ ] 1.25 Run `node scripts/npm-run.js run verify:dedupe`.
+- [ ] 1.26 Run `node scripts/npm-run.js run typecheck`.
+- [ ] 1.27 Run
       `openspec validate update-equipment-liquidation-group-ordering --strict`.
-- [ ] 1.25 Confirm the final diff changes no more than the planned migration and
+- [ ] 1.28 Confirm the final diff changes no more than the planned migration and
       two focused test files.
 
 **Exit criteria:** PR 2 is green, reviewable as one ordering change, and merged
@@ -123,6 +130,16 @@ mix follow-up code into the rollout.
       row counts and no data backfill occurred.
 - [ ] 2.14 Record migration version, smoke result, advisor result, and rollback
       readiness in the tracking issue or rollout handoff.
+
+### Phase 2D - Conditional forward rollback
+
+- [ ] 2.15 If Phase 2C fails, stop the rollout and open a separate forward-only
+      rollback PR; otherwise record this subsection as not applicable.
+- [ ] 2.16 Before any rollback apply, request explicit user authorization for
+      that exact live DB write; otherwise record this task as not applicable.
+- [ ] 2.17 After an authorized rollback, re-run the overload regression,
+      function-security inspection, and applicable ordering smoke; otherwise
+      record this task as not applicable.
 
 **Exit criteria:** live ordering is verified, no data was rewritten, and any
 change-caused advisor finding is resolved or explicitly tracked.

--- a/openspec/changes/update-equipment-liquidation-group-ordering/tasks.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/tasks.md
@@ -1,0 +1,146 @@
+# Implementation Tasks
+
+Each phase has a narrow review boundary. Do not combine Phase 1 runtime work with
+unrelated equipment, frontend, audit, or schema changes.
+
+**Task-sizing rule:** each checklist item must produce one observable result and
+be independently reviewable or verifiable. PR 2 has a hard cap of one migration
+and two existing focused test files. If implementation requires another source
+file, shared helper, refactor, or schema addition, stop and propose a separate
+follow-up change instead of expanding the PR.
+
+## Phase 0 - Proposal And Approval (PR 1: Docs Only)
+
+**Review boundary:** OpenSpec artifacts only. No runtime code and no live DB
+writes.
+
+- [x] 0.1 Document the current ordering root cause and read-only live evidence.
+- [x] 0.2 Define the liquidation chronology, legacy-null, filter, pagination,
+      requested-sort, and opt-out requirements.
+- [x] 0.3 Record the rejected `updated_at`, audit-join, client-sort, and new
+      timestamp alternatives.
+- [x] 0.4 Split implementation, rollout, and archive into separate review
+      boundaries.
+- [x] 0.5 Run
+      `openspec validate update-equipment-liquidation-group-ordering --strict`.
+- [ ] 0.6 Obtain proposal approval before starting Phase 1.
+
+**Exit criteria:** strict validation passes and the proposal PR is approved.
+
+## Phase 1 - SQL Ordering Contract (PR 2: Migration Plus Focused Tests)
+
+**Review boundary:** at most three changed files: one superseding migration and
+two existing focused test files. No frontend files, helper extraction, unrelated
+SQL cleanup, or live DB apply.
+
+### Phase 1A - RED: Lock the source contract
+
+- [ ] 1.1 Create the implementation branch from the latest clean `main`.
+- [ ] 1.2 Add a failing source-contract assertion requiring the liquidation
+      chronology key before the requested sort.
+- [ ] 1.3 Run the focused migration test and confirm the new assertion fails for
+      the current SQL.
+
+### Phase 1B - GREEN: Change only the RPC ordering expression
+
+- [ ] 1.4 Create a migration whose filename sorts after
+      `20260722094302_equipment_list_liquidation_last.sql`.
+- [ ] 1.5 Copy the latest local `equipment_list_enhanced` definition into the
+      superseding migration.
+- [ ] 1.6 Add the null-safe ISO-text `ngay_ngung_su_dung` chronology key between
+      the liquidation bucket and requested sort.
+- [ ] 1.7 Verify that the 18-argument signature and default-false flag are
+      unchanged in the migration.
+- [ ] 1.8 Verify that JWT guards, tenant scope, `SECURITY DEFINER`, fixed
+      `search_path`, and grants are unchanged in the migration.
+- [ ] 1.9 Verify that filters, the result envelope, and pagination are unchanged
+      in the migration.
+- [ ] 1.10 Run the focused migration source-contract test and confirm it passes.
+
+### Phase 1C - Prove behavior through the transactional smoke test
+
+- [ ] 1.11 Extend the transactional smoke fixture with null, old, same-day, and
+      newest liquidation dates.
+- [ ] 1.12 Add an unfiltered smoke expectation proving the newest dated
+      liquidation row is last in the liquidation group.
+- [ ] 1.13 Add a warehouse-filtered smoke expectation proving the same newest
+      row is last in the filtered result.
+- [ ] 1.14 Add a custom-sort expectation proving liquidation chronology remains
+      stronger than the requested sort.
+- [ ] 1.15 Add an unfiltered page-boundary expectation proving chronology is
+      applied before pagination.
+- [ ] 1.16 Add a warehouse-filtered page-boundary expectation proving the same
+      chronology is applied before pagination.
+- [ ] 1.17 Run the focused transactional smoke test.
+
+### Phase 1D - Regression gates and PR handoff
+
+- [ ] 1.18 Run the focused migration source-contract Vitest file.
+- [ ] 1.19 Run the existing caller-scope Vitest file.
+- [ ] 1.20 Run `node scripts/npm-run.js run format:check`.
+- [ ] 1.21 Run `node scripts/npm-run.js run verify:no-explicit-any`.
+- [ ] 1.22 Run `node scripts/npm-run.js run verify:dedupe`.
+- [ ] 1.23 Run `node scripts/npm-run.js run typecheck`.
+- [ ] 1.24 Run
+      `openspec validate update-equipment-liquidation-group-ordering --strict`.
+- [ ] 1.25 Confirm the final diff changes no more than the planned migration and
+      two focused test files.
+
+**Exit criteria:** PR 2 is green, reviewable as one ordering change, and merged
+without applying the migration live.
+
+## Phase 2 - Live Rollout And Verification (Operational Checkpoint)
+
+**Review boundary:** Supabase MCP operations and recorded evidence only. Do not
+mix follow-up code into the rollout.
+
+### Phase 2A - Approval and read-only preflight
+
+- [ ] 2.1 Request explicit user permission for the specific migration apply and
+      rollback-only smoke write set.
+- [ ] 2.2 Inspect the live migration state read-only.
+- [ ] 2.3 Inspect the live function signature and body read-only.
+- [ ] 2.4 Inspect the live function security attributes and grants read-only.
+
+### Phase 2B - Apply the approved migration
+
+- [ ] 2.5 Apply the approved superseding migration through Supabase MCP.
+
+### Phase 2C - Verify behavior and deployment safety
+
+- [ ] 2.6 Verify the live migration version and ordering expression read-only.
+- [ ] 2.7 Verify the live signature and default-false flag read-only.
+- [ ] 2.8 Verify the live security attributes and grants read-only.
+- [ ] 2.9 Run
+      `supabase/tests/equipment_list_enhanced_overload_regression.sql` read-only
+      through Supabase MCP.
+- [ ] 2.10 Run the approved transactional smoke fixture and confirm it rolls
+      back all fixture rows.
+- [ ] 2.11 Run Supabase MCP security advisors.
+- [ ] 2.12 Run Supabase MCP performance advisors and triage only findings caused
+      by this change.
+- [ ] 2.13 Verify read-only that the liquidation warehouse still has unchanged
+      row counts and no data backfill occurred.
+- [ ] 2.14 Record migration version, smoke result, advisor result, and rollback
+      readiness in the tracking issue or rollout handoff.
+
+**Exit criteria:** live ordering is verified, no data was rewritten, and any
+change-caused advisor finding is resolved or explicitly tracked.
+
+## Phase 3 - Completion And Archive (PR 3: Docs Only)
+
+**Review boundary:** OpenSpec status/spec publication only. No runtime changes.
+
+- [ ] 3.1 Mark completed tasks with links or identifiers for PR 2 and rollout
+      evidence.
+- [ ] 3.2 Run
+      `openspec archive update-equipment-liquidation-group-ordering --yes`.
+- [ ] 3.3 Run `openspec validate --strict`.
+- [ ] 3.4 Review the archive diff and confirm it only moves the change and
+      publishes the capability spec.
+- [ ] 3.5 Merge the archive PR.
+- [ ] 3.6 Sync local `main` with the merged remote state.
+- [ ] 3.7 Prune the merged docs branch.
+
+**Exit criteria:** the deployed contract is represented in current OpenSpec
+truth and the repository is clean and synchronized.


### PR DESCRIPTION
## Summary
- document the current liquidation-group ordering behavior and read-only live evidence
- define v1 date-cohort chronology using `ngay_ngung_su_dung ASC`, with legacy null/blank dates first and requested sort after chronology
- cover both the general Equipments list and the `VT-TBYT- KHO THANH LÍ` filtered result before pagination
- split delivery into a docs proposal PR, a maximum-three-file SQL/TDD PR, an explicitly approved live rollout checkpoint, and a docs-only archive PR

## Scope guard
- docs only; no runtime code changes
- no live Supabase writes
- Phase 1 remains blocked until proposal approval
- exact same-day or department-only warehouse-entry chronology is out of scope for v1 and would require a dedicated transition timestamp

## Validation
- `node scripts/npm-run.js run format:check`
- `openspec validate update-equipment-liquidation-group-ordering --strict`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only proposal defining v1 liquidation equipment chronology: keep the liquidation group last and order it by `ngay_ngung_su_dung` ascending, with legacy null/blank dates first and chronology stronger than the requested sort. Applies to both the general Equipments list and the liquidation-warehouse filter, before pagination; no runtime changes.

- **Migration**
  - Future PR adds a superseding migration to sort `equipment_list_enhanced` by a null-safe `ngay_ngung_su_dung` between the liquidation bucket and requested sort, keeping the existing signature, security, filters, and pagination.
  - Scope stays opt-in via `p_liquidation_last`; other callers remain unchanged.
  - Live apply requires explicit approval and rollout verification with read-only regression checks and a rollback-only smoke.

<sup>Written for commit c109082a330ff983ed899bd33f65df3683f2ece9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specifications and implementation guidance for improved liquidation-group ordering.
  * Documented chronological ordering by decommission date, with undated records shown first.
  * Clarified pagination, filtering, backward compatibility, rollout phases, and regression-testing requirements.
  * No runtime, API, schema, or response-format changes are included in this documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->