### PR TITLE
feat: add technical configuration evaluation contract

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/p11a-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p11a-tdd-plan.md
@@ -1,0 +1,128 @@
+# P11A Manual Evaluation Domain Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Freeze the pure manual-evaluation domain values, Vietnamese labels, and deterministic derived-status rule required by P11A.
+
+**Architecture:** Add one dependency-free TypeScript module under `src/lib` and one exhaustive Vitest suite. The module validates every supplied non-null axis value before applying the canonical precedence table; it exposes no persistence, RPC, client, hook, UI, or AI runtime behavior.
+
+**Tech Stack:** TypeScript, Vitest, OpenSpec
+
+---
+
+## Scope And Frozen Inputs
+
+- Base commit: `0aa44a602f9b050464eec5fd2ae9400187d3b1ef`
+- Branch: `feat/p11a-manual-evaluation-domain-contract`
+- Depends on completed P4 and P8A3 artifacts already present on `main`.
+- Create only:
+  - `src/lib/technical-configuration-evaluation.ts`
+  - `src/lib/__tests__/technical-configuration-evaluation.test.ts`
+- Update only P11A planning/task artifacts needed to record the executed leaf.
+- Do not add or change migrations, SQL, RPC manifests, API routes, typed clients,
+  hooks, React components, query keys, persistence types, or AI runtime code.
+
+## Domain Contract
+
+The module owns these stable ASCII values and Vietnamese display labels:
+
+- Technical axis:
+  - `exceeds` -> `Vượt yêu cầu`
+  - `meets` -> `Đạt`
+  - `fails` -> `Không đạt`
+  - `unclear` -> `Chưa rõ`
+  - `not_applicable` -> `Không áp dụng`
+- Evidence axis:
+  - `complete` -> `Đầy đủ`
+  - `partial` -> `Một phần`
+  - `missing` -> `Thiếu`
+  - `not_required` -> `Không yêu cầu`
+- Derived status:
+  - `not_evaluated` -> `Chưa đánh giá`
+  - `not_applicable` -> `Không áp dụng`
+  - `fails` -> `Không đạt`
+  - `unclear` -> `Chưa rõ`
+  - `insufficient_evidence` -> `Chưa đủ bằng chứng`
+  - `exceeds` -> `Vượt yêu cầu`
+  - `meets` -> `Đạt`
+
+`deriveTechnicalConfigurationEvaluationStatus` accepts nullable axis values and
+returns one derived status. Every supplied non-null value must be canonical;
+invalid technical or evidence values throw before precedence is evaluated.
+
+## Chunk 1: RED - Freeze Values And Labels
+
+- [x] Create `src/lib/__tests__/technical-configuration-evaluation.test.ts`.
+- [x] Assert the exact ordered technical-axis tuple and label map.
+- [x] Assert the exact ordered evidence-axis tuple and label map.
+- [x] Assert the exact ordered derived-status tuple and label map.
+- [x] Run the focused test and confirm it fails because the P11A module does not
+      exist:
+
+```bash
+node scripts/npm-run.js run test:run -- \
+  src/lib/__tests__/technical-configuration-evaluation.test.ts
+```
+
+## Chunk 2: RED - Freeze The Complete Truth Table
+
+- [x] Add table-driven cases for `TC-16-S01` through `TC-16-S07`.
+- [x] Cover `fails`, `unclear`, and `not_applicable` with every canonical
+      evidence value plus `null` and `undefined`.
+- [x] Cover `meets` and `exceeds` with `complete`, `not_required`, `partial`,
+      `missing`, `null`, and `undefined`.
+- [x] Cover missing technical axis with every canonical evidence value plus
+      `null` and `undefined`.
+- [x] Assert invalid non-null technical and evidence values throw even when the
+      other axis would otherwise determine the result by precedence.
+- [x] Run the focused test and confirm the new cases fail for missing behavior.
+
+## Chunk 3: GREEN - Implement The Minimal Pure Contract
+
+- [x] Create `src/lib/technical-configuration-evaluation.ts`.
+- [x] Export readonly canonical value tuples and union types derived from them.
+- [x] Export exhaustive Vietnamese label maps checked with `satisfies Record`.
+- [x] Implement only the validation and precedence needed by the frozen truth
+      table.
+- [x] Keep the module dependency-free and side-effect-free.
+- [x] Run the focused test until all cases pass.
+
+## Chunk 4: REFACTOR And Boundary Audit
+
+- [x] Remove test or implementation duplication without widening the API.
+- [x] Confirm no equivalent manual-evaluation contract already exists through
+      Code Review Graph, GitNexus, and repository search.
+- [x] Confirm the diff adds no DB, migration, SQL, RPC, route, client, hook,
+      React, query-key, persistence, or AI runtime artifact.
+- [x] Mark only `P11A.1` through `P11A.5` complete in `tasks.md`.
+
+## Verification
+
+Run the TypeScript gates in repository order, followed by the focused test and
+OpenSpec validation:
+
+```bash
+node scripts/npm-run.js run format:check
+node scripts/npm-run.js run verify:no-explicit-any
+node scripts/npm-run.js run verify:dedupe
+node scripts/npm-run.js run verify:ts-docstrings
+node scripts/npm-run.js run typecheck
+node scripts/npm-run.js run test:run -- \
+  src/lib/__tests__/technical-configuration-evaluation.test.ts
+node scripts/npm-run.js run react-doctor
+openspec validate add-technical-configuration-comparison \
+  --type change --strict --no-interactive
+```
+
+Final review requirements:
+
+- Re-run Code Review Graph and GitNexus against the changed files.
+- Dispatch an independent code-review subagent with the base and head commits.
+- Fix all valid Critical and Important findings, then rerun affected checks.
+- Commit and push the feature branch. Do not merge without a separate request.
+
+## Exit Gate
+
+P11A is complete when canonical values, labels, invalid-input behavior, and every
+derived-status precedence row are frozen by exhaustive tests; the final diff has
+no runtime integration beyond the new pure domain module.

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -505,14 +505,14 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P11A - Manual Evaluation Domain Contract
 
