### PR TITLE
feat(technical-configurations): add dormant evaluation core

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -2220,24 +2220,24 @@ core, TC-15, TC-16, TC-17, TC-20
 
 ### Tasks
 
-- [ ] Add a criterion list in canonical group/order with only a simple current
+- [x] Add a criterion list in canonical group/order with only a simple current
       derived-status badge; counters, summaries and filters remain P12B.
-- [ ] Make `TechnicalConfigurationEvaluationPanel` a thin wrapper around the
+- [x] Make `TechnicalConfigurationEvaluationPanel` a thin wrapper around the
       shared `TechnicalConfigurationCriterionPanel` for baseline, response,
       supplementary information and evidence.
-- [ ] Compose notes and both manual axes through
+- [x] Compose notes and both manual axes through
       `TechnicalConfigurationAssessmentControls`; reuse P11A values, labels and
       `deriveTechnicalConfigurationEvaluationStatus()` as the only source of
       truth.
-- [ ] Add pure/local draft state and a core save command that adopts the saved
+- [x] Add pure/local draft state and a core save command that adopts the saved
       assessment row revision and returned comparison-set revision.
-- [ ] Preserve the current criterion and local input on validation,
+- [x] Preserve the current criterion and local input on validation,
       authorization, conflict or persistence failure.
-- [ ] Adopt the saved assessment locally without adding a second comparison,
+- [x] Adopt the saved assessment locally without adding a second comparison,
       assessment or evidence fetch path.
-- [ ] Keep every component and hook dormant; do not mount them in the comparison
+- [x] Keep every component and hook dormant; do not mount them in the comparison
       tab or workspace shell in this leaf.
-- [ ] Add no progress summaries, counters, filters, ranking or AI controls.
+- [x] Add no progress summaries, counters, filters, ranking or AI controls.
 
 ### TDD and verification
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -566,16 +566,16 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P12A1 - Evaluation Core And Shared Composition
 
-- [ ] P12A1.1 Thêm criterion list theo canonical group/order với simple current
+- [x] P12A1.1 Thêm criterion list theo canonical group/order với simple current
       status badge; chưa thêm counter, summary hoặc filter.
-- [ ] P12A1.2 Compose evaluation panel từ P10B
+- [x] P12A1.2 Compose evaluation panel từ P10B
       `TechnicalConfigurationCriterionPanel`; không duplicate read
       renderer/query/evidence path.
-- [ ] P12A1.3 Thêm assessment controls cho hai trục, notes và derived status từ
+- [x] P12A1.3 Thêm assessment controls cho hai trục, notes và derived status từ
       đúng P11A source of truth.
-- [ ] P12A1.4 Thêm local draft/save state machine, adopt row revision sau save
+- [x] P12A1.4 Thêm local draft/save state machine, adopt row revision sau save
       và giữ criterion/input khi validation/auth/conflict/persistence thất bại.
-- [ ] P12A1.5 Viết core/state/composition tests; giữ toàn bộ component/hook
+- [x] P12A1.5 Viết core/state/composition tests; giữ toàn bộ component/hook
       dormant, chưa mount vào production UI.
 
 ## Phase P12A2 - Guarded Navigation And Workspace Activation

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -574,9 +574,11 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 - [x] P12A1.3 Thêm assessment controls cho hai trục, notes và derived status từ
       đúng P11A source of truth.
 - [x] P12A1.4 Thêm local draft/save state machine, adopt row revision sau save
-      và giữ criterion/input khi validation/auth/conflict/persistence thất bại.
+      bằng cùng immutable draft snapshot cho saving state và mutation payload;
+      reject stale callback sau context switch và giữ criterion/input khi
+      validation/auth/conflict/persistence thất bại.
 - [x] P12A1.5 Viết core/state/composition tests; giữ toàn bộ component/hook
-      dormant, chưa mount vào production UI.
+      dormant, khóa edit-then-save cùng một nhịp và chưa mount vào production UI.
 
 ## Phase P12A2 - Guarded Navigation And Workspace Activation
 

--- a/src/app/(app)/technical-configurations/__tests__/assessment-test-fixtures.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-test-fixtures.ts
@@ -38,6 +38,14 @@ export const assessment: TechnicalConfigurationAssessmentWire = {
   updated_at: "2026-07-30T01:00:00.000Z",
 }
 
