### PR TITLE
feat: add P11C manual assessment client contract

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -2083,12 +2083,18 @@ database contracts, but no application proxy or client can call them yet.
 
 - Create: `src/lib/technical-configuration-assessment-rpcs.ts`
 - Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
-- Modify: `src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+- Create:
+  `src/app/api/rpc/__tests__/technical-configuration-assessment-rpc-whitelist.test.ts`
 - Create: `src/app/(app)/technical-configurations/assessment-types.ts`
 - Create: `src/app/(app)/technical-configurations/technical-configuration-assessment-rpc.ts`
 - Modify: `src/app/(app)/technical-configurations/technical-configuration-query-keys.ts`
 - Create: `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts`
 - Create: `src/app/(app)/technical-configurations/__tests__/assessment-contract.test.ts`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/assessment-test-fixtures.ts`
+- Modify: `openspec/changes/add-technical-configuration-comparison/tasks.md`
 
 ### Tasks
 
@@ -2098,9 +2104,11 @@ database contracts, but no application proxy or client can call them yet.
       notes, audit metadata and row revisions without remapping derived status.
 - [ ] Reuse the P8A4 nullable comparison-set read and the P8B2
       no-write-on-open/first-save orchestration over P8A3 get-or-create; P11C
-      must not introduce a second comparison-set mutation path.
+      must not introduce a second comparison-set mutation path and concurrent
+      first saves must share one in-flight comparison-set acquisition.
 - [ ] Add a bounded assessment query key and a dedicated hook outside the
-      workspace shell.
+      workspace shell; successful writes invalidate every bounded page for the
+      affected comparison set.
 - [ ] Preserve validation, authorization and stale-revision errors for P12A;
       do not add navigation, dirty-draft handling or save controls.
 - [ ] Add no production UI, ranking or AI runtime artifact.

