### PR TITLE
P10B3: Add lazy read-only comparison evidence inspector

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/baseline-evidence-query-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/baseline-evidence-query-cases.tsx
@@ -122,7 +122,6 @@ export function registerBaselineEvidenceQueryTests(documentRpc: DocumentRpcMocks
       expect(onNavigationBlockedChange.mock.calls.flat()).toEqual([true, false, true, false])
       expect(invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["technical-configurations", "documents", baselineVersion.id],
-        exact: true,
       })
       expect(invalidateQueries).toHaveBeenCalledWith({
         queryKey: ["technical-configurations", "baseline-versions", baselineVersion.dossier_id],

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-core.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-core.test.tsx
@@ -32,6 +32,16 @@ vi.mock("../technical-configuration-comparison-rpc", () => ({
   getTechnicalConfigurationComparison: (...args: unknown[]) => getComparisonMock(...args),
 }))
 
+vi.mock("../technical-configuration-document-rpc", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../technical-configuration-document-rpc")>()
+  const emptyPage = { data: [], total: 0, page: 1, page_size: 20 }
+  return {
+    ...original,
+    listTechnicalConfigurationBaselineDocuments: vi.fn().mockResolvedValue(emptyPage),
+    listTechnicalConfigurationOptionDocuments: vi.fn().mockResolvedValue(emptyPage),
+  }
+})
+
 function createTestQueryClient() {
   return new QueryClient({
     defaultOptions: {

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-evidence-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-evidence-fixtures.tsx
@@ -1,0 +1,109 @@
+import { createElement, type PropsWithChildren } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render } from "@testing-library/react"
+import { vi } from "vitest"
+
+import {
+  TechnicalConfigurationCriterionPanel,
+  type TechnicalConfigurationCriterionDetail,
+} from "../_components/comparison/TechnicalConfigurationCriterionPanel"
+
+export function createEvidenceTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  })
+}
+
+function createQueryWrapper(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: PropsWithChildren) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+export function createEvidenceDetail({
+  hasEvidence = true,
+  owner = "baseline",
+}: {
+  hasEvidence?: boolean
+  owner?: "baseline" | "option"
+} = {}): TechnicalConfigurationCriterionDetail {
+  return {
+    criterionCode: "TS-02",
+    criterionTitle: "Độ phân giải",
+    optionLabel: owner === "option" ? "Nhà cung cấp B · Phương án B" : null,
+    requirementText: "Độ phân giải tối thiểu 1920x1080.",
+    responseText: owner === "option" ? "Đáp ứng 3840x2160." : null,
+    supplementaryInformation: null,
+    evidence: {
+      documentCount: hasEvidence ? 1 : 0,
+      citationCount: hasEvidence ? 1 : 0,
+      hasEvidence,
+    },
+    evidenceTarget:
+      owner === "baseline"
+        ? {
+            kind: "baseline",
+            baselineVersionId: "baseline-1",
+            criterionId: "criterion-2",
+          }
+        : {
+            kind: "option",
+            baselineVersionId: "baseline-1",
+            optionId: "option-b",
+            criterionId: "criterion-2",
+          },
+  }
+}
+
+export function renderEvidencePanel({
+  detail,
+  open,
+  queryClient = createEvidenceTestQueryClient(),
+}: {
+  detail: TechnicalConfigurationCriterionDetail
+  open: boolean
+  queryClient?: QueryClient
+}) {
+  return {
+    queryClient,
+    ...render(
+      <TechnicalConfigurationCriterionPanel detail={detail} open={open} onOpenChange={vi.fn()} />,
+      { wrapper: createQueryWrapper(queryClient) }
+    ),
+  }
+}
+
+export function baselineEvidenceDocument({
+  id,
+  ownerType = "baseline",
+  ownerId = "baseline-1",
+  criterionId = "criterion-2",
+  excerpt = "Đoạn trích xác nhận độ phân giải.",
+}: {
+  id: string
+  ownerType?: "baseline" | "reference_product"
+  ownerId?: string
+  criterionId?: string
+  excerpt?: string
+}) {
+  return {
+    id,
+    owner_type: ownerType,
+    owner_id: ownerId,
+    name: `Tài liệu ${id}`,
+    url: `https://example.com/${id}`,
+    created_by: 1,
+    created_at: "2026-07-29T00:00:00Z",
+    updated_at: "2026-07-29T00:00:00Z",
+    citations: [
+      {
+        id: `citation-${id}`,
+        criterion_id: criterionId,
+        page_section: "Trang 12",
+        excerpt,
+      },
+    ],
+  }
+}

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-evidence.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-evidence.test.tsx
@@ -1,0 +1,303 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationCriterionPanel } from "../_components/comparison/TechnicalConfigurationCriterionPanel"
+import {
+  technicalConfigurationDocumentsQueryKey,
+  technicalConfigurationOptionDocumentsQueryKey,
+} from "../technical-configuration-query-keys"
+
+import {
+  baselineEvidenceDocument,
+  createEvidenceDetail,
+  createEvidenceTestQueryClient,
+  renderEvidencePanel,
+} from "./comparison-matrix-evidence-fixtures"
+
+const documentRpc = vi.hoisted(() => ({
+  listBaselineDocuments: vi.fn(),
+  listOptionDocuments: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-document-rpc", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../technical-configuration-document-rpc")>()
+  return {
+    ...original,
+    listTechnicalConfigurationBaselineDocuments: (...args: unknown[]) =>
+      documentRpc.listBaselineDocuments(...args),
+    listTechnicalConfigurationOptionDocuments: (...args: unknown[]) =>
+      documentRpc.listOptionDocuments(...args),
+  }
+})
+
+describe("P10B3 lazy comparison evidence", () => {
+  beforeEach(() => {
+    documentRpc.listBaselineDocuments.mockReset()
+    documentRpc.listOptionDocuments.mockReset()
+  })
+
+  it("does not query while the panel is closed or the summary reports no evidence", async () => {
+    const { rerender } = renderEvidencePanel({
+      detail: createEvidenceDetail(),
+      open: false,
+    })
+
+    rerender(
+      <TechnicalConfigurationCriterionPanel
+        detail={createEvidenceDetail({ hasEvidence: false })}
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(documentRpc.listBaselineDocuments).not.toHaveBeenCalled()
+      expect(documentRpc.listOptionDocuments).not.toHaveBeenCalled()
+    })
+  })
+
+  it("uses the existing bounded baseline document path for one open baseline cell", async () => {
+    const queryClient = createEvidenceTestQueryClient()
+    documentRpc.listBaselineDocuments.mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      page_size: 20,
+    })
+
+    renderEvidencePanel({ detail: createEvidenceDetail(), open: true, queryClient })
+
+    await waitFor(() => expect(documentRpc.listBaselineDocuments).toHaveBeenCalledTimes(1))
+    expect(documentRpc.listBaselineDocuments).toHaveBeenCalledWith(
+      {
+        p_baseline_version_id: "baseline-1",
+        p_page: 1,
+        p_page_size: 20,
+      },
+      expect.any(AbortSignal)
+    )
+    expect(documentRpc.listOptionDocuments).not.toHaveBeenCalled()
+    expect(
+      queryClient
+        .getQueryCache()
+        .findAll({ queryKey: technicalConfigurationDocumentsQueryKey("baseline-1") })
+    ).toHaveLength(1)
+  })
+
+  it("uses the existing exact-baseline option document path for one open option cell", async () => {
+    const queryClient = createEvidenceTestQueryClient()
+    documentRpc.listOptionDocuments.mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      page_size: 20,
+    })
+
+    renderEvidencePanel({
+      detail: createEvidenceDetail({ owner: "option" }),
+      open: true,
+      queryClient,
+    })
+
+    await waitFor(() => expect(documentRpc.listOptionDocuments).toHaveBeenCalledTimes(1))
+    expect(documentRpc.listOptionDocuments).toHaveBeenCalledWith(
+      {
+        p_option_id: "option-b",
+        p_baseline_version_id: "baseline-1",
+        p_page: 1,
+        p_page_size: 20,
+      },
+      expect.any(AbortSignal)
+    )
+    expect(documentRpc.listBaselineDocuments).not.toHaveBeenCalled()
+    expect(
+      queryClient.getQueryCache().findAll({
+        queryKey: technicalConfigurationOptionDocumentsQueryKey("option-b", "baseline-1"),
+      })
+    ).toHaveLength(1)
+  })
+
+  it("renders only baseline-owned documents and citations for the active criterion", async () => {
+    const longExcerpt =
+      "Đây là đoạn trích rất dài dùng để xác nhận nội dung bằng chứng được giữ nguyên, tự xuống dòng và không bị rút gọn trong panel chi tiết."
+    documentRpc.listBaselineDocuments.mockResolvedValue({
+      data: [
+        baselineEvidenceDocument({ id: "matching", excerpt: longExcerpt }),
+        baselineEvidenceDocument({ id: "other-criterion", criterionId: "criterion-other" }),
+        baselineEvidenceDocument({
+          id: "reference-product",
+          ownerType: "reference_product",
+          ownerId: "reference-1",
+        }),
+      ],
+      total: 3,
+      page: 1,
+      page_size: 20,
+    })
+
+    renderEvidencePanel({ detail: createEvidenceDetail(), open: true })
+
+    expect(await screen.findByRole("link", { name: /Tài liệu matching/ })).toHaveAttribute(
+      "href",
+      "https://example.com/matching"
+    )
+    expect(screen.getByText(longExcerpt)).toHaveClass("whitespace-pre-wrap", "break-words")
+    expect(screen.queryByText("Tài liệu other-criterion")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Tài liệu chưa có trích dẫn cho tiêu chí này.")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Tài liệu reference-product")).not.toBeInTheDocument()
+    expect(screen.queryByText("Đoạn trích xác nhận độ phân giải.")).not.toBeInTheDocument()
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+    expect(screen.queryByText("Thêm tài liệu")).not.toBeInTheDocument()
+    expect(screen.queryByText("Lưu thay đổi")).not.toBeInTheDocument()
+    expect(screen.queryByText("Xóa")).not.toBeInTheDocument()
+  })
+
+  it("loads one bounded page at a time", async () => {
+    const user = userEvent.setup()
+    documentRpc.listBaselineDocuments
+      .mockResolvedValueOnce({
+        data: [baselineEvidenceDocument({ id: "page-1" })],
+        total: 21,
+        page: 1,
+        page_size: 20,
+      })
+      .mockResolvedValueOnce({
+        data: [baselineEvidenceDocument({ id: "page-2" })],
+        total: 21,
+        page: 2,
+        page_size: 20,
+      })
+
+    renderEvidencePanel({ detail: createEvidenceDetail(), open: true })
+
+    expect(await screen.findByText("Tài liệu page-1")).toBeInTheDocument()
+    expect(screen.queryByText("Tài liệu page-2")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Tải thêm" }))
+
+    expect(await screen.findByText("Tài liệu page-2")).toBeInTheDocument()
+    expect(documentRpc.listBaselineDocuments).toHaveBeenNthCalledWith(
+      2,
+      {
+        p_baseline_version_id: "baseline-1",
+        p_page: 2,
+        p_page_size: 20,
+      },
+      expect.any(AbortSignal)
+    )
+    expect(screen.queryByRole("button", { name: "Tải thêm" })).not.toBeInTheDocument()
+  })
+
+  it("renders an initial error with one retry action and recovers", async () => {
+    const user = userEvent.setup()
+    documentRpc.listBaselineDocuments
+      .mockRejectedValueOnce(new Error("network_error"))
+      .mockResolvedValueOnce({
+        data: [baselineEvidenceDocument({ id: "recovered" })],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+
+    renderEvidencePanel({ detail: createEvidenceDetail(), open: true })
+
+    expect(await screen.findByText("Không thể tải bằng chứng.")).toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: "Thử lại" })).toHaveLength(1)
+
+    await user.click(screen.getByRole("button", { name: "Thử lại" }))
+
+    expect(await screen.findByText("Tài liệu recovered")).toBeInTheDocument()
+    expect(screen.queryByText("Không thể tải bằng chứng.")).not.toBeInTheDocument()
+  })
+
+  it("replaces load more with one retry action after a later page fails", async () => {
+    const user = userEvent.setup()
+    documentRpc.listBaselineDocuments
+      .mockResolvedValueOnce({
+        data: [baselineEvidenceDocument({ id: "page-1" })],
+        total: 21,
+        page: 1,
+        page_size: 20,
+      })
+      .mockRejectedValueOnce(new Error("page_2_failed"))
+      .mockResolvedValueOnce({
+        data: [baselineEvidenceDocument({ id: "page-2" })],
+        total: 21,
+        page: 2,
+        page_size: 20,
+      })
+
+    renderEvidencePanel({ detail: createEvidenceDetail(), open: true })
+
+    await user.click(await screen.findByRole("button", { name: "Tải thêm" }))
+
+    expect(await screen.findByText("Không thể tải thêm bằng chứng.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Tải thêm" })).not.toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: "Thử lại" })).toHaveLength(1)
+
+    await user.click(screen.getByRole("button", { name: "Thử lại" }))
+
+    expect(await screen.findByText("Tài liệu page-2")).toBeInTheDocument()
+    expect(screen.queryByText("Không thể tải thêm bằng chứng.")).not.toBeInTheDocument()
+  })
+
+  it("aborts the obsolete request when the active detail closes", async () => {
+    let requestSignal: AbortSignal | undefined
+    documentRpc.listBaselineDocuments.mockImplementation((_args: unknown, signal: AbortSignal) => {
+      requestSignal = signal
+      return new Promise(() => undefined)
+    })
+    const detail = createEvidenceDetail()
+    const { rerender } = renderEvidencePanel({ detail, open: true })
+
+    await waitFor(() => expect(requestSignal).toBeDefined())
+
+    rerender(
+      <TechnicalConfigurationCriterionPanel detail={detail} open={false} onOpenChange={vi.fn()} />
+    )
+
+    await waitFor(() => expect(requestSignal?.aborted).toBe(true))
+  })
+
+  it("aborts the obsolete request when the active detail switches target", async () => {
+    let baselineRequestSignal: AbortSignal | undefined
+    documentRpc.listBaselineDocuments.mockImplementation((_args: unknown, signal: AbortSignal) => {
+      baselineRequestSignal = signal
+      return new Promise(() => undefined)
+    })
+    documentRpc.listOptionDocuments.mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      page_size: 20,
+    })
+    const { rerender } = renderEvidencePanel({
+      detail: createEvidenceDetail(),
+      open: true,
+    })
+
+    await waitFor(() => expect(baselineRequestSignal).toBeDefined())
+
+    rerender(
+      <TechnicalConfigurationCriterionPanel
+        detail={createEvidenceDetail({ owner: "option" })}
+        open
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(baselineRequestSignal?.aborted).toBe(true))
+    expect(documentRpc.listOptionDocuments).toHaveBeenCalledWith(
+      {
+        p_option_id: "option-b",
+        p_baseline_version_id: "baseline-1",
+        p_page: 1,
+        p_page_size: 20,
+      },
+      expect.any(AbortSignal)
+    )
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-rendering-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-rendering-cases.tsx
@@ -10,6 +10,7 @@ import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 
 import {
   ComparisonDetailHarness,
+  ComparisonQueryProvider,
   createComparisonResult,
   LONG_REQUIREMENT,
   LONG_RESPONSE,
@@ -308,8 +309,18 @@ export function registerComparisonMatrixRenderingTests() {
         responseText: LONG_RESPONSE,
         supplementaryInformation: "Có đầu dò bổ sung.",
         evidence: { documentCount: 1, citationCount: 1, hasEvidence: true },
+        evidenceTarget: {
+          kind: "option",
+          baselineVersionId: "baseline-1",
+          optionId: "option-b",
+          criterionId: "criterion-2",
+        },
       }
-      render(<TechnicalConfigurationCriterionPanel detail={detail} open onOpenChange={vi.fn()} />)
+      render(
+        <ComparisonQueryProvider>
+          <TechnicalConfigurationCriterionPanel detail={detail} open onOpenChange={vi.fn()} />
+        </ComparisonQueryProvider>
+      )
 
       expect(screen.getByText(LONG_REQUIREMENT)).toBeInTheDocument()
       expect(screen.getByText(LONG_RESPONSE)).toBeInTheDocument()

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-review-regression-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-review-regression-cases.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest"
 import { TechnicalConfigurationCriterionPanel } from "../_components/comparison/TechnicalConfigurationCriterionPanel"
 import { TechnicalConfigurationMatrix } from "../_components/comparison/TechnicalConfigurationMatrix"
 
-import { createComparisonResult } from "./comparison-matrix-test-fixtures"
+import { ComparisonQueryProvider, createComparisonResult } from "./comparison-matrix-test-fixtures"
 
 export function registerComparisonMatrixReviewRegressionTests() {
   describe("P10B1 review regressions", () => {
@@ -34,19 +34,26 @@ export function registerComparisonMatrixReviewRegressionTests() {
 
     it("shows only baseline-relevant fields in baseline detail", () => {
       render(
-        <TechnicalConfigurationCriterionPanel
-          detail={{
-            criterionCode: "TS-01",
-            criterionTitle: "Độ phân giải",
-            optionLabel: null,
-            requirementText: "Độ phân giải tối thiểu 1920 x 1080",
-            responseText: null,
-            supplementaryInformation: null,
-            evidence: { documentCount: 2, citationCount: 1, hasEvidence: true },
-          }}
-          open
-          onOpenChange={vi.fn()}
-        />
+        <ComparisonQueryProvider>
+          <TechnicalConfigurationCriterionPanel
+            detail={{
+              criterionCode: "TS-01",
+              criterionTitle: "Độ phân giải",
+              optionLabel: null,
+              requirementText: "Độ phân giải tối thiểu 1920 x 1080",
+              responseText: null,
+              supplementaryInformation: null,
+              evidence: { documentCount: 2, citationCount: 1, hasEvidence: true },
+              evidenceTarget: {
+                kind: "baseline",
+                baselineVersionId: "baseline-1",
+                criterionId: "criterion-1",
+              },
+            }}
+            open
+            onOpenChange={vi.fn()}
+          />
+        </ComparisonQueryProvider>
       )
 
       expect(screen.getByText("Yêu cầu cơ sở")).toBeInTheDocument()

--- a/src/app/(app)/technical-configurations/__tests__/comparison-matrix-test-fixtures.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/comparison-matrix-test-fixtures.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { vi } from "vitest"
 
 import {
@@ -12,6 +13,19 @@ export const LONG_REQUIREMENT =
   "Yêu cầu cơ sở rất dài để xác nhận ô ma trận chỉ hiển thị nội dung rút gọn nhưng panel chi tiết vẫn giữ nguyên toàn bộ văn bản kỹ thuật."
 export const LONG_RESPONSE =
   "Phản hồi phương án rất dài để xác nhận người dùng có thể mở phần chi tiết bằng bàn phím và đọc toàn bộ nội dung."
+
+export function ComparisonQueryProvider({ children }: React.PropsWithChildren) {
+  const [queryClient] = React.useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: { retry: false, gcTime: 0 },
+        },
+      })
+  )
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
 
 export function createComparisonResult(): TechnicalConfigurationComparisonResult {
   return {
@@ -122,7 +136,7 @@ export function ComparisonDetailHarness() {
   }
 
   return (
-    <>
+    <ComparisonQueryProvider>
       <TechnicalConfigurationMatrix
         hasRequest
         result={createComparisonResult()}
@@ -138,6 +152,6 @@ export function ComparisonDetailHarness() {
           if (!open) setDetail(null)
         }}
       />
-    </>
+    </ComparisonQueryProvider>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonEvidence.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonEvidence.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { AlertCircle, ExternalLink, Loader2, RefreshCw } from "lucide-react"
+
+import {
+  type TechnicalConfigurationComparisonEvidenceTarget,
+  useTechnicalConfigurationComparisonEvidence,
+} from "../../_hooks/useTechnicalConfigurationComparisonEvidence"
+import { Button } from "@/components/ui/button"
+
+type TechnicalConfigurationComparisonEvidenceProps = {
+  target: TechnicalConfigurationComparisonEvidenceTarget
+}
+
+/** Renders bounded documents and criterion citations without authoring controls. */
+export function TechnicalConfigurationComparisonEvidence({
+  target,
+}: Readonly<TechnicalConfigurationComparisonEvidenceProps>) {
+  const { documents, evidenceQuery } = useTechnicalConfigurationComparisonEvidence(target)
+  const applicableDocuments = documents.flatMap((document) => {
+    const citations = document.citations.filter(
+      (citation) => citation.criterion_id === target.criterionId
+    )
+    return citations.length > 0 ? [{ ...document, citations }] : []
+  })
+  const hasInitialError = evidenceQuery.isError && evidenceQuery.data === undefined
+  const hasLoadedDocuments = applicableDocuments.length > 0
+
+  if (evidenceQuery.isLoading) {
+    return (
+      <div className="flex min-h-24 items-center justify-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        Đang tải bằng chứng...
+      </div>
+    )
+  }
+
+  if (hasInitialError) {
+    return (
+      <div className="space-y-3 rounded-md border border-destructive/40 p-4" role="alert">
+        <div className="flex items-center gap-2 text-sm text-destructive">
+          <AlertCircle className="size-4" aria-hidden="true" />
+          Không thể tải bằng chứng.
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={evidenceQuery.isFetching}
+          onClick={() => void evidenceQuery.refetch()}
+        >
+          <RefreshCw className={evidenceQuery.isFetching ? "animate-spin" : undefined} />
+          Thử lại
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {evidenceQuery.isError ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm" role="alert">
+          <span className="text-destructive">Không thể tải thêm bằng chứng.</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={evidenceQuery.isFetchingNextPage}
+            onClick={() => void evidenceQuery.fetchNextPage()}
+          >
+            <RefreshCw className={evidenceQuery.isFetchingNextPage ? "animate-spin" : undefined} />
+            Thử lại
+          </Button>
+        </div>
+      ) : null}
+
+      {hasLoadedDocuments ? (
+        <div className="divide-y rounded-md border">
+          {applicableDocuments.map((document) => (
+            <article key={document.id} className="space-y-3 p-4">
+              <a
+                className="inline-flex max-w-full items-start gap-1.5 font-medium text-primary hover:underline"
+                href={document.url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <span className="break-words">{document.name}</span>
+                <ExternalLink className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+              </a>
+
+              <ul className="space-y-3">
+                {document.citations.map((citation) => (
+                  <li key={citation.id} className="space-y-1 border-l-2 pl-3">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      {citation.page_section || "Không ghi trang hoặc mục"}
+                    </p>
+                    <p className="whitespace-pre-wrap break-words leading-6">
+                      {citation.excerpt || "Không có đoạn trích."}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Chưa có tài liệu phù hợp trên các trang đã tải.
+        </p>
+      )}
+
+      {evidenceQuery.hasNextPage && !evidenceQuery.isError ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={evidenceQuery.isFetchingNextPage}
+          onClick={() => void evidenceQuery.fetchNextPage()}
+        >
+          {evidenceQuery.isFetchingNextPage ? (
+            <Loader2 className="animate-spin" aria-hidden="true" />
+          ) : null}
+          Tải thêm
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonEvidence.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonEvidence.tsx
@@ -5,7 +5,7 @@ import { AlertCircle, ExternalLink, Loader2, RefreshCw } from "lucide-react"
 import {
   type TechnicalConfigurationComparisonEvidenceTarget,
   useTechnicalConfigurationComparisonEvidence,
-} from "../../_hooks/useTechnicalConfigurationComparisonEvidence"
+} from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonEvidence"
 import { Button } from "@/components/ui/button"
 
 type TechnicalConfigurationComparisonEvidenceProps = {

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
@@ -2,8 +2,11 @@
 
 import * as React from "react"
 
+import type { TechnicalConfigurationComparisonEvidenceTarget } from "../../_hooks/useTechnicalConfigurationComparisonEvidence"
 import type { TechnicalConfigurationComparisonEvidence } from "../../comparison-types"
 import { SideSheetShell } from "@/components/shared/SideSheetShell"
+
+import { TechnicalConfigurationComparisonEvidence as TechnicalConfigurationComparisonEvidenceSection } from "./TechnicalConfigurationComparisonEvidence"
 
 export type TechnicalConfigurationCriterionDetail = {
   criterionCode: string
@@ -13,6 +16,7 @@ export type TechnicalConfigurationCriterionDetail = {
   responseText: string | null
   supplementaryInformation: string | null
   evidence: TechnicalConfigurationComparisonEvidence
+  evidenceTarget: TechnicalConfigurationComparisonEvidenceTarget
 }
 
 type TechnicalConfigurationCriterionPanelProps = {
@@ -27,7 +31,7 @@ function formatEvidenceSummary(evidence: TechnicalConfigurationComparisonEvidenc
   return `${evidence.documentCount} tài liệu · ${evidence.citationCount} trích dẫn`
 }
 
-/** Renders full comparison text without loading evidence documents or assessment controls. */
+/** Renders full comparison text and lazy read-only evidence without assessment controls. */
 export function TechnicalConfigurationCriterionPanel({
   detail,
   open,
@@ -85,6 +89,9 @@ export function TechnicalConfigurationCriterionPanel({
           <section className="space-y-2">
             <h3 className="font-semibold">Tóm tắt bằng chứng</h3>
             <p className="text-muted-foreground">{formatEvidenceSummary(detail.evidence)}</p>
+            {open && detail.evidence.hasEvidence ? (
+              <TechnicalConfigurationComparisonEvidenceSection target={detail.evidenceTarget} />
+            ) : null}
           </section>
         </div>
       ) : null}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
@@ -2,9 +2,10 @@
 
 import * as React from "react"
 
-import type { TechnicalConfigurationComparisonEvidenceTarget } from "../../_hooks/useTechnicalConfigurationComparisonEvidence"
-import type { TechnicalConfigurationComparisonEvidence } from "../../comparison-types"
+import type { TechnicalConfigurationComparisonEvidenceTarget } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonEvidence"
 import { SideSheetShell } from "@/components/shared/SideSheetShell"
+
+import type { TechnicalConfigurationComparisonEvidence } from "../../comparison-types"
 
 import { TechnicalConfigurationComparisonEvidence as TechnicalConfigurationComparisonEvidenceSection } from "./TechnicalConfigurationComparisonEvidence"
 

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -212,6 +212,7 @@ export function TechnicalConfigurationMatrix({
                   key={row.criterion.id}
                   row={row}
                   options={renderedOptions}
+                  baselineVersionId={result.data.baselineVersion.id}
                   pinnedOptionIds={renderedPinnedOptionIds}
                   valueByOptionId={
                     new Map(row.optionValues.map((value) => [value.optionId, value]))

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
@@ -19,6 +19,7 @@ const EMPTY_EVIDENCE: TechnicalConfigurationComparisonEvidence = {
 type TechnicalConfigurationMatrixRowProps = {
   row: TechnicalConfigurationComparisonResult["data"]["criteria"][number]
   options: TechnicalConfigurationComparisonResult["data"]["options"]
+  baselineVersionId: string
   pinnedOptionIds: readonly string[]
   valueByOptionId: ReadonlyMap<string, TechnicalConfigurationComparisonOptionValue>
   onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
@@ -33,6 +34,7 @@ function formatEvidenceSummary(evidence: TechnicalConfigurationComparisonEvidenc
 export function TechnicalConfigurationMatrixRow({
   row,
   options,
+  baselineVersionId,
   pinnedOptionIds,
   valueByOptionId,
   onOpenDetail,
@@ -68,6 +70,11 @@ export function TechnicalConfigurationMatrixRow({
               responseText: null,
               supplementaryInformation: null,
               evidence: row.baselineEvidence,
+              evidenceTarget: {
+                kind: "baseline",
+                baselineVersionId,
+                criterionId: row.criterion.id,
+              },
             })
           }
         >
@@ -111,6 +118,12 @@ export function TechnicalConfigurationMatrixRow({
                   responseText: response?.responseText ?? null,
                   supplementaryInformation: response?.supplementaryInformation ?? null,
                   evidence,
+                  evidenceTarget: {
+                    kind: "option",
+                    baselineVersionId,
+                    optionId: option.id,
+                    criterionId: row.criterion.id,
+                  },
                 })
               }
             >

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonEvidence.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonEvidence.ts
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import { useInfiniteQuery } from "@tanstack/react-query"
+
+import type {
+  TechnicalConfigurationCitationWire,
+  TechnicalConfigurationDocumentWire,
+  TechnicalConfigurationOptionDocumentWire,
+} from "../document-types"
+import {
+  listTechnicalConfigurationBaselineDocuments,
+  listTechnicalConfigurationOptionDocuments,
+} from "../technical-configuration-document-rpc"
+import {
+  technicalConfigurationDocumentsQueryKey,
+  technicalConfigurationOptionDocumentsQueryKey,
+} from "../technical-configuration-query-keys"
+
+const COMPARISON_EVIDENCE_PAGE_SIZE = 20
+
+export type TechnicalConfigurationComparisonEvidenceTarget =
+  | {
+      kind: "baseline"
+      baselineVersionId: string
+      criterionId: string
+    }
+  | {
+      kind: "option"
+      baselineVersionId: string
+      optionId: string
+      criterionId: string
+    }
+
+export type TechnicalConfigurationComparisonEvidenceDocument = {
+  id: string
+  name: string
+  url: string
+  citations: TechnicalConfigurationCitationWire[]
+}
+
+type TechnicalConfigurationComparisonEvidencePage = {
+  data: TechnicalConfigurationComparisonEvidenceDocument[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+function normalizeComparisonEvidenceDocument(
+  document: TechnicalConfigurationDocumentWire | TechnicalConfigurationOptionDocumentWire
+): TechnicalConfigurationComparisonEvidenceDocument {
+  return {
+    id: document.id,
+    name: document.name,
+    url: document.url,
+    citations: document.citations,
+  }
+}
+
+function getComparisonEvidenceQueryKey(target: TechnicalConfigurationComparisonEvidenceTarget) {
+  const ownerQueryKey =
+    target.kind === "baseline"
+      ? technicalConfigurationDocumentsQueryKey(target.baselineVersionId)
+      : technicalConfigurationOptionDocumentsQueryKey(target.optionId, target.baselineVersionId)
+
+  return [...ownerQueryKey, "comparison-evidence", COMPARISON_EVIDENCE_PAGE_SIZE] as const
+}
+
+async function listComparisonEvidencePage(
+  target: TechnicalConfigurationComparisonEvidenceTarget,
+  page: number,
+  signal: AbortSignal
+): Promise<TechnicalConfigurationComparisonEvidencePage> {
+  if (target.kind === "baseline") {
+    const response = await listTechnicalConfigurationBaselineDocuments(
+      {
+        p_baseline_version_id: target.baselineVersionId,
+        p_page: page,
+        p_page_size: COMPARISON_EVIDENCE_PAGE_SIZE,
+      },
+      signal
+    )
+
+    const data: TechnicalConfigurationComparisonEvidenceDocument[] = []
+    for (const document of response.data) {
+      if (document.owner_type === "baseline" && document.owner_id === target.baselineVersionId) {
+        data.push(normalizeComparisonEvidenceDocument(document))
+      }
+    }
+
+    return {
+      data,
+      total: response.total,
+      page: response.page,
+      pageSize: response.page_size,
+    }
+  }
+
+  const response = await listTechnicalConfigurationOptionDocuments(
+    {
+      p_option_id: target.optionId,
+      p_baseline_version_id: target.baselineVersionId,
+      p_page: page,
+      p_page_size: COMPARISON_EVIDENCE_PAGE_SIZE,
+    },
+    signal
+  )
+
+  return {
+    data: response.data.map(normalizeComparisonEvidenceDocument),
+    total: response.total,
+    page: response.page,
+    pageSize: response.page_size,
+  }
+}
+
+/** Lazily loads bounded read-only evidence for one active comparison cell. */
+export function useTechnicalConfigurationComparisonEvidence(
+  target: TechnicalConfigurationComparisonEvidenceTarget
+) {
+  const evidenceQuery = useInfiniteQuery({
+    queryKey: getComparisonEvidenceQueryKey(target),
+    queryFn: ({ pageParam, signal }) => listComparisonEvidencePage(target, pageParam, signal),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) =>
+      lastPage.page * lastPage.pageSize < lastPage.total ? lastPage.page + 1 : undefined,
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+  const documents = React.useMemo(
+    () => evidenceQuery.data?.pages.flatMap((page) => page.data) ?? [],
+    [evidenceQuery.data?.pages]
+  )
+
+  return {
+    documents,
+    evidenceQuery,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonEvidence.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonEvidence.ts
@@ -1,7 +1,11 @@
 "use client"
 
 import * as React from "react"
-import { useInfiniteQuery } from "@tanstack/react-query"
+import {
+  type InfiniteData,
+  type UseInfiniteQueryResult,
+  useInfiniteQuery,
+} from "@tanstack/react-query"
 
 import type {
   TechnicalConfigurationCitationWire,
@@ -44,6 +48,14 @@ type TechnicalConfigurationComparisonEvidencePage = {
   total: number
   page: number
   pageSize: number
+}
+
+export type TechnicalConfigurationComparisonEvidenceResult = {
+  documents: TechnicalConfigurationComparisonEvidenceDocument[]
+  evidenceQuery: UseInfiniteQueryResult<
+    InfiniteData<TechnicalConfigurationComparisonEvidencePage>,
+    Error
+  >
 }
 
 function normalizeComparisonEvidenceDocument(
@@ -117,7 +129,7 @@ async function listComparisonEvidencePage(
 /** Lazily loads bounded read-only evidence for one active comparison cell. */
 export function useTechnicalConfigurationComparisonEvidence(
   target: TechnicalConfigurationComparisonEvidenceTarget
-) {
+): TechnicalConfigurationComparisonEvidenceResult {
   const evidenceQuery = useInfiniteQuery({
     queryKey: getComparisonEvidenceQueryKey(target),
     queryFn: ({ pageParam, signal }) => listComparisonEvidencePage(target, pageParam, signal),

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDocuments.ts
@@ -131,7 +131,7 @@ export function useTechnicalConfigurationDocuments({
       revisionRef.current = revision
       onRevisionChange?.(revision)
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey, exact: true }),
+        queryClient.invalidateQueries({ queryKey }),
         queryClient.invalidateQueries({
           queryKey: technicalConfigurationBaselineVersionsQueryKey(baselineVersion.dossier_id),
           exact: true,


### PR DESCRIPTION
## Summary

- add one-active-cell lazy read-only evidence loading for baseline and exact-baseline option comparisons
- reuse the P7/P9 document RPC and query-key roots with bounded 20-item pagination, cancellation, criterion filtering, and read-only error/empty/load-more states
- keep baseline inspector caches coherent with P7 evidence mutations and preserve focus return from the shared criterion panel

## Verification

- `format:check`, `verify:no-explicit-any`, `verify:dedupe`, and `typecheck`
- 11 focused/upstream Vitest files: 103/103 tests passed
- React Doctor: 100/100, no diagnostics
- OpenSpec strict validation and `git diff --check main`
- independent review completed; all findings resolved and re-reviewed

## Scope

- no SQL or live DB changes
- no evidence mutation or assessment controls
- no browser test; P13B owns browser screenshot/interaction verification
- P10B3 OpenSpec tasks remain unchecked until merge and issue closeout

Closes #819

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lazy, read-only evidence inspector for comparison cells. It loads criterion-specific citations from bounded document pages for one active cell, supporting baseline and exact-baseline option targets (P10B3; Linear #819).

- **New Features**
  - Loads evidence only when a criterion panel opens; no requests when closed or when no evidence exists.
  - Uses existing document RPCs with `@tanstack/react-query` infinite pagination (20/page); supports baseline and exact-baseline option paths.
  - Filters to documents owned by the target and citations for the active criterion; links open in a new tab; clear empty, error, retry, and “load more” states.
  - Aborts in-flight requests when the panel closes or the active target switches; shares query-key roots for cache coherence.

- **Bug Fixes**
  - Broadened document query invalidation by removing `exact: true`, keeping comparison evidence caches in sync after P7 evidence mutations.

<sup>Written for commit 70ad1596b880cb068c063cf449a9a4c3370b5029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only evidence viewing to technical configuration comparisons.
  * Evidence loads only when a comparison detail is opened and supports filtering by criterion.
  * Added pagination with “Load more” and retry options for loading errors.
  * Evidence documents open as links in a new tab.

* **Bug Fixes**
  * Improved cache refresh behavior after document updates.
  * Added request cancellation when closing or switching comparison details.

* **Tests**
  * Expanded coverage for evidence loading, pagination, errors, filtering, and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->