-- [ ] P11A.1 Thêm stable ASCII values và Vietnamese label maps cho hai trục và
+- [x] P11A.1 Thêm stable ASCII values và Vietnamese label maps cho hai trục và
       derived status.
-- [ ] P11A.2 Thêm pure derived-status function; không persist hoặc cho sửa trực
+- [x] P11A.2 Thêm pure derived-status function; không persist hoặc cho sửa trực
       tiếp derived status.
-- [ ] P11A.3 Chốt cả missing technical-axis và missing evidence-axis thành
+- [x] P11A.3 Chốt cả missing technical-axis và missing evidence-axis thành
       `not_evaluated` theo canonical precedence.
-- [ ] P11A.4 Viết exhaustive table-driven mapping và invalid-value tests.
-- [ ] P11A.5 Audit leaf không thêm DB, RPC, hook, UI hoặc AI runtime artifact.
+- [x] P11A.4 Viết exhaustive table-driven mapping và invalid-value tests.
+- [x] P11A.5 Audit leaf không thêm DB, RPC, hook, UI hoặc AI runtime artifact.
 
 ## Phase P11B - Manual Assessment Persistence And Security
 

--- a/src/lib/__tests__/technical-configuration-evaluation.test.ts
+++ b/src/lib/__tests__/technical-configuration-evaluation.test.ts
@@ -139,8 +139,8 @@ describe("technical configuration manual evaluation contract", () => {
     ).toThrow(`Invalid technical configuration technical axis: ${String(value)}`)
   })
 
