### PR TITLE
feat(technical-configurations): add selected-option progress

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -2370,30 +2370,30 @@ draft loss, including deterministic save-next across page boundaries.
 
 ### Tasks
 
-- [ ] Start RED with a pure progress-model matrix covering zero/sparse/>100
+- [x] Start RED with a pure progress-model matrix covering zero/sparse/>100
       assessments, every derived status, repeated/mixed status distributions,
       exact group/option reconciliation and selected-option changes.
-- [ ] Build one immutable progress model from
+- [x] Build one immutable progress model from
       `useTechnicalConfigurationBaselineVersionSelection().selectedVersion`,
       whose `TechnicalConfigurationBaselineDraftWire.groups[].criteria[]`
       contains the complete ordered criterion universe for one locked version,
       and the selected option's complete assessment collection. Reconcile only
       by `criterion_id`; baseline-history pagination is across versions, not
       criteria.
-- [ ] Count only `not_evaluated` as incomplete; expose option totals, evaluated
+- [x] Count only `not_evaluated` as incomplete; expose option totals, evaluated
       totals, canonical status counters and compact group totals without adding
       filter or navigation state.
-- [ ] Render loading/error/no-comparison-set states without false
+- [x] Render loading/error/no-comparison-set states without false
       all-unassessed counters.
-- [ ] Adopt a successful mutation result into the complete assessment cache by
+- [x] Adopt a successful mutation result into the complete assessment cache by
       `criterion_id` before retaining the existing prefix invalidation,
       cancellation, pagination and exact error contracts.
-- [ ] Pass the complete `selectedVersion.groups[].criteria[]` snapshot into the
+- [x] Pass the complete `selectedVersion.groups[].criteria[]` snapshot into the
       active evaluation composition and extract summary/model ownership as
       needed so
       `TechnicalConfigurationEvaluationActiveWorkspace.tsx` stays below the
       450-line ceiling and does not absorb P12B2 navigation logic.
-- [ ] Add no migration, RPC, proxy path, query contract, ranking, scoring or AI.
+- [x] Add no migration, RPC, proxy path, query contract, ranking, scoring or AI.
 
 ### TDD and verification
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -639,7 +639,7 @@ Filter/navigation và task scope-guard P12B.4 không thuộc leaf này.
     đổi navigation, save-next, dirty/pending guards, DB/RPC/proxy/query contract.
 - Verification:
   - `format:check`, `verify:no-explicit-any`, `verify:dedupe`, `typecheck`: pass;
