### PR TITLE
docs(openspec): record liquidation rollout

### DIFF
--- a/openspec/changes/update-equipment-liquidation-group-ordering/rollout.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/rollout.md
@@ -1,0 +1,64 @@
+# Phase 2 Rollout Record
+
+## Deployment
+
+- Date: 2026-07-29 UTC.
+- Supabase project: `cdthersvldpnlbvpufrr`.
+- Approved local migration:
+  `20260729062450_equipment_list_liquidation_chronology.sql`.
+- Live migration version: `20260729072002`.
+- Live migration name: `equipment_list_liquidation_chronology`.
+- Local and recorded statement MD5:
+  `087636696f06a1a8fc6117c9e03267a1`.
+- Phase 1 implementation: PR #817, merge commit
+  `eb180b9d11b5c40e25c068bcd580c8581a162121`.
+
+The first MCP request was rejected before commit because its manually
+transcribed ACL signature omitted the final funding-source `text, text[]`
+pair. Postgres returned `42883`, and the surrounding transaction rolled back.
+The local migration file was unchanged. The exact approved payload was then
+applied successfully, and the recorded statement MD5 matches the local file.
+
+## Live Contract
+
+- Exactly one `public.equipment_list_enhanced` overload exists.
+- The function has 18 input parameters.
+- `p_liquidation_last` defaults to `false`.
+- The liquidation priority key precedes the null-safe, trimmed
+  `ngay_ngung_su_dung` chronology key.
+- The chronology key precedes the requested sort, which precedes `id ASC`.
+- The function remains `SECURITY DEFINER` with
+  `search_path = public, pg_temp`.
+- `authenticated`, `service_role`, and `postgres` have `EXECUTE`.
+- `anon` and `PUBLIC` do not have `EXECUTE`.
+
+The chronology key is the decommission date, not equipment `created_at` or a
+warehouse-entry timestamp. This distinction was reviewed before authorization.
+
+## Verification
+
+- `equipment_list_enhanced_overload_regression.sql`: passed.
+- Transactional liquidation-order smoke: all scenarios passed.
+- Smoke fixture cleanup:
+  - tenant rows remaining: `0`;
+  - `ELE-LIQ-*` equipment rows remaining: `0`.
+- Liquidation warehouse baseline before and after rollout:
+  - exact liquidation rows: `272`;
+  - warehouse rows: `272`;
+  - exact liquidation rows with null or blank dates: `72`.
+- No data backfill or production-row rewrite occurred.
+
+Security and performance advisors were run after deployment. They returned
+project-wide baseline findings unrelated to this ordering-only function
+replacement. No finding caused by this migration required a rollout change.
+The function's authenticated `SECURITY DEFINER` access remains intentional:
+the RPC validates JWT claims and tenant scope before reading data.
+
+## Rollback
+
+Phase 2C passed, so forward rollback tasks 2.15-2.17 are not applicable. If a
+future regression requires rollback, create a later migration restoring the
+function body from
+`20260722094302_equipment_list_liquidation_last.sql`, obtain explicit
+operation-specific authorization, then rerun the overload, security, and
+ordering checks.

--- a/openspec/changes/update-equipment-liquidation-group-ordering/tasks.md
+++ b/openspec/changes/update-equipment-liquidation-group-ordering/tasks.md
@@ -103,41 +103,43 @@ mix follow-up code into the rollout.
 
 ### Phase 2A - Approval and read-only preflight
 
-- [ ] 2.1 Request explicit user permission for the specific migration apply and
+- [x] 2.1 Request explicit user permission for the specific migration apply and
       rollback-only smoke write set.
-- [ ] 2.2 Inspect the live migration state read-only.
-- [ ] 2.3 Inspect the live function signature and body read-only.
-- [ ] 2.4 Inspect the live function security attributes and grants read-only.
+- [x] 2.2 Inspect the live migration state read-only.
+- [x] 2.3 Inspect the live function signature and body read-only.
+- [x] 2.4 Inspect the live function security attributes and grants read-only.
 
 ### Phase 2B - Apply the approved migration
 
