### PR TITLE
feat(technical-configurations): activate guarded evaluation workspace

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -2326,7 +2326,7 @@ ranking deferred
 - Defer all real-browser, desktop/mobile screenshot, interaction,
   accessibility and the canonical full regression matrix to P13B; retain
   focused P10B3/P11D/P12A1 regressions in P12A2.
-- Implementation evidence on 2026-07-30: 16 focused Vitest files / 134 tests
+- Implementation evidence on 2026-07-30: 16 focused Vitest files / 135 tests
   pass across P10B, P11D, P12A1 and P12A2; React Doctor reports 100/100.
 
 ### Exit gate

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -2269,10 +2269,19 @@ ranking deferred
 
 - Create:
   `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx`
+- Create:
+  `src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx`
+- Create shared P10B/P12A2 seams:
+  `src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPagination.tsx`,
+  `src/app/(app)/technical-configurations/_components/comparison/technical-configuration-criterion-detail.ts`
+  and
+  `src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationGuardedNavigation.tsx`.
 - Modify:
   `src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx`
 - Modify:
   `src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx`
+- Modify P10B matrix composition only to consume the shared criterion pagination
+  and option-detail builder.
 - Modify P12A1 components/hooks only where activation or navigation contracts
   require it.
 - Create focused workflow, navigation and shell-integration tests using
@@ -2280,26 +2289,26 @@ ranking deferred
 
 ### Tasks
 
-- [ ] Activate evaluation as an internal `Ma trận` / `Đánh giá` segmented mode
+- [x] Activate evaluation as an internal `Ma trận` / `Đánh giá` segmented mode
       inside the existing `So sánh & đánh giá` tab; do not add a sixth
       top-level tab.
-- [ ] Add one independent option selector and reuse the existing canonical
+- [x] Add one independent option selector and reuse the existing canonical
       criterion page controls; do not add a toolbar or duplicate option actions.
-- [ ] Expose only the two primary assessment commands: `Lưu` and
+- [x] Expose only the two primary assessment commands: `Lưu` and
       `Lưu & tiếp tục`.
-- [ ] Keep `Lưu` on the current criterion. Advance only after
+- [x] Keep `Lưu` on the current criterion. Advance only after
       `Lưu & tiếp tục` succeeds, including across canonical page boundaries;
       keep the final criterion selected.
-- [ ] Use one navigation contract for option, criterion, page, internal mode,
+- [x] Use one navigation contract for option, criterion, page, internal mode,
       top-level tab and dossier/back changes: pending mutation hard-blocks;
       dirty idle state asks for confirm-discard; cancel keeps the draft.
-- [ ] Add the existing before-unload guard without creating persistent
+- [x] Add the existing before-unload guard without creating persistent
       multi-criterion drafts.
-- [ ] Propagate comparison-set revision to the existing workspace revision seam
+- [x] Propagate comparison-set revision to the existing workspace revision seam
       only when first acquisition changes that aggregate; keep assessment row
       revision local to assessment state.
-- [ ] Keep evaluation state/data hooks outside the workspace shell.
-- [ ] Add no progress summaries, counters, filters, ranking or AI controls.
+- [x] Keep evaluation state/data hooks outside the workspace shell.
+- [x] Add no progress summaries, counters, filters, ranking or AI controls.
 
 ### TDD and verification
 
@@ -2317,6 +2326,8 @@ ranking deferred
 - Defer all real-browser, desktop/mobile screenshot, interaction,
   accessibility and the canonical full regression matrix to P13B; retain
   focused P10B3/P11D/P12A1 regressions in P12A2.
+- Implementation evidence on 2026-07-30: 16 focused Vitest files / 134 tests
+  pass across P10B, P11D, P12A1 and P12A2; React Doctor reports 100/100.
 
 ### Exit gate
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -582,16 +582,16 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 
 ## Phase P12A2 - Guarded Navigation And Workspace Activation
 
-- [ ] P12A2.1 Mount evaluation workspace bằng internal segmented mode
+- [x] P12A2.1 Mount evaluation workspace bằng internal segmented mode
       `Ma trận` / `Đánh giá` trong tab `So sánh & đánh giá`; không thêm
       top-level tab thứ sáu.
-- [ ] P12A2.2 Dùng một option selector, canonical criterion page controls và chỉ
+- [x] P12A2.2 Dùng một option selector, canonical criterion page controls và chỉ
       hai action chính `Lưu`, `Lưu & tiếp tục`.
-- [ ] P12A2.3 `Lưu` giữ criterion; save-next chỉ chuyển sau success, đi qua page
+- [x] P12A2.3 `Lưu` giữ criterion; save-next chỉ chuyển sau success, đi qua page
       boundary và giữ criterion cuối.
-- [ ] P12A2.4 Dùng một dirty-navigation contract cho option/criterion/page/view/
+- [x] P12A2.4 Dùng một dirty-navigation contract cho option/criterion/page/view/
       tab/dossier: pending hard-block, dirty idle confirm-discard, cancel giữ draft.
-- [ ] P12A2.5 Tích hợp workspace revision đúng ownership; viết workflow,
+- [x] P12A2.5 Tích hợp workspace revision đúng ownership; viết workflow,
       navigation và shell-integration tests bằng `@testing-library/user-event`;
       defer toàn bộ browser verification sang P13B.
 

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-core-composition.test.tsx
@@ -203,7 +203,7 @@ describe("P12A1 evaluation core composition", () => {
     expect(screen.getByLabelText("Ghi chú")).toHaveValue("Đánh giá độc lập với nội dung nguồn.")
   })
 
