### PR TITLE
feat(technical-config): add canonical export snapshot manifest

### DIFF
--- a/openspec/changes/add-technical-configuration-comparison/contracts.md
+++ b/openspec/changes/add-technical-configuration-comparison/contracts.md
@@ -490,6 +490,13 @@ exceeds_count, rank }`. `eligibility` is `eligible` or `incomplete`; `rank`
   dossier/baseline scope. The response is
   `{ data: { dossier, baseline_version, option_total, criterion_total,
 snapshot_token, ranking_snapshot_token } }`.
+  `dossier` is exactly
+  `{ id, device_type_name, name, revision, archived_at }`.
+  `baseline_version` is exactly
+  `{ id, dossier_id, version_number, status, revision, locked_at }`.
+  The private P14A1 helper may additionally carry ordered option and criterion
+  IDs for P14A2 consumers, but the public manifest response exposes no extra
+  fields.
 - The P14A1 full `snapshot_token` is opaque, non-empty and covers every field
   that can change visible workbook output: dossier/baseline identity, ordered
   option/supplier identity, ordered criteria, comparison-set identity,

--- a/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/implementation-plan.md
@@ -2977,16 +2977,16 @@ No release-blocking UI, accessibility or Equipment regression remains.
 
 ### Tasks
 
-- [ ] Inspect current migrations, live functions/grants read-only and the P12C1
+- [x] Inspect current migrations, live functions/grants read-only and the P12C1
       ranking snapshot contract before choosing the migration timestamp.
-- [ ] Write RED migration/source tests for the exact manifest request/response,
+- [x] Write RED migration/source tests for the exact manifest request/response,
       `admin/global` authorization, canonical ordered scope validation,
       side-effect-free behavior and opaque full/ranking snapshot tokens.
-- [ ] Add the smallest shared SQL helper and manifest RPC needed to fingerprint
+- [x] Add the smallest shared SQL helper and manifest RPC needed to fingerprint
       every workbook-visible source field without creating comparison sets or
       missing rows.
-- [ ] Add only the P14A1 RPC name to the dedicated manifest and proxy allowlist.
-- [ ] Run migration contract tests, rollback-only phase gate after explicit live
+- [x] Add only the P14A1 RPC name to the dedicated manifest and proxy allowlist.
+- [x] Run migration contract tests, rollback-only phase gate after explicit live
       approval, read-only security advisor and strict OpenSpec validation.
 
 ### Exit gate

--- a/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
+++ b/openspec/changes/add-technical-configuration-comparison/p14-tdd-plan.md
@@ -102,6 +102,8 @@ with merged `main` evidence before its successor starts.
 
 ### Planned Files
 
+- Modify:
+  `openspec/changes/add-technical-configuration-comparison/contracts.md`
 - Create at execution time after migration-order inspection:
   `supabase/migrations/<timestamp>_technical_configuration_result_export_manifest.sql`
 - Create:
@@ -112,6 +114,23 @@ with merged `main` evidence before its successor starts.
   `supabase/tests/technical_configuration_result_export_manifest_phase_gate.sql`
 - Create: `src/lib/technical-configuration-result-export-rpcs.ts`
 - Modify: `src/app/api/rpc/[fn]/allowed-functions.ts`
+
+### Locked Manifest Contract
+
+- Request:
+  `{ p_dossier_id, p_baseline_version_id, p_option_ids, p_criterion_ids }`.
+- `p_option_ids` and `p_criterion_ids` are nullable. Non-null arrays are
+  ordered, non-empty, null-free, unique and must belong to the exact
+  dossier/baseline scope.
+- Response:
+  `{ data: { dossier, baseline_version, option_total, criterion_total,
+snapshot_token, ranking_snapshot_token } }`.
+- `dossier` is exactly
+  `{ id, device_type_name, name, revision, archived_at }`.
+- `baseline_version` is exactly
+  `{ id, dossier_id, version_number, status, revision, locked_at }`.
+- The private helper may additionally carry ordered option/criterion IDs for
+  P14A2 consumers, but the public manifest response exposes no extra fields.
 
 ### RED
 
@@ -145,6 +164,23 @@ with merged `main` evidence before its successor starts.
 
 **Deploy boundary:** dormant read-only manifest RPC; no page RPC, client,
 workbook, UI or download.
+
+### P14A1 Execution Evidence - 2026-08-02
+
+- RED migration/source coverage failed on missing volatility, canonical UTC
+  timestamps and runtime validation cases before the implementation fix.
+- Supabase MCP applied
+  `20260802054948_technical_configuration_result_export_manifest.sql` as live
+  migration `20260802073104`.
+- Live metadata confirms the helper, public manifest RPC and P12C1 ranking RPC
+  are `STABLE`, `SECURITY DEFINER` and pinned to
+  `search_path = public, pg_temp`; grants match the locked contract.
+- The rollback-only phase gate passed authorization, exact response shape,
+  ordered scopes, validation branches, canonical timestamp, token sensitivity
+  and side-effect checks. Post-gate fixture counts are zero.
+- Security/performance advisors were reviewed with no P14A1 blocker. Independent
+  re-review reached zero findings; required local gates and strict OpenSpec
+  validation passed.
 
 ## P14A2 - Paginated Export Ranking And Matrix Contracts
 

--- a/openspec/changes/add-technical-configuration-comparison/tasks.md
+++ b/openspec/changes/add-technical-configuration-comparison/tasks.md
@@ -856,13 +856,13 @@ p_baseline_version_id, p_page, p_page_size)` read-only, set-based cho toàn
 
 ## Phase P14A1 - Canonical Export Snapshot Manifest
 
-- [ ] P14A1.1 Khóa exact manifest request/response, canonical scope và hai opaque
+- [x] P14A1.1 Khóa exact manifest request/response, canonical scope và hai opaque
       snapshot token bằng RED migration/source tests.
-- [ ] P14A1.2 Thêm helper + manifest RPC read-only nhỏ nhất; không get-or-create,
+- [x] P14A1.2 Thêm helper + manifest RPC read-only nhỏ nhất; không get-or-create,
       không ghi row/revision/audit.
-- [ ] P14A1.3 Thêm đúng một RPC name vào dedicated manifest/proxy allowlist và
+- [x] P14A1.3 Thêm đúng một RPC name vào dedicated manifest/proxy allowlist và
       kiểm tra `admin/global`, denied roles, missing claims.
-- [ ] P14A1.4 Chỉ apply/rollback-only gate qua Supabase MCP sau explicit approval;
+- [x] P14A1.4 Chỉ apply/rollback-only gate qua Supabase MCP sau explicit approval;
       chạy security advisor và strict OpenSpec validation.
 
 ## Phase P14A2 - Paginated Export Ranking And Matrix Contracts