--- a/openspec/changes/add-technical-configuration-comparison/p11c-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p11c-tdd-plan.md
@@ -1,0 +1,236 @@
+# P11C Manual Assessment Client Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use
+> `superpowers:subagent-driven-development` or `superpowers:executing-plans` to
+> implement this plan. Steps use checkbox syntax for tracking.
+
+**Goal:** Expose the applied P11B manual-assessment RPC contract through the
+existing RPC proxy, a typed module-local client, bounded TanStack Query keys and
+a dormant hook for future P12A manual evaluation.
+
+**Architecture:** Freeze the two P11B RPC names in a dedicated shared manifest,
+append them to the existing proxy allowlist, and call them through the unchanged
+`callTechnicalConfigurationRpc()` transport. The assessment hook reuses the
+P8A4 nullable comparison-set read and the P8B2 first-save get-or-create path, so
+opening a manual-evaluation context remains read-only and the first explicit
+save does not introduce another comparison-set mutation adapter.
+
+**Tech Stack:** Next.js App Router RPC proxy, TypeScript, React, TanStack Query
+v5, Vitest, Testing Library.
+
+---
+
+## Scope And Frozen Inputs
+
+- Start from `main` commit `eb2baae46a0333c44eb085e5de2d4ccd32d84f01`.
+- P11B migrations are applied on live Supabase as registry versions
+  `20260729144351` and `20260729155147`.
+- Live read-only inspection on 2026-07-30 confirmed:
+  - `technical_configuration_assessments_list(uuid, integer, integer)`
+  - `technical_configuration_assessment_upsert(uuid, uuid, text, text, text, bigint)`
+  - both functions are `SECURITY DEFINER` with
+    `search_path=public, pg_temp`
+  - `authenticated` and `service_role` have execute privilege
+  - direct `anon`/`authenticated` table access remains denied by RLS and grants
+  - upsert conflicts remain `PT409/stale_revision`
+- Reuse:
+  - `useTechnicalConfigurationOptionResponsesQuery()` for the P8A4 nullable
+    comparison-set read
+  - `getOrCreateTechnicalConfigurationComparisonSet()` from
+    `technical-configuration-option-response-operations.ts` for first save
+  - `callTechnicalConfigurationRpc()` for error-preserving transport
+- Do not change P11B migrations, SQL tests, grants, policies or live DB state.
+- Do not add P12A controls, navigation, dirty drafts, progress, ranking or AI
+  runtime artifacts.
+
+## Planned Files
+
+- Create: `src/lib/technical-configuration-assessment-rpcs.ts`
+- Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
+- Create:
+  `src/app/api/rpc/__tests__/technical-configuration-assessment-rpc-whitelist.test.ts`
+- Create:
+  `src/app/(app)/technical-configurations/assessment-types.ts`
+- Create:
+  `src/app/(app)/technical-configurations/technical-configuration-assessment-rpc.ts`
+- Modify:
+  `src/app/(app)/technical-configurations/technical-configuration-query-keys.ts`
+- Create:
+  `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/assessment-contract.test.ts`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts`
+- Create:
+  `src/app/(app)/technical-configurations/__tests__/assessment-test-fixtures.ts`
+- Modify:
+  `openspec/changes/add-technical-configuration-comparison/tasks.md`
+
+## Frozen Client Contract
+
+### Manifest
+
+```text
+technical_configuration_assessments_list
+technical_configuration_assessment_upsert
+```
+
+No create/delete/bulk/ranking/AI name is added.
+
+### Wire And Request Shapes
+
+The assessment row preserves these exact P11B fields:
+
+```text
+id
+comparison_set_id
+baseline_version_id
+criterion_id
+technical_axis
+evidence_axis
+notes
+revision
+created_by
+created_at
+updated_by
+updated_at
+```
+
+- `technical_axis` is
+  `TechnicalConfigurationTechnicalAxis | null`.
+- `evidence_axis` is
+  `TechnicalConfigurationEvidenceAxis | null`.
+- `notes` is the non-null string returned by P11B.
+- `revision` is the assessment row revision and is never remapped to dossier or
+  comparison-set revision.
+- The typed adapter forwards exact `p_*` names and returns the P11B envelopes.
+
+### Hook Contract
+
+`useTechnicalConfigurationAssessments()` accepts:
+
+- `optionId`
+- nullable `baselineVersionId`
+- `page`
+- `pageSize`
+
+The hook returns:
+
+- the reused nullable comparison-set query
+- the bounded assessment query and its exact key
+- one assessment upsert mutation
+
+Opening behavior:
+
+- read the nullable comparison set only
+- do not call list when no comparison set exists
+- never call get-or-create or assessment upsert on mount
+
+Explicit mutation input contains:
+
+- `criterionId`
+- nullable canonical `technicalAxis`
+- nullable canonical `evidenceAxis`
+- nullable `notes`
+- assessment `expectedRevision`
+- dossier `expectedDossierRevision`, used only if the comparison set is absent
+
+First-save behavior:
+
+1. Read the latest P8A4 query cache and, when absent, reuse the existing P8A3
+   get-or-create adapter with `expectedDossierRevision`.
+2. Deduplicate an in-flight comparison-set acquisition per query client,
+   option and baseline so simultaneous first saves share one lifecycle call.
+3. Publish the returned comparison set into the existing P8A4 query cache.
+4. Call P11B assessment upsert with the returned comparison-set ID and the
+   assessment row revision supplied by the caller.
+5. Invalidate every bounded assessment page for the affected comparison set.
+6. Return both the comparison set and saved assessment so P12A can adopt
+   revisions without another read.
+
+Existing-set behavior skips get-or-create.
+
+Validation, authorization, archived-dossier and stale-revision failures pass
+through unchanged as `TechnicalConfigurationRpcError`; the hook does not replace
+their message, status or code.
+
+## Chunk 1: RED - Manifest And Proxy Boundary
+
+- [x] Add failing tests that require one dedicated assessment RPC manifest.
+- [x] Freeze the exact two ordered names and assert no unrelated RPC names.
+- [x] Require both names in `ALLOWED_FUNCTIONS`.
+- [x] Require both names to reach the existing proxy boundary.
+- [x] Run the focused whitelist test and confirm RED because the manifest and
+      allowlist entries do not exist.
+
+## Chunk 2: RED - Types And Adapter
+
+- [x] Add failing contract tests for exact request and wire fields.
+- [x] Require canonical P11A axis types instead of duplicated string unions.
+- [x] Require exact list arguments and `AbortSignal` forwarding.
+- [x] Require exact upsert arguments without renaming or normalization.
+- [x] Require list and upsert errors to preserve object identity.
+- [x] Run the focused assessment contract test and confirm RED.
+
+## Chunk 3: RED - Query Key And Hook
+
+- [x] Require the bounded key to include comparison-set ID, page and page size.
+- [x] Require invalid or missing comparison-set contexts to keep list disabled.
+- [x] Prove opening a missing context performs only the nullable P8A4 read.
+- [x] Prove an existing context loads the bounded list with the query signal.
+- [x] Prove simultaneous first saves share the existing get-or-create path
+      exactly once.
+- [x] Prove existing-set save skips get-or-create.
+- [x] Prove the comparison-set cache is populated before assessment upsert.
+- [x] Prove every bounded assessment page for the comparison set is invalidated
+      after success.
+- [x] Prove `PT422`, `42501`, `PT409/archived_dossier` and
+      `PT409/stale_revision` errors are not caught or remapped.
+- [x] Confirm RED because the key and hook do not exist.
+
+## Chunk 4: GREEN - Minimal Implementation
+
+- [x] Add the manifest and append its names to the proxy allowlist.
+- [x] Add typed P11B request/response contracts.
+- [x] Add the thin module-local assessment RPC adapter.
+- [x] Add the bounded assessment query-key factory.
+- [x] Add the dormant assessment hook using the existing nullable read and
+      get-or-create capabilities.
+- [x] Keep all production UI and workspace files unchanged.
+- [x] Run focused tests until GREEN.
+
+## Chunk 5: REFACTOR And Boundary Audit
+
+- [x] Remove test-only duplication without adding a new shared abstraction.
+- [x] Keep new source files below the 350-line extraction threshold.
+- [x] Use Code Review Graph and GitNexus on the final diff.
+- [x] Audit the diff for P11B persistence changes, P12A UI, ranking or AI
+      artifacts.
+- [x] Mark only P11C tasks complete in `tasks.md`.
+
+## Verification
+
+Run in this order:
+
+1. `node scripts/npm-run.js run format:check`
+2. `node scripts/npm-run.js run verify:no-explicit-any`
+3. `node scripts/npm-run.js run verify:dedupe`
+4. `node scripts/npm-run.js run typecheck`
+5. `node scripts/npm-run.js run test -- src/app/api/rpc/__tests__/technical-configuration-rpc-whitelist.test.ts`
+6. `node scripts/npm-run.js run test -- src/app/api/rpc/__tests__/technical-configuration-assessment-rpc-whitelist.test.ts`
+7. `node scripts/npm-run.js run test -- src/app/(app)/technical-configurations/__tests__/assessment-contract.test.ts src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts`
+8. `node scripts/npm-run.js run test -- src/lib/__tests__/technical-configuration-evaluation.test.ts`
+9. `node scripts/npm-run.js run react-doctor`
+10. `npx openspec validate add-technical-configuration-comparison --strict`
+
+Then dispatch a subagent review for specification compliance and code quality,
+address valuable findings, and rerun the affected gates.
+
+## Exit Gate
+
+The two applied P11B RPCs are reachable only through the existing authenticated
+proxy and a typed, tested P11C client/hook surface. Opening the future
+manual-evaluation context remains side-effect-free, first save reuses the
+existing comparison-set lifecycle without concurrent acquisition races, all
+affected assessment pages are invalidated, server errors and row revisions
+remain intact, and no P11B persistence or P12A UI behavior changes.

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -535,16 +535,17 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P11C - Manual Assessment Client Contract
 
-- [ ] P11C.1 Thêm dedicated RPC manifest và proxy allowlist sau khi P11B đã
+- [x] P11C.1 Thêm dedicated RPC manifest và proxy allowlist sau khi P11B đã
       merged/applied/gated.
-- [ ] P11C.2 Thêm typed wire/request contracts, RPC adapter và bounded query key.
-- [ ] P11C.3 Reuse P8A4 nullable read và P8B2 no-write-on-open/first-save
+- [x] P11C.2 Thêm typed wire/request contracts, RPC adapter và bounded query key.
+- [x] P11C.3 Reuse P8A4 nullable read và P8B2 no-write-on-open/first-save
       orchestration trên P8A3 get-or-create; thêm assessment hook ngoài
-      workspace shell nhưng không tạo mutation path thứ hai, production controls
-      hoặc navigation.
-- [ ] P11C.4 Bảo toàn validation/auth/conflict errors và row revisions cho P12A.
-- [ ] P11C.5 Viết manifest, whitelist, wire, adapter và hook contract tests;
-      audit không có ranking/AI runtime artifact.
+      workspace shell, dedupe in-flight acquisition cho concurrent first saves
+      nhưng không tạo mutation path thứ hai, production controls hoặc navigation.
+- [x] P11C.4 Bảo toàn validation/auth/conflict errors và row revisions cho P12A.
+- [x] P11C.5 Viết manifest, whitelist, wire, adapter và hook contract tests;
+      invalidate mọi bounded assessment page sau save và audit không có
+      ranking/AI runtime artifact.
 
 ## Phase P12A - Manual Evaluation Save And Navigation Workflow
 

--- a/src/app/(app)/technical-configurations/__tests__/assessment-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-contract.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  ASSESSMENT_RPC_FUNCTIONS,
+  ASSESSMENT_RPC_FUNCTION_NAMES,
+} from "@/lib/technical-configuration-assessment-rpcs"
+import {
+  listTechnicalConfigurationAssessments,
+  upsertTechnicalConfigurationAssessment,
+} from "../technical-configuration-assessment-rpc"
+import {
+  technicalConfigurationAssessmentsQueryKey,
+  technicalConfigurationAssessmentsQueryKeyPrefix,
+} from "../technical-configuration-query-keys"
+import {
+  assessment,
+  assessmentListResponse,
+  comparisonSetId,
+  criterionId,
+} from "./assessment-test-fixtures"
+
+const callRpcMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => callRpcMock(...args),
+}))
+
+describe("P11C assessment RPC manifest and adapter", () => {
+  beforeEach(() => {
+    callRpcMock.mockReset()
+  })
+
+  it("freezes only the applied P11B assessment RPC names", () => {
+    expect(ASSESSMENT_RPC_FUNCTIONS).toEqual({
+      listAssessments: "technical_configuration_assessments_list",
+      upsertAssessment: "technical_configuration_assessment_upsert",
+    })
+    expect(ASSESSMENT_RPC_FUNCTION_NAMES).toEqual(Object.values(ASSESSMENT_RPC_FUNCTIONS))
+    expect(ASSESSMENT_RPC_FUNCTION_NAMES).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/rank|recommend|ai/i)])
+    )
+  })
+
+  it("preserves the exact P11B assessment wire fields and canonical axes", () => {
+    expect(Object.keys(assessment)).toEqual([
+      "id",
+      "comparison_set_id",
+      "baseline_version_id",
+      "criterion_id",
+      "technical_axis",
+      "evidence_axis",
+      "notes",
+      "revision",
+      "created_by",
+      "created_at",
+      "updated_by",
+      "updated_at",
+    ])
+  })
+
+  it("forwards the bounded list request and AbortSignal unchanged", async () => {
+    const signal = new AbortController().signal
+    const args = {
+      p_comparison_set_id: comparisonSetId,
+      p_page: 1,
+      p_page_size: 25,
+    }
+    callRpcMock.mockResolvedValue(assessmentListResponse)
+
+    await expect(listTechnicalConfigurationAssessments(args, signal)).resolves.toEqual(
+      assessmentListResponse
+    )
+    expect(callRpcMock).toHaveBeenCalledWith(ASSESSMENT_RPC_FUNCTIONS.listAssessments, args, {
+      signal,
+    })
+  })
+
+  it("preserves list adapter errors without remapping", async () => {
+    const error = Object.assign(new Error("permission_denied"), {
+      code: "42501",
+      status: 403,
+    })
+    callRpcMock.mockRejectedValue(error)
+
+    await expect(
+      listTechnicalConfigurationAssessments({
+        p_comparison_set_id: comparisonSetId,
+        p_page: 1,
+        p_page_size: 25,
+      })
+    ).rejects.toBe(error)
+  })
+
+  it("forwards exact nullable axes, notes and row revision on upsert", async () => {
+    const args = {
+      p_comparison_set_id: comparisonSetId,
+      p_criterion_id: criterionId,
+      p_technical_axis: null,
+      p_evidence_axis: "missing" as const,
+      p_notes: null,
+      p_expected_revision: 0,
+    }
+    callRpcMock.mockResolvedValue({ data: assessment })
+
+    await expect(upsertTechnicalConfigurationAssessment(args)).resolves.toEqual({
+      data: assessment,
+    })
+    expect(callRpcMock).toHaveBeenCalledWith(ASSESSMENT_RPC_FUNCTIONS.upsertAssessment, args, {
+      signal: undefined,
+    })
+  })
+
+  it.each([
+    ["validation", Object.assign(new Error("validation_error"), { code: "PT422", status: 422 })],
+    [
+      "authorization",
+      Object.assign(new Error("permission_denied"), { code: "42501", status: 403 }),
+    ],
+    [
+      "archived dossier",
+      Object.assign(new Error("archived_dossier"), { code: "PT409", status: 409 }),
+    ],
+    ["stale revision", Object.assign(new Error("stale_revision"), { code: "PT409", status: 409 })],
+  ])("preserves %s adapter errors without remapping", async (_label, error) => {
+    callRpcMock.mockRejectedValue(error)
+
+    await expect(
+      upsertTechnicalConfigurationAssessment({
+        p_comparison_set_id: comparisonSetId,
+        p_criterion_id: criterionId,
+        p_technical_axis: "meets",
+        p_evidence_axis: "complete",
+        p_notes: "",
+        p_expected_revision: 1,
+      })
+    ).rejects.toBe(error)
+  })
+})
+
+describe("P11C bounded assessment query key", () => {
+  it("builds a comparison-set prefix for invalidating every cached page", () => {
+    expect(technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId)).toEqual([
+      "technical-configurations",
+      "assessments",
+      comparisonSetId,
+    ])
+  })
+
+  it("snapshots every bounded list dimension", () => {
+    expect(
+      technicalConfigurationAssessmentsQueryKey({
+        comparisonSetId,
+        page: 2,
+        pageSize: 50,
+      })
+    ).toEqual(["technical-configurations", "assessments", comparisonSetId, 2, 50])
+  })
+
+  it.each([
+    ["comparison set", { comparisonSetId: "other-set" }],
+    ["page", { page: 3 }],
+    ["page size", { pageSize: 100 }],
+  ])("changes when %s changes", (_label, overrides) => {
+    const input = {
+      comparisonSetId,
+      page: 2,
+      pageSize: 50,
+    }
+
+    expect(technicalConfigurationAssessmentsQueryKey({ ...input, ...overrides })).not.toEqual(
+      technicalConfigurationAssessmentsQueryKey(input)
+    )
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts
@@ -1,0 +1,270 @@
+import { createElement, type PropsWithChildren } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
+import { useTechnicalConfigurationAssessments } from "../_hooks/useTechnicalConfigurationAssessments"
+import {
+  technicalConfigurationAssessmentsQueryKey,
+  technicalConfigurationAssessmentsQueryKeyPrefix,
+  technicalConfigurationOptionResponsesQueryKey,
+} from "../technical-configuration-query-keys"
+import {
+  assessment,
+  assessmentListResponse,
+  assessmentUpsertInput,
+  baselineVersionId,
+  comparisonSet,
+  comparisonSetId,
+  criterionId,
+  optionId,
+} from "./assessment-test-fixtures"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+  getOrCreateComparisonSet: vi.fn(),
+  readComparisonSet: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => mocks.callRpc(...args),
+}))
+
+vi.mock("../technical-configuration-option-response-operations", () => ({
+  getOrCreateTechnicalConfigurationComparisonSet: (...args: unknown[]) =>
+    mocks.getOrCreateComparisonSet(...args),
+  readTechnicalConfigurationComparisonSet: (...args: unknown[]) => mocks.readComparisonSet(...args),
+}))
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+function createQueryWrapper(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: PropsWithChildren) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function renderAssessmentsHook(queryClient = createTestQueryClient()) {
+  const hook = renderHook(
+    () =>
+      useTechnicalConfigurationAssessments({
+        optionId,
+        baselineVersionId,
+        page: 1,
+        pageSize: 25,
+      }),
+    { wrapper: createQueryWrapper(queryClient) }
+  )
+  return { ...hook, queryClient }
+}
+
+describe("P11C assessment hook contract", () => {
+  beforeEach(() => {
+    mocks.callRpc.mockReset()
+    mocks.getOrCreateComparisonSet.mockReset()
+    mocks.readComparisonSet.mockReset()
+  })
+
+  it("keeps opening side-effect free when the nullable comparison set is absent", async () => {
+    mocks.readComparisonSet.mockResolvedValue(null)
+
+    const { result } = renderAssessmentsHook()
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+    expect(mocks.readComparisonSet).toHaveBeenCalledWith(
+      {
+        p_option_id: optionId,
+        p_baseline_version_id: baselineVersionId,
+      },
+      expect.any(AbortSignal)
+    )
+    expect(result.current.assessmentsQuery.fetchStatus).toBe("idle")
+    expect(mocks.getOrCreateComparisonSet).not.toHaveBeenCalled()
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+
+  it("loads only the bounded assessment page when a comparison set exists", async () => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockResolvedValue(assessmentListResponse)
+
+    const { result } = renderAssessmentsHook()
+
+    await waitFor(() => expect(result.current.assessmentsQuery.isSuccess).toBe(true))
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      ASSESSMENT_RPC_FUNCTIONS.listAssessments,
+      {
+        p_comparison_set_id: comparisonSetId,
+        p_page: 1,
+        p_page_size: 25,
+      },
+      { signal: expect.any(AbortSignal) }
+    )
+  })
+
+  it("keeps an invalid assessment page disabled after the comparison set loads", async () => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    const queryClient = createTestQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationAssessments({
+          optionId,
+          baselineVersionId,
+          page: 0,
+          pageSize: 101,
+        }),
+      { wrapper: createQueryWrapper(queryClient) }
+    )
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+    expect(result.current.assessmentsQuery.fetchStatus).toBe("idle")
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+
+  it("publishes the first-save set before upsert and invalidates every cached page", async () => {
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
+    const queryClient = createTestQueryClient()
+    queryClient.setQueryDefaults(technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId), {
+      gcTime: Infinity,
+    })
+    const comparisonSetQueryKey = technicalConfigurationOptionResponsesQueryKey(
+      optionId,
+      baselineVersionId
+    )
+    const secondPageQueryKey = technicalConfigurationAssessmentsQueryKey({
+      comparisonSetId,
+      page: 2,
+      pageSize: 25,
+    })
+    queryClient.setQueryData(secondPageQueryKey, assessmentListResponse)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        expect(queryClient.getQueryData(comparisonSetQueryKey)).toEqual(comparisonSet)
+        return Promise.resolve({ data: assessment })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve(assessmentListResponse)
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+
+    let saved: unknown
+    await act(async () => {
+      saved = await result.current.upsertAssessment.mutateAsync({
+        ...assessmentUpsertInput,
+        expectedRevision: 0,
+      })
+    })
+
+    expect(mocks.getOrCreateComparisonSet).toHaveBeenCalledTimes(1)
+    expect(mocks.getOrCreateComparisonSet).toHaveBeenCalledWith({
+      p_option_id: optionId,
+      p_baseline_version_id: baselineVersionId,
+      p_expected_revision: assessmentUpsertInput.expectedDossierRevision,
+    })
+    expect(queryClient.getQueryData(comparisonSetQueryKey)).toEqual(comparisonSet)
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      ASSESSMENT_RPC_FUNCTIONS.upsertAssessment,
+      {
+        p_comparison_set_id: comparisonSetId,
+        p_criterion_id: criterionId,
+        p_technical_axis: "meets",
+        p_evidence_axis: "partial",
+        p_notes: "Cần bổ sung chứng cứ.",
+        p_expected_revision: 0,
+      },
+      { signal: undefined }
+    )
+    expect(saved).toEqual({ comparisonSet, assessment })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
+    })
+    expect(queryClient.getQueryState(secondPageQueryKey)?.isInvalidated).toBe(true)
+  })
+
+  it("deduplicates comparison-set acquisition across simultaneous first saves", async () => {
+    const comparisonSetDeferred = createDeferred<typeof comparisonSet>()
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockReturnValue(comparisonSetDeferred.promise)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: assessment })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve(assessmentListResponse)
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const { result } = renderAssessmentsHook()
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+
+    let saves: Promise<unknown>[] = []
+    act(() => {
+      saves = [
+        result.current.upsertAssessment.mutateAsync({
+          ...assessmentUpsertInput,
+          expectedRevision: 0,
+        }),
+        result.current.upsertAssessment.mutateAsync({
+          ...assessmentUpsertInput,
+          criterionId: "criterion-id-2",
+          expectedRevision: 0,
+        }),
+      ]
+    })
+
+    await waitFor(() => expect(mocks.getOrCreateComparisonSet).toHaveBeenCalledTimes(1))
+
+    comparisonSetDeferred.resolve(comparisonSet)
+    await act(async () => {
+      await Promise.all(saves)
+    })
+
+    expect(
+      mocks.callRpc.mock.calls.filter(([fn]) => fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment)
+    ).toHaveLength(2)
+  })
+
+  it("skips get-or-create for an existing set and preserves stale-revision identity", async () => {
+    const staleRevision = Object.assign(new Error("stale_revision"), {
+      code: "PT409",
+      status: 409,
+    })
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve(assessmentListResponse)
+      }
+      return Promise.reject(staleRevision)
+    })
+    const { result } = renderAssessmentsHook()
+
+    await waitFor(() => expect(result.current.assessmentsQuery.isSuccess).toBe(true))
+
+    await expect(result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)).rejects.toBe(
+      staleRevision
+    )
+    expect(mocks.getOrCreateComparisonSet).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/assessment-test-fixtures.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-test-fixtures.ts
@@ -1,0 +1,55 @@
+import type {
+  TechnicalConfigurationAssessmentListWireResponse,
+  TechnicalConfigurationAssessmentUpsertInput,
+  TechnicalConfigurationAssessmentWire,
+} from "../assessment-types"
+import type { TechnicalConfigurationComparisonSetWire } from "../supplier-option-types"
+
+export const optionId = "00000000-0000-0000-0000-000000000001"
+export const baselineVersionId = "00000000-0000-0000-0000-000000000002"
+export const comparisonSetId = "00000000-0000-0000-0000-000000000003"
+export const criterionId = "00000000-0000-0000-0000-000000000004"
+
+export const comparisonSet: TechnicalConfigurationComparisonSetWire = {
+  id: comparisonSetId,
+  dossier_id: "00000000-0000-0000-0000-000000000005",
+  option_id: optionId,
+  baseline_version_id: baselineVersionId,
+  created_at: "2026-07-30T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-30T00:00:00.000Z",
+  updated_by: 1,
+  revision: 7,
+  responses: [],
+}
+
+export const assessment: TechnicalConfigurationAssessmentWire = {
+  id: "00000000-0000-0000-0000-000000000006",
+  comparison_set_id: comparisonSetId,
+  baseline_version_id: baselineVersionId,
+  criterion_id: criterionId,
+  technical_axis: "meets",
+  evidence_axis: "partial",
+  notes: "Cần bổ sung chứng cứ.",
+  revision: 2,
+  created_by: 1,
+  created_at: "2026-07-30T00:00:00.000Z",
+  updated_by: 2,
+  updated_at: "2026-07-30T01:00:00.000Z",
+}
+
+export const assessmentListResponse: TechnicalConfigurationAssessmentListWireResponse = {
+  data: [assessment],
+  total: 1,
+  page: 1,
+  page_size: 25,
+}
+
+export const assessmentUpsertInput: TechnicalConfigurationAssessmentUpsertInput = {
+  criterionId,
+  technicalAxis: "meets",
+  evidenceAxis: "partial",
+  notes: "Cần bổ sung chứng cứ.",
+  expectedRevision: 1,
+  expectedDossierRevision: 6,
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
@@ -1,0 +1,186 @@
+"use client"
+
+import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { useTechnicalConfigurationOptionResponsesQuery } from "./useTechnicalConfigurationOptionResponsesQuery"
+import type {
+  TechnicalConfigurationAssessmentListWireResponse,
+  TechnicalConfigurationAssessmentUpsertInput,
+  TechnicalConfigurationAssessmentWire,
+} from "../assessment-types"
+import {
+  listTechnicalConfigurationAssessments,
+  upsertTechnicalConfigurationAssessment,
+} from "../technical-configuration-assessment-rpc"
+import { getOrCreateTechnicalConfigurationComparisonSet } from "../technical-configuration-option-response-operations"
+import {
+  technicalConfigurationAssessmentsQueryKey,
+  technicalConfigurationAssessmentsQueryKeyPrefix,
+} from "../technical-configuration-query-keys"
+import type { TechnicalConfigurationComparisonSetWire } from "../supplier-option-types"
+
+interface UseTechnicalConfigurationAssessmentsInput {
+  optionId: string
+  baselineVersionId: string | null
+  page: number
+  pageSize: number
+}
+
+interface TechnicalConfigurationAssessmentSaveResult {
+  comparisonSet: TechnicalConfigurationComparisonSetWire
+  assessment: TechnicalConfigurationAssessmentWire
+}
+
+const comparisonSetAcquisitions = new WeakMap<
+  QueryClient,
+  Map<string, Promise<TechnicalConfigurationComparisonSetWire>>
+>()
+
+function isValidAssessmentPage(page: number, pageSize: number): boolean {
+  return (
+    Number.isInteger(page) &&
+    page >= 1 &&
+    Number.isInteger(pageSize) &&
+    pageSize >= 1 &&
+    pageSize <= 100
+  )
+}
+
+function acquireAssessmentComparisonSet({
+  queryClient,
+  comparisonSetQueryKey,
+  optionId,
+  baselineVersionId,
+  expectedDossierRevision,
+}: {
+  queryClient: QueryClient
+  comparisonSetQueryKey: readonly unknown[]
+  optionId: string
+  baselineVersionId: string
+  expectedDossierRevision: number
+}): Promise<TechnicalConfigurationComparisonSetWire> {
+  const cachedComparisonSet =
+    queryClient.getQueryData<TechnicalConfigurationComparisonSetWire | null>(comparisonSetQueryKey)
+  if (cachedComparisonSet) {
+    return Promise.resolve(cachedComparisonSet)
+  }
+
+  let acquisitions = comparisonSetAcquisitions.get(queryClient)
+  if (!acquisitions) {
+    acquisitions = new Map()
+    comparisonSetAcquisitions.set(queryClient, acquisitions)
+  }
+
+  const acquisitionKey = `${optionId}:${baselineVersionId}`
+  const inFlightAcquisition = acquisitions.get(acquisitionKey)
+  if (inFlightAcquisition) {
+    return inFlightAcquisition
+  }
+
+  const acquisition = Promise.resolve()
+    .then(() =>
+      getOrCreateTechnicalConfigurationComparisonSet({
+        p_option_id: optionId,
+        p_baseline_version_id: baselineVersionId,
+        p_expected_revision: expectedDossierRevision,
+      })
+    )
+    .then((comparisonSet) => {
+      queryClient.setQueryData(comparisonSetQueryKey, comparisonSet)
+      return comparisonSet
+    })
+    .finally(() => {
+      acquisitions.delete(acquisitionKey)
+      if (acquisitions.size === 0) {
+        comparisonSetAcquisitions.delete(queryClient)
+      }
+    })
+
+  acquisitions.set(acquisitionKey, acquisition)
+  return acquisition
+}
+
+/** Exposes the dormant P11C assessment data contract without mounting assessment UI. */
+export function useTechnicalConfigurationAssessments({
+  optionId,
+  baselineVersionId,
+  page,
+  pageSize,
+}: UseTechnicalConfigurationAssessmentsInput) {
+  const queryClient = useQueryClient()
+  const { queryKey: comparisonSetQueryKey, responseQuery: comparisonSetQuery } =
+    useTechnicalConfigurationOptionResponsesQuery({
+      optionId,
+      baselineVersionId,
+    })
+  const comparisonSetId = comparisonSetQuery.data?.id ?? ""
+  const queryKey = technicalConfigurationAssessmentsQueryKey({
+    comparisonSetId,
+    page,
+    pageSize,
+  })
+  const enabled = comparisonSetId !== "" && isValidAssessmentPage(page, pageSize)
+  const assessmentsQuery = useQuery<TechnicalConfigurationAssessmentListWireResponse>({
+    queryKey,
+    queryFn: ({ signal }) => {
+      if (!enabled) {
+        return Promise.reject(new Error("Technical configuration assessment query is disabled"))
+      }
+
+      return listTechnicalConfigurationAssessments(
+        {
+          p_comparison_set_id: comparisonSetId,
+          p_page: page,
+          p_page_size: pageSize,
+        },
+        signal
+      )
+    },
+    enabled,
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+  const upsertAssessment = useMutation<
+    TechnicalConfigurationAssessmentSaveResult,
+    unknown,
+    TechnicalConfigurationAssessmentUpsertInput
+  >({
+    mutationFn: async (input) => {
+      if (!baselineVersionId) {
+        throw new Error("technical_configuration_assessment_context_unavailable")
+      }
+
+      const comparisonSet = await acquireAssessmentComparisonSet({
+        queryClient,
+        comparisonSetQueryKey,
+        optionId,
+        baselineVersionId,
+        expectedDossierRevision: input.expectedDossierRevision,
+      })
+
+      const response = await upsertTechnicalConfigurationAssessment({
+        p_comparison_set_id: comparisonSet.id,
+        p_criterion_id: input.criterionId,
+        p_technical_axis: input.technicalAxis,
+        p_evidence_axis: input.evidenceAxis,
+        p_notes: input.notes,
+        p_expected_revision: input.expectedRevision,
+      })
+
+      return { comparisonSet, assessment: response.data }
+    },
+    onSuccess: async ({ comparisonSet }) => {
+      await queryClient.invalidateQueries({
+        queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSet.id),
+      })
+    },
+  })
+
+  return {
+    comparisonSetQuery,
+    queryKey,
+    assessmentsQuery,
+    upsertAssessment,
+  }
+}

--- a/src/app/(app)/technical-configurations/assessment-types.ts
+++ b/src/app/(app)/technical-configurations/assessment-types.ts
@@ -1,0 +1,54 @@
+import type {
+  TechnicalConfigurationEvidenceAxis,
+  TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+
+export interface TechnicalConfigurationAssessmentWire {
+  id: string
+  comparison_set_id: string
+  baseline_version_id: string
+  criterion_id: string
+  technical_axis: TechnicalConfigurationTechnicalAxis | null
+  evidence_axis: TechnicalConfigurationEvidenceAxis | null
+  notes: string
+  revision: number
+  created_by: number
+  created_at: string
+  updated_by: number
+  updated_at: string
+}
+
+export interface TechnicalConfigurationAssessmentListWireResponse {
+  data: TechnicalConfigurationAssessmentWire[]
+  total: number
+  page: number
+  page_size: number
+}
+
+export interface TechnicalConfigurationAssessmentWireResponse {
+  data: TechnicalConfigurationAssessmentWire
+}
+
+export interface TechnicalConfigurationAssessmentListRpcArgs {
+  p_comparison_set_id: string
+  p_page: number
+  p_page_size: number
+}
+
+export interface TechnicalConfigurationAssessmentUpsertRpcArgs {
+  p_comparison_set_id: string
+  p_criterion_id: string
+  p_technical_axis: TechnicalConfigurationTechnicalAxis | null
+  p_evidence_axis: TechnicalConfigurationEvidenceAxis | null
+  p_notes: string | null
+  p_expected_revision: number
+}
+
+export interface TechnicalConfigurationAssessmentUpsertInput {
+  criterionId: string
+  technicalAxis: TechnicalConfigurationTechnicalAxis | null
+  evidenceAxis: TechnicalConfigurationEvidenceAxis | null
+  notes: string | null
+  expectedRevision: number
+  expectedDossierRevision: number
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-assessment-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-assessment-rpc.ts
@@ -1,0 +1,25 @@
+import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
+
+import type {
+  TechnicalConfigurationAssessmentListRpcArgs,
+  TechnicalConfigurationAssessmentListWireResponse,
+  TechnicalConfigurationAssessmentUpsertRpcArgs,
+  TechnicalConfigurationAssessmentWireResponse,
+} from "./assessment-types"
+import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
+
+/** Lists one bounded page of manual assessments for an existing comparison set. */
+export function listTechnicalConfigurationAssessments(
+  args: TechnicalConfigurationAssessmentListRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationAssessmentListWireResponse> {
+  return callTechnicalConfigurationRpc(ASSESSMENT_RPC_FUNCTIONS.listAssessments, args, { signal })
+}
+
+/** Upserts one manual assessment while preserving the P11B row revision contract. */
+export function upsertTechnicalConfigurationAssessment(
+  args: TechnicalConfigurationAssessmentUpsertRpcArgs,
+  signal?: AbortSignal
+): Promise<TechnicalConfigurationAssessmentWireResponse> {
+  return callTechnicalConfigurationRpc(ASSESSMENT_RPC_FUNCTIONS.upsertAssessment, args, { signal })
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-query-keys.ts
@@ -58,6 +58,28 @@ export function technicalConfigurationOptionResponsesQueryKey(
   return ["technical-configurations", "option-responses", optionId, baselineVersionId] as const
 }
 
+/** Builds the cache-key prefix for every manual-assessment page in one comparison set. */
+export function technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId: string) {
+  return ["technical-configurations", "assessments", comparisonSetId] as const
+}
+
+/** Builds the cache key for one bounded manual-assessment page. */
+export function technicalConfigurationAssessmentsQueryKey({
+  comparisonSetId,
+  page,
+  pageSize,
+}: {
+  comparisonSetId: string
+  page: number
+  pageSize: number
+}) {
+  return [
+    ...technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
+    page,
+    pageSize,
+  ] as const
+}
+
 /** Builds the ordered cache key for one bounded comparison page. */
 export function technicalConfigurationComparisonQueryKey({
   baselineVersionId,

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -1,3 +1,4 @@
+import { ASSESSMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-assessment-rpcs"
 import { BASELINE_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-baseline-rpcs"
 import { COMPARISON_READ_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-comparison-rpcs"
 import { DOCUMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-document-rpcs"
@@ -112,6 +113,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   ...OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
   ...OPTION_IMPORT_RPC_FUNCTION_NAMES,
   ...COMPARISON_READ_RPC_FUNCTION_NAMES,
+  ...ASSESSMENT_RPC_FUNCTION_NAMES,
   // AI Assistant (read-only)
   "ai_equipment_lookup",
   "ai_maintenance_plan_lookup",

--- a/src/app/api/rpc/__tests__/technical-configuration-assessment-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-assessment-rpc-whitelist.test.ts
@@ -30,11 +30,7 @@ describe("technical configuration assessment RPC whitelist", () => {
 
   it("allowlists exactly the P11C assessment RPC manifest", () => {
     expect(
-      [...ALLOWED_FUNCTIONS].filter(
-        (fn) =>
-          fn === "technical_configuration_assessments_list" ||
-          fn === "technical_configuration_assessment_upsert"
-      )
+      [...ALLOWED_FUNCTIONS].filter((fn) => fn.startsWith("technical_configuration_assessment"))
     ).toEqual(P11B_ASSESSMENT_RPC_FUNCTIONS)
   })
 

--- a/src/app/api/rpc/__tests__/technical-configuration-assessment-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-assessment-rpc-whitelist.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("server-only", () => ({}))
+
+import { ALLOWED_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
+import { POST } from "@/app/api/rpc/[fn]/route"
+import {
+  ASSESSMENT_RPC_FUNCTION_NAMES,
+  ASSESSMENT_RPC_FUNCTIONS,
+} from "@/lib/technical-configuration-assessment-rpcs"
+
+const P11B_ASSESSMENT_RPC_FUNCTIONS = [
+  "technical_configuration_assessments_list",
+  "technical_configuration_assessment_upsert",
+] as const
+
+async function invokeRpcProxy(fn: string) {
+  const request = new Request(`http://localhost/api/rpc/${fn}`, { method: "POST" })
+  return POST(request as never, { params: Promise.resolve({ fn }) })
+}
+
+describe("technical configuration assessment RPC whitelist", () => {
+  it("freezes exactly the two applied P11B assessment RPC names", () => {
+    expect(ASSESSMENT_RPC_FUNCTIONS).toEqual({
+      listAssessments: "technical_configuration_assessments_list",
+      upsertAssessment: "technical_configuration_assessment_upsert",
+    })
+    expect(ASSESSMENT_RPC_FUNCTION_NAMES).toEqual(P11B_ASSESSMENT_RPC_FUNCTIONS)
+  })
+
+  it("allowlists exactly the P11C assessment RPC manifest", () => {
+    expect(
+      [...ALLOWED_FUNCTIONS].filter(
+        (fn) =>
+          fn === "technical_configuration_assessments_list" ||
+          fn === "technical_configuration_assessment_upsert"
+      )
+    ).toEqual(P11B_ASSESSMENT_RPC_FUNCTIONS)
+  })
+
+  it.each(P11B_ASSESSMENT_RPC_FUNCTIONS)(
+    'allows assessment RPC "%s" through the whitelist',
+    async (fn) => {
+      const response = await invokeRpcProxy(fn)
+
+      expect(response.status).toBe(411)
+      await expect(response.json()).resolves.toEqual({ error: "Content-Length header required" })
+    }
+  )
+})