+export const savedAssessment: TechnicalConfigurationAssessmentWire = {
+  ...assessment,
+  technical_axis: "exceeds",
+  evidence_axis: "complete",
+  notes: "Đã xác nhận.",
+  revision: 3,
+}
+
 export const assessmentListResponse: TechnicalConfigurationAssessmentListWireResponse = {
   data: [assessment],
   total: 1,

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
@@ -1,0 +1,228 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { join, relative } from "node:path"
+import * as React from "react"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationAssessmentControls } from "../_components/evaluation/TechnicalConfigurationAssessmentControls"
+import { TechnicalConfigurationCriterionList } from "../_components/evaluation/TechnicalConfigurationCriterionList"
+import { TechnicalConfigurationEvaluationPanel } from "../_components/evaluation/TechnicalConfigurationEvaluationPanel"
+import type { TechnicalConfigurationCriterionDetail } from "../_components/comparison/TechnicalConfigurationCriterionPanel"
+import { assessment } from "./assessment-test-fixtures"
+import { createComparisonResult } from "./comparison-matrix-test-fixtures"
+
+const evaluationDetail: TechnicalConfigurationCriterionDetail = {
+  criterionCode: "TS-02",
+  criterionTitle: "Độ phân giải",
+  optionLabel: "Nhà cung cấp B · Phương án B",
+  requirementText: "Yêu cầu tối thiểu",
+  responseText: "Phản hồi hiện tại",
+  supplementaryInformation: "Thông tin tham khảo, không dùng để chấm điểm.",
+  evidence: {
+    documentCount: 0,
+    citationCount: 0,
+    hasEvidence: false,
+  },
+  evidenceTarget: {
+    kind: "option",
+    baselineVersionId: "baseline-1",
+    optionId: "option-b",
+    criterionId: "criterion-2",
+  },
+}
+
+const originalScrollIntoView = Element.prototype.scrollIntoView
+
+function collectTypeScriptFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      return entry.name === "__tests__" ? [] : collectTypeScriptFiles(entryPath)
+    }
+    return /\.[jt]sx?$/.test(entry.name) ? [entryPath] : []
+  })
+}
+
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  })
+})
+
+afterAll(() => {
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: originalScrollIntoView,
+  })
+})
+
+describe("P12A1 evaluation core composition", () => {
+  it("orders criteria canonically and renders only the current derived-status badge", async () => {
+    const user = userEvent.setup()
+    const onSelectCriterion = vi.fn()
+    const comparison = createComparisonResult()
+
+    render(
+      <TechnicalConfigurationCriterionList
+        criteria={comparison.data.criteria}
+        assessmentsByCriterionId={{
+          "criterion-2": {
+            ...assessment,
+            criterion_id: "criterion-2",
+            technical_axis: "meets",
+            evidence_axis: "complete",
+          },
+          "criterion-3": {
+            ...assessment,
+            criterion_id: "criterion-3",
+            technical_axis: "fails",
+            evidence_axis: "complete",
+          },
+        }}
+        currentCriterionId="criterion-2"
+        onSelectCriterion={onSelectCriterion}
+      />
+    )
+
+    const criterionButtons = screen.getAllByTestId("evaluation-criterion")
+    expect(criterionButtons.map((button) => button.getAttribute("data-criterion-id"))).toEqual([
+      "criterion-1",
+      "criterion-2",
+      "criterion-3",
+    ])
+    expect(
+      screen.getAllByRole("heading", { level: 3 }).map((heading) => heading.textContent)
+    ).toEqual(["Thông số chính", "Phụ kiện"])
+    expect(within(criterionButtons[0]).getByText("Chưa đánh giá")).toBeInTheDocument()
+    expect(within(criterionButtons[1]).getByText("Đạt")).toBeInTheDocument()
+    expect(within(criterionButtons[2]).getByText("Không đạt")).toBeInTheDocument()
+    expect(criterionButtons[1]).toHaveAttribute("aria-current", "true")
+    expect(screen.queryByText(/tiến độ|tổng|bộ lọc/i)).not.toBeInTheDocument()
+
+    await user.click(criterionButtons[0])
+    expect(onSelectCriterion).toHaveBeenCalledWith("criterion-1")
+  })
+
+  it("uses the canonical P11A axis labels and derives status without scoring supplementary text", async () => {
+    const user = userEvent.setup()
+
+    const { rerender } = render(
+      <TechnicalConfigurationAssessmentControls
+        technicalAxis="meets"
+        evidenceAxis="partial"
+        notes="Giữ nguyên đánh giá thủ công."
+        onTechnicalAxisChange={vi.fn()}
+        onEvidenceAxisChange={vi.fn()}
+        onNotesChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("status")).toHaveTextContent("Chưa đủ bằng chứng")
+    expect(screen.getByLabelText("Ghi chú")).toHaveValue("Giữ nguyên đánh giá thủ công.")
+
+    screen.getByRole("combobox", { name: "Mức đáp ứng kỹ thuật" }).focus()
+    await user.keyboard("{Enter}")
+    for (const label of [
+      "Chưa chọn",
+      "Vượt yêu cầu",
+      "Đạt",
+      "Không đạt",
+      "Chưa rõ",
+      "Không áp dụng",
+    ]) {
+      expect(await screen.findByRole("option", { name: label })).toBeInTheDocument()
+    }
+    await user.keyboard("{Escape}")
+
+    screen.getByRole("combobox", { name: "Mức đầy đủ bằng chứng" }).focus()
+    await user.keyboard("{Enter}")
+    for (const label of ["Chưa chọn", "Đầy đủ", "Một phần", "Thiếu", "Không yêu cầu"]) {
+      expect(await screen.findByRole("option", { name: label })).toBeInTheDocument()
+    }
+
+    await user.keyboard("{Escape}")
+    rerender(
+      <TechnicalConfigurationAssessmentControls
+        technicalAxis="meets"
+        evidenceAxis="partial"
+        notes="Giữ nguyên đánh giá thủ công."
+        errorMessage="Không thể lưu đánh giá."
+        onTechnicalAxisChange={vi.fn()}
+        onEvidenceAxisChange={vi.fn()}
+        onNotesChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Không thể lưu đánh giá.")
+    expect(screen.getByLabelText("Ghi chú")).not.toHaveAttribute("aria-invalid")
+  })
+
+  it("composes assessment controls into the shared criterion detail exactly once", () => {
+    const { rerender } = render(
+      <TechnicalConfigurationEvaluationPanel
+        detail={evaluationDetail}
+        open
+        onOpenChange={vi.fn()}
+        technicalAxis="meets"
+        evidenceAxis="complete"
+        notes="Đánh giá độc lập với nội dung nguồn."
+        onTechnicalAxisChange={vi.fn()}
+        onEvidenceAxisChange={vi.fn()}
+        onNotesChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText("Yêu cầu tối thiểu")).toHaveLength(1)
+    expect(screen.getAllByText("Phản hồi hiện tại")).toHaveLength(1)
+    expect(screen.getAllByText("Thông tin tham khảo, không dùng để chấm điểm.")).toHaveLength(1)
+    expect(screen.getByLabelText("Ghi chú")).toHaveValue("Đánh giá độc lập với nội dung nguồn.")
+
+    rerender(
+      <TechnicalConfigurationEvaluationPanel
+        detail={{
+          ...evaluationDetail,
+          responseText: "Phản hồi nguồn đã thay đổi",
+          supplementaryInformation: "Thông tin bổ sung đã thay đổi",
+          evidence: { documentCount: 1, citationCount: 1, hasEvidence: false },
+        }}
+        open
+        onOpenChange={vi.fn()}
+        technicalAxis="meets"
+        evidenceAxis="complete"
+        notes="Đánh giá độc lập với nội dung nguồn."
+        onTechnicalAxisChange={vi.fn()}
+        onEvidenceAxisChange={vi.fn()}
+        onNotesChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Phản hồi nguồn đã thay đổi")).toBeInTheDocument()
+    expect(screen.getByText("Thông tin bổ sung đã thay đổi")).toBeInTheDocument()
+    expect(screen.getByLabelText("Ghi chú")).toHaveValue("Đánh giá độc lập với nội dung nguồn.")
+  })
+
+  it("keeps the evaluation core dormant outside production tabs and shell", () => {
+    const repoRoot = process.cwd()
+    const sourceRoot = join(repoRoot, "src")
+    const featureRoot = join(repoRoot, "src/app/(app)/technical-configurations")
+    const evaluationCoreFiles = new Set(
+      [
+        "_components/evaluation/TechnicalConfigurationAssessmentControls.tsx",
+        "_components/evaluation/TechnicalConfigurationCriterionList.tsx",
+        "_components/evaluation/TechnicalConfigurationEvaluationPanel.tsx",
+        "_hooks/useTechnicalConfigurationEvaluationDraft.ts",
+        "technical-configuration-evaluation-state.ts",
+      ].map((file) => join(featureRoot, file))
+    )
+    const evaluationCoreReference =
+      /TechnicalConfiguration(?:AssessmentControls|CriterionList|EvaluationPanel)|useTechnicalConfigurationEvaluationDraft|technical-configuration-evaluation-state|_components\/evaluation\//
+    const productionReferences = collectTypeScriptFiles(sourceRoot)
+      .filter((file) => !evaluationCoreFiles.has(file))
+      .filter((file) => evaluationCoreReference.test(readFileSync(file, "utf8")))
+      .map((file) => relative(repoRoot, file))
+
+    expect(productionReferences).toEqual([])
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-context-switch.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-context-switch.test.tsx
@@ -1,0 +1,253 @@
+import {
+  getEvaluationDraftMocks,
+  hasAssessmentUpsertCall,
+  resetEvaluationDraftMocks,
+  useEvaluationDraftForTest,
+} from "./evaluation-draft-test-support"
+
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
+import {
+  createAssessmentQueryWrapper,
+  createAssessmentTestQueryClient,
+} from "./assessment-hook-test-support"
+import {
+  assessment,
+  baselineVersionId,
+  comparisonSet,
+  criterionId,
+  optionId,
+  savedAssessment,
+} from "./assessment-test-fixtures"
+
+const mocks = getEvaluationDraftMocks()
+const otherOptionId = "00000000-0000-0000-0000-000000000007"
+const otherBaselineVersionId = "00000000-0000-0000-0000-000000000008"
+const otherCriterionId = "00000000-0000-0000-0000-000000000009"
+
+describe("P12A1 evaluation draft context switches", () => {
+  beforeEach(() => resetEvaluationDraftMocks(mocks))
+
+  it("rejects stale callbacks across option switches, including an A-B-A cycle", async () => {
+    mocks.readComparisonSet
+      .mockResolvedValueOnce(comparisonSet)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(comparisonSet)
+    mocks.callRpc.mockResolvedValue({
+      data: [assessment],
+      total: 1,
+      page: 1,
+      page_size: 100,
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result, rerender } = renderHook(
+      ({ currentOptionId }) =>
+        useEvaluationDraftForTest({
+          optionId: currentOptionId,
+          baselineVersionId,
+          criterionId,
+          expectedDossierRevision: 6,
+        }),
+      {
+        initialProps: { currentOptionId: optionId },
+        wrapper: createAssessmentQueryWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    const staleSetNotes = result.current.setNotes
+    const staleSave = result.current.save
+
+    rerender({ currentOptionId: otherOptionId })
+    await waitFor(() =>
+      expect(result.current.draft).toMatchObject({
+        technicalAxis: null,
+        evidenceAxis: null,
+        notes: "",
+        expectedAssessmentRevision: 0,
+      })
+    )
+    act(() => {
+      result.current.setNotes("Bản nháp của phương án mới.")
+      staleSetNotes("Không được ghi đè.")
+    })
+    await act(async () => {
+      await expect(staleSave()).rejects.toThrow(
+        "technical_configuration_evaluation_save_unavailable"
+      )
+    })
+    expect(result.current.draft).toMatchObject({
+      notes: "Bản nháp của phương án mới.",
+      isDirty: true,
+    })
+
+    rerender({ currentOptionId: optionId })
+    await waitFor(() =>
+      expect(result.current.draft).toMatchObject({
+        notes: assessment.notes,
+        expectedAssessmentRevision: assessment.revision,
+      })
+    )
+    act(() => staleSetNotes("Callback A cũ không được khôi phục."))
+    await expect(staleSave()).rejects.toThrow("technical_configuration_evaluation_save_unavailable")
+    expect(result.current.draft).toMatchObject({
+      notes: assessment.notes,
+      isDirty: false,
+    })
+    expect(hasAssessmentUpsertCall(mocks.callRpc)).toBe(false)
+  })
+
+  it("starts a fresh draft when switching baselines for the same option and criterion", async () => {
+    mocks.readComparisonSet.mockResolvedValueOnce(comparisonSet).mockResolvedValueOnce(null)
+    mocks.callRpc.mockResolvedValue({
+      data: [assessment],
+      total: 1,
+      page: 1,
+      page_size: 100,
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result, rerender } = renderHook(
+      ({ currentBaselineVersionId }) =>
+        useEvaluationDraftForTest({
+          optionId,
+          baselineVersionId: currentBaselineVersionId,
+          criterionId,
+          expectedDossierRevision: 6,
+        }),
+      {
+        initialProps: { currentBaselineVersionId: baselineVersionId },
+        wrapper: createAssessmentQueryWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    rerender({ currentBaselineVersionId: otherBaselineVersionId })
+    expect(result.current.draft).toBeNull()
+
+    await waitFor(() =>
+      expect(result.current.draft).toMatchObject({
+        technicalAxis: null,
+        evidenceAxis: null,
+        notes: "",
+        expectedAssessmentRevision: 0,
+      })
+    )
+  })
+
+  it("starts a fresh draft when switching criteria within one comparison set", async () => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockResolvedValue({
+      data: [assessment],
+      total: 1,
+      page: 1,
+      page_size: 100,
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result, rerender } = renderHook(
+      ({ currentCriterionId }) =>
+        useEvaluationDraftForTest({
+          optionId,
+          baselineVersionId,
+          criterionId: currentCriterionId,
+          expectedDossierRevision: 6,
+        }),
+      {
+        initialProps: { currentCriterionId: criterionId },
+        wrapper: createAssessmentQueryWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    rerender({ currentCriterionId: otherCriterionId })
+
+    expect(result.current.draft).toMatchObject({
+      criterionId: otherCriterionId,
+      technicalAxis: null,
+      evidenceAxis: null,
+      notes: "",
+      expectedAssessmentRevision: 0,
+    })
+  })
+
+  it("does not adopt a pending save into a newly selected option", async () => {
+    let resolveSave!: (value: { data: typeof savedAssessment }) => void
+    const pendingSave = new Promise<{ data: typeof savedAssessment }>((resolve) => {
+      resolveSave = resolve
+    })
+    mocks.readComparisonSet.mockResolvedValueOnce(comparisonSet).mockResolvedValueOnce(null)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve({
+          data: [assessment],
+          total: 1,
+          page: 1,
+          page_size: 100,
+        })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return pendingSave
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result, rerender } = renderHook(
+      ({ currentOptionId }) =>
+        useEvaluationDraftForTest({
+          optionId: currentOptionId,
+          baselineVersionId,
+          criterionId,
+          expectedDossierRevision: 6,
+        }),
+      {
+        initialProps: { currentOptionId: optionId },
+        wrapper: createAssessmentQueryWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    act(() => {
+      result.current.setNotes("Bản nháp của phương án cũ.")
+    })
+
+    let savePromise!: ReturnType<typeof result.current.save>
+    await act(async () => {
+      savePromise = result.current.save()
+      await Promise.resolve()
+    })
+    expect(result.current.isSaving).toBe(true)
+
+    rerender({ currentOptionId: otherOptionId })
+    expect(result.current.isSaving).toBe(true)
+    await expect(result.current.save()).rejects.toThrow(
+      "technical_configuration_evaluation_save_unavailable"
+    )
+    await waitFor(() =>
+      expect(result.current.draft).toMatchObject({
+        technicalAxis: null,
+        evidenceAxis: null,
+        notes: "",
+        expectedAssessmentRevision: 0,
+      })
+    )
+
+    await act(async () => {
+      resolveSave({ data: savedAssessment })
+      await savePromise
+    })
+
+    expect(result.current.isSaving).toBe(false)
+    expect(result.current.draft).toMatchObject({
+      technicalAxis: null,
+      evidenceAxis: null,
+      notes: "",
+      expectedAssessmentRevision: 0,
+      isDirty: false,
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
@@ -37,6 +37,22 @@ vi.mock("../technical-configuration-option-response-operations", () => ({
 const otherOptionId = "00000000-0000-0000-0000-000000000007"
 const otherBaselineVersionId = "00000000-0000-0000-0000-000000000008"
 const otherCriterionId = "00000000-0000-0000-0000-000000000009"
+const otherComparisonSetId = "00000000-0000-0000-0000-000000000010"
+
+function renderEvaluationDraftHook(onDossierRevisionChange?: (revision: number) => void) {
+  const queryClient = createAssessmentTestQueryClient()
+  return renderHook(
+    () =>
+      useTechnicalConfigurationEvaluationDraft({
+        optionId,
+        baselineVersionId,
+        criterionId,
+        expectedDossierRevision: 6,
+        onDossierRevisionChange,
+      }),
+    { wrapper: createAssessmentQueryWrapper(queryClient) }
+  )
+}
 
 describe("P12A1 evaluation draft state", () => {
   beforeEach(() => {
@@ -63,18 +79,7 @@ describe("P12A1 evaluation draft state", () => {
       throw new Error(`Unexpected RPC: ${fn}`)
     })
 
-    const queryClient = createAssessmentTestQueryClient()
-    const { result } = renderHook(
-      () =>
-        useTechnicalConfigurationEvaluationDraft({
-          optionId,
-          baselineVersionId,
-          criterionId,
-          expectedDossierRevision: 6,
-          onDossierRevisionChange,
-        }),
-      { wrapper: createAssessmentQueryWrapper(queryClient) }
-    )
+    const { result } = renderEvaluationDraftHook(onDossierRevisionChange)
 
     await waitFor(() => expect(result.current.isReady).toBe(true))
     expect(result.current.assessmentsByCriterionId[criterionId]).toEqual(assessment)
@@ -123,6 +128,53 @@ describe("P12A1 evaluation draft state", () => {
       },
       { signal: undefined }
     )
+  })
+
+  it("rejects a misrouted assessment row and preserves the local draft", async () => {
+    const onDossierRevisionChange = vi.fn()
+    const misroutedAssessment = {
+      ...savedAssessment,
+      comparison_set_id: otherComparisonSetId,
+    }
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve({
+          data: [assessment],
+          total: 1,
+          page: 1,
+          page_size: 100,
+        })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: misroutedAssessment })
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+
+    const { result } = renderEvaluationDraftHook(onDossierRevisionChange)
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    act(() => {
+      result.current.setNotes("Giữ bản nháp này.")
+    })
+
+    await act(async () => {
+      await expect(result.current.save()).rejects.toThrow(
+        "technical_configuration_evaluation_save_result_comparison_set_mismatch"
+      )
+    })
+
+    expect(result.current.draft).toMatchObject({
+      criterionId,
+      comparisonSetId,
+      notes: "Giữ bản nháp này.",
+      expectedAssessmentRevision: assessment.revision,
+      expectedDossierRevision: 6,
+      saveStatus: "error",
+      isDirty: true,
+    })
+    expect(onDossierRevisionChange).not.toHaveBeenCalled()
   })
 
   it("starts a fresh draft when switching options for the same criterion", async () => {
@@ -339,17 +391,7 @@ describe("P12A1 evaluation draft state", () => {
       throw new Error(`Unexpected RPC: ${fn}`)
     })
 
-    const queryClient = createAssessmentTestQueryClient()
-    const { result } = renderHook(
-      () =>
-        useTechnicalConfigurationEvaluationDraft({
-          optionId,
-          baselineVersionId,
-          criterionId,
-          expectedDossierRevision: 6,
-        }),
-      { wrapper: createAssessmentQueryWrapper(queryClient) }
-    )
+    const { result } = renderEvaluationDraftHook()
 
     await waitFor(() => expect(result.current.isReady).toBe(true))
     expect(mocks.getOrCreateComparisonSet).not.toHaveBeenCalled()

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
@@ -1,0 +1,404 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
+import { useTechnicalConfigurationEvaluationDraft } from "../_hooks/useTechnicalConfigurationEvaluationDraft"
+import type { TechnicalConfigurationAssessmentListWireResponse } from "../assessment-types"
+import {
+  createAssessmentQueryWrapper,
+  createAssessmentTestQueryClient,
+} from "./assessment-hook-test-support"
+import {
+  assessment,
+  baselineVersionId,
+  comparisonSet,
+  comparisonSetId,
+  criterionId,
+  optionId,
+  savedAssessment,
+} from "./assessment-test-fixtures"
+
+const mocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+  getOrCreateComparisonSet: vi.fn(),
+  readComparisonSet: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => mocks.callRpc(...args),
+}))
+
+vi.mock("../technical-configuration-option-response-operations", () => ({
+  getOrCreateTechnicalConfigurationComparisonSet: (...args: unknown[]) =>
+    mocks.getOrCreateComparisonSet(...args),
+  readTechnicalConfigurationComparisonSet: (...args: unknown[]) => mocks.readComparisonSet(...args),
+}))
+
+const otherOptionId = "00000000-0000-0000-0000-000000000007"
+const otherBaselineVersionId = "00000000-0000-0000-0000-000000000008"
+const otherCriterionId = "00000000-0000-0000-0000-000000000009"
+
+describe("P12A1 evaluation draft state", () => {
+  beforeEach(() => {
+    mocks.callRpc.mockReset()
+    mocks.getOrCreateComparisonSet.mockReset()
+    mocks.readComparisonSet.mockReset()
+  })
+
+  it("consumes the P11D complete collection and adopts successful save locally", async () => {
+    const onDossierRevisionChange = vi.fn()
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve({
+          data: [assessment],
+          total: 1,
+          page: 1,
+          page_size: 100,
+        })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: savedAssessment })
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationEvaluationDraft({
+          optionId,
+          baselineVersionId,
+          criterionId,
+          expectedDossierRevision: 6,
+          onDossierRevisionChange,
+        }),
+      { wrapper: createAssessmentQueryWrapper(queryClient) }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    expect(result.current.assessmentsByCriterionId[criterionId]).toEqual(assessment)
+    expect(mocks.getOrCreateComparisonSet).not.toHaveBeenCalled()
+    expect(
+      mocks.callRpc.mock.calls.some(
+        ([fn, args]) =>
+          fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments &&
+          typeof args === "object" &&
+          args !== null &&
+          "p_comparison_set_id" in args &&
+          args.p_comparison_set_id === comparisonSetId &&
+          "p_page_size" in args &&
+          args.p_page_size === 100
+      )
+    ).toBe(true)
+
+    act(() => {
+      result.current.setTechnicalAxis("exceeds")
+      result.current.setEvidenceAxis("complete")
+      result.current.setNotes("Đã xác nhận.")
+    })
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    expect(result.current.draft).toMatchObject({
+      technicalAxis: "exceeds",
+      evidenceAxis: "complete",
+      notes: "Đã xác nhận.",
+      expectedAssessmentRevision: 3,
+      expectedDossierRevision: 7,
+      isDirty: false,
+    })
+    expect(onDossierRevisionChange).toHaveBeenCalledWith(7)
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      ASSESSMENT_RPC_FUNCTIONS.upsertAssessment,
+      {
+        p_comparison_set_id: comparisonSetId,
+        p_criterion_id: criterionId,
+        p_technical_axis: "exceeds",
+        p_evidence_axis: "complete",
+        p_notes: "Đã xác nhận.",
+        p_expected_revision: assessment.revision,
+      },
+      { signal: undefined }
+    )
+  })
+
+  it("starts a fresh draft when switching options for the same criterion", async () => {
+    mocks.readComparisonSet.mockResolvedValueOnce(comparisonSet).mockResolvedValueOnce(null)
+    mocks.callRpc.mockResolvedValue({
+      data: [assessment],
+      total: 1,
+      page: 1,
+      page_size: 100,
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result, rerender } = renderHook(
+      ({ currentOptionId }) =>
+        useTechnicalConfigurationEvaluationDraft({
+          optionId: currentOptionId,
+          baselineVersionId,
+          criterionId,
+          expectedDossierRevision: 6,
+        }),
+      {
+        initialProps: { currentOptionId: optionId },
+        wrapper: createAssessmentQueryWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    expect(result.current.draft).toMatchObject({
+      technicalAxis: "meets",
+      evidenceAxis: "partial",
+      notes: "Cần bổ sung chứng cứ.",
+    })
+
+    rerender({ currentOptionId: otherOptionId })
+    expect(result.current.draft).toBeNull()
+
+    await waitFor(() =>
+      expect(result.current.draft).toMatchObject({
+        technicalAxis: null,
+        evidenceAxis: null,
+        notes: "",
+        expectedAssessmentRevision: 0,
+      })
+    )
+  })
+
+  it("starts a fresh draft when switching baselines for the same option and criterion", async () => {
+    mocks.readComparisonSet.mockResolvedValueOnce(comparisonSet).mockResolvedValueOnce(null)
+    mocks.callRpc.mockResolvedValue({
+      data: [assessment],
+      total: 1,
+      page: 1,
+      page_size: 100,
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result, rerender } = renderHook(
+      ({ currentBaselineVersionId }) =>
+        useTechnicalConfigurationEvaluationDraft({
+          optionId,
+          baselineVersionId: currentBaselineVersionId,
+          criterionId,
+          expectedDossierRevision: 6,
+        }),
+      {
+        initialProps: { currentBaselineVersionId: baselineVersionId },
+        wrapper: createAssessmentQueryWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    rerender({ currentBaselineVersionId: otherBaselineVersionId })
+    expect(result.current.draft).toBeNull()
+
+    await waitFor(() =>
+      expect(result.current.draft).toMatchObject({
+        technicalAxis: null,
+        evidenceAxis: null,
+        notes: "",
+        expectedAssessmentRevision: 0,
+      })
+    )
+  })
+
+  it("starts a fresh draft when switching criteria within one comparison set", async () => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockResolvedValue({
+      data: [assessment],
+      total: 1,
+      page: 1,
+      page_size: 100,
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result, rerender } = renderHook(
+      ({ currentCriterionId }) =>
+        useTechnicalConfigurationEvaluationDraft({
+          optionId,
+          baselineVersionId,
+          criterionId: currentCriterionId,
+          expectedDossierRevision: 6,
+        }),
+      {
+        initialProps: { currentCriterionId: criterionId },
+        wrapper: createAssessmentQueryWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    rerender({ currentCriterionId: otherCriterionId })
+
+    expect(result.current.draft).toMatchObject({
+      criterionId: otherCriterionId,
+      technicalAxis: null,
+      evidenceAxis: null,
+      notes: "",
+      expectedAssessmentRevision: 0,
+    })
+  })
+
+  it("does not adopt a pending save into a newly selected option", async () => {
+    let resolveSave!: (value: { data: typeof savedAssessment }) => void
+    const pendingSave = new Promise<{ data: typeof savedAssessment }>((resolve) => {
+      resolveSave = resolve
+    })
+    mocks.readComparisonSet.mockResolvedValueOnce(comparisonSet).mockResolvedValueOnce(null)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve({
+          data: [assessment],
+          total: 1,
+          page: 1,
+          page_size: 100,
+        })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return pendingSave
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result, rerender } = renderHook(
+      ({ currentOptionId }) =>
+        useTechnicalConfigurationEvaluationDraft({
+          optionId: currentOptionId,
+          baselineVersionId,
+          criterionId,
+          expectedDossierRevision: 6,
+        }),
+      {
+        initialProps: { currentOptionId: optionId },
+        wrapper: createAssessmentQueryWrapper(queryClient),
+      }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    act(() => {
+      result.current.setNotes("Bản nháp của phương án cũ.")
+    })
+
+    let savePromise!: ReturnType<typeof result.current.save>
+    await act(async () => {
+      savePromise = result.current.save()
+      await Promise.resolve()
+    })
+    expect(result.current.isSaving).toBe(true)
+
+    rerender({ currentOptionId: otherOptionId })
+    expect(result.current.isSaving).toBe(true)
+    await expect(result.current.save()).rejects.toThrow(
+      "technical_configuration_evaluation_save_unavailable"
+    )
+    await waitFor(() =>
+      expect(result.current.draft).toMatchObject({
+        technicalAxis: null,
+        evidenceAxis: null,
+        notes: "",
+        expectedAssessmentRevision: 0,
+      })
+    )
+
+    await act(async () => {
+      resolveSave({ data: savedAssessment })
+      await savePromise
+    })
+
+    expect(result.current.isSaving).toBe(false)
+    expect(result.current.draft).toMatchObject({
+      technicalAxis: null,
+      evidenceAxis: null,
+      notes: "",
+      expectedAssessmentRevision: 0,
+      isDirty: false,
+    })
+  })
+
+  it("keeps the first-save draft while the newly created comparison set starts loading", async () => {
+    let resolveAssessmentList!: (value: TechnicalConfigurationAssessmentListWireResponse) => void
+    const pendingAssessmentList = new Promise<TechnicalConfigurationAssessmentListWireResponse>(
+      (resolve) => {
+        resolveAssessmentList = resolve
+      }
+    )
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return pendingAssessmentList
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: savedAssessment })
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+
+    const queryClient = createAssessmentTestQueryClient()
+    const { result } = renderHook(
+      () =>
+        useTechnicalConfigurationEvaluationDraft({
+          optionId,
+          baselineVersionId,
+          criterionId,
+          expectedDossierRevision: 6,
+        }),
+      { wrapper: createAssessmentQueryWrapper(queryClient) }
+    )
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    expect(mocks.getOrCreateComparisonSet).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.setTechnicalAxis("exceeds")
+      result.current.setEvidenceAxis("complete")
+      result.current.setNotes("Đánh giá lần đầu.")
+    })
+
+    await act(async () => {
+      await result.current.save()
+    })
+
+    expect(result.current.draft).toMatchObject({
+      criterionId,
+      technicalAxis: "exceeds",
+      evidenceAxis: "complete",
+      notes: "Đã xác nhận.",
+      expectedAssessmentRevision: 3,
+      expectedDossierRevision: 7,
+      isDirty: false,
+    })
+    expect(mocks.getOrCreateComparisonSet).toHaveBeenCalledWith({
+      p_option_id: optionId,
+      p_baseline_version_id: baselineVersionId,
+      p_expected_revision: 6,
+    })
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      ASSESSMENT_RPC_FUNCTIONS.upsertAssessment,
+      {
+        p_comparison_set_id: comparisonSetId,
+        p_criterion_id: criterionId,
+        p_technical_axis: "exceeds",
+        p_evidence_axis: "complete",
+        p_notes: "Đánh giá lần đầu.",
+        p_expected_revision: 0,
+      },
+      { signal: undefined }
+    )
+
+    await act(async () => {
+      resolveAssessmentList({
+        data: [savedAssessment],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+      await pendingAssessmentList
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
@@ -1,13 +1,15 @@
-import { act, renderHook, waitFor } from "@testing-library/react"
+import {
+  getEvaluationDraftMocks,
+  mockExistingAssessmentSave,
+  renderEvaluationDraftHook,
+  resetEvaluationDraftMocks,
+} from "./evaluation-draft-test-support"
+
+import { act, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
-import { useTechnicalConfigurationEvaluationDraft } from "../_hooks/useTechnicalConfigurationEvaluationDraft"
 import type { TechnicalConfigurationAssessmentListWireResponse } from "../assessment-types"
-import {
-  createAssessmentQueryWrapper,
-  createAssessmentTestQueryClient,
-} from "./assessment-hook-test-support"
 import {
   assessment,
   baselineVersionId,
@@ -18,66 +20,15 @@ import {
   savedAssessment,
 } from "./assessment-test-fixtures"
 
-const mocks = vi.hoisted(() => ({
-  callRpc: vi.fn(),
-  getOrCreateComparisonSet: vi.fn(),
-  readComparisonSet: vi.fn(),
-}))
-
-vi.mock("../technical-configuration-rpc", () => ({
-  callTechnicalConfigurationRpc: (...args: unknown[]) => mocks.callRpc(...args),
-}))
-
-vi.mock("../technical-configuration-option-response-operations", () => ({
-  getOrCreateTechnicalConfigurationComparisonSet: (...args: unknown[]) =>
-    mocks.getOrCreateComparisonSet(...args),
-  readTechnicalConfigurationComparisonSet: (...args: unknown[]) => mocks.readComparisonSet(...args),
-}))
-
-const otherOptionId = "00000000-0000-0000-0000-000000000007"
-const otherBaselineVersionId = "00000000-0000-0000-0000-000000000008"
-const otherCriterionId = "00000000-0000-0000-0000-000000000009"
+const mocks = getEvaluationDraftMocks()
 const otherComparisonSetId = "00000000-0000-0000-0000-000000000010"
 
-function renderEvaluationDraftHook(onDossierRevisionChange?: (revision: number) => void) {
-  const queryClient = createAssessmentTestQueryClient()
-  return renderHook(
-    () =>
-      useTechnicalConfigurationEvaluationDraft({
-        optionId,
-        baselineVersionId,
-        criterionId,
-        expectedDossierRevision: 6,
-        onDossierRevisionChange,
-      }),
-    { wrapper: createAssessmentQueryWrapper(queryClient) }
-  )
-}
-
 describe("P12A1 evaluation draft state", () => {
-  beforeEach(() => {
-    mocks.callRpc.mockReset()
-    mocks.getOrCreateComparisonSet.mockReset()
-    mocks.readComparisonSet.mockReset()
-  })
+  beforeEach(() => resetEvaluationDraftMocks(mocks))
 
   it("consumes the P11D complete collection and adopts successful save locally", async () => {
     const onDossierRevisionChange = vi.fn()
-    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
-    mocks.callRpc.mockImplementation((fn: string) => {
-      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
-        return Promise.resolve({
-          data: [assessment],
-          total: 1,
-          page: 1,
-          page_size: 100,
-        })
-      }
-      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
-        return Promise.resolve({ data: savedAssessment })
-      }
-      throw new Error(`Unexpected RPC: ${fn}`)
-    })
+    mockExistingAssessmentSave(mocks)
 
     const { result } = renderEvaluationDraftHook(onDossierRevisionChange)
 
@@ -130,27 +81,41 @@ describe("P12A1 evaluation draft state", () => {
     )
   })
 
+  it("saves the latest draft update when editing and saving in one turn", async () => {
+    mockExistingAssessmentSave(mocks)
+
+    const { result } = renderEvaluationDraftHook()
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+
+    await act(async () => {
+      result.current.setTechnicalAxis("exceeds")
+      result.current.setEvidenceAxis("complete")
+      result.current.setNotes("Nội dung vừa cập nhật.")
+      await result.current.save()
+    })
+
+    expect(mocks.callRpc).toHaveBeenCalledWith(
+      ASSESSMENT_RPC_FUNCTIONS.upsertAssessment,
+      {
+        p_comparison_set_id: comparisonSetId,
+        p_criterion_id: criterionId,
+        p_technical_axis: "exceeds",
+        p_evidence_axis: "complete",
+        p_notes: "Nội dung vừa cập nhật.",
+        p_expected_revision: assessment.revision,
+      },
+      { signal: undefined }
+    )
+  })
+
   it("rejects a misrouted assessment row and preserves the local draft", async () => {
     const onDossierRevisionChange = vi.fn()
     const misroutedAssessment = {
       ...savedAssessment,
       comparison_set_id: otherComparisonSetId,
     }
-    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
-    mocks.callRpc.mockImplementation((fn: string) => {
-      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
-        return Promise.resolve({
-          data: [assessment],
-          total: 1,
-          page: 1,
-          page_size: 100,
-        })
-      }
-      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
-        return Promise.resolve({ data: misroutedAssessment })
-      }
-      throw new Error(`Unexpected RPC: ${fn}`)
-    })
+    mockExistingAssessmentSave(mocks, misroutedAssessment)
 
     const { result } = renderEvaluationDraftHook(onDossierRevisionChange)
 
@@ -175,201 +140,6 @@ describe("P12A1 evaluation draft state", () => {
       isDirty: true,
     })
     expect(onDossierRevisionChange).not.toHaveBeenCalled()
-  })
-
-  it("starts a fresh draft when switching options for the same criterion", async () => {
-    mocks.readComparisonSet.mockResolvedValueOnce(comparisonSet).mockResolvedValueOnce(null)
-    mocks.callRpc.mockResolvedValue({
-      data: [assessment],
-      total: 1,
-      page: 1,
-      page_size: 100,
-    })
-
-    const queryClient = createAssessmentTestQueryClient()
-    const { result, rerender } = renderHook(
-      ({ currentOptionId }) =>
-        useTechnicalConfigurationEvaluationDraft({
-          optionId: currentOptionId,
-          baselineVersionId,
-          criterionId,
-          expectedDossierRevision: 6,
-        }),
-      {
-        initialProps: { currentOptionId: optionId },
-        wrapper: createAssessmentQueryWrapper(queryClient),
-      }
-    )
-
-    await waitFor(() => expect(result.current.isReady).toBe(true))
-    expect(result.current.draft).toMatchObject({
-      technicalAxis: "meets",
-      evidenceAxis: "partial",
-      notes: "Cần bổ sung chứng cứ.",
-    })
-
-    rerender({ currentOptionId: otherOptionId })
-    expect(result.current.draft).toBeNull()
-
-    await waitFor(() =>
-      expect(result.current.draft).toMatchObject({
-        technicalAxis: null,
-        evidenceAxis: null,
-        notes: "",
-        expectedAssessmentRevision: 0,
-      })
-    )
-  })
-
-  it("starts a fresh draft when switching baselines for the same option and criterion", async () => {
-    mocks.readComparisonSet.mockResolvedValueOnce(comparisonSet).mockResolvedValueOnce(null)
-    mocks.callRpc.mockResolvedValue({
-      data: [assessment],
-      total: 1,
-      page: 1,
-      page_size: 100,
-    })
-
-    const queryClient = createAssessmentTestQueryClient()
-    const { result, rerender } = renderHook(
-      ({ currentBaselineVersionId }) =>
-        useTechnicalConfigurationEvaluationDraft({
-          optionId,
-          baselineVersionId: currentBaselineVersionId,
-          criterionId,
-          expectedDossierRevision: 6,
-        }),
-      {
-        initialProps: { currentBaselineVersionId: baselineVersionId },
-        wrapper: createAssessmentQueryWrapper(queryClient),
-      }
-    )
-
-    await waitFor(() => expect(result.current.isReady).toBe(true))
-    rerender({ currentBaselineVersionId: otherBaselineVersionId })
-    expect(result.current.draft).toBeNull()
-
-    await waitFor(() =>
-      expect(result.current.draft).toMatchObject({
-        technicalAxis: null,
-        evidenceAxis: null,
-        notes: "",
-        expectedAssessmentRevision: 0,
-      })
-    )
-  })
-
-  it("starts a fresh draft when switching criteria within one comparison set", async () => {
-    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
-    mocks.callRpc.mockResolvedValue({
-      data: [assessment],
-      total: 1,
-      page: 1,
-      page_size: 100,
-    })
-
-    const queryClient = createAssessmentTestQueryClient()
-    const { result, rerender } = renderHook(
-      ({ currentCriterionId }) =>
-        useTechnicalConfigurationEvaluationDraft({
-          optionId,
-          baselineVersionId,
-          criterionId: currentCriterionId,
-          expectedDossierRevision: 6,
-        }),
-      {
-        initialProps: { currentCriterionId: criterionId },
-        wrapper: createAssessmentQueryWrapper(queryClient),
-      }
-    )
-
-    await waitFor(() => expect(result.current.isReady).toBe(true))
-    rerender({ currentCriterionId: otherCriterionId })
-
-    expect(result.current.draft).toMatchObject({
-      criterionId: otherCriterionId,
-      technicalAxis: null,
-      evidenceAxis: null,
-      notes: "",
-      expectedAssessmentRevision: 0,
-    })
-  })
-
-  it("does not adopt a pending save into a newly selected option", async () => {
-    let resolveSave!: (value: { data: typeof savedAssessment }) => void
-    const pendingSave = new Promise<{ data: typeof savedAssessment }>((resolve) => {
-      resolveSave = resolve
-    })
-    mocks.readComparisonSet.mockResolvedValueOnce(comparisonSet).mockResolvedValueOnce(null)
-    mocks.callRpc.mockImplementation((fn: string) => {
-      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
-        return Promise.resolve({
-          data: [assessment],
-          total: 1,
-          page: 1,
-          page_size: 100,
-        })
-      }
-      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
-        return pendingSave
-      }
-      throw new Error(`Unexpected RPC: ${fn}`)
-    })
-
-    const queryClient = createAssessmentTestQueryClient()
-    const { result, rerender } = renderHook(
-      ({ currentOptionId }) =>
-        useTechnicalConfigurationEvaluationDraft({
-          optionId: currentOptionId,
-          baselineVersionId,
-          criterionId,
-          expectedDossierRevision: 6,
-        }),
-      {
-        initialProps: { currentOptionId: optionId },
-        wrapper: createAssessmentQueryWrapper(queryClient),
-      }
-    )
-
-    await waitFor(() => expect(result.current.isReady).toBe(true))
-    act(() => {
-      result.current.setNotes("Bản nháp của phương án cũ.")
-    })
-
-    let savePromise!: ReturnType<typeof result.current.save>
-    await act(async () => {
-      savePromise = result.current.save()
-      await Promise.resolve()
-    })
-    expect(result.current.isSaving).toBe(true)
-
-    rerender({ currentOptionId: otherOptionId })
-    expect(result.current.isSaving).toBe(true)
-    await expect(result.current.save()).rejects.toThrow(
-      "technical_configuration_evaluation_save_unavailable"
-    )
-    await waitFor(() =>
-      expect(result.current.draft).toMatchObject({
-        technicalAxis: null,
-        evidenceAxis: null,
-        notes: "",
-        expectedAssessmentRevision: 0,
-      })
-    )
-
-    await act(async () => {
-      resolveSave({ data: savedAssessment })
-      await savePromise
-    })
-
-    expect(result.current.isSaving).toBe(false)
-    expect(result.current.draft).toMatchObject({
-      technicalAxis: null,
-      evidenceAxis: null,
-      notes: "",
-      expectedAssessmentRevision: 0,
-      isDirty: false,
-    })
   })
 
   it("keeps the first-save draft while the newly created comparison set starts loading", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-test-support.ts
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-test-support.ts
@@ -1,0 +1,96 @@
+import { renderHook } from "@testing-library/react"
+import { vi, type Mock } from "vitest"
+
+import { ASSESSMENT_RPC_FUNCTIONS } from "@/lib/technical-configuration-assessment-rpcs"
+import { useTechnicalConfigurationEvaluationDraft } from "../_hooks/useTechnicalConfigurationEvaluationDraft"
+import {
+  createAssessmentQueryWrapper,
+  createAssessmentTestQueryClient,
+} from "./assessment-hook-test-support"
+import {
+  assessment,
+  baselineVersionId,
+  comparisonSet,
+  criterionId,
+  optionId,
+  savedAssessment,
+} from "./assessment-test-fixtures"
+
+type EvaluationDraftMocks = {
+  callRpc: Mock
+  getOrCreateComparisonSet: Mock
+  readComparisonSet: Mock
+}
+
+const evaluationDraftMocks = vi.hoisted(() => ({
+  callRpc: vi.fn(),
+  getOrCreateComparisonSet: vi.fn(),
+  readComparisonSet: vi.fn(),
+}))
+
+vi.mock("../technical-configuration-rpc", () => ({
+  callTechnicalConfigurationRpc: (...args: unknown[]) => evaluationDraftMocks.callRpc(...args),
+}))
+
+vi.mock("../technical-configuration-option-response-operations", () => ({
+  getOrCreateTechnicalConfigurationComparisonSet: (...args: unknown[]) =>
+    evaluationDraftMocks.getOrCreateComparisonSet(...args),
+  readTechnicalConfigurationComparisonSet: (...args: unknown[]) =>
+    evaluationDraftMocks.readComparisonSet(...args),
+}))
+
+export function useEvaluationDraftForTest(
+  input: Parameters<typeof useTechnicalConfigurationEvaluationDraft>[0]
+) {
+  return useTechnicalConfigurationEvaluationDraft(input)
+}
+
+export function getEvaluationDraftMocks(): EvaluationDraftMocks {
+  return evaluationDraftMocks
+}
+
+export function renderEvaluationDraftHook(onDossierRevisionChange?: (revision: number) => void) {
+  const queryClient = createAssessmentTestQueryClient()
+  return renderHook(
+    () =>
+      useTechnicalConfigurationEvaluationDraft({
+        optionId,
+        baselineVersionId,
+        criterionId,
+        expectedDossierRevision: 6,
+        onDossierRevisionChange,
+      }),
+    { wrapper: createAssessmentQueryWrapper(queryClient) }
+  )
+}
+
+export function mockExistingAssessmentSave(
+  mocks: Pick<EvaluationDraftMocks, "callRpc" | "readComparisonSet">,
+  data = savedAssessment
+): void {
+  mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+  mocks.callRpc.mockImplementation((fn: string) => {
+    if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+      return Promise.resolve({
+        data: [assessment],
+        total: 1,
+        page: 1,
+        page_size: 100,
+      })
+    }
+    if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+      return Promise.resolve({ data })
+    }
+    throw new Error(`Unexpected RPC: ${fn}`)
+  })
+}
+
+export function resetEvaluationDraftMocks(mocks: EvaluationDraftMocks): void {
+  mocks.callRpc.mockReset()
+  mocks.getOrCreateComparisonSet.mockReset()
+  mocks.readComparisonSet.mockReset()
+}
+
+export function hasAssessmentUpsertCall(callRpc: Mock): boolean {
+  return callRpc.mock.calls.some(([fn]) => fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment)
+}

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-transitions.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-transitions.test.ts
@@ -10,10 +10,14 @@ import {
 } from "../technical-configuration-evaluation-state"
 import { assessment, comparisonSet, criterionId, savedAssessment } from "./assessment-test-fixtures"
 
+const otherComparisonSetId = "00000000-0000-0000-0000-000000000010"
+const otherCriterionId = "00000000-0000-0000-0000-000000000011"
+
 describe("P12A1 evaluation draft transitions", () => {
   it("creates first-save revision zero and adopts both saved row and comparison-set revisions", () => {
     const initial = createTechnicalConfigurationEvaluationDraftState({
       criterionId,
+      comparisonSetId: null,
       assessment: null,
       expectedDossierRevision: 6,
     })
@@ -40,6 +44,7 @@ describe("P12A1 evaluation draft transitions", () => {
 
     expect(saved).toMatchObject({
       criterionId,
+      comparisonSetId: comparisonSet.id,
       technicalAxis: "exceeds",
       evidenceAxis: "complete",
       notes: "Đã xác nhận.",
@@ -54,6 +59,7 @@ describe("P12A1 evaluation draft transitions", () => {
   it("allows both nullable axes to be cleared back to not evaluated", () => {
     const initial = createTechnicalConfigurationEvaluationDraftState({
       criterionId,
+      comparisonSetId: comparisonSet.id,
       assessment,
       expectedDossierRevision: 6,
     })
@@ -81,6 +87,7 @@ describe("P12A1 evaluation draft transitions", () => {
   ])("preserves criterion and local input after %s failure", (_label, error) => {
     const initial = createTechnicalConfigurationEvaluationDraftState({
       criterionId,
+      comparisonSetId: comparisonSet.id,
       assessment,
       expectedDossierRevision: 6,
     })
@@ -105,5 +112,66 @@ describe("P12A1 evaluation draft transitions", () => {
       error,
       isDirty: true,
     })
+  })
+
+  it.each([
+    [
+      "criterion",
+      {
+        criterionId,
+        comparisonSetId: comparisonSet.id,
+        assessment: { ...assessment, criterion_id: otherCriterionId },
+        expectedDossierRevision: 6,
+      },
+      "technical_configuration_evaluation_assessment_criterion_mismatch",
+    ],
+    [
+      "comparison set",
+      {
+        criterionId,
+        comparisonSetId: otherComparisonSetId,
+        assessment,
+        expectedDossierRevision: 6,
+      },
+      "technical_configuration_evaluation_assessment_comparison_set_mismatch",
+    ],
+  ])("rejects a persisted assessment with mismatched %s identity", (_label, input, error) => {
+    expect(() => createTechnicalConfigurationEvaluationDraftState(input)).toThrow(error)
+  })
+
+  it.each([
+    [
+      "draft comparison set",
+      {
+        comparisonSet: { ...comparisonSet, id: otherComparisonSetId },
+        assessment: { ...savedAssessment, comparison_set_id: otherComparisonSetId },
+      },
+      "technical_configuration_evaluation_save_comparison_set_mismatch",
+    ],
+    [
+      "result comparison set",
+      {
+        comparisonSet,
+        assessment: { ...savedAssessment, comparison_set_id: otherComparisonSetId },
+      },
+      "technical_configuration_evaluation_save_result_comparison_set_mismatch",
+    ],
+    [
+      "criterion",
+      {
+        comparisonSet,
+        assessment: { ...savedAssessment, criterion_id: otherCriterionId },
+      },
+      "technical_configuration_evaluation_save_criterion_mismatch",
+    ],
+  ])("rejects a save result with mismatched %s identity", (_label, result, error) => {
+    const initial = createTechnicalConfigurationEvaluationDraftState({
+      criterionId,
+      comparisonSetId: comparisonSet.id,
+      assessment,
+      expectedDossierRevision: 6,
+    })
+
+    expect(() => adoptTechnicalConfigurationEvaluationSave(initial, result)).toThrow(error)
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-transitions.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-transitions.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  adoptTechnicalConfigurationEvaluationSave,
+  applyTechnicalConfigurationEvaluationSaveFailure,
+  beginTechnicalConfigurationEvaluationSave,
+  createTechnicalConfigurationEvaluationDraftState,
+  toTechnicalConfigurationAssessmentUpsertInput,
+  updateTechnicalConfigurationEvaluationDraft,
+} from "../technical-configuration-evaluation-state"
+import { assessment, comparisonSet, criterionId, savedAssessment } from "./assessment-test-fixtures"
+
+describe("P12A1 evaluation draft transitions", () => {
+  it("creates first-save revision zero and adopts both saved row and comparison-set revisions", () => {
+    const initial = createTechnicalConfigurationEvaluationDraftState({
+      criterionId,
+      assessment: null,
+      expectedDossierRevision: 6,
+    })
+    const edited = updateTechnicalConfigurationEvaluationDraft(initial, {
+      technicalAxis: "exceeds",
+      evidenceAxis: "complete",
+      notes: "Đã xác nhận.",
+    })
+
+    expect(toTechnicalConfigurationAssessmentUpsertInput(edited)).toEqual({
+      criterionId,
+      technicalAxis: "exceeds",
+      evidenceAxis: "complete",
+      notes: "Đã xác nhận.",
+      expectedRevision: 0,
+      expectedDossierRevision: 6,
+    })
+
+    const saving = beginTechnicalConfigurationEvaluationSave(edited)
+    const saved = adoptTechnicalConfigurationEvaluationSave(saving, {
+      comparisonSet,
+      assessment: savedAssessment,
+    })
+
+    expect(saved).toMatchObject({
+      criterionId,
+      technicalAxis: "exceeds",
+      evidenceAxis: "complete",
+      notes: "Đã xác nhận.",
+      expectedAssessmentRevision: 3,
+      expectedDossierRevision: 7,
+      saveStatus: "idle",
+      error: null,
+      isDirty: false,
+    })
+  })
+
+  it("allows both nullable axes to be cleared back to not evaluated", () => {
+    const initial = createTechnicalConfigurationEvaluationDraftState({
+      criterionId,
+      assessment,
+      expectedDossierRevision: 6,
+    })
+    const cleared = updateTechnicalConfigurationEvaluationDraft(initial, {
+      technicalAxis: null,
+      evidenceAxis: null,
+    })
+
+    expect(cleared).toMatchObject({
+      technicalAxis: null,
+      evidenceAxis: null,
+      isDirty: true,
+    })
+    expect(toTechnicalConfigurationAssessmentUpsertInput(cleared)).toMatchObject({
+      technicalAxis: null,
+      evidenceAxis: null,
+    })
+  })
+
+  it.each([
+    ["validation", Object.assign(new Error("validation_error"), { code: "PT422" })],
+    ["authorization", Object.assign(new Error("permission_denied"), { code: "42501" })],
+    ["conflict", Object.assign(new Error("stale_revision"), { code: "PT409" })],
+    ["persistence", new Error("network_failure")],
+  ])("preserves criterion and local input after %s failure", (_label, error) => {
+    const initial = createTechnicalConfigurationEvaluationDraftState({
+      criterionId,
+      assessment,
+      expectedDossierRevision: 6,
+    })
+    const edited = updateTechnicalConfigurationEvaluationDraft(initial, {
+      technicalAxis: "exceeds",
+      evidenceAxis: "missing",
+      notes: "Không được mất nội dung này.",
+    })
+    const failed = applyTechnicalConfigurationEvaluationSaveFailure(
+      beginTechnicalConfigurationEvaluationSave(edited),
+      error
+    )
+
+    expect(failed).toMatchObject({
+      criterionId,
+      technicalAxis: "exceeds",
+      evidenceAxis: "missing",
+      notes: "Không được mất nội dung này.",
+      expectedAssessmentRevision: assessment.revision,
+      expectedDossierRevision: 6,
+      saveStatus: "error",
+      error,
+      isDirty: true,
+    })
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-workspace-cases.tsx
@@ -331,21 +331,36 @@ export function registerReferenceProductWorkspaceTests({
 
     it("registers beforeunload protection while the reference draft is dirty", async () => {
       const user = userEvent.setup()
+      const addEventListener = vi.spyOn(window, "addEventListener")
       referenceRpc.listProducts.mockResolvedValue(listResponse([]))
 
-      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
-      expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
+      try {
+        renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+        expect(await screen.findByText("Chưa có sản phẩm tham chiếu.")).toBeInTheDocument()
 
-      const cleanEvent = new Event("beforeunload", { cancelable: true })
-      window.dispatchEvent(cleanEvent)
-      expect(cleanEvent.defaultPrevented).toBe(false)
+        const cleanHandlerCount = addEventListener.mock.calls.filter(
+          ([eventName]) => eventName === "beforeunload"
+        ).length
 
-      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
-      await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
+        await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+        await user.type(screen.getByLabelText("Model"), "Model chưa lưu")
 
-      const dirtyEvent = new Event("beforeunload", { cancelable: true })
-      window.dispatchEvent(dirtyEvent)
-      expect(dirtyEvent.defaultPrevented).toBe(true)
+        await waitFor(() =>
+          expect(
+            addEventListener.mock.calls.filter(([eventName]) => eventName === "beforeunload")
+          ).toHaveLength(cleanHandlerCount + 1)
+        )
+        const beforeUnloadHandler = addEventListener.mock.calls
+          .filter(([eventName]) => eventName === "beforeunload")
+          .at(-1)?.[1]
+        expect(beforeUnloadHandler).toBeTypeOf("function")
+
+        const dirtyEvent = new Event("beforeunload", { cancelable: true })
+        ;(beforeUnloadHandler as EventListener)(dirtyEvent)
+        expect(dirtyEvent.defaultPrevented).toBe(true)
+      } finally {
+        addEventListener.mockRestore()
+      }
     })
 
     it("renders locked reference products read-only without mutation affordances", async () => {

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPanel.tsx
@@ -20,11 +20,12 @@ export type TechnicalConfigurationCriterionDetail = {
   evidenceTarget: TechnicalConfigurationComparisonEvidenceTarget
 }
 
-type TechnicalConfigurationCriterionPanelProps = {
+export type TechnicalConfigurationCriterionPanelProps = {
   detail: TechnicalConfigurationCriterionDetail | null
   open: boolean
   onOpenChange: (open: boolean) => void
   returnFocusRef?: React.RefObject<HTMLElement | null>
+  assessmentControls?: React.ReactNode
 }
 
 function formatEvidenceSummary(evidence: TechnicalConfigurationComparisonEvidence) {
@@ -38,6 +39,7 @@ export function TechnicalConfigurationCriterionPanel({
   open,
   onOpenChange,
   returnFocusRef,
+  assessmentControls,
 }: Readonly<TechnicalConfigurationCriterionPanelProps>) {
   return (
     <SideSheetShell
@@ -94,6 +96,10 @@ export function TechnicalConfigurationCriterionPanel({
               <TechnicalConfigurationComparisonEvidenceSection target={detail.evidenceTarget} />
             ) : null}
           </section>
+
+          {assessmentControls ? (
+            <section className="border-t pt-5">{assessmentControls}</section>
+          ) : null}
         </div>
       ) : null}
     </SideSheetShell>

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationAssessmentControls.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationAssessmentControls.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  deriveTechnicalConfigurationEvaluationStatus,
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS,
+  TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_LABELS,
+  TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES,
+  TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_LABELS,
+  TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES,
+  type TechnicalConfigurationEvidenceAxis,
+  type TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+
+const UNSELECTED_AXIS_VALUE = "__unselected__"
+
+export type TechnicalConfigurationAssessmentControlsProps = {
+  technicalAxis: TechnicalConfigurationTechnicalAxis | null
+  evidenceAxis: TechnicalConfigurationEvidenceAxis | null
+  notes: string
+  onTechnicalAxisChange: (value: TechnicalConfigurationTechnicalAxis | null) => void
+  onEvidenceAxisChange: (value: TechnicalConfigurationEvidenceAxis | null) => void
+  onNotesChange: (value: string) => void
+  disabled?: boolean
+  loading?: boolean
+  errorMessage?: string | null
+}
+
+function toTechnicalAxis(value: string): TechnicalConfigurationTechnicalAxis | null {
+  if (value === UNSELECTED_AXIS_VALUE) return null
+  return (
+    TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES.find((candidate) => candidate === value) ?? null
+  )
+}
+
+function toEvidenceAxis(value: string): TechnicalConfigurationEvidenceAxis | null {
+  if (value === UNSELECTED_AXIS_VALUE) return null
+  return (
+    TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES.find((candidate) => candidate === value) ?? null
+  )
+}
+
+/** Renders controlled P11A manual axes, notes, and their canonical derived status. */
+export function TechnicalConfigurationAssessmentControls({
+  technicalAxis,
+  evidenceAxis,
+  notes,
+  onTechnicalAxisChange,
+  onEvidenceAxisChange,
+  onNotesChange,
+  disabled = false,
+  loading = false,
+  errorMessage = null,
+}: Readonly<TechnicalConfigurationAssessmentControlsProps>) {
+  const derivedStatus = deriveTechnicalConfigurationEvaluationStatus(technicalAxis, evidenceAxis)
+  const controlsDisabled = disabled || loading
+  const errorId = errorMessage ? "technical-configuration-assessment-error" : undefined
+
+  return (
+    <div className="space-y-4" aria-busy={loading}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-semibold">Đánh giá thủ công</h3>
+        <Badge role="status" variant="outline" className="whitespace-normal text-center">
+          {TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[derivedStatus]}
+        </Badge>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="technical-configuration-technical-axis">Mức đáp ứng kỹ thuật</Label>
+          <Select
+            value={technicalAxis ?? UNSELECTED_AXIS_VALUE}
+            onValueChange={(value) => onTechnicalAxisChange(toTechnicalAxis(value))}
+            disabled={controlsDisabled}
+          >
+            <SelectTrigger
+              id="technical-configuration-technical-axis"
+              aria-label="Mức đáp ứng kỹ thuật"
+              aria-describedby={errorId}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={UNSELECTED_AXIS_VALUE}>Chưa chọn</SelectItem>
+              {TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_VALUES.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {TECHNICAL_CONFIGURATION_TECHNICAL_AXIS_LABELS[value]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="technical-configuration-evidence-axis">Mức đầy đủ bằng chứng</Label>
+          <Select
+            value={evidenceAxis ?? UNSELECTED_AXIS_VALUE}
+            onValueChange={(value) => onEvidenceAxisChange(toEvidenceAxis(value))}
+            disabled={controlsDisabled}
+          >
+            <SelectTrigger
+              id="technical-configuration-evidence-axis"
+              aria-label="Mức đầy đủ bằng chứng"
+              aria-describedby={errorId}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={UNSELECTED_AXIS_VALUE}>Chưa chọn</SelectItem>
+              {TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_VALUES.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {TECHNICAL_CONFIGURATION_EVIDENCE_AXIS_LABELS[value]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="technical-configuration-assessment-notes">Ghi chú</Label>
+        <Textarea
+          id="technical-configuration-assessment-notes"
+          value={notes}
+          rows={4}
+          disabled={controlsDisabled}
+          aria-describedby={errorId}
+          onChange={(event) => onNotesChange(event.target.value)}
+        />
+      </div>
+
+      {errorMessage ? (
+        <p id={errorId} role="alert" className="text-sm text-destructive">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationCriterionList.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import {
+  deriveTechnicalConfigurationEvaluationStatus,
+  TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS,
+  type TechnicalConfigurationDerivedStatus,
+} from "@/lib/technical-configuration-evaluation"
+import { cn } from "@/lib/utils"
+
+import type { TechnicalConfigurationAssessmentWire } from "../../assessment-types"
+import type { TechnicalConfigurationComparisonCriterionRow } from "../../comparison-types"
+
+type TechnicalConfigurationCriterionListProps = {
+  criteria: readonly TechnicalConfigurationComparisonCriterionRow[]
+  assessmentsByCriterionId: Readonly<Record<string, TechnicalConfigurationAssessmentWire>>
+  currentCriterionId: string | null
+  onSelectCriterion: (criterionId: string) => void
+  disabled?: boolean
+}
+
+type TechnicalConfigurationCriterionGroup = {
+  id: string
+  name: string
+  criteria: TechnicalConfigurationComparisonCriterionRow[]
+}
+
+function compareCanonicalCriteria(
+  left: TechnicalConfigurationComparisonCriterionRow,
+  right: TechnicalConfigurationComparisonCriterionRow
+) {
+  return (
+    left.group.sortOrder - right.group.sortOrder ||
+    left.group.id.localeCompare(right.group.id) ||
+    left.criterion.sortOrder - right.criterion.sortOrder ||
+    left.criterion.id.localeCompare(right.criterion.id)
+  )
+}
+
+function groupCanonicalCriteria(
+  criteria: readonly TechnicalConfigurationComparisonCriterionRow[]
+): TechnicalConfigurationCriterionGroup[] {
+  const groups: TechnicalConfigurationCriterionGroup[] = []
+
+  for (const row of [...criteria].sort(compareCanonicalCriteria)) {
+    const currentGroup = groups.at(-1)
+    if (currentGroup?.id === row.group.id) {
+      currentGroup.criteria.push(row)
+      continue
+    }
+
+    groups.push({
+      id: row.group.id,
+      name: row.group.name,
+      criteria: [row],
+    })
+  }
+
+  return groups
+}
+
+function getCriterionStatus(
+  assessment: TechnicalConfigurationAssessmentWire | undefined
+): TechnicalConfigurationDerivedStatus {
+  return deriveTechnicalConfigurationEvaluationStatus(
+    assessment?.technical_axis,
+    assessment?.evidence_axis
+  )
+}
+
+function getStatusVariant(status: TechnicalConfigurationDerivedStatus) {
+  if (status === "fails") return "destructive" as const
+  if (status === "meets" || status === "exceeds") return "secondary" as const
+  if (status === "not_evaluated") return "muted" as const
+  return "outline" as const
+}
+
+/** Renders the canonical criterion sequence with one compact manual-status badge per row. */
+export function TechnicalConfigurationCriterionList({
+  criteria,
+  assessmentsByCriterionId,
+  currentCriterionId,
+  onSelectCriterion,
+  disabled = false,
+}: Readonly<TechnicalConfigurationCriterionListProps>) {
+  const groups = groupCanonicalCriteria(criteria)
+
+  return (
+    <nav aria-label="Danh sách tiêu chí đánh giá" className="divide-y border-y">
+      {groups.map((group) => (
+        <section key={group.id} aria-labelledby={`evaluation-group-${group.id}`}>
+          <h3
+            id={`evaluation-group-${group.id}`}
+            className="bg-muted/40 px-3 py-2 text-xs font-semibold text-muted-foreground"
+          >
+            {group.name}
+          </h3>
+          <div className="divide-y">
+            {group.criteria.map((row) => {
+              const criterionId = row.criterion.id
+              const status = getCriterionStatus(assessmentsByCriterionId[criterionId])
+              const isCurrent = criterionId === currentCriterionId
+
+              return (
+                <button
+                  key={criterionId}
+                  type="button"
+                  data-testid="evaluation-criterion"
+                  data-criterion-id={criterionId}
+                  aria-current={isCurrent ? "true" : undefined}
+                  disabled={disabled}
+                  className={cn(
+                    "grid min-h-16 w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-l-2 border-l-transparent px-3 py-2.5 text-left outline-none transition-colors",
+                    "hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+                    isCurrent && "border-l-primary bg-primary/10"
+                  )}
+                  onClick={() => onSelectCriterion(criterionId)}
+                >
+                  <span className="min-w-0">
+                    <span className="block text-xs font-medium text-muted-foreground">
+                      {row.criterion.criterionCode}
+                    </span>
+                    <span className="mt-1 block break-words text-sm font-medium leading-5">
+                      {row.criterion.title ?? "Chưa có tiêu đề"}
+                    </span>
+                  </span>
+                  <Badge
+                    variant={getStatusVariant(status)}
+                    className="max-w-32 justify-center whitespace-normal text-center"
+                  >
+                    {TECHNICAL_CONFIGURATION_DERIVED_STATUS_LABELS[status]}
+                  </Badge>
+                </button>
+              )
+            })}
+          </div>
+        </section>
+      ))}
+    </nav>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationPanel.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationPanel.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import type * as React from "react"
+
+import {
+  TechnicalConfigurationCriterionPanel,
+  type TechnicalConfigurationCriterionDetail,
+} from "../comparison/TechnicalConfigurationCriterionPanel"
+import {
+  TechnicalConfigurationAssessmentControls,
+  type TechnicalConfigurationAssessmentControlsProps,
+} from "./TechnicalConfigurationAssessmentControls"
+
+type TechnicalConfigurationEvaluationPanelProps = TechnicalConfigurationAssessmentControlsProps & {
+  detail: TechnicalConfigurationCriterionDetail | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  returnFocusRef?: React.RefObject<HTMLElement | null>
+}
+
+/** Adds manual assessment controls to the single shared P10B criterion detail surface. */
+export function TechnicalConfigurationEvaluationPanel({
+  detail,
+  open,
+  onOpenChange,
+  returnFocusRef,
+  ...assessmentControls
+}: Readonly<TechnicalConfigurationEvaluationPanelProps>) {
+  return (
+    <TechnicalConfigurationCriterionPanel
+      detail={detail}
+      open={open}
+      onOpenChange={onOpenChange}
+      returnFocusRef={returnFocusRef}
+      assessmentControls={<TechnicalConfigurationAssessmentControls {...assessmentControls} />}
+    />
+  )
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
@@ -5,6 +5,7 @@ import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tansta
 import { useTechnicalConfigurationOptionResponsesQuery } from "./useTechnicalConfigurationOptionResponsesQuery"
 import type {
   TechnicalConfigurationAssessmentListWireResponse,
+  TechnicalConfigurationAssessmentSaveResult,
   TechnicalConfigurationAssessmentUpsertInput,
   TechnicalConfigurationAssessmentWire,
 } from "../assessment-types"
@@ -39,11 +40,6 @@ type UseTechnicalConfigurationAssessmentsInput = TechnicalConfigurationAssessmen
         collectionMode: "complete"
       }
   )
-
-interface TechnicalConfigurationAssessmentSaveResult {
-  comparisonSet: TechnicalConfigurationComparisonSetWire
-  assessment: TechnicalConfigurationAssessmentWire
-}
 
 const comparisonSetAcquisitions = new WeakMap<
   QueryClient,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationDraft.ts
@@ -37,17 +37,20 @@ type TechnicalConfigurationEvaluationDraftEntry = {
 function reconcileTechnicalConfigurationEvaluationDraft({
   draft,
   criterionId,
+  comparisonSetId,
   assessment,
   expectedDossierRevision,
 }: {
   draft: TechnicalConfigurationEvaluationDraftState | null
   criterionId: string
+  comparisonSetId: string | null
   assessment: TechnicalConfigurationAssessmentWire | null
   expectedDossierRevision: number
 }): TechnicalConfigurationEvaluationDraftState {
   if (!draft) {
     return createTechnicalConfigurationEvaluationDraftState({
       criterionId,
+      comparisonSetId,
       assessment,
       expectedDossierRevision,
     })
@@ -60,6 +63,7 @@ function reconcileTechnicalConfigurationEvaluationDraft({
   ) {
     return createTechnicalConfigurationEvaluationDraftState({
       criterionId,
+      comparisonSetId,
       assessment,
       expectedDossierRevision: Math.max(draft.expectedDossierRevision, expectedDossierRevision),
     })
@@ -96,6 +100,7 @@ export function useTechnicalConfigurationEvaluationDraft({
   const isCollectionReady =
     assessmentSource.completeAssessmentsQuery.isSuccess || hasNoComparisonSet
   const assessment = criterionId ? (assessmentsByCriterionId[criterionId] ?? null) : null
+  const comparisonSetId = assessmentSource.comparisonSetQuery.data?.id ?? null
   const draftContextKey = JSON.stringify([optionId, baselineVersionId, criterionId])
   const [draftEntry, setDraftEntry] =
     React.useState<TechnicalConfigurationEvaluationDraftEntry | null>(null)
@@ -107,6 +112,7 @@ export function useTechnicalConfigurationEvaluationDraft({
       ? reconcileTechnicalConfigurationEvaluationDraft({
           draft: storedDraft,
           criterionId,
+          comparisonSetId,
           assessment,
           expectedDossierRevision,
         })
@@ -120,6 +126,7 @@ export function useTechnicalConfigurationEvaluationDraft({
             ? reconcileTechnicalConfigurationEvaluationDraft({
                 draft: current.draft,
                 criterionId: current.draft.criterionId,
+                comparisonSetId,
                 assessment,
                 expectedDossierRevision,
               })
@@ -133,7 +140,7 @@ export function useTechnicalConfigurationEvaluationDraft({
         }
       })
     },
-    [assessment, currentDraft, draftContextKey, expectedDossierRevision]
+    [assessment, comparisonSetId, currentDraft, draftContextKey, expectedDossierRevision]
   )
 
   const save = React.useCallback(async () => {
@@ -158,13 +165,14 @@ export function useTechnicalConfigurationEvaluationDraft({
       const result = await assessmentSource.upsertAssessment.mutateAsync(
         toTechnicalConfigurationAssessmentUpsertInput(saveSnapshot.draft)
       )
+      const adoptedDraft = adoptTechnicalConfigurationEvaluationSave(saveSnapshot.draft, result)
       setDraftEntry((current) => {
         if (current?.contextKey !== saveSnapshot.contextKey) {
           return current
         }
         return {
           ...current,
-          draft: adoptTechnicalConfigurationEvaluationSave(current.draft, result),
+          draft: adoptedDraft,
         }
       })
       onDossierRevisionChange?.(result.comparisonSet.revision)

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationDraft.ts
@@ -1,0 +1,227 @@
+"use client"
+
+import * as React from "react"
+
+import type {
+  TechnicalConfigurationEvidenceAxis,
+  TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+
+import { useTechnicalConfigurationAssessments } from "./useTechnicalConfigurationAssessments"
+import type { TechnicalConfigurationAssessmentWire } from "../assessment-types"
+import {
+  adoptTechnicalConfigurationEvaluationSave,
+  applyTechnicalConfigurationEvaluationSaveFailure,
+  beginTechnicalConfigurationEvaluationSave,
+  createTechnicalConfigurationEvaluationDraftState,
+  toTechnicalConfigurationAssessmentUpsertInput,
+  updateTechnicalConfigurationEvaluationDraft,
+  type TechnicalConfigurationEvaluationDraftState,
+} from "../technical-configuration-evaluation-state"
+
+const EMPTY_ASSESSMENTS: Readonly<Record<string, TechnicalConfigurationAssessmentWire>> = {}
+
+type UseTechnicalConfigurationEvaluationDraftInput = {
+  optionId: string
+  baselineVersionId: string | null
+  criterionId: string | null
+  expectedDossierRevision: number
+  onDossierRevisionChange?: (revision: number) => void
+}
+
+type TechnicalConfigurationEvaluationDraftEntry = {
+  contextKey: string
+  draft: TechnicalConfigurationEvaluationDraftState
+}
+
+function reconcileTechnicalConfigurationEvaluationDraft({
+  draft,
+  criterionId,
+  assessment,
+  expectedDossierRevision,
+}: {
+  draft: TechnicalConfigurationEvaluationDraftState | null
+  criterionId: string
+  assessment: TechnicalConfigurationAssessmentWire | null
+  expectedDossierRevision: number
+}): TechnicalConfigurationEvaluationDraftState {
+  if (!draft) {
+    return createTechnicalConfigurationEvaluationDraftState({
+      criterionId,
+      assessment,
+      expectedDossierRevision,
+    })
+  }
+
+  if (
+    !draft.isDirty &&
+    draft.saveStatus !== "saving" &&
+    (assessment?.revision ?? 0) > draft.expectedAssessmentRevision
+  ) {
+    return createTechnicalConfigurationEvaluationDraftState({
+      criterionId,
+      assessment,
+      expectedDossierRevision: Math.max(draft.expectedDossierRevision, expectedDossierRevision),
+    })
+  }
+
+  if (expectedDossierRevision > draft.expectedDossierRevision) {
+    return {
+      ...draft,
+      expectedDossierRevision,
+    }
+  }
+
+  return draft
+}
+
+/** Composes P11D complete reads with one criterion-local draft and save command. */
+export function useTechnicalConfigurationEvaluationDraft({
+  optionId,
+  baselineVersionId,
+  criterionId,
+  expectedDossierRevision,
+  onDossierRevisionChange,
+}: UseTechnicalConfigurationEvaluationDraftInput) {
+  const assessmentSource = useTechnicalConfigurationAssessments({
+    optionId,
+    baselineVersionId,
+    collectionMode: "complete",
+  })
+  const assessmentsByCriterionId =
+    assessmentSource.completeAssessmentsQuery.data ?? EMPTY_ASSESSMENTS
+  const hasNoComparisonSet =
+    assessmentSource.comparisonSetQuery.isSuccess &&
+    assessmentSource.comparisonSetQuery.data === null
+  const isCollectionReady =
+    assessmentSource.completeAssessmentsQuery.isSuccess || hasNoComparisonSet
+  const assessment = criterionId ? (assessmentsByCriterionId[criterionId] ?? null) : null
+  const draftContextKey = JSON.stringify([optionId, baselineVersionId, criterionId])
+  const [draftEntry, setDraftEntry] =
+    React.useState<TechnicalConfigurationEvaluationDraftEntry | null>(null)
+  const [isSaveInFlight, setIsSaveInFlight] = React.useState(false)
+  const saveInFlightRef = React.useRef(false)
+  const storedDraft = draftEntry?.contextKey === draftContextKey ? draftEntry.draft : null
+  const currentDraft =
+    criterionId && (isCollectionReady || storedDraft)
+      ? reconcileTechnicalConfigurationEvaluationDraft({
+          draft: storedDraft,
+          criterionId,
+          assessment,
+          expectedDossierRevision,
+        })
+      : null
+
+  const updateDraft = React.useCallback(
+    (patch: Parameters<typeof updateTechnicalConfigurationEvaluationDraft>[1]) => {
+      setDraftEntry((current) => {
+        const baseDraft =
+          current?.contextKey === draftContextKey
+            ? reconcileTechnicalConfigurationEvaluationDraft({
+                draft: current.draft,
+                criterionId: current.draft.criterionId,
+                assessment,
+                expectedDossierRevision,
+              })
+            : currentDraft
+        if (!baseDraft) {
+          return current
+        }
+        return {
+          contextKey: draftContextKey,
+          draft: updateTechnicalConfigurationEvaluationDraft(baseDraft, patch),
+        }
+      })
+    },
+    [assessment, currentDraft, draftContextKey, expectedDossierRevision]
+  )
+
+  const save = React.useCallback(async () => {
+    if (!currentDraft || currentDraft.criterionId !== criterionId || saveInFlightRef.current) {
+      throw new Error("technical_configuration_evaluation_save_unavailable")
+    }
+
+    saveInFlightRef.current = true
+    setIsSaveInFlight(true)
+    const saveSnapshot = {
+      contextKey: draftContextKey,
+      draft: currentDraft,
+    }
+    setDraftEntry((current) => ({
+      contextKey: saveSnapshot.contextKey,
+      draft: beginTechnicalConfigurationEvaluationSave(
+        current?.contextKey === saveSnapshot.contextKey ? current.draft : saveSnapshot.draft
+      ),
+    }))
+
+    try {
+      const result = await assessmentSource.upsertAssessment.mutateAsync(
+        toTechnicalConfigurationAssessmentUpsertInput(saveSnapshot.draft)
+      )
+      setDraftEntry((current) => {
+        if (current?.contextKey !== saveSnapshot.contextKey) {
+          return current
+        }
+        return {
+          ...current,
+          draft: adoptTechnicalConfigurationEvaluationSave(current.draft, result),
+        }
+      })
+      onDossierRevisionChange?.(result.comparisonSet.revision)
+      return result
+    } catch (error) {
+      setDraftEntry((current) => {
+        if (current?.contextKey !== saveSnapshot.contextKey) {
+          return current
+        }
+        return {
+          ...current,
+          draft: applyTechnicalConfigurationEvaluationSaveFailure(current.draft, error),
+        }
+      })
+      throw error
+    } finally {
+      saveInFlightRef.current = false
+      setIsSaveInFlight(false)
+    }
+  }, [
+    assessmentSource.upsertAssessment,
+    criterionId,
+    currentDraft,
+    draftContextKey,
+    onDossierRevisionChange,
+  ])
+
+  const setTechnicalAxis = React.useCallback(
+    (technicalAxis: TechnicalConfigurationTechnicalAxis | null) => {
+      updateDraft({ technicalAxis })
+    },
+    [updateDraft]
+  )
+  const setEvidenceAxis = React.useCallback(
+    (evidenceAxis: TechnicalConfigurationEvidenceAxis | null) => {
+      updateDraft({ evidenceAxis })
+    },
+    [updateDraft]
+  )
+  const setNotes = React.useCallback(
+    (notes: string) => {
+      updateDraft({ notes })
+    },
+    [updateDraft]
+  )
+
+  return {
+    assessmentsByCriterionId,
+    assessmentQuery: assessmentSource.completeAssessmentsQuery,
+    comparisonSetQuery: assessmentSource.comparisonSetQuery,
+    draft: currentDraft,
+    isReady: currentDraft !== null,
+    isSaving: isSaveInFlight,
+    error: currentDraft?.error ?? null,
+    setTechnicalAxis,
+    setEvidenceAxis,
+    setNotes,
+    save,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationDraft.ts
@@ -102,8 +102,11 @@ export function useTechnicalConfigurationEvaluationDraft({
   const assessment = criterionId ? (assessmentsByCriterionId[criterionId] ?? null) : null
   const comparisonSetId = assessmentSource.comparisonSetQuery.data?.id ?? null
   const draftContextKey = JSON.stringify([optionId, baselineVersionId, criterionId])
+  const draftContextToken = React.useMemo(() => Symbol(draftContextKey), [draftContextKey])
   const [draftEntry, setDraftEntry] =
     React.useState<TechnicalConfigurationEvaluationDraftEntry | null>(null)
+  const draftEntryRef = React.useRef<TechnicalConfigurationEvaluationDraftEntry | null>(null)
+  const activeDraftContextTokenRef = React.useRef(draftContextToken)
   const [isSaveInFlight, setIsSaveInFlight] = React.useState(false)
   const saveInFlightRef = React.useRef(false)
   const storedDraft = draftEntry?.contextKey === draftContextKey ? draftEntry.draft : null
@@ -118,86 +121,119 @@ export function useTechnicalConfigurationEvaluationDraft({
         })
       : null
 
+  React.useLayoutEffect(() => {
+    activeDraftContextTokenRef.current = draftContextToken
+  }, [draftContextToken])
+
+  const replaceDraftEntry = React.useCallback(
+    (entry: TechnicalConfigurationEvaluationDraftEntry) => {
+      draftEntryRef.current = entry
+      setDraftEntry(entry)
+    },
+    []
+  )
+
   const updateDraft = React.useCallback(
     (patch: Parameters<typeof updateTechnicalConfigurationEvaluationDraft>[1]) => {
-      setDraftEntry((current) => {
-        const baseDraft =
-          current?.contextKey === draftContextKey
-            ? reconcileTechnicalConfigurationEvaluationDraft({
-                draft: current.draft,
-                criterionId: current.draft.criterionId,
-                comparisonSetId,
-                assessment,
-                expectedDossierRevision,
-              })
-            : currentDraft
-        if (!baseDraft) {
-          return current
-        }
-        return {
-          contextKey: draftContextKey,
-          draft: updateTechnicalConfigurationEvaluationDraft(baseDraft, patch),
-        }
+      if (activeDraftContextTokenRef.current !== draftContextToken) return
+
+      const current = draftEntryRef.current
+      const baseDraft =
+        current?.contextKey === draftContextKey
+          ? reconcileTechnicalConfigurationEvaluationDraft({
+              draft: current.draft,
+              criterionId: current.draft.criterionId,
+              comparisonSetId,
+              assessment,
+              expectedDossierRevision,
+            })
+          : currentDraft
+      if (!baseDraft) return
+
+      replaceDraftEntry({
+        contextKey: draftContextKey,
+        draft: updateTechnicalConfigurationEvaluationDraft(baseDraft, patch),
       })
     },
-    [assessment, comparisonSetId, currentDraft, draftContextKey, expectedDossierRevision]
+    [
+      assessment,
+      comparisonSetId,
+      currentDraft,
+      draftContextKey,
+      draftContextToken,
+      expectedDossierRevision,
+      replaceDraftEntry,
+    ]
   )
 
   const save = React.useCallback(async () => {
-    if (!currentDraft || currentDraft.criterionId !== criterionId || saveInFlightRef.current) {
+    const current = draftEntryRef.current
+    const latestDraft = current?.contextKey === draftContextKey ? current.draft : currentDraft
+    if (
+      activeDraftContextTokenRef.current !== draftContextToken ||
+      !latestDraft ||
+      latestDraft.criterionId !== criterionId ||
+      saveInFlightRef.current
+    ) {
       throw new Error("technical_configuration_evaluation_save_unavailable")
     }
 
+    const draftToSave = reconcileTechnicalConfigurationEvaluationDraft({
+      draft: latestDraft,
+      criterionId: latestDraft.criterionId,
+      comparisonSetId,
+      assessment,
+      expectedDossierRevision,
+    })
     saveInFlightRef.current = true
     setIsSaveInFlight(true)
     const saveSnapshot = {
       contextKey: draftContextKey,
-      draft: currentDraft,
+      draft: draftToSave,
     }
-    setDraftEntry((current) => ({
+    replaceDraftEntry({
       contextKey: saveSnapshot.contextKey,
-      draft: beginTechnicalConfigurationEvaluationSave(
-        current?.contextKey === saveSnapshot.contextKey ? current.draft : saveSnapshot.draft
-      ),
-    }))
+      draft: beginTechnicalConfigurationEvaluationSave(saveSnapshot.draft),
+    })
 
     try {
       const result = await assessmentSource.upsertAssessment.mutateAsync(
         toTechnicalConfigurationAssessmentUpsertInput(saveSnapshot.draft)
       )
       const adoptedDraft = adoptTechnicalConfigurationEvaluationSave(saveSnapshot.draft, result)
-      setDraftEntry((current) => {
-        if (current?.contextKey !== saveSnapshot.contextKey) {
-          return current
-        }
-        return {
-          ...current,
+      const latestEntry = draftEntryRef.current
+      if (latestEntry?.contextKey === saveSnapshot.contextKey) {
+        replaceDraftEntry({
+          ...latestEntry,
           draft: adoptedDraft,
-        }
-      })
+        })
+      }
       onDossierRevisionChange?.(result.comparisonSet.revision)
       return result
     } catch (error) {
-      setDraftEntry((current) => {
-        if (current?.contextKey !== saveSnapshot.contextKey) {
-          return current
-        }
-        return {
-          ...current,
-          draft: applyTechnicalConfigurationEvaluationSaveFailure(current.draft, error),
-        }
-      })
+      const latestEntry = draftEntryRef.current
+      if (latestEntry?.contextKey === saveSnapshot.contextKey) {
+        replaceDraftEntry({
+          ...latestEntry,
+          draft: applyTechnicalConfigurationEvaluationSaveFailure(latestEntry.draft, error),
+        })
+      }
       throw error
     } finally {
       saveInFlightRef.current = false
       setIsSaveInFlight(false)
     }
   }, [
+    assessment,
     assessmentSource.upsertAssessment,
+    comparisonSetId,
     criterionId,
     currentDraft,
     draftContextKey,
+    draftContextToken,
+    expectedDossierRevision,
     onDossierRevisionChange,
+    replaceDraftEntry,
   ])
 
   const setTechnicalAxis = React.useCallback(

--- a/src/app/(app)/technical-configurations/assessment-types.ts
+++ b/src/app/(app)/technical-configurations/assessment-types.ts
@@ -3,6 +3,8 @@ import type {
   TechnicalConfigurationTechnicalAxis,
 } from "@/lib/technical-configuration-evaluation"
 
+import type { TechnicalConfigurationComparisonSetWire } from "./supplier-option-types"
+
 export interface TechnicalConfigurationAssessmentWire {
   id: string
   comparison_set_id: string
@@ -51,4 +53,9 @@ export interface TechnicalConfigurationAssessmentUpsertInput {
   notes: string | null
   expectedRevision: number
   expectedDossierRevision: number
+}
+
+export interface TechnicalConfigurationAssessmentSaveResult {
+  comparisonSet: TechnicalConfigurationComparisonSetWire
+  assessment: TechnicalConfigurationAssessmentWire
 }

--- a/src/app/(app)/technical-configurations/technical-configuration-evaluation-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-evaluation-state.ts
@@ -1,0 +1,148 @@
+import type {
+  TechnicalConfigurationEvidenceAxis,
+  TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+
+import type {
+  TechnicalConfigurationAssessmentSaveResult,
+  TechnicalConfigurationAssessmentUpsertInput,
+  TechnicalConfigurationAssessmentWire,
+} from "./assessment-types"
+
+type TechnicalConfigurationEvaluationValues = {
+  technicalAxis: TechnicalConfigurationTechnicalAxis | null
+  evidenceAxis: TechnicalConfigurationEvidenceAxis | null
+  notes: string
+}
+
+export type TechnicalConfigurationEvaluationDraftState = TechnicalConfigurationEvaluationValues & {
+  criterionId: string
+  expectedAssessmentRevision: number
+  expectedDossierRevision: number
+  saveStatus: "idle" | "saving" | "error"
+  error: unknown | null
+  isDirty: boolean
+  persistedValues: TechnicalConfigurationEvaluationValues
+}
+
+type CreateTechnicalConfigurationEvaluationDraftStateInput = {
+  criterionId: string
+  assessment: TechnicalConfigurationAssessmentWire | null
+  expectedDossierRevision: number
+}
+
+function toEvaluationValues(
+  assessment: TechnicalConfigurationAssessmentWire | null
+): TechnicalConfigurationEvaluationValues {
+  return {
+    technicalAxis: assessment?.technical_axis ?? null,
+    evidenceAxis: assessment?.evidence_axis ?? null,
+    notes: assessment?.notes ?? "",
+  }
+}
+
+function hasEvaluationValuesChanged(
+  values: TechnicalConfigurationEvaluationValues,
+  persistedValues: TechnicalConfigurationEvaluationValues
+): boolean {
+  return (
+    values.technicalAxis !== persistedValues.technicalAxis ||
+    values.evidenceAxis !== persistedValues.evidenceAxis ||
+    values.notes !== persistedValues.notes
+  )
+}
+
+/** Creates one criterion-local manual assessment draft from the persisted row. */
+export function createTechnicalConfigurationEvaluationDraftState({
+  criterionId,
+  assessment,
+  expectedDossierRevision,
+}: CreateTechnicalConfigurationEvaluationDraftStateInput): TechnicalConfigurationEvaluationDraftState {
+  const persistedValues = toEvaluationValues(assessment)
+
+  return {
+    criterionId,
+    ...persistedValues,
+    expectedAssessmentRevision: assessment?.revision ?? 0,
+    expectedDossierRevision,
+    saveStatus: "idle",
+    error: null,
+    isDirty: false,
+    persistedValues,
+  }
+}
+
+/** Applies controlled field changes while preserving the persisted revision snapshot. */
+export function updateTechnicalConfigurationEvaluationDraft(
+  state: TechnicalConfigurationEvaluationDraftState,
+  patch: Partial<TechnicalConfigurationEvaluationValues>
+): TechnicalConfigurationEvaluationDraftState {
+  if (state.saveStatus === "saving") return state
+
+  const values = {
+    technicalAxis: "technicalAxis" in patch ? (patch.technicalAxis ?? null) : state.technicalAxis,
+    evidenceAxis: "evidenceAxis" in patch ? (patch.evidenceAxis ?? null) : state.evidenceAxis,
+    notes: patch.notes ?? state.notes,
+  }
+
+  return {
+    ...state,
+    ...values,
+    saveStatus: "idle",
+    error: null,
+    isDirty: hasEvaluationValuesChanged(values, state.persistedValues),
+  }
+}
+
+/** Marks the current immutable save snapshot as pending. */
+export function beginTechnicalConfigurationEvaluationSave(
+  state: TechnicalConfigurationEvaluationDraftState
+): TechnicalConfigurationEvaluationDraftState {
+  return {
+    ...state,
+    saveStatus: "saving",
+    error: null,
+  }
+}
+
+/** Adopts canonical server values and both optimistic revision tokens after save. */
+export function adoptTechnicalConfigurationEvaluationSave(
+  state: TechnicalConfigurationEvaluationDraftState,
+  result: TechnicalConfigurationAssessmentSaveResult
+): TechnicalConfigurationEvaluationDraftState {
+  if (result.assessment.criterion_id !== state.criterionId) {
+    throw new Error("technical_configuration_evaluation_save_criterion_mismatch")
+  }
+
+  return createTechnicalConfigurationEvaluationDraftState({
+    criterionId: state.criterionId,
+    assessment: result.assessment,
+    expectedDossierRevision: result.comparisonSet.revision,
+  })
+}
+
+/** Records the exact failure while preserving criterion, input, and revision tokens. */
+export function applyTechnicalConfigurationEvaluationSaveFailure(
+  state: TechnicalConfigurationEvaluationDraftState,
+  error: unknown
+): TechnicalConfigurationEvaluationDraftState {
+  return {
+    ...state,
+    saveStatus: "error",
+    error,
+  }
+}
+
+/** Builds the existing P11C upsert input without deriving or remapping assessment values. */
+export function toTechnicalConfigurationAssessmentUpsertInput(
+  state: TechnicalConfigurationEvaluationDraftState
+): TechnicalConfigurationAssessmentUpsertInput {
+  return {
+    criterionId: state.criterionId,
+    technicalAxis: state.technicalAxis,
+    evidenceAxis: state.evidenceAxis,
+    notes: state.notes,
+    expectedRevision: state.expectedAssessmentRevision,
+    expectedDossierRevision: state.expectedDossierRevision,
+  }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-evaluation-state.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-evaluation-state.ts
@@ -17,6 +17,7 @@ type TechnicalConfigurationEvaluationValues = {
 
 export type TechnicalConfigurationEvaluationDraftState = TechnicalConfigurationEvaluationValues & {
   criterionId: string
+  comparisonSetId: string | null
   expectedAssessmentRevision: number
   expectedDossierRevision: number
   saveStatus: "idle" | "saving" | "error"
@@ -27,8 +28,26 @@ export type TechnicalConfigurationEvaluationDraftState = TechnicalConfigurationE
 
 type CreateTechnicalConfigurationEvaluationDraftStateInput = {
   criterionId: string
+  comparisonSetId: string | null
   assessment: TechnicalConfigurationAssessmentWire | null
   expectedDossierRevision: number
+}
+
+function validatePersistedAssessmentIdentity({
+  criterionId,
+  comparisonSetId,
+  assessment,
+}: Pick<
+  CreateTechnicalConfigurationEvaluationDraftStateInput,
+  "criterionId" | "comparisonSetId" | "assessment"
+>): void {
+  if (!assessment) return
+  if (assessment.criterion_id !== criterionId) {
+    throw new Error("technical_configuration_evaluation_assessment_criterion_mismatch")
+  }
+  if (!comparisonSetId || assessment.comparison_set_id !== comparisonSetId) {
+    throw new Error("technical_configuration_evaluation_assessment_comparison_set_mismatch")
+  }
 }
 
 function toEvaluationValues(
@@ -55,13 +74,16 @@ function hasEvaluationValuesChanged(
 /** Creates one criterion-local manual assessment draft from the persisted row. */
 export function createTechnicalConfigurationEvaluationDraftState({
   criterionId,
+  comparisonSetId,
   assessment,
   expectedDossierRevision,
 }: CreateTechnicalConfigurationEvaluationDraftStateInput): TechnicalConfigurationEvaluationDraftState {
+  validatePersistedAssessmentIdentity({ criterionId, comparisonSetId, assessment })
   const persistedValues = toEvaluationValues(assessment)
 
   return {
     criterionId,
+    comparisonSetId,
     ...persistedValues,
     expectedAssessmentRevision: assessment?.revision ?? 0,
     expectedDossierRevision,
@@ -113,9 +135,16 @@ export function adoptTechnicalConfigurationEvaluationSave(
   if (result.assessment.criterion_id !== state.criterionId) {
     throw new Error("technical_configuration_evaluation_save_criterion_mismatch")
   }
+  if (result.assessment.comparison_set_id !== result.comparisonSet.id) {
+    throw new Error("technical_configuration_evaluation_save_result_comparison_set_mismatch")
+  }
+  if (state.comparisonSetId && result.comparisonSet.id !== state.comparisonSetId) {
+    throw new Error("technical_configuration_evaluation_save_comparison_set_mismatch")
+  }
 
   return createTechnicalConfigurationEvaluationDraftState({
     criterionId: state.criterionId,
+    comparisonSetId: result.comparisonSet.id,
     assessment: result.assessment,
     expectedDossierRevision: result.comparisonSet.revision,
   })


### PR DESCRIPTION
## Summary
- add the dormant P12A1 criterion list, manual assessment controls, evaluation panel composition, and local draft/save core
- reuse the P10B3 criterion detail/evidence surface, P11A axis/status contract, and P11D complete assessment collection without a parallel fetch/render path
- key draft/save adoption by option, baseline version, and criterion; preserve local input and revision tokens across save failures
- update the P12A1 OpenSpec checklists

## UX and scope
- keep controls compact, labeled, responsive, and accessible with explicit loading/error semantics
- keep the entire evaluation core dormant: no production mount, navigation, counters, filters, ranking, AI, or browser tests

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused P10B3/P11A/P11D/P12A1 Vitest suite: 8 files, 97 tests passed
- `node scripts/npm-run.js run react-doctor`: 100/100, no issues
- `openspec validate add-technical-configuration-comparison --strict`
- `git diff --cached --check`

## Review notes
- dependency/overlap subagent review completed
- addressed option-context draft leakage, pending-save state visibility, global dormant-boundary coverage, and option/baseline/criterion identity regressions before push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the dormant P12A1 evaluation core: a canonical criterion list, manual assessment controls, an evaluation panel, and a hardened local draft/save flow with strict identity checks and context-safe saves. Composes existing P10B3/P11A/P11D work and stays unmounted in production to satisfy P12A1.

- **New Features**
  - Canonical criterion list with one derived-status badge per row; no counters, summaries, or filters.
  - Manual controls for technical/evidence axes and notes with P11A labels and derived status; clear loading/error.
  - `TechnicalConfigurationEvaluationPanel` wraps the shared criterion detail once; no duplicate fetch/render paths.
  - Local draft/save keyed by option, baseline, and criterion; immutable save snapshot for edit-then-save; rejects stale callbacks and pending-save adoption after option/baseline/criterion switches; starts fresh drafts on context change; adopts saved assessment and comparison-set revisions; strictly validates criterion/comparison-set identity and rejects mismatches; preserves inputs on validation/auth/conflict/persistence failures; feature remains dormant.

- **Refactors**
  - `TechnicalConfigurationCriterionPanel` accepts an `assessmentControls` slot to compose controls without duplicating UI.
  - New state module and hook manage draft transitions and saves with context tokens and save locking; reuse P11D complete assessment collection.

<sup>Written for commit 0074a2cdfbb378f7a8a095c5d92769f157d04966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added assessment controls for technical/evidence axis selection, notes, and canonical status badges with error/disabled/loading states.
  * Added criterion list navigation with grouped ordering, selection highlighting, and status badges.
  * Introduced a technical configuration evaluation draft hook with save/dirty-state and revision-tracking adoption.
  * Added an evaluation panel wrapper integrating assessment controls into criterion detail.
* **Bug Fixes**
  * Hardened draft transitions to reject stale callbacks and mismatched identity/saved state during context switching and saves.
* **Tests**
  * Expanded evaluation core/draft transition/saving coverage, improved fixture utilities, and strengthened beforeunload behavior assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->