### PR TITLE
feat(db): add P11B manual assessment persistence

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/p11b-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p11b-tdd-plan.md
@@ -1,0 +1,189 @@
+# P11B Manual Assessment Persistence And Security Implementation Plan
+
+> **For agentic workers:** Execute this plan test-first. Do not apply the migration
+> or run the rollback-only live DB gate without separate explicit user approval.
+
+**Goal:** Add the dormant database persistence and guarded RPC contract for
+manual technical-configuration assessments without exposing it through the
+application proxy, client, hooks, query keys or UI.
+
+**Architecture:** Store one assessment per exact comparison-set/criterion pair.
+The row persists only the two canonical P11A axes, notes, audit metadata and its
+own optimistic revision. Two `SECURITY DEFINER` RPCs provide bounded reads and
+row-level upserts behind the existing global-user guard, exact ownership checks,
+archived-dossier protection and deny-by-default table access.
+
+**Tech Stack:** PostgreSQL/Supabase migrations, PL/pgSQL, RLS, Vitest migration
+source tests and rollback-only SQL phase gates.
+
+---
+
+## Scope And Frozen Inputs
+
+- Base commit: `81200b8410abb300f084043b409d7edf3be5a1c1` from merged P11A.
+- Create:
+  `supabase/migrations/20260729134453_technical_configuration_manual_assessments.sql`.
+- Create:
+  `supabase/tests/technical_configuration_manual_assessments_phase_gate.sql`.
+- Create:
+  `src/app/api/rpc/__tests__/technical-configuration-manual-assessments-migration.test.ts`.
+- Update:
+  `openspec/changes/add-technical-configuration-comparison/tasks.md`.
+- Keep `src/lib/technical-configuration-evaluation.ts` unchanged.
+- Do not change RPC allowlists/manifests, typed clients, hooks, query keys,
+  routes, UI components or AI runtime artifacts.
+- Do not use the Supabase CLI.
+- Live DB inspection remains read-only unless the user separately authorizes
+  the exact migration apply or rollback-only phase gate.
+
+## Frozen Persistence Contract
+
+`public.technical_configuration_manual_assessments` contains:
+
+- `id UUID PRIMARY KEY DEFAULT gen_random_uuid()`
+- `comparison_set_id UUID NOT NULL`
+- `baseline_version_id UUID NOT NULL`
+- `criterion_id UUID NOT NULL`
+- nullable `technical_axis TEXT`
+- nullable `evidence_axis TEXT`
+- `notes TEXT NOT NULL DEFAULT ''`
+- `revision BIGINT NOT NULL DEFAULT 1 CHECK (revision > 0)`
+- standard `created_at`, `created_by`, `updated_at`, `updated_by`
+- `UNIQUE (comparison_set_id, criterion_id)`
+- composite FK `(comparison_set_id, baseline_version_id)` to the exact
+  comparison set with `ON DELETE CASCADE`
+- composite FK `(criterion_id, baseline_version_id)` to the exact criterion
+  with `ON DELETE CASCADE`
+- checks accepting only the P11A canonical ASCII values or SQL `NULL`
+
+The table does not contain derived status, stale state, machine result, source
+response, supplementary information, document or citation data.
+
+## Frozen RPC Contract
+
+`technical_configuration_assessments_list(UUID, INTEGER, INTEGER)`:
+
+- requires non-null `p_comparison_set_id`
+- requires `p_page >= 1` and `1 <= p_page_size <= 100`
+- requires an existing comparison set and global/admin session
+- remains readable when the owning dossier is archived
+- does not create a comparison set or mutate dossier/assessment revisions
+- returns `{ data, total, page, page_size }`
+- orders by baseline group order, criterion order and criterion ID
+
+`technical_configuration_assessment_upsert(UUID, UUID, TEXT, TEXT, TEXT, BIGINT)`:
+
+- accepts nullable canonical axes and nullable notes
+- canonicalizes SQL `NULL` notes to `''`
+- requires an existing exact comparison set and criterion in the same baseline
+- rejects archived dossiers and non-global/missing claims fail-closed
+- creates only when `p_expected_revision = 0`, returning revision `1`
+- updates only when `p_expected_revision` equals the current assessment
+  revision, incrementing that row revision exactly once
+- returns `PT409/stale_revision` for create/update revision conflicts
+- never increments dossier revision
+
+Both RPCs return only:
+
+`id`, `comparison_set_id`, `baseline_version_id`, `criterion_id`,
+`technical_axis`, `evidence_axis`, `notes`, `revision`, `created_by`,
+`created_at`, `updated_by`, `updated_at`.
+
+## Chunk 1: RED - Freeze Migration And Boundary Contract
+
+- [x] Create the focused Vitest migration-source test.
+- [x] Assert the migration timestamp sorts after every existing local migration
+      touching the same technical-configuration ownership chain.
+- [x] Freeze the exact table columns, canonical checks, unique key, composite
+      FKs, cascade behavior and supporting indexes.
+- [x] Freeze both RPC signatures, argument nullability, SQLSTATE messages,
+      deterministic wire fields and list ordering.
+- [x] Freeze first-create revision `0 -> 1`, exact-update increment and stale
+      conflict behavior without dossier revision mutation.
+- [x] Freeze global/admin claim guards, archived mutation denial, RLS policy,
+      table revokes, service-role table grant and RPC execute grants.
+- [x] Freeze the no-derived/no-stale/no-machine boundary.
+- [x] Freeze rollback-only phase-gate markers for auth, ownership, archive,
+      conflict, source preservation, cascades and direct privileges.
+- [x] Run:
+      `node scripts/npm-run.js run test -- src/app/api/rpc/__tests__/technical-configuration-manual-assessments-migration.test.ts`.
+- [x] Confirm RED because the migration and SQL phase-gate files do not exist.
+
+## Chunk 2: GREEN - Add Minimal Persistence And RPCs
+
+- [x] Create the ordered migration inside one `BEGIN`/`COMMIT` transaction.
+- [x] Add the assessment table, composite-child indexes and canonical checks.
+- [x] Enable RLS and add an explicit deny-all policy for `anon` and
+      `authenticated`.
+- [x] Revoke all direct table privileges from `PUBLIC`, `anon` and
+      `authenticated`; grant table privileges only to `service_role`.
+- [x] Implement the bounded list RPC with the existing global-user helper.
+- [x] Implement the upsert RPC with an active-dossier lock, exact
+      comparison-set/criterion ownership and row-level optimistic concurrency.
+- [x] Map concurrent first-create conflicts to `PT409/stale_revision`.
+- [x] Revoke function execution from all roles, then grant only
+      `authenticated` and `service_role`.
+- [x] Run the focused Vitest test and confirm only the missing phase-gate
+      assertions remain RED.
+
+## Chunk 3: GREEN - Add Rollback-Only SQL Phase Gate
+
+- [x] Create a transaction-scoped fixture without depending on application
+      proxy/client code.
+- [x] Prove missing claims and non-global roles fail; raw `admin` succeeds.
+- [x] Prove list bounds, exact ordering, wire fields and archived reads.
+- [x] Prove canonical nullable axes/notes and reject non-canonical values.
+- [x] Prove first create, exact update, stale create, stale update and creation
+      audit preservation.
+- [x] Prove response, supplementary-information and option-document updates do
+      not change the assessment row or its revision.
+- [x] Prove exact ownership FKs and option/baseline/dossier cascade cleanup.
+- [x] Prove no direct `anon`/`authenticated` table access and exact function
+      execute privileges.
+- [x] End with `ROLLBACK`.
+- [x] Run the focused Vitest migration-source test and confirm GREEN.
+
+## Chunk 4: REFACTOR And Boundary Audit
+
+- [x] Remove duplicated source-test helpers or SQL assertions without widening
+      the production contract.
+- [x] Confirm migration, source test and phase gate each stay at or below 450
+      lines.
+- [x] Confirm the diff contains no P11C/P12A proxy, client, hook, query-key or UI
+      changes.
+- [x] Confirm no P11A domain constants or derivation rules changed.
+- [x] Mark `P11B.1` through `P11B.5` complete in `tasks.md`.
+- [x] Keep `P11B.6` and `P11B.7` unchecked until their separate live DB
+      approvals and executions occur.
+
+## Verification
+
+Run in repository order through one context-mode batch:
+
+1. `node scripts/npm-run.js run format:check`
+2. `node scripts/npm-run.js run verify:no-explicit-any`
+3. `node scripts/npm-run.js run verify:dedupe`
+4. `node scripts/npm-run.js run typecheck`
+5. `node scripts/npm-run.js run test -- src/app/api/rpc/__tests__/technical-configuration-manual-assessments-migration.test.ts`
+6. `node scripts/npm-run.js run test -- src/lib/__tests__/technical-configuration-evaluation.test.ts`
+7. `node scripts/npm-run.js run react-doctor`
+
+Then run Code Review Graph/GitNexus change-impact checks, dispatch a focused
+subagent review, triage every finding and rerun affected gates after valid fixes.
+
+## Live DB Gates
+
+- [x] Applied `20260729134453_technical_configuration_manual_assessments.sql`
+      after explicit approval through Supabase MCP `apply_migration`; live
+      migration registry version: `20260729144351`.
+- [x] Ran `supabase/tests/technical_configuration_manual_assessments_phase_gate.sql`
+      after explicit approval; every assertion passed and the transaction
+      rolled back.
+- [x] Ran read-only security/performance advisors after both operations and
+      confirmed `assessment_count = 0` plus `fixture_dossier_count = 0`.
+
+## Exit Gate
+
+The repository contains a complete, tested and dormant P11B persistence
+contract. No application surface can call the new RPCs yet. The authorized
+migration is deployed, and the rollback-only phase gate left no fixture data.