-- [ ] 2.5 Apply the approved superseding migration through Supabase MCP.
+- [x] 2.5 Apply the approved superseding migration through Supabase MCP.
 
 ### Phase 2C - Verify behavior and deployment safety
 
-- [ ] 2.6 Verify the live migration version and ordering expression read-only.
-- [ ] 2.7 Verify the live signature and default-false flag read-only.
-- [ ] 2.8 Verify the live security attributes and grants read-only.
-- [ ] 2.9 Run
+- [x] 2.6 Verify the live migration version and ordering expression read-only.
+- [x] 2.7 Verify the live signature and default-false flag read-only.
+- [x] 2.8 Verify the live security attributes and grants read-only.
+- [x] 2.9 Run
       `supabase/tests/equipment_list_enhanced_overload_regression.sql` read-only
       through Supabase MCP.
-- [ ] 2.10 Run the approved transactional smoke fixture and confirm it rolls
+- [x] 2.10 Run the approved transactional smoke fixture and confirm it rolls
       back all fixture rows.
-- [ ] 2.11 Run Supabase MCP security advisors.
-- [ ] 2.12 Run Supabase MCP performance advisors and triage only findings caused
+- [x] 2.11 Run Supabase MCP security advisors.
+- [x] 2.12 Run Supabase MCP performance advisors and triage only findings caused
       by this change.
-- [ ] 2.13 Verify read-only that the liquidation warehouse still has unchanged
+- [x] 2.13 Verify read-only that the liquidation warehouse still has unchanged
       row counts and no data backfill occurred.
-- [ ] 2.14 Record migration version, smoke result, advisor result, and rollback
+- [x] 2.14 Record migration version, smoke result, advisor result, and rollback
       readiness in the tracking issue or rollout handoff.
+
+Evidence: [Phase 2 rollout record](rollout.md).
 
 ### Phase 2D - Conditional forward rollback
 
-- [ ] 2.15 If Phase 2C fails, stop the rollout and open a separate forward-only
+- [x] 2.15 If Phase 2C fails, stop the rollout and open a separate forward-only
       rollback PR; otherwise record this subsection as not applicable.
-- [ ] 2.16 Before any rollback apply, request explicit user authorization for
+- [x] 2.16 Before any rollback apply, request explicit user authorization for
       that exact live DB write; otherwise record this task as not applicable.
-- [ ] 2.17 After an authorized rollback, re-run the overload regression,
+- [x] 2.17 After an authorized rollback, re-run the overload regression,
       function-security inspection, and applicable ordering smoke; otherwise
       record this task as not applicable.
 


### PR DESCRIPTION
## Summary
- mark OpenSpec Phase 2 rollout tasks complete
- record the live migration version, exact payload hash, function/grant contract, smoke rollback proof, advisor triage, and rollback readiness
- document the rejected first MCP payload and successful exact retry without changing the approved migration file

## Live rollout evidence
- Supabase migration: `20260729072002 equipment_list_liquidation_chronology`
- local/live statement MD5: `087636696f06a1a8fc6117c9e03267a1`
- overload regression: passed
- transactional smoke: passed and rolled back
- fixture residue: 0 tenant rows, 0 `ELE-LIQ-*` rows
- production baseline unchanged: 272 exact liquidation rows, 272 warehouse rows, 72 null/blank dates
- security/performance advisors: no change-caused finding requiring remediation

## Verification
- `node scripts/npm-run.js run format:check`
- `openspec validate update-equipment-liquidation-group-ordering --strict`
- `git diff --check`
- Lefthook pre-commit and pre-push gates

## Scope
Docs only. Phase 3 archive remains separate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented Phase 2 rollout for equipment liquidation ordering, including migration version, statement MD5, function and grants, smoke rollback proof, and advisor results. Updated the checklist to mark Phase 2 tasks complete, and noted the initial MCP payload rejection followed by a successful exact retry without changing the approved migration file.

<sup>Written for commit 208cc0ecc5a5d3ca4345706edbf10715473835d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