-  - focused P11D/P12A1/P12A2/P12B1: 11 files, 100 tests pass;
+  - focused P11D/P12A1/P12A2/P12B1: 12 files, 102 tests pass;
   - React Doctor changed-scope: 100/100, no issues;
   - `openspec validate add-technical-configuration-comparison --type change
 --strict --no-interactive`: valid.

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -601,22 +601,48 @@ chưa lưu` trong criterion navigator bằng icon/màu nhỏ.
 Legacy mapping: hoàn tất P12B.1 và phần counter/cache/integration của P12B.5.
 Filter/navigation và task scope-guard P12B.4 không thuộc leaf này.
 
-- [ ] P12B1.1 Chốt entry gate về group-summary density; recommended default là
+- [x] P12B1.1 Chốt entry gate về group-summary density; recommended default là
       `đã đánh giá / tổng`, không seven-status breakdown, percentage hoặc card grid.
-- [ ] P12B1.2 Viết RED tests dùng complete
+- [x] P12B1.2 Viết RED tests dùng complete
       `selectedVersion.groups[].criteria[]`, sparse/>100 assessments, đủ bảy
       derived statuses với repeated/mixed distributions, group/option totals
       reconcile và mỗi criterion đóng góp đúng một status theo `criterion_id`.
-- [ ] P12B1.3 Thêm selected-option progress model, option/group counters và
+- [x] P12B1.3 Thêm selected-option progress model, option/group counters và
       loading/error/no-comparison-set states; không thêm filter/navigation.
-- [ ] P12B1.4 Adopt assessment trả về sau save vào complete cache theo
+- [x] P12B1.4 Adopt assessment trả về sau save vào complete cache theo
       `criterion_id`, vẫn giữ prefix invalidation và P11D collection contracts.
-- [ ] P12B1.5 Truyền complete `selectedVersion.groups[].criteria[]` từ
+- [x] P12B1.5 Truyền complete `selectedVersion.groups[].criteria[]` từ
       `useTechnicalConfigurationBaselineVersionSelection` vào evaluation
       composition và extract summary/model ownership để active workspace không
       vượt file ceiling; không lấy denominator từ bounded comparison page.
-- [ ] P12B1.6 Viết counter/cache/workspace integration tests và khóa deploy state:
+- [x] P12B1.6 Viết counter/cache/workspace integration tests và khóa deploy state:
       summary đúng, existing navigation/save-next không đổi, không DB/RPC/proxy.
+
+### Evidence P12B1 - 2026-07-30
+
+- RED:
+  - pure progress tests fail vì production model chưa tồn tại;
+  - cache contract fail vì complete cache còn assessment revision 2 thay vì
+    mutation result revision 3;
+  - workspace integration fail vì selected-option summary và loading/error
+    progress states chưa được compose.
+- GREEN:
+  - pure model dùng complete `selectedVersion.groups[].criteria[]`, reconcile
+    assessment bằng `criterion_id`, cover zero/sparse/repeated/mixed/>100 và đủ
+    bảy derived statuses;
+  - summary chỉ hiện option đang chọn và compact group `đã đánh giá / tổng`,
+    không percentage, progressbar, card grid hoặc seven-status breakdown;
+  - successful save publish assessment vào complete cache trước prefix
+    invalidation; P11D consumer test giữ refetch pending để chứng minh immediate
+    adoption;
+  - `TechnicalConfigurationEvaluationActiveWorkspace.tsx` còn 347 dòng; không
+    đổi navigation, save-next, dirty/pending guards, DB/RPC/proxy/query contract.
+- Verification:
+  - `format:check`, `verify:no-explicit-any`, `verify:dedupe`, `typecheck`: pass;
+  - focused P11D/P12A1/P12A2/P12B1: 11 files, 100 tests pass;
+  - React Doctor changed-scope: 100/100, no issues;
+  - `openspec validate add-technical-configuration-comparison --type change
+--strict --no-interactive`: valid.
 
 ## Phase P12B2 - Filtered Guarded Navigation
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -639,7 +639,7 @@ Filter/navigation và task scope-guard P12B.4 không thuộc leaf này.
     đổi navigation, save-next, dirty/pending guards, DB/RPC/proxy/query contract.
 - Verification:
   - `format:check`, `verify:no-explicit-any`, `verify:dedupe`, `typecheck`: pass;
-  - focused P11D/P12A1/P12A2/P12B1: 12 files, 102 tests pass;
+  - focused P11D/P12A1/P12A2/P12B1: 12 files, 103 tests pass;
   - React Doctor changed-scope: 100/100, no issues;
   - `openspec validate add-technical-configuration-comparison --type change
 --strict --no-interactive`: valid.

--- a/src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts
@@ -22,6 +22,7 @@ import {
   comparisonSetId,
   criterionId,
   optionId,
+  savedAssessment,
 } from "./assessment-test-fixtures"
 
 const mocks = vi.hoisted(() => ({
@@ -136,14 +137,22 @@ describe("P11C assessment hook contract", () => {
     mocks.callRpc.mockImplementation((fn: string) => {
       if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
         expect(queryClient.getQueryData(comparisonSetQueryKey)).toEqual(comparisonSet)
-        return Promise.resolve({ data: assessment })
+        return Promise.resolve({ data: savedAssessment })
       }
       if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
         return Promise.resolve(assessmentListResponse)
       }
       return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
     })
-    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries")
+    const originalInvalidateQueries = queryClient.invalidateQueries.bind(queryClient)
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockImplementation((filters, options) => {
+        expect(queryClient.getQueryData(completeQueryKey)).toEqual({
+          [criterionId]: savedAssessment,
+        })
+        return originalInvalidateQueries(filters, options)
+      })
     const { result } = renderAssessmentsHook(queryClient)
 
     await waitFor(() => expect(result.current.comparisonSetQuery.isSuccess).toBe(true))
@@ -175,7 +184,10 @@ describe("P11C assessment hook contract", () => {
       },
       { signal: undefined }
     )
-    expect(saved).toEqual({ comparisonSet, assessment })
+    expect(saved).toEqual({ comparisonSet, assessment: savedAssessment })
+    expect(queryClient.getQueryData(completeQueryKey)).toEqual({
+      [criterionId]: savedAssessment,
+    })
     expect(invalidateQueries).toHaveBeenCalledWith({
       queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
     })

--- a/src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/assessment-hook-contract.test.ts
@@ -93,6 +93,34 @@ describe("P11C assessment hook contract", () => {
     expect(mocks.callRpc).toHaveBeenCalledTimes(1)
   })
 
+  it("does not synthesize a complete collection when bounded save has not loaded it", async () => {
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        return Promise.resolve(assessmentListResponse)
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        return Promise.resolve({ data: savedAssessment })
+      }
+      return Promise.reject(new Error(`Unexpected RPC: ${fn}`))
+    })
+    const queryClient = createAssessmentTestQueryClient()
+    const completeQueryKey = [
+      ...technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
+      "complete",
+    ] as const
+    const { result } = renderAssessmentsHook(queryClient)
+
+    await waitFor(() => expect(result.current.assessmentsQuery.isSuccess).toBe(true))
+    expect(queryClient.getQueryData(completeQueryKey)).toBeUndefined()
+
+    await act(async () => {
+      await result.current.upsertAssessment.mutateAsync(assessmentUpsertInput)
+    })
+
+    expect(queryClient.getQueryData(completeQueryKey)).toBeUndefined()
+  })
+
   it("keeps an invalid assessment page disabled after the comparison set loads", async () => {
     mocks.readComparisonSet.mockResolvedValue(comparisonSet)
     const queryClient = createAssessmentTestQueryClient()

--- a/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/evaluation-draft-state.test.tsx
@@ -23,6 +23,14 @@ import {
 const mocks = getEvaluationDraftMocks()
 const otherComparisonSetId = "00000000-0000-0000-0000-000000000010"
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 describe("P12A1 evaluation draft state", () => {
   beforeEach(() => resetEvaluationDraftMocks(mocks))
 
@@ -79,6 +87,55 @@ describe("P12A1 evaluation draft state", () => {
       },
       { signal: undefined }
     )
+  })
+
+  it("publishes the saved assessment before the complete-cache refetch finishes", async () => {
+    const refetch = createDeferred<TechnicalConfigurationAssessmentListWireResponse>()
+    let hasSaved = false
+    mocks.readComparisonSet.mockResolvedValue(comparisonSet)
+    mocks.callRpc.mockImplementation((fn: string) => {
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.listAssessments) {
+        if (hasSaved) return refetch.promise
+        return Promise.resolve({
+          data: [assessment],
+          total: 1,
+          page: 1,
+          page_size: 100,
+        })
+      }
+      if (fn === ASSESSMENT_RPC_FUNCTIONS.upsertAssessment) {
+        hasSaved = true
+        return Promise.resolve({ data: savedAssessment })
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+    const { result } = renderEvaluationDraftHook()
+
+    await waitFor(() => expect(result.current.isReady).toBe(true))
+    act(() => {
+      result.current.setTechnicalAxis("exceeds")
+      result.current.setEvidenceAxis("complete")
+      result.current.setNotes("Đã xác nhận.")
+    })
+
+    let savePromise!: Promise<unknown>
+    act(() => {
+      savePromise = result.current.save()
+    })
+
+    await waitFor(() =>
+      expect(result.current.assessmentsByCriterionId[criterionId]).toEqual(savedAssessment)
+    )
+
+    refetch.resolve({
+      data: [savedAssessment],
+      total: 1,
+      page: 1,
+      page_size: 100,
+    })
+    await act(async () => {
+      await savePromise
+    })
   })
 
   it("saves the latest draft update when editing and saving in one turn", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  TechnicalConfigurationDerivedStatus,
+  TechnicalConfigurationEvidenceAxis,
+  TechnicalConfigurationTechnicalAxis,
+} from "@/lib/technical-configuration-evaluation"
+import {
+  buildTechnicalConfigurationEvaluationProgress,
+  type TechnicalConfigurationEvaluationProgress,
+} from "../_components/evaluation/technical-configuration-evaluation-progress"
+import type { TechnicalConfigurationAssessmentWire } from "../assessment-types"
+import type {
+  TechnicalConfigurationBaselineCriterionWire,
+  TechnicalConfigurationBaselineGroupWire,
+} from "../baseline-types"
+
+const STATUS_AXES: Record<
+  TechnicalConfigurationDerivedStatus,
+  readonly [TechnicalConfigurationTechnicalAxis | null, TechnicalConfigurationEvidenceAxis | null]
+> = {
+  not_evaluated: [null, null],
+  not_applicable: ["not_applicable", null],
+  fails: ["fails", null],
+  unclear: ["unclear", null],
+  insufficient_evidence: ["meets", "partial"],
+  exceeds: ["exceeds", "complete"],
+  meets: ["meets", "complete"],
+}
+
+function createCriterion(
+  groupId: string,
+  index: number
+): TechnicalConfigurationBaselineCriterionWire {
+  const id = `${groupId}-criterion-${index}`
+  return {
+    id,
+    baseline_version_id: "baseline-1",
+    group_id: groupId,
+    criterion_code: `TC-${index.toString().padStart(3, "0")}`,
+    title: `Tiêu chí ${index}`,
+    requirement_text: `Yêu cầu ${index}`,
+    sort_order: index,
+    source_criterion_id: null,
+    created_at: "2026-07-30T00:00:00.000Z",
+    created_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+  }
+}
+
+function createGroup(
+  id: string,
+  name: string,
+  criterionCount: number
+): TechnicalConfigurationBaselineGroupWire {
+  return {
+    id,
+    baseline_version_id: "baseline-1",
+    name,
+    sort_order: Number(id.replace(/\D/g, "")) || 1,
+    created_at: "2026-07-30T00:00:00.000Z",
+    created_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+    criteria: Array.from({ length: criterionCount }, (_, index) => createCriterion(id, index + 1)),
+  }
+}
+
+function createAssessment(
+  criterionId: string,
+  status: TechnicalConfigurationDerivedStatus,
+  optionId = "option-1"
+): TechnicalConfigurationAssessmentWire {
+  const [technicalAxis, evidenceAxis] = STATUS_AXES[status]
+  return {
+    id: `${optionId}-${criterionId}`,
+    comparison_set_id: `comparison-set-${optionId}`,
+    baseline_version_id: "baseline-1",
+    criterion_id: criterionId,
+    technical_axis: technicalAxis,
+    evidence_axis: evidenceAxis,
+    notes: "",
+    revision: 1,
+    created_by: 1,
+    created_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
+  }
+}
+
+function expectReconciledTotals(progress: TechnicalConfigurationEvaluationProgress): void {
+  expect(progress.groups.reduce((sum, group) => sum + group.total, 0)).toBe(progress.total)
+  expect(progress.groups.reduce((sum, group) => sum + group.evaluated, 0)).toBe(progress.evaluated)
+  expect(Object.values(progress.statusCounts).reduce((sum, count) => sum + count, 0)).toBe(
+    progress.total
+  )
+}
+
+describe("P12B1 selected-option evaluation progress", () => {
+  it("returns a stable zero model for an empty criterion universe", () => {
+    const progress = buildTechnicalConfigurationEvaluationProgress({
+      groups: [],
+      assessments: [],
+    })
+
+    expect(progress).toEqual({
+      total: 0,
+      evaluated: 0,
+      statusCounts: {
+        not_evaluated: 0,
+        not_applicable: 0,
+        fails: 0,
+        unclear: 0,
+        insufficient_evidence: 0,
+        exceeds: 0,
+        meets: 0,
+      },
+      groups: [],
+    })
+  })
+
+  it("reconciles sparse mixed and repeated statuses by criterion_id", () => {
+    const groups = [
+      createGroup("group-1", "Thông số chính", 4),
+      createGroup("group-2", "An toàn", 5),
+    ]
+    const assessments = [
+      createAssessment("group-2-criterion-4", "meets"),
+      createAssessment("group-1-criterion-3", "unclear"),
+      createAssessment("group-2-criterion-1", "insufficient_evidence"),
+      createAssessment("criterion-outside-selected-version", "exceeds"),
+      createAssessment("group-1-criterion-1", "not_applicable"),
+      createAssessment("group-1-criterion-4", "not_evaluated"),
+      createAssessment("group-2-criterion-3", "meets"),
+      createAssessment("group-1-criterion-2", "fails"),
+      createAssessment("group-2-criterion-2", "exceeds"),
+    ]
+
+    const progress = buildTechnicalConfigurationEvaluationProgress({ groups, assessments })
+
+    expect(progress).toEqual({
+      total: 9,
+      evaluated: 7,
+      statusCounts: {
+        not_evaluated: 2,
+        not_applicable: 1,
+        fails: 1,
+        unclear: 1,
+        insufficient_evidence: 1,
+        exceeds: 1,
+        meets: 2,
+      },
+      groups: [
+        {
+          id: "group-1",
+          name: "Thông số chính",
+          total: 4,
+          evaluated: 3,
+        },
+        {
+          id: "group-2",
+          name: "An toàn",
+          total: 5,
+          evaluated: 4,
+        },
+      ],
+    })
+    expectReconciledTotals(progress)
+  })
+
+  it("uses the complete baseline universe when it contains more than 100 criteria", () => {
+    const groups = [createGroup("group-1", "Nhóm một", 60), createGroup("group-2", "Nhóm hai", 55)]
+    const assessments = groups
+      .flatMap((group) => group.criteria)
+      .slice(0, 100)
+      .map((criterion) => createAssessment(criterion.id, "meets"))
+
+    const progress = buildTechnicalConfigurationEvaluationProgress({ groups, assessments })
+
+    expect(progress.total).toBe(115)
+    expect(progress.evaluated).toBe(100)
+    expect(progress.statusCounts.not_evaluated).toBe(15)
+    expect(progress.statusCounts.meets).toBe(100)
+    expect(progress.groups).toEqual([
+      { id: "group-1", name: "Nhóm một", total: 60, evaluated: 60 },
+      { id: "group-2", name: "Nhóm hai", total: 55, evaluated: 40 },
+    ])
+    expectReconciledTotals(progress)
+  })
+
+  it("derives progress only from the currently selected option assessments", () => {
+    const groups = [createGroup("group-1", "Thông số chính", 3)]
+    const optionAProgress = buildTechnicalConfigurationEvaluationProgress({
+      groups,
+      assessments: [
+        createAssessment("group-1-criterion-1", "meets", "option-a"),
+        createAssessment("group-1-criterion-2", "fails", "option-a"),
+      ],
+    })
+    const optionBProgress = buildTechnicalConfigurationEvaluationProgress({
+      groups,
+      assessments: [createAssessment("group-1-criterion-3", "exceeds", "option-b")],
+    })
+
+    expect(optionAProgress.evaluated).toBe(2)
+    expect(optionAProgress.statusCounts.fails).toBe(1)
+    expect(optionBProgress.evaluated).toBe(1)
+    expect(optionBProgress.statusCounts.fails).toBe(0)
+    expect(optionBProgress.statusCounts.exceeds).toBe(1)
+    expectReconciledTotals(optionAProgress)
+    expectReconciledTotals(optionBProgress)
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-progress.test.ts
@@ -8,12 +8,12 @@ import type {
 import {
   buildTechnicalConfigurationEvaluationProgress,
   type TechnicalConfigurationEvaluationProgress,
-} from "../_components/evaluation/technical-configuration-evaluation-progress"
-import type { TechnicalConfigurationAssessmentWire } from "../assessment-types"
+} from "@/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress"
+import type { TechnicalConfigurationAssessmentWire } from "@/app/(app)/technical-configurations/assessment-types"
 import type {
   TechnicalConfigurationBaselineCriterionWire,
   TechnicalConfigurationBaselineGroupWire,
-} from "../baseline-types"
+} from "@/app/(app)/technical-configurations/baseline-types"
 
 const STATUS_AXES: Record<
   TechnicalConfigurationDerivedStatus,

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test-support.ts
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test-support.ts
@@ -5,6 +5,11 @@ import type {
   TechnicalConfigurationComparisonCriterionRow,
   TechnicalConfigurationComparisonResult,
 } from "../comparison-types"
+import type { TechnicalConfigurationAssessmentWire } from "../assessment-types"
+import type {
+  TechnicalConfigurationBaselineCriterionWire,
+  TechnicalConfigurationBaselineGroupWire,
+} from "../baseline-types"
 import type { TechnicalConfigurationOptionWire } from "../supplier-option-types"
 import type { TechnicalConfigurationDossierWire } from "../types"
 
@@ -38,6 +43,79 @@ export function createOption(id: string, displayLabel: string): TechnicalConfigu
     updated_at: "2026-07-30T00:00:00.000Z",
     updated_by: 1,
     revision: 1,
+  }
+}
+
+function createBaselineCriterion(
+  id: string,
+  groupId: string,
+  sortOrder: number
+): TechnicalConfigurationBaselineCriterionWire {
+  return {
+    id,
+    baseline_version_id: "baseline-1",
+    group_id: groupId,
+    criterion_code: `TC-0${sortOrder}`,
+    title: `Tiêu chí ${sortOrder}`,
+    requirement_text: `Yêu cầu ${sortOrder}`,
+    sort_order: sortOrder,
+    source_criterion_id: null,
+    created_at: "2026-07-30T00:00:00.000Z",
+    created_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+  }
+}
+
+export function createBaselineGroups(): TechnicalConfigurationBaselineGroupWire[] {
+  return [
+    {
+      id: "group-1",
+      baseline_version_id: "baseline-1",
+      name: "Thông số chính",
+      sort_order: 1,
+      created_at: "2026-07-30T00:00:00.000Z",
+      created_by: 1,
+      updated_at: "2026-07-30T00:00:00.000Z",
+      updated_by: 1,
+      criteria: [
+        createBaselineCriterion("criterion-1", "group-1", 1),
+        createBaselineCriterion("criterion-2", "group-1", 2),
+      ],
+    },
+    {
+      id: "group-2",
+      baseline_version_id: "baseline-1",
+      name: "An toàn",
+      sort_order: 2,
+      created_at: "2026-07-30T00:00:00.000Z",
+      created_by: 1,
+      updated_at: "2026-07-30T00:00:00.000Z",
+      updated_by: 1,
+      criteria: [createBaselineCriterion("criterion-3", "group-2", 3)],
+    },
+  ]
+}
+
+export function createEvaluationAssessment(
+  optionId: string,
+  criterionId: string,
+  technicalAxis: TechnicalConfigurationAssessmentWire["technical_axis"],
+  evidenceAxis: TechnicalConfigurationAssessmentWire["evidence_axis"]
+): TechnicalConfigurationAssessmentWire {
+  return {
+    id: `${optionId}-${criterionId}`,
+    comparison_set_id: `comparison-set-${optionId}`,
+    baseline_version_id: "baseline-1",
+    criterion_id: criterionId,
+    technical_axis: technicalAxis,
+    evidence_axis: evidenceAxis,
+    notes: "",
+    revision: 1,
+    created_by: 1,
+    created_at: "2026-07-30T00:00:00.000Z",
+    updated_by: 1,
+    updated_at: "2026-07-30T00:00:00.000Z",
   }
 }
 

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
@@ -5,9 +5,12 @@ import userEvent from "@testing-library/user-event"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TechnicalConfigurationEvaluationWorkspace } from "../_components/evaluation/TechnicalConfigurationEvaluationWorkspace"
+import type { TechnicalConfigurationAssessmentWire } from "../assessment-types"
 import {
+  createBaselineGroups,
   createComparisonResult,
   createDraft,
+  createEvaluationAssessment,
   createOption,
   dossier,
   getCriterion,
@@ -15,7 +18,12 @@ import {
 } from "./technical-configuration-evaluation-workspace.test-support"
 
 const mocks = vi.hoisted(() => ({
+  assessmentsByOptionId: {} as Record<
+    string,
+    Readonly<Record<string, TechnicalConfigurationAssessmentWire>>
+  >,
   assessmentQueryError: null as Error | null,
+  assessmentQueryLoading: false,
   comparisonSetQueryError: null as Error | null,
   discard: vi.fn(),
   refetchAssessment: vi.fn(),
@@ -32,7 +40,7 @@ vi.mock("../_hooks/useTechnicalConfigurationBaselineVersionSelection", () => ({
       version_number: 2,
       status: "locked",
       revision: 4,
-      groups: [],
+      groups: createBaselineGroups(),
     },
     synchronizeVersion: mocks.synchronizeVersion,
     versionState: {
@@ -151,9 +159,9 @@ vi.mock("../_hooks/useTechnicalConfigurationEvaluationDraft", async () => {
       }, [baselineVersionId, criterionId, onDossierRevisionChange, optionId])
 
       return {
-        assessmentsByCriterionId: {},
+        assessmentsByCriterionId: mocks.assessmentsByOptionId[optionId] ?? {},
         assessmentQuery: {
-          isLoading: false,
+          isLoading: mocks.assessmentQueryLoading,
           isError: mocks.assessmentQueryError !== null,
           error: mocks.assessmentQueryError,
           refetch: mocks.refetchAssessment,
@@ -202,9 +210,46 @@ afterAll(() => {
 describe("P12A2 technical configuration evaluation workspace", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.assessmentsByOptionId = {
+      "option-1": {
+        "criterion-1": createEvaluationAssessment("option-1", "criterion-1", "meets", "complete"),
+        "criterion-2": createEvaluationAssessment("option-1", "criterion-2", "fails", null),
+      },
+      "option-2": {
+        "criterion-3": createEvaluationAssessment("option-2", "criterion-3", "exceeds", "complete"),
+      },
+    }
     mocks.assessmentQueryError = null
+    mocks.assessmentQueryLoading = false
     mocks.comparisonSetQueryError = null
     mocks.save.mockResolvedValue({})
+  })
+
+  it("renders progress only for the selected option across the complete baseline universe", async () => {
+    const user = userEvent.setup()
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    expect(await screen.findByText("Đã đánh giá 2 / 3 tiêu chí")).toBeInTheDocument()
+    expect(screen.getByText("2 / 2")).toBeInTheDocument()
+    expect(screen.getByText("0 / 1")).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText("Phương án đánh giá"))
+    await user.click(await screen.findByRole("option", { name: "Nhà cung cấp B · Model B" }))
+
+    expect(await screen.findByText("Đã đánh giá 1 / 3 tiêu chí")).toBeInTheDocument()
+    expect(screen.getByText("0 / 2")).toBeInTheDocument()
+    expect(screen.getByText("1 / 1")).toBeInTheDocument()
+    expect(screen.queryByText("Đã đánh giá 2 / 3 tiêu chí")).not.toBeInTheDocument()
+  })
+
+  it("does not render false progress counters while complete assessments are loading", () => {
+    mocks.assessmentQueryLoading = true
+
+    render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
+
+    expect(screen.getByText("Đang tải tiến độ đánh giá...")).toBeInTheDocument()
+    expect(screen.queryByText(/Đã đánh giá \d+ \/ 3 tiêu chí/)).not.toBeInTheDocument()
   })
 
   it("keeps Lưu on the criterion and advances Lưu & tiếp tục across page boundaries", async () => {
@@ -320,6 +365,8 @@ describe("P12A2 technical configuration evaluation workspace", () => {
     render(<TechnicalConfigurationEvaluationWorkspace dossier={dossier} />)
 
     expect(await screen.findByText("Không thể tải dữ liệu đánh giá")).toBeInTheDocument()
+    expect(screen.getByText("Chưa thể tính tiến độ đánh giá.")).toBeInTheDocument()
+    expect(screen.queryByText(/Đã đánh giá \d+ \/ 3 tiêu chí/)).not.toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: "Thử lại" }))
 
     expect(mocks.refetchAssessment).toHaveBeenCalledTimes(1)

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-evaluation-workspace.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event"
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TechnicalConfigurationEvaluationWorkspace } from "../_components/evaluation/TechnicalConfigurationEvaluationWorkspace"
-import type { TechnicalConfigurationAssessmentWire } from "../assessment-types"
+import type { TechnicalConfigurationAssessmentWire } from "@/app/(app)/technical-configurations/assessment-types"
 import {
   createBaselineGroups,
   createComparisonResult,

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx
@@ -1,0 +1,111 @@
+import "@testing-library/jest-dom"
+import { render, screen, within } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { TechnicalConfigurationProgressSummary } from "../_components/evaluation/TechnicalConfigurationProgressSummary"
+import type { TechnicalConfigurationEvaluationProgress } from "../_components/evaluation/technical-configuration-evaluation-progress"
+
+const progress: TechnicalConfigurationEvaluationProgress = {
+  total: 6,
+  evaluated: 4,
+  statusCounts: {
+    not_evaluated: 2,
+    not_applicable: 1,
+    fails: 1,
+    unclear: 0,
+    insufficient_evidence: 1,
+    exceeds: 0,
+    meets: 1,
+  },
+  groups: [
+    { id: "group-1", name: "Thông số chính", total: 4, evaluated: 3 },
+    { id: "group-2", name: "An toàn", total: 2, evaluated: 1 },
+  ],
+}
+
+describe("P12B1 technical configuration progress summary", () => {
+  it("renders compact selected-option and group evaluated totals only", () => {
+    render(
+      <TechnicalConfigurationProgressSummary
+        progress={progress}
+        isLoading={false}
+        isError={false}
+      />
+    )
+
+    const summary = screen.getByRole("region", { name: "Tiến độ đánh giá" })
+    expect(within(summary).getByText("Đã đánh giá 4 / 6 tiêu chí")).toBeInTheDocument()
+
+    const groupRows = within(summary).getAllByTestId("evaluation-progress-group")
+    expect(groupRows).toHaveLength(2)
+    expect(within(groupRows[0]!).getByText("Thông số chính")).toBeInTheDocument()
+    expect(within(groupRows[0]!).getByText("3 / 4")).toBeInTheDocument()
+    expect(within(groupRows[1]!).getByText("An toàn")).toBeInTheDocument()
+    expect(within(groupRows[1]!).getByText("1 / 2")).toBeInTheDocument()
+
+    expect(within(summary).queryByRole("progressbar")).not.toBeInTheDocument()
+    expect(within(summary).queryByText(/%/)).not.toBeInTheDocument()
+    for (const statusLabel of [
+      "Chưa đánh giá",
+      "Không áp dụng",
+      "Không đạt",
+      "Chưa rõ",
+      "Chưa đủ bằng chứng",
+      "Vượt yêu cầu",
+      "Đạt",
+    ]) {
+      expect(within(summary).queryByText(statusLabel, { exact: true })).not.toBeInTheDocument()
+    }
+  })
+
+  it("does not render false all-unassessed counters while progress is loading or failed", () => {
+    const { rerender } = render(
+      <TechnicalConfigurationProgressSummary
+        progress={{ ...progress, evaluated: 0 }}
+        isLoading
+        isError={false}
+      />
+    )
+
+    expect(screen.getByText("Đang tải tiến độ đánh giá...")).toBeInTheDocument()
+    expect(screen.queryByText("Đã đánh giá 0 / 6 tiêu chí")).not.toBeInTheDocument()
+
+    rerender(
+      <TechnicalConfigurationProgressSummary
+        progress={{ ...progress, evaluated: 0 }}
+        isLoading={false}
+        isError
+      />
+    )
+
+    expect(screen.getByText("Chưa thể tính tiến độ đánh giá.")).toBeInTheDocument()
+    expect(screen.queryByText("Đã đánh giá 0 / 6 tiêu chí")).not.toBeInTheDocument()
+  })
+
+  it("renders a truthful zero counter when the selected option has no comparison set", () => {
+    render(
+      <TechnicalConfigurationProgressSummary
+        progress={{
+          ...progress,
+          evaluated: 0,
+          statusCounts: {
+            not_evaluated: 6,
+            not_applicable: 0,
+            fails: 0,
+            unclear: 0,
+            insufficient_evidence: 0,
+            exceeds: 0,
+            meets: 0,
+          },
+          groups: progress.groups.map((group) => ({ ...group, evaluated: 0 })),
+        }}
+        isLoading={false}
+        isError={false}
+      />
+    )
+
+    expect(screen.getByText("Đã đánh giá 0 / 6 tiêu chí")).toBeInTheDocument()
+    expect(screen.getByText("0 / 4")).toBeInTheDocument()
+    expect(screen.getByText("0 / 2")).toBeInTheDocument()
+  })
+})

--- a/src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/technical-configuration-progress-summary.test.tsx
@@ -2,8 +2,8 @@ import "@testing-library/jest-dom"
 import { render, screen, within } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
-import { TechnicalConfigurationProgressSummary } from "../_components/evaluation/TechnicalConfigurationProgressSummary"
-import type { TechnicalConfigurationEvaluationProgress } from "../_components/evaluation/technical-configuration-evaluation-progress"
+import { TechnicalConfigurationProgressSummary } from "@/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary"
+import type { TechnicalConfigurationEvaluationProgress } from "@/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress"
 
 const progress: TechnicalConfigurationEvaluationProgress = {
   total: 6,
@@ -34,7 +34,9 @@ describe("P12B1 technical configuration progress summary", () => {
     )
 
     const summary = screen.getByRole("region", { name: "Tiến độ đánh giá" })
-    expect(within(summary).getByText("Đã đánh giá 4 / 6 tiêu chí")).toBeInTheDocument()
+    const evaluatedOutput = within(summary).getByText("Đã đánh giá 4 / 6 tiêu chí")
+    expect(evaluatedOutput).toBeInTheDocument()
+    expect(evaluatedOutput.tagName).toBe("OUTPUT")
 
     const groupRows = within(summary).getAllByTestId("evaluation-progress-group")
     expect(groupRows).toHaveLength(2)

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -16,7 +16,7 @@ import {
 import { useTechnicalConfigurationComparison } from "../../_hooks/useTechnicalConfigurationComparison"
 import { useTechnicalConfigurationEvaluationDraft } from "../../_hooks/useTechnicalConfigurationEvaluationDraft"
 import { useTechnicalConfigurationGuardedNavigation } from "../../_hooks/useTechnicalConfigurationGuardedNavigation"
-import type { TechnicalConfigurationBaselineGroupWire } from "../../baseline-types"
+import type { TechnicalConfigurationBaselineGroupWire } from "@/app/(app)/technical-configurations/baseline-types"
 import { TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE } from "../../comparison-matrix-constants"
 import type {
   TechnicalConfigurationComparisonCriterionRow,

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationActiveWorkspace.tsx
@@ -16,6 +16,7 @@ import {
 import { useTechnicalConfigurationComparison } from "../../_hooks/useTechnicalConfigurationComparison"
 import { useTechnicalConfigurationEvaluationDraft } from "../../_hooks/useTechnicalConfigurationEvaluationDraft"
 import { useTechnicalConfigurationGuardedNavigation } from "../../_hooks/useTechnicalConfigurationGuardedNavigation"
+import type { TechnicalConfigurationBaselineGroupWire } from "../../baseline-types"
 import { TECHNICAL_CONFIGURATION_CRITERION_PAGE_SIZE } from "../../comparison-matrix-constants"
 import type {
   TechnicalConfigurationComparisonCriterionRow,
@@ -26,13 +27,20 @@ import { toTechnicalConfigurationComparisonOption } from "../../technical-config
 import type { TechnicalConfigurationDossierWire } from "../../types"
 import { TechnicalConfigurationCriterionPagination } from "../comparison/TechnicalConfigurationCriterionPagination"
 import { createTechnicalConfigurationOptionCriterionDetail } from "../comparison/technical-configuration-criterion-detail"
+import { buildTechnicalConfigurationEvaluationProgress } from "./technical-configuration-evaluation-progress"
 import { TechnicalConfigurationCriterionList } from "./TechnicalConfigurationCriterionList"
 import { TechnicalConfigurationEvaluationLoadError } from "./TechnicalConfigurationEvaluationLoadError"
 import { TechnicalConfigurationEvaluationPanel } from "./TechnicalConfigurationEvaluationPanel"
+import { TechnicalConfigurationProgressSummary } from "./TechnicalConfigurationProgressSummary"
+import {
+  resolveTechnicalConfigurationCriterionId,
+  toTechnicalConfigurationSaveErrorMessage,
+} from "./TechnicalConfigurationEvaluationWorkspaceUtils"
 
 type TechnicalConfigurationEvaluationActiveWorkspaceProps = {
   dossier: TechnicalConfigurationDossierWire
   baselineVersionId: string
+  baselineGroups: TechnicalConfigurationBaselineGroupWire[]
   options: TechnicalConfigurationOptionWire[]
   onDirtyChange: (dirty: boolean) => void
   onNavigationBlockedChange: (blocked: boolean) => void
@@ -41,24 +49,11 @@ type TechnicalConfigurationEvaluationActiveWorkspaceProps = {
 
 const EMPTY_CRITERIA: TechnicalConfigurationComparisonCriterionRow[] = []
 
-function toSaveErrorMessage(error: unknown): string {
-  return error instanceof Error && error.message ? error.message : "Không thể lưu đánh giá."
-}
-
-function resolveCriterionId(
-  criteria: TechnicalConfigurationComparisonCriterionRow[],
-  requestedCriterionId: string | null
-): string | null {
-  if (requestedCriterionId && criteria.some((row) => row.criterion.id === requestedCriterionId)) {
-    return requestedCriterionId
-  }
-  return criteria[0]?.criterion.id ?? null
-}
-
 /** Owns the selected option, page, criterion and P12A1 draft for evaluation mode. */
 export function TechnicalConfigurationEvaluationActiveWorkspace({
   dossier,
   baselineVersionId,
+  baselineGroups,
   options,
   onDirtyChange,
   onNavigationBlockedChange,
@@ -79,7 +74,7 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
   })
   const result = comparison.comparisonQuery.data
   const criteria = result?.data.criteria ?? EMPTY_CRITERIA
-  const criterionId = resolveCriterionId(criteria, requestedCriterionId)
+  const criterionId = resolveTechnicalConfigurationCriterionId(criteria, requestedCriterionId)
   const currentRow = criteria.find((row) => row.criterion.id === criterionId) ?? null
   const evaluation = useTechnicalConfigurationEvaluationDraft({
     optionId: activeSelectedOptionId,
@@ -115,6 +110,14 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
   const evaluationReadError = isComparisonSetQueryError
     ? comparisonSetQueryError
     : assessmentQueryError
+  const progress = React.useMemo(
+    () =>
+      buildTechnicalConfigurationEvaluationProgress({
+        groups: baselineGroups,
+        assessments: Object.values(evaluation.assessmentsByCriterionId),
+      }),
+    [baselineGroups, evaluation.assessmentsByCriterionId]
+  )
 
   React.useEffect(() => {
     // react-doctor-disable-next-line react-doctor/no-pass-live-state-to-parent, react-doctor/no-pass-data-to-parent, react-doctor/no-prop-callback-in-effect -- P12A2 exposes one criterion-local draft to every enclosing navigation boundary.
@@ -249,6 +252,12 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
         </Select>
       </div>
 
+      <TechnicalConfigurationProgressSummary
+        progress={progress}
+        isLoading={comparisonSetQuery.isLoading || assessmentQuery.isLoading}
+        isError={hasEvaluationReadError}
+      />
+
       {comparison.comparisonQuery.isLoading ? (
         <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="size-4 animate-spin" aria-hidden="true" />
@@ -303,7 +312,9 @@ export function TechnicalConfigurationEvaluationActiveWorkspace({
         onNotesChange={evaluation.setNotes}
         disabled={Boolean(dossier.archived_at)}
         loading={!evaluation.isReady}
-        errorMessage={evaluation.error ? toSaveErrorMessage(evaluation.error) : null}
+        errorMessage={
+          evaluation.error ? toTechnicalConfigurationSaveErrorMessage(evaluation.error) : null
+        }
         actions={
           <>
             <Button

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspace.tsx
@@ -128,6 +128,7 @@ export function TechnicalConfigurationEvaluationWorkspace({
     <TechnicalConfigurationEvaluationActiveWorkspace
       dossier={dossier}
       baselineVersionId={selection.selectedVersion.id}
+      baselineGroups={selection.selectedVersion.groups}
       options={options}
       onDirtyChange={setIsDirty}
       onNavigationBlockedChange={setIsNavigationBlocked}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspaceUtils.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspaceUtils.ts
@@ -1,4 +1,4 @@
-import type { TechnicalConfigurationComparisonCriterionRow } from "../../comparison-types"
+import type { TechnicalConfigurationComparisonCriterionRow } from "@/app/(app)/technical-configurations/comparison-types"
 
 /** Normalizes an unknown assessment save failure for the evaluation panel. */
 export function toTechnicalConfigurationSaveErrorMessage(error: unknown): string {

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspaceUtils.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationEvaluationWorkspaceUtils.ts
@@ -1,0 +1,17 @@
+import type { TechnicalConfigurationComparisonCriterionRow } from "../../comparison-types"
+
+/** Normalizes an unknown assessment save failure for the evaluation panel. */
+export function toTechnicalConfigurationSaveErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : "Không thể lưu đánh giá."
+}
+
+/** Keeps the requested criterion when it exists on the current bounded page. */
+export function resolveTechnicalConfigurationCriterionId(
+  criteria: TechnicalConfigurationComparisonCriterionRow[],
+  requestedCriterionId: string | null
+): string | null {
+  if (requestedCriterionId && criteria.some((row) => row.criterion.id === requestedCriterionId)) {
+    return requestedCriterionId
+  }
+  return criteria[0]?.criterion.id ?? null
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary.tsx
@@ -1,0 +1,65 @@
+import type { TechnicalConfigurationEvaluationProgress } from "./technical-configuration-evaluation-progress"
+
+type TechnicalConfigurationProgressSummaryProps = {
+  progress: TechnicalConfigurationEvaluationProgress
+  isLoading: boolean
+  isError: boolean
+}
+
+/** Renders compact selected-option progress without scoring or status breakdowns. */
+export function TechnicalConfigurationProgressSummary({
+  progress,
+  isLoading,
+  isError,
+}: Readonly<TechnicalConfigurationProgressSummaryProps>) {
+  if (isLoading) {
+    return (
+      <section className="border-y py-3" aria-label="Tiến độ đánh giá">
+        <p className="text-sm text-muted-foreground" role="status">
+          Đang tải tiến độ đánh giá...
+        </p>
+      </section>
+    )
+  }
+
+  if (isError) {
+    return (
+      <section className="border-y py-3" aria-label="Tiến độ đánh giá">
+        <p className="text-sm text-destructive" role="alert">
+          Chưa thể tính tiến độ đánh giá.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="border-y py-3" aria-label="Tiến độ đánh giá">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <h3 className="text-sm font-medium">Tiến độ đánh giá</h3>
+          <p className="text-sm tabular-nums text-muted-foreground">
+            Đã đánh giá {progress.evaluated} / {progress.total} tiêu chí
+          </p>
+        </div>
+        {progress.groups.length > 0 ? (
+          <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">
+            {progress.groups.map((group) => (
+              <div
+                key={group.id}
+                className="flex min-w-0 items-baseline justify-between gap-3 text-sm"
+                data-testid="evaluation-progress-group"
+              >
+                <dt className="min-w-0 truncate text-muted-foreground" title={group.name}>
+                  {group.name}
+                </dt>
+                <dd className="shrink-0 tabular-nums font-medium">
+                  {group.evaluated} / {group.total}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary.tsx
+++ b/src/app/(app)/technical-configurations/_components/evaluation/TechnicalConfigurationProgressSummary.tsx
@@ -37,9 +37,9 @@ export function TechnicalConfigurationProgressSummary({
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-baseline justify-between gap-2">
           <h3 className="text-sm font-medium">Tiến độ đánh giá</h3>
-          <p className="text-sm tabular-nums text-muted-foreground">
+          <output className="text-sm tabular-nums text-muted-foreground">
             Đã đánh giá {progress.evaluated} / {progress.total} tiêu chí
-          </p>
+          </output>
         </div>
         {progress.groups.length > 0 ? (
           <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress.ts
@@ -3,8 +3,8 @@ import {
   type TechnicalConfigurationDerivedStatus,
 } from "@/lib/technical-configuration-evaluation"
 
-import type { TechnicalConfigurationAssessmentWire } from "../../assessment-types"
-import type { TechnicalConfigurationBaselineGroupWire } from "../../baseline-types"
+import type { TechnicalConfigurationAssessmentWire } from "@/app/(app)/technical-configurations/assessment-types"
+import type { TechnicalConfigurationBaselineGroupWire } from "@/app/(app)/technical-configurations/baseline-types"
 
 /** Compact progress for one canonical baseline group. */
 export type TechnicalConfigurationEvaluationGroupProgress = Readonly<{
@@ -47,7 +47,7 @@ export function buildTechnicalConfigurationEvaluationProgress({
   const assessmentsByCriterionId = new Map(
     assessments.map((assessment) => [assessment.criterion_id, assessment])
   )
-  const statusCounts = createEmptyStatusCounts()
+  let statusCounts = createEmptyStatusCounts()
   let evaluated = 0
 
   const groupProgress = groups.map((group) => {
@@ -59,7 +59,10 @@ export function buildTechnicalConfigurationEvaluationProgress({
         assessment?.technical_axis,
         assessment?.evidence_axis
       )
-      statusCounts[status] += 1
+      statusCounts = {
+        ...statusCounts,
+        [status]: statusCounts[status] + 1,
+      }
       if (status !== "not_evaluated") {
         evaluated += 1
         groupEvaluated += 1

--- a/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress.ts
+++ b/src/app/(app)/technical-configurations/_components/evaluation/technical-configuration-evaluation-progress.ts
@@ -1,0 +1,83 @@
+import {
+  deriveTechnicalConfigurationEvaluationStatus,
+  type TechnicalConfigurationDerivedStatus,
+} from "@/lib/technical-configuration-evaluation"
+
+import type { TechnicalConfigurationAssessmentWire } from "../../assessment-types"
+import type { TechnicalConfigurationBaselineGroupWire } from "../../baseline-types"
+
+/** Compact progress for one canonical baseline group. */
+export type TechnicalConfigurationEvaluationGroupProgress = Readonly<{
+  id: string
+  name: string
+  total: number
+  evaluated: number
+}>
+
+/** Full-universe progress for the currently selected option. */
+export type TechnicalConfigurationEvaluationProgress = Readonly<{
+  total: number
+  evaluated: number
+  statusCounts: Readonly<Record<TechnicalConfigurationDerivedStatus, number>>
+  groups: readonly TechnicalConfigurationEvaluationGroupProgress[]
+}>
+
+type BuildTechnicalConfigurationEvaluationProgressInput = Readonly<{
+  groups: readonly TechnicalConfigurationBaselineGroupWire[]
+  assessments: readonly TechnicalConfigurationAssessmentWire[]
+}>
+
+function createEmptyStatusCounts(): Record<TechnicalConfigurationDerivedStatus, number> {
+  return {
+    not_evaluated: 0,
+    not_applicable: 0,
+    fails: 0,
+    unclear: 0,
+    insufficient_evidence: 0,
+    exceeds: 0,
+    meets: 0,
+  }
+}
+
+/** Reconciles complete assessments by criterion ID against one locked baseline universe. */
+export function buildTechnicalConfigurationEvaluationProgress({
+  groups,
+  assessments,
+}: BuildTechnicalConfigurationEvaluationProgressInput): TechnicalConfigurationEvaluationProgress {
+  const assessmentsByCriterionId = new Map(
+    assessments.map((assessment) => [assessment.criterion_id, assessment])
+  )
+  const statusCounts = createEmptyStatusCounts()
+  let evaluated = 0
+
+  const groupProgress = groups.map((group) => {
+    let groupEvaluated = 0
+
+    for (const criterion of group.criteria) {
+      const assessment = assessmentsByCriterionId.get(criterion.id)
+      const status = deriveTechnicalConfigurationEvaluationStatus(
+        assessment?.technical_axis,
+        assessment?.evidence_axis
+      )
+      statusCounts[status] += 1
+      if (status !== "not_evaluated") {
+        evaluated += 1
+        groupEvaluated += 1
+      }
+    }
+
+    return {
+      id: group.id,
+      name: group.name,
+      total: group.criteria.length,
+      evaluated: groupEvaluated,
+    }
+  })
+
+  return {
+    total: groupProgress.reduce((sum, group) => sum + group.total, 0),
+    evaluated,
+    statusCounts,
+    groups: groupProgress,
+  }
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
@@ -151,10 +151,13 @@ function adoptCompleteAssessment(
   ] as const
   queryClient.setQueryData<Readonly<Record<string, TechnicalConfigurationAssessmentWire>>>(
     completeQueryKey,
-    (current = {}) => ({
-      ...current,
-      [assessment.criterion_id]: assessment,
-    })
+    (current) =>
+      current
+        ? {
+            ...current,
+            [assessment.criterion_id]: assessment,
+          }
+        : current
   )
 }
 

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationAssessments.ts
@@ -140,6 +140,24 @@ function acquireAssessmentComparisonSet({
   return acquisition
 }
 
+function adoptCompleteAssessment(
+  queryClient: QueryClient,
+  comparisonSetId: string,
+  assessment: TechnicalConfigurationAssessmentWire
+): void {
+  const completeQueryKey = [
+    ...technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSetId),
+    "complete",
+  ] as const
+  queryClient.setQueryData<Readonly<Record<string, TechnicalConfigurationAssessmentWire>>>(
+    completeQueryKey,
+    (current = {}) => ({
+      ...current,
+      [assessment.criterion_id]: assessment,
+    })
+  )
+}
+
 /** Exposes the dormant P11C assessment data contract without mounting assessment UI. */
 export function useTechnicalConfigurationAssessments(
   input: UseTechnicalConfigurationAssessmentsInput
@@ -243,7 +261,8 @@ export function useTechnicalConfigurationAssessments(
 
       return { comparisonSet, assessment: response.data }
     },
-    onSuccess: async ({ comparisonSet }) => {
+    onSuccess: async ({ comparisonSet, assessment }) => {
+      adoptCompleteAssessment(queryClient, comparisonSet.id, assessment)
       await queryClient.invalidateQueries({
         queryKey: technicalConfigurationAssessmentsQueryKeyPrefix(comparisonSet.id),
       })


### PR DESCRIPTION
## Summary
- add a pure full-universe progress model for the currently selected option, including canonical status counters and compact option/group totals
- render loading/error/no-comparison-set progress states without false counters, while preserving the existing P12A2 navigation and save-next behavior
- adopt successful assessment results into the complete cache by `criterion_id` before the existing prefix invalidation, and record actual P12B1 OpenSpec evidence

## Scope
- no migration, DB/RPC/proxy/query contract, ranking, filter, or navigation changes
- `TechnicalConfigurationEvaluationActiveWorkspace.tsx` remains below the extraction threshold at 347 lines

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused P11D/P12A1/P12A2/P12B1 suite: 11 files, 100 tests passed
- React Doctor changed-scope: 100/100, no issues
- `openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full‑universe, selected‑option progress model and a compact progress summary in the evaluation workspace. Progress shows accurate option/group totals, avoids false counters while loading/failed, and updates instantly after saves while preserving `complete` cache ownership.