--- a/openspec/changes/add-technical-configuration-comparison/p11b-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p11b-tdd-plan.md
@@ -116,7 +116,8 @@ Both RPCs return only:
 - [x] Enable RLS and add an explicit deny-all policy for `anon` and
       `authenticated`.
 - [x] Revoke all direct table privileges from `PUBLIC`, `anon` and
-      `authenticated`; grant table privileges only to `service_role`.
+      `authenticated`; grant only `SELECT`, `INSERT`, `UPDATE` and `DELETE`
+      to `service_role`.
 - [x] Implement the bounded list RPC with the existing global-user helper.
 - [x] Implement the upsert RPC with an active-dossier lock, exact
       comparison-set/criterion ownership and row-level optimistic concurrency.
@@ -176,11 +177,20 @@ subagent review, triage every finding and rerun affected gates after valid fixes
 - [x] Applied `20260729134453_technical_configuration_manual_assessments.sql`
       after explicit approval through Supabase MCP `apply_migration`; live
       migration registry version: `20260729144351`.
+- [x] Preserved the already-applied original migration and applied the
+      superseding
+      `20260729150646_technical_configuration_manual_assessments_service_role_grants.sql`
+      after explicit approval; live migration registry version:
+      `20260729155147`.
 - [x] Ran `supabase/tests/technical_configuration_manual_assessments_phase_gate.sql`
-      after explicit approval; every assertion passed and the transaction
-      rolled back.
-- [x] Ran read-only security/performance advisors after both operations and
-      confirmed `assessment_count = 0` plus `fixture_dossier_count = 0`.
+      again after the privilege repair; every assertion passed and the
+      transaction rolled back.
+- [x] Ran read-only security/performance advisors after the repair and phase
+      gate. The project baseline remains; no blocking P11B regression was
+      identified.
+- [x] Confirmed `assessment_count = 0`, `fixture_dossier_count = 0`, both RPCs
+      and the table still exist, and `service_role` has exactly the four
+      required DML privileges.
 
 ## Exit Gate
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -516,21 +516,21 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P11B - Manual Assessment Persistence And Security
 
-- [ ] P11B.1 Thêm bảng assessment unique theo comparison set + criterion với
+- [x] P11B.1 Thêm bảng assessment unique theo comparison set + criterion với
       exact ownership FKs và canonical two-axis values.
-- [ ] P11B.2 Thêm notes, row-level `revision BIGINT`; dùng
+- [x] P11B.2 Thêm notes, row-level `revision BIGINT`; dùng
       `updated_by`/`updated_at` làm latest evaluator metadata.
-- [ ] P11B.3 Đóng băng và triển khai exact list/upsert arguments, nullability,
+- [x] P11B.3 Đóng băng và triển khai exact list/upsert arguments, nullability,
       wire order, first-create revision semantics cùng JWT, admin/global,
       archived-dossier và deny-by-default guards.
-- [ ] P11B.4 Giữ manual conclusions tách khỏi source updates và future AI data;
+- [x] P11B.4 Giữ manual conclusions tách khỏi source updates và future AI data;
       không thêm derived/stale/machine-result fields.
-- [ ] P11B.5 Viết migration source tests và rollback-only DB phase gate cho
+- [x] P11B.5 Viết migration source tests và rollback-only DB phase gate cho
       auth, ownership, conflict, source preservation, cascade, grants/RLS và
       no-AI audit.
-- [ ] P11B.6 Xin explicit approval riêng để apply exact migration; sau apply chạy
+- [x] P11B.6 Xin explicit approval riêng để apply exact migration; sau apply chạy
       read-only security/performance advisors.
-- [ ] P11B.7 Xin explicit approval riêng để chạy rollback-only phase gate; xác
+- [x] P11B.7 Xin explicit approval riêng để chạy rollback-only phase gate; xác
       nhận rollback/fixture cleanup và chạy lại read-only advisors.
 
 ## Phase P11C - Manual Assessment Client Contract