-  it.each(["fails", "unclear", "not_applicable"] as const)(
-    "rejects invalid evidence values before applying %s precedence",
+  it.each([null, undefined, ...TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES] as const)(
+    "rejects invalid evidence values before deriving from technical-axis %s",
     (technicalAxis) => {
       const invalidEvidenceValues = [
         ["empty string", ""],

--- a/src/lib/__tests__/technical-configuration-evaluation.test.ts
+++ b/src/lib/__tests__/technical-configuration-evaluation.test.ts
@@ -14,6 +14,14 @@ import {
 
 const EVIDENCE_INPUTS = [...TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES, null, undefined] as const
 
+const INVALID_RUNTIME_AXIS_VALUES: ReadonlyArray<readonly [string, unknown]> = [
+  ["number", 42],
+  ["boolean", true],
+  ["array", []],
+  ["object", {}],
+  ["symbol", Symbol("invalid")],
+]
+
 describe("technical configuration manual evaluation contract", () => {
   it("freezes the canonical technical-axis values and Vietnamese labels", () => {
     expect(TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES).toEqual([
@@ -115,24 +123,42 @@ describe("technical configuration manual evaluation contract", () => {
     }
   )
 
-  it.each(["", "unexpected"])("rejects invalid technical-axis value %j", (value) => {
+  it.each([
+    ["empty string", ""],
+    ["unknown string", "unexpected"],
+    ...TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES.map(
+      (value) => [`evidence-axis value ${value}`, value] as const
+    ),
+    ...INVALID_RUNTIME_AXIS_VALUES,
+  ] as const)("rejects invalid technical-axis %s", (_label, value) => {
     expect(() =>
       deriveTechnicalConfigurationEvaluationStatus(
         value as TechnicalConfigurationTechnicalAxis,
         "complete"
       )
-    ).toThrow(`Invalid technical configuration technical axis: ${value}`)
+    ).toThrow(`Invalid technical configuration technical axis: ${String(value)}`)
   })
 
-  it.each(["", "unexpected"])(
-    "rejects invalid evidence-axis value %j before applying technical precedence",
-    (value) => {
-      expect(() =>
-        deriveTechnicalConfigurationEvaluationStatus(
-          "fails",
-          value as TechnicalConfigurationEvidenceAxis
-        )
-      ).toThrow(`Invalid technical configuration evidence axis: ${value}`)
+  it.each(["fails", "unclear", "not_applicable"] as const)(
+    "rejects invalid evidence values before applying %s precedence",
+    (technicalAxis) => {
+      const invalidEvidenceValues = [
+        ["empty string", ""],
+        ["unknown string", "unexpected"],
+        ...TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES.map(
+          (value) => [`technical-axis value ${value}`, value] as const
+        ),
+        ...INVALID_RUNTIME_AXIS_VALUES,
+      ] as const
+
+      for (const [_label, value] of invalidEvidenceValues) {
+        expect(() =>
+          deriveTechnicalConfigurationEvaluationStatus(
+            technicalAxis,
+            value as TechnicalConfigurationEvidenceAxis
+          )
+        ).toThrow(`Invalid technical configuration evidence axis: ${String(value)}`)
+      }
     }
   )
 })

--- a/src/lib/__tests__/technical-configuration-evaluation.test.ts
+++ b/src/lib/__tests__/technical-configuration-evaluation.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS,
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES,
+  TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_LABELS,
+  TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES,
+  TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_LABELS,
+  TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES,
+  deriveTechnicalConfigurationEvaluationStatus,
+  type TechnicalConfigurationEvidenceAxis,
+  type TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+
+const EVIDENCE_INPUTS = [...TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES, null, undefined] as const
+
+describe("technical configuration manual evaluation contract", () => {
+  it("freezes the canonical technical-axis values and Vietnamese labels", () => {
+    expect(TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES).toEqual([
+      "exceeds",
+      "meets",
+      "fails",
+      "unclear",
+      "not_applicable",
+    ])
+    expect(TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_LABELS).toEqual({
+      exceeds: "Vượt yêu cầu",
+      meets: "Đạt",
+      fails: "Không đạt",
+      unclear: "Chưa rõ",
+      not_applicable: "Không áp dụng",
+    })
+  })
+
+  it("freezes the canonical evidence-axis values and Vietnamese labels", () => {
+    expect(TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES).toEqual([
+      "complete",
+      "partial",
+      "missing",
+      "not_required",
+    ])
+    expect(TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_LABELS).toEqual({
+      complete: "Đầy đủ",
+      partial: "Một phần",
+      missing: "Thiếu",
+      not_required: "Không yêu cầu",
+    })
+  })
+
+  it("freezes the canonical derived statuses and Vietnamese labels", () => {
+    expect(TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES).toEqual([
+      "not_evaluated",
+      "not_applicable",
+      "fails",
+      "unclear",
+      "insufficient_evidence",
+      "exceeds",
+      "meets",
+    ])
+    expect(TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS).toEqual({
+      not_evaluated: "Chưa đánh giá",
+      not_applicable: "Không áp dụng",
+      fails: "Không đạt",
+      unclear: "Chưa rõ",
+      insufficient_evidence: "Chưa đủ bằng chứng",
+      exceeds: "Vượt yêu cầu",
+      meets: "Đạt",
+    })
+  })
+
+  it.each([
+    ["fails", "fails"],
+    ["unclear", "unclear"],
+    ["not_applicable", "not_applicable"],
+  ] as const)(
+    "keeps %s authoritative for every canonical or missing evidence value",
+    (technicalAxis, expectedStatus) => {
+      for (const evidenceAxis of EVIDENCE_INPUTS) {
+        expect(deriveTechnicalConfigurationEvaluationStatus(technicalAxis, evidenceAxis)).toBe(
+          expectedStatus
+        )
+      }
+    }
+  )
+
+  it.each([
+    ["exceeds", "complete", "exceeds"],
+    ["exceeds", "not_required", "exceeds"],
+    ["meets", "complete", "meets"],
+    ["meets", "not_required", "meets"],
+    ["exceeds", "partial", "insufficient_evidence"],
+    ["exceeds", "missing", "insufficient_evidence"],
+    ["meets", "partial", "insufficient_evidence"],
+    ["meets", "missing", "insufficient_evidence"],
+    ["exceeds", null, "not_evaluated"],
+    ["exceeds", undefined, "not_evaluated"],
+    ["meets", null, "not_evaluated"],
+    ["meets", undefined, "not_evaluated"],
+  ] as const)(
+    "derives %s with %s evidence as %s",
+    (technicalAxis, evidenceAxis, expectedStatus) => {
+      expect(deriveTechnicalConfigurationEvaluationStatus(technicalAxis, evidenceAxis)).toBe(
+        expectedStatus
+      )
+    }
+  )
+
+  it.each(EVIDENCE_INPUTS)(
+    "maps a missing technical axis with %s evidence to not_evaluated",
+    (evidenceAxis) => {
+      expect(deriveTechnicalConfigurationEvaluationStatus(null, evidenceAxis)).toBe("not_evaluated")
+      expect(deriveTechnicalConfigurationEvaluationStatus(undefined, evidenceAxis)).toBe(
+        "not_evaluated"
+      )
+    }
+  )
+
+  it.each(["", "unexpected"])("rejects invalid technical-axis value %j", (value) => {
+    expect(() =>
+      deriveTechnicalConfigurationEvaluationStatus(
+        value as TechnicalConfigurationTechnicalAxis,
+        "complete"
+      )
+    ).toThrow(`Invalid technical configuration technical axis: ${value}`)
+  })
+
+  it.each(["", "unexpected"])(
+    "rejects invalid evidence-axis value %j before applying technical precedence",
+    (value) => {
+      expect(() =>
+        deriveTechnicalConfigurationEvaluationStatus(
+          "fails",
+          value as TechnicalConfigurationEvidenceAxis
+        )
+      ).toThrow(`Invalid technical configuration evidence axis: ${value}`)
+    }
+  )
+})

--- a/src/lib/technical-configuration-evaluation.ts
+++ b/src/lib/technical-configuration-evaluation.ts
@@ -91,7 +91,7 @@ export function deriveTechnicalConfigurationEvaluationStatus(
     technicalAxis !== undefined &&
     !isTechnicalConfigurationTechnicalAxis(technicalAxis)
   ) {
-    throw new Error(`Invalid technical configuration technical axis: ${technicalAxis}`)
+    throw new Error(`Invalid technical configuration technical axis: ${String(technicalAxis)}`)
   }
 
   if (
@@ -99,7 +99,7 @@ export function deriveTechnicalConfigurationEvaluationStatus(
     evidenceAxis !== undefined &&
     !isTechnicalConfigurationEvidenceAxis(evidenceAxis)
   ) {
-    throw new Error(`Invalid technical configuration evidence axis: ${evidenceAxis}`)
+    throw new Error(`Invalid technical configuration evidence axis: ${String(evidenceAxis)}`)
   }
 
   if (technicalAxis === null || technicalAxis === undefined) {

--- a/src/lib/technical-configuration-evaluation.ts
+++ b/src/lib/technical-configuration-evaluation.ts
@@ -1,0 +1,126 @@
+/** Stable persisted/domain values for the manual technical assessment axis. */
+export const TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES = [
+  "exceeds",
+  "meets",
+  "fails",
+  "unclear",
+  "not_applicable",
+] as const
+
+export type TechnicalConfigurationTechnicalAxis =
+  (typeof TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES)[number]
+
+/** Vietnamese display labels for the manual technical assessment axis. */
+export const TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_LABELS = {
+  exceeds: "Vượt yêu cầu",
+  meets: "Đạt",
+  fails: "Không đạt",
+  unclear: "Chưa rõ",
+  not_applicable: "Không áp dụng",
+} as const satisfies Record<TechnicalConfigurationTechnicalAxis, string>
+
+/** Stable persisted/domain values for the manual evidence assessment axis. */
+export const TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES = [
+  "complete",
+  "partial",
+  "missing",
+  "not_required",
+] as const
+
+export type TechnicalConfigurationEvidenceAxis =
+  (typeof TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES)[number]
+
+/** Vietnamese display labels for the manual evidence assessment axis. */
+export const TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_LABELS = {
+  complete: "Đầy đủ",
+  partial: "Một phần",
+  missing: "Thiếu",
+  not_required: "Không yêu cầu",
+} as const satisfies Record<TechnicalConfigurationEvidenceAxis, string>
+
+/** Stable derived statuses calculated from the two manual assessment axes. */
+export const TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES = [
+  "not_evaluated",
+  "not_applicable",
+  "fails",
+  "unclear",
+  "insufficient_evidence",
+  "exceeds",
+  "meets",
+] as const
+
+export type TechnicalConfigurationDerivedStatus =
+  (typeof TECHNICAL_CONFIGURATION_DERIVED_STATUS_VALUES)[number]
+
+/** Vietnamese display labels for the derived manual evaluation status. */
+export const TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS = {
+  not_evaluated: "Chưa đánh giá",
+  not_applicable: "Không áp dụng",
+  fails: "Không đạt",
+  unclear: "Chưa rõ",
+  insufficient_evidence: "Chưa đủ bằng chứng",
+  exceeds: "Vượt yêu cầu",
+  meets: "Đạt",
+} as const satisfies Record<TechnicalConfigurationDerivedStatus, string>
+
+function isTechnicalConfigurationTechnicalAxis(
+  value: unknown
+): value is TechnicalConfigurationTechnicalAxis {
+  return (
+    typeof value === "string" &&
+    (TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES as readonly string[]).includes(value)
+  )
+}
+
+function isTechnicalConfigurationEvidenceAxis(
+  value: unknown
+): value is TechnicalConfigurationEvidenceAxis {
+  return (
+    typeof value === "string" &&
+    (TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES as readonly string[]).includes(value)
+  )
+}
+
+/** Derives the canonical overall status from nullable manual assessment axes. */
+export function deriveTechnicalConfigurationEvaluationStatus(
+  technicalAxis: TechnicalConfigurationTechnicalAxis | null | undefined,
+  evidenceAxis: TechnicalConfigurationEvidenceAxis | null | undefined
+): TechnicalConfigurationDerivedStatus {
+  if (
+    technicalAxis !== null &&
+    technicalAxis !== undefined &&
+    !isTechnicalConfigurationTechnicalAxis(technicalAxis)
+  ) {
+    throw new Error(`Invalid technical configuration technical axis: ${technicalAxis}`)
+  }
+
+  if (
+    evidenceAxis !== null &&
+    evidenceAxis !== undefined &&
+    !isTechnicalConfigurationEvidenceAxis(evidenceAxis)
+  ) {
+    throw new Error(`Invalid technical configuration evidence axis: ${evidenceAxis}`)
+  }
+
+  if (technicalAxis === null || technicalAxis === undefined) {
+    return "not_evaluated"
+  }
+
+  if (
+    technicalAxis === "not_applicable" ||
+    technicalAxis === "fails" ||
+    technicalAxis === "unclear"
+  ) {
+    return technicalAxis
+  }
+
+  if (evidenceAxis === null || evidenceAxis === undefined) {
+    return "not_evaluated"
+  }
+
+  if (evidenceAxis === "partial" || evidenceAxis === "missing") {
+    return "insufficient_evidence"
+  }
+
+  return technicalAxis
+}


### PR DESCRIPTION
## Summary

- define stable ASCII values and Vietnamese labels for both manual-evaluation axes and derived statuses
- add pure deterministic status derivation, including missing-axis behavior and defensive invalid-input handling
- add 38 focused tests and record the P11A TDD plan for OpenSpec change `add-technical-configuration-comparison`

## Scope

This PR implements P11A only: the pure manual-evaluation domain contract. Database persistence, migrations, RPC/client/hooks, UI, query keys, and AI runtime work remain explicitly out of scope for P11B, P11C, and P12A.

## Verification

- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- TypeScript docstring verification
- `typecheck`
- focused Vitest: 38/38 passed
- React Doctor: 100/100
- strict OpenSpec validation
- P11A diff and scope audit
- pre-commit and pre-push hooks

Independent subagent review completed; the valid invalid-input finding was fixed and re-reviewed with no remaining Critical or Important findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pure, deterministic technical-configuration evaluation contract with frozen ASCII values and Vietnamese labels, plus a status derivation function. P11A domain only; no DB, RPC, or UI changes.

- **New Features**
  - Export canonical tuples and labels for technical axis, evidence axis, and derived statuses.
  - Implement strict precedence: `not_applicable`/`fails`/`unclear` are authoritative; missing technical or evidence → `not_evaluated`; `partial`/`missing` evidence with `meets`/`exceeds` → `insufficient_evidence`; else return the technical axis.
  - Validate inputs strictly: any non-null, non-canonical axis value throws before precedence.
  - Add 38 focused tests for the full truth table, invalid technical values, and invalid evidence across all technical states.
  - Record the P11A TDD plan and update tasks for the `add-technical-configuration-comparison` change.

<sup>Written for commit a6536372d9b150eea7e2c899d6a7f6a2612a9ee2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized technical and evidence evaluation categories with Vietnamese labels.
  * Added automatic overall status calculation based on technical results and evidence quality.
  * Added handling for incomplete, unclear, failed, and not-applicable evaluations.

* **Bug Fixes**
  * Added validation to reject invalid evaluation values and prevent inconsistent statuses.

* **Tests**
  * Added comprehensive coverage for evaluation mappings, precedence rules, missing values, and validation behavior.

* **Documentation**
  * Documented the evaluation contract and implementation checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->