-  it("keeps the evaluation core dormant outside production tabs and shell", () => {
+  it("keeps evaluation core activation scoped to the P12A2 workspace", () => {
     const repoRoot = process.cwd()
     const sourceRoot = join(repoRoot, "src")
     const featureRoot = join(repoRoot, "src/app/(app)/technical-configurations")
@@ -223,6 +223,8 @@ describe("P12A1 evaluation core composition", () => {
       .filter((file) => evaluationCoreReference.test(readFileSync(file, "utf8")))
       .map((file) => relative(repoRoot, file))
 
-    expect(productionReferences).toEqual([])
+    expect(productionReferences).toEqual([
+      "src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx",
+    ])
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
@@ -66,7 +66,7 @@ describe("P12A1 evaluation draft state", () => {
       expectedDossierRevision: 7,
       isDirty: false,
     })
-    expect(onDossierRevisionChange).toHaveBeenCalledWith(7)
+    expect(onDossierRevisionChange).not.toHaveBeenCalled()
     expect(mocks.callRpc).toHaveBeenCalledWith(
       ASSESSMENT_RPC_FUNCTIONS.upsertAssessment,
       {
@@ -109,6 +109,36 @@ describe("P12A1 evaluation draft state", () => {
     )
   })
 
+  it("discards the current dirty draft back to the persisted assessment", async () => {
+    mockExistingAssessmentSave(mocks)
+    const { result } = renderEvaluationDraftHook()
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+
+    act(() => {
+      result.current.setTechnicalAxis("fails")
+      result.current.setEvidenceAxis("none")
+      result.current.setNotes("Nháp sẽ bỏ.")
+    })
+    expect(result.current.draft).toMatchObject({
+      technicalAxis: "fails",
+      evidenceAxis: "none",
+      notes: "Nháp sẽ bỏ.",
+      isDirty: true,
+    })
+
+    act(() => {
+      result.current.discard()
+    })
+
+    expect(result.current.draft).toMatchObject({
+      technicalAxis: "meets",
+      evidenceAxis: "partial",
+      notes: "Cần bổ sung chứng cứ.",
+      isDirty: false,
+    })
+  })
+
   it("rejects a misrouted assessment row and preserves the local draft", async () => {
     const onDossierRevisionChange = vi.fn()
     const misroutedAssessment = {
@@ -143,6 +173,7 @@ describe("P12A1 evaluation draft state", () => {
   })
 
   it("keeps the first-save draft while the newly created comparison set starts loading", async () => {
+    const onDossierRevisionChange = vi.fn()
     let resolveAssessmentList!: (value: TechnicalConfigurationAssessmentListWireResponse) => void
     const pendingAssessmentList = new Promise<TechnicalConfigurationAssessmentListWireResponse>(
       (resolve) => {
@@ -161,7 +192,7 @@ describe("P12A1 evaluation draft state", () => {
       throw new Error(`Unexpected RPC: ${fn}`)
     })
 
-    const { result } = renderEvaluationDraftHook()
+    const { result } = renderEvaluationDraftHook(onDossierRevisionChange)
 
     await waitFor(() => expect(result.current.isReady).toBe(true))
     expect(mocks.getOrCreateComparisonSet).not.toHaveBeenCalled()
@@ -190,6 +221,7 @@ describe("P12A1 evaluation draft state", () => {
       p_baseline_version_id: baselineVersionId,
       p_expected_revision: 6,
     })
+    expect(onDossierRevisionChange).toHaveBeenCalledWith(7)
     expect(mocks.callRpc).toHaveBeenCalledWith(
       ASSESSMENT_RPC_FUNCTIONS.upsertAssessment,
       {
@@ -211,6 +243,45 @@ describe("P12A1 evaluation draft state", () => {
         page_size: 100,
       })
       await pendingAssessmentList
+    })
+  })
+
+  it("propagates the acquired comparison-set revision when assessment upsert fails", async () => {
+    const onDossierRevisionChange = vi.fn()
+    const persistenceError = new Error("assessment persistence failed")
+    mocks.readComparisonSet.mockResolvedValue(null)
+    mocks.getOrCreateComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve({
+          data: [],
+          total: 0,
+          page: 1,
+          page_size: 100,
+        })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.reject(persistenceError)
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+
+    const { result } = renderEvaluationDraftHook(onDossierRevisionChange)
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    act(() => {
+      result.current.setTechnicalAxis("meets")
+      result.current.setEvidenceAxis("partial")
+    })
+
+    await act(async () => {
+      await expect(result.current.save()).rejects.toBe(persistenceError)
+    })
+
+    expect(onDossierRevisionChange).toHaveBeenCalledWith(comparisonSet.revision)
+    expect(result.current.draft).toMatchObject({
+      isDirty: true,
+      error: persistenceError,
     })
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-evaluation-mode.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-evaluation-mode.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { TechnicalConfigurationDossierWire } from "../types"
 import { TechnicalConfigurationComparisonTab } from "../_components/comparison/TechnicalConfigurationComparisonTab"
+import type { TechnicalConfigurationCriterionDetail } from "../_components/comparison/TechnicalConfigurationCriterionPanel"
 
 const mocks = vi.hoisted(() => ({
   onDirtyChange: vi.fn(),
@@ -52,11 +53,46 @@ vi.mock("../_components/comparison/TechnicalConfigurationMatrixToolbar", () => (
 }))
 
 vi.mock("../_components/comparison/TechnicalConfigurationMatrix", () => ({
-  TechnicalConfigurationMatrix: () => <div>Matrix view</div>,
+  TechnicalConfigurationMatrix: ({
+    onOpenDetail,
+  }: {
+    onOpenDetail: (detail: TechnicalConfigurationCriterionDetail) => void
+  }) => (
+    <div>
+      <span>Matrix view</span>
+      <button
+        type="button"
+        onClick={() =>
+          onOpenDetail({
+            criterionCode: "TS-01",
+            criterionTitle: "Cấu hình chung",
+            optionLabel: null,
+            requirementText: "Yêu cầu cấu hình.",
+            responseText: null,
+            supplementaryInformation: null,
+            evidence: {
+              documentCount: 0,
+              citationCount: 0,
+              hasEvidence: false,
+            },
+            evidenceTarget: {
+              kind: "baseline",
+              baselineVersionId: "baseline-1",
+              criterionId: "criterion-1",
+            },
+          })
+        }
+      >
+        Mở chi tiết ma trận
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock("../_components/comparison/TechnicalConfigurationCriterionPanel", () => ({
-  TechnicalConfigurationCriterionPanel: () => null,
+  TechnicalConfigurationCriterionPanel: ({ open }: { open: boolean }) => (
+    <div data-testid="matrix-detail-state">{open ? "open" : "closed"}</div>
+  ),
 }))
 
 vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationWorkspace", () => ({
@@ -147,5 +183,18 @@ describe("P12A2 comparison evaluation mode", () => {
     await waitFor(() => expect(screen.getByRole("tab", { name: "Ma trận" })).toBeDisabled())
     expect(mocks.onNavigationBlockedChange).toHaveBeenLastCalledWith(true)
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+  })
+
+  it("does not reopen stale matrix detail after returning from evaluation mode", async () => {
+    const user = userEvent.setup()
+    renderComparisonTab()
+
+    await user.click(screen.getByRole("button", { name: "Mở chi tiết ma trận" }))
+    expect(screen.getByTestId("matrix-detail-state")).toHaveTextContent("open")
+
+    await user.click(screen.getByRole("tab", { name: "Đánh giá" }))
+    await user.click(screen.getByRole("tab", { name: "Ma trận" }))
+
+    expect(screen.getByTestId("matrix-detail-state")).toHaveTextContent("closed")
   })
 })

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-evaluation-mode.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-evaluation-mode.test.tsx
@@ -1,0 +1,151 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { TechnicalConfigurationDossierWire } from "../types"
+import { TechnicalConfigurationComparisonTab } from "../_components/comparison/TechnicalConfigurationComparisonTab"
+
+const mocks = vi.hoisted(() => ({
+  onDirtyChange: vi.fn(),
+  onNavigationBlockedChange: vi.fn(),
+  onRevisionChange: vi.fn(),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationComparisonMatrix", () => ({
+  useTechnicalConfigurationComparisonMatrix: () => ({
+    baselineVersionId: null,
+    versions: [],
+    versionsQuery: { isLoading: false, isError: false },
+    options: [],
+    optionsQuery: { isLoading: false, isError: false },
+    selectedOptions: [],
+    visibleOptionIds: [],
+    pinnedOptionIds: [],
+    focusedOptionId: null,
+    isSelectionLimitReached: false,
+    comparison: {
+      comparisonQuery: {
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: vi.fn(),
+      },
+    },
+    selectBaselineVersion: vi.fn(),
+    loadMoreVersions: vi.fn(),
+    retryVersions: vi.fn(),
+    addOption: vi.fn(),
+    removeOption: vi.fn(),
+    toggleOptionVisibility: vi.fn(),
+    toggleOptionPin: vi.fn(),
+    focusOption: vi.fn(),
+    exitFocusMode: vi.fn(),
+    setPage: vi.fn(),
+  }),
+}))
+
+vi.mock("../_components/comparison/TechnicalConfigurationMatrixToolbar", () => ({
+  TechnicalConfigurationMatrixToolbar: () => <div>Matrix toolbar</div>,
+}))
+
+vi.mock("../_components/comparison/TechnicalConfigurationMatrix", () => ({
+  TechnicalConfigurationMatrix: () => <div>Matrix view</div>,
+}))
+
+vi.mock("../_components/comparison/TechnicalConfigurationCriterionPanel", () => ({
+  TechnicalConfigurationCriterionPanel: () => null,
+}))
+
+vi.mock("../_components/evaluation/TechnicalConfigurationEvaluationWorkspace", () => ({
+  TechnicalConfigurationEvaluationWorkspace: ({
+    onDirtyChange,
+    onNavigationBlockedChange,
+    onRevisionChange,
+  }: {
+    onDirtyChange?: (dirty: boolean) => void
+    onNavigationBlockedChange?: (blocked: boolean) => void
+    onRevisionChange?: (revision: number) => void
+  }) => (
+    <div>
+      <span>Evaluation view</span>
+      <button type="button" onClick={() => onDirtyChange?.(true)}>
+        Mark evaluation dirty
+      </button>
+      <button type="button" onClick={() => onNavigationBlockedChange?.(true)}>
+        Mark evaluation pending
+      </button>
+      <button type="button" onClick={() => onRevisionChange?.(9)}>
+        Bump evaluation revision
+      </button>
+    </div>
+  ),
+}))
+
+const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy siêu âm",
+  name: "Cấu hình máy siêu âm",
+  description: null,
+  revision: 6,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-30T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-30T00:00:00.000Z",
+  updated_by: 1,
+}
+
+function renderComparisonTab() {
+  return render(
+    <TechnicalConfigurationComparisonTab
+      dossier={dossier}
+      onDirtyChange={mocks.onDirtyChange}
+      onNavigationBlockedChange={mocks.onNavigationBlockedChange}
+      onRevisionChange={mocks.onRevisionChange}
+    />
+  )
+}
+
+describe("P12A2 comparison evaluation mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("guards dirty internal mode changes and discards only after confirmation", async () => {
+    const user = userEvent.setup()
+    renderComparisonTab()
+
+    expect(screen.getByText("Matrix view")).toBeInTheDocument()
+    await user.click(screen.getByRole("tab", { name: "Đánh giá" }))
+    await user.click(screen.getByRole("button", { name: "Mark evaluation dirty" }))
+    await waitFor(() => expect(mocks.onDirtyChange).toHaveBeenLastCalledWith(true))
+
+    await user.click(screen.getByRole("tab", { name: "Ma trận" }))
+    expect(await screen.findByRole("alertdialog")).toHaveTextContent("Bỏ thay đổi chưa lưu?")
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+    expect(screen.getByRole("tab", { name: "Đánh giá" })).toHaveAttribute("data-state", "active")
+
+    await user.click(screen.getByRole("tab", { name: "Ma trận" }))
+    await user.click(screen.getByRole("button", { name: "Bỏ thay đổi" }))
+
+    expect(screen.getByRole("tab", { name: "Ma trận" })).toHaveAttribute("data-state", "active")
+    await waitFor(() => expect(mocks.onDirtyChange).toHaveBeenLastCalledWith(false))
+  })
+
+  it("hard-blocks mode changes during save and forwards workspace revision", async () => {
+    const user = userEvent.setup()
+    renderComparisonTab()
+
+    await user.click(screen.getByRole("tab", { name: "Đánh giá" }))
+    await user.click(screen.getByRole("button", { name: "Bump evaluation revision" }))
+    expect(mocks.onRevisionChange).toHaveBeenCalledWith(9)
+
+    await user.click(screen.getByRole("button", { name: "Mark evaluation pending" }))
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Ma trận" })).toBeDisabled())
+    expect(mocks.onNavigationBlockedChange).toHaveBeenLastCalledWith(true)
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-shell-guard.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-comparison-shell-guard.test.tsx
@@ -1,0 +1,97 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { TechnicalConfigurationDossierWire } from "../types"
+import { TechnicalConfigurationWorkspaceShell } from "../_components/TechnicalConfigurationWorkspaceShell"
+
+vi.mock("../_components/TechnicalConfigurationBaselineTab", () => ({
+  TechnicalConfigurationBaselineTab: () => <div>Baseline workspace</div>,
+}))
+vi.mock("../_components/TechnicalConfigurationBaselineEvidence", () => ({
+  TechnicalConfigurationBaselineEvidence: () => <div>Evidence workspace</div>,
+}))
+vi.mock("../_components/TechnicalConfigurationReferenceProducts", () => ({
+  TechnicalConfigurationReferenceProducts: () => <div>Reference workspace</div>,
+}))
+vi.mock("../_components/TechnicalConfigurationSuppliers", () => ({
+  TechnicalConfigurationSuppliers: () => <div>Option workspace</div>,
+}))
+vi.mock("../_components/comparison/TechnicalConfigurationComparisonTab", () => ({
+  TechnicalConfigurationComparisonTab: ({
+    onDirtyChange,
+    onNavigationBlockedChange,
+  }: {
+    onDirtyChange?: (dirty: boolean) => void
+    onNavigationBlockedChange?: (blocked: boolean) => void
+  }) => (
+    <div>
+      <span>Comparison workspace</span>
+      <button type="button" onClick={() => onDirtyChange?.(true)}>
+        Mark comparison dirty
+      </button>
+      <button type="button" onClick={() => onNavigationBlockedChange?.(true)}>
+        Mark comparison pending
+      </button>
+    </div>
+  ),
+}))
+
+const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy siêu âm",
+  name: "Cấu hình máy siêu âm",
+  description: null,
+  revision: 6,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-30T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-30T00:00:00.000Z",
+  updated_by: 1,
+}
+
+describe("P12A2 comparison shell guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("guards top-level tab and dossier navigation for a dirty evaluation draft", async () => {
+    const onBack = vi.fn()
+    const user = userEvent.setup()
+    render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />)
+
+    await user.click(screen.getByRole("tab", { name: "So sánh & đánh giá" }))
+    await user.click(screen.getByRole("button", { name: "Mark comparison dirty" }))
+    await user.click(screen.getByRole("tab", { name: "Cấu hình cơ sở" }))
+
+    expect(await screen.findByRole("alertdialog")).toHaveTextContent("Bỏ thay đổi chưa lưu?")
+    await user.click(screen.getByRole("button", { name: "Tiếp tục chỉnh sửa" }))
+    expect(screen.getByRole("tab", { name: "So sánh & đánh giá" })).toHaveAttribute(
+      "data-state",
+      "active"
+    )
+
+    await user.click(screen.getByRole("button", { name: "Danh sách hồ sơ" }))
+    await user.click(screen.getByRole("button", { name: "Bỏ thay đổi" }))
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+
+  it("hard-blocks top-level tab and dossier navigation while evaluation save is pending", async () => {
+    const onBack = vi.fn()
+    const user = userEvent.setup()
+    render(<TechnicalConfigurationWorkspaceShell dossier={dossier} onBack={onBack} />)
+
+    await user.click(screen.getByRole("tab", { name: "So sánh & đánh giá" }))
+    await user.click(screen.getByRole("button", { name: "Mark comparison pending" }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Danh sách hồ sơ" })).toBeDisabled()
+    )
+    expect(screen.getByRole("tab", { name: "Cấu hình cơ sở" })).toBeDisabled()
+    expect(onBack).not.toHaveBeenCalled()
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test-support.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test-support.ts
@@ -1,0 +1,173 @@
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import type {
+  TechnicalConfigurationComparisonCriterionRow,
+  TechnicalConfigurationComparisonResult,
+} from "../comparison-types"
+import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "../types"
+
+export const dossier: TechnicalConfigurationDossierWire = {
+  id: "dossier-1",
+  device_type_name: "Máy siêu âm",
+  name: "Cấu hình máy siêu âm",
+  description: null,
+  revision: 6,
+  archived_at: null,
+  archived_by: null,
+  created_at: "2026-07-30T00:00:00.000Z",
+  created_by: 1,
+  updated_at: "2026-07-30T00:00:00.000Z",
+  updated_by: 1,
+}
+
+export function createOption(id: string, displayLabel: string): TechnicalConfigurationOptionWire {
+  return {
+    id,
+    dossier_id: dossier.id,
+    supplier_id: `supplier-${id}`,
+    supplier_name: displayLabel.split(" · ")[0] ?? displayLabel,
+    model: null,
+    manufacturer: null,
+    option_name: null,
+    notes: null,
+    display_label: displayLabel,
+    created_at: "2026-07-30T00:00:00.000Z",
+    created_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+    revision: 1,
+  }
+}
+
+function createCriterion(
+  id: string,
+  criterionCode: string
+): TechnicalConfigurationComparisonCriterionRow {
+  return {
+    group: {
+      id: "group-1",
+      name: "Thông số chính",
+      sortOrder: 1,
+    },
+    criterion: {
+      id,
+      criterionCode,
+      title: `Tiêu chí ${criterionCode}`,
+      requirementText: `Yêu cầu ${criterionCode}`,
+      sortOrder: Number(criterionCode.replace(/\D/g, "")),
+    },
+    baselineEvidence: {
+      documentCount: 0,
+      citationCount: 0,
+      hasEvidence: false,
+    },
+    optionValues: [
+      {
+        optionId: "option-1",
+        comparisonSetId: "comparison-set-1",
+        response: {
+          id: `response-${id}`,
+          responseText: `Phản hồi ${criterionCode}`,
+          supplementaryInformation: "",
+        },
+        evidence: {
+          documentCount: 0,
+          citationCount: 0,
+          hasEvidence: false,
+        },
+      },
+      {
+        optionId: "option-2",
+        comparisonSetId: "comparison-set-2",
+        response: {
+          id: `response-option-2-${id}`,
+          responseText: `Phản hồi B ${criterionCode}`,
+          supplementaryInformation: "",
+        },
+        evidence: {
+          documentCount: 0,
+          citationCount: 0,
+          hasEvidence: false,
+        },
+      },
+    ],
+  }
+}
+
+export function createComparisonResult(
+  page: number,
+  optionId: string
+): TechnicalConfigurationComparisonResult {
+  const rows =
+    page === 1
+      ? [createCriterion("criterion-1", "TC-01"), createCriterion("criterion-2", "TC-02")]
+      : [createCriterion("criterion-3", "TC-03")]
+  const option = createOption(
+    optionId,
+    optionId === "option-1" ? "Nhà cung cấp A · Model A" : "Nhà cung cấp B · Model B"
+  )
+
+  return {
+    data: {
+      dossier: {
+        id: dossier.id,
+        deviceTypeName: dossier.device_type_name,
+        name: dossier.name,
+        revision: dossier.revision,
+        archivedAt: null,
+      },
+      baselineVersion: {
+        id: "baseline-1",
+        dossierId: dossier.id,
+        versionNumber: 2,
+        status: "locked",
+        revision: 4,
+      },
+      options: [
+        {
+          id: option.id,
+          supplierId: option.supplier_id,
+          supplierName: option.supplier_name,
+          model: option.model,
+          manufacturer: option.manufacturer,
+          optionName: option.option_name,
+          displayLabel: option.display_label,
+        },
+      ],
+      criteria: rows,
+    },
+    total: 3,
+    page,
+    pageSize: 2,
+  }
+}
+
+export function createDraft(criterionId: string | null) {
+  return {
+    criterionId,
+    comparisonSetId: "comparison-set-1",
+    technicalAxis: null,
+    evidenceAxis: null,
+    notes: "",
+    expectedAssessmentRevision: 0,
+    expectedDossierRevision: dossier.revision,
+    saveStatus: "idle" as const,
+    error: null as unknown,
+    isDirty: false,
+  }
+}
+
+export async function openCurrentCriterion(user: ReturnType<typeof userEvent.setup>) {
+  await user.click((await screen.findAllByTestId("evaluation-criterion"))[0]!)
+  return screen.findByRole("dialog")
+}
+
+export function getCriterion(criterionId: string): HTMLElement {
+  const criterion = screen
+    .getAllByTestId("evaluation-criterion")
+    .find((row) => row.getAttribute("data-criterion-id") === criterionId)
+  if (!criterion) throw new Error(`Missing evaluation criterion ${criterionId}`)
+  return criterion
+}

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
@@ -227,7 +227,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     await user.type(screen.getByLabelText("Ghi chú"), "Qua trang kế")
     await user.click(screen.getByRole("button", { name: "Lưu & tiếp tục" }))
 
-    await waitFor(() => expect(screen.getByText("Trang 2/2")).toBeInTheDocument())
+    expect(await screen.findByText("Trang 2/2")).toBeInTheDocument()
     expect(getCriterion("criterion-3")).toHaveAttribute("data-criterion-id", "criterion-3")
     expect(getCriterion("criterion-3")).toHaveAttribute("aria-current", "true")
 
@@ -280,7 +280,7 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     await user.click(within(dialog).getByRole("button", { name: "Bỏ thay đổi" }))
 
     expect(mocks.discard).toHaveBeenCalledTimes(1)
-    await waitFor(() => expect(screen.getByText("Trang 2/2")).toBeInTheDocument())
+    expect(await screen.findByText("Trang 2/2")).toBeInTheDocument()
     expect(getCriterion("criterion-3")).toHaveAttribute("data-criterion-id", "criterion-3")
   })
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
@@ -1,0 +1,328 @@
+import * as React from "react"
+import "@testing-library/jest-dom"
+import { act, render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TechnicalConfigurationEvaluationWorkspace } from "../_components/evaluation/TechnicalConfigurationEvaluationWorkspace"
+import {
+  createComparisonResult,
+  createDraft,
+  createOption,
+  dossier,
+  getCriterion,
+  openCurrentCriterion,
+} from "./technical-configuration-evaluation-workspace.test-support"
+
+const mocks = vi.hoisted(() => ({
+  assessmentQueryError: null as Error | null,
+  comparisonSetQueryError: null as Error | null,
+  discard: vi.fn(),
+  refetchAssessment: vi.fn(),
+  refetchComparisonSet: vi.fn(),
+  save: vi.fn(),
+  synchronizeVersion: vi.fn(),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationBaselineVersionSelection", () => ({
+  useTechnicalConfigurationBaselineVersionSelection: () => ({
+    selectedVersion: {
+      id: "baseline-1",
+      dossier_id: "dossier-1",
+      version_number: 2,
+      status: "locked",
+      revision: 4,
+      groups: [],
+    },
+    synchronizeVersion: mocks.synchronizeVersion,
+    versionState: {
+      versions: [],
+      versionsQuery: {
+        isLoading: false,
+        isError: false,
+      },
+      retryVersions: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationOptionListQuery", () => ({
+  useTechnicalConfigurationOptionListQuery: () => ({
+    optionsQuery: {
+      data: {
+        options: [
+          createOption("option-1", "Nhà cung cấp A · Model A"),
+          createOption("option-2", "Nhà cung cấp B · Model B"),
+        ],
+        revision: 3,
+      },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationComparison", () => ({
+  useTechnicalConfigurationComparison: ({
+    optionIds,
+    page,
+  }: {
+    optionIds: readonly string[]
+    page: number
+  }) => ({
+    comparisonQuery: {
+      data: optionIds[0] ? createComparisonResult(page, optionIds[0]) : undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    },
+  }),
+}))
+
+vi.mock("../_hooks/useTechnicalConfigurationEvaluationDraft", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react")
+
+  return {
+    useTechnicalConfigurationEvaluationDraft: ({
+      optionId,
+      baselineVersionId,
+      criterionId,
+      onDossierRevisionChange,
+    }: {
+      optionId: string
+      baselineVersionId: string | null
+      criterionId: string | null
+      onDossierRevisionChange?: (revision: number) => void
+    }) => {
+      const contextKey = JSON.stringify([optionId, baselineVersionId, criterionId])
+      const [draft, setDraft] = ReactModule.useState(() => createDraft(criterionId))
+      const [isSaving, setIsSaving] = ReactModule.useState(false)
+
+      ReactModule.useEffect(() => {
+        setDraft(createDraft(criterionId))
+      }, [contextKey, criterionId])
+
+      const updateDraft = ReactModule.useCallback(
+        (patch: {
+          technicalAxis?: "fails" | "meets" | "exceeds" | null
+          evidenceAxis?: "none" | "partial" | "complete" | null
+          notes?: string
+        }) => {
+          setDraft((current) => ({
+            ...current,
+            ...patch,
+            isDirty: true,
+            error: null,
+          }))
+        },
+        []
+      )
+
+      const save = ReactModule.useCallback(async () => {
+        setIsSaving(true)
+        setDraft((current) => ({ ...current, saveStatus: "saving", error: null }))
+        try {
+          const result = await mocks.save({
+            optionId,
+            baselineVersionId,
+            criterionId,
+          })
+          setDraft((current) => ({
+            ...current,
+            isDirty: false,
+            saveStatus: "idle",
+            error: null,
+          }))
+          onDossierRevisionChange?.(7)
+          return result
+        } catch (error) {
+          setDraft((current) => ({
+            ...current,
+            isDirty: true,
+            saveStatus: "error",
+            error,
+          }))
+          throw error
+        } finally {
+          setIsSaving(false)
+        }
+      }, [baselineVersionId, criterionId, onDossierRevisionChange, optionId])
+
+      return {
+        assessmentsByCriterionId: {},
+        assessmentQuery: {
+          isLoading: false,
+          isError: mocks.assessmentQueryError !== null,
+          error: mocks.assessmentQueryError,
+          refetch: mocks.refetchAssessment,
+        },
+        comparisonSetQuery: {
+          isLoading: false,
+          isError: mocks.comparisonSetQueryError !== null,
+          error: mocks.comparisonSetQueryError,
+          refetch: mocks.refetchComparisonSet,
+        },
+        draft,
+        isReady: criterionId !== null,
+        isSaving,
+        error: draft.error,
+        setTechnicalAxis: (technicalAxis: "fails" | "meets" | "exceeds" | null) =>
+          updateDraft({ technicalAxis }),
+        setEvidenceAxis: (evidenceAxis: "none" | "partial" | "complete" | null) =>
+          updateDraft({ evidenceAxis }),
+        setNotes: (notes: string) => updateDraft({ notes }),
+        discard: mocks.discard,
+        save,
+      }
+    },
+  }
+})
+
+const originalHasPointerCapture = HTMLElement.prototype.hasPointerCapture
+const originalSetPointerCapture = HTMLElement.prototype.setPointerCapture
+const originalReleasePointerCapture = HTMLElement.prototype.releasePointerCapture
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+
+beforeAll(() => {
+  HTMLElement.prototype.hasPointerCapture = () => false
+  HTMLElement.prototype.setPointerCapture = () => undefined
+  HTMLElement.prototype.releasePointerCapture = () => undefined
+  HTMLElement.prototype.scrollIntoView = () => undefined
+})
+
+afterAll(() => {
+  HTMLElement.prototype.hasPointerCapture = originalHasPointerCapture
+  HTMLElement.prototype.setPointerCapture = originalSetPointerCapture
+  HTMLElement.prototype.releasePointerCapture = originalReleasePointerCapture
+  HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+})
+
+describe("P12A2 technical configuration evaluation workspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.assessmentQueryError = null
+    mocks.comparisonSetQueryError = null
+    mocks.save.mockResolvedValue({})
+  })
+
+  it("keeps Lưu on the criterion and advances Lưu & tiếp tục across page boundaries", async () => {
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    await openCurrentCriterion(user)
+    await user.type(screen.getByLabelText("Ghi chú"), "Giữ tiêu chí hiện tại")
+    await user.click(screen.getByRole("button", { name: "Lưu", exact: true }))
+
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledTimes(1))
+    expect(getCriterion("criterion-1")).toHaveAttribute("aria-current", "true")
+
+    await user.type(screen.getByLabelText("Ghi chú"), " rồi tiếp tục")
+    await user.click(screen.getByRole("button", { name: "Lưu & tiếp tục" }))
+
+    await waitFor(() => expect(getCriterion("criterion-2")).toHaveAttribute("aria-current", "true"))
+
+    await user.type(screen.getByLabelText("Ghi chú"), "Qua trang kế")
+    await user.click(screen.getByRole("button", { name: "Lưu & tiếp tục" }))
+
+    await waitFor(() => expect(screen.getByText("Trang 2/2")).toBeInTheDocument())
+    expect(getCriterion("criterion-3")).toHaveAttribute("data-criterion-id", "criterion-3")
+    expect(getCriterion("criterion-3")).toHaveAttribute("aria-current", "true")
+
+    await user.type(screen.getByLabelText("Ghi chú"), "Tiêu chí cuối")
+    await user.click(screen.getByRole("button", { name: "Lưu & tiếp tục" }))
+
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledTimes(4))
+    expect(screen.getByText("Trang 2/2")).toBeInTheDocument()
+    expect(getCriterion("criterion-3")).toHaveAttribute("data-criterion-id", "criterion-3")
+  })
+
+  it("guards dirty criterion, option and page navigation while preserving cancel state", async () => {
+    const user = userEvent.setup()
+    const addEventListener = vi.spyOn(window, "addEventListener")
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    await openCurrentCriterion(user)
+    await user.type(screen.getByLabelText("Ghi chú"), "Không được mất")
+
+    const beforeUnloadHandler = addEventListener.mock.calls.find(
+      ([eventName]) => eventName === "beforeunload"
+    )?.[1]
+    expect(beforeUnloadHandler).toEqual(expect.any(Function))
+    const beforeUnloadEvent = new Event("beforeunload", { cancelable: true })
+    act(() => {
+      beforeUnloadHandler?.(beforeUnloadEvent)
+    })
+    expect(beforeUnloadEvent.defaultPrevented).toBe(true)
+
+    await user.click(screen.getByRole("button", { name: "Đóng chi tiết tiêu chí" }))
+    await user.click(getCriterion("criterion-2"))
+    expect(await screen.findByRole("alertdialog")).toHaveTextContent("Bỏ thay đổi chưa lưu?")
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+
+    await user.click(getCriterion("criterion-1"))
+    expect(screen.getByLabelText("Ghi chú")).toHaveValue("Không được mất")
+    expect(getCriterion("criterion-1")).toHaveAttribute("data-criterion-id", "criterion-1")
+    await user.click(screen.getByRole("button", { name: "Đóng chi tiết tiêu chí" }))
+
+    await user.click(screen.getByLabelText("Phương án đánh giá"))
+    await user.click(await screen.findByRole("option", { name: "Nhà cung cấp B · Model B" }))
+    await user.click(screen.getByRole("button", { name: "Hủy" }))
+    expect(screen.getByLabelText("Phương án đánh giá")).toHaveTextContent(
+      "Nhà cung cấp A · Model A"
+    )
+
+    await user.click(screen.getByRole("button", { name: "Trang tiếp theo" }))
+    const dialog = await screen.findByRole("alertdialog")
+    await user.click(within(dialog).getByRole("button", { name: "Bỏ thay đổi" }))
+
+    expect(mocks.discard).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(screen.getByText("Trang 2/2")).toBeInTheDocument())
+    expect(getCriterion("criterion-3")).toHaveAttribute("data-criterion-id", "criterion-3")
+  })
+
+  it("hard-blocks navigation while a save is pending", async () => {
+    let resolveSave!: (value: object) => void
+    mocks.save.mockReturnValue(
+      new Promise<object>((resolve) => {
+        resolveSave = resolve
+      })
+    )
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    await openCurrentCriterion(user)
+    await user.type(screen.getByLabelText("Ghi chú"), "Đang lưu")
+    await user.click(screen.getByRole("button", { name: "Lưu", exact: true }))
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Trang tiếp theo", hidden: true })).toBeDisabled()
+    )
+    expect(screen.getByLabelText("Phương án đánh giá")).toBeDisabled()
+    for (const criterion of screen.getAllByTestId("evaluation-criterion")) {
+      expect(criterion).toBeDisabled()
+    }
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveSave({})
+    })
+  })
+
+  it("surfaces assessment read failures with an explicit retry", async () => {
+    mocks.assessmentQueryError = new Error("assessment read failed")
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    expect(await screen.findByText("Không thể tải dữ liệu đánh giá")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Thử lại" }))
+
+    expect(mocks.refetchAssessment).toHaveBeenCalledTimes(1)
+    expect(mocks.refetchComparisonSet).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationWorkspaceShell.tsx
@@ -10,19 +10,10 @@ import {
 } from "lucide-react"
 
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
+import { useTechnicalConfigurationGuardedNavigation } from "../_hooks/useTechnicalConfigurationGuardedNavigation"
 import { TechnicalConfigurationBaselineTab } from "./TechnicalConfigurationBaselineTab"
 import { TechnicalConfigurationBaselineEvidence } from "./TechnicalConfigurationBaselineEvidence"
 import { TechnicalConfigurationComparisonTab } from "./comparison/TechnicalConfigurationComparisonTab"
@@ -33,13 +24,6 @@ type TechnicalConfigurationWorkspaceShellProps = {
   dossier: TechnicalConfigurationDossierWire
   onBack: () => void
 }
-
-type PendingWorkspaceNavigation =
-  | { kind: "back" }
-  | {
-      kind: "tab"
-      value: string
-    }
 
 type WorkspaceRevisionOverride = {
   dossierId: string
@@ -55,8 +39,6 @@ export function TechnicalConfigurationWorkspaceShell({
   const [revisionOverride, setRevisionOverride] = React.useState<WorkspaceRevisionOverride | null>(
     null
   )
-  const [pendingNavigation, setPendingNavigation] =
-    React.useState<PendingWorkspaceNavigation | null>(null)
   const [isBaselineDirty, setIsBaselineDirty] = React.useState(false)
   const [isBaselineNavigationBlocked, setIsBaselineNavigationBlocked] = React.useState(false)
   const [isEvidenceDirty, setIsEvidenceDirty] = React.useState(false)
@@ -65,12 +47,24 @@ export function TechnicalConfigurationWorkspaceShell({
   const [isReferenceNavigationBlocked, setIsReferenceNavigationBlocked] = React.useState(false)
   const [isOptionDirty, setIsOptionDirty] = React.useState(false)
   const [isOptionNavigationBlocked, setIsOptionNavigationBlocked] = React.useState(false)
-  const isDirty = isBaselineDirty || isEvidenceDirty || isReferenceDirty || isOptionDirty
+  const [isComparisonDirty, setIsComparisonDirty] = React.useState(false)
+  const [isComparisonNavigationBlocked, setIsComparisonNavigationBlocked] = React.useState(false)
+  const isDirty =
+    isBaselineDirty || isEvidenceDirty || isReferenceDirty || isOptionDirty || isComparisonDirty
   const isNavigationBlocked =
     isBaselineNavigationBlocked ||
     isEvidenceNavigationBlocked ||
     isReferenceNavigationBlocked ||
-    isOptionNavigationBlocked
+    isOptionNavigationBlocked ||
+    isComparisonNavigationBlocked
+  const { requestNavigation, discardConfirmationDialog } =
+    useTechnicalConfigurationGuardedNavigation({
+      isDirty,
+      isBlocked: isNavigationBlocked,
+      cancelLabel: "Tiếp tục chỉnh sửa",
+      description:
+        "Các thay đổi chưa lưu sẽ bị mất nếu bạn tiếp tục. Hãy tiếp tục chỉnh sửa để lưu hoặc xác nhận bỏ thay đổi.",
+    })
   const workspaceRevision =
     revisionOverride?.dossierId === dossier.id
       ? Math.max(dossier.revision, revisionOverride.revision)
@@ -97,60 +91,16 @@ export function TechnicalConfigurationWorkspaceShell({
   )
 
   const handleBack = React.useCallback(() => {
-    if (isNavigationBlocked) return
-    if (isDirty) {
-      setPendingNavigation({ kind: "back" })
-      return
-    }
-    onBack()
-  }, [isDirty, isNavigationBlocked, onBack])
+    requestNavigation(onBack)
+  }, [onBack, requestNavigation])
 
   const handleTabChange = React.useCallback(
     (nextTab: string) => {
       if (nextTab === activeTab) return
-      const isCurrentTabDirty =
-        (activeTab === "baseline" && isBaselineDirty) ||
-        (activeTab === "evidence" && isEvidenceDirty) ||
-        (activeTab === "references" && isReferenceDirty) ||
-        (activeTab === "options" && isOptionDirty)
-      const isCurrentTabBlocked =
-        (activeTab === "baseline" && isBaselineNavigationBlocked) ||
-        (activeTab === "evidence" && isEvidenceNavigationBlocked) ||
-        (activeTab === "references" && isReferenceNavigationBlocked) ||
-        (activeTab === "options" && isOptionNavigationBlocked)
-      if (isCurrentTabBlocked) return
-      if (isCurrentTabDirty) {
-        setPendingNavigation({ kind: "tab", value: nextTab })
-        return
-      }
-      setActiveTab(nextTab)
+      requestNavigation(() => setActiveTab(nextTab))
     },
-    [
-      activeTab,
-      isBaselineDirty,
-      isBaselineNavigationBlocked,
-      isEvidenceDirty,
-      isEvidenceNavigationBlocked,
-      isOptionDirty,
-      isOptionNavigationBlocked,
-      isReferenceDirty,
-      isReferenceNavigationBlocked,
-    ]
+    [activeTab, requestNavigation]
   )
-
-  const dismissPendingNavigation = React.useCallback(() => {
-    setPendingNavigation(null)
-  }, [])
-
-  const confirmPendingNavigation = React.useCallback(() => {
-    if (!pendingNavigation) return
-    setPendingNavigation(null)
-    if (pendingNavigation.kind === "back") {
-      onBack()
-      return
-    }
-    setActiveTab(pendingNavigation.value)
-  }, [onBack, pendingNavigation])
 
   return (
     <div className="w-full">
@@ -182,23 +132,43 @@ export function TechnicalConfigurationWorkspaceShell({
 
       <Tabs value={activeTab} onValueChange={handleTabChange} className="mt-6">
         <TabsList className="grid h-auto w-full grid-cols-1 gap-1 sm:grid-cols-5">
-          <TabsTrigger value="baseline" className="min-h-10 gap-2">
+          <TabsTrigger
+            value="baseline"
+            className="min-h-10 gap-2"
+            disabled={isNavigationBlocked && activeTab !== "baseline"}
+          >
             <ListChecks className="size-4" aria-hidden="true" />
             Cấu hình cơ sở
           </TabsTrigger>
-          <TabsTrigger value="evidence" className="min-h-10 gap-2">
+          <TabsTrigger
+            value="evidence"
+            className="min-h-10 gap-2"
+            disabled={isNavigationBlocked && activeTab !== "evidence"}
+          >
             <FileText className="size-4" aria-hidden="true" />
             Tài liệu &amp; trích dẫn
           </TabsTrigger>
-          <TabsTrigger value="references" className="min-h-10 gap-2">
+          <TabsTrigger
+            value="references"
+            className="min-h-10 gap-2"
+            disabled={isNavigationBlocked && activeTab !== "references"}
+          >
             <LibraryBig className="size-4" aria-hidden="true" />
             Sản phẩm tham chiếu
           </TabsTrigger>
-          <TabsTrigger value="options" className="min-h-10 gap-2">
+          <TabsTrigger
+            value="options"
+            className="min-h-10 gap-2"
+            disabled={isNavigationBlocked && activeTab !== "options"}
+          >
             <PackageSearch className="size-4" aria-hidden="true" />
             Phương án
           </TabsTrigger>
-          <TabsTrigger value="comparison" className="min-h-10 gap-2">
+          <TabsTrigger
+            value="comparison"
+            className="min-h-10 gap-2"
+            disabled={isNavigationBlocked && activeTab !== "comparison"}
+          >
             <GitCompareArrows className="size-4" aria-hidden="true" />
             So sánh &amp; đánh giá
           </TabsTrigger>
@@ -234,35 +204,16 @@ export function TechnicalConfigurationWorkspaceShell({
           />
         </TabsContent>
         <TabsContent value="comparison" className="mt-6">
-          <TechnicalConfigurationComparisonTab dossier={workspaceDossier} />
+          <TechnicalConfigurationComparisonTab
+            dossier={workspaceDossier}
+            onDirtyChange={setIsComparisonDirty}
+            onNavigationBlockedChange={setIsComparisonNavigationBlocked}
+            onRevisionChange={handleRevisionChange}
+          />
         </TabsContent>
       </Tabs>
 
-      <AlertDialog
-        open={pendingNavigation !== null}
-        onOpenChange={(open) => {
-          if (!open) dismissPendingNavigation()
-        }}
-      >
-        <AlertDialogContent className="sm:max-w-md">
-          <AlertDialogHeader>
-            <AlertDialogTitle>Bỏ thay đổi chưa lưu?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Các thay đổi chưa lưu sẽ bị mất nếu bạn tiếp tục. Hãy tiếp tục chỉnh sửa để lưu hoặc
-              xác nhận bỏ thay đổi.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Tiếp tục chỉnh sửa</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={confirmPendingNavigation}
-            >
-              Bỏ thay đổi
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      {discardConfirmationDialog}
     </div>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
@@ -2,8 +2,12 @@
 
 import * as React from "react"
 
-import type { TechnicalConfigurationDossierWire } from "../../types"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
 import { useTechnicalConfigurationComparisonMatrix } from "../../_hooks/useTechnicalConfigurationComparisonMatrix"
+import { useTechnicalConfigurationGuardedNavigation } from "../../_hooks/useTechnicalConfigurationGuardedNavigation"
+import type { TechnicalConfigurationDossierWire } from "../../types"
+import { TechnicalConfigurationEvaluationWorkspace } from "../evaluation/TechnicalConfigurationEvaluationWorkspace"
 import {
   TechnicalConfigurationCriterionPanel,
   type TechnicalConfigurationCriterionDetail,
@@ -13,70 +17,139 @@ import { TechnicalConfigurationMatrixToolbar } from "./TechnicalConfigurationMat
 
 type TechnicalConfigurationComparisonTabProps = {
   dossier: TechnicalConfigurationDossierWire
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+  onRevisionChange?: (revision: number) => void
 }
 
-/** Composes the read-only P10B1 comparison request, matrix, and criterion detail. */
+type TechnicalConfigurationComparisonMode = "matrix" | "evaluation"
+
+/** Composes the P10B matrix and P12A2 evaluation as internal workspace modes. */
 export function TechnicalConfigurationComparisonTab({
   dossier,
+  onDirtyChange,
+  onNavigationBlockedChange,
+  onRevisionChange,
 }: Readonly<TechnicalConfigurationComparisonTabProps>) {
   const matrix = useTechnicalConfigurationComparisonMatrix(dossier.id)
+  const [activeMode, setActiveMode] = React.useState<TechnicalConfigurationComparisonMode>("matrix")
+  const [isEvaluationDirty, setIsEvaluationDirty] = React.useState(false)
+  const [isEvaluationNavigationBlocked, setIsEvaluationNavigationBlocked] = React.useState(false)
   const [detail, setDetail] = React.useState<TechnicalConfigurationCriterionDetail | null>(null)
   const detailReturnFocusRef = React.useRef<HTMLElement | null>(null)
   const { comparisonQuery } = matrix.comparison
   const hasRequest = matrix.baselineVersionId !== null && matrix.selectedOptionIds.length > 0
+  const isDirty = activeMode === "evaluation" && isEvaluationDirty
+  const isNavigationBlocked = activeMode === "evaluation" && isEvaluationNavigationBlocked
+  const { requestNavigation, discardConfirmationDialog } =
+    useTechnicalConfigurationGuardedNavigation({
+      isDirty,
+      isBlocked: isNavigationBlocked,
+    })
+
   const openDetail = React.useCallback((nextDetail: TechnicalConfigurationCriterionDetail) => {
     detailReturnFocusRef.current =
       document.activeElement instanceof HTMLElement ? document.activeElement : null
     setDetail(nextDetail)
   }, [])
 
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- WorkspaceShell owns top-level guards while this tab owns its internal mode.
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Evaluation save lifecycle must block mode, tab and dossier navigation.
+    onNavigationBlockedChange?.(isNavigationBlocked)
+  }, [isNavigationBlocked, onNavigationBlockedChange])
+  React.useEffect(
+    () => () => {
+      onDirtyChange?.(false)
+      onNavigationBlockedChange?.(false)
+    },
+    [onDirtyChange, onNavigationBlockedChange]
+  )
+
+  const handleModeChange = React.useCallback(
+    (nextMode: string) => {
+      if ((nextMode !== "matrix" && nextMode !== "evaluation") || nextMode === activeMode) {
+        return
+      }
+      requestNavigation(() => setActiveMode(nextMode))
+    },
+    [activeMode, requestNavigation]
+  )
+
   return (
-    <section className="min-w-0 space-y-4" aria-label="Ma trận so sánh cấu hình kỹ thuật">
-      <TechnicalConfigurationMatrixToolbar
-        baselineVersionId={matrix.baselineVersionId}
-        versions={matrix.versions}
-        versionsQuery={matrix.versionsQuery}
-        options={matrix.options}
-        optionsQuery={matrix.optionsQuery}
-        selectedOptions={matrix.selectedOptions}
-        visibleOptionIds={matrix.visibleOptionIds}
-        pinnedOptionIds={matrix.pinnedOptionIds}
-        focusedOptionId={matrix.focusedOptionId}
-        isSelectionLimitReached={matrix.isSelectionLimitReached}
-        onSelectBaselineVersion={matrix.selectBaselineVersion}
-        onLoadMoreVersions={() => void matrix.loadMoreVersions()}
-        onRetryVersions={() => void matrix.retryVersions()}
-        onRetryOptions={() => void matrix.optionsQuery.refetch()}
-        onAddOption={matrix.addOption}
-        onRemoveOption={matrix.removeOption}
-        onToggleOptionVisibility={matrix.toggleOptionVisibility}
-        onToggleOptionPin={matrix.toggleOptionPin}
-        onFocusOption={matrix.focusOption}
-        onExitFocus={matrix.exitFocusMode}
-      />
+    <section className="min-w-0" aria-label="So sánh và đánh giá cấu hình kỹ thuật">
+      <Tabs value={activeMode} onValueChange={handleModeChange}>
+        <div className="flex justify-end border-b pb-3">
+          <TabsList
+            className="grid h-auto w-full max-w-56 grid-cols-2"
+            aria-label="Chế độ so sánh và đánh giá"
+          >
+            <TabsTrigger value="matrix" disabled={isNavigationBlocked}>
+              Ma trận
+            </TabsTrigger>
+            <TabsTrigger value="evaluation">Đánh giá</TabsTrigger>
+          </TabsList>
+        </div>
 
-      <TechnicalConfigurationMatrix
-        hasRequest={hasRequest}
-        result={comparisonQuery.data}
-        visibleOptionIds={matrix.visibleOptionIds}
-        pinnedOptionIds={matrix.pinnedOptionIds}
-        focusedOptionId={matrix.focusedOptionId}
-        isLoading={comparisonQuery.isLoading}
-        isError={comparisonQuery.isError}
-        error={comparisonQuery.error}
-        onRetry={() => void comparisonQuery.refetch()}
-        onPageChange={matrix.setPage}
-        onOpenDetail={openDetail}
-      />
+        <TabsContent value="matrix" className="mt-4 space-y-4">
+          <TechnicalConfigurationMatrixToolbar
+            baselineVersionId={matrix.baselineVersionId}
+            versions={matrix.versions}
+            versionsQuery={matrix.versionsQuery}
+            options={matrix.options}
+            optionsQuery={matrix.optionsQuery}
+            selectedOptions={matrix.selectedOptions}
+            visibleOptionIds={matrix.visibleOptionIds}
+            pinnedOptionIds={matrix.pinnedOptionIds}
+            focusedOptionId={matrix.focusedOptionId}
+            isSelectionLimitReached={matrix.isSelectionLimitReached}
+            onSelectBaselineVersion={matrix.selectBaselineVersion}
+            onLoadMoreVersions={() => void matrix.loadMoreVersions()}
+            onRetryVersions={() => void matrix.retryVersions()}
+            onRetryOptions={() => void matrix.optionsQuery.refetch()}
+            onAddOption={matrix.addOption}
+            onRemoveOption={matrix.removeOption}
+            onToggleOptionVisibility={matrix.toggleOptionVisibility}
+            onToggleOptionPin={matrix.toggleOptionPin}
+            onFocusOption={matrix.focusOption}
+            onExitFocus={matrix.exitFocusMode}
+          />
+          <TechnicalConfigurationMatrix
+            hasRequest={hasRequest}
+            result={comparisonQuery.data}
+            visibleOptionIds={matrix.visibleOptionIds}
+            pinnedOptionIds={matrix.pinnedOptionIds}
+            focusedOptionId={matrix.focusedOptionId}
+            isLoading={comparisonQuery.isLoading}
+            isError={comparisonQuery.isError}
+            error={comparisonQuery.error}
+            onRetry={() => void comparisonQuery.refetch()}
+            onPageChange={matrix.setPage}
+            onOpenDetail={openDetail}
+          />
+          <TechnicalConfigurationCriterionPanel
+            detail={detail}
+            open={detail !== null}
+            returnFocusRef={detailReturnFocusRef}
+            onOpenChange={(open) => {
+              if (!open) setDetail(null)
+            }}
+          />
+        </TabsContent>
 
-      <TechnicalConfigurationCriterionPanel
-        detail={detail}
-        open={detail !== null}
-        returnFocusRef={detailReturnFocusRef}
-        onOpenChange={(open) => {
-          if (!open) setDetail(null)
-        }}
-      />
+        <TabsContent value="evaluation" className="mt-4">
+          <TechnicalConfigurationEvaluationWorkspace
+            dossier={dossier}
+            onDirtyChange={setIsEvaluationDirty}
+            onNavigationBlockedChange={setIsEvaluationNavigationBlocked}
+            onRevisionChange={onRevisionChange}
+          />
+        </TabsContent>
+      </Tabs>
+      {discardConfirmationDialog}
     </section>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationComparisonTab.tsx
@@ -74,7 +74,10 @@ export function TechnicalConfigurationComparisonTab({
       if ((nextMode !== "matrix" && nextMode !== "evaluation") || nextMode === activeMode) {
         return
       }
-      requestNavigation(() => setActiveMode(nextMode))
+      requestNavigation(() => {
+        setActiveMode(nextMode)
+        if (activeMode === "matrix") setDetail(null)
+      })
     },
     [activeMode, requestNavigation]
   )

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPagination.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationCriterionPagination.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { ChevronLeft, ChevronRight } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+type TechnicalConfigurationCriterionPaginationProps = {
+  page: number
+  pageSize: number
+  total: number
+  onPageChange: (page: number) => void
+  disabled?: boolean
+}
+
+/** Renders the canonical criterion page summary and previous/next controls. */
+export function TechnicalConfigurationCriterionPagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  disabled = false,
+}: Readonly<TechnicalConfigurationCriterionPaginationProps>) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  const startItem = total === 0 ? 0 : (page - 1) * pageSize + 1
+  const endItem = Math.min(page * pageSize, total)
+
+  return (
+    <div className="flex min-h-10 flex-wrap items-center justify-between gap-3 text-sm">
+      <p className="flex flex-wrap gap-x-2 text-muted-foreground">
+        <span>
+          Tiêu chí {startItem}-{endItem} trên {total}
+        </span>
+        <span>
+          Trang {page}/{totalPages}
+        </span>
+      </p>
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label="Trang trước"
+          disabled={disabled || page <= 1}
+          onClick={() => onPageChange(page - 1)}
+        >
+          <ChevronLeft aria-hidden="true" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label="Trang tiếp theo"
+          disabled={disabled || page >= totalPages}
+          onClick={() => onPageChange(page + 1)}
+        >
+          <ChevronRight aria-hidden="true" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrix.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react"
+import { ChevronLeft, RefreshCw } from "lucide-react"
 
 import {
   COMPARISON_MATRIX_LAYOUT,
@@ -10,6 +10,7 @@ import type { TechnicalConfigurationComparisonResult } from "@/app/(app)/technic
 import { Button } from "@/components/ui/button"
 
 import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
+import { TechnicalConfigurationCriterionPagination } from "./TechnicalConfigurationCriterionPagination"
 import { TechnicalConfigurationMatrixRow } from "./TechnicalConfigurationMatrixRow"
 
 type TechnicalConfigurationMatrixProps = {
@@ -146,10 +147,6 @@ export function TechnicalConfigurationMatrix({
     }
   }
   const criterionGroups = groupCriterionRows(criteria)
-  const totalPages = Math.max(1, Math.ceil(result.total / result.pageSize))
-  const startItem = (result.page - 1) * result.pageSize + 1
-  const endItem = Math.min(result.page * result.pageSize, result.total)
-
   return (
     <div className="space-y-3">
       <div
@@ -225,33 +222,12 @@ export function TechnicalConfigurationMatrix({
         </table>
       </div>
 
-      <div className="flex min-h-10 items-center justify-between gap-4 text-sm">
-        <p className="text-muted-foreground">
-          Tiêu chí {startItem}-{endItem} trên {result.total} · Trang {result.page}/{totalPages}
-        </p>
-        <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            aria-label="Trang trước"
-            disabled={result.page <= 1}
-            onClick={() => onPageChange(result.page - 1)}
-          >
-            <ChevronLeft aria-hidden="true" />
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            aria-label="Trang tiếp theo"
-            disabled={result.page >= totalPages}
-            onClick={() => onPageChange(result.page + 1)}
-          >
-            <ChevronRight aria-hidden="true" />
-          </Button>
-        </div>
-      </div>
+      <TechnicalConfigurationCriterionPagination
+        page={result.page}
+        pageSize={result.pageSize}
+        total={result.total}
+        onPageChange={onPageChange}
+      />
     </div>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
+++ b/src/app/(app)/technical-configurations/_components/comparison/TechnicalConfigurationMatrixRow.tsx
@@ -9,12 +9,7 @@ import type {
 } from "@/app/(app)/technical-configurations/comparison-types"
 
 import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
-
-const EMPTY_EVIDENCE: TechnicalConfigurationComparisonEvidence = {
-  documentCount: 0,
-  citationCount: 0,
-  hasEvidence: false,
-}
+import { createTechnicalConfigurationOptionCriterionDetail } from "./technical-configuration-criterion-detail"
 
 type TechnicalConfigurationMatrixRowProps = {
   row: TechnicalConfigurationComparisonResult["data"]["criteria"][number]
@@ -88,8 +83,12 @@ export function TechnicalConfigurationMatrixRow({
       </td>
       {options.map((option) => {
         const value = valueByOptionId.get(option.id)
-        const response = value?.response
-        const evidence = value?.evidence ?? EMPTY_EVIDENCE
+        const detail = createTechnicalConfigurationOptionCriterionDetail({
+          row,
+          option,
+          value,
+          baselineVersionId,
+        })
         const pinnedIndex = pinnedOptionIds.indexOf(option.id)
         const isPinned = pinnedIndex >= 0
 
@@ -109,37 +108,23 @@ export function TechnicalConfigurationMatrixRow({
               type="button"
               className="h-full w-full space-y-2 px-3 py-3 text-left outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
               aria-label={`Xem chi tiết ${row.criterion.criterionCode} · ${option.displayLabel}`}
-              onClick={() =>
-                onOpenDetail({
-                  criterionCode: row.criterion.criterionCode,
-                  criterionTitle: title,
-                  optionLabel: option.displayLabel,
-                  requirementText: row.criterion.requirementText,
-                  responseText: response?.responseText ?? null,
-                  supplementaryInformation: response?.supplementaryInformation ?? null,
-                  evidence,
-                  evidenceTarget: {
-                    kind: "option",
-                    baselineVersionId,
-                    optionId: option.id,
-                    criterionId: row.criterion.id,
-                  },
-                })
-              }
+              onClick={() => onOpenDetail(detail)}
             >
-              {response ? (
+              {detail.responseText !== null ? (
                 <>
                   <p className="line-clamp-4 whitespace-pre-wrap break-words leading-5">
-                    {response.responseText}
+                    {detail.responseText}
                   </p>
-                  {response.supplementaryInformation ? (
+                  {detail.supplementaryInformation ? (
                     <p className="text-xs font-medium text-foreground">Có thông tin bổ sung</p>
                   ) : null}
                 </>
               ) : (
                 <p className="text-muted-foreground">Chưa có phản hồi</p>
               )}
-              <p className="text-xs text-muted-foreground">{formatEvidenceSummary(evidence)}</p>
+              <p className="text-xs text-muted-foreground">
+                {formatEvidenceSummary(detail.evidence)}
+              </p>
             </button>
           </td>
         )

--- a/src/app/(app)/technical-configurations/_components/comparison/technical-configuration-criterion-detail.ts
+++ b/src/app/(app)/technical-configurations/_components/comparison/technical-configuration-criterion-detail.ts
@@ -1,0 +1,41 @@
+import type {
+  TechnicalConfigurationComparisonCriterionRow,
+  TechnicalConfigurationComparisonOption,
+  TechnicalConfigurationComparisonOptionValue,
+} from "../../comparison-types"
+import type { TechnicalConfigurationCriterionDetail } from "./TechnicalConfigurationCriterionPanel"
+
+const EMPTY_EVIDENCE = {
+  documentCount: 0,
+  citationCount: 0,
+  hasEvidence: false,
+} as const
+
+/** Builds the shared P10B option-detail contract for comparison and evaluation. */
+export function createTechnicalConfigurationOptionCriterionDetail({
+  row,
+  option,
+  value,
+  baselineVersionId,
+}: {
+  row: TechnicalConfigurationComparisonCriterionRow
+  option: TechnicalConfigurationComparisonOption
+  value: TechnicalConfigurationComparisonOptionValue | undefined
+  baselineVersionId: string
+}): TechnicalConfigurationCriterionDetail {
+  return {
+    criterionCode: row.criterion.criterionCode,
+    criterionTitle: row.criterion.title ?? "Chưa có tiêu đề",
+    optionLabel: option.displayLabel,
+    requirementText: row.criterion.requirementText,
+    responseText: value?.response?.responseText ?? null,
+    supplementaryInformation: value?.response?.supplementaryInformation ?? null,
+    evidence: value?.evidence ?? EMPTY_EVIDENCE,
+    evidenceTarget: {
+      kind: "option",
+      baselineVersionId,
+      optionId: option.id,
+      criterionId: row.criterion.id,
+    },
+  }
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -45,6 +45,16 @@ function toSaveErrorMessage(error: unknown): string {
   return error instanceof Error && error.message ? error.message : "Không thể lưu đánh giá."
 }
 
+function resolveCriterionId(
+  criteria: TechnicalConfigurationComparisonCriterionRow[],
+  requestedCriterionId: string | null
+): string | null {
+  if (requestedCriterionId && criteria.some((row) => row.criterion.id === requestedCriterionId)) {
+    return requestedCriterionId
+  }
+  return criteria[0]?.criterion.id ?? null
+}
+
 /** Owns the selected option, page, criterion and P12A1 draft for evaluation mode. */
 export function TechnicalConfigurationEvaluationActiveWorkspace({
   dossier,
@@ -69,10 +79,7 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
   })
   const result = comparison.comparisonQuery.data
   const criteria = result?.data.criteria ?? EMPTY_CRITERIA
-  const criterionId =
-    requestedCriterionId && criteria.some((row) => row.criterion.id === requestedCriterionId)
-      ? requestedCriterionId
-      : (criteria[0]?.criterion.id ?? null)
+  const criterionId = resolveCriterionId(criteria, requestedCriterionId)
   const currentRow = criteria.find((row) => row.criterion.id === criterionId) ?? null
   const evaluation = useTechnicalConfigurationEvaluationDraft({
     optionId: activeSelectedOptionId,

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -1,0 +1,329 @@
+"use client"
+
+import * as React from "react"
+import { Loader2, Save, StepForward } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+import { useTechnicalConfigurationComparison } from "../../_hooks/useTechnicalConfigurationComparison"
+import { useTechnicalConfigurationEvaluationDraft } from "../../_hooks/useTechnicalConfigurationEvaluationDraft"
+import { useTechnicalConfigurationGuardedNavigation } from "../../_hooks/useTechnicalConfigurationGuardedNavigation"
+import { TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE } from "../../comparison-matrix-constants"
+import type {
+  TechnicalConfigurationComparisonCriterionRow,
+  TechnicalConfigurationComparisonOption,
+} from "../../comparison-types"
+import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import { toTechnicalConfigurationComparisonOption } from "../../technical-configuration-comparison-mappers"
+import type { TechnicalConfigurationDossierWire } from "../../types"
+import { TechnicalConfigurationCriterionPagination } from "../comparison/TechnicalConfigurationCriterionPagination"
+import { createTechnicalConfigurationOptionCriterionDetail } from "../comparison/technical-configuration-criterion-detail"
+import { TechnicalConfigurationCriterionList } from "./TechnicalConfigurationCriterionList"
+import { TechnicalConfigurationEvaluationLoadError } from "./TechnicalConfigurationEvaluationLoadError"
+import { TechnicalConfigurationEvaluationPanel } from "./TechnicalConfigurationEvaluationPanel"
+
+type TechnicalConfigurationEvaluationActiveWorkspaceProps = {
+  dossier: TechnicalConfigurationDossierWire
+  baselineVersionId: string
+  options: TechnicalConfigurationOptionWire[]
+  onDirtyChange: (dirty: boolean) => void
+  onNavigationBlockedChange: (blocked: boolean) => void
+  onRevisionChange?: (revision: number) => void
+}
+
+const EMPTY_CRITERIA: TechnicalConfigurationComparisonCriterionRow[] = []
+
+function toSaveErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : "Không thể lưu đánh giá."
+}
+
+/** Owns the selected option, page, criterion and P12A1 draft for evaluation mode. */
+export function TechnicalConfigurationEvaluationActiveWorkspace({
+  dossier,
+  baselineVersionId,
+  options,
+  onDirtyChange,
+  onNavigationBlockedChange,
+  onRevisionChange,
+}: Readonly<TechnicalConfigurationEvaluationActiveWorkspaceProps>) {
+  const [selectedOptionId, setSelectedOptionId] = React.useState(options[0]?.id ?? "")
+  const [page, setPage] = React.useState(1)
+  const [requestedCriterionId, setRequestedCriterionId] = React.useState<string | null>(null)
+  const [isPanelOpen, setIsPanelOpen] = React.useState(false)
+  const detailReturnFocusRef = React.useRef<HTMLElement | null>(null)
+  const selectedOption = options.find((option) => option.id === selectedOptionId) ?? options[0]
+  const activeSelectedOptionId = selectedOption?.id ?? ""
+  const comparison = useTechnicalConfigurationComparison({
+    baselineVersionId,
+    optionIds: activeSelectedOptionId ? [activeSelectedOptionId] : [],
+    page,
+    pageSize: TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE,
+  })
+  const result = comparison.comparisonQuery.data
+  const criteria = result?.data.criteria ?? EMPTY_CRITERIA
+  const criterionId =
+    requestedCriterionId && criteria.some((row) => row.criterion.id === requestedCriterionId)
+      ? requestedCriterionId
+      : (criteria[0]?.criterion.id ?? null)
+  const currentRow = criteria.find((row) => row.criterion.id === criterionId) ?? null
+  const evaluation = useTechnicalConfigurationEvaluationDraft({
+    optionId: activeSelectedOptionId,
+    baselineVersionId,
+    criterionId,
+    expectedDossierRevision: dossier.revision,
+    onDossierRevisionChange: onRevisionChange,
+  })
+  const { assessmentQuery, comparisonSetQuery } = evaluation
+  const {
+    error: assessmentQueryError,
+    isError: isAssessmentQueryError,
+    refetch: refetchAssessments,
+  } = assessmentQuery
+  const {
+    error: comparisonSetQueryError,
+    isError: isComparisonSetQueryError,
+    refetch: refetchComparisonSet,
+  } = comparisonSetQuery
+  const isDirty = evaluation.draft?.isDirty ?? false
+  const isNavigationBlocked = evaluation.isSaving
+  const currentIndex = currentRow
+    ? criteria.findIndex((row) => row.criterion.id === currentRow.criterion.id)
+    : -1
+  const hasNextPage = result ? result.page * result.pageSize < result.total : false
+  const { requestNavigation, discardConfirmationDialog } =
+    useTechnicalConfigurationGuardedNavigation({
+      isDirty,
+      isBlocked: isNavigationBlocked,
+      onDiscard: evaluation.discard,
+    })
+  const hasEvaluationReadError = isComparisonSetQueryError || isAssessmentQueryError
+  const evaluationReadError = isComparisonSetQueryError
+    ? comparisonSetQueryError
+    : assessmentQueryError
+
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- P12A2 exposes one criterion-local draft to every enclosing navigation boundary.
+    onDirtyChange(isDirty)
+  }, [isDirty, onDirtyChange])
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Pending assessment saves hard-block option, page, mode, tab and dossier navigation.
+    onNavigationBlockedChange(isNavigationBlocked)
+  }, [isNavigationBlocked, onNavigationBlockedChange])
+  React.useEffect(
+    () => () => {
+      onDirtyChange(false)
+      onNavigationBlockedChange(false)
+    },
+    [onDirtyChange, onNavigationBlockedChange]
+  )
+
+  const handleOptionChange = React.useCallback(
+    (nextOptionId: string) => {
+      if (nextOptionId === activeSelectedOptionId) return
+      requestNavigation(() => {
+        setSelectedOptionId(nextOptionId)
+        setPage(1)
+        setRequestedCriterionId(null)
+        setIsPanelOpen(false)
+      })
+    },
+    [activeSelectedOptionId, requestNavigation]
+  )
+  const handlePageChange = React.useCallback(
+    (nextPage: number) => {
+      if (nextPage === page) return
+      requestNavigation(() => {
+        setPage(nextPage)
+        setRequestedCriterionId(null)
+      })
+    },
+    [page, requestNavigation]
+  )
+  const handleCriterionChange = React.useCallback(
+    (nextCriterionId: string) => {
+      const navigate = () => {
+        detailReturnFocusRef.current =
+          document.activeElement instanceof HTMLElement ? document.activeElement : null
+        setRequestedCriterionId(nextCriterionId)
+        setIsPanelOpen(true)
+      }
+      if (nextCriterionId === criterionId) {
+        navigate()
+        return
+      }
+      requestNavigation(navigate)
+    },
+    [criterionId, requestNavigation]
+  )
+  const handleSave = React.useCallback(async () => {
+    try {
+      await evaluation.save()
+    } catch {
+      // The draft hook preserves input and exposes the actionable error.
+    }
+  }, [evaluation])
+  const handleSaveAndContinue = React.useCallback(async () => {
+    try {
+      await evaluation.save()
+      const nextCriterionId = criteria[currentIndex + 1]?.criterion.id
+      if (nextCriterionId) {
+        setRequestedCriterionId(nextCriterionId)
+        setIsPanelOpen(true)
+      } else if (hasNextPage) {
+        setPage((current) => current + 1)
+        setRequestedCriterionId(null)
+        setIsPanelOpen(true)
+      }
+    } catch {
+      // Failed saves intentionally remain on the current criterion.
+    }
+  }, [criteria, currentIndex, evaluation, hasNextPage])
+  const handleRetryEvaluationData = React.useCallback(() => {
+    if (isComparisonSetQueryError) {
+      void refetchComparisonSet()
+    }
+    if (isAssessmentQueryError) {
+      void refetchAssessments()
+    }
+  }, [isAssessmentQueryError, isComparisonSetQueryError, refetchAssessments, refetchComparisonSet])
+
+  const comparisonOption: TechnicalConfigurationComparisonOption | null = selectedOption
+    ? (result?.data.options.find((option) => option.id === activeSelectedOptionId) ??
+      toTechnicalConfigurationComparisonOption(selectedOption))
+    : null
+  const currentOptionValue =
+    currentRow && comparisonOption
+      ? currentRow.optionValues.find((value) => value.optionId === comparisonOption.id)
+      : undefined
+  const detail =
+    currentRow && comparisonOption
+      ? createTechnicalConfigurationOptionCriterionDetail({
+          row: currentRow,
+          option: comparisonOption,
+          value: currentOptionValue,
+          baselineVersionId,
+        })
+      : null
+  const draft = evaluation.draft
+  const saveDisabled =
+    Boolean(dossier.archived_at) || !evaluation.isReady || !isDirty || isNavigationBlocked
+
+  return (
+    <section className="min-w-0 space-y-4" aria-label="Không gian đánh giá cấu hình kỹ thuật">
+      <div className="flex flex-col gap-2 border-y py-3 sm:flex-row sm:items-center sm:justify-between">
+        <Label htmlFor="technical-configuration-evaluation-option">Phương án đánh giá</Label>
+        <Select
+          value={activeSelectedOptionId}
+          onValueChange={handleOptionChange}
+          disabled={isNavigationBlocked}
+        >
+          <SelectTrigger
+            id="technical-configuration-evaluation-option"
+            aria-label="Phương án đánh giá"
+            className="w-full sm:max-w-md"
+          >
+            <SelectValue placeholder="Chọn phương án" />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.id} value={option.id}>
+                {option.display_label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {comparison.comparisonQuery.isLoading ? (
+        <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          Đang tải tiêu chí...
+        </div>
+      ) : null}
+      {comparison.comparisonQuery.isError ? (
+        <TechnicalConfigurationEvaluationLoadError
+          title="Không thể tải tiêu chí đánh giá"
+          error={comparison.comparisonQuery.error}
+          fallback="Không thể tải dữ liệu so sánh."
+          onRetry={() => void comparison.comparisonQuery.refetch()}
+        />
+      ) : null}
+      {hasEvaluationReadError ? (
+        <TechnicalConfigurationEvaluationLoadError
+          title="Không thể tải dữ liệu đánh giá"
+          error={evaluationReadError}
+          fallback="Không thể tải comparison set hoặc đánh giá đã lưu."
+          onRetry={handleRetryEvaluationData}
+        />
+      ) : null}
+      {result ? (
+        <>
+          <TechnicalConfigurationCriterionList
+            criteria={criteria}
+            assessmentsByCriterionId={evaluation.assessmentsByCriterionId}
+            currentCriterionId={criterionId}
+            onSelectCriterion={handleCriterionChange}
+            disabled={isNavigationBlocked}
+          />
+          <TechnicalConfigurationCriterionPagination
+            page={result.page}
+            pageSize={result.pageSize}
+            total={result.total}
+            onPageChange={handlePageChange}
+            disabled={isNavigationBlocked}
+          />
+        </>
+      ) : null}
+
+      <TechnicalConfigurationEvaluationPanel
+        detail={detail}
+        open={isPanelOpen && detail !== null}
+        onOpenChange={setIsPanelOpen}
+        returnFocusRef={detailReturnFocusRef}
+        technicalAxis={draft?.technicalAxis ?? null}
+        evidenceAxis={draft?.evidenceAxis ?? null}
+        notes={draft?.notes ?? ""}
+        onTechnicalAxisChange={evaluation.setTechnicalAxis}
+        onEvidenceAxisChange={evaluation.setEvidenceAxis}
+        onNotesChange={evaluation.setNotes}
+        disabled={Boolean(dossier.archived_at)}
+        loading={!evaluation.isReady}
+        errorMessage={evaluation.error ? toSaveErrorMessage(evaluation.error) : null}
+        actions={
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={saveDisabled}
+              onClick={() => void handleSave()}
+            >
+              {isNavigationBlocked ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Save className="size-4" aria-hidden="true" />
+              )}
+              Lưu
+            </Button>
+            <Button
+              type="button"
+              disabled={saveDisabled}
+              onClick={() => void handleSaveAndContinue()}
+            >
+              <StepForward className="size-4" aria-hidden="true" />
+              Lưu &amp; tiếp tục
+            </Button>
+          </>
+        }
+      />
+      {discardConfirmationDialog}
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationLoadError.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationLoadError.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { AlertCircle, RefreshCw } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+
+type TechnicalConfigurationEvaluationLoadErrorProps = {
+  title: string
+  error: unknown
+  fallback: string
+  onRetry: () => void
+}
+
+function toErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback
+}
+
+/** Renders the shared evaluation load failure and explicit retry action. */
+export function TechnicalConfigurationEvaluationLoadError({
+  title,
+  error,
+  fallback,
+  onRetry,
+}: Readonly<TechnicalConfigurationEvaluationLoadErrorProps>) {
+  return (
+    <Alert variant="destructive">
+      <AlertCircle className="size-4" aria-hidden="true" />
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription className="space-y-3">
+        <p>{toErrorMessage(error, fallback)}</p>
+        <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+          <RefreshCw className="size-4" aria-hidden="true" />
+          Thử lại
+        </Button>
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationPanel.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationPanel.tsx
@@ -16,6 +16,7 @@ type TechnicalConfigurationEvaluationPanelProps = TechnicalConfigurationAssessme
   open: boolean
   onOpenChange: (open: boolean) => void
   returnFocusRef?: React.RefObject<HTMLElement | null>
+  actions?: React.ReactNode
 }
 
 /** Adds manual assessment controls to the single shared P10B criterion detail surface. */
@@ -24,6 +25,7 @@ export function TechnicalConfigurationEvaluationPanel({
   open,
   onOpenChange,
   returnFocusRef,
+  actions,
   ...assessmentControls
 }: Readonly<TechnicalConfigurationEvaluationPanelProps>) {
   return (
@@ -32,7 +34,12 @@ export function TechnicalConfigurationEvaluationPanel({
       open={open}
       onOpenChange={onOpenChange}
       returnFocusRef={returnFocusRef}
-      assessmentControls={<TechnicalConfigurationAssessmentControls {...assessmentControls} />}
+      assessmentControls={
+        <div className="space-y-4">
+          <TechnicalConfigurationAssessmentControls {...assessmentControls} />
+          {actions ? <div className="flex flex-wrap justify-end gap-2">{actions}</div> : null}
+        </div>
+      }
     />
   )
 }

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import * as React from "react"
+import { AlertCircle, Loader2, RefreshCw } from "lucide-react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+
+import { useTechnicalConfigurationBaselineVersionSelection } from "../../_hooks/useTechnicalConfigurationBaselineVersionSelection"
+import { useTechnicalConfigurationBeforeUnloadGuard } from "../../_hooks/useTechnicalConfigurationBeforeUnloadGuard"
+import { useTechnicalConfigurationOptionListQuery } from "../../_hooks/useTechnicalConfigurationOptionListQuery"
+import type { TechnicalConfigurationOptionWire } from "../../supplier-option-types"
+import type { TechnicalConfigurationDossierWire } from "../../types"
+import { TechnicalConfigurationEvaluationActiveWorkspace } from "./TechnicalConfigurationEvaluationActiveWorkspace"
+
+type TechnicalConfigurationEvaluationWorkspaceProps = {
+  dossier: TechnicalConfigurationDossierWire
+  onDirtyChange?: (dirty: boolean) => void
+  onNavigationBlockedChange?: (blocked: boolean) => void
+  onRevisionChange?: (revision: number) => void
+}
+
+const EMPTY_OPTIONS: TechnicalConfigurationOptionWire[] = []
+
+/** Activates one option-at-a-time manual assessment over canonical comparison pages. */
+export function TechnicalConfigurationEvaluationWorkspace({
+  dossier,
+  onDirtyChange,
+  onNavigationBlockedChange,
+  onRevisionChange,
+}: Readonly<TechnicalConfigurationEvaluationWorkspaceProps>) {
+  const [isDirty, setIsDirty] = React.useState(false)
+  const [isNavigationBlocked, setIsNavigationBlocked] = React.useState(false)
+  const selection = useTechnicalConfigurationBaselineVersionSelection(dossier.id)
+  const { synchronizeVersion } = selection
+  const { optionsQuery } = useTechnicalConfigurationOptionListQuery(dossier.id)
+  const options = optionsQuery.data?.options ?? EMPTY_OPTIONS
+
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent -- Async baseline refresh must preserve the active assessment draft.
+    synchronizeVersion(isDirty || isNavigationBlocked)
+  }, [isDirty, isNavigationBlocked, synchronizeVersion])
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- WorkspaceShell owns top-level guards while this workspace owns assessment state.
+    onDirtyChange?.(isDirty)
+  }, [isDirty, onDirtyChange])
+  React.useEffect(() => {
+    // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- Pending saves block mode, tab and dossier navigation.
+    onNavigationBlockedChange?.(isNavigationBlocked)
+  }, [isNavigationBlocked, onNavigationBlockedChange])
+  React.useEffect(
+    () => () => {
+      onDirtyChange?.(false)
+      onNavigationBlockedChange?.(false)
+    },
+    [onDirtyChange, onNavigationBlockedChange]
+  )
+  useTechnicalConfigurationBeforeUnloadGuard(isDirty || isNavigationBlocked)
+
+  if (selection.versionState.versionsQuery.isLoading || optionsQuery.isLoading) {
+    return (
+      <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        Đang tải không gian đánh giá...
+      </div>
+    )
+  }
+
+  if (selection.versionState.versionsQuery.isError && !selection.selectedVersion) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="size-4" aria-hidden="true" />
+        <AlertTitle>Không thể tải cấu hình cơ sở</AlertTitle>
+        <AlertDescription>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={selection.versionState.retryVersions}
+          >
+            <RefreshCw className="size-4" aria-hidden="true" />
+            Thử lại
+          </Button>
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (!selection.selectedVersion) {
+    return (
+      <Alert>
+        <AlertTitle>Chưa có cấu hình cơ sở</AlertTitle>
+        <AlertDescription>Khóa một phiên bản cấu hình trước khi đánh giá.</AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (optionsQuery.isError && options.length === 0) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="size-4" aria-hidden="true" />
+        <AlertTitle>Không thể tải phương án</AlertTitle>
+        <AlertDescription>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void optionsQuery.refetch()}
+          >
+            <RefreshCw className="size-4" aria-hidden="true" />
+            Thử lại
+          </Button>
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (options.length === 0) {
+    return (
+      <Alert>
+        <AlertTitle>Chưa có phương án</AlertTitle>
+        <AlertDescription>Tạo phương án nhà cung cấp trước khi đánh giá.</AlertDescription>
+      </Alert>
+    )
+  }
+
+  return (
+    <TechnicalConfigurationEvaluationActiveWorkspace
+      dossier={dossier}
+      baselineVersionId={selection.selectedVersion.id}
+      options={options}
+      onDirtyChange={setIsDirty}
+      onNavigationBlockedChange={setIsNavigationBlocked}
+      onRevisionChange={onRevisionChange}
+    />
+  )
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
@@ -27,6 +27,7 @@ const ASSESSMENT_PAGINATION_SNAPSHOT_ERROR = "Assessment pagination snapshot cha
 interface TechnicalConfigurationAssessmentContext {
   optionId: string
   baselineVersionId: string | null
+  onComparisonSetReady?: (comparisonSet: TechnicalConfigurationComparisonSetWire) => void
 }
 
 type UseTechnicalConfigurationAssessmentsInput = TechnicalConfigurationAssessmentContext &
@@ -143,7 +144,7 @@ function acquireAssessmentComparisonSet({
 export function useTechnicalConfigurationAssessments(
   input: UseTechnicalConfigurationAssessmentsInput
 ) {
-  const { optionId, baselineVersionId } = input
+  const { optionId, baselineVersionId, onComparisonSetReady } = input
   const isCompleteCollection = input.collectionMode === "complete"
   const page = isCompleteCollection ? 1 : input.page
   const pageSize = isCompleteCollection ? ASSESSMENT_COLLECTION_PAGE_SIZE : input.pageSize
@@ -216,6 +217,10 @@ export function useTechnicalConfigurationAssessments(
         throw new Error("technical_configuration_assessment_context_unavailable")
       }
 
+      const cachedComparisonSet =
+        queryClient.getQueryData<TechnicalConfigurationComparisonSetWire | null>(
+          comparisonSetQueryKey
+        )
       const comparisonSet = await acquireAssessmentComparisonSet({
         queryClient,
         comparisonSetQueryKey,
@@ -223,6 +228,9 @@ export function useTechnicalConfigurationAssessments(
         baselineVersionId,
         expectedDossierRevision: input.expectedDossierRevision,
       })
+      if (!cachedComparisonSet) {
+        onComparisonSetReady?.(comparisonSet)
+      }
 
       const response = await upsertTechnicalConfigurationAssessment({
         p_comparison_set_id: comparisonSet.id,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonMatrix.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationComparisonMatrix.ts
@@ -2,7 +2,10 @@
 
 import * as React from "react"
 
-import { COMPARISON_MATRIX_LIMITS } from "@/app/(app)/technical-configurations/comparison-matrix-constants"
+import {
+  COMPARISON_MATRIX_LIMITS,
+  TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE,
+} from "@/app/(app)/technical-configurations/comparison-matrix-constants"
 
 import { useTechnicalConfigurationBaseline } from "./useTechnicalConfigurationBaseline"
 import { useTechnicalConfigurationBaselineVersions } from "./useTechnicalConfigurationBaselineVersions"
@@ -10,7 +13,6 @@ import { useTechnicalConfigurationComparison } from "./useTechnicalConfiguration
 import { useTechnicalConfigurationOptionListQuery } from "./useTechnicalConfigurationOptionListQuery"
 import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 
-const COMPARISON_PAGE_SIZE = 50
 const EMPTY_OPTIONS: TechnicalConfigurationOptionWire[] = []
 
 type ComparisonRequestState = {
@@ -277,7 +279,7 @@ export function useTechnicalConfigurationComparisonMatrix(dossierId: string) {
     baselineVersionId,
     optionIds: selectedOptionIds,
     page,
-    pageSize: COMPARISON_PAGE_SIZE,
+    pageSize: TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE,
   })
 
   return {
@@ -295,7 +297,7 @@ export function useTechnicalConfigurationComparisonMatrix(dossierId: string) {
     pinnedOptionIds,
     focusedOptionId,
     page,
-    pageSize: COMPARISON_PAGE_SIZE,
+    pageSize: TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE,
     isSelectionLimitReached: selectedOptionIds.length >= COMPARISON_MATRIX_LIMITS.selectedOptions,
     comparison,
     selectBaselineVersion,

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation.tsx
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation.tsx
@@ -18,8 +18,14 @@ interface TechnicalConfigurationDiscardConfirmationState {
   ) => void
 }
 
+interface TechnicalConfigurationDiscardConfirmationOptions {
+  cancelLabel?: React.ReactNode
+}
+
 /** Queues one destructive draft-discard action behind the shared alert dialog. */
-export function useTechnicalConfigurationDiscardConfirmation(): TechnicalConfigurationDiscardConfirmationState {
+export function useTechnicalConfigurationDiscardConfirmation({
+  cancelLabel,
+}: TechnicalConfigurationDiscardConfirmationOptions = {}): TechnicalConfigurationDiscardConfirmationState {
   const [pendingConfirmation, setPendingConfirmation] =
     React.useState<PendingDiscardConfirmation | null>(null)
 
@@ -49,6 +55,7 @@ export function useTechnicalConfigurationDiscardConfirmation(): TechnicalConfigu
         onOpenChange={handleOpenChange}
         title="Bỏ thay đổi chưa lưu?"
         description={pendingConfirmation?.description ?? ""}
+        cancelLabel={cancelLabel}
         confirmLabel="Bỏ thay đổi"
         isPending={false}
         onConfirm={handleConfirm}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationDraft.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationEvaluationDraft.ts
@@ -91,6 +91,9 @@ export function useTechnicalConfigurationEvaluationDraft({
     optionId,
     baselineVersionId,
     collectionMode: "complete",
+    onComparisonSetReady: (comparisonSet) => {
+      onDossierRevisionChange?.(comparisonSet.revision)
+    },
   })
   const assessmentsByCriterionId =
     assessmentSource.completeAssessmentsQuery.data ?? EMPTY_ASSESSMENTS
@@ -166,6 +169,14 @@ export function useTechnicalConfigurationEvaluationDraft({
     ]
   )
 
+  const discard = React.useCallback(() => {
+    if (activeDraftContextTokenRef.current !== draftContextToken || saveInFlightRef.current) {
+      return
+    }
+    draftEntryRef.current = null
+    setDraftEntry(null)
+  }, [draftContextToken])
+
   const save = React.useCallback(async () => {
     const current = draftEntryRef.current
     const latestDraft = current?.contextKey === draftContextKey ? current.draft : currentDraft
@@ -208,7 +219,6 @@ export function useTechnicalConfigurationEvaluationDraft({
           draft: adoptedDraft,
         })
       }
-      onDossierRevisionChange?.(result.comparisonSet.revision)
       return result
     } catch (error) {
       const latestEntry = draftEntryRef.current
@@ -232,7 +242,6 @@ export function useTechnicalConfigurationEvaluationDraft({
     draftContextKey,
     draftContextToken,
     expectedDossierRevision,
-    onDossierRevisionChange,
     replaceDraftEntry,
   ])
 
@@ -266,6 +275,7 @@ export function useTechnicalConfigurationEvaluationDraft({
     setTechnicalAxis,
     setEvidenceAxis,
     setNotes,
+    discard,
     save,
   }
 }

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationGuardedNavigation.tsx
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationGuardedNavigation.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+
+import { useTechnicalConfigurationDiscardConfirmation } from "./useTechnicalConfigurationDiscardConfirmation"
+
+type UseTechnicalConfigurationGuardedNavigationInput = {
+  isDirty: boolean
+  isBlocked: boolean
+  description?: React.ReactNode
+  cancelLabel?: React.ReactNode
+  onDiscard?: () => void
+}
+
+const DEFAULT_DISCARD_DESCRIPTION =
+  "Các thay đổi chưa lưu sẽ bị mất nếu bạn tiếp tục chuyển khỏi nội dung hiện tại."
+
+/** Applies the shared pending-block and dirty-confirm contract to one navigation boundary. */
+export function useTechnicalConfigurationGuardedNavigation({
+  isDirty,
+  isBlocked,
+  description = DEFAULT_DISCARD_DESCRIPTION,
+  cancelLabel,
+  onDiscard,
+}: UseTechnicalConfigurationGuardedNavigationInput) {
+  const { requestDiscardConfirmation, discardConfirmationDialog } =
+    useTechnicalConfigurationDiscardConfirmation({ cancelLabel })
+
+  const requestNavigation = React.useCallback(
+    (navigate: () => void) => {
+      if (isBlocked) return
+      if (!isDirty) {
+        navigate()
+        return
+      }
+      requestDiscardConfirmation(description, () => {
+        onDiscard?.()
+        navigate()
+      })
+    },
+    [description, isBlocked, isDirty, onDiscard, requestDiscardConfirmation]
+  )
+
+  return {
+    requestNavigation,
+    discardConfirmationDialog,
+  }
+}

--- a/src/app/(app)/technical-configurations/comparison-matrix-constants.ts
+++ b/src/app/(app)/technical-configurations/comparison-matrix-constants.ts
@@ -4,6 +4,9 @@ export const COMPARISON_MATRIX_LIMITS = {
   pinnedOptions: 2,
 } as const
 
+/** Keeps criterion paging identical across comparison and evaluation workspaces. */
+export const TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE = 50
+
 /** Stable desktop column geometry shared by matrix headers and body rows. */
 export const COMPARISON_MATRIX_LAYOUT = {
   criterionWidth: 220,

--- a/src/app/(app)/technical-configurations/technical-configuration-comparison-mappers.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-comparison-mappers.ts
@@ -1,0 +1,19 @@
+import type {
+  TechnicalConfigurationComparisonOption,
+  TechnicalConfigurationComparisonOptionWire,
+} from "./comparison-types"
+
+/** Normalizes one comparison option for shared matrix and evaluation consumers. */
+export function toTechnicalConfigurationComparisonOption(
+  option: TechnicalConfigurationComparisonOptionWire
+): TechnicalConfigurationComparisonOption {
+  return {
+    id: option.id,
+    supplierId: option.supplier_id,
+    supplierName: option.supplier_name,
+    model: option.model,
+    manufacturer: option.manufacturer,
+    optionName: option.option_name,
+    displayLabel: option.display_label,
+  }
+}

--- a/src/app/(app)/technical-configurations/technical-configuration-comparison-rpc.ts
+++ b/src/app/(app)/technical-configurations/technical-configuration-comparison-rpc.ts
@@ -13,6 +13,7 @@ import type {
   TechnicalConfigurationComparisonRpcArgs,
   TechnicalConfigurationComparisonWireResponse,
 } from "./comparison-types"
+import { toTechnicalConfigurationComparisonOption } from "./technical-configuration-comparison-mappers"
 import { callTechnicalConfigurationRpc } from "./technical-configuration-rpc"
 
 function normalizeEvidence(
@@ -103,15 +104,7 @@ export async function getTechnicalConfigurationComparison(
         status: response.data.baseline_version.status,
         revision: response.data.baseline_version.revision,
       },
-      options: response.data.options.map((option) => ({
-        id: option.id,
-        supplierId: option.supplier_id,
-        supplierName: option.supplier_name,
-        model: option.model,
-        manufacturer: option.manufacturer,
-        optionName: option.option_name,
-        displayLabel: option.display_label,
-      })),
+      options: response.data.options.map(toTechnicalConfigurationComparisonOption),
       criteria: response.data.criteria.map(normalizeCriterionRow),
     },
     total: response.total,

--- a/src/components/shared/DestructiveConfirmDialog.tsx
+++ b/src/components/shared/DestructiveConfirmDialog.tsx
@@ -19,6 +19,7 @@ export interface DestructiveConfirmDialogProps {
   readonly onOpenChange: (open: boolean) => void
   readonly title: React.ReactNode
   readonly description: React.ReactNode
+  readonly cancelLabel?: React.ReactNode
   readonly confirmLabel: React.ReactNode
   readonly isPending: boolean
   readonly onConfirm: () => void
@@ -32,6 +33,7 @@ export function DestructiveConfirmDialog({
   onOpenChange,
   title,
   description,
+  cancelLabel = "Hủy",
   confirmLabel,
   isPending,
   onConfirm,
@@ -52,7 +54,7 @@ export function DestructiveConfirmDialog({
           <AlertDialogDescription>{description}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>Hủy</AlertDialogCancel>
+          <AlertDialogCancel disabled={isPending}>{cancelLabel}</AlertDialogCancel>
           <Button
             type="button"
             onClick={onConfirm}


### PR DESCRIPTION
## Summary
- activate the P12A1 evaluation core inside the existing `So sánh & đánh giá` tab through the internal `Ma trận` / `Đánh giá` mode, without adding a top-level tab
- reuse P10B criterion detail/evidence composition, P11D complete assessment collection, canonical pagination, and shared option mapping
- support one-option evaluation with `Lưu` and `Lưu & tiếp tục`, including cross-page advance and final-criterion retention
- guard dirty and pending state across criterion, option, page, internal mode, top-level tab, and dossier/back navigation; confirmed discard clears the active draft
- propagate first comparison-set acquisition revisions before assessment persistence, and expose explicit retry for assessment read failures
- keep progress counters, filters, ranking, AI, and browser tests outside P12A2

## TDD coverage
- save, save-next, cross-page advance, and final-criterion behavior
- dirty cancel/confirm and pending hard-block across every navigation boundary
- discard reset, first-acquisition partial failure, validation/auth/conflict/persistence preservation, and read retry
- comparison-tab, workspace-shell, P10B, P11D, and P12A1 regressions

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused P10B/P11D/P12A1/P12A2 Vitest suite: 16 files, 134 tests passed
- `node scripts/npm-run.js run react-doctor`: 100/100, no issues
- `openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`
- `git diff --check` and `git diff --cached --check`
- Lefthook pre-commit and pre-push gates passed

## Review notes
- depends on P12A1 PR #826, merged into `main` on 2026-07-30 before this branch was created
- Code Review Graph, GitNexus, and semantic dedup/overlap review found no competing implementation; shared seams remain inside the technical-configuration ownership boundary
- independent review findings addressed before push: confirmed discard reset, first-save revision propagation, and visible assessment-read retry
- no SQL, API route, migration, top-level navigation, browser harness, progress/filter/ranking, or AI changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates a guarded evaluation workspace inside the existing `So sánh & đánh giá` tab, adding an internal `Ma trận`/`Đánh giá` mode for one-option assessments with save and save-next. Delivers P12A2 using shared P10B/P11D seams and consistent navigation guards, and clears stale matrix detail when switching modes.

- **New Features**
  - Internal `Ma trận`/`Đánh giá` segmented mode; no new top-level tab.
  - One-option evaluation with `Lưu` and `Lưu & tiếp tục`; advances across pages and keeps the final criterion.
  - Guarded navigation across criterion/option/page/mode/tab/back: pending hard-blocks; dirty asks to discard; before-unload guard; confirmed discard clears the draft and mode switches clear stale matrix detail.
  - Propagates comparison-set revision on first acquisition and when upsert fails; surfaces assessment read failures with explicit retry.

- **Refactors**
  - Added shared criterion pagination and option-detail builders; `TechnicalConfigurationMatrix` now uses them.
  - Introduced `useTechnicalConfigurationGuardedNavigation`; adopted in the workspace shell and comparison tab; comparison tab emits dirty/blocked/revision to the shell.
  - Unified criterion page size via `TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE`; minor hook and mapper cleanups; focused tests added for save/save-next, guards, discard/reset, and retry.

<sup>Written for commit 92cb218dc337848b2105b8903bb06ac37ef647cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an evaluation mode within technical configuration comparisons, alongside the existing matrix view.
  * Added paginated criterion browsing with consistent navigation across comparison and evaluation views.
  * Added criterion assessment editing, save, and “Save & Continue” actions, including cross-page progression.
  * Added retryable error states for evaluation data loading.
* **Bug Fixes**
  * Improved protection against losing unsaved changes with confirmation prompts, navigation blocking, and before-unload warnings.
  * Restoring discarded drafts now returns them to their last saved state.
* **Tests**
  * Added coverage for evaluation workflows, navigation guards, saving, pagination, errors, and draft handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->