### PR TITLE
feat(technical-configurations): implement P11D assessment collection

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -552,16 +552,16 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P11D - Complete Manual Assessment Collection
 
-- [ ] P11D.1 Thêm complete-collection query dưới assessment query prefix hiện
+- [x] P11D.1 Thêm complete-collection query dưới assessment query prefix hiện
       có; giữ bounded single-page contract của P11C.
-- [ ] P11D.2 Thu thập các trang ổn định qua RPC hiện có và
+- [x] P11D.2 Thu thập các trang ổn định qua RPC hiện có và
       `collectStableTechnicalConfigurationPages()`, sau đó reconcile theo
       `criterion_id`; không ghép assessment page N với criterion page N.
-- [ ] P11D.3 Bảo toàn `AbortSignal`, exact wire values, typed errors,
+- [x] P11D.3 Bảo toàn `AbortSignal`, exact wire values, typed errors,
       no-write-on-open và comparison-set acquisition hiện có.
-- [ ] P11D.4 Khóa zero/sparse/>100 rows, duplicate/incomplete-page protection,
+- [x] P11D.4 Khóa zero/sparse/>100 rows, duplicate/incomplete-page protection,
       prefix invalidation và no-write-on-mount bằng test.
-- [ ] P11D.5 Không thêm migration, RPC/proxy path, UI, navigation, ranking hoặc
+- [x] P11D.5 Không thêm migration, RPC/proxy path, UI, navigation, ranking hoặc
       AI runtime artifact.
 
 ## Phase P12A1 - Evaluation Core And Shared Composition

