### PR TITLE
fix(equipment): order liquidation rows by decommission date

### DIFF
--- a/src/app/api/rpc/__tests__/equipment-list-liquidation-order-migration.test.ts
+++ b/src/app/api/rpc/__tests__/equipment-list-liquidation-order-migration.test.ts
@@ -3,8 +3,8 @@ import path from "node:path"
 
 import { describe, expect, it } from "vitest"
 
-const MIGRATION_SUFFIX = "equipment_list_liquidation_last.sql"
-const PREVIOUS_MIGRATION = "20260704074500_align_equipment_list_filters_with_bucket_labels.sql"
+const MIGRATION_SUFFIX = "equipment_list_liquidation_chronology.sql"
+const PREVIOUS_MIGRATION = "20260722094302_equipment_list_liquidation_last.sql"
 
 function getMigration() {
   const migrationsDir = path.resolve(process.cwd(), "supabase/migrations")
@@ -37,9 +37,39 @@ describe("equipment list liquidation-last migration", () => {
     const createPosition = compact.indexOf(
       "CREATE OR REPLACE FUNCTION public.equipment_list_enhanced("
     )
+    const createEnd = compact.indexOf(") RETURNS jsonb", createPosition)
+    const parameterDeclarations = [
+      "p_q text DEFAULT NULL::text",
+      "p_sort text DEFAULT 'id.asc'::text",
+      "p_page integer DEFAULT 1",
+      "p_page_size integer DEFAULT 50",
+      "p_don_vi bigint DEFAULT NULL::bigint",
+      "p_khoa_phong text DEFAULT NULL::text",
+      "p_khoa_phong_array text[] DEFAULT NULL::text[]",
+      "p_nguoi_su_dung text DEFAULT NULL::text",
+      "p_nguoi_su_dung_array text[] DEFAULT NULL::text[]",
+      "p_vi_tri_lap_dat text DEFAULT NULL::text",
+      "p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[]",
+      "p_tinh_trang text DEFAULT NULL::text",
+      "p_tinh_trang_array text[] DEFAULT NULL::text[]",
+      "p_phan_loai text DEFAULT NULL::text",
+      "p_phan_loai_array text[] DEFAULT NULL::text[]",
+      "p_nguon_kinh_phi text DEFAULT NULL::text",
+      "p_nguon_kinh_phi_array text[] DEFAULT NULL::text[]",
+      "p_liquidation_last boolean DEFAULT false",
+    ]
+    const createSignature = compact
+      .slice(
+        createPosition + "CREATE OR REPLACE FUNCTION public.equipment_list_enhanced(".length,
+        createEnd
+      )
+      .trim()
 
     expect(dropPosition).toBeGreaterThanOrEqual(0)
     expect(createPosition).toBeGreaterThan(dropPosition)
+    expect(createEnd).toBeGreaterThan(createPosition)
+    expect(parameterDeclarations).toHaveLength(18)
+    expect(createSignature).toBe(parameterDeclarations.join(", "))
     expect(compact).toContain("p_liquidation_last boolean DEFAULT false ) RETURNS jsonb")
     expect(compact).toContain("SECURITY DEFINER")
     expect(compact).toContain("SET search_path = public, pg_temp")
@@ -51,10 +81,13 @@ describe("equipment list liquidation-last migration", () => {
     const flagBranch = compact.indexOf("IF p_liquidation_last THEN")
     const priorityStart = compact.indexOf("CASE", flagBranch)
     const priorityEnd = compact.indexOf("END ASC", priorityStart)
-    const requestedSort = compact.indexOf("tb.%I %s", priorityEnd)
+    const chronologyStart = compact.indexOf("CASE", priorityEnd)
+    const chronologyEnd = compact.indexOf("END ASC", chronologyStart)
+    const requestedSort = compact.indexOf("tb.%I %s", chronologyEnd)
     const dynamicOrder = compact.indexOf("ORDER BY %s", requestedSort)
     const offset = compact.indexOf("OFFSET %s LIMIT %s", dynamicOrder)
     const priorityExpression = compact.slice(priorityStart, priorityEnd).replace(/''/g, "'")
+    const chronologyExpression = compact.slice(chronologyStart, chronologyEnd).replace(/''/g, "'")
 
     expect(flagBranch).toBeGreaterThanOrEqual(0)
     expect(priorityStart).toBeGreaterThanOrEqual(0)
@@ -64,7 +97,18 @@ describe("equipment list liquidation-last migration", () => {
     )
     expect(priorityExpression).toContain("AND btrim(tb.tinh_trang_hien_tai) = 'Ngưng sử dụng'")
     expect(priorityExpression).not.toMatch(/\b(?:LIKE|ILIKE)\b/i)
-    expect(requestedSort).toBeGreaterThan(priorityEnd)
+    expect(chronologyStart).toBeGreaterThan(priorityEnd)
+    expect(chronologyEnd).toBeGreaterThan(chronologyStart)
+    expect(chronologyExpression).toContain(
+      "public._normalize_department_scope(tb.khoa_phong_quan_ly) = public._normalize_department_scope('VT-TBYT- KHO THANH LÍ')"
+    )
+    expect(chronologyExpression).toContain("AND btrim(tb.tinh_trang_hien_tai) = 'Ngưng sử dụng'")
+    expect(chronologyExpression).toContain(
+      "THEN COALESCE(NULLIF(btrim(tb.ngay_ngung_su_dung), ''), '')"
+    )
+    expect(chronologyExpression).toContain("ELSE ''")
+    expect(chronologyExpression).not.toMatch(/\b(?:LIKE|ILIKE)\b/i)
+    expect(requestedSort).toBeGreaterThan(chronologyEnd)
     expect(dynamicOrder).toBeGreaterThan(requestedSort)
     expect(offset).toBeGreaterThan(dynamicOrder)
     expect(compact).toContain("ELSE v_order_by := format('tb.%I %s', v_sort_col, v_sort_dir)")
@@ -84,6 +128,48 @@ describe("equipment list liquidation-last migration", () => {
     )
     expect(compact).toContain(
       `GRANT EXECUTE ON FUNCTION public.equipment_list_enhanced( ${signature} ) TO authenticated`
+    )
+  })
+
+  it("preserves JWT, tenant, filter, envelope, and pagination contracts", () => {
+    const { source } = getMigration()
+    const compact = compactSql(source)
+
+    expect(compact).toContain("v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb")
+    expect(compact).toContain("v_user_id := NULLIF(v_jwt_claims ->>'user_id', '')")
+    expect(compact).toContain(
+      "RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501'"
+    )
+    expect(compact).toContain("v_allowed_don_vi := public.allowed_don_vi_for_session_safe()")
+    expect(compact).toContain("IF lower(v_role) IN ('global', 'admin') THEN")
+    expect(compact).toContain(
+      "IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin')"
+    )
+    expect(compact).toContain(
+      "v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])'"
+    )
+    expect(compact).toContain(
+      "IF lower(v_role) = 'user' THEN v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = ' || quote_literal(v_department_scope)"
+    )
+
+    for (const arrayFilter of [
+      "p_khoa_phong_array",
+      "p_nguoi_su_dung_array",
+      "p_vi_tri_lap_dat_array",
+      "p_tinh_trang_array",
+      "p_phan_loai_array",
+      "p_nguon_kinh_phi_array",
+    ]) {
+      expect(compact).toContain(`unnest(${arrayFilter})`)
+    }
+
+    expect(compact).toContain("v_sanitized_q := public._sanitize_ilike_pattern(p_q)")
+    expect(compact).toContain(
+      "v_limit INT := GREATEST(p_page_size, 1); v_offset INT := GREATEST(p_page - 1, 0) * GREATEST(p_page_size, 1)"
+    )
+    expect(compact).toContain("OFFSET %s LIMIT %s")
+    expect(compact).toContain(
+      "RETURN jsonb_build_object( 'data', v_data, 'total', v_total, 'page', p_page, 'pageSize', p_page_size )"
     )
   })
 })

--- a/src/app/api/rpc/__tests__/equipment-list-liquidation-order-migration.test.ts
+++ b/src/app/api/rpc/__tests__/equipment-list-liquidation-order-migration.test.ts
@@ -68,7 +68,7 @@ describe("equipment list liquidation-last migration", () => {
     expect(dropPosition).toBeGreaterThanOrEqual(0)
     expect(createPosition).toBeGreaterThan(dropPosition)
     expect(createEnd).toBeGreaterThan(createPosition)
-    expect(parameterDeclarations).toHaveLength(18)
+    expect(createSignature.split(", ")).toHaveLength(18)
     expect(createSignature).toBe(parameterDeclarations.join(", "))
     expect(compact).toContain("p_liquidation_last boolean DEFAULT false ) RETURNS jsonb")
     expect(compact).toContain("SECURITY DEFINER")

--- a/supabase/migrations/20260729062450_equipment_list_liquidation_chronology.sql
+++ b/supabase/migrations/20260729062450_equipment_list_liquidation_chronology.sql
@@ -1,0 +1,391 @@
+-- Keep liquidation equipment at the end of the main Equipments result when requested,
+-- ordered from unknown/older decommission dates to newer dates within that group.
+--
+-- The final flag defaults to false so existing RPC consumers retain their
+-- current ordering. The main Equipments table opts in explicitly.
+--
+-- Forward-only rollback: add a later migration that restores the
+-- equipment_list_enhanced body from
+-- 20260722094302_equipment_list_liquidation_last.sql.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[]
+);
+
+CREATE OR REPLACE FUNCTION public.equipment_list_enhanced(
+  p_q text DEFAULT NULL::text,
+  p_sort text DEFAULT 'id.asc'::text,
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_don_vi bigint DEFAULT NULL::bigint,
+  p_khoa_phong text DEFAULT NULL::text,
+  p_khoa_phong_array text[] DEFAULT NULL::text[],
+  p_nguoi_su_dung text DEFAULT NULL::text,
+  p_nguoi_su_dung_array text[] DEFAULT NULL::text[],
+  p_vi_tri_lap_dat text DEFAULT NULL::text,
+  p_vi_tri_lap_dat_array text[] DEFAULT NULL::text[],
+  p_tinh_trang text DEFAULT NULL::text,
+  p_tinh_trang_array text[] DEFAULT NULL::text[],
+  p_phan_loai text DEFAULT NULL::text,
+  p_phan_loai_array text[] DEFAULT NULL::text[],
+  p_nguon_kinh_phi text DEFAULT NULL::text,
+  p_nguon_kinh_phi_array text[] DEFAULT NULL::text[],
+  p_liquidation_last boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_role TEXT := '';
+  v_user_id TEXT := NULL;
+  v_claim_donvi BIGINT := NULL;
+  v_allowed_don_vi BIGINT[];
+  v_effective_donvi BIGINT := NULL;
+  v_department_scope TEXT;
+  v_sort_col TEXT := 'id';
+  v_sort_dir TEXT := 'ASC';
+  v_order_by TEXT;
+  v_limit INT := GREATEST(p_page_size, 1);
+  v_offset INT := GREATEST(p_page - 1, 0) * GREATEST(p_page_size, 1);
+  v_where TEXT := '1=1 AND is_deleted = false';
+  v_total BIGINT := 0;
+  v_data JSONB := '[]'::jsonb;
+  v_jwt_claims JSONB;
+  v_sanitized_q TEXT;
+  v_unclassified_label CONSTANT TEXT := 'Chưa phân loại';
+  v_empty_user_label CONSTANT TEXT := 'Chưa có người sử dụng';
+  v_empty_location_label CONSTANT TEXT := 'Chưa có vị trí';
+BEGIN
+  BEGIN
+    v_jwt_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN OTHERS THEN
+    v_jwt_claims := NULL;
+  END;
+
+  v_role := COALESCE(
+    v_jwt_claims ->>'app_role',
+    v_jwt_claims ->>'role',
+    ''
+  );
+  v_user_id := NULLIF(v_jwt_claims ->>'user_id', '');
+  v_claim_donvi := NULLIF(v_jwt_claims ->>'don_vi', '')::BIGINT;
+
+  IF lower(v_role) = 'admin' THEN
+    v_role := 'global';
+  END IF;
+
+  IF v_role = '' OR v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Missing required JWT claims' USING ERRCODE = '42501';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_department_scope := public._normalize_department_scope(v_jwt_claims ->>'khoa_phong');
+  END IF;
+
+  IF p_sort IS NOT NULL AND p_sort != '' THEN
+    v_sort_col := split_part(p_sort, '.', 1);
+    v_sort_dir := UPPER(COALESCE(NULLIF(split_part(p_sort, '.', 2), ''), 'ASC'));
+    IF v_sort_dir NOT IN ('ASC', 'DESC') THEN
+      v_sort_dir := 'ASC';
+    END IF;
+    IF v_sort_col NOT IN (
+      'id', 'ma_thiet_bi', 'ten_thiet_bi', 'model', 'serial',
+      'khoa_phong_quan_ly', 'tinh_trang_hien_tai', 'vi_tri_lap_dat',
+      'nguoi_dang_truc_tiep_quan_ly', 'phan_loai_theo_nd98', 'nguon_kinh_phi', 'don_vi',
+      'gia_goc', 'ngay_nhap', 'ngay_dua_vao_su_dung', 'ngay_bt_tiep_theo',
+      'so_luu_hanh'
+    ) THEN
+      v_sort_col := 'id';
+    END IF;
+  END IF;
+
+  IF p_liquidation_last THEN
+    v_order_by := format(
+      'CASE
+         WHEN public._normalize_department_scope(tb.khoa_phong_quan_ly)
+                = public._normalize_department_scope(''VT-TBYT- KHO THANH LÍ'')
+          AND btrim(tb.tinh_trang_hien_tai) = ''Ngưng sử dụng''
+         THEN 1
+         ELSE 0
+       END ASC,
+       CASE
+         WHEN public._normalize_department_scope(tb.khoa_phong_quan_ly)
+                = public._normalize_department_scope(''VT-TBYT- KHO THANH LÍ'')
+          AND btrim(tb.tinh_trang_hien_tai) = ''Ngưng sử dụng''
+         THEN COALESCE(NULLIF(btrim(tb.ngay_ngung_su_dung), ''''), '''')
+         ELSE ''''
+       END ASC,
+       tb.%I %s,
+       tb.id ASC',
+      v_sort_col,
+      v_sort_dir
+    );
+  ELSE
+    v_order_by := format('tb.%I %s', v_sort_col, v_sort_dir);
+  END IF;
+
+  v_allowed_don_vi := public.allowed_don_vi_for_session_safe();
+
+  IF lower(v_role) IN ('global', 'admin') THEN
+    IF p_don_vi IS NOT NULL THEN
+      v_effective_donvi := p_don_vi;
+    ELSE
+      v_effective_donvi := NULL;
+    END IF;
+  ELSE
+    IF v_allowed_don_vi IS NOT NULL AND array_length(v_allowed_don_vi, 1) > 0 THEN
+      IF p_don_vi IS NOT NULL THEN
+        IF p_don_vi = ANY(v_allowed_don_vi) THEN
+          v_effective_donvi := p_don_vi;
+        ELSE
+          RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'Access denied for tenant');
+        END IF;
+      ELSE
+        v_effective_donvi := NULL;
+      END IF;
+    ELSE
+      RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size, 'error', 'No tenant access');
+    END IF;
+  END IF;
+
+  IF lower(v_role) = 'user' AND v_department_scope IS NULL THEN
+    RETURN jsonb_build_object('data', '[]'::jsonb, 'total', 0, 'page', p_page, 'pageSize', p_page_size);
+  END IF;
+
+  IF v_effective_donvi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ' || v_effective_donvi;
+  END IF;
+
+  IF v_effective_donvi IS NULL AND lower(v_role) NOT IN ('global', 'admin') AND v_allowed_don_vi IS NOT NULL THEN
+    v_where := v_where || ' AND don_vi = ANY(ARRAY[' || array_to_string(v_allowed_don_vi, ',') || '])';
+  END IF;
+
+  IF lower(v_role) = 'user' THEN
+    v_where := v_where || ' AND public._normalize_department_scope(khoa_phong_quan_ly) = '
+      || quote_literal(v_department_scope);
+  END IF;
+
+  IF p_khoa_phong_array IS NOT NULL AND array_length(p_khoa_phong_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_khoa_phong_array) AS x), ',') || '])';
+  ELSIF p_khoa_phong IS NOT NULL AND trim(p_khoa_phong) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(khoa_phong_quan_ly), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_khoa_phong);
+  END IF;
+
+  IF p_nguoi_su_dung_array IS NOT NULL AND array_length(p_nguoi_su_dung_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''''), ' || quote_literal(v_empty_user_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguoi_su_dung_array) AS x), ',') || '])';
+  ELSIF p_nguoi_su_dung IS NOT NULL AND trim(p_nguoi_su_dung) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(nguoi_dang_truc_tiep_quan_ly), ''''), ' || quote_literal(v_empty_user_label) || ') = ' || quote_literal(p_nguoi_su_dung);
+  END IF;
+
+  IF p_vi_tri_lap_dat_array IS NOT NULL AND array_length(p_vi_tri_lap_dat_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''''), ' || quote_literal(v_empty_location_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_vi_tri_lap_dat_array) AS x), ',') || '])';
+  ELSIF p_vi_tri_lap_dat IS NOT NULL AND trim(p_vi_tri_lap_dat) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(vi_tri_lap_dat), ''''), ' || quote_literal(v_empty_location_label) || ') = ' || quote_literal(p_vi_tri_lap_dat);
+  END IF;
+
+  IF p_tinh_trang_array IS NOT NULL AND array_length(p_tinh_trang_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_tinh_trang_array) AS x), ',') || '])';
+  ELSIF p_tinh_trang IS NOT NULL AND trim(p_tinh_trang) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(tinh_trang_hien_tai), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_tinh_trang);
+  END IF;
+
+  IF p_phan_loai_array IS NOT NULL AND array_length(p_phan_loai_array, 1) > 0 THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''''), ' || quote_literal(v_unclassified_label) || ') = ANY(ARRAY[' ||
+               array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_phan_loai_array) AS x), ',') || '])';
+  ELSIF p_phan_loai IS NOT NULL AND trim(p_phan_loai) != '' THEN
+    v_where := v_where || ' AND COALESCE(NULLIF(TRIM(phan_loai_theo_nd98), ''''), ' || quote_literal(v_unclassified_label) || ') = ' || quote_literal(p_phan_loai);
+  END IF;
+
+  IF p_nguon_kinh_phi_array IS NOT NULL AND array_length(p_nguon_kinh_phi_array, 1) > 0 THEN
+    IF 'Chưa có' = ANY(p_nguon_kinh_phi_array) THEN
+      DECLARE v_non_empty_sources TEXT[];
+      BEGIN
+        SELECT ARRAY(SELECT x FROM unnest(p_nguon_kinh_phi_array) AS x WHERE x != 'Chưa có') INTO v_non_empty_sources;
+        IF v_non_empty_sources IS NOT NULL AND array_length(v_non_empty_sources, 1) > 0 THEN
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''' OR TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+            array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(v_non_empty_sources) AS x), ',') || ']))';
+        ELSE
+          v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+        END IF;
+      END;
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ANY(ARRAY[' ||
+        array_to_string(ARRAY(SELECT quote_literal(x) FROM unnest(p_nguon_kinh_phi_array) AS x), ',') || '])';
+    END IF;
+  ELSIF p_nguon_kinh_phi IS NOT NULL AND trim(p_nguon_kinh_phi) != '' THEN
+    IF p_nguon_kinh_phi = 'Chưa có' THEN
+      v_where := v_where || ' AND (nguon_kinh_phi IS NULL OR TRIM(nguon_kinh_phi) = '''')';
+    ELSE
+      v_where := v_where || ' AND TRIM(nguon_kinh_phi) = ' || quote_literal(p_nguon_kinh_phi);
+    END IF;
+  END IF;
+
+  v_sanitized_q := public._sanitize_ilike_pattern(p_q);
+
+  IF v_sanitized_q IS NOT NULL THEN
+    v_where := v_where || ' AND (ten_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR ma_thiet_bi ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR serial ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR so_luu_hanh ILIKE ' || quote_literal('%' || v_sanitized_q || '%') ||
+              ' OR model ILIKE ' || quote_literal('%' || v_sanitized_q || '%') || ')';
+  END IF;
+
+  EXECUTE format('SELECT count(*) FROM public.thiet_bi WHERE %s', v_where) INTO v_total;
+
+  EXECUTE format(
+    'SELECT COALESCE(jsonb_agg(t), ''[]''::jsonb) FROM (
+       SELECT (jsonb_build_object(
+         ''ma_thiet_bi'', tb.ma_thiet_bi,
+         ''ten_thiet_bi'', tb.ten_thiet_bi,
+         ''model'', tb.model,
+         ''serial'', tb.serial,
+         ''cau_hinh_thiet_bi'', tb.cau_hinh_thiet_bi,
+         ''phu_kien_kem_theo'', tb.phu_kien_kem_theo,
+         ''hang_san_xuat'', tb.hang_san_xuat,
+         ''noi_san_xuat'', tb.noi_san_xuat,
+         ''nam_san_xuat'', tb.nam_san_xuat,
+         ''ngay_nhap'', tb.ngay_nhap,
+         ''ngay_dua_vao_su_dung'', tb.ngay_dua_vao_su_dung,
+         ''nguon_kinh_phi'', tb.nguon_kinh_phi,
+         ''gia_goc'', tb.gia_goc,
+         ''nam_tinh_hao_mon'', tb.nam_tinh_hao_mon,
+         ''ty_le_hao_mon'', tb.ty_le_hao_mon,
+         ''han_bao_hanh'', tb.han_bao_hanh,
+         ''vi_tri_lap_dat'', tb.vi_tri_lap_dat,
+         ''nguoi_dang_truc_tiep_quan_ly'', tb.nguoi_dang_truc_tiep_quan_ly,
+         ''khoa_phong_quan_ly'', tb.khoa_phong_quan_ly,
+         ''tinh_trang_hien_tai'', tb.tinh_trang_hien_tai,
+         ''ghi_chu'', tb.ghi_chu,
+         ''chu_ky_bt_dinh_ky'', tb.chu_ky_bt_dinh_ky,
+         ''ngay_bt_tiep_theo'', tb.ngay_bt_tiep_theo,
+         ''chu_ky_hc_dinh_ky'', tb.chu_ky_hc_dinh_ky,
+         ''ngay_hc_tiep_theo'', tb.ngay_hc_tiep_theo,
+         ''chu_ky_kd_dinh_ky'', tb.chu_ky_kd_dinh_ky,
+         ''ngay_kd_tiep_theo'', tb.ngay_kd_tiep_theo,
+         ''phan_loai_theo_nd98'', tb.phan_loai_theo_nd98,
+         ''id'', tb.id,
+         ''created_at'', tb.created_at,
+         ''don_vi'', tb.don_vi,
+         ''nguon_nhap'', tb.nguon_nhap,
+         ''so_luu_hanh'', tb.so_luu_hanh,
+         ''nhom_thiet_bi_id'', tb.nhom_thiet_bi_id,
+         ''is_deleted'', tb.is_deleted,
+         ''ngay_ngung_su_dung'', tb.ngay_ngung_su_dung,
+         ''google_drive_folder_url'', dv.google_drive_folder_url,
+         ''don_vi_name'', dv.name,
+         ''active_repair_request_id'', ar.active_id
+       )) AS t
+       FROM public.thiet_bi tb
+       LEFT JOIN public.don_vi dv ON dv.id = tb.don_vi
+       LEFT JOIN LATERAL (
+         SELECT r.id AS active_id
+         FROM public.yeu_cau_sua_chua r
+         WHERE r.thiet_bi_id = tb.id
+           AND r.trang_thai IN (''Chờ xử lý'', ''Đã duyệt'')
+         ORDER BY r.ngay_yeu_cau DESC, r.id DESC
+         LIMIT 1
+       ) ar ON TRUE
+       WHERE %s
+       ORDER BY %s
+       OFFSET %s LIMIT %s
+     ) sub',
+    v_where, v_order_by, v_offset, v_limit
+  ) INTO v_data;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'total', v_total,
+    'page', p_page,
+    'pageSize', p_page_size
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  boolean
+) FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  boolean
+) FROM anon;
+
+GRANT EXECUTE ON FUNCTION public.equipment_list_enhanced(
+  text,
+  text,
+  integer,
+  integer,
+  bigint,
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  text,
+  text[],
+  boolean
+) TO authenticated;
+
+COMMIT;

--- a/supabase/tests/equipment_list_enhanced_liquidation_order_smoke.sql
+++ b/supabase/tests/equipment_list_enhanced_liquidation_order_smoke.sql
@@ -1,5 +1,6 @@
--- Purpose: smoke-test optional liquidation-last ordering across server pagination.
+-- Purpose: smoke-test liquidation chronology across filters, sorts, and pagination.
 -- Non-destructive: wrapped in a transaction and rolled back.
+-- Run only after the superseding chronology migration has been applied.
 
 BEGIN;
 
@@ -42,43 +43,89 @@ BEGIN
     ten_thiet_bi,
     don_vi,
     khoa_phong_quan_ly,
-    tinh_trang_hien_tai
+    tinh_trang_hien_tai,
+    ngay_ngung_su_dung
   )
   VALUES
     (
       'ELE-LIQ-1',
-      'Liquidation Z',
+      'Liquidation null Z',
       v_tenant_id,
       'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng'
+      'Ngưng sử dụng',
+      NULL
     ),
     (
       'ELE-LIQ-2',
       'Status only Y',
       v_tenant_id,
       'Khoa A',
-      'Ngưng sử dụng'
+      'Ngưng sử dụng',
+      '2026-07-28'
     ),
     (
       'ELE-LIQ-3',
-      'Department only X',
+      'Warehouse only X',
       v_tenant_id,
       'VT-TBYT- KHO THANH LÍ',
-      'Hoạt động'
+      'Hoạt động',
+      NULL
     ),
     (
       'ELE-LIQ-4',
       'Normal W',
       v_tenant_id,
       'Khoa B',
-      'Hoạt động'
+      'Hoạt động',
+      NULL
     ),
     (
       'ELE-LIQ-5',
-      'Liquidation V',
+      'Liquidation blank Y',
       v_tenant_id,
       'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng'
+      'Ngưng sử dụng',
+      ''
+    ),
+    (
+      'ELE-LIQ-6',
+      'Liquidation old A',
+      v_tenant_id,
+      'VT-TBYT- KHO THANH LÍ',
+      'Ngưng sử dụng',
+      '2024-01-15'
+    ),
+    (
+      'ELE-LIQ-7',
+      'Liquidation same Z',
+      v_tenant_id,
+      'VT-TBYT- KHO THANH LÍ',
+      'Ngưng sử dụng',
+      '2025-06-20'
+    ),
+    (
+      'ELE-LIQ-8',
+      'Liquidation same M',
+      v_tenant_id,
+      'VT-TBYT- KHO THANH LÍ',
+      'Ngưng sử dụng',
+      '2025-06-20'
+    ),
+    (
+      'ELE-LIQ-9',
+      'Liquidation same M',
+      v_tenant_id,
+      'VT-TBYT- KHO THANH LÍ',
+      'Ngưng sử dụng',
+      '2025-06-20'
+    ),
+    (
+      'ELE-LIQ-10',
+      'Liquidation newest Z',
+      v_tenant_id,
+      'VT-TBYT- KHO THANH LÍ',
+      'Ngưng sử dụng',
+      '2026-07-29'
     );
 
   PERFORM pg_temp._ele_liquidation_set_claims('to_qltb', v_user_id, v_tenant_id);
@@ -101,7 +148,12 @@ BEGIN
     'ELE-LIQ-2',
     'ELE-LIQ-3',
     'ELE-LIQ-4',
-    'ELE-LIQ-5'
+    'ELE-LIQ-5',
+    'ELE-LIQ-6',
+    'ELE-LIQ-7',
+    'ELE-LIQ-8',
+    'ELE-LIQ-9',
+    'ELE-LIQ-10'
   ]::text[] THEN
     RAISE EXCEPTION 'Flag false failed: expected ID order, got %', v_codes;
   END IF;
@@ -124,20 +176,28 @@ BEGIN
     'ELE-LIQ-3',
     'ELE-LIQ-4',
     'ELE-LIQ-1',
-    'ELE-LIQ-5'
+    'ELE-LIQ-5',
+    'ELE-LIQ-6',
+    'ELE-LIQ-7',
+    'ELE-LIQ-8',
+    'ELE-LIQ-9',
+    'ELE-LIQ-10'
   ]::text[] THEN
-    RAISE EXCEPTION 'Flag true failed: expected liquidation rows last, got %', v_codes;
+    RAISE EXCEPTION
+      'Flag true chronology failed: expected null/blank, old, same-day, newest order, got %',
+      v_codes;
   END IF;
 
-  IF (v_payload->>'total')::integer <> 5 THEN
-    RAISE EXCEPTION 'Expected unchanged total 5, got %', v_payload->>'total';
+  IF (v_payload->>'total')::integer <> 10 THEN
+    RAISE EXCEPTION 'Expected unchanged total 10, got %', v_payload->>'total';
   END IF;
 
   v_payload := public.equipment_list_enhanced(
     p_sort => 'id.asc',
     p_page => 1,
-    p_page_size => 3,
+    p_page_size => 10,
     p_don_vi => v_tenant_id,
+    p_khoa_phong => 'VT-TBYT- KHO THANH LÍ',
     p_liquidation_last => true
   );
 
@@ -147,31 +207,18 @@ BEGIN
     WITH ORDINALITY AS rows(row_value, ordinal_position);
 
   IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-2',
     'ELE-LIQ-3',
-    'ELE-LIQ-4'
-  ]::text[] THEN
-    RAISE EXCEPTION 'Page 1 failed: expected only normal-priority rows, got %', v_codes;
-  END IF;
-
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'id.asc',
-    p_page => 2,
-    p_page_size => 3,
-    p_don_vi => v_tenant_id,
-    p_liquidation_last => true
-  );
-
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
     'ELE-LIQ-1',
-    'ELE-LIQ-5'
+    'ELE-LIQ-5',
+    'ELE-LIQ-6',
+    'ELE-LIQ-7',
+    'ELE-LIQ-8',
+    'ELE-LIQ-9',
+    'ELE-LIQ-10'
   ]::text[] THEN
-    RAISE EXCEPTION 'Final page failed: expected liquidation rows, got %', v_codes;
+    RAISE EXCEPTION
+      'Warehouse filter chronology failed: expected newest liquidation row last, got %',
+      v_codes;
   END IF;
 
   v_payload := public.equipment_list_enhanced(
@@ -188,13 +235,120 @@ BEGIN
     WITH ORDINALITY AS rows(row_value, ordinal_position);
 
   IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-3',
     'ELE-LIQ-2',
     'ELE-LIQ-4',
+    'ELE-LIQ-1',
+    'ELE-LIQ-5',
+    'ELE-LIQ-6',
+    'ELE-LIQ-7',
+    'ELE-LIQ-8',
+    'ELE-LIQ-9',
+    'ELE-LIQ-10'
+  ]::text[] THEN
+    RAISE EXCEPTION
+      'Custom sort failed: expected chronology, requested sort, then ID tie-break, got %',
+      v_codes;
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'id.asc',
+    p_page => 1,
+    p_page_size => 5,
+    p_don_vi => v_tenant_id,
+    p_liquidation_last => true
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-2',
     'ELE-LIQ-3',
+    'ELE-LIQ-4',
     'ELE-LIQ-1',
     'ELE-LIQ-5'
   ]::text[] THEN
-    RAISE EXCEPTION 'Secondary sort failed: expected grouped name DESC order, got %', v_codes;
+    RAISE EXCEPTION
+      'Unfiltered page 1 failed: expected normal rows then legacy liquidation rows, got %',
+      v_codes;
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'id.asc',
+    p_page => 2,
+    p_page_size => 5,
+    p_don_vi => v_tenant_id,
+    p_liquidation_last => true
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-6',
+    'ELE-LIQ-7',
+    'ELE-LIQ-8',
+    'ELE-LIQ-9',
+    'ELE-LIQ-10'
+  ]::text[] THEN
+    RAISE EXCEPTION
+      'Unfiltered page 2 failed: expected dated chronology with newest last, got %',
+      v_codes;
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'id.asc',
+    p_page => 1,
+    p_page_size => 4,
+    p_don_vi => v_tenant_id,
+    p_khoa_phong => 'VT-TBYT- KHO THANH LÍ',
+    p_liquidation_last => true
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-3',
+    'ELE-LIQ-1',
+    'ELE-LIQ-5',
+    'ELE-LIQ-6'
+  ]::text[] THEN
+    RAISE EXCEPTION
+      'Warehouse page 1 failed: expected grouping before filtered pagination, got %',
+      v_codes;
+  END IF;
+
+  v_payload := public.equipment_list_enhanced(
+    p_sort => 'id.asc',
+    p_page => 2,
+    p_page_size => 4,
+    p_don_vi => v_tenant_id,
+    p_khoa_phong => 'VT-TBYT- KHO THANH LÍ',
+    p_liquidation_last => true
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM ARRAY[
+    'ELE-LIQ-7',
+    'ELE-LIQ-8',
+    'ELE-LIQ-9',
+    'ELE-LIQ-10'
+  ]::text[] THEN
+    RAISE EXCEPTION
+      'Warehouse page 2 failed: expected same-day cohort then newest row, got %',
+      v_codes;
   END IF;
 
   RAISE NOTICE 'equipment_list_enhanced_liquidation_order smoke: ALL SCENARIOS PASSED';

--- a/supabase/tests/equipment_list_enhanced_liquidation_order_smoke.sql
+++ b/supabase/tests/equipment_list_enhanced_liquidation_order_smoke.sql
@@ -27,12 +27,54 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION pg_temp._ele_liquidation_assert_codes(
+  p_scenario text,
+  p_expected text[],
+  p_sort text,
+  p_page integer,
+  p_page_size integer,
+  p_don_vi bigint,
+  p_khoa_phong text,
+  p_liquidation_last boolean
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_payload jsonb;
+  v_codes text[];
+BEGIN
+  v_payload := public.equipment_list_enhanced(
+    p_sort => p_sort,
+    p_page => p_page,
+    p_page_size => p_page_size,
+    p_don_vi => p_don_vi,
+    p_khoa_phong => p_khoa_phong,
+    p_liquidation_last => p_liquidation_last
+  );
+
+  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
+  INTO v_codes
+  FROM jsonb_array_elements(v_payload->'data')
+    WITH ORDINALITY AS rows(row_value, ordinal_position);
+
+  IF v_codes IS DISTINCT FROM p_expected THEN
+    RAISE EXCEPTION '% failed: expected %, got %', p_scenario, p_expected, v_codes;
+  END IF;
+
+  RETURN v_payload;
+END;
+$$;
+
 DO $$
 DECLARE
   v_tenant_id bigint;
   v_user_id bigint := 3383002;
   v_payload jsonb;
-  v_codes text[];
+  v_liquidation_department CONSTANT text := 'VT-TBYT- KHO THANH LÍ';
+  v_liquidation_status CONSTANT text := 'Ngưng sử dụng';
+  v_same_date CONSTANT text := '2025-06-20';
+  v_id_sort CONSTANT text := 'id.asc';
 BEGIN
   INSERT INTO public.don_vi(name)
   VALUES ('Tenant equipment liquidation order smoke')
@@ -51,8 +93,8 @@ BEGIN
       'ELE-LIQ-1',
       'Liquidation null Z',
       v_tenant_id,
-      'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng',
+      v_liquidation_department,
+      v_liquidation_status,
       NULL
     ),
     (
@@ -60,14 +102,14 @@ BEGIN
       'Status only Y',
       v_tenant_id,
       'Khoa A',
-      'Ngưng sử dụng',
+      v_liquidation_status,
       '2026-07-28'
     ),
     (
       'ELE-LIQ-3',
       'Warehouse only X',
       v_tenant_id,
-      'VT-TBYT- KHO THANH LÍ',
+      v_liquidation_department,
       'Hoạt động',
       NULL
     ),
@@ -83,273 +125,208 @@ BEGIN
       'ELE-LIQ-5',
       'Liquidation blank Y',
       v_tenant_id,
-      'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng',
+      v_liquidation_department,
+      v_liquidation_status,
       ''
     ),
     (
       'ELE-LIQ-6',
       'Liquidation old A',
       v_tenant_id,
-      'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng',
+      v_liquidation_department,
+      v_liquidation_status,
       '2024-01-15'
     ),
     (
       'ELE-LIQ-7',
       'Liquidation same Z',
       v_tenant_id,
-      'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng',
-      '2025-06-20'
+      v_liquidation_department,
+      v_liquidation_status,
+      v_same_date
     ),
     (
       'ELE-LIQ-8',
       'Liquidation same M',
       v_tenant_id,
-      'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng',
-      '2025-06-20'
+      v_liquidation_department,
+      v_liquidation_status,
+      v_same_date
     ),
     (
       'ELE-LIQ-9',
       'Liquidation same M',
       v_tenant_id,
-      'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng',
-      '2025-06-20'
+      v_liquidation_department,
+      v_liquidation_status,
+      v_same_date
     ),
     (
       'ELE-LIQ-10',
       'Liquidation newest Z',
       v_tenant_id,
-      'VT-TBYT- KHO THANH LÍ',
-      'Ngưng sử dụng',
+      v_liquidation_department,
+      v_liquidation_status,
       '2026-07-29'
     );
 
   PERFORM pg_temp._ele_liquidation_set_claims('to_qltb', v_user_id, v_tenant_id);
 
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'id.asc',
-    p_page => 1,
-    p_page_size => 10,
-    p_don_vi => v_tenant_id,
-    p_liquidation_last => false
+  v_payload := pg_temp._ele_liquidation_assert_codes(
+    'Flag false ID order',
+    ARRAY[
+      'ELE-LIQ-1',
+      'ELE-LIQ-2',
+      'ELE-LIQ-3',
+      'ELE-LIQ-4',
+      'ELE-LIQ-5',
+      'ELE-LIQ-6',
+      'ELE-LIQ-7',
+      'ELE-LIQ-8',
+      'ELE-LIQ-9',
+      'ELE-LIQ-10'
+    ]::text[],
+    v_id_sort,
+    1,
+    10,
+    v_tenant_id,
+    NULL,
+    false
   );
 
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-1',
-    'ELE-LIQ-2',
-    'ELE-LIQ-3',
-    'ELE-LIQ-4',
-    'ELE-LIQ-5',
-    'ELE-LIQ-6',
-    'ELE-LIQ-7',
-    'ELE-LIQ-8',
-    'ELE-LIQ-9',
-    'ELE-LIQ-10'
-  ]::text[] THEN
-    RAISE EXCEPTION 'Flag false failed: expected ID order, got %', v_codes;
-  END IF;
-
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'id.asc',
-    p_page => 1,
-    p_page_size => 10,
-    p_don_vi => v_tenant_id,
-    p_liquidation_last => true
+  v_payload := pg_temp._ele_liquidation_assert_codes(
+    'Flag true chronology',
+    ARRAY[
+      'ELE-LIQ-2',
+      'ELE-LIQ-3',
+      'ELE-LIQ-4',
+      'ELE-LIQ-1',
+      'ELE-LIQ-5',
+      'ELE-LIQ-6',
+      'ELE-LIQ-7',
+      'ELE-LIQ-8',
+      'ELE-LIQ-9',
+      'ELE-LIQ-10'
+    ]::text[],
+    v_id_sort,
+    1,
+    10,
+    v_tenant_id,
+    NULL,
+    true
   );
-
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-2',
-    'ELE-LIQ-3',
-    'ELE-LIQ-4',
-    'ELE-LIQ-1',
-    'ELE-LIQ-5',
-    'ELE-LIQ-6',
-    'ELE-LIQ-7',
-    'ELE-LIQ-8',
-    'ELE-LIQ-9',
-    'ELE-LIQ-10'
-  ]::text[] THEN
-    RAISE EXCEPTION
-      'Flag true chronology failed: expected null/blank, old, same-day, newest order, got %',
-      v_codes;
-  END IF;
 
   IF (v_payload->>'total')::integer <> 10 THEN
     RAISE EXCEPTION 'Expected unchanged total 10, got %', v_payload->>'total';
   END IF;
 
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'id.asc',
-    p_page => 1,
-    p_page_size => 10,
-    p_don_vi => v_tenant_id,
-    p_khoa_phong => 'VT-TBYT- KHO THANH LÍ',
-    p_liquidation_last => true
+  PERFORM pg_temp._ele_liquidation_assert_codes(
+    'Warehouse filter chronology',
+    ARRAY[
+      'ELE-LIQ-3',
+      'ELE-LIQ-1',
+      'ELE-LIQ-5',
+      'ELE-LIQ-6',
+      'ELE-LIQ-7',
+      'ELE-LIQ-8',
+      'ELE-LIQ-9',
+      'ELE-LIQ-10'
+    ]::text[],
+    v_id_sort,
+    1,
+    10,
+    v_tenant_id,
+    v_liquidation_department,
+    true
   );
 
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-3',
-    'ELE-LIQ-1',
-    'ELE-LIQ-5',
-    'ELE-LIQ-6',
-    'ELE-LIQ-7',
-    'ELE-LIQ-8',
-    'ELE-LIQ-9',
-    'ELE-LIQ-10'
-  ]::text[] THEN
-    RAISE EXCEPTION
-      'Warehouse filter chronology failed: expected newest liquidation row last, got %',
-      v_codes;
-  END IF;
-
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'ten_thiet_bi.desc',
-    p_page => 1,
-    p_page_size => 10,
-    p_don_vi => v_tenant_id,
-    p_liquidation_last => true
+  PERFORM pg_temp._ele_liquidation_assert_codes(
+    'Custom sort chronology and ID tie-break',
+    ARRAY[
+      'ELE-LIQ-3',
+      'ELE-LIQ-2',
+      'ELE-LIQ-4',
+      'ELE-LIQ-1',
+      'ELE-LIQ-5',
+      'ELE-LIQ-6',
+      'ELE-LIQ-7',
+      'ELE-LIQ-8',
+      'ELE-LIQ-9',
+      'ELE-LIQ-10'
+    ]::text[],
+    'ten_thiet_bi.desc',
+    1,
+    10,
+    v_tenant_id,
+    NULL,
+    true
   );
 
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-3',
-    'ELE-LIQ-2',
-    'ELE-LIQ-4',
-    'ELE-LIQ-1',
-    'ELE-LIQ-5',
-    'ELE-LIQ-6',
-    'ELE-LIQ-7',
-    'ELE-LIQ-8',
-    'ELE-LIQ-9',
-    'ELE-LIQ-10'
-  ]::text[] THEN
-    RAISE EXCEPTION
-      'Custom sort failed: expected chronology, requested sort, then ID tie-break, got %',
-      v_codes;
-  END IF;
-
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'id.asc',
-    p_page => 1,
-    p_page_size => 5,
-    p_don_vi => v_tenant_id,
-    p_liquidation_last => true
+  PERFORM pg_temp._ele_liquidation_assert_codes(
+    'Unfiltered page 1',
+    ARRAY[
+      'ELE-LIQ-2',
+      'ELE-LIQ-3',
+      'ELE-LIQ-4',
+      'ELE-LIQ-1',
+      'ELE-LIQ-5'
+    ]::text[],
+    v_id_sort,
+    1,
+    5,
+    v_tenant_id,
+    NULL,
+    true
   );
 
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-2',
-    'ELE-LIQ-3',
-    'ELE-LIQ-4',
-    'ELE-LIQ-1',
-    'ELE-LIQ-5'
-  ]::text[] THEN
-    RAISE EXCEPTION
-      'Unfiltered page 1 failed: expected normal rows then legacy liquidation rows, got %',
-      v_codes;
-  END IF;
-
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'id.asc',
-    p_page => 2,
-    p_page_size => 5,
-    p_don_vi => v_tenant_id,
-    p_liquidation_last => true
+  PERFORM pg_temp._ele_liquidation_assert_codes(
+    'Unfiltered page 2',
+    ARRAY[
+      'ELE-LIQ-6',
+      'ELE-LIQ-7',
+      'ELE-LIQ-8',
+      'ELE-LIQ-9',
+      'ELE-LIQ-10'
+    ]::text[],
+    v_id_sort,
+    2,
+    5,
+    v_tenant_id,
+    NULL,
+    true
   );
 
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-6',
-    'ELE-LIQ-7',
-    'ELE-LIQ-8',
-    'ELE-LIQ-9',
-    'ELE-LIQ-10'
-  ]::text[] THEN
-    RAISE EXCEPTION
-      'Unfiltered page 2 failed: expected dated chronology with newest last, got %',
-      v_codes;
-  END IF;
-
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'id.asc',
-    p_page => 1,
-    p_page_size => 4,
-    p_don_vi => v_tenant_id,
-    p_khoa_phong => 'VT-TBYT- KHO THANH LÍ',
-    p_liquidation_last => true
+  PERFORM pg_temp._ele_liquidation_assert_codes(
+    'Warehouse page 1',
+    ARRAY[
+      'ELE-LIQ-3',
+      'ELE-LIQ-1',
+      'ELE-LIQ-5',
+      'ELE-LIQ-6'
+    ]::text[],
+    v_id_sort,
+    1,
+    4,
+    v_tenant_id,
+    v_liquidation_department,
+    true
   );
 
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-3',
-    'ELE-LIQ-1',
-    'ELE-LIQ-5',
-    'ELE-LIQ-6'
-  ]::text[] THEN
-    RAISE EXCEPTION
-      'Warehouse page 1 failed: expected grouping before filtered pagination, got %',
-      v_codes;
-  END IF;
-
-  v_payload := public.equipment_list_enhanced(
-    p_sort => 'id.asc',
-    p_page => 2,
-    p_page_size => 4,
-    p_don_vi => v_tenant_id,
-    p_khoa_phong => 'VT-TBYT- KHO THANH LÍ',
-    p_liquidation_last => true
+  PERFORM pg_temp._ele_liquidation_assert_codes(
+    'Warehouse page 2',
+    ARRAY[
+      'ELE-LIQ-7',
+      'ELE-LIQ-8',
+      'ELE-LIQ-9',
+      'ELE-LIQ-10'
+    ]::text[],
+    v_id_sort,
+    2,
+    4,
+    v_tenant_id,
+    v_liquidation_department,
+    true
   );
-
-  SELECT array_agg(row_value->>'ma_thiet_bi' ORDER BY ordinal_position)
-  INTO v_codes
-  FROM jsonb_array_elements(v_payload->'data')
-    WITH ORDINALITY AS rows(row_value, ordinal_position);
-
-  IF v_codes IS DISTINCT FROM ARRAY[
-    'ELE-LIQ-7',
-    'ELE-LIQ-8',
-    'ELE-LIQ-9',
-    'ELE-LIQ-10'
-  ]::text[] THEN
-    RAISE EXCEPTION
-      'Warehouse page 2 failed: expected same-day cohort then newest row, got %',
-      v_codes;
-  END IF;
 
   RAISE NOTICE 'equipment_list_enhanced_liquidation_order smoke: ALL SCENARIOS PASSED';
 END;


### PR DESCRIPTION
## Summary
- add a superseding equipment_list_enhanced migration that keeps liquidation rows last and orders that group by ngay_ngung_su_dung ascending
- preserve requested sorting within a date cohort and id ascending as the final tie-breaker
- extend source-contract and transactional smoke coverage for null/blank dates, custom sort, warehouse filtering, and pagination boundaries

## Review boundary
- exactly one migration and two focused test files
- no frontend changes or schema additions
- no live Supabase migration apply in this PR
- transactional SQL smoke prepared and reviewed only; it must run after an explicitly authorized Phase 2 apply

## Verification
- RED confirmed before implementation: chronologyStart was -1
- format:check
- verify:no-explicit-any
- verify:dedupe
- typecheck
- focused Vitest: 2 files, 9 tests passed
- React Doctor: 100/100
- openspec validate update-equipment-liquidation-group-ordering --strict
- independent review findings resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Orders liquidation equipment to the end of `equipment_list_enhanced` and sorts that group by decommission date ascending (NULL/blank first, then oldest→newest) when `p_liquidation_last=true`. Default ordering is unchanged, and requested `p_sort` is preserved within same-date cohorts with `id` as the final tie-breaker.

- **Bug Fixes**
  - Added `20260729062450_equipment_list_liquidation_chronology.sql` to apply liquidation-last with date chronology using `ngay_ngung_su_dung`.
  - Honors requested sort within same-date cohorts, then `id ASC`.
  - Validated function signature and the ORDER BY chain (priority → chronology → requested sort → `id`), plus JWT/tenant filtering and pagination.
  - Smoke tests cover NULL/blank dates, warehouse-only and same-date ties, custom sorts, and pagination; assertions deduped via a helper.

- **Migration**
  - Apply after `20260722094302_equipment_list_liquidation_last.sql`.
  - Opt in by calling the RPC with `p_liquidation_last=true`.
  - Run `supabase/tests/equipment_list_enhanced_liquidation_order_smoke.sql` to verify.

<sup>Written for commit 79e8cd80dbb0fb52961b765bc3cc3fe7b396ec10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to place equipment marked “Ngưng sử dụng” at the end of results, ordered chronologically.
  * Preserved filtering by department, funding source, warehouse, and other criteria, along with pagination and JSON response formatting.

* **Bug Fixes**
  * Improved ordering consistency across filters, custom sorting, and paginated results.
  * Enhanced handling of missing or blank liquidation dates and funding sources.

* **Tests**
  * Expanded coverage for chronology ordering, access controls, filtering, pagination, and response contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->