### PR TITLE
feat(technical-config): improve reference product editor UX

### DIFF
--- a/src/app/(app)/technical-configurations/__tests__/reference-products-editor-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-editor-workspace-cases.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 
@@ -18,30 +18,48 @@ type RegisterReferenceProductEditorWorkspaceTestsArgs = {
   referenceRpc: ReferenceProductRpcMocks
 }
 
-const originalHasPointerCapture = HTMLElement.prototype.hasPointerCapture
-const originalSetPointerCapture = HTMLElement.prototype.setPointerCapture
-const originalReleasePointerCapture = HTMLElement.prototype.releasePointerCapture
-const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
-
-beforeAll(() => {
-  HTMLElement.prototype.hasPointerCapture = () => false
-  HTMLElement.prototype.setPointerCapture = () => undefined
-  HTMLElement.prototype.releasePointerCapture = () => undefined
-  HTMLElement.prototype.scrollIntoView = () => undefined
-})
-
-afterAll(() => {
-  HTMLElement.prototype.hasPointerCapture = originalHasPointerCapture
-  HTMLElement.prototype.setPointerCapture = originalSetPointerCapture
-  HTMLElement.prototype.releasePointerCapture = originalReleasePointerCapture
-  HTMLElement.prototype.scrollIntoView = originalScrollIntoView
-})
-
 export function registerReferenceProductEditorWorkspaceTests({
   baselineRpc,
   referenceRpc,
 }: RegisterReferenceProductEditorWorkspaceTestsArgs) {
   describe("technical configuration reference-product editor workspace", () => {
+    const prototypeMethodNames = [
+      "hasPointerCapture",
+      "setPointerCapture",
+      "releasePointerCapture",
+      "scrollIntoView",
+    ] as const
+    const originalPrototypeDescriptors = new Map<
+      (typeof prototypeMethodNames)[number],
+      PropertyDescriptor | undefined
+    >()
+
+    beforeAll(() => {
+      prototypeMethodNames.forEach((methodName) => {
+        originalPrototypeDescriptors.set(
+          methodName,
+          Object.getOwnPropertyDescriptor(HTMLElement.prototype, methodName)
+        )
+      })
+      Object.defineProperties(HTMLElement.prototype, {
+        hasPointerCapture: { configurable: true, value: () => false },
+        setPointerCapture: { configurable: true, value: () => undefined },
+        releasePointerCapture: { configurable: true, value: () => undefined },
+        scrollIntoView: { configurable: true, value: () => undefined },
+      })
+    })
+
+    afterAll(() => {
+      prototypeMethodNames.forEach((methodName) => {
+        const originalDescriptor = originalPrototypeDescriptors.get(methodName)
+        if (originalDescriptor) {
+          Object.defineProperty(HTMLElement.prototype, methodName, originalDescriptor)
+          return
+        }
+        Reflect.deleteProperty(HTMLElement.prototype, methodName)
+      })
+    })
+
     beforeEach(() => {
       baselineRpc.listVersions.mockReset()
       baselineRpc.listVersions.mockResolvedValue({
@@ -114,7 +132,7 @@ export function registerReferenceProductEditorWorkspaceTests({
 
       expect(
         screen.getByRole("button", {
-          name: "Chọn Sản phẩm mới 2, thiếu thông tin",
+          name: "Chọn Sản phẩm 2, thiếu thông tin",
         })
       ).toHaveAttribute("aria-current", "true")
       await user.type(screen.getByLabelText("Model"), "Model mới")
@@ -230,7 +248,7 @@ export function registerReferenceProductEditorWorkspaceTests({
       expect(search).toHaveValue("")
       expect(
         screen.getByRole("button", {
-          name: "Chọn Sản phẩm mới 3, thiếu thông tin",
+          name: "Chọn Sản phẩm 3, thiếu thông tin",
         })
       ).toHaveAttribute("aria-current", "true")
     })
@@ -266,6 +284,26 @@ export function registerReferenceProductEditorWorkspaceTests({
       ).toBeInTheDocument()
     })
 
+    it("does not repeat the manufacturer when it is the product fallback name", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([
+          {
+            ...product("product-1", ""),
+            manufacturer: "B.Braun",
+          },
+        ])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const productButton = await screen.findByRole("button", { name: "Chọn B.Braun" })
+      await user.click(productButton)
+
+      expect(screen.getByRole("button", { name: "Xóa B.Braun" })).toBeInTheDocument()
+      expect(within(productButton).getAllByText("B.Braun")).toHaveLength(1)
+    })
+
     it("resets search and selection when returning to a baseline version", async () => {
       const user = userEvent.setup()
       const lockedVersion = {
@@ -276,7 +314,7 @@ export function registerReferenceProductEditorWorkspaceTests({
         locked_at: "2026-07-18T00:00:00.000Z",
         locked_by: 1,
       }
-      baselineRpc.listVersions.mockResolvedValueOnce({
+      baselineRpc.listVersions.mockResolvedValue({
         data: [baselineVersion, lockedVersion],
         total: 2,
         page: 1,
@@ -326,7 +364,7 @@ export function registerReferenceProductEditorWorkspaceTests({
       expect(screen.getByRole("searchbox", { name: "Tìm sản phẩm tham chiếu" })).toHaveValue("")
     })
 
-    it("gives blank drafts unique accessible names with validation status", async () => {
+    it("aligns blank draft names across navigation and editor actions", async () => {
       const user = userEvent.setup()
       referenceRpc.listProducts.mockResolvedValue(listResponse([]))
 
@@ -340,14 +378,15 @@ export function registerReferenceProductEditorWorkspaceTests({
 
       expect(
         screen.getByRole("button", {
-          name: "Chọn Sản phẩm mới 1, thiếu thông tin",
+          name: "Chọn Sản phẩm 1, thiếu thông tin",
         })
       ).toBeInTheDocument()
       expect(
         screen.getByRole("button", {
-          name: "Chọn Sản phẩm mới 2, thiếu thông tin",
+          name: "Chọn Sản phẩm 2, thiếu thông tin",
         })
       ).toHaveAttribute("aria-current", "true")
+      expect(screen.getByRole("button", { name: "Xóa Sản phẩm 2" })).toBeInTheDocument()
     })
 
     it("selects the nearest product after removing the active draft", async () => {

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-editor-workspace-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-editor-workspace-cases.tsx
@@ -1,0 +1,381 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { TechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts"
+import {
+  baselineVersion,
+  dossier,
+  listResponse,
+  product,
+  renderWithQueryClient,
+  type BaselineVersionRpcMocks,
+  type ReferenceProductRpcMocks,
+} from "./reference-products-fixtures"
+
+type RegisterReferenceProductEditorWorkspaceTestsArgs = {
+  baselineRpc: BaselineVersionRpcMocks
+  referenceRpc: ReferenceProductRpcMocks
+}
+
+const originalHasPointerCapture = HTMLElement.prototype.hasPointerCapture
+const originalSetPointerCapture = HTMLElement.prototype.setPointerCapture
+const originalReleasePointerCapture = HTMLElement.prototype.releasePointerCapture
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+
+beforeAll(() => {
+  HTMLElement.prototype.hasPointerCapture = () => false
+  HTMLElement.prototype.setPointerCapture = () => undefined
+  HTMLElement.prototype.releasePointerCapture = () => undefined
+  HTMLElement.prototype.scrollIntoView = () => undefined
+})
+
+afterAll(() => {
+  HTMLElement.prototype.hasPointerCapture = originalHasPointerCapture
+  HTMLElement.prototype.setPointerCapture = originalSetPointerCapture
+  HTMLElement.prototype.releasePointerCapture = originalReleasePointerCapture
+  HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+})
+
+export function registerReferenceProductEditorWorkspaceTests({
+  baselineRpc,
+  referenceRpc,
+}: RegisterReferenceProductEditorWorkspaceTestsArgs) {
+  describe("technical configuration reference-product editor workspace", () => {
+    beforeEach(() => {
+      baselineRpc.listVersions.mockReset()
+      baselineRpc.listVersions.mockResolvedValue({
+        data: [baselineVersion],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      })
+      Object.values(referenceRpc).forEach((mock) => mock.mockReset())
+    })
+
+    it("renders one editor beside a compact navigator for many products", async () => {
+      const products = Array.from({ length: 10 }, (_, index) =>
+        product(`product-${index + 1}`, `Model ${index + 1}`)
+      )
+      referenceRpc.listProducts.mockResolvedValue(listResponse(products))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      expect(
+        await screen.findByRole("region", {
+          name: "Không gian chỉnh sửa sản phẩm tham chiếu",
+        })
+      ).toBeInTheDocument()
+      expect(screen.getAllByRole("button", { name: /^Chọn Model/ })).toHaveLength(10)
+      expect(screen.getAllByLabelText("Model")).toHaveLength(1)
+      expect(screen.getByDisplayValue("Model 1")).toBeInTheDocument()
+      expect(screen.getByText("10 sản phẩm")).toBeInTheDocument()
+      expect(
+        screen.getByRole("region", { name: "Ma trận đối chiếu sản phẩm tham chiếu" })
+      ).toBeInTheDocument()
+    })
+
+    it("preserves draft edits while switching the selected product", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([product("product-1", "Model A"), product("product-2", "Model B")])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const modelInput = await screen.findByDisplayValue("Model A")
+      await user.clear(modelInput)
+      await user.type(modelInput, "Model A2")
+      await user.click(screen.getByRole("button", { name: "Chọn Model B, Hãng A" }))
+      expect(screen.getByDisplayValue("Model B")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Chọn Model A2, Hãng A" }))
+      expect(screen.getByDisplayValue("Model A2")).toBeInTheDocument()
+      expect(referenceRpc.updateProduct).not.toHaveBeenCalled()
+      expect(referenceRpc.deleteProduct).not.toHaveBeenCalled()
+    })
+
+    it("selects a new draft and keeps it selected after save replaces its local id", async () => {
+      const user = userEvent.setup()
+      const existing = product("product-1", "Model A")
+      const created = {
+        ...product("product-2", "Model mới", baselineVersion.revision + 1),
+        manufacturer: null,
+      }
+      referenceRpc.listProducts
+        .mockResolvedValueOnce(listResponse([existing]))
+        .mockResolvedValueOnce(listResponse([existing, created], created.revision))
+      referenceRpc.createProduct.mockResolvedValueOnce({ data: created })
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      await screen.findByDisplayValue("Model A")
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+
+      expect(
+        screen.getByRole("button", {
+          name: "Chọn Sản phẩm mới 2, thiếu thông tin",
+        })
+      ).toHaveAttribute("aria-current", "true")
+      await user.type(screen.getByLabelText("Model"), "Model mới")
+      await user.click(screen.getByRole("button", { name: "Lưu thay đổi" }))
+
+      await waitFor(() => expect(referenceRpc.createProduct).toHaveBeenCalledTimes(1))
+      expect(await screen.findByDisplayValue("Model mới")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Chọn Model mới" })).toHaveAttribute(
+        "aria-current",
+        "true"
+      )
+    })
+
+    it("filters products by model or manufacturer and handles an empty result", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([
+          { ...product("product-1", "4008S"), manufacturer: "Fresenius Medical Care" },
+          { ...product("product-2", "Dialog +"), manufacturer: "B.Braun Avitum AG" },
+          { ...product("product-3", "AK 98"), manufacturer: "Baxter" },
+        ])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const search = await screen.findByRole("searchbox", {
+        name: "Tìm sản phẩm tham chiếu",
+      })
+      await user.type(search, "b.braun")
+
+      expect(
+        screen.getByRole("button", { name: "Chọn Dialog +, B.Braun Avitum AG" })
+      ).toHaveAttribute("aria-current", "true")
+      expect(screen.queryByRole("button", { name: /Chọn 4008S/ })).not.toBeInTheDocument()
+      expect(screen.getByText("1/3 sản phẩm")).toBeInTheDocument()
+      expect(screen.getByDisplayValue("Dialog +")).toBeInTheDocument()
+
+      await user.clear(search)
+      await user.type(search, "không có")
+      expect(screen.getByText("Không tìm thấy sản phẩm phù hợp.")).toBeInTheDocument()
+      expect(screen.getByDisplayValue("Dialog +")).toBeInTheDocument()
+    })
+
+    it("keeps the active editor mounted and hands focus to a visible row after filtered deletion", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([
+          { ...product("product-1", "Model A"), manufacturer: "Hãng A" },
+          { ...product("product-2", "Model B"), manufacturer: "B.Braun Avitum AG" },
+          { ...product("product-3", "Model C"), manufacturer: "B.Braun Medical" },
+        ])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const search = await screen.findByRole("searchbox", {
+        name: "Tìm sản phẩm tham chiếu",
+      })
+      await user.type(search, "b.braun")
+      const modelInput = screen.getByDisplayValue("Model B")
+      const manufacturerInput = screen.getByDisplayValue("B.Braun Avitum AG")
+      await user.clear(modelInput)
+      await user.type(modelInput, "Model đổi tên")
+      await user.clear(manufacturerInput)
+
+      expect(screen.getByDisplayValue("Model đổi tên")).toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Xóa Model đổi tên" }))
+
+      const nextProduct = screen.getByRole("button", {
+        name: "Chọn Model C, B.Braun Medical",
+      })
+      expect(screen.getByDisplayValue("Model C")).toBeInTheDocument()
+      await waitFor(() => expect(nextProduct).toHaveFocus())
+    })
+
+    it("keeps a manual navigator selection as the search fallback", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([
+          { ...product("product-1", "Model A"), manufacturer: "Hãng A" },
+          { ...product("product-2", "Model B"), manufacturer: "B.Braun Avitum AG" },
+          { ...product("product-3", "Model C"), manufacturer: "B.Braun Medical" },
+        ])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const search = await screen.findByRole("searchbox", {
+        name: "Tìm sản phẩm tham chiếu",
+      })
+      await user.type(search, "b.braun")
+      await user.click(screen.getByRole("button", { name: "Chọn Model C, B.Braun Medical" }))
+      await user.type(search, " không có")
+
+      expect(screen.getByText("Không tìm thấy sản phẩm phù hợp.")).toBeInTheDocument()
+      expect(screen.getByRole("textbox", { name: "Model" })).toHaveValue("Model C")
+    })
+
+    it("clears the search when adding a draft so the selected row stays visible", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([product("product-1", "Model A"), product("product-2", "Model B")])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const search = await screen.findByRole("searchbox", {
+        name: "Tìm sản phẩm tham chiếu",
+      })
+      await user.type(search, "Model B")
+      await user.click(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" }))
+
+      expect(search).toHaveValue("")
+      expect(
+        screen.getByRole("button", {
+          name: "Chọn Sản phẩm mới 3, thiếu thông tin",
+        })
+      ).toHaveAttribute("aria-current", "true")
+    })
+
+    it("disambiguates accessible names for products with the same model and manufacturer", async () => {
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([
+          product("product-1", "Model A"),
+          product("product-2", "Model A"),
+          {
+            ...product("product-3", "Model A"),
+            manufacturer: "Hãng A, sản phẩm 1",
+          },
+        ])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      expect(
+        await screen.findByRole("button", {
+          name: "Chọn Model A, Hãng A, sản phẩm 1",
+        })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", {
+          name: "Chọn Model A, Hãng A, sản phẩm 2",
+        })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", {
+          name: "Chọn Model A, Hãng A, sản phẩm 1, mục 3",
+        })
+      ).toBeInTheDocument()
+    })
+
+    it("resets search and selection when returning to a baseline version", async () => {
+      const user = userEvent.setup()
+      const lockedVersion = {
+        ...baselineVersion,
+        id: "version-2",
+        version_number: 2,
+        status: "locked" as const,
+        locked_at: "2026-07-18T00:00:00.000Z",
+        locked_by: 1,
+      }
+      baselineRpc.listVersions.mockResolvedValueOnce({
+        data: [baselineVersion, lockedVersion],
+        total: 2,
+        page: 1,
+        page_size: 20,
+      })
+      referenceRpc.listProducts.mockImplementation(
+        ({ p_baseline_version_id }: { p_baseline_version_id: string }) => {
+          if (p_baseline_version_id === lockedVersion.id) {
+            return Promise.resolve(
+              listResponse([
+                {
+                  ...product("product-b1", "Model B1"),
+                  baseline_version_id: lockedVersion.id,
+                },
+                {
+                  ...product("product-b2", "Model B2"),
+                  baseline_version_id: lockedVersion.id,
+                },
+              ])
+            )
+          }
+          return Promise.resolve(
+            listResponse([product("product-a1", "Model A1"), product("product-a2", "Model A2")])
+          )
+        }
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const search = await screen.findByRole("searchbox", {
+        name: "Tìm sản phẩm tham chiếu",
+      })
+      await user.type(search, "Model A2")
+      expect(screen.getByRole("textbox", { name: "Model" })).toHaveValue("Model A2")
+
+      const versionPicker = screen.getByRole("combobox", {
+        name: "Phiên bản cấu hình cơ sở",
+      })
+      await user.click(versionPicker)
+      await user.click(await screen.findByRole("option", { name: "Phiên bản 2 · Đã khóa" }))
+      expect(await screen.findByRole("textbox", { name: "Model" })).toHaveValue("Model B1")
+
+      await user.click(versionPicker)
+      await user.click(await screen.findByRole("option", { name: "Phiên bản 1 · Bản nháp" }))
+
+      expect(await screen.findByRole("textbox", { name: "Model" })).toHaveValue("Model A1")
+      expect(screen.getByRole("searchbox", { name: "Tìm sản phẩm tham chiếu" })).toHaveValue("")
+    })
+
+    it("gives blank drafts unique accessible names with validation status", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(listResponse([]))
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const addProduct = await screen.findByRole("button", {
+        name: "Thêm sản phẩm tham chiếu",
+      })
+      await user.click(addProduct)
+      await user.click(addProduct)
+
+      expect(
+        screen.getByRole("button", {
+          name: "Chọn Sản phẩm mới 1, thiếu thông tin",
+        })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", {
+          name: "Chọn Sản phẩm mới 2, thiếu thông tin",
+        })
+      ).toHaveAttribute("aria-current", "true")
+    })
+
+    it("selects the nearest product after removing the active draft", async () => {
+      const user = userEvent.setup()
+      referenceRpc.listProducts.mockResolvedValue(
+        listResponse([
+          product("product-1", "Model A"),
+          product("product-2", "Model B"),
+          product("product-3", "Model C"),
+        ])
+      )
+
+      renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
+
+      const search = await screen.findByRole("searchbox", {
+        name: "Tìm sản phẩm tham chiếu",
+      })
+      await user.click(await screen.findByRole("button", { name: "Chọn Model B, Hãng A" }))
+      await user.click(screen.getByRole("button", { name: "Xóa Model B" }))
+      expect(screen.getByDisplayValue("Model C")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Xóa Model C" }))
+      expect(screen.getByDisplayValue("Model A")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Xóa Model A" }))
+      expect(screen.getByText("Danh sách chưa có sản phẩm.")).toBeInTheDocument()
+      expect(screen.queryByLabelText("Model")).not.toBeInTheDocument()
+      await waitFor(() => expect(search).toHaveFocus())
+    })
+  })
+}

--- a/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products-resilience-cases.tsx
@@ -159,6 +159,8 @@ export function registerReferenceProductResilienceTests({
 
       expect(screen.getByRole("combobox", { name: "Phiên bản cấu hình cơ sở" })).toBeDisabled()
       expect(screen.getByRole("button", { name: "Thêm sản phẩm tham chiếu" })).toBeDisabled()
+      expect(screen.getByRole("searchbox", { name: "Tìm sản phẩm tham chiếu" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Chọn Model chưa lưu" })).toBeDisabled()
 
       resolveVersions?.({
         data: [baselineVersion],
@@ -198,10 +200,11 @@ export function registerReferenceProductResilienceTests({
       })
 
       renderWithQueryClient(<TechnicalConfigurationReferenceProducts dossier={dossier} />)
-      const modelInputs = await screen.findAllByLabelText("Model")
-      await user.clear(modelInputs[0]!)
-      await user.type(modelInputs[0]!, "Model A2")
+      const modelInput = await screen.findByDisplayValue("Model A")
+      await user.clear(modelInput)
+      await user.type(modelInput, "Model A2")
       await user.type(screen.getByLabelText("Phản hồi Model A2 cho TC-0001"), "Phản hồi cập nhật")
+      await user.click(screen.getByRole("button", { name: "Chọn Model B, Hãng A" }))
       await user.click(screen.getByRole("button", { name: "Xóa Model B" }))
 
       expect(referenceRpc.updateProduct).not.toHaveBeenCalled()

--- a/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
+++ b/src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, vi } from "vitest"
 
 import { registerReferenceProductComparisonTests } from "./reference-products-comparison-cases"
 import { registerReferenceProductConflictTests } from "./reference-products-conflict-cases"
+import { registerReferenceProductEditorWorkspaceTests } from "./reference-products-editor-workspace-cases"
 import { registerReferenceProductEvidenceTests } from "./reference-products-evidence-cases"
 import { registerReferenceProductHookTests } from "./reference-products-hook-cases"
 import { registerReferenceProductOperationLockTests } from "./reference-products-operation-lock-cases"
@@ -104,5 +105,6 @@ registerReferenceProductSaveResumeTests(referenceRpc)
 registerReferenceProductConflictTests(referenceRpc)
 registerReferenceProductComparisonTests()
 registerReferenceProductEvidenceTests({ evidenceState, baselineDocumentsMock })
+registerReferenceProductEditorWorkspaceTests({ baselineRpc, referenceRpc })
 registerReferenceProductWorkspaceTests({ baselineRpc, referenceRpc })
 registerReferenceProductResilienceTests({ baselineRpc, referenceRpc })

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductEditor.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductEditor.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
 type TechnicalConfigurationReferenceProductEditorProps = {
   product: TechnicalConfigurationReferenceProductDraft
@@ -34,10 +35,14 @@ export function TechnicalConfigurationReferenceProductEditor({
   const fieldPrefix = `reference-product-${product.id}`
 
   return (
-    <section className="rounded-md border p-4">
+    <section
+      className="flex min-h-full flex-col p-4 sm:p-5"
+      aria-label="Chi tiết sản phẩm tham chiếu"
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <h3 className="break-words text-sm font-semibold">{productName}</h3>
+          <h3 className="text-sm font-semibold">Chi tiết sản phẩm</h3>
+          <p className="mt-1 break-words text-sm text-muted-foreground">{productName}</p>
           {invalid ? (
             <p className="mt-1 text-sm text-destructive">
               Nhập ít nhất model, hãng sản xuất hoặc mô tả.
@@ -45,20 +50,27 @@ export function TechnicalConfigurationReferenceProductEditor({
           ) : null}
         </div>
         {!readOnly ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label={`Xóa ${productName}`}
-            disabled={navigationBlocked}
-            onClick={() => onRemove(product.id)}
-          >
-            <Trash2 className="size-4" aria-hidden="true" />
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Xóa ${productName}`}
+                  disabled={navigationBlocked}
+                  onClick={() => onRemove(product.id)}
+                >
+                  <Trash2 className="size-4" aria-hidden="true" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Xóa sản phẩm</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ) : null}
       </div>
 
-      <div className="mt-4 grid gap-4 md:grid-cols-2">
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
         <div className="space-y-2">
           <Label htmlFor={`${fieldPrefix}-model`}>Model</Label>
           <Input
@@ -79,27 +91,33 @@ export function TechnicalConfigurationReferenceProductEditor({
             onChange={(event) => onUpdate(product.id, { manufacturer: event.target.value })}
           />
         </div>
-        <div className="space-y-2 md:col-span-2">
+        <div className="space-y-2">
           <Label htmlFor={`${fieldPrefix}-description`}>Mô tả</Label>
           <Textarea
             id={`${fieldPrefix}-description`}
             value={product.description}
             readOnly={readOnly}
             disabled={navigationBlocked}
+            className="min-h-24 resize-y"
             onChange={(event) => onUpdate(product.id, { description: event.target.value })}
           />
         </div>
-        <div className="space-y-2 md:col-span-2">
+        <div className="space-y-2">
           <Label htmlFor={`${fieldPrefix}-notes`}>Ghi chú</Label>
           <Textarea
             id={`${fieldPrefix}-notes`}
             value={product.notes}
             readOnly={readOnly}
             disabled={navigationBlocked}
+            className="min-h-24 resize-y"
             onChange={(event) => onUpdate(product.id, { notes: event.target.value })}
           />
         </div>
       </div>
+
+      <p className="mt-auto pt-5 text-xs text-muted-foreground">
+        Thay đổi được lưu cùng toàn bộ danh sách.
+      </p>
     </section>
   )
 }

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductNavigator.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductNavigator.tsx
@@ -1,0 +1,181 @@
+import * as React from "react"
+import { AlertCircle, Search } from "lucide-react"
+
+import {
+  getTechnicalConfigurationReferenceProductName,
+  type TechnicalConfigurationReferenceProductDraft,
+} from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+import { Input } from "@/components/ui/input"
+
+type ReferenceProductNavigatorWorkspace = {
+  products: TechnicalConfigurationReferenceProductDraft[]
+  visibleProducts: TechnicalConfigurationReferenceProductDraft[]
+  invalidProductIds: ReadonlySet<string>
+  selectedProductId: string | null
+  searchQuery: string
+  productCountLabel: string
+  navigationBlocked: boolean
+}
+
+type TechnicalConfigurationReferenceProductNavigatorProps = {
+  workspace: ReferenceProductNavigatorWorkspace
+  searchInputRef: React.RefObject<HTMLInputElement | null>
+  onSearchChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onSelectProduct: (productId: string) => void
+  onProductButtonRef: (productId: string, element: HTMLButtonElement | null) => void
+}
+
+type NavigatorProductMetadata = {
+  index: number
+  name: string
+  manufacturer: string
+  accessibleDescription: string
+}
+
+function getReferenceProductNavigatorName(
+  product: TechnicalConfigurationReferenceProductDraft,
+  index: number
+) {
+  const hasProductName = Boolean(
+    product.model.trim() || product.manufacturer.trim() || product.description.trim()
+  )
+  if (!product.persistedId && !hasProductName) return `Sản phẩm mới ${index + 1}`
+  return getTechnicalConfigurationReferenceProductName(product, index)
+}
+
+/** Renders the searchable reference-product list and its selection states. */
+export function TechnicalConfigurationReferenceProductNavigator({
+  workspace,
+  searchInputRef,
+  onSearchChange,
+  onSelectProduct,
+  onProductButtonRef,
+}: Readonly<TechnicalConfigurationReferenceProductNavigatorProps>) {
+  const {
+    products,
+    visibleProducts,
+    invalidProductIds,
+    selectedProductId,
+    searchQuery,
+    productCountLabel,
+    navigationBlocked,
+  } = workspace
+  const metadataById = React.useMemo(() => {
+    const nextMetadataById = new Map<string, NavigatorProductMetadata>()
+    const descriptionCounts = new Map<string, number>()
+
+    products.forEach((product, index) => {
+      const name = getReferenceProductNavigatorName(product, index)
+      const manufacturer = product.manufacturer.trim()
+      const accessibleDescription = manufacturer ? `${name}, ${manufacturer}` : name
+      nextMetadataById.set(product.id, {
+        index,
+        name,
+        manufacturer,
+        accessibleDescription,
+      })
+      descriptionCounts.set(
+        accessibleDescription,
+        (descriptionCounts.get(accessibleDescription) ?? 0) + 1
+      )
+    })
+
+    const usedAccessibleDescriptions = new Set<string>()
+    products.forEach((product) => {
+      const metadata = nextMetadataById.get(product.id)
+      if (!metadata) return
+
+      const preferredDescription =
+        (descriptionCounts.get(metadata.accessibleDescription) ?? 0) > 1
+          ? `${metadata.accessibleDescription}, sản phẩm ${metadata.index + 1}`
+          : metadata.accessibleDescription
+      let uniqueDescription = preferredDescription
+      let collisionOrdinal = metadata.index + 1
+      while (usedAccessibleDescriptions.has(uniqueDescription)) {
+        uniqueDescription = `${preferredDescription}, mục ${collisionOrdinal}`
+        collisionOrdinal += 1
+      }
+      usedAccessibleDescriptions.add(uniqueDescription)
+      nextMetadataById.set(product.id, {
+        ...metadata,
+        accessibleDescription: uniqueDescription,
+      })
+    })
+
+    return nextMetadataById
+  }, [products])
+
+  return (
+    <div className="flex min-h-0 flex-col border-b lg:border-b-0 lg:border-r">
+      <div className="shrink-0 space-y-3 border-b p-4">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold">Sản phẩm tham chiếu</h3>
+          <span className="text-xs text-muted-foreground">{productCountLabel}</span>
+        </div>
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            ref={searchInputRef}
+            type="search"
+            value={searchQuery}
+            aria-label="Tìm sản phẩm tham chiếu"
+            placeholder="Tìm model hoặc hãng"
+            className="pl-9"
+            disabled={navigationBlocked}
+            onChange={onSearchChange}
+          />
+        </div>
+      </div>
+
+      <div className="max-h-56 min-h-0 flex-1 overflow-y-auto lg:max-h-none">
+        {products.length === 0 ? (
+          <p className="p-4 text-sm text-muted-foreground">Danh sách chưa có sản phẩm.</p>
+        ) : visibleProducts.length === 0 ? (
+          <p className="p-4 text-sm text-muted-foreground">Không tìm thấy sản phẩm phù hợp.</p>
+        ) : (
+          <div className="divide-y">
+            {visibleProducts.map((product) => {
+              const metadata = metadataById.get(product.id)
+              if (!metadata) return null
+
+              const selected = product.id === selectedProductId
+              const invalid = invalidProductIds.has(product.id)
+              const accessibleName = `Chọn ${metadata.accessibleDescription}${
+                invalid ? ", thiếu thông tin" : ""
+              }`
+
+              return (
+                <button
+                  key={product.id}
+                  ref={(element) => onProductButtonRef(product.id, element)}
+                  type="button"
+                  aria-label={accessibleName}
+                  aria-current={selected ? "true" : undefined}
+                  disabled={navigationBlocked}
+                  className="flex min-h-16 w-full items-center gap-3 border-l-2 border-transparent px-4 py-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60 aria-current:border-primary aria-current:bg-primary/10"
+                  onClick={() => onSelectProduct(product.id)}
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{metadata.name}</span>
+                    <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                      {metadata.manufacturer || "Chưa có hãng sản xuất"}
+                    </span>
+                    {invalid ? (
+                      <span className="mt-1 flex items-center gap-1 text-xs text-destructive">
+                        <AlertCircle className="size-3" aria-hidden="true" />
+                        Thiếu thông tin
+                      </span>
+                    ) : null}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductNavigator.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductNavigator.tsx
@@ -36,10 +36,6 @@ function getReferenceProductNavigatorName(
   product: TechnicalConfigurationReferenceProductDraft,
   index: number
 ) {
-  const hasProductName = Boolean(
-    product.model.trim() || product.manufacturer.trim() || product.description.trim()
-  )
-  if (!product.persistedId && !hasProductName) return `Sản phẩm mới ${index + 1}`
   return getTechnicalConfigurationReferenceProductName(product, index)
 }
 
@@ -67,7 +63,8 @@ export function TechnicalConfigurationReferenceProductNavigator({
     products.forEach((product, index) => {
       const name = getReferenceProductNavigatorName(product, index)
       const manufacturer = product.manufacturer.trim()
-      const accessibleDescription = manufacturer ? `${name}, ${manufacturer}` : name
+      const accessibleDescription =
+        manufacturer && manufacturer !== name ? `${name}, ${manufacturer}` : name
       nextMetadataById.set(product.id, {
         index,
         name,
@@ -160,9 +157,11 @@ export function TechnicalConfigurationReferenceProductNavigator({
                 >
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-sm font-medium">{metadata.name}</span>
-                    <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-                      {metadata.manufacturer || "Chưa có hãng sản xuất"}
-                    </span>
+                    {metadata.manufacturer !== metadata.name ? (
+                      <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                        {metadata.manufacturer || "Chưa có hãng sản xuất"}
+                      </span>
+                    ) : null}
                     {invalid ? (
                       <span className="mt-1 flex items-center gap-1 text-xs text-destructive">
                         <AlertCircle className="size-3" aria-hidden="true" />

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
@@ -1,30 +1,25 @@
 import * as React from "react"
-import { AlertCircle, Archive, Loader2, LockKeyhole, Plus, RefreshCw, Save } from "lucide-react"
+import { AlertCircle, Archive, Loader2, LockKeyhole, RefreshCw } from "lucide-react"
 
 import { TechnicalConfigurationReferenceProductsBody } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody"
+import {
+  LOAD_MORE_BASELINE_VERSIONS_VALUE,
+  TechnicalConfigurationReferenceProductsToolbar,
+} from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsToolbar"
 import { useTechnicalConfigurationBaselineVersionSelection } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBaselineVersionSelection"
 import { useTechnicalConfigurationBeforeUnloadGuard } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationBeforeUnloadGuard"
 import { useTechnicalConfigurationDiscardConfirmation } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationDiscardConfirmation"
 import { useTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts"
+import { useTechnicalConfigurationReferenceProductSelection } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProductSelection"
 import type { TechnicalConfigurationDossierWire } from "@/app/(app)/technical-configurations/types"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
-import { Label } from "@/components/ui/label"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 
 type TechnicalConfigurationReferenceProductsProps = {
   dossier: TechnicalConfigurationDossierWire
   onDirtyChange?: (dirty: boolean) => void
   onNavigationBlockedChange?: (blocked: boolean) => void
 }
-
-const LOAD_MORE_BASELINE_VERSIONS_VALUE = "__load-more-baseline-versions__"
 
 /** Renders reference-product management and its baseline-first comparison surface. */
 export function TechnicalConfigurationReferenceProducts({
@@ -44,6 +39,7 @@ export function TechnicalConfigurationReferenceProducts({
   const [isEvidenceDirty, setIsEvidenceDirty] = React.useState(false)
   const [isEvidenceNavigationBlocked, setIsEvidenceNavigationBlocked] = React.useState(false)
   const [isReferenceNavigationBlocked, setIsReferenceNavigationBlocked] = React.useState(false)
+  const [referenceProductSearchRevision, setReferenceProductSearchRevision] = React.useState(0)
   const { discardConfirmationDialog, requestDiscardConfirmation } =
     useTechnicalConfigurationDiscardConfirmation()
   const evidenceNavigationBlockedRef = React.useRef(false)
@@ -69,6 +65,10 @@ export function TechnicalConfigurationReferenceProducts({
     isArchived: Boolean(dossier.archived_at),
     onRevisionChange: handleRevisionChange,
     onNavigationBlockedChange: handleReferenceNavigationBlockedChange,
+  })
+  const productSelection = useTechnicalConfigurationReferenceProductSelection({
+    scopeKey: selectedVersion?.id ?? "",
+    products: referenceState.products,
   })
   const isDirty = referenceState.isDirty || isEvidenceDirty
   const isNavigationBlocked =
@@ -144,6 +144,11 @@ export function TechnicalConfigurationReferenceProducts({
     void reloadReferenceProducts()
   }, [isDirty, reloadReferenceProducts, requestDiscardConfirmation, selectedVersion])
 
+  const handleAddProduct = React.useCallback(() => {
+    productSelection.selectAddedProduct(referenceState.addProduct())
+    setReferenceProductSearchRevision((revision) => revision + 1)
+  }, [productSelection.selectAddedProduct, referenceState.addProduct])
+
   if (versionState.versionsQuery.isLoading) {
     return (
       <div className="flex min-h-32 items-center justify-center gap-2 text-sm text-muted-foreground">
@@ -188,87 +193,28 @@ export function TechnicalConfigurationReferenceProducts({
 
   return (
     <div className="space-y-6">
-      <section className="flex flex-col gap-4 border-y py-4 lg:flex-row lg:items-end lg:justify-between">
-        <div className="min-w-0">
-          <Label htmlFor="reference-baseline-version">Phiên bản cấu hình cơ sở</Label>
-          <Select
-            value={selectedVersion.id}
-            disabled={isNavigationBlocked}
-            onValueChange={handleVersionSelect}
-          >
-            <SelectTrigger id="reference-baseline-version" className="mt-2 w-full sm:w-[300px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {versionOptions
-                .toSorted((left, right) => right.version_number - left.version_number)
-                .map((version) => (
-                  <SelectItem key={version.id} value={version.id}>
-                    Phiên bản {version.version_number} ·{" "}
-                    {version.status === "locked" ? "Đã khóa" : "Bản nháp"}
-                  </SelectItem>
-                ))}
-              {versionState.versionsQuery.hasNextPage || versionState.hasHistoryRecoveryError ? (
-                <SelectItem
-                  value={LOAD_MORE_BASELINE_VERSIONS_VALUE}
-                  disabled={versionState.versionsQuery.isFetchingNextPage}
-                >
-                  {versionState.versionsQuery.isFetchingNextPage
-                    ? "Đang tải phiên bản..."
-                    : versionState.hasHistoryRecoveryError
-                      ? "Thử tải lại lịch sử phiên bản"
-                      : "Tải thêm phiên bản"}
-                </SelectItem>
-              ) : null}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            disabled={isNavigationBlocked || isProductDataUnavailable}
-            onClick={handleReload}
-          >
-            <RefreshCw
-              className={`size-4 ${referenceState.isReloading ? "animate-spin" : ""}`}
-              aria-hidden="true"
-            />
-            Tải lại dữ liệu
-          </Button>
-          {!referenceState.isReadOnly ? (
-            <>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={isNavigationBlocked || isProductDataUnavailable}
-                onClick={referenceState.addProduct}
-              >
-                <Plus className="size-4" aria-hidden="true" />
-                Thêm sản phẩm tham chiếu
-              </Button>
-              <Button
-                type="button"
-                disabled={
-                  !referenceState.isDirty ||
-                  referenceState.invalidProductIds.length > 0 ||
-                  isNavigationBlocked ||
-                  isProductDataUnavailable
-                }
-                onClick={referenceState.save}
-              >
-                {referenceState.isSaving ? (
-                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-                ) : (
-                  <Save className="size-4" aria-hidden="true" />
-                )}
-                Lưu thay đổi
-              </Button>
-            </>
-          ) : null}
-        </div>
-      </section>
+      <TechnicalConfigurationReferenceProductsToolbar
+        selectedVersion={selectedVersion}
+        versionOptions={versionOptions}
+        versionHistory={{
+          hasMoreVersions: Boolean(versionState.versionsQuery.hasNextPage),
+          hasHistoryRecoveryError: versionState.hasHistoryRecoveryError,
+          isFetchingNextPage: versionState.versionsQuery.isFetchingNextPage,
+        }}
+        workspaceStatus={{
+          isNavigationBlocked,
+          isProductDataUnavailable,
+          isReadOnly: referenceState.isReadOnly,
+          isDirty: referenceState.isDirty,
+          isReloading: referenceState.isReloading,
+          isSaving: referenceState.isSaving,
+        }}
+        invalidProductCount={referenceState.invalidProductIds.length}
+        onVersionSelect={handleVersionSelect}
+        onReload={handleReload}
+        onAddProduct={handleAddProduct}
+        onSave={referenceState.save}
+      />
 
       {readOnlyMessage ? (
         <Alert>
@@ -307,9 +253,13 @@ export function TechnicalConfigurationReferenceProducts({
       ) : null}
 
       <TechnicalConfigurationReferenceProductsBody
+        key={selectedVersion.id}
         baselineVersion={selectedVersion}
         referenceState={referenceState}
         navigationBlocked={isNavigationBlocked}
+        searchScopeKey={`${selectedVersion.id}:${referenceProductSearchRevision}`}
+        selectedProductId={productSelection.selectedProductId}
+        onSelectProduct={productSelection.selectProduct}
         onRevisionChange={handleRevisionChange}
         onEvidenceDirtyChange={setIsEvidenceDirty}
         onEvidenceNavigationBlockedChange={handleEvidenceNavigationBlockedChange}

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProducts.tsx
@@ -145,7 +145,9 @@ export function TechnicalConfigurationReferenceProducts({
   }, [isDirty, reloadReferenceProducts, requestDiscardConfirmation, selectedVersion])
 
   const handleAddProduct = React.useCallback(() => {
-    productSelection.selectAddedProduct(referenceState.addProduct())
+    const addedProductId = referenceState.addProduct()
+    if (!addedProductId) return
+    productSelection.selectAddedProduct(addedProductId)
     setReferenceProductSearchRevision((revision) => revision + 1)
   }, [productSelection.selectAddedProduct, referenceState.addProduct])
 

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
@@ -161,10 +161,8 @@ export function TechnicalConfigurationReferenceProductsBody({
       target.kind === "search"
         ? searchInputRef.current
         : productButtonRefs.current.get(target.productId)
-    if (!element) return
-
-    element.focus()
     pendingFocusTargetRef.current = null
+    element?.focus()
   }, [referenceState.products, searchQuery, selectedProductId])
 
   const handleProductButtonRef = React.useCallback(

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsBody.tsx
@@ -3,8 +3,10 @@ import { AlertCircle, Loader2 } from "lucide-react"
 
 import { TechnicalConfigurationReferenceComparison } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceComparison"
 import { TechnicalConfigurationReferenceProductEditor } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductEditor"
+import { TechnicalConfigurationReferenceProductNavigator } from "@/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductNavigator"
 import type { useTechnicalConfigurationReferenceProducts } from "@/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProducts"
 import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import type { TechnicalConfigurationReferenceProductDraft } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 
@@ -12,9 +14,28 @@ type TechnicalConfigurationReferenceProductsBodyProps = {
   baselineVersion: TechnicalConfigurationBaselineDraftWire
   referenceState: ReturnType<typeof useTechnicalConfigurationReferenceProducts>
   navigationBlocked: boolean
+  searchScopeKey: string
+  selectedProductId: string | null
+  onSelectProduct: (productId: string) => void
   onRevisionChange?: (revision: number) => void
   onEvidenceDirtyChange?: (dirty: boolean) => void
   onEvidenceNavigationBlockedChange?: (blocked: boolean) => void
+}
+
+type ReferenceProductSearchState = {
+  scopeKey: string
+  query: string
+}
+
+function filterReferenceProducts(
+  products: TechnicalConfigurationReferenceProductDraft[],
+  query: string
+) {
+  const normalizedQuery = query.trim().toLocaleLowerCase("vi-VN")
+  if (!normalizedQuery) return products
+  return products.filter((product) =>
+    `${product.model}\n${product.manufacturer}`.toLocaleLowerCase("vi-VN").includes(normalizedQuery)
+  )
 }
 
 /** Renders reference-product query states, metadata editors, and comparison matrix. */
@@ -22,17 +43,140 @@ export function TechnicalConfigurationReferenceProductsBody({
   baselineVersion,
   referenceState,
   navigationBlocked,
+  searchScopeKey,
+  selectedProductId,
+  onSelectProduct,
   onRevisionChange,
   onEvidenceDirtyChange,
   onEvidenceNavigationBlockedChange,
 }: Readonly<TechnicalConfigurationReferenceProductsBodyProps>) {
+  const [searchState, setSearchState] = React.useState<ReferenceProductSearchState>({
+    scopeKey: searchScopeKey,
+    query: "",
+  })
+  const searchInputRef = React.useRef<HTMLInputElement>(null)
+  const searchAnchorProductIdRef = React.useRef<string | null>(null)
+  const productButtonRefs = React.useRef(new Map<string, HTMLButtonElement>())
+  const pendingFocusTargetRef = React.useRef<
+    { kind: "product"; productId: string } | { kind: "search" } | null
+  >(null)
+  const searchQuery = searchState.scopeKey === searchScopeKey ? searchState.query : ""
   const invalidProductIdSet = React.useMemo(
     () => new Set(referenceState.invalidProductIds),
     [referenceState.invalidProductIds]
   )
+  const visibleProducts = React.useMemo(
+    () => filterReferenceProducts(referenceState.products, searchQuery),
+    [referenceState.products, searchQuery]
+  )
+  const activeProduct =
+    referenceState.products.find((product) => product.id === selectedProductId) ?? null
+  const activeProductIndex = activeProduct
+    ? referenceState.products.findIndex((product) => product.id === activeProduct.id)
+    : -1
   const hasInitialQueryError =
     referenceState.productsQuery.isError && referenceState.productsQuery.data === undefined
   const canRenderProducts = !referenceState.productsQuery.isLoading && !hasInitialQueryError
+  const hasSearchQuery = Boolean(searchQuery.trim())
+  const productCountLabel = hasSearchQuery
+    ? `${visibleProducts.length}/${referenceState.products.length} sản phẩm`
+    : `${referenceState.products.length} sản phẩm`
+
+  const handleSearchChange = React.useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const query = event.target.value
+      const nextVisibleProducts = filterReferenceProducts(referenceState.products, query)
+      if (!searchQuery && query) {
+        searchAnchorProductIdRef.current = selectedProductId
+      }
+      const searchAnchorProductId = searchAnchorProductIdRef.current
+      if (!query) {
+        searchAnchorProductIdRef.current = null
+      }
+      setSearchState({ scopeKey: searchScopeKey, query })
+      if (nextVisibleProducts.length === 0) {
+        if (searchAnchorProductId && searchAnchorProductId !== selectedProductId) {
+          onSelectProduct(searchAnchorProductId)
+        }
+      } else if (!nextVisibleProducts.some((product) => product.id === selectedProductId)) {
+        onSelectProduct(nextVisibleProducts[0]!.id)
+      }
+    },
+    [onSelectProduct, referenceState.products, searchQuery, searchScopeKey, selectedProductId]
+  )
+
+  const handleSelectProduct = React.useCallback(
+    (productId: string) => {
+      if (searchQuery) {
+        searchAnchorProductIdRef.current = productId
+      }
+      onSelectProduct(productId)
+    },
+    [onSelectProduct, searchQuery]
+  )
+
+  const handleRemoveProduct = React.useCallback(
+    (productId: string) => {
+      const visibleProductIndex = visibleProducts.findIndex((product) => product.id === productId)
+      const remainingVisibleProducts = visibleProducts.filter((product) => product.id !== productId)
+      let nextProduct =
+        remainingVisibleProducts[
+          Math.min(Math.max(visibleProductIndex, 0), remainingVisibleProducts.length - 1)
+        ] ?? null
+      let shouldClearSearch = false
+
+      if (!nextProduct) {
+        const productIndex = referenceState.products.findIndex(
+          (product) => product.id === productId
+        )
+        const remainingProducts = referenceState.products.filter(
+          (product) => product.id !== productId
+        )
+        nextProduct =
+          remainingProducts[Math.min(Math.max(productIndex, 0), remainingProducts.length - 1)] ??
+          null
+        shouldClearSearch = Boolean(nextProduct && searchQuery)
+      }
+
+      pendingFocusTargetRef.current = nextProduct
+        ? { kind: "product", productId: nextProduct.id }
+        : { kind: "search" }
+      if (shouldClearSearch) {
+        searchAnchorProductIdRef.current = null
+        setSearchState({ scopeKey: searchScopeKey, query: "" })
+      }
+      referenceState.removeProduct(productId)
+      if (nextProduct) {
+        handleSelectProduct(nextProduct.id)
+      }
+    },
+    [handleSelectProduct, referenceState, searchQuery, searchScopeKey, visibleProducts]
+  )
+
+  React.useEffect(() => {
+    const target = pendingFocusTargetRef.current
+    if (!target) return
+
+    const element =
+      target.kind === "search"
+        ? searchInputRef.current
+        : productButtonRefs.current.get(target.productId)
+    if (!element) return
+
+    element.focus()
+    pendingFocusTargetRef.current = null
+  }, [referenceState.products, searchQuery, selectedProductId])
+
+  const handleProductButtonRef = React.useCallback(
+    (productId: string, element: HTMLButtonElement | null) => {
+      if (element) {
+        productButtonRefs.current.set(productId, element)
+      } else {
+        productButtonRefs.current.delete(productId)
+      }
+    },
+    []
+  )
 
   return (
     <>
@@ -64,20 +208,46 @@ export function TechnicalConfigurationReferenceProductsBody({
       ) : null}
 
       {canRenderProducts ? (
-        <div className="space-y-4">
-          {referenceState.products.map((product, index) => (
-            <TechnicalConfigurationReferenceProductEditor
-              key={product.id}
-              product={product}
-              index={index}
-              invalid={invalidProductIdSet.has(product.id)}
-              readOnly={referenceState.isReadOnly}
-              navigationBlocked={navigationBlocked}
-              onUpdate={referenceState.updateProduct}
-              onRemove={referenceState.removeProduct}
-            />
-          ))}
-        </div>
+        <section
+          className="grid min-h-0 overflow-hidden rounded-md border bg-background lg:h-[clamp(24rem,50vh,28rem)] lg:grid-cols-[20rem_minmax(0,1fr)]"
+          aria-label="Không gian chỉnh sửa sản phẩm tham chiếu"
+        >
+          <TechnicalConfigurationReferenceProductNavigator
+            workspace={{
+              products: referenceState.products,
+              visibleProducts,
+              invalidProductIds: invalidProductIdSet,
+              selectedProductId,
+              searchQuery,
+              productCountLabel,
+              navigationBlocked,
+            }}
+            searchInputRef={searchInputRef}
+            onSearchChange={handleSearchChange}
+            onSelectProduct={handleSelectProduct}
+            onProductButtonRef={handleProductButtonRef}
+          />
+
+          <div className="min-h-0 overflow-y-auto">
+            {activeProduct ? (
+              <TechnicalConfigurationReferenceProductEditor
+                product={activeProduct}
+                index={activeProductIndex}
+                invalid={invalidProductIdSet.has(activeProduct.id)}
+                readOnly={referenceState.isReadOnly}
+                navigationBlocked={navigationBlocked}
+                onUpdate={referenceState.updateProduct}
+                onRemove={handleRemoveProduct}
+              />
+            ) : (
+              <div className="flex min-h-64 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+                {referenceState.products.length === 0
+                  ? "Thêm sản phẩm tham chiếu để bắt đầu."
+                  : "Chọn một sản phẩm để xem chi tiết."}
+              </div>
+            )}
+          </div>
+        </section>
       ) : null}
 
       {canRenderProducts ? (

--- a/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsToolbar.tsx
+++ b/src/app/(app)/technical-configurations/_components/TechnicalConfigurationReferenceProductsToolbar.tsx
@@ -1,0 +1,139 @@
+import { Loader2, Plus, RefreshCw, Save } from "lucide-react"
+
+import type { TechnicalConfigurationBaselineDraftWire } from "@/app/(app)/technical-configurations/baseline-types"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+/** Sentinel option value that requests another page of baseline versions. */
+export const LOAD_MORE_BASELINE_VERSIONS_VALUE = "__load-more-baseline-versions__"
+
+type TechnicalConfigurationReferenceProductsToolbarProps = {
+  selectedVersion: TechnicalConfigurationBaselineDraftWire
+  versionOptions: TechnicalConfigurationBaselineDraftWire[]
+  versionHistory: {
+    hasMoreVersions: boolean
+    hasHistoryRecoveryError: boolean
+    isFetchingNextPage: boolean
+  }
+  workspaceStatus: {
+    isNavigationBlocked: boolean
+    isProductDataUnavailable: boolean
+    isReadOnly: boolean
+    isDirty: boolean
+    isReloading: boolean
+    isSaving: boolean
+  }
+  invalidProductCount: number
+  onVersionSelect: (value: string) => void
+  onReload: () => void
+  onAddProduct: () => void
+  onSave: () => void
+}
+
+/** Renders baseline-version selection and reference-product workspace actions. */
+export function TechnicalConfigurationReferenceProductsToolbar({
+  selectedVersion,
+  versionOptions,
+  versionHistory,
+  workspaceStatus,
+  invalidProductCount,
+  onVersionSelect,
+  onReload,
+  onAddProduct,
+  onSave,
+}: Readonly<TechnicalConfigurationReferenceProductsToolbarProps>) {
+  const { hasMoreVersions, hasHistoryRecoveryError, isFetchingNextPage } = versionHistory
+  const {
+    isNavigationBlocked,
+    isProductDataUnavailable,
+    isReadOnly,
+    isDirty,
+    isReloading,
+    isSaving,
+  } = workspaceStatus
+
+  return (
+    <section className="flex flex-col gap-4 border-y py-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="min-w-0">
+        <Label htmlFor="reference-baseline-version">Phiên bản cấu hình cơ sở</Label>
+        <Select
+          value={selectedVersion.id}
+          disabled={isNavigationBlocked}
+          onValueChange={onVersionSelect}
+        >
+          <SelectTrigger id="reference-baseline-version" className="mt-2 w-full sm:w-[300px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {versionOptions
+              .toSorted((left, right) => right.version_number - left.version_number)
+              .map((version) => (
+                <SelectItem key={version.id} value={version.id}>
+                  Phiên bản {version.version_number} ·{" "}
+                  {version.status === "locked" ? "Đã khóa" : "Bản nháp"}
+                </SelectItem>
+              ))}
+            {hasMoreVersions || hasHistoryRecoveryError ? (
+              <SelectItem value={LOAD_MORE_BASELINE_VERSIONS_VALUE} disabled={isFetchingNextPage}>
+                {isFetchingNextPage
+                  ? "Đang tải phiên bản..."
+                  : hasHistoryRecoveryError
+                    ? "Thử tải lại lịch sử phiên bản"
+                    : "Tải thêm phiên bản"}
+              </SelectItem>
+            ) : null}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isNavigationBlocked || isProductDataUnavailable}
+          onClick={onReload}
+        >
+          <RefreshCw className={`size-4 ${isReloading ? "animate-spin" : ""}`} aria-hidden="true" />
+          Tải lại dữ liệu
+        </Button>
+        {!isReadOnly ? (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isNavigationBlocked || isProductDataUnavailable}
+              onClick={onAddProduct}
+            >
+              <Plus className="size-4" aria-hidden="true" />
+              Thêm sản phẩm tham chiếu
+            </Button>
+            <Button
+              type="button"
+              disabled={
+                !isDirty ||
+                invalidProductCount > 0 ||
+                isNavigationBlocked ||
+                isProductDataUnavailable
+              }
+              onClick={onSave}
+            >
+              {isSaving ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Save className="size-4" aria-hidden="true" />
+              )}
+              Lưu thay đổi
+            </Button>
+          </>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProductSelection.ts
+++ b/src/app/(app)/technical-configurations/_hooks/useTechnicalConfigurationReferenceProductSelection.ts
@@ -1,0 +1,67 @@
+import * as React from "react"
+
+import type { TechnicalConfigurationReferenceProductDraft } from "@/app/(app)/technical-configurations/technical-configuration-reference-product-state"
+
+type ReferenceProductSelectionState = {
+  scopeKey: string
+  productId: string | null
+  fallbackIndex: number
+}
+
+type UseTechnicalConfigurationReferenceProductSelectionArgs = {
+  scopeKey: string
+  products: TechnicalConfigurationReferenceProductDraft[]
+}
+
+/** Keeps one reference product selected across local edits, deletes, reloads, and saved ID swaps. */
+export function useTechnicalConfigurationReferenceProductSelection({
+  scopeKey,
+  products,
+}: UseTechnicalConfigurationReferenceProductSelectionArgs) {
+  const [selection, setSelection] = React.useState<ReferenceProductSelectionState>({
+    scopeKey,
+    productId: null,
+    fallbackIndex: 0,
+  })
+  React.useEffect(() => {
+    setSelection((currentSelection) =>
+      currentSelection.scopeKey === scopeKey
+        ? currentSelection
+        : {
+            scopeKey,
+            productId: null,
+            fallbackIndex: 0,
+          }
+    )
+  }, [scopeKey])
+
+  const isCurrentScope = selection.scopeKey === scopeKey
+  const preferredProductId = isCurrentScope ? selection.productId : null
+  const fallbackIndex = isCurrentScope ? selection.fallbackIndex : 0
+  const preferredProduct = products.find((product) => product.id === preferredProductId)
+  const selectedProduct =
+    preferredProduct ?? products[Math.min(fallbackIndex, Math.max(products.length - 1, 0))] ?? null
+
+  const selectProduct = React.useCallback(
+    (productId: string) => {
+      const productIndex = products.findIndex((product) => product.id === productId)
+      if (productIndex < 0) return
+      setSelection({ scopeKey, productId, fallbackIndex: productIndex })
+    },
+    [products, scopeKey]
+  )
+
+  const selectAddedProduct = React.useCallback(
+    (productId: string) => {
+      if (!productId) return
+      setSelection({ scopeKey, productId, fallbackIndex: products.length })
+    },
+    [products.length, scopeKey]
+  )
+
+  return {
+    selectedProductId: selectedProduct?.id ?? null,
+    selectAddedProduct,
+    selectProduct,
+  }
+}


### PR DESCRIPTION
## Summary
- replace the stacked reference-product editors with a compact master-detail inline workspace
- keep product selection, search, add/delete focus handoff, baseline changes, and saved ID replacement stable
- add unique accessible navigator labels and extract toolbar/navigator components to keep the React surface maintainable

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run verify:ts-docstrings`
- `node scripts/npm-run.js run typecheck`
- `node scripts/npm-run.js run test:run -- 'src/app/(app)/technical-configurations/__tests__/reference-products.test.tsx'` (53/53)
- `node scripts/npm-run.js run react-doctor` (100/100)
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the stacked reference-product editors with a compact master–detail workspace featuring a searchable navigator and a single editor panel. Improves clarity, keyboard focus, and accessibility while keeping selection and drafts stable across edits, deletes, reloads, version switches, and saved‑ID swaps.

- **New Features**
  - Search and filter by model/manufacturer with live counts and empty-state handling; clear search on add; keep manual selection as a fallback when filters hide matches; reset search/selection on version change.
  - Navigator shows unique, descriptive a11y names (adds ordinals to disambiguate; avoids repeating manufacturer-as-name); disables search and selection while loading/blocked.
  - Stable selection across add/save (local→persisted ID), delete, reload, and baseline version switches; keeps the editor mounted; after filtered delete, focus moves to the next visible row or back to search.
  - Editor tweaks: clearer header with product name, delete tooltip, resizable taller textareas, and a save hint.
  - Toolbar supports version select (with “load more”), reload, add product, and save (gated by invalid items).

- **Refactors**
  - Extracted navigator and toolbar components; added `useTechnicalConfigurationReferenceProductSelection` to maintain robust selection and fallback across ID swaps and version switches.
  - Reworked body into a master–detail grid with managed focus and search state; added focused editor‑workspace tests covering selection, search, focus, and resilience.

<sup>Written for commit 143fa01f4022b22d10d74935c1caed990c42c44d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a searchable reference-product navigator with clear selected, invalid, empty, and filtered states.
  * The workspace now displays one active product editor at a time, automatically preserving selection while products are added, removed, refreshed, or saved.
  * Added toolbar controls for switching baseline versions, loading history, reloading data, adding products, and saving changes.
* **Usability**
  * Improved focus restoration, accessibility labels, responsive editor layout, resizable fields, delete-action guidance, and save-status messaging.
  * Product search and selection are temporarily disabled while version data refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->