--- a/src/app/(app)/technical-configurations/__tests__/assessment-complete-collection.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-complete-collection.test.ts
@@ -1,0 +1,271 @@
+import { act, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
+import type {
+  TechnicalConfigurationAssessmentListRpcArgs,
+  TechnicalConfigurationAssessmentListWireResponse,
+  TechnicalConfigurationAssessmentWire,
+} from "../assessment-types"
+import {
+  createAssessmentTestQueryClient,
+  renderCompleteAssessmentsHook,
+} from "./assessment-hook-test-support"
+import { assessment, assessmentListResponse, comparisonSet } from "./assessment-test-fixtures"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+  getOrCreateComparisonSet: vi.fn(),
+  readComparisonSet: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => mocks.callRpc(...args),
+}))
+
+vi.mock("../technical-configuration-option-response-operations", () => ({
+  getOrCreateTechnicalConfigurationComparisonSet: (...args: unknown[]) =>
+    mocks.getOrCreateComparisonSet(...args),
+  readTechnicalConfigurationComparisonSet: (...args: unknown[]) => mocks.readComparisonSet(...args),
+}))
+
+function createAssessment(assessmentCriterionId: string, index: number) {
+  return {
+    ...assessment,
+    id: `assessment-${index}`,
+    criterion_id: assessmentCriterionId,
+    revision: index + 1,
+  } satisfies TechnicalConfigurationAssessmentWire
+}
+
+function createAssessmentPage({
+  data,
+  total,
+  page,
+}: {
+  data: TechnicalConfigurationAssessmentWire[]
+  total: number
+  page: number
+}): TechnicalConfigurationAssessmentListWireResponse {
+  return { data, total, page, page_size: 100 }
+}
+
+function mockAssessmentPages(pages: TechnicalConfigurationAssessmentListWireResponse[]) {
+  mocks.callRpc.mockImplementation((fn: string, rawArgs: unknown) => {
+    if (fn !== ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    }
+
+    const args = rawArgs as TechnicalConfigurationAssessmentListRpcArgs
+    if (args.p_page_size !== 100) {
+      return Promise.resolve({ ...assessmentListResponse, page_size: args.p_page_size })
+    }
+    return Promise.resolve(
+      pages[args.p_page - 1] ?? createAssessmentPage({ data: [], total: 0, page: args.p_page })
+    )
+  })
+}
+
+describe("P11D complete assessment collection", () => {
+  beforeEach(() => {
+    mocks.callRpc.mockReset()
+    mocks.getOrCreateComparisonSet.mockReset()
+    mocks.readComparisonSet.mockReset()
+  })
+
+  it("keeps complete mode side-effect free when the nullable comparison set is absent", async () => {
+    mocks.readComparisonSet.mockResolvedValue(null)
+
+    const { result } = renderCompleteAssessmentsHook()
+
+    await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
+    expect(result.current.completeAssessmentsQuery.fetchStatus).toBe("idle")
+    expect(mocks.getOrCreateComparisonSet).not.toHaveBeenCalled()
+    expect(mocks.callRpc).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      name: "zero rows",
+      pages: [createAssessmentPage({ data: [], total: 0, page: 1 })],
+      expectedCriterionIds: [],
+    },
+    {
+      name: "sparse rows",
+      pages: [
+        createAssessmentPage({
+          data: [createAssessment("criterion-1", 1), createAssessment("criterion-150", 2)],
+          total: 2,
+          page: 1,
+        }),
+      ],
+      expectedCriterionIds: ["criterion-1", "criterion-150"],
+    },
+    {
+      name: "more than one hundred rows without criterion-page alignment",
+      pages: [
+        createAssessmentPage({
+          data: Array.from({ length: 100 }, (_, index) =>
+            createAssessment(`criterion-${index + 1}`, index + 1)
+          ),
+          total: 101,
+          page: 1,
+        }),
+        createAssessmentPage({
+          data: [createAssessment("criterion-from-first-criterion-page", 101)],
+          total: 101,
+          page: 2,
+        }),
+      ],
+      expectedCriterionIds: [
+        ...Array.from({ length: 100 }, (_, index) => `criterion-${index + 1}`),
+        "criterion-from-first-criterion-page",
+      ],
+    },
+  ])("collects $name into one map keyed by criterion_id", async (testCase) => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mockAssessmentPages(testCase.pages)
+
+    const { result } = renderCompleteAssessmentsHook()
+
+    await waitFor(() => expect(result.current.completeAssessmentsQuery.isSuccess).toBe(true))
+    expect(Object.keys(result.current.completeAssessmentsQuery.data ?? {})).toEqual(
+      testCase.expectedCriterionIds
+    )
+    expect(
+      mocks.callRpc.mock.calls.filter(([, rawArgs]) => {
+        const args = rawArgs as TechnicalConfigurationAssessmentListRpcArgs
+        return args.p_page_size === 100
+      })
+    ).toHaveLength(testCase.pages.length)
+    expect(mocks.callRpc).toHaveBeenCalledTimes(testCase.pages.length)
+  })
+
+  it.each([
+    {
+      name: "duplicate rows",
+      pages: [
+        createAssessmentPage({
+          data: [createAssessment("criterion-1", 1)],
+          total: 2,
+          page: 1,
+        }),
+        createAssessmentPage({
+          data: [createAssessment("criterion-1", 2)],
+          total: 2,
+          page: 2,
+        }),
+      ],
+    },
+    {
+      name: "incomplete rows",
+      pages: [
+        createAssessmentPage({
+          data: [createAssessment("criterion-1", 1)],
+          total: 2,
+          page: 1,
+        }),
+        createAssessmentPage({ data: [], total: 2, page: 2 }),
+      ],
+    },
+  ])("rejects $name instead of returning a partial map", async (testCase) => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mockAssessmentPages(testCase.pages)
+
+    const { result } = renderCompleteAssessmentsHook()
+
+    await waitFor(() => expect(result.current.completeAssessmentsQuery.isError).toBe(true))
+    expect(result.current.completeAssessmentsQuery.error).toMatchObject({
+      message: "Assessment pagination snapshot changed during load.",
+    })
+  })
+
+  it.each([
+    {
+      name: "wrong page number",
+      page: createAssessmentPage({
+        data: [createAssessment("criterion-1", 1)],
+        total: 1,
+        page: 2,
+      }),
+    },
+    {
+      name: "wrong page size",
+      page: {
+        ...createAssessmentPage({
+          data: [createAssessment("criterion-1", 1)],
+          total: 1,
+          page: 1,
+        }),
+        page_size: 25,
+      },
+    },
+  ])("rejects a page with $name", async (testCase) => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mockAssessmentPages([testCase.page])
+
+    const { result } = renderCompleteAssessmentsHook()
+
+    await waitFor(() => expect(result.current.completeAssessmentsQuery.isError).toBe(true))
+    expect(result.current.completeAssessmentsQuery.error).toMatchObject({
+      message: "Assessment pagination snapshot changed during load.",
+    })
+  })
+
+  it("preserves the exact RPC error from complete collection", async () => {
+    const rpcError = Object.assign(new Error("assessment_list_forbidden"), {
+      code: "42501",
+      status: 403,
+    })
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string, rawArgs: unknown) => {
+      const args = rawArgs as TechnicalConfigurationAssessmentListRpcArgs
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments && args.p_page_size === 100) {
+        return Promise.reject(rpcError)
+      }
+      return Promise.resolve(assessmentListResponse)
+    })
+
+    const { result } = renderCompleteAssessmentsHook()
+
+    await waitFor(() => expect(result.current.completeAssessmentsQuery.isError).toBe(true))
+    expect(result.current.completeAssessmentsQuery.error).toBe(rpcError)
+  })
+
+  it("propagates cancellation to the active complete-collection RPC", async () => {
+    let completeSignal: AbortSignal | undefined
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation(
+      (
+        fn: string,
+        rawArgs: unknown,
+        options: {
+          signal?: AbortSignal
+        }
+      ) => {
+        const args = rawArgs as TechnicalConfigurationAssessmentListRpcArgs
+        if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments && args.p_page_size === 100) {
+          completeSignal = options.signal
+          return new Promise((_resolve, reject) => {
+            completeSignal?.addEventListener("abort", () => reject(completeSignal?.reason), {
+              once: true,
+            })
+          })
+        }
+        return Promise.resolve(assessmentListResponse)
+      }
+    )
+    const queryClient = createAssessmentTestQueryClient()
+    const { result } = renderCompleteAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(completeSignal).toBeInstanceOf(AbortSignal))
+    await act(async () => {
+      await queryClient.cancelQueries({
+        queryKey: result.current.completeQueryKey,
+        exact: true,
+      })
+    })
+
+    expect(completeSignal?.aborted).toBe(true)
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts
@@ -1,5 +1,3 @@
-import { createElement, type PropsWithChildren } from "react"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -10,6 +8,11 @@ import {
   technicalConfigurationAssessmentsQueryKeyPrefix,
   technicalConfigurationOptionResponsesQueryKey,
 } from "../technical-configuration-query-keys"
