### PR TITLE
test: record P13A-P1 non-seeded scale blocker

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -775,6 +775,17 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
       Supabase MCP; leaf này không apply migration và không sửa production code.
 - [ ] P13A-P1.6 Chạy focused TC-20 ranking performance assertions, lưu plan/result
       evidence và xác minh mọi scale seed đã được rollback.
+
+> **Execution status (2026-08-02): blocked before representative plan capture.**
+> Read-only discovery found `max_options_per_dossier = 1`,
+> `max_criteria_per_baseline = 102` and `representative_candidate_count = 0`.
+> The user cancelled production seeding before any live write. Exact evidence:
+> [P13A-P1 representative ranking plan](./verification/P13A-P1-representative-ranking-plan.md).
+> The non-seeded dataset blocker is tracked by
+> [GitHub issue #836](https://github.com/thienchi2109/qltbyt-nam-phong/issues/836).
+> P13A-P2 is not instantiated because no query/index invariant failed;
+> P13A-V remains blocked.
+
 - [ ] P13A-P1.7 Nếu tất cả assertion pass, bỏ qua P13A-P2 và unblock P13A-V; nếu
       fail, giữ P13A-P1 failed, ghi đúng query/index invariant tái lập được, chỉ
       instantiate P13A-P2 với scope đó và giữ P13A-V blocked.

--- a/openspec/changes/add-technical-configuration-comparison/verification/P13A-P1-representative-ranking-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/verification/P13A-P1-representative-ranking-plan.md
@@ -1,0 +1,86 @@
+# P13A-P1 Representative Ranking Plan Evidence
+
+Date: 2026-08-02
+
+Status: P13A-P1 blocked because representative scale is unavailable.
+
+## Scope
+
+This artifact covers only the mandatory representative ranking performance
+evidence leaf. It does not change the production RPC, indexes, schema or data.
+
+The user cancelled production seeding before any live write. The persistent
+fixture, status and cleanup design was removed from the branch.
+
+## Required invariant
+
+The upper-limit workload requires:
+
+- required option_count > 100 and criterion_count = 102 at page_size = 100
+- `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` or an equivalent JSON plan
+- bounded result cardinality and work
+- no temp spill
+- no repeated correlated `SubPlan`
+- no unbounded full rescan outside the ranking contract
+- no hard latency threshold without an approved SLO
+
+## Read-only discovery
+
+The live inventory query grouped options by dossier and criteria by baseline
+version, then counted pairs satisfying the required invariant.
+
+Observed on 2026-08-02:
+
+| Metric                         | Value |
+| ------------------------------ | ----: |
+| dossier_total                  |     2 |
+| option_total                   |     1 |
+| criterion_total                |   102 |
+| max_options_per_dossier        |     1 |
+| max_criteria_per_baseline      |   102 |
+| representative_candidate_count |     0 |
+
+The checked-in read-only preflight reproduced SQLSTATE `P0001` with:
+
+```text
+P13A-P1 representative scale unavailable: required option_count > 100 and
+criterion_count = 102 at page_size = 100; observed {"page_size": 100,
+"option_total": 1, "dossier_total": 2, "criterion_total": 102,
+"max_options_per_dossier": 1, "max_criteria_per_baseline": 102,
+"representative_candidate_count": 0}
+```
+
+The exact unmet invariant is:
+
+`max_options_per_dossier = 1`, `max_criteria_per_baseline = 102`, and
+`representative_candidate_count = 0`, while P13A-P1 requires
+`option_count > 100` paired with `criterion_count = 102` and `page_size = 100`.
+
+## Plan result
+
+No representative EXPLAIN was captured. Running the plan against one option
+would not prove bounded work, cardinality, spill behavior or correlated
+`SubPlan` behavior at the required scale.
+
+The test-only read-only preflight is:
+
+`supabase/tests/technical_configuration_reference_ranking_performance_preflight.sql`
+
+It fails closed with the observed inventory until existing data satisfies the
+required scale. Passing this preflight means only that plan capture may begin;
+it is not representative performance evidence by itself. It does not seed data
+or execute a write statement.
+
+## Phase decision
+
+P13A-P1 remains blocked before plan capture and P13A-V remains blocked.
+
+P13A-P2 is not instantiated because no representative plan ran and therefore
+no reproducible ranking query or index invariant failed. Treating missing test
+data as a query remediation would exceed the approved P13A-P2 scope.
+
+The non-seeded representative-data blocker is tracked by
+[GitHub issue #836](https://github.com/thienchi2109/qltbyt-nam-phong/issues/836).
+
+No live write occurred. No migration, RPC, index or production remediation was
+created or applied.

--- a/src/app/api/rpc/__tests__/technical-configuration-reference-ranking-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-reference-ranking-migration.test.ts
@@ -12,6 +12,14 @@ const PHASE_GATE_PATH = path.join(
   REPO_ROOT,
   "supabase/tests/technical_configuration_reference_ranking_phase_gate.sql"
 )
+const PERFORMANCE_PREFLIGHT_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_reference_ranking_performance_preflight.sql"
+)
+const PERFORMANCE_EVIDENCE_PATH = path.join(
+  REPO_ROOT,
+  "openspec/changes/add-technical-configuration-comparison/verification/P13A-P1-representative-ranking-plan.md"
+)
 
 function readIfExists(filePath: string): string {
   return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
@@ -39,6 +47,8 @@ function getSqlObjectKeys(source: string, startMarker: string, endMarker: string
 const migrationSource = readIfExists(MIGRATION_PATH)
 const functionBlock = getFunctionBlock(migrationSource)
 const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+const performancePreflightSource = readIfExists(PERFORMANCE_PREFLIGHT_PATH)
+const performanceEvidenceSource = readIfExists(PERFORMANCE_EVIDENCE_PATH)
 
 describe("P12C1 technical configuration reference ranking migration", () => {
   it("sorts after the applied P12B2 dependency", () => {
@@ -176,6 +186,39 @@ describe("P12C1 technical configuration reference ranking migration", () => {
     expect(phaseGateSource).toContain("snapshot token ignores session timestamp formatting")
     expect(phaseGateSource).toContain("raw admin can read ranking")
     expect(phaseGateSource).toContain("denied role cannot read ranking")
+  })
+
+  it("ships a read-only representative-data preflight without fixture writes", () => {
+    expect(performancePreflightSource).toContain("BEGIN READ ONLY;")
+    expect(performancePreflightSource).toContain(
+      "-- P13A-P1 representative ranking scale preflight."
+    )
+    expect(performancePreflightSource).toContain("v_page_size CONSTANT INTEGER := 100")
+    expect(performancePreflightSource).toMatch(
+      /count\(\*\) FILTER \(\s*WHERE candidates\.option_count > 100\s*AND candidates\.criterion_count = 102/
+    )
+    expect(performancePreflightSource).toContain("P13A-P1 representative scale unavailable")
+    expect(performancePreflightSource).not.toContain("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)")
+    expect(performancePreflightSource).not.toContain(
+      "technical_configuration_reference_ranking_list("
+    )
+    expect(performancePreflightSource).toContain("COMMIT;")
+    expect(performancePreflightSource).not.toMatch(
+      /\b(?:INSERT|UPDATE|DELETE|MERGE|TRUNCATE|COPY|CREATE|ALTER|DROP|GRANT|REVOKE|CALL|PERFORM)\b/i
+    )
+  })
+
+  it("records the exact representative-data blocker without inventing a query remediation", () => {
+    expect(performanceEvidenceSource).toContain("Status: P13A-P1 blocked")
+    expect(performanceEvidenceSource).toContain("max_options_per_dossier = 1")
+    expect(performanceEvidenceSource).toContain("max_criteria_per_baseline = 102")
+    expect(performanceEvidenceSource).toContain("representative_candidate_count = 0")
+    expect(performanceEvidenceSource).toContain(
+      "required option_count > 100 and criterion_count = 102 at page_size = 100"
+    )
+    expect(performanceEvidenceSource).toContain("No representative EXPLAIN was captured")
+    expect(performanceEvidenceSource).toContain("P13A-P2 is not instantiated")
+    expect(performanceEvidenceSource).toContain("No live write occurred")
   })
 
   it("documents forward-only rollback without editing applied history", () => {

--- a/src/app/api/rpc/__tests__/technical-configuration-reference-ranking-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-reference-ranking-migration.test.ts
@@ -197,6 +197,14 @@ describe("P12C1 technical configuration reference ranking migration", () => {
     expect(performancePreflightSource).toMatch(
       /count\(\*\) FILTER \(\s*WHERE candidates\.option_count > 100\s*AND candidates\.criterion_count = 102/
     )
+    expect(
+      performancePreflightSource.match(
+        /WHERE candidates\.option_count > 100\s*AND candidates\.criterion_count = 102/g
+      )
+    ).toHaveLength(1)
+    expect(
+      performancePreflightSource.match(/candidate_summary\.representative_candidate_count/g)
+    ).toHaveLength(2)
     expect(performancePreflightSource).toContain("P13A-P1 representative scale unavailable")
     expect(performancePreflightSource).not.toContain("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)")
     expect(performancePreflightSource).not.toContain(

--- a/supabase/tests/technical_configuration_reference_ranking_performance_preflight.sql
+++ b/supabase/tests/technical_configuration_reference_ranking_performance_preflight.sql
@@ -1,0 +1,77 @@
+-- P13A-P1 representative ranking scale preflight.
+-- Read-only and fail-closed: plan capture starts only when existing data satisfies
+-- option_count > 100, criterion_count = 102, and page_size = 100.
+BEGIN READ ONLY;
+
+DO $gate$
+DECLARE
+  v_page_size CONSTANT INTEGER := 100;
+  v_candidate_count BIGINT;
+  v_observed JSONB;
+BEGIN
+  WITH option_counts AS (
+    SELECT
+      option_row.dossier_id,
+      count(*)::BIGINT AS option_count
+    FROM public.technical_configuration_options option_row
+    GROUP BY option_row.dossier_id
+  ),
+  criterion_counts AS (
+    SELECT
+      version_row.dossier_id,
+      criterion.baseline_version_id,
+      count(*)::BIGINT AS criterion_count
+    FROM public.technical_configuration_baseline_versions version_row
+    JOIN public.technical_configuration_baseline_groups group_row
+      ON group_row.baseline_version_id = version_row.id
+    JOIN public.technical_configuration_baseline_criteria criterion
+      ON criterion.group_id = group_row.id
+    GROUP BY version_row.dossier_id, criterion.baseline_version_id
+  ),
+  candidates AS (
+    SELECT
+      criterion_counts.dossier_id,
+      criterion_counts.baseline_version_id,
+      COALESCE(option_counts.option_count, 0) AS option_count,
+      criterion_counts.criterion_count
+    FROM criterion_counts
+    LEFT JOIN option_counts
+      ON option_counts.dossier_id = criterion_counts.dossier_id
+  )
+  SELECT
+    count(*) FILTER (
+      WHERE candidates.option_count > 100
+        AND candidates.criterion_count = 102
+    ),
+    jsonb_build_object(
+      'dossier_total',
+      (SELECT count(*) FROM public.technical_configuration_dossiers),
+      'option_total',
+      (SELECT count(*) FROM public.technical_configuration_options),
+      'criterion_total',
+      (SELECT count(*) FROM public.technical_configuration_baseline_criteria),
+      'page_size',
+      v_page_size,
+      'max_options_per_dossier',
+      COALESCE((SELECT max(option_count) FROM option_counts), 0),
+      'max_criteria_per_baseline',
+      COALESCE((SELECT max(criterion_count) FROM criterion_counts), 0),
+      'representative_candidate_count',
+      count(*) FILTER (
+        WHERE candidates.option_count > 100
+          AND candidates.criterion_count = 102
+      )
+    )
+  INTO v_candidate_count, v_observed
+  FROM candidates;
+
+  IF v_candidate_count = 0 THEN
+    RAISE EXCEPTION
+      'P13A-P1 representative scale unavailable: required option_count > 100 and criterion_count = 102 at page_size = %; observed %',
+      v_page_size,
+      v_observed;
+  END IF;
+END
+$gate$;
+
+COMMIT;

--- a/supabase/tests/technical_configuration_reference_ranking_performance_preflight.sql
+++ b/supabase/tests/technical_configuration_reference_ranking_performance_preflight.sql
@@ -37,12 +37,16 @@ BEGIN
     FROM criterion_counts
     LEFT JOIN option_counts
       ON option_counts.dossier_id = criterion_counts.dossier_id
-  )
-  SELECT
-    count(*) FILTER (
+  ),
+  candidate_summary AS (
+    SELECT count(*) FILTER (
       WHERE candidates.option_count > 100
         AND candidates.criterion_count = 102
-    ),
+    ) AS representative_candidate_count
+    FROM candidates
+  )
+  SELECT
+    candidate_summary.representative_candidate_count,
     jsonb_build_object(
       'dossier_total',
       (SELECT count(*) FROM public.technical_configuration_dossiers),
@@ -57,13 +61,10 @@ BEGIN
       'max_criteria_per_baseline',
       COALESCE((SELECT max(criterion_count) FROM criterion_counts), 0),
       'representative_candidate_count',
-      count(*) FILTER (
-        WHERE candidates.option_count > 100
-          AND candidates.criterion_count = 102
-      )
+      candidate_summary.representative_candidate_count
     )
   INTO v_candidate_count, v_observed
-  FROM candidates;
+  FROM candidate_summary;
 
   IF v_candidate_count = 0 THEN
     RAISE EXCEPTION


### PR DESCRIPTION
## Summary
- add a test-only `BEGIN READ ONLY` preflight for the required `>100 options x 102 criteria` workload at page size `100`
- record the exact live SQLSTATE `P0001` inventory blocker: max `1` option per dossier, max `102` criteria per baseline, and `0` representative candidates
- mark P13A-P1 blocked before plan capture and keep P13A-P2 uninstantiated because no query/index invariant has failed

## TDD evidence
- RED: focused source-contract suite failed on the old persistent-fixture gate and missing evidence artifact
- GREEN: focused ranking migration suite passes `9/9`
- independent review findings were addressed; final re-review reports no remaining findings

## Verification
- `node scripts/npm-run.js run format:check`
- `node scripts/npm-run.js run verify:no-explicit-any`
- `node scripts/npm-run.js run verify:dedupe`
- `node scripts/npm-run.js run typecheck`
- focused Vitest: `9/9`
- React Doctor: `100/100`
- `openspec validate add-technical-configuration-comparison --type change --strict --no-interactive`
- `git diff --check`
- live read-only preflight reproduced the documented SQLSTATE `P0001` and exact inventory metrics

## Scope notes
- no production seed or other live write occurred
- no migration, production RPC, index, P13A-P2 remediation, or P13A-V work
- no representative `EXPLAIN` or bounded-work/spill/`SubPlan` claim is made because the required dataset does not exist
- P13A-V remains blocked
- non-seeded dataset follow-up: #836

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only performance preflight for technical configuration ranking and records evidence that the dataset blocks P13A-P1 (required >100 options x 102 criteria at page size 100 not met). Deduplicates representative-candidate counting, reproduces SQLSTATE `P0001`, keeps P13A-P2 uninstantiated, and makes no production writes.

- **New Features**
  - Add `supabase/tests/technical_configuration_reference_ranking_performance_preflight.sql` to fail-closed until data meets the required scale; no DML or plan capture.
  - Add `openspec/changes/add-technical-configuration-comparison/verification/P13A-P1-representative-ranking-plan.md` with exact inventory metrics and the phase decision.

- **Bug Fixes**
  - Deduplicate representative candidate counting in the preflight and enforce via tests (single filter, read-only, no DML).

<sup>Written for commit f50581217475dbbeb815f3c5601f28739724ff06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added verification records explaining why representative ranking performance validation is currently blocked.
  - Documented dataset requirements, observed metrics, missing performance evidence, and follow-up status.

- **Safety Improvements**
  - Added a read-only preflight check to confirm representative data is available before validation begins.
  - The check reports diagnostic details and prevents validation from proceeding when requirements are unmet.

- **Tests**
  - Added coverage confirming the preflight performs no writes or production changes and correctly identifies insufficient data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->