### PR TITLE
docs: record Issue #836 non-seeded dataset audit

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -781,6 +781,10 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
 > `max_criteria_per_baseline = 102` and `representative_candidate_count = 0`.
 > The user cancelled production seeding before any live write. Exact evidence:
 > [P13A-P1 representative ranking plan](./verification/P13A-P1-representative-ranking-plan.md).
+> Issue #836 read-only discovery also found `0` Supabase development branches,
+> only two available VPS snapshots with `1` option and `102` criteria each, no
+> other local dump, no dump in `gdrive:qltbyt-backup/` and no GitHub Actions
+> artifact. No non-seeded source satisfies `>100 options x 102 criteria`.
 > The non-seeded dataset blocker is tracked by
 > [GitHub issue #836](https://github.com/thienchi2109/qltbyt-nam-phong/issues/836).
 > P13A-P2 is not instantiated because no query/index invariant failed;

--- a/openspec/changes/add-technical-configuration-comparison/verification/P13A-P1-representative-ranking-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/verification/P13A-P1-representative-ranking-plan.md
@@ -56,6 +56,30 @@ The exact unmet invariant is:
 `representative_candidate_count = 0`, while P13A-P1 requires
 `option_count > 100` paired with `criterion_count = 102` and `page_size = 100`.
 
+## Non-seeded dataset source audit
+
+Issue #836 was investigated through read-only sources only. The audit did not
+create a Supabase branch, restore a dump, seed data or write to a database.
+
+| Source                               | Read-only evidence                                                                                                               | Representative candidate |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| Live Supabase project                | `2` dossiers, `1` option, `102` criteria; the checked-in preflight failed with SQLSTATE `P0001`                                  | No                       |
+| Supabase development branches        | The project reported `0` existing branches                                                                                       | No source available      |
+| VPS snapshot `20260731T150001Z.dump` | Offline `pg_restore --data-only` inspection found `2` dossiers, `1` option, `1` baseline version, `4` groups and `102` criteria  | No                       |
+| VPS snapshot `20260801T150001Z.dump` | Offline `pg_restore --data-only` inspection found `2` dossiers, `1` option, `2` baseline versions, `8` groups and `102` criteria | No                       |
+| Other local snapshots                | A read-only filesystem search found no `.dump` files beyond the two snapshots above                                              | No source available      |
+| `gdrive:qltbyt-backup/`              | The configured rclone directory contained no dump files                                                                          | No source available      |
+| GitHub repository and Actions        | Actions reported `0` artifacts; `database/` contains migrations only                                                             | No source available      |
+
+Both available snapshots fail the upper-limit invariant from total option
+cardinality alone, so restoring either snapshot would not make representative
+plan capture possible. No restore was attempted.
+
+The exact blocker is the absence of an already-existing environment or snapshot
+where one dossier has more than `100` options and a paired baseline has exactly
+`102` criteria. P13A-P1 cannot proceed through the approved read-only,
+non-seeded path until such a source is made available.
+
 ## Plan result
 
 No representative EXPLAIN was captured. Running the plan against one option
@@ -82,5 +106,6 @@ data as a query remediation would exceed the approved P13A-P2 scope.
 The non-seeded representative-data blocker is tracked by
 [GitHub issue #836](https://github.com/thienchi2109/qltbyt-nam-phong/issues/836).
 
-No live write occurred. No migration, RPC, index or production remediation was
-created or applied.
+No live write occurred. No Supabase branch was created, and no dump restore or
+seed occurred. No migration, RPC, index or production remediation was created
+or applied.


### PR DESCRIPTION
## Summary

- audit every available read-only/non-seeded dataset source for P13A-P1
- record that live Supabase, development branches, two VPS snapshots, rclone and GitHub artifacts cannot satisfy >100 options x 102 criteria
- keep P13A-P2 uninstantiated and P13A-V blocked without seed, restore, migration, RPC or index changes

## Evidence

- live read-only preflight: SQLSTATE P0001, 1 option x 102 criteria
- snapshots 20260731T150001Z and 20260801T150001Z: 1 option x 102 criteria each
- 0 Supabase development branches, 0 GitHub Actions artifacts, no other local/Drive dump

## Verification

- format:check
- openspec validate add-technical-configuration-comparison --strict
- typecheck
- focused Vitest: 9/9 passed
- pre-commit and pre-push Lefthook gates passed

## Known baseline

- full npm run lint remains blocked by pre-existing repository errors tracked in #140; this PR changes Markdown only

Refs #836

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented a read-only audit for Issue #836 showing no non-seeded dataset source meets the P13A-P1 requirement (>100 options x 102 criteria). Adds evidence across live Supabase, two VPS snapshots, rclone `gdrive:qltbyt-backup/`, and GitHub; notes P13A-P2 is not instantiated and P13A-V remains blocked until a seed/restore is available, with no live write or migration changes.

<sup>Written for commit 1fb7bfe28a751f08fccb3f00c7bcf5789b9fccb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