--- a/src/lib/technical-configuration-assessment-rpcs.ts
+++ b/src/lib/technical-configuration-assessment-rpcs.ts
@@ -1,0 +1,8 @@
+/** Named P11C manual-assessment RPCs shared by client and server code. */
+export const ASSESSMENT_RPC_FUNCTIONS = {
+  listAssessments: "technical_configuration_assessments_list",
+  upsertAssessment: "technical_configuration_assessment_upsert",
+} as const
+
+/** Ordered P11C assessment RPC names for allowlists and contract iteration. */
+export const ASSESSMENT_RPC_FUNCTION_NAMES = Object.values(ASSESSMENT_RPC_FUNCTIONS)


### PR DESCRIPTION
## Summary
- Add the dedicated P11B manual-assessment RPC manifest to the authenticated RPC proxy allowlist.
- Add exact typed assessment contracts/client, bounded query keys, and a dormant manual-evaluation hook.
- Keep open read-only, deduplicate concurrent first-save comparison-set acquisition, and invalidate all cached assessment pages after save.

## Scope
- P11C only: RPC proxy/allowlist, typed client, hooks, query keys, tests, and OpenSpec artifacts.
- No P11B persistence or migration changes; no live database writes.
- No P12A UI/navigation, ranking, recommendation, or AI runtime work.