--- a/src/app/api/rpc/[fn]/allowed-functions.ts
+++ b/src/app/api/rpc/[fn]/allowed-functions.ts
@@ -4,6 +4,7 @@ import { COMPARISON_READ_RPC_FUNCTION_NAMES } from "@/lib/technical-configuratio
 import { DOCUMENT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-document-rpcs"
 import { REFERENCE_RANKING_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-ranking-rpcs"
 import { REFERENCE_PRODUCT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-reference-rpcs"
+import { RESULT_EXPORT_RPC_FUNCTION_NAMES } from "@/lib/technical-configuration-result-export-rpcs"
 import {
   OPTION_IMPORT_RPC_FUNCTION_NAMES,
   OPTION_RESPONSE_READ_RPC_FUNCTION_NAMES,
@@ -116,6 +117,7 @@ export const ALLOWED_FUNCTIONS = new Set<string>([
   ...COMPARISON_READ_RPC_FUNCTION_NAMES,
   ...ASSESSMENT_RPC_FUNCTION_NAMES,
   ...REFERENCE_RANKING_RPC_FUNCTION_NAMES,
+  ...RESULT_EXPORT_RPC_FUNCTION_NAMES,
   // AI Assistant (read-only)
   "ai_equipment_lookup",
   "ai_maintenance_plan_lookup",

--- a/src/app/api/rpc/__tests__/technical-configuration-result-export-manifest-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-result-export-manifest-migration.test.ts
@@ -1,0 +1,267 @@
+import { existsSync, readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const REPO_ROOT = path.resolve(process.cwd())
+const MIGRATIONS_DIR = path.join(REPO_ROOT, "supabase/migrations")
+const LATEST_DEPENDENCY_MIGRATION = "20260731102715_technical_configuration_reference_ranking.sql"
+const MIGRATION_FILE = "20260802054948_technical_configuration_result_export_manifest.sql"
+const MIGRATION_PATH = path.join(MIGRATIONS_DIR, MIGRATION_FILE)
+const PHASE_GATE_PATH = path.join(
+  REPO_ROOT,
+  "supabase/tests/technical_configuration_result_export_manifest_phase_gate.sql"
+)
+
+function readIfExists(filePath: string): string {
+  return existsSync(filePath) ? readFileSync(filePath, "utf8") : ""
+}
+
+function getFunctionBlock(source: string, functionName: string): string {
+  const marker = `CREATE OR REPLACE FUNCTION public.${functionName}(`
+  const start = source.indexOf(marker)
+  if (start === -1) return ""
+
+  const end = source.indexOf("\n$$;", start + marker.length)
+  const functionStart = start + "CREATE OR REPLACE ".length
+  return source.slice(functionStart, end === -1 ? source.length : end)
+}
+
+function getSqlObjectKeys(source: string, startMarker: string, endMarker: string): string[] {
+  const start = source.indexOf(startMarker)
+  if (start === -1) return []
+
+  const contentStart = start + startMarker.length
+  const end = source.indexOf(endMarker, contentStart)
+  if (end === -1) return []
+
+  return [...source.slice(contentStart, end).matchAll(/^\s*'([a-z_]+)',/gm)].map(
+    (match) => match[1]
+  )
+}
+
+const migrationSource = readIfExists(MIGRATION_PATH)
+const helperBlock = getFunctionBlock(
+  migrationSource,
+  "_technical_configuration_result_export_snapshot"
+)
+const manifestBlock = getFunctionBlock(
+  migrationSource,
+  "technical_configuration_result_export_manifest_get"
+)
+const phaseGateSource = readIfExists(PHASE_GATE_PATH)
+
+describe("P14A1 technical configuration result export manifest migration", () => {
+  it("sorts after the applied P12C1 dependency", () => {
+    expect(MIGRATION_FILE.localeCompare(LATEST_DEPENDENCY_MIGRATION)).toBeGreaterThan(0)
+    expect(migrationSource).not.toBe("")
+  })
+
+  it("freezes the private snapshot helper and exact public manifest signatures", () => {
+    expect(helperBlock).toContain(
+      "_technical_configuration_result_export_snapshot(\n" +
+        "  p_dossier_id UUID,\n" +
+        "  p_baseline_version_id UUID,\n" +
+        "  p_option_ids UUID[],\n" +
+        "  p_criterion_ids UUID[]"
+    )
+    expect(manifestBlock).toContain(
+      "technical_configuration_result_export_manifest_get(\n" +
+        "  p_dossier_id UUID,\n" +
+        "  p_baseline_version_id UUID,\n" +
+        "  p_option_ids UUID[],\n" +
+        "  p_criterion_ids UUID[]"
+    )
+
+    for (const functionBlock of [helperBlock, manifestBlock]) {
+      expect(functionBlock).toContain("RETURNS JSONB")
+      expect(functionBlock).toContain("LANGUAGE plpgsql\nSTABLE\nSECURITY DEFINER")
+      expect(functionBlock).toContain("SECURITY DEFINER")
+      expect(functionBlock).toContain("SET search_path = public, pg_temp")
+      expect(functionBlock).toContain(
+        "PERFORM public._technical_configuration_require_global_user()"
+      )
+    }
+
+    expect(migrationSource).toContain(
+      "ALTER FUNCTION public.technical_configuration_reference_ranking_list(" +
+        "UUID, UUID, INTEGER, INTEGER) STABLE;"
+    )
+  })
+
+  it("rejects malformed, duplicate and foreign ordered scopes fail closed", () => {
+    expect(helperBlock).toContain("p_dossier_id IS NULL OR p_baseline_version_id IS NULL")
+    expect(helperBlock).toContain("cardinality(p_option_ids) = 0")
+    expect(helperBlock).toContain("cardinality(p_criterion_ids) = 0")
+    expect(helperBlock).toContain("array_position(p_option_ids, NULL) IS NOT NULL")
+    expect(helperBlock).toContain("array_position(p_criterion_ids, NULL) IS NOT NULL")
+    expect(helperBlock).toContain("count(DISTINCT requested.option_id)")
+    expect(helperBlock).toContain("count(DISTINCT requested.criterion_id)")
+    expect(helperBlock).toContain("RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422'")
+    expect(helperBlock).toContain("RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404'")
+    expect(helperBlock).toContain("WITH ORDINALITY")
+    expect(helperBlock).toContain("ORDER BY scoped_option.ordinal")
+    expect(helperBlock).toContain("ORDER BY scoped_criterion.ordinal")
+  })
+
+  it("returns only the approved public manifest shape", () => {
+    expect(getSqlObjectKeys(manifestBlock, "RETURN jsonb_build_object(", "\n  );\nEND;")).toEqual([
+      "data",
+      "dossier",
+      "baseline_version",
+      "option_total",
+      "criterion_total",
+      "snapshot_token",
+      "ranking_snapshot_token",
+    ])
+
+    expect(
+      getSqlObjectKeys(
+        helperBlock,
+        "'dossier', jsonb_build_object(",
+        "\n      ),\n      'baseline_version'"
+      )
+    ).toEqual(["id", "device_type_name", "name", "revision", "archived_at"])
+    expect(
+      getSqlObjectKeys(
+        helperBlock,
+        "'baseline_version', jsonb_build_object(",
+        "\n      ),\n      'option_ids'"
+      )
+    ).toEqual(["id", "dossier_id", "version_number", "status", "revision", "locked_at"])
+    expect(helperBlock).toContain("dossier.archived_at AT TIME ZONE 'UTC'")
+    expect(helperBlock).toContain("version.locked_at AT TIME ZONE 'UTC'")
+    expect(helperBlock.match(/AT TIME ZONE 'UTC'/g)).toHaveLength(2)
+  })
+
+  it("builds one canonical scoped digest over every workbook-visible source", () => {
+    expect(helperBlock).toContain("INTO v_snapshot_data, v_snapshot_payload")
+    expect(helperBlock).toContain("md5(v_snapshot_payload::TEXT)")
+
+    for (const tableName of [
+      "technical_configuration_dossiers",
+      "technical_configuration_baseline_versions",
+      "technical_configuration_options",
+      "technical_configuration_suppliers",
+      "technical_configuration_baseline_groups",
+      "technical_configuration_baseline_criteria",
+      "technical_configuration_comparison_sets",
+      "technical_configuration_option_responses",
+      "technical_configuration_option_documents",
+      "technical_configuration_option_citations",
+      "technical_configuration_manual_assessments",
+    ]) {
+      expect(helperBlock).toContain(`public.${tableName}`)
+    }
+
+    for (const fieldName of [
+      "device_type_name",
+      "archived_at",
+      "locked_at",
+      "supplier_name",
+      "model",
+      "manufacturer",
+      "option_name",
+      "group_name",
+      "criterion_code",
+      "criterion_title",
+      "requirement_text",
+      "comparison_set_id",
+      "response_text",
+      "supplementary_information",
+      "document_name",
+      "document_url",
+      "page_section",
+      "excerpt",
+      "technical_axis",
+      "evidence_axis",
+      "assessment_notes",
+      "assessment_revision",
+    ]) {
+      expect(helperBlock).toContain(`'${fieldName}'`)
+    }
+  })
+
+  it("reuses the exact complete-universe P12C1 ranking token", () => {
+    expect(helperBlock).toContain("public.technical_configuration_reference_ranking_list(")
+    expect(helperBlock).toContain("->>'snapshot_token'")
+    expect(helperBlock).toContain("'ranking_snapshot_token'")
+    expect(helperBlock).not.toContain("DENSE_RANK() OVER")
+  })
+
+  it("keeps both functions read-only and grants only the intended execution paths", () => {
+    for (const functionBlock of [helperBlock, manifestBlock]) {
+      expect(functionBlock).not.toMatch(
+        /\b(?:INSERT|UPDATE|DELETE|MERGE|TRUNCATE|COPY|CREATE|ALTER|DROP|CALL|PERFORM\s+public\.technical_configuration_comparison_set_get_or_create)\b/i
+      )
+      expect(functionBlock).not.toContain("get_or_create")
+    }
+
+    expect(migrationSource).toContain(
+      "REVOKE ALL ON FUNCTION public._technical_configuration_result_export_snapshot("
+    )
+    expect(migrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public._technical_configuration_result_export_snapshot("
+    )
+    expect(migrationSource).toContain(
+      "REVOKE ALL ON FUNCTION public.technical_configuration_result_export_manifest_get("
+    )
+    expect(migrationSource).toContain(
+      "GRANT EXECUTE ON FUNCTION public.technical_configuration_result_export_manifest_get("
+    )
+  })
+
+  it("ships a rollback-only phase gate for authorization, scope and token coverage", () => {
+    expect(phaseGateSource).toContain("BEGIN;")
+    expect(phaseGateSource).toContain("ROLLBACK;")
+
+    for (const assertionLabel of [
+      "raw admin can read export manifest",
+      "global can read export manifest",
+      "denied role cannot read export manifest",
+      "missing claims rejected",
+      "helper is stable",
+      "manifest is stable",
+      "P12C1 ranking is stable",
+      "null dossier rejected",
+      "null baseline rejected",
+      "dossier baseline mismatch rejected",
+      "empty option scope rejected",
+      "null option element rejected",
+      "duplicate option scope rejected",
+      "foreign option scope rejected",
+      "empty criterion scope rejected",
+      "null criterion element rejected",
+      "duplicate criterion scope rejected",
+      "foreign criterion scope rejected",
+      "ranking token matches P12C1",
+      "manifest timestamps are UTC canonical",
+      "manifest timestamp representation ignores session timezone",
+      "full token changes with dossier name",
+      "full token changes with baseline lock date",
+      "full token changes with option identity",
+      "full token changes with supplier identity",
+      "full token changes with criterion requirement",
+      "full token changes with response text",
+      "full token changes with supplementary information",
+      "full token changes with document metadata",
+      "full token changes with citation excerpt",
+      "full token changes with manual assessment notes",
+      "missing rows remain absent",
+      "manifest read preserves revisions and audit metadata",
+    ]) {
+      expect(phaseGateSource).toContain(assertionLabel)
+    }
+  })
+
+  it("documents forward-only rollback without editing applied history", () => {
+    expect(migrationSource).toContain(
+      "-- Rollback (forward-only; never edit applied history): ship a separately reviewed migration with:"
+    )
+    expect(migrationSource).toContain(
+      "DROP FUNCTION IF EXISTS public.technical_configuration_result_export_manifest_get("
+    )
+    expect(migrationSource).toContain(
+      "DROP FUNCTION IF EXISTS public._technical_configuration_result_export_snapshot("
+    )
+  })
+})

--- a/src/app/api/rpc/__tests__/technical-configuration-result-export-manifest-migration.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-result-export-manifest-migration.test.ts
@@ -190,6 +190,7 @@ describe("P14A1 technical configuration result export manifest migration", () =>
 
   it("keeps both functions read-only and grants only the intended execution paths", () => {
     for (const functionBlock of [helperBlock, manifestBlock]) {
+      expect(functionBlock).not.toBe("")
       expect(functionBlock).not.toMatch(
         /\b(?:INSERT|UPDATE|DELETE|MERGE|TRUNCATE|COPY|CREATE|ALTER|DROP|CALL|PERFORM\s+public\.technical_configuration_comparison_set_get_or_create)\b/i
       )
@@ -246,6 +247,7 @@ describe("P14A1 technical configuration result export manifest migration", () =>
       "full token changes with document metadata",
       "full token changes with citation excerpt",
       "full token changes with manual assessment notes",
+      "full token changes with manual assessment technical axis",
       "missing rows remain absent",
       "manifest read preserves revisions and audit metadata",
     ]) {
@@ -262,6 +264,10 @@ describe("P14A1 technical configuration result export manifest migration", () =>
     )
     expect(migrationSource).toContain(
       "DROP FUNCTION IF EXISTS public._technical_configuration_result_export_snapshot("
+    )
+    expect(migrationSource).toContain(
+      "-- ALTER FUNCTION public.technical_configuration_reference_ranking_list(" +
+        "UUID, UUID, INTEGER, INTEGER) VOLATILE;"
     )
   })
 })

--- a/src/app/api/rpc/__tests__/technical-configuration-result-export-rpc-whitelist.test.ts
+++ b/src/app/api/rpc/__tests__/technical-configuration-result-export-rpc-whitelist.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("server-only", () => ({}))
+
+import { ALLOWED_FUNCTIONS } from "@/app/api/rpc/[fn]/allowed-functions"
+import { POST } from "@/app/api/rpc/[fn]/route"
+import {
+  RESULT_EXPORT_RPC_FUNCTION_NAMES,
+  RESULT_EXPORT_RPC_FUNCTIONS,
+} from "@/lib/technical-configuration-result-export-rpcs"
+
+const P14A1_RPC_FUNCTIONS = ["technical_configuration_result_export_manifest_get"] as const
+
+async function invokeRpcProxy(fn: string) {
+  const request = new Request(`http://localhost/api/rpc/${fn}`, { method: "POST" })
+  return POST(request as never, { params: Promise.resolve({ fn }) })
+}
+
+describe("technical configuration result export RPC whitelist", () => {
+  it("freezes exactly the P14A1 manifest RPC", () => {
+    expect(RESULT_EXPORT_RPC_FUNCTIONS).toEqual({
+      getManifest: "technical_configuration_result_export_manifest_get",
+    })
+    expect(RESULT_EXPORT_RPC_FUNCTION_NAMES).toEqual(P14A1_RPC_FUNCTIONS)
+  })
+
+  it("imports and spreads only the P14A1 manifest into the shared allowlist", () => {
+    expect(
+      [...ALLOWED_FUNCTIONS].filter((fn) => fn.startsWith("technical_configuration_result_export_"))
+    ).toEqual(P14A1_RPC_FUNCTIONS)
+  })
+
+  it.each(P14A1_RPC_FUNCTIONS)('allows result export RPC "%s" through the proxy', async (fn) => {
+    const response = await invokeRpcProxy(fn)
+
+    expect(response.status).toBe(411)
+    await expect(response.json()).resolves.toEqual({
+      error: "Content-Length header required",
+    })
+  })
+})

--- a/src/lib/technical-configuration-result-export-rpcs.ts
+++ b/src/lib/technical-configuration-result-export-rpcs.ts
@@ -1,0 +1,7 @@
+/** Named P14A1 result-export RPC shared by the proxy and future typed clients. */
+export const RESULT_EXPORT_RPC_FUNCTIONS = {
+  getManifest: "technical_configuration_result_export_manifest_get",
+} as const
+
+/** Ordered P14A1 result-export RPC names for allowlists and contract iteration. */
+export const RESULT_EXPORT_RPC_FUNCTION_NAMES = Object.values(RESULT_EXPORT_RPC_FUNCTIONS)

--- a/supabase/migrations/20260802054948_technical_configuration_result_export_manifest.sql
+++ b/supabase/migrations/20260802054948_technical_configuration_result_export_manifest.sql
@@ -1,0 +1,445 @@
+-- P14A1: canonical, scoped, read-only result-export snapshot manifest.
+-- Rollback (forward-only; never edit applied history): ship a separately reviewed migration with:
+-- REVOKE ALL ON FUNCTION public.technical_configuration_result_export_manifest_get(
+--   UUID, UUID, UUID[], UUID[]
+-- ) FROM PUBLIC, anon, authenticated, service_role;
+-- DROP FUNCTION IF EXISTS public.technical_configuration_result_export_manifest_get(
+--   UUID, UUID, UUID[], UUID[]
+-- );
+-- REVOKE ALL ON FUNCTION public._technical_configuration_result_export_snapshot(
+--   UUID, UUID, UUID[], UUID[]
+-- ) FROM PUBLIC, anon, authenticated, service_role;
+-- DROP FUNCTION IF EXISTS public._technical_configuration_result_export_snapshot(
+--   UUID, UUID, UUID[], UUID[]
+-- );
+BEGIN;
+ALTER FUNCTION public.technical_configuration_reference_ranking_list(UUID, UUID, INTEGER, INTEGER) STABLE;
+CREATE OR REPLACE FUNCTION public._technical_configuration_result_export_snapshot(
+  p_dossier_id UUID,
+  p_baseline_version_id UUID,
+  p_option_ids UUID[],
+  p_criterion_ids UUID[]
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_snapshot_data JSONB;
+  v_snapshot_payload JSONB;
+  v_option_total BIGINT;
+  v_criterion_total BIGINT;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  IF p_dossier_id IS NULL OR p_baseline_version_id IS NULL THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  IF p_option_ids IS NOT NULL AND (
+    cardinality(p_option_ids) = 0
+    OR array_position(p_option_ids, NULL) IS NOT NULL
+    OR (
+      SELECT count(DISTINCT requested.option_id)
+      FROM unnest(p_option_ids) AS requested(option_id)
+    ) <> cardinality(p_option_ids)
+  ) THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  IF p_criterion_ids IS NOT NULL AND (
+    cardinality(p_criterion_ids) = 0
+    OR array_position(p_criterion_ids, NULL) IS NOT NULL
+    OR (
+      SELECT count(DISTINCT requested.criterion_id)
+      FROM unnest(p_criterion_ids) AS requested(criterion_id)
+    ) <> cardinality(p_criterion_ids)
+  ) THEN
+    RAISE EXCEPTION 'validation_error' USING ERRCODE = 'PT422';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.technical_configuration_baseline_versions version
+    WHERE version.id = p_baseline_version_id
+      AND version.dossier_id = p_dossier_id
+  ) THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  WITH requested_options AS MATERIALIZED (
+    SELECT requested.option_id, requested.ordinal::BIGINT
+    FROM unnest(p_option_ids) WITH ORDINALITY AS requested(option_id, ordinal)
+    WHERE p_option_ids IS NOT NULL
+    UNION ALL
+    SELECT
+      option_row.id,
+      row_number() OVER (
+        ORDER BY
+          supplier.normalized_name,
+          COALESCE(option_row.model, option_row.option_name),
+          option_row.id
+      )
+    FROM public.technical_configuration_options option_row
+    JOIN public.technical_configuration_suppliers supplier
+      ON supplier.id = option_row.supplier_id
+     AND supplier.dossier_id = option_row.dossier_id
+    WHERE p_option_ids IS NULL
+      AND option_row.dossier_id = p_dossier_id
+  ),
+  scoped_options AS MATERIALIZED (
+    SELECT
+      requested.ordinal,
+      option_row.id AS option_id,
+      option_row.supplier_id,
+      supplier.name AS supplier_name,
+      supplier.normalized_name AS supplier_normalized_name,
+      option_row.model,
+      option_row.manufacturer,
+      option_row.option_name
+    FROM requested_options requested
+    JOIN public.technical_configuration_options option_row
+      ON option_row.id = requested.option_id
+     AND option_row.dossier_id = p_dossier_id
+    JOIN public.technical_configuration_suppliers supplier
+      ON supplier.id = option_row.supplier_id
+     AND supplier.dossier_id = option_row.dossier_id
+  ),
+  requested_criteria AS MATERIALIZED (
+    SELECT requested.criterion_id, requested.ordinal::BIGINT
+    FROM unnest(p_criterion_ids) WITH ORDINALITY AS requested(criterion_id, ordinal)
+    WHERE p_criterion_ids IS NOT NULL
+    UNION ALL
+    SELECT
+      criterion.id,
+      row_number() OVER (
+        ORDER BY group_row.sort_order, criterion.sort_order, criterion.id
+      )
+    FROM public.technical_configuration_baseline_criteria criterion
+    JOIN public.technical_configuration_baseline_groups group_row
+      ON group_row.id = criterion.group_id
+     AND group_row.baseline_version_id = criterion.baseline_version_id
+    WHERE p_criterion_ids IS NULL
+      AND criterion.baseline_version_id = p_baseline_version_id
+  ),
+  scoped_criteria AS MATERIALIZED (
+    SELECT
+      requested.ordinal,
+      group_row.id AS group_id,
+      group_row.name AS group_name,
+      group_row.sort_order AS group_order,
+      criterion.id AS criterion_id,
+      criterion.criterion_code,
+      criterion.title AS criterion_title,
+      criterion.requirement_text,
+      criterion.sort_order AS criterion_order
+    FROM requested_criteria requested
+    JOIN public.technical_configuration_baseline_criteria criterion
+      ON criterion.id = requested.criterion_id
+     AND criterion.baseline_version_id = p_baseline_version_id
+    JOIN public.technical_configuration_baseline_groups group_row
+      ON group_row.id = criterion.group_id
+     AND group_row.baseline_version_id = criterion.baseline_version_id
+  ),
+  dossier_context AS MATERIALIZED (
+    SELECT
+      dossier.id AS dossier_id,
+      dossier.device_type_name,
+      dossier.name AS dossier_name,
+      dossier.revision AS dossier_revision,
+      CASE WHEN dossier.archived_at IS NULL THEN NULL ELSE to_char(
+        dossier.archived_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+      ) END AS archived_at,
+      version.id AS baseline_version_id,
+      version.dossier_id AS baseline_dossier_id,
+      version.version_number,
+      version.status AS baseline_status,
+      version.revision AS baseline_revision,
+      CASE WHEN version.locked_at IS NULL THEN NULL ELSE to_char(
+        version.locked_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+      ) END AS locked_at
+    FROM public.technical_configuration_dossiers dossier
+    JOIN public.technical_configuration_baseline_versions version
+      ON version.dossier_id = dossier.id
+     AND version.id = p_baseline_version_id
+    WHERE dossier.id = p_dossier_id
+  ),
+  ranking_snapshot AS MATERIALIZED (
+    SELECT public.technical_configuration_reference_ranking_list(
+      p_dossier_id,
+      p_baseline_version_id,
+      1,
+      1
+    ) AS response
+  )
+  SELECT
+    jsonb_build_object(
+      'dossier', jsonb_build_object(
+        'id', context.dossier_id,
+        'device_type_name', context.device_type_name,
+        'name', context.dossier_name,
+        'revision', context.dossier_revision,
+        'archived_at', context.archived_at
+      ),
+      'baseline_version', jsonb_build_object(
+        'id', context.baseline_version_id,
+        'dossier_id', context.baseline_dossier_id,
+        'version_number', context.version_number,
+        'status', context.baseline_status,
+        'revision', context.baseline_revision,
+        'locked_at', context.locked_at
+      ),
+      'option_ids', COALESCE(
+        (
+          SELECT jsonb_agg(scoped_option.option_id ORDER BY scoped_option.ordinal)
+          FROM scoped_options scoped_option
+        ),
+        '[]'::JSONB
+      ),
+      'criterion_ids', COALESCE(
+        (
+          SELECT jsonb_agg(scoped_criterion.criterion_id ORDER BY scoped_criterion.ordinal)
+          FROM scoped_criteria scoped_criterion
+        ),
+        '[]'::JSONB
+      ),
+      'option_total', (SELECT count(*) FROM scoped_options),
+      'criterion_total', (SELECT count(*) FROM scoped_criteria),
+      'ranking_snapshot_token', ranking.response->>'snapshot_token'
+    ),
+    jsonb_build_object(
+      'dossier', jsonb_build_object(
+        'id', context.dossier_id,
+        'device_type_name', context.device_type_name,
+        'name', context.dossier_name,
+        'revision', context.dossier_revision,
+        'archived_at', context.archived_at
+      ),
+      'baseline_version', jsonb_build_object(
+        'id', context.baseline_version_id,
+        'dossier_id', context.baseline_dossier_id,
+        'version_number', context.version_number,
+        'status', context.baseline_status,
+        'revision', context.baseline_revision,
+        'locked_at', context.locked_at
+      ),
+      'options', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'option_id', scoped_option.option_id,
+              'supplier_id', scoped_option.supplier_id,
+              'supplier_name', scoped_option.supplier_name,
+              'supplier_normalized_name', scoped_option.supplier_normalized_name,
+              'model', scoped_option.model,
+              'manufacturer', scoped_option.manufacturer,
+              'option_name', scoped_option.option_name
+            )
+            ORDER BY scoped_option.ordinal
+          )
+          FROM scoped_options scoped_option
+        ),
+        '[]'::JSONB
+      ),
+      'criteria', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'group_id', scoped_criterion.group_id,
+              'group_name', scoped_criterion.group_name,
+              'group_order', scoped_criterion.group_order,
+              'criterion_id', scoped_criterion.criterion_id,
+              'criterion_code', scoped_criterion.criterion_code,
+              'criterion_title', scoped_criterion.criterion_title,
+              'requirement_text', scoped_criterion.requirement_text,
+              'criterion_order', scoped_criterion.criterion_order
+            )
+            ORDER BY scoped_criterion.ordinal
+          )
+          FROM scoped_criteria scoped_criterion
+        ),
+        '[]'::JSONB
+      ),
+      'comparison_sets', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'comparison_set_id', comparison_set.id,
+              'option_id', comparison_set.option_id,
+              'baseline_version_id', comparison_set.baseline_version_id
+            )
+            ORDER BY scoped_option.ordinal
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_comparison_sets comparison_set
+            ON comparison_set.option_id = scoped_option.option_id
+           AND comparison_set.dossier_id = p_dossier_id
+           AND comparison_set.baseline_version_id = p_baseline_version_id
+        ),
+        '[]'::JSONB
+      ),
+      'responses', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'response_id', response.id,
+              'comparison_set_id', response.comparison_set_id,
+              'criterion_id', response.criterion_id,
+              'response_text', response.response_text,
+              'supplementary_information', response.supplementary_information
+            )
+            ORDER BY scoped_option.ordinal, scoped_criterion.ordinal
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_comparison_sets comparison_set
+            ON comparison_set.option_id = scoped_option.option_id
+           AND comparison_set.dossier_id = p_dossier_id
+           AND comparison_set.baseline_version_id = p_baseline_version_id
+          JOIN public.technical_configuration_option_responses response
+            ON response.comparison_set_id = comparison_set.id
+           AND response.baseline_version_id = p_baseline_version_id
+          JOIN scoped_criteria scoped_criterion
+            ON scoped_criterion.criterion_id = response.criterion_id
+        ),
+        '[]'::JSONB
+      ),
+      'documents', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'document_id', document.id,
+              'option_id', document.option_id,
+              'document_name', document.name,
+              'document_url', document.url
+            )
+            ORDER BY scoped_option.ordinal, document.name, document.id
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_option_documents document
+            ON document.option_id = scoped_option.option_id
+        ),
+        '[]'::JSONB
+      ),
+      'citations', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'citation_id', citation.id,
+              'option_id', citation.option_id,
+              'comparison_set_id', citation.comparison_set_id,
+              'criterion_id', citation.criterion_id,
+              'document_id', citation.option_document_id,
+              'page_section', citation.page_section,
+              'excerpt', citation.excerpt
+            )
+            ORDER BY
+              scoped_option.ordinal,
+              scoped_criterion.ordinal,
+              citation.option_document_id,
+              citation.id
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_comparison_sets comparison_set
+            ON comparison_set.option_id = scoped_option.option_id
+           AND comparison_set.dossier_id = p_dossier_id
+           AND comparison_set.baseline_version_id = p_baseline_version_id
+          JOIN public.technical_configuration_option_citations citation
+            ON citation.comparison_set_id = comparison_set.id
+           AND citation.option_id = scoped_option.option_id
+           AND citation.baseline_version_id = p_baseline_version_id
+          JOIN scoped_criteria scoped_criterion
+            ON scoped_criterion.criterion_id = citation.criterion_id
+        ),
+        '[]'::JSONB
+      ),
+      'assessments', COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'assessment_id', assessment.id,
+              'comparison_set_id', assessment.comparison_set_id,
+              'criterion_id', assessment.criterion_id,
+              'technical_axis', assessment.technical_axis,
+              'evidence_axis', assessment.evidence_axis,
+              'assessment_notes', assessment.notes,
+              'assessment_revision', assessment.revision
+            )
+            ORDER BY scoped_option.ordinal, scoped_criterion.ordinal
+          )
+          FROM scoped_options scoped_option
+          JOIN public.technical_configuration_comparison_sets comparison_set
+            ON comparison_set.option_id = scoped_option.option_id
+           AND comparison_set.dossier_id = p_dossier_id
+           AND comparison_set.baseline_version_id = p_baseline_version_id
+          JOIN public.technical_configuration_manual_assessments assessment
+            ON assessment.comparison_set_id = comparison_set.id
+           AND assessment.baseline_version_id = p_baseline_version_id
+          JOIN scoped_criteria scoped_criterion
+            ON scoped_criterion.criterion_id = assessment.criterion_id
+        ),
+        '[]'::JSONB
+      ),
+      'ranking_snapshot_token', ranking.response->>'snapshot_token'
+    ),
+    (SELECT count(*) FROM scoped_options),
+    (SELECT count(*) FROM scoped_criteria)
+  INTO v_snapshot_data, v_snapshot_payload, v_option_total, v_criterion_total
+  FROM dossier_context context
+  CROSS JOIN ranking_snapshot ranking;
+  IF p_option_ids IS NOT NULL AND v_option_total <> cardinality(p_option_ids) THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  IF p_criterion_ids IS NOT NULL
+     AND v_criterion_total <> cardinality(p_criterion_ids) THEN
+    RAISE EXCEPTION 'not_found' USING ERRCODE = 'PT404';
+  END IF;
+  RETURN v_snapshot_data || jsonb_build_object(
+    'snapshot_token',
+    md5(v_snapshot_payload::TEXT)
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public._technical_configuration_result_export_snapshot(
+  UUID, UUID, UUID[], UUID[]
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public._technical_configuration_result_export_snapshot(
+  UUID, UUID, UUID[], UUID[]
+) TO service_role;
+CREATE OR REPLACE FUNCTION public.technical_configuration_result_export_manifest_get(
+  p_dossier_id UUID,
+  p_baseline_version_id UUID,
+  p_option_ids UUID[],
+  p_criterion_ids UUID[]
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_snapshot JSONB;
+BEGIN
+  PERFORM public._technical_configuration_require_global_user();
+  v_snapshot := public._technical_configuration_result_export_snapshot(
+    p_dossier_id,
+    p_baseline_version_id,
+    p_option_ids,
+    p_criterion_ids
+  );
+  RETURN jsonb_build_object(
+    'data', jsonb_build_object(
+      'dossier', v_snapshot->'dossier',
+      'baseline_version', v_snapshot->'baseline_version',
+      'option_total', v_snapshot->'option_total',
+      'criterion_total', v_snapshot->'criterion_total',
+      'snapshot_token', v_snapshot->'snapshot_token',
+      'ranking_snapshot_token', v_snapshot->'ranking_snapshot_token'
+    )
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.technical_configuration_result_export_manifest_get(
+  UUID, UUID, UUID[], UUID[]
+) FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.technical_configuration_result_export_manifest_get(
+  UUID, UUID, UUID[], UUID[]
+) TO authenticated, service_role;
+COMMIT;

--- a/supabase/migrations/20260802054948_technical_configuration_result_export_manifest.sql
+++ b/supabase/migrations/20260802054948_technical_configuration_result_export_manifest.sql
@@ -12,6 +12,7 @@
 -- DROP FUNCTION IF EXISTS public._technical_configuration_result_export_snapshot(
 --   UUID, UUID, UUID[], UUID[]
 -- );
+-- ALTER FUNCTION public.technical_configuration_reference_ranking_list(UUID, UUID, INTEGER, INTEGER) VOLATILE;
 BEGIN;
 ALTER FUNCTION public.technical_configuration_reference_ranking_list(UUID, UUID, INTEGER, INTEGER) STABLE;
 CREATE OR REPLACE FUNCTION public._technical_configuration_result_export_snapshot(

--- a/supabase/tests/technical_configuration_result_export_manifest_phase_gate.sql
+++ b/supabase/tests/technical_configuration_result_export_manifest_phase_gate.sql
@@ -108,10 +108,8 @@ BEGIN
     NOT has_function_privilege('authenticated', v_helper_signature, 'EXECUTE'));
   PERFORM pg_temp.assert_true('helper service role execute granted',
     has_function_privilege('service_role', v_helper_signature, 'EXECUTE'));
-  PERFORM pg_temp.assert_true('helper is stable',
-    (SELECT proc.provolatile = 's' FROM pg_proc proc WHERE proc.oid = v_helper_signature::regprocedure));
-  PERFORM pg_temp.assert_true('manifest is stable',
-    (SELECT proc.provolatile = 's' FROM pg_proc proc WHERE proc.oid = v_manifest_signature::regprocedure));
+  PERFORM pg_temp.assert_true('helper is stable', (SELECT proc.provolatile = 's' FROM pg_proc proc WHERE proc.oid = v_helper_signature::regprocedure));
+  PERFORM pg_temp.assert_true('manifest is stable', (SELECT proc.provolatile = 's' FROM pg_proc proc WHERE proc.oid = v_manifest_signature::regprocedure));
   PERFORM pg_temp.assert_true('P12C1 ranking is stable', (SELECT proc.provolatile = 's'
     FROM pg_proc proc WHERE proc.oid = 'public.technical_configuration_reference_ranking_list(uuid,uuid,integer,integer)'::regprocedure));
   INSERT INTO public.technical_configuration_dossiers (
@@ -441,9 +439,11 @@ BEGIN
   SET notes = 'Changed assessment'
   WHERE id = v_assessment_id;
   v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
-  PERFORM pg_temp.assert_changed(
-    'full token changes with manual assessment notes', v_token, v_next_token
-  );
+  PERFORM pg_temp.assert_changed('full token changes with manual assessment notes', v_token, v_next_token);
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_manual_assessments SET technical_axis = 'exceeds' WHERE id = v_assessment_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed('full token changes with manual assessment technical axis', v_token, v_next_token);
 END;
 $gate$;
 ROLLBACK;

--- a/supabase/tests/technical_configuration_result_export_manifest_phase_gate.sql
+++ b/supabase/tests/technical_configuration_result_export_manifest_phase_gate.sql
@@ -1,0 +1,449 @@
+-- P14A1 rollback-only export-manifest authorization, scope and snapshot gate.
+BEGIN;
+CREATE FUNCTION pg_temp.assert_true(p_label TEXT, p_condition BOOLEAN)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  IF p_condition IS DISTINCT FROM true THEN RAISE EXCEPTION '%', p_label; END IF;
+END;
+$gate$;
+CREATE FUNCTION pg_temp.assert_changed(p_label TEXT, p_before TEXT, p_after TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  PERFORM pg_temp.assert_true(p_label, p_before IS NOT NULL
+    AND p_after IS NOT NULL AND p_before IS DISTINCT FROM p_after);
+END;
+$gate$;
+CREATE FUNCTION pg_temp.expect_error(
+  p_label TEXT, p_statement TEXT, p_expected_state TEXT, p_expected_message TEXT
+) RETURNS VOID LANGUAGE plpgsql AS $gate$
+DECLARE v_state TEXT; v_message TEXT;
+BEGIN
+  BEGIN
+    EXECUTE p_statement;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_state = RETURNED_SQLSTATE, v_message = MESSAGE_TEXT;
+    IF v_state IS DISTINCT FROM p_expected_state
+       OR v_message IS DISTINCT FROM p_expected_message THEN
+      RAISE EXCEPTION '%: expected [%] %, got [%] %',
+        p_label, p_expected_state, p_expected_message, v_state, v_message;
+    END IF;
+    RETURN;
+  END;
+  RAISE EXCEPTION '%: expected statement to fail', p_label;
+END;
+$gate$;
+CREATE FUNCTION pg_temp.set_claims(p_app_role TEXT, p_user_id BIGINT)
+RETURNS VOID LANGUAGE plpgsql AS $gate$
+BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    jsonb_build_object('app_role', p_app_role, 'role', 'authenticated',
+      'user_id', p_user_id::TEXT, 'sub', p_user_id::TEXT)::TEXT, true
+  );
+END;
+$gate$;
+CREATE FUNCTION pg_temp.read_manifest(p_dossier_id UUID, p_version_id UUID)
+RETURNS JSONB LANGUAGE sql AS $gate$
+  SELECT public.technical_configuration_result_export_manifest_get(
+    p_dossier_id, p_version_id, NULL::UUID[], NULL::UUID[]);
+$gate$;
+CREATE FUNCTION pg_temp.snapshot_row_counts(p_dossier_id UUID, p_version_id UUID)
+RETURNS JSONB LANGUAGE sql AS $gate$
+  SELECT jsonb_build_object(
+    'sets', (SELECT count(*) FROM public.technical_configuration_comparison_sets
+      WHERE dossier_id = p_dossier_id AND baseline_version_id = p_version_id),
+    'responses', (SELECT count(*) FROM public.technical_configuration_option_responses
+      WHERE baseline_version_id = p_version_id),
+    'documents', (SELECT count(*) FROM public.technical_configuration_option_documents d
+      JOIN public.technical_configuration_options o ON o.id = d.option_id
+      WHERE o.dossier_id = p_dossier_id),
+    'citations', (SELECT count(*) FROM public.technical_configuration_option_citations
+      WHERE baseline_version_id = p_version_id),
+    'assessments', (SELECT count(*) FROM public.technical_configuration_manual_assessments
+      WHERE baseline_version_id = p_version_id));
+$gate$;
+DO $gate$
+DECLARE
+  v_suffix TEXT := to_char(clock_timestamp(), 'YYYYMMDDHH24MISSMS');
+  v_user_id BIGINT;
+  v_dossier_id UUID := gen_random_uuid(); v_other_dossier_id UUID := gen_random_uuid();
+  v_version_id UUID := gen_random_uuid(); v_other_version_id UUID := gen_random_uuid();
+  v_group_id UUID := gen_random_uuid(); v_other_group_id UUID := gen_random_uuid();
+  v_criterion_a_id UUID := gen_random_uuid(); v_criterion_b_id UUID := gen_random_uuid();
+  v_other_criterion_id UUID := gen_random_uuid();
+  v_supplier_a_id UUID := gen_random_uuid(); v_supplier_b_id UUID := gen_random_uuid();
+  v_other_supplier_id UUID := gen_random_uuid();
+  v_option_a_id UUID := gen_random_uuid(); v_option_b_id UUID := gen_random_uuid();
+  v_other_option_id UUID := gen_random_uuid();
+  v_set_id UUID := gen_random_uuid(); v_response_id UUID := gen_random_uuid();
+  v_document_id UUID := gen_random_uuid(); v_citation_id UUID := gen_random_uuid();
+  v_assessment_id UUID := gen_random_uuid();
+  v_manifest JSONB; v_snapshot JSONB; v_ranking JSONB; v_utc_manifest JSONB; v_local_manifest JSONB;
+  v_token TEXT; v_next_token TEXT; v_utc_token TEXT; v_local_token TEXT;
+  v_before_counts JSONB; v_after_counts JSONB;
+  v_before_metadata JSONB; v_after_metadata JSONB;
+  v_case RECORD;
+  v_manifest_signature TEXT := 'public.technical_configuration_result_export_manifest_get(uuid,uuid,uuid[],uuid[])';
+  v_helper_signature TEXT := 'public._technical_configuration_result_export_snapshot(uuid,uuid,uuid[],uuid[])';
+BEGIN
+  PERFORM pg_advisory_xact_lock(
+    hashtext('technical_configuration_result_export_manifest_phase_gate'));
+  SELECT nv.id INTO v_user_id
+  FROM public.nhan_vien nv
+  WHERE nv.is_active IS TRUE
+  ORDER BY nv.id
+  LIMIT 1;
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'P14A1 phase gate requires one active public.nhan_vien row';
+  END IF;
+  PERFORM pg_temp.assert_true('manifest PUBLIC execute revoked',
+    NOT has_function_privilege('public', v_manifest_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('manifest anon execute revoked',
+    NOT has_function_privilege('anon', v_manifest_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('manifest authenticated execute granted',
+    has_function_privilege('authenticated', v_manifest_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('manifest service role execute granted',
+    has_function_privilege('service_role', v_manifest_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('helper authenticated execute revoked',
+    NOT has_function_privilege('authenticated', v_helper_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('helper service role execute granted',
+    has_function_privilege('service_role', v_helper_signature, 'EXECUTE'));
+  PERFORM pg_temp.assert_true('helper is stable',
+    (SELECT proc.provolatile = 's' FROM pg_proc proc WHERE proc.oid = v_helper_signature::regprocedure));
+  PERFORM pg_temp.assert_true('manifest is stable',
+    (SELECT proc.provolatile = 's' FROM pg_proc proc WHERE proc.oid = v_manifest_signature::regprocedure));
+  PERFORM pg_temp.assert_true('P12C1 ranking is stable', (SELECT proc.provolatile = 's'
+    FROM pg_proc proc WHERE proc.oid = 'public.technical_configuration_reference_ranking_list(uuid,uuid,integer,integer)'::regprocedure));
+  INSERT INTO public.technical_configuration_dossiers (
+    id, device_type_name, name, created_by, updated_by
+  ) VALUES
+    (
+      v_dossier_id, 'P14A1 device ' || v_suffix, 'P14A1 dossier ' || v_suffix,
+      v_user_id, v_user_id
+    ),
+    (
+      v_other_dossier_id, 'P14A1 other device ' || v_suffix,
+      'P14A1 other dossier ' || v_suffix, v_user_id, v_user_id
+    );
+  INSERT INTO public.technical_configuration_baseline_versions (
+    id, dossier_id, version_number, status, next_criterion_number, revision,
+    created_by, updated_by
+  ) VALUES
+    (v_version_id, v_dossier_id, 1, 'draft', 3, 1, v_user_id, v_user_id),
+    (v_other_version_id, v_other_dossier_id, 1, 'draft', 2, 1, v_user_id, v_user_id);
+  INSERT INTO public.technical_configuration_baseline_groups (
+    id, baseline_version_id, name, sort_order, created_by, updated_by
+  ) VALUES
+    (v_group_id, v_version_id, 'P14A1 Group', 1, v_user_id, v_user_id),
+    (
+      v_other_group_id, v_other_version_id, 'P14A1 Other Group', 1,
+      v_user_id, v_user_id
+    );
+  INSERT INTO public.technical_configuration_baseline_criteria (
+    id, baseline_version_id, group_id, criterion_code, title, requirement_text,
+    sort_order, created_by, updated_by
+  ) VALUES
+    (
+      v_criterion_a_id, v_version_id, v_group_id, 'TC-0001', 'Criterion A',
+      'Requirement A', 1, v_user_id, v_user_id
+    ),
+    (
+      v_criterion_b_id, v_version_id, v_group_id, 'TC-0002', 'Criterion B',
+      'Requirement B', 2, v_user_id, v_user_id
+    ),
+    (
+      v_other_criterion_id, v_other_version_id, v_other_group_id, 'TC-0001',
+      'Other criterion', 'Other requirement', 1, v_user_id, v_user_id
+    );
+  INSERT INTO public.technical_configuration_suppliers (
+    id, dossier_id, name, created_by, updated_by
+  ) VALUES
+    (v_supplier_a_id, v_dossier_id, 'A Supplier', v_user_id, v_user_id),
+    (v_supplier_b_id, v_dossier_id, 'B Supplier', v_user_id, v_user_id),
+    (
+      v_other_supplier_id, v_other_dossier_id, 'Other Supplier',
+      v_user_id, v_user_id
+    );
+  INSERT INTO public.technical_configuration_options (
+    id, dossier_id, supplier_id, model, manufacturer, option_name,
+    created_by, updated_by
+  ) VALUES
+    (
+      v_option_a_id, v_dossier_id, v_supplier_a_id, 'Model A', 'Maker A',
+      'Option A', v_user_id, v_user_id
+    ),
+    (
+      v_option_b_id, v_dossier_id, v_supplier_b_id, 'Model B', 'Maker B',
+      'Option B', v_user_id, v_user_id
+    ),
+    (
+      v_other_option_id, v_other_dossier_id, v_other_supplier_id, 'Other Model',
+      'Other Maker', 'Other Option', v_user_id, v_user_id
+    );
+  INSERT INTO public.technical_configuration_comparison_sets (
+    id, dossier_id, option_id, baseline_version_id, created_by, updated_by
+  ) VALUES (
+    v_set_id, v_dossier_id, v_option_a_id, v_version_id, v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_option_responses (
+    id, comparison_set_id, baseline_version_id, criterion_id,
+    response_text, supplementary_information, created_by, updated_by
+  ) VALUES (
+    v_response_id, v_set_id, v_version_id, v_criterion_a_id,
+    'Original response', 'Original supplementary', v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_option_documents (
+    id, option_id, name, url, created_by, updated_by
+  ) VALUES (
+    v_document_id, v_option_a_id, 'Original document',
+    'https://example.com/original.pdf', v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_option_citations (
+    id, option_id, baseline_version_id, comparison_set_id, option_document_id,
+    criterion_id, page_section, excerpt, created_by, updated_by
+  ) VALUES (
+    v_citation_id, v_option_a_id, v_version_id, v_set_id, v_document_id,
+    v_criterion_a_id, 'Section 1', 'Original excerpt', v_user_id, v_user_id
+  );
+  INSERT INTO public.technical_configuration_manual_assessments (
+    id, comparison_set_id, baseline_version_id, criterion_id,
+    technical_axis, evidence_axis, notes, created_by, updated_by
+  ) VALUES (
+    v_assessment_id, v_set_id, v_version_id, v_criterion_a_id,
+    'meets', 'complete', 'Original assessment', v_user_id, v_user_id
+  );
+  PERFORM set_config('request.jwt.claims', '{}'::JSONB::TEXT, true);
+  PERFORM pg_temp.expect_error(
+    'missing claims rejected',
+    format(
+      'SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, NULL::UUID[], NULL::UUID[])',
+      v_dossier_id, v_version_id
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('qltb_khoa', v_user_id);
+  PERFORM pg_temp.expect_error(
+    'denied role cannot read export manifest',
+    format(
+      'SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, NULL::UUID[], NULL::UUID[])',
+      v_dossier_id, v_version_id
+    ),
+    '42501', 'permission_denied'
+  );
+  PERFORM pg_temp.set_claims('admin', v_user_id);
+  v_manifest := pg_temp.read_manifest(v_dossier_id, v_version_id);
+  PERFORM pg_temp.assert_true(
+    'raw admin can read export manifest',
+    (v_manifest->'data'->>'option_total')::BIGINT = 2
+  );
+  PERFORM pg_temp.set_claims('global', v_user_id);
+  v_manifest := pg_temp.read_manifest(v_dossier_id, v_version_id);
+  PERFORM pg_temp.assert_true(
+    'global can read export manifest',
+    (v_manifest->'data'->>'criterion_total')::BIGINT = 2
+  );
+  PERFORM pg_temp.assert_true(
+    'public manifest root is exact',
+    (SELECT array_agg(key ORDER BY key) FROM jsonb_object_keys(v_manifest) key)
+      = ARRAY['data']
+  );
+  PERFORM pg_temp.assert_true(
+    'public manifest data fields are exact',
+    (
+      SELECT array_agg(key ORDER BY key)
+      FROM jsonb_object_keys(v_manifest->'data') key
+    ) = ARRAY[
+      'baseline_version', 'criterion_total', 'dossier', 'option_total',
+      'ranking_snapshot_token', 'snapshot_token'
+    ]
+  );
+  SELECT public._technical_configuration_result_export_snapshot(
+    v_dossier_id,
+    v_version_id,
+    ARRAY[v_option_b_id, v_option_a_id],
+    ARRAY[v_criterion_b_id, v_criterion_a_id]
+  ) INTO v_snapshot;
+  PERFORM pg_temp.assert_true(
+    'ordered scopes preserve request order',
+    v_snapshot->'option_ids' = to_jsonb(ARRAY[v_option_b_id, v_option_a_id])
+      AND v_snapshot->'criterion_ids'
+        = to_jsonb(ARRAY[v_criterion_b_id, v_criterion_a_id])
+  );
+  FOR v_case IN
+    SELECT cases.label, cases.statement, cases.expected_state, cases.expected_message
+    FROM (VALUES
+      ('null dossier rejected', format('SELECT public.technical_configuration_result_export_manifest_get(NULL::UUID, %L::UUID, NULL::UUID[], NULL::UUID[])', v_version_id), 'PT422', 'validation_error'),
+      ('null baseline rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, NULL::UUID, NULL::UUID[], NULL::UUID[])', v_dossier_id), 'PT422', 'validation_error'),
+      ('dossier baseline mismatch rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, NULL::UUID[], NULL::UUID[])', v_dossier_id, v_other_version_id), 'PT404', 'not_found'),
+      ('empty option scope rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, ARRAY[]::UUID[], NULL::UUID[])', v_dossier_id, v_version_id), 'PT422', 'validation_error'),
+      ('null option element rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, ARRAY[%L::UUID, NULL::UUID], NULL::UUID[])', v_dossier_id, v_version_id, v_option_a_id), 'PT422', 'validation_error'),
+      ('duplicate option scope rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, ARRAY[%L::UUID, %L::UUID], NULL::UUID[])', v_dossier_id, v_version_id, v_option_a_id, v_option_a_id), 'PT422', 'validation_error'),
+      ('foreign option scope rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, ARRAY[%L::UUID], NULL::UUID[])', v_dossier_id, v_version_id, v_other_option_id), 'PT404', 'not_found'),
+      ('empty criterion scope rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, NULL::UUID[], ARRAY[]::UUID[])', v_dossier_id, v_version_id), 'PT422', 'validation_error'),
+      ('null criterion element rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, NULL::UUID[], ARRAY[%L::UUID, NULL::UUID])', v_dossier_id, v_version_id, v_criterion_a_id), 'PT422', 'validation_error'),
+      ('duplicate criterion scope rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, NULL::UUID[], ARRAY[%L::UUID, %L::UUID])', v_dossier_id, v_version_id, v_criterion_a_id, v_criterion_a_id), 'PT422', 'validation_error'),
+      ('foreign criterion scope rejected', format('SELECT public.technical_configuration_result_export_manifest_get(%L::UUID, %L::UUID, NULL::UUID[], ARRAY[%L::UUID])', v_dossier_id, v_version_id, v_other_criterion_id), 'PT404', 'not_found')
+    ) AS cases(label, statement, expected_state, expected_message)
+  LOOP
+    PERFORM pg_temp.expect_error(
+      v_case.label, v_case.statement, v_case.expected_state, v_case.expected_message);
+  END LOOP;
+  SELECT public.technical_configuration_reference_ranking_list(
+    v_dossier_id, v_version_id, 1, 1
+  ) INTO v_ranking;
+  PERFORM pg_temp.assert_true(
+    'ranking token matches P12C1',
+    v_manifest->'data'->>'ranking_snapshot_token' = v_ranking->>'snapshot_token'
+  );
+  v_before_counts := pg_temp.snapshot_row_counts(v_dossier_id, v_version_id);
+  PERFORM pg_temp.read_manifest(v_dossier_id, v_version_id);
+  v_after_counts := pg_temp.snapshot_row_counts(v_dossier_id, v_version_id);
+  PERFORM pg_temp.assert_true(
+    'missing rows remain absent',
+    v_before_counts = v_after_counts
+      AND (v_after_counts->>'sets')::BIGINT = 1
+      AND (v_after_counts->>'responses')::BIGINT = 1
+      AND (v_after_counts->>'documents')::BIGINT = 1
+      AND (v_after_counts->>'citations')::BIGINT = 1
+      AND (v_after_counts->>'assessments')::BIGINT = 1
+  );
+  SELECT jsonb_build_object(
+    'dossier_revision', dossier.revision,
+    'dossier_updated_at', dossier.updated_at,
+    'baseline_revision', version.revision,
+    'baseline_updated_at', version.updated_at,
+    'set_updated_at', comparison_set.updated_at,
+    'assessment_revision', assessment.revision,
+    'assessment_updated_at', assessment.updated_at
+  ) INTO v_before_metadata
+  FROM public.technical_configuration_dossiers dossier
+  JOIN public.technical_configuration_baseline_versions version
+    ON version.id = v_version_id AND version.dossier_id = dossier.id
+  JOIN public.technical_configuration_comparison_sets comparison_set
+    ON comparison_set.id = v_set_id
+  JOIN public.technical_configuration_manual_assessments assessment
+    ON assessment.id = v_assessment_id
+  WHERE dossier.id = v_dossier_id;
+  PERFORM pg_temp.read_manifest(v_dossier_id, v_version_id);
+  SELECT jsonb_build_object(
+    'dossier_revision', dossier.revision,
+    'dossier_updated_at', dossier.updated_at,
+    'baseline_revision', version.revision,
+    'baseline_updated_at', version.updated_at,
+    'set_updated_at', comparison_set.updated_at,
+    'assessment_revision', assessment.revision,
+    'assessment_updated_at', assessment.updated_at
+  ) INTO v_after_metadata
+  FROM public.technical_configuration_dossiers dossier
+  JOIN public.technical_configuration_baseline_versions version
+    ON version.id = v_version_id AND version.dossier_id = dossier.id
+  JOIN public.technical_configuration_comparison_sets comparison_set
+    ON comparison_set.id = v_set_id
+  JOIN public.technical_configuration_manual_assessments assessment
+    ON assessment.id = v_assessment_id
+  WHERE dossier.id = v_dossier_id;
+  PERFORM pg_temp.assert_true(
+    'manifest read preserves revisions and audit metadata',
+    v_before_metadata = v_after_metadata
+  );
+  UPDATE public.technical_configuration_dossiers SET
+    archived_at = TIMESTAMPTZ '2026-08-02 01:02:03.456789+00', archived_by = v_user_id
+  WHERE id = v_dossier_id;
+  UPDATE public.technical_configuration_baseline_versions SET status = 'locked',
+    locked_at = TIMESTAMPTZ '2026-08-02 04:05:06.123456+00', locked_by = v_user_id
+  WHERE id = v_version_id;
+  PERFORM set_config('TimeZone', 'UTC', true);
+  v_utc_manifest := pg_temp.read_manifest(v_dossier_id, v_version_id);
+  PERFORM set_config('TimeZone', 'Asia/Ho_Chi_Minh', true);
+  v_local_manifest := pg_temp.read_manifest(v_dossier_id, v_version_id);
+  PERFORM pg_temp.assert_true('manifest timestamps are UTC canonical',
+    v_local_manifest->'data'->'dossier'->>'archived_at' = '2026-08-02T01:02:03.456789Z'
+      AND v_local_manifest->'data'->'baseline_version'->>'locked_at' = '2026-08-02T04:05:06.123456Z');
+  PERFORM pg_temp.assert_true('manifest timestamp representation ignores session timezone',
+    v_utc_manifest->'data'->'dossier' = v_local_manifest->'data'->'dossier'
+      AND v_utc_manifest->'data'->'baseline_version' = v_local_manifest->'data'->'baseline_version');
+  v_utc_token := v_utc_manifest->'data'->>'snapshot_token';
+  v_local_token := v_local_manifest->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_true(
+    'full token ignores session timestamp formatting',
+    v_utc_token = v_local_token
+  );
+  v_token := v_local_token;
+  UPDATE public.technical_configuration_dossiers
+  SET name = 'Changed dossier ' || v_suffix
+  WHERE id = v_dossier_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed('full token changes with dossier name', v_token, v_next_token);
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_baseline_criteria
+  SET requirement_text = 'Changed requirement'
+  WHERE id = v_criterion_a_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed(
+    'full token changes with criterion requirement', v_token, v_next_token
+  );
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_baseline_versions
+  SET locked_at = TIMESTAMPTZ '2026-08-02 05:06:07.654321+00'
+  WHERE id = v_version_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed(
+    'full token changes with baseline lock date', v_token, v_next_token
+  );
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_options
+  SET model = 'Changed model'
+  WHERE id = v_option_a_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed(
+    'full token changes with option identity', v_token, v_next_token
+  );
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_suppliers
+  SET name = 'Changed Supplier'
+  WHERE id = v_supplier_a_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed(
+    'full token changes with supplier identity', v_token, v_next_token
+  );
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_option_responses
+  SET response_text = 'Changed response'
+  WHERE id = v_response_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed('full token changes with response text', v_token, v_next_token);
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_option_responses
+  SET supplementary_information = 'Changed supplementary'
+  WHERE id = v_response_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed(
+    'full token changes with supplementary information', v_token, v_next_token
+  );
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_option_documents
+  SET name = 'Changed document', url = 'https://example.com/changed.pdf'
+  WHERE id = v_document_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed(
+    'full token changes with document metadata', v_token, v_next_token
+  );
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_option_citations
+  SET excerpt = 'Changed excerpt'
+  WHERE id = v_citation_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed(
+    'full token changes with citation excerpt', v_token, v_next_token
+  );
+  v_token := v_next_token;
+  UPDATE public.technical_configuration_manual_assessments
+  SET notes = 'Changed assessment'
+  WHERE id = v_assessment_id;
+  v_next_token := pg_temp.read_manifest(v_dossier_id, v_version_id)->'data'->>'snapshot_token';
+  PERFORM pg_temp.assert_changed(
+    'full token changes with manual assessment notes', v_token, v_next_token
+  );
+END;
+$gate$;
+ROLLBACK;


### PR DESCRIPTION
## Summary
- add the guarded, read-only P14A1 canonical snapshot helper and public manifest RPC
- expose only the manifest RPC through the dedicated function manifest and proxy allowlist
- normalize exported timestamps to canonical UTC, hash every workbook-visible source, and reuse the P12C1 ranking token
- add RED/GREEN migration contract tests, rollback-only live phase gate, and OpenSpec execution evidence

## Scope
P14A1 only. No P14A2 page RPCs, client, workbook, UI, download, get-or-create path, or persistent live fixture data.

## Verification
- RED evidence: 3 expected failures for volatility, canonical timestamps, and phase-gate coverage
- focused/regression Vitest: 6 files, 147 tests passed
- format:check, verify:no-explicit-any, verify:dedupe, typecheck: passed
- React Doctor: 100/100, zero issues
- OpenSpec strict validation: passed
- SQL line ceilings: migration 445, phase gate 449
- independent review loop: zero findings after fixes and zero findings on final diff

## Live DB evidence
- applied through Supabase MCP as migration 20260802073104 after explicit approval
- helper, public manifest RPC, and P12C1 ranking RPC are STABLE, SECURITY DEFINER, and pinned to search_path = public, pg_temp
- grants match the locked contract; the private helper remains service-role-only
- rollback-only phase gate passed; post-gate P14A1 fixture counts are zero
- security and performance advisors reviewed with no P14A1 blocker

Closes #839

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the P14A1 canonical export snapshot manifest. Provides a read-only manifest RPC that fingerprints all workbook-visible data with UTC-normalized timestamps and stable tokens to meet Linear #839.

- **New Features**
  - Public RPC: technical_configuration_result_export_manifest_get (read-only, STABLE, SECURITY DEFINER) returning only dossier, baseline_version, option_total, criterion_total, snapshot_token, and ranking_snapshot_token.
  - Private helper: _technical_configuration_result_export_snapshot builds the canonical digest; may carry ordered option/criterion IDs for P14A2. UTC-normalized timestamps; snapshot token covers all workbook-visible sources; reuses the P12C1 ranking token.
  - Shared constants `RESULT_EXPORT_RPC_FUNCTIONS`/`RESULT_EXPORT_RPC_FUNCTION_NAMES`; proxy allowlist exposes only the manifest RPC; whitelist test locks this.

- **Migration**
  - New SQL migration adds both functions, pins search_path, and sets the P12C1 ranking list to STABLE. Grants: public RPC to `authenticated`/`service_role`; helper `service_role`-only.
  - Rollback-only phase gate validates auth, ordered scopes, exact public shape, UTC canonical timestamps, token sensitivity, and no side effects. OpenSpec updated with the exact manifest shape; no P14A2 page RPCs, clients, workbook, UI, or download paths.

<sup>Written for commit 56f94ef7270b1cb4275f7ea31ebc24c8fbf8c2c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thienchi2109/qltbyt-nam-phong/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a technical configuration result-export manifest.
  * Supports selecting dossiers, baseline versions, options, and criteria for scoped exports.
  * Provides summary metadata and deterministic snapshot tokens for comparing exported results.
  * Exposes ranking and source-data consistency information while keeping internal details private.

* **Security**
  * Restricted export access and validated requested scopes to prevent unauthorized or invalid data retrieval.

* **Tests**
  * Added comprehensive coverage for authorization, validation, stable snapshots, response format, and non-mutating reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->