- **New Features**
  - Build progress from full `selectedVersion.groups[].criteria[]` and the current option’s assessments; reconcile by `criterion_id`, supports >100 criteria; includes status counts and per‑group totals.
  - Render a compact summary: “Đã đánh giá X / Y” and group “X / Y”; clear loading (“Đang tải…”) and error (“Chưa thể tính…”) states; no percentages or status breakdowns.
  - Adopt saved assessments into the `complete` cache (when present) before query invalidation for immediate progress updates; do not synthesize a `complete` cache if it wasn’t loaded.

- **Refactors**
  - Pass `baselineGroups` into `TechnicalConfigurationEvaluationActiveWorkspace`; add `technical-configuration-evaluation-progress` and `TechnicalConfigurationProgressSummary`.
  - Extract `resolveTechnicalConfigurationCriterionId` and `toTechnicalConfigurationSaveErrorMessage` into `TechnicalConfigurationEvaluationWorkspaceUtils`; P12A2 navigation and save‑next unchanged.

<sup>Written for commit e7c844b0e9b34f4980966504bb56f669e02cb69e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact evaluation progress summaries showing completed vs total criteria, with optional per-group breakdown.
  * Progress updates now follow the currently selected option and use the selected comparison baseline.
* **Bug Fixes**
  * Fixed progress reconciliation to correctly handle mixed, repeated, and incomplete assessment statuses.
  * Ensured saved assessments appear immediately, and prevented premature “complete” cache population.
  * Updated evaluation progress error text to the expected message.
* **Documentation**
  * Updated technical configuration phase checklist and verification results.
* **Tests**
  * Expanded contract, workspace, and progress-calculation test coverage, including loading/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->