## Verification
- format:check
- verify:no-explicit-any
- verify:dedupe
- typecheck
- 139 focused/regression tests (73 generic proxy + 4 P11C whitelist + 20 assessment contract/hook + 42 P11A evaluation)
- React Doctor 100/100
- OpenSpec strict validation
- Two independent subagent reviews after fixes: no Critical, Important, or Minor findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the P11C manual‑assessment client contract and proxy whitelist, exposing read/save of assessment pages via a typed adapter and dormant hook. First save reuses get‑or‑create, dedupes races, and invalidates cached pages; server error codes and row revisions stay intact.

- New Features
  - Froze manifest and allowlisted `technical_configuration_assessments_list` and `technical_configuration_assessment_upsert`; added a dedicated whitelist contract test to lock RPC names and proxy access.
  - Added typed request/response contracts and a thin RPC adapter; preserves P11B wire fields and row revisions.
  - Added bounded assessment query keys and a comparison‑set prefix for broad cache invalidation.
  - Added `useTechnicalConfigurationAssessments`: read‑only on open; first save acquires/publishes the comparison set, upserts, returns `{ comparisonSet, assessment }`, dedupes concurrent first saves, and preserves `PT422`, `42501`, and `PT409` errors.

<sup>Written for commit db2584125b77185f2d611bc3545f952c670e62b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and saving paginated technical configuration assessments.
  * Added assessment data handling with revision tracking, notes, evidence, and technical ratings.
  * Added automatic cache updates and invalidation after successful assessment saves.
  * Added validation for assessment pagination and required comparison-set context.

* **Tests**
  * Added coverage for assessment loading, saving, caching, concurrency, error handling, and RPC access controls.

* **Documentation**
  * Added implementation and TDD planning documentation for the assessment client contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->