+import {
+  createAssessmentQueryWrapper,
+  createAssessmentTestQueryClient,
+  renderAssessmentsHook,
+} from "./assessment-hook-test-support"
 import {
   assessment,
   assessmentListResponse,
@@ -37,41 +40,12 @@ vi.mock("../technical-configuration-option-response-operations", () => ({
   readTechnicalConfigurationComparisonSet: (...args: unknown[]) => mocks.readComparisonSet(...args),
 }))
 
-function createTestQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: { retry: false, gcTime: 0 },
-      mutations: { retry: false },
-    },
-  })
-}
-
-function createQueryWrapper(queryClient: QueryClient) {
-  return function QueryWrapper({ children }: PropsWithChildren) {
-    return createElement(QueryClientProvider, { client: queryClient }, children)
-  }
-}
-
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
   const promise = new Promise<T>((resolvePromise) => {
     resolve = resolvePromise
   })
   return { promise, resolve }
-}
-
-function renderAssessmentsHook(queryClient = createTestQueryClient()) {
-  const hook = renderHook(
-    () =>
-      useTechnicalConfigurationAssessments({
-        optionId,
-        baselineVersionId,
-        page: 1,
-        pageSize: 25,
-      }),
-    { wrapper: createQueryWrapper(queryClient) }
-  )
-  return { ...hook, queryClient }
 }
 
 describe("P11C assessment hook contract", () => {
@@ -115,11 +89,12 @@ describe("P11C assessment hook contract", () => {
       },
       { signal: expect.any(AbortSignal) }
     )
+    expect(mocks.callRpc).toHaveBeenCalledTimes(1)
   })
 
   it("keeps an invalid assessment page disabled after the comparison set loads", async () => {
     mocks.readComparisonSet.mockResolvedValue(comparisonSet)
-    const queryClient = createTestQueryClient()
+    const queryClient = createAssessmentTestQueryClient()
     const { result } = renderHook(
       () =>
         useTechnicalConfigurationAssessments({
@@ -128,7 +103,7 @@ describe("P11C assessment hook contract", () => {
           page: 0,
           pageSize: 101,
         }),
-      { wrapper: createQueryWrapper(queryClient) }
+      { wrapper: createAssessmentQueryWrapper(queryClient) }
     )
 
     await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
@@ -139,7 +114,7 @@ describe("P11C assessment hook contract", () => {
   it("publishes the first-save set before upsert and invalidates every cached page", async () => {
     mocks.readComparisonSet.mockResolvedValue(null)
     mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
-    const queryClient = createTestQueryClient()
+    const queryClient = createAssessmentTestQueryClient()
     queryClient.setQueryDefaults(technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId), {
       gcTime: Infinity,
     })
@@ -152,7 +127,12 @@ describe("P11C assessment hook contract", () => {
       page: 2,
       pageSize: 25,
     })
+    const completeQueryKey = [
+      ...technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
+      "complete",
+    ] as const
     queryClient.setQueryData(secondPageQueryKey, assessmentListResponse)
+    queryClient.setQueryData(completeQueryKey, { [criterionId]: assessment })
     mocks.callRpc.mockImplementation((fn: string) => {
       if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
         expect(queryClient.getQueryData(comparisonSetQueryKey)).toEqual(comparisonSet)
@@ -199,7 +179,9 @@ describe("P11C assessment hook contract", () => {
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
     })
+    expect(result.current.completeQueryKey).toEqual(completeQueryKey)
     expect(queryClient.getQueryState(secondPageQueryKey)?.isInvalidated).toBe(true)
+    expect(queryClient.getQueryState(completeQueryKey)?.isInvalidated).toBe(true)
   })
 
   it("deduplicates comparison-set acquisition across simultaneous first saves", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/assessment-hook-test-support.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-hook-test-support.ts
@@ -1,0 +1,52 @@
+import { createElement, type PropsWithChildren } from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook } from "@testing-library/react"
+
+import { useTechnicalConfigurationAssessments } from "../_hooks/useTechnicalConfigurationAssessments"
+import { baselineVersionId, optionId } from "./assessment-test-fixtures"
+
+export function createAssessmentTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+export function createAssessmentQueryWrapper(queryClient: QueryClient) {
+  return function QueryWrapper({ children }: PropsWithChildren) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+function renderAssessmentHook(collectionMode: "bounded" | "complete", queryClient: QueryClient) {
+  const hook = renderHook(
+    () => {
+      const commonInput = {
+        optionId,
+        baselineVersionId,
+      }
+      return collectionMode === "complete"
+        ? useTechnicalConfigurationAssessments({
+            ...commonInput,
+            collectionMode,
+          })
+        : useTechnicalConfigurationAssessments({
+            ...commonInput,
+            page: 1,
+            pageSize: 25,
+          })
+    },
+    { wrapper: createAssessmentQueryWrapper(queryClient) }
+  )
+  return { ...hook, queryClient }
+}
+
+export function renderAssessmentsHook(queryClient = createAssessmentTestQueryClient()) {
+  return renderAssessmentHook("bounded", queryClient)
+}
+
+export function renderCompleteAssessmentsHook(queryClient = createAssessmentTestQueryClient()) {
+  return renderAssessmentHook("complete", queryClient)
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
@@ -17,14 +17,28 @@ import {
   technicalConfigurationAssessmentsQueryKey,
   technicalConfigurationAssessmentsQueryKeyPrefix,
 } from "../technical-configuration-query-keys"
+import { collectStableTechnicalConfigurationPages } from "../technical-configuration-pagination"
 import type { TechnicalConfigurationComparisonSetWire } from "../supplier-option-types"
 
-interface UseTechnicalConfigurationAssessmentsInput {
+const ASSESSMENT_COLLECTION_PAGE_SIZE = 100
+const ASSESSMENT_PAGINATION_SNAPSHOT_ERROR = "Assessment pagination snapshot changed during load."
+
+interface TechnicalConfigurationAssessmentContext {
   optionId: string
   baselineVersionId: string | null
-  page: number
-  pageSize: number
 }
+
+type UseTechnicalConfigurationAssessmentsInput = TechnicalConfigurationAssessmentContext &
+  (
+    | {
+        collectionMode?: "bounded"
+        page: number
+        pageSize: number
+      }
+    | {
+        collectionMode: "complete"
+      }
+  )
 
 interface TechnicalConfigurationAssessmentSaveResult {
   comparisonSet: TechnicalConfigurationComparisonSetWire
@@ -44,6 +58,35 @@ function isValidAssessmentPage(page: number, pageSize: number): boolean {
     pageSize >= 1 &&
     pageSize <= 100
   )
+}
+
+async function collectTechnicalConfigurationAssessments(
+  comparisonSetId: string,
+  signal?: AbortSignal
+): Promise<Readonly<Record<string, TechnicalConfigurationAssessmentWire>>> {
+  const { items } = await collectStableTechnicalConfigurationPages<
+    TechnicalConfigurationAssessmentWire,
+    TechnicalConfigurationAssessmentListWireResponse
+  >({
+    loadPage: async (page) => {
+      const response = await listTechnicalConfigurationAssessments(
+        {
+          p_comparison_set_id: comparisonSetId,
+          p_page: page,
+          p_page_size: ASSESSMENT_COLLECTION_PAGE_SIZE,
+        },
+        signal
+      )
+      if (response.page !== page || response.page_size !== ASSESSMENT_COLLECTION_PAGE_SIZE) {
+        throw new Error(ASSESSMENT_PAGINATION_SNAPSHOT_ERROR)
+      }
+      return response
+    },
+    snapshotError: ASSESSMENT_PAGINATION_SNAPSHOT_ERROR,
+    getItemKey: (item) => item.criterion_id,
+  })
+
+  return Object.fromEntries(items.map((item) => [item.criterion_id, item]))
 }
 
 function acquireAssessmentComparisonSet({
@@ -101,12 +144,13 @@ function acquireAssessmentComparisonSet({
 }
 
 /** Exposes the dormant P11C assessment data contract without mounting assessment UI. */
-export function useTechnicalConfigurationAssessments({
-  optionId,
-  baselineVersionId,
-  page,
-  pageSize,
-}: UseTechnicalConfigurationAssessmentsInput) {
+export function useTechnicalConfigurationAssessments(
+  input: UseTechnicalConfigurationAssessmentsInput
+) {
+  const { optionId, baselineVersionId } = input
+  const isCompleteCollection = input.collectionMode === "complete"
+  const page = isCompleteCollection ? 1 : input.page
+  const pageSize = isCompleteCollection ? ASSESSMENT_COLLECTION_PAGE_SIZE : input.pageSize
   const queryClient = useQueryClient()
   const { queryKey: comparisonSetQueryKey, responseQuery: comparisonSetQuery } =
     useTechnicalConfigurationOptionResponsesQuery({
@@ -119,11 +163,18 @@ export function useTechnicalConfigurationAssessments({
     page,
     pageSize,
   })
-  const enabled = comparisonSetId !== "" && isValidAssessmentPage(page, pageSize)
+  const completeQueryKey = [
+    ...technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
+    "complete",
+  ] as const
+  const hasComparisonSet = comparisonSetId !== ""
+  const boundedQueryEnabled =
+    hasComparisonSet && !isCompleteCollection && isValidAssessmentPage(page, pageSize)
+  const completeQueryEnabled = hasComparisonSet && isCompleteCollection
   const assessmentsQuery = useQuery<TechnicalConfigurationAssessmentListWireResponse>({
     queryKey,
     queryFn: ({ signal }) => {
-      if (!enabled) {
+      if (!boundedQueryEnabled) {
         return Promise.reject(new Error("Technical configuration assessment query is disabled"))
       }
 
@@ -136,7 +187,25 @@ export function useTechnicalConfigurationAssessments({
         signal
       )
     },
-    enabled,
+    enabled: boundedQueryEnabled,
+    staleTime: 30_000,
+    retry: false,
+    refetchOnWindowFocus: false,
+  })
+  const completeAssessmentsQuery = useQuery<
+    Readonly<Record<string, TechnicalConfigurationAssessmentWire>>
+  >({
+    queryKey: completeQueryKey,
+    queryFn: ({ signal }) => {
+      if (!completeQueryEnabled) {
+        return Promise.reject(
+          new Error("Technical configuration assessment collection query is disabled")
+        )
+      }
+
+      return collectTechnicalConfigurationAssessments(comparisonSetId, signal)
+    },
+    enabled: completeQueryEnabled,
     staleTime: 30_000,
     retry: false,
     refetchOnWindowFocus: false,
@@ -181,6 +250,8 @@ export function useTechnicalConfigurationAssessments({
     comparisonSetQuery,
     queryKey,
     assessmentsQuery,
+    completeQueryKey,
+    completeAssessmentsQuery,
     upsertAssessment,
   }
 }


### PR DESCRIPTION
## Tóm tắt

- Triển khai P11D complete manual assessment collection trên RPC bounded hiện có.
- Tách rõ `bounded` và `complete` read mode để mỗi lần chỉ có một assessment fetch path.
- Thu thập trang ổn định với page size 100, kiểm tra `page`/`page_size`, chống duplicate/incomplete snapshot và reconcile theo `criterion_id`.
- Giữ nguyên AbortSignal, typed RPC errors, comparison-set acquisition, no-write-on-open và prefix invalidation.
- Đánh dấu hoàn tất các task P11D trong OpenSpec.

## Phạm vi

- Không có migration, DB write, RPC/proxy path mới, UI, navigation, ranking hoặc AI runtime artifact.
- Browser verification vẫn thuộc P13B; PR này chỉ có Vitest/contract verification theo exit gate P11D.

## Kiểm thử

- `format:check`
- `verify:no-explicit-any`
- `verify:dedupe`
- `typecheck`
- RPC/assessment whitelist regressions
- 30 assessment contract/hook/collection tests
- 42 evaluation domain tests
- React Doctor 100/100
- `openspec validate add-technical-configuration-comparison --strict`
- `git diff --check`

## Review

- Hai subagent đã review dependency, feasibility, overlap và code correctness; re-review cuối đều PASS.
- OpenSpec split PR #824 đã merge vào `main` trước khi branch này được triển khai.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements P11D complete manual assessment collection for technical configurations. Adds a “complete” mode to `useTechnicalConfigurationAssessments` to load all pages via the existing RPC, with strict consistency checks and proper cache invalidation.

- New Features
  - Added complete collection using the existing list RPC with page size 100; reconciles into a map keyed by `criterion_id`.
  - Split read modes: `bounded` (paged) vs `complete`; only one path is active at a time. Exposes `completeQueryKey` and `completeAssessmentsQuery`.
  - Enforced stable pagination: validates `page`/`page_size`, rejects duplicate or incomplete snapshots with "Assessment pagination snapshot changed during load."
  - Preserved `AbortSignal` propagation and exact RPC errors; no write-on-open.
  - Upsert now invalidates the entire assessments prefix, including the `complete` cache. No migrations, new RPC/proxy paths, or UI changes.

<sup>Written for commit b5f368256cf0272611161cb0ee4bc1d3d8235fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