--- a/src/app/api/rpc/__tests__/technical-configuration-manual-assessments-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-manual-assessments-migration.test.ts
@@ -1,0 +1,345 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = path.resolve(process.cwd())
+const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
+const MIGRATION_FILE = "20260729134453_technical_configuration_manual_assessments.sql"
+const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const PHASE_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_manual_assessments_phase_gate.sql"
+)
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function countLines(source: string): number {
+  return source === "" ? 0 : source.trimEnd().split("\n").length
+}
+
+function getSqlBlock(source: string, marker: string, nextMarker: string): string {
+  const start = source.indexOf(marker)
+  if (start === -1) return ""
+
+  const next = source.indexOf(nextMarker, start + marker.length)
+  return source.slice(start, next === -1 ? source.length : next)
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  return getSqlBlock(
+    source,
+    `FUNCTION public.${functionName}(`,
+    "\nCREATE OR REPLACE FUNCTION public."
+  )
+}
+
+function getTableColumnNames(tableBlock: string): string[] {
+  return tableBlock
+    .slice(0, tableBlock.indexOf("\n  UNIQUE"))
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^[a-z_]+ [A-Z]/.test(line))
+    .map((line) => line.split(/\s+/, 1)[0])
+}
+
+function getJsonObjectKeys(objectBlock: string): string[] {
+  return Array.from(objectBlock.matchAll(/^\s*'([^']+)',/gm), (match) => match[1])
+}
+
+const migrationSource = readIfExists(MIGRATION_PATH)
+const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+
+const ASSESSMENT_RPC_SIGNATURES = [
+  "technical_configuration_assessments_list(\n  p_comparison_set_id UUID,\n  p_page INTEGER,\n  p_page_size INTEGER",
+  "technical_configuration_assessment_upsert(\n  p_comparison_set_id UUID,\n  p_criterion_id UUID,\n  p_technical_axis TEXT,\n  p_evidence_axis TEXT,\n  p_notes TEXT,\n  p_expected_revision BIGINT",
+] as const
+
+const ASSESSMENT_RPC_NAMES = [
+  "technical_configuration_assessments_list",
+  "technical_configuration_assessment_upsert",
+] as const
+
+const ASSESSMENT_WIRE_FIELDS = [
+  "'id'",
+  "'comparison_set_id'",
+  "'baseline_version_id'",
+  "'criterion_id'",
+  "'technical_axis'",
+  "'evidence_axis'",
+  "'notes'",
+  "'revision'",
+  "'created_by'",
+  "'created_at'",
+  "'updated_by'",
+  "'updated_at'",
+] as const
+
+describe("P11B technical configuration manual assessment migration", () => {
+  it("uses one ordered migration after the current technical configuration chain", () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true)
+    expect(
+      readdirSync(MIGRATIONS_DIR)
+        .filter((file) => file.includes("technical_configuration_manual_assessments"))
+        .sort()
+    ).toEqual([MIGRATION_FILE])
+    expect(
+      MIGRATION_FILE.localeCompare("20260729062450_equipment_list_liquidation_chronology.sql")
+    ).toBeGreaterThan(0)
+    expect(
+      MIGRATION_FILE.localeCompare("20260727090000_technical_configuration_comparison_reads.sql")
+    ).toBeGreaterThan(0)
+  })
+
+  it("creates one row-revisioned assessment per exact comparison set and criterion", () => {
+    const tableBlock = getSqlBlock(
+      migrationSource,
+      "CREATE TABLE public.technical_configuration_manual_assessments",
+      "\n);"
+    )
+
+    for (const column of [
+      "id UUID PRIMARY KEY DEFAULT gen_random_uuid()",
+      "comparison_set_id UUID NOT NULL",
+      "baseline_version_id UUID NOT NULL",
+      "criterion_id UUID NOT NULL",
+      "technical_axis TEXT",
+      "evidence_axis TEXT",
+      "notes TEXT NOT NULL DEFAULT ''",
+      "revision BIGINT NOT NULL DEFAULT 1",
+      "created_at TIMESTAMPTZ NOT NULL DEFAULT now()",
+      "created_by BIGINT NOT NULL",
+      "updated_at TIMESTAMPTZ NOT NULL DEFAULT now()",
+      "updated_by BIGINT NOT NULL",
+    ]) {
+      expect(tableBlock).toContain(column)
+    }
+
+    expect(getTableColumnNames(tableBlock)).toEqual([
+      "id",
+      "comparison_set_id",
+      "baseline_version_id",
+      "criterion_id",
+      "technical_axis",
+      "evidence_axis",
+      "notes",
+      "revision",
+      "created_at",
+      "created_by",
+      "updated_at",
+      "updated_by",
+    ])
+    expect(tableBlock).toContain("UNIQUE (comparison_set_id, criterion_id)")
+    expect(tableBlock).toContain("CHECK (revision > 0)")
+    expect(tableBlock).toContain("FOREIGN KEY (comparison_set_id, baseline_version_id)")
+    expect(tableBlock).toContain(
+      "REFERENCES public.technical_configuration_comparison_sets (id, baseline_version_id)"
+    )
+    expect(tableBlock).toContain("FOREIGN KEY (criterion_id, baseline_version_id)")
+    expect(tableBlock).toContain(
+      "REFERENCES public.technical_configuration_baseline_criteria (id, baseline_version_id)"
+    )
+    expect(tableBlock.match(/ON DELETE CASCADE/g)).toHaveLength(2)
+  })
+
+  it("stores only nullable canonical axes and notes without derived or machine state", () => {
+    const tableBlock = getSqlBlock(
+      migrationSource,
+      "CREATE TABLE public.technical_configuration_manual_assessments",
+      "\n);"
+    )
+
+    expect(tableBlock).toMatch(
+      /CHECK \(\s*technical_axis IS NULL\s+OR technical_axis IN \(\s*'exceeds',\s*'meets',\s*'fails',\s*'unclear',\s*'not_applicable'\s*\)\s*\)/
+    )
+    expect(tableBlock).toMatch(
+      /CHECK \(\s*evidence_axis IS NULL\s+OR evidence_axis IN \(\s*'complete',\s*'partial',\s*'missing',\s*'not_required'\s*\)\s*\)/
+    )
+    expect(tableBlock).not.toMatch(
+      /derived|overall_status|stale|machine|ai_result|source_response|supplementary|document|citation/i
+    )
+  })
+
+  it("adds leftmost-prefix indexes for both composite ownership foreign keys", () => {
+    for (const index of [
+      "ON public.technical_configuration_manual_assessments (comparison_set_id, baseline_version_id)",
+      "ON public.technical_configuration_manual_assessments (criterion_id, baseline_version_id)",
+    ]) {
+      expect(migrationSource).toContain(index)
+    }
+  })
+
+  it("freezes both dormant DB RPC signatures and exact deterministic wire fields", () => {
+    for (const signature of ASSESSMENT_RPC_SIGNATURES) {
+      expect(migrationSource).toContain(`FUNCTION public.${signature}`)
+    }
+
+    for (const functionName of ASSESSMENT_RPC_NAMES) {
+      const block = getFunctionBlock(migrationSource, functionName)
+      expect(block).toContain("SECURITY DEFINER")
+      expect(block).toContain("SET search_path = public, pg_temp")
+      expect(migrationSource).toContain(`REVOKE ALL ON FUNCTION public.${functionName}`)
+      expect(migrationSource).toContain(`GRANT EXECUTE ON FUNCTION public.${functionName}`)
+      expect(block).not.toMatch(
+        /'derived_status'|'overall_status'|'response_text'|'supplementary_information'|'documents'|'citations'|'machine_result'/
+      )
+    }
+
+    const listBlock = getFunctionBlock(migrationSource, "technical_configuration_assessments_list")
+    const listItemBlock = getSqlBlock(listBlock, "jsonb_build_object(", ") AS item")
+    const upsertBlock = getFunctionBlock(
+      migrationSource,
+      "technical_configuration_assessment_upsert"
+    )
+    const upsertDataBlock = getSqlBlock(
+      upsertBlock,
+      "SELECT jsonb_build_object(",
+      "\n  INTO v_data"
+    )
+
+    expect(getJsonObjectKeys(listItemBlock)).toEqual(
+      ASSESSMENT_WIRE_FIELDS.map((field) => field.slice(1, -1))
+    )
+    expect(getJsonObjectKeys(upsertDataBlock)).toEqual(
+      ASSESSMENT_WIRE_FIELDS.map((field) => field.slice(1, -1))
+    )
+    expect(listBlock).toContain("ORDER BY bg.sort_order, bc.sort_order, bc.id")
+    expect(listBlock).toContain("WITH ordered_assessments AS MATERIALIZED")
+    expect(listBlock).toContain("paged_assessments AS")
+    expect(listBlock).toContain("(SELECT count(*) FROM ordered_assessments)")
+    expect(listBlock).not.toContain("SELECT count(*)\n  INTO v_total")
+    expect(listBlock).toContain("'data'")
+    expect(listBlock).toContain("'total'")
+    expect(listBlock).toContain("'page'")
+    expect(listBlock).toContain("'page_size'")
+  })
+
+  it("keeps list reads bounded, authorized, archived-readable and mutation-free", () => {
+    const listBlock = getFunctionBlock(migrationSource, "technical_configuration_assessments_list")
+
+    expect(listBlock).toContain("PERFORM public._technical_configuration_require_global_user()")
+    expect(listBlock).toContain("p_comparison_set_id IS NULL")
+    expect(listBlock).toContain("p_page IS NULL OR p_page < 1")
+    expect(listBlock).toContain("p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 100")
+    expect(listBlock).toContain("RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422'")
+    expect(listBlock).toContain("RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404'")
+    expect(listBlock).toContain("LIMIT p_page_size")
+    expect(listBlock).toContain("OFFSET (p_page - 1)::BIGINT * p_page_size")
+    expect(listBlock).not.toContain("_technical_configuration_require_editable_dossier")
+    expect(listBlock).not.toMatch(/\bINSERT INTO public\.|\bUPDATE public\.|\bDELETE FROM public\./)
+  })
+
+  it("uses row-level optimistic concurrency and never increments dossier revision", () => {
+    const upsertBlock = getFunctionBlock(
+      migrationSource,
+      "technical_configuration_assessment_upsert"
+    )
+
+    expect(upsertBlock).toContain(
+      "v_user_id := public._technical_configuration_require_global_user()"
+    )
+    expect(upsertBlock).toContain("p_expected_revision IS NULL OR p_expected_revision < 0")
+    expect(upsertBlock).toContain("p_technical_axis IS NOT NULL")
+    expect(upsertBlock).toContain("p_evidence_axis IS NOT NULL")
+    expect(upsertBlock).toContain("RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422'")
+    expect(upsertBlock).toContain("RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404'")
+    expect(upsertBlock).toContain("RAISE EXCEPTION 'archived_dossier' USING ERRCODE = 'PT409'")
+    expect(upsertBlock).toContain("RAISE EXCEPTION 'stale_revision' USING ERRCODE = 'PT409'")
+    expect(upsertBlock).not.toContain("FOR SHARE OF cs, d")
+    expect(upsertBlock).toContain("AND cs.dossier_id = v_dossier_id")
+    expect(upsertBlock.indexOf("FROM public.technical_configuration_dossiers d")).toBeLessThan(
+      upsertBlock.indexOf("AND cs.dossier_id = v_dossier_id")
+    )
+    expect(upsertBlock.indexOf("AND cs.dossier_id = v_dossier_id")).toBeLessThan(
+      upsertBlock.indexOf("FROM public.technical_configuration_baseline_criteria c")
+    )
+    expect(upsertBlock).toContain("FOR UPDATE")
+    expect(upsertBlock).toContain("COALESCE(p_notes, '')")
+    expect(upsertBlock).toContain("p_expected_revision = 0")
+    expect(upsertBlock).toContain("ON CONFLICT (comparison_set_id, criterion_id) DO NOTHING")
+    expect(upsertBlock).toContain("revision = a.revision + 1")
+    expect(upsertBlock).toContain("updated_at = now()")
+    expect(upsertBlock).toContain("updated_by = v_user_id")
+    expect(upsertBlock).not.toContain("_technical_configuration_require_editable_dossier")
+    expect(upsertBlock).not.toMatch(
+      /UPDATE public\.technical_configuration_dossiers|revision = revision \+ 1/
+    )
+  })
+
+  it("keeps the table RPC-only with deny-by-default RLS and explicit grants", () => {
+    const tableName = "technical_configuration_manual_assessments"
+
+    expect(migrationSource).toContain(`ALTER TABLE public.${tableName} ENABLE ROW LEVEL SECURITY`)
+    expect(migrationSource).toContain(`CREATE POLICY ${tableName}_no_client_access`)
+    expect(migrationSource).toContain(
+      "FOR ALL TO anon, authenticated USING (false) WITH CHECK (false)"
+    )
+    expect(migrationSource).toMatch(
+      new RegExp(`REVOKE ALL ON TABLE public\\.${tableName}\\s+FROM PUBLIC, anon, authenticated`)
+    )
+    expect(migrationSource).toContain(`GRANT ALL ON TABLE public.${tableName} TO service_role`)
+
+    for (const functionName of ASSESSMENT_RPC_NAMES) {
+      expect(migrationSource).toMatch(
+        new RegExp(
+          `REVOKE ALL ON FUNCTION public\\.${functionName}\\([\\s\\S]*?\\) FROM PUBLIC, anon, authenticated, service_role`
+        )
+      )
+      expect(migrationSource).toMatch(
+        new RegExp(
+          `GRANT EXECUTE ON FUNCTION public\\.${functionName}\\([\\s\\S]*?\\) TO authenticated, service_role`
+        )
+      )
+    }
+  })
+
+  it("ships one bounded rollback-only phase gate for the complete P11B contract", () => {
+    expect(existsSync(PHASE_GATE_PATH)).toBe(true)
+    expect(countLines(migrationSource)).toBeLessThanOrEqual(450)
+    expect(countLines(phaseGateSource)).toBeLessThanOrEqual(450)
+
+    for (const marker of [
+      "BEGIN;",
+      "ROLLBACK;",
+      "missing claims rejected",
+      "non-global role rejected",
+      "raw admin accepted",
+      "assessment list bounds enforced",
+      "null comparison set rejected",
+      "null page rejected",
+      "null page size rejected",
+      "invalid page rejected",
+      "zero page size rejected",
+      "oversized page size rejected",
+      "archived assessment reads remain available",
+      "archived assessment mutation rejected",
+      "cross-version criterion rejected",
+      "assessment comparison set ownership FK enforced",
+      "assessment criterion ownership FK enforced",
+      "canonical nullable axes and notes preserved",
+      "invalid technical axis rejected",
+      "invalid evidence axis rejected",
+      "first create revision is one",
+      "create response exact wire fields",
+      "existing row rejects expected revision zero",
+      "missing row rejects positive expected revision",
+      "exact update increments only assessment revision",
+      "update response exact wire fields",
+      "stale update leaves assessment unchanged",
+      "source response update preserves manual assessment",
+      "option document update preserves manual assessment",
+      "to_jsonb(a)",
+      "assessment update preserves creation audit",
+      "option delete cascades assessments",
+      "baseline delete cascades assessments",
+      "dossier delete cascades assessments",
+      "manual assessment table exposes no derived or machine fields",
+      "v_column_names = ARRAY[",
+      "FOREACH v_function_signature IN ARRAY",
+      "FOREACH v_table_privilege IN ARRAY",
+    ]) {
+      expect(phaseGateSource).toContain(marker)
+    }
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-manual-assessments-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-manual-assessments-migration.test.ts
@@ -6,6 +6,9 @@ const REPO_ROOT = path.resolve(process.cwd())
 const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
 const MIGRATION_FILE = "20260729134453_technical_configuration_manual_assessments.sql"
 const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const GRANT_REPAIR_FILE =
+  "20260729150646_technical_configuration_manual_assessments_service_role_grants.sql"
+const GRANT_REPAIR_PATH = path.join(MIGRATIONS_DIR, GRANT_REPAIR_FILE)
 const PHASE_GATE_PATH = path.join(
   REPO_ROOT,
   "supabase/tests/technical_configuration_manual_assessments_phase_gate.sql"
@@ -28,11 +31,17 @@ function getSqlBlock(source: string, marker: string, nextMarker: string): string
 }
 
 function getFunctionBlock(source: string, functionName: string): string {
-  return getSqlBlock(
-    source,
-    `FUNCTION public.${functionName}(`,
-    "\nCREATE OR REPLACE FUNCTION public."
-  )
+  const marker = `FUNCTION public.${functionName}(`
+  const start = source.indexOf(marker)
+  if (start === -1) return ""
+
+  const candidates = [
+    source.indexOf("\n$$;", start + marker.length),
+    source.indexOf("\nCREATE OR REPLACE FUNCTION public.", start + marker.length),
+  ].filter((index) => index !== -1)
+  const end = candidates.length > 0 ? Math.min(...candidates) : source.length
+
+  return source.slice(start, end)
 }
 
 function getTableColumnNames(tableBlock: string): string[] {
@@ -49,6 +58,7 @@ function getJsonObjectKeys(objectBlock: string): string[] {
 }
 
 const migrationSource = readIfExists(MIGRATION_PATH)
+const grantRepairSource = readIfExists(GRANT_REPAIR_PATH)
 const phaseGateSource = readIfExists(PHASE_GATE_PATH)
 
 const ASSESSMENT_RPC_SIGNATURES = [
@@ -77,19 +87,21 @@ const ASSESSMENT_WIRE_FIELDS = [
 ] as const
 
 describe("P11B technical configuration manual assessment migration", () => {
-  it("uses one ordered migration after the current technical configuration chain", () => {
+  it("uses ordered migrations after the current technical configuration chain", () => {
     expect(existsSync(MIGRATION_PATH)).toBe(true)
+    expect(existsSync(GRANT_REPAIR_PATH)).toBe(true)
     expect(
       readdirSync(MIGRATIONS_DIR)
         .filter((file) => file.includes("technical_configuration_manual_assessments"))
         .sort()
-    ).toEqual([MIGRATION_FILE])
+    ).toEqual([MIGRATION_FILE, GRANT_REPAIR_FILE])
     expect(
       MIGRATION_FILE.localeCompare("20260729062450_equipment_list_liquidation_chronology.sql")
     ).toBeGreaterThan(0)
     expect(
       MIGRATION_FILE.localeCompare("20260727090000_technical_configuration_comparison_reads.sql")
     ).toBeGreaterThan(0)
+    expect(GRANT_REPAIR_FILE.localeCompare(MIGRATION_FILE)).toBeGreaterThan(0)
   })
 
   it("creates one row-revisioned assessment per exact comparison set and criterion", () => {
@@ -204,6 +216,8 @@ describe("P11B technical configuration manual assessment migration", () => {
     expect(getJsonObjectKeys(upsertDataBlock)).toEqual(
       ASSESSMENT_WIRE_FIELDS.map((field) => field.slice(1, -1))
     )
+    expect(upsertBlock).not.toContain("REVOKE ALL ON FUNCTION")
+    expect(upsertBlock).not.toContain("COMMIT;")
     expect(listBlock).toContain("ORDER BY bg.sort_order, bc.sort_order, bc.id")
     expect(listBlock).toContain("WITH ordered_assessments AS MATERIALIZED")
     expect(listBlock).toContain("paged_assessments AS")
@@ -278,7 +292,15 @@ describe("P11B technical configuration manual assessment migration", () => {
     expect(migrationSource).toMatch(
       new RegExp(`REVOKE ALL ON TABLE public\\.${tableName}\\s+FROM PUBLIC, anon, authenticated`)
     )
+    const serviceRoleDmlGrant = new RegExp(
+      `GRANT SELECT, INSERT, UPDATE, DELETE\\s+ON TABLE public\\.${tableName} TO service_role`
+    )
     expect(migrationSource).toContain(`GRANT ALL ON TABLE public.${tableName} TO service_role`)
+    expect(grantRepairSource).toMatch(
+      new RegExp(`REVOKE ALL ON TABLE public\\.${tableName}\\s+FROM service_role`)
+    )
+    expect(grantRepairSource).toMatch(serviceRoleDmlGrant)
+    expect(grantRepairSource).not.toContain(`GRANT ALL ON TABLE public.${tableName}`)
 
     for (const functionName of ASSESSMENT_RPC_NAMES) {
       expect(migrationSource).toMatch(
@@ -338,6 +360,8 @@ describe("P11B technical configuration manual assessment migration", () => {
       "v_column_names = ARRAY[",
       "FOREACH v_function_signature IN ARRAY",
       "FOREACH v_table_privilege IN ARRAY",
+      "ARRAY['TRUNCATE', 'REFERENCES', 'TRIGGER']",
+      "service role table privilege denied",
     ]) {
       expect(phaseGateSource).toContain(marker)
     }

--- a/supabase/migrations/20260729134453_technical_configuration_manual_assessments.sql
+++ b/supabase/migrations/20260729134453_technical_configuration_manual_assessments.sql
@@ -1,0 +1,340 @@
+-- P11B: dormant manual-assessment persistence and guarded database contracts.
+BEGIN;
+
+CREATE TABLE public.technical_configuration_manual_assessments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  comparison_set_id UUID NOT NULL,
+  baseline_version_id UUID NOT NULL,
+  criterion_id UUID NOT NULL,
+  technical_axis TEXT,
+  evidence_axis TEXT,
+  notes TEXT NOT NULL DEFAULT '',
+  revision BIGINT NOT NULL DEFAULT 1,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by BIGINT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by BIGINT NOT NULL,
+  UNIQUE (comparison_set_id, criterion_id),
+  CHECK (
+    technical_axis IS NULL
+    OR technical_axis IN (
+      'exceeds',
+      'meets',
+      'fails',
+      'unclear',
+      'not_applicable'
+    )
+  ),
+  CHECK (
+    evidence_axis IS NULL
+    OR evidence_axis IN (
+      'complete',
+      'partial',
+      'missing',
+      'not_required'
+    )
+  ),
+  CHECK (revision > 0),
+  FOREIGN KEY (comparison_set_id, baseline_version_id)
+    REFERENCES public.technical_configuration_comparison_sets (id, baseline_version_id)
+    ON DELETE CASCADE,
+  FOREIGN KEY (criterion_id, baseline_version_id)
+    REFERENCES public.technical_configuration_baseline_criteria (id, baseline_version_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX technical_configuration_manual_assessments_set_version_idx
+  ON public.technical_configuration_manual_assessments (comparison_set_id, baseline_version_id);
+CREATE INDEX technical_configuration_manual_assessments_criterion_version_idx
+  ON public.technical_configuration_manual_assessments (criterion_id, baseline_version_id);
+
+ALTER TABLE public.technical_configuration_manual_assessments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY technical_configuration_manual_assessments_no_client_access
+  ON public.technical_configuration_manual_assessments
+  FOR ALL TO anon, authenticated USING (false) WITH CHECK (false);
+
+REVOKE ALL ON TABLE public.technical_configuration_manual_assessments
+  FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.technical_configuration_manual_assessments TO service_role;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_assessments_list(
+  p_comparison_set_id UUID,
+  p_page INTEGER,
+  p_page_size INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_baseline_version_id UUID;
+  v_total BIGINT;
+  v_data JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+
+  IF p_comparison_set_id IS NULL
+     OR p_page IS NULL OR p_page < 1
+     OR p_page_size IS NULL OR p_page_size < 1 OR p_page_size > 100 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  SELECT cs.baseline_version_id
+  INTO v_baseline_version_id
+  FROM public.technical_configuration_comparison_sets cs
+  WHERE cs.id = p_comparison_set_id
+  FOR SHARE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  WITH ordered_assessments AS MATERIALIZED (
+    SELECT
+      jsonb_build_object(
+        'id', a.id,
+        'comparison_set_id', a.comparison_set_id,
+        'baseline_version_id', a.baseline_version_id,
+        'criterion_id', a.criterion_id,
+        'technical_axis', a.technical_axis,
+        'evidence_axis', a.evidence_axis,
+        'notes', a.notes,
+        'revision', a.revision,
+        'created_by', a.created_by,
+        'created_at', a.created_at,
+        'updated_by', a.updated_by,
+        'updated_at', a.updated_at
+      ) AS item,
+      bg.sort_order AS group_order,
+      bc.sort_order AS criterion_order,
+      bc.id AS criterion_id
+    FROM public.technical_configuration_manual_assessments a
+    JOIN public.technical_configuration_baseline_criteria bc
+      ON bc.id = a.criterion_id
+     AND bc.baseline_version_id = a.baseline_version_id
+    JOIN public.technical_configuration_baseline_groups bg
+      ON bg.id = bc.group_id
+     AND bg.baseline_version_id = bc.baseline_version_id
+    WHERE a.comparison_set_id = p_comparison_set_id
+      AND a.baseline_version_id = v_baseline_version_id
+    ORDER BY bg.sort_order, bc.sort_order, bc.id
+  ),
+  paged_assessments AS (
+    SELECT *
+    FROM ordered_assessments
+    ORDER BY group_order, criterion_order, criterion_id
+    LIMIT p_page_size
+    OFFSET (p_page - 1)::BIGINT * p_page_size
+  )
+  SELECT
+    (SELECT count(*) FROM ordered_assessments),
+    COALESCE(
+      jsonb_agg(
+        paged.item
+        ORDER BY paged.group_order, paged.criterion_order, paged.criterion_id
+      ),
+      '[]'::JSONB
+    )
+  INTO v_total, v_data
+  FROM paged_assessments paged;
+
+  RETURN jsonb_build_object(
+    'data', v_data,
+    'total', v_total,
+    'page', p_page,
+    'page_size', p_page_size
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.technical_configuration_assessment_upsert(
+  p_comparison_set_id UUID,
+  p_criterion_id UUID,
+  p_technical_axis TEXT,
+  p_evidence_axis TEXT,
+  p_notes TEXT,
+  p_expected_revision BIGINT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_user_id BIGINT;
+  v_dossier_id UUID;
+  v_baseline_version_id UUID;
+  v_criterion_version_id UUID;
+  v_archived_at TIMESTAMPTZ;
+  v_assessment_id UUID;
+  v_current_revision BIGINT;
+  v_data JSONB;
+BEGIN
+  v_user_id := public._technical_configuration_require_global_user();
+
+  IF p_comparison_set_id IS NULL
+     OR p_criterion_id IS NULL
+     OR p_expected_revision IS NULL OR p_expected_revision < 0 THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  IF p_technical_axis IS NOT NULL
+     AND p_technical_axis NOT IN (
+       'exceeds',
+       'meets',
+       'fails',
+       'unclear',
+       'not_applicable'
+     ) THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  IF p_evidence_axis IS NOT NULL
+     AND p_evidence_axis NOT IN (
+       'complete',
+       'partial',
+       'missing',
+       'not_required'
+     ) THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  SELECT cs.dossier_id
+  INTO v_dossier_id
+  FROM public.technical_configuration_comparison_sets cs
+  WHERE cs.id = p_comparison_set_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  SELECT d.archived_at
+  INTO v_archived_at
+  FROM public.technical_configuration_dossiers d
+  WHERE d.id = v_dossier_id
+  FOR SHARE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  IF v_archived_at IS NOT NULL THEN
+    RAISE EXCEPTION 'archived_dossier' USING ERRCODE = 'PT409';
+  END IF;
+
+  SELECT cs.baseline_version_id
+  INTO v_baseline_version_id
+  FROM public.technical_configuration_comparison_sets cs
+  WHERE cs.id = p_comparison_set_id
+    AND cs.dossier_id = v_dossier_id
+  FOR SHARE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  SELECT c.baseline_version_id
+  INTO v_criterion_version_id
+  FROM public.technical_configuration_baseline_criteria c
+  WHERE c.id = p_criterion_id
+  FOR SHARE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+
+  IF v_baseline_version_id IS DISTINCT FROM v_criterion_version_id THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+
+  SELECT a.id, a.revision
+  INTO v_assessment_id, v_current_revision
+  FROM public.technical_configuration_manual_assessments a
+  WHERE a.comparison_set_id = p_comparison_set_id
+    AND a.criterion_id = p_criterion_id
+  FOR UPDATE;
+
+  IF FOUND THEN
+    IF v_current_revision IS DISTINCT FROM p_expected_revision THEN
+      RAISE EXCEPTION 'stale_revision' USING ERRCODE = 'PT409';
+    END IF;
+
+    UPDATE public.technical_configuration_manual_assessments AS a
+    SET technical_axis = p_technical_axis,
+        evidence_axis = p_evidence_axis,
+        notes = COALESCE(p_notes, ''),
+        revision = a.revision + 1,
+        updated_at = now(),
+        updated_by = v_user_id
+    WHERE a.id = v_assessment_id;
+  ELSE
+    IF p_expected_revision = 0 THEN
+      INSERT INTO public.technical_configuration_manual_assessments (
+        comparison_set_id,
+        baseline_version_id,
+        criterion_id,
+        technical_axis,
+        evidence_axis,
+        notes,
+        created_by,
+        updated_by
+      )
+      VALUES (
+        p_comparison_set_id,
+        v_baseline_version_id,
+        p_criterion_id,
+        p_technical_axis,
+        p_evidence_axis,
+        COALESCE(p_notes, ''),
+        v_user_id,
+        v_user_id
+      )
+      ON CONFLICT (comparison_set_id, criterion_id) DO NOTHING
+      RETURNING id INTO v_assessment_id;
+
+      IF v_assessment_id IS NULL THEN
+        RAISE EXCEPTION 'stale_revision' USING ERRCODE = 'PT409';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'stale_revision' USING ERRCODE = 'PT409';
+    END IF;
+  END IF;
+
+  SELECT jsonb_build_object(
+    'id', a.id,
+    'comparison_set_id', a.comparison_set_id,
+    'baseline_version_id', a.baseline_version_id,
+    'criterion_id', a.criterion_id,
+    'technical_axis', a.technical_axis,
+    'evidence_axis', a.evidence_axis,
+    'notes', a.notes,
+    'revision', a.revision,
+    'created_by', a.created_by,
+    'created_at', a.created_at,
+    'updated_by', a.updated_by,
+    'updated_at', a.updated_at
+  )
+  INTO v_data
+  FROM public.technical_configuration_manual_assessments a
+  WHERE a.id = v_assessment_id;
+
+  RETURN jsonb_build_object('data', v_data);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.technical_configuration_assessments_list(
+  UUID, INTEGER, INTEGER
+) FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.technical_configuration_assessment_upsert(
+  UUID, UUID, TEXT, TEXT, TEXT, BIGINT
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_assessments_list(
+  UUID, INTEGER, INTEGER
+) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_assessment_upsert(
+  UUID, UUID, TEXT, TEXT, TEXT, BIGINT
+) TO authenticated, service_role;
+
+COMMIT;

--- a/supabase/migrations/20260729150646_technical_configuration_manual_assessments_service_role_grants.sql
+++ b/supabase/migrations/20260729150646_technical_configuration_manual_assessments_service_role_grants.sql
@@ -1,0 +1,9 @@
+-- P11B: narrow service-role access for the already-deployed assessment table.
+BEGIN;
+
+REVOKE ALL ON TABLE public.technical_configuration_manual_assessments
+  FROM service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON TABLE public.technical_configuration_manual_assessments TO service_role;
+
+COMMIT;

--- a/supabase/tests/technical_configuration_manual_assessments_phase_gate.sql
+++ b/supabase/tests/technical_configuration_manual_assessments_phase_gate.sql
@@ -426,23 +426,23 @@ BEGIN
     'technical_configuration_manual_assessments RLS enabled',
     v_rls_enabled
   );
-  FOREACH v_table_privilege IN ARRAY ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']
-  LOOP
+  FOREACH v_table_privilege IN ARRAY ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE'] LOOP
     PERFORM pg_temp.assert_true('authenticated table privilege denied',
       NOT has_table_privilege(
-        'authenticated', 'public.technical_configuration_manual_assessments',
-        v_table_privilege
-      ));
+        'authenticated', 'public.technical_configuration_manual_assessments', v_table_privilege));
     PERFORM pg_temp.assert_true('anon table privilege denied',
       NOT has_table_privilege(
-        'anon', 'public.technical_configuration_manual_assessments',
-        v_table_privilege
-      ));
+        'anon', 'public.technical_configuration_manual_assessments', v_table_privilege));
     PERFORM pg_temp.assert_true('service role table privilege granted',
       has_table_privilege(
         'service_role', 'public.technical_configuration_manual_assessments',
         v_table_privilege
       ));
+  END LOOP;
+  FOREACH v_table_privilege IN ARRAY ARRAY['TRUNCATE', 'REFERENCES', 'TRIGGER'] LOOP
+    PERFORM pg_temp.assert_true('service role table privilege denied',
+      NOT has_table_privilege(
+        'service_role', 'public.technical_configuration_manual_assessments', v_table_privilege));
   END LOOP;
 END;
 $gate$;

--- a/supabase/tests/technical_configuration_manual_assessments_phase_gate.sql
+++ b/supabase/tests/technical_configuration_manual_assessments_phase_gate.sql
@@ -1,0 +1,450 @@
+-- P11B rollback-only manual-assessment auth, ownership, revision, and ACL gate.
+BEGIN;
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT, p_statement TEXT, p_expected_state TEXT, p_expected_message TEXT
+) RETURNS VOID LANGUAGE plpgsql AS $gate$
+DECLARE v_state TEXT; v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_state = RETURNED_SQLSTATE, v_message = MESSAGE_TEXT;
+    IF v_state IS DISTINCT FROM p_expected_state
+       OR v_message IS DISTINCT FROM p_expected_message THEN
+      RAISE EXCEPTION '%: expected [%] %, got [%] %',
+        p_label, p_expected_state, p_expected_message, v_state, v_message;
+    END IF;
+    RETURN;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+CREATE FUNCTION pg_temp.expect_state(
+  p_label TEXT, p_statement TEXT, p_expected_state TEXT
+) RETURNS VOID LANGUAGE plpgsql AS $gate$
+DECLARE v_state TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_state = RETURNED_SQLSTATE;
+    IF v_state IS DISTINCT FROM p_expected_state THEN
+      RAISE EXCEPTION '%: expected [%], got [%]', p_label, p_expected_state, v_state;
+    END IF;
+    RETURN;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object(
+      'app_role', p_app_role, 'role', 'authenticated',
+      'user_id', p_user_id::TEXT, 'sub', p_user_id::TEXT
+    )::TEXT,
+    true
+  );
+END;
+$gate$;
+CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN RAISE EXCEPTION '%', p_label; END IF;
+END;
+$gate$;
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT; v_created_by BIGINT; v_dossier_revision BIGINT; v_count BIGINT;
+  v_created_at TIMESTAMPTZ; v_rls_enabled BOOLEAN;
+  v_response JSONB; v_list JSONB; v_assessment_snapshot JSONB;
+  v_column_names TEXT[];
+  v_wire_fields CONSTANT TEXT[] := ARRAY['baseline_version_id', 'comparison_set_id', 'created_at', 'created_by', 'criterion_id', 'evidence_axis', 'id', 'notes', 'revision', 'technical_axis', 'updated_at', 'updated_by'];
+  v_function_signature TEXT; v_table_privilege TEXT;
+  v_dossier_id UUID := gen_random_uuid();
+  v_archived_dossier_id UUID := gen_random_uuid();
+  v_supplier_id UUID := gen_random_uuid();
+  v_archived_supplier_id UUID := gen_random_uuid();
+  v_option_id UUID := gen_random_uuid();
+  v_archived_option_id UUID := gen_random_uuid();
+  v_version_id UUID := gen_random_uuid();
+  v_other_version_id UUID := gen_random_uuid();
+  v_cascade_version_id UUID := gen_random_uuid();
+  v_archived_version_id UUID := gen_random_uuid();
+  v_first_group_id UUID := gen_random_uuid();
+  v_second_group_id UUID := gen_random_uuid();
+  v_other_group_id UUID := gen_random_uuid();
+  v_cascade_group_id UUID := gen_random_uuid();
+  v_archived_group_id UUID := gen_random_uuid();
+  v_first_criterion_id UUID := gen_random_uuid();
+  v_second_criterion_id UUID := gen_random_uuid();
+  v_missing_criterion_id UUID := gen_random_uuid();
+  v_other_criterion_id UUID := gen_random_uuid();
+  v_cascade_criterion_id UUID := gen_random_uuid();
+  v_archived_criterion_id UUID := gen_random_uuid();
+  v_set_id UUID := gen_random_uuid();
+  v_cascade_set_id UUID := gen_random_uuid();
+  v_archived_set_id UUID := gen_random_uuid();
+  v_response_id UUID := gen_random_uuid();
+  v_document_id UUID := gen_random_uuid();
+  v_archived_assessment_id UUID := gen_random_uuid();
+  v_cascade_assessment_id UUID := gen_random_uuid();
+  v_assessment_id UUID; v_second_assessment_id UUID;
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_manual_assessments_phase_gate')
+  );
+  SELECT nv.id INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P11B phase gate requires one active public.nhan_vien row';
+  END IF;
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, archived_at, archived_by, created_by, updated_by
+  ) VALUES
+    (v_dossier_id, 'P11B device ' || v_suffix, 'P11B dossier ' || v_suffix,
+      NULL, NULL, v_user_id, v_user_id),
+    (v_archived_dossier_id, 'P11B archived device ' || v_suffix,
+      'P11B archived dossier ' || v_suffix, now(), v_user_id, v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_suppliers (
+    id, dossier_id, name, created_by, updated_by
+  ) VALUES
+    (v_supplier_id, v_dossier_id, 'P11B Supplier', v_user_id, v_user_id),
+    (v_archived_supplier_id, v_archived_dossier_id, 'P11B Archived Supplier',
+      v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_options (
+    id, dossier_id, supplier_id, option_name, created_by, updated_by
+  ) VALUES
+    (v_option_id, v_dossier_id, v_supplier_id, 'P11B Option', v_user_id, v_user_id),
+    (v_archived_option_id, v_archived_dossier_id, v_archived_supplier_id,
+      'P11B Archived Option', v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id, dossier_id, version_number, status, next_criterion_number, revision,
+    locked_at, locked_by, created_by, updated_by
+  ) VALUES
+    (v_version_id, v_dossier_id, 1, 'locked', 4, 1,
+      now(), v_user_id, v_user_id, v_user_id),
+    (v_other_version_id, v_dossier_id, 2, 'locked', 2, 1,
+      now(), v_user_id, v_user_id, v_user_id),
+    (v_cascade_version_id, v_dossier_id, 3, 'locked', 2, 1,
+      now(), v_user_id, v_user_id, v_user_id),
+    (v_archived_version_id, v_archived_dossier_id, 1, 'locked', 2, 1,
+      now(), v_user_id, v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id, baseline_version_id, name, sort_order, created_by, updated_by
+  ) VALUES
+    (v_first_group_id, v_version_id, 'First Group', 1, v_user_id, v_user_id),
+    (v_second_group_id, v_version_id, 'Second Group', 2, v_user_id, v_user_id),
+    (v_other_group_id, v_other_version_id, 'Other Group', 1, v_user_id, v_user_id),
+    (v_cascade_group_id, v_cascade_version_id, 'Cascade Group', 1,
+      v_user_id, v_user_id),
+    (v_archived_group_id, v_archived_version_id, 'Archived Group', 1,
+      v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id, baseline_version_id, group_id, criterion_code, requirement_text,
+    sort_order, created_by, updated_by
+  ) VALUES
+    (v_first_criterion_id, v_version_id, v_second_group_id,
+      'TC-0001', 'First criterion', 1, v_user_id, v_user_id),
+    (v_second_criterion_id, v_version_id, v_first_group_id,
+      'TC-0002', 'Second criterion', 1, v_user_id, v_user_id),
+    (v_missing_criterion_id, v_version_id, v_first_group_id,
+      'TC-0003', 'Missing criterion', 2, v_user_id, v_user_id),
+    (v_other_criterion_id, v_other_version_id, v_other_group_id,
+      'TC-0001', 'Other criterion', 1, v_user_id, v_user_id),
+    (v_cascade_criterion_id, v_cascade_version_id, v_cascade_group_id,
+      'TC-0001', 'Cascade criterion', 1, v_user_id, v_user_id),
+    (v_archived_criterion_id, v_archived_version_id, v_archived_group_id,
+      'TC-0001', 'Archived criterion', 1, v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_comparison_sets (
+    id, dossier_id, option_id, baseline_version_id, created_by, updated_by
+  ) VALUES
+    (v_set_id, v_dossier_id, v_option_id, v_version_id, v_user_id, v_user_id),
+    (v_cascade_set_id, v_dossier_id, v_option_id, v_cascade_version_id,
+      v_user_id, v_user_id),
+    (v_archived_set_id, v_archived_dossier_id, v_archived_option_id,
+      v_archived_version_id, v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_option_responses (
+    id, comparison_set_id, baseline_version_id, criterion_id,
+    response_text, supplementary_information, created_by, updated_by
+  ) VALUES (
+    v_response_id, v_set_id, v_version_id, v_first_criterion_id,
+    'Original response', 'Original supplementary', v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_option_documents (
+    id, option_id, name, url, created_by, updated_by
+  ) VALUES (
+    v_document_id, v_option_id, 'Original document',
+    'https://example.com/original.pdf', v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_manual_assessments (
+    id, comparison_set_id, baseline_version_id, criterion_id,
+    technical_axis, evidence_axis, notes, created_by, updated_by
+  ) VALUES (
+    v_archived_assessment_id, v_archived_set_id, v_archived_version_id,
+    v_archived_criterion_id, 'meets', 'complete', 'Archived note',
+    v_user_id, v_user_id
+  );
+  -- missing claims rejected
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error('missing claims rejected', format(
+    'SELECT public.technical_configuration_assessments_list(%L::UUID, 1, 100)',
+    v_set_id), '42501', 'permission_denied');
+  -- non-global role rejected
+  PERFORM pg_temp.set_claims('to_qltb', v_user_id);
+  PERFORM pg_temp.expect_error('non-global role rejected', format(
+    'SELECT public.technical_configuration_assessment_upsert(%L::UUID, %L::UUID, NULL, NULL, NULL, 0)',
+    v_set_id, v_first_criterion_id), '42501', 'permission_denied');
+  -- raw admin accepted
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  SELECT public.technical_configuration_assessments_list(v_set_id, 1, 100)
+  INTO v_list;
+  PERFORM pg_temp.assert_true('raw admin accepted', (v_list->>'total')::BIGINT = 0);
+  -- assessment list bounds enforced
+  PERFORM pg_temp.expect_error('null comparison set rejected',
+    'SELECT public.technical_configuration_assessments_list(NULL, 1, 100)',
+    'PT422', 'validation_error');
+  PERFORM pg_temp.expect_error('null page rejected', format(
+    'SELECT public.technical_configuration_assessments_list(%L::UUID, NULL, 100)',
+    v_set_id), 'PT422', 'validation_error');
+  PERFORM pg_temp.expect_error('null page size rejected', format(
+    'SELECT public.technical_configuration_assessments_list(%L::UUID, 1, NULL)',
+    v_set_id), 'PT422', 'validation_error');
+  PERFORM pg_temp.expect_error('invalid page rejected', format(
+    'SELECT public.technical_configuration_assessments_list(%L::UUID, 0, 100)',
+    v_set_id), 'PT422', 'validation_error');
+  PERFORM pg_temp.expect_error('zero page size rejected', format(
+    'SELECT public.technical_configuration_assessments_list(%L::UUID, 1, 0)',
+    v_set_id), 'PT422', 'validation_error');
+  PERFORM pg_temp.expect_error('oversized page size rejected', format(
+    'SELECT public.technical_configuration_assessments_list(%L::UUID, 1, 101)',
+    v_set_id), 'PT422', 'validation_error');
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  SELECT revision INTO v_dossier_revision
+  FROM public.technical_configuration_dossiers WHERE id = v_dossier_id;
+  -- cross-version criterion rejected
+  PERFORM pg_temp.expect_error('cross-version criterion rejected', format(
+    'SELECT public.technical_configuration_assessment_upsert(%L::UUID, %L::UUID, %L, %L, NULL, 0)',
+    v_set_id, v_other_criterion_id, 'meets', 'complete'),
+    'PT422', 'validation_error');
+  -- assessment comparison set ownership FK enforced
+  PERFORM pg_temp.expect_state('assessment comparison set ownership FK enforced', format(
+    'INSERT INTO public.technical_configuration_manual_assessments (comparison_set_id, baseline_version_id, criterion_id, created_by, updated_by) VALUES (%L::UUID, %L::UUID, %L::UUID, %s, %s)',
+    v_set_id, v_other_version_id, v_other_criterion_id, v_user_id, v_user_id),
+    '23503');
+  -- assessment criterion ownership FK enforced
+  PERFORM pg_temp.expect_state('assessment criterion ownership FK enforced', format(
+    'INSERT INTO public.technical_configuration_manual_assessments (comparison_set_id, baseline_version_id, criterion_id, created_by, updated_by) VALUES (%L::UUID, %L::UUID, %L::UUID, %s, %s)',
+    v_set_id, v_version_id, v_other_criterion_id, v_user_id, v_user_id),
+    '23503');
+  -- invalid technical axis rejected
+  PERFORM pg_temp.expect_error('invalid technical axis rejected', format(
+    'SELECT public.technical_configuration_assessment_upsert(%L::UUID, %L::UUID, %L, NULL, NULL, 0)',
+    v_set_id, v_first_criterion_id, 'invalid'), 'PT422', 'validation_error');
+  -- invalid evidence axis rejected
+  PERFORM pg_temp.expect_error('invalid evidence axis rejected', format(
+    'SELECT public.technical_configuration_assessment_upsert(%L::UUID, %L::UUID, NULL, %L, NULL, 0)',
+    v_set_id, v_first_criterion_id, 'invalid'), 'PT422', 'validation_error');
+  -- first create revision is one
+  SELECT public.technical_configuration_assessment_upsert(
+    v_set_id, v_first_criterion_id, 'exceeds', 'complete', NULL, 0
+  ) INTO v_response;
+  SELECT array_agg(key ORDER BY key) INTO v_column_names FROM jsonb_object_keys(v_response->'data') AS key;
+  PERFORM pg_temp.assert_true('create response exact wire fields', v_column_names = v_wire_fields);
+  v_assessment_id := (v_response->'data'->>'id')::UUID;
+  SELECT created_at, created_by INTO v_created_at, v_created_by
+  FROM public.technical_configuration_manual_assessments WHERE id = v_assessment_id;
+  PERFORM pg_temp.assert_true('first create revision is one',
+    (v_response->'data'->>'revision')::BIGINT = 1
+    AND v_response->'data'->>'notes' = ''
+    AND (SELECT revision FROM public.technical_configuration_dossiers
+         WHERE id = v_dossier_id) = v_dossier_revision);
+  -- canonical nullable axes and notes preserved
+  SELECT public.technical_configuration_assessment_upsert(
+    v_set_id, v_second_criterion_id, NULL, NULL, NULL, 0
+  ) INTO v_response;
+  v_second_assessment_id := (v_response->'data'->>'id')::UUID;
+  PERFORM pg_temp.assert_true('canonical nullable axes and notes preserved',
+    v_response->'data'->'technical_axis' = 'null'::JSONB
+    AND v_response->'data'->'evidence_axis' = 'null'::JSONB
+    AND v_response->'data'->>'notes' = '');
+  SELECT public.technical_configuration_assessments_list(v_set_id, 1, 100)
+  INTO v_list;
+  SELECT count(*) INTO v_count FROM jsonb_object_keys(v_list->'data'->0);
+  PERFORM pg_temp.assert_true('assessment list ordering and wire fields',
+    (v_list->>'total')::BIGINT = 2
+    AND jsonb_array_length(v_list->'data') = 2
+    AND (v_list->'data'->0->>'criterion_id')::UUID = v_second_criterion_id
+    AND (v_list->'data'->1->>'criterion_id')::UUID = v_first_criterion_id
+    AND v_count = 12);
+  -- archived assessment reads remain available
+  SELECT public.technical_configuration_assessments_list(v_archived_set_id, 1, 100)
+  INTO v_list;
+  PERFORM pg_temp.assert_true('archived assessment reads remain available',
+    (v_list->>'total')::BIGINT = 1
+    AND (v_list->'data'->0->>'id')::UUID = v_archived_assessment_id);
+  -- archived assessment mutation rejected
+  PERFORM pg_temp.expect_error('archived assessment mutation rejected', format(
+    'SELECT public.technical_configuration_assessment_upsert(%L::UUID, %L::UUID, %L, %L, NULL, 1)',
+    v_archived_set_id, v_archived_criterion_id, 'fails', 'missing'),
+    'PT409', 'archived_dossier');
+  -- existing row rejects expected revision zero
+  PERFORM pg_temp.expect_error('existing row rejects expected revision zero', format(
+    'SELECT public.technical_configuration_assessment_upsert(%L::UUID, %L::UUID, %L, %L, NULL, 0)',
+    v_set_id, v_first_criterion_id, 'meets', 'complete'),
+    'PT409', 'stale_revision');
+  -- missing row rejects positive expected revision
+  PERFORM pg_temp.expect_error('missing row rejects positive expected revision', format(
+    'SELECT public.technical_configuration_assessment_upsert(%L::UUID, %L::UUID, %L, %L, NULL, 1)',
+    v_set_id, v_missing_criterion_id, 'meets', 'complete'),
+    'PT409', 'stale_revision');
+  -- exact update increments only assessment revision
+  SELECT public.technical_configuration_assessment_upsert(
+    v_set_id, v_first_criterion_id, 'meets', 'partial', 'Reviewed', 1
+  ) INTO v_response;
+  SELECT array_agg(key ORDER BY key) INTO v_column_names FROM jsonb_object_keys(v_response->'data') AS key;
+  PERFORM pg_temp.assert_true('update response exact wire fields', v_column_names = v_wire_fields);
+  PERFORM pg_temp.assert_true('exact update increments only assessment revision',
+    (v_response->'data'->>'revision')::BIGINT = 2
+    AND (SELECT revision FROM public.technical_configuration_dossiers
+         WHERE id = v_dossier_id) = v_dossier_revision);
+  -- stale update leaves assessment unchanged
+  PERFORM pg_temp.expect_error('stale update leaves assessment unchanged', format(
+    'SELECT public.technical_configuration_assessment_upsert(%L::UUID, %L::UUID, %L, %L, %L, 1)',
+    v_set_id, v_first_criterion_id, 'fails', 'missing', 'Stale'),
+    'PT409', 'stale_revision');
+  PERFORM pg_temp.assert_true('stale update leaves assessment unchanged',
+    (SELECT revision = 2 AND notes = 'Reviewed'
+     FROM public.technical_configuration_manual_assessments
+     WHERE id = v_assessment_id));
+
+  -- source response update preserves manual assessment
+  SELECT to_jsonb(a) INTO v_assessment_snapshot
+  FROM public.technical_configuration_manual_assessments a
+  WHERE a.id = v_assessment_id;
+  UPDATE public.technical_configuration_option_responses
+  SET response_text = 'Changed response',
+      supplementary_information = 'Changed supplementary',
+      updated_at = now(), updated_by = v_user_id
+  WHERE id = v_response_id;
+  PERFORM pg_temp.assert_true('source response update preserves manual assessment',
+    (SELECT to_jsonb(a) = v_assessment_snapshot
+     FROM public.technical_configuration_manual_assessments a
+     WHERE a.id = v_assessment_id));
+  SELECT public.technical_configuration_assessment_upsert(
+    v_set_id, v_first_criterion_id, 'meets', 'complete', 'After response', 2
+  ) INTO v_response;
+  PERFORM pg_temp.assert_true('post-response assessment update succeeds',
+    (v_response->'data'->>'revision')::BIGINT = 3);
+  -- option document update preserves manual assessment
+  SELECT to_jsonb(a) INTO v_assessment_snapshot
+  FROM public.technical_configuration_manual_assessments a
+  WHERE a.id = v_assessment_id;
+  UPDATE public.technical_configuration_option_documents
+  SET name = 'Changed document', url = 'https://example.com/changed.pdf',
+      updated_at = now(), updated_by = v_user_id
+  WHERE id = v_document_id;
+  PERFORM pg_temp.assert_true('option document update preserves manual assessment',
+    (SELECT to_jsonb(a) = v_assessment_snapshot
+     FROM public.technical_configuration_manual_assessments a
+     WHERE a.id = v_assessment_id));
+  SELECT public.technical_configuration_assessment_upsert(
+    v_set_id, v_first_criterion_id, 'meets', 'complete', 'After document', 3
+  ) INTO v_response;
+  PERFORM pg_temp.assert_true('post-document assessment update succeeds',
+    (v_response->'data'->>'revision')::BIGINT = 4);
+  -- assessment update preserves creation audit
+  PERFORM pg_temp.assert_true('assessment update preserves creation audit',
+    (SELECT created_at = v_created_at AND created_by = v_created_by
+     FROM public.technical_configuration_manual_assessments
+     WHERE id = v_assessment_id));
+
+  INSERT INTO public.technical_configuration_manual_assessments (
+    id, comparison_set_id, baseline_version_id, criterion_id,
+    technical_axis, evidence_axis, created_by, updated_by
+  ) VALUES (
+    v_cascade_assessment_id, v_cascade_set_id, v_cascade_version_id,
+    v_cascade_criterion_id, 'meets', 'complete', v_user_id, v_user_id
+  );
+  -- baseline delete cascades assessments
+  DELETE FROM public.technical_configuration_baseline_versions
+  WHERE id = v_cascade_version_id;
+  PERFORM pg_temp.assert_true('baseline delete cascades assessments',
+    NOT EXISTS (
+      SELECT 1 FROM public.technical_configuration_manual_assessments
+      WHERE id = v_cascade_assessment_id
+    ));
+  -- option delete cascades assessments
+  DELETE FROM public.technical_configuration_options WHERE id = v_option_id;
+  PERFORM pg_temp.assert_true('option delete cascades assessments',
+    NOT EXISTS (
+      SELECT 1 FROM public.technical_configuration_manual_assessments
+      WHERE id IN (v_assessment_id, v_second_assessment_id)
+    ));
+  -- dossier delete cascades assessments
+  DELETE FROM public.technical_configuration_dossiers WHERE id = v_archived_dossier_id;
+  PERFORM pg_temp.assert_true('dossier delete cascades assessments',
+    NOT EXISTS (
+      SELECT 1 FROM public.technical_configuration_manual_assessments
+      WHERE id = v_archived_assessment_id
+    ));
+
+  SELECT array_agg(column_name::TEXT ORDER BY ordinal_position)
+  INTO v_column_names
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'technical_configuration_manual_assessments';
+  PERFORM pg_temp.assert_true(
+    'manual assessment table exposes no derived or machine fields',
+    v_column_names = ARRAY[
+      'id', 'comparison_set_id', 'baseline_version_id', 'criterion_id',
+      'technical_axis', 'evidence_axis', 'notes', 'revision',
+      'created_at', 'created_by', 'updated_at', 'updated_by'
+    ]
+  );
+  FOREACH v_function_signature IN ARRAY ARRAY[
+    'public.technical_configuration_assessments_list(uuid,integer,integer)',
+    'public.technical_configuration_assessment_upsert(uuid,uuid,text,text,text,bigint)'
+  ] LOOP
+    PERFORM pg_temp.assert_true('authenticated executes ' || v_function_signature,
+      has_function_privilege('authenticated', v_function_signature, 'EXECUTE'));
+    PERFORM pg_temp.assert_true('service role executes ' || v_function_signature,
+      has_function_privilege('service_role', v_function_signature, 'EXECUTE'));
+    PERFORM pg_temp.assert_true('anon cannot execute ' || v_function_signature,
+      NOT has_function_privilege('anon', v_function_signature, 'EXECUTE'));
+  END LOOP;
+  SELECT c.relrowsecurity INTO v_rls_enabled
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = 'technical_configuration_manual_assessments';
+  PERFORM pg_temp.assert_true(
+    'technical_configuration_manual_assessments RLS enabled',
+    v_rls_enabled
+  );
+  FOREACH v_table_privilege IN ARRAY ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']
+  LOOP
+    PERFORM pg_temp.assert_true('authenticated table privilege denied',
+      NOT has_table_privilege(
+        'authenticated', 'public.technical_configuration_manual_assessments',
+        v_table_privilege
+      ));
+    PERFORM pg_temp.assert_true('anon table privilege denied',
+      NOT has_table_privilege(
+        'anon', 'public.technical_configuration_manual_assessments',
+        v_table_privilege
+      ));
+    PERFORM pg_temp.assert_true('service role table privilege granted',
+      has_table_privilege(
+        'service_role', 'public.technical_configuration_manual_assessments',
+        v_table_privilege
+      ));
+  END LOOP;
+END;
+$gate$;
+
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add RPC-only persistence for manual technical-configuration assessments
- add dormant guarded list/upsert database contracts with row-level optimistic concurrency
- add focused migration-source tests and a rollback-only PostgreSQL phase gate
- update OpenSpec P11B tasks and live execution evidence

## Scope
- P11B persistence/DB contract only
- no RPC proxy, client, hook, query-key, or UI work from P11C/P12A
- no derived, stale, or machine-result fields

## Live DB verification
- migration applied through Supabase MCP after explicit approval
- live migration registry version: `20260729144351`
- rollback-only phase gate passed after separate explicit approval
- cleanup confirmed: `assessment_count = 0`, `fixture_dossier_count = 0`
- security/performance advisors executed after apply and after the phase gate

## Review
- subagent review completed in multiple rounds
- all six valid findings were fixed and re-reviewed
- final reviewer result: no remaining findings or regressions

## Verification
- `openspec validate add-technical-configuration-comparison --strict`
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- P11B focused tests: 9/9
- P11A regression tests: 42/42
- React Doctor: 100/100
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dormant, RPC-only persistence for manual technical-configuration assessments (P11B) with optimistic row revisions and strict auth/ACLs. Adds a follow-up migration to narrow `service_role` table privileges to DML only; no proxy, client, or UI integration.

- **New Features**
  - New table `public.technical_configuration_manual_assessments` with `UNIQUE (comparison_set_id, criterion_id)`, composite FKs to comparison sets and baseline criteria, canonical axis checks, `notes`, and `revision`.
  - `SECURITY DEFINER` RPCs: `technical_configuration_assessments_list(p_comparison_set_id, p_page, p_page_size)` and `technical_configuration_assessment_upsert(p_comparison_set_id, p_criterion_id, p_technical_axis, p_evidence_axis, p_notes, p_expected_revision)`. Bounded reads, archived reads allowed, optimistic concurrency, deterministic fields only.
  - Deny-by-default RLS; DML-only table privileges to `service_role`; RPC execute grants to `authenticated` and `service_role`.

- **Migration**
  - Added `supabase/migrations/20260729134453_technical_configuration_manual_assessments.sql`, rollback-only gate `supabase/tests/technical_configuration_manual_assessments_phase_gate.sql`, and a focused Vitest source test.
  - Added follow-up `supabase/migrations/20260729150646_technical_configuration_manual_assessments_service_role_grants.sql` to replace `GRANT ALL` with `SELECT/INSERT/UPDATE/DELETE` only for `service_role`.
  - Live DB: both migrations applied via Supabase MCP; phase gate passed with ROLLBACK; advisors clean; no fixture data.

<sup>Written for commit 59702cccaa7070957c1f4f6ce460860dea99109b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new manual technical-configuration assessment persistence table with revision history, uniqueness, and cascade behavior.
  - Added controlled listing and upsert RPCs with pagination, strict validation, and audit-preserving optimistic concurrency.
  - Tightened security with deny-by-default table access, row-level security, and service-role-only permissions.

- **Documentation**
  - Added an implementation plan for the manual assessment persistence and security phase.

- **Tests**
  - Added migration verification, phase-gate rollback harness, and service-